### PR TITLE
fix(tests): resolve 126 optimization test failures — @patch compat + torch skip markers (#5728)

### DIFF
--- a/autobot-backend/llm_interface_pkg/optimization/__init__.py
+++ b/autobot-backend/llm_interface_pkg/optimization/__init__.py
@@ -88,6 +88,17 @@ from .token_optimizer import (
     get_token_optimizer,
 )
 
+# Expose submodules as package attributes so @patch("...optimization.<submodule>.X")
+# resolves correctly under pytest --import-mode=importlib (#5728)
+from . import (  # noqa: E402
+    attention_backend,
+    flash_attention,
+    hf_quantizer,
+    meta_eviction,
+    model_inspector,
+    token_optimizer,
+)
+
 __all__ = [
     # Router
     "OptimizationRouter",

--- a/autobot-backend/llm_interface_pkg/optimization/flash_attention_test.py
+++ b/autobot-backend/llm_interface_pkg/optimization/flash_attention_test.py
@@ -7,10 +7,15 @@ Unit tests for Flash Attention v2 with variable-length sequence optimization.
 Issue #1955: Flash Attention v2 with variable-length sequence optimization.
 """
 
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+
+# Skip all tests in this file when torch is the conftest MagicMock stub (#5728)
+_TORCH_IS_STUB = not isinstance(torch, types.ModuleType)
+pytestmark = pytest.mark.skipif(_TORCH_IS_STUB, reason="requires real PyTorch")
 
 from llm_interface_pkg.optimization.flash_attention import (
     AttentionBackend,

--- a/autobot-backend/llm_interface_pkg/optimization/kv_cache_test.py
+++ b/autobot-backend/llm_interface_pkg/optimization/kv_cache_test.py
@@ -7,8 +7,14 @@ Unit tests for layer-aligned KV cache management.
 Issue #1964: Layer-aligned KV cache management for sequential layer processing.
 """
 
+import types
+
 import pytest
 import torch
+
+# Detect conftest MagicMock torch stub; skip tensor-operation tests when absent (#5728)
+_TORCH_IS_STUB = not isinstance(torch, types.ModuleType)
+requires_torch = pytest.mark.skipif(_TORCH_IS_STUB, reason="requires real PyTorch")
 
 from llm_interface_pkg.optimization.kv_cache import (
     RTX_4070_KV_CACHE_FRACTION,
@@ -143,6 +149,7 @@ class TestKVCacheConfig:
 # ---------------------------------------------------------------------------
 
 
+@requires_torch
 class TestLayerKVCacheGetUpdate:
     """Tests for LayerKVCache.get() and update()."""
 
@@ -232,6 +239,7 @@ class TestLayerKVCacheGetUpdate:
 # ---------------------------------------------------------------------------
 
 
+@requires_torch
 class TestLayerKVCacheValidation:
     """Tests for input tensor shape validation."""
 
@@ -277,6 +285,7 @@ class TestLayerKVCacheValidation:
 # ---------------------------------------------------------------------------
 
 
+@requires_torch
 class TestLayerKVCacheTrim:
     """Tests for LayerKVCache.trim_to_length()."""
 
@@ -345,6 +354,7 @@ class TestLayerKVCacheTrim:
 # ---------------------------------------------------------------------------
 
 
+@requires_torch
 class TestLayerKVCacheClearMemory:
     """Tests for clear() and memory_usage_bytes()."""
 
@@ -403,6 +413,7 @@ class TestLayerKVCacheClearMemory:
 # ---------------------------------------------------------------------------
 
 
+@requires_torch
 class TestNumFilledLayers:
     """Tests for the num_filled_layers property."""
 

--- a/autobot-backend/llm_interface_pkg/optimization/layer_inference_test.py
+++ b/autobot-backend/llm_interface_pkg/optimization/layer_inference_test.py
@@ -9,11 +9,16 @@ Issue #1946: Layer-by-layer inference mode for batch/offline processing.
 
 import os
 import tempfile
+import types
 from typing import Any, Dict, List
 from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+
+# Detect conftest MagicMock torch stub; skip tensor-operation tests when absent (#5728)
+_TORCH_IS_STUB = not isinstance(torch, types.ModuleType)
+requires_torch = pytest.mark.skipif(_TORCH_IS_STUB, reason="requires real PyTorch")
 
 from llm_interface_pkg.optimization.layer_inference import (
     LayerInferenceConfig,
@@ -197,6 +202,7 @@ class TestGetLayerNames:
 # ---------------------------------------------------------------------------
 
 
+@requires_torch
 class TestLoadEvictCycle:
     """Tests for LayerInferenceEngine.load_layer() and evict_layer()."""
 
@@ -282,6 +288,7 @@ class TestLoadEvictCycle:
 # ---------------------------------------------------------------------------
 
 
+@requires_torch
 class TestForwardPass:
     """Tests for LayerInferenceEngine.forward_pass()."""
 
@@ -343,6 +350,7 @@ class TestForwardPass:
 # ---------------------------------------------------------------------------
 
 
+@requires_torch
 class TestGenerate:
     """Tests for LayerInferenceEngine.generate() with mocked dependencies."""
 
@@ -448,6 +456,7 @@ class TestGenerate:
 # ---------------------------------------------------------------------------
 
 
+@requires_torch
 class TestStatsTracking:
     """Tests that LayerInferenceStats is populated correctly."""
 
@@ -487,6 +496,7 @@ class TestStatsTracking:
 # ---------------------------------------------------------------------------
 
 
+@requires_torch
 class TestModuleHelpers:
     """Tests for module-level private helpers."""
 

--- a/autobot-backend/llm_interface_pkg/optimization/meta_eviction_test.py
+++ b/autobot-backend/llm_interface_pkg/optimization/meta_eviction_test.py
@@ -247,8 +247,8 @@ class TestEvictLayerToMetaQuantized:
         layer = MagicMock(name="Layer")
         set_fn = self._run_quantized_eviction(layer, param_names=("weight", "bias"))
         assert set_fn.call_count == 2
-        calls = [c[0] for c in set_fn.call_args_list]  # positional args
-        devices = [c[2] for c in calls]
+        # device is passed as keyword arg: set_fn(layer, name, device="meta")
+        devices = [c.kwargs.get("device") for c in set_fn.call_args_list]
         assert all(d == "meta" for d in devices), "All tensors must target 'meta'"
 
     def test_calls_set_module_tensor_for_buffers(self):

--- a/autobot-backend/llm_interface_pkg/optimization/token_optimizer_test.py
+++ b/autobot-backend/llm_interface_pkg/optimization/token_optimizer_test.py
@@ -4,6 +4,7 @@
 """Tests for TokenOptimizer — Issue #2098."""
 
 import json
+import time
 from unittest.mock import MagicMock, patch
 
 from .token_optimizer import (
@@ -256,14 +257,15 @@ class TestL1ToL2Fallback:
     @patch("llm_interface_pkg.optimization.token_optimizer.get_redis_client")
     def test_l2_hit_promotes_to_l1(self, mock_get_redis):
         """When L1 misses but L2 hits, entry should be promoted to L1."""
+        now = time.time()
         entry = CompactionEntry(
             fingerprint="fp_test",
             original_length=500,
             compacted_text="compact",
             compacted_length=7,
             hit_count=0,
-            created_at=1000.0,
-            last_accessed=1000.0,
+            created_at=now,
+            last_accessed=now,
         )
         serialized = json.dumps(
             {


### PR DESCRIPTION
## Summary

- **Root cause 1 (100 failures):** `pytest --import-mode=importlib` does not set submodules as package attributes when using `from .X import Y`. `@patch("llm_interface_pkg.optimization.<submodule>.X")` resolved via `getattr(optimization, 'submodule')` → AttributeError for 6 submodules. Fix: add explicit `from . import attention_backend, flash_attention, hf_quantizer, meta_eviction, model_inspector, token_optimizer` to `optimization/__init__.py`
- **Root cause 2 (24 failures):** conftest stubs `torch` as `MagicMock` when not installed. Tests using real tensor ops (`ndim` comparisons, `torch.save/load`, `torch.allclose`) failed because `MagicMock.ndim` is truthy. Fix: `_TORCH_IS_STUB = not isinstance(torch, types.ModuleType)` + `pytestmark`/`@requires_torch` skip markers on torch-dependent test classes in `kv_cache_test.py`, `flash_attention_test.py`, `layer_inference_test.py`
- **2 logic bugs exposed after clearing infrastructure noise:**
  - `meta_eviction_test`: `set_fn` called with `device=` as keyword arg, test checked positional index 2 → IndexError; fixed to `c.kwargs["device"]`
  - `token_optimizer_test`: `CompactionEntry(created_at=1000.0)` was immediately expired by L1Cache TTL check; fixed to `time.time()`

## Test Plan

- [x] `pytest autobot-backend/llm_interface_pkg/optimization/ --tb=no -q` → **206 passed, 88 skipped, 0 failed** (88 skips = torch-dependent tests on system without real PyTorch — correct behavior)
- [x] Previously: 126 failed, 168 passed

Closes #5728

🤖 Generated with Claude Code