### PR TITLE
fix(deps): add dependabot.yml ignore rules for deleted config/ manifest paths (#5682)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,16 @@ updates:
       - "dependencies"
       - "frontend"
 
+  - package-ecosystem: "pip"
+    directory: "/config"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "Dev_new_gui"


### PR DESCRIPTION
Adds a pip entry for `directory: /config` with `open-pull-requests-limit: 0` and `ignore: - dependency-name: "*"` to the existing `.github/dependabot.yml`. The `config/` directory was deleted in PR #781; this prevents Dependabot from re-opening ~35 alerts on every push. Closes #5682