### PR TITLE
fix(deps): pin cryptography>=46.0.7 and python-multipart>=0.0.26 in knowledge-base-mcp (#5683)

### DIFF
--- a/autobot-infrastructure/shared/mcp/tools/knowledge-base-mcp/pyproject.toml
+++ b/autobot-infrastructure/shared/mcp/tools/knowledge-base-mcp/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "mcp>=1.0.0",
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
+    "cryptography>=46.0.7",
+    "python-multipart>=0.0.26",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Adds explicit floor constraints to `knowledge-base-mcp/pyproject.toml` so future plain `uv lock` runs cannot silently resolve back to vulnerable versions. Closes #5683