### PR TITLE
fix(deps): remove redundant @types/uuid from mcp-autobot-tracker and mcp-task-manager-server (#5684)

### DIFF
--- a/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/package.json
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/package.json
@@ -21,7 +21,6 @@
     "@types/natural": "^5.0.0",
     "@types/node": "^20.0.0",
     "@types/tail": "^2.2.3",
-    "@types/uuid": "^10.0.0",
     "tail": "^2.2.6",
     "tsx": "^4.0.0",
     "typescript": "^5.0.0"

--- a/autobot-infrastructure/shared/mcp/tools/mcp-task-manager-server/package.json
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-task-manager-server/package.json
@@ -22,7 +22,6 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/inquirer": "^9.0.7",
-    "@types/uuid": "^10.0.0",
     "better-sqlite3": "^11.9.1",
     "chalk": "^5.3.0",
     "inquirer": "^12.5.0",


### PR DESCRIPTION
Removes `@types/uuid` from both MCP package devDependencies. uuid v7+ ships bundled TypeScript declarations; the DefinitelyTyped stubs are redundant and may conflict with uuid v14's types. Lock file cleanup deferred to next `npm install`. Closes #5684