### PR TITLE
fix(deps): add dependabot monitoring for autobot-infrastructure/shared/config (#5685)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,6 +79,18 @@ updates:
     ignore:
       - dependency-name: "*"
 
+  - package-ecosystem: "pip"
+    directory: "/autobot-infrastructure/shared/config"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "backend"
+      - "infrastructure"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "Dev_new_gui"


### PR DESCRIPTION
## Summary
- Adds a pip Dependabot entry for `/autobot-infrastructure/shared/config` so security version bumps to the infrastructure requirements files are tracked automatically alongside the root ones
- Eliminates the double-maintenance burden: previously, every CVE fix required manually updating both the root `requirements*.txt` AND the infrastructure copies
- Dependabot will now open PRs for both sets simultaneously when vulnerable packages are detected

Closes #5685

🤖 Generated with [Claude Code](https://claude.com/claude-code)