### PR TITLE
fix(sync-queue): schedule prune_done via Celery Beat (#5081)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -188,4 +188,11 @@ celery_app.conf.beat_schedule = {
         ),
         "kwargs": {"dry_run": False},
     },
+    # Issue #5081: prune expired entries from the doc_sync:queue:done zset
+    "knowledge-sync-queue-prune": {
+        "task": "tasks.prune_sync_queue_done",
+        "schedule": _crontab_from_string(
+            ssot_config.knowledge_sync_queue_prune_schedule
+        ),
+    },
 }

--- a/autobot-backend/tasks/knowledge_tasks.py
+++ b/autobot-backend/tasks/knowledge_tasks.py
@@ -811,6 +811,41 @@ def cleanup_generated_files(
 
 
 # =========================================================================
+# Issue #5081: Prune done entries from the sync queue DONE zset
+# =========================================================================
+
+
+@celery_app.task(bind=True, name="tasks.prune_sync_queue_done")
+def prune_sync_queue_done(self) -> dict:
+    """Remove expired entries from the doc_sync:queue:done zset.
+
+    Issue #5081: The DONE zset grew unbounded because prune_done() was only
+    callable via admin API.  This task is scheduled via Celery Beat so
+    pruning runs automatically on a configurable cron.
+
+    Returns:
+        Dict with pruning statistics:
+            - status: 'success' | 'failed'
+            - pruned: Number of entries removed
+    """
+    from services.knowledge.sync_queue import get_document_sync_queue
+
+    try:
+        self.update_state(
+            state="PROGRESS",
+            meta={"current": 0, "total": 1, "status": "Pruning sync queue done entries..."},
+        )
+        logger.info("Starting sync queue done-entry pruning...")
+        queue = get_document_sync_queue()
+        pruned = _run_async_in_loop(queue.prune_done())
+        logger.info("prune_sync_queue_done: pruned=%d", pruned)
+        return {"status": "success", "pruned": pruned}
+    except Exception as e:
+        logger.exception("prune_sync_queue_done failed: %s", e)
+        return {"status": "failed", "error": str(e), "pruned": 0}
+
+
+# =========================================================================
 # Periodic Task Beat Schedule (add to celery_app.conf.beat_schedule)
 # =========================================================================
 #

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1257,6 +1257,14 @@ class AutoBotConfig(BaseSettings):
             "Default 04:00 UTC nightly. 5-field cron: 'm h dom mon dow'."
         ),
     )
+    knowledge_sync_queue_prune_schedule: str = Field(
+        default="0 5 * * *",
+        alias="AUTOBOT_KNOWLEDGE_SYNC_QUEUE_PRUNE_SCHEDULE",
+        description=(
+            "Cron schedule for prune_sync_queue_done task. "
+            "Default 05:00 UTC nightly. 5-field cron: 'm h dom mon dow'."
+        ),
+    )
     knowledge_cache_ttl_days: int = Field(
         default=7,
         alias="AUTOBOT_KNOWLEDGE_CACHE_TTL_DAYS",


### PR DESCRIPTION
Schedules `prune_done` so the DONE zset doesn't grow unbounded. Closes #5081