### PR TITLE
fix(tests): skip torch-dependent tests when torch is stubbed (#5737)

### DIFF
--- a/autobot-backend/llm_interface_pkg/inference_utils_test.py
+++ b/autobot-backend/llm_interface_pkg/inference_utils_test.py
@@ -7,8 +7,14 @@ Unit tests for only-last-logit inference optimization.
 Issue #1968: Only-last-logit optimization for autoregressive generation.
 """
 
+import types
+
 import pytest
 import torch
+
+# Detect conftest MagicMock torch stub; skip tensor-operation tests when absent (#5737)
+_TORCH_IS_STUB = not isinstance(torch, types.ModuleType)
+requires_torch = pytest.mark.skipif(_TORCH_IS_STUB, reason="requires real PyTorch")
 
 from llm_interface_pkg.optimization.inference_utils import (
     InferenceConfig,
@@ -19,6 +25,7 @@ from llm_interface_pkg.optimization.inference_utils import (
 )
 
 
+@requires_torch
 class TestLastLogitOptimizer:
     """Tests for LastLogitOptimizer class."""
 
@@ -147,6 +154,7 @@ class TestLastLogitOptimizer:
         assert stats.total_saved_mb == pytest.approx(50.0)
 
 
+@requires_torch
 class TestSliceHiddenForGeneration:
     """Tests for the convenience function."""
 


### PR DESCRIPTION
## Summary
- Add `_TORCH_IS_STUB = not isinstance(torch, types.ModuleType)` detection
- Add `requires_torch = pytest.mark.skipif(...)` marker
- Apply `@requires_torch` to `TestLastLogitOptimizer` and `TestSliceHiddenForGeneration` only
- Leaves `TestInferenceConfig`, `TestMemoryStats`, `TestInferenceModeEnum` unskipped (no torch ops)

## Test Plan
- [ ] `pytest autobot-backend/llm_interface_pkg/inference_utils_test.py -q` → 0 failed (was 11)
- [ ] Non-torch test classes still pass
- [ ] Pattern consistent with #5728 fix for `optimization/` test files

Closes #5737

🤖 Generated with Claude Code