### PR TITLE
refactor(llm_cache): remove dead get_llm_cache_async export (#5740)

### DIFF
--- a/autobot-backend/llm_interface_pkg/__init__.py
+++ b/autobot-backend/llm_interface_pkg/__init__.py
@@ -24,7 +24,7 @@ Package Structure:
 from .adapters import AdapterBase, AdapterRegistry, get_adapter_registry
 
 # Issue #551: L1/L2 dual-tier caching
-from .cache import CachedResponse, LLMResponseCache, get_llm_cache, get_llm_cache_async
+from .cache import CachedResponse, LLMResponseCache, get_llm_cache
 
 # Hardware detection
 from .hardware import TORCH_AVAILABLE, HardwareDetector
@@ -72,7 +72,6 @@ __all__ = [
     "LLMResponseCache",
     "CachedResponse",
     "get_llm_cache",
-    "get_llm_cache_async",
     # Mock providers
     "LocalLLM",
     "MockPalm",

--- a/autobot-backend/llm_interface_pkg/cache.py
+++ b/autobot-backend/llm_interface_pkg/cache.py
@@ -434,14 +434,8 @@ class LLMResponseCache:
 get_llm_cache = lazy_singleton(LLMResponseCache)
 
 
-async def get_llm_cache_async() -> LLMResponseCache:
-    """Async accessor for the LLM response cache — delegates to get_llm_cache()."""
-    return get_llm_cache()
-
-
 __all__ = [
     "LLMResponseCache",
     "CachedResponse",
     "get_llm_cache",
-    "get_llm_cache_async",
 ]


### PR DESCRIPTION
## Summary
- Remove `get_llm_cache_async()` function from `cache.py` — zero callers anywhere in codebase
- Remove from `__all__` in `cache.py` and `llm_interface_pkg/__init__.py`
- `get_llm_cache()` is sufficient for both sync and async callers (construction is synchronous)

## Test Plan
- [ ] `from llm_interface_pkg import get_llm_cache` imports cleanly
- [ ] `grep -r get_llm_cache_async autobot-backend/` returns no results
- [ ] `pytest autobot-backend/llm_interface_pkg/` — no regressions

Closes #5740

🤖 Generated with Claude Code