### PR TITLE
fix(redis): add double-checked lock to _get_redis_client in detector.py (#5729)

### DIFF
--- a/autobot-backend/code_intelligence/cross_language_patterns/detector.py
+++ b/autobot-backend/code_intelligence/cross_language_patterns/detector.py
@@ -129,6 +129,7 @@ class CrossLanguagePatternDetector:
 
         # Thread-safe initialization locks
         self._cache_lock = asyncio.Lock()
+        self._redis_lock = asyncio.Lock()
 
         # Statistics
         self._cache_hits = 0
@@ -166,12 +167,16 @@ class CrossLanguagePatternDetector:
     async def _get_redis_client(self):
         """Get Redis client for caching."""
         if self._redis_client is None and self.use_cache:
-            try:
-                self._redis_client = await get_async_redis_client(database="analytics")
-                logger.info("Redis client initialized for analytics")
-            except Exception as e:
-                logger.warning("Redis not available for caching: %s", e)
-                self._redis_client = None
+            async with self._redis_lock:
+                if self._redis_client is None:
+                    try:
+                        self._redis_client = await get_async_redis_client(
+                            database="analytics"
+                        )
+                        logger.info("Redis client initialized for analytics")
+                    except Exception as e:
+                        logger.warning("Redis not available for caching: %s", e)
+                        self._redis_client = None
         return self._redis_client
 
     async def _get_embedding_cache(self):


### PR DESCRIPTION
## Summary
- Add `self._redis_lock = asyncio.Lock()` in `CrossLanguagePatternDetector.__init__`
- Wrap `_get_redis_client()` body with `async with self._redis_lock:` + double-check inside
- Dedicated lock keeps Redis init separate from `_cache_lock` (which guards embedding cache)
- Prevents two concurrent coroutines both calling `get_async_redis_client()` when `self._redis_client is None`, leaking a connection

## Test Plan
- [ ] `python3 -m py_compile autobot-backend/code_intelligence/cross_language_patterns/detector.py`
- [ ] `flake8 detector.py --max-line-length=100` — no new errors
- [ ] Pattern matches `analytics_infrastructure.py` double-checked locking reference

Closes #5729

🤖 Generated with Claude Code