### PR TITLE
fix(i18n): convert analytics.sources.share to object in 10 non-English locales (#5021)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -1439,7 +1439,13 @@
       "syncing": "Syncing...",
       "syncNow": "Sync Now",
       "edit": "تعديل",
-      "share": "Share",
+      "share": {
+        "userIds": "User IDs",
+        "userIdsHint": "comma-separated",
+        "userIdsHelp": "Enter user IDs to grant access to this source.",
+        "currentlySharedWith": "Currently shared with",
+        "updateAccess": "Update Access"
+      },
       "deleteTitle": "حذف",
       "indexingRunning": "Indexing running",
       "removeFromQueue": "Remove from queue",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -1439,7 +1439,13 @@
       "syncing": "Synchronisiere...",
       "syncNow": "Jetzt synchronisieren",
       "edit": "Bearbeiten",
-      "share": "Share",
+      "share": {
+        "userIds": "User IDs",
+        "userIdsHint": "comma-separated",
+        "userIdsHelp": "Enter user IDs to grant access to this source.",
+        "currentlySharedWith": "Currently shared with",
+        "updateAccess": "Update Access"
+      },
       "deleteTitle": "Quelle löschen",
       "indexingRunning": "Indexierung läuft",
       "removeFromQueue": "Aus Warteschlange entfernen",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -1439,7 +1439,13 @@
       "syncing": "Sincronizando...",
       "syncNow": "Sincronizar ahora",
       "edit": "Editar",
-      "share": "Share",
+      "share": {
+        "userIds": "User IDs",
+        "userIdsHint": "comma-separated",
+        "userIdsHelp": "Enter user IDs to grant access to this source.",
+        "currentlySharedWith": "Currently shared with",
+        "updateAccess": "Update Access"
+      },
       "deleteTitle": "Eliminar fuente",
       "indexingRunning": "Indexación en curso",
       "removeFromQueue": "Quitar de la cola",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -978,7 +978,13 @@
       "syncing": "Syncing...",
       "syncNow": "Sync Now",
       "edit": "Edit",
-      "share": "Share",
+      "share": {
+        "userIds": "User IDs",
+        "userIdsHint": "comma-separated",
+        "userIdsHelp": "Enter user IDs to grant access to this source.",
+        "currentlySharedWith": "Currently shared with",
+        "updateAccess": "Update Access"
+      },
       "deleteTitle": "Delete",
       "indexingRunning": "Indexing running",
       "removeFromQueue": "Remove from queue",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -1439,7 +1439,13 @@
       "syncing": "Synchronisation...",
       "syncNow": "Synchroniser maintenant",
       "edit": "Modifier",
-      "share": "Share",
+      "share": {
+        "userIds": "User IDs",
+        "userIdsHint": "comma-separated",
+        "userIdsHelp": "Enter user IDs to grant access to this source.",
+        "currentlySharedWith": "Currently shared with",
+        "updateAccess": "Update Access"
+      },
       "deleteTitle": "Supprimer la source",
       "indexingRunning": "Indexation en cours",
       "removeFromQueue": "Retirer de la file d'attente",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -978,7 +978,13 @@
       "syncing": "Syncing...",
       "syncNow": "Sync Now",
       "edit": "Edit",
-      "share": "Share",
+      "share": {
+        "userIds": "User IDs",
+        "userIdsHint": "comma-separated",
+        "userIdsHelp": "Enter user IDs to grant access to this source.",
+        "currentlySharedWith": "Currently shared with",
+        "updateAccess": "Update Access"
+      },
       "deleteTitle": "Delete",
       "indexingRunning": "Indexing running",
       "removeFromQueue": "Remove from queue",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -1439,7 +1439,13 @@
       "syncing": "Syncing...",
       "syncNow": "Sync Now",
       "edit": "Edit",
-      "share": "Share",
+      "share": {
+        "userIds": "User IDs",
+        "userIdsHint": "comma-separated",
+        "userIdsHelp": "Enter user IDs to grant access to this source.",
+        "currentlySharedWith": "Currently shared with",
+        "updateAccess": "Update Access"
+      },
       "deleteTitle": "Delete",
       "indexingRunning": "Indexing running",
       "removeFromQueue": "Remove from queue",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -1439,7 +1439,13 @@
       "syncing": "Syncing...",
       "syncNow": "Sync Now",
       "edit": "Edit",
-      "share": "Share",
+      "share": {
+        "userIds": "User IDs",
+        "userIdsHint": "comma-separated",
+        "userIdsHelp": "Enter user IDs to grant access to this source.",
+        "currentlySharedWith": "Currently shared with",
+        "updateAccess": "Update Access"
+      },
       "deleteTitle": "Delete",
       "indexingRunning": "Indexing running",
       "removeFromQueue": "Remove from queue",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -1439,7 +1439,13 @@
       "syncing": "Syncing...",
       "syncNow": "Sync Now",
       "edit": "Edit",
-      "share": "Share",
+      "share": {
+        "userIds": "User IDs",
+        "userIdsHint": "comma-separated",
+        "userIdsHelp": "Enter user IDs to grant access to this source.",
+        "currentlySharedWith": "Currently shared with",
+        "updateAccess": "Update Access"
+      },
       "deleteTitle": "Delete",
       "indexingRunning": "Indexing running",
       "removeFromQueue": "Remove from queue",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -978,7 +978,13 @@
       "syncing": "Syncing...",
       "syncNow": "Sync Now",
       "edit": "Edit",
-      "share": "Share",
+      "share": {
+        "userIds": "User IDs",
+        "userIdsHint": "comma-separated",
+        "userIdsHelp": "Enter user IDs to grant access to this source.",
+        "currentlySharedWith": "Currently shared with",
+        "updateAccess": "Update Access"
+      },
       "deleteTitle": "Delete",
       "indexingRunning": "Indexing running",
       "removeFromQueue": "Remove from queue",


### PR DESCRIPTION
## Summary
- Converts `analytics.sources.share` from a plain string `"Share"` to a 5-key object in all 10 non-English locale files (`ar.json`, `de.json`, `es.json`, `fa.json`, `fr.json`, `he.json`, `lv.json`, `pl.json`, `pt.json`, `ur.json`)
- Prevents runtime `undefined` / silent errors when `ShareSourceModal.vue` reads `t('analytics.sources.share.userIds')` etc.
- English text used as fallback values — actual translation is out of scope

## Test plan
- [ ] All 10 locale files pass `python3 -m json.tool` ✅
- [ ] `analytics.sources.share` is now an object in all non-English locales (same structure as `en.json`)

Closes #5021

🤖 Generated with [Claude Code](https://claude.com/claude-code)