### PR TITLE
fix(i18n): add missing knowledge.connectors.tier keys to 10 non-English locales (#5056)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -2782,6 +2782,14 @@
         "create": "إنشاء",
         "sqlQueryPlaceholder": "SELECT * FROM documents WHERE updated_at > :last_sync",
         "connectorNamePlaceholder": "My Connector"
+      },
+      "tier": {
+        "ready": "Ready",
+        "readyTooltip": "Zero-config connector — works immediately, no credentials required.",
+        "freeKey": "Free key needed",
+        "freeKeyTooltip": "Needs a free API key or environment variable (for example a Notion integration token).",
+        "setupRequired": "Setup required",
+        "setupRequiredTooltip": "Needs credentials, OAuth, a cookie, or a private connection string."
       }
     },
     "modals": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -2782,6 +2782,14 @@
         "create": "Erstellen",
         "sqlQueryPlaceholder": "SELECT * FROM documents WHERE updated_at > :last_sync",
         "connectorNamePlaceholder": "Mein Konnektor"
+      },
+      "tier": {
+        "ready": "Ready",
+        "readyTooltip": "Zero-config connector — works immediately, no credentials required.",
+        "freeKey": "Free key needed",
+        "freeKeyTooltip": "Needs a free API key or environment variable (for example a Notion integration token).",
+        "setupRequired": "Setup required",
+        "setupRequiredTooltip": "Needs credentials, OAuth, a cookie, or a private connection string."
       }
     },
     "modals": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -2782,6 +2782,14 @@
         "create": "Crear",
         "sqlQueryPlaceholder": "SELECT * FROM documents WHERE updated_at > :last_sync",
         "connectorNamePlaceholder": "Mi conector"
+      },
+      "tier": {
+        "ready": "Ready",
+        "readyTooltip": "Zero-config connector — works immediately, no credentials required.",
+        "freeKey": "Free key needed",
+        "freeKeyTooltip": "Needs a free API key or environment variable (for example a Notion integration token).",
+        "setupRequired": "Setup required",
+        "setupRequiredTooltip": "Needs credentials, OAuth, a cookie, or a private connection string."
       }
     },
     "modals": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -2118,7 +2118,15 @@
       "title": "Source Connectors",
       "loadingHistory": "Loading history...",
       "historyDeleted": "deleted",
-      "noConnectorsMessage": "Add a source connector to automatically ingest documents from file servers, web pages, or databases."
+      "noConnectorsMessage": "Add a source connector to automatically ingest documents from file servers, web pages, or databases.",
+      "tier": {
+        "ready": "Ready",
+        "readyTooltip": "Zero-config connector — works immediately, no credentials required.",
+        "freeKey": "Free key needed",
+        "freeKeyTooltip": "Needs a free API key or environment variable (for example a Notion integration token).",
+        "setupRequired": "Setup required",
+        "setupRequiredTooltip": "Needs credentials, OAuth, a cookie, or a private connection string."
+      }
     },
     "entityExtractor": {
       "entitiesCreated": "Entities Created",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -2782,6 +2782,14 @@
         "create": "Créer",
         "sqlQueryPlaceholder": "SELECT * FROM documents WHERE updated_at > :last_sync",
         "connectorNamePlaceholder": "Mon connecteur"
+      },
+      "tier": {
+        "ready": "Ready",
+        "readyTooltip": "Zero-config connector — works immediately, no credentials required.",
+        "freeKey": "Free key needed",
+        "freeKeyTooltip": "Needs a free API key or environment variable (for example a Notion integration token).",
+        "setupRequired": "Setup required",
+        "setupRequiredTooltip": "Needs credentials, OAuth, a cookie, or a private connection string."
       }
     },
     "modals": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -2118,7 +2118,15 @@
       "title": "Source Connectors",
       "loadingHistory": "Loading history...",
       "historyDeleted": "deleted",
-      "noConnectorsMessage": "Add a source connector to automatically ingest documents from file servers, web pages, or databases."
+      "noConnectorsMessage": "Add a source connector to automatically ingest documents from file servers, web pages, or databases.",
+      "tier": {
+        "ready": "Ready",
+        "readyTooltip": "Zero-config connector — works immediately, no credentials required.",
+        "freeKey": "Free key needed",
+        "freeKeyTooltip": "Needs a free API key or environment variable (for example a Notion integration token).",
+        "setupRequired": "Setup required",
+        "setupRequiredTooltip": "Needs credentials, OAuth, a cookie, or a private connection string."
+      }
     },
     "entityExtractor": {
       "entitiesCreated": "Entities Created",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -2782,6 +2782,14 @@
         "create": "Izveidot",
         "sqlQueryPlaceholder": "SELECT * FROM documents WHERE updated_at > :last_sync",
         "connectorNamePlaceholder": "Mans savienotājs"
+      },
+      "tier": {
+        "ready": "Ready",
+        "readyTooltip": "Zero-config connector — works immediately, no credentials required.",
+        "freeKey": "Free key needed",
+        "freeKeyTooltip": "Needs a free API key or environment variable (for example a Notion integration token).",
+        "setupRequired": "Setup required",
+        "setupRequiredTooltip": "Needs credentials, OAuth, a cookie, or a private connection string."
       }
     },
     "modals": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -2782,6 +2782,14 @@
         "create": "Utwórz",
         "sqlQueryPlaceholder": "SELECT * FROM documents WHERE updated_at > :last_sync",
         "connectorNamePlaceholder": "Mój konektor"
+      },
+      "tier": {
+        "ready": "Ready",
+        "readyTooltip": "Zero-config connector — works immediately, no credentials required.",
+        "freeKey": "Free key needed",
+        "freeKeyTooltip": "Needs a free API key or environment variable (for example a Notion integration token).",
+        "setupRequired": "Setup required",
+        "setupRequiredTooltip": "Needs credentials, OAuth, a cookie, or a private connection string."
       }
     },
     "modals": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -2782,6 +2782,14 @@
         "create": "Criar",
         "sqlQueryPlaceholder": "SELECT * FROM documents WHERE updated_at > :last_sync",
         "connectorNamePlaceholder": "Meu conector"
+      },
+      "tier": {
+        "ready": "Ready",
+        "readyTooltip": "Zero-config connector — works immediately, no credentials required.",
+        "freeKey": "Free key needed",
+        "freeKeyTooltip": "Needs a free API key or environment variable (for example a Notion integration token).",
+        "setupRequired": "Setup required",
+        "setupRequiredTooltip": "Needs credentials, OAuth, a cookie, or a private connection string."
       }
     },
     "modals": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -2118,7 +2118,15 @@
       "title": "Source Connectors",
       "loadingHistory": "Loading history...",
       "historyDeleted": "deleted",
-      "noConnectorsMessage": "Add a source connector to automatically ingest documents from file servers, web pages, or databases."
+      "noConnectorsMessage": "Add a source connector to automatically ingest documents from file servers, web pages, or databases.",
+      "tier": {
+        "ready": "Ready",
+        "readyTooltip": "Zero-config connector — works immediately, no credentials required.",
+        "freeKey": "Free key needed",
+        "freeKeyTooltip": "Needs a free API key or environment variable (for example a Notion integration token).",
+        "setupRequired": "Setup required",
+        "setupRequiredTooltip": "Needs credentials, OAuth, a cookie, or a private connection string."
+      }
     },
     "entityExtractor": {
       "entitiesCreated": "Entities Created",


### PR DESCRIPTION
## Summary
- Adds 6 missing `knowledge.connectors.tier.*` keys to all 10 non-English locale files (`ar.json`, `de.json`, `es.json`, `fa.json`, `fr.json`, `he.json`, `lv.json`, `pl.json`, `pt.json`, `ur.json`)
- Keys: `ready`, `readyTooltip`, `freeKey`, `freeKeyTooltip`, `setupRequired`, `setupRequiredTooltip`
- English text used as fallback values — actual translation is out of scope
- Prevents users on non-English locales from seeing raw key strings in the connector tier UI

## Test plan
- [ ] All 10 locale files pass `python3 -m json.tool` ✅
- [ ] All 6 tier keys present in every non-English locale

Closes #5056

🤖 Generated with [Claude Code](https://claude.com/claude-code)