### PR TITLE
fix(infra): fix broken requirements.txt path in start-celery-worker.sh (#5753)

### DIFF
--- a/autobot-infrastructure/shared/scripts/start-celery-worker.sh
+++ b/autobot-infrastructure/shared/scripts/start-celery-worker.sh
@@ -31,7 +31,7 @@ source venv/bin/activate
 if ! python -c "import celery" 2>/dev/null; then
     echo "ERROR: Celery not found in virtual environment"
     echo "Installing Celery and dependencies..."
-    pip install -r config/requirements.txt
+    pip install -r "${SCRIPT_DIR}/../config/requirements.txt"
 fi
 
 # Load environment variables


### PR DESCRIPTION
## Summary

- Fix `pip install -r config/requirements.txt` → `pip install -r "${SCRIPT_DIR}/../config/requirements.txt"` in `start-celery-worker.sh`
- After `cd "$PROJECT_ROOT"` (repo root), the relative path `config/` does not exist — the requirements file lives one level up from the script directory
- Only executes as a fallback when Celery is not already installed

Closes #5753

## Test plan
- [ ] Verify `start-celery-worker.sh` line 34 uses SCRIPT_DIR-relative path
- [ ] Confirm `${SCRIPT_DIR}/../config/requirements.txt` resolves correctly from `autobot-infrastructure/shared/scripts/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)