### PR TITLE
feat(api): add schemas_common.py and wire response_model into terminal endpoints (#5739)

### DIFF
--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -1,0 +1,323 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Shared Pydantic response schemas for AutoBot API endpoints.
+
+Provides typed response models for terminal.py and terminal_tools.py.
+All models are used as response_model= on FastAPI router decorators so that
+FastAPI generates accurate OpenAPI docs and validates outbound data.
+
+Schema naming convention:
+  <Domain><EntityOrAction>Response
+"""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# Generic / reusable
+# ---------------------------------------------------------------------------
+
+
+class SuccessResponse(BaseModel):
+    """Minimal success/failure envelope used by several endpoints."""
+
+    success: bool
+    message: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Terminal session schemas  (terminal.py — session lifecycle)
+# ---------------------------------------------------------------------------
+
+
+class TerminalSessionCreateResponse(BaseModel):
+    """Response for POST /sessions."""
+
+    session_id: str
+    status: str
+    security_level: str
+    websocket_url: str
+    created_at: str
+    ssh_keys: Optional[Dict[str, Any]] = None
+
+
+class TerminalSessionItem(BaseModel):
+    """Single session entry within a list response."""
+
+    session_id: str
+    user_id: Optional[str] = None
+    security_level: Optional[str] = None
+    created_at: Optional[str] = None
+    is_active: bool
+
+
+class TerminalSessionListResponse(BaseModel):
+    """Response for GET /sessions."""
+
+    sessions: List[TerminalSessionItem]
+    total: int
+    active: int
+
+
+class TerminalSessionDetailResponse(BaseModel):
+    """Response for GET /sessions/{session_id}."""
+
+    session_id: str
+    config: Dict[str, Any]
+    is_active: bool
+    statistics: Dict[str, Any]
+
+
+class TerminalSessionDeleteResponse(BaseModel):
+    """Response for DELETE /sessions/{session_id}."""
+
+    session_id: str
+    status: str
+
+
+# ---------------------------------------------------------------------------
+# SSH key management schemas  (terminal.py — Issue #211)
+# ---------------------------------------------------------------------------
+
+
+class SSHKeyItem(BaseModel):
+    """A single SSH key entry as returned by get_session_keys()."""
+
+    name: str
+    fingerprint: Optional[str] = None
+    has_passphrase: Optional[bool] = None
+    key_path: Optional[str] = None
+
+
+class SSHKeyListResponse(BaseModel):
+    """Response for GET /sessions/{session_id}/ssh-keys."""
+
+    session_id: str
+    keys: List[Any]  # key dicts are opaque — shape defined by terminal_secrets_service
+    total: int
+
+
+class SSHKeyAgentResponse(BaseModel):
+    """Response for POST /sessions/{session_id}/ssh-keys/{key_name}/agent."""
+
+    session_id: str
+    key_name: str
+    status: str
+    message: str
+
+
+class SSHKeyPathResponse(BaseModel):
+    """Response for GET /sessions/{session_id}/ssh-keys/{key_name}/path."""
+
+    session_id: str
+    key_name: str
+    key_path: str
+    usage: str
+
+
+# ---------------------------------------------------------------------------
+# Command / input / signal schemas
+# ---------------------------------------------------------------------------
+
+
+class CommandAssessResponse(BaseModel):
+    """Response for POST /command."""
+
+    command: str
+    risk_level: str
+    status: str
+    message: str
+    requires_confirmation: bool
+
+
+class TerminalInputResponse(BaseModel):
+    """Response for POST /sessions/{session_id}/input."""
+
+    session_id: str
+    status: str
+    input: str
+
+
+class TerminalSignalResponse(BaseModel):
+    """Response for POST /sessions/{session_id}/signal/{signal_name}."""
+
+    session_id: str
+    signal: str
+    status: str
+
+
+# ---------------------------------------------------------------------------
+# History / audit schemas
+# ---------------------------------------------------------------------------
+
+
+class TerminalCommandHistoryResponse(BaseModel):
+    """Response for GET /sessions/{session_id}/history."""
+
+    session_id: str
+    is_active: bool
+    history: List[Any]
+    total_commands: Optional[int] = None
+    message: Optional[str] = None
+
+
+class TerminalAuditLogResponse(BaseModel):
+    """Response for GET /audit/{session_id}."""
+
+    session_id: str
+    audit_available: bool
+    security_level: Optional[str] = None
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Info / health / status schemas
+# ---------------------------------------------------------------------------
+
+
+class TerminalInfoResponse(BaseModel):
+    """Response for GET /."""
+
+    name: str
+    version: str
+    description: str
+    features: List[str]
+    endpoints: Dict[str, str]
+    security_levels: List[str]
+    notice: str
+
+
+class TerminalHealthComponents(BaseModel):
+    terminal_manager: str
+    websocket_manager: str
+    pty_system: str
+    session_manager: str
+
+
+class TerminalHealthMetrics(BaseModel):
+    active_sessions: int
+    manager_initialized: bool
+
+
+class TerminalHealthResponse(BaseModel):
+    """Response for GET /health (healthy path)."""
+
+    status: str
+    service: str
+    components: Optional[TerminalHealthComponents] = None
+    metrics: Optional[TerminalHealthMetrics] = None
+    error: Optional[str] = None
+
+
+class TerminalStatusFeatures(BaseModel):
+    pty_support: bool
+    websocket_support: bool
+    command_validation: bool
+    security_policies: bool
+    approval_workflow: bool
+    agent_integration: bool
+
+
+class TerminalStatusSessionInfo(BaseModel):
+    active_sessions: int
+    max_concurrent_sessions: Optional[int] = None
+
+
+class TerminalSystemStatusResponse(BaseModel):
+    """Response for GET /status."""
+
+    status: str
+    terminal_types: Optional[List[str]] = None
+    features: Optional[TerminalStatusFeatures] = None
+    session_info: Optional[TerminalStatusSessionInfo] = None
+    error: Optional[str] = None
+
+
+class TerminalCapabilitiesResponse(BaseModel):
+    """Response for GET /capabilities."""
+
+    pty_management: bool
+    websocket_streaming: bool
+    command_execution: bool
+    security_validation: bool
+    session_management: bool
+    terminal_types: Dict[str, Any]
+    pty_features: Dict[str, Any]
+    websocket_features: Dict[str, Any]
+
+
+class TerminalSecurityPoliciesResponse(BaseModel):
+    """Response for GET /security."""
+
+    command_validation: str
+    risk_assessment: str
+    risk_levels: Dict[str, str]
+    security_executor: str
+    approval_workflow: Dict[str, Any]
+    audit_logging: Dict[str, Any]
+
+
+class TerminalImplementationItem(BaseModel):
+    name: str
+    description: str
+    frontend_component: str
+    backend_api: str
+    approval_workflow: bool
+    service_layer: Optional[str] = None
+
+
+class TerminalFeaturesResponse(BaseModel):
+    """Response for GET /features."""
+
+    manager_class: str
+    websocket_class: str
+    pty_implementation: str
+    implementations: List[TerminalImplementationItem]
+    features: Dict[str, str]
+    shared_infrastructure: Dict[str, str]
+
+
+# ---------------------------------------------------------------------------
+# Stats schema
+# ---------------------------------------------------------------------------
+
+
+class TerminalStatsResponse(BaseModel):
+    """Response for GET /stats.
+
+    The session manager returns an opaque dict whose shape varies between
+    the 'all sessions' and 'single session' cases.  A permissive model
+    lets FastAPI pass the dict through while still documenting the endpoint.
+    """
+
+    model_config = {"extra": "allow"}
+
+
+# ---------------------------------------------------------------------------
+# Admin execute schema  (SLM admin terminal — Issue #983)
+# ---------------------------------------------------------------------------
+
+
+class AdminExecuteResponse(BaseModel):
+    """Response for POST /execute."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+# ---------------------------------------------------------------------------
+# terminal_tools.py schemas
+# ---------------------------------------------------------------------------
+
+
+class PackageManagersResponse(BaseModel):
+    """Response for GET /terminal/package-managers."""
+
+    detected: Optional[str] = None
+    available: List[str]
+    package_managers: Dict[str, Any]

--- a/autobot-backend/api/terminal.py
+++ b/autobot-backend/api/terminal.py
@@ -120,6 +120,30 @@ from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 
+# Response schemas for OpenAPI documentation and response validation
+from api.schemas_common import (
+    AdminExecuteResponse,
+    CommandAssessResponse,
+    SSHKeyAgentResponse,
+    SSHKeyListResponse,
+    SSHKeyPathResponse,
+    TerminalAuditLogResponse,
+    TerminalCapabilitiesResponse,
+    TerminalCommandHistoryResponse,
+    TerminalFeaturesResponse,
+    TerminalHealthResponse,
+    TerminalInfoResponse,
+    TerminalSecurityPoliciesResponse,
+    TerminalSessionCreateResponse,
+    TerminalSessionDeleteResponse,
+    TerminalSessionDetailResponse,
+    TerminalSessionListResponse,
+    TerminalSignalResponse,
+    TerminalInputResponse,
+    TerminalStatsResponse,
+    TerminalSystemStatusResponse,
+)
+
 # Import models from dedicated module (Issue #185 - split oversized files)
 from api.terminal_models import (
     MODERATE_RISK_PATTERNS,
@@ -300,7 +324,7 @@ router.include_router(tools_router, prefix="/terminal")
     operation="create_terminal_session",
     error_code_prefix="TERMINAL",
 )
-@router.post("/sessions")
+@router.post("/sessions", response_model=TerminalSessionCreateResponse)
 async def create_terminal_session(
     request: TerminalSessionRequest,
     current_user: dict = Depends(get_current_user),
@@ -371,7 +395,7 @@ async def create_terminal_session(
     operation="list_terminal_sessions",
     error_code_prefix="TERMINAL",
 )
-@router.get("/sessions")
+@router.get("/sessions", response_model=TerminalSessionListResponse)
 async def list_terminal_sessions(
     current_user: dict = Depends(get_current_user),
 ):
@@ -403,7 +427,7 @@ async def list_terminal_sessions(
     operation="get_terminal_session",
     error_code_prefix="TERMINAL",
 )
-@router.get("/sessions/{session_id}")
+@router.get("/sessions/{session_id}", response_model=TerminalSessionDetailResponse)
 async def get_terminal_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -435,7 +459,7 @@ async def get_terminal_session(
     operation="delete_terminal_session",
     error_code_prefix="TERMINAL",
 )
-@router.delete("/sessions/{session_id}")
+@router.delete("/sessions/{session_id}", response_model=TerminalSessionDeleteResponse)
 async def delete_terminal_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -476,7 +500,7 @@ async def delete_terminal_session(
     operation="setup_ssh_keys",
     error_code_prefix="TERMINAL",
 )
-@router.post("/sessions/{session_id}/ssh-keys")
+@router.post("/sessions/{session_id}/ssh-keys", response_model=SSHKeyListResponse)
 async def setup_ssh_keys(
     session_id: str,
     request: SSHKeySetupRequest,
@@ -519,7 +543,7 @@ async def setup_ssh_keys(
     operation="list_session_ssh_keys",
     error_code_prefix="TERMINAL",
 )
-@router.get("/sessions/{session_id}/ssh-keys")
+@router.get("/sessions/{session_id}/ssh-keys", response_model=SSHKeyListResponse)
 async def list_session_ssh_keys(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -549,7 +573,7 @@ async def list_session_ssh_keys(
     operation="add_key_to_agent",
     error_code_prefix="TERMINAL",
 )
-@router.post("/sessions/{session_id}/ssh-keys/{key_name}/agent")
+@router.post("/sessions/{session_id}/ssh-keys/{key_name}/agent", response_model=SSHKeyAgentResponse)
 async def add_key_to_ssh_agent(
     session_id: str,
     key_name: str,
@@ -591,7 +615,7 @@ async def add_key_to_ssh_agent(
     operation="get_key_path",
     error_code_prefix="TERMINAL",
 )
-@router.get("/sessions/{session_id}/ssh-keys/{key_name}/path")
+@router.get("/sessions/{session_id}/ssh-keys/{key_name}/path", response_model=SSHKeyPathResponse)
 async def get_ssh_key_path(
     session_id: str,
     key_name: str,
@@ -626,7 +650,7 @@ async def get_ssh_key_path(
     operation="execute_single_command",
     error_code_prefix="TERMINAL",
 )
-@router.post("/command")
+@router.post("/command", response_model=CommandAssessResponse)
 async def execute_single_command(
     request: CommandRequest,
     current_user: dict = Depends(get_current_user),
@@ -670,7 +694,7 @@ async def execute_single_command(
     operation="send_terminal_input",
     error_code_prefix="TERMINAL",
 )
-@router.post("/sessions/{session_id}/input")
+@router.post("/sessions/{session_id}/input", response_model=TerminalInputResponse)
 async def send_terminal_input(
     session_id: str,
     request: TerminalInputRequest,
@@ -701,7 +725,7 @@ async def send_terminal_input(
     operation="send_terminal_signal",
     error_code_prefix="TERMINAL",
 )
-@router.post("/sessions/{session_id}/signal/{signal_name}")
+@router.post("/sessions/{session_id}/signal/{signal_name}", response_model=TerminalSignalResponse)
 async def send_terminal_signal(
     session_id: str,
     signal_name: str,
@@ -738,7 +762,7 @@ async def send_terminal_signal(
     operation="get_terminal_command_history",
     error_code_prefix="TERMINAL",
 )
-@router.get("/sessions/{session_id}/history")
+@router.get("/sessions/{session_id}/history", response_model=TerminalCommandHistoryResponse)
 async def get_terminal_command_history(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -777,7 +801,7 @@ async def get_terminal_command_history(
     operation="get_session_audit_log",
     error_code_prefix="TERMINAL",
 )
-@router.get("/audit/{session_id}")
+@router.get("/audit/{session_id}", response_model=TerminalAuditLogResponse)
 async def get_session_audit_log(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1065,7 +1089,7 @@ async def ssh_terminal_websocket(
     operation="terminal_info",
     error_code_prefix="TERMINAL",
 )
-@router.get("/")
+@router.get("/", response_model=TerminalInfoResponse)
 async def terminal_info(
     current_user: dict = Depends(get_current_user),
 ):
@@ -1104,7 +1128,7 @@ async def terminal_info(
     operation="terminal_health_check",
     error_code_prefix="TERMINAL",
 )
-@router.get("/health")
+@router.get("/health", response_model=TerminalHealthResponse)
 async def terminal_health_check(
     current_user: dict = Depends(get_current_user),
 ):
@@ -1150,7 +1174,7 @@ async def terminal_health_check(
     operation="get_terminal_system_status",
     error_code_prefix="TERMINAL",
 )
-@router.get("/status")
+@router.get("/status", response_model=TerminalSystemStatusResponse)
 async def get_terminal_system_status(
     current_user: dict = Depends(get_current_user),
 ):
@@ -1194,7 +1218,7 @@ async def get_terminal_system_status(
     operation="get_terminal_capabilities",
     error_code_prefix="TERMINAL",
 )
-@router.get("/capabilities")
+@router.get("/capabilities", response_model=TerminalCapabilitiesResponse)
 async def get_terminal_capabilities(
     current_user: dict = Depends(get_current_user),
 ):
@@ -1250,7 +1274,7 @@ async def get_terminal_capabilities(
     operation="get_security_policies",
     error_code_prefix="TERMINAL",
 )
-@router.get("/security")
+@router.get("/security", response_model=TerminalSecurityPoliciesResponse)
 async def get_security_policies(
     current_user: dict = Depends(get_current_user),
 ):
@@ -1292,7 +1316,7 @@ async def get_security_policies(
     operation="get_terminal_features",
     error_code_prefix="TERMINAL",
 )
-@router.get("/features")
+@router.get("/features", response_model=TerminalFeaturesResponse)
 async def get_terminal_features(
     current_user: dict = Depends(get_current_user),
 ):
@@ -1351,7 +1375,7 @@ async def get_terminal_features(
     operation="get_terminal_statistics",
     error_code_prefix="TERMINAL",
 )
-@router.get("/stats")
+@router.get("/stats", response_model=TerminalStatsResponse)
 async def get_terminal_statistics(
     session_id: str = None,
     current_user: dict = Depends(get_current_user),
@@ -1380,8 +1404,8 @@ async def get_terminal_statistics(
 # SLM Admin Terminal (Issue #983) ================================================
 
 
-@router.post("/execute", summary="Execute command (SLM admin terminal)")
-async def admin_execute_command(body: AdminExecuteRequest) -> dict:
+@router.post("/execute", summary="Execute command (SLM admin terminal)", response_model=AdminExecuteResponse)
+async def admin_execute_command(body: AdminExecuteRequest) -> AdminExecuteResponse:
     """Execute a single shell command and return stdout/stderr/exit_code.
 
     Runs on the local backend machine. No auth required — accessible via

--- a/autobot-backend/api/terminal_tools.py
+++ b/autobot-backend/api/terminal_tools.py
@@ -18,9 +18,11 @@ These endpoints are imported into terminal.py via router inclusion.
 """
 
 import logging
+from typing import Any, Dict
 
 from fastapi import APIRouter
 
+from api.schemas_common import PackageManagersResponse
 from api.terminal_models import ToolInstallRequest
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
@@ -38,7 +40,7 @@ router = APIRouter(tags=["terminal-tools"])
     operation="install_tool",
     error_code_prefix="TERMINAL",
 )
-@router.post("/install-tool")
+@router.post("/install-tool", response_model=Dict[str, Any])
 async def install_tool(request: ToolInstallRequest):
     """Install a tool with terminal streaming"""
     # Import system command agent for tool installation
@@ -63,7 +65,7 @@ async def install_tool(request: ToolInstallRequest):
     operation="check_tool_installed",
     error_code_prefix="TERMINAL",
 )
-@router.post("/check-tool")
+@router.post("/check-tool", response_model=Dict[str, Any])
 async def check_tool_installed(tool_name: str):
     """Check if a tool is installed"""
     from agents.system_command_agent import SystemCommandAgent
@@ -78,7 +80,7 @@ async def check_tool_installed(tool_name: str):
     operation="validate_command",
     error_code_prefix="TERMINAL",
 )
-@router.post("/validate-command")
+@router.post("/validate-command", response_model=Dict[str, Any])
 async def validate_command(command: str):
     """Validate command safety"""
     from agents.system_command_agent import SystemCommandAgent
@@ -93,7 +95,7 @@ async def validate_command(command: str):
     operation="get_package_managers",
     error_code_prefix="TERMINAL",
 )
-@router.get("/package-managers")
+@router.get("/package-managers", response_model=PackageManagersResponse)
 async def get_package_managers():
     """Get available package managers"""
     from agents.system_command_agent import SystemCommandAgent


### PR DESCRIPTION
## Summary

- Create `autobot-backend/api/schemas_common.py` with 25 Pydantic response model schemas covering all terminal API endpoints
- Wire `response_model=` into 21 HTTP endpoints in `terminal.py` and 4 endpoints in `terminal_tools.py`
- WebSocket endpoints correctly skipped (no response_model support)
- Enables OpenAPI documentation, response validation, and prevents internal field leakage

**New schemas:** `SuccessResponse`, `TerminalSessionCreateResponse`, `TerminalSessionListResponse`, `TerminalSessionDetailResponse`, `TerminalSessionDeleteResponse`, `SSHKeyListResponse`, `SSHKeyAgentResponse`, `SSHKeyPathResponse`, `CommandAssessResponse`, `TerminalInputResponse`, `TerminalSignalResponse`, `TerminalCommandHistoryResponse`, `TerminalAuditLogResponse`, `TerminalInfoResponse`, `TerminalHealthResponse`, `TerminalSystemStatusResponse`, `TerminalCapabilitiesResponse`, `TerminalSecurityPoliciesResponse`, `TerminalFeaturesResponse`, `TerminalStatsResponse`, `AdminExecuteResponse`, `PackageManagersResponse`

Closes #5739

## Test plan
- [ ] `python -c "import ast; ast.parse(open('autobot-backend/api/schemas_common.py').read())"` passes
- [ ] `python -m py_compile autobot-backend/api/terminal.py autobot-backend/api/terminal_tools.py` passes
- [ ] All 21 HTTP endpoints in terminal.py have `response_model=`
- [ ] WebSocket endpoints have no `response_model=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)