### PR TITLE
feat(api): add response_model= to terminal endpoints + create schemas_common.py (#5317)

### DIFF
--- a/autobot-backend/api/agent_terminal.py
+++ b/autobot-backend/api/agent_terminal.py
@@ -231,6 +231,18 @@ from typing import Dict, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
+from api.schemas_common import (
+    AgentSessionCreatedResponse,
+    AgentSessionDeletedResponse,
+    AgentSessionListResponse,
+    CommandStateResponse,
+    HostSelectionCancelResponse,
+    HostSelectionRequestResponse,
+    HostSelectionStatusResponse,
+    HostSelectionSubmitResponse,
+    PendingHostSelectionsResponse,
+    ToolApprovalResponse,
+)
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.error_constants import ERR_SESSION_NOT_FOUND
@@ -385,7 +397,7 @@ def get_agent_terminal_service(
     operation="create_agent_terminal_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions")
+@router.post("/sessions", response_model=AgentSessionCreatedResponse)
 async def create_agent_terminal_session(
     current_user: dict = Depends(get_current_user),
     request: CreateSessionRequest = None,
@@ -440,7 +452,7 @@ async def create_agent_terminal_session(
     operation="list_agent_terminal_sessions",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.get("/sessions")
+@router.get("/sessions", response_model=AgentSessionListResponse)
 async def list_agent_terminal_sessions(
     current_user: dict = Depends(get_current_user),
     agent_id: Optional[str] = None,
@@ -489,7 +501,7 @@ async def list_agent_terminal_sessions(
     operation="get_agent_terminal_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.get("/sessions/{session_id}")
+@router.get("/sessions/{session_id}", response_model=None)
 async def get_agent_terminal_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -516,7 +528,7 @@ async def get_agent_terminal_session(
     operation="delete_agent_terminal_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.delete("/sessions/{session_id}")
+@router.delete("/sessions/{session_id}", response_model=AgentSessionDeletedResponse)
 async def delete_agent_terminal_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -543,7 +555,7 @@ async def delete_agent_terminal_session(
     operation="execute_agent_command",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/execute")
+@router.post("/execute", response_model=None)
 async def execute_agent_command(
     current_user: dict = Depends(get_current_user),
     session_id: str = None,
@@ -581,7 +593,7 @@ async def execute_agent_command(
     operation="approve_agent_command",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/approve")
+@router.post("/sessions/{session_id}/approve", response_model=None)
 async def approve_agent_command(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -622,7 +634,7 @@ async def approve_agent_command(
     operation="submit_tool_approval",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/tools/approve/{approval_id}")
+@router.post("/tools/approve/{approval_id}", response_model=ToolApprovalResponse)
 async def submit_tool_approval(
     approval_id: str,
     request: ToolApprovalRequest,
@@ -661,7 +673,7 @@ async def submit_tool_approval(
     operation="interrupt_agent_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/interrupt")
+@router.post("/sessions/{session_id}/interrupt", response_model=None)
 async def interrupt_agent_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -692,7 +704,7 @@ async def interrupt_agent_session(
     operation="resume_agent_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/resume")
+@router.post("/sessions/{session_id}/resume", response_model=None)
 async def resume_agent_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -714,7 +726,7 @@ async def resume_agent_session(
     operation="get_command_state",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.get("/commands/{command_id}")
+@router.get("/commands/{command_id}", response_model=CommandStateResponse)
 async def get_command_state(
     command_id: str,
     current_user: dict = Depends(get_current_user),
@@ -787,7 +799,7 @@ async def get_command_state(
     operation="agent_terminal_info",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.get("/")
+@router.get("/", response_model=None)
 async def agent_terminal_info(
     current_user: dict = Depends(get_current_user),
 ):
@@ -856,7 +868,7 @@ _pending_host_selections: Dict[str, Dict] = {}
     operation="request_host_selection",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/host-selection/request")
+@router.post("/host-selection/request", response_model=HostSelectionRequestResponse)
 async def request_host_selection(
     current_user: dict = Depends(get_current_user),
     request: HostSelectionRequest = None,
@@ -910,7 +922,7 @@ async def request_host_selection(
     operation="get_host_selection",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.get("/host-selection/{request_id}")
+@router.get("/host-selection/{request_id}", response_model=HostSelectionStatusResponse)
 async def get_host_selection(
     request_id: str,
     current_user: dict = Depends(get_current_user),
@@ -949,7 +961,7 @@ async def get_host_selection(
     operation="submit_host_selection",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/host-selection/{request_id}/select")
+@router.post("/host-selection/{request_id}/select", response_model=HostSelectionSubmitResponse)
 async def submit_host_selection(
     request_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1019,7 +1031,7 @@ async def submit_host_selection(
     operation="cancel_host_selection",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/host-selection/{request_id}/cancel")
+@router.post("/host-selection/{request_id}/cancel", response_model=HostSelectionCancelResponse)
 async def cancel_host_selection(
     request_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1061,7 +1073,7 @@ async def cancel_host_selection(
     operation="list_pending_host_selections",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.get("/host-selection")
+@router.get("/host-selection", response_model=PendingHostSelectionsResponse)
 async def list_pending_host_selections(
     current_user: dict = Depends(get_current_user),
 ):

--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -1,0 +1,326 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Shared Pydantic response models for AutoBot API endpoints.
+
+These models are used across multiple API modules to ensure consistent
+response shapes for FastAPI response_model= annotations.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class SuccessResponse(BaseModel):
+    """Generic success/failure response."""
+
+    success: bool
+    message: Optional[str] = None
+
+
+class StatusResponse(BaseModel):
+    """Response with a status string and optional message."""
+
+    status: str
+    message: Optional[str] = None
+
+
+class ErrorResponse(BaseModel):
+    """Error response with detail."""
+
+    error: str
+    details: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Terminal session responses
+# ---------------------------------------------------------------------------
+
+
+class TerminalSessionCreatedResponse(BaseModel):
+    """Response from POST /terminal/sessions."""
+
+    session_id: str
+    status: str
+    security_level: str
+    websocket_url: str
+    created_at: str
+    ssh_keys: Optional[Dict[str, Any]] = None
+
+
+class TerminalSessionEntry(BaseModel):
+    """Single entry in the session list."""
+
+    session_id: str
+    user_id: Optional[str] = None
+    security_level: Optional[str] = None
+    created_at: Optional[str] = None
+    is_active: bool
+
+
+class TerminalSessionListResponse(BaseModel):
+    """Response from GET /terminal/sessions."""
+
+    sessions: List[TerminalSessionEntry]
+    total: int
+    active: int
+
+
+class TerminalSessionDetailResponse(BaseModel):
+    """Response from GET /terminal/sessions/{session_id}."""
+
+    session_id: str
+    config: Dict[str, Any]
+    is_active: bool
+    statistics: Dict[str, Any]
+
+
+class TerminalSessionDeletedResponse(BaseModel):
+    """Response from DELETE /terminal/sessions/{session_id}."""
+
+    session_id: str
+    status: str
+
+
+class SSHKeyListResponse(BaseModel):
+    """Response from GET /terminal/sessions/{session_id}/ssh-keys."""
+
+    session_id: str
+    keys: List[Any]
+    total: int
+
+
+class SSHKeyAgentResponse(BaseModel):
+    """Response from POST /terminal/sessions/{session_id}/ssh-keys/{key_name}/agent."""
+
+    session_id: str
+    key_name: str
+    status: str
+    message: str
+
+
+class SSHKeyPathResponse(BaseModel):
+    """Response from GET /terminal/sessions/{session_id}/ssh-keys/{key_name}/path."""
+
+    session_id: str
+    key_name: str
+    key_path: str
+    usage: str
+
+
+class CommandAssessmentResponse(BaseModel):
+    """Response from POST /terminal/command (risk assessment only)."""
+
+    command: str
+    risk_level: str
+    status: str
+    message: str
+    requires_confirmation: bool
+
+
+class TerminalInputResponse(BaseModel):
+    """Response from POST /terminal/sessions/{session_id}/input."""
+
+    session_id: str
+    status: str
+    input: str
+
+
+class TerminalSignalResponse(BaseModel):
+    """Response from POST /terminal/sessions/{session_id}/signal/{signal_name}."""
+
+    session_id: str
+    signal: str
+    status: str
+
+
+class TerminalHistoryResponse(BaseModel):
+    """Response from GET /terminal/sessions/{session_id}/history."""
+
+    session_id: str
+    is_active: bool
+    history: List[Any]
+    total_commands: Optional[int] = None
+    message: Optional[str] = None
+
+
+class TerminalAuditResponse(BaseModel):
+    """Response from GET /terminal/audit/{session_id}."""
+
+    session_id: str
+    audit_available: bool
+    security_level: Optional[str] = None
+    message: str
+
+
+class AdminExecuteResponse(BaseModel):
+    """Response from POST /terminal/execute (SLM admin terminal)."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+# ---------------------------------------------------------------------------
+# Agent terminal responses
+# ---------------------------------------------------------------------------
+
+
+class AgentSessionCreatedResponse(BaseModel):
+    """Response from POST /agent-terminal/sessions."""
+
+    status: str
+    session_id: str
+    agent_id: str
+    agent_role: str
+    conversation_id: Optional[str] = None
+    host: str
+    state: str
+    created_at: Any
+    pty_session_id: Optional[str] = None
+
+
+class AgentSessionEntry(BaseModel):
+    """Single session in the agent session list."""
+
+    session_id: str
+    agent_id: str
+    agent_role: str
+    conversation_id: Optional[str] = None
+    host: str
+    state: str
+    created_at: Any
+    last_activity: Any
+    command_count: int
+    pty_session_id: Optional[str] = None
+
+
+class AgentSessionListResponse(BaseModel):
+    """Response from GET /agent-terminal/sessions."""
+
+    status: str
+    total: int
+    sessions: List[AgentSessionEntry]
+
+
+class AgentSessionDeletedResponse(BaseModel):
+    """Response from DELETE /agent-terminal/sessions/{session_id}."""
+
+    status: str
+    session_id: str
+
+
+class ToolApprovalResponse(BaseModel):
+    """Response from POST /agent-terminal/tools/approve/{approval_id}."""
+
+    status: str
+    approval_id: str
+    approved: bool
+
+
+class HostSelectionRequestResponse(BaseModel):
+    """Response from POST /agent-terminal/host-selection/request."""
+
+    request_id: str
+    status: str
+    message: str
+
+
+class HostSelectionStatusResponse(BaseModel):
+    """Response from GET /agent-terminal/host-selection/{request_id}."""
+
+    request_id: str
+    status: str
+    selected_host_id: Optional[str] = None
+    selected_host_name: Optional[str] = None
+    connection_info: Optional[Dict[str, Any]] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class HostSelectionSubmitResponse(BaseModel):
+    """Response from POST /agent-terminal/host-selection/{request_id}/select."""
+
+    status: str
+    request_id: str
+    selected_host_id: Optional[str] = None
+    selected_host_name: Optional[str] = None
+    connection_info: Optional[Dict[str, Any]] = None
+
+
+class HostSelectionCancelResponse(BaseModel):
+    """Response from POST /agent-terminal/host-selection/{request_id}/cancel."""
+
+    status: str
+    request_id: str
+
+
+class PendingHostSelectionEntry(BaseModel):
+    """Single entry in pending host selection list."""
+
+    request_id: str
+    command: Optional[str] = None
+    purpose: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+class PendingHostSelectionsResponse(BaseModel):
+    """Response from GET /agent-terminal/host-selection."""
+
+    status: str
+    pending_count: int
+    pending_selections: List[PendingHostSelectionEntry]
+
+
+class CommandStateResponse(BaseModel):
+    """Response from GET /agent-terminal/commands/{command_id}."""
+
+    command_id: str
+    terminal_session_id: Optional[str] = None
+    chat_id: Optional[str] = None
+    command: str
+    purpose: Optional[str] = None
+    state: str
+    output: Optional[str] = None
+    stderr: Optional[str] = None
+    return_code: Optional[int] = None
+    risk_level: str
+    risk_reasons: Optional[List[str]] = None
+    requested_at: Optional[Any] = None
+    approved_at: Optional[Any] = None
+    execution_started_at: Optional[Any] = None
+    execution_completed_at: Optional[Any] = None
+    approved_by_user_id: Optional[str] = None
+    approval_comment: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Terminal tools responses
+# ---------------------------------------------------------------------------
+
+
+class PackageManagersResponse(BaseModel):
+    """Response from GET /terminal/package-managers."""
+
+    detected: Optional[str] = None
+    available: List[str]
+    package_managers: Dict[str, Any]
+
+
+class ToolCheckResponse(BaseModel):
+    """Response from POST /terminal/check-tool."""
+
+    installed: bool
+    command: Optional[str] = None
+    message: str
+
+
+class CommandValidationResponse(BaseModel):
+    """Response from POST /terminal/validate-command."""
+
+    safe: bool
+    risk_level: str
+    issues: List[str]
+    recommendation: str

--- a/autobot-backend/api/terminal.py
+++ b/autobot-backend/api/terminal.py
@@ -120,6 +120,23 @@ from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 
+
+from api.schemas_common import (
+    AdminExecuteResponse,
+    CommandAssessmentResponse,
+    SSHKeyAgentResponse,
+    SSHKeyListResponse,
+    SSHKeyPathResponse,
+    TerminalAuditResponse,
+    TerminalHistoryResponse,
+    TerminalInputResponse,
+    TerminalSessionCreatedResponse,
+    TerminalSessionDeletedResponse,
+    TerminalSessionDetailResponse,
+    TerminalSessionListResponse,
+    TerminalSignalResponse,
+)
+
 # Import models from dedicated module (Issue #185 - split oversized files)
 from api.terminal_models import (
     MODERATE_RISK_PATTERNS,
@@ -300,7 +317,7 @@ router.include_router(tools_router, prefix="/terminal")
     operation="create_terminal_session",
     error_code_prefix="TERMINAL",
 )
-@router.post("/sessions")
+@router.post("/sessions", response_model=TerminalSessionCreatedResponse)
 async def create_terminal_session(
     request: TerminalSessionRequest,
     current_user: dict = Depends(get_current_user),
@@ -371,7 +388,7 @@ async def create_terminal_session(
     operation="list_terminal_sessions",
     error_code_prefix="TERMINAL",
 )
-@router.get("/sessions")
+@router.get("/sessions", response_model=TerminalSessionListResponse)
 async def list_terminal_sessions(
     current_user: dict = Depends(get_current_user),
 ):
@@ -403,7 +420,7 @@ async def list_terminal_sessions(
     operation="get_terminal_session",
     error_code_prefix="TERMINAL",
 )
-@router.get("/sessions/{session_id}")
+@router.get("/sessions/{session_id}", response_model=TerminalSessionDetailResponse)
 async def get_terminal_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -435,7 +452,7 @@ async def get_terminal_session(
     operation="delete_terminal_session",
     error_code_prefix="TERMINAL",
 )
-@router.delete("/sessions/{session_id}")
+@router.delete("/sessions/{session_id}", response_model=TerminalSessionDeletedResponse)
 async def delete_terminal_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -476,7 +493,7 @@ async def delete_terminal_session(
     operation="setup_ssh_keys",
     error_code_prefix="TERMINAL",
 )
-@router.post("/sessions/{session_id}/ssh-keys")
+@router.post("/sessions/{session_id}/ssh-keys", response_model=None)
 async def setup_ssh_keys(
     session_id: str,
     request: SSHKeySetupRequest,
@@ -519,7 +536,7 @@ async def setup_ssh_keys(
     operation="list_session_ssh_keys",
     error_code_prefix="TERMINAL",
 )
-@router.get("/sessions/{session_id}/ssh-keys")
+@router.get("/sessions/{session_id}/ssh-keys", response_model=SSHKeyListResponse)
 async def list_session_ssh_keys(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -549,7 +566,7 @@ async def list_session_ssh_keys(
     operation="add_key_to_agent",
     error_code_prefix="TERMINAL",
 )
-@router.post("/sessions/{session_id}/ssh-keys/{key_name}/agent")
+@router.post("/sessions/{session_id}/ssh-keys/{key_name}/agent", response_model=SSHKeyAgentResponse)
 async def add_key_to_ssh_agent(
     session_id: str,
     key_name: str,
@@ -591,7 +608,7 @@ async def add_key_to_ssh_agent(
     operation="get_key_path",
     error_code_prefix="TERMINAL",
 )
-@router.get("/sessions/{session_id}/ssh-keys/{key_name}/path")
+@router.get("/sessions/{session_id}/ssh-keys/{key_name}/path", response_model=SSHKeyPathResponse)
 async def get_ssh_key_path(
     session_id: str,
     key_name: str,
@@ -626,7 +643,7 @@ async def get_ssh_key_path(
     operation="execute_single_command",
     error_code_prefix="TERMINAL",
 )
-@router.post("/command")
+@router.post("/command", response_model=CommandAssessmentResponse)
 async def execute_single_command(
     request: CommandRequest,
     current_user: dict = Depends(get_current_user),
@@ -670,7 +687,7 @@ async def execute_single_command(
     operation="send_terminal_input",
     error_code_prefix="TERMINAL",
 )
-@router.post("/sessions/{session_id}/input")
+@router.post("/sessions/{session_id}/input", response_model=TerminalInputResponse)
 async def send_terminal_input(
     session_id: str,
     request: TerminalInputRequest,
@@ -701,7 +718,7 @@ async def send_terminal_input(
     operation="send_terminal_signal",
     error_code_prefix="TERMINAL",
 )
-@router.post("/sessions/{session_id}/signal/{signal_name}")
+@router.post("/sessions/{session_id}/signal/{signal_name}", response_model=TerminalSignalResponse)
 async def send_terminal_signal(
     session_id: str,
     signal_name: str,
@@ -738,7 +755,7 @@ async def send_terminal_signal(
     operation="get_terminal_command_history",
     error_code_prefix="TERMINAL",
 )
-@router.get("/sessions/{session_id}/history")
+@router.get("/sessions/{session_id}/history", response_model=TerminalHistoryResponse)
 async def get_terminal_command_history(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -777,7 +794,7 @@ async def get_terminal_command_history(
     operation="get_session_audit_log",
     error_code_prefix="TERMINAL",
 )
-@router.get("/audit/{session_id}")
+@router.get("/audit/{session_id}", response_model=TerminalAuditResponse)
 async def get_session_audit_log(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1065,7 +1082,7 @@ async def ssh_terminal_websocket(
     operation="terminal_info",
     error_code_prefix="TERMINAL",
 )
-@router.get("/")
+@router.get("/", response_model=None)
 async def terminal_info(
     current_user: dict = Depends(get_current_user),
 ):
@@ -1104,7 +1121,7 @@ async def terminal_info(
     operation="terminal_health_check",
     error_code_prefix="TERMINAL",
 )
-@router.get("/health")
+@router.get("/health", response_model=None)
 async def terminal_health_check(
     current_user: dict = Depends(get_current_user),
 ):
@@ -1150,7 +1167,7 @@ async def terminal_health_check(
     operation="get_terminal_system_status",
     error_code_prefix="TERMINAL",
 )
-@router.get("/status")
+@router.get("/status", response_model=None)
 async def get_terminal_system_status(
     current_user: dict = Depends(get_current_user),
 ):
@@ -1194,7 +1211,7 @@ async def get_terminal_system_status(
     operation="get_terminal_capabilities",
     error_code_prefix="TERMINAL",
 )
-@router.get("/capabilities")
+@router.get("/capabilities", response_model=None)
 async def get_terminal_capabilities(
     current_user: dict = Depends(get_current_user),
 ):
@@ -1250,7 +1267,7 @@ async def get_terminal_capabilities(
     operation="get_security_policies",
     error_code_prefix="TERMINAL",
 )
-@router.get("/security")
+@router.get("/security", response_model=None)
 async def get_security_policies(
     current_user: dict = Depends(get_current_user),
 ):
@@ -1292,7 +1309,7 @@ async def get_security_policies(
     operation="get_terminal_features",
     error_code_prefix="TERMINAL",
 )
-@router.get("/features")
+@router.get("/features", response_model=None)
 async def get_terminal_features(
     current_user: dict = Depends(get_current_user),
 ):
@@ -1351,7 +1368,7 @@ async def get_terminal_features(
     operation="get_terminal_statistics",
     error_code_prefix="TERMINAL",
 )
-@router.get("/stats")
+@router.get("/stats", response_model=None)
 async def get_terminal_statistics(
     session_id: str = None,
     current_user: dict = Depends(get_current_user),
@@ -1380,7 +1397,7 @@ async def get_terminal_statistics(
 # SLM Admin Terminal (Issue #983) ================================================
 
 
-@router.post("/execute", summary="Execute command (SLM admin terminal)")
+@router.post("/execute", response_model=AdminExecuteResponse, summary="Execute command (SLM admin terminal)")
 async def admin_execute_command(body: AdminExecuteRequest) -> dict:
     """Execute a single shell command and return stdout/stderr/exit_code.
 

--- a/autobot-backend/api/terminal_tools.py
+++ b/autobot-backend/api/terminal_tools.py
@@ -21,6 +21,11 @@ import logging
 
 from fastapi import APIRouter
 
+from api.schemas_common import (
+    CommandValidationResponse,
+    PackageManagersResponse,
+    ToolCheckResponse,
+)
 from api.terminal_models import ToolInstallRequest
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
@@ -38,7 +43,7 @@ router = APIRouter(tags=["terminal-tools"])
     operation="install_tool",
     error_code_prefix="TERMINAL",
 )
-@router.post("/install-tool")
+@router.post("/install-tool", response_model=None)
 async def install_tool(request: ToolInstallRequest):
     """Install a tool with terminal streaming"""
     # Import system command agent for tool installation
@@ -63,7 +68,7 @@ async def install_tool(request: ToolInstallRequest):
     operation="check_tool_installed",
     error_code_prefix="TERMINAL",
 )
-@router.post("/check-tool")
+@router.post("/check-tool", response_model=ToolCheckResponse)
 async def check_tool_installed(tool_name: str):
     """Check if a tool is installed"""
     from agents.system_command_agent import SystemCommandAgent
@@ -78,7 +83,7 @@ async def check_tool_installed(tool_name: str):
     operation="validate_command",
     error_code_prefix="TERMINAL",
 )
-@router.post("/validate-command")
+@router.post("/validate-command", response_model=CommandValidationResponse)
 async def validate_command(command: str):
     """Validate command safety"""
     from agents.system_command_agent import SystemCommandAgent
@@ -93,7 +98,7 @@ async def validate_command(command: str):
     operation="get_package_managers",
     error_code_prefix="TERMINAL",
 )
-@router.get("/package-managers")
+@router.get("/package-managers", response_model=PackageManagersResponse)
 async def get_package_managers():
     """Get available package managers"""
     from agents.system_command_agent import SystemCommandAgent


### PR DESCRIPTION
## Summary
- Creates `autobot-backend/api/schemas_common.py` with 30 shared Pydantic response models (SuccessResponse, StatusResponse, ErrorResponse + domain-specific)
- Annotates all 41 endpoints in `terminal.py` (21), `agent_terminal.py` (16), `terminal_tools.py` (4)
- `response_model=None` for streaming/proxy/variable-shape endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)