### PR TITLE
fix(deps): remove dead /config dependabot entry targeting non-existent path (#5751)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,16 +70,6 @@ updates:
       - "frontend"
 
   - package-ecosystem: "pip"
-    directory: "/config"
-    target-branch: "Dev_new_gui"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 0
-    ignore:
-      - dependency-name: "*"
-
-  - package-ecosystem: "pip"
     directory: "/autobot-infrastructure/shared/config"
     target-branch: "Dev_new_gui"
     schedule:


### PR DESCRIPTION
## Summary

- Remove the `directory: "/config"` dependabot entry from `.github/dependabot.yml`
- The `/config` directory at repo root was deleted in d6d5c66ee (#781) — no manifest file exists at that path
- This entry was a silent no-op but caused Dependabot to generate spurious alerts on every push (#5682)
- The `/autobot-infrastructure/shared/config` entry added in PR #5738 correctly covers the actual infrastructure requirements files

Closes #5751

## Test plan
- [ ] `.github/dependabot.yml` no longer contains `directory: "/config"` entry
- [ ] Dependabot alerts for deleted `/config` path stop appearing after next push

🤖 Generated with [Claude Code](https://claude.com/claude-code)