### PR TITLE
feat(api): add response_model= to vnc_manager, vnc_mcp, vnc_proxy, browser_mcp endpoints (#5317)

### DIFF
--- a/autobot-backend/api/browser_mcp.py
+++ b/autobot-backend/api/browser_mcp.py
@@ -28,7 +28,7 @@ import json
 import logging
 import re
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 import aiohttp
@@ -257,6 +257,115 @@ class HoverRequest(BaseModel):
     """Request model for hovering over elements"""
 
     selector: str = Field(..., description="CSS selector for element to hover")
+
+
+# Response models for Browser MCP endpoints
+class BrowserNavigateResponse(BaseModel):
+    """Response for navigate MCP action"""
+    success: bool
+    action: str
+    url: str
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserClickResponse(BaseModel):
+    """Response for click MCP action"""
+    success: bool
+    action: str
+    selector: str
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserFillResponse(BaseModel):
+    """Response for fill MCP action"""
+    success: bool
+    action: str
+    selector: str
+    value_length: int
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserScreenshotResponse(BaseModel):
+    """Response for screenshot MCP action"""
+    success: bool
+    action: str
+    selector: Optional[str] = None
+    full_page: Optional[bool] = None
+    base64_image: Optional[str] = None
+    mime_type: str
+    timestamp: str
+
+
+class BrowserEvaluateResponse(BaseModel):
+    """Response for evaluate MCP action"""
+    success: bool
+    action: str
+    script_preview: str
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserWaitForSelectorResponse(BaseModel):
+    """Response for wait_for_selector MCP action"""
+    success: bool
+    action: str
+    selector: str
+    state: Optional[str] = None
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserGetTextResponse(BaseModel):
+    """Response for get_text MCP action"""
+    success: bool
+    action: str
+    selector: str
+    text: Optional[str] = None
+    timestamp: str
+
+
+class BrowserGetAttributeResponse(BaseModel):
+    """Response for get_attribute MCP action"""
+    success: bool
+    action: str
+    selector: str
+    attribute: str
+    value: Optional[str] = None
+    timestamp: str
+
+
+class BrowserSelectResponse(BaseModel):
+    """Response for select MCP action"""
+    success: bool
+    action: str
+    selector: str
+    value: str
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserHoverResponse(BaseModel):
+    """Response for hover MCP action"""
+    success: bool
+    action: str
+    selector: str
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserMcpStatusResponse(BaseModel):
+    """Response for Browser MCP status endpoint"""
+    success: bool
+    bridge: str
+    browser_vm: Dict[str, str]
+    security: Dict[str, Any]
+    rate_limit_status: Dict[str, Any]
+    tools_available: int
+    timestamp: str
+
 
 
 def _get_browser_navigation_tools() -> List[MCPTool]:
@@ -533,7 +642,7 @@ def _get_browser_extraction_tools() -> List[MCPTool]:
     operation="get_browser_mcp_tools",
     error_code_prefix="BROWSER_MCP",
 )
-@router.get("/mcp/tools")
+@router.get("/mcp/tools", response_model=List[MCPTool])
 async def get_browser_mcp_tools() -> List[MCPTool]:
     """Get available MCP tools for browser automation operations"""
     # Issue #281: Use extracted helpers for tool definitions by category
@@ -595,7 +704,7 @@ async def send_to_browser_vm(action: str, params: Metadata) -> Metadata:
     operation="navigate_mcp",
     error_code_prefix="BROWSER_MCP",
 )
-@router.post("/mcp/navigate")
+@router.post("/mcp/navigate", response_model=BrowserNavigateResponse)
 async def navigate_mcp(request: NavigateRequest) -> Metadata:
     """Navigate browser to URL with security validation"""
     if not await check_rate_limit():
@@ -632,7 +741,7 @@ async def navigate_mcp(request: NavigateRequest) -> Metadata:
     operation="click_mcp",
     error_code_prefix="BROWSER_MCP",
 )
-@router.post("/mcp/click")
+@router.post("/mcp/click", response_model=BrowserClickResponse)
 async def click_mcp(request: ClickRequest) -> Metadata:
     """Click on element by selector"""
     if not await check_rate_limit():
@@ -659,7 +768,7 @@ async def click_mcp(request: ClickRequest) -> Metadata:
     operation="fill_mcp",
     error_code_prefix="BROWSER_MCP",
 )
-@router.post("/mcp/fill")
+@router.post("/mcp/fill", response_model=BrowserFillResponse)
 async def fill_mcp(request: FillRequest) -> Metadata:
     """Fill form field with value"""
     if not await check_rate_limit():
@@ -691,7 +800,7 @@ async def fill_mcp(request: FillRequest) -> Metadata:
     operation="screenshot_mcp",
     error_code_prefix="BROWSER_MCP",
 )
-@router.post("/mcp/screenshot")
+@router.post("/mcp/screenshot", response_model=BrowserScreenshotResponse)
 async def screenshot_mcp(request: ScreenshotRequest) -> Metadata:
     """Capture screenshot of page or element"""
     if not await check_rate_limit():
@@ -722,7 +831,7 @@ async def screenshot_mcp(request: ScreenshotRequest) -> Metadata:
     operation="evaluate_mcp",
     error_code_prefix="BROWSER_MCP",
 )
-@router.post("/mcp/evaluate")
+@router.post("/mcp/evaluate", response_model=BrowserEvaluateResponse)
 async def evaluate_mcp(request: EvaluateRequest) -> Metadata:
     """Execute JavaScript with security validation"""
     if not await check_rate_limit():
@@ -752,7 +861,7 @@ async def evaluate_mcp(request: EvaluateRequest) -> Metadata:
     operation="wait_for_selector_mcp",
     error_code_prefix="BROWSER_MCP",
 )
-@router.post("/mcp/wait_for_selector")
+@router.post("/mcp/wait_for_selector", response_model=BrowserWaitForSelectorResponse)
 async def wait_for_selector_mcp(request: WaitForSelectorRequest) -> Metadata:
     """Wait for element to reach specified state"""
     if not await check_rate_limit():
@@ -784,7 +893,7 @@ async def wait_for_selector_mcp(request: WaitForSelectorRequest) -> Metadata:
     operation="get_text_mcp",
     error_code_prefix="BROWSER_MCP",
 )
-@router.post("/mcp/get_text")
+@router.post("/mcp/get_text", response_model=BrowserGetTextResponse)
 async def get_text_mcp(request: GetTextRequest) -> Metadata:
     """Extract text content from element"""
     if not await check_rate_limit():
@@ -808,7 +917,7 @@ async def get_text_mcp(request: GetTextRequest) -> Metadata:
     operation="get_attribute_mcp",
     error_code_prefix="BROWSER_MCP",
 )
-@router.post("/mcp/get_attribute")
+@router.post("/mcp/get_attribute", response_model=BrowserGetAttributeResponse)
 async def get_attribute_mcp(request: GetAttributeRequest) -> Metadata:
     """Get attribute value from element"""
     if not await check_rate_limit():
@@ -836,7 +945,7 @@ async def get_attribute_mcp(request: GetAttributeRequest) -> Metadata:
     operation="select_mcp",
     error_code_prefix="BROWSER_MCP",
 )
-@router.post("/mcp/select")
+@router.post("/mcp/select", response_model=BrowserSelectResponse)
 async def select_mcp(request: SelectRequest) -> Metadata:
     """Select option from dropdown"""
     if not await check_rate_limit():
@@ -864,7 +973,7 @@ async def select_mcp(request: SelectRequest) -> Metadata:
     operation="hover_mcp",
     error_code_prefix="BROWSER_MCP",
 )
-@router.post("/mcp/hover")
+@router.post("/mcp/hover", response_model=BrowserHoverResponse)
 async def hover_mcp(request: HoverRequest) -> Metadata:
     """Hover mouse over element"""
     if not await check_rate_limit():
@@ -888,7 +997,7 @@ async def hover_mcp(request: HoverRequest) -> Metadata:
     operation="get_browser_mcp_status",
     error_code_prefix="BROWSER_MCP",
 )
-@router.get("/mcp/status")
+@router.get("/mcp/status", response_model=BrowserMcpStatusResponse)
 async def get_browser_mcp_status() -> Metadata:
     """Get Browser MCP bridge status and statistics"""
     # Check Browser VM connectivity

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -15,7 +15,7 @@ import subprocess  # nosec B404
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -37,6 +37,116 @@ from constants.threshold_constants import TimingConstants
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Response models
+class VncRunningResponse(BaseModel):
+    """Response for VNC running status check"""
+    running: bool
+
+
+class VncStatusMessageResponse(BaseModel):
+    """Generic status + message response"""
+    status: str
+    message: str
+
+
+class VncScreenshotResponse(BaseModel):
+    """Response for screenshot capture"""
+    status: str
+    message: str
+    image_data: str
+
+
+class MacroStopResponse(BaseModel):
+    """Response for stop-macro-recording"""
+    status: str
+    message: str
+    action_count: int
+
+
+class MacroListResponse(BaseModel):
+    """Response for list-macros"""
+    macros: List[Dict[str, Any]]
+
+
+class VncQualityMetricsResponse(BaseModel):
+    """Response for connection quality metrics"""
+    vnc_running: bool
+    timestamp: str
+    vnc_port_reachable: Optional[bool] = None
+    latency_ms: Optional[float] = None
+    websockify_running: Optional[bool] = None
+    websockify_processes: Optional[int] = None
+
+
+class VncDesktopContextResponse(BaseModel):
+    """Response for desktop context info"""
+    system: Dict[str, str]
+    desktop: Dict[str, str]
+    processes: List[Dict[str, str]]
+    timestamp: str
+
+
+class VncOcrResponse(BaseModel):
+    """Response for OCR text recognition"""
+    status: str
+    text: str
+    message: str
+
+
+class VncFindImageResponse(BaseModel):
+    """Response for image template matching"""
+    status: str
+    found: bool
+    message: str
+    x: Optional[int] = None
+    y: Optional[int] = None
+    confidence: Optional[float] = None
+
+
+class WaitForTextResponse(BaseModel):
+    """Response for wait-for-text"""
+    status: str
+    found: bool
+    message: str
+
+
+class WaitForImageResponse(BaseModel):
+    """Response for wait-for-image"""
+    status: str
+    found: bool
+    message: str
+    x: Optional[int] = None
+    y: Optional[int] = None
+    confidence: Optional[float] = None
+
+
+class RestoreStateResponse(BaseModel):
+    """Response for restore-session-desktop-state"""
+    status: str
+    message: str
+    state: Optional[Dict[str, Any]] = None
+
+
+class SessionActionLogResponse(BaseModel):
+    """Response for get-session-action-log"""
+    status: str
+    actions: List[Dict[str, Any]]
+    message: str
+
+
+class SessionScreenshotsResponse(BaseModel):
+    """Response for get-session-screenshots"""
+    status: str
+    screenshots: List[str]
+    message: str
+
+
+class SessionScreenshotSaveResponse(BaseModel):
+    """Response for save-session-screenshot"""
+    status: str
+    message: str
+    screenshot_path: Optional[str] = None
 
 
 # Pydantic models for request bodies (Issue #74)
@@ -210,7 +320,7 @@ def start_vnc_server() -> Dict[str, str]:
         return {"status": "error", "message": "Operation failed"}
 
 
-@router.get("/status")
+@router.get("/status", response_model=VncRunningResponse)
 @with_error_handling(error_code_prefix="VNC_STATUS")
 async def get_vnc_status(
     admin_check: bool = Depends(check_admin_permission),
@@ -226,7 +336,7 @@ async def get_vnc_status(
     return {"running": running}
 
 
-@router.post("/ensure-running")
+@router.post("/ensure-running", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_ENSURE")
 async def ensure_vnc_running(
     admin_check: bool = Depends(check_admin_permission),
@@ -245,7 +355,7 @@ async def ensure_vnc_running(
     return start_vnc_server()
 
 
-@router.post("/restart")
+@router.post("/restart", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_RESTART")
 async def restart_vnc_server(
     admin_check: bool = Depends(check_admin_permission),
@@ -374,7 +484,7 @@ def _run_xdotool_cmd(args: list[str], timeout: int = 5) -> Dict[str, str]:
         return {"status": "error", "message": "Internal server error"}
 
 
-@router.post("/click")
+@router.post("/click", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_CLICK")
 async def vnc_mouse_click(
     request: MouseClickRequest,
@@ -405,7 +515,7 @@ async def vnc_mouse_click(
     )
 
 
-@router.post("/type")
+@router.post("/type", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_TYPE")
 async def vnc_keyboard_type(
     request: KeyboardTypeRequest,
@@ -452,7 +562,7 @@ async def vnc_keyboard_type(
         return _run_xdotool_cmd(["type", "--delay", str(delay_ms), "--", request.text])
 
 
-@router.post("/key")
+@router.post("/key", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_KEY")
 async def vnc_special_key(
     request: SpecialKeyRequest,
@@ -471,7 +581,7 @@ async def vnc_special_key(
     return _run_xdotool_cmd(["key", request.key])
 
 
-@router.post("/scroll")
+@router.post("/scroll", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_SCROLL")
 async def vnc_mouse_scroll(
     request: MouseScrollRequest,
@@ -498,7 +608,7 @@ async def vnc_mouse_scroll(
     return _run_xdotool_cmd(args)
 
 
-@router.post("/drag")
+@router.post("/drag", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_DRAG")
 async def vnc_mouse_drag(
     request: MouseDragRequest,
@@ -538,7 +648,7 @@ async def vnc_mouse_drag(
     return _run_xdotool_cmd(["mouseup", "1"])
 
 
-@router.get("/screenshot")
+@router.get("/screenshot", response_model=VncScreenshotResponse)
 @with_error_handling(error_code_prefix="VNC_SCREENSHOT")
 async def vnc_screenshot(
     admin_check: bool = Depends(check_admin_permission),
@@ -602,7 +712,7 @@ async def vnc_screenshot(
         return {"status": "error", "message": "Operation failed", "image_data": ""}
 
 
-@router.post("/clipboard")
+@router.post("/clipboard", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_CLIPBOARD")
 async def vnc_clipboard_sync(
     request: ClipboardSyncRequest,
@@ -648,7 +758,7 @@ async def vnc_clipboard_sync(
 # Connection Settings Management (Issue #74 - Area 4)
 
 
-@router.get("/connection/settings")
+@router.get("/connection/settings", response_model=ConnectionSettings)
 @with_error_handling(error_code_prefix="VNC_CONN_GET")
 async def get_connection_settings(
     session_id: str = "default",
@@ -670,7 +780,7 @@ async def get_connection_settings(
         return _connection_settings[session_id]
 
 
-@router.post("/connection/settings")
+@router.post("/connection/settings", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_CONN_SET")
 async def update_connection_settings(
     settings: ConnectionSettings,
@@ -701,7 +811,7 @@ async def update_connection_settings(
     return {"status": "success", "message": "Connection settings updated"}
 
 
-@router.get("/connection/quality-metrics")
+@router.get("/connection/quality-metrics", response_model=VncQualityMetricsResponse)
 @with_error_handling(error_code_prefix="VNC_QUALITY")
 async def get_connection_quality_metrics(
     admin_check: bool = Depends(check_admin_permission),
@@ -921,7 +1031,7 @@ def _get_process_list() -> List[Dict[str, str]]:
     return processes
 
 
-@router.get("/desktop/context")
+@router.get("/desktop/context", response_model=VncDesktopContextResponse)
 @with_error_handling(error_code_prefix="VNC_CONTEXT")
 async def get_desktop_context(
     admin_check: bool = Depends(check_admin_permission),
@@ -973,7 +1083,7 @@ _recording_session: Dict[str, MacroRecording] = {}
 _macros_lock = asyncio.Lock()
 
 
-@router.post("/macro/record/start")
+@router.post("/macro/record/start", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_MACRO_START")
 async def start_macro_recording(
     name: str, admin_check: bool = Depends(check_admin_permission)
@@ -998,7 +1108,7 @@ async def start_macro_recording(
     return {"status": "success", "message": f"Started recording macro '{name}'"}
 
 
-@router.post("/macro/record/stop")
+@router.post("/macro/record/stop", response_model=MacroStopResponse)
 @with_error_handling(error_code_prefix="VNC_MACRO_STOP")
 async def stop_macro_recording(
     name: str, admin_check: bool = Depends(check_admin_permission)
@@ -1030,7 +1140,7 @@ async def stop_macro_recording(
     }
 
 
-@router.get("/macros")
+@router.get("/macros", response_model=MacroListResponse)
 @with_error_handling(error_code_prefix="VNC_MACROS_LIST")
 async def list_macros(
     admin_check: bool = Depends(check_admin_permission),
@@ -1055,7 +1165,7 @@ async def list_macros(
     return {"macros": macro_list}
 
 
-@router.post("/macro/playback")
+@router.post("/macro/playback", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_MACRO_PLAY")
 async def playback_macro(
     name: str, admin_check: bool = Depends(check_admin_permission)
@@ -1113,7 +1223,7 @@ async def playback_macro(
     }
 
 
-@router.delete("/macro/{name}")
+@router.delete("/macro/{name}", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_MACRO_DELETE")
 async def delete_macro(
     name: str, admin_check: bool = Depends(check_admin_permission)
@@ -1150,7 +1260,7 @@ class OCRRequest(BaseModel):
     )
 
 
-@router.post("/ocr")
+@router.post("/ocr", response_model=VncOcrResponse)
 @with_error_handling(error_code_prefix="VNC_OCR")
 async def vnc_ocr_text(
     request: OCRRequest, admin_check: bool = Depends(check_admin_permission)
@@ -1290,7 +1400,7 @@ def _build_match_result(
     }
 
 
-@router.post("/find-image")
+@router.post("/find-image", response_model=VncFindImageResponse)
 @with_error_handling(error_code_prefix="VNC_FIND_IMAGE")
 async def vnc_find_image(
     request: FindImageRequest, admin_check: bool = Depends(check_admin_permission)
@@ -1359,7 +1469,7 @@ class WaitForTextRequest(BaseModel):
     )
 
 
-@router.post("/wait-for-text")
+@router.post("/wait-for-text", response_model=WaitForTextResponse)
 @with_error_handling(error_code_prefix="VNC_WAIT_TEXT")
 async def vnc_wait_for_text(
     request: WaitForTextRequest, admin_check: bool = Depends(check_admin_permission)
@@ -1409,7 +1519,7 @@ class WaitForImageRequest(BaseModel):
     threshold: float = Field(default=0.8, ge=0.0, le=1.0)
 
 
-@router.post("/wait-for-image")
+@router.post("/wait-for-image", response_model=WaitForImageResponse)
 @with_error_handling(error_code_prefix="VNC_WAIT_IMAGE")
 async def vnc_wait_for_image(
     request: WaitForImageRequest, admin_check: bool = Depends(check_admin_permission)
@@ -1497,7 +1607,7 @@ _session_states: Dict[str, DesktopSessionState] = {}
 _session_lock = asyncio.Lock()
 
 
-@router.post("/session/save-state")
+@router.post("/session/save-state", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_SAVE")
 async def save_session_desktop_state(
     session_id: str,
@@ -1544,7 +1654,7 @@ async def save_session_desktop_state(
     }
 
 
-@router.get("/session/restore-state")
+@router.get("/session/restore-state", response_model=RestoreStateResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_RESTORE")
 async def restore_session_desktop_state(
     session_id: str,
@@ -1580,7 +1690,7 @@ async def restore_session_desktop_state(
     }
 
 
-@router.post("/session/log-action")
+@router.post("/session/log-action", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_LOG")
 async def log_session_action(
     session_id: str,
@@ -1610,7 +1720,7 @@ async def log_session_action(
     return {"status": "success", "message": "Action logged to session"}
 
 
-@router.get("/session/action-log")
+@router.get("/session/action-log", response_model=SessionActionLogResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_LOG_GET")
 async def get_session_action_log(
     session_id: str,
@@ -1648,7 +1758,7 @@ async def get_session_action_log(
     }
 
 
-@router.post("/session/save-screenshot")
+@router.post("/session/save-screenshot", response_model=SessionScreenshotSaveResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_SCREENSHOT")
 async def save_session_screenshot(
     session_id: str,
@@ -1710,7 +1820,7 @@ async def save_session_screenshot(
     }
 
 
-@router.get("/session/screenshots")
+@router.get("/session/screenshots", response_model=SessionScreenshotsResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_SCREENSHOTS")
 async def get_session_screenshots(
     session_id: str,
@@ -1748,7 +1858,7 @@ async def get_session_screenshots(
     }
 
 
-@router.delete("/session/clear-state")
+@router.delete("/session/clear-state", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_CLEAR")
 async def clear_session_state(
     session_id: str,

--- a/autobot-backend/api/vnc_mcp.py
+++ b/autobot-backend/api/vnc_mcp.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from autobot_shared.time_utils import parse_utc_iso
-from typing import List
+from typing import Any, Dict, List, Optional
 
 import aiohttp
 from fastapi import APIRouter, Depends, HTTPException
@@ -222,12 +222,95 @@ class VNCObservationRequest(BaseModel):
     )
 
 
+# Response models for VNC MCP endpoints
+class VncStatusMcpResponse(BaseModel):
+    """Response for check_vnc_status MCP tool"""
+    success: bool
+    vnc_type: str
+    accessible: bool
+    endpoint: Optional[str] = None
+    status_code: Optional[int] = None
+    message: str
+    error: Optional[str] = None
+
+
+class VncObservationMcpResponse(BaseModel):
+    """Response for observe_vnc_activity MCP tool"""
+    success: bool
+    vnc_type: str
+    duration_seconds: int
+    observation_count: int
+    observations: List[Dict[str, Any]]
+    last_check: Optional[str] = None
+    message: str
+
+
+class BrowserVncContextResponse(BaseModel):
+    """Response for get_browser_vnc_context MCP tool"""
+    success: bool
+    timestamp: str
+    playwright_state: Dict[str, Any]
+    vnc_state: Dict[str, Any]
+
+
+class VncRecordObservationResponse(BaseModel):
+    """Response for record_vnc_observation"""
+    success: bool
+    recorded: bool
+
+
+class DesktopClickMcpResponse(BaseModel):
+    """Response for desktop_mouse_click MCP tool"""
+    success: bool
+    message: str
+    action: str
+    coordinates: Dict[str, int]
+    button: str
+
+
+class DesktopKeyboardTypeMcpResponse(BaseModel):
+    """Response for desktop_keyboard_type MCP tool"""
+    success: bool
+    message: str
+    action: str
+    text_length: int
+
+
+class DesktopSpecialKeyMcpResponse(BaseModel):
+    """Response for desktop_special_key MCP tool"""
+    success: bool
+    message: str
+    action: str
+    key: str
+
+
+class DesktopScreenshotMcpResponse(BaseModel):
+    """Response for desktop_screenshot MCP tool"""
+    success: bool
+    message: str
+    action: str
+    image_data: Optional[str] = None
+    format: Optional[str] = None
+
+
+class DesktopObserveStateMcpResponse(BaseModel):
+    """Response for desktop_observe_state MCP tool"""
+    success: bool
+    action: str
+    timestamp: str
+    resolution: Optional[str] = None
+    active_window: Optional[str] = None
+    screenshot: Optional[str] = None
+    screenshot_format: Optional[str] = None
+
+
+
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_vnc_mcp_tools",
     error_code_prefix="VNC_MCP",
 )
-@router.get("/mcp/tools")
+@router.get("/mcp/tools", response_model=List[MCPTool])
 async def get_vnc_mcp_tools() -> List[MCPTool]:
     """
     Get available MCP tools for VNC observation.
@@ -251,7 +334,7 @@ async def get_vnc_mcp_tools() -> List[MCPTool]:
     operation="check_vnc_status_mcp",
     error_code_prefix="VNC_MCP",
 )
-@router.post("/mcp/check_vnc_status")
+@router.post("/mcp/check_vnc_status", response_model=VncStatusMcpResponse)
 async def check_vnc_status_mcp(request: VNCStatusRequest) -> Metadata:
     """
     MCP tool implementation: check_vnc_status
@@ -306,7 +389,7 @@ async def check_vnc_status_mcp(request: VNCStatusRequest) -> Metadata:
     operation="observe_vnc_activity_mcp",
     error_code_prefix="VNC_MCP",
 )
-@router.post("/mcp/observe_vnc_activity")
+@router.post("/mcp/observe_vnc_activity", response_model=VncObservationMcpResponse)
 async def observe_vnc_activity_mcp(request: VNCObservationRequest) -> Metadata:
     """
     MCP tool implementation: observe_vnc_activity
@@ -353,7 +436,7 @@ async def observe_vnc_activity_mcp(request: VNCObservationRequest) -> Metadata:
     operation="get_browser_vnc_context_mcp",
     error_code_prefix="VNC_MCP",
 )
-@router.post("/mcp/get_browser_vnc_context")
+@router.post("/mcp/get_browser_vnc_context", response_model=BrowserVncContextResponse)
 async def get_browser_vnc_context_mcp() -> Metadata:
     """Get comprehensive browser VNC context: Playwright state + VNC activity. Ref: #1088."""
     backend_url = (
@@ -423,7 +506,7 @@ async def get_browser_vnc_context_mcp() -> Metadata:
     operation="record_vnc_observation",
     error_code_prefix="VNC_MCP",
 )
-@router.post("/observations/{vnc_type}")
+@router.post("/observations/{vnc_type}", response_model=VncRecordObservationResponse)
 async def record_vnc_observation(vnc_type: str, observation: Metadata):
     """
     Record VNC observation from the proxy
@@ -488,7 +571,7 @@ class DesktopObserveStateRequest(BaseModel):
     operation="desktop_mouse_click_mcp",
     error_code_prefix="VNC_MCP",
 )
-@router.post("/mcp/desktop_mouse_click")
+@router.post("/mcp/desktop_mouse_click", response_model=DesktopClickMcpResponse)
 async def desktop_mouse_click_mcp(request: DesktopMouseClickRequest) -> Metadata:
     """
     MCP tool: Click mouse at coordinates on desktop.
@@ -517,7 +600,7 @@ async def desktop_mouse_click_mcp(request: DesktopMouseClickRequest) -> Metadata
     operation="desktop_keyboard_type_mcp",
     error_code_prefix="VNC_MCP",
 )
-@router.post("/mcp/desktop_keyboard_type")
+@router.post("/mcp/desktop_keyboard_type", response_model=DesktopKeyboardTypeMcpResponse)
 async def desktop_keyboard_type_mcp(request: DesktopKeyboardTypeRequest) -> Metadata:
     """
     MCP tool: Type text on desktop keyboard.
@@ -540,7 +623,7 @@ async def desktop_keyboard_type_mcp(request: DesktopKeyboardTypeRequest) -> Meta
     operation="desktop_special_key_mcp",
     error_code_prefix="VNC_MCP",
 )
-@router.post("/mcp/desktop_special_key")
+@router.post("/mcp/desktop_special_key", response_model=DesktopSpecialKeyMcpResponse)
 async def desktop_special_key_mcp(request: DesktopSpecialKeyRequest) -> Metadata:
     """
     MCP tool: Send special key or key combination.
@@ -563,7 +646,7 @@ async def desktop_special_key_mcp(request: DesktopSpecialKeyRequest) -> Metadata
     operation="desktop_screenshot_mcp",
     error_code_prefix="VNC_MCP",
 )
-@router.post("/mcp/desktop_screenshot")
+@router.post("/mcp/desktop_screenshot", response_model=DesktopScreenshotMcpResponse)
 async def desktop_screenshot_mcp() -> Metadata:
     """
     MCP tool: Capture desktop screenshot.
@@ -633,7 +716,7 @@ async def desktop_screenshot_mcp() -> Metadata:
     operation="desktop_observe_state_mcp",
     error_code_prefix="VNC_MCP",
 )
-@router.post("/mcp/desktop_observe_state")
+@router.post("/mcp/desktop_observe_state", response_model=DesktopObserveStateMcpResponse)
 async def desktop_observe_state_mcp(request: DesktopObserveStateRequest) -> Metadata:
     """
     MCP tool: Observe current desktop state with metadata.

--- a/autobot-backend/api/vnc_proxy.py
+++ b/autobot-backend/api/vnc_proxy.py
@@ -14,10 +14,12 @@ enabling the agent to see what users are viewing in real-time.
 
 import asyncio
 import logging
+from typing import Optional
 
 import aiohttp
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.responses import Response
+from pydantic import BaseModel
 
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -27,6 +29,15 @@ from type_defs.common import Metadata
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+class VncProxyStatusResponse(BaseModel):
+    """Response for VNC proxy status check"""
+    vnc_type: str
+    endpoint: str
+    accessible: bool
+    status: Optional[int] = None
+    error: Optional[str] = None
 
 
 async def _send_client_data_to_vnc(data: dict, vnc_ws, vnc_type: str) -> bool:
@@ -145,7 +156,7 @@ async def record_observation(vnc_type: str, observation_type: str, data: Metadat
     operation="get_vnc_client",
     error_code_prefix="VNC_PROXY",
 )
-@router.get("/{vnc_type}/vnc.html")
+@router.get("/{vnc_type}/vnc.html", response_model=None)
 async def get_vnc_client(vnc_type: str, current_user: dict = Depends(get_current_user)):
     """
     Serve noVNC client HTML for specified VNC type
@@ -189,7 +200,7 @@ async def get_vnc_client(vnc_type: str, current_user: dict = Depends(get_current
     operation="proxy_vnc_assets",
     error_code_prefix="VNC_PROXY",
 )
-@router.get("/{vnc_type}/{path:path}")
+@router.get("/{vnc_type}/{path:path}", response_model=None)
 async def proxy_vnc_assets(
     vnc_type: str, path: str, current_user: dict = Depends(get_current_user)
 ):
@@ -289,7 +300,7 @@ async def websocket_proxy(websocket: WebSocket, vnc_type: str):
     operation="get_vnc_status",
     error_code_prefix="VNC_PROXY",
 )
-@router.get("/{vnc_type}/status")
+@router.get("/{vnc_type}/status", response_model=VncProxyStatusResponse)
 async def get_vnc_status(vnc_type: str, current_user: dict = Depends(get_current_user)):
     """
     Check if VNC server is accessible


### PR DESCRIPTION
## Summary
- Annotates all 55 endpoints across vnc_manager.py (30), vnc_mcp.py (10), vnc_proxy.py (3), browser_mcp.py (12)
- 14 new response models in vnc_manager.py; 9 in vnc_mcp.py; 11 in browser_mcp.py
- Proxy pass-through endpoints correctly marked response_model=None

🤖 Generated with [Claude Code](https://claude.com/claude-code)