### PR TITLE
feat(api): add response_model= to agent and ai_stack endpoints (#5317)

### DIFF
--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -36,6 +36,13 @@ from type_defs.common import Metadata
 from utils.chat_exceptions import InternalError, SubprocessError
 from utils.response_helpers import create_success_response, handle_ai_stack_error
 
+from api.schemas_common import (
+    AgentCommandApprovalResponse,
+    AgentHealthResponse,
+    AgentMessageResponse,
+    DataResponse,
+)
+
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
@@ -760,7 +767,7 @@ async def _execute_goal_with_error_handling(
     operation="receive_goal",
     error_code_prefix="AGENT",
 )
-@router.post("/goal")
+@router.post("/goal", response_model=AgentMessageResponse)
 async def receive_goal(
     request: Request,
     payload: GoalPayload,
@@ -827,7 +834,7 @@ async def receive_goal(
     operation="pause_agent",
     error_code_prefix="AGENT",
 )
-@router.post("/pause")
+@router.post("/pause", response_model=AgentMessageResponse)
 async def pause_agent_api(
     request: Request,
     user_role: str = Form("user"),
@@ -884,7 +891,7 @@ async def pause_agent_api(
     operation="resume_agent",
     error_code_prefix="AGENT",
 )
-@router.post("/resume")
+@router.post("/resume", response_model=AgentMessageResponse)
 async def resume_agent_api(
     request: Request,
     user_role: str = Form("user"),
@@ -941,7 +948,7 @@ async def resume_agent_api(
     operation="command_approval",
     error_code_prefix="AGENT",
 )
-@router.post("/command_approval")
+@router.post("/command_approval", response_model=AgentCommandApprovalResponse)
 async def command_approval(
     request: Request,
     payload: CommandApprovalPayload,
@@ -983,7 +990,7 @@ async def command_approval(
     operation="execute_command",
     error_code_prefix="AGENT",
 )
-@router.post("/execute_command")
+@router.post("/execute_command", response_model=None)
 async def execute_command(
     request: Request,
     command_data: dict,
@@ -1168,7 +1175,7 @@ def _determine_coordination_mode(payload, selected_agents: list) -> str:
     operation="execute_enhanced_goal",
     error_code_prefix="AGENT",
 )
-@router.post("/goal/enhanced")
+@router.post("/goal/enhanced", response_model=DataResponse)
 async def execute_enhanced_goal(
     payload: EnhancedGoalPayload,
     request: Request,
@@ -1232,7 +1239,7 @@ async def execute_enhanced_goal(
     operation="coordinate_multi_agent_task",
     error_code_prefix="AGENT",
 )
-@router.post("/multi-agent/coordinate")
+@router.post("/multi-agent/coordinate", response_model=DataResponse)
 async def coordinate_multi_agent_task(
     payload: MultiAgentTaskPayload,
     request: Request,
@@ -1298,7 +1305,7 @@ async def coordinate_multi_agent_task(
     operation="comprehensive_research_task",
     error_code_prefix="AGENT",
 )
-@router.post("/research/comprehensive")
+@router.post("/research/comprehensive", response_model=DataResponse)
 async def comprehensive_research_task(
     request_data: ResearchTaskRequest,
     knowledge_base=Depends(get_knowledge_base),
@@ -1363,7 +1370,7 @@ async def comprehensive_research_task(
     operation="analyze_development_task",
     error_code_prefix="AGENT",
 )
-@router.post("/development/analyze")
+@router.post("/development/analyze", response_model=DataResponse)
 async def analyze_development_task(
     request_data: AgentAnalysisRequest,
     current_user: dict = Depends(get_current_user),
@@ -1402,7 +1409,7 @@ async def analyze_development_task(
     operation="list_available_agents",
     error_code_prefix="AGENT",
 )
-@router.get("/agents/available")
+@router.get("/agents/available", response_model=DataResponse)
 async def list_available_agents():
     """
     List all available AI Stack agents with their capabilities.
@@ -1450,7 +1457,7 @@ async def list_available_agents():
     operation="get_agents_status",
     error_code_prefix="AGENT",
 )
-@router.get("/agents/status")
+@router.get("/agents/status", response_model=DataResponse)
 async def get_agents_status():
     """Get comprehensive status of all AI Stack agents.
 
@@ -1491,7 +1498,7 @@ async def get_agents_status():
     operation="enhanced_agent_health",
     error_code_prefix="AGENT",
 )
-@router.get("/health/enhanced")
+@router.get("/health/enhanced", response_model=AgentHealthResponse)
 async def enhanced_agent_health():
     """Enhanced health check for agent services."""
     try:

--- a/autobot-backend/api/agent_config.py
+++ b/autobot-backend/api/agent_config.py
@@ -21,6 +21,13 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.schemas_common import (
+    AgentConfigEnableDisableResponse,
+    AgentConfigHealthResponse,
+    AgentConfigOverviewResponse,
+    AgentConfigUpdateModelResponse,
+)
+
 from api.user_management.dependencies import get_db_session
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -577,7 +584,7 @@ async def _resolve_agent_effective_config(
     operation="list_agents",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents")
+@router.get("/agents", response_model=None)
 async def list_agents(admin_check: bool = Depends(check_admin_permission)):
     """
     Get list of all available agents with their configurations
@@ -697,7 +704,7 @@ async def _resolve_agent_entry(
     operation="get_all_agents",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents/all")
+@router.get("/agents/all", response_model=None)
 async def get_all_agents(admin_check: bool = Depends(check_admin_permission)):
     """
     Get all AutoBot agents for the Agent Registry dashboard.
@@ -743,7 +750,7 @@ async def get_all_agents(admin_check: bool = Depends(check_admin_permission)):
     operation="list_specialized_agents",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents/specialized")
+@router.get("/agents/specialized", response_model=None)
 async def list_specialized_agents(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -776,7 +783,7 @@ async def list_specialized_agents(
     operation="get_specialized_agent",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents/specialized/{agent_id}")
+@router.get("/agents/specialized/{agent_id}", response_model=None)
 async def get_specialized_agent(
     agent_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -806,7 +813,7 @@ async def get_specialized_agent(
     operation="get_agents_usage",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents/usage")
+@router.get("/agents/usage", response_model=None)
 async def get_agents_usage(
     agent_id: Optional[str] = Query(
         None, description="Filter to a specific agent (all agents if omitted)"
@@ -923,7 +930,7 @@ async def get_agents_usage(
     operation="get_agent_config",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents/{agent_id}")
+@router.get("/agents/{agent_id}", response_model=None)
 async def get_agent_config(
     agent_id: str, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -1050,7 +1057,7 @@ async def _apply_agent_model_update(
     operation="update_agent_model",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.post("/agents/{agent_id}/model")
+@router.post("/agents/{agent_id}/model", response_model=AgentConfigUpdateModelResponse)
 async def update_agent_model(
     agent_id: str,
     update: AgentModelUpdate,
@@ -1093,7 +1100,7 @@ async def update_agent_model(
     operation="enable_agent",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.post("/agents/{agent_id}/enable")
+@router.post("/agents/{agent_id}/enable", response_model=AgentConfigEnableDisableResponse)
 async def enable_agent(
     agent_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -1144,7 +1151,7 @@ async def enable_agent(
     operation="disable_agent",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.post("/agents/{agent_id}/disable")
+@router.post("/agents/{agent_id}/disable", response_model=AgentConfigEnableDisableResponse)
 async def disable_agent(
     agent_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -1232,7 +1239,7 @@ async def _check_provider_availability(agent_id: str) -> tuple:
     operation="check_agent_health",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents/{agent_id}/health")
+@router.get("/agents/{agent_id}/health", response_model=AgentConfigHealthResponse)
 async def check_agent_health(
     agent_id: str, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -1278,7 +1285,7 @@ async def check_agent_health(
     operation="get_agents_overview",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/status/overview")
+@router.get("/status/overview", response_model=AgentConfigOverviewResponse)
 async def get_agents_overview(admin_check: bool = Depends(check_admin_permission)):
     """
     Get overview of all agents' status for dashboard

--- a/autobot-backend/api/ai_stack_integration.py
+++ b/autobot-backend/api/ai_stack_integration.py
@@ -26,6 +26,8 @@ from type_defs.common import Metadata
 # Import shared response utilities (Issue #292 - Eliminate duplicate code)
 from utils.response_helpers import create_success_response
 
+from api.schemas_common import DataResponse
+
 logger = logging.getLogger(__name__)
 
 # Type alias for agent handlers (Issue #336)
@@ -127,7 +129,7 @@ class ContentClassificationRequest(BaseModel):
     operation="ai_stack_health_check",
     error_code_prefix="AI_STACK",
 )
-@router.get("/health")
+@router.get("/health", response_model=None)
 async def ai_stack_health_check(admin_check: bool = Depends(check_admin_permission)):
     """
     Check AI Stack health and connectivity.
@@ -162,7 +164,7 @@ async def ai_stack_health_check(admin_check: bool = Depends(check_admin_permissi
     operation="list_ai_agents",
     error_code_prefix="AI_STACK",
 )
-@router.get("/agents")
+@router.get("/agents", response_model=DataResponse)
 async def list_ai_agents(admin_check: bool = Depends(check_admin_permission)):
     """
     List all available AI agents.
@@ -185,7 +187,7 @@ async def list_ai_agents(admin_check: bool = Depends(check_admin_permission)):
     operation="rag_query",
     error_code_prefix="AI_STACK",
 )
-@router.post("/rag/query")
+@router.post("/rag/query", response_model=DataResponse)
 async def rag_query(
     request: RAGQueryRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -229,7 +231,7 @@ async def rag_query(
     operation="reformulate_query",
     error_code_prefix="AI_STACK",
 )
-@router.post("/rag/reformulate")
+@router.post("/rag/reformulate", response_model=DataResponse)
 async def reformulate_query(
     query: str,
     context: Optional[str] = None,
@@ -251,7 +253,7 @@ async def reformulate_query(
     operation="analyze_documents",
     error_code_prefix="AI_STACK",
 )
-@router.post("/rag/analyze-documents")
+@router.post("/rag/analyze-documents", response_model=DataResponse)
 async def analyze_documents(
     documents: List[Metadata], admin_check: bool = Depends(check_admin_permission)
 ):
@@ -276,7 +278,7 @@ async def analyze_documents(
     operation="enhanced_chat",
     error_code_prefix="AI_STACK",
 )
-@router.post("/chat/enhanced")
+@router.post("/chat/enhanced", response_model=DataResponse)
 async def enhanced_chat(
     request: EnhancedChatRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -328,7 +330,7 @@ async def enhanced_chat(
     operation="extract_knowledge",
     error_code_prefix="AI_STACK",
 )
-@router.post("/knowledge/extract")
+@router.post("/knowledge/extract", response_model=DataResponse)
 async def extract_knowledge(
     request: KnowledgeExtractionRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -355,7 +357,7 @@ async def extract_knowledge(
     operation="enhanced_knowledge_search",
     error_code_prefix="AI_STACK",
 )
-@router.post("/knowledge/enhanced-search")
+@router.post("/knowledge/enhanced-search", response_model=DataResponse)
 async def enhanced_knowledge_search(
     query: str,
     search_type: str = "comprehensive",
@@ -400,7 +402,7 @@ async def enhanced_knowledge_search(
     operation="get_system_knowledge",
     error_code_prefix="AI_STACK",
 )
-@router.get("/knowledge/system")
+@router.get("/knowledge/system", response_model=DataResponse)
 async def get_system_knowledge(
     knowledge_category: Optional[str] = None,
     admin_check: bool = Depends(check_admin_permission),
@@ -426,7 +428,7 @@ async def get_system_knowledge(
     operation="comprehensive_research",
     error_code_prefix="AI_STACK",
 )
-@router.post("/research/comprehensive")
+@router.post("/research/comprehensive", response_model=DataResponse)
 async def comprehensive_research(
     request: ResearchRequest, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -467,7 +469,7 @@ async def comprehensive_research(
     operation="web_research",
     error_code_prefix="AI_STACK",
 )
-@router.post("/research/web")
+@router.post("/research/web", response_model=DataResponse)
 async def web_research(
     query: str,
     max_pages: int = 10,
@@ -497,7 +499,7 @@ async def web_research(
     operation="search_code",
     error_code_prefix="AI_STACK",
 )
-@router.post("/development/search-code")
+@router.post("/development/search-code", response_model=DataResponse)
 async def search_code(
     request: CodeSearchRequest, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -521,7 +523,7 @@ async def search_code(
     operation="analyze_development_speedup",
     error_code_prefix="AI_STACK",
 )
-@router.post("/development/analyze-speedup")
+@router.post("/development/analyze-speedup", response_model=DataResponse)
 async def analyze_development_speedup(
     request: DevelopmentAnalysisRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -551,7 +553,7 @@ async def analyze_development_speedup(
     operation="classify_content",
     error_code_prefix="AI_STACK",
 )
-@router.post("/classification/classify")
+@router.post("/classification/classify", response_model=DataResponse)
 async def classify_content(
     request: ContentClassificationRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -678,7 +680,7 @@ async def _execute_sequential_agents(
     operation="multi_agent_query",
     error_code_prefix="AI_STACK",
 )
-@router.post("/orchestrate/multi-agent-query")
+@router.post("/orchestrate/multi-agent-query", response_model=DataResponse)
 async def multi_agent_query(
     query: str,
     agents: List[str],
@@ -724,7 +726,7 @@ async def multi_agent_query(
     operation="legacy_rag_search",
     error_code_prefix="AI_STACK",
 )
-@router.post("/legacy/rag-search")
+@router.post("/legacy/rag-search", response_model=DataResponse)
 async def legacy_rag_search(
     query: str,
     max_results: int = 10,
@@ -744,7 +746,7 @@ async def legacy_rag_search(
     operation="legacy_enhanced_chat",
     error_code_prefix="AI_STACK",
 )
-@router.post("/legacy/enhanced-chat")
+@router.post("/legacy/enhanced-chat", response_model=DataResponse)
 async def legacy_enhanced_chat(
     message: str,
     context: Optional[str] = None,

--- a/autobot-backend/api/enhanced_memory.py
+++ b/autobot-backend/api/enhanced_memory.py
@@ -16,6 +16,20 @@ from typing import List, Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
+from api.schemas_common import (
+    MemoryActiveTasksResponse,
+    MemoryCleanupResponse,
+    MemoryDocumentReferencesResponse,
+    MemoryEmbeddingCacheStatsResponse,
+    MemoryMarkdownReferenceResponse,
+    MemoryMarkdownScanResponse,
+    MemoryMarkdownSearchResponse,
+    MemoryStatisticsResponse,
+    MemoryTaskCreateResponse,
+    MemoryTaskHistoryResponse,
+    MemoryTaskUpdateResponse,
+)
+
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from enhanced_memory_manager_async import (
     AsyncEnhancedMemoryManager,
@@ -123,7 +137,7 @@ class MarkdownReferenceRequest(BaseModel):
     operation="get_memory_statistics",
     error_code_prefix="MEMORY",
 )
-@router.get("/statistics")
+@router.get("/statistics", response_model=MemoryStatisticsResponse)
 async def get_memory_statistics(days_back: int = Query(30, ge=1, le=365)):
     """Get comprehensive memory and task execution statistics.
 
@@ -158,7 +172,7 @@ async def get_memory_statistics(days_back: int = Query(30, ge=1, le=365)):
     operation="get_task_history",
     error_code_prefix="MEMORY",
 )
-@router.get("/tasks/history")
+@router.get("/tasks/history", response_model=MemoryTaskHistoryResponse)
 async def get_task_history(
     agent_type: Optional[str] = Query(None),
     status: Optional[str] = Query(None),
@@ -202,7 +216,7 @@ async def get_task_history(
     operation="create_task",
     error_code_prefix="MEMORY",
 )
-@router.post("/tasks")
+@router.post("/tasks", response_model=MemoryTaskCreateResponse)
 async def create_task(request: TaskCreateRequest):
     """Create a new task record.
 
@@ -258,7 +272,7 @@ async def create_task(request: TaskCreateRequest):
     operation="update_task",
     error_code_prefix="MEMORY",
 )
-@router.put("/tasks/{task_id}")
+@router.put("/tasks/{task_id}", response_model=MemoryTaskUpdateResponse)
 async def update_task(task_id: str, request: TaskUpdateRequest):
     """Update task status and information.
 
@@ -309,7 +323,7 @@ async def update_task(task_id: str, request: TaskUpdateRequest):
     operation="add_markdown_reference",
     error_code_prefix="MEMORY",
 )
-@router.post("/tasks/{task_id}/markdown-reference")
+@router.post("/tasks/{task_id}/markdown-reference", response_model=MemoryMarkdownReferenceResponse)
 async def add_markdown_reference(task_id: str, request: MarkdownReferenceRequest):
     """Add markdown file reference to a task.
 
@@ -355,7 +369,7 @@ async def add_markdown_reference(task_id: str, request: MarkdownReferenceRequest
     operation="scan_markdown_system",
     error_code_prefix="MEMORY",
 )
-@router.get("/markdown/scan")
+@router.get("/markdown/scan", response_model=MemoryMarkdownScanResponse)
 async def scan_markdown_system():
     """Initialize and scan markdown reference system.
 
@@ -379,7 +393,7 @@ async def scan_markdown_system():
     operation="search_markdown",
     error_code_prefix="MEMORY",
 )
-@router.get("/markdown/search")
+@router.get("/markdown/search", response_model=MemoryMarkdownSearchResponse)
 async def search_markdown(
     query: str = Query(..., min_length=2),
     document_type: Optional[str] = Query(None),
@@ -413,7 +427,7 @@ async def search_markdown(
     operation="get_document_references",
     error_code_prefix="MEMORY",
 )
-@router.get("/markdown/{file_path:path}/references")
+@router.get("/markdown/{file_path:path}/references", response_model=MemoryDocumentReferencesResponse)
 async def get_document_references(file_path: str):
     """Get all references for a specific markdown document.
 
@@ -441,7 +455,7 @@ async def get_document_references(file_path: str):
     operation="get_embedding_cache_stats",
     error_code_prefix="MEMORY",
 )
-@router.get("/embeddings/cache-stats")
+@router.get("/embeddings/cache-stats", response_model=MemoryEmbeddingCacheStatsResponse)
 async def get_embedding_cache_stats():
     """Get embedding cache statistics.
 
@@ -470,7 +484,7 @@ async def get_embedding_cache_stats():
     operation="cleanup_old_data",
     error_code_prefix="MEMORY",
 )
-@router.delete("/cleanup")
+@router.delete("/cleanup", response_model=MemoryCleanupResponse)
 async def cleanup_old_data(days_to_keep: int = Query(90, ge=30, le=365)):
     """Clean up old task records and cached data.
 
@@ -497,7 +511,7 @@ async def cleanup_old_data(days_to_keep: int = Query(90, ge=30, le=365)):
     operation="get_active_tasks",
     error_code_prefix="MEMORY",
 )
-@router.get("/active-tasks")
+@router.get("/active-tasks", response_model=MemoryActiveTasksResponse)
 async def get_active_tasks():
     """Get currently active tasks"""
     try:

--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -321,3 +321,206 @@ class PackageManagersResponse(BaseModel):
     detected: Optional[str] = None
     available: List[str]
     package_managers: Dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Generic data envelope  (ai_stack_integration, agent, etc.)
+# ---------------------------------------------------------------------------
+
+
+class DataResponse(BaseModel):
+    """Generic envelope returned by create_success_response() helpers.
+
+    Covers all endpoints that delegate to utils.response_helpers.create_success_response,
+    which always produces {"success": True, "data": ..., "message": ..., "timestamp": ...}.
+    """
+
+    success: bool
+    data: Optional[Any] = None
+    message: Optional[str] = None
+    timestamp: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# agent.py — simple message / approval responses
+# ---------------------------------------------------------------------------
+
+
+class AgentMessageResponse(BaseModel):
+    """Response for /goal, /pause, /resume — plain {"message": str}."""
+
+    message: str
+
+
+class AgentCommandApprovalResponse(BaseModel):
+    """Response for POST /command_approval."""
+
+    message: str
+    task_id: str
+    approved: bool
+
+
+class AgentCommandExecuteResponse(BaseModel):
+    """Response for POST /execute_command — success path returns {"message", "output", "status"}."""
+
+    message: str
+    output: Optional[str] = None
+    status: Optional[str] = None
+
+
+class AgentHealthResponse(BaseModel):
+    """Response for GET /health/enhanced."""
+
+    status: str
+    ai_stack_available: bool
+    multi_agent_coordination: bool
+    enhanced_capabilities: bool
+    timestamp: str
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# enhanced_memory.py schemas
+# ---------------------------------------------------------------------------
+
+
+class MemoryStatisticsResponse(BaseModel):
+    """Response for GET /statistics."""
+
+    period_days: int
+    timestamp: str
+    task_execution: Optional[Any] = None
+    markdown_system: Optional[Any] = None
+    active_tasks: Optional[Any] = None
+    performance_insights: Optional[Any] = None
+
+
+class MemoryTaskHistoryResponse(BaseModel):
+    """Response for GET /tasks/history."""
+
+    total_records: int
+    filter_criteria: Dict[str, Any]
+    tasks: List[Any]
+
+
+class MemoryTaskCreateResponse(BaseModel):
+    """Response for POST /tasks."""
+
+    task_id: str
+    status: str
+    timestamp: str
+
+
+class MemoryTaskUpdateResponse(BaseModel):
+    """Response for PUT /tasks/{task_id}."""
+
+    task_id: str
+    status: str
+    timestamp: str
+
+
+class MemoryMarkdownReferenceResponse(BaseModel):
+    """Response for POST /tasks/{task_id}/markdown-reference."""
+
+    task_id: str
+    markdown_file: str
+    reference_type: str
+    status: str
+    timestamp: str
+
+
+class MemoryMarkdownScanResponse(BaseModel):
+    """Response for GET /markdown/scan."""
+
+    status: str
+    scan_results: Optional[Any] = None
+    timestamp: str
+
+
+class MemoryMarkdownSearchResponse(BaseModel):
+    """Response for GET /markdown/search."""
+
+    query: str
+    filters: Dict[str, Any]
+    total_results: int
+    results: List[Any]
+
+
+class MemoryDocumentReferencesResponse(BaseModel):
+    """Response for GET /markdown/{file_path}/references."""
+
+    file_path: str
+    timestamp: str
+    references: Optional[Any] = None
+
+
+class MemoryEmbeddingCacheStatsResponse(BaseModel):
+    """Response for GET /embeddings/cache-stats."""
+
+    cache_size: Optional[Any] = None
+    timestamp: str
+    status: str
+
+
+class MemoryCleanupResponse(BaseModel):
+    """Response for DELETE /cleanup."""
+
+    status: str
+    cleanup_results: Dict[str, Any]
+    days_kept: int
+    timestamp: str
+
+
+class MemoryActiveTasksResponse(BaseModel):
+    """Response for GET /active-tasks."""
+
+    count: int
+    active_tasks: List[Any]
+    timestamp: str
+
+
+# ---------------------------------------------------------------------------
+# agent_config.py schemas
+# ---------------------------------------------------------------------------
+
+
+class AgentConfigEnableDisableResponse(BaseModel):
+    """Response for POST /agents/{agent_id}/enable and /disable."""
+
+    status: str
+    message: str
+    agent_name: str
+
+
+class AgentConfigUpdateModelResponse(BaseModel):
+    """Response for POST /agents/{agent_id}/model."""
+
+    status: str
+    message: str
+    updated_config: Dict[str, Any]
+
+
+class AgentConfigHealthResponse(BaseModel):
+    """Response for GET /agents/{agent_id}/health."""
+
+    agent_id: str
+    agent_name: str
+    status: str
+    enabled: bool
+    model: Optional[str] = None
+    checks: Dict[str, Any]
+    timestamp: str
+    response_time: float
+
+
+class AgentConfigOverviewResponse(BaseModel):
+    """Response for GET /status/overview."""
+
+    total_agents: int
+    enabled_agents: int
+    healthy_agents: int
+    unhealthy_agents: int
+    disabled_agents: int
+    overall_health: str
+    agents: List[Any]
+    timestamp: str


### PR DESCRIPTION
## Summary
- Added `response_model=` annotations to endpoints in `agent.py`, `agent_config.py`, `ai_stack_integration.py`, `enhanced_memory.py`
- New Pydantic response models added to `schemas_common.py`
- Endpoints that return streaming or dynamic dicts annotated with `response_model=None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)