### PR TITLE
feat(api): add response_model= to chat endpoints (#5317)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -790,8 +790,8 @@ async def stream_chat_response(
     operation="list_chats",
     error_code_prefix="CHAT",
 )
-@router.get("/chats")
-@router.get("/chat/chats")  # Frontend compatibility alias
+@router.get("/chats", response_model=None)
+@router.get("/chat/chats", response_model=None)  # Frontend compatibility alias
 async def list_chats(
     current_user: dict = Depends(get_current_user),
     request: Request = None,
@@ -832,8 +832,8 @@ async def list_chats(
     operation="send_message",
     error_code_prefix="CHAT",
 )
-@router.post("/chat")
-@router.post("/chat/message")  # Alternative endpoint
+@router.post("/chat", response_model=None)
+@router.post("/chat/message", response_model=None)  # Alternative endpoint
 async def send_message(
     current_user: dict = Depends(get_current_user),
     message: ChatMessage = None,
@@ -917,7 +917,7 @@ async def send_message(
     operation="stream_message",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/stream")
+@router.post("/chat/stream", response_model=None)
 async def stream_message(
     current_user: dict = Depends(get_current_user),
     message: ChatMessage = None,
@@ -962,7 +962,7 @@ async def stream_message(
     operation="chat_health_check",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/health")
+@router.get("/chat/health", response_model=None)
 async def chat_health_check(
     current_user: dict = Depends(get_current_user),
     request: Request = None,
@@ -1015,7 +1015,7 @@ async def chat_health_check(
     operation="chat_statistics",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/stats")
+@router.get("/chat/stats", response_model=None)
 async def chat_statistics(
     current_user: dict = Depends(get_current_user),
     request: Request = None,
@@ -1177,7 +1177,7 @@ def _validate_workflow_manager(chat_workflow_manager) -> None:
     operation="send_chat_message_by_id",
     error_code_prefix="CHAT",
 )
-@router.post("/chats/{chat_id}/message")
+@router.post("/chats/{chat_id}/message", response_model=None)
 async def send_chat_message_by_id(
     chat_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1252,7 +1252,7 @@ async def _stream_graph_resume(
     operation="resume_chat_graph",
     error_code_prefix="CHAT",
 )
-@router.post("/chats/{chat_id}/resume")
+@router.post("/chats/{chat_id}/resume", response_model=None)
 async def resume_chat_graph(
     chat_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1392,7 +1392,7 @@ async def _merge_chat_messages(
     operation="save_chat_by_id",
     error_code_prefix="CHAT",
 )
-@router.post("/chats/{chat_id}/save")
+@router.post("/chats/{chat_id}/save", response_model=None)
 async def save_chat_by_id(
     chat_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1443,7 +1443,7 @@ async def save_chat_by_id(
     operation="delete_chat_by_id",
     error_code_prefix="CHAT",
 )
-@router.delete("/chats/{chat_id}")
+@router.delete("/chats/{chat_id}", response_model=None)
 async def delete_chat_by_id(
     chat_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1489,7 +1489,7 @@ async def delete_chat_by_id(
     operation="send_direct_chat_response",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/direct")
+@router.post("/chat/direct", response_model=None)
 async def send_direct_chat_response(
     current_user: dict = Depends(get_current_user),
     request: Request = None,
@@ -1950,7 +1950,7 @@ async def _generate_enhanced_stream(
     operation="enhanced_chat",
     error_code_prefix="CHAT",
 )
-@router.post("/enhanced")
+@router.post("/enhanced", response_model=None)
 async def enhanced_chat(
     current_user: dict = Depends(get_current_user),
     message: EnhancedChatMessage = None,
@@ -2022,7 +2022,7 @@ async def enhanced_chat(
     operation="stream_enhanced_chat",
     error_code_prefix="CHAT",
 )
-@router.post("/stream-enhanced")
+@router.post("/stream-enhanced", response_model=None)
 async def stream_enhanced_chat(
     current_user: dict = Depends(get_current_user),
     message: EnhancedChatMessage = None,
@@ -2056,7 +2056,7 @@ async def stream_enhanced_chat(
     operation="enhanced_chat_health_check",
     error_code_prefix="CHAT",
 )
-@router.get("/health-enhanced")
+@router.get("/health-enhanced", response_model=None)
 async def enhanced_chat_health_check(
     current_user: dict = Depends(get_current_user),
 ):
@@ -2110,7 +2110,7 @@ async def enhanced_chat_health_check(
     operation="get_enhanced_chat_capabilities",
     error_code_prefix="CHAT",
 )
-@router.get("/capabilities")
+@router.get("/capabilities", response_model=None)
 async def get_enhanced_chat_capabilities(
     current_user: dict = Depends(get_current_user),
 ):
@@ -2201,7 +2201,7 @@ class DetectLanguageRequest(BaseModel):
     operation="translate_text",
     error_code_prefix="TRANSLATE",
 )
-@router.post("/translate")
+@router.post("/translate", response_model=None)
 async def translate_text(
     body: TranslateRequest,
     current_user: dict = Depends(get_current_user),
@@ -2230,7 +2230,7 @@ async def translate_text(
     operation="detect_language",
     error_code_prefix="TRANSLATE",
 )
-@router.post("/detect-language")
+@router.post("/detect-language", response_model=None)
 async def detect_language(
     body: DetectLanguageRequest,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/chat_compare.py
+++ b/autobot-backend/api/chat_compare.py
@@ -150,7 +150,7 @@ async def _fan_out_stream(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/chat/compare")
+@router.post("/chat/compare", response_model=None)
 async def compare_models(
     body: CompareRequest,
     request: Request,

--- a/autobot-backend/api/chat_knowledge.py
+++ b/autobot-backend/api/chat_knowledge.py
@@ -544,7 +544,7 @@ class CreateContextRequest(BaseModel):
     operation="create_chat_context",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/context/create")
+@router.post("/context/create", response_model=None)
 async def create_chat_context(request_data: CreateContextRequest, request: Request):
     """Create or update knowledge context for a chat (Issue #688: added user_id)."""
     try:
@@ -585,7 +585,7 @@ class AssociateFileRequest(BaseModel):
     operation="associate_file_with_chat",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/files/associate")
+@router.post("/files/associate", response_model=None)
 async def associate_file_with_chat(
     request_data: AssociateFileRequest, request: Request
 ):
@@ -619,7 +619,7 @@ async def associate_file_with_chat(
     operation="upload_file_to_chat",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/files/upload/{chat_id}")
+@router.post("/files/upload/{chat_id}", response_model=None)
 async def upload_file_to_chat(
     chat_id: str,
     file: UploadFile = File(...),
@@ -672,7 +672,7 @@ class AddKnowledgeRequest(BaseModel):
     operation="add_temporary_knowledge",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/knowledge/add_temporary")
+@router.post("/knowledge/add_temporary", response_model=None)
 async def add_temporary_knowledge(request: AddKnowledgeRequest):
     """Add temporary knowledge to chat context"""
     try:
@@ -692,7 +692,7 @@ async def add_temporary_knowledge(request: AddKnowledgeRequest):
     operation="get_pending_knowledge_decisions",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.get("/knowledge/pending/{chat_id}")
+@router.get("/knowledge/pending/{chat_id}", response_model=None)
 async def get_pending_knowledge_decisions(chat_id: str):
     """Get knowledge items pending user decision"""
     try:
@@ -720,7 +720,7 @@ class KnowledgeDecisionRequest(BaseModel):
     operation="apply_knowledge_decision",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/knowledge/decide")
+@router.post("/knowledge/decide", response_model=None)
 async def apply_knowledge_decision(request: KnowledgeDecisionRequest):
     """Apply user decision for temporary knowledge"""
     try:
@@ -751,7 +751,7 @@ class CompileChatRequest(BaseModel):
     operation="compile_chat_to_knowledge",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/compile")
+@router.post("/compile", response_model=None)
 async def compile_chat_to_knowledge(request_data: CompileChatRequest, request: Request):
     """Compile entire chat conversation to knowledge base"""
     try:
@@ -780,7 +780,7 @@ class SearchRequest(BaseModel):
     operation="search_chat_knowledge",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/search")
+@router.post("/search", response_model=None)
 async def search_chat_knowledge(request: SearchRequest):
     """Search knowledge across chats or within specific chat"""
     try:
@@ -802,7 +802,7 @@ async def search_chat_knowledge(request: SearchRequest):
     operation="get_chat_context",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.get("/context/{chat_id}")
+@router.get("/context/{chat_id}", response_model=None)
 async def get_chat_context(chat_id: str):
     """Get complete knowledge context for a chat"""
     try:
@@ -846,7 +846,7 @@ async def get_chat_context(chat_id: str):
     operation="health_check",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.get("/health")
+@router.get("/health", response_model=None)
 async def health_check():
     """Health check endpoint for chat knowledge system"""
     try:
@@ -873,7 +873,7 @@ class MarkFactsPreservedRequest(BaseModel):
     preserve: bool = True
 
 
-@router.get("/chat/sessions/{session_id}/facts")
+@router.get("/chat/sessions/{session_id}/facts", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_session_facts",
@@ -998,7 +998,7 @@ def _count_preserve_results(results: list, session_id: str) -> tuple[int, int, l
     return updated_count, failed_count, errors
 
 
-@router.post("/chat/sessions/{session_id}/facts/preserve")
+@router.post("/chat/sessions/{session_id}/facts/preserve", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="preserve_session_facts",

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -374,7 +374,7 @@ _EXPORT_CONTENT_TYPES = {
     operation="get_session_messages",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/sessions/{session_id}")
+@router.get("/chat/sessions/{session_id}", response_model=None)
 async def get_session_messages(
     session_id: str,
     request: Request,
@@ -421,7 +421,7 @@ async def get_session_messages(
     operation="list_sessions",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/sessions")
+@router.get("/chat/sessions", response_model=None)
 async def list_sessions(
     request: Request,
     current_user: dict = Depends(get_current_user),
@@ -777,7 +777,7 @@ async def _track_session_in_memory_graph(
     operation="create_session",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/sessions")
+@router.post("/chat/sessions", response_model=None)
 async def create_session(session_data: SessionCreate, request: Request):
     """
     Create a new chat session.
@@ -847,7 +847,7 @@ async def create_session(session_data: SessionCreate, request: Request):
     operation="update_session",
     error_code_prefix="CHAT",
 )
-@router.put("/chat/sessions/{session_id}")
+@router.put("/chat/sessions/{session_id}", response_model=None)
 async def update_session(
     session_id: str,
     session_data: SessionUpdate,
@@ -1348,7 +1348,7 @@ def _build_delete_session_response(
     operation="delete_session",
     error_code_prefix="CHAT",
 )
-@router.delete("/chat/sessions/{session_id}")
+@router.delete("/chat/sessions/{session_id}", response_model=None)
 async def delete_session(
     session_id: str,
     request: Request,
@@ -1410,7 +1410,7 @@ async def delete_session(
     operation="export_session",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/sessions/{session_id}/export")
+@router.get("/chat/sessions/{session_id}/export", response_model=None)
 async def export_session(session_id: str, request: Request, format: str = "json"):
     """
     Export a chat session in various formats.
@@ -1495,7 +1495,7 @@ def _clear_and_restore_session(
     operation="reset_chat",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/reset")
+@router.post("/chat/reset", response_model=None)
 async def reset_chat(
     request: Request, reset_request: Optional[ChatResetRequest] = None
 ):
@@ -1668,7 +1668,7 @@ async def _process_activity_batch(
     operation="add_session_activity",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/sessions/{session_id}/activities")
+@router.post("/chat/sessions/{session_id}/activities", response_model=None)
 async def add_session_activity(
     session_id: str,
     activity_data: ActivityCreate,
@@ -1732,7 +1732,7 @@ async def add_session_activity(
     operation="add_session_activities_batch",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/sessions/{session_id}/activities/batch")
+@router.post("/chat/sessions/{session_id}/activities/batch", response_model=None)
 async def add_session_activities_batch(
     session_id: str,
     batch_data: ActivityBatchCreate,
@@ -1835,7 +1835,7 @@ async def _fetch_activities_from_graph(
     operation="get_session_activities",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/sessions/{session_id}/activities")
+@router.get("/chat/sessions/{session_id}/activities", response_model=None)
 async def get_session_activities(
     session_id: str,
     request: Request,
@@ -1917,7 +1917,7 @@ async def _share_session_facts(
     operation="share_session",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/sessions/{session_id}/share")
+@router.post("/chat/sessions/{session_id}/share", response_model=None)
 async def share_session(
     session_id: str,
     share_data: SessionShareRequest,
@@ -1969,7 +1969,7 @@ async def share_session(
     operation="get_session_share_preview",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/sessions/{session_id}/share/preview")
+@router.get("/chat/sessions/{session_id}/share/preview", response_model=None)
 async def get_share_preview(
     session_id: str,
     request: Request,
@@ -2006,7 +2006,7 @@ async def get_share_preview(
     )
 
 
-@router.delete("/sessions/{session_id}/checkpoints")
+@router.delete("/sessions/{session_id}/checkpoints", response_model=None)
 async def clear_session_checkpoints(
     session_id: str,
     current_user: Dict = Depends(get_current_user),


### PR DESCRIPTION
## Summary
- Adds explicit `response_model=None` to all 44 `@router.*` decorators across `chat.py` (18), `chat_sessions.py` (13), `chat_knowledge.py` (12), and `chat_compare.py` (1)
- All endpoints return `StreamingResponse`, `JSONResponse` directly, or ad-hoc dict wrappers with variable shapes — `response_model=None` is correct for all

## Part of #5317 — response_model= 100% coverage campaign (Round 2a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)