### PR TITLE
refactor(composables): deprecate useAnalyticsFetch as thin alias of useFetchEndpoint (#5172)

### DIFF
--- a/autobot-frontend/src/composables/useAnalyticsFetch.ts
+++ b/autobot-frontend/src/composables/useAnalyticsFetch.ts
@@ -1,0 +1,28 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * @deprecated
+ * `useAnalyticsFetch` was removed in #5208/#5235 and fully superseded by
+ * `useFetchEndpoint` (originally shipped as `analytics/useAnalyticsEndpoint`
+ * in #5112, then rehomed in #5154).
+ *
+ * This file is a thin re-export alias kept only for editor-tooling discoverability.
+ * No runtime callers remain — all five former callers were migrated in #5208.
+ *
+ * **Migrate any new usage to the canonical import:**
+ * ```ts
+ * import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
+ * ```
+ *
+ * Issue #5172.
+ */
+
+export {
+  useFetchEndpoint as useAnalyticsFetch,
+  type UseFetchEndpointOptions as UseAnalyticsFetchOptions,
+  type UseFetchEndpointDeps as UseAnalyticsFetchDeps,
+  type UseFetchEndpointReturn as UseAnalyticsFetchReturn,
+  type FetchEndpointMethod,
+} from '@/composables/api/useFetchEndpoint'


### PR DESCRIPTION
## Summary
- Creates `autobot-frontend/src/composables/useAnalyticsFetch.ts` as a `@deprecated` thin re-export of `useFetchEndpoint`
- All 5 callers listed in the issue have already migrated to `useFetchEndpoint` (via #5208/#5235)
- The re-export acts as a safety net: any future code accidentally importing the old name gets IDE deprecation warnings and correct behavior

## Behavioral grep audit

Before:
```bash
$ grep -rn "from.*useAnalyticsFetch" autobot-frontend/src
# 0 hits — all 5 callers already migrated to useFetchEndpoint
```

After:
```bash
$ grep -rn "from.*useAnalyticsFetch" autobot-frontend/src
# 0 hits — no new callers introduced
```

## Test plan
- [ ] `useAnalyticsFetch` re-export compiles correctly
- [ ] No existing callers broken (none import from useAnalyticsFetch)

Closes #5172

🤖 Generated with [Claude Code](https://claude.com/claude-code)