### PR TITLE
fix(redis): guard set_budget_alert and get_all_budget_alerts against None Redis (#5767)

### DIFF
--- a/autobot-backend/services/llm_cost_tracker.py
+++ b/autobot-backend/services/llm_cost_tracker.py
@@ -1049,8 +1049,14 @@ class LLMCostTracker(AsyncRedisClientMixin):
 
     async def set_budget_alert(self, name: str, alert_data: dict) -> None:
         """Persist a budget alert configuration to Redis (#5731)."""
-        redis = await self._get_redis()
-        await redis.hset(self.BUDGET_ALERTS_KEY, name, json.dumps(alert_data))
+        try:
+            redis = await self._get_redis()
+            if redis is None:
+                logger.warning("Redis unavailable — budget alert '%s' not persisted", name)
+                return
+            await redis.hset(self.BUDGET_ALERTS_KEY, name, json.dumps(alert_data))
+        except Exception as e:
+            logger.error("Failed to persist budget alert '%s': %s", name, e)
 
     async def get_all_budget_alerts(self) -> dict:
         """Return all budget alert configurations from Redis (#5731).
@@ -1058,14 +1064,21 @@ class LLMCostTracker(AsyncRedisClientMixin):
         Returns:
             Dict mapping alert name (str) to decoded alert dict.
         """
-        redis = await self._get_redis()
-        raw = await redis.hgetall(self.BUDGET_ALERTS_KEY)
-        result = {}
-        for k, v in raw.items():
-            k_str = k if isinstance(k, str) else k.decode("utf-8")
-            v_str = v if isinstance(v, str) else v.decode("utf-8")
-            result[k_str] = json.loads(v_str)
-        return result
+        try:
+            redis = await self._get_redis()
+            if redis is None:
+                logger.warning("Redis unavailable — returning empty budget alerts")
+                return {}
+            raw = await redis.hgetall(self.BUDGET_ALERTS_KEY)
+            result = {}
+            for k, v in raw.items():
+                k_str = k if isinstance(k, str) else k.decode("utf-8")
+                v_str = v if isinstance(v, str) else v.decode("utf-8")
+                result[k_str] = json.loads(v_str)
+            return result
+        except Exception as e:
+            logger.error("Failed to retrieve budget alerts: %s", e)
+            return {}
 
     async def get_all_user_costs(self) -> list[dict[str, Any]]:
         """Get cost breakdown for all users (#1807)."""


### PR DESCRIPTION
## Summary
- Add `try/except` + `if redis is None` guard to `set_budget_alert` and `get_all_budget_alerts` in `LLMCostTracker`
- Matches the exact pattern used by `get_all_user_costs` and `_store_usage_record` in the same class
- `get_async_redis_client()` returns `Optional[Redis]`; without the guard both methods raise `AttributeError` when Redis is unavailable

## Test Plan
- [ ] `pytest autobot-backend/services/llm_cost_tracker_test.py -q` → 63 passed
- [ ] `redis is None` path logs warning and returns cleanly (no AttributeError)

Closes #5767

🤖 Generated with Claude Code