### PR TITLE
refactor(redis): upgrade UserBehaviorAnalytics to AsyncRedisClientLockedMixin (#5770)

### DIFF
--- a/autobot-backend/services/user_behavior_analytics.py
+++ b/autobot-backend/services/user_behavior_analytics.py
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from autobot_shared.redis_client import RedisDatabase
-from autobot_shared.redis_mixin import AsyncRedisClientMixin
+from autobot_shared.redis_mixin import AsyncRedisClientLockedMixin
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.ttl_constants import TTL_24_HOURS, TTL_30_DAYS, TTL_90_DAYS
@@ -84,7 +84,7 @@ class FeatureMetrics:
     bounce_rate: float = 0.0
 
 
-class UserBehaviorAnalytics(AsyncRedisClientMixin):
+class UserBehaviorAnalytics(AsyncRedisClientLockedMixin):
     """
     Service for tracking and analyzing user behavior patterns.
 


### PR DESCRIPTION
## Summary
- Change `class UserBehaviorAnalytics(AsyncRedisClientMixin)` → `AsyncRedisClientLockedMixin`
- `lazy_singleton` means one instance handles all concurrent requests; the unlocked mixin allowed two coroutines to race through `if self._redis is None:` and create duplicate connections
- Drop-in replacement — same `_get_redis()` interface, adds double-checked locking

## Test Plan
- [ ] `grep AsyncRedisClientMixin user_behavior_analytics.py` → no matches
- [ ] `python3 -m py_compile user_behavior_analytics.py` → syntax ok

Closes #5770

🤖 Generated with Claude Code