### PR TITLE
test(browser): add URL normalization unit tests for VisualBrowserPanel (#5575)

### DIFF
--- a/autobot-frontend/src/components/__tests__/VisualBrowserPanel.test.ts
+++ b/autobot-frontend/src/components/__tests__/VisualBrowserPanel.test.ts
@@ -1,0 +1,36 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import { describe, it, expect } from 'vitest'
+import { normalizeUrl } from '../../utils/urlUtils'
+
+describe('normalizeUrl (#5575)', () => {
+  it('prefixes localhost with http://', () => {
+    expect(normalizeUrl('localhost')).toBe('http://localhost')
+  })
+
+  it('prefixes localhost:PORT with http://', () => {
+    expect(normalizeUrl('localhost:3000')).toBe('http://localhost:3000')
+  })
+
+  it('prefixes a domain/path with https://', () => {
+    expect(normalizeUrl('example.com/path')).toBe('https://example.com/path')
+  })
+
+  it('leaves an http:// URL unchanged', () => {
+    expect(normalizeUrl('http://already-has-protocol')).toBe('http://already-has-protocol')
+  })
+
+  it('leaves an https:// URL unchanged', () => {
+    expect(normalizeUrl('https://already-has-protocol')).toBe('https://already-has-protocol')
+  })
+
+  it('routes a bare word through DuckDuckGo search', () => {
+    expect(normalizeUrl('google')).toBe('https://duckduckgo.com/?q=google')
+  })
+
+  it('URL-encodes spaces in a bare-word search query', () => {
+    expect(normalizeUrl('hello world')).toBe('https://duckduckgo.com/?q=hello%20world')
+  })
+})

--- a/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
+++ b/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
@@ -22,6 +22,7 @@ import {
   type AutomationOpportunity,
 } from '@/utils/VisionMultimodalApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { normalizeUrl } from '@/utils/urlUtils'
 
 const { t } = useI18n()
 const logger = createLogger('VisualBrowserPanel')
@@ -80,22 +81,8 @@ async function navigate(): Promise<void> {
   loading.value = true
   error.value = null
 
-  // #5139: if no scheme is present, normalize to a usable URL:
-  //   - `localhost` / `localhost:PORT` → `http://…` (HTTPS would fail for local dev)
-  //   - anything with a `.` → `https://…` (treat as domain)
-  //   - bare words → route through DuckDuckGo as a search query
-  // The prior branch excluded `localhost` at the outer condition AND then
-  // re-checked for it in the inner branch — dead code on both sides.
-  let targetUrl = url.value.trim()
-  if (!targetUrl.includes('://')) {
-    if (targetUrl.startsWith('localhost')) {
-      targetUrl = `http://${targetUrl}`
-    } else if (targetUrl.includes('.')) {
-      targetUrl = `https://${targetUrl}`
-    } else {
-      targetUrl = `https://duckduckgo.com/?q=${encodeURIComponent(targetUrl)}`
-    }
-  }
+  // #5139: normalise the raw input to a fully-qualified URL (#5575).
+  const targetUrl = normalizeUrl(url.value)
   url.value = targetUrl
 
   try {

--- a/autobot-frontend/src/utils/urlUtils.ts
+++ b/autobot-frontend/src/utils/urlUtils.ts
@@ -1,0 +1,20 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Normalize a raw URL/search string into a fully-qualified URL.
+ *
+ * Rules (#5139):
+ *   - Already has a scheme (`://`) → returned as-is
+ *   - Starts with `localhost` → prefixed with `http://`
+ *   - Contains a dot → prefixed with `https://`
+ *   - Bare word → routed through DuckDuckGo search
+ */
+export function normalizeUrl(raw: string): string {
+  const input = raw.trim()
+  if (input.includes('://')) return input
+  if (input.startsWith('localhost')) return `http://${input}`
+  if (input.includes('.')) return `https://${input}`
+  return `https://duckduckgo.com/?q=${encodeURIComponent(input)}`
+}


### PR DESCRIPTION
## Summary
- Extracts URL normalization logic from `VisualBrowserPanel.vue` into `src/utils/urlUtils.ts` as `normalizeUrl()` (testable in isolation)
- Adds 7 vitest unit tests in `src/components/__tests__/VisualBrowserPanel.test.ts` covering all 6 normalization cases from the issue
- `VisualBrowserPanel.vue` updated to call the extracted helper — no behavior change

## Test plan
- [ ] All 7 tests pass: `npx vitest run src/components/__tests__/VisualBrowserPanel.test.ts` ✅
- [ ] Cases covered: localhost, localhost:port, domain/path, http:// no-op, https:// no-op, bare word → DuckDuckGo

Closes #5575

🤖 Generated with [Claude Code](https://claude.com/claude-code)