### PR TITLE
fix(agent_terminal): use server deadline_ts for approval countdown to prevent clock drift (#5024)

### DIFF
--- a/autobot-backend/events/types.py
+++ b/autobot-backend/events/types.py
@@ -19,6 +19,7 @@ Event Types:
 
 import json
 import logging
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -626,6 +627,7 @@ class ApprovalContent:
     reason: str  # Human-readable explanation of why approval is needed
     risk_level: str = "high"  # low | medium | high | critical
     timeout_seconds: int = 300  # How long to wait before treating as denied
+    deadline_ts: float = 0.0  # Unix epoch seconds when approval expires (Issue #5024)
 
     def to_dict(self) -> dict:
         return {
@@ -635,6 +637,7 @@ class ApprovalContent:
             "reason": self.reason,
             "risk_level": self.risk_level,
             "timeout_seconds": self.timeout_seconds,
+            "deadline_ts": self.deadline_ts,
         }
 
     @classmethod
@@ -646,6 +649,7 @@ class ApprovalContent:
             reason=data.get("reason", ""),
             risk_level=data.get("risk_level", "high"),
             timeout_seconds=data.get("timeout_seconds", 300),
+            deadline_ts=data.get("deadline_ts", 0.0),
         )
 
 
@@ -694,6 +698,7 @@ def create_approval_required_event(
         reason=reason,
         risk_level=risk_level,
         timeout_seconds=timeout_seconds,
+        deadline_ts=time.time() + timeout_seconds,
     )
     return AgentEvent(
         event_type=EventType.APPROVAL_REQUIRED,

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -223,7 +223,7 @@
               <div class="tool-approval-countdown-bar-track">
                 <div
                   class="tool-approval-countdown-bar-fill"
-                  :style="{ width: `${(toolApprovalSecondsLeft / pendingToolApproval.timeout_seconds) * 100}%` }"
+                  :style="{ width: `${(toolApprovalSecondsLeft / Math.max(1, pendingToolApproval?.timeout_seconds ?? 1)) * 100}%` }"
                   :class="toolApprovalSecondsLeft <= 10 ? 'tool-approval-countdown-bar-fill--urgent' : ''"
                 ></div>
               </div>
@@ -352,15 +352,19 @@ const _stopCountdown = (): void => {
   }
 }
 
-const _startCountdown = (timeoutSeconds: number): void => {
+const _startCountdown = (timeoutSeconds: number, deadlineTs?: number): void => {
   _stopCountdown()
   toolApprovalSecondsLeft.value = timeoutSeconds
   _countdownInterval = setInterval(() => {
-    if (toolApprovalSecondsLeft.value <= 1) {
-      _stopCountdown()
-      toolApprovalSecondsLeft.value = 0
+    // Issue #5024: use server deadline_ts for drift-free countdown when available
+    const currentApproval = pendingToolApproval.value
+    if (currentApproval?.deadline_ts) {
+      toolApprovalSecondsLeft.value = Math.max(0, Math.round(currentApproval.deadline_ts - Date.now() / 1000))
     } else {
-      toolApprovalSecondsLeft.value -= 1
+      toolApprovalSecondsLeft.value = Math.max(0, toolApprovalSecondsLeft.value - 1)
+    }
+    if (toolApprovalSecondsLeft.value <= 0) {
+      _stopCountdown()
     }
   }, 1000)
 }
@@ -368,7 +372,7 @@ const _startCountdown = (timeoutSeconds: number): void => {
 // Start countdown when a new approval arrives; stop when cleared
 watch(pendingToolApproval, (approval: PendingToolApproval | null) => {
   if (approval) {
-    _startCountdown(approval.timeout_seconds)
+    _startCountdown(approval.timeout_seconds, approval.deadline_ts)
   } else {
     _stopCountdown()
   }

--- a/autobot-frontend/src/composables/useToolApproval.ts
+++ b/autobot-frontend/src/composables/useToolApproval.ts
@@ -38,6 +38,8 @@ export interface PendingToolApproval {
   risk_level: string
   /** How many seconds until the loop times out waiting */
   timeout_seconds: number
+  /** Unix epoch seconds when approval expires — used for drift-free countdown (Issue #5024) */
+  deadline_ts?: number
   /** Optional task_id carried from the agent context */
   task_id?: string | null
 }


### PR DESCRIPTION
## Summary
- Backend `ApprovalContent`: adds `deadline_ts: float = 0.0` field (populated as `time.time() + timeout_seconds`) in `events/types.py`
- Frontend `PendingToolApproval`: adds optional `deadline_ts?: number` field for backward compat
- `ChatInterface.vue`: countdown uses `Math.max(0, Math.round(deadline_ts - Date.now()/1000))` when `deadline_ts` is present, falls back to decrement when absent
- Fixes NaN% CSS width bug: guards `timeout_seconds=0` with `Math.max(1, ...)` 

## Test plan
- [ ] Python syntax: `py_compile` passes for `events/types.py` ✅
- [ ] Backward compatible — `deadline_ts` is optional; old events without it fall back to decrement countdown

Closes #5024

🤖 Generated with [Claude Code](https://claude.com/claude-code)