### PR TITLE
feat(api): add response_model= to system, security_assessment, memory, agent_terminal (#5317)

### DIFF
--- a/autobot-backend/api/agent_terminal.py
+++ b/autobot-backend/api/agent_terminal.py
@@ -238,6 +238,20 @@ from autobot_shared.redis_client import get_redis_client
 from services.agent_terminal import AgentSessionState, AgentTerminalService
 from services.command_approval_manager import AgentRole
 from services.command_execution_queue import get_command_queue
+from api.schemas_common import (
+    AgentTerminalSessionCreateResponse,
+    AgentTerminalSessionListResponse,
+    AgentTerminalSessionDetailResponse,
+    AgentTerminalSessionDeleteResponse,
+    AgentTerminalCommandStateResponse,
+    AgentTerminalInfoResponse,
+    AgentTerminalToolApprovalResponse,
+    AgentTerminalHostSelectionRequestResponse,
+    AgentTerminalHostSelectionGetResponse,
+    AgentTerminalHostSelectionSubmitResponse,
+    AgentTerminalHostSelectionCancelResponse,
+    AgentTerminalPendingSelectionsResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -385,7 +399,7 @@ def get_agent_terminal_service(
     operation="create_agent_terminal_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions")
+@router.post("/sessions", response_model=AgentTerminalSessionCreateResponse)
 async def create_agent_terminal_session(
     current_user: dict = Depends(get_current_user),
     request: CreateSessionRequest = None,
@@ -440,7 +454,7 @@ async def create_agent_terminal_session(
     operation="list_agent_terminal_sessions",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.get("/sessions")
+@router.get("/sessions", response_model=AgentTerminalSessionListResponse)
 async def list_agent_terminal_sessions(
     current_user: dict = Depends(get_current_user),
     agent_id: Optional[str] = None,
@@ -489,7 +503,7 @@ async def list_agent_terminal_sessions(
     operation="get_agent_terminal_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.get("/sessions/{session_id}")
+@router.get("/sessions/{session_id}", response_model=AgentTerminalSessionDetailResponse)
 async def get_agent_terminal_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -516,7 +530,7 @@ async def get_agent_terminal_session(
     operation="delete_agent_terminal_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.delete("/sessions/{session_id}")
+@router.delete("/sessions/{session_id}", response_model=AgentTerminalSessionDeleteResponse)
 async def delete_agent_terminal_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -543,7 +557,7 @@ async def delete_agent_terminal_session(
     operation="execute_agent_command",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/execute")
+@router.post("/execute", response_model=None)
 async def execute_agent_command(
     current_user: dict = Depends(get_current_user),
     session_id: str = None,
@@ -581,7 +595,7 @@ async def execute_agent_command(
     operation="approve_agent_command",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/approve")
+@router.post("/sessions/{session_id}/approve", response_model=None)
 async def approve_agent_command(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -622,7 +636,7 @@ async def approve_agent_command(
     operation="submit_tool_approval",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/tools/approve/{approval_id}")
+@router.post("/tools/approve/{approval_id}", response_model=AgentTerminalToolApprovalResponse)
 async def submit_tool_approval(
     approval_id: str,
     request: ToolApprovalRequest,
@@ -661,7 +675,7 @@ async def submit_tool_approval(
     operation="interrupt_agent_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/interrupt")
+@router.post("/sessions/{session_id}/interrupt", response_model=None)
 async def interrupt_agent_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -692,7 +706,7 @@ async def interrupt_agent_session(
     operation="resume_agent_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/resume")
+@router.post("/sessions/{session_id}/resume", response_model=None)
 async def resume_agent_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -714,7 +728,7 @@ async def resume_agent_session(
     operation="get_command_state",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.get("/commands/{command_id}")
+@router.get("/commands/{command_id}", response_model=AgentTerminalCommandStateResponse)
 async def get_command_state(
     command_id: str,
     current_user: dict = Depends(get_current_user),
@@ -787,7 +801,7 @@ async def get_command_state(
     operation="agent_terminal_info",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.get("/")
+@router.get("/", response_model=AgentTerminalInfoResponse)
 async def agent_terminal_info(
     current_user: dict = Depends(get_current_user),
 ):
@@ -856,7 +870,7 @@ _pending_host_selections: Dict[str, Dict] = {}
     operation="request_host_selection",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/host-selection/request")
+@router.post("/host-selection/request", response_model=AgentTerminalHostSelectionRequestResponse)
 async def request_host_selection(
     current_user: dict = Depends(get_current_user),
     request: HostSelectionRequest = None,
@@ -910,7 +924,7 @@ async def request_host_selection(
     operation="get_host_selection",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.get("/host-selection/{request_id}")
+@router.get("/host-selection/{request_id}", response_model=AgentTerminalHostSelectionGetResponse)
 async def get_host_selection(
     request_id: str,
     current_user: dict = Depends(get_current_user),
@@ -949,7 +963,7 @@ async def get_host_selection(
     operation="submit_host_selection",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/host-selection/{request_id}/select")
+@router.post("/host-selection/{request_id}/select", response_model=AgentTerminalHostSelectionSubmitResponse)
 async def submit_host_selection(
     request_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1019,7 +1033,7 @@ async def submit_host_selection(
     operation="cancel_host_selection",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/host-selection/{request_id}/cancel")
+@router.post("/host-selection/{request_id}/cancel", response_model=AgentTerminalHostSelectionCancelResponse)
 async def cancel_host_selection(
     request_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1061,7 +1075,7 @@ async def cancel_host_selection(
     operation="list_pending_host_selections",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.get("/host-selection")
+@router.get("/host-selection", response_model=AgentTerminalPendingSelectionsResponse)
 async def list_pending_host_selections(
     current_user: dict = Depends(get_current_user),
 ):

--- a/autobot-backend/api/memory.py
+++ b/autobot-backend/api/memory.py
@@ -28,7 +28,6 @@ Performance:
 """
 
 import logging
-from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request
@@ -477,7 +476,7 @@ def _build_list_entities_response(
     operation="create_entity",
     error_code_prefix="MEMORY",
 )
-@router.post("/entities", status_code=201)
+@router.post("/entities", status_code=201, response_model=None)
 async def create_entity(
     admin_check: bool = Depends(check_admin_permission),
     entity_data: EntityCreateRequest = Body(...),
@@ -541,7 +540,7 @@ async def create_entity(
     operation="list_all_entities",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities/all")
+@router.get("/entities/all", response_model=None)
 async def list_all_entities(
     admin_check: bool = Depends(check_admin_permission),
     entity_type: Optional[str] = Query(None, description="Filter by entity type"),
@@ -586,7 +585,7 @@ async def list_all_entities(
     operation="find_orphaned_conversation_entities",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities/orphans")
+@router.get("/entities/orphans", response_model=None)
 async def find_orphaned_conversation_entities(
     admin_check: bool = Depends(check_admin_permission),
     request: Request = None,
@@ -903,7 +902,7 @@ async def _detect_orphaned_entities(
     operation="cleanup_orphaned_conversation_entities",
     error_code_prefix="MEMORY",
 )
-@router.delete("/entities/orphans")
+@router.delete("/entities/orphans", response_model=None)
 async def cleanup_orphaned_conversation_entities(
     admin_check: bool = Depends(check_admin_permission),
     request: Request = None,
@@ -953,7 +952,7 @@ async def cleanup_orphaned_conversation_entities(
     operation="get_entity_by_id",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities/{entity_id}")
+@router.get("/entities/{entity_id}", response_model=None)
 async def get_entity_by_id(
     entity_id: str = Path(..., description="Entity UUID"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1011,7 +1010,7 @@ async def get_entity_by_id(
     operation="get_entity_by_name",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities")
+@router.get("/entities", response_model=None)
 async def get_entity_by_name(
     admin_check: bool = Depends(check_admin_permission),
     name: str = Query(..., description="Entity name to search for"),
@@ -1067,7 +1066,7 @@ async def get_entity_by_name(
     operation="add_observations",
     error_code_prefix="MEMORY",
 )
-@router.patch("/entities/{entity_id}/observations")
+@router.patch("/entities/{entity_id}/observations", response_model=None)
 async def add_observations(
     entity_id: str = Path(..., description="Entity UUID"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1130,7 +1129,7 @@ async def add_observations(
     operation="delete_entity",
     error_code_prefix="MEMORY",
 )
-@router.delete("/entities/{entity_id}")
+@router.delete("/entities/{entity_id}", response_model=None)
 async def delete_entity(
     entity_id: str = Path(..., description="Entity UUID"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1193,7 +1192,7 @@ async def delete_entity(
     operation="create_relation",
     error_code_prefix="MEMORY",
 )
-@router.post("/relations", status_code=201)
+@router.post("/relations", status_code=201, response_model=None)
 async def create_relation(
     admin_check: bool = Depends(check_admin_permission),
     relation_data: RelationCreateRequest = Body(...),
@@ -1262,7 +1261,7 @@ async def create_relation(
     operation="get_related_entities",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities/{entity_id}/relations")
+@router.get("/entities/{entity_id}/relations", response_model=None)
 async def get_related_entities(
     entity_id: str = Path(..., description="Entity UUID"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1317,7 +1316,7 @@ async def get_related_entities(
     operation="delete_relation",
     error_code_prefix="MEMORY",
 )
-@router.delete("/relations")
+@router.delete("/relations", response_model=None)
 async def delete_relation(
     admin_check: bool = Depends(check_admin_permission),
     from_entity: str = Query(..., description="Source entity name"),
@@ -1387,7 +1386,7 @@ async def delete_relation(
     operation="search_entities",
     error_code_prefix="MEMORY",
 )
-@router.get("/search")
+@router.get("/search", response_model=None)
 async def search_entities(
     admin_check: bool = Depends(check_admin_permission),
     query: str = Query(..., min_length=1, description="Search query"),
@@ -1460,7 +1459,7 @@ async def search_entities(
     operation="get_entity_graph",
     error_code_prefix="MEMORY",
 )
-@router.get("/graph")
+@router.get("/graph", response_model=None)
 async def get_entity_graph(
     admin_check: bool = Depends(check_admin_permission),
     entity_id: Optional[str] = Query(None, description="Root entity ID (optional)"),
@@ -1523,7 +1522,7 @@ async def get_entity_graph(
     operation="memory_health_check",
     error_code_prefix="MEMORY",
 )
-@router.get("/health")
+@router.get("/health", response_model=None)
 async def memory_health_check(
     admin_check: bool = Depends(check_admin_permission),
     memory_graph: AutoBotMemoryGraph = Depends(get_memory_graph),
@@ -1656,7 +1655,7 @@ def _build_invalidate_relation_response(
     operation="invalidate_entity",
     error_code_prefix="MEMORY",
 )
-@router.patch("/entities/{entity_id}/invalidate")
+@router.patch("/entities/{entity_id}/invalidate", response_model=None)
 async def invalidate_entity(
     entity_id: str = Path(..., description="UUID of the entity to invalidate"),
     body: InvalidateEntityRequest = Body(default_factory=InvalidateEntityRequest),
@@ -1720,7 +1719,7 @@ async def invalidate_entity(
     operation="invalidate_relation",
     error_code_prefix="MEMORY",
 )
-@router.patch("/relations/invalidate")
+@router.patch("/relations/invalidate", response_model=None)
 async def invalidate_relation(
     body: InvalidateRelationRequest = Body(...),
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -788,3 +788,288 @@ class LLMAwarenessHealthResponse(BaseModel):
     timestamp: str
 
 
+# ---------------------------------------------------------------------------
+# system.py schemas
+# ---------------------------------------------------------------------------
+
+
+class SystemFrontendConfigResponse(BaseModel):
+    """Response for GET /frontend-config."""
+
+    status: str
+    config: Dict[str, Any]
+    timestamp: str
+
+
+class SystemHealthResponse(BaseModel):
+    """Response for GET /health and GET /system/health.
+
+    Shape varies between healthy/degraded/unhealthy paths — extra fields
+    (cpu_percent, memory_percent, services, etc.) are allowed through.
+    """
+
+    model_config = {"extra": "allow"}
+
+    status: str
+    timestamp: str
+
+
+class SystemInfoResponse(BaseModel):
+    """Response for GET /info."""
+
+    name: str
+    version: str
+    python_version: str
+    timestamp: str
+    features: Dict[str, Any]
+
+
+class SystemReloadConfigResponse(BaseModel):
+    """Response for POST /reload_config."""
+
+    status: str
+    message: str
+    timestamp: str
+
+
+class SystemPromptReloadResponse(BaseModel):
+    """Response for GET /prompt_reload."""
+
+    status: str
+    message: str
+    timestamp: str
+
+
+class SystemAdminCheckResponse(BaseModel):
+    """Response for GET /admin_check."""
+
+    user: str
+    admin: bool
+    timestamp: str
+
+
+class SystemDynamicImportResponse(BaseModel):
+    """Response for POST /dynamic_import."""
+
+    status: str
+    message: str
+    module_info: Dict[str, Any]
+    timestamp: str
+
+
+class SystemCacheStatsResponse(BaseModel):
+    """Response for GET /cache/stats.
+
+    Redis info and performance sections are dynamic — extra fields allowed.
+    """
+
+    model_config = {"extra": "allow"}
+
+    timestamp: str
+    cache: Dict[str, Any]
+
+
+class SystemCacheActivityResponse(BaseModel):
+    """Response for GET /cache/activity."""
+
+    model_config = {"extra": "allow"}
+
+    timestamp: str
+    activity: Dict[str, Any]
+
+
+class SystemMetricsResponse(BaseModel):
+    """Response for GET /metrics.
+
+    psutil-derived payload is dynamic; extra fields allowed through.
+    """
+
+    model_config = {"extra": "allow"}
+
+    timestamp: str
+
+
+class SystemCacheCoordinatorStatsResponse(BaseModel):
+    """Response for GET /api/cache/stats.
+
+    Shape is defined by CacheCoordinator.get_unified_stats() — opaque.
+    """
+
+    model_config = {"extra": "allow"}
+
+
+class SystemCacheEvictResponse(BaseModel):
+    """Response for POST /api/cache/evict."""
+
+    status: str
+    evicted: int
+    timestamp: str
+
+
+class SystemCacheClearResponse(BaseModel):
+    """Response for POST /api/cache/clear/{cache_name}."""
+
+    status: str
+    cache: str
+    timestamp: str
+
+
+class SystemBackupStatusResponse(BaseModel):
+    """Response for GET /system/backup/status.
+
+    BackupScheduler.get_status() returns an opaque dict with a timestamp added.
+    """
+
+    model_config = {"extra": "allow"}
+
+    timestamp: str
+
+
+# ---------------------------------------------------------------------------
+# agent_terminal.py schemas
+# ---------------------------------------------------------------------------
+
+
+class AgentTerminalSessionCreateResponse(BaseModel):
+    """Response for POST /agent-terminal/sessions."""
+
+    status: str
+    session_id: str
+    agent_id: str
+    agent_role: str
+    conversation_id: Optional[str] = None
+    host: str
+    state: str
+    created_at: float
+    pty_session_id: Optional[str] = None
+
+
+class AgentTerminalSessionItem(BaseModel):
+    """Single session entry within list response."""
+
+    session_id: str
+    agent_id: str
+    agent_role: str
+    conversation_id: Optional[str] = None
+    host: str
+    state: str
+    created_at: float
+    last_activity: Optional[float] = None
+    command_count: int
+    pty_session_id: Optional[str] = None
+
+
+class AgentTerminalSessionListResponse(BaseModel):
+    """Response for GET /agent-terminal/sessions."""
+
+    status: str
+    total: int
+    sessions: List[AgentTerminalSessionItem]
+
+
+class AgentTerminalSessionDetailResponse(BaseModel):
+    """Response for GET /agent-terminal/sessions/{session_id}.
+
+    session_info dict shape is opaque — extra fields allowed.
+    """
+
+    model_config = {"extra": "allow"}
+
+    status: str
+
+
+class AgentTerminalSessionDeleteResponse(BaseModel):
+    """Response for DELETE /agent-terminal/sessions/{session_id}."""
+
+    status: str
+    session_id: str
+
+
+class AgentTerminalCommandStateResponse(BaseModel):
+    """Response for GET /agent-terminal/commands/{command_id}."""
+
+    command_id: str
+    terminal_session_id: Optional[str] = None
+    chat_id: Optional[str] = None
+    command: str
+    purpose: Optional[str] = None
+    state: str
+    output: Optional[str] = None
+    stderr: Optional[str] = None
+    return_code: Optional[int] = None
+    risk_level: str
+    risk_reasons: Optional[List[str]] = None
+    requested_at: Optional[float] = None
+    approved_at: Optional[float] = None
+    execution_started_at: Optional[float] = None
+    execution_completed_at: Optional[float] = None
+    approved_by_user_id: Optional[str] = None
+    approval_comment: Optional[str] = None
+
+
+class AgentTerminalInfoResponse(BaseModel):
+    """Response for GET /agent-terminal/."""
+
+    name: str
+    version: str
+    description: str
+    features: List[str]
+    agent_roles: List[str]
+    session_states: List[str]
+    endpoints: Dict[str, str]
+    security_features: Dict[str, str]
+
+
+class AgentTerminalToolApprovalResponse(BaseModel):
+    """Response for POST /agent-terminal/tools/approve/{approval_id}."""
+
+    status: str
+    approval_id: str
+    approved: bool
+
+
+class AgentTerminalHostSelectionRequestResponse(BaseModel):
+    """Response for POST /agent-terminal/host-selection/request."""
+
+    request_id: str
+    status: str
+    message: str
+
+
+class AgentTerminalHostSelectionGetResponse(BaseModel):
+    """Response for GET /agent-terminal/host-selection/{request_id}."""
+
+    request_id: str
+    status: str
+    selected_host_id: Optional[str] = None
+    selected_host_name: Optional[str] = None
+    connection_info: Optional[Dict[str, Any]] = None
+    created_at: str
+    updated_at: Optional[str] = None
+
+
+class AgentTerminalHostSelectionSubmitResponse(BaseModel):
+    """Response for POST /agent-terminal/host-selection/{request_id}/select."""
+
+    status: str
+    request_id: str
+    selected_host_id: Optional[str] = None
+    selected_host_name: Optional[str] = None
+    connection_info: Optional[Dict[str, Any]] = None
+
+
+class AgentTerminalHostSelectionCancelResponse(BaseModel):
+    """Response for POST /agent-terminal/host-selection/{request_id}/cancel."""
+
+    status: str
+    request_id: str
+
+
+class AgentTerminalPendingSelectionsResponse(BaseModel):
+    """Response for GET /agent-terminal/host-selection."""
+
+    status: str
+    pending_count: int
+    pending_selections: List[Dict[str, Any]]
+
+

--- a/autobot-backend/api/security_assessment.py
+++ b/autobot-backend/api/security_assessment.py
@@ -122,7 +122,7 @@ async def get_workflow_manager() -> SecurityWorkflowManager:
 # API Endpoints
 
 
-@router.post("/assessments")
+@router.post("/assessments", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="create_assessment",
@@ -171,7 +171,7 @@ async def create_assessment(
     )
 
 
-@router.get("/assessments")
+@router.get("/assessments", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_assessments",
@@ -216,7 +216,7 @@ async def list_assessments(
     )
 
 
-@router.get("/assessments/{assessment_id}")
+@router.get("/assessments/{assessment_id}", response_model=None)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="get_assessment",
@@ -256,7 +256,7 @@ async def get_assessment(
     )
 
 
-@router.get("/assessments/{assessment_id}/summary")
+@router.get("/assessments/{assessment_id}/summary", response_model=None)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="get_assessment_summary",
@@ -296,7 +296,7 @@ async def get_assessment_summary(
     )
 
 
-@router.delete("/assessments/{assessment_id}")
+@router.delete("/assessments/{assessment_id}", response_model=None)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="delete_assessment",
@@ -336,7 +336,7 @@ async def delete_assessment(
     )
 
 
-@router.get("/assessments/{assessment_id}/phase")
+@router.get("/assessments/{assessment_id}/phase", response_model=None)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="get_phase",
@@ -386,7 +386,7 @@ async def get_current_phase(
     )
 
 
-@router.post("/assessments/{assessment_id}/phase")
+@router.post("/assessments/{assessment_id}/phase", response_model=None)
 @with_error_handling(
     category=ErrorCategory.VALIDATION,
     operation="advance_phase",
@@ -436,7 +436,7 @@ async def advance_phase(
     )
 
 
-@router.post("/assessments/{assessment_id}/hosts")
+@router.post("/assessments/{assessment_id}/hosts", response_model=None)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="add_host",
@@ -485,7 +485,7 @@ async def add_host(
     )
 
 
-@router.post("/assessments/{assessment_id}/ports")
+@router.post("/assessments/{assessment_id}/ports", response_model=None)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="add_port",
@@ -536,7 +536,7 @@ async def add_port(
     )
 
 
-@router.post("/assessments/{assessment_id}/vulnerabilities")
+@router.post("/assessments/{assessment_id}/vulnerabilities", response_model=None)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="add_vulnerability",
@@ -589,7 +589,7 @@ async def add_vulnerability(
     )
 
 
-@router.post("/assessments/{assessment_id}/findings")
+@router.post("/assessments/{assessment_id}/findings", response_model=None)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="add_finding",
@@ -641,7 +641,7 @@ async def add_finding(
     )
 
 
-@router.get("/assessments/{assessment_id}/findings")
+@router.get("/assessments/{assessment_id}/findings", response_model=None)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="get_findings",
@@ -789,7 +789,7 @@ async def _store_parsed_vulnerabilities(manager, assessment_id: str, parsed) -> 
     return vulns_added
 
 
-@router.post("/assessments/{assessment_id}/parse")
+@router.post("/assessments/{assessment_id}/parse", response_model=None)
 @with_error_handling(
     category=ErrorCategory.VALIDATION,
     operation="parse_tool_output",
@@ -857,7 +857,7 @@ async def parse_and_store_tool_output(
     )
 
 
-@router.post("/assessments/{assessment_id}/error")
+@router.post("/assessments/{assessment_id}/error", response_model=None)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="set_error",
@@ -899,7 +899,7 @@ async def set_error_state(
     )
 
 
-@router.post("/assessments/{assessment_id}/recover")
+@router.post("/assessments/{assessment_id}/recover", response_model=None)
 @with_error_handling(
     category=ErrorCategory.VALIDATION,
     operation="recover_from_error",
@@ -949,7 +949,7 @@ async def recover_from_error(
     )
 
 
-@router.get("/phases")
+@router.get("/phases", response_model=None)
 async def get_phase_definitions(
     admin_check: bool = Depends(check_admin_permission),
 ) -> JSONResponse:

--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -17,6 +17,22 @@ from constants.model_constants import ModelConstants as ModelConsts
 
 # Add caching support from unified cache manager (P4 Cache Consolidation)
 from utils.advanced_cache_manager import cache_manager, cache_response
+from api.schemas_common import (
+    SystemFrontendConfigResponse,
+    SystemHealthResponse,
+    SystemInfoResponse,
+    SystemReloadConfigResponse,
+    SystemPromptReloadResponse,
+    SystemAdminCheckResponse,
+    SystemDynamicImportResponse,
+    SystemCacheStatsResponse,
+    SystemCacheActivityResponse,
+    SystemMetricsResponse,
+    SystemCacheCoordinatorStatsResponse,
+    SystemCacheEvictResponse,
+    SystemCacheClearResponse,
+    SystemBackupStatusResponse,
+)
 
 config = get_config_manager()
 
@@ -146,7 +162,7 @@ def _build_frontend_meta_config() -> dict:
     operation="get_frontend_config",
     error_code_prefix="SYSTEM",
 )
-@router.get("/frontend-config")
+@router.get("/frontend-config", response_model=SystemFrontendConfigResponse)
 @cache_response(cache_key="frontend_config", ttl=60)  # Cache for 1 minute
 async def get_frontend_config(admin_check: bool = Depends(check_admin_permission)):
     """Get configuration values needed by the frontend.
@@ -180,8 +196,8 @@ async def get_frontend_config(admin_check: bool = Depends(check_admin_permission
     operation="get_system_health",
     error_code_prefix="SYSTEM",
 )
-@router.get("/health")
-@router.get("/system/health")  # Frontend compatibility alias
+@router.get("/health", response_model=SystemHealthResponse)
+@router.get("/system/health", response_model=SystemHealthResponse)  # Frontend compatibility alias
 @cache_response(cache_key="system_health", ttl=30)  # Cache for 30 seconds
 async def get_system_health(
     request: Request = None,
@@ -240,7 +256,7 @@ async def get_system_health(
     operation="get_system_info",
     error_code_prefix="SYSTEM",
 )
-@router.get("/info")
+@router.get("/info", response_model=SystemInfoResponse)
 @cache_response(cache_key="system_info", ttl=300)  # Cache for 5 minutes
 async def get_system_info(admin_check: bool = Depends(check_admin_permission)):
     """Get system information
@@ -273,7 +289,7 @@ async def get_system_info(admin_check: bool = Depends(check_admin_permission)):
     operation="reload_system_config",
     error_code_prefix="SYSTEM",
 )
-@router.post("/reload_config")
+@router.post("/reload_config", response_model=SystemReloadConfigResponse)
 async def reload_system_config(admin_check: bool = Depends(check_admin_permission)):
     """Reload system configuration and clear caches
 
@@ -307,7 +323,7 @@ async def reload_system_config(admin_check: bool = Depends(check_admin_permissio
     operation="reload_prompts",
     error_code_prefix="SYSTEM",
 )
-@router.get("/prompt_reload")
+@router.get("/prompt_reload", response_model=SystemPromptReloadResponse)
 async def reload_prompts(admin_check: bool = Depends(check_admin_permission)):
     """Reload prompt templates
 
@@ -339,7 +355,7 @@ async def reload_prompts(admin_check: bool = Depends(check_admin_permission)):
     operation="admin_check",
     error_code_prefix="SYSTEM",
 )
-@router.get("/admin_check")
+@router.get("/admin_check", response_model=SystemAdminCheckResponse)
 async def admin_check(admin_check: bool = Depends(check_admin_permission)):
     """Check admin status and permissions
 
@@ -361,7 +377,7 @@ async def admin_check(admin_check: bool = Depends(check_admin_permission)):
     operation="dynamic_import",
     error_code_prefix="SYSTEM",
 )
-@router.post("/dynamic_import")
+@router.post("/dynamic_import", response_model=SystemDynamicImportResponse)
 async def dynamic_import(
     request: Request,
     module_name: str = Form(...),
@@ -403,7 +419,7 @@ async def dynamic_import(
     operation="get_detailed_health",
     error_code_prefix="SYSTEM",
 )
-@router.get("/health/detailed")
+@router.get("/health/detailed", response_model=SystemHealthResponse)
 @cache_response(cache_key="system_health_detailed", ttl=30)  # Cache for 30 seconds
 async def get_detailed_health(
     request: Request, admin_check: bool = Depends(check_admin_permission)
@@ -541,7 +557,7 @@ def _determine_overall_health_status(health_status: dict) -> None:
     operation="get_cache_stats",
     error_code_prefix="SYSTEM",
 )
-@router.get("/cache/stats")
+@router.get("/cache/stats", response_model=SystemCacheStatsResponse)
 @cache_response(cache_key="cache_stats", ttl=15)  # Cache for 15 seconds
 async def get_cache_stats(admin_check: bool = Depends(check_admin_permission)):
     """Get cache statistics and performance metrics
@@ -649,7 +665,7 @@ def _analyze_key_patterns(cache_keys: list, cache_prefix: str) -> dict:
     operation="get_cache_activity",
     error_code_prefix="SYSTEM",
 )
-@router.get("/cache/activity")
+@router.get("/cache/activity", response_model=SystemCacheActivityResponse)
 @cache_response(cache_key="cache_activity", ttl=10)  # Cache for 10 seconds
 async def get_cache_activity(admin_check: bool = Depends(check_admin_permission)):
     """Get recent cache activity and key information.
@@ -711,7 +727,7 @@ async def get_cache_activity(admin_check: bool = Depends(check_admin_permission)
     operation="get_system_metrics",
     error_code_prefix="SYSTEM",
 )
-@router.get("/metrics")
+@router.get("/metrics", response_model=SystemMetricsResponse)
 @cache_response(cache_key="system_metrics", ttl=15)  # Cache for 15 seconds
 async def get_system_metrics(admin_check: bool = Depends(check_admin_permission)):
     """Get system performance metrics
@@ -780,7 +796,7 @@ async def get_system_metrics(admin_check: bool = Depends(check_admin_permission)
     operation="get_cache_coordinator_stats",
     error_code_prefix="SYSTEM",
 )
-@router.get("/api/cache/stats")
+@router.get("/api/cache/stats", response_model=SystemCacheCoordinatorStatsResponse)
 async def get_cache_coordinator_stats(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -812,7 +828,7 @@ async def get_cache_coordinator_stats(
     operation="trigger_cache_eviction",
     error_code_prefix="SYSTEM",
 )
-@router.post("/api/cache/evict")
+@router.post("/api/cache/evict", response_model=SystemCacheEvictResponse)
 async def trigger_cache_eviction(admin_check: bool = Depends(check_admin_permission)):
     """
     Manually trigger coordinated cache eviction.
@@ -842,7 +858,7 @@ async def trigger_cache_eviction(admin_check: bool = Depends(check_admin_permiss
     operation="clear_cache",
     error_code_prefix="SYSTEM",
 )
-@router.post("/api/cache/clear/{cache_name}")
+@router.post("/api/cache/clear/{cache_name}", response_model=SystemCacheClearResponse)
 async def clear_cache(
     cache_name: str, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -874,7 +890,7 @@ async def clear_cache(
         raise HTTPException(status_code=500, detail="Error clearing cache")
 
 
-@router.get("/system/backup/status")
+@router.get("/system/backup/status", response_model=SystemBackupStatusResponse)
 async def get_backup_status(
     request: Request,
     _: None = Depends(check_admin_permission),


### PR DESCRIPTION
## Summary
- Annotates 64 endpoints across `system.py` (16), `security_assessment.py` (16), `memory.py` (16), `agent_terminal.py` (16)
- Adds 26 typed Pydantic models to `schemas_common.py` for system and agent_terminal domains
- Opaque `JSONResponse` returns (security assessment to_dict(), memory graph entities) use `response_model=None`

## Part of #5317 (Round 3a)
🤖 Generated with [Claude Code](https://claude.com/claude-code)