### PR TITLE
feat(api): add response_model= to filesystem_mcp, knowledge_tags, scheduler, error_monitoring (#5317)

### DIFF
--- a/autobot-backend/api/error_monitoring.py
+++ b/autobot-backend/api/error_monitoring.py
@@ -13,7 +13,7 @@ import json
 import logging
 import os
 import sys
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Header, HTTPException, status
 from pydantic import BaseModel
@@ -42,12 +42,64 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Error Monitoring"])
 
 
+# ---------------------------------------------------------------------------
+# Response models for error_monitoring endpoints
+# ---------------------------------------------------------------------------
+
+
+class ErrorMonitoringDataResponse(BaseModel):
+    """Generic envelope for endpoints returning {"status": str, "data": Any}."""
+
+    status: str
+    data: Optional[Any] = None
+
+
+class ErrorMonitoringClearResponse(BaseModel):
+    """Response for POST /clear."""
+
+    status: str
+    message: str
+
+
+class ErrorMonitoringTestErrorResponse(BaseModel):
+    """Response for POST /test-error."""
+
+    status: str
+    message: str
+    error_caught: Optional[str] = None
+    error_type: Optional[str] = None
+
+
+class ErrorMonitoringResolveResponse(BaseModel):
+    """Response for POST /metrics/resolve/{trace_id}."""
+
+    status: str
+    message: str
+
+
+class ErrorMonitoringAlertThresholdResponse(BaseModel):
+    """Response for POST /metrics/alert-threshold."""
+
+    status: str
+    message: str
+    threshold_key: str
+    threshold: int
+
+
+class ErrorMonitoringCleanupResponse(BaseModel):
+    """Response for POST /metrics/cleanup."""
+
+    status: str
+    message: str
+    removed_count: int
+
+
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_system_error_statistics",
     error_code_prefix="ERROR_MONITORING",
 )
-@router.get("/statistics")
+@router.get("/statistics", response_model=ErrorMonitoringDataResponse)
 async def get_system_error_statistics():
     """Get system-wide error statistics"""
     try:
@@ -66,7 +118,7 @@ async def get_system_error_statistics():
     operation="get_recent_errors",
     error_code_prefix="ERROR_MONITORING",
 )
-@router.get("/recent")
+@router.get("/recent", response_model=ErrorMonitoringDataResponse)
 async def get_recent_errors(limit: int = 20):
     """Get recent error reports"""
     try:
@@ -121,7 +173,7 @@ async def get_recent_errors(limit: int = 20):
     operation="get_error_categories",
     error_code_prefix="ERROR_MONITORING",
 )
-@router.get("/categories")
+@router.get("/categories", response_model=ErrorMonitoringDataResponse)
 async def get_error_categories():
     """Get error breakdown by category"""
     try:
@@ -156,7 +208,7 @@ async def get_error_categories():
     operation="get_error_by_component",
     error_code_prefix="ERROR_MONITORING",
 )
-@router.get("/components")
+@router.get("/components", response_model=ErrorMonitoringDataResponse)
 async def get_error_by_component():
     """Get error breakdown by component"""
     try:
@@ -203,7 +255,7 @@ def _calculate_health_status(
     operation="get_error_system_health",
     error_code_prefix="ERROR_MONITORING",
 )
-@router.get("/health")
+@router.get("/health", response_model=ErrorMonitoringDataResponse)
 async def get_error_system_health():
     """Get error system health status"""
     try:
@@ -243,7 +295,7 @@ async def get_error_system_health():
     operation="clear_error_history",
     error_code_prefix="ERROR_MONITORING",
 )
-@router.post("/clear")
+@router.post("/clear", response_model=ErrorMonitoringClearResponse)
 async def clear_error_history(authorization: Optional[str] = Header(None)):
     """Clear error history (admin only)"""
     try:
@@ -292,7 +344,7 @@ class TestErrorRequest(BaseModel):
     operation="test_error_system",
     error_code_prefix="ERROR_MONITORING",
 )
-@router.post("/test-error")
+@router.post("/test-error", response_model=ErrorMonitoringTestErrorResponse)
 async def test_error_system(request: TestErrorRequest):
     """Test the error boundary system (development only)"""
     try:
@@ -389,7 +441,7 @@ def _get_health_recommendations(health_status: str, stats: Metadata) -> list:
     operation="get_metrics_summary",
     error_code_prefix="ERROR_MONITORING",
 )
-@router.get("/metrics/summary")
+@router.get("/metrics/summary", response_model=ErrorMonitoringDataResponse)
 async def get_metrics_summary():
     """
     Get comprehensive error metrics summary
@@ -415,7 +467,7 @@ async def get_metrics_summary():
     operation="get_error_timeline",
     error_code_prefix="ERROR_MONITORING",
 )
-@router.get("/metrics/timeline")
+@router.get("/metrics/timeline", response_model=ErrorMonitoringDataResponse)
 async def get_error_timeline_endpoint(hours: int = 24, component: Optional[str] = None):
     """
     Get error timeline data for visualization
@@ -454,7 +506,7 @@ async def get_error_timeline_endpoint(hours: int = 24, component: Optional[str] 
     operation="get_top_errors",
     error_code_prefix="ERROR_MONITORING",
 )
-@router.get("/metrics/top-errors")
+@router.get("/metrics/top-errors", response_model=ErrorMonitoringDataResponse)
 async def get_top_errors_endpoint(limit: int = 10):
     """
     Get top N most frequent errors
@@ -485,7 +537,7 @@ async def get_top_errors_endpoint(limit: int = 10):
     operation="mark_error_resolved",
     error_code_prefix="ERROR_MONITORING",
 )
-@router.post("/metrics/resolve/{trace_id}")
+@router.post("/metrics/resolve/{trace_id}", response_model=ErrorMonitoringResolveResponse)
 async def mark_error_resolved_endpoint(trace_id: str):
     """
     Mark an error as resolved
@@ -526,7 +578,7 @@ class AlertThresholdRequest(BaseModel):
     operation="set_alert_threshold",
     error_code_prefix="ERROR_MONITORING",
 )
-@router.post("/metrics/alert-threshold")
+@router.post("/metrics/alert-threshold", response_model=ErrorMonitoringAlertThresholdResponse)
 async def set_alert_threshold_endpoint(request: AlertThresholdRequest):
     """
     Set alert threshold for a component/error
@@ -563,7 +615,7 @@ async def set_alert_threshold_endpoint(request: AlertThresholdRequest):
     operation="cleanup_metrics",
     error_code_prefix="ERROR_MONITORING",
 )
-@router.post("/metrics/cleanup")
+@router.post("/metrics/cleanup", response_model=ErrorMonitoringCleanupResponse)
 async def cleanup_metrics_endpoint():
     """
     Clean up old metrics beyond retention period

--- a/autobot-backend/api/filesystem_mcp.py
+++ b/autobot-backend/api/filesystem_mcp.py
@@ -71,6 +71,146 @@ from utils.catalog_http_exceptions import raise_internal_error, raise_invalid_in
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["filesystem_mcp", "mcp"])
 
+
+# ---------------------------------------------------------------------------
+# Response models for filesystem_mcp endpoints
+# ---------------------------------------------------------------------------
+
+
+class FilesystemReadTextResponse(BaseModel):
+    """Response for POST /mcp/read_text_file."""
+
+    success: bool
+    path: str
+    content: str
+    lines: int
+    size_bytes: int
+
+
+class FilesystemReadMediaResponse(BaseModel):
+    """Response for POST /mcp/read_media_file."""
+
+    success: bool
+    path: str
+    mime_type: str
+    base64_data: str
+    size_bytes: int
+
+
+class FilesystemReadMultipleResponse(BaseModel):
+    """Response for POST /mcp/read_multiple_files."""
+
+    success: bool
+    files_read: int
+    files_failed: int
+    results: List[Dict]
+    errors: Optional[List[Dict]] = None
+
+
+class FilesystemWriteFileResponse(BaseModel):
+    """Response for POST /mcp/write_file."""
+
+    success: bool
+    path: str
+    size_bytes: int
+    message: str
+
+
+class FilesystemEditFileResponse(BaseModel):
+    """Response for POST /mcp/edit_file."""
+
+    success: bool
+    path: str
+    edits_applied: int
+    dry_run: bool
+    changes: List[Dict]
+    size_before: int
+    size_after: int
+
+
+class FilesystemCreateDirectoryResponse(BaseModel):
+    """Response for POST /mcp/create_directory."""
+
+    success: bool
+    path: str
+    message: str
+
+
+class FilesystemListDirectoryResponse(BaseModel):
+    """Response for POST /mcp/list_directory."""
+
+    success: bool
+    path: str
+    entry_count: int
+    entries: List[str]
+
+
+class FilesystemListDirectoryWithSizesResponse(BaseModel):
+    """Response for POST /mcp/list_directory_with_sizes."""
+
+    success: bool
+    path: str
+    entry_count: int
+    sorted_by: Optional[str] = None
+    entries: List[Dict]
+
+
+class FilesystemMoveFileResponse(BaseModel):
+    """Response for POST /mcp/move_file."""
+
+    success: bool
+    source: str
+    destination: str
+    message: str
+
+
+class FilesystemSearchFilesResponse(BaseModel):
+    """Response for POST /mcp/search_files."""
+
+    success: bool
+    search_path: str
+    pattern: str
+    matches_found: int
+    matches: List[str]
+
+
+class FilesystemDirectoryTreeResponse(BaseModel):
+    """Response for POST /mcp/directory_tree."""
+
+    success: bool
+    root_path: str
+    tree: Dict
+
+
+class FilesystemFileInfoResponse(BaseModel):
+    """Response for POST /mcp/get_file_info."""
+
+    success: bool
+    path: str
+    name: str
+    type: str
+    size_bytes: int
+    created: str
+    modified: str
+    accessed: str
+    permissions: str
+    mime_type: Optional[str] = None
+
+
+class FilesystemSecurityInfo(BaseModel):
+    path_traversal_blocked: bool
+    symlink_validation: bool
+    max_file_size_bytes: int
+
+
+class FilesystemListAllowedResponse(BaseModel):
+    """Response for GET /mcp/list_allowed_directories."""
+
+    success: bool
+    allowed_directories: List[str]
+    directory_count: int
+    security_info: FilesystemSecurityInfo
+
 # Security Configuration: Allowed Directories
 # Only paths within these directories are accessible
 _BASE_DIR = os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot")
@@ -641,7 +781,7 @@ def _get_discovery_analysis_tools() -> List[MCPTool]:
     operation="get_filesystem_mcp_tools",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.get("/mcp/tools")
+@router.get("/mcp/tools", response_model=List[MCPTool])
 async def get_filesystem_mcp_tools(
     admin_check: bool = Depends(check_admin_permission),
 ) -> List[MCPTool]:
@@ -667,7 +807,7 @@ async def get_filesystem_mcp_tools(
     operation="read_text_file_mcp",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.post("/mcp/read_text_file")
+@router.post("/mcp/read_text_file", response_model=FilesystemReadTextResponse)
 async def read_text_file_mcp(
     request: ReadTextFileRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -725,7 +865,7 @@ async def read_text_file_mcp(
     operation="read_media_file_mcp",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.post("/mcp/read_media_file")
+@router.post("/mcp/read_media_file", response_model=FilesystemReadMediaResponse)
 async def read_media_file_mcp(
     request: ReadMediaFileRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -850,7 +990,7 @@ def _separate_batch_read_results(all_results: list) -> tuple:
     operation="read_multiple_files_mcp",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.post("/mcp/read_multiple_files")
+@router.post("/mcp/read_multiple_files", response_model=FilesystemReadMultipleResponse)
 async def read_multiple_files_mcp(
     request: ReadMultipleFilesRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -884,7 +1024,7 @@ async def read_multiple_files_mcp(
     operation="write_file_mcp",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.post("/mcp/write_file")
+@router.post("/mcp/write_file", response_model=FilesystemWriteFileResponse)
 async def write_file_mcp(
     request: WriteFileRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -984,7 +1124,7 @@ def _apply_edits_to_content(content: str, edits: list) -> tuple:
     operation="edit_file_mcp",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.post("/mcp/edit_file")
+@router.post("/mcp/edit_file", response_model=FilesystemEditFileResponse)
 async def edit_file_mcp(
     request: EditFileRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1034,7 +1174,7 @@ async def edit_file_mcp(
     operation="create_directory_mcp",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.post("/mcp/create_directory")
+@router.post("/mcp/create_directory", response_model=FilesystemCreateDirectoryResponse)
 async def create_directory_mcp(
     request: CreateDirectoryRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1063,7 +1203,7 @@ async def create_directory_mcp(
     operation="list_directory_mcp",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.post("/mcp/list_directory")
+@router.post("/mcp/list_directory", response_model=FilesystemListDirectoryResponse)
 async def list_directory_mcp(
     request: ListDirectoryRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1189,7 +1329,7 @@ async def _build_directory_entries_with_sizes(path: str) -> list:
     operation="list_directory_with_sizes_mcp",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.post("/mcp/list_directory_with_sizes")
+@router.post("/mcp/list_directory_with_sizes", response_model=FilesystemListDirectoryWithSizesResponse)
 async def list_directory_with_sizes_mcp(
     request: ListDirectoryWithSizesRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1231,7 +1371,7 @@ async def list_directory_with_sizes_mcp(
     operation="move_file_mcp",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.post("/mcp/move_file")
+@router.post("/mcp/move_file", response_model=FilesystemMoveFileResponse)
 async def move_file_mcp(
     request: MoveFileRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1272,7 +1412,7 @@ async def move_file_mcp(
     operation="search_files_mcp",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.post("/mcp/search_files")
+@router.post("/mcp/search_files", response_model=FilesystemSearchFilesResponse)
 async def search_files_mcp(
     request: SearchFilesRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1324,7 +1464,7 @@ async def search_files_mcp(
     operation="directory_tree_mcp",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.post("/mcp/directory_tree")
+@router.post("/mcp/directory_tree", response_model=FilesystemDirectoryTreeResponse)
 async def directory_tree_mcp(
     request: DirectoryTreeRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1380,7 +1520,7 @@ async def directory_tree_mcp(
     operation="get_file_info_mcp",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.post("/mcp/get_file_info")
+@router.post("/mcp/get_file_info", response_model=FilesystemFileInfoResponse)
 async def get_file_info_mcp(
     request: GetFileInfoRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1427,7 +1567,7 @@ async def get_file_info_mcp(
     operation="list_allowed_directories_mcp",
     error_code_prefix="FILESYSTEM_MCP",
 )
-@router.get("/mcp/list_allowed_directories")
+@router.get("/mcp/list_allowed_directories", response_model=FilesystemListAllowedResponse)
 async def list_allowed_directories_mcp(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Metadata:

--- a/autobot-backend/api/knowledge_tags.py
+++ b/autobot-backend/api/knowledge_tags.py
@@ -28,9 +28,10 @@ Related Issues: #77 (Tags), #185 (Split), #209 (Knowledge split), #409 (Tag CRUD
 
 import logging
 import re
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from pydantic import BaseModel
 from starlette.requests import Request
 
 from api.knowledge_models import (
@@ -49,6 +50,135 @@ from constants.threshold_constants import QueryDefaults
 from knowledge_factory import get_or_create_knowledge_base
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Response models for knowledge_tags endpoints
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeTagFactTagsResponse(BaseModel):
+    """Response for POST/DELETE/GET /fact/{fact_id}/tags."""
+
+    status: str
+    fact_id: str
+    tags: List[Any]
+    message: Optional[str] = None
+    added_count: Optional[int] = None
+    removed_count: Optional[int] = None
+
+
+class KnowledgeTagGetFactTagsResponse(BaseModel):
+    """Response for GET /fact/{fact_id}/tags."""
+
+    status: str
+    fact_id: str
+    tags: List[Any]
+
+
+class KnowledgeTagSearchResponse(BaseModel):
+    """Response for POST /tags/search."""
+
+    status: str
+    facts: List[Any]
+    total_count: int
+    tags_searched: List[str]
+    match_all: bool
+    limit: int
+    offset: int
+
+
+class KnowledgeTagListResponse(BaseModel):
+    """Response for GET /tags."""
+
+    status: str
+    tags: List[Any]
+    total_count: int
+
+
+class KnowledgeTagBulkResponse(BaseModel):
+    """Response for POST /tags/bulk."""
+
+    status: str
+    operation: str
+    processed_count: int
+    failed_count: int
+    results: List[Any]
+
+
+class KnowledgeTagRenameResponse(BaseModel):
+    """Response for PUT /tags/{tag_name}."""
+
+    status: str
+    old_tag: str
+    new_tag: str
+    affected_count: int
+    message: str
+
+
+class KnowledgeTagDeleteResponse(BaseModel):
+    """Response for DELETE /tags/{tag_name}."""
+
+    status: str
+    tag: str
+    affected_count: int
+    message: str
+
+
+class KnowledgeTagMergeResponse(BaseModel):
+    """Response for POST /tags/merge."""
+
+    status: str
+    source_tags: List[str]
+    target_tag: str
+    affected_count: int
+    message: str
+
+
+class KnowledgeTagFactsByTagResponse(BaseModel):
+    """Response for GET /tags/{tag_name}/facts."""
+
+    status: str
+    tag: str
+    facts: List[Any]
+    total_count: int
+    returned_count: int
+    limit: int
+    offset: int
+    has_more: bool
+
+
+class KnowledgeTagInfoResponse(BaseModel):
+    """Response for GET /tags/{tag_name}/info."""
+
+    status: str
+    tag: str
+    fact_count: int
+
+
+class KnowledgeTagStyleInfo(BaseModel):
+    color: Optional[str] = None
+    icon: Optional[str] = None
+    description: Optional[str] = None
+    is_default: bool
+
+
+class KnowledgeTagStyleResponse(BaseModel):
+    """Response for PATCH/GET /tags/{tag_name}/style."""
+
+    status: str
+    tag: str
+    style: Dict[str, Any]
+    message: Optional[str] = None
+
+
+class KnowledgeTagDeleteStyleResponse(BaseModel):
+    """Response for DELETE /tags/{tag_name}/style."""
+
+    status: str
+    tag: str
+    message: str
+
 
 # Issue #380: Pre-compiled regex for tag prefix validation
 _TAG_PREFIX_RE = re.compile(r"^[a-z0-9_-]*$")
@@ -73,7 +203,7 @@ def _raise_kb_error(error_message: str, default_code: int = 500) -> None:
     operation="add_tags_to_fact",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/fact/{fact_id}/tags")
+@router.post("/fact/{fact_id}/tags", response_model=KnowledgeTagFactTagsResponse)
 async def add_tags_to_fact(
     fact_id: str = Path(..., description="Fact ID to add tags to"),
     request: AddTagsRequest = ...,
@@ -128,7 +258,7 @@ async def add_tags_to_fact(
     operation="remove_tags_from_fact",
     error_code_prefix="KNOWLEDGE",
 )
-@router.delete("/fact/{fact_id}/tags")
+@router.delete("/fact/{fact_id}/tags", response_model=KnowledgeTagFactTagsResponse)
 async def remove_tags_from_fact(
     fact_id: str = Path(..., description="Fact ID to remove tags from"),
     request: RemoveTagsRequest = ...,
@@ -183,7 +313,7 @@ async def remove_tags_from_fact(
     operation="get_fact_tags",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/fact/{fact_id}/tags")
+@router.get("/fact/{fact_id}/tags", response_model=KnowledgeTagGetFactTagsResponse)
 async def get_fact_tags(
     fact_id: str = Path(..., description="Fact ID to get tags for"),
     admin_check: bool = Depends(check_admin_permission),
@@ -229,7 +359,7 @@ async def get_fact_tags(
     operation="search_facts_by_tags",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/tags/search")
+@router.post("/tags/search", response_model=KnowledgeTagSearchResponse)
 async def search_facts_by_tags(
     request: SearchByTagsRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -288,7 +418,7 @@ async def search_facts_by_tags(
     operation="list_all_tags",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/tags")
+@router.get("/tags", response_model=KnowledgeTagListResponse)
 async def list_all_tags(
     admin_check: bool = Depends(check_admin_permission),
     limit: int = Query(default=QueryDefaults.KNOWLEDGE_DEFAULT_LIMIT, ge=1, le=1000),
@@ -339,7 +469,7 @@ async def list_all_tags(
     operation="bulk_tag_facts",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/tags/bulk")
+@router.post("/tags/bulk", response_model=KnowledgeTagBulkResponse)
 async def bulk_tag_facts(
     request: BulkTagRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -397,7 +527,7 @@ async def bulk_tag_facts(
     operation="rename_tag",
     error_code_prefix="KNOWLEDGE",
 )
-@router.put("/tags/{tag_name}")
+@router.put("/tags/{tag_name}", response_model=KnowledgeTagRenameResponse)
 async def rename_tag(
     tag_name: str = Path(..., description="Current tag name to rename"),
     request: RenameTagRequest = ...,
@@ -457,7 +587,7 @@ async def rename_tag(
     operation="delete_tag_globally",
     error_code_prefix="KNOWLEDGE",
 )
-@router.delete("/tags/{tag_name}")
+@router.delete("/tags/{tag_name}", response_model=KnowledgeTagDeleteResponse)
 async def delete_tag_globally(
     tag_name: str = Path(..., description="Tag name to delete"),
     admin_check: bool = Depends(check_admin_permission),
@@ -513,7 +643,7 @@ async def delete_tag_globally(
     operation="merge_tags",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/tags/merge")
+@router.post("/tags/merge", response_model=KnowledgeTagMergeResponse)
 async def merge_tags(
     request: MergeTagsRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -571,7 +701,7 @@ async def merge_tags(
     operation="get_facts_by_tag",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/tags/{tag_name}/facts")
+@router.get("/tags/{tag_name}/facts", response_model=KnowledgeTagFactsByTagResponse)
 async def get_facts_by_tag(
     tag_name: str = Path(..., description="Tag name to get facts for"),
     admin_check: bool = Depends(check_admin_permission),
@@ -643,7 +773,7 @@ async def get_facts_by_tag(
     operation="get_tag_info",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/tags/{tag_name}/info")
+@router.get("/tags/{tag_name}/info", response_model=KnowledgeTagInfoResponse)
 async def get_tag_info(
     tag_name: str = Path(..., description="Tag name to get info for"),
     admin_check: bool = Depends(check_admin_permission),
@@ -699,7 +829,7 @@ async def get_tag_info(
     operation="update_tag_style",
     error_code_prefix="KNOWLEDGE",
 )
-@router.patch("/tags/{tag_name}/style")
+@router.patch("/tags/{tag_name}/style", response_model=KnowledgeTagStyleResponse)
 async def update_tag_style(
     tag_name: str = Path(..., description="Tag name to update styling for"),
     request: UpdateTagStyleRequest = ...,
@@ -769,7 +899,7 @@ async def update_tag_style(
     operation="get_tag_style",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/tags/{tag_name}/style")
+@router.get("/tags/{tag_name}/style", response_model=KnowledgeTagStyleResponse)
 async def get_tag_style(
     tag_name: str = Path(..., description="Tag name to get styling for"),
     admin_check: bool = Depends(check_admin_permission),
@@ -830,7 +960,7 @@ async def get_tag_style(
     operation="delete_tag_style",
     error_code_prefix="KNOWLEDGE",
 )
-@router.delete("/tags/{tag_name}/style")
+@router.delete("/tags/{tag_name}/style", response_model=KnowledgeTagDeleteStyleResponse)
 async def delete_tag_style(
     tag_name: str = Path(..., description="Tag name to reset styling for"),
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/scheduler.py
+++ b/autobot-backend/api/scheduler.py
@@ -28,6 +28,142 @@ from workflow_scheduler import WorkflowStatus, workflow_scheduler
 router = APIRouter(dependencies=[Depends(check_admin_permission)])
 
 
+# ---------------------------------------------------------------------------
+# Response models for scheduler endpoints
+# ---------------------------------------------------------------------------
+
+from typing import Any, Dict  # noqa: E402 — after logger init
+
+
+class SchedulerWorkflowCreateResponse(BaseModel):
+    """Response for POST /schedule."""
+
+    success: bool
+    workflow_id: str
+    scheduled_workflow: Any
+
+
+class SchedulerWorkflowListResponse(BaseModel):
+    """Response for GET /workflows."""
+
+    success: bool
+    workflows: List[Any]
+    total: int
+
+
+class SchedulerWorkflowDetailResponse(BaseModel):
+    """Response for GET /workflows/{workflow_id}."""
+
+    success: bool
+    workflow: Any
+
+
+class SchedulerRescheduleWorkflowItem(BaseModel):
+    id: str
+    scheduled_time: str
+    priority: str
+    status: str
+    complexity: str
+
+
+class SchedulerRescheduleResponse(BaseModel):
+    """Response for PUT /workflows/{workflow_id}/reschedule."""
+
+    success: bool
+    message: str
+    workflow: SchedulerRescheduleWorkflowItem
+
+
+class SchedulerCancelResponse(BaseModel):
+    """Response for DELETE /workflows/{workflow_id}."""
+
+    success: bool
+    message: str
+    workflow_id: str
+
+
+class SchedulerStatusResponse(BaseModel):
+    """Response for GET /status."""
+
+    success: bool
+    scheduler_status: Any
+
+
+class SchedulerQueueWorkflowItem(BaseModel):
+    id: str
+    name: str
+    priority: str
+    complexity: str
+    estimated_duration_minutes: int
+
+
+class SchedulerQueueResponse(BaseModel):
+    """Response for GET /queue."""
+
+    success: bool
+    queue_status: Any
+    queued_workflows: List[SchedulerQueueWorkflowItem]
+    running_workflows: List[SchedulerQueueWorkflowItem]
+
+
+class SchedulerQueueControlResponse(BaseModel):
+    """Response for POST /queue/control."""
+
+    success: bool
+    message: str
+    queue_status: Any
+
+
+class SchedulerStartResponse(BaseModel):
+    """Response for POST /start."""
+
+    success: bool
+    message: str
+    status: Any
+
+
+class SchedulerStopResponse(BaseModel):
+    """Response for POST /stop."""
+
+    success: bool
+    message: str
+
+
+class SchedulerTemplateWorkflowItem(BaseModel):
+    id: str
+    name: str
+    scheduled_time: str
+    priority: str
+    status: str
+    complexity: str
+
+
+class SchedulerTemplateScheduleResponse(BaseModel):
+    """Response for GET /templates/schedule/{template_id}."""
+
+    success: bool
+    workflow_id: str
+    template_info: Dict[str, Any]
+    scheduled_workflow: SchedulerTemplateWorkflowItem
+
+
+class SchedulerStatsResponse(BaseModel):
+    """Response for GET /stats."""
+
+    success: bool
+    statistics: Dict[str, Any]
+
+
+class SchedulerBatchScheduleResponse(BaseModel):
+    """Response for POST /batch-schedule."""
+
+    success: bool
+    scheduled_workflows: List[str]
+    errors: List[str]
+    total_scheduled: int
+    total_errors: int
+
+
 class ScheduleWorkflowRequest(BaseModel):
     user_message: str
     scheduled_time: Union[str, datetime]
@@ -59,7 +195,7 @@ class QueueControlRequest(BaseModel):
     operation="schedule_workflow",
     error_code_prefix="SCHEDULER",
 )
-@router.post("/schedule")
+@router.post("/schedule", response_model=SchedulerWorkflowCreateResponse)
 async def schedule_workflow(request: ScheduleWorkflowRequest):
     """Schedule a workflow for future execution"""
     # Validate priority
@@ -103,7 +239,7 @@ async def schedule_workflow(request: ScheduleWorkflowRequest):
     operation="list_scheduled_workflows",
     error_code_prefix="SCHEDULER",
 )
-@router.get("/workflows")
+@router.get("/workflows", response_model=SchedulerWorkflowListResponse)
 async def list_scheduled_workflows(
     status: Optional[str] = Query(None, description="Filter by status"),
     user_id: Optional[str] = Query(None, description="Filter by user ID"),
@@ -142,7 +278,7 @@ async def list_scheduled_workflows(
     operation="get_workflow_details",
     error_code_prefix="SCHEDULER",
 )
-@router.get("/workflows/{workflow_id}")
+@router.get("/workflows/{workflow_id}", response_model=SchedulerWorkflowDetailResponse)
 async def get_workflow_details(workflow_id: str):
     """Get detailed information about a specific scheduled workflow (Issue #372)"""
     workflow = workflow_scheduler.get_workflow(workflow_id)
@@ -161,7 +297,7 @@ async def get_workflow_details(workflow_id: str):
     operation="reschedule_workflow",
     error_code_prefix="SCHEDULER",
 )
-@router.put("/workflows/{workflow_id}/reschedule")
+@router.put("/workflows/{workflow_id}/reschedule", response_model=SchedulerRescheduleResponse)
 async def reschedule_workflow(workflow_id: str, request: RescheduleRequest):
     """Reschedule an existing workflow"""
     # Parse new priority if provided
@@ -204,7 +340,7 @@ async def reschedule_workflow(workflow_id: str, request: RescheduleRequest):
     operation="cancel_workflow",
     error_code_prefix="SCHEDULER",
 )
-@router.delete("/workflows/{workflow_id}")
+@router.delete("/workflows/{workflow_id}", response_model=SchedulerCancelResponse)
 async def cancel_workflow(workflow_id: str):
     """Cancel a scheduled or queued workflow"""
     success = workflow_scheduler.cancel_workflow(workflow_id)
@@ -226,7 +362,7 @@ async def cancel_workflow(workflow_id: str):
     operation="get_scheduler_status",
     error_code_prefix="SCHEDULER",
 )
-@router.get("/status")
+@router.get("/status", response_model=SchedulerStatusResponse)
 async def get_scheduler_status():
     """Get current scheduler and queue status"""
     status = workflow_scheduler.get_scheduler_status()
@@ -239,7 +375,7 @@ async def get_scheduler_status():
     operation="get_queue_status",
     error_code_prefix="SCHEDULER",
 )
-@router.get("/queue")
+@router.get("/queue", response_model=SchedulerQueueResponse)
 async def get_queue_status():
     """Get current queue status and workflows"""
     queue_status = workflow_scheduler.queue.get_queue_status()
@@ -284,7 +420,7 @@ async def get_queue_status():
     operation="control_queue",
     error_code_prefix="SCHEDULER",
 )
-@router.post("/queue/control")
+@router.post("/queue/control", response_model=SchedulerQueueControlResponse)
 async def control_queue(request: QueueControlRequest):
     """Control queue operations (pause, resume, set max concurrent)"""
     if request.action == "pause":
@@ -316,7 +452,7 @@ async def control_queue(request: QueueControlRequest):
     operation="start_scheduler",
     error_code_prefix="SCHEDULER",
 )
-@router.post("/start")
+@router.post("/start", response_model=SchedulerStartResponse)
 async def start_scheduler():
     """Start the workflow scheduler"""
     await workflow_scheduler.start()
@@ -333,7 +469,7 @@ async def start_scheduler():
     operation="stop_scheduler",
     error_code_prefix="SCHEDULER",
 )
-@router.post("/stop")
+@router.post("/stop", response_model=SchedulerStopResponse)
 async def stop_scheduler():
     """Stop the workflow scheduler"""
     await workflow_scheduler.stop()
@@ -416,7 +552,7 @@ def _build_template_schedule_request(
     operation="schedule_template_workflow",
     error_code_prefix="SCHEDULER",
 )
-@router.get("/templates/schedule/{template_id}")
+@router.get("/templates/schedule/{template_id}", response_model=SchedulerTemplateScheduleResponse)
 async def schedule_template_workflow(
     template_id: str,
     scheduled_time: str = Query(..., description="When to execute the workflow"),
@@ -476,7 +612,7 @@ async def schedule_template_workflow(
     operation="get_scheduler_statistics",
     error_code_prefix="SCHEDULER",
 )
-@router.get("/stats")
+@router.get("/stats", response_model=SchedulerStatsResponse)
 async def get_scheduler_statistics():
     """Get detailed scheduler statistics"""
     status = workflow_scheduler.get_scheduler_status()
@@ -531,7 +667,7 @@ async def get_scheduler_statistics():
     operation="batch_schedule_workflows",
     error_code_prefix="SCHEDULER",
 )
-@router.post("/batch-schedule")
+@router.post("/batch-schedule", response_model=SchedulerBatchScheduleResponse)
 async def batch_schedule_workflows(workflows: List[ScheduleWorkflowRequest]):
     """Schedule multiple workflows in batch"""
     scheduled_workflows = []


### PR DESCRIPTION
## Summary
- Annotates 54 endpoints across `filesystem_mcp.py` (14), `knowledge_tags.py` (14), `scheduler.py` (13), `error_monitoring.py` (13)
- All new models are file-local (no schemas_common.py changes needed)
- error_monitoring uses a shared `ErrorMonitoringDataResponse` envelope for 8 endpoints returning `{"status", "data": Any}`

## Part of #5317 (Round 3c)
🤖 Generated with [Claude Code](https://claude.com/claude-code)