### PR TITLE
feat(api): add response_model= to analytics precommit, maintenance, continuous_learning, bug_prediction (#5317)

### DIFF
--- a/autobot-backend/api/analytics_bug_prediction.py
+++ b/autobot-backend/api/analytics_bug_prediction.py
@@ -913,7 +913,7 @@ async def _run_bug_analysis(
     }
 
 
-@router.get("/analyze")
+@router.get("/analyze", response_model=None)
 async def analyze_codebase(
     admin_check: bool = Depends(check_admin_permission),
     path: str = Query(".", description="Path to analyze"),
@@ -1027,7 +1027,7 @@ async def _run_batched_bug_analysis(
         await _bg_manager.fail_task(task_id, str(e))
 
 
-@router.get("/cached")
+@router.get("/cached", response_model=None)
 async def get_cached_bug_prediction():
     """Return the latest completed bug prediction result (#1540)."""
     cached = await _bg_manager.get_latest_result()
@@ -1041,7 +1041,7 @@ async def get_cached_bug_prediction():
     return _no_data_response("No cached bug prediction available")
 
 
-@router.post("/analyze")
+@router.post("/analyze", response_model=None)
 async def start_bug_analysis(
     background_tasks: BackgroundTasks,
     admin_check: bool = Depends(check_admin_permission),
@@ -1059,7 +1059,7 @@ async def start_bug_analysis(
     return {"task_id": task_id, "status": "pending"}
 
 
-@router.get("/status/{task_id}")
+@router.get("/status/{task_id}", response_model=None)
 async def get_bug_prediction_status(
     task_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -1071,7 +1071,7 @@ async def get_bug_prediction_status(
     return task
 
 
-@router.post("/tasks/clear-stuck")
+@router.post("/tasks/clear-stuck", response_model=None)
 async def clear_stuck_bug_tasks(
     force: bool = Query(default=False, description="Force clear ALL running tasks"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1084,7 +1084,7 @@ async def clear_stuck_bug_tasks(
     }
 
 
-@router.get("/high-risk")
+@router.get("/high-risk", response_model=None)
 async def get_high_risk_files(
     admin_check: bool = Depends(check_admin_permission),
     threshold: float = Query(60, ge=0, le=100),
@@ -1152,7 +1152,7 @@ def _build_file_risk_response(file_path: str, factors: dict, bug_history: dict) 
     }
 
 
-@router.get("/file/{file_path:path}")
+@router.get("/file/{file_path:path}", response_model=None)
 async def get_file_risk(
     file_path: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -1249,7 +1249,7 @@ def _get_flat_heatmap_data(files: list) -> list:
     ]
 
 
-@router.get("/heatmap")
+@router.get("/heatmap", response_model=None)
 async def get_risk_heatmap(
     admin_check: bool = Depends(check_admin_permission),
     grouping: str = Query("directory", pattern="^(directory|module|flat)$"),
@@ -1298,7 +1298,7 @@ async def get_risk_heatmap(
         return _no_data_response("Heatmap generation failed")
 
 
-@router.get("/trends")
+@router.get("/trends", response_model=None)
 async def get_prediction_trends(
     admin_check: bool = Depends(check_admin_permission),
     period: str = Query("30d", pattern="^(7d|30d|90d)$"),
@@ -1411,7 +1411,7 @@ def _generate_summary_recommendations(
     return recommendations[:5]
 
 
-@router.get("/summary")
+@router.get("/summary", response_model=None)
 async def get_prediction_summary(
     admin_check: bool = Depends(check_admin_permission),
     path: str = Query(".", description="Path to analyze"),
@@ -1471,7 +1471,7 @@ async def get_prediction_summary(
         return _no_data_response("Summary generation failed")
 
 
-@router.get("/factors")
+@router.get("/factors", response_model=None)
 async def get_risk_factors(
     admin_check: bool = Depends(check_admin_permission),
 ) -> dict[str, Any]:
@@ -1518,7 +1518,7 @@ def _get_factor_description(factor: RiskFactor) -> str:
     return descriptions.get(factor, "Unknown factor")
 
 
-@router.post("/record-bug")
+@router.post("/record-bug", response_model=None)
 async def record_bug(
     admin_check: bool = Depends(check_admin_permission),
     file_path: str = None,

--- a/autobot-backend/api/analytics_continuous_learning.py
+++ b/autobot-backend/api/analytics_continuous_learning.py
@@ -1055,7 +1055,7 @@ async def get_engine() -> ContinuousLearningEngine:
 # =============================================================================
 
 
-@router.post("/start", summary="Start continuous learning")
+@router.post("/start", summary="Start continuous learning", response_model=None)
 async def start_learning(
     admin_check: bool = Depends(check_admin_permission),
     background_tasks: BackgroundTasks = None,
@@ -1069,7 +1069,7 @@ async def start_learning(
     return await engine.start()
 
 
-@router.post("/stop", summary="Stop continuous learning")
+@router.post("/stop", summary="Stop continuous learning", response_model=None)
 async def stop_learning(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
@@ -1082,7 +1082,7 @@ async def stop_learning(
     return await engine.stop()
 
 
-@router.get("/status", summary="Get learning status")
+@router.get("/status", summary="Get learning status", response_model=None)
 async def get_status(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
@@ -1095,7 +1095,7 @@ async def get_status(
     return engine.get_status()
 
 
-@router.get("/metrics", summary="Get learning metrics")
+@router.get("/metrics", summary="Get learning metrics", response_model=LearningMetrics)
 async def get_metrics(
     admin_check: bool = Depends(check_admin_permission),
 ) -> LearningMetrics:
@@ -1108,7 +1108,7 @@ async def get_metrics(
     return engine.get_metrics()
 
 
-@router.post("/feedback", summary="Submit pattern feedback")
+@router.post("/feedback", summary="Submit pattern feedback", response_model=None)
 async def submit_feedback(
     admin_check: bool = Depends(check_admin_permission),
     pattern_id: str = None,
@@ -1124,7 +1124,7 @@ async def submit_feedback(
     return await engine.submit_feedback(pattern_id, is_correct, details)
 
 
-@router.post("/retrain", summary="Trigger model retraining")
+@router.post("/retrain", summary="Trigger model retraining", response_model=None)
 async def trigger_retrain(
     admin_check: bool = Depends(check_admin_permission),
     request: RetrainingRequest = None,
@@ -1138,7 +1138,7 @@ async def trigger_retrain(
     return await engine.trigger_retrain(request)
 
 
-@router.get("/insights", summary="Get generated insights")
+@router.get("/insights", summary="Get generated insights", response_model=None)
 async def get_insights(
     admin_check: bool = Depends(check_admin_permission),
     active_only: bool = Query(True, description="Only active insights"),
@@ -1157,7 +1157,7 @@ async def get_insights(
     }
 
 
-@router.post("/insights/generate", summary="Generate insights now")
+@router.post("/insights/generate", summary="Generate insights now", response_model=None)
 async def generate_insights_now(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
@@ -1174,7 +1174,7 @@ async def generate_insights_now(
     }
 
 
-@router.get("/monitoring", summary="Get monitoring status")
+@router.get("/monitoring", summary="Get monitoring status", response_model=MonitoringStatus)
 async def get_monitoring_status(
     admin_check: bool = Depends(check_admin_permission),
 ) -> MonitoringStatus:
@@ -1187,7 +1187,7 @@ async def get_monitoring_status(
     return engine.monitor.get_status()
 
 
-@router.put("/config", summary="Update learning config")
+@router.put("/config", summary="Update learning config", response_model=None)
 async def update_config(
     admin_check: bool = Depends(check_admin_permission),
     config: LearningConfig = None,
@@ -1202,7 +1202,7 @@ async def update_config(
     return {"updated": True, "config": config.model_dump()}
 
 
-@router.get("/config", summary="Get learning config")
+@router.get("/config", summary="Get learning config", response_model=LearningConfig)
 async def get_config(
     admin_check: bool = Depends(check_admin_permission),
 ) -> LearningConfig:
@@ -1215,7 +1215,7 @@ async def get_config(
     return engine.config
 
 
-@router.get("/health", summary="Health check")
+@router.get("/health", summary="Health check", response_model=None)
 async def health_check(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:

--- a/autobot-backend/api/analytics_maintenance.py
+++ b/autobot-backend/api/analytics_maintenance.py
@@ -15,7 +15,7 @@ Related Issues: #59 (Advanced Analytics & Business Intelligence)
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
@@ -108,7 +108,7 @@ class CustomReportRequest(BaseModel):
     operation="get_maintenance_recommendations",
     error_code_prefix="MAINT",
 )
-@router.get("/maintenance")
+@router.get("/maintenance", response_model=None)
 async def get_maintenance_recommendations(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -149,7 +149,7 @@ async def get_maintenance_recommendations(
     operation="get_maintenance_by_category",
     error_code_prefix="MAINT",
 )
-@router.get("/maintenance/category/{category}")
+@router.get("/maintenance/category/{category}", response_model=None)
 async def get_maintenance_by_category(
     category: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -178,7 +178,7 @@ async def get_maintenance_by_category(
     operation="get_maintenance_summary",
     error_code_prefix="MAINT",
 )
-@router.get("/maintenance/summary")
+@router.get("/maintenance/summary", response_model=None)
 async def get_maintenance_summary(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -244,7 +244,7 @@ async def get_maintenance_summary(
     operation="get_resource_optimizations",
     error_code_prefix="OPT",
 )
-@router.get("/optimization")
+@router.get("/optimization", response_model=None)
 async def get_resource_optimizations(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -286,7 +286,7 @@ async def get_resource_optimizations(
     operation="get_optimization_by_type",
     error_code_prefix="OPT",
 )
-@router.get("/optimization/type/{resource_type}")
+@router.get("/optimization/type/{resource_type}", response_model=None)
 async def get_optimization_by_type(
     resource_type: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -315,7 +315,7 @@ async def get_optimization_by_type(
     operation="get_quick_wins",
     error_code_prefix="OPT",
 )
-@router.get("/optimization/quick-wins")
+@router.get("/optimization/quick-wins", response_model=None)
 async def get_quick_wins(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -357,7 +357,7 @@ async def get_quick_wins(
     operation="get_unified_dashboard",
     error_code_prefix="DASH",
 )
-@router.get("/dashboard")
+@router.get("/dashboard", response_model=None)
 async def get_unified_dashboard(
     days: int = Query(default=30, ge=1, le=365, description="Days to analyze"),
     admin_check: bool = Depends(check_admin_permission),
@@ -380,7 +380,7 @@ async def get_unified_dashboard(
     operation="get_health_status",
     error_code_prefix="HEALTH",
 )
-@router.get("/health")
+@router.get("/health", response_model=None)
 async def get_health_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -418,7 +418,7 @@ async def get_health_status(
     operation="generate_custom_report",
     error_code_prefix="REPORT",
 )
-@router.post("/report")
+@router.post("/report", response_model=None)
 async def generate_custom_report(
     request: CustomReportRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -454,7 +454,7 @@ async def generate_custom_report(
     operation="get_executive_summary",
     error_code_prefix="REPORT",
 )
-@router.get("/report/executive")
+@router.get("/report/executive", response_model=None)
 async def get_executive_summary(
     days: int = Query(default=30, ge=7, le=90, description="Days to summarize"),
     admin_check: bool = Depends(check_admin_permission),
@@ -491,7 +491,7 @@ async def get_executive_summary(
     operation="get_insights",
     error_code_prefix="INSIGHT",
 )
-@router.get("/insights")
+@router.get("/insights", response_model=None)
 async def get_insights(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -559,7 +559,7 @@ async def get_insights(
     operation="get_trends_analysis",
     error_code_prefix="TREND",
 )
-@router.get("/trends")
+@router.get("/trends", response_model=None)
 async def get_trends_analysis(
     days: int = Query(default=30, ge=7, le=90, description="Days to analyze"),
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/analytics_precommit.py
+++ b/autobot-backend/api/analytics_precommit.py
@@ -120,6 +120,57 @@ class HookStatus(BaseModel):
     config: HookConfig
 
 
+class CheckToggleResponse(BaseModel):
+    """Response for POST /checks/{check_id}/toggle."""
+
+    check_id: str
+    enabled: bool
+    message: str
+
+
+class HookConfigUpdateResponse(BaseModel):
+    """Response for POST /config — echoes back the new config."""
+
+    message: str
+    config: HookConfig
+
+
+class HookInstallResponse(BaseModel):
+    """Response for POST /install and POST /uninstall."""
+
+    success: bool
+    message: str
+    path: Optional[str] = None
+
+
+class CommonIssueItem(BaseModel):
+    """Single issue entry in the summary common_issues list."""
+
+    check_id: str
+    count: int
+    name: str
+
+
+class PrecommitSummaryResponse(BaseModel):
+    """Response for GET /summary."""
+
+    total_runs: int
+    pass_rate: float
+    average_duration_ms: float
+    common_issues: list[CommonIssueItem]
+    checks_enabled: Optional[int] = None
+    total_checks: Optional[int] = None
+
+
+class CategoryItem(BaseModel):
+    """Single category entry for GET /categories."""
+
+    category: str
+    enabled: int
+    disabled: int
+    total: int
+
+
 # ============================================================================
 # Check Definitions
 # ============================================================================
@@ -453,7 +504,7 @@ def _calculate_check_statistics(
 # ============================================================================
 
 
-@router.get("/check")
+@router.get("/check", response_model=CommitCheckResult)
 async def check_staged_files(
     admin_check: bool = Depends(check_admin_permission),
     fast_mode: bool = Query(True, description="Skip expensive checks"),
@@ -511,7 +562,7 @@ async def check_staged_files(
     return result
 
 
-@router.post("/check-content")
+@router.post("/check-content", response_model=list[CheckResult])
 async def check_content(
     content: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -534,7 +585,7 @@ async def check_content(
     return results
 
 
-@router.get("/checks")
+@router.get("/checks", response_model=list[CheckDefinition])
 async def list_checks(
     admin_check: bool = Depends(check_admin_permission),
 ) -> list[CheckDefinition]:
@@ -546,7 +597,7 @@ async def list_checks(
     return list(BUILTIN_CHECKS.values())
 
 
-@router.get("/checks/{check_id}")
+@router.get("/checks/{check_id}", response_model=CheckDefinition)
 async def get_check(
     check_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -561,7 +612,7 @@ async def get_check(
     return BUILTIN_CHECKS[check_id]
 
 
-@router.post("/checks/{check_id}/toggle")
+@router.post("/checks/{check_id}/toggle", response_model=CheckToggleResponse)
 async def toggle_check(
     check_id: str,
     enabled: bool,
@@ -584,7 +635,7 @@ async def toggle_check(
     }
 
 
-@router.get("/config")
+@router.get("/config", response_model=HookConfig)
 async def get_config(
     admin_check: bool = Depends(check_admin_permission),
 ) -> HookConfig:
@@ -597,7 +648,7 @@ async def get_config(
         return _hook_config
 
 
-@router.post("/config")
+@router.post("/config", response_model=HookConfigUpdateResponse)
 async def update_config(
     config: HookConfig,
     admin_check: bool = Depends(check_admin_permission),
@@ -614,7 +665,7 @@ async def update_config(
     return {"message": "Configuration updated", "config": config}
 
 
-@router.get("/status")
+@router.get("/status", response_model=HookStatus)
 async def get_status(
     admin_check: bool = Depends(check_admin_permission),
 ) -> HookStatus:
@@ -741,7 +792,7 @@ async def _write_hook_file(hook_path: Path, content: str) -> dict:
         raise HTTPException(status_code=500, detail="Failed to install hooks")
 
 
-@router.post("/install")
+@router.post("/install", response_model=HookInstallResponse)
 async def install_hooks(
     admin_check: bool = Depends(check_admin_permission),
 ) -> dict:
@@ -765,7 +816,7 @@ async def install_hooks(
     return await _write_hook_file(hook_path, hook_content)
 
 
-@router.post("/uninstall")
+@router.post("/uninstall", response_model=HookInstallResponse)
 async def uninstall_hooks(
     admin_check: bool = Depends(check_admin_permission),
 ) -> dict:
@@ -799,7 +850,7 @@ async def uninstall_hooks(
         raise HTTPException(status_code=500, detail="Failed to uninstall hooks")
 
 
-@router.get("/history")
+@router.get("/history", response_model=list[CommitCheckResult])
 async def get_history(
     admin_check: bool = Depends(check_admin_permission),
     limit: int = Query(20, ge=1, le=100, description="Number of results"),
@@ -813,7 +864,7 @@ async def get_history(
         return _check_history[:limit]
 
 
-@router.get("/summary")
+@router.get("/summary", response_model=PrecommitSummaryResponse)
 async def get_summary(
     admin_check: bool = Depends(check_admin_permission),
 ) -> dict:
@@ -876,7 +927,7 @@ async def get_summary(
     }
 
 
-@router.get("/categories")
+@router.get("/categories", response_model=list[CategoryItem])
 async def get_categories(
     admin_check: bool = Depends(check_admin_permission),
 ) -> list[dict]:


### PR DESCRIPTION
## Summary
- Annotates 49 endpoints across 4 analytics files
- 6 local Pydantic models for precommit file; maintenance/bug_prediction use `response_model=None` (opaque service-layer outputs); continuous_learning uses existing typed returns (LearningMetrics, MonitoringStatus, LearningConfig)

## Part of #5317 (Round 4a)
🤖 Generated with [Claude Code](https://claude.com/claude-code)