### PR TITLE
feat(api): add response_model= to knowledge_metadata, knowledge_collections, knowledge_categories, validation_dashboard (#5317)

### DIFF
--- a/autobot-backend/api/knowledge_categories.py
+++ b/autobot-backend/api/knowledge_categories.py
@@ -34,6 +34,18 @@ from api.knowledge_models import (
     SearchCategoriesByPathRequest,
     UpdateCategoryRequest,
 )
+from api.schemas_common import (
+    KnowledgeCategoryAncestorsResponse,
+    KnowledgeCategoryChildrenResponse,
+    KnowledgeCategoryCreateResponse,
+    KnowledgeCategoryDeleteResponse,
+    KnowledgeCategoryDetailResponse,
+    KnowledgeCategoryFactsResponse,
+    KnowledgeCategorySearchResponse,
+    KnowledgeCategoryTreeResponse,
+    KnowledgeCategoryUpdateResponse,
+    KnowledgeFactAssignCategoryResponse,
+)
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.threshold_constants import QueryDefaults
@@ -70,7 +82,7 @@ def _raise_kb_error(error_message: str, default_code: int = 500) -> None:
     operation="create_category",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/categories")
+@router.post("/categories", response_model=KnowledgeCategoryCreateResponse)
 async def create_category(
     request: CreateCategoryRequest,
     req: Request = None,
@@ -127,7 +139,7 @@ async def create_category(
     operation="get_category_tree",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/categories/tree")
+@router.get("/categories/tree", response_model=KnowledgeCategoryTreeResponse)
 async def get_category_tree(
     root_id: Optional[str] = Query(
         default=None, description="Start from specific category"
@@ -188,7 +200,7 @@ async def get_category_tree(
     operation="get_category",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/categories/{category_id}")
+@router.get("/categories/{category_id}", response_model=KnowledgeCategoryDetailResponse)
 async def get_category(
     category_id: str = Path(..., description="Category UUID"),
     req: Request = None,
@@ -231,7 +243,7 @@ async def get_category(
     operation="get_category_by_path",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/categories/path/{path:path}")
+@router.get("/categories/path/{path:path}", response_model=KnowledgeCategoryDetailResponse)
 async def get_category_by_path(
     path: str = Path(..., description="Category path (e.g., 'tech/python/async')"),
     req: Request = None,
@@ -269,7 +281,7 @@ async def get_category_by_path(
     operation="update_category",
     error_code_prefix="KNOWLEDGE",
 )
-@router.put("/categories/{category_id}")
+@router.put("/categories/{category_id}", response_model=KnowledgeCategoryUpdateResponse)
 async def update_category(
     category_id: str = Path(..., description="Category UUID"),
     request: UpdateCategoryRequest = ...,
@@ -334,7 +346,7 @@ async def update_category(
     operation="delete_category",
     error_code_prefix="KNOWLEDGE",
 )
-@router.delete("/categories/{category_id}")
+@router.delete("/categories/{category_id}", response_model=KnowledgeCategoryDeleteResponse)
 async def delete_category(
     category_id: str = Path(..., description="Category UUID"),
     recursive: bool = Query(default=False, description="Delete descendants"),
@@ -416,7 +428,7 @@ def _raise_delete_category_error(result: dict) -> None:
     operation="get_category_children",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/categories/{category_id}/children")
+@router.get("/categories/{category_id}/children", response_model=KnowledgeCategoryChildrenResponse)
 async def get_category_children(
     category_id: str = Path(..., description="Parent category UUID"),
     req: Request = None,
@@ -462,7 +474,7 @@ async def get_category_children(
     operation="get_category_ancestors",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/categories/{category_id}/ancestors")
+@router.get("/categories/{category_id}/ancestors", response_model=KnowledgeCategoryAncestorsResponse)
 async def get_category_ancestors(
     category_id: str = Path(..., description="Category UUID"),
     req: Request = None,
@@ -511,7 +523,7 @@ async def get_category_ancestors(
     operation="get_facts_in_category",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/categories/{category_id}/facts")
+@router.get("/categories/{category_id}/facts", response_model=KnowledgeCategoryFactsResponse)
 async def get_facts_in_category(
     category_id: str = Path(..., description="Category UUID"),
     include_descendants: bool = Query(
@@ -576,7 +588,7 @@ async def get_facts_in_category(
     operation="assign_fact_to_category",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/facts/{fact_id}/category")
+@router.post("/facts/{fact_id}/category", response_model=KnowledgeFactAssignCategoryResponse)
 async def assign_fact_to_category(
     fact_id: str = Path(..., description="Fact UUID"),
     request: AssignFactToCategoryRequest = ...,
@@ -631,7 +643,7 @@ async def assign_fact_to_category(
     operation="search_categories_by_path",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/categories/search")
+@router.post("/categories/search", response_model=KnowledgeCategorySearchResponse)
 async def search_categories_by_path(
     request: SearchCategoriesByPathRequest,
     req: Request = None,

--- a/autobot-backend/api/knowledge_collections.py
+++ b/autobot-backend/api/knowledge_collections.py
@@ -33,6 +33,19 @@ from api.knowledge_models import (
     CreateCollectionRequest,
     UpdateCollectionRequest,
 )
+from api.schemas_common import (
+    KnowledgeCollectionAddFactsResponse,
+    KnowledgeCollectionBulkDeleteResponse,
+    KnowledgeCollectionCreateResponse,
+    KnowledgeCollectionDeleteResponse,
+    KnowledgeCollectionDetailResponse,
+    KnowledgeCollectionExportResponse,
+    KnowledgeCollectionFactsListResponse,
+    KnowledgeCollectionListResponse,
+    KnowledgeCollectionRemoveFactsResponse,
+    KnowledgeCollectionUpdateResponse,
+    KnowledgeFactCollectionsResponse,
+)
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.models.pagination import PaginationParams
@@ -66,7 +79,7 @@ def _raise_kb_error(error_message: str, default_code: int = 500) -> None:
     operation="create_collection",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/collections")
+@router.post("/collections", response_model=KnowledgeCollectionCreateResponse)
 async def create_collection(
     request: CreateCollectionRequest,
     req: Request = None,
@@ -121,7 +134,7 @@ async def create_collection(
     operation="list_collections",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/collections")
+@router.get("/collections", response_model=KnowledgeCollectionListResponse)
 async def list_collections(
     pagination: PaginationParams = Depends(),
     sort_by: str = Query(default="name", pattern="^(name|created_at|fact_count)$"),
@@ -175,7 +188,7 @@ async def list_collections(
     operation="get_collection",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/collections/{collection_id}")
+@router.get("/collections/{collection_id}", response_model=KnowledgeCollectionDetailResponse)
 async def get_collection(
     collection_id: str = Path(..., description="Collection UUID"),
     req: Request = None,
@@ -224,7 +237,7 @@ async def get_collection(
     operation="update_collection",
     error_code_prefix="KNOWLEDGE",
 )
-@router.put("/collections/{collection_id}")
+@router.put("/collections/{collection_id}", response_model=KnowledgeCollectionUpdateResponse)
 async def update_collection(
     collection_id: str = Path(..., description="Collection UUID"),
     request: UpdateCollectionRequest = ...,
@@ -289,7 +302,7 @@ async def update_collection(
     operation="delete_collection",
     error_code_prefix="KNOWLEDGE",
 )
-@router.delete("/collections/{collection_id}")
+@router.delete("/collections/{collection_id}", response_model=KnowledgeCollectionDeleteResponse)
 async def delete_collection(
     collection_id: str = Path(..., description="Collection UUID"),
     delete_facts: bool = Query(default=False, description="Also delete all facts"),
@@ -354,7 +367,7 @@ async def delete_collection(
     operation="add_facts_to_collection",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/collections/{collection_id}/facts")
+@router.post("/collections/{collection_id}/facts", response_model=KnowledgeCollectionAddFactsResponse)
 async def add_facts_to_collection(
     collection_id: str = Path(..., description="Collection UUID"),
     request: CollectionFactsRequest = ...,
@@ -419,7 +432,7 @@ async def add_facts_to_collection(
     operation="remove_facts_from_collection",
     error_code_prefix="KNOWLEDGE",
 )
-@router.delete("/collections/{collection_id}/facts")
+@router.delete("/collections/{collection_id}/facts", response_model=KnowledgeCollectionRemoveFactsResponse)
 async def remove_facts_from_collection(
     collection_id: str = Path(..., description="Collection UUID"),
     request: CollectionFactsRequest = ...,
@@ -482,7 +495,7 @@ async def remove_facts_from_collection(
     operation="get_facts_in_collection",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/collections/{collection_id}/facts")
+@router.get("/collections/{collection_id}/facts", response_model=KnowledgeCollectionFactsListResponse)
 async def get_facts_in_collection(
     collection_id: str = Path(..., description="Collection UUID"),
     pagination: PaginationParams = Depends(),
@@ -548,7 +561,7 @@ async def get_facts_in_collection(
     operation="get_fact_collections",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/facts/{fact_id}/collections")
+@router.get("/facts/{fact_id}/collections", response_model=KnowledgeFactCollectionsResponse)
 async def get_fact_collections(
     fact_id: str = Path(..., description="Fact UUID"),
     req: Request = None,
@@ -603,7 +616,7 @@ async def get_fact_collections(
     operation="export_collection",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/collections/{collection_id}/export")
+@router.post("/collections/{collection_id}/export", response_model=KnowledgeCollectionExportResponse)
 async def export_collection(
     collection_id: str = Path(..., description="Collection UUID"),
     include_content: bool = Query(default=True, description="Include fact content"),
@@ -667,7 +680,7 @@ async def export_collection(
     operation="bulk_delete_collection_facts",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/collections/{collection_id}/bulk-delete")
+@router.post("/collections/{collection_id}/bulk-delete", response_model=KnowledgeCollectionBulkDeleteResponse)
 async def bulk_delete_collection_facts(
     collection_id: str = Path(..., description="Collection UUID"),
     confirm: bool = Query(default=False, description="Must be True to delete"),

--- a/autobot-backend/api/knowledge_metadata.py
+++ b/autobot-backend/api/knowledge_metadata.py
@@ -26,6 +26,19 @@ from api.knowledge_models import (
     UpdateMetadataTemplateRequest,
     ValidateMetadataRequest,
 )
+from api.schemas_common import (
+    KnowledgeFactRevertResponse,
+    KnowledgeFactVersionCompareResponse,
+    KnowledgeFactVersionDetailResponse,
+    KnowledgeFactVersionHistoryDeleteResponse,
+    KnowledgeFactVersionListResponse,
+    KnowledgeMetadataSearchResponse,
+    KnowledgeMetadataTemplateDeleteResponse,
+    KnowledgeMetadataTemplateDetailResponse,
+    KnowledgeMetadataTemplateListResponse,
+    KnowledgeMetadataTemplateResponse,
+    KnowledgeMetadataValidateResponse,
+)
 from auth_middleware import check_admin_permission
 from constants.error_constants import ERR_TEMPLATE_NOT_FOUND
 from knowledge import get_knowledge_base
@@ -43,7 +56,7 @@ router = APIRouter(
 # ============================================================================
 
 
-@router.post("/metadata/templates")
+@router.post("/metadata/templates", response_model=KnowledgeMetadataTemplateResponse)
 async def create_metadata_template(request: CreateMetadataTemplateRequest):
     """
     Create a new metadata template.
@@ -93,7 +106,7 @@ async def create_metadata_template(request: CreateMetadataTemplateRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/metadata/templates")
+@router.get("/metadata/templates", response_model=KnowledgeMetadataTemplateListResponse)
 async def list_metadata_templates(category: str = None):
     """
     List all metadata templates, optionally filtered by category.
@@ -120,7 +133,7 @@ async def list_metadata_templates(category: str = None):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/metadata/templates/{template_id}")
+@router.get("/metadata/templates/{template_id}", response_model=KnowledgeMetadataTemplateDetailResponse)
 async def get_metadata_template(template_id: str):
     """Get a specific metadata template by ID."""
     try:
@@ -139,7 +152,7 @@ async def get_metadata_template(template_id: str):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.put("/metadata/templates/{template_id}")
+@router.put("/metadata/templates/{template_id}", response_model=KnowledgeMetadataTemplateResponse)
 async def update_metadata_template(
     template_id: str, request: UpdateMetadataTemplateRequest
 ):
@@ -176,7 +189,7 @@ async def update_metadata_template(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.delete("/metadata/templates/{template_id}")
+@router.delete("/metadata/templates/{template_id}", response_model=KnowledgeMetadataTemplateDeleteResponse)
 async def delete_metadata_template(template_id: str):
     """Delete a metadata template."""
     try:
@@ -204,7 +217,7 @@ async def delete_metadata_template(template_id: str):
 # ============================================================================
 
 
-@router.post("/metadata/validate")
+@router.post("/metadata/validate", response_model=KnowledgeMetadataValidateResponse)
 async def validate_metadata(request: ValidateMetadataRequest):
     """
     Validate metadata against applicable templates.
@@ -231,7 +244,7 @@ async def validate_metadata(request: ValidateMetadataRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/metadata/search")
+@router.post("/metadata/search", response_model=KnowledgeMetadataSearchResponse)
 async def search_by_metadata(request: SearchByMetadataRequest):
     """
     Search facts by metadata field value.
@@ -283,7 +296,7 @@ async def search_by_metadata(request: SearchByMetadataRequest):
 # ============================================================================
 
 
-@router.get("/facts/{fact_id}/versions")
+@router.get("/facts/{fact_id}/versions", response_model=KnowledgeFactVersionListResponse)
 async def list_fact_versions(fact_id: str, limit: int = 10):
     """
     List version history for a fact.
@@ -316,7 +329,7 @@ async def list_fact_versions(fact_id: str, limit: int = 10):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/facts/{fact_id}/versions/{version}")
+@router.get("/facts/{fact_id}/versions/{version}", response_model=KnowledgeFactVersionDetailResponse)
 async def get_fact_version(fact_id: str, version: int):
     """
     Get a specific version of a fact.
@@ -342,7 +355,7 @@ async def get_fact_version(fact_id: str, version: int):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/facts/{fact_id}/revert")
+@router.post("/facts/{fact_id}/revert", response_model=KnowledgeFactRevertResponse)
 async def revert_to_version(fact_id: str, request: RevertToVersionRequest):
     """
     Revert a fact to a previous version.
@@ -382,7 +395,7 @@ async def revert_to_version(fact_id: str, request: RevertToVersionRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/facts/{fact_id}/versions/compare")
+@router.post("/facts/{fact_id}/versions/compare", response_model=KnowledgeFactVersionCompareResponse)
 async def compare_versions(fact_id: str, request: CompareVersionsRequest):
     """
     Compare two versions of a fact.
@@ -412,7 +425,7 @@ async def compare_versions(fact_id: str, request: CompareVersionsRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.delete("/facts/{fact_id}/versions")
+@router.delete("/facts/{fact_id}/versions", response_model=KnowledgeFactVersionHistoryDeleteResponse)
 async def delete_version_history(fact_id: str, confirm: bool = False):
     """
     Delete all version history for a fact.

--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -1073,3 +1073,418 @@ class AgentTerminalPendingSelectionsResponse(BaseModel):
     pending_selections: List[Dict[str, Any]]
 
 
+# ---------------------------------------------------------------------------
+# knowledge_metadata.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeMetadataTemplateResponse(BaseModel):
+    """Response for POST /metadata/templates and PUT /metadata/templates/{id}."""
+
+    status: str
+    message: Optional[str] = None
+    template: Optional[Dict[str, Any]] = None
+
+    model_config = {"extra": "allow"}
+
+
+class KnowledgeMetadataTemplateListResponse(BaseModel):
+    """Response for GET /metadata/templates."""
+
+    status: str
+    count: Optional[int] = None
+    templates: Optional[List[Any]] = None
+
+    model_config = {"extra": "allow"}
+
+
+class KnowledgeMetadataTemplateDetailResponse(BaseModel):
+    """Response for GET /metadata/templates/{template_id}."""
+
+    status: str
+    template: Optional[Dict[str, Any]] = None
+
+    model_config = {"extra": "allow"}
+
+
+class KnowledgeMetadataTemplateDeleteResponse(BaseModel):
+    """Response for DELETE /metadata/templates/{template_id}."""
+
+    status: str
+    message: Optional[str] = None
+
+    model_config = {"extra": "allow"}
+
+
+class KnowledgeMetadataValidateResponse(BaseModel):
+    """Response for POST /metadata/validate."""
+
+    valid: Optional[bool] = None
+    errors: Optional[List[Any]] = None
+    warnings: Optional[List[Any]] = None
+
+    model_config = {"extra": "allow"}
+
+
+class KnowledgeMetadataSearchResponse(BaseModel):
+    """Response for POST /metadata/search."""
+
+    status: str
+    count: Optional[int] = None
+    facts: Optional[List[Any]] = None
+
+    model_config = {"extra": "allow"}
+
+
+class KnowledgeFactVersionListResponse(BaseModel):
+    """Response for GET /facts/{fact_id}/versions."""
+
+    status: str
+    fact_id: Optional[str] = None
+    versions: Optional[List[Any]] = None
+    count: Optional[int] = None
+
+    model_config = {"extra": "allow"}
+
+
+class KnowledgeFactVersionDetailResponse(BaseModel):
+    """Response for GET /facts/{fact_id}/versions/{version}."""
+
+    status: str
+    fact_id: Optional[str] = None
+    version: Optional[int] = None
+    content: Optional[Any] = None
+
+    model_config = {"extra": "allow"}
+
+
+class KnowledgeFactRevertResponse(BaseModel):
+    """Response for POST /facts/{fact_id}/revert."""
+
+    status: str
+    message: Optional[str] = None
+    new_version: Optional[int] = None
+
+    model_config = {"extra": "allow"}
+
+
+class KnowledgeFactVersionCompareResponse(BaseModel):
+    """Response for POST /facts/{fact_id}/versions/compare."""
+
+    status: str
+    fact_id: Optional[str] = None
+    version_a: Optional[int] = None
+    version_b: Optional[int] = None
+    diff: Optional[Any] = None
+
+    model_config = {"extra": "allow"}
+
+
+class KnowledgeFactVersionHistoryDeleteResponse(BaseModel):
+    """Response for DELETE /facts/{fact_id}/versions."""
+
+    status: str
+    message: Optional[str] = None
+
+    model_config = {"extra": "allow"}
+
+
+# ---------------------------------------------------------------------------
+# knowledge_collections.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeCollectionCreateResponse(BaseModel):
+    """Response for POST /collections."""
+
+    status: str
+    collection: Optional[Dict[str, Any]] = None
+    message: Optional[str] = None
+
+
+class KnowledgeCollectionListResponse(BaseModel):
+    """Response for GET /collections."""
+
+    status: str
+    collections: List[Any]
+    total_count: int
+    returned_count: int
+    limit: int
+    offset: int
+    has_more: bool
+
+
+class KnowledgeCollectionDetailResponse(BaseModel):
+    """Response for GET /collections/{collection_id}."""
+
+    status: str
+    collection: Optional[Dict[str, Any]] = None
+
+
+class KnowledgeCollectionUpdateResponse(BaseModel):
+    """Response for PUT /collections/{collection_id}."""
+
+    status: str
+    collection: Optional[Dict[str, Any]] = None
+    message: Optional[str] = None
+
+
+class KnowledgeCollectionDeleteResponse(BaseModel):
+    """Response for DELETE /collections/{collection_id}."""
+
+    status: str
+    collection_id: Optional[str] = None
+    facts_in_collection: int
+    facts_deleted: int
+    message: Optional[str] = None
+
+
+class KnowledgeCollectionAddFactsResponse(BaseModel):
+    """Response for POST /collections/{collection_id}/facts."""
+
+    status: str
+    collection_id: Optional[str] = None
+    added_count: int
+    already_in_collection: int
+    not_found: List[Any]
+    total_facts: int
+    message: Optional[str] = None
+
+
+class KnowledgeCollectionRemoveFactsResponse(BaseModel):
+    """Response for DELETE /collections/{collection_id}/facts."""
+
+    status: str
+    collection_id: Optional[str] = None
+    removed_count: int
+    not_in_collection: int
+    total_facts: int
+    message: Optional[str] = None
+
+
+class KnowledgeCollectionFactsListResponse(BaseModel):
+    """Response for GET /collections/{collection_id}/facts."""
+
+    status: str
+    collection_id: Optional[str] = None
+    collection_name: Optional[str] = None
+    facts: List[Any]
+    total_count: int
+    returned_count: int
+    limit: int
+    offset: int
+    has_more: bool
+
+
+class KnowledgeFactCollectionsResponse(BaseModel):
+    """Response for GET /facts/{fact_id}/collections."""
+
+    status: str
+    fact_id: Optional[str] = None
+    collections: List[Any]
+    count: int
+
+
+class KnowledgeCollectionExportResponse(BaseModel):
+    """Response for POST /collections/{collection_id}/export."""
+
+    status: str
+    collection: Optional[Dict[str, Any]] = None
+    facts: List[Any]
+    total_count: int
+    exported_at: Optional[str] = None
+
+
+class KnowledgeCollectionBulkDeleteResponse(BaseModel):
+    """Response for POST /collections/{collection_id}/bulk-delete."""
+
+    status: str
+    collection_id: Optional[str] = None
+    facts_to_delete: Optional[int] = None
+    deleted_count: int
+    confirm_required: bool
+    message: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# knowledge_categories.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeCategoryCreateResponse(BaseModel):
+    """Response for POST /categories."""
+
+    status: str
+    category: Optional[Dict[str, Any]] = None
+    message: Optional[str] = None
+
+
+class KnowledgeCategoryTreeResponse(BaseModel):
+    """Response for GET /categories/tree."""
+
+    status: str
+    tree: List[Any]
+    total_categories: int
+
+
+class KnowledgeCategoryDetailResponse(BaseModel):
+    """Response for GET /categories/{category_id} and GET /categories/path/{path}."""
+
+    status: str
+    category: Optional[Dict[str, Any]] = None
+
+
+class KnowledgeCategoryUpdateResponse(BaseModel):
+    """Response for PUT /categories/{category_id}."""
+
+    status: str
+    category: Optional[Dict[str, Any]] = None
+    message: Optional[str] = None
+
+
+class KnowledgeCategoryDeleteResponse(BaseModel):
+    """Response for DELETE /categories/{category_id}."""
+
+    status: str
+    deleted_count: int
+    facts_reassigned: int
+    message: Optional[str] = None
+
+
+class KnowledgeCategoryChildrenResponse(BaseModel):
+    """Response for GET /categories/{category_id}/children."""
+
+    status: str
+    parent_id: Optional[str] = None
+    children: List[Any]
+    count: int
+
+
+class KnowledgeCategoryAncestorsResponse(BaseModel):
+    """Response for GET /categories/{category_id}/ancestors."""
+
+    status: str
+    category_id: Optional[str] = None
+    ancestors: List[Any]
+    depth: int
+
+
+class KnowledgeCategoryFactsResponse(BaseModel):
+    """Response for GET /categories/{category_id}/facts."""
+
+    status: str
+    category_id: Optional[str] = None
+    category_path: Optional[str] = None
+    facts: List[Any]
+    total_count: int
+    returned_count: int
+    limit: int
+    offset: int
+    has_more: bool
+    include_descendants: bool
+
+
+class KnowledgeFactAssignCategoryResponse(BaseModel):
+    """Response for POST /facts/{fact_id}/category."""
+
+    status: str
+    fact_id: Optional[str] = None
+    category_id: Optional[str] = None
+    category_path: Optional[str] = None
+    message: Optional[str] = None
+
+
+class KnowledgeCategorySearchResponse(BaseModel):
+    """Response for POST /categories/search."""
+
+    status: str
+    pattern: Optional[str] = None
+    categories: List[Any]
+    count: int
+
+
+# ---------------------------------------------------------------------------
+# validation_dashboard.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class ValidationDashboardStatusResponse(BaseModel):
+    """Response for GET /status (healthy path; unavailable path uses JSONResponse)."""
+
+    status: str
+    service: str
+    output_directory: Optional[str] = None
+    refresh_interval: Optional[int] = None
+    data_retention_days: Optional[int] = None
+    timestamp: str
+
+
+class ValidationDashboardReportResponse(BaseModel):
+    """Response for GET /report."""
+
+    status: str
+    report: Optional[Any] = None
+    timestamp: str
+
+
+class ValidationDashboardGenerateResponse(BaseModel):
+    """Response for POST /generate."""
+
+    status: str
+    message: str
+    settings: Dict[str, Any]
+    timestamp: str
+
+
+class ValidationDashboardMetricsResponse(BaseModel):
+    """Response for GET /metrics."""
+
+    status: str
+    metrics: Dict[str, Any]
+    timestamp: str
+
+
+class ValidationDashboardTrendsResponse(BaseModel):
+    """Response for GET /trends."""
+
+    status: str
+    trends: Optional[Any] = None
+    timestamp: str
+
+
+class ValidationDashboardAlertsResponse(BaseModel):
+    """Response for GET /alerts."""
+
+    status: str
+    alerts: List[Any]
+    alert_counts: Dict[str, int]
+    timestamp: str
+
+
+class ValidationDashboardRecommendationsResponse(BaseModel):
+    """Response for GET /recommendations."""
+
+    status: str
+    recommendations: List[Any]
+    recommendation_counts: Dict[str, int]
+    timestamp: str
+
+
+class ValidationJudgmentResponse(BaseModel):
+    """Response for POST /judge_workflow_step and POST /judge_agent_response."""
+
+    status: str
+    judgment: Dict[str, Any]
+    timestamp: str
+
+
+class ValidationJudgeStatusResponse(BaseModel):
+    """Response for GET /judge_status (healthy path; unavailable path uses JSONResponse)."""
+
+    status: str
+    service: str
+    available_judges: List[str]
+    judge_metrics: Dict[str, Any]
+    timestamp: str
+
+

--- a/autobot-backend/api/validation_dashboard.py
+++ b/autobot-backend/api/validation_dashboard.py
@@ -19,6 +19,15 @@ from fastapi import APIRouter, BackgroundTasks
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from pydantic import BaseModel
 
+from api.schemas_common import (
+    ValidationDashboardAlertsResponse,
+    ValidationDashboardGenerateResponse,
+    ValidationDashboardMetricsResponse,
+    ValidationDashboardRecommendationsResponse,
+    ValidationDashboardReportResponse,
+    ValidationDashboardTrendsResponse,
+    ValidationJudgmentResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from type_defs.common import Metadata
 from utils.catalog_http_exceptions import (
@@ -150,7 +159,7 @@ class DashboardGenerateRequest(BaseModel):
     operation="get_dashboard_status",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.get("/status")
+@router.get("/status", response_model=None)
 async def get_dashboard_status():
     """Get validation dashboard service status"""
     generator = get_dashboard_generator()
@@ -185,7 +194,7 @@ async def get_dashboard_status():
     operation="get_validation_report",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.get("/report")
+@router.get("/report", response_model=ValidationDashboardReportResponse)
 async def get_validation_report():
     """Get current validation report data.
 
@@ -238,7 +247,7 @@ async def get_validation_report():
     operation="get_dashboard_html",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.get("/dashboard", response_class=HTMLResponse)
+@router.get("/dashboard", response_class=HTMLResponse, response_model=None)
 async def get_dashboard_html():
     """Get HTML validation dashboard"""
     generator = get_dashboard_generator()
@@ -296,7 +305,7 @@ async def get_dashboard_html():
     operation="get_dashboard_file",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.get("/dashboard/file")
+@router.get("/dashboard/file", response_model=None)
 async def get_dashboard_file():
     """Get dashboard HTML file for download"""
     generator = get_dashboard_generator()
@@ -329,7 +338,7 @@ async def get_dashboard_file():
     operation="generate_dashboard",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.post("/generate")
+@router.post("/generate", response_model=ValidationDashboardGenerateResponse)
 async def generate_dashboard(
     request: DashboardGenerateRequest, background_tasks: BackgroundTasks
 ):
@@ -391,7 +400,7 @@ async def generate_dashboard(
     operation="get_dashboard_metrics",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.get("/metrics")
+@router.get("/metrics", response_model=ValidationDashboardMetricsResponse)
 async def get_dashboard_metrics():
     """Get dashboard-specific metrics"""
     generator = get_dashboard_generator()
@@ -452,7 +461,7 @@ async def get_dashboard_metrics():
     operation="get_trend_data",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.get("/trends")
+@router.get("/trends", response_model=ValidationDashboardTrendsResponse)
 async def get_trend_data():
     """Get trend data for charts"""
     generator = get_dashboard_generator()
@@ -482,7 +491,7 @@ async def get_trend_data():
     operation="get_system_alerts",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.get("/alerts")
+@router.get("/alerts", response_model=ValidationDashboardAlertsResponse)
 async def get_system_alerts():
     """Get current system alerts"""
     generator = get_dashboard_generator()
@@ -521,7 +530,7 @@ async def get_system_alerts():
     operation="get_system_recommendations",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.get("/recommendations")
+@router.get("/recommendations", response_model=ValidationDashboardRecommendationsResponse)
 async def get_system_recommendations():
     """Get current system recommendations"""
     generator = get_dashboard_generator()
@@ -569,7 +578,7 @@ async def get_system_recommendations():
     operation="judge_workflow_step",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.post("/judge_workflow_step")
+@router.post("/judge_workflow_step", response_model=ValidationJudgmentResponse)
 async def judge_workflow_step(request: dict):
     """Use LLM judges to evaluate a workflow step"""
     try:
@@ -626,7 +635,7 @@ async def judge_workflow_step(request: dict):
     operation="judge_agent_response",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.post("/judge_agent_response")
+@router.post("/judge_agent_response", response_model=ValidationJudgmentResponse)
 async def judge_agent_response(request: dict):
     """Use LLM judges to evaluate an agent response"""
     judges = get_validation_judges()
@@ -686,7 +695,7 @@ async def judge_agent_response(request: dict):
     operation="get_judge_status",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.get("/judge_status")
+@router.get("/judge_status", response_model=None)
 async def get_judge_status():
     """Get status of validation judges"""
     judges = get_validation_judges()


### PR DESCRIPTION
## Summary
- Annotates 46 endpoints across 4 knowledge/validation files
- Adds 33 typed Pydantic models to `schemas_common.py` for knowledge metadata, collections, categories, and validation dashboard domains

## Part of #5317 (Round 4b)
🤖 Generated with [Claude Code](https://claude.com/claude-code)