### PR TITLE
feat(api): add response_model= to templates, state_tracking, secrets, development_speedup, analytics_code_review (#5317)

### DIFF
--- a/autobot-backend/api/analytics_code_review.py
+++ b/autobot-backend/api/analytics_code_review.py
@@ -26,6 +26,17 @@ from api.analytics_shared import (  # noqa: F401 – used by history/metrics/sum
     resolve_source_or_404 as _resolve_source_or_404,
 )
 from api.analytics_shared import resolve_source_root_or_404 as _resolve_source_root_or_404
+from api.schemas_common import (
+    CodeReviewAnalyzeResponse,
+    CodeReviewFeedbackResponse,
+    CodeReviewFileResponse,
+    CodeReviewHistoryResponse,
+    CodeReviewMetricsResponse,
+    CodeReviewPatternPreferencesResponse,
+    CodeReviewPatternToggleResponse,
+    CodeReviewReviewByIdResponse,
+    CodeReviewSummaryResponse,
+)
 from auth_middleware import check_admin_permission, get_current_user
 from constants.threshold_constants import TimingConstants
 from constants.ttl_constants import TTL_7_DAYS
@@ -457,7 +468,7 @@ async def get_git_diff(commit_range: Optional[str] = None) -> str:
 # ============================================================================
 
 
-@router.get("/analyze")
+@router.get("/analyze", response_model=CodeReviewAnalyzeResponse)
 async def analyze_diff(
     admin_check: bool = Depends(check_admin_permission),
     commit_range: Optional[str] = Query(
@@ -576,7 +587,7 @@ async def analyze_diff(
     }
 
 
-@router.get("/review/{review_id}")
+@router.get("/review/{review_id}", response_model=CodeReviewReviewByIdResponse)
 async def get_review_by_id(
     review_id: str,
     _user: dict = Depends(get_current_user),
@@ -617,7 +628,7 @@ async def get_review_by_id(
         raise HTTPException(status_code=500, detail="Failed to retrieve review result")
 
 
-@router.post("/review-file")
+@router.post("/review-file", response_model=CodeReviewFileResponse)
 async def review_file(
     admin_check: bool = Depends(check_admin_permission),
     file_path: str = None,
@@ -659,7 +670,7 @@ async def review_file(
     }
 
 
-@router.get("/patterns")
+@router.get("/patterns", response_model=None)
 async def get_review_patterns(
     admin_check: bool = Depends(check_admin_permission),
 ) -> list[dict[str, Any]]:
@@ -684,7 +695,7 @@ async def get_review_patterns(
     ]
 
 
-@router.get("/history")
+@router.get("/history", response_model=CodeReviewHistoryResponse)
 async def get_review_history(
     admin_check: bool = Depends(check_admin_permission),
     limit: int = Query(20, ge=1, le=100),
@@ -744,7 +755,7 @@ async def get_review_history(
         )
 
 
-@router.get("/metrics")
+@router.get("/metrics", response_model=CodeReviewMetricsResponse)
 async def get_review_metrics(
     admin_check: bool = Depends(check_admin_permission),
     period: str = Query("30d", pattern="^(7d|30d|90d)$"),
@@ -765,7 +776,7 @@ async def get_review_metrics(
     )
 
 
-@router.post("/feedback")
+@router.post("/feedback", response_model=CodeReviewFeedbackResponse)
 async def submit_feedback(
     admin_check: bool = Depends(check_admin_permission),
     comment_id: str = None,
@@ -811,7 +822,7 @@ async def submit_feedback(
     }
 
 
-@router.get("/summary")
+@router.get("/summary", response_model=CodeReviewSummaryResponse)
 async def get_review_summary(
     admin_check: bool = Depends(check_admin_permission),
     source_id: Optional[str] = Query(None, description="Project source ID to scope analysis"),
@@ -831,7 +842,7 @@ async def get_review_summary(
     )
 
 
-@router.get("/categories")
+@router.get("/categories", response_model=None)
 async def get_review_categories(
     admin_check: bool = Depends(check_admin_permission),
 ) -> list[dict[str, Any]]:
@@ -858,7 +869,7 @@ class PatternToggleRequest(BaseModel):
     enabled: bool
 
 
-@router.post("/patterns/toggle")
+@router.post("/patterns/toggle", response_model=CodeReviewPatternToggleResponse)
 async def toggle_pattern_preference(
     request: PatternToggleRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -907,7 +918,7 @@ async def toggle_pattern_preference(
         raise HTTPException(status_code=500, detail="Failed to save preference")
 
 
-@router.get("/patterns/preferences")
+@router.get("/patterns/preferences", response_model=CodeReviewPatternPreferencesResponse)
 async def get_pattern_preferences(
     admin_check: bool = Depends(check_admin_permission),
 ) -> dict[str, Any]:

--- a/autobot-backend/api/development_speedup.py
+++ b/autobot-backend/api/development_speedup.py
@@ -98,7 +98,7 @@ class AnalysisRequest(BaseModel):
     operation="analyze_codebase_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.post("/analyze")
+@router.post("/analyze", response_model=None)
 async def analyze_codebase_endpoint(request: AnalysisRequest):
     """
     Comprehensive codebase analysis for development speedup.
@@ -147,7 +147,7 @@ async def analyze_codebase_endpoint(request: AnalysisRequest):
     operation="analyze_codebase_get",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/analyze")
+@router.get("/analyze", response_model=None)
 async def analyze_codebase_get(
     path: str = Query(..., description="Root path to analyze"),
     type: str = Query("comprehensive", description="Analysis type"),
@@ -168,7 +168,7 @@ async def analyze_codebase_get(
     operation="find_duplicates_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/duplicates")
+@router.get("/duplicates", response_model=None)
 async def find_duplicates_endpoint(
     path: str = Query(..., description="Root path to analyze"),
     min_lines: int = Query(
@@ -216,7 +216,7 @@ async def find_duplicates_endpoint(
     operation="analyze_patterns_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/patterns")
+@router.get("/patterns", response_model=None)
 async def analyze_patterns_endpoint(
     path: str = Query(..., description="Root path to analyze"),
     pattern_type: Optional[str] = Query(
@@ -264,7 +264,7 @@ async def analyze_patterns_endpoint(
     operation="analyze_imports_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/imports")
+@router.get("/imports", response_model=None)
 async def analyze_imports_endpoint(
     path: str = Query(..., description="Root path to analyze"),
     show_unused: bool = Query(True, description="Include potentially unused imports"),
@@ -304,7 +304,7 @@ async def analyze_imports_endpoint(
     operation="detect_dead_code_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/dead-code")
+@router.get("/dead-code", response_model=None)
 async def detect_dead_code_endpoint(
     path: str = Query(..., description="Root path to analyze")
 ):
@@ -338,7 +338,7 @@ async def detect_dead_code_endpoint(
     operation="find_refactoring_opportunities_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/refactoring")
+@router.get("/refactoring", response_model=None)
 async def find_refactoring_opportunities_endpoint(
     path: str = Query(..., description="Root path to analyze"),
     min_complexity: float = Query(
@@ -387,7 +387,7 @@ async def find_refactoring_opportunities_endpoint(
     operation="analyze_quality_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/quality")
+@router.get("/quality", response_model=None)
 async def analyze_quality_endpoint(
     path: str = Query(..., description="Root path to analyze"),
     severity: Optional[str] = Query(
@@ -476,7 +476,7 @@ def _calculate_health_score(result: dict, metrics: dict) -> int:
     operation="get_recommendations_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/recommendations")
+@router.get("/recommendations", response_model=None)
 async def get_recommendations_endpoint(
     path: str = Query(..., description="Root path to analyze")
 ):
@@ -518,7 +518,7 @@ async def get_recommendations_endpoint(
     operation="get_development_speedup_status",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/status")
+@router.get("/status", response_model=None)
 async def get_development_speedup_status():
     """
     Get development speedup system status.
@@ -585,7 +585,7 @@ async def get_development_speedup_status():
     operation="get_analysis_examples",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/examples")
+@router.get("/examples", response_model=None)
 async def get_analysis_examples():
     """
     Get example analysis requests and usage patterns.

--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -1488,3 +1488,318 @@ class ValidationJudgeStatusResponse(BaseModel):
     timestamp: str
 
 
+
+# ---------------------------------------------------------------------------
+# templates.py schemas
+# ---------------------------------------------------------------------------
+
+
+class TemplatesRootResponse(BaseModel):
+    """Response for GET / (templates root)."""
+
+    message: str
+    endpoints: Dict[str, str]
+
+
+class TemplateListResponse(BaseModel):
+    """Response for GET /templates."""
+
+    success: bool
+    templates: List[Any]
+    total: int
+
+
+class TemplateSecretsUsageResponse(BaseModel):
+    """Response for GET /templates/secrets-usage."""
+
+    success: bool
+    secrets_usage: Dict[str, Any]
+
+
+class TemplateSearchResponse(BaseModel):
+    """Response for GET /templates/search."""
+
+    success: bool
+    query: str
+    results: List[Any]
+    total: int
+
+
+class TemplateCategoriesResponse(BaseModel):
+    """Response for GET /templates/categories."""
+
+    success: bool
+    categories: List[Any]
+
+
+class TemplateStatsResponse(BaseModel):
+    """Response for GET /templates/stats."""
+
+    success: bool
+    statistics: Dict[str, Any]
+
+
+class TemplateDetailResponse(BaseModel):
+    """Response for GET /templates/{template_id}."""
+
+    success: bool
+    template: Dict[str, Any]
+
+
+class TemplatePreviewResponse(BaseModel):
+    """Response for GET /templates/{template_id}/preview."""
+
+    success: bool
+    template_id: str
+    template_name: str
+    description: str
+    estimated_duration_minutes: Optional[int] = None
+    agents_involved: List[str]
+    workflow_preview: List[str]
+    variables_used: Dict[str, Any]
+    total_steps: int
+    approval_required_steps: int
+
+
+class TemplateValidationResponse(BaseModel):
+    """Response for POST /templates/{template_id}/validate."""
+
+    success: bool
+    template_id: str
+    validation: Dict[str, Any]
+
+
+class TemplateCreateWorkflowResponse(BaseModel):
+    """Response for POST /templates/{template_id}/create-workflow.
+
+    success=False path includes validation dict; success=True includes workflow.
+    Extra fields allowed to handle both paths.
+    """
+
+    model_config = {"extra": "allow"}
+
+    success: bool
+
+
+class TemplateExecuteResponse(BaseModel):
+    """Response for POST /templates/{template_id}/execute."""
+
+    success: bool
+    workflow_id: str
+    template_info: Dict[str, Any]
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# state_tracking.py schemas
+# ---------------------------------------------------------------------------
+
+
+class StateTrackingStatusResponse(BaseModel):
+    """Response for GET /status."""
+
+    status: str
+    service: str
+    timestamp: str
+    tracking_active: bool
+    snapshot_count: Optional[Any] = None
+    change_count: Optional[Any] = None
+    latest_snapshot: Optional[Any] = None
+
+
+class StateTrackingSummaryResponse(BaseModel):
+    """Response for GET /summary."""
+
+    status: str
+    summary: Dict[str, Any]
+    timestamp: str
+
+
+class StateTrackingSnapshotResponse(BaseModel):
+    """Response for POST /snapshot."""
+
+    status: str
+    message: str
+    timestamp: str
+
+
+class StateTrackingChangeResponse(BaseModel):
+    """Response for POST /change (success path only).
+
+    JSONResponse(400) for invalid change_type bypasses response_model.
+    """
+
+    status: str
+    message: str
+    change_type: str
+    timestamp: str
+
+
+class StateTrackingMilestonesResponse(BaseModel):
+    """Response for GET /milestones."""
+
+    status: str
+    milestones: Dict[str, Any]
+    achieved_count: int
+    total_count: int
+    timestamp: str
+
+
+class StateTrackingTrendsResponse(BaseModel):
+    """Response for GET /trends/{metric} (success path only).
+
+    JSONResponse(400) for invalid metrics bypasses response_model.
+    """
+
+    status: str
+    metric: str
+    days: int
+    data_points: int
+    trend_data: List[Any]
+    timestamp: str
+
+
+class StateTrackingChangesResponse(BaseModel):
+    """Response for GET /changes."""
+
+    status: str
+    changes: List[Any]
+    total_changes: int
+    showing: int
+    timestamp: str
+
+
+class StateTrackingReportResponse(BaseModel):
+    """Response for GET /report."""
+
+    status: str
+    report: str
+    format: str
+    timestamp: str
+
+
+class StateTrackingExportResponse(BaseModel):
+    """Response for POST /export."""
+
+    status: str
+    message: str
+    filename: str
+    path: str
+    format: str
+    timestamp: str
+
+
+class StateTrackingMetricsAllResponse(BaseModel):
+    """Response for GET /metrics/all."""
+
+    status: str
+    metrics: Dict[str, Any]
+    available_metrics: List[str]
+    timestamp: str
+
+
+class StateTrackingPhaseHistoryResponse(BaseModel):
+    """Response for GET /phase-history/{phase_name}."""
+
+    status: str
+    phase_name: str
+    days: int
+    data_points: int
+    history: List[Any]
+    timestamp: str
+
+
+# ---------------------------------------------------------------------------
+# secrets.py schemas  (all endpoints use JSONResponse → response_model=None)
+# development_speedup.py schemas  (all endpoints use JSONResponse → response_model=None)
+# No new Pydantic models needed for those two files.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# analytics_code_review.py schemas
+# ---------------------------------------------------------------------------
+
+
+class CodeReviewAnalyzeResponse(BaseModel):
+    """Response for GET /analyze (code review diff analysis).
+
+    Returns either the no-data envelope or the full analysis payload.
+    Extra fields allowed to cover both shapes.
+    """
+
+    model_config = {"extra": "allow"}
+
+    status: str
+
+
+class CodeReviewReviewByIdResponse(BaseModel):
+    """Response for GET /review/{review_id}.
+
+    Shape is the opaque result_payload dict stored in Redis — allow extra fields.
+    """
+
+    model_config = {"extra": "allow"}
+
+
+class CodeReviewFileResponse(BaseModel):
+    """Response for POST /review-file."""
+
+    status: str
+    file_path: Optional[str] = None
+    timestamp: str
+    total_comments: int
+    score: float
+    comments: List[Any]
+    summary: Dict[str, Any]
+
+
+class CodeReviewHistoryResponse(BaseModel):
+    """Response for GET /history.
+
+    Returns either no-data envelope or success+reviews shape.
+    Extra fields allowed.
+    """
+
+    model_config = {"extra": "allow"}
+
+    status: str
+
+
+class CodeReviewMetricsResponse(BaseModel):
+    """Response for GET /metrics — no-data envelope."""
+
+    model_config = {"extra": "allow"}
+
+    status: str
+
+
+class CodeReviewFeedbackResponse(BaseModel):
+    """Response for POST /feedback."""
+
+    status: str
+    feedback: Dict[str, Any]
+
+
+class CodeReviewSummaryResponse(BaseModel):
+    """Response for GET /summary — no-data envelope."""
+
+    model_config = {"extra": "allow"}
+
+    status: str
+
+
+class CodeReviewPatternToggleResponse(BaseModel):
+    """Response for POST /patterns/toggle."""
+
+    status: str
+    pattern_id: str
+    enabled: bool
+
+
+class CodeReviewPatternPreferencesResponse(BaseModel):
+    """Response for GET /patterns/preferences."""
+
+    patterns: Dict[str, Any]
+
+

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -690,7 +690,7 @@ def audit_log(
     operation="create_secret",
     error_code_prefix="SECRETS",
 )
-@router.post("/")
+@router.post("/", response_model=None)
 async def create_secret(
     request: SecretCreateRequest,
     http_request: Request,
@@ -735,7 +735,7 @@ async def create_secret(
     operation="list_secrets",
     error_code_prefix="SECRETS",
 )
-@router.get("/")
+@router.get("/", response_model=None)
 async def list_secrets(
     http_request: Request,
     chat_id: Optional[str] = Query(None),
@@ -768,7 +768,7 @@ async def list_secrets(
     operation="get_secret_types",
     error_code_prefix="SECRETS",
 )
-@router.get("/types")
+@router.get("/types", response_model=None)
 async def get_secret_types(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -792,7 +792,7 @@ async def get_secret_types(
     operation="get_secrets_status",
     error_code_prefix="SECRETS",
 )
-@router.get("/status")
+@router.get("/status", response_model=None)
 async def get_secrets_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -824,7 +824,7 @@ async def get_secrets_status(
     operation="get_secrets_stats",
     error_code_prefix="SECRETS",
 )
-@router.get("/stats")
+@router.get("/stats", response_model=None)
 async def get_secrets_stats(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -873,7 +873,7 @@ async def get_secrets_stats(
     operation="get_secret",
     error_code_prefix="SECRETS",
 )
-@router.get("/{secret_id}")
+@router.get("/{secret_id}", response_model=None)
 async def get_secret(
     secret_id: str,
     http_request: Request,
@@ -948,7 +948,7 @@ async def get_secret(
     operation="update_secret",
     error_code_prefix="SECRETS",
 )
-@router.put("/{secret_id}")
+@router.put("/{secret_id}", response_model=None)
 async def update_secret(
     secret_id: str,
     request: SecretUpdateRequest,
@@ -1011,7 +1011,7 @@ async def update_secret(
     operation="delete_secret",
     error_code_prefix="SECRETS",
 )
-@router.delete("/{secret_id}")
+@router.delete("/{secret_id}", response_model=None)
 async def delete_secret(
     secret_id: str,
     http_request: Request,
@@ -1060,7 +1060,7 @@ async def delete_secret(
     operation="transfer_secrets",
     error_code_prefix="SECRETS",
 )
-@router.post("/transfer")
+@router.post("/transfer", response_model=None)
 async def transfer_secrets(
     request: SecretTransferRequest,
     http_request: Request,
@@ -1102,7 +1102,7 @@ async def transfer_secrets(
     operation="get_chat_cleanup_info",
     error_code_prefix="SECRETS",
 )
-@router.get("/chat/{chat_id}/cleanup")
+@router.get("/chat/{chat_id}/cleanup", response_model=None)
 async def get_chat_cleanup_info(
     chat_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -1122,7 +1122,7 @@ async def get_chat_cleanup_info(
     operation="delete_chat_secrets",
     error_code_prefix="SECRETS",
 )
-@router.delete("/chat/{chat_id}")
+@router.delete("/chat/{chat_id}", response_model=None)
 async def delete_chat_secrets(
     chat_id: str,
     http_request: Request,

--- a/autobot-backend/api/state_tracking.py
+++ b/autobot-backend/api/state_tracking.py
@@ -15,6 +15,19 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from api.schemas_common import (
+    StateTrackingChangeResponse,
+    StateTrackingChangesResponse,
+    StateTrackingExportResponse,
+    StateTrackingMetricsAllResponse,
+    StateTrackingMilestonesResponse,
+    StateTrackingPhaseHistoryResponse,
+    StateTrackingReportResponse,
+    StateTrackingSnapshotResponse,
+    StateTrackingStatusResponse,
+    StateTrackingSummaryResponse,
+    StateTrackingTrendsResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from enhanced_project_state_tracker import (
     StateChangeType,
@@ -47,7 +60,7 @@ class ExportRequest(BaseModel):
     operation="get_state_tracking_status",
     error_code_prefix="STATE",
 )
-@router.get("/status")
+@router.get("/status", response_model=StateTrackingStatusResponse)
 async def get_state_tracking_status():
     """Get overall state tracking system status"""
     try:
@@ -84,7 +97,7 @@ async def get_state_tracking_status():
     operation="get_state_summary",
     error_code_prefix="STATE",
 )
-@router.get("/summary")
+@router.get("/summary", response_model=StateTrackingSummaryResponse)
 async def get_state_summary():
     """Get comprehensive state summary"""
     try:
@@ -109,7 +122,7 @@ async def get_state_summary():
     operation="capture_state_snapshot",
     error_code_prefix="STATE",
 )
-@router.post("/snapshot")
+@router.post("/snapshot", response_model=StateTrackingSnapshotResponse)
 async def capture_state_snapshot(background_tasks: BackgroundTasks):
     """Manually trigger a state snapshot"""
     try:
@@ -141,7 +154,7 @@ async def capture_state_snapshot(background_tasks: BackgroundTasks):
     operation="record_state_change",
     error_code_prefix="STATE",
 )
-@router.post("/change")
+@router.post("/change", response_model=StateTrackingChangeResponse)
 async def record_state_change(request: StateChangeRequest):
     """Record a state change event"""
     try:
@@ -192,7 +205,7 @@ async def record_state_change(request: StateChangeRequest):
     operation="get_milestones",
     error_code_prefix="STATE",
 )
-@router.get("/milestones")
+@router.get("/milestones", response_model=StateTrackingMilestonesResponse)
 async def get_milestones():
     """Get project milestone status"""
     try:
@@ -221,7 +234,7 @@ async def get_milestones():
     operation="get_metric_trends",
     error_code_prefix="STATE",
 )
-@router.get("/trends/{metric}")
+@router.get("/trends/{metric}", response_model=StateTrackingTrendsResponse)
 async def get_metric_trends(metric: str, days: int = Query(7, ge=1, le=90)):
     """Get trend data for a specific metric"""
     try:
@@ -280,7 +293,7 @@ async def get_metric_trends(metric: str, days: int = Query(7, ge=1, le=90)):
     operation="get_recent_changes",
     error_code_prefix="STATE",
 )
-@router.get("/changes")
+@router.get("/changes", response_model=StateTrackingChangesResponse)
 async def get_recent_changes(
     limit: int = Query(10, ge=1, le=100), change_type: Optional[str] = None
 ):
@@ -337,7 +350,7 @@ async def get_recent_changes(
     operation="generate_state_report",
     error_code_prefix="STATE",
 )
-@router.get("/report")
+@router.get("/report", response_model=StateTrackingReportResponse)
 async def generate_state_report():
     """Generate comprehensive state tracking report"""
     try:
@@ -368,7 +381,7 @@ async def generate_state_report():
     operation="export_state_data",
     error_code_prefix="STATE",
 )
-@router.post("/export")
+@router.post("/export", response_model=StateTrackingExportResponse)
 async def export_state_data(request: ExportRequest):
     """Export state tracking data"""
     try:
@@ -423,7 +436,7 @@ async def export_state_data(request: ExportRequest):
     operation="get_all_metrics",
     error_code_prefix="STATE",
 )
-@router.get("/metrics/all")
+@router.get("/metrics/all", response_model=StateTrackingMetricsAllResponse)
 async def get_all_metrics():
     """Get current values for all tracking metrics"""
     try:
@@ -451,7 +464,7 @@ async def get_all_metrics():
     operation="get_phase_history",
     error_code_prefix="STATE",
 )
-@router.get("/phase-history/{phase_name}")
+@router.get("/phase-history/{phase_name}", response_model=StateTrackingPhaseHistoryResponse)
 async def get_phase_history(phase_name: str, days: int = Query(30, ge=1, le=365)):
     """Get historical data for a specific phase"""
     try:

--- a/autobot-backend/api/templates.py
+++ b/autobot-backend/api/templates.py
@@ -17,6 +17,19 @@ from typing import Dict, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
+from api.schemas_common import (
+    TemplateCategoriesResponse,
+    TemplateCreateWorkflowResponse,
+    TemplateDetailResponse,
+    TemplateExecuteResponse,
+    TemplateListResponse,
+    TemplatePreviewResponse,
+    TemplatesRootResponse,
+    TemplateSearchResponse,
+    TemplateSecretsUsageResponse,
+    TemplateStatsResponse,
+    TemplateValidationResponse,
+)
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_types import TaskComplexity
@@ -59,7 +72,7 @@ def _generate_templates_cache_key(category, tags, complexity):
     operation="get_templates_root",
     error_code_prefix="TEMPLATES",
 )
-@router.get("/")
+@router.get("/", response_model=TemplatesRootResponse)
 async def get_templates_root():
     """Root endpoint for templates API - redirects to /templates"""
     return {
@@ -79,7 +92,7 @@ async def get_templates_root():
     operation="list_workflow_templates",
     error_code_prefix="TEMPLATES",
 )
-@router.get("/templates")
+@router.get("/templates", response_model=TemplateListResponse)
 @smart_cache(
     data_type="templates",
     key_func=lambda category=None, tags=None, complexity=None: _generate_templates_cache_key(
@@ -149,7 +162,7 @@ async def list_workflow_templates(
     operation="get_secrets_usage",
     error_code_prefix="TEMPLATES",
 )
-@router.get("/templates/secrets-usage")
+@router.get("/templates/secrets-usage", response_model=TemplateSecretsUsageResponse)
 async def get_secrets_usage():
     """Map secret keys to the templates that require them (#1415)."""
     try:
@@ -180,7 +193,7 @@ async def get_secrets_usage():
     operation="search_templates",
     error_code_prefix="TEMPLATES",
 )
-@router.get("/templates/search")
+@router.get("/templates/search", response_model=TemplateSearchResponse)
 async def search_templates(
     q: str = Query(
         ..., description="Search query for template name, description, or tags"
@@ -209,7 +222,7 @@ async def search_templates(
     operation="list_template_categories",
     error_code_prefix="TEMPLATES",
 )
-@router.get("/templates/categories")
+@router.get("/templates/categories", response_model=TemplateCategoriesResponse)
 async def list_template_categories():
     """List all available template categories"""
     try:
@@ -238,7 +251,7 @@ async def list_template_categories():
     operation="get_template_statistics",
     error_code_prefix="TEMPLATES",
 )
-@router.get("/templates/stats")
+@router.get("/templates/stats", response_model=TemplateStatsResponse)
 async def get_template_statistics():
     """Get statistics about available templates"""
     try:
@@ -295,7 +308,7 @@ async def get_template_statistics():
     operation="get_template_details",
     error_code_prefix="TEMPLATES",
 )
-@router.get("/templates/{template_id}")
+@router.get("/templates/{template_id}", response_model=TemplateDetailResponse)
 @smart_cache(
     data_type="templates", key_func=lambda template_id: f"detail:{template_id}"
 )
@@ -323,7 +336,7 @@ async def get_template_details(template_id: str):
     operation="preview_template_workflow",
     error_code_prefix="TEMPLATES",
 )
-@router.get("/templates/{template_id}/preview")
+@router.get("/templates/{template_id}/preview", response_model=TemplatePreviewResponse)
 async def preview_template_workflow(
     template_id: str,
     variables: Optional[str] = Query(None, description="Variables as JSON string"),
@@ -387,7 +400,7 @@ async def preview_template_workflow(
     operation="validate_template_variables",
     error_code_prefix="TEMPLATES",
 )
-@router.post("/templates/{template_id}/validate")
+@router.post("/templates/{template_id}/validate", response_model=TemplateValidationResponse)
 async def validate_template_variables(
     template_id: str, request: TemplateValidationRequest
 ):
@@ -415,7 +428,7 @@ async def validate_template_variables(
     operation="create_workflow_from_template",
     error_code_prefix="TEMPLATES",
 )
-@router.post("/templates/{template_id}/create-workflow")
+@router.post("/templates/{template_id}/create-workflow", response_model=TemplateCreateWorkflowResponse)
 async def create_workflow_from_template(
     template_id: str, request: TemplateExecutionRequest
 ):
@@ -469,7 +482,7 @@ async def create_workflow_from_template(
     operation="execute_template_workflow",
     error_code_prefix="TEMPLATES",
 )
-@router.post("/templates/{template_id}/execute")
+@router.post("/templates/{template_id}/execute", response_model=TemplateExecuteResponse)
 async def execute_template_workflow(
     template_id: str, request: TemplateExecutionRequest
 ):


### PR DESCRIPTION
## Summary
- Annotates 55 endpoints across 5 files
- Adds 28 typed Pydantic models to `schemas_common.py` for templates, state_tracking, analytics_code_review domains
- secrets/development_speedup use `response_model=None` (all return JSONResponse directly)

## Part of #5317 (Round 4c)
🤖 Generated with [Claude Code](https://claude.com/claude-code)