### PR TITLE
fix(composables): abort in-flight requests on concurrent refresh() in useApiResource (#5179)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useApiResource.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useApiResource.test.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 mrveiss
 // Author: mrveiss
 //
-// Tests for useApiResource (#5149)
+// Tests for useApiResource (#5149, #5179)
 
 import { describe, it, expect, vi } from 'vitest'
 import { effectScope, nextTick } from 'vue'
@@ -223,5 +223,80 @@ describe('useApiResource', () => {
     // frozen at its last-observed state, data/error untouched.
     expect(ref1.data.value).toBe(null)
     expect(ref1.error.value).toBe(null)
+  })
+
+  it('AbortController: passes signal to fetcher on each refresh()', async () => {
+    const signals: (AbortSignal | undefined)[] = []
+    const { refresh } = useApiResource((signal) => {
+      signals.push(signal)
+      return Promise.resolve(1)
+    })
+
+    await refresh()
+    await refresh()
+
+    expect(signals).toHaveLength(2)
+    expect(signals[0]).toBeInstanceOf(AbortSignal)
+    expect(signals[1]).toBeInstanceOf(AbortSignal)
+    // Each call gets a distinct signal
+    expect(signals[0]).not.toBe(signals[1])
+  })
+
+  it('AbortController: aborts previous in-flight signal when new refresh() starts', async () => {
+    const d = deferred<number>()
+    let capturedSignal: AbortSignal | undefined
+
+    const { refresh } = useApiResource((signal) => {
+      capturedSignal = signal
+      return d.promise
+    })
+
+    // Start first refresh — captures signal from first controller
+    const p1 = refresh()
+    const firstSignal = capturedSignal!
+    expect(firstSignal.aborted).toBe(false)
+
+    // Start second refresh — first controller must be aborted
+    const p2 = refresh()
+    expect(firstSignal.aborted).toBe(true)
+
+    d.resolve(99)
+    await Promise.allSettled([p1, p2])
+  })
+
+  it('AbortController: AbortError from fetcher does not surface in error.value', async () => {
+    const abortError = new DOMException('Aborted', 'AbortError')
+    const { data, error, isLoading, refresh } = useApiResource(() =>
+      Promise.reject(abortError)
+    )
+
+    await refresh()
+
+    // AbortError is swallowed — not a user-visible failure
+    expect(error.value).toBe(null)
+    expect(data.value).toBe(null)
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('AbortController: onScopeDispose aborts the active controller', async () => {
+    const d = deferred<number>()
+    const scope = effectScope()
+    let capturedSignal: AbortSignal | undefined
+
+    let resource!: ReturnType<typeof useApiResource<number>>
+    scope.run(() => {
+      resource = useApiResource((signal) => {
+        capturedSignal = signal
+        return d.promise
+      })
+    })
+
+    resource.refresh()
+    const signalBeforeDispose = capturedSignal!
+    expect(signalBeforeDispose.aborted).toBe(false)
+
+    // Disposing the scope should abort the active controller
+    scope.stop()
+    expect(signalBeforeDispose.aborted).toBe(true)
   })
 })

--- a/autobot-frontend/src/composables/useApiResource.ts
+++ b/autobot-frontend/src/composables/useApiResource.ts
@@ -18,11 +18,17 @@
  *   onMounted(stats.refresh)
  *   // stats.data.value, stats.error.value, stats.isLoading.value are reactive
  *
+ * Fetchers that want abort support accept an AbortSignal:
+ *
+ *   const stats = useApiResource<KnowledgeStats>((signal) =>
+ *     apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats`, { signal })
+ *   )
+ *
  * Prior art in this repo: `composables/analytics/useAnalyticsEndpoint.ts`
  * solves a narrower problem (fetchWithAuth + path + source-scoping). This
  * composable is the generic form — any fetcher callback, no URL assumptions.
  *
- * Issue #5149.
+ * Issue #5149. AbortController integration: #5179.
  */
 
 import { ref, getCurrentScope, onScopeDispose, type Ref } from 'vue'
@@ -36,6 +42,13 @@ export interface UseApiResourceOptions {
    * Set to false to clear `data` before each refresh.
    */
   keepPreviousData?: boolean
+  /**
+   * Abort the prior in-flight request when `refresh()` is called again.
+   * Default: true. The signal is passed to the fetcher only when the fetcher
+   * declares at least one parameter (`fetcher.length >= 1`), preserving full
+   * backward compatibility with zero-arg fetchers.
+   */
+  abortPrior?: boolean
 }
 
 export interface UseApiResourceReturn<T> {
@@ -57,13 +70,17 @@ export interface UseApiResourceReturn<T> {
  * caller wins. This prevents stale data from overwriting fresh data when a
  * consumer fires refresh() multiple times in quick succession.
  *
+ * Network efficiency: when `abortPrior` is true (default), each new refresh()
+ * call aborts the previous in-flight request via AbortController so no
+ * redundant network requests complete in the background.
+ *
  * Lifecycle: on `onScopeDispose` (component unmount / effect scope teardown),
- * any pending fetches are effectively ignored — their resolutions no longer
- * touch the refs. This prevents the classic "setState on unmounted component"
- * warning and any memory leak from stale closures.
+ * any pending fetches are aborted and their resolutions no longer touch the
+ * refs. This prevents the classic "setState on unmounted component" warning
+ * and any memory leak from stale closures.
  */
 export function useApiResource<T>(
-  fetcher: () => Promise<T>,
+  fetcher: ((signal: AbortSignal) => Promise<T>) | (() => Promise<T>),
   options: UseApiResourceOptions = {}
 ): UseApiResourceReturn<T> {
   const data = ref<T | null>(null) as Ref<T | null>
@@ -71,13 +88,24 @@ export function useApiResource<T>(
   const isLoading = ref(false)
 
   const keepPreviousData = options.keepPreviousData !== false
+  const abortPrior = options.abortPrior !== false
 
   // Monotonic ID for race-condition tracking. Incremented per refresh() call.
   // When a fetch resolves, we ignore it unless its ID still matches the latest.
   let latestCallId = 0
   let disposed = false
+  // Tracks the AbortController for the current in-flight request.
+  let currentController: AbortController | null = null
 
   const refresh = async (): Promise<void> => {
+    // Abort the previous in-flight request before starting a new one.
+    if (abortPrior && currentController !== null) {
+      currentController.abort()
+    }
+
+    const controller = abortPrior ? new AbortController() : null
+    currentController = controller
+
     const callId = ++latestCallId
     isLoading.value = true
     error.value = null
@@ -86,15 +114,32 @@ export function useApiResource<T>(
     }
 
     try {
-      const result = await fetcher()
+      // Pass the signal only when the fetcher declares a parameter — this
+      // preserves backward compatibility with zero-arg fetchers that do not
+      // accept (or need) an AbortSignal.
+      const result =
+        controller !== null && fetcher.length >= 1
+          ? await (fetcher as (signal: AbortSignal) => Promise<T>)(
+              controller.signal
+            )
+          : await (fetcher as () => Promise<T>)()
+
       if (disposed || callId !== latestCallId) return
       data.value = result
     } catch (e) {
+      // AbortError means this call was superseded — not a real failure.
+      // Check by name to handle both DOMException (browser) and plain Error
+      // objects with name='AbortError' (some fetch polyfills / jsdom).
+      if (e instanceof Error && e.name === 'AbortError') return
       if (disposed || callId !== latestCallId) return
       error.value = e instanceof Error ? e : new Error(String(e))
     } finally {
+      // Only clear the loading state for the call that is still current.
       if (disposed || callId !== latestCallId) return
       isLoading.value = false
+      if (currentController === controller) {
+        currentController = null
+      }
     }
   }
 
@@ -105,6 +150,10 @@ export function useApiResource<T>(
   if (getCurrentScope()) {
     onScopeDispose(() => {
       disposed = true
+      if (currentController !== null) {
+        currentController.abort()
+        currentController = null
+      }
     })
   }
 


### PR DESCRIPTION
## Summary

- Add `AbortController` integration to `useApiResource` so each new `refresh()` call cancels the previous in-flight request
- Fetchers that accept a parameter receive the `AbortSignal`; zero-arg fetchers called unchanged (full backward compatibility)
- New `abortPrior` option (default: `true`) to opt out if needed
- `onScopeDispose` now aborts any pending fetch in addition to ignoring its result
- Adds tests covering concurrent refresh, abort behavior, and backward compat

Closes #5179

## Test plan
- [ ] `npm run type-check` passes in autobot-frontend
- [ ] New tests in `useApiResource.test.ts` pass
- [ ] Existing zero-arg fetcher callers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)