### PR TITLE
feat(api): add response_model= to research_browser, metrics, enterprise_features, web_research_settings, orchestration (#5317)

### DIFF
--- a/autobot-backend/api/enterprise_features.py
+++ b/autobot-backend/api/enterprise_features.py
@@ -283,7 +283,7 @@ def _build_service_distribution(vm_topology: dict) -> dict:
     operation="get_enterprise_status",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.get("/status")
+@router.get("/status", response_model=None)
 async def get_enterprise_status():
     """
     Get comprehensive enterprise feature status.
@@ -317,7 +317,7 @@ async def get_enterprise_status():
     operation="enable_enterprise_feature",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.post("/features/enable")
+@router.post("/features/enable", response_model=None)
 async def enable_enterprise_feature(request: FeatureEnableRequest):
     """
     Enable a specific enterprise feature.
@@ -374,7 +374,7 @@ async def enable_enterprise_feature(request: FeatureEnableRequest):
     operation="enable_all_enterprise_features",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.post("/features/enable-all")
+@router.post("/features/enable-all", response_model=None)
 async def enable_all_enterprise_features():
     """
     Enable all enterprise features in dependency order.
@@ -410,7 +410,7 @@ async def enable_all_enterprise_features():
     operation="list_enterprise_features",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.get("/features")
+@router.get("/features", response_model=None)
 async def list_enterprise_features(
     category: Optional[FeatureCategory] = Query(
         None, description="Filter by feature category"
@@ -468,7 +468,7 @@ async def list_enterprise_features(
     operation="bulk_enable_features",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.post("/features/bulk-enable")
+@router.post("/features/bulk-enable", response_model=None)
 async def bulk_enable_features(request: BulkFeatureRequest):
     """
     Enable multiple enterprise features in batch.
@@ -529,7 +529,7 @@ async def bulk_enable_features(request: BulkFeatureRequest):
     operation="get_enterprise_health",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.get("/health")
+@router.get("/health", response_model=None)
 async def get_enterprise_health():
     """
     Get health status of all enterprise features.
@@ -584,7 +584,7 @@ async def get_enterprise_health():
     operation="optimize_system_performance",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.post("/performance/optimize")
+@router.post("/performance/optimize", response_model=None)
 async def optimize_system_performance(request: PerformanceOptimizationRequest):
     """
     Optimize system performance based on target metrics.
@@ -625,7 +625,7 @@ async def optimize_system_performance(request: PerformanceOptimizationRequest):
     operation="get_infrastructure_status",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.get("/infrastructure")
+@router.get("/infrastructure", response_model=None)
 async def get_infrastructure_status():
     """
     Get 6-VM distributed infrastructure status and topology.
@@ -674,7 +674,7 @@ async def get_infrastructure_status():
     operation="deploy_zero_downtime",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.post("/deployment/zero-downtime")
+@router.post("/deployment/zero-downtime", response_model=None)
 async def deploy_zero_downtime():
     """
     Execute zero-downtime deployment across the distributed infrastructure.
@@ -722,7 +722,7 @@ async def deploy_zero_downtime():
     operation="validate_phase4_completion",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.get("/phase4/validation")
+@router.get("/phase4/validation", response_model=None)
 async def validate_phase4_completion():
     """
     Validate that Phase 4 enterprise features are properly implemented.

--- a/autobot-backend/api/metrics.py
+++ b/autobot-backend/api/metrics.py
@@ -14,6 +14,17 @@ from fastapi import APIRouter, HTTPException, Query
 
 # Prometheus query helpers shared from monitoring module (Issue #1283)
 from api.monitoring import _query_prometheus_range
+from api.schemas_common import (
+    MetricsDashboardResponse,
+    MetricsExportResponse,
+    MetricsMonitoringStartResponse,
+    MetricsMonitoringStopResponse,
+    MetricsPerformanceSummaryResponse,
+    MetricsSystemCurrentResponse,
+    MetricsSystemHistoryResponse,
+    MetricsSystemSummaryResponse,
+    MetricsWorkflowResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from metrics.system_monitor import system_monitor
 from metrics.workflow_metrics import workflow_metrics
@@ -28,7 +39,7 @@ router = APIRouter()
     operation="get_workflow_metrics",
     error_code_prefix="METRICS",
 )
-@router.get("/workflow/{workflow_id}")
+@router.get("/workflow/{workflow_id}", response_model=MetricsWorkflowResponse)
 async def get_workflow_metrics(workflow_id: str):
     """Get metrics for a specific workflow"""
     try:
@@ -47,7 +58,7 @@ async def get_workflow_metrics(workflow_id: str):
     operation="get_performance_summary",
     error_code_prefix="METRICS",
 )
-@router.get("/performance/summary")
+@router.get("/performance/summary", response_model=MetricsPerformanceSummaryResponse)
 async def get_performance_summary(
     time_window_hours: int = Query(
         default=24, ge=1, le=168, description="Time window in hours (1-168)"
@@ -68,7 +79,7 @@ async def get_performance_summary(
     operation="get_current_system_metrics",
     error_code_prefix="METRICS",
 )
-@router.get("/system/current")
+@router.get("/system/current", response_model=MetricsSystemCurrentResponse)
 async def get_current_system_metrics():
     """Get current system resource metrics"""
     try:
@@ -96,7 +107,7 @@ _HISTORY_DURATION_MAP = {
     operation="get_system_metrics_history",
     error_code_prefix="METRICS",
 )
-@router.get("/system/history")
+@router.get("/system/history", response_model=MetricsSystemHistoryResponse)
 async def get_system_metrics_history(
     duration: str = Query(
         "1h", description="Time duration (e.g., 15m, 1h, 6h, 1d, 7d)"
@@ -133,7 +144,7 @@ async def get_system_metrics_history(
     operation="get_system_summary",
     error_code_prefix="METRICS",
 )
-@router.get("/system/summary")
+@router.get("/system/summary", response_model=MetricsSystemSummaryResponse)
 async def get_system_summary(
     minutes: int = Query(
         default=10, ge=1, le=60, description="Time window in minutes (1-60)"
@@ -159,7 +170,7 @@ async def get_system_summary(
     operation="export_workflow_metrics",
     error_code_prefix="METRICS",
 )
-@router.get("/export/workflow")
+@router.get("/export/workflow", response_model=MetricsExportResponse)
 async def export_workflow_metrics(
     format: str = Query(default="json", description="Export format")
 ):
@@ -178,7 +189,7 @@ async def export_workflow_metrics(
     operation="export_system_metrics",
     error_code_prefix="METRICS",
 )
-@router.get("/export/system")
+@router.get("/export/system", response_model=MetricsExportResponse)
 async def export_system_metrics(
     format: str = Query(default="json", description="Export format")
 ):
@@ -197,7 +208,7 @@ async def export_system_metrics(
     operation="start_system_monitoring",
     error_code_prefix="METRICS",
 )
-@router.post("/system/monitoring/start")
+@router.post("/system/monitoring/start", response_model=MetricsMonitoringStartResponse)
 async def start_system_monitoring():
     """Start continuous system monitoring"""
     try:
@@ -218,7 +229,7 @@ async def start_system_monitoring():
     operation="stop_system_monitoring",
     error_code_prefix="METRICS",
 )
-@router.post("/system/monitoring/stop")
+@router.post("/system/monitoring/stop", response_model=MetricsMonitoringStopResponse)
 async def stop_system_monitoring():
     """Stop continuous system monitoring"""
     try:
@@ -235,7 +246,7 @@ async def stop_system_monitoring():
     operation="get_metrics_dashboard",
     error_code_prefix="METRICS",
 )
-@router.get("/dashboard")
+@router.get("/dashboard", response_model=MetricsDashboardResponse)
 async def get_metrics_dashboard():
     """Get comprehensive metrics dashboard data"""
     try:

--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -103,7 +103,7 @@ def _build_single_task_response(result: dict) -> JSONResponse:
     )
 
 
-@router.post("/workflow/execute")
+@router.post("/workflow/execute", response_model=None)
 async def execute_workflow(
     request: WorkflowRequest,
     current_user: dict = Depends(get_current_user),
@@ -153,7 +153,7 @@ async def execute_workflow(
     operation="create_workflow_plan",
     error_code_prefix="ORCHESTRATION",
 )
-@router.post("/workflow/plan")
+@router.post("/workflow/plan", response_model=None)
 async def create_workflow_plan(
     request: WorkflowRequest,
     current_user: dict = Depends(get_current_user),
@@ -218,7 +218,7 @@ async def create_workflow_plan(
     operation="get_agent_performance",
     error_code_prefix="ORCHESTRATION",
 )
-@router.get("/agents/performance")
+@router.get("/agents/performance", response_model=None)
 async def get_agent_performance(
     current_user: dict = Depends(get_current_user),
 ):
@@ -251,7 +251,7 @@ async def get_agent_performance(
     operation="recommend_agents",
     error_code_prefix="ORCHESTRATION",
 )
-@router.post("/agents/recommend")
+@router.post("/agents/recommend", response_model=None)
 async def recommend_agents(
     request: AgentRecommendationRequest,
     current_user: dict = Depends(get_current_user),
@@ -307,7 +307,7 @@ async def recommend_agents(
     operation="get_active_workflows",
     error_code_prefix="ORCHESTRATION",
 )
-@router.get("/workflow/active")
+@router.get("/workflow/active", response_model=None)
 async def get_active_workflows(
     current_user: dict = Depends(get_current_user),
 ):
@@ -358,7 +358,7 @@ async def get_active_workflows(
     operation="get_execution_strategies",
     error_code_prefix="ORCHESTRATION",
 )
-@router.get("/strategies")
+@router.get("/strategies", response_model=None)
 async def get_execution_strategies(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -405,7 +405,7 @@ async def get_execution_strategies(
     operation="get_agent_capabilities",
     error_code_prefix="ORCHESTRATION",
 )
-@router.get("/capabilities")
+@router.get("/capabilities", response_model=None)
 async def get_agent_capabilities(
     current_user: dict = Depends(get_current_user),
 ):
@@ -461,7 +461,7 @@ async def get_agent_capabilities(
     operation="get_orchestration_status",
     error_code_prefix="ORCHESTRATION",
 )
-@router.get("/status")
+@router.get("/status", response_model=None)
 async def get_orchestration_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -516,7 +516,7 @@ async def get_orchestration_status(
     operation="get_orchestration_examples",
     error_code_prefix="ORCHESTRATION",
 )
-@router.get("/examples")
+@router.get("/examples", response_model=None)
 async def get_orchestration_examples(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/research_browser.py
+++ b/autobot-backend/api/research_browser.py
@@ -69,7 +69,7 @@ def _require_browser():
     operation="health_check",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.get("/health")
+@router.get("/health", response_model=None)
 async def health_check():
     """Health check endpoint for research browser service"""
     if not _BROWSER_AVAILABLE:
@@ -97,7 +97,7 @@ async def health_check():
     operation="research_url",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.post("/url")
+@router.post("/url", response_model=None)
 async def research_url(request: ResearchRequest):
     """Research a URL with automatic fallbacks and interaction handling"""
     _require_browser()
@@ -113,7 +113,7 @@ async def research_url(request: ResearchRequest):
     operation="handle_session_action",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.post("/session/action")
+@router.post("/session/action", response_model=None)
 async def handle_session_action(request: SessionAction):
     """Handle actions on a research session"""
     _require_browser()
@@ -163,7 +163,7 @@ async def handle_session_action(request: SessionAction):
     operation="get_session_status",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.get("/session/{session_id}/status")
+@router.get("/session/{session_id}/status", response_model=None)
 async def get_session_status(session_id: str):
     """Get the status of a research session"""
     _require_browser()
@@ -192,7 +192,7 @@ async def get_session_status(session_id: str):
     operation="download_mhtml",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.get("/session/{session_id}/mhtml/{filename}")
+@router.get("/session/{session_id}/mhtml/{filename}", response_model=None)
 async def download_mhtml(session_id: str, filename: str):
     """Download an MHTML file from a research session"""
     _require_browser()
@@ -238,7 +238,7 @@ async def download_mhtml(session_id: str, filename: str):
     operation="cleanup_session",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.delete("/session/{session_id}")
+@router.delete("/session/{session_id}", response_model=None)
 async def cleanup_session(session_id: str):
     """Clean up a research session"""
     _require_browser()
@@ -255,7 +255,7 @@ async def cleanup_session(session_id: str):
     operation="list_sessions",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.get("/sessions")
+@router.get("/sessions", response_model=None)
 async def list_sessions():
     """List all active research sessions"""
     _require_browser()
@@ -289,7 +289,7 @@ class NavigationRequest(BaseModel):
     operation="navigate_session",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.post("/session/{session_id}/navigate")
+@router.post("/session/{session_id}/navigate", response_model=None)
 async def navigate_session(session_id: str, request: NavigationRequest):
     """Navigate a research session to a specific URL"""
     _require_browser()
@@ -308,7 +308,7 @@ async def navigate_session(session_id: str, request: NavigationRequest):
     operation="get_browser_info",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.get("/browser/{session_id}")
+@router.get("/browser/{session_id}", response_model=None)
 async def get_browser_info(session_id: str):
     """Get browser information for frontend integration (Issue #665: refactored)."""
     _require_browser()
@@ -417,7 +417,7 @@ class CreateChatBrowserRequest(BaseModel):
     operation="get_or_create_chat_browser_session",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.post("/chat-session")
+@router.post("/chat-session", response_model=None)
 async def get_or_create_chat_browser_session(request: CreateChatBrowserRequest):
     """
     Get existing or create new browser session for a chat conversation.
@@ -485,7 +485,7 @@ async def get_or_create_chat_browser_session(request: CreateChatBrowserRequest):
     operation="get_chat_browser_session",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.get("/chat-session/{conversation_id}")
+@router.get("/chat-session/{conversation_id}", response_model=None)
 async def get_chat_browser_session(conversation_id: str):
     """
     Get browser session info for a chat conversation.
@@ -536,7 +536,7 @@ async def get_chat_browser_session(conversation_id: str):
     operation="delete_chat_browser_session",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.delete("/chat-session/{conversation_id}")
+@router.delete("/chat-session/{conversation_id}", response_model=None)
 async def delete_chat_browser_session(conversation_id: str):
     """
     Close browser session for a chat conversation.

--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -1803,3 +1803,76 @@ class CodeReviewPatternPreferencesResponse(BaseModel):
     patterns: Dict[str, Any]
 
 
+# ---------------------------------------------------------------------------
+# metrics.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class MetricsWorkflowResponse(BaseModel):
+    """Response for GET /workflow/{workflow_id}."""
+
+    success: bool
+    workflow_id: str
+    metrics: Optional[Any] = None
+
+
+class MetricsPerformanceSummaryResponse(BaseModel):
+    """Response for GET /performance/summary."""
+
+    success: bool
+    performance_summary: Optional[Any] = None
+
+
+class MetricsSystemCurrentResponse(BaseModel):
+    """Response for GET /system/current."""
+
+    success: bool
+    system_metrics: Optional[Any] = None
+
+
+class MetricsSystemHistoryResponse(BaseModel):
+    """Response for GET /system/history."""
+
+    success: bool
+    cpu_history: List[Any]
+    memory_history: List[Any]
+    time_range: Dict[str, str]
+
+
+class MetricsSystemSummaryResponse(BaseModel):
+    """Response for GET /system/summary."""
+
+    success: bool
+    resource_summary: Optional[Any] = None
+
+
+class MetricsExportResponse(BaseModel):
+    """Response for GET /export/workflow and GET /export/system."""
+
+    success: bool
+    format: str
+    data: Optional[Any] = None
+
+
+class MetricsMonitoringStartResponse(BaseModel):
+    """Response for POST /system/monitoring/start."""
+
+    success: bool
+    message: str
+    collection_interval: Optional[Any] = None
+
+
+class MetricsMonitoringStopResponse(BaseModel):
+    """Response for POST /system/monitoring/stop."""
+
+    success: bool
+    message: str
+
+
+class MetricsDashboardResponse(BaseModel):
+    """Response for GET /dashboard."""
+
+    success: bool
+    dashboard: Dict[str, Any]
+
+

--- a/autobot-backend/api/web_research_settings.py
+++ b/autobot-backend/api/web_research_settings.py
@@ -50,7 +50,7 @@ class ResearchPreferences(BaseModel):
     operation="get_research_status",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.get("/status")
+@router.get("/status", response_model=None)
 async def get_research_status():
     """Get current web research status and configuration"""
     try:
@@ -99,7 +99,7 @@ async def get_research_status():
     operation="enable_web_research",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.post("/enable")
+@router.post("/enable", response_model=None)
 async def enable_web_research():
     """Enable web research functionality"""
     try:
@@ -151,7 +151,7 @@ async def enable_web_research():
     operation="disable_web_research",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.post("/disable")
+@router.post("/disable", response_model=None)
 async def disable_web_research():
     """Disable web research functionality"""
     try:
@@ -203,7 +203,7 @@ async def disable_web_research():
     operation="get_research_settings",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.get("/settings")
+@router.get("/settings", response_model=None)
 async def get_research_settings():
     """Get current web research settings"""
     try:
@@ -255,7 +255,7 @@ async def get_research_settings():
     operation="update_research_settings",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.put("/settings")
+@router.put("/settings", response_model=None)
 async def update_research_settings(settings: WebResearchSettings):
     """Update web research settings"""
     try:
@@ -317,7 +317,7 @@ async def update_research_settings(settings: WebResearchSettings):
     operation="test_web_research",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.post("/test")
+@router.post("/test", response_model=None)
 async def test_web_research(query: str = "test query"):
     """Test web research functionality"""
     try:
@@ -360,7 +360,7 @@ async def test_web_research(query: str = "test query"):
     operation="clear_research_cache",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.post("/clear-cache")
+@router.post("/clear-cache", response_model=None)
 async def clear_research_cache():
     """Clear web research cache"""
     try:
@@ -392,7 +392,7 @@ async def clear_research_cache():
     operation="reset_circuit_breakers",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.post("/reset-circuit-breakers")
+@router.post("/reset-circuit-breakers", response_model=None)
 async def reset_circuit_breakers():
     """Reset all circuit breakers for web research"""
     try:
@@ -424,7 +424,7 @@ async def reset_circuit_breakers():
     operation="get_usage_stats",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.get("/usage-stats")
+@router.get("/usage-stats", response_model=None)
 async def get_usage_stats():
     """Get web research usage statistics"""
     try:


### PR DESCRIPTION
## Summary
- Annotates 50 endpoints; 9 new Pydantic models for metrics domain in schemas_common.py
- research_browser/enterprise_features/web_research_settings/orchestration use response_model=None (dynamic JSONResponse shapes)
- metrics.py gets fully typed models

## Part of #5317 (Round 5a)
🤖 Generated with [Claude Code](https://claude.com/claude-code)