### PR TITLE
feat(api): add response_model= to logs, git_mcp, analytics_llm_patterns, voice, skills_governance (#5317)

### DIFF
--- a/autobot-backend/api/analytics_llm_patterns.py
+++ b/autobot-backend/api/analytics_llm_patterns.py
@@ -28,6 +28,18 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
+
+from api.schemas_common import (
+    LLMPatternsCacheOpportunitiesResponse,
+    LLMPatternsCategoryDistributionResponse,
+    LLMPatternsCostBreakdownResponse,
+    LLMPatternsHealthResponse,
+    LLMPatternsAnalyzeResponse,
+    LLMPatternsModelComparisonResponse,
+    LLMPatternsRecordResponse,
+    LLMPatternsRecommendationsResponse,
+    LLMPatternsStatsResponse,
+)
 from redis.exceptions import RedisError
 
 from autobot_shared.redis_client import RedisDatabase
@@ -1005,7 +1017,7 @@ def get_pattern_analyzer() -> LLMPatternAnalyzer:
 # =============================================================================
 
 
-@router.get("/health")
+@router.get("/health", response_model=LLMPatternsHealthResponse)
 async def get_health():
     """Get LLM pattern analyzer health status.
 
@@ -1033,7 +1045,7 @@ async def get_health():
     }
 
 
-@router.post("/analyze")
+@router.post("/analyze", response_model=LLMPatternsAnalyzeResponse)
 async def analyze_prompt(request: PromptAnalysisRequest):
     """
     Analyze a prompt for optimization opportunities.
@@ -1044,7 +1056,7 @@ async def analyze_prompt(request: PromptAnalysisRequest):
     return await analyzer.analyze_prompt(request.prompt, request.model)
 
 
-@router.post("/record")
+@router.post("/record", response_model=LLMPatternsRecordResponse)
 async def record_usage(request: UsageRecordRequest):
     """
     Record an LLM usage event.
@@ -1055,7 +1067,7 @@ async def record_usage(request: UsageRecordRequest):
     return await analyzer.record_usage(request)
 
 
-@router.get("/stats")
+@router.get("/stats", response_model=LLMPatternsStatsResponse)
 async def get_usage_stats(days: int = Query(default=7, ge=1, le=30)):
     """
     Get usage statistics for the specified period.
@@ -1066,7 +1078,7 @@ async def get_usage_stats(days: int = Query(default=7, ge=1, le=30)):
     return await analyzer.get_usage_stats(days)
 
 
-@router.get("/cache-opportunities")
+@router.get("/cache-opportunities", response_model=LLMPatternsCacheOpportunitiesResponse)
 async def get_cache_opportunities(
     min_occurrences: int = Query(default=3, ge=2, le=100)
 ):
@@ -1085,7 +1097,7 @@ async def get_cache_opportunities(
     }
 
 
-@router.get("/recommendations")
+@router.get("/recommendations", response_model=LLMPatternsRecommendationsResponse)
 async def get_recommendations():
     """
     Get optimization recommendations based on usage patterns.
@@ -1096,7 +1108,7 @@ async def get_recommendations():
     return {"recommendations": await analyzer.get_optimization_recommendations()}
 
 
-@router.get("/model-comparison")
+@router.get("/model-comparison", response_model=LLMPatternsModelComparisonResponse)
 async def get_model_comparison():
     """
     Compare costs and usage across different models.
@@ -1107,7 +1119,7 @@ async def get_model_comparison():
     return {"models": await analyzer.get_model_comparison(), "period_days": 7}
 
 
-@router.get("/category-distribution")
+@router.get("/category-distribution", response_model=LLMPatternsCategoryDistributionResponse)
 async def get_category_distribution():
     """
     Get distribution of prompt categories.
@@ -1118,7 +1130,7 @@ async def get_category_distribution():
     return await analyzer.get_category_distribution()
 
 
-@router.get("/cost-breakdown")
+@router.get("/cost-breakdown", response_model=LLMPatternsCostBreakdownResponse)
 async def get_cost_breakdown(days: int = Query(default=7, ge=1, le=30)):
     """
     Get detailed cost breakdown.

--- a/autobot-backend/api/git_mcp.py
+++ b/autobot-backend/api/git_mcp.py
@@ -35,6 +35,12 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
+from api.schemas_common import (
+    GitMCPInfoResponse,
+    GitMCPOperationResponse,
+    GitMCPServiceStatusResponse,
+)
+
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_path
@@ -719,7 +725,7 @@ def _get_git_change_tools() -> List[MCPTool]:
     operation="get_git_mcp_tools",
     error_code_prefix="GIT_MCP",
 )
-@router.get("/mcp/tools")
+@router.get("/mcp/tools", response_model=List[MCPTool])
 async def get_git_mcp_tools() -> List[MCPTool]:
     """
     Return all available Git Operations MCP tools
@@ -742,7 +748,7 @@ async def get_git_mcp_tools() -> List[MCPTool]:
     operation="git_status_mcp",
     error_code_prefix="GIT_MCP",
 )
-@router.post("/mcp/status")
+@router.post("/mcp/status", response_model=GitMCPOperationResponse)
 async def git_status_mcp(request: GitStatusRequest) -> Metadata:
     """
     Get git repository status
@@ -781,7 +787,7 @@ async def git_status_mcp(request: GitStatusRequest) -> Metadata:
     operation="git_log_mcp",
     error_code_prefix="GIT_MCP",
 )
-@router.post("/mcp/log")
+@router.post("/mcp/log", response_model=GitMCPOperationResponse)
 async def git_log_mcp(request: GitLogRequest) -> Metadata:
     """
     Get commit history
@@ -828,7 +834,7 @@ async def git_log_mcp(request: GitLogRequest) -> Metadata:
     operation="git_diff_mcp",
     error_code_prefix="GIT_MCP",
 )
-@router.post("/mcp/diff")
+@router.post("/mcp/diff", response_model=GitMCPOperationResponse)
 async def git_diff_mcp(request: GitDiffRequest) -> Metadata:
     """
     Show git diff
@@ -879,7 +885,7 @@ async def git_diff_mcp(request: GitDiffRequest) -> Metadata:
     operation="git_branch_mcp",
     error_code_prefix="GIT_MCP",
 )
-@router.post("/mcp/branch")
+@router.post("/mcp/branch", response_model=GitMCPOperationResponse)
 async def git_branch_mcp(request: GitBranchRequest) -> Metadata:
     """
     List git branches
@@ -932,7 +938,7 @@ async def git_branch_mcp(request: GitBranchRequest) -> Metadata:
     operation="git_blame_mcp",
     error_code_prefix="GIT_MCP",
 )
-@router.post("/mcp/blame")
+@router.post("/mcp/blame", response_model=GitMCPOperationResponse)
 async def git_blame_mcp(request: GitBlameRequest) -> Metadata:
     """
     Show git blame for a file
@@ -976,7 +982,7 @@ async def git_blame_mcp(request: GitBlameRequest) -> Metadata:
     operation="git_show_mcp",
     error_code_prefix="GIT_MCP",
 )
-@router.post("/mcp/show")
+@router.post("/mcp/show", response_model=GitMCPOperationResponse)
 async def git_show_mcp(request: GitShowRequest) -> Metadata:
     """
     Show git commit details
@@ -1009,7 +1015,7 @@ async def git_show_mcp(request: GitShowRequest) -> Metadata:
     }
 
 
-@router.get("/mcp/info")
+@router.get("/mcp/info", response_model=GitMCPInfoResponse)
 async def get_git_repo_info() -> Metadata:
     """
     Get information about whitelisted repositories
@@ -1072,7 +1078,7 @@ async def get_git_repo_info() -> Metadata:
     operation="get_git_mcp_status",
     error_code_prefix="GIT_MCP",
 )
-@router.get("/mcp/service_status")
+@router.get("/mcp/service_status", response_model=GitMCPServiceStatusResponse)
 async def get_git_mcp_status() -> Metadata:
     """
     Get Git MCP service status

--- a/autobot-backend/api/logs.py
+++ b/autobot-backend/api/logs.py
@@ -21,6 +21,15 @@ import aiofiles
 from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket
 from fastapi.responses import StreamingResponse
 
+from api.schemas_common import (
+    AgentMessageResponse,
+    LogContainerResponse,
+    LogRecentResponse,
+    LogReadResponse,
+    LogSearchResponse,
+    LogSourcesResponse,
+    LogUnifiedResponse,
+)
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_relative_path
@@ -400,7 +409,7 @@ async def _get_container_log_sources() -> List[Metadata]:
     error_code_prefix="LOGS",
 )
 # Issue #552: Fixed duplicate /logs prefix - router already mounted at /api/logs
-@router.get("/sources")
+@router.get("/sources", response_model=LogSourcesResponse)
 async def get_log_sources(admin_check: bool = Depends(check_admin_permission)):
     """Get all available log sources (files + Docker containers) (Issue #315 - refactored).
 
@@ -467,7 +476,7 @@ async def _read_recent_log_lines(log_path: str, limit: int) -> List[str]:
     operation="get_recent_logs",
     error_code_prefix="LOGS",
 )
-@router.get("/recent")
+@router.get("/recent", response_model=LogRecentResponse)
 async def get_recent_logs(
     limit: int = 100,
     admin_check: bool = Depends(check_admin_permission),
@@ -506,7 +515,7 @@ async def get_recent_logs(
     operation="list_logs",
     error_code_prefix="LOGS",
 )
-@router.get("/list")
+@router.get("/list", response_model=None)
 async def list_logs(
     admin_check: bool = Depends(check_admin_permission),
 ) -> List[Metadata]:
@@ -527,7 +536,7 @@ async def list_logs(
     operation="read_log",
     error_code_prefix="LOGS",
 )
-@router.get("/read/{filename}")
+@router.get("/read/{filename}", response_model=LogReadResponse)
 async def read_log(
     filename: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -648,7 +657,7 @@ def _parse_and_limit_container_output(
     operation="read_container_logs",
     error_code_prefix="LOGS",
 )
-@router.get("/container/{service}")
+@router.get("/container/{service}", response_model=LogContainerResponse)
 async def read_container_logs(
     service: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -753,7 +762,7 @@ def parse_docker_log_line(line: str, service: str) -> Metadata:
     operation="get_unified_logs",
     error_code_prefix="LOGS",
 )
-@router.get("/unified")
+@router.get("/unified", response_model=LogUnifiedResponse)
 async def get_unified_logs(
     admin_check: bool = Depends(check_admin_permission),
     lines: int = Query(
@@ -834,7 +843,7 @@ def parse_file_log_line(line: str, source: str) -> Metadata:
     operation="stream_log",
     error_code_prefix="LOGS",
 )
-@router.get("/stream/{filename}")
+@router.get("/stream/{filename}", response_model=None)
 async def stream_log(
     filename: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -962,7 +971,7 @@ async def _search_single_log_file(
     operation="search_logs",
     error_code_prefix="LOGS",
 )
-@router.get("/search")
+@router.get("/search", response_model=LogSearchResponse)
 async def search_logs(
     admin_check: bool = Depends(check_admin_permission),
     query: str = Query(..., description="Search query"),
@@ -1019,7 +1028,7 @@ async def search_logs(
     operation="clear_log",
     error_code_prefix="LOGS",
 )
-@router.delete("/clear/{filename}")
+@router.delete("/clear/{filename}", response_model=AgentMessageResponse)
 async def clear_log(
     filename: str,
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -1876,3 +1876,312 @@ class MetricsDashboardResponse(BaseModel):
     dashboard: Dict[str, Any]
 
 
+
+# ---------------------------------------------------------------------------
+# logs.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class LogSourcesResponse(BaseModel):
+    """Response for GET /logs/sources."""
+
+    file_logs: List[Any]
+    container_logs: List[Any]
+    total_sources: int
+
+
+class LogRecentResponse(BaseModel):
+    """Response for GET /logs/recent."""
+
+    entries: List[Any]
+    count: int
+    limit: int
+    source: str
+    error: Optional[str] = None
+
+
+class LogReadResponse(BaseModel):
+    """Response for GET /logs/read/{filename}."""
+
+    filename: str
+    lines: List[str]
+    total_lines: int
+    offset: int
+    count: int
+
+
+class LogContainerResponse(BaseModel):
+    """Response for GET /logs/container/{service}."""
+
+    service: str
+    container: str
+    lines: List[Any]
+    count: int
+    source_type: str
+
+
+class LogUnifiedResponse(BaseModel):
+    """Response for GET /logs/unified."""
+
+    logs: List[Any]
+    total_count: int
+    sources_included: List[str]
+
+
+class LogSearchResponse(BaseModel):
+    """Response for GET /logs/search."""
+
+    query: str
+    results: List[Any]
+    count: int
+    truncated: bool
+
+
+# ---------------------------------------------------------------------------
+# git_mcp.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class GitMCPOperationResponse(BaseModel):
+    """Shared response for all POST /git/mcp/* operation endpoints.
+
+    All git MCP operation endpoints return the same stable shape.
+    Extra fields (repository-specific) are allowed through.
+    """
+
+    model_config = {"extra": "allow"}
+
+    success: bool
+    repository: str
+    output: str
+    timestamp: str
+    errors: Optional[str] = None
+
+
+class GitMCPInfoResponse(BaseModel):
+    """Response for GET /git/mcp/info."""
+
+    success: bool
+    repositories: List[Any]
+    repository_count: int
+    timestamp: str
+
+
+class GitMCPServiceStatusResponse(BaseModel):
+    """Response for GET /git/mcp/service_status."""
+
+    status: str
+    service: str
+    rate_limit: Dict[str, Any]
+    configuration: Dict[str, Any]
+    timestamp: str
+
+
+# ---------------------------------------------------------------------------
+# analytics_llm_patterns.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class LLMPatternsHealthResponse(BaseModel):
+    """Response for GET /llm-patterns/health."""
+
+    status: str
+    service: str
+    deprecated: bool
+    use_instead: str
+    features: List[str]
+    supported_categories: List[str]
+    optimization_types: List[str]
+
+
+class LLMPatternsAnalyzeResponse(BaseModel):
+    """Response for POST /llm-patterns/analyze."""
+
+    prompt_hash: str
+    category: str
+    estimated_tokens: int
+    estimated_cost: float
+    issues: List[Any]
+    recommendations: List[str]
+    cache_potential: bool
+
+
+class LLMPatternsRecordResponse(BaseModel):
+    """Response for POST /llm-patterns/record."""
+
+    recorded: bool
+    prompt_hash: str
+    category: str
+    cost: float
+    cache_count: int
+
+
+class LLMPatternsStatsResponse(BaseModel):
+    """Response for GET /llm-patterns/stats.
+
+    Shape includes totals and by_date/by_model/by_category which are dynamic;
+    extra fields allowed.
+    """
+
+    model_config = {"extra": "allow"}
+
+    period_days: int
+    total_requests: int
+    total_cost: float
+    successful_requests: int
+
+
+class LLMPatternsCacheOpportunitiesResponse(BaseModel):
+    """Response for GET /llm-patterns/cache-opportunities."""
+
+    opportunities: List[Any]
+    count: int
+    min_occurrences: int
+
+
+class LLMPatternsRecommendationsResponse(BaseModel):
+    """Response for GET /llm-patterns/recommendations."""
+
+    recommendations: List[Any]
+
+
+class LLMPatternsModelComparisonResponse(BaseModel):
+    """Response for GET /llm-patterns/model-comparison."""
+
+    models: List[Any]
+    period_days: int
+
+
+class LLMPatternsCategoryDistributionResponse(BaseModel):
+    """Response for GET /llm-patterns/category-distribution."""
+
+    categories: List[Any]
+    total_count: int
+    total_cost: float
+
+
+class LLMPatternsCostBreakdownResponse(BaseModel):
+    """Response for GET /llm-patterns/cost-breakdown."""
+
+    period_days: int
+    total_cost: float
+    total_requests: int
+    avg_cost_per_request: float
+    by_model: List[Any]
+    by_category: List[Any]
+    daily_trend: List[Any]
+
+
+# ---------------------------------------------------------------------------
+# voice.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class VoiceListenResponse(BaseModel):
+    """Response for POST /voice/listen (success path)."""
+
+    message: str
+    text: str
+
+
+class VoiceSpeakResponse(BaseModel):
+    """Response for POST /voice/speak (success path)."""
+
+    message: str
+
+
+class VoiceDeleteResponse(BaseModel):
+    """Response for DELETE /voice/voices/{voice_id} (success path)."""
+
+    deleted: str
+
+
+class VoiceTranscribeResponse(BaseModel):
+    """Response for POST /voice/transcribe."""
+
+    text: str
+    language: str
+    confidence: float
+
+
+# ---------------------------------------------------------------------------
+# skills_governance.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class SkillsGapResponse(BaseModel):
+    """Response for POST /skills-governance/gaps.
+
+    Both success and failure paths share this shape.
+    """
+
+    success: bool
+    errors: Optional[List[str]] = None
+    draft: Optional[Any] = None
+    draft_id: Optional[str] = None
+    name: Optional[str] = None
+    tools_found: Optional[List[str]] = None
+
+
+class SkillsDraftListItem(BaseModel):
+    """Single draft entry in the list response."""
+
+    id: str
+    name: str
+    version: Optional[Any] = None
+    gap_reason: Optional[str] = None
+    created_at: Optional[Any] = None
+    trust_level: Optional[Any] = None
+
+
+class SkillsDraftTestResponse(BaseModel):
+    """Response for POST /skills-governance/drafts/{skill_id}/test."""
+
+    valid: bool
+    errors: List[Any]
+    tools_found: List[str]
+
+
+class SkillsDraftPromoteResponse(BaseModel):
+    """Response for POST /skills-governance/drafts/{skill_id}/promote."""
+
+    promoted: bool
+    path: str
+    name: str
+
+
+class SkillsApprovalItem(BaseModel):
+    """Single approval entry in the list response."""
+
+    id: str
+    skill_id: str
+    requested_by: Optional[str] = None
+    requested_at: Optional[Any] = None
+    reason: Optional[str] = None
+    status: str
+
+
+class SkillsApprovalDecisionResponse(BaseModel):
+    """Response for POST /skills-governance/approvals/{approval_id}."""
+
+    approval_id: str
+    status: str
+
+
+class SkillsGovernanceConfigResponse(BaseModel):
+    """Response for GET /skills-governance/ (may return default dict or full config).
+
+    Extra fields allowed to cover the default-dict path.
+    """
+
+    model_config = {"extra": "allow"}
+
+    mode: Any
+
+
+class SkillsGovernanceUpdateResponse(BaseModel):
+    """Response for PUT /skills-governance/."""
+
+    mode: Any
+
+

--- a/autobot-backend/api/skills_governance.py
+++ b/autobot-backend/api/skills_governance.py
@@ -9,6 +9,17 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+
+from api.schemas_common import (
+    SkillsApprovalDecisionResponse,
+    SkillsApprovalItem,
+    SkillsDraftListItem,
+    SkillsDraftPromoteResponse,
+    SkillsDraftTestResponse,
+    SkillsGapResponse,
+    SkillsGovernanceConfigResponse,
+    SkillsGovernanceUpdateResponse,
+)
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -85,7 +96,7 @@ def _governance_default() -> Dict[str, Any]:
     return {"mode": "semi_auto", "gap_detection_enabled": True}
 
 
-@router.post("/gaps", summary="Generate a skill to fill a capability gap")
+@router.post("/gaps", summary="Generate a skill to fill a capability gap", response_model=SkillsGapResponse)
 async def detect_gap(
     req: GapRequest,
     _: None = Depends(check_admin_permission),
@@ -131,7 +142,7 @@ async def detect_gap(
     }
 
 
-@router.get("/drafts", summary="List all skill drafts")
+@router.get("/drafts", summary="List all skill drafts", response_model=List[SkillsDraftListItem])
 async def list_drafts() -> List[Dict[str, Any]]:
     """Return all SkillPackage records in DRAFT state."""
     engine = get_skills_engine()
@@ -153,7 +164,7 @@ async def list_drafts() -> List[Dict[str, Any]]:
     ]
 
 
-@router.post("/drafts/{skill_id}/test", summary="Validate a skill draft")
+@router.post("/drafts/{skill_id}/test", summary="Validate a skill draft", response_model=SkillsDraftTestResponse)
 async def test_draft(
     skill_id: str,
     _: None = Depends(check_admin_permission),
@@ -173,7 +184,7 @@ async def test_draft(
     }
 
 
-@router.post("/drafts/{skill_id}/promote", summary="Promote a draft skill to builtin")
+@router.post("/drafts/{skill_id}/promote", summary="Promote a draft skill to builtin", response_model=SkillsDraftPromoteResponse)
 async def promote_draft(
     skill_id: str,
     _: None = Depends(check_admin_permission),
@@ -228,7 +239,7 @@ async def promote_draft(
     return {"promoted": True, "path": promoted_path, "name": skill.name}
 
 
-@router.get("/approvals", summary="List pending skill approvals")
+@router.get("/approvals", summary="List pending skill approvals", response_model=List[SkillsApprovalItem])
 async def list_approvals() -> List[Dict[str, Any]]:
     """Return all SkillApproval records with status 'pending'."""
     engine = get_skills_engine()
@@ -250,7 +261,7 @@ async def list_approvals() -> List[Dict[str, Any]]:
     ]
 
 
-@router.post("/approvals/{approval_id}", summary="Approve or reject a skill approval")
+@router.post("/approvals/{approval_id}", summary="Approve or reject a skill approval", response_model=SkillsApprovalDecisionResponse)
 async def decide_approval(
     approval_id: str,
     body: ApprovalDecision,
@@ -269,7 +280,7 @@ async def decide_approval(
     return {"approval_id": approval_id, "status": approval.status}
 
 
-@router.get("/", summary="Get current governance configuration")
+@router.get("/", summary="Get current governance configuration", response_model=SkillsGovernanceConfigResponse)
 async def get_governance() -> Dict[str, Any]:
     """Return the active GovernanceConfig, or the default if none exists."""
     engine = get_skills_engine()
@@ -287,7 +298,7 @@ async def get_governance() -> Dict[str, Any]:
     }
 
 
-@router.put("/", summary="Update the governance mode")
+@router.put("/", summary="Update the governance mode", response_model=SkillsGovernanceUpdateResponse)
 async def update_governance(
     body: GovernanceModeUpdate,
     _: None = Depends(check_admin_permission),

--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -9,6 +9,12 @@ import tempfile
 from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
 from fastapi.responses import JSONResponse, Response
 
+from api.schemas_common import (
+    VoiceDeleteResponse,
+    VoiceListenResponse,
+    VoiceSpeakResponse,
+    VoiceTranscribeResponse,
+)
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.tts_client import get_tts_client
@@ -24,7 +30,7 @@ logger = logging.getLogger(__name__)
     operation="voice_listen_api",
     error_code_prefix="VOICE",
 )
-@router.post("/listen")
+@router.post("/listen", response_model=VoiceListenResponse)
 async def voice_listen_api(request: Request, user_role: str = Form("user")):
     """Listen and convert speech to text"""
     security_layer = request.app.state.security_layer
@@ -65,7 +71,7 @@ async def voice_listen_api(request: Request, user_role: str = Form("user")):
     operation="voice_speak_api",
     error_code_prefix="VOICE",
 )
-@router.post("/speak")
+@router.post("/speak", response_model=VoiceSpeakResponse)
 async def voice_speak_api(
     request: Request, text: str = Form(...), user_role: str = Form("user")
 ):
@@ -114,7 +120,7 @@ async def voice_speak_api(
     operation="voice_synthesize_api",
     error_code_prefix="VOICE",
 )
-@router.post("/synthesize")
+@router.post("/synthesize", response_model=None)
 async def voice_synthesize_api(
     request: Request,
     text: str = Form(...),
@@ -150,7 +156,7 @@ async def voice_synthesize_api(
     operation="voice_clone_api",
     error_code_prefix="VOICE",
 )
-@router.post("/clone-voice")
+@router.post("/clone-voice", response_model=None)
 async def voice_clone_api(
     request: Request,
     text: str = Form(...),
@@ -186,7 +192,7 @@ async def voice_clone_api(
 # ------------------------------------------------------------------
 
 
-@router.get("/voices")
+@router.get("/voices", response_model=None)
 async def voice_list_api():
     """List available voice profiles from TTS worker."""
     tts = get_tts_client()
@@ -199,7 +205,7 @@ async def voice_list_api():
     operation="voice_create_api",
     error_code_prefix="VOICE",
 )
-@router.post("/voices/create")
+@router.post("/voices/create", response_model=None)
 async def voice_create_api(
     name: str = Form(...),
     audio: UploadFile = File(...),
@@ -216,7 +222,7 @@ async def voice_create_api(
     operation="voice_delete_api",
     error_code_prefix="VOICE",
 )
-@router.delete("/voices/{voice_id}")
+@router.delete("/voices/{voice_id}", response_model=VoiceDeleteResponse)
 async def voice_delete_api(voice_id: str):
     """Delete a custom voice profile."""
     tts = get_tts_client()
@@ -299,7 +305,7 @@ async def _transcribe_with_whisper(
     operation="voice_transcribe_api",
     error_code_prefix="VOICE",
 )
-@router.post("/transcribe")
+@router.post("/transcribe", response_model=VoiceTranscribeResponse)
 async def voice_transcribe_api(
     request: Request,
     audio: UploadFile = File(...),


### PR DESCRIPTION
## Summary
- Annotates 43 endpoints; 30 new Pydantic models in schemas_common.py
- Full typed coverage for git_mcp, analytics_llm_patterns, skills_governance; partial for logs/voice (StreamingResponse endpoints get None)

## Part of #5317 (Round 5b)
🤖 Generated with [Claude Code](https://claude.com/claude-code)