### PR TITLE
fix(composables): guard AbortError by name only in useApiResource (#5179)

### DIFF
--- a/autobot-frontend/src/composables/useApiResource.ts
+++ b/autobot-frontend/src/composables/useApiResource.ts
@@ -128,9 +128,9 @@ export function useApiResource<T>(
       data.value = result
     } catch (e) {
       // AbortError means this call was superseded — not a real failure.
-      // Check by name to handle both DOMException (browser) and plain Error
-      // objects with name='AbortError' (some fetch polyfills / jsdom).
-      if (e instanceof Error && e.name === 'AbortError') return
+      // Guard by name only: DOMException is not an Error subclass in jsdom,
+      // and some fetch polyfills throw plain Error objects with name='AbortError'.
+      if (e != null && (e as { name?: unknown }).name === 'AbortError') return
       if (disposed || callId !== latestCallId) return
       error.value = e instanceof Error ? e : new Error(String(e))
     } finally {


### PR DESCRIPTION
## Summary

- Fix AbortError guard in `useApiResource`: change `e instanceof Error && e.name === 'AbortError'` to `e != null && (e as { name?: unknown }).name === 'AbortError'`
- `DOMException` is not an `Error` subclass in jsdom; some fetch polyfills also throw plain objects with `name='AbortError'`
- The prior guard silently let aborted fetches fall through to the error handler in test environments

Follow-up to #5787 / PR #5787.

## Test plan
- [ ] `npm run type-check` passes in autobot-frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)