### PR TITLE
refactor(knowledge): type gpu_vector_search.py client params as BaseClient (#5732)

### DIFF
--- a/autobot-backend/ARCHITECTURE_EXCEPTIONS.md
+++ b/autobot-backend/ARCHITECTURE_EXCEPTIONS.md
@@ -1,0 +1,32 @@
+# Architecture Exceptions
+
+This file documents intentional deviations from standard AutoBot architecture patterns.
+Each exception must state: the file, the pattern bypassed, and the technical rationale.
+
+---
+
+## `utils/gpu_vector_search.py` — FAISS-GPU hybrid search client type
+
+**Pattern bypassed:** Direct use of raw chromadb client methods rather than going
+through a `BaseCollection` ABC instance.
+
+**Status:** Partially migrated. The `HybridVectorSearch` constructor and
+`get_hybrid_vector_search` factory now accept a `BaseClient` (from
+`knowledge.backends`) rather than `Any`. The internal call sites
+(`get_or_create_collection`, `get_collection`, `list_collections`) all exist on
+`BaseClient`, so any conformant adapter works.
+
+**Why the collection call sites are NOT wrapped in `BaseCollection`:**
+`HybridVectorSearch` interleaves FAISS-GPU vector search with ChromaDB document
+storage in a single hybrid pipeline. The collection object returned by
+`get_or_create_collection` / `get_collection` is used immediately for
+`collection.add(...)`, `collection.get(...)`, `collection.query(...)`, and
+`collection.count()` — all of which are defined on `BaseCollection`. The code
+therefore already benefits from the abstraction at the client level; the collection
+objects returned satisfy the `BaseCollection` contract and callers do not reach for
+any chromadb-specific attribute.
+
+**GPU-specific operations** (`faiss.StandardGpuResources`, `faiss.index_cpu_to_gpu`,
+`faiss.index_gpu_to_cpu`) exist in `GPUVectorIndex` and are entirely independent of
+the ChromaDB client. They cannot be expressed through any vector-store ABC; they
+require direct FAISS C++ bindings by design.

--- a/autobot-backend/utils/gpu_vector_search.py
+++ b/autobot-backend/utils/gpu_vector_search.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 
+from knowledge.backends import BaseClient
 from utils.async_initializable import AsyncInitializable
 
 # FAISS import with graceful fallback
@@ -749,7 +750,7 @@ class HybridVectorSearch(AsyncInitializable):
 
     def __init__(
         self,
-        chromadb_client: Optional[Any] = None,
+        chromadb_client: Optional[BaseClient] = None,
         config: Optional[VectorSearchConfig] = None,
     ):
         """Initialize hybrid search; FAISS/GPU init is deferred to _initialize_impl."""
@@ -1062,7 +1063,7 @@ _hybrid_search_lock = asyncio.Lock()
 
 
 async def get_hybrid_vector_search(
-    chromadb_client: Optional[Any] = None,
+    chromadb_client: Optional[BaseClient] = None,
     config: Optional[VectorSearchConfig] = None,
 ) -> HybridVectorSearch:
     """


### PR DESCRIPTION
## Summary

- Replace `Optional[Any]` with `Optional[BaseClient]` for `chromadb_client` parameter in `HybridVectorSearch.__init__` and `get_hybrid_vector_search`
- Add `from knowledge.backends import BaseClient` import
- Add `autobot-backend/ARCHITECTURE_EXCEPTIONS.md` documenting why the internal collection call sites remain unwrapped (FAISS-GPU pipeline constraint — collection objects satisfy BaseCollection contract but GPU index operations require direct FAISS C++ bindings)
- Completes the second half of #5732 (autonomous_loop.py was done in PR #5788)

Closes #5732

## Test plan
- [ ] `python -m py_compile autobot-backend/utils/gpu_vector_search.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)