### PR TITLE
feat(api): add response_model= to cache_management, monitoring, settings (#5317)

### DIFF
--- a/autobot-backend/api/cache_management.py
+++ b/autobot-backend/api/cache_management.py
@@ -10,7 +10,7 @@ Consolidates all cache-related endpoints (Issue #1286).
 import asyncio
 import json
 import logging
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -107,6 +107,103 @@ class CacheWarmingRequest(BaseModel):
     force_refresh: bool = False
 
 
+class RedisDbInfo(BaseModel):
+    """Per-database Redis info."""
+
+    database: int
+    key_count: int
+    memory_usage: str
+    connected: bool
+    error: Optional[str] = None
+
+
+class RedisClearEntry(BaseModel):
+    """Result for a single cleared database."""
+
+    name: str
+    database: int
+    keys_cleared: int
+    error: Optional[str] = None
+
+
+class RedisStatsResponse(BaseModel):
+    """Response for GET /stats."""
+
+    status: str
+    stats: Dict[str, Any]
+
+
+class RedisClearResponse(BaseModel):
+    """Response for POST /redis/clear/{database}."""
+
+    status: str
+    message: str
+    cleared_databases: List[Dict[str, Any]]
+
+
+class CacheClearTypeResponse(BaseModel):
+    """Response for POST /clear/{cache_type}."""
+
+    status: str
+    message: str
+    cache_type: str
+
+
+class CacheConfigResponse(BaseModel):
+    """Response for GET/POST /config."""
+
+    status: str
+    message: Optional[str] = None
+    config: Dict[str, Any]
+    source: Optional[str] = None
+
+
+class CacheWarmupResponse(BaseModel):
+    """Response for POST /warmup."""
+
+    status: str
+    message: str
+    warmed_caches: List[Dict[str, Any]]
+
+
+class WarmCacheResponse(BaseModel):
+    """Response for POST /warm."""
+
+    success: bool
+    warmed_types: List[str]
+    failed_types: List[str]
+    total_warmed: int
+
+
+class InvalidateCacheResponse(BaseModel):
+    """Response for DELETE /invalidate/{data_type}."""
+
+    success: bool
+    data_type: str
+    key_pattern: str
+    user_id: Optional[str] = None
+    deleted_count: int
+
+
+class ClearAllResponse(BaseModel):
+    """Response for POST /clear-all."""
+
+    success: bool
+    message: str
+    total_deleted: int
+
+
+class CacheHealthResponse(BaseModel):
+    """Response for GET /health."""
+
+    status: str
+    redis_status: Optional[str] = None
+    total_keys: Optional[int] = None
+    memory_usage: Optional[str] = None
+    global_hit_rate: Optional[str] = None
+    error: Optional[str] = None
+
+
 def _process_data_type_stats_results(
     data_types: List[str], stats_results: list
 ) -> Dict[str, Dict]:
@@ -129,7 +226,7 @@ def _process_data_type_stats_results(
     operation="get_cache_stats",
     error_code_prefix="CACHE",
 )
-@router.get("/stats")
+@router.get("/stats", response_model=RedisStatsResponse)
 async def get_cache_stats():
     """Get comprehensive cache statistics from all Redis databases."""
     stats = {
@@ -178,7 +275,7 @@ async def get_cache_stats():
     operation="clear_redis_cache",
     error_code_prefix="CACHE",
 )
-@router.post("/redis/clear/{database}")
+@router.post("/redis/clear/{database}", response_model=RedisClearResponse)
 async def clear_redis_cache(database: str):
     """Clear Redis cache for specific database or all databases."""
     cleared_databases = []
@@ -224,7 +321,7 @@ async def clear_redis_cache(database: str):
     operation="clear_cache_type",
     error_code_prefix="CACHE",
 )
-@router.post("/clear/{cache_type}")
+@router.post("/clear/{cache_type}", response_model=CacheClearTypeResponse)
 async def clear_cache_type(cache_type: str):
     """Clear specific backend cache type."""
     if cache_type == "llm":
@@ -253,7 +350,7 @@ async def clear_cache_type(cache_type: str):
     operation="save_cache_config",
     error_code_prefix="CACHE",
 )
-@router.post("/config")
+@router.post("/config", response_model=CacheConfigResponse)
 async def save_cache_config(config_data: Metadata):
     """Save cache configuration settings."""
     required_fields = [
@@ -287,7 +384,7 @@ async def save_cache_config(config_data: Metadata):
     operation="get_cache_config",
     error_code_prefix="CACHE",
 )
-@router.get("/config")
+@router.get("/config", response_model=CacheConfigResponse)
 async def get_cache_config():
     """Get current cache configuration."""
     try:
@@ -316,7 +413,7 @@ async def get_cache_config():
     operation="warmup_caches",
     error_code_prefix="CACHE",
 )
-@router.post("/warmup")
+@router.post("/warmup", response_model=CacheWarmupResponse)
 async def warmup_caches():
     """Warm up commonly used caches."""
     logger.info("Cache warmup requested")
@@ -385,7 +482,7 @@ async def get_advanced_cache_stats(
     operation="warm_cache",
     error_code_prefix="CACHE_MANAGEMENT",
 )
-@router.post("/warm")
+@router.post("/warm", response_model=WarmCacheResponse)
 async def warm_cache(
     request: CacheWarmingRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -429,7 +526,7 @@ async def warm_cache(
     operation="invalidate_cache",
     error_code_prefix="CACHE_MANAGEMENT",
 )
-@router.delete("/invalidate/{data_type}")
+@router.delete("/invalidate/{data_type}", response_model=InvalidateCacheResponse)
 async def invalidate_cache(
     data_type: str,
     key: str = Query("*", description="Key pattern to invalidate (* for all)"),
@@ -461,7 +558,7 @@ async def invalidate_cache(
     operation="clear_all_cache",
     error_code_prefix="CACHE_MANAGEMENT",
 )
-@router.post("/clear-all")
+@router.post("/clear-all", response_model=ClearAllResponse)
 async def clear_all_cache(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -607,7 +704,7 @@ async def _warm_data_type(data_type: str, force_refresh: bool = False) -> bool:
     operation="cache_health_check",
     error_code_prefix="CACHE_MANAGEMENT",
 )
-@router.get("/health")
+@router.get("/health", response_model=CacheHealthResponse)
 async def cache_health_check():
     """Check cache system health"""
     try:
@@ -638,7 +735,7 @@ async def cache_health_check():
     operation="semantic_cache_stats",
     error_code_prefix="CACHE_MANAGEMENT",
 )
-@router.get("/semantic-cache/stats")
+@router.get("/semantic-cache/stats", response_model=dict)
 async def semantic_cache_stats(
     _user: dict = Depends(get_current_user),
 ):
@@ -654,7 +751,7 @@ async def semantic_cache_stats(
     operation="semantic_cache_clear",
     error_code_prefix="CACHE_MANAGEMENT",
 )
-@router.delete("/semantic-cache/clear")
+@router.delete("/semantic-cache/clear", response_model=dict)
 async def semantic_cache_clear(
     _user: dict = Depends(check_admin_permission),
 ):
@@ -680,7 +777,7 @@ class SemanticCacheConfigUpdate(BaseModel):
     operation="semantic_cache_config",
     error_code_prefix="CACHE_MANAGEMENT",
 )
-@router.put("/semantic-cache/config")
+@router.put("/semantic-cache/config", response_model=dict)
 async def semantic_cache_update_config(
     update: SemanticCacheConfigUpdate,
     _user: dict = Depends(check_admin_permission),
@@ -707,7 +804,7 @@ async def semantic_cache_update_config(
     operation="context_sufficiency_stats",
     error_code_prefix="CACHE_MANAGEMENT",
 )
-@router.get("/context-sufficiency/stats")
+@router.get("/context-sufficiency/stats", response_model=dict)
 async def context_sufficiency_stats(
     _user: dict = Depends(get_current_user),
 ):
@@ -732,7 +829,7 @@ class SufficiencyConfigUpdate(BaseModel):
     operation="context_sufficiency_config",
     error_code_prefix="CACHE_MANAGEMENT",
 )
-@router.put("/context-sufficiency/config")
+@router.put("/context-sufficiency/config", response_model=dict)
 async def context_sufficiency_update_config(
     update: SufficiencyConfigUpdate,
     _user: dict = Depends(check_admin_permission),
@@ -755,7 +852,7 @@ async def context_sufficiency_update_config(
     operation="topic_cache_stats",
     error_code_prefix="CACHE_MANAGEMENT",
 )
-@router.get("/topic-cache/stats")
+@router.get("/topic-cache/stats", response_model=dict)
 async def topic_cache_stats(
     _user: dict = Depends(get_current_user),
 ):
@@ -780,7 +877,7 @@ class TopicCacheConfigUpdate(BaseModel):
     operation="topic_cache_config",
     error_code_prefix="CACHE_MANAGEMENT",
 )
-@router.put("/topic-cache/config")
+@router.put("/topic-cache/config", response_model=dict)
 async def topic_cache_update_config(
     update: TopicCacheConfigUpdate,
     _user: dict = Depends(check_admin_permission),

--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -257,6 +257,125 @@ router = APIRouter(tags=["AutoBot Monitoring"])
 CRITICAL_SERVICE_STATUSES = {"critical", "offline"}
 
 
+class ServicesSummaryResponse(BaseModel):
+    """Response for GET /services/health."""
+
+    total_services: int
+    healthy_services: int
+    degraded_services: int
+    critical_services: int
+    overall_status: str
+    health_percentage: float
+    services: List[Dict[str, Any]]
+
+
+class MonitoringActionResponse(BaseModel):
+    """Response for monitoring start/stop endpoints."""
+
+    status: str
+    message: str
+    collection_interval: Optional[float] = None
+
+
+class CurrentMetricsResponse(BaseModel):
+    """Response for GET /metrics/current."""
+
+    timestamp: float
+    metrics: Dict[str, Any]
+    collection_successful: bool
+
+
+class ThresholdUpdateResponse(BaseModel):
+    """Response for POST /thresholds/update."""
+
+    status: str
+    threshold_key: str
+    new_value: float
+    comparison: str
+    old_value: Optional[float] = None
+
+
+class TestPerformanceResponse(BaseModel):
+    """Response for POST /test/performance."""
+
+    message: str
+    metrics_collected: bool
+    timestamp: float
+
+
+class ClaudeApiDetails(BaseModel):
+    """Claude API metrics from Prometheus."""
+
+    rate_limit_remaining: Optional[float] = None
+    requests_per_minute: Optional[float] = None
+    p95_latency_seconds: Optional[float] = None
+    failure_rate: Optional[float] = None
+
+
+class ClaudeApiStatusResponse(BaseModel):
+    """Response for GET /claude-api/status."""
+
+    success: bool
+    claude_api_status: ClaudeApiDetails
+    timestamp: str
+
+
+class GitHubApiDetails(BaseModel):
+    """GitHub API metrics from Prometheus."""
+
+    rate_limit_remaining: Optional[float] = None
+    total_operations: Optional[float] = None
+    p95_latency_seconds: Optional[float] = None
+
+
+class GitHubStatusResponse(BaseModel):
+    """Response for GET /github/status."""
+
+    success: bool
+    github_status: GitHubApiDetails
+    timestamp: str
+
+
+class AlertSources(BaseModel):
+    """Alert source counts."""
+
+    alertmanager: int
+    performance_monitor: int
+
+
+class AlertCheckResponse(BaseModel):
+    """Response for GET /alerts/check."""
+
+    timestamp: float
+    alerts: List[Dict[str, Any]]
+    total_count: int
+    critical_count: int
+    warning_count: int
+    high_count: int
+    sources: AlertSources
+
+
+class AlertManagerSeverityCounts(BaseModel):
+    """Severity breakdown for alertmanager response."""
+
+    critical: int
+    high: int
+    warning: int
+    info: int
+
+
+class AlertManagerResponse(BaseModel):
+    """Response for GET /alerts/alertmanager."""
+
+    timestamp: float
+    source: str
+    alertmanager_url: str
+    alerts: List[Dict[str, Any]]
+    total_count: int
+    by_severity: AlertManagerSeverityCounts
+    active_alerts: Dict[str, List[Dict[str, Any]]]
+
+
 class MonitoringStatus(BaseModel):
     """Monitoring system status"""
 
@@ -519,7 +638,7 @@ def _compute_overall_status(svc_list: list) -> dict:
     operation="get_services_health",
     error_code_prefix="MONITORING",
 )
-@router.get("/services/health")
+@router.get("/services/health", response_model=ServicesSummaryResponse)
 async def get_services_health():
     """Return service health in ServicesSummary format for frontend.
 
@@ -587,7 +706,7 @@ async def get_monitoring_status(
     operation="start_monitoring",
     error_code_prefix="MONITORING",
 )
-@router.post("/start")
+@router.post("/start", response_model=MonitoringActionResponse)
 async def start_monitoring_endpoint(
     admin_check: bool = Depends(check_admin_permission),
     background_tasks: BackgroundTasks = None,
@@ -627,7 +746,7 @@ async def start_monitoring_endpoint(
     operation="stop_monitoring",
     error_code_prefix="MONITORING",
 )
-@router.post("/stop")
+@router.post("/stop", response_model=MonitoringActionResponse)
 async def stop_monitoring_endpoint(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -651,7 +770,7 @@ async def stop_monitoring_endpoint(
     operation="get_performance_dashboard",
     error_code_prefix="MONITORING",
 )
-@router.get("/dashboard")
+@router.get("/dashboard", response_model=dict)
 async def get_dashboard_endpoint(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -674,7 +793,7 @@ async def get_dashboard_endpoint(
     operation="get_dashboard_overview",
     error_code_prefix="MONITORING",
 )
-@router.get("/dashboard/overview")
+@router.get("/dashboard/overview", response_model=dict)
 async def get_dashboard_overview(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -697,7 +816,7 @@ async def get_dashboard_overview(
     operation="get_current_metrics",
     error_code_prefix="MONITORING",
 )
-@router.get("/metrics/current")
+@router.get("/metrics/current", response_model=CurrentMetricsResponse)
 async def get_current_metrics(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -715,7 +834,7 @@ async def get_current_metrics(
     operation="query_metrics",
     error_code_prefix="MONITORING",
 )
-@router.post("/metrics/query")
+@router.post("/metrics/query", response_model=dict)
 async def query_metrics(
     admin_check: bool = Depends(check_admin_permission),
     query: MetricsQuery = None,
@@ -852,7 +971,7 @@ async def get_performance_alerts(
     operation="check_alerts",
     error_code_prefix="MONITORING",
 )
-@router.get("/alerts/check")
+@router.get("/alerts/check", response_model=AlertCheckResponse)
 async def check_alerts(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -892,7 +1011,7 @@ async def check_alerts(
     operation="get_alertmanager_alerts",
     error_code_prefix="MONITORING",
 )
-@router.get("/alerts/alertmanager")
+@router.get("/alerts/alertmanager", response_model=AlertManagerResponse)
 async def get_alertmanager_alerts(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -934,7 +1053,7 @@ async def get_alertmanager_alerts(
     operation="update_performance_threshold",
     error_code_prefix="MONITORING",
 )
-@router.post("/thresholds/update")
+@router.post("/thresholds/update", response_model=ThresholdUpdateResponse)
 async def update_performance_threshold(
     admin_check: bool = Depends(check_admin_permission),
     threshold: ThresholdUpdate = None,
@@ -1129,7 +1248,7 @@ async def realtime_monitoring_websocket(websocket: WebSocket):
     operation="test_performance_monitoring",
     error_code_prefix="MONITORING",
 )
-@router.post("/test/performance")
+@router.post("/test/performance", response_model=TestPerformanceResponse)
 @monitor_performance("api_test")
 async def test_performance_monitoring(
     admin_check: bool = Depends(check_admin_permission),
@@ -1159,7 +1278,7 @@ async def test_performance_monitoring(
     operation="get_hardware_npu",
     error_code_prefix="MONITORING",
 )
-@router.get("/hardware/npu")
+@router.get("/hardware/npu", response_model=dict)
 async def get_hardware_npu_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -1172,7 +1291,7 @@ async def get_hardware_npu_status(
     operation="get_hardware_gpu",
     error_code_prefix="MONITORING",
 )
-@router.get("/hardware/gpu")
+@router.get("/hardware/gpu", response_model=dict)
 async def get_hardware_gpu_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -1185,7 +1304,7 @@ async def get_hardware_gpu_status(
     operation="get_hardware_system",
     error_code_prefix="MONITORING",
 )
-@router.get("/hardware/system")
+@router.get("/hardware/system", response_model=dict)
 async def get_hardware_system_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -1201,7 +1320,7 @@ async def get_hardware_system_status(
     operation="get_claude_api_status",
     error_code_prefix="MONITORING",
 )
-@router.get("/claude-api/status")
+@router.get("/claude-api/status", response_model=ClaudeApiStatusResponse)
 async def get_claude_api_status():
     """Get Claude API status via Prometheus metrics.
 
@@ -1240,7 +1359,7 @@ async def get_claude_api_status():
     operation="get_github_status",
     error_code_prefix="MONITORING",
 )
-@router.get("/github/status")
+@router.get("/github/status", response_model=GitHubStatusResponse)
 async def get_github_status():
     """Get GitHub API status via Prometheus metrics.
 

--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -42,6 +42,64 @@ import re
 RBAC_MARKER_PATH = Path("/etc/autobot/rbac-initialized")
 
 
+class SaveSettingsResponse(BaseModel):
+    """Response for save settings endpoints — passes through ConfigService result dict."""
+
+    status: Optional[str] = None
+    message: Optional[str] = None
+    success: Optional[bool] = None
+
+
+class ClearCacheResponse(BaseModel):
+    """Response for POST /clear-cache."""
+
+    status: str
+    message: str
+    available_endpoints: Optional[dict] = None
+
+
+class TaskQueuedResponse(BaseModel):
+    """Response when a Celery task is queued."""
+
+    task_id: str
+    status: str
+    message: str
+    dry_run: Optional[bool] = None
+
+
+class TaskStatusResponse(BaseModel):
+    """Response for Celery task status polling."""
+
+    task_id: str
+    status: str
+    message: Optional[str] = None
+    progress: Optional[Any] = None
+    result: Optional[Any] = None
+    error: Optional[str] = None
+
+
+class RBACStatusResponse(BaseModel):
+    """Response for GET /rbac/status."""
+
+    initialized: bool
+    message: str
+
+
+class WorkerStatusResponse(BaseModel):
+    """Response for GET /updates/worker-status."""
+
+    available: bool
+    message: str
+
+
+class UpdateStatusResponse(BaseModel):
+    """Response for GET /updates/status."""
+
+    last_update: Optional[str] = None
+    marker_exists: bool
+    message: str
+
+
 class RBACInitRequest(BaseModel):
     """Request model for RBAC initialization."""
 
@@ -70,7 +128,7 @@ class RBACInitRequest(BaseModel):
     operation="get_settings",
     error_code_prefix="SETTINGS",
 )
-@router.get("/")
+@router.get("/", response_model=dict)
 async def get_settings():
     """Get application settings - now uses full config from config.yaml"""
     try:
@@ -85,7 +143,7 @@ async def get_settings():
     operation="get_settings_explicit",
     error_code_prefix="SETTINGS",
 )
-@router.get("/settings")
+@router.get("/settings", response_model=dict)
 async def get_settings_explicit():
     """Get application settings.
 
@@ -109,7 +167,7 @@ async def get_settings_explicit():
     operation="save_settings",
     error_code_prefix="SETTINGS",
 )
-@router.post("/")
+@router.post("/", response_model=dict)
 async def save_settings(
     settings_data: dict,
     session: AsyncSession = Depends(get_db_session),
@@ -143,7 +201,7 @@ async def save_settings(
     operation="save_settings_explicit",
     error_code_prefix="SETTINGS",
 )
-@router.post("/settings")
+@router.post("/settings", response_model=dict)
 async def save_settings_explicit(
     settings_data: dict,
     session: AsyncSession = Depends(get_db_session),
@@ -185,7 +243,7 @@ async def save_settings_explicit(
     operation="get_backend_settings",
     error_code_prefix="SETTINGS",
 )
-@router.get("/backend")
+@router.get("/backend", response_model=dict)
 async def get_backend_settings():
     """Get backend-specific settings"""
     try:
@@ -200,7 +258,7 @@ async def get_backend_settings():
     operation="save_backend_settings",
     error_code_prefix="SETTINGS",
 )
-@router.post("/backend")
+@router.post("/backend", response_model=dict)
 async def save_backend_settings(
     backend_settings: dict,
     session: AsyncSession = Depends(get_db_session),
@@ -229,7 +287,7 @@ async def save_backend_settings(
     operation="get_full_config",
     error_code_prefix="SETTINGS",
 )
-@router.get("/config")
+@router.get("/config", response_model=dict)
 async def get_full_config():
     """Get complete application configuration"""
     try:
@@ -244,7 +302,7 @@ async def get_full_config():
     operation="save_full_config",
     error_code_prefix="SETTINGS",
 )
-@router.post("/config")
+@router.post("/config", response_model=dict)
 async def save_full_config(
     config_data: dict,
     session: AsyncSession = Depends(get_db_session),
@@ -273,7 +331,7 @@ async def save_full_config(
     operation="clear_cache",
     error_code_prefix="SETTINGS",
 )
-@router.post("/clear-cache")
+@router.post("/clear-cache", response_model=ClearCacheResponse)
 async def clear_cache():
     """Clear application cache - includes config cache"""
     try:
@@ -306,7 +364,7 @@ async def clear_cache():
     operation="initialize_rbac",
     error_code_prefix="RBAC",
 )
-@router.post("/rbac/initialize")
+@router.post("/rbac/initialize", response_model=TaskQueuedResponse)
 async def initialize_rbac_endpoint(
     request: RBACInitRequest,
     _: None = Depends(check_admin_permission),
@@ -355,7 +413,7 @@ async def initialize_rbac_endpoint(
     operation="get_rbac_task_status",
     error_code_prefix="RBAC",
 )
-@router.get("/rbac/status/{task_id}")
+@router.get("/rbac/status/{task_id}", response_model=TaskStatusResponse)
 async def get_rbac_task_status(
     task_id: str,
     _: None = Depends(check_admin_permission),
@@ -402,7 +460,7 @@ async def get_rbac_task_status(
     operation="get_rbac_status",
     error_code_prefix="RBAC",
 )
-@router.get("/rbac/status")
+@router.get("/rbac/status", response_model=RBACStatusResponse)
 async def get_rbac_status(
     _: None = Depends(check_admin_permission),
 ):
@@ -458,7 +516,7 @@ class SystemUpdateRequest(BaseModel):
     operation="run_system_update",
     error_code_prefix="UPDATES",
 )
-@router.post("/updates/run")
+@router.post("/updates/run", response_model=TaskQueuedResponse)
 async def run_system_update_endpoint(
     request: SystemUpdateRequest,
     _: None = Depends(check_admin_permission),
@@ -526,7 +584,7 @@ async def run_system_update_endpoint(
     operation="get_update_task_status",
     error_code_prefix="UPDATES",
 )
-@router.get("/updates/status/{task_id}")
+@router.get("/updates/status/{task_id}", response_model=TaskStatusResponse)
 async def get_update_task_status(
     task_id: str,
     _: None = Depends(check_admin_permission),
@@ -615,7 +673,7 @@ def _check_celery_worker_available() -> tuple[bool, str]:
     operation="check_celery_health",
     error_code_prefix="UPDATES",
 )
-@router.get("/updates/worker-status")
+@router.get("/updates/worker-status", response_model=WorkerStatusResponse)
 async def check_celery_worker_status(
     _: None = Depends(check_admin_permission),
 ):
@@ -638,7 +696,7 @@ async def check_celery_worker_status(
     operation="check_available_updates",
     error_code_prefix="UPDATES",
 )
-@router.post("/updates/check")
+@router.post("/updates/check", response_model=TaskQueuedResponse)
 async def check_updates_endpoint(
     _: None = Depends(check_admin_permission),
 ):
@@ -690,7 +748,7 @@ async def check_updates_endpoint(
     operation="get_update_status",
     error_code_prefix="UPDATES",
 )
-@router.get("/updates/status")
+@router.get("/updates/status", response_model=UpdateStatusResponse)
 async def get_update_status(
     _: None = Depends(check_admin_permission),
 ):


### PR DESCRIPTION
## Summary

- Wire `response_model=` into all HTTP endpoints in `cache_management.py`, `monitoring.py`, `settings.py`
- Part of the systematic response_model= audit (#5317)

## Test plan
- [ ] `python -m py_compile` passes for all 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)