### PR TITLE
docs(config): mark VNC browser-path env vars as dormant in .env.example (#5138)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -239,6 +239,9 @@ AUTOBOT_SINGLE_USER_MODE=true
 # =============================================================================
 # VNC CONFIGURATION
 # =============================================================================
+# DORMANT: VNC browser path replaced by screenshot panel (#1130).
+# These variables are preserved for future VNC re-integration.
+# See: https://github.com/mrveiss/AutoBot-AI/issues/5136
 # VNC desktop and terminal configuration.
 
 AUTOBOT_VNC_PASSWORD=<GENERATE_SECURE_PASSWORD>
@@ -377,6 +380,7 @@ VITE_BROWSER_HOST=YOUR_BROWSER_VM_IP
 VITE_BROWSER_PORT=3000
 VITE_HTTP_PROTOCOL=http
 
+# DORMANT: VNC browser path replaced by screenshot panel (#1130). Preserved for #5136 re-integration.
 # VNC Configuration
 VITE_DESKTOP_VNC_HOST=YOUR_BACKEND_IP
 VITE_DESKTOP_VNC_PORT=6080


### PR DESCRIPTION
## Summary
- Updated `.env.example` to annotate VNC browser-path env vars as dormant/deprecated
- References the abandoned browser-worker VNC path that is no longer active

Closes #5138

🤖 Generated with [Claude Code](https://claude.com/claude-code)