### PR TITLE
docs(config): complete VNC dormant comments in ssot-config, AppConfig, ServiceDiscovery, stores, slm-frontend, docs (#5138)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -239,6 +239,9 @@ AUTOBOT_SINGLE_USER_MODE=true
 # =============================================================================
 # VNC CONFIGURATION
 # =============================================================================
+# DORMANT: VNC browser path replaced by screenshot panel (#1130).
+# These variables are preserved for future VNC re-integration.
+# See: https://github.com/mrveiss/AutoBot-AI/issues/5136
 # VNC desktop and terminal configuration.
 
 AUTOBOT_VNC_PASSWORD=<GENERATE_SECURE_PASSWORD>
@@ -377,6 +380,7 @@ VITE_BROWSER_HOST=YOUR_BROWSER_VM_IP
 VITE_BROWSER_PORT=3000
 VITE_HTTP_PROTOCOL=http
 
+# DORMANT: VNC browser path replaced by screenshot panel (#1130). Preserved for #5136 re-integration.
 # VNC Configuration
 VITE_DESKTOP_VNC_HOST=YOUR_BACKEND_IP
 VITE_DESKTOP_VNC_PORT=6080

--- a/autobot-frontend/src/config/AppConfig.js
+++ b/autobot-frontend/src/config/AppConfig.js
@@ -40,6 +40,7 @@ export class AppConfigService {
           port: import.meta.env.VITE_REDIS_PORT || '6379',
           protocol: 'redis'
         },
+        // DORMANT: VNC browser path replaced by screenshot panel (#1130). Preserved for #5136 re-integration.
         vnc: {
           desktop: {
             host: import.meta.env.VITE_DESKTOP_VNC_HOST,
@@ -166,7 +167,7 @@ export class AppConfigService {
         enableDebug: import.meta.env.VITE_ENABLE_DEBUG === 'true',
         enableRum: import.meta.env.VITE_ENABLE_RUM !== 'false',
         enableWebSockets: import.meta.env.VITE_ENABLE_WEBSOCKETS !== 'false',
-        enableVncDesktop: import.meta.env.VITE_ENABLE_VNC_DESKTOP !== 'false',
+        enableVncDesktop: import.meta.env.VITE_ENABLE_VNC_DESKTOP !== 'false', // DORMANT: VNC replaced by screenshot panel (#1130); see #5136
         enableNpuWorker: import.meta.env.VITE_ENABLE_NPU_WORKER !== 'false'
       },
 
@@ -188,7 +189,8 @@ export class AppConfigService {
   }
 
   /**
-   * Get VNC URL with auto-connection parameters
+   * Get VNC URL with auto-connection parameters.
+   * DORMANT: VNC browser path replaced by screenshot panel (#1130). Preserved for #5136 re-integration.
    */
   async getVncUrl(type = 'desktop', options = {}) {
     const vncConfig = this.config.services.vnc[type];

--- a/autobot-frontend/src/config/ServiceDiscovery.js
+++ b/autobot-frontend/src/config/ServiceDiscovery.js
@@ -175,6 +175,7 @@ export default class ServiceDiscovery {
         protocol: 'redis',
         fallbackHosts: [cfg.vm.redis, 'localhost', '127.0.0.1']
       },
+      // DORMANT: VNC browser path replaced by screenshot panel (#1130). Preserved for #5136 re-integration.
       vnc_desktop: {
         envVar: 'VITE_DESKTOP_VNC_URL',
         hostVar: 'VITE_DESKTOP_VNC_HOST',
@@ -339,6 +340,7 @@ export default class ServiceDiscovery {
       }
 
       // Handle VNC services
+      // DORMANT: VNC browser path replaced by screenshot panel (#1130). Preserved for #5136 re-integration.
       if (serviceName.startsWith('vnc_')) {
         const vncType = serviceName.replace('vnc_', '');
         return buildDefaultVncUrl(vncType);
@@ -427,6 +429,7 @@ export default class ServiceDiscovery {
 
       // Use different endpoints based on service type
       let testEndpoint = `${getApiBase()}/system/health`;
+      // DORMANT: VNC health-check preserved for #5136 re-integration (#1130).
       if (serviceName.startsWith('vnc_')) {
         testEndpoint = '/vnc.html';
       } else if (serviceName === 'redis') {

--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -108,6 +108,7 @@ export interface TimeoutConfig {
 
 /**
  * VNC configuration for desktop streaming.
+ * DORMANT: VNC browser path replaced by screenshot panel (#1130). Preserved for #5136 re-integration.
  */
 export interface VNCConfig {
   desktop: {
@@ -389,6 +390,7 @@ function buildConfig(): AutoBotConfig {
     websocket: getEnvNumber('VITE_WEBSOCKET_TIMEOUT', 30000),
   };
 
+  // DORMANT: VNC browser path replaced by screenshot panel (#1130). Preserved for #5136 re-integration.
   // VNC configuration
   const vnc: VNCConfig = {
     desktop: {
@@ -468,6 +470,7 @@ function buildConfig(): AutoBotConfig {
       return `${httpProtocol}://${vm.browser}:${port.browser}`;
     },
 
+    // DORMANT: VNC browser path replaced by screenshot panel (#1130). Preserved for #5136 re-integration.
     get vncUrl(): string {
       return `${httpProtocol}://${vm.main}:${port.vnc}/vnc.html`;
     },

--- a/autobot-frontend/src/stores/useChatStore.ts
+++ b/autobot-frontend/src/stores/useChatStore.ts
@@ -56,6 +56,7 @@ export interface ChatSession {
   // Issue #608: Session-scoped secrets
   sessionSecrets?: SessionSecret[]
   // Desktop automation context
+  // DORMANT: vncUrl preserved for future VNC re-integration (#1130 → #5136)
   desktopSession?: {
     id?: string
     vncUrl?: string
@@ -538,6 +539,7 @@ export const useChatStore = defineStore('chat', () => {
     return desktopSessionId
   }
 
+  // DORMANT: getDesktopUrl generates VNC URLs; VNC path replaced by screenshot panel (#1130). Preserved for #5136.
   function getDesktopUrl(sessionId: string): string {
     let session = sessions.value.find(s => s.id === sessionId)
     if (!session?.desktopSession) {

--- a/autobot-slm-frontend/src/config/ssot-config.ts
+++ b/autobot-slm-frontend/src/config/ssot-config.ts
@@ -116,7 +116,7 @@ const config: SLMConfig = {
     grafana: getEnvNumber('VITE_GRAFANA_PORT', 3000),
     prometheus: getEnvNumber('VITE_PROMETHEUS_PORT', 9090),
     redis: getEnvNumber('VITE_REDIS_PORT', 6379),
-    vnc: getEnvNumber('VITE_DESKTOP_VNC_PORT', 6080),
+    vnc: getEnvNumber('VITE_DESKTOP_VNC_PORT', 6080), // DORMANT: VNC replaced by screenshot panel (#1130); see #5136
     ollama: getEnvNumber('VITE_OLLAMA_PORT', 11434),
     elasticsearch: getEnvNumber('VITE_ELASTICSEARCH_PORT', 9200),
     tlsFrontend: getEnvNumber('VITE_TLS_FRONTEND_PORT', 443),
@@ -192,6 +192,7 @@ export function getHosts(): SLMConfig['hosts'] {
  * Get VNC-enabled hosts with port configuration.
  * Returns empty -- VNC hosts are discovered dynamically via the SLM API
  * from nodes that have the 'vnc' role active (#2900).
+ * DORMANT: VNC browser path replaced by screenshot panel (#1130). Preserved for #5136 re-integration.
  */
 export function getVNCHosts(): Array<{ id: string; name: string; host: string; port: number; description: string }> {
   return []

--- a/docs/infrastructure/BROWSER_VNC_SETUP.md
+++ b/docs/infrastructure/BROWSER_VNC_SETUP.md
@@ -1,5 +1,9 @@
 # Browser VM VNC Setup - Infrastructure as Code
 
+> **DORMANT (as of #1130):** The VNC-based browser path has been replaced by the screenshot
+> panel approach in `VisualBrowserPanel.vue`. This document is preserved for reference.
+> VNC will be re-integrated as part of #5136 (region-marking).
+
 ## Overview
 
 Real-time collaborative browser viewing system for AutoBot - enables both users and AI agents to observe and control the same browser instance through VNC on Browser VM (<browser-ip>).


### PR DESCRIPTION
## Summary
Follow-up to PR #5814 which only marked `.env.example`. Adds DORMANT comments to the remaining 6 files that reference the VNC browser path (replaced by screenshot panel in #1130):

- `autobot-frontend/src/config/ssot-config.ts` — VNCConfig interface + config block + vncUrl getter
- `autobot-frontend/src/config/AppConfig.js` — vnc services block + enableVncDesktop + getVncUrl()
- `autobot-frontend/src/config/ServiceDiscovery.js` — vnc_desktop/terminal/playwright service config + health-check endpoint
- `autobot-frontend/src/stores/useChatStore.ts` — desktopSession.vncUrl + getDesktopUrl()
- `autobot-slm-frontend/src/config/ssot-config.ts` — vnc port field + getVNCHosts()
- `docs/infrastructure/BROWSER_VNC_SETUP.md` — prominent DORMANT notice at top

No code or values deleted. Comments reference #1130 (replaced) and #5136 (future re-integration).

Closes #5138

🤖 Generated with Claude Code