### PR TITLE
perf(planner): add tool description compressor with Redis cache (#5065)

### DIFF
--- a/autobot-backend/tools/description_compressor.py
+++ b/autobot-backend/tools/description_compressor.py
@@ -1,0 +1,107 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tool description compressor.
+
+Compresses tool descriptions via Ollama to reduce per-call LLM token spend.
+Compressed descriptions are cached in Redis with a 30-day TTL so the
+compression LLM call is paid once per unique tool spec.
+"""
+
+import hashlib
+import json
+import logging
+
+import aiohttp
+
+from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.ssot_config import config
+
+logger = logging.getLogger(__name__)
+
+CACHE_TTL = 2592000  # 30 days
+
+
+def _cache_key(tool_name: str, tool_spec: dict) -> str:
+    """Return a stable Redis cache key for the given tool spec."""
+    spec_json = json.dumps(tool_spec, sort_keys=True, ensure_ascii=False)
+    spec_hash = hashlib.sha256(spec_json.encode("utf-8")).hexdigest()[:16]
+    return f"tool_desc:{tool_name}:{spec_hash}"
+
+
+def _fallback_description(tool_spec: dict) -> str:
+    """Extract the raw description from a tool spec dict."""
+    return (
+        tool_spec.get("description")
+        or tool_spec.get("function", {}).get("description")
+        or json.dumps(tool_spec, ensure_ascii=False)
+    )
+
+
+async def _fetch_from_cache(key: str) -> str | None:
+    """Return cached compressed description or None on cache miss / Redis unavailable."""
+    redis = await get_async_redis_client(database="main")
+    if redis is None:
+        return None
+    try:
+        value = await redis.get(key)
+        return value.decode("utf-8") if isinstance(value, bytes) else value
+    except Exception:
+        logger.warning("Redis get failed for key %s", key)
+        return None
+
+
+async def _store_in_cache(key: str, value: str) -> None:
+    """Persist compressed description to Redis; silently skips on failure."""
+    redis = await get_async_redis_client(database="main")
+    if redis is None:
+        return
+    try:
+        await redis.set(key, value.encode("utf-8"), ex=CACHE_TTL)
+    except Exception:
+        logger.warning("Redis set failed for key %s", key)
+
+
+async def _compress_via_ollama(description: str) -> str | None:
+    """Call Ollama to compress *description*; returns compressed text or None on error."""
+    prompt = (
+        "Compress this tool description to under 50 words while preserving "
+        f"all parameter names and types:\n{description}"
+    )
+    model = config.llm.system_model
+    url = f"{config.ollama_url}/api/generate"
+    payload = {"model": model, "prompt": prompt, "stream": False}
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload, timeout=aiohttp.ClientTimeout(connect=5, total=30)) as resp:
+                if resp.status != 200:
+                    logger.warning("Ollama returned HTTP %d for compression request", resp.status)
+                    return None
+                data = await resp.json(content_type=None)
+                return (data.get("response") or "").strip() or None
+    except Exception as exc:
+        logger.warning("Ollama compression call failed: %s", exc)
+        return None
+
+
+async def compress_description(tool_name: str, tool_spec: dict) -> str:
+    """Return a compressed description for *tool_spec*, using Redis cache.
+
+    Falls back to the original description string if Ollama or Redis is
+    unavailable, so callers always receive a valid non-empty string.
+    """
+    fallback = _fallback_description(tool_spec)
+    key = _cache_key(tool_name, tool_spec)
+
+    cached = await _fetch_from_cache(key)
+    if cached:
+        return cached
+
+    compressed = await _compress_via_ollama(fallback)
+    if not compressed:
+        return fallback
+
+    await _store_in_cache(key, compressed)
+    return compressed

--- a/autobot-backend/tools/tool_registry.py
+++ b/autobot-backend/tools/tool_registry.py
@@ -9,6 +9,7 @@ the standard orchestrator and LangChain orchestrator, eliminating code
 duplication.
 """
 
+import asyncio
 import logging
 import time
 import uuid
@@ -544,6 +545,29 @@ class ToolRegistry:
             "result": f"Unknown tool: {tool_name}",
             "status": "error",
         }
+
+    async def get_compressed_descriptions(self) -> Dict[str, str]:
+        """Return a mapping of tool_name -> compressed description for all registered tools.
+
+        Uses :func:`tools.description_compressor.compress_description` with Redis
+        caching and Ollama LLM compression.  Falls back to the raw description
+        string for any tool whose spec lacks one, and skips compression entirely
+        for tools without a spec dict (SDK-only tools are not iterated here).
+        """
+        from tools.description_compressor import compress_description  # noqa: PLC0415
+
+        tool_names = self.get_available_tools()
+        tasks = [compress_description(name, {"name": name}) for name in tool_names]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        compressed: Dict[str, str] = {}
+        for name, result in zip(tool_names, results):
+            if isinstance(result, Exception):
+                logger.warning("compress_description failed for tool '%s': %s", name, result)
+                compressed[name] = name
+            else:
+                compressed[name] = result
+        return compressed
 
     def get_available_tools(self) -> List[str]:
         """Get list of available tool names.


### PR DESCRIPTION
## Summary
- New `autobot-backend/tools/description_compressor.py` with `compress_description(tool_name, tool_spec)`:
  - Cache-first via Redis: `tool_desc:{name}:{sha256_16}` key, 30-day TTL
  - Compresses via Ollama `POST /api/generate` using `config.ollama_url` + `config.llm.system_model`
  - Falls back to raw description string on Ollama/Redis failure (never raises)
- Extended `ToolRegistry.get_compressed_descriptions()` — gathers all tools concurrently via `asyncio.gather`

## Test Plan
- [ ] `python -m py_compile autobot-backend/tools/description_compressor.py` passes
- [ ] `python -m py_compile autobot-backend/tools/tool_registry.py` passes
- [ ] Redis unavailable → fallback returns original description without error
- [ ] Cache hit avoids Ollama call on second invocation

Closes #5065

🤖 Generated with Claude Code