### PR TITLE
docs(frontend): add TypeScript error baseline and delta-check script (#5096)

### DIFF
--- a/autobot-frontend/scripts/check-ts-delta.sh
+++ b/autobot-frontend/scripts/check-ts-delta.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# check-ts-delta.sh — Fail if TypeScript errors exceed the baseline.
+#
+# Usage: bash autobot-frontend/scripts/check-ts-delta.sh
+#
+# Reads baseline from docs/developer/audits/typescript-baseline.md (Total: N line).
+# Exits 1 if current error count exceeds baseline; exits 0 otherwise.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+FRONTEND_DIR="${REPO_ROOT}/autobot-frontend"
+BASELINE_FILE="${REPO_ROOT}/docs/developer/audits/typescript-baseline.md"
+
+# --- Resolve baseline ---
+if [[ ! -f "${BASELINE_FILE}" ]]; then
+  echo "ERROR: Baseline file not found: ${BASELINE_FILE}" >&2
+  exit 1
+fi
+
+BASELINE=$(grep -m1 "^\*\*Total:" "${BASELINE_FILE}" | grep -o '[0-9]*')
+if [[ -z "${BASELINE}" ]]; then
+  echo "ERROR: Could not parse 'Total:' from ${BASELINE_FILE}" >&2
+  exit 1
+fi
+
+# --- Run TypeScript check ---
+echo "Running vue-tsc (baseline: ${BASELINE} errors)..."
+CURRENT=$(
+  cd "${FRONTEND_DIR}"
+  npx vue-tsc --noEmit -p tsconfig.app.json 2>&1 | grep -c "error TS" || true
+)
+
+echo "Current TS errors : ${CURRENT}"
+echo "Baseline TS errors: ${BASELINE}"
+
+# --- Compare ---
+if (( CURRENT > BASELINE )); then
+  DELTA=$(( CURRENT - BASELINE ))
+  echo ""
+  echo "FAIL: ${DELTA} new TypeScript error(s) introduced (${CURRENT} > ${BASELINE})."
+  echo "Fix the new errors or, if intentional, update the baseline:"
+  echo "  docs/developer/audits/typescript-baseline.md"
+  exit 1
+else
+  DELTA=$(( BASELINE - CURRENT ))
+  if (( DELTA > 0 )); then
+    echo "PASS: ${CURRENT} errors (${DELTA} below baseline — consider updating the baseline)."
+  else
+    echo "PASS: ${CURRENT} errors (matches baseline exactly)."
+  fi
+  exit 0
+fi

--- a/docs/developer/audits/typescript-baseline.md
+++ b/docs/developer/audits/typescript-baseline.md
@@ -1,0 +1,107 @@
+# TypeScript Error Baseline — Dev_new_gui
+
+**Date:** 2026-04-24
+**Branch:** Dev_new_gui
+**Command:** `npx vue-tsc --noEmit -p tsconfig.app.json`
+**Total: 2005**
+
+> Note: Issue #5096 originally reported 169 errors. The actual count at audit time is 2005.
+> The delta-check gate uses this file as the authoritative baseline.
+
+---
+
+## Breakdown by Error Code (top 20)
+
+| Error Code | Count | Description |
+|-----------|-------|-------------|
+| TS7006 | 772 | Parameter implicitly has an `any` type |
+| TS2307 | 686 | Cannot find module or its type declarations |
+| TS2339 | 331 | Property does not exist on type |
+| TS18046 | 100 | Variable is of type `unknown` |
+| TS2365 | 26 | Operator not applicable to types |
+| TS2304 | 18 | Cannot find name |
+| TS2882 | 15 | Cannot access ambient const before init |
+| TS7031 | 13 | Binding element implicitly has `any` type |
+| TS7053 | 12 | Element implicitly has `any` (index expression) |
+| TS2345 | 9 | Argument of type X not assignable to parameter of type Y |
+| TS2362 | 5 | Left-hand side of arithmetic not of type `any`/`number`/`bigint` |
+| TS5097 | 3 | `rootDir` is not below `rootDirs` |
+| TS2352 | 3 | Type conversion may be a mistake |
+| TS2769 | 2 | No overload matches this call |
+| TS2559 | 2 | Type has no properties in common |
+| TS2322 | 2 | Type X is not assignable to type Y |
+| TS5083 | 1 | Cannot read file `tsconfig.node.json` |
+| TS2664 | 1 | Invalid module name in augmentation |
+| TS2554 | 1 | Expected N arguments but got M |
+| TS2363 | 1 | Right-hand side of arithmetic not of type `any`/`number`/`bigint` |
+
+---
+
+## Breakdown by File (top 15 files)
+
+| File | Error Count |
+|------|-------------|
+| `src/components/desktop/PopoutChromiumBrowser.vue` | 170 |
+| `src/App.vue` | 105 |
+| `src/components/browser/BrowserSessionManager.vue` | 59 |
+| `src/stores/useChatStore.ts` | 43 |
+| `src/components/charts/FunctionCallGraph.vue` | 27 |
+| `src/components/visualizations/ResourceHeatmap.vue` | 23 |
+| `src/stores/useKnowledgeStore.ts` | 22 |
+| `src/main.ts` | 20 |
+| `src/composables/useBatchProcessing.ts` | 20 |
+| `src/views/WorkflowBuilderView.vue` | 18 |
+| `src/components/knowledge/KnowledgeStats.vue` | 17 |
+| `src/stores/useAppStore.ts` | 16 |
+| `src/composables/useApi.ts` | 16 |
+| `src/components/knowledge/KnowledgeGraph.vue` | 16 |
+| `src/composables/useAuditApi.ts` | 15 |
+
+---
+
+## How to Update This Baseline
+
+Run the following from `autobot-frontend/`:
+
+```bash
+cd autobot-frontend
+
+# Get full error list
+npx vue-tsc --noEmit -p tsconfig.app.json 2>&1 > /tmp/ts-errors.txt
+
+# Total count
+grep -c "error TS" /tmp/ts-errors.txt
+
+# Breakdown by error code
+grep "error TS" /tmp/ts-errors.txt \
+  | sed 's/.*error \(TS[0-9]*\).*/\1/' \
+  | sort | uniq -c | sort -rn | head -20
+
+# Breakdown by file
+grep "error TS" /tmp/ts-errors.txt \
+  | cut -d'(' -f1 \
+  | sort | uniq -c | sort -rn | head -15
+```
+
+Update the `Total:` line and the tables in this file, then commit with message:
+`docs(frontend): update TypeScript baseline to <N> errors (#<issue>)`
+
+The delta-check script (`autobot-frontend/scripts/check-ts-delta.sh`) reads the `Total:` line
+from this file automatically — no changes to the script are needed after updating this doc.
+
+---
+
+## CI Delta-Check
+
+The script `autobot-frontend/scripts/check-ts-delta.sh` enforces this baseline:
+- Runs `npx vue-tsc --noEmit -p tsconfig.app.json` and counts errors
+- Reads the `Total:` value from this file
+- Exits 1 (fail) if `current_errors > baseline`
+- Exits 0 (pass) if `current_errors <= baseline`
+
+Add to CI:
+```yaml
+- name: TypeScript delta check
+  run: bash autobot-frontend/scripts/check-ts-delta.sh
+  working-directory: .
+```


### PR DESCRIPTION
## Summary
- New `docs/developer/audits/typescript-baseline.md`: current baseline is **2,005 errors** (issue cited 169 — that was an earlier partial count); breakdown by error code (top: TS7006=772, TS2307=686, TS2339=331) and by file (top: PopoutChromiumBrowser.vue=170, App.vue=105)
- New `autobot-frontend/scripts/check-ts-delta.sh`: runs `npx vue-tsc --noEmit -p tsconfig.app.json`, compares count against `Total:` in baseline doc, exits 1 if new errors introduced (prints delta), exits 0 otherwise

## Test Plan
- [ ] `bash autobot-frontend/scripts/check-ts-delta.sh` exits 0 on clean checkout
- [ ] Introducing a deliberate TS error causes the script to exit 1
- [ ] Baseline doc renders correctly in GitHub markdown

Closes #5096

🤖 Generated with Claude Code