### PR TITLE
feat(api): add response_model= to advanced_control, analytics, integration_github, npu_workers (#5317)

### DIFF
--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -8,11 +8,24 @@ Provides monitoring, desktop streaming, and takeover management endpoints
 
 import asyncio
 import logging
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel
 
+from .schemas_common import (
+    AdvancedControlActiveTakeoversResponse,
+    AdvancedControlEmergencyStopResponse,
+    AdvancedControlInfoResponse,
+    AdvancedControlPendingTakeoversResponse,
+    AdvancedControlStreamingSessionsResponse,
+    AdvancedControlStreamingTerminateResponse,
+    AdvancedControlSystemHealthResponse,
+    AdvancedControlTakeoverActionResponse,
+    AdvancedControlTakeoverApproveResponse,
+    AdvancedControlTakeoverRequestResponse,
+    AdvancedControlTakeoverSessionStatusResponse,
+)
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.error_constants import ERR_SESSION_NOT_FOUND
@@ -113,7 +126,7 @@ async def create_streaming_session(
     operation="terminate_streaming_session",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.delete("/streaming/{session_id}")
+@router.delete("/streaming/{session_id}", response_model=AdvancedControlStreamingTerminateResponse)
 async def terminate_streaming_session(
     session_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -136,7 +149,7 @@ async def terminate_streaming_session(
     operation="list_streaming_sessions",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/streaming/sessions")
+@router.get("/streaming/sessions", response_model=AdvancedControlStreamingSessionsResponse)
 async def list_streaming_sessions(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -154,7 +167,7 @@ async def list_streaming_sessions(
     operation="get_streaming_capabilities",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/streaming/capabilities")
+@router.get("/streaming/capabilities", response_model=Dict[str, Any])
 async def get_streaming_capabilities(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -173,7 +186,7 @@ async def get_streaming_capabilities(
     operation="request_takeover",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.post("/takeover/request")
+@router.post("/takeover/request", response_model=AdvancedControlTakeoverRequestResponse)
 async def request_takeover(
     request: TakeoverRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -229,7 +242,7 @@ async def request_takeover(
     operation="approve_takeover",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.post("/takeover/{request_id}/approve")
+@router.post("/takeover/{request_id}/approve", response_model=AdvancedControlTakeoverApproveResponse)
 async def approve_takeover(
     request_id: str,
     approval: TakeoverApprovalRequest,
@@ -261,7 +274,7 @@ async def approve_takeover(
     operation="execute_takeover_action",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.post("/takeover/sessions/{session_id}/action")
+@router.post("/takeover/sessions/{session_id}/action", response_model=AdvancedControlTakeoverActionResponse)
 async def execute_takeover_action(
     session_id: str,
     action: TakeoverActionRequest,
@@ -293,7 +306,7 @@ async def execute_takeover_action(
     operation="pause_takeover_session",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.post("/takeover/sessions/{session_id}/pause")
+@router.post("/takeover/sessions/{session_id}/pause", response_model=AdvancedControlTakeoverSessionStatusResponse)
 async def pause_takeover_session(
     session_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -315,7 +328,7 @@ async def pause_takeover_session(
     operation="resume_takeover_session",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.post("/takeover/sessions/{session_id}/resume")
+@router.post("/takeover/sessions/{session_id}/resume", response_model=AdvancedControlTakeoverSessionStatusResponse)
 async def resume_takeover_session(
     session_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -339,7 +352,7 @@ async def resume_takeover_session(
     operation="complete_takeover_session",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.post("/takeover/sessions/{session_id}/complete")
+@router.post("/takeover/sessions/{session_id}/complete", response_model=AdvancedControlTakeoverSessionStatusResponse)
 async def complete_takeover_session(
     session_id: str,
     completion_data: Metadata,
@@ -367,7 +380,7 @@ async def complete_takeover_session(
     operation="get_pending_takeovers",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/takeover/pending")
+@router.get("/takeover/pending", response_model=AdvancedControlPendingTakeoversResponse)
 async def get_pending_takeovers(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -385,7 +398,7 @@ async def get_pending_takeovers(
     operation="get_active_takeovers",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/takeover/active")
+@router.get("/takeover/active", response_model=AdvancedControlActiveTakeoversResponse)
 async def get_active_takeovers(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -403,7 +416,7 @@ async def get_active_takeovers(
     operation="get_takeover_status",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/takeover/status")
+@router.get("/takeover/status", response_model=Dict[str, Any])
 async def get_takeover_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -471,7 +484,7 @@ async def get_system_status(
     operation="emergency_system_stop",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.post("/system/emergency-stop")
+@router.post("/system/emergency-stop", response_model=AdvancedControlEmergencyStopResponse)
 async def emergency_system_stop(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -502,7 +515,7 @@ async def emergency_system_stop(
     operation="get_system_health",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/system/health")
+@router.get("/system/health", response_model=AdvancedControlSystemHealthResponse)
 async def get_system_health(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -598,7 +611,7 @@ async def desktop_streaming_websocket(websocket: WebSocket, session_id: str):
     operation="advanced_control_info",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/")
+@router.get("/", response_model=AdvancedControlInfoResponse)
 async def advanced_control_info(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/analytics.py
+++ b/autobot-backend/api/analytics.py
@@ -35,6 +35,13 @@ from api.analytics_controller import (
 
 # Import models from dedicated module (Issue #185 - split oversized files)
 from api.analytics_models import AnalyticsOverview, RealTimeEvent
+from .schemas_common import (
+    AnalyticsClearStuckTasksResponse,
+    AnalyticsCollectionStartResponse,
+    AnalyticsCollectionStopResponse,
+    AnalyticsDashboardAnalyzeResponse,
+    AnalyticsTrackEventResponse,
+)
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import RedisDatabase
@@ -218,7 +225,7 @@ def _check_resource_alerts(system_resources: Dict) -> List[Dict[str, Any]]:
     operation="get_detailed_system_health",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/system/health-detailed")
+@router.get("/system/health-detailed", response_model=Dict[str, Any])
 async def get_detailed_system_health(current_user: Dict = Depends(get_current_user)):
     """Get detailed system health with enhanced analytics (Issue #398: refactored)."""
     base_health = await hardware_monitor.get_system_health()
@@ -275,7 +282,7 @@ async def get_detailed_system_health(current_user: Dict = Depends(get_current_us
     operation="get_performance_metrics",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/performance/metrics")
+@router.get("/performance/metrics", response_model=Dict[str, Any])
 async def get_performance_metrics(current_user: Dict = Depends(get_current_user)):
     """Get comprehensive performance metrics"""
     metrics = await analytics_controller.collect_performance_metrics()
@@ -321,7 +328,7 @@ async def get_performance_metrics(current_user: Dict = Depends(get_current_user)
     operation="get_communication_patterns",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/communication/patterns")
+@router.get("/communication/patterns", response_model=Dict[str, Any])
 async def get_communication_patterns(current_user: Dict = Depends(get_current_user)):
     """Get detailed communication pattern analysis"""
     patterns = await analytics_controller.analyze_communication_patterns()
@@ -374,7 +381,7 @@ async def get_communication_patterns(current_user: Dict = Depends(get_current_us
     operation="get_usage_statistics",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/usage/statistics")
+@router.get("/usage/statistics", response_model=Dict[str, Any])
 async def get_usage_statistics(current_user: Dict = Depends(get_current_user)):
     """Get comprehensive usage statistics"""
     stats = await analytics_controller.get_usage_statistics()
@@ -485,7 +492,7 @@ async def _collect_realtime_metrics_data() -> Dict[str, Any]:
     operation="get_realtime_metrics",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/realtime/metrics")
+@router.get("/realtime/metrics", response_model=Dict[str, Any])
 async def get_realtime_metrics(current_user: Dict = Depends(get_current_user)):
     """Get current real-time metrics snapshot"""
     return await _collect_realtime_metrics_data()
@@ -496,7 +503,7 @@ async def get_realtime_metrics(current_user: Dict = Depends(get_current_user)):
     operation="track_analytics_event",
     error_code_prefix="ANALYTICS",
 )
-@router.post("/events/track")
+@router.post("/events/track", response_model=AnalyticsTrackEventResponse)
 async def track_analytics_event(
     event: RealTimeEvent, current_user: Dict = Depends(get_current_user)
 ):
@@ -601,7 +608,7 @@ def _compute_hourly_stats(historical_calls: list) -> dict:
     operation="get_historical_trends",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/trends/historical")
+@router.get("/trends/historical", response_model=Dict[str, Any])
 async def get_historical_trends(
     hours: int = Query(24, description="Number of hours to analyze", ge=1, le=168),
     current_user: Dict = Depends(get_current_user),
@@ -734,7 +741,7 @@ async def websocket_realtime_analytics(websocket: WebSocket):
     operation="start_analytics_collection",
     error_code_prefix="ANALYTICS",
 )
-@router.post("/collection/start")
+@router.post("/collection/start", response_model=AnalyticsCollectionStartResponse)
 async def start_analytics_collection(current_user: Dict = Depends(get_current_user)):
     """Start continuous analytics collection"""
     # Initialize session tracking
@@ -760,7 +767,7 @@ async def start_analytics_collection(current_user: Dict = Depends(get_current_us
     operation="stop_analytics_collection",
     error_code_prefix="ANALYTICS",
 )
-@router.post("/collection/stop")
+@router.post("/collection/stop", response_model=AnalyticsCollectionStopResponse)
 async def stop_analytics_collection(current_user: Dict = Depends(get_current_user)):
     """Stop continuous analytics collection"""
     # Stop metrics collection
@@ -820,7 +827,7 @@ async def _check_analytics_redis_connectivity() -> Dict[str, str]:
     operation="get_analytics_status",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/status")
+@router.get("/status", response_model=Dict[str, Any])
 async def get_analytics_status(current_user: Dict = Depends(get_current_user)):
     """Get comprehensive analytics system status (Issue #398: refactored)."""
     status = _build_analytics_status_base(analytics_controller.metrics_collector)
@@ -1206,7 +1213,7 @@ async def websocket_live_analytics(websocket: WebSocket):
 # ------------------------------------------------------------------
 
 
-@router.get("/root-cause/{task_id}")
+@router.get("/root-cause/{task_id}", response_model=Dict[str, Any])
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="analyze_root_cause",
@@ -1311,7 +1318,7 @@ async def _run_dashboard_analysis(task_id: str) -> None:
         await _dash_manager.fail_task(task_id, str(e))
 
 
-@router.post("/dashboard/overview/analyze")
+@router.post("/dashboard/overview/analyze", response_model=AnalyticsDashboardAnalyzeResponse)
 async def start_dashboard_analysis(
     background_tasks: BackgroundTasks,
     current_user: Dict = Depends(get_current_user),
@@ -1322,7 +1329,7 @@ async def start_dashboard_analysis(
     return {"task_id": task_id, "status": "pending"}
 
 
-@router.get("/dashboard/overview/status/{task_id}")
+@router.get("/dashboard/overview/status/{task_id}", response_model=Dict[str, Any])
 async def get_dashboard_status(task_id: str):
     """Get dashboard overview task status (#1304)."""
     task = await _dash_manager.get_status(task_id)
@@ -1331,7 +1338,7 @@ async def get_dashboard_status(task_id: str):
     return task
 
 
-@router.post("/dashboard/overview/tasks/clear-stuck")
+@router.post("/dashboard/overview/tasks/clear-stuck", response_model=AnalyticsClearStuckTasksResponse)
 async def clear_stuck_dashboard_tasks(
     force: bool = Query(
         default=False,

--- a/autobot-backend/api/integration_github.py
+++ b/autobot-backend/api/integration_github.py
@@ -105,7 +105,7 @@ async def test_connection(
         raise HTTPException(status_code=500, detail="Connection test failed")
 
 
-@router.get("/{owner}/{repo}/pull-requests")
+@router.get("/{owner}/{repo}/pull-requests", response_model=Dict[str, Any])
 async def list_pull_requests(
     owner: str,
     repo: str,
@@ -134,7 +134,7 @@ async def list_pull_requests(
         raise HTTPException(status_code=500, detail="Failed to list pull requests")
 
 
-@router.get("/{owner}/{repo}/pull-requests/{pull_number}")
+@router.get("/{owner}/{repo}/pull-requests/{pull_number}", response_model=Dict[str, Any])
 async def get_pull_request(
     owner: str,
     repo: str,
@@ -158,7 +158,7 @@ async def get_pull_request(
         raise HTTPException(status_code=500, detail="Failed to get pull request")
 
 
-@router.get("/{owner}/{repo}/pull-requests/{pull_number}/diff")
+@router.get("/{owner}/{repo}/pull-requests/{pull_number}/diff", response_model=Dict[str, Any])
 async def get_pull_request_diff(
     owner: str,
     repo: str,
@@ -182,7 +182,7 @@ async def get_pull_request_diff(
         raise HTTPException(status_code=500, detail="Failed to get pull request diff")
 
 
-@router.get("/{owner}/{repo}/pull-requests/{pull_number}/comments")
+@router.get("/{owner}/{repo}/pull-requests/{pull_number}/comments", response_model=Dict[str, Any])
 async def list_pr_review_comments(
     owner: str,
     repo: str,
@@ -206,7 +206,7 @@ async def list_pr_review_comments(
         raise HTTPException(status_code=500, detail="Failed to list PR comments")
 
 
-@router.post("/{owner}/{repo}/pull-requests/{pull_number}/comments")
+@router.post("/{owner}/{repo}/pull-requests/{pull_number}/comments", response_model=Dict[str, Any])
 async def post_pr_comment(request: GitHubCommentRequest) -> Dict[str, Any]:
     """Post an issue-level comment to a pull request.
 
@@ -233,7 +233,7 @@ async def post_pr_comment(request: GitHubCommentRequest) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail="Failed to post PR comment")
 
 
-@router.post("/{owner}/{repo}/pull-requests/{pull_number}/reviews")
+@router.post("/{owner}/{repo}/pull-requests/{pull_number}/reviews", response_model=Dict[str, Any])
 async def submit_pr_review(request: GitHubReviewRequest) -> Dict[str, Any]:
     """Submit a formal pull request review.
 
@@ -270,7 +270,7 @@ async def submit_pr_review(request: GitHubReviewRequest) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail="Failed to submit PR review")
 
 
-@router.get("/{owner}/{repo}/issues")
+@router.get("/{owner}/{repo}/issues", response_model=Dict[str, Any])
 async def list_issues(
     owner: str,
     repo: str,
@@ -299,7 +299,7 @@ async def list_issues(
         raise HTTPException(status_code=500, detail="Failed to list issues")
 
 
-@router.get("/{owner}/{repo}/issues/{issue_number}")
+@router.get("/{owner}/{repo}/issues/{issue_number}", response_model=Dict[str, Any])
 async def get_issue(
     owner: str,
     repo: str,
@@ -323,7 +323,7 @@ async def get_issue(
         raise HTTPException(status_code=500, detail="Failed to get issue")
 
 
-@router.get("/{owner}/{repo}")
+@router.get("/{owner}/{repo}", response_model=Dict[str, Any])
 async def get_repository(
     owner: str,
     repo: str,
@@ -345,7 +345,7 @@ async def get_repository(
         raise HTTPException(status_code=500, detail="Failed to get repository")
 
 
-@router.get("/{owner}/{repo}/commits")
+@router.get("/{owner}/{repo}/commits", response_model=Dict[str, Any])
 async def list_commits(
     owner: str,
     repo: str,
@@ -371,7 +371,7 @@ async def list_commits(
         raise HTTPException(status_code=500, detail="Failed to list commits")
 
 
-@router.get("/{owner}/{repo}/commits/{ref}")
+@router.get("/{owner}/{repo}/commits/{ref}", response_model=Dict[str, Any])
 async def get_commit(
     owner: str,
     repo: str,
@@ -394,7 +394,7 @@ async def get_commit(
         raise HTTPException(status_code=500, detail="Failed to get commit")
 
 
-@router.get("/{owner}/{repo}/tree/{tree_sha}")
+@router.get("/{owner}/{repo}/tree/{tree_sha}", response_model=Dict[str, Any])
 async def get_repository_tree(
     owner: str,
     repo: str,
@@ -419,7 +419,7 @@ async def get_repository_tree(
         raise HTTPException(status_code=500, detail="Failed to get repository tree")
 
 
-@router.get("/{owner}/{repo}/contents/{path:path}")
+@router.get("/{owner}/{repo}/contents/{path:path}", response_model=Dict[str, Any])
 async def get_file_contents(
     owner: str,
     repo: str,
@@ -444,7 +444,7 @@ async def get_file_contents(
         raise HTTPException(status_code=500, detail="Failed to get file contents")
 
 
-@router.get("/providers")
+@router.get("/providers", response_model=List[Dict[str, Any]])
 async def get_providers() -> List[Dict[str, Any]]:
     """List supported GitHub integration providers.
 

--- a/autobot-backend/api/npu_workers.py
+++ b/autobot-backend/api/npu_workers.py
@@ -33,11 +33,20 @@ Endpoints:
 """
 
 import logging
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
 
+from .schemas_common import (
+    NPUPoolReloadResponse,
+    NPUPoolWorkersResponse,
+    NPUStatusResponse,
+    NPUWorkerHeartbeatResponse,
+    NPUWorkerPairResponse,
+    NPUWorkerRepairResponse,
+    NPUWorkerUnpairResponse,
+)
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_management.types import DATABASE_MAPPING
@@ -231,7 +240,7 @@ async def update_worker(
     operation="remove_worker",
     error_code_prefix="NPU_WORKERS",
 )
-@router.delete("/npu/workers/{worker_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/npu/workers/{worker_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 async def remove_worker(
     admin_check: bool = Depends(check_admin_permission),
     worker_id: str = None,
@@ -364,7 +373,7 @@ async def get_worker_metrics(
     operation="get_worker_log_level",
     error_code_prefix="NPU_WORKERS",
 )
-@router.get("/npu/workers/{worker_id}/logging")
+@router.get("/npu/workers/{worker_id}/logging", response_model=Dict[str, Any])
 async def get_worker_log_level(
     admin_check: bool = Depends(check_admin_permission),
     worker_id: str = None,
@@ -429,7 +438,7 @@ async def _send_log_level_to_worker(
     operation="set_worker_log_level",
     error_code_prefix="NPU_WORKERS",
 )
-@router.put("/npu/workers/{worker_id}/logging")
+@router.put("/npu/workers/{worker_id}/logging", response_model=Dict[str, Any])
 async def set_worker_log_level(
     admin_check: bool = Depends(check_admin_permission),
     worker_id: str = None,
@@ -557,7 +566,7 @@ async def update_load_balancing_config(
     operation="get_npu_status",
     error_code_prefix="NPU_WORKERS",
 )
-@router.get("/npu/status")
+@router.get("/npu/status", response_model=NPUStatusResponse)
 async def get_npu_status(admin_check: bool = Depends(check_admin_permission)):
     """
     Get overall NPU worker pool status.
@@ -607,7 +616,7 @@ async def get_npu_status(admin_check: bool = Depends(check_admin_permission)):
     operation="proxy_npu_health",
     error_code_prefix="NPU_WORKERS",
 )
-@router.get("/npu/health")
+@router.get("/npu/health", response_model=None)
 async def proxy_npu_health():
     """
     Proxy NPU worker health check to avoid CORS/mixed content.
@@ -650,7 +659,7 @@ async def proxy_npu_health():
     operation="unpair_worker",
     error_code_prefix="NPU_WORKERS",
 )
-@router.post("/npu/workers/{worker_id}/unpair")
+@router.post("/npu/workers/{worker_id}/unpair", response_model=NPUWorkerUnpairResponse)
 async def unpair_worker(
     admin_check: bool = Depends(check_admin_permission),
     worker_id: str = None,
@@ -788,7 +797,7 @@ async def _resolve_repair_worker_info(
     operation="repair_worker",
     error_code_prefix="NPU_WORKERS",
 )
-@router.post("/npu/workers/{worker_id}/repair")
+@router.post("/npu/workers/{worker_id}/repair", response_model=NPUWorkerRepairResponse)
 async def repair_worker(
     admin_check: bool = Depends(check_admin_permission),
     worker_id: str = None,
@@ -1064,7 +1073,7 @@ async def _execute_worker_pairing(
     operation="pair_worker",
     error_code_prefix="NPU_WORKERS",
 )
-@router.post("/npu/workers/pair")
+@router.post("/npu/workers/pair", response_model=NPUWorkerPairResponse)
 async def pair_worker(
     admin_check: bool = Depends(check_admin_permission),
     request: dict = None,
@@ -1162,7 +1171,7 @@ def _reject_unpaired_heartbeat(heartbeat: WorkerHeartbeat) -> None:
     )
 
 
-@router.post("/npu/workers/heartbeat")
+@router.post("/npu/workers/heartbeat", response_model=NPUWorkerHeartbeatResponse)
 async def worker_heartbeat(heartbeat: WorkerHeartbeat):
     """
     Receive heartbeat/telemetry from NPU worker.
@@ -1337,7 +1346,7 @@ def _build_bootstrap_response(
     operation="worker_bootstrap",
     error_code_prefix="NPU_WORKERS",
 )
-@router.post("/npu/workers/bootstrap")
+@router.post("/npu/workers/bootstrap", response_model=Dict[str, Any])
 async def worker_bootstrap(request: dict):
     """
     Bootstrap configuration endpoint for NPU workers.
@@ -1386,7 +1395,7 @@ async def worker_bootstrap(request: dict):
     operation="get_pool_stats",
     error_code_prefix="NPU_WORKERS",
 )
-@router.get("/npu/pool/stats")
+@router.get("/npu/pool/stats", response_model=Dict[str, Any])
 async def get_pool_stats(admin_check: bool = Depends(check_admin_permission)):
     """
     Get NPU worker pool statistics (Issue #168).
@@ -1419,7 +1428,7 @@ async def get_pool_stats(admin_check: bool = Depends(check_admin_permission)):
     operation="get_pool_workers",
     error_code_prefix="NPU_WORKERS",
 )
-@router.get("/npu/pool/workers")
+@router.get("/npu/pool/workers", response_model=NPUPoolWorkersResponse)
 async def get_pool_workers(admin_check: bool = Depends(check_admin_permission)):
     """
     Get per-worker health states from the pool (Issue #168).
@@ -1471,7 +1480,7 @@ async def get_pool_workers(admin_check: bool = Depends(check_admin_permission)):
     operation="reload_pool_config",
     error_code_prefix="NPU_WORKERS",
 )
-@router.post("/npu/pool/reload")
+@router.post("/npu/pool/reload", response_model=NPUPoolReloadResponse)
 async def reload_pool_config(admin_check: bool = Depends(check_admin_permission)):
     """
     Hot-reload worker pool configuration (Issue #168).

--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -3296,3 +3296,210 @@ class StructuredThinkingSessionsResponse(BaseModel):
     sessions: List[Any]
 
 
+# ---------------------------------------------------------------------------
+# advanced_control.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class AdvancedControlStreamingTerminateResponse(BaseModel):
+    """Response for DELETE /streaming/{session_id}."""
+
+    success: bool
+    session_id: str
+
+
+class AdvancedControlStreamingSessionsResponse(BaseModel):
+    """Response for GET /streaming/sessions."""
+
+    sessions: List[Any]
+    count: int
+
+
+class AdvancedControlTakeoverRequestResponse(BaseModel):
+    """Response for POST /takeover/request."""
+
+    success: bool
+    request_id: str
+
+
+class AdvancedControlTakeoverApproveResponse(BaseModel):
+    """Response for POST /takeover/{request_id}/approve."""
+
+    success: bool
+    session_id: str
+
+
+class AdvancedControlTakeoverActionResponse(BaseModel):
+    """Response for POST /takeover/sessions/{session_id}/action."""
+
+    success: bool
+    result: Any
+
+
+class AdvancedControlTakeoverSessionStatusResponse(BaseModel):
+    """Response for pause/resume/complete takeover session endpoints."""
+
+    success: bool
+    session_id: str
+    status: str
+
+
+class AdvancedControlPendingTakeoversResponse(BaseModel):
+    """Response for GET /takeover/pending."""
+
+    pending_requests: List[Any]
+    count: int
+
+
+class AdvancedControlActiveTakeoversResponse(BaseModel):
+    """Response for GET /takeover/active."""
+
+    active_sessions: List[Any]
+    count: int
+
+
+class AdvancedControlEmergencyStopResponse(BaseModel):
+    """Response for POST /system/emergency-stop."""
+
+    success: bool
+    message: str
+    takeover_request_id: str
+
+
+class AdvancedControlSystemHealthResponse(BaseModel):
+    """Response for GET /system/health."""
+
+    status: str
+    desktop_streaming_available: bool
+    novnc_available: bool
+    active_streaming_sessions: int
+    pending_takeovers: int
+    active_takeovers: int
+    paused_tasks: int
+
+
+class AdvancedControlInfoResponse(BaseModel):
+    """Response for GET /."""
+
+    name: str
+    version: str
+    features: List[str]
+    endpoints: Dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# analytics.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class AnalyticsTrackEventResponse(BaseModel):
+    """Response for POST /events/track."""
+
+    status: str
+    event_id: str
+    broadcast_count: int
+
+
+class AnalyticsCollectionStartResponse(BaseModel):
+    """Response for POST /collection/start."""
+
+    status: str
+    message: str
+    session_id: str
+    metrics_collection: bool
+
+
+class AnalyticsCollectionStopResponse(BaseModel):
+    """Response for POST /collection/stop."""
+
+    status: str
+    message: str
+    session_duration: str
+
+
+class AnalyticsDashboardAnalyzeResponse(BaseModel):
+    """Response for POST /dashboard/overview/analyze."""
+
+    task_id: str
+    status: str
+
+
+class AnalyticsClearStuckTasksResponse(BaseModel):
+    """Response for POST /dashboard/overview/tasks/clear-stuck."""
+
+    cleared_count: int
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# npu_workers.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class NPUStatusResponse(BaseModel):
+    """Response for GET /npu/status."""
+
+    status: str
+    total_workers: int
+    online_workers: int
+    offline_workers: int
+    total_capacity: int
+    current_load: int
+    utilization_percent: float
+    load_balancing_strategy: str
+
+
+class NPUWorkerUnpairResponse(BaseModel):
+    """Response for POST /npu/workers/{worker_id}/unpair."""
+
+    success: bool
+    worker_id: str
+    message: str
+
+
+class NPUWorkerRepairResponse(BaseModel):
+    """Response for POST /npu/workers/{worker_id}/repair."""
+
+    success: bool
+    old_worker_id: str
+    new_worker_id: str
+    config: Dict[str, Any]
+    server_timestamp: str
+    message: str
+
+
+class NPUWorkerPairResponse(BaseModel):
+    """Response for POST /npu/workers/pair."""
+
+    success: bool
+    worker_id: str
+    url: str
+    platform: str
+    device_info: Dict[str, Any]
+    paired_at: str
+    message: str
+
+
+class NPUWorkerHeartbeatResponse(BaseModel):
+    """Response for POST /npu/workers/heartbeat."""
+
+    acknowledged: bool
+    worker_id: str
+    server_timestamp: str
+    message: str
+
+
+class NPUPoolWorkersResponse(BaseModel):
+    """Response for GET /npu/pool/workers."""
+
+    workers: List[Any]
+
+
+class NPUPoolReloadResponse(BaseModel):
+    """Response for POST /npu/pool/reload."""
+
+    success: bool
+    workers_loaded: int
+    message: str
+
+


### PR DESCRIPTION
## Summary
- Adds `response_model=` to all 56 endpoints across advanced_control.py (15), analytics.py (14), integration_github.py (14), npu_workers.py (13)
- New Pydantic schemas added to schemas_common.py

## Issue
Closes part of #5317 (response_model= 100% coverage campaign)

🤖 Generated with [Claude Code](https://claude.com/claude-code)