### PR TITLE
feat(api): add response_model= to wake_word, analytics_cost, conversation_files, files (#5317)

### DIFF
--- a/autobot-backend/api/analytics_cost.py
+++ b/autobot-backend/api/analytics_cost.py
@@ -27,6 +27,18 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from services.llm_cost_tracker import MODEL_PRICING, get_cost_tracker
 
+from .schemas_common import (
+    AllAgentCostsResponse,
+    BudgetAlertCreateResponse,
+    BudgetAlertsListResponse,
+    BudgetStatusResponse,
+    CostByModelResponse,
+    CostEstimateResponse,
+    CostForecastResponse,
+    ModelPricingResponse,
+    RecentUsageResponse,
+)
+
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/cost", tags=["analytics", "cost"])
 
@@ -148,7 +160,7 @@ async def get_cost_summary(
     operation="get_cost_by_model",
     error_code_prefix="COST",
 )
-@router.get("/by-model")
+@router.get("/by-model", response_model=CostByModelResponse)
 async def get_cost_by_model(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -263,7 +275,7 @@ async def get_cost_trends(
     operation="get_cost_forecast",
     error_code_prefix="COST",
 )
-@router.get("/forecast")
+@router.get("/forecast", response_model=CostForecastResponse)
 async def get_cost_forecast(
     days_to_forecast: int = Query(
         default=30, ge=1, le=90, description="Days to forecast"
@@ -326,7 +338,7 @@ async def get_cost_forecast(
     operation="get_recent_usage",
     error_code_prefix="COST",
 )
-@router.get("/usage/recent")
+@router.get("/usage/recent", response_model=RecentUsageResponse)
 async def get_recent_usage(
     limit: int = Query(
         default=100, ge=1, le=1000, description="Number of records to return"
@@ -359,7 +371,7 @@ async def get_recent_usage(
     operation="get_model_pricing",
     error_code_prefix="COST",
 )
-@router.get("/pricing")
+@router.get("/pricing", response_model=ModelPricingResponse)
 async def get_model_pricing(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -411,7 +423,7 @@ async def get_model_pricing(
     operation="calculate_cost_estimate",
     error_code_prefix="COST",
 )
-@router.get("/estimate")
+@router.get("/estimate", response_model=CostEstimateResponse)
 async def calculate_cost_estimate(
     model: str = Query(..., description="Model name"),
     input_tokens: int = Query(..., ge=0, description="Number of input tokens"),
@@ -447,7 +459,7 @@ async def calculate_cost_estimate(
     operation="set_budget_alert",
     error_code_prefix="COST",
 )
-@router.post("/budget-alert")
+@router.post("/budget-alert", response_model=BudgetAlertCreateResponse)
 async def set_budget_alert(
     alert: BudgetAlertRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -484,7 +496,7 @@ async def set_budget_alert(
     operation="get_budget_alerts",
     error_code_prefix="COST",
 )
-@router.get("/budget-alerts")
+@router.get("/budget-alerts", response_model=BudgetAlertsListResponse)
 async def get_budget_alerts(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -578,7 +590,7 @@ async def _get_current_costs(tracker, today: datetime) -> dict:
     operation="get_budget_status",
     error_code_prefix="COST",
 )
-@router.get("/budget-status")
+@router.get("/budget-status", response_model=BudgetStatusResponse)
 async def get_budget_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -635,7 +647,7 @@ class AgentCostResponse(BaseModel):
     operation="get_cost_by_agent_all",
     error_code_prefix="COST",
 )
-@router.get("/by-agent")
+@router.get("/by-agent", response_model=AllAgentCostsResponse)
 async def get_cost_by_agent_all(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -680,7 +692,7 @@ async def get_cost_by_agent_all(
     operation="get_cost_by_agent_single",
     error_code_prefix="COST",
 )
-@router.get("/by-agent/{agent_id}")
+@router.get("/by-agent/{agent_id}", response_model=None)
 async def get_cost_by_agent_single(
     agent_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -705,7 +717,7 @@ async def get_cost_by_agent_single(
     operation="set_agent_budget",
     error_code_prefix="COST",
 )
-@router.put("/by-agent/{agent_id}/budget")
+@router.put("/by-agent/{agent_id}/budget", response_model=None)
 async def set_agent_budget(
     agent_id: str,
     request: AgentBudgetRequest,
@@ -726,7 +738,7 @@ async def set_agent_budget(
     operation="get_agent_budget_status",
     error_code_prefix="COST",
 )
-@router.get("/by-agent/{agent_id}/budget")
+@router.get("/by-agent/{agent_id}/budget", response_model=None)
 async def get_agent_budget_status(
     agent_id: str,
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/conversation_files.py
+++ b/autobot-backend/api/conversation_files.py
@@ -650,7 +650,7 @@ def _build_download_response(file_info_dict: Dict, file_path: Path) -> FileRespo
     operation="download_conversation_file",
     error_code_prefix="CONVERSATION_FILES",
 )
-@router.get("/conversation/{session_id}/download/{file_id}")
+@router.get("/conversation/{session_id}/download/{file_id}", response_model=None)
 async def download_conversation_file(request: Request, session_id: str, file_id: str):
     """
     Download a specific file from a conversation.
@@ -836,7 +836,7 @@ def _build_delete_response(session_id: str, file_id: str) -> JSONResponse:
     operation="delete_conversation_file",
     error_code_prefix="CONVERSATION_FILES",
 )
-@router.delete("/conversation/{session_id}/files/{file_id}")
+@router.delete("/conversation/{session_id}/files/{file_id}", response_model=None)
 async def delete_conversation_file(request: Request, session_id: str, file_id: str):
     """
     Delete a specific file from a conversation.
@@ -939,7 +939,7 @@ async def transfer_conversation_files(
     operation="create_conversation_file",
     error_code_prefix="CONVERSATION_FILES",
 )
-@router.post("/conversation/{session_id}/files/create")
+@router.post("/conversation/{session_id}/files/create", response_model=None)
 async def create_conversation_file(
     request: Request, session_id: str, body: CreateFileRequest
 ):
@@ -982,7 +982,7 @@ async def create_conversation_file(
     operation="rename_conversation_file",
     error_code_prefix="CONVERSATION_FILES",
 )
-@router.put("/conversation/{session_id}/files/{file_id}/rename")
+@router.put("/conversation/{session_id}/files/{file_id}/rename", response_model=None)
 async def rename_conversation_file(
     request: Request, session_id: str, file_id: str, body: RenameFileRequest
 ):
@@ -1022,7 +1022,7 @@ async def rename_conversation_file(
     operation="get_file_content",
     error_code_prefix="CONVERSATION_FILES",
 )
-@router.get("/conversation/{session_id}/files/{file_id}/content")
+@router.get("/conversation/{session_id}/files/{file_id}/content", response_model=None)
 async def get_file_content(request: Request, session_id: str, file_id: str):
     """Get the text content of a file (Issue #70)."""
     try:
@@ -1051,7 +1051,7 @@ async def get_file_content(request: Request, session_id: str, file_id: str):
     operation="update_file_content",
     error_code_prefix="CONVERSATION_FILES",
 )
-@router.put("/conversation/{session_id}/files/{file_id}/content")
+@router.put("/conversation/{session_id}/files/{file_id}/content", response_model=None)
 async def update_file_content(
     request: Request, session_id: str, file_id: str, body: UpdateFileContentRequest
 ):
@@ -1090,7 +1090,7 @@ async def update_file_content(
     operation="copy_conversation_file",
     error_code_prefix="CONVERSATION_FILES",
 )
-@router.post("/conversation/{session_id}/files/{file_id}/copy")
+@router.post("/conversation/{session_id}/files/{file_id}/copy", response_model=None)
 async def copy_conversation_file(
     request: Request, session_id: str, file_id: str, body: CopyFileRequest
 ):
@@ -1130,7 +1130,7 @@ async def copy_conversation_file(
     operation="search_conversation_files",
     error_code_prefix="CONVERSATION_FILES",
 )
-@router.get("/conversation/{session_id}/files/search")
+@router.get("/conversation/{session_id}/files/search", response_model=None)
 async def search_conversation_files(request: Request, session_id: str, q: str = ""):
     """Search files by name within a conversation session (Issue #70)."""
     try:
@@ -1155,7 +1155,7 @@ async def search_conversation_files(request: Request, session_id: str, q: str = 
     operation="agent_generate_file",
     error_code_prefix="CONVERSATION_FILES",
 )
-@router.post("/conversation/{session_id}/generate")
+@router.post("/conversation/{session_id}/generate", response_model=None)
 async def agent_generate_file(
     request: Request, session_id: str, body: AgentGenerateFileRequest
 ):
@@ -1280,7 +1280,7 @@ class MCPToolCallRequest(BaseModel):
     operation="session_mcp_tools",
     error_code_prefix="CONVERSATION_FILES",
 )
-@router.get("/conversation/{session_id}/mcp/tools")
+@router.get("/conversation/{session_id}/mcp/tools", response_model=None)
 async def get_session_mcp_tools(request: Request, session_id: str):
     """Return MCP tool definitions scoped to this session (Issue #70)."""
     await _authorize_file_operation(request, session_id, "view")
@@ -1344,7 +1344,7 @@ async def _dispatch_mcp_tool(
     operation="session_mcp_call_tool",
     error_code_prefix="CONVERSATION_FILES",
 )
-@router.post("/conversation/{session_id}/mcp/call")
+@router.post("/conversation/{session_id}/mcp/call", response_model=None)
 async def session_mcp_call_tool(
     request: Request, session_id: str, body: MCPToolCallRequest
 ):

--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -18,6 +18,18 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
 
+from .schemas_common import (
+    AdminFileListResponse,
+    AdminFileReadResponse,
+    FileSandboxCreateDirResponse,
+    FileSandboxDeleteResponse,
+    FileSandboxPreviewResponse,
+    FileSandboxRenameResponse,
+    FileSandboxStatsResponse,
+    FileSandboxTreeResponse,
+    FileSandboxViewResponse,
+)
+
 import aiofiles
 from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse
@@ -739,7 +751,7 @@ async def upload_file(
     operation="download_file",
     error_code_prefix="FILES",
 )
-@router.get("/download/{path:path}")
+@router.get("/download/{path:path}", response_model=None)
 async def download_file(request: Request, path: str):
     """
     Download a file from the sandbox.
@@ -798,7 +810,7 @@ async def download_file(request: Request, path: str):
     operation="view_file",
     error_code_prefix="FILES",
 )
-@router.get("/view/{path:path}")
+@router.get("/view/{path:path}", response_model=FileSandboxViewResponse)
 async def view_file(request: Request, path: str):
     """
     View file content (for text files) or get file info.
@@ -922,7 +934,7 @@ async def _validate_rename_paths(source_path: Path, new_name: str) -> Path:
     operation="rename_file_or_directory",
     error_code_prefix="FILES",
 )
-@router.post("/rename")
+@router.post("/rename", response_model=FileSandboxRenameResponse)
 async def rename_file_or_directory(
     request: Request, path: str = Form(...), new_name: str = Form(...)
 ):
@@ -1012,7 +1024,7 @@ async def _read_text_content(target_file: Path) -> tuple:
     operation="preview_file",
     error_code_prefix="FILES",
 )
-@router.get("/preview")
+@router.get("/preview", response_model=FileSandboxPreviewResponse)
 async def preview_file(request: Request, path: str):
     """
     Get file preview with content and download URL.
@@ -1060,7 +1072,7 @@ async def preview_file(request: Request, path: str):
     operation="delete_file",
     error_code_prefix="FILES",
 )
-@router.delete("/delete")
+@router.delete("/delete", response_model=FileSandboxDeleteResponse)
 async def delete_file(request: Request, path: str):
     """
     Delete a file or directory within the sandbox.
@@ -1135,7 +1147,7 @@ def _log_directory_create_audit(
     operation="create_directory",
     error_code_prefix="FILES",
 )
-@router.post("/create_directory")
+@router.post("/create_directory", response_model=FileSandboxCreateDirResponse)
 async def create_directory(
     request: Request, path: str = Form(...), name: str = Form(...)
 ):
@@ -1179,7 +1191,7 @@ async def create_directory(
     operation="get_directory_tree",
     error_code_prefix="FILES",
 )
-@router.get("/tree")
+@router.get("/tree", response_model=FileSandboxTreeResponse)
 async def get_directory_tree(request: Request, path: str = ""):
     """Get directory tree structure for file browser"""
     # SECURITY FIX: Enable proper authentication and authorization
@@ -1247,7 +1259,7 @@ async def get_directory_tree(request: Request, path: str = ""):
     operation="get_file_stats",
     error_code_prefix="FILES",
 )
-@router.get("/stats")
+@router.get("/stats", response_model=FileSandboxStatsResponse)
 async def get_file_stats(request: Request):
     """Get file system statistics for the sandbox"""
     # SECURITY FIX: Enable proper authentication and authorization
@@ -1343,7 +1355,7 @@ def _entry_to_file_item(entry: Path) -> dict:
         }
 
 
-@router.get("", summary="List directory for SLM admin file browser")
+@router.get("", summary="List directory for SLM admin file browser", response_model=AdminFileListResponse)
 async def admin_list_directory(path: str = "/home/autobot") -> dict:  # noqa: ssot-path
     """List directory contents at an absolute path.
 
@@ -1364,7 +1376,7 @@ async def admin_list_directory(path: str = "/home/autobot") -> dict:  # noqa: ss
         raise HTTPException(status_code=403, detail="Permission denied")
 
 
-@router.get("/read", summary="Read file content for SLM admin file browser")
+@router.get("/read", summary="Read file content for SLM admin file browser", response_model=AdminFileReadResponse)
 async def admin_read_file(path: str) -> dict:
     """Return text content of a file at an absolute path.
 

--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -3503,3 +3503,249 @@ class NPUPoolReloadResponse(BaseModel):
     message: str
 
 
+
+
+# ---------------------------------------------------------------------------
+# wake_word.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class WakeWordListResponse(BaseModel):
+    """Response for GET /words."""
+
+    wake_words: List[str]
+    total: int
+
+
+class WakeWordMutateResponse(BaseModel):
+    """Response for POST /words and DELETE /words/{wake_word}."""
+
+    success: bool
+    message: str
+    wake_words: List[str]
+
+
+class WakeWordConfigUpdateResponse(BaseModel):
+    """Response for PUT /config."""
+
+    success: bool
+    message: str
+    config: Dict[str, Any]
+
+
+class WakeWordStatsResetResponse(BaseModel):
+    """Response for POST /stats/reset."""
+
+    success: bool
+    message: str
+    stats: Dict[str, Any]
+
+
+class WakeWordFeedbackResponse(BaseModel):
+    """Response for POST /feedback."""
+
+    success: bool
+    message: str
+    stats: Dict[str, Any]
+
+
+class WakeWordToggleResponse(BaseModel):
+    """Response for POST /enable and POST /disable."""
+
+    success: bool
+    message: str
+    config: Dict[str, Any]
+
+
+class WakeWordListeningToggleResponse(BaseModel):
+    """Response for POST /listening/start and POST /listening/stop."""
+
+    success: bool
+    message: str
+    status: Dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# analytics_cost.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class CostModelEntry(BaseModel):
+    model: str
+    cost_usd: float
+    input_tokens: int
+    output_tokens: int
+    call_count: int
+    avg_cost_per_call: float
+
+
+class CostByModelResponse(BaseModel):
+    """Response for GET /cost/by-model."""
+
+    timestamp: str
+    models: List[CostModelEntry]
+    total_models: int
+
+
+class CostForecastPeriod(BaseModel):
+    start: str
+    days: int
+
+
+class CostForecastBaseline(BaseModel):
+    avg_daily_cost: float
+    trend: str
+    growth_rate_percent: float
+
+
+class CostForecastValues(BaseModel):
+    total_estimated_usd: float
+    daily_estimates: Dict[str, Any]
+
+
+class CostForecastResponse(BaseModel):
+    """Response for GET /cost/forecast."""
+
+    forecast_period: CostForecastPeriod
+    baseline: CostForecastBaseline
+    forecast: CostForecastValues
+    confidence: str
+
+
+class RecentUsageResponse(BaseModel):
+    """Response for GET /cost/usage/recent."""
+
+    count: int
+    records: List[Any]
+
+
+class ModelPricingEntry(BaseModel):
+    model: str
+    provider: str
+    input_price_per_1m: float
+    output_price_per_1m: float
+    is_free: bool
+
+
+class ModelPricingResponse(BaseModel):
+    """Response for GET /cost/pricing."""
+
+    pricing_date: str
+    currency: str
+    models: List[ModelPricingEntry]
+    total_models: int
+
+
+class CostEstimateResponse(BaseModel):
+    """Response for GET /cost/estimate."""
+
+    model: str
+    input_tokens: int
+    output_tokens: int
+    estimated_cost_usd: float
+    total_tokens: int
+
+
+class BudgetAlertCreateResponse(BaseModel):
+    """Response for POST /cost/budget-alert."""
+
+    status: str
+    alert: Dict[str, Any]
+
+
+class BudgetAlertsListResponse(BaseModel):
+    """Response for GET /cost/budget-alerts."""
+
+    alerts: List[Any]
+    count: int
+
+
+class BudgetStatusResponse(BaseModel):
+    """Response for GET /cost/budget-status."""
+
+    timestamp: str
+    current_costs: Dict[str, Any]
+    budget_statuses: List[Any]
+
+
+class AllAgentCostsResponse(BaseModel):
+    """Response for GET /cost/by-agent."""
+
+    timestamp: str
+    agents: List[Any]
+    total_agents: int
+
+
+# ---------------------------------------------------------------------------
+# files.py schemas  (Issue #5317)
+# ---------------------------------------------------------------------------
+
+
+class FileSandboxViewResponse(BaseModel):
+    """Response for GET /files/view/{path}."""
+
+    file_info: Any
+    content: Optional[str] = None
+    is_text: bool
+
+
+class FileSandboxRenameResponse(BaseModel):
+    """Response for POST /files/rename."""
+
+    message: str
+    item_info: Any
+
+
+class FileSandboxPreviewResponse(BaseModel):
+    """Response for GET /files/preview."""
+
+    type: str
+    url: str
+    content: Optional[str] = None
+    mime_type: Optional[str] = None
+    size: int
+    name: str
+
+
+class FileSandboxDeleteResponse(BaseModel):
+    """Response for DELETE /files/delete."""
+
+    message: str
+
+
+class FileSandboxCreateDirResponse(BaseModel):
+    """Response for POST /files/create_directory."""
+
+    message: str
+    directory_info: Any
+
+
+class FileSandboxTreeResponse(BaseModel):
+    """Response for GET /files/tree."""
+
+    path: str
+    tree: List[Any]
+
+
+class FileSandboxStatsResponse(BaseModel):
+    """Response for GET /files/stats."""
+
+    sandbox_root: str
+    total_files: int
+    total_directories: int
+    total_size: int
+    total_size_mb: float
+    max_file_size_mb: int
+    allowed_extensions: List[str]
+
+
+class AdminFileListResponse(BaseModel):
+    """Response for GET /files (admin list directory)."""
+
+    files: List[Any]
+
+
+class AdminFileReadResponse(BaseModel):
+    """Response for GET /files/read (admin read file)."""
+
+    content: str

--- a/autobot-backend/api/wake_word.py
+++ b/autobot-backend/api/wake_word.py
@@ -16,6 +16,16 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.wake_word_service import WakeWordDetector, get_wake_word_detector
 from type_defs.common import Metadata
 
+from .schemas_common import (
+    WakeWordConfigUpdateResponse,
+    WakeWordFeedbackResponse,
+    WakeWordListResponse,
+    WakeWordListeningToggleResponse,
+    WakeWordMutateResponse,
+    WakeWordStatsResetResponse,
+    WakeWordToggleResponse,
+)
+
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["wake_word", "voice"])
 
@@ -98,7 +108,7 @@ async def check_wake_word(request: WakeWordCheckRequest) -> WakeWordCheckRespons
     operation="get_wake_words",
     error_code_prefix="WAKE_WORD",
 )
-@router.get("/words")
+@router.get("/words", response_model=WakeWordListResponse)
 async def get_wake_words() -> Metadata:
     """Get list of configured wake words"""
     detector = get_wake_word_detector()
@@ -113,7 +123,7 @@ async def get_wake_words() -> Metadata:
     operation="add_wake_word",
     error_code_prefix="WAKE_WORD",
 )
-@router.post("/words")
+@router.post("/words", response_model=WakeWordMutateResponse)
 async def add_wake_word(request: AddWakeWordRequest) -> Metadata:
     """Add a new wake word to the detection list"""
     detector = get_wake_word_detector()
@@ -138,7 +148,7 @@ async def add_wake_word(request: AddWakeWordRequest) -> Metadata:
     operation="remove_wake_word",
     error_code_prefix="WAKE_WORD",
 )
-@router.delete("/words/{wake_word}")
+@router.delete("/words/{wake_word}", response_model=WakeWordMutateResponse)
 async def remove_wake_word(wake_word: str) -> Metadata:
     """Remove a wake word from the detection list"""
     detector = get_wake_word_detector()
@@ -167,7 +177,7 @@ async def remove_wake_word(wake_word: str) -> Metadata:
     operation="get_wake_word_config",
     error_code_prefix="WAKE_WORD",
 )
-@router.get("/config")
+@router.get("/config", response_model=None)
 async def get_wake_word_config() -> Metadata:
     """Get current wake word detection configuration"""
     detector = get_wake_word_detector()
@@ -179,7 +189,7 @@ async def get_wake_word_config() -> Metadata:
     operation="update_wake_word_config",
     error_code_prefix="WAKE_WORD",
 )
-@router.put("/config")
+@router.put("/config", response_model=WakeWordConfigUpdateResponse)
 async def update_wake_word_config(request: WakeWordConfigRequest) -> Metadata:
     """Update wake word detection configuration"""
     detector = get_wake_word_detector()
@@ -215,7 +225,7 @@ async def update_wake_word_config(request: WakeWordConfigRequest) -> Metadata:
     operation="get_wake_word_stats",
     error_code_prefix="WAKE_WORD",
 )
-@router.get("/stats")
+@router.get("/stats", response_model=None)
 async def get_wake_word_stats() -> Metadata:
     """Get wake word detection statistics"""
     detector = get_wake_word_detector()
@@ -227,7 +237,7 @@ async def get_wake_word_stats() -> Metadata:
     operation="reset_wake_word_stats",
     error_code_prefix="WAKE_WORD",
 )
-@router.post("/stats/reset")
+@router.post("/stats/reset", response_model=WakeWordStatsResetResponse)
 async def reset_wake_word_stats() -> Metadata:
     """Reset wake word detection statistics"""
     detector = get_wake_word_detector()
@@ -244,7 +254,7 @@ async def reset_wake_word_stats() -> Metadata:
     operation="report_detection_feedback",
     error_code_prefix="WAKE_WORD",
 )
-@router.post("/feedback")
+@router.post("/feedback", response_model=WakeWordFeedbackResponse)
 async def report_detection_feedback(request: ReportFeedbackRequest) -> Metadata:
     """
     Report feedback on the last wake word detection.
@@ -270,7 +280,7 @@ async def report_detection_feedback(request: ReportFeedbackRequest) -> Metadata:
     operation="enable_wake_word",
     error_code_prefix="WAKE_WORD",
 )
-@router.post("/enable")
+@router.post("/enable", response_model=WakeWordToggleResponse)
 async def enable_wake_word() -> Metadata:
     """Enable wake word detection"""
     detector = get_wake_word_detector()
@@ -287,7 +297,7 @@ async def enable_wake_word() -> Metadata:
     operation="disable_wake_word",
     error_code_prefix="WAKE_WORD",
 )
-@router.post("/disable")
+@router.post("/disable", response_model=WakeWordToggleResponse)
 async def disable_wake_word() -> Metadata:
     """Disable wake word detection"""
     detector = get_wake_word_detector()
@@ -309,7 +319,7 @@ async def disable_wake_word() -> Metadata:
     operation="start_listening",
     error_code_prefix="WAKE_WORD",
 )
-@router.post("/listening/start")
+@router.post("/listening/start", response_model=WakeWordListeningToggleResponse)
 async def start_listening() -> Metadata:
     """
     Start the always-on background listening loop.
@@ -331,7 +341,7 @@ async def start_listening() -> Metadata:
     operation="stop_listening",
     error_code_prefix="WAKE_WORD",
 )
-@router.post("/listening/stop")
+@router.post("/listening/stop", response_model=WakeWordListeningToggleResponse)
 async def stop_listening() -> Metadata:
     """Stop the always-on background listening loop."""
     detector: WakeWordDetector = get_wake_word_detector()
@@ -348,7 +358,7 @@ async def stop_listening() -> Metadata:
     operation="get_listening_status",
     error_code_prefix="WAKE_WORD",
 )
-@router.get("/listening/status")
+@router.get("/listening/status", response_model=None)
 async def get_listening_status() -> Metadata:
     """
     Get background listening status including real-time CPU metrics.


### PR DESCRIPTION
## Summary
- Adds `response_model=` to all 46 endpoints across wake_word.py (13), analytics_cost.py (12), conversation_files.py (11), files.py (10)
- New Pydantic schemas added to schemas_common.py

## Issue
Closes part of #5317 (response_model= 100% coverage campaign)

🤖 Generated with [Claude Code](https://claude.com/claude-code)