### PR TITLE
refactor(api): replace response_model=None with typed schemas in chat endpoints (#5773)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -30,6 +30,8 @@ from autobot_shared.error_utils import safe_http_detail
 from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
 from constants.threshold_constants import CategoryDefaults, TimingConstants
 
+from api.schemas_common import DataResponse
+
 # Import dependencies and utilities - Using available dependencies
 from dependencies import get_config, get_knowledge_base
 
@@ -790,8 +792,8 @@ async def stream_chat_response(
     operation="list_chats",
     error_code_prefix="CHAT",
 )
-@router.get("/chats", response_model=None)
-@router.get("/chat/chats", response_model=None)  # Frontend compatibility alias
+@router.get("/chats", response_model=DataResponse)
+@router.get("/chat/chats", response_model=DataResponse)  # Frontend compatibility alias
 async def list_chats(
     current_user: dict = Depends(get_current_user),
     request: Request = None,
@@ -832,8 +834,8 @@ async def list_chats(
     operation="send_message",
     error_code_prefix="CHAT",
 )
-@router.post("/chat", response_model=None)
-@router.post("/chat/message", response_model=None)  # Alternative endpoint
+@router.post("/chat", response_model=DataResponse)
+@router.post("/chat/message", response_model=DataResponse)  # Alternative endpoint
 async def send_message(
     current_user: dict = Depends(get_current_user),
     message: ChatMessage = None,
@@ -962,7 +964,7 @@ async def stream_message(
     operation="chat_health_check",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/health", response_model=None)
+@router.get("/chat/health", response_model=DataResponse)
 async def chat_health_check(
     current_user: dict = Depends(get_current_user),
     request: Request = None,
@@ -1015,7 +1017,7 @@ async def chat_health_check(
     operation="chat_statistics",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/stats", response_model=None)
+@router.get("/chat/stats", response_model=DataResponse)
 async def chat_statistics(
     current_user: dict = Depends(get_current_user),
     request: Request = None,
@@ -1392,7 +1394,7 @@ async def _merge_chat_messages(
     operation="save_chat_by_id",
     error_code_prefix="CHAT",
 )
-@router.post("/chats/{chat_id}/save", response_model=None)
+@router.post("/chats/{chat_id}/save", response_model=DataResponse)
 async def save_chat_by_id(
     chat_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1443,7 +1445,7 @@ async def save_chat_by_id(
     operation="delete_chat_by_id",
     error_code_prefix="CHAT",
 )
-@router.delete("/chats/{chat_id}", response_model=None)
+@router.delete("/chats/{chat_id}", response_model=DataResponse)
 async def delete_chat_by_id(
     chat_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1950,7 +1952,7 @@ async def _generate_enhanced_stream(
     operation="enhanced_chat",
     error_code_prefix="CHAT",
 )
-@router.post("/enhanced", response_model=None)
+@router.post("/enhanced", response_model=DataResponse)
 async def enhanced_chat(
     current_user: dict = Depends(get_current_user),
     message: EnhancedChatMessage = None,
@@ -2056,7 +2058,7 @@ async def stream_enhanced_chat(
     operation="enhanced_chat_health_check",
     error_code_prefix="CHAT",
 )
-@router.get("/health-enhanced", response_model=None)
+@router.get("/health-enhanced", response_model=DataResponse)
 async def enhanced_chat_health_check(
     current_user: dict = Depends(get_current_user),
 ):
@@ -2110,7 +2112,7 @@ async def enhanced_chat_health_check(
     operation="get_enhanced_chat_capabilities",
     error_code_prefix="CHAT",
 )
-@router.get("/capabilities", response_model=None)
+@router.get("/capabilities", response_model=DataResponse)
 async def get_enhanced_chat_capabilities(
     current_user: dict = Depends(get_current_user),
 ):
@@ -2201,7 +2203,7 @@ class DetectLanguageRequest(BaseModel):
     operation="translate_text",
     error_code_prefix="TRANSLATE",
 )
-@router.post("/translate", response_model=None)
+@router.post("/translate", response_model=DataResponse)
 async def translate_text(
     body: TranslateRequest,
     current_user: dict = Depends(get_current_user),
@@ -2230,7 +2232,7 @@ async def translate_text(
     operation="detect_language",
     error_code_prefix="TRANSLATE",
 )
-@router.post("/detect-language", response_model=None)
+@router.post("/detect-language", response_model=DataResponse)
 async def detect_language(
     body: DetectLanguageRequest,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/chat_knowledge.py
+++ b/autobot-backend/api/chat_knowledge.py
@@ -55,6 +55,8 @@ from knowledge_base import KnowledgeBase
 from llm_interface import LLMInterface
 from type_defs.common import Metadata
 
+from api.schemas_common import DataResponse
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["chat_knowledge"])
@@ -544,7 +546,7 @@ class CreateContextRequest(BaseModel):
     operation="create_chat_context",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/context/create", response_model=None)
+@router.post("/context/create", response_model=DataResponse)
 async def create_chat_context(request_data: CreateContextRequest, request: Request):
     """Create or update knowledge context for a chat (Issue #688: added user_id)."""
     try:
@@ -585,7 +587,7 @@ class AssociateFileRequest(BaseModel):
     operation="associate_file_with_chat",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/files/associate", response_model=None)
+@router.post("/files/associate", response_model=DataResponse)
 async def associate_file_with_chat(
     request_data: AssociateFileRequest, request: Request
 ):
@@ -619,7 +621,7 @@ async def associate_file_with_chat(
     operation="upload_file_to_chat",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/files/upload/{chat_id}", response_model=None)
+@router.post("/files/upload/{chat_id}", response_model=DataResponse)
 async def upload_file_to_chat(
     chat_id: str,
     file: UploadFile = File(...),
@@ -672,7 +674,7 @@ class AddKnowledgeRequest(BaseModel):
     operation="add_temporary_knowledge",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/knowledge/add_temporary", response_model=None)
+@router.post("/knowledge/add_temporary", response_model=DataResponse)
 async def add_temporary_knowledge(request: AddKnowledgeRequest):
     """Add temporary knowledge to chat context"""
     try:
@@ -692,7 +694,7 @@ async def add_temporary_knowledge(request: AddKnowledgeRequest):
     operation="get_pending_knowledge_decisions",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.get("/knowledge/pending/{chat_id}", response_model=None)
+@router.get("/knowledge/pending/{chat_id}", response_model=DataResponse)
 async def get_pending_knowledge_decisions(chat_id: str):
     """Get knowledge items pending user decision"""
     try:
@@ -720,7 +722,7 @@ class KnowledgeDecisionRequest(BaseModel):
     operation="apply_knowledge_decision",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/knowledge/decide", response_model=None)
+@router.post("/knowledge/decide", response_model=DataResponse)
 async def apply_knowledge_decision(request: KnowledgeDecisionRequest):
     """Apply user decision for temporary knowledge"""
     try:
@@ -751,7 +753,7 @@ class CompileChatRequest(BaseModel):
     operation="compile_chat_to_knowledge",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/compile", response_model=None)
+@router.post("/compile", response_model=DataResponse)
 async def compile_chat_to_knowledge(request_data: CompileChatRequest, request: Request):
     """Compile entire chat conversation to knowledge base"""
     try:
@@ -780,7 +782,7 @@ class SearchRequest(BaseModel):
     operation="search_chat_knowledge",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.post("/search", response_model=None)
+@router.post("/search", response_model=DataResponse)
 async def search_chat_knowledge(request: SearchRequest):
     """Search knowledge across chats or within specific chat"""
     try:
@@ -802,7 +804,7 @@ async def search_chat_knowledge(request: SearchRequest):
     operation="get_chat_context",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.get("/context/{chat_id}", response_model=None)
+@router.get("/context/{chat_id}", response_model=DataResponse)
 async def get_chat_context(chat_id: str):
     """Get complete knowledge context for a chat"""
     try:
@@ -846,7 +848,7 @@ async def get_chat_context(chat_id: str):
     operation="health_check",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=DataResponse)
 async def health_check():
     """Health check endpoint for chat knowledge system"""
     try:
@@ -873,7 +875,7 @@ class MarkFactsPreservedRequest(BaseModel):
     preserve: bool = True
 
 
-@router.get("/chat/sessions/{session_id}/facts", response_model=None)
+@router.get("/chat/sessions/{session_id}/facts", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_session_facts",
@@ -998,7 +1000,7 @@ def _count_preserve_results(results: list, session_id: str) -> tuple[int, int, l
     return updated_count, failed_count, errors
 
 
-@router.post("/chat/sessions/{session_id}/facts/preserve", response_model=None)
+@router.post("/chat/sessions/{session_id}/facts/preserve", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="preserve_session_facts",

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -18,6 +18,8 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from security.session_ownership import validate_session_ownership
 from type_defs.common import Metadata
 
+from api.schemas_common import DataResponse
+
 # Import shared exception classes (Issue #292 - Eliminate duplicate code)
 from utils.chat_exceptions import get_exceptions_lazy
 
@@ -374,7 +376,7 @@ _EXPORT_CONTENT_TYPES = {
     operation="get_session_messages",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/sessions/{session_id}", response_model=None)
+@router.get("/chat/sessions/{session_id}", response_model=DataResponse)
 async def get_session_messages(
     session_id: str,
     request: Request,
@@ -421,7 +423,7 @@ async def get_session_messages(
     operation="list_sessions",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/sessions", response_model=None)
+@router.get("/chat/sessions", response_model=DataResponse)
 async def list_sessions(
     request: Request,
     current_user: dict = Depends(get_current_user),
@@ -777,7 +779,7 @@ async def _track_session_in_memory_graph(
     operation="create_session",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/sessions", response_model=None)
+@router.post("/chat/sessions", response_model=DataResponse)
 async def create_session(session_data: SessionCreate, request: Request):
     """
     Create a new chat session.
@@ -847,7 +849,7 @@ async def create_session(session_data: SessionCreate, request: Request):
     operation="update_session",
     error_code_prefix="CHAT",
 )
-@router.put("/chat/sessions/{session_id}", response_model=None)
+@router.put("/chat/sessions/{session_id}", response_model=DataResponse)
 async def update_session(
     session_id: str,
     session_data: SessionUpdate,
@@ -1348,7 +1350,7 @@ def _build_delete_session_response(
     operation="delete_session",
     error_code_prefix="CHAT",
 )
-@router.delete("/chat/sessions/{session_id}", response_model=None)
+@router.delete("/chat/sessions/{session_id}", response_model=DataResponse)
 async def delete_session(
     session_id: str,
     request: Request,
@@ -1495,7 +1497,7 @@ def _clear_and_restore_session(
     operation="reset_chat",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/reset", response_model=None)
+@router.post("/chat/reset", response_model=DataResponse)
 async def reset_chat(
     request: Request, reset_request: Optional[ChatResetRequest] = None
 ):
@@ -1668,7 +1670,7 @@ async def _process_activity_batch(
     operation="add_session_activity",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/sessions/{session_id}/activities", response_model=None)
+@router.post("/chat/sessions/{session_id}/activities", response_model=DataResponse)
 async def add_session_activity(
     session_id: str,
     activity_data: ActivityCreate,
@@ -1732,7 +1734,7 @@ async def add_session_activity(
     operation="add_session_activities_batch",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/sessions/{session_id}/activities/batch", response_model=None)
+@router.post("/chat/sessions/{session_id}/activities/batch", response_model=DataResponse)
 async def add_session_activities_batch(
     session_id: str,
     batch_data: ActivityBatchCreate,
@@ -1835,7 +1837,7 @@ async def _fetch_activities_from_graph(
     operation="get_session_activities",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/sessions/{session_id}/activities", response_model=None)
+@router.get("/chat/sessions/{session_id}/activities", response_model=DataResponse)
 async def get_session_activities(
     session_id: str,
     request: Request,
@@ -1917,7 +1919,7 @@ async def _share_session_facts(
     operation="share_session",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/sessions/{session_id}/share", response_model=None)
+@router.post("/chat/sessions/{session_id}/share", response_model=DataResponse)
 async def share_session(
     session_id: str,
     share_data: SessionShareRequest,
@@ -1969,7 +1971,7 @@ async def share_session(
     operation="get_session_share_preview",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/sessions/{session_id}/share/preview", response_model=None)
+@router.get("/chat/sessions/{session_id}/share/preview", response_model=DataResponse)
 async def get_share_preview(
     session_id: str,
     request: Request,
@@ -2006,7 +2008,7 @@ async def get_share_preview(
     )
 
 
-@router.delete("/sessions/{session_id}/checkpoints", response_model=None)
+@router.delete("/sessions/{session_id}/checkpoints", response_model=DataResponse)
 async def clear_session_checkpoints(
     session_id: str,
     current_user: Dict = Depends(get_current_user),


### PR DESCRIPTION
## Summary
- Replaces `response_model=None` with `DataResponse` on all non-streaming endpoints in `chat_sessions.py` (12/13), `chat.py` (11/18), `chat_knowledge.py` (12 endpoints)
- Streaming endpoints (StreamingResponse/EventSourceResponse) correctly remain `response_model=None`
- `chat_compare.py` unchanged — its single endpoint is streaming
- Reuses existing `DataResponse` from `schemas_common.py` which matches the `create_success_response()` return shape used throughout chat endpoints

## Behavioral grep audit
Before: `grep -n "response_model=None" autobot-backend/api/chat*.py` → 40+ hits
After: only streaming endpoints retain `response_model=None`

Closes #5773