### PR TITLE
fix(planner): pass real tool descriptions to compress_description + use AsyncRedisClientLockedMixin (#5826 #5828)

### DIFF
--- a/autobot-backend/tools/description_compressor.py
+++ b/autobot-backend/tools/description_compressor.py
@@ -15,12 +15,20 @@ import logging
 
 import aiohttp
 
-from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.redis_mixin import AsyncRedisClientLockedMixin
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config
 
 logger = logging.getLogger(__name__)
 
 CACHE_TTL = 2592000  # 30 days
+
+
+class _RedisHelper(AsyncRedisClientLockedMixin):
+    _redis_database = "main"
+
+
+_get_redis_helper = lazy_singleton(_RedisHelper)
 
 
 def _cache_key(tool_name: str, tool_spec: dict) -> str:
@@ -41,7 +49,7 @@ def _fallback_description(tool_spec: dict) -> str:
 
 async def _fetch_from_cache(key: str) -> str | None:
     """Return cached compressed description or None on cache miss / Redis unavailable."""
-    redis = await get_async_redis_client(database="main")
+    redis = await _get_redis_helper()._get_redis()
     if redis is None:
         return None
     try:
@@ -54,7 +62,7 @@ async def _fetch_from_cache(key: str) -> str | None:
 
 async def _store_in_cache(key: str, value: str) -> None:
     """Persist compressed description to Redis; silently skips on failure."""
-    redis = await get_async_redis_client(database="main")
+    redis = await _get_redis_helper()._get_redis()
     if redis is None:
         return
     try:

--- a/autobot-backend/tools/tool_registry.py
+++ b/autobot-backend/tools/tool_registry.py
@@ -550,14 +550,34 @@ class ToolRegistry:
         """Return a mapping of tool_name -> compressed description for all registered tools.
 
         Uses :func:`tools.description_compressor.compress_description` with Redis
-        caching and Ollama LLM compression.  Falls back to the raw description
-        string for any tool whose spec lacks one, and skips compression entirely
-        for tools without a spec dict (SDK-only tools are not iterated here).
+        caching and Ollama LLM compression.  Falls back to the tool name string for
+        any tool whose description cannot be resolved.
         """
+        import inspect  # noqa: PLC0415
+
         from tools.description_compressor import compress_description  # noqa: PLC0415
 
+        def _get_description(name: str) -> str:
+            # Registry tools: use method docstring first line
+            method = getattr(self, name, None)
+            if method is not None:
+                doc = inspect.getdoc(method)
+                if doc:
+                    return doc.split("\n")[0]
+            # Browser/builtin tools: use Anthropic schema description
+            try:
+                from chat_workflow.tool_handler import _BUILTIN_TOOL_SCHEMAS  # noqa: PLC0415
+
+                schema = _BUILTIN_TOOL_SCHEMAS.get(name, {})
+                desc = (schema or {}).get("description", "")
+                if desc:
+                    return desc
+            except ImportError:
+                pass
+            return name  # last resort
+
         tool_names = self.get_available_tools()
-        tasks = [compress_description(name, {"name": name}) for name in tool_names]
+        tasks = [compress_description(name, {"description": _get_description(name)}) for name in tool_names]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         compressed: Dict[str, str] = {}


### PR DESCRIPTION
## Summary
- **#5826**: `get_compressed_descriptions()` now resolves actual tool descriptions via `inspect.getdoc()` on ToolRegistry methods (registry tools) and `_BUILTIN_TOOL_SCHEMAS` lookup (browser tools), instead of passing `{"name": name}` stub. `_fallback_description` now receives a real description string.
- **#5828**: `description_compressor.py` migrated from bare `get_async_redis_client()` calls to `AsyncRedisClientLockedMixin` via a `_RedisHelper` singleton — single connection reused across fetch/store, consistent with codebase pattern.

## Test Plan
- [ ] `python3 -m py_compile autobot-backend/tools/description_compressor.py` passes
- [ ] `python3 -m py_compile autobot-backend/tools/tool_registry.py` passes
- [ ] `get_compressed_descriptions()` returns meaningful text (not JSON stub) for each tool

Closes #5826
Closes #5828

🤖 Generated with Claude Code