### PR TITLE
fix(api): response_model=None for 5 streaming/binary endpoints — #5317 follow-up

### DIFF
--- a/autobot-backend/api/a2a.py
+++ b/autobot-backend/api/a2a.py
@@ -289,7 +289,7 @@ async def get_task(task_id: str) -> Dict[str, Any]:
     "/tasks/{task_id}/stream",
     summary="Stream A2A task events (SSE)",
     tags=["a2a"],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def stream_task_events(task_id: str) -> StreamingResponse:
     """

--- a/autobot-backend/api/conversation_files.py
+++ b/autobot-backend/api/conversation_files.py
@@ -651,7 +651,7 @@ def _build_download_response(file_info_dict: Dict, file_path: Path) -> FileRespo
     operation="download_conversation_file",
     error_code_prefix="CONVERSATION_FILES",
 )
-@router.get("/conversation/{session_id}/download/{file_id}", response_model=DataResponse)
+@router.get("/conversation/{session_id}/download/{file_id}", response_model=None)
 async def download_conversation_file(request: Request, session_id: str, file_id: str):
     """
     Download a specific file from a conversation.

--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -740,7 +740,7 @@ async def upload_file(
     operation="download_file",
     error_code_prefix="FILES",
 )
-@router.get("/download/{path:path}", response_model=DataResponse)
+@router.get("/download/{path:path}", response_model=None)
 async def download_file(request: Request, path: str):
     """
     Download a file from the sandbox.

--- a/autobot-backend/api/process_management.py
+++ b/autobot-backend/api/process_management.py
@@ -109,7 +109,7 @@ async def get_process_status(
     return JSONResponse(status_code=200, content=data)
 
 
-@router.get("/processes/{process_id}/logs", response_model=DataResponse)
+@router.get("/processes/{process_id}/logs", response_model=None)
 async def get_process_logs(
     process_id: str,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/prometheus_endpoint.py
+++ b/autobot-backend/api/prometheus_endpoint.py
@@ -17,7 +17,7 @@ from api.schemas_common import DataResponse, SuccessResponse
 router = APIRouter()
 
 
-@router.get("", response_model=DataResponse)
+@router.get("", response_model=None)
 async def metrics_endpoint():
     """
     Expose Prometheus metrics in text/plain format for scraping


### PR DESCRIPTION
## Summary

Fixes a bug introduced by #5834 (#5317 sweep): 5 endpoints received `response_model=DataResponse` but actually return non-JSON responses and must use `response_model=None`.

| File | Endpoint | Returns |
|------|----------|---------|
| `api/a2a.py` | `stream_task_events()` | `StreamingResponse` (SSE) |
| `api/conversation_files.py` | `download_conversation_file()` | `FileResponse` |
| `api/files.py` | `download_file()` | `FileResponse` |
| `api/process_management.py` | `get_process_logs()` | `PlainTextResponse` |
| `api/prometheus_endpoint.py` | `metrics_endpoint()` | Prometheus text (`CONTENT_TYPE_LATEST`) |

`response_model=DataResponse` on a streaming/binary endpoint would produce incorrect OpenAPI documentation claiming a JSON body is returned.

## Discovery process

Caught by post-implementation gap review: AST-scanned all endpoints annotated with `DataResponse` and cross-referenced function bodies for `StreamingResponse`, `FileResponse`, and `PlainTextResponse` returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)