### PR TITLE
fix(composables): forward AbortSignal in useFetchEndpoint + expose abort() for clean reset (#5823 #5824)

### DIFF
--- a/autobot-frontend/src/composables/api/useFetchEndpoint.ts
+++ b/autobot-frontend/src/composables/api/useFetchEndpoint.ts
@@ -216,7 +216,7 @@ export function useFetchEndpoint<TRaw, TOut, Ctx = undefined>(
   //
   // fallbackData is handled by catching inside the fetcher and returning the
   // fallback value rather than re-throwing, so useApiResource sees a success.
-  const resource = useApiResource<TOut | null>(async () => {
+  const resource = useApiResource<TOut | null>(async (signal?: AbortSignal) => {
     const ctx = pendingCtx
     const queryExtras = pendingExtras
 
@@ -233,6 +233,7 @@ export function useFetchEndpoint<TRaw, TOut, Ctx = undefined>(
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
+      signal, // forward the AbortSignal so fetchWithAuth cancels the network request
     }
     if (method !== 'GET' && opts.body) {
       init.body = JSON.stringify(opts.body())
@@ -290,11 +291,10 @@ export function useFetchEndpoint<TRaw, TOut, Ctx = undefined>(
   }
 
   const reset = (): void => {
+    resource.abort() // cancel any in-flight request and clear isLoading atomically
     resource.data.value = null
     resource.error.value = null
-    // isLoading is cleared by useApiResource after refresh resolves;
-    // force it to false on reset() since no in-flight request remains.
-    resource.isLoading.value = false
+    // isLoading is now managed by resource.abort() — do NOT set it directly here
   }
 
   // Map useApiResource's shape to useFetchEndpoint's public API:

--- a/autobot-frontend/src/composables/useApiResource.ts
+++ b/autobot-frontend/src/composables/useApiResource.ts
@@ -60,6 +60,13 @@ export interface UseApiResourceReturn<T> {
   isLoading: Ref<boolean>
   /** Invoke the fetcher. Resolves after state has been updated. */
   refresh: () => Promise<void>
+  /**
+   * Abort the current in-flight request (if any) and immediately clear
+   * `isLoading`. Safe to call when no request is in flight. Advances the
+   * internal call-ID counter so the in-flight finally block exits early
+   * without touching the refs.
+   */
+  abort: () => void
 }
 
 /**
@@ -145,6 +152,17 @@ export function useApiResource<T>(
     }
   }
 
+  const abort = (): void => {
+    if (currentController !== null) {
+      currentController.abort()
+      currentController = null
+    }
+    // Advance the call ID so the in-flight finally block sees a stale ID and
+    // exits without touching isLoading or data.
+    latestCallId++
+    isLoading.value = false
+  }
+
   // Only register the disposer if called inside an effect scope (e.g. a Vue
   // component setup). Calling onScopeDispose outside a scope emits a warning
   // and does nothing — guarding here keeps unit tests quiet and the callsite
@@ -165,5 +183,5 @@ export function useApiResource<T>(
     refresh()
   }
 
-  return { data, error, isLoading, refresh }
+  return { data, error, isLoading, refresh, abort }
 }


### PR DESCRIPTION
## Summary
- Fixes `useFetchEndpoint` fetcher closure to accept and forward `AbortSignal` to `fetchWithAuth`, so in-flight network requests are actually cancelled when a newer `load()` fires (#5823)
- Adds `abort()` to `useApiResource` return interface; `reset()` now calls `resource.abort()` instead of directly mutating `isLoading.value`, eliminating the false-idle flicker when reset during an in-flight request (#5824)

## Changes
- `useApiResource.ts`: `abort()` aborts `currentController`, increments `latestCallId`, sets `isLoading=false`
- `useFetchEndpoint.ts`: fetcher `async ()` → `async (signal?: AbortSignal)`; `signal` wired into `RequestInit`; `reset()` delegates to `resource.abort()`

## Test plan
- [ ] `cd autobot-frontend && npx vue-tsc --noEmit -p tsconfig.app.json` — no new TS errors
- [ ] Rapid `load()` calls: only last result shown, prior requests cancelled at network level
- [ ] `reset()` during in-flight: `loading` goes false immediately

Closes #5823
Closes #5824

🤖 Generated with [Claude Code](https://claude.com/claude-code)