### PR TITLE
feat(planner): wire compress_description into planner call path (#5827)

### DIFF
--- a/autobot-backend/llm_interface_pkg/interface.py
+++ b/autobot-backend/llm_interface_pkg/interface.py
@@ -1403,6 +1403,28 @@ class LLMInterface:
 
         from agent_tier_classifier import get_base_prompt_for_agent
         from prompt_manager import get_optimized_prompt
+        from tools import get_tool_registry
+
+        tool_descriptions: dict | None = None
+        if available_tools:
+            try:
+                registry = get_tool_registry()
+                raw_descs = {
+                    name: desc
+                    for name, desc in (
+                        await registry.get_compressed_descriptions()
+                    ).items()
+                    if name in available_tools
+                }
+                before_bytes = sum(len(d) for d in raw_descs.values())
+                tool_descriptions = raw_descs
+                logger.debug(
+                    "[#5827] Compressed tool descriptions: %d tools, %d bytes",
+                    len(tool_descriptions),
+                    before_bytes,
+                )
+            except Exception:
+                logger.warning("[#5827] compress_description failed; falling back to tool names only", exc_info=True)
 
         system_prompt = get_optimized_prompt(
             base_prompt_key=get_base_prompt_for_agent(agent_type),
@@ -1412,6 +1434,7 @@ class LLMInterface:
             available_tools=available_tools,
             recent_context=recent_context,
             additional_params=additional_params,
+            tool_descriptions=tool_descriptions,
         )
 
         request_id = llm_params.pop("request_id", str(uuid.uuid4()))

--- a/autobot-backend/prompt_manager.py
+++ b/autobot-backend/prompt_manager.py
@@ -1210,6 +1210,7 @@ def _build_dynamic_context(
     available_tools: Optional[List[str]],
     recent_context: Optional[str],
     additional_params: Optional[Dict],
+    tool_descriptions: Optional[Dict] = None,
 ) -> str:
     """
     Build dynamic context section for optimized prompts.
@@ -1224,6 +1225,7 @@ def _build_dynamic_context(
         available_tools: List of available tool names
         recent_context: Recent conversation context or task history
         additional_params: Additional dynamic parameters
+        tool_descriptions: Optional mapping of tool_name -> compressed description (Issue #5827)
 
     Returns:
         Rendered dynamic context string
@@ -1240,6 +1242,7 @@ def _build_dynamic_context(
             available_tools=available_tools or [],
             recent_context=recent_context or "",
             additional_params=additional_params or {},
+            tool_descriptions=tool_descriptions,
         )
     except KeyError:
         logger.warning(
@@ -1259,6 +1262,7 @@ def get_optimized_prompt(
     available_tools: Optional[List[str]] = None,
     recent_context: Optional[str] = None,
     additional_params: Optional[Dict] = None,
+    tool_descriptions: Optional[Dict] = None,
 ) -> str:
     """
     Get a prompt optimized for vLLM prefix caching.
@@ -1275,6 +1279,7 @@ def get_optimized_prompt(
         available_tools: List of available tool names
         recent_context: Recent conversation context or task history
         additional_params: Additional dynamic parameters
+        tool_descriptions: Optional mapping of tool_name -> compressed description (Issue #5827)
 
     Returns:
         Combined prompt with static prefix + dynamic suffix
@@ -1290,6 +1295,7 @@ def get_optimized_prompt(
         available_tools,
         recent_context,
         additional_params,
+        tool_descriptions,
     )
 
     # Combine: static prefix + dynamic suffix (CRITICAL for vLLM prefix caching)

--- a/autobot-backend/resources/prompts/default/agent.system.dynamic_context.md
+++ b/autobot-backend/resources/prompts/default/agent.system.dynamic_context.md
@@ -11,7 +11,13 @@
 
 **Available Tools:**
 {% if available_tools %}
+{% if tool_descriptions %}
+{% for tool in available_tools %}
+- {{ tool }}: {{ tool_descriptions.get(tool, tool) }}
+{% endfor %}
+{% else %}
 {{ available_tools | join(", ") }}
+{% endif %}
 {% else %}
 All standard AutoBot tools
 {% endif %}

--- a/autobot-backend/tools/__init__.py
+++ b/autobot-backend/tools/__init__.py
@@ -9,6 +9,6 @@ between the standard orchestrator and LangChain orchestrator implementations.
 """
 
 from .code_interpreter import CODE_INTERPRETER_SCHEMA, execute_code
-from .tool_registry import ToolRegistry
+from .tool_registry import ToolRegistry, get_tool_registry
 
-__all__ = ["CODE_INTERPRETER_SCHEMA", "ToolRegistry", "execute_code"]
+__all__ = ["CODE_INTERPRETER_SCHEMA", "ToolRegistry", "execute_code", "get_tool_registry"]

--- a/autobot-backend/tools/tool_registry.py
+++ b/autobot-backend/tools/tool_registry.py
@@ -624,3 +624,8 @@ class ToolRegistry:
         # (#4557)
         from chat_workflow.tool_handler import BROWSER_TOOL_NAMES  # noqa: PLC0415
         return registry_tools + sorted(BROWSER_TOOL_NAMES)
+
+
+from autobot_shared.singleton_factory import lazy_singleton  # noqa: E402
+
+get_tool_registry = lazy_singleton(ToolRegistry)


### PR DESCRIPTION
## Summary

- Adds `get_tool_registry = lazy_singleton(ToolRegistry)` so callers share one ToolRegistry instance
- Exports `get_tool_registry` from `tools/__init__.py`
- Adds `tool_descriptions: dict | None` param to `_build_dynamic_context()` and `get_optimized_prompt()` in `prompt_manager.py`
- Updates `agent.system.dynamic_context.md` template: renders `- name: compressed_desc` per tool when `tool_descriptions` is provided; falls back to comma-joined names when `None`
- In `chat_completion_optimized()` (`interface.py`): when `available_tools` is non-empty, calls `registry.get_compressed_descriptions()`, filters to requested tools, logs byte count, passes as `tool_descriptions` to `get_optimized_prompt()`; any exception falls back gracefully

Prerequisite #5826 (stub spec fix) is already merged.

## Test plan
- [ ] `python3 -m py_compile` passes on all 4 modified Python files ✅
- [ ] Template renders `- name: desc` when `tool_descriptions` is provided ✅
- [ ] Template falls back to comma-join when `tool_descriptions=None` ✅
- [ ] Exception in `get_compressed_descriptions()` logs warning and leaves `tool_descriptions=None` (tool availability unaffected)
- [ ] `before_bytes` logged at DEBUG level when available_tools is non-empty

Closes #5827

🤖 Generated with [Claude Code](https://claude.com/claude-code)