### PR TITLE
refact(api): remove unused SuccessResponse import from 82 API files (#5846)

### DIFF
--- a/autobot-backend/api/a2a.py
+++ b/autobot-backend/api/a2a.py
@@ -42,7 +42,7 @@ from a2a.task_manager import get_task_manager
 from a2a.tracing import extract_caller_id, new_trace_id
 from a2a.types import Task
 from auth_middleware import check_admin_permission
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/adapters.py
+++ b/autobot-backend/api/adapters.py
@@ -15,7 +15,7 @@ from fastapi.responses import JSONResponse
 
 from auth_middleware import get_current_user
 from llm_interface_pkg.adapters.registry import get_adapter_registry
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -22,7 +22,7 @@ from enhanced_memory_manager_async import TaskPriority
 from takeover_manager import TakeoverTrigger, takeover_manager
 from task_execution_tracker import task_tracker
 from type_defs.common import Metadata
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["advanced_control"])

--- a/autobot-backend/api/alertmanager_webhook.py
+++ b/autobot-backend/api/alertmanager_webhook.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel
 
 from api.monitoring import ws_manager
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/analytics.py
+++ b/autobot-backend/api/analytics.py
@@ -403,7 +403,7 @@ from api import (
     analytics_cost,
     analytics_export,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 # Include sub-routers
 router.include_router(analytics_code.router)

--- a/autobot-backend/api/analytics_agents.py
+++ b/autobot-backend/api/analytics_agents.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, Field
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.agent_analytics import AgentType, TaskStatus, get_agent_analytics
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/agents", tags=["analytics", "agents"])

--- a/autobot-backend/api/analytics_behavior.py
+++ b/autobot-backend/api/analytics_behavior.py
@@ -27,7 +27,7 @@ from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from services.user_behavior_analytics import UserEvent, get_behavior_analytics
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/behavior", tags=["analytics", "behavior"])

--- a/autobot-backend/api/analytics_code_generation.py
+++ b/autobot-backend/api/analytics_code_generation.py
@@ -34,7 +34,7 @@ from api.analytics_shared import resolve_source_or_404 as _resolve_source_or_404
 from auth_middleware import check_admin_permission
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 # LLM Interface for real code generation
 try:

--- a/autobot-backend/api/analytics_conversation.py
+++ b/autobot-backend/api/analytics_conversation.py
@@ -22,7 +22,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.time_utils import parse_utc_iso
 from constants.path_constants import PATH
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/analytics_cost.py
+++ b/autobot-backend/api/analytics_cost.py
@@ -26,7 +26,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from services.llm_cost_tracker import MODEL_PRICING, get_cost_tracker
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/cost", tags=["analytics", "cost"])

--- a/autobot-backend/api/analytics_dfa.py
+++ b/autobot-backend/api/analytics_dfa.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.security.path_validator import validate_path
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/analytics_evolution.py
+++ b/autobot-backend/api/analytics_evolution.py
@@ -30,7 +30,7 @@ from autobot_shared.redis_client import get_redis_client
 from autobot_shared.redis_utils import decode_redis_value as _decode_redis_value
 from autobot_shared.security.path_validator import validate_path
 from autobot_shared.time_utils import parse_utc_iso
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(

--- a/autobot-backend/api/analytics_log_patterns.py
+++ b/autobot-backend/api/analytics_log_patterns.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/analytics_performance.py
+++ b/autobot-backend/api/analytics_performance.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.security.path_validator import validate_path
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/anti_pattern.py
+++ b/autobot-backend/api/anti_pattern.py
@@ -106,7 +106,7 @@ ANTI_PATTERN_TYPE_DEFINITIONS = (
 
 # Lazy initialization for detector (thread-safe)
 import asyncio
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 _detector_instance = None
 _detector_lock = asyncio.Lock()

--- a/autobot-backend/api/approval_gates.py
+++ b/autobot-backend/api/approval_gates.py
@@ -21,7 +21,7 @@ from auth_middleware import get_current_user
 from autobot_shared.models.pagination import PaginationParams
 from models.approval import ApprovalStatus, ApprovalType
 from services.approval_gate_service import ApprovalGateService
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/autobot-backend/api/audit.py
+++ b/autobot-backend/api/audit.py
@@ -33,7 +33,7 @@ from utils.catalog_http_exceptions import (
     raise_server_error,
     raise_validation_error,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter(prefix="/audit", tags=["audit"])
 logger = logging.getLogger(__name__)

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -21,7 +21,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.error_constants import ERR_INVALID_CREDENTIALS, ERR_INVALID_TOKEN
 from user_management.database import db_session_context
 from user_management.services.user_service import UserService
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/autobot-backend/api/batch_jobs.py
+++ b/autobot-backend/api/batch_jobs.py
@@ -27,7 +27,7 @@ from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.models.pagination import PaginationParams
 from autobot_shared.redis_client import get_redis_client
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["batch-jobs", "management"])

--- a/autobot-backend/api/bi_export_endpoints.py
+++ b/autobot-backend/api/bi_export_endpoints.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.saved_reports_service import get_saved_reports_service
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter(tags=["bi-reports"])
 

--- a/autobot-backend/api/captcha.py
+++ b/autobot-backend/api/captcha.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel
 
 from autobot_shared.time_utils import utc_timestamp
 from services.captcha_human_loop import CaptchaResolutionStatus, get_captcha_human_loop
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter(prefix="/captcha", tags=["captcha"])
 logger = logging.getLogger(__name__)

--- a/autobot-backend/api/collaboration.py
+++ b/autobot-backend/api/collaboration.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth_middleware import get_current_user
 from models.session_collaboration import PermissionLevel, SessionCollaboration
 from user_management.database import get_async_session
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/conversation_export.py
+++ b/autobot-backend/api/conversation_export.py
@@ -32,7 +32,7 @@ from services.conversation_export import (
 )
 from utils.chat_exceptions import get_exceptions_lazy
 from utils.chat_utils import get_chat_history_manager, validate_chat_session_id
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/conversation_files.py
+++ b/autobot-backend/api/conversation_files.py
@@ -25,7 +25,7 @@ from auth_middleware import auth_middleware, check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from security_layer import SecurityLayer
 from utils.catalog_http_exceptions import raise_internal_error, raise_invalid_input, raise_not_found
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter(
     dependencies=[Depends(check_admin_permission)],

--- a/autobot-backend/api/data_storage.py
+++ b/autobot-backend/api/data_storage.py
@@ -24,7 +24,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_relative_path
 from utils.catalog_http_exceptions import raise_server_error
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter(prefix="/data-storage", tags=["Data Storage"])
 logger = logging.getLogger(__name__)

--- a/autobot-backend/api/developer.py
+++ b/autobot-backend/api/developer.py
@@ -20,7 +20,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from config import unified_config_manager
 from services.config_service import ConfigService
 from type_defs.common import Metadata
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/autobot-backend/api/diagnostics.py
+++ b/autobot-backend/api/diagnostics.py
@@ -27,7 +27,7 @@ from services.causal_inference_engine import (
     CausalAnalysisReport,
     CausalInferenceEngine,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/documents.py
+++ b/autobot-backend/api/documents.py
@@ -35,7 +35,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_async_redis_client
 from constants.ttl_constants import TTL_365_DAYS
 from models.document import AIDocument
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/embeddings.py
+++ b/autobot-backend/api/embeddings.py
@@ -21,7 +21,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.ssot_config import DEFAULT_EMBEDDING_MODEL
 from config import unified_config_manager
 from services.config_service import ConfigService
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/enhanced_search.py
+++ b/autobot-backend/api/enhanced_search.py
@@ -21,7 +21,7 @@ from autobot_shared.logging_manager import get_llm_logger
 # Import NPU semantic search components
 from npu_semantic_search import get_npu_search_engine
 from type_defs.common import Metadata
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = get_llm_logger("enhanced_search_api")
 

--- a/autobot-backend/api/error_resilience.py
+++ b/autobot-backend/api/error_resilience.py
@@ -18,7 +18,7 @@ from services.resilience.circuit_breaker_manager import (
 )
 from services.resilience.error_budget import get_error_budget_tracker
 from services.resilience.fallback_manager import get_fallback_manager
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -37,7 +37,7 @@ from security_layer import SecurityLayer
 from utils.io_executor import run_in_file_executor
 from utils.path_validation import is_invalid_name
 from utils.paths_manager import ensure_data_directory, get_data_path
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/autobot-backend/api/frontend_config.py
+++ b/autobot-backend/api/frontend_config.py
@@ -10,7 +10,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.network_constants import NetworkConstants
 from constants.path_constants import PathConstants
 from services.config_service import ConfigService
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/autobot-backend/api/gpu_monitoring.py
+++ b/autobot-backend/api/gpu_monitoring.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/graph_rag.py
+++ b/autobot-backend/api/graph_rag.py
@@ -34,7 +34,7 @@ from autobot_shared.time_utils import utc_timestamp
 from services.graph_rag_service import GraphRAGService
 from type_defs.common import Metadata
 from utils.request_utils import generate_request_id
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 # ====================================================================
 # Router Configuration

--- a/autobot-backend/api/heartbeat.py
+++ b/autobot-backend/api/heartbeat.py
@@ -29,7 +29,7 @@ from models.heartbeat import (
     WakeupTrigger,
 )
 from services.heartbeat_scheduler import HeartbeatScheduler, _get_or_create_state
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/autobot-backend/api/hot_reload.py
+++ b/autobot-backend/api/hot_reload.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from type_defs.common import Metadata
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/infrastructure.py
+++ b/autobot-backend/api/infrastructure.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, Query
 
 from auth_middleware import get_current_user
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["infrastructure"])

--- a/autobot-backend/api/integration_cicd.py
+++ b/autobot-backend/api/integration_cicd.py
@@ -17,7 +17,7 @@ from integrations.cicd_integration import (
     GitLabCIIntegration,
     JenkinsIntegration,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/integration_cloud.py
+++ b/autobot-backend/api/integration_cloud.py
@@ -22,7 +22,7 @@ from integrations.cloud_integration import (
     AzureIntegration,
     GCPIntegration,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter(
     tags=["integrations-cloud"],

--- a/autobot-backend/api/integration_database.py
+++ b/autobot-backend/api/integration_database.py
@@ -22,7 +22,7 @@ from integrations.database_integration import (
     MySQLIntegration,
     PostgreSQLIntegration,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/integration_github.py
+++ b/autobot-backend/api/integration_github.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 from auth_middleware import check_admin_permission
 from integrations.base import IntegrationConfig, IntegrationHealth
 from integrations.github_integration import GitHubIntegration
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/integration_monitoring.py
+++ b/autobot-backend/api/integration_monitoring.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field, validator
 from auth_middleware import check_admin_permission
 from integrations.base import IntegrationConfig
 from integrations.monitoring_integration import DatadogIntegration, NewRelicIntegration
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(

--- a/autobot-backend/api/integration_project_management.py
+++ b/autobot-backend/api/integration_project_management.py
@@ -26,7 +26,7 @@ from integrations.project_management_integration import (
     JiraIntegration,
     TrelloIntegration,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/integration_version_control.py
+++ b/autobot-backend/api/integration_version_control.py
@@ -16,7 +16,7 @@ from integrations.version_control_integration import (
     BitbucketIntegration,
     GitLabIntegration,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(

--- a/autobot-backend/api/intelligent_agent.py
+++ b/autobot-backend/api/intelligent_agent.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from monitoring.prometheus_metrics import get_metrics_manager
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 # CRITICAL FIX: Use lazy loading to prevent startup deadlock
 logger = logging.getLogger(__name__)

--- a/autobot-backend/api/kb_librarian.py
+++ b/autobot-backend/api/kb_librarian.py
@@ -41,7 +41,7 @@ from agents.kb_librarian_agent import get_kb_librarian
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from type_defs.common import Metadata
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -50,7 +50,7 @@ from knowledge.schemas.connectors import (
     CreateConnectorRequest,
     UpdateConnectorRequest,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/knowledge_graph_routes.py
+++ b/autobot-backend/api/knowledge_graph_routes.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from auth_middleware import get_current_user
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/knowledge_test.py
+++ b/autobot-backend/api/knowledge_test.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.threshold_constants import TimingConstants
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/autobot-backend/api/long_running_operations.py
+++ b/autobot-backend/api/long_running_operations.py
@@ -38,7 +38,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_path
 from constants.path_constants import PATH
 from constants.threshold_constants import TimingConstants
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 # Add AutoBot paths
 sys.path.append(str(PATH.PROJECT_ROOT))

--- a/autobot-backend/api/manual_mcp.py
+++ b/autobot-backend/api/manual_mcp.py
@@ -23,7 +23,7 @@ from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_redis_client
 from services.man_page_parser import ManPageContent, get_man_page_content
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["manual_mcp", "mcp"])

--- a/autobot-backend/api/marketplace.py
+++ b/autobot-backend/api/marketplace.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field
 
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_config import config
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/merge_conflict_resolution.py
+++ b/autobot-backend/api/merge_conflict_resolution.py
@@ -35,7 +35,7 @@ from code_intelligence.merge_conflict_resolver import (
     ResolutionStrategy,
     analyze_repository,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/models.py
+++ b/autobot-backend/api/models.py
@@ -16,7 +16,7 @@ from fastapi.responses import JSONResponse
 
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -59,7 +59,7 @@ from utils.performance_monitor import (
     start_monitoring,
     stop_monitoring,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/multimodal.py
+++ b/autobot-backend/api/multimodal.py
@@ -29,7 +29,7 @@ from multimodal_processor import (
 # Import AutoBot multi-modal components
 from npu_semantic_search import get_npu_search_engine
 from type_defs.common import Metadata
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/natural_language_search.py
+++ b/autobot-backend/api/natural_language_search.py
@@ -25,7 +25,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
 from constants.threshold_constants import QueryDefaults
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/nl_database.py
+++ b/autobot-backend/api/nl_database.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import get_current_user
 from services.nl_database_service import get_nl_database_service
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/overseer_handlers.py
+++ b/autobot-backend/api/overseer_handlers.py
@@ -26,7 +26,7 @@ from agents.overseer.types import (
 )
 from auth_middleware import get_current_user
 from chat_history import ChatHistoryManager
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/permissions.py
+++ b/autobot-backend/api/permissions.py
@@ -34,7 +34,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.ssot_config import PermissionAction, PermissionMode, config
 from services.approval_memory import get_approval_memory
 from services.permission_matcher import get_permission_matcher
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/personality.py
+++ b/autobot-backend/api/personality.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, field_validator
 
 from auth_middleware import check_admin_permission
 from services.personality_service import SUPPORTED_LANGUAGES, get_personality_manager
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["personality"])

--- a/autobot-backend/api/process_management.py
+++ b/autobot-backend/api/process_management.py
@@ -20,7 +20,7 @@ from auth_middleware import get_current_user
 from autobot_shared.error_utils import safe_http_detail
 from constants.threshold_constants import TimingConstants
 from services.process_adapter_service import ProcessAdapterService
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/autobot-backend/api/project_state.py
+++ b/autobot-backend/api/project_state.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from project_state_manager import DevelopmentPhase, get_project_state_manager
 from utils.advanced_cache_manager import smart_cache
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/prometheus_endpoint.py
+++ b/autobot-backend/api/prometheus_endpoint.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Response
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from monitoring.prometheus_metrics import get_metrics_manager
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter()
 

--- a/autobot-backend/api/prometheus_mcp.py
+++ b/autobot-backend/api/prometheus_mcp.py
@@ -22,7 +22,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
 from autobot_shared.ssot_config import get_config
 from type_defs.common import Metadata
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(

--- a/autobot-backend/api/prompts.py
+++ b/autobot-backend/api/prompts.py
@@ -14,7 +14,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_relative_path
 from constants.ttl_constants import TTL_5_MINUTES
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter()
 

--- a/autobot-backend/api/redis.py
+++ b/autobot-backend/api/redis.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, HTTPException
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.config_service import ConfigService
 from utils.connection_utils import ConnectionTester
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter()
 

--- a/autobot-backend/api/sandbox.py
+++ b/autobot-backend/api/sandbox.py
@@ -27,7 +27,7 @@ from utils.response_builder import (
     service_unavailable_response,
     success_response,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/autobot-backend/api/security.py
+++ b/autobot-backend/api/security.py
@@ -24,7 +24,7 @@ from enhanced_security_layer import EnhancedSecurityLayer
 from security.domain_security import get_domain_security_manager
 from security.threat_intelligence import ThreatLevel, get_threat_intelligence_service
 from type_defs.common import Metadata
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(dependencies=[Depends(check_admin_permission)])

--- a/autobot-backend/api/self_capabilities.py
+++ b/autobot-backend/api/self_capabilities.py
@@ -24,7 +24,7 @@ from fastapi.openapi.utils import get_openapi
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.ttl_constants import TTL_5_MINUTES
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/sequential_thinking_mcp.py
+++ b/autobot-backend/api/sequential_thinking_mcp.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel, Field
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from type_defs.common import Metadata
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(

--- a/autobot-backend/api/service_monitor.py
+++ b/autobot-backend/api/service_monitor.py
@@ -18,7 +18,7 @@ import aiohttp
 from fastapi import APIRouter
 
 from autobot_shared.ssot_config import config as _ssot
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/services.py
+++ b/autobot-backend/api/services.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 # Import existing monitoring functionality
 try:

--- a/autobot-backend/api/skills_repos.py
+++ b/autobot-backend/api/skills_repos.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth_middleware import check_admin_permission
 from skills.db import get_skills_engine
 from skills.models import RepoType, SkillRepo
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/autobot-backend/api/startup.py
+++ b/autobot-backend/api/startup.py
@@ -24,7 +24,7 @@ router = APIRouter(tags=["startup", "status"])
 
 # Thread lock for synchronous access to startup_state
 import threading
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 _startup_lock = threading.Lock()
 

--- a/autobot-backend/api/system_validation.py
+++ b/autobot-backend/api/system_validation.py
@@ -16,7 +16,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from type_defs.common import Metadata
 from utils.catalog_http_exceptions import raise_catalog_error_simple, raise_server_error
 from utils.system_validator import get_system_validator
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/triggers.py
+++ b/autobot-backend/api/triggers.py
@@ -26,7 +26,7 @@ from services.trigger_service import (
     TriggerService,
     TriggerType,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/vision.py
+++ b/autobot-backend/api/vision.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 # Global screen analyzer instance (thread-safe)
 import threading
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 _screen_analyzer: Optional[ScreenAnalyzer] = None
 _screen_analyzer_lock = threading.Lock()

--- a/autobot-backend/api/wake_word.py
+++ b/autobot-backend/api/wake_word.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.wake_word_service import WakeWordDetector, get_wake_word_detector
 from type_defs.common import Metadata
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["wake_word", "voice"])

--- a/autobot-backend/api/workflow_permissions.py
+++ b/autobot-backend/api/workflow_permissions.py
@@ -27,7 +27,7 @@ from services.workflow_permission_service import (
     WorkflowPermissionService,
 )
 from services.workflow_rbac import require_workflow_permission
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/workflow_secrets.py
+++ b/autobot-backend/api/workflow_secrets.py
@@ -30,7 +30,7 @@ from services.workflow_secret_service import (
     WorkflowSecretService,
     get_workflow_secret_service,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- The #5317 `response_model=` sweep added `SuccessResponse` to 82 import lines in `autobot-backend/api/` files
- In practice, only `DataResponse` was used; `SuccessResponse` was never assigned to `response_model=`
- Removes `SuccessResponse` from import lines in all 82 affected files
- `elevation.py` (actual `response_model=SuccessResponse` usage) and `schemas_common.py` (class definition) correctly skipped

## Test Plan
- [x] Python syntax check: `python3 -m py_compile *.py` on all 82 files — all OK
- [x] Verified zero remaining unused `SuccessResponse` imports via grep

Closes #5846

🤖 Generated with Claude Code