### PR TITLE
fix(composables): suppress spurious AbortError in useFetchEndpoint (#5859)

### DIFF
--- a/autobot-frontend/src/composables/api/useFetchEndpoint.ts
+++ b/autobot-frontend/src/composables/api/useFetchEndpoint.ts
@@ -260,6 +260,11 @@ export function useFetchEndpoint<TRaw, TOut, Ctx = undefined>(
       opts.onSuccess?.(picked, raw, ctx)
       return picked
     } catch (err: unknown) {
+      // AbortError fires on reset()/disposal/rapid reload — not a real failure
+      if (
+        (err instanceof DOMException && err.name === 'AbortError') ||
+        (err as Error)?.name === 'AbortError'
+      ) return
       const message = err instanceof Error ? err.message : String(err)
       logger.error(`Failed to load ${label}:`, err)
       opts.onError?.(message, err, ctx)


### PR DESCRIPTION
## Summary
- `useFetchEndpoint.ts` inner catch block was logging errors and firing `onError` for AbortErrors
- AbortErrors fire on `reset()`, scope disposal, or rapid successive `load()` calls — not real failures
- Adds early-return guard: `if (err instanceof DOMException && err.name === 'AbortError') return` before the `logger.error` call

## Test Plan
- [x] Guard covers both `DOMException` (browser) and name-based check for environments that may not subclass DOMException
- [x] No TypeScript errors introduced

Closes #5859

🤖 Generated with Claude Code