### PR TITLE
refactor(composables): extract useLoadingState from useBrowserAutomation (#5861)

### DIFF
--- a/autobot-frontend/src/composables/useBrowserAutomation.ts
+++ b/autobot-frontend/src/composables/useBrowserAutomation.ts
@@ -12,6 +12,7 @@ import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 import { usePollingJob } from '@/composables/usePollingJob'
+import { useLoadingState } from '@/composables/useLoadingState'
 
 const logger = createLogger('useBrowserAutomation')
 
@@ -77,7 +78,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
   const sessions = ref<BrowserSession[]>([])
   const currentSession = ref<BrowserSession | null>(null)
   const screenshots = ref<ScreenshotResult[]>([])
-  const isLoading = ref(false)
+  const { isLoading, wrap } = useLoadingState()
   const error = ref<string | null>(null)
 
   // ===== API Methods =====
@@ -95,28 +96,24 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
   }
 
   async function launchSession(url?: string): Promise<BrowserSession | null> {
-    isLoading.value = true
     error.value = null
-    try {
+    return wrap(async () => {
       const data = await ApiClient.post<{ session: BrowserSession }>(`${getApiBase()}/browser/launch`, { url: url || 'about:blank' })
       sessions.value.push(data.session)
       currentSession.value = data.session
       logger.debug('Launched browser session:', data.session)
       return data.session
-    } catch (err) {
+    }).catch((err) => {
       const message = err instanceof Error ? err.message : 'Failed to launch session'
       logger.error('Failed to launch session:', err)
       error.value = message
       return null
-    } finally {
-      isLoading.value = false
-    }
+    })
   }
 
   async function closeSession(sessionId: string): Promise<boolean> {
-    isLoading.value = true
     error.value = null
-    try {
+    return wrap(async () => {
       await ApiClient.post(`${getApiBase()}/browser/close`, { session_id: sessionId })
       sessions.value = sessions.value.filter(s => s.id !== sessionId)
       if (currentSession.value?.id === sessionId) {
@@ -124,14 +121,12 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
       }
       logger.debug('Closed session:', sessionId)
       return true
-    } catch (err) {
+    }).catch((err) => {
       const message = err instanceof Error ? err.message : 'Failed to close session'
       logger.error('Failed to close session:', err)
       error.value = message
       return false
-    } finally {
-      isLoading.value = false
-    }
+    })
   }
 
   async function fetchSessions(): Promise<void> {
@@ -161,125 +156,104 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
   }
 
   async function navigate(sessionId: string, url: string): Promise<boolean> {
-    isLoading.value = true
     error.value = null
-    try {
+    return wrap(async () => {
       await ApiClient.post(`${getApiBase()}/browser/navigate`, { session_id: sessionId, url })
       logger.debug('Navigated to:', url)
       await fetchSessions()
       return true
-    } catch (err) {
+    }).catch((err) => {
       const message = err instanceof Error ? err.message : 'Failed to navigate'
       logger.error('Failed to navigate:', err)
       error.value = message
       return false
-    } finally {
-      isLoading.value = false
-    }
+    })
   }
 
   async function click(sessionId: string, selector: string): Promise<boolean> {
-    isLoading.value = true
     error.value = null
-    try {
+    return wrap(async () => {
       await ApiClient.post(`${getApiBase()}/browser/click`, { session_id: sessionId, selector })
       logger.debug('Clicked element:', selector)
       return true
-    } catch (err) {
+    }).catch((err) => {
       const message = err instanceof Error ? err.message : 'Failed to click'
       logger.error('Failed to click:', err)
       error.value = message
       return false
-    } finally {
-      isLoading.value = false
-    }
+    })
   }
 
   async function type(sessionId: string, selector: string, text: string): Promise<boolean> {
-    isLoading.value = true
     error.value = null
-    try {
+    return wrap(async () => {
       await ApiClient.post(`${getApiBase()}/browser/type`, { session_id: sessionId, selector, text })
       logger.debug('Typed text into:', selector)
       return true
-    } catch (err) {
+    }).catch((err) => {
       const message = err instanceof Error ? err.message : 'Failed to type'
       logger.error('Failed to type:', err)
       error.value = message
       return false
-    } finally {
-      isLoading.value = false
-    }
+    })
   }
 
   async function takeScreenshot(sessionId: string): Promise<ScreenshotResult | null> {
-    isLoading.value = true
     error.value = null
-    try {
+    return wrap(async () => {
       const data = await ApiClient.post<ScreenshotResult>(`${getApiBase()}/browser/screenshot`, { session_id: sessionId })
       screenshots.value.unshift(data)
       logger.debug('Captured screenshot')
       return data
-    } catch (err) {
+    }).catch((err) => {
       const message = err instanceof Error ? err.message : 'Failed to take screenshot'
       logger.error('Failed to take screenshot:', err)
       error.value = message
       return null
-    } finally {
-      isLoading.value = false
-    }
+    })
   }
 
   async function executeScript(sessionId: string, script: string): Promise<unknown> {
-    isLoading.value = true
     error.value = null
-    try {
+    return wrap(async () => {
       const data = await ApiClient.post<{ result: unknown }>(`${getApiBase()}/browser/execute`, { session_id: sessionId, script })
       logger.debug('Executed script, result:', data.result)
       return data.result
-    } catch (err) {
+    }).catch((err) => {
       const message = err instanceof Error ? err.message : 'Failed to execute script'
       logger.error('Failed to execute script:', err)
       error.value = message
       return null
-    } finally {
-      isLoading.value = false
-    }
+    })
   }
 
   async function runAutomationScript(script: string): Promise<unknown> {
-    isLoading.value = true
     error.value = null
-    try {
+    return wrap(async () => {
       const data = await ApiClient.post<{ result: unknown }>(`${getApiBase()}/browser/automation/run`, { script })
       logger.debug('Automation script completed:', data)
       return data.result
-    } catch (err) {
+    }).catch((err) => {
       const message = err instanceof Error ? err.message : 'Failed to run automation'
       logger.error('Failed to run automation:', err)
       error.value = message
       return null
-    } finally {
-      isLoading.value = false
-    }
+    })
   }
 
   async function deleteSession(sessionId: string): Promise<boolean> {
-    isLoading.value = true
     error.value = null
-    try {
+    return wrap(async () => {
       await ApiClient.delete(`${getApiBase()}/browser/session/${sessionId}`)
       sessions.value = sessions.value.filter(s => s.id !== sessionId)
       logger.debug('Deleted session:', sessionId)
       return true
-    } catch (err) {
+    }).catch((err) => {
       const message = err instanceof Error ? err.message : 'Failed to delete session'
       logger.error('Failed to delete session:', err)
       error.value = message
       return false
-    } finally {
-      isLoading.value = false
-    }
+    })
   }
 
   // ===== Polling Methods =====

--- a/autobot-frontend/src/composables/useLoadingState.ts
+++ b/autobot-frontend/src/composables/useLoadingState.ts
@@ -1,0 +1,37 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+
+/**
+ * Lightweight composable that eliminates the manual isLoading boilerplate:
+ *   isLoading.value = true
+ *   try { ... } finally { isLoading.value = false }
+ *
+ * Usage:
+ *   const { isLoading, wrap } = useLoadingState()
+ *   async function doSomething() {
+ *     return wrap(() => apiClient.post('/endpoint', payload))
+ *   }
+ */
+export function useLoadingState(initial = false): {
+  isLoading: Ref<boolean>
+  wrap: <T>(fn: () => Promise<T>) => Promise<T>
+} {
+  const isLoading = ref(initial)
+
+  async function wrap<T>(fn: () => Promise<T>): Promise<T> {
+    isLoading.value = true
+    try {
+      return await fn()
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  return { isLoading, wrap }
+}
+
+export default useLoadingState


### PR DESCRIPTION
## Summary
- `useBrowserAutomation.ts` had 8+ manual `isLoading = ref(false)` + try/finally patterns
- Created `autobot-frontend/src/composables/useLoadingState.ts` with `wrap<T>(fn: () => Promise<T>)` helper
- Replaced all 8 manual patterns in `useBrowserAutomation.ts` with `useLoadingState()` — zero boilerplate changes to callers
- `isLoading` still exposed identically in the composable's return value — no breaking change

## Test Plan
- [x] Zero remaining `isLoading.value` assignments in `useBrowserAutomation.ts`
- [x] `useLoadingState.ts` created with correct TypeScript return type

Closes #5861

🤖 Generated with Claude Code