### PR TITLE
fix(api): replace unjustified response_model=None with DataResponse (#5843)

### DIFF
--- a/autobot-backend/api/a2a.py
+++ b/autobot-backend/api/a2a.py
@@ -146,7 +146,7 @@ def _remote_addr(request: Request) -> str:
     "/agent-card",
     summary="A2A Agent Card",
     tags=["a2a"],
-    response_model=None,
+    response_model=DataResponse,
 )
 async def get_agent_card(request: Request) -> Dict[str, Any]:
     """
@@ -162,7 +162,7 @@ async def get_agent_card(request: Request) -> Dict[str, Any]:
     "/agent-card/signed",
     summary="Signed A2A Agent Card",
     tags=["a2a"],
-    response_model=None,
+    response_model=DataResponse,
 )
 async def get_signed_agent_card(request: Request) -> Dict[str, Any]:
     """

--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -990,7 +990,7 @@ async def command_approval(
     operation="execute_command",
     error_code_prefix="AGENT",
 )
-@router.post("/execute_command", response_model=None)
+@router.post("/execute_command", response_model=DataResponse)
 async def execute_command(
     request: Request,
     command_data: dict,

--- a/autobot-backend/api/agent_config.py
+++ b/autobot-backend/api/agent_config.py
@@ -584,7 +584,7 @@ async def _resolve_agent_effective_config(
     operation="list_agents",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents", response_model=None)
+@router.get("/agents", response_model=DataResponse)
 async def list_agents(admin_check: bool = Depends(check_admin_permission)):
     """
     Get list of all available agents with their configurations
@@ -704,7 +704,7 @@ async def _resolve_agent_entry(
     operation="get_all_agents",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents/all", response_model=None)
+@router.get("/agents/all", response_model=DataResponse)
 async def get_all_agents(admin_check: bool = Depends(check_admin_permission)):
     """
     Get all AutoBot agents for the Agent Registry dashboard.
@@ -750,7 +750,7 @@ async def get_all_agents(admin_check: bool = Depends(check_admin_permission)):
     operation="list_specialized_agents",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents/specialized", response_model=None)
+@router.get("/agents/specialized", response_model=DataResponse)
 async def list_specialized_agents(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -783,7 +783,7 @@ async def list_specialized_agents(
     operation="get_specialized_agent",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents/specialized/{agent_id}", response_model=None)
+@router.get("/agents/specialized/{agent_id}", response_model=DataResponse)
 async def get_specialized_agent(
     agent_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -813,7 +813,7 @@ async def get_specialized_agent(
     operation="get_agents_usage",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents/usage", response_model=None)
+@router.get("/agents/usage", response_model=DataResponse)
 async def get_agents_usage(
     agent_id: Optional[str] = Query(
         None, description="Filter to a specific agent (all agents if omitted)"
@@ -930,7 +930,7 @@ async def get_agents_usage(
     operation="get_agent_config",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents/{agent_id}", response_model=None)
+@router.get("/agents/{agent_id}", response_model=DataResponse)
 async def get_agent_config(
     agent_id: str, admin_check: bool = Depends(check_admin_permission)
 ):

--- a/autobot-backend/api/agent_terminal.py
+++ b/autobot-backend/api/agent_terminal.py
@@ -557,7 +557,7 @@ async def delete_agent_terminal_session(
     operation="execute_agent_command",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/execute", response_model=None)
+@router.post("/execute", response_model=DataResponse)
 async def execute_agent_command(
     current_user: dict = Depends(get_current_user),
     session_id: str = None,
@@ -595,7 +595,7 @@ async def execute_agent_command(
     operation="approve_agent_command",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/approve", response_model=None)
+@router.post("/sessions/{session_id}/approve", response_model=DataResponse)
 async def approve_agent_command(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -675,7 +675,7 @@ async def submit_tool_approval(
     operation="interrupt_agent_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/interrupt", response_model=None)
+@router.post("/sessions/{session_id}/interrupt", response_model=DataResponse)
 async def interrupt_agent_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -706,7 +706,7 @@ async def interrupt_agent_session(
     operation="resume_agent_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/resume", response_model=None)
+@router.post("/sessions/{session_id}/resume", response_model=DataResponse)
 async def resume_agent_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/ai_stack_integration.py
+++ b/autobot-backend/api/ai_stack_integration.py
@@ -129,7 +129,7 @@ class ContentClassificationRequest(BaseModel):
     operation="ai_stack_health_check",
     error_code_prefix="AI_STACK",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=DataResponse)
 async def ai_stack_health_check(admin_check: bool = Depends(check_admin_permission)):
     """
     Check AI Stack health and connectivity.

--- a/autobot-backend/api/analytics_architecture.py
+++ b/autobot-backend/api/analytics_architecture.py
@@ -32,6 +32,7 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -1270,7 +1271,7 @@ async def analyze_architecture(
     )
 
 
-@router.get("/patterns", response_model=None, summary="List available pattern types")
+@router.get("/patterns", response_model=DataResponse, summary="List available pattern types")
 async def list_pattern_types(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
@@ -1293,7 +1294,7 @@ async def list_pattern_types(
     return {"patterns": patterns, "total": len(patterns)}
 
 
-@router.get("/quick-scan", response_model=None, summary="Quick architecture scan")
+@router.get("/quick-scan", response_model=DataResponse, summary="Quick architecture scan")
 async def quick_scan(
     admin_check: bool = Depends(check_admin_permission),
     path: str = Query("backend/api/", description="Path to scan"),
@@ -1326,7 +1327,7 @@ async def quick_scan(
     }
 
 
-@router.get("/layers", response_model=None, summary="Get architecture layers")
+@router.get("/layers", response_model=DataResponse, summary="Get architecture layers")
 async def get_layers(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
@@ -1350,7 +1351,7 @@ async def get_layers(
     }
 
 
-@router.get("/diagram", response_model=None, summary="Generate architecture diagram")
+@router.get("/diagram", response_model=DataResponse, summary="Generate architecture diagram")
 async def get_diagram(
     admin_check: bool = Depends(check_admin_permission),
     format: str = Query("mermaid", description="Diagram format"),
@@ -1375,7 +1376,7 @@ async def get_diagram(
     }
 
 
-@router.get("/consistency", response_model=None, summary="Check pattern consistency")
+@router.get("/consistency", response_model=DataResponse, summary="Check pattern consistency")
 async def check_consistency(
     admin_check: bool = Depends(check_admin_permission),
     pattern: Optional[PatternType] = Query(None, description="Specific pattern"),
@@ -1404,7 +1405,7 @@ async def check_consistency(
     }
 
 
-@router.get("/health", response_model=None, summary="Health check")
+@router.get("/health", response_model=DataResponse, summary="Health check")
 async def health_check(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:

--- a/autobot-backend/api/analytics_bug_prediction.py
+++ b/autobot-backend/api/analytics_bug_prediction.py
@@ -26,6 +26,7 @@ from autobot_shared.redis_client import get_redis_client
 from constants.threshold_constants import TimingConstants
 from constants.ttl_constants import TTL_5_MINUTES
 from utils.background_task_manager import BackgroundTaskManager
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -913,7 +914,7 @@ async def _run_bug_analysis(
     }
 
 
-@router.get("/analyze", response_model=None)
+@router.get("/analyze", response_model=DataResponse)
 async def analyze_codebase(
     admin_check: bool = Depends(check_admin_permission),
     path: str = Query(".", description="Path to analyze"),
@@ -1027,7 +1028,7 @@ async def _run_batched_bug_analysis(
         await _bg_manager.fail_task(task_id, str(e))
 
 
-@router.get("/cached", response_model=None)
+@router.get("/cached", response_model=DataResponse)
 async def get_cached_bug_prediction():
     """Return the latest completed bug prediction result (#1540)."""
     cached = await _bg_manager.get_latest_result()
@@ -1041,7 +1042,7 @@ async def get_cached_bug_prediction():
     return _no_data_response("No cached bug prediction available")
 
 
-@router.post("/analyze", response_model=None)
+@router.post("/analyze", response_model=DataResponse)
 async def start_bug_analysis(
     background_tasks: BackgroundTasks,
     admin_check: bool = Depends(check_admin_permission),
@@ -1059,7 +1060,7 @@ async def start_bug_analysis(
     return {"task_id": task_id, "status": "pending"}
 
 
-@router.get("/status/{task_id}", response_model=None)
+@router.get("/status/{task_id}", response_model=DataResponse)
 async def get_bug_prediction_status(
     task_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -1071,7 +1072,7 @@ async def get_bug_prediction_status(
     return task
 
 
-@router.post("/tasks/clear-stuck", response_model=None)
+@router.post("/tasks/clear-stuck", response_model=DataResponse)
 async def clear_stuck_bug_tasks(
     force: bool = Query(default=False, description="Force clear ALL running tasks"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1084,7 +1085,7 @@ async def clear_stuck_bug_tasks(
     }
 
 
-@router.get("/high-risk", response_model=None)
+@router.get("/high-risk", response_model=DataResponse)
 async def get_high_risk_files(
     admin_check: bool = Depends(check_admin_permission),
     threshold: float = Query(60, ge=0, le=100),
@@ -1152,7 +1153,7 @@ def _build_file_risk_response(file_path: str, factors: dict, bug_history: dict) 
     }
 
 
-@router.get("/file/{file_path:path}", response_model=None)
+@router.get("/file/{file_path:path}", response_model=DataResponse)
 async def get_file_risk(
     file_path: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -1249,7 +1250,7 @@ def _get_flat_heatmap_data(files: list) -> list:
     ]
 
 
-@router.get("/heatmap", response_model=None)
+@router.get("/heatmap", response_model=DataResponse)
 async def get_risk_heatmap(
     admin_check: bool = Depends(check_admin_permission),
     grouping: str = Query("directory", pattern="^(directory|module|flat)$"),
@@ -1298,7 +1299,7 @@ async def get_risk_heatmap(
         return _no_data_response("Heatmap generation failed")
 
 
-@router.get("/trends", response_model=None)
+@router.get("/trends", response_model=DataResponse)
 async def get_prediction_trends(
     admin_check: bool = Depends(check_admin_permission),
     period: str = Query("30d", pattern="^(7d|30d|90d)$"),
@@ -1411,7 +1412,7 @@ def _generate_summary_recommendations(
     return recommendations[:5]
 
 
-@router.get("/summary", response_model=None)
+@router.get("/summary", response_model=DataResponse)
 async def get_prediction_summary(
     admin_check: bool = Depends(check_admin_permission),
     path: str = Query(".", description="Path to analyze"),
@@ -1471,7 +1472,7 @@ async def get_prediction_summary(
         return _no_data_response("Summary generation failed")
 
 
-@router.get("/factors", response_model=None)
+@router.get("/factors", response_model=DataResponse)
 async def get_risk_factors(
     admin_check: bool = Depends(check_admin_permission),
 ) -> dict[str, Any]:
@@ -1518,7 +1519,7 @@ def _get_factor_description(factor: RiskFactor) -> str:
     return descriptions.get(factor, "Unknown factor")
 
 
-@router.post("/record-bug", response_model=None)
+@router.post("/record-bug", response_model=DataResponse)
 async def record_bug(
     admin_check: bool = Depends(check_admin_permission),
     file_path: str = None,

--- a/autobot-backend/api/analytics_cfg.py
+++ b/autobot-backend/api/analytics_cfg.py
@@ -29,6 +29,7 @@ from pydantic import BaseModel, Field
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_path
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -1144,7 +1145,7 @@ def _calculate_cfg_summary(
     operation="analyze_cfg",
     error_code_prefix="CFG",
 )
-@router.post("/analyze", response_model=None)
+@router.post("/analyze", response_model=DataResponse)
 async def analyze_control_flow(
     request: AnalyzeRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1200,7 +1201,7 @@ async def analyze_control_flow(
     operation="analyze_cfg_file",
     error_code_prefix="CFG",
 )
-@router.post("/analyze-file", response_model=None)
+@router.post("/analyze-file", response_model=DataResponse)
 async def analyze_file_control_flow(
     request: AnalyzeFileRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1306,7 +1307,7 @@ async def export_cfg_dot(
     operation="get_complexity_metrics",
     error_code_prefix="CFG",
 )
-@router.post("/complexity", response_model=None)
+@router.post("/complexity", response_model=DataResponse)
 async def get_complexity_metrics(
     request: AnalyzeRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1365,7 +1366,7 @@ async def get_complexity_metrics(
     operation="detect_unreachable",
     error_code_prefix="CFG",
 )
-@router.post("/unreachable", response_model=None)
+@router.post("/unreachable", response_model=DataResponse)
 async def detect_unreachable_code(
     request: AnalyzeRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1401,7 +1402,7 @@ async def detect_unreachable_code(
     operation="detect_infinite_loops",
     error_code_prefix="CFG",
 )
-@router.post("/infinite-loops", response_model=None)
+@router.post("/infinite-loops", response_model=DataResponse)
 async def detect_infinite_loops(
     request: AnalyzeRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1445,7 +1446,7 @@ async def detect_infinite_loops(
     operation="cfg_health",
     error_code_prefix="CFG",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=DataResponse)
 async def cfg_health(
     admin_check: bool = Depends(check_admin_permission),
 ) -> JSONResponse:

--- a/autobot-backend/api/analytics_code.py
+++ b/autobot-backend/api/analytics_code.py
@@ -18,6 +18,7 @@ from api.analytics_models import CodeAnalysisRequest
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_path
+from api.schemas_common import DataResponse, SuccessResponse
 
 # Import shared analytics controller from analytics module
 # This will be set after analytics.py is updated
@@ -49,7 +50,7 @@ def set_analytics_dependencies(controller, state):
     operation="index_codebase",
     error_code_prefix="ANALYTICS",
 )
-@router.post("/code/index", response_model=None)
+@router.post("/code/index", response_model=DataResponse)
 async def index_codebase(
     request: CodeAnalysisRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -84,7 +85,7 @@ async def index_codebase(
     operation="get_code_analysis_status",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/code/status", response_model=None)
+@router.get("/code/status", response_model=DataResponse)
 async def get_code_analysis_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -140,7 +141,7 @@ async def get_code_analysis_status(
     operation="get_code_quality_assessment",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/quality/assessment", response_model=None)
+@router.get("/quality/assessment", response_model=DataResponse)
 async def get_code_quality_assessment(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -209,7 +210,7 @@ async def get_code_quality_assessment(
     operation="get_code_quality_metrics",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/code/quality-metrics", response_model=None)
+@router.get("/code/quality-metrics", response_model=DataResponse)
 async def get_code_quality_metrics(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -319,7 +320,7 @@ def _build_chain_insights(static_endpoints: list, runtime_patterns: dict) -> lis
     operation="get_communication_chains",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/code/communication-chains", response_model=None)
+@router.get("/code/communication-chains", response_model=DataResponse)
 async def get_communication_chains(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -447,7 +448,7 @@ def _generate_communication_chain_insights(
     operation="analyze_communication_chains_detailed",
     error_code_prefix="ANALYTICS",
 )
-@router.post("/code/analyze/communication-chains", response_model=None)
+@router.post("/code/analyze/communication-chains", response_model=DataResponse)
 async def analyze_communication_chains_detailed(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -591,7 +592,7 @@ def _score_to_grade(score: float) -> str:
     operation="get_code_quality_score",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/code/metrics/quality-score", response_model=None)
+@router.get("/code/metrics/quality-score", response_model=DataResponse)
 async def get_code_quality_score(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/analytics_code_review.py
+++ b/autobot-backend/api/analytics_code_review.py
@@ -670,7 +670,7 @@ async def review_file(
     }
 
 
-@router.get("/patterns", response_model=None)
+@router.get("/patterns", response_model=DataResponse)
 async def get_review_patterns(
     admin_check: bool = Depends(check_admin_permission),
 ) -> list[dict[str, Any]]:
@@ -842,7 +842,7 @@ async def get_review_summary(
     )
 
 
-@router.get("/categories", response_model=None)
+@router.get("/categories", response_model=DataResponse)
 async def get_review_categories(
     admin_check: bool = Depends(check_admin_permission),
 ) -> list[dict[str, Any]]:

--- a/autobot-backend/api/analytics_continuous_learning.py
+++ b/autobot-backend/api/analytics_continuous_learning.py
@@ -30,6 +30,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, Query
 from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -1055,7 +1056,7 @@ async def get_engine() -> ContinuousLearningEngine:
 # =============================================================================
 
 
-@router.post("/start", summary="Start continuous learning", response_model=None)
+@router.post("/start", summary="Start continuous learning", response_model=DataResponse)
 async def start_learning(
     admin_check: bool = Depends(check_admin_permission),
     background_tasks: BackgroundTasks = None,
@@ -1069,7 +1070,7 @@ async def start_learning(
     return await engine.start()
 
 
-@router.post("/stop", summary="Stop continuous learning", response_model=None)
+@router.post("/stop", summary="Stop continuous learning", response_model=DataResponse)
 async def stop_learning(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
@@ -1082,7 +1083,7 @@ async def stop_learning(
     return await engine.stop()
 
 
-@router.get("/status", summary="Get learning status", response_model=None)
+@router.get("/status", summary="Get learning status", response_model=DataResponse)
 async def get_status(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
@@ -1108,7 +1109,7 @@ async def get_metrics(
     return engine.get_metrics()
 
 
-@router.post("/feedback", summary="Submit pattern feedback", response_model=None)
+@router.post("/feedback", summary="Submit pattern feedback", response_model=DataResponse)
 async def submit_feedback(
     admin_check: bool = Depends(check_admin_permission),
     pattern_id: str = None,
@@ -1124,7 +1125,7 @@ async def submit_feedback(
     return await engine.submit_feedback(pattern_id, is_correct, details)
 
 
-@router.post("/retrain", summary="Trigger model retraining", response_model=None)
+@router.post("/retrain", summary="Trigger model retraining", response_model=DataResponse)
 async def trigger_retrain(
     admin_check: bool = Depends(check_admin_permission),
     request: RetrainingRequest = None,
@@ -1138,7 +1139,7 @@ async def trigger_retrain(
     return await engine.trigger_retrain(request)
 
 
-@router.get("/insights", summary="Get generated insights", response_model=None)
+@router.get("/insights", summary="Get generated insights", response_model=DataResponse)
 async def get_insights(
     admin_check: bool = Depends(check_admin_permission),
     active_only: bool = Query(True, description="Only active insights"),
@@ -1157,7 +1158,7 @@ async def get_insights(
     }
 
 
-@router.post("/insights/generate", summary="Generate insights now", response_model=None)
+@router.post("/insights/generate", summary="Generate insights now", response_model=DataResponse)
 async def generate_insights_now(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
@@ -1187,7 +1188,7 @@ async def get_monitoring_status(
     return engine.monitor.get_status()
 
 
-@router.put("/config", summary="Update learning config", response_model=None)
+@router.put("/config", summary="Update learning config", response_model=DataResponse)
 async def update_config(
     admin_check: bool = Depends(check_admin_permission),
     config: LearningConfig = None,
@@ -1215,7 +1216,7 @@ async def get_config(
     return engine.config
 
 
-@router.get("/health", summary="Health check", response_model=None)
+@router.get("/health", summary="Health check", response_model=DataResponse)
 async def health_check(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:

--- a/autobot-backend/api/analytics_debt.py
+++ b/autobot-backend/api/analytics_debt.py
@@ -30,6 +30,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.redis_utils import decode_redis_value as _decode_redis_value
 from constants.ttl_constants import TTL_30_DAYS
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(
@@ -520,7 +521,7 @@ def _get_latest_debt_data() -> Optional[Dict[str, Any]]:
     operation="calculate_debt",
     error_code_prefix="DEBT",
 )
-@router.post("/calculate", response_model=None)
+@router.post("/calculate", response_model=DataResponse)
 async def calculate_technical_debt(
     request: DebtCalculationRequest, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -569,7 +570,7 @@ async def calculate_technical_debt(
     operation="get_debt_summary",
     error_code_prefix="DEBT",
 )
-@router.get("/summary", response_model=None)
+@router.get("/summary", response_model=DataResponse)
 async def get_debt_summary(admin_check: bool = Depends(check_admin_permission)):
     """
     Get summary of current technical debt (Issue #543 - refactored).
@@ -601,7 +602,7 @@ async def get_debt_summary(admin_check: bool = Depends(check_admin_permission)):
     operation="get_debt_by_category",
     error_code_prefix="DEBT",
 )
-@router.get("/by-category/{category}", response_model=None)
+@router.get("/by-category/{category}", response_model=DataResponse)
 async def get_debt_by_category(
     category: str, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -701,7 +702,7 @@ def _calculate_trend_change(trend_data: List[Dict[str, Any]]) -> tuple:
     operation="get_debt_trends",
     error_code_prefix="DEBT",
 )
-@router.get("/trends", response_model=None)
+@router.get("/trends", response_model=DataResponse)
 async def get_debt_trends(
     days: int = Query(default=30, ge=1, le=365),
     admin_check: bool = Depends(check_admin_permission),
@@ -733,7 +734,7 @@ async def get_debt_trends(
     operation="get_roi_priorities",
     error_code_prefix="DEBT",
 )
-@router.get("/roi-priorities", response_model=None)
+@router.get("/roi-priorities", response_model=DataResponse)
 async def get_roi_priorities(
     limit: int = Query(default=20, ge=1, le=100),
     admin_check: bool = Depends(check_admin_permission),
@@ -859,7 +860,7 @@ def _generate_markdown_report(debt_data: dict) -> str:
     operation="get_debt_report",
     error_code_prefix="DEBT",
 )
-@router.get("/report", response_model=None)
+@router.get("/report", response_model=DataResponse)
 async def get_debt_report(
     format: str = Query(default="json", description="json or markdown"),
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/analytics_embedding_patterns.py
+++ b/autobot-backend/api/analytics_embedding_patterns.py
@@ -516,6 +516,7 @@ class EmbeddingPatternAnalyzer(AsyncRedisClientLockedMixin):
 # =============================================================================
 
 import threading
+from api.schemas_common import DataResponse, SuccessResponse
 
 _embedding_analyzer: Optional[EmbeddingPatternAnalyzer] = None
 _embedding_analyzer_lock = threading.Lock()
@@ -536,7 +537,7 @@ def get_embedding_analyzer() -> EmbeddingPatternAnalyzer:
 # =============================================================================
 
 
-@router.post("/record", response_model=None)
+@router.post("/record", response_model=DataResponse)
 async def record_embedding_usage(
     request: EmbeddingUsageRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -557,7 +558,7 @@ async def record_embedding_usage(
     )
 
 
-@router.get("/stats", response_model=None)
+@router.get("/stats", response_model=DataResponse)
 async def get_embedding_stats(
     days: int = Query(default=7, ge=1, le=90, description="Number of days to analyze"),
     model: Optional[str] = Query(None, description="Filter by model"),
@@ -579,7 +580,7 @@ async def get_embedding_stats(
     )
 
 
-@router.get("/model-comparison", response_model=None)
+@router.get("/model-comparison", response_model=DataResponse)
 async def get_model_comparison(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -599,7 +600,7 @@ async def get_model_comparison(
     )
 
 
-@router.get("/optimization-recommendations", response_model=None)
+@router.get("/optimization-recommendations", response_model=DataResponse)
 async def get_optimization_recommendations(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -619,7 +620,7 @@ async def get_optimization_recommendations(
     )
 
 
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=DataResponse)
 async def embedding_analytics_health(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/analytics_export.py
+++ b/autobot-backend/api/analytics_export.py
@@ -29,6 +29,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from services.agent_analytics import get_agent_analytics
 from services.llm_cost_tracker import get_cost_tracker
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/export", tags=["analytics", "export"])
@@ -214,7 +215,7 @@ async def export_usage_csv(
     operation="export_full_json",
     error_code_prefix="EXPORT",
 )
-@router.get("/json/full", response_model=None)
+@router.get("/json/full", response_model=DataResponse)
 async def export_full_json(
     days: int = Query(default=30, ge=1, le=365, description="Number of days"),
     admin_check: bool = Depends(check_admin_permission),
@@ -548,7 +549,7 @@ def _get_grafana_panels() -> list:
     operation="export_grafana_dashboard",
     error_code_prefix="EXPORT",
 )
-@router.get("/grafana-dashboard", response_model=None)
+@router.get("/grafana-dashboard", response_model=DataResponse)
 async def export_grafana_dashboard(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -604,7 +605,7 @@ async def export_grafana_dashboard(
     operation="get_export_formats",
     error_code_prefix="EXPORT",
 )
-@router.get("/formats", response_model=None)
+@router.get("/formats", response_model=DataResponse)
 async def get_export_formats(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/analytics_maintenance.py
+++ b/autobot-backend/api/analytics_maintenance.py
@@ -29,6 +29,7 @@ from services.analytics_service import (
     ResourceType,
     get_analytics_service,
 )
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 # Issue #3355: prefix moved to router registry (analytics_routers.py)
@@ -108,7 +109,7 @@ class CustomReportRequest(BaseModel):
     operation="get_maintenance_recommendations",
     error_code_prefix="MAINT",
 )
-@router.get("/maintenance", response_model=None)
+@router.get("/maintenance", response_model=DataResponse)
 async def get_maintenance_recommendations(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -149,7 +150,7 @@ async def get_maintenance_recommendations(
     operation="get_maintenance_by_category",
     error_code_prefix="MAINT",
 )
-@router.get("/maintenance/category/{category}", response_model=None)
+@router.get("/maintenance/category/{category}", response_model=DataResponse)
 async def get_maintenance_by_category(
     category: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -178,7 +179,7 @@ async def get_maintenance_by_category(
     operation="get_maintenance_summary",
     error_code_prefix="MAINT",
 )
-@router.get("/maintenance/summary", response_model=None)
+@router.get("/maintenance/summary", response_model=DataResponse)
 async def get_maintenance_summary(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -244,7 +245,7 @@ async def get_maintenance_summary(
     operation="get_resource_optimizations",
     error_code_prefix="OPT",
 )
-@router.get("/optimization", response_model=None)
+@router.get("/optimization", response_model=DataResponse)
 async def get_resource_optimizations(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -286,7 +287,7 @@ async def get_resource_optimizations(
     operation="get_optimization_by_type",
     error_code_prefix="OPT",
 )
-@router.get("/optimization/type/{resource_type}", response_model=None)
+@router.get("/optimization/type/{resource_type}", response_model=DataResponse)
 async def get_optimization_by_type(
     resource_type: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -315,7 +316,7 @@ async def get_optimization_by_type(
     operation="get_quick_wins",
     error_code_prefix="OPT",
 )
-@router.get("/optimization/quick-wins", response_model=None)
+@router.get("/optimization/quick-wins", response_model=DataResponse)
 async def get_quick_wins(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -357,7 +358,7 @@ async def get_quick_wins(
     operation="get_unified_dashboard",
     error_code_prefix="DASH",
 )
-@router.get("/dashboard", response_model=None)
+@router.get("/dashboard", response_model=DataResponse)
 async def get_unified_dashboard(
     days: int = Query(default=30, ge=1, le=365, description="Days to analyze"),
     admin_check: bool = Depends(check_admin_permission),
@@ -380,7 +381,7 @@ async def get_unified_dashboard(
     operation="get_health_status",
     error_code_prefix="HEALTH",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=DataResponse)
 async def get_health_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -418,7 +419,7 @@ async def get_health_status(
     operation="generate_custom_report",
     error_code_prefix="REPORT",
 )
-@router.post("/report", response_model=None)
+@router.post("/report", response_model=DataResponse)
 async def generate_custom_report(
     request: CustomReportRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -454,7 +455,7 @@ async def generate_custom_report(
     operation="get_executive_summary",
     error_code_prefix="REPORT",
 )
-@router.get("/report/executive", response_model=None)
+@router.get("/report/executive", response_model=DataResponse)
 async def get_executive_summary(
     days: int = Query(default=30, ge=7, le=90, description="Days to summarize"),
     admin_check: bool = Depends(check_admin_permission),
@@ -491,7 +492,7 @@ async def get_executive_summary(
     operation="get_insights",
     error_code_prefix="INSIGHT",
 )
-@router.get("/insights", response_model=None)
+@router.get("/insights", response_model=DataResponse)
 async def get_insights(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -559,7 +560,7 @@ async def get_insights(
     operation="get_trends_analysis",
     error_code_prefix="TREND",
 )
-@router.get("/trends", response_model=None)
+@router.get("/trends", response_model=DataResponse)
 async def get_trends_analysis(
     days: int = Query(default=30, ge=7, le=90, description="Days to analyze"),
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/analytics_pattern_learning.py
+++ b/autobot-backend/api/analytics_pattern_learning.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -1058,7 +1059,7 @@ async def get_learning_engine() -> PatternLearningEngine:
 # =============================================================================
 
 
-@router.post("/feedback", response_model=None, summary="Submit pattern feedback")
+@router.post("/feedback", response_model=DataResponse, summary="Submit pattern feedback")
 async def submit_pattern_feedback(feedback: PatternFeedback) -> Dict[str, Any]:
     """
     Submit developer feedback for a pattern match.
@@ -1069,7 +1070,7 @@ async def submit_pattern_feedback(feedback: PatternFeedback) -> Dict[str, Any]:
     return await engine.submit_feedback(feedback)
 
 
-@router.get("/confidence", response_model=None, summary="Get pattern confidence scores")
+@router.get("/confidence", response_model=DataResponse, summary="Get pattern confidence scores")
 async def get_pattern_confidence(
     pattern_ids: Optional[str] = Query(None, description="Comma-separated pattern IDs"),
 ) -> Dict[str, Any]:
@@ -1092,7 +1093,7 @@ async def get_learning_metrics() -> LearningMetrics:
     return await engine.get_learning_metrics()
 
 
-@router.get("/active-learning", response_model=None, summary="Get active learning queries")
+@router.get("/active-learning", response_model=DataResponse, summary="Get active learning queries")
 async def get_active_learning_queries(
     limit: int = Query(10, ge=1, le=50, description="Maximum queries to return"),
 ) -> Dict[str, Any]:
@@ -1111,14 +1112,14 @@ async def get_active_learning_queries(
     }
 
 
-@router.post("/patterns", response_model=None, summary="Register a new pattern")
+@router.post("/patterns", response_model=DataResponse, summary="Register a new pattern")
 async def register_pattern(pattern: PatternDefinition) -> Dict[str, Any]:
     """Register a new pattern for learning."""
     engine = await get_learning_engine()
     return await engine.register_pattern(pattern)
 
 
-@router.get("/patterns/{pattern_id}/history", response_model=None, summary="Get pattern feedback history")
+@router.get("/patterns/{pattern_id}/history", response_model=DataResponse, summary="Get pattern feedback history")
 async def get_pattern_history(
     pattern_id: str,
     limit: int = Query(50, ge=1, le=200, description="Maximum records to return"),
@@ -1137,7 +1138,7 @@ async def get_pattern_history(
     }
 
 
-@router.post("/learn", response_model=None, summary="Run learning cycle")
+@router.post("/learn", response_model=DataResponse, summary="Run learning cycle")
 async def run_learning_cycle() -> Dict[str, Any]:
     """
     Trigger a learning cycle to analyze feedback and update patterns.
@@ -1151,7 +1152,7 @@ async def run_learning_cycle() -> Dict[str, Any]:
     return await engine.run_learning_cycle()
 
 
-@router.get("/health", response_model=None, summary="Health check")
+@router.get("/health", response_model=DataResponse, summary="Health check")
 async def health_check() -> Dict[str, Any]:
     """Check the health of the pattern learning system."""
     try:

--- a/autobot-backend/api/analytics_performance.py
+++ b/autobot-backend/api/analytics_performance.py
@@ -532,7 +532,7 @@ def _calculate_analysis_score(
     return critical, high, medium, low, score
 
 
-@router.get("/analyze", response_model=None)
+@router.get("/analyze", response_model=DataResponse)
 async def analyze_path(
     path: str = Query(..., description="Path to analyze"),
     include_ast: bool = Query(True, description="Include AST analysis"),

--- a/autobot-backend/api/analytics_quality.py
+++ b/autobot-backend/api/analytics_quality.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field
 
 from api.analytics_shared import resolve_source_root_or_404 as _resolve_source_root_or_404
 from auth_middleware import check_admin_permission
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -965,7 +966,7 @@ manager = ConnectionManager()
 # ============================================================================
 
 
-@router.get("/health-score", response_model=None)
+@router.get("/health-score", response_model=DataResponse)
 async def get_health_score(
     admin_check: bool = Depends(check_admin_permission),
     source_id: Optional[str] = Query(None, description="Project source ID to scope analysis"),
@@ -1003,7 +1004,7 @@ async def get_health_score(
     }
 
 
-@router.get("/metrics", response_model=None)
+@router.get("/metrics", response_model=DataResponse)
 async def get_quality_metrics(
     category: Optional[MetricCategory] = Query(None, description="Filter by category"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1062,7 +1063,7 @@ async def get_quality_metrics(
     }
 
 
-@router.get("/patterns", response_model=None)
+@router.get("/patterns", response_model=DataResponse)
 async def get_pattern_distribution(
     severity: Optional[str] = Query(None, description="Filter by severity"),
     limit: int = Query(20, ge=1, le=100),
@@ -1115,7 +1116,7 @@ async def get_pattern_distribution(
     return {"status": "success", "patterns": result}
 
 
-@router.get("/complexity", response_model=None)
+@router.get("/complexity", response_model=DataResponse)
 async def get_complexity_metrics(
     top_n: int = Query(10, ge=1, le=50, description="Number of hotspots to return"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1232,7 +1233,7 @@ def _calculate_trend_statistics(scores: list) -> dict:
     }
 
 
-@router.get("/trends", response_model=None)
+@router.get("/trends", response_model=DataResponse)
 async def get_quality_trends(
     period: str = Query("30d", pattern="^(7d|14d|30d|90d)$"),
     metric: Optional[str] = Query(None, description="Specific metric to trend"),
@@ -1267,7 +1268,7 @@ async def get_quality_trends(
     }
 
 
-@router.get("/snapshot", response_model=None)
+@router.get("/snapshot", response_model=DataResponse)
 async def get_quality_snapshot(
     admin_check: bool = Depends(check_admin_permission),
     source_id: Optional[str] = Query(None, description="Project source ID to scope analysis"),
@@ -1335,7 +1336,7 @@ async def get_quality_snapshot(
     }
 
 
-@router.get("/drill-down/{category}", response_model=None)
+@router.get("/drill-down/{category}", response_model=DataResponse)
 async def drill_down_category(
     category: str,
     file_filter: Optional[str] = Query(None, description="Filter by file path"),
@@ -1384,7 +1385,7 @@ async def drill_down_category(
     }
 
 
-@router.get("/export", response_model=None)
+@router.get("/export", response_model=DataResponse)
 async def export_quality_report(
     format: str = Query("json", pattern="^(json|csv|pdf)$"),
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/analytics_reporting.py
+++ b/autobot-backend/api/analytics_reporting.py
@@ -22,6 +22,7 @@ from fastapi.responses import JSONResponse
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
 from autobot_shared.time_utils import utc_timestamp
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 # Issue #3355: prefix moved to router registry (analytics_routers.py)
@@ -290,7 +291,7 @@ def _build_unified_report_response(
     category=ErrorCategory.API,
     error_code_prefix="UNIFIED",
 )
-@router.get("/report", response_model=None)
+@router.get("/report", response_model=DataResponse)
 async def get_unified_report():
     """
     Get unified analytics report aggregating all analytics sources.
@@ -329,7 +330,7 @@ async def get_unified_report():
     category=ErrorCategory.API,
     error_code_prefix="UNIFIED",
 )
-@router.get("/summary", response_model=None)
+@router.get("/summary", response_model=DataResponse)
 async def get_quick_summary():
     """
     Get a quick summary of code health.
@@ -365,7 +366,7 @@ async def get_quick_summary():
     category=ErrorCategory.API,
     error_code_prefix="UNIFIED",
 )
-@router.get("/trends", response_model=None)
+@router.get("/trends", response_model=DataResponse)
 async def get_trends():
     """
     Get analytics trends over time.

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -1179,7 +1179,7 @@ def _validate_workflow_manager(chat_workflow_manager) -> None:
     operation="send_chat_message_by_id",
     error_code_prefix="CHAT",
 )
-@router.post("/chats/{chat_id}/message", response_model=None)
+@router.post("/chats/{chat_id}/message", response_model=DataResponse)
 async def send_chat_message_by_id(
     chat_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1254,7 +1254,7 @@ async def _stream_graph_resume(
     operation="resume_chat_graph",
     error_code_prefix="CHAT",
 )
-@router.post("/chats/{chat_id}/resume", response_model=None)
+@router.post("/chats/{chat_id}/resume", response_model=DataResponse)
 async def resume_chat_graph(
     chat_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1491,7 +1491,7 @@ async def delete_chat_by_id(
     operation="send_direct_chat_response",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/direct", response_model=None)
+@router.post("/chat/direct", response_model=DataResponse)
 async def send_direct_chat_response(
     current_user: dict = Depends(get_current_user),
     request: Request = None,

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -1412,7 +1412,7 @@ async def delete_session(
     operation="export_session",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/sessions/{session_id}/export", response_model=None)
+@router.get("/chat/sessions/{session_id}/export", response_model=DataResponse)
 async def export_session(session_id: str, request: Request, format: str = "json"):
     """
     Export a chat session in various formats.

--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -768,7 +768,7 @@ class QuickScanRequest(BaseModel):
     operation="analyze_codebase",
     error_code_prefix="CODE_INTEL",
 )
-@router.post("/analyze", response_model=None)
+@router.post("/analyze", response_model=DataResponse)
 async def analyze_codebase(
     request: AnalysisRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -918,7 +918,7 @@ async def get_code_suggestions(
     operation="quick_scan",
     error_code_prefix="CODE_INTEL",
 )
-@router.post("/scan-file", response_model=None)
+@router.post("/scan-file", response_model=DataResponse)
 async def quick_scan_file(
     request: QuickScanRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -967,7 +967,7 @@ async def quick_scan_file(
     operation="get_health_score",
     error_code_prefix="CODE_INTEL",
 )
-@router.get("/health-score", response_model=None)
+@router.get("/health-score", response_model=DataResponse)
 async def get_codebase_health_score(
     path: str = Query(..., description="Directory path to analyze"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1018,7 +1018,7 @@ async def get_codebase_health_score(
     operation="get_pattern_types",
     error_code_prefix="CODE_INTEL",
 )
-@router.get("/pattern-types", response_model=None)
+@router.get("/pattern-types", response_model=DataResponse)
 async def get_supported_pattern_types(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -1076,7 +1076,7 @@ class RedisFileScanRequest(BaseModel):
     operation="analyze_redis_usage",
     error_code_prefix="CODE_INTEL",
 )
-@router.post("/redis/analyze", response_model=None)
+@router.post("/redis/analyze", response_model=DataResponse)
 async def analyze_redis_usage_endpoint(
     request: RedisAnalysisRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1122,7 +1122,7 @@ async def analyze_redis_usage_endpoint(
     operation="scan_redis_file",
     error_code_prefix="CODE_INTEL",
 )
-@router.post("/redis/scan-file", response_model=None)
+@router.post("/redis/scan-file", response_model=DataResponse)
 async def scan_redis_file(
     request: RedisFileScanRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1171,7 +1171,7 @@ async def scan_redis_file(
     operation="get_redis_optimization_types",
     error_code_prefix="CODE_INTEL",
 )
-@router.get("/redis/optimization-types", response_model=None)
+@router.get("/redis/optimization-types", response_model=DataResponse)
 async def get_redis_optimization_types(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -1207,7 +1207,7 @@ _REDIS_HEALTH_TIMEOUT = 30.0  # seconds
     operation="get_redis_health",
     error_code_prefix="CODE_INTEL",
 )
-@router.get("/redis/health-score", response_model=None)
+@router.get("/redis/health-score", response_model=DataResponse)
 async def get_redis_usage_health_score(
     path: str = Query(..., description="Directory path to analyze"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1317,7 +1317,7 @@ class SecurityFileScanRequest(BaseModel):
     operation="security_analyze",
     error_code_prefix="SECURITY",
 )
-@router.post("/security/analyze", response_model=None)
+@router.post("/security/analyze", response_model=DataResponse)
 async def security_analyze(
     request: SecurityAnalysisRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1370,7 +1370,7 @@ async def security_analyze(
     operation="security_scan_file",
     error_code_prefix="SECURITY",
 )
-@router.post("/security/scan-file", response_model=None)
+@router.post("/security/scan-file", response_model=DataResponse)
 async def security_scan_file(
     request: SecurityFileScanRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1427,7 +1427,7 @@ async def security_scan_file(
     operation="get_vulnerability_types",
     error_code_prefix="SECURITY",
 )
-@router.get("/security/vulnerability-types", response_model=None)
+@router.get("/security/vulnerability-types", response_model=DataResponse)
 async def list_vulnerability_types(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -1466,7 +1466,7 @@ async def list_vulnerability_types(
     operation="security_score",
     error_code_prefix="SECURITY",
 )
-@router.get("/security/score", response_model=None)
+@router.get("/security/score", response_model=DataResponse)
 async def get_security_score(
     path: str = Query(..., description="Directory path to analyze"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1523,7 +1523,7 @@ async def get_security_score(
     operation="security_report",
     error_code_prefix="SECURITY",
 )
-@router.get("/security/report", response_model=None)
+@router.get("/security/report", response_model=DataResponse)
 async def get_security_report(
     path: str = Query(..., description="Directory path to analyze"),
     format: str = Query(default="json", description="Report format: json or markdown"),
@@ -1584,7 +1584,7 @@ class PerformanceFileScanRequest(BaseModel):
     operation="performance_analyze",
     error_code_prefix="PERFORMANCE",
 )
-@router.post("/performance/analyze", response_model=None)
+@router.post("/performance/analyze", response_model=DataResponse)
 async def performance_analyze(
     request: PerformanceAnalysisRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1636,7 +1636,7 @@ async def performance_analyze(
     operation="performance_scan_file",
     error_code_prefix="PERFORMANCE",
 )
-@router.post("/performance/scan-file", response_model=None)
+@router.post("/performance/scan-file", response_model=DataResponse)
 async def performance_scan_file(
     request: PerformanceFileScanRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -1693,7 +1693,7 @@ async def performance_scan_file(
     operation="get_performance_issue_types",
     error_code_prefix="PERFORMANCE",
 )
-@router.get("/performance/issue-types", response_model=None)
+@router.get("/performance/issue-types", response_model=DataResponse)
 async def list_performance_issue_types(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -1732,7 +1732,7 @@ async def list_performance_issue_types(
     operation="performance_score",
     error_code_prefix="PERFORMANCE",
 )
-@router.get("/performance/score", response_model=None)
+@router.get("/performance/score", response_model=DataResponse)
 async def get_performance_score(
     path: str = Query(..., description="Directory path to analyze"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1798,7 +1798,7 @@ async def get_performance_score(
     operation="performance_report",
     error_code_prefix="PERFORMANCE",
 )
-@router.get("/performance/report", response_model=None)
+@router.get("/performance/report", response_model=DataResponse)
 async def get_performance_report(
     path: str = Query(..., description="Directory path to analyze"),
     format: str = Query(default="json", description="Report format: json or markdown"),
@@ -1829,6 +1829,7 @@ async def get_performance_report(
 # Issue #243: Code Evolution Mining Endpoints
 
 from code_intelligence.code_evolution_miner import CodeEvolutionMiner
+from api.schemas_common import DataResponse, SuccessResponse
 
 
 @with_error_handling(
@@ -1836,7 +1837,7 @@ from code_intelligence.code_evolution_miner import CodeEvolutionMiner
     operation="analyze_evolution",
     error_code_prefix="EVOLUTION",
 )
-@router.post("/evolution/analyze", response_model=None)
+@router.post("/evolution/analyze", response_model=DataResponse)
 async def analyze_code_evolution(
     path: str = Query(..., description="Repository path to analyze"),
     start_date: Optional[str] = Query(None, description="Start date (ISO format)"),
@@ -1892,7 +1893,7 @@ async def analyze_code_evolution(
     operation="get_pattern_evolution",
     error_code_prefix="EVOLUTION",
 )
-@router.get("/evolution/patterns", response_model=None)
+@router.get("/evolution/patterns", response_model=DataResponse)
 async def get_pattern_evolution(
     path: str = Query(..., description="Repository path to analyze"),
     pattern_type: Optional[str] = Query(None, description="Filter by pattern type"),
@@ -1948,7 +1949,7 @@ async def get_pattern_evolution(
     operation="detect_refactorings",
     error_code_prefix="EVOLUTION",
 )
-@router.get("/evolution/refactorings", response_model=None)
+@router.get("/evolution/refactorings", response_model=DataResponse)
 async def detect_refactorings(
     path: str = Query(..., description="Repository path to analyze"),
     limit: int = Query(
@@ -2004,7 +2005,7 @@ async def detect_refactorings(
     operation="get_timeline",
     error_code_prefix="EVOLUTION",
 )
-@router.get("/evolution/timeline", response_model=None)
+@router.get("/evolution/timeline", response_model=DataResponse)
 async def get_evolution_timeline(
     path: str = Query(..., description="Repository path to analyze"),
     admin_check: bool = Depends(check_admin_permission),
@@ -2072,7 +2073,7 @@ def _build_evolution_summary(evolution_report: dict) -> dict:
     operation="get_evolution_report",
     error_code_prefix="EVOLUTION",
 )
-@router.get("/evolution/report", response_model=None)
+@router.get("/evolution/report", response_model=DataResponse)
 async def get_full_evolution_report(
     path: str = Query(..., description="Repository path to analyze"),
     start_date: Optional[str] = Query(None, description="Start date (ISO format)"),

--- a/autobot-backend/api/code_search.py
+++ b/autobot-backend/api/code_search.py
@@ -26,6 +26,7 @@ from agents.npu_code_search_agent import (
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_redis_client
+from api.schemas_common import DataResponse, SuccessResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -160,7 +161,7 @@ class SearchResponse(BaseModel):
     operation="index_codebase",
     error_code_prefix="CODE_SEARCH",
 )
-@router.post("/index", response_model=None)
+@router.post("/index", response_model=DataResponse)
 async def index_codebase(request: IndexRequest):
     """
     Index a codebase for fast searching.
@@ -212,7 +213,7 @@ async def index_codebase(request: IndexRequest):
     operation="search_code",
     error_code_prefix="CODE_SEARCH",
 )
-@router.post("/search", response_model=None)
+@router.post("/search", response_model=DataResponse)
 async def search_code(request: SearchRequest):
     """
     Search through indexed code.
@@ -284,7 +285,7 @@ async def search_code(request: SearchRequest):
     operation="search_code_get",
     error_code_prefix="CODE_SEARCH",
 )
-@router.get("/search", response_model=None)
+@router.get("/search", response_model=DataResponse)
 async def search_code_get(
     q: str = Query(..., description="Search query"),
     type: str = Query("semantic", description="Search type"),
@@ -309,7 +310,7 @@ async def search_code_get(
     operation="get_search_status",
     error_code_prefix="CODE_SEARCH",
 )
-@router.get("/status", response_model=None)
+@router.get("/status", response_model=DataResponse)
 async def get_search_status():
     """
     Get code search system status.
@@ -366,7 +367,7 @@ async def get_search_status():
     operation="clear_search_cache",
     error_code_prefix="CODE_SEARCH",
 )
-@router.delete("/cache", response_model=None)
+@router.delete("/cache", response_model=DataResponse)
 async def clear_search_cache():
     """
     Clear the search cache.
@@ -404,7 +405,7 @@ async def clear_search_cache():
     operation="get_search_examples",
     error_code_prefix="CODE_SEARCH",
 )
-@router.get("/examples", response_model=None)
+@router.get("/examples", response_model=DataResponse)
 async def get_search_examples():
     """
     Get example search queries and usage patterns.
@@ -787,7 +788,7 @@ async def _analyze_all_pattern_types() -> dict:
     operation="analyze_declarations",
     error_code_prefix="CODE_SEARCH",
 )
-@router.post("/analytics/declarations", response_model=None)
+@router.post("/analytics/declarations", response_model=DataResponse)
 async def analyze_declarations(request: AnalyticsRequest):
     """
     Analyze codebase declarations for usage statistics and reusability potential.
@@ -820,7 +821,7 @@ async def analyze_declarations(request: AnalyticsRequest):
     operation="find_code_duplicates",
     error_code_prefix="CODE_SEARCH",
 )
-@router.post("/analytics/duplicates", response_model=None)
+@router.post("/analytics/duplicates", response_model=DataResponse)
 async def find_code_duplicates(request: AnalyticsRequest):
     """
     Find potential code duplicates and similar patterns for refactoring opportunities.
@@ -867,7 +868,7 @@ async def find_code_duplicates(request: AnalyticsRequest):
     operation="get_codebase_statistics",
     error_code_prefix="CODE_SEARCH",
 )
-@router.get("/analytics/stats", response_model=None)
+@router.get("/analytics/stats", response_model=DataResponse)
 async def get_codebase_statistics():
     """
     Get comprehensive codebase statistics from Redis index.
@@ -959,7 +960,7 @@ def _build_refactor_response(root_path: str, suggestions: list) -> dict:
     operation="get_refactor_suggestions",
     error_code_prefix="CODE_SEARCH",
 )
-@router.post("/analytics/refactor-suggestions", response_model=None)
+@router.post("/analytics/refactor-suggestions", response_model=DataResponse)
 async def get_refactor_suggestions(request: AnalyticsRequest):
     """
     Generate intelligent refactoring suggestions based on codebase analysis.

--- a/autobot-backend/api/development_speedup.py
+++ b/autobot-backend/api/development_speedup.py
@@ -21,6 +21,7 @@ from agents.development_speedup_agent import (
 )
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from api.schemas_common import DataResponse, SuccessResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -98,7 +99,7 @@ class AnalysisRequest(BaseModel):
     operation="analyze_codebase_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.post("/analyze", response_model=None)
+@router.post("/analyze", response_model=DataResponse)
 async def analyze_codebase_endpoint(request: AnalysisRequest):
     """
     Comprehensive codebase analysis for development speedup.
@@ -147,7 +148,7 @@ async def analyze_codebase_endpoint(request: AnalysisRequest):
     operation="analyze_codebase_get",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/analyze", response_model=None)
+@router.get("/analyze", response_model=DataResponse)
 async def analyze_codebase_get(
     path: str = Query(..., description="Root path to analyze"),
     type: str = Query("comprehensive", description="Analysis type"),
@@ -168,7 +169,7 @@ async def analyze_codebase_get(
     operation="find_duplicates_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/duplicates", response_model=None)
+@router.get("/duplicates", response_model=DataResponse)
 async def find_duplicates_endpoint(
     path: str = Query(..., description="Root path to analyze"),
     min_lines: int = Query(
@@ -216,7 +217,7 @@ async def find_duplicates_endpoint(
     operation="analyze_patterns_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/patterns", response_model=None)
+@router.get("/patterns", response_model=DataResponse)
 async def analyze_patterns_endpoint(
     path: str = Query(..., description="Root path to analyze"),
     pattern_type: Optional[str] = Query(
@@ -264,7 +265,7 @@ async def analyze_patterns_endpoint(
     operation="analyze_imports_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/imports", response_model=None)
+@router.get("/imports", response_model=DataResponse)
 async def analyze_imports_endpoint(
     path: str = Query(..., description="Root path to analyze"),
     show_unused: bool = Query(True, description="Include potentially unused imports"),
@@ -304,7 +305,7 @@ async def analyze_imports_endpoint(
     operation="detect_dead_code_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/dead-code", response_model=None)
+@router.get("/dead-code", response_model=DataResponse)
 async def detect_dead_code_endpoint(
     path: str = Query(..., description="Root path to analyze")
 ):
@@ -338,7 +339,7 @@ async def detect_dead_code_endpoint(
     operation="find_refactoring_opportunities_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/refactoring", response_model=None)
+@router.get("/refactoring", response_model=DataResponse)
 async def find_refactoring_opportunities_endpoint(
     path: str = Query(..., description="Root path to analyze"),
     min_complexity: float = Query(
@@ -387,7 +388,7 @@ async def find_refactoring_opportunities_endpoint(
     operation="analyze_quality_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/quality", response_model=None)
+@router.get("/quality", response_model=DataResponse)
 async def analyze_quality_endpoint(
     path: str = Query(..., description="Root path to analyze"),
     severity: Optional[str] = Query(
@@ -476,7 +477,7 @@ def _calculate_health_score(result: dict, metrics: dict) -> int:
     operation="get_recommendations_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/recommendations", response_model=None)
+@router.get("/recommendations", response_model=DataResponse)
 async def get_recommendations_endpoint(
     path: str = Query(..., description="Root path to analyze")
 ):
@@ -518,7 +519,7 @@ async def get_recommendations_endpoint(
     operation="get_development_speedup_status",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/status", response_model=None)
+@router.get("/status", response_model=DataResponse)
 async def get_development_speedup_status():
     """
     Get development speedup system status.
@@ -585,7 +586,7 @@ async def get_development_speedup_status():
     operation="get_analysis_examples",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/examples", response_model=None)
+@router.get("/examples", response_model=DataResponse)
 async def get_analysis_examples():
     """
     Get example analysis requests and usage patterns.

--- a/autobot-backend/api/enterprise_features.py
+++ b/autobot-backend/api/enterprise_features.py
@@ -21,6 +21,7 @@ from enterprise_feature_manager import (
     FeatureStatus,
     get_enterprise_manager,
 )
+from api.schemas_common import DataResponse, SuccessResponse
 
 router = APIRouter(dependencies=[Depends(check_admin_permission)])
 logger = logging.getLogger(__name__)
@@ -283,7 +284,7 @@ def _build_service_distribution(vm_topology: dict) -> dict:
     operation="get_enterprise_status",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.get("/status", response_model=None)
+@router.get("/status", response_model=DataResponse)
 async def get_enterprise_status():
     """
     Get comprehensive enterprise feature status.
@@ -317,7 +318,7 @@ async def get_enterprise_status():
     operation="enable_enterprise_feature",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.post("/features/enable", response_model=None)
+@router.post("/features/enable", response_model=DataResponse)
 async def enable_enterprise_feature(request: FeatureEnableRequest):
     """
     Enable a specific enterprise feature.
@@ -374,7 +375,7 @@ async def enable_enterprise_feature(request: FeatureEnableRequest):
     operation="enable_all_enterprise_features",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.post("/features/enable-all", response_model=None)
+@router.post("/features/enable-all", response_model=DataResponse)
 async def enable_all_enterprise_features():
     """
     Enable all enterprise features in dependency order.
@@ -410,7 +411,7 @@ async def enable_all_enterprise_features():
     operation="list_enterprise_features",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.get("/features", response_model=None)
+@router.get("/features", response_model=DataResponse)
 async def list_enterprise_features(
     category: Optional[FeatureCategory] = Query(
         None, description="Filter by feature category"
@@ -468,7 +469,7 @@ async def list_enterprise_features(
     operation="bulk_enable_features",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.post("/features/bulk-enable", response_model=None)
+@router.post("/features/bulk-enable", response_model=DataResponse)
 async def bulk_enable_features(request: BulkFeatureRequest):
     """
     Enable multiple enterprise features in batch.
@@ -529,7 +530,7 @@ async def bulk_enable_features(request: BulkFeatureRequest):
     operation="get_enterprise_health",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=DataResponse)
 async def get_enterprise_health():
     """
     Get health status of all enterprise features.
@@ -584,7 +585,7 @@ async def get_enterprise_health():
     operation="optimize_system_performance",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.post("/performance/optimize", response_model=None)
+@router.post("/performance/optimize", response_model=DataResponse)
 async def optimize_system_performance(request: PerformanceOptimizationRequest):
     """
     Optimize system performance based on target metrics.
@@ -625,7 +626,7 @@ async def optimize_system_performance(request: PerformanceOptimizationRequest):
     operation="get_infrastructure_status",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.get("/infrastructure", response_model=None)
+@router.get("/infrastructure", response_model=DataResponse)
 async def get_infrastructure_status():
     """
     Get 6-VM distributed infrastructure status and topology.
@@ -674,7 +675,7 @@ async def get_infrastructure_status():
     operation="deploy_zero_downtime",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.post("/deployment/zero-downtime", response_model=None)
+@router.post("/deployment/zero-downtime", response_model=DataResponse)
 async def deploy_zero_downtime():
     """
     Execute zero-downtime deployment across the distributed infrastructure.
@@ -722,7 +723,7 @@ async def deploy_zero_downtime():
     operation="validate_phase4_completion",
     error_code_prefix="ENTERPRISE_FEATURES",
 )
-@router.get("/phase4/validation", response_model=None)
+@router.get("/phase4/validation", response_model=DataResponse)
 async def validate_phase4_completion():
     """
     Validate that Phase 4 enterprise features are properly implemented.

--- a/autobot-backend/api/knowledge_ai_stack.py
+++ b/autobot-backend/api/knowledge_ai_stack.py
@@ -32,6 +32,7 @@ from utils.response_helpers import (
 )
 
 from .schemas_common import DataResponse
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -731,7 +732,7 @@ async def get_enhanced_stats(
     operation="enhanced_knowledge_health",
     error_code_prefix="KNOWLEDGE_ENHANCED",
 )
-@router.get("/health/enhanced", response_model=None)
+@router.get("/health/enhanced", response_model=DataResponse)
 async def enhanced_knowledge_health(
     current_user: dict = Depends(get_current_user),
 ):

--- a/autobot-backend/api/llm.py
+++ b/autobot-backend/api/llm.py
@@ -50,7 +50,7 @@ def _get_llm_interface():
     operation="get_llm_config",
     error_code_prefix="LLM",
 )
-@router.get("/config", response_model=None)
+@router.get("/config", response_model=DataResponse)
 async def get_llm_config(
     current_user: dict = Depends(get_current_user),
 ):
@@ -65,7 +65,7 @@ async def get_llm_config(
         raise HTTPException(status_code=500, detail="Error getting LLM config")
 
 
-@router.post("/config", response_model=None)
+@router.post("/config", response_model=DataResponse)
 async def update_llm_config(
     config_data: dict,
     admin_check: bool = Depends(check_admin_permission),
@@ -220,7 +220,7 @@ def _build_llm_update_response() -> dict:
     }
 
 
-@router.post("/provider", response_model=None)
+@router.post("/provider", response_model=DataResponse)
 async def update_llm_provider(
     provider_data: dict,
     admin_check: bool = Depends(check_admin_permission),
@@ -321,7 +321,7 @@ async def _apply_embedding_config(
     await asyncio.to_thread(config.save_config_to_yaml)
 
 
-@router.post("/embedding", response_model=None)
+@router.post("/embedding", response_model=DataResponse)
 async def update_embedding_model(
     embedding_data: dict,
     admin_check: bool = Depends(check_admin_permission),
@@ -463,7 +463,7 @@ def _build_active_provider_info(
     operation="get_comprehensive_llm_status",
     error_code_prefix="LLM",
 )
-@router.get("/status/comprehensive", response_model=None)
+@router.get("/status/comprehensive", response_model=DataResponse)
 @cache_response(cache_key="llm_status_comprehensive", ttl=30)  # Cache for 30 seconds
 async def get_comprehensive_llm_status(
     current_user: dict = Depends(get_current_user),
@@ -515,7 +515,7 @@ async def get_comprehensive_llm_status(
     operation="get_llm_status",
     error_code_prefix="LLM",
 )
-@router.get("/status", response_model=None)
+@router.get("/status", response_model=DataResponse)
 async def get_llm_status(
     current_user: dict = Depends(get_current_user),
 ):
@@ -583,7 +583,7 @@ def _get_model_from_cloud_config(unified_config: dict) -> str:
     operation="get_quick_llm_status",
     error_code_prefix="LLM",
 )
-@router.get("/status/quick", response_model=None)
+@router.get("/status/quick", response_model=DataResponse)
 @cache_response(cache_key="llm_status_quick", ttl=15)  # Cache for 15 seconds
 async def get_quick_llm_status(
     current_user: dict = Depends(get_current_user),
@@ -658,7 +658,7 @@ def _build_providers_health_dict(results: dict) -> tuple:
     operation="get_all_providers_health",
     error_code_prefix="LLM",
 )
-@router.get("/health/providers", response_model=None)
+@router.get("/health/providers", response_model=DataResponse)
 @cache_response(cache_key="llm_providers_health", ttl=30)
 async def get_all_providers_health():
     """
@@ -719,7 +719,7 @@ async def get_all_providers_health():
     operation="get_provider_health",
     error_code_prefix="LLM",
 )
-@router.get("/health/providers/{provider_name}", response_model=None)
+@router.get("/health/providers/{provider_name}", response_model=DataResponse)
 async def get_provider_health(provider_name: str, use_cache: bool = True):
     """
     Get health status of a specific LLM provider.
@@ -780,7 +780,7 @@ async def get_provider_health(provider_name: str, use_cache: bool = True):
     operation="clear_provider_health_cache",
     error_code_prefix="LLM",
 )
-@router.post("/health/providers/clear-cache", response_model=None)
+@router.post("/health/providers/clear-cache", response_model=DataResponse)
 async def clear_provider_health_cache(
     provider_name: str = None,
     admin_check: bool = Depends(check_admin_permission),
@@ -832,7 +832,7 @@ async def clear_provider_health_cache(
     operation="get_tiered_routing_metrics",
     error_code_prefix="LLM",
 )
-@router.get("/tiered-routing/metrics", response_model=None)
+@router.get("/tiered-routing/metrics", response_model=DataResponse)
 async def get_tiered_routing_metrics(
     current_user: dict = Depends(get_current_user),
 ):
@@ -887,7 +887,7 @@ async def get_tiered_routing_metrics(
     operation="get_tiered_routing_config",
     error_code_prefix="LLM",
 )
-@router.get("/tiered-routing/config", response_model=None)
+@router.get("/tiered-routing/config", response_model=DataResponse)
 async def get_tiered_routing_config(
     current_user: dict = Depends(get_current_user),
 ):
@@ -1013,7 +1013,7 @@ def _build_tiered_routing_response(tier_router) -> dict:
     operation="update_tiered_routing_config",
     error_code_prefix="LLM",
 )
-@router.post("/tiered-routing/config", response_model=None)
+@router.post("/tiered-routing/config", response_model=DataResponse)
 async def update_tiered_routing_config(
     config_data: dict,
     admin_check: bool = Depends(check_admin_permission),
@@ -1060,7 +1060,7 @@ async def update_tiered_routing_config(
     operation="reset_tiered_routing_metrics",
     error_code_prefix="LLM",
 )
-@router.post("/tiered-routing/metrics/reset", response_model=None)
+@router.post("/tiered-routing/metrics/reset", response_model=DataResponse)
 async def reset_tiered_routing_metrics(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/llm_providers.py
+++ b/autobot-backend/api/llm_providers.py
@@ -14,6 +14,7 @@ from fastapi.responses import JSONResponse
 
 from auth_middleware import check_admin_permission, get_current_user
 from utils.advanced_cache_manager import cache_response
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ def _get_llm_interface():
     return LLMInterface()
 
 
-@router.post("/switch", response_model=None)
+@router.post("/switch", response_model=DataResponse)
 async def switch_llm_provider(
     switch_data: dict,
     admin_check: bool = Depends(check_admin_permission),
@@ -51,7 +52,7 @@ async def switch_llm_provider(
     return JSONResponse(status_code=200, content=result)
 
 
-@router.get("/providers", response_model=None)
+@router.get("/providers", response_model=DataResponse)
 @cache_response(cache_key="llm_providers_list", ttl=30)
 async def list_llm_providers(
     current_user: dict = Depends(get_current_user),
@@ -65,7 +66,7 @@ async def list_llm_providers(
     )
 
 
-@router.post("/providers/{provider_name}/test", response_model=None)
+@router.post("/providers/{provider_name}/test", response_model=DataResponse)
 async def test_llm_provider(
     provider_name: str,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/log_forwarding.py
+++ b/autobot-backend/api/log_forwarding.py
@@ -40,6 +40,7 @@ from scripts.logging.log_forwarder import (
     LogForwarder,
     SyslogProtocol,
 )
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -348,7 +349,7 @@ def _destination_to_response(dest) -> DestinationResponse:
     operation="list_destinations",
     error_code_prefix="LOGFWD",
 )
-@router.get("/destinations", response_model=None)
+@router.get("/destinations", response_model=DataResponse)
 async def list_destinations(
     admin_check: bool = Depends(check_admin_permission),
 ) -> List[Dict[str, Any]]:
@@ -380,7 +381,7 @@ async def list_destinations(
     operation="get_destination",
     error_code_prefix="LOGFWD",
 )
-@router.get("/destinations/{name}", response_model=None)
+@router.get("/destinations/{name}", response_model=DataResponse)
 async def get_destination(
     name: str,
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/logs.py
+++ b/autobot-backend/api/logs.py
@@ -515,7 +515,7 @@ async def get_recent_logs(
     operation="list_logs",
     error_code_prefix="LOGS",
 )
-@router.get("/list", response_model=None)
+@router.get("/list", response_model=DataResponse)
 async def list_logs(
     admin_check: bool = Depends(check_admin_permission),
 ) -> List[Metadata]:

--- a/autobot-backend/api/memory.py
+++ b/autobot-backend/api/memory.py
@@ -41,6 +41,7 @@ from autobot_shared.time_utils import utc_timestamp
 from autobot_shared.time_utils import now_utc
 from type_defs.common import Metadata
 from utils.request_utils import generate_request_id
+from api.schemas_common import DataResponse, SuccessResponse
 
 # ====================================================================
 # Router Configuration
@@ -476,7 +477,7 @@ def _build_list_entities_response(
     operation="create_entity",
     error_code_prefix="MEMORY",
 )
-@router.post("/entities", status_code=201, response_model=None)
+@router.post("/entities", status_code=201, response_model=DataResponse)
 async def create_entity(
     admin_check: bool = Depends(check_admin_permission),
     entity_data: EntityCreateRequest = Body(...),
@@ -540,7 +541,7 @@ async def create_entity(
     operation="list_all_entities",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities/all", response_model=None)
+@router.get("/entities/all", response_model=DataResponse)
 async def list_all_entities(
     admin_check: bool = Depends(check_admin_permission),
     entity_type: Optional[str] = Query(None, description="Filter by entity type"),
@@ -585,7 +586,7 @@ async def list_all_entities(
     operation="find_orphaned_conversation_entities",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities/orphans", response_model=None)
+@router.get("/entities/orphans", response_model=DataResponse)
 async def find_orphaned_conversation_entities(
     admin_check: bool = Depends(check_admin_permission),
     request: Request = None,
@@ -902,7 +903,7 @@ async def _detect_orphaned_entities(
     operation="cleanup_orphaned_conversation_entities",
     error_code_prefix="MEMORY",
 )
-@router.delete("/entities/orphans", response_model=None)
+@router.delete("/entities/orphans", response_model=DataResponse)
 async def cleanup_orphaned_conversation_entities(
     admin_check: bool = Depends(check_admin_permission),
     request: Request = None,
@@ -952,7 +953,7 @@ async def cleanup_orphaned_conversation_entities(
     operation="get_entity_by_id",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities/{entity_id}", response_model=None)
+@router.get("/entities/{entity_id}", response_model=DataResponse)
 async def get_entity_by_id(
     entity_id: str = Path(..., description="Entity UUID"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1010,7 +1011,7 @@ async def get_entity_by_id(
     operation="get_entity_by_name",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities", response_model=None)
+@router.get("/entities", response_model=DataResponse)
 async def get_entity_by_name(
     admin_check: bool = Depends(check_admin_permission),
     name: str = Query(..., description="Entity name to search for"),
@@ -1066,7 +1067,7 @@ async def get_entity_by_name(
     operation="add_observations",
     error_code_prefix="MEMORY",
 )
-@router.patch("/entities/{entity_id}/observations", response_model=None)
+@router.patch("/entities/{entity_id}/observations", response_model=DataResponse)
 async def add_observations(
     entity_id: str = Path(..., description="Entity UUID"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1129,7 +1130,7 @@ async def add_observations(
     operation="delete_entity",
     error_code_prefix="MEMORY",
 )
-@router.delete("/entities/{entity_id}", response_model=None)
+@router.delete("/entities/{entity_id}", response_model=DataResponse)
 async def delete_entity(
     entity_id: str = Path(..., description="Entity UUID"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1192,7 +1193,7 @@ async def delete_entity(
     operation="create_relation",
     error_code_prefix="MEMORY",
 )
-@router.post("/relations", status_code=201, response_model=None)
+@router.post("/relations", status_code=201, response_model=DataResponse)
 async def create_relation(
     admin_check: bool = Depends(check_admin_permission),
     relation_data: RelationCreateRequest = Body(...),
@@ -1261,7 +1262,7 @@ async def create_relation(
     operation="get_related_entities",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities/{entity_id}/relations", response_model=None)
+@router.get("/entities/{entity_id}/relations", response_model=DataResponse)
 async def get_related_entities(
     entity_id: str = Path(..., description="Entity UUID"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1316,7 +1317,7 @@ async def get_related_entities(
     operation="delete_relation",
     error_code_prefix="MEMORY",
 )
-@router.delete("/relations", response_model=None)
+@router.delete("/relations", response_model=DataResponse)
 async def delete_relation(
     admin_check: bool = Depends(check_admin_permission),
     from_entity: str = Query(..., description="Source entity name"),
@@ -1386,7 +1387,7 @@ async def delete_relation(
     operation="search_entities",
     error_code_prefix="MEMORY",
 )
-@router.get("/search", response_model=None)
+@router.get("/search", response_model=DataResponse)
 async def search_entities(
     admin_check: bool = Depends(check_admin_permission),
     query: str = Query(..., min_length=1, description="Search query"),
@@ -1459,7 +1460,7 @@ async def search_entities(
     operation="get_entity_graph",
     error_code_prefix="MEMORY",
 )
-@router.get("/graph", response_model=None)
+@router.get("/graph", response_model=DataResponse)
 async def get_entity_graph(
     admin_check: bool = Depends(check_admin_permission),
     entity_id: Optional[str] = Query(None, description="Root entity ID (optional)"),
@@ -1522,7 +1523,7 @@ async def get_entity_graph(
     operation="memory_health_check",
     error_code_prefix="MEMORY",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=DataResponse)
 async def memory_health_check(
     admin_check: bool = Depends(check_admin_permission),
     memory_graph: AutoBotMemoryGraph = Depends(get_memory_graph),
@@ -1655,7 +1656,7 @@ def _build_invalidate_relation_response(
     operation="invalidate_entity",
     error_code_prefix="MEMORY",
 )
-@router.patch("/entities/{entity_id}/invalidate", response_model=None)
+@router.patch("/entities/{entity_id}/invalidate", response_model=DataResponse)
 async def invalidate_entity(
     entity_id: str = Path(..., description="UUID of the entity to invalidate"),
     body: InvalidateEntityRequest = Body(default_factory=InvalidateEntityRequest),
@@ -1719,7 +1720,7 @@ async def invalidate_entity(
     operation="invalidate_relation",
     error_code_prefix="MEMORY",
 )
-@router.patch("/relations/invalidate", response_model=None)
+@router.patch("/relations/invalidate", response_model=DataResponse)
 async def invalidate_relation(
     body: InvalidateRelationRequest = Body(...),
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/npu_workers.py
+++ b/autobot-backend/api/npu_workers.py
@@ -240,7 +240,7 @@ async def update_worker(
     operation="remove_worker",
     error_code_prefix="NPU_WORKERS",
 )
-@router.delete("/npu/workers/{worker_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
+@router.delete("/npu/workers/{worker_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=DataResponse)
 async def remove_worker(
     admin_check: bool = Depends(check_admin_permission),
     worker_id: str = None,
@@ -867,6 +867,7 @@ from datetime import datetime
 from typing import Dict, Tuple
 
 import httpx
+from api.schemas_common import DataResponse, SuccessResponse
 
 
 @dataclass

--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -33,6 +33,7 @@ except ImportError:
     )
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from api.schemas_common import DataResponse, SuccessResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -103,7 +104,7 @@ def _build_single_task_response(result: dict) -> JSONResponse:
     )
 
 
-@router.post("/workflow/execute", response_model=None)
+@router.post("/workflow/execute", response_model=DataResponse)
 async def execute_workflow(
     request: WorkflowRequest,
     current_user: dict = Depends(get_current_user),
@@ -153,7 +154,7 @@ async def execute_workflow(
     operation="create_workflow_plan",
     error_code_prefix="ORCHESTRATION",
 )
-@router.post("/workflow/plan", response_model=None)
+@router.post("/workflow/plan", response_model=DataResponse)
 async def create_workflow_plan(
     request: WorkflowRequest,
     current_user: dict = Depends(get_current_user),
@@ -218,7 +219,7 @@ async def create_workflow_plan(
     operation="get_agent_performance",
     error_code_prefix="ORCHESTRATION",
 )
-@router.get("/agents/performance", response_model=None)
+@router.get("/agents/performance", response_model=DataResponse)
 async def get_agent_performance(
     current_user: dict = Depends(get_current_user),
 ):
@@ -251,7 +252,7 @@ async def get_agent_performance(
     operation="recommend_agents",
     error_code_prefix="ORCHESTRATION",
 )
-@router.post("/agents/recommend", response_model=None)
+@router.post("/agents/recommend", response_model=DataResponse)
 async def recommend_agents(
     request: AgentRecommendationRequest,
     current_user: dict = Depends(get_current_user),
@@ -307,7 +308,7 @@ async def recommend_agents(
     operation="get_active_workflows",
     error_code_prefix="ORCHESTRATION",
 )
-@router.get("/workflow/active", response_model=None)
+@router.get("/workflow/active", response_model=DataResponse)
 async def get_active_workflows(
     current_user: dict = Depends(get_current_user),
 ):
@@ -358,7 +359,7 @@ async def get_active_workflows(
     operation="get_execution_strategies",
     error_code_prefix="ORCHESTRATION",
 )
-@router.get("/strategies", response_model=None)
+@router.get("/strategies", response_model=DataResponse)
 async def get_execution_strategies(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -405,7 +406,7 @@ async def get_execution_strategies(
     operation="get_agent_capabilities",
     error_code_prefix="ORCHESTRATION",
 )
-@router.get("/capabilities", response_model=None)
+@router.get("/capabilities", response_model=DataResponse)
 async def get_agent_capabilities(
     current_user: dict = Depends(get_current_user),
 ):
@@ -461,7 +462,7 @@ async def get_agent_capabilities(
     operation="get_orchestration_status",
     error_code_prefix="ORCHESTRATION",
 )
-@router.get("/status", response_model=None)
+@router.get("/status", response_model=DataResponse)
 async def get_orchestration_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -516,7 +517,7 @@ async def get_orchestration_status(
     operation="get_orchestration_examples",
     error_code_prefix="ORCHESTRATION",
 )
-@router.get("/examples", response_model=None)
+@router.get("/examples", response_model=DataResponse)
 async def get_orchestration_examples(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/playwright.py
+++ b/autobot-backend/api/playwright.py
@@ -24,6 +24,7 @@ from services.playwright_service import (
     send_test_message_embedded,
     test_frontend_embedded,
 )
+from api.schemas_common import DataResponse, SuccessResponse
 
 router = APIRouter(dependencies=[Depends(check_admin_permission)])
 logger = logging.getLogger(__name__)
@@ -80,7 +81,7 @@ BROWSER_VM_URL = (
     operation="get_playwright_status",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.get("/status", response_model=None)
+@router.get("/status", response_model=DataResponse)
 async def get_playwright_status():
     """Get Playwright service status and capabilities"""
     try:
@@ -103,7 +104,7 @@ async def get_playwright_status():
     operation="health_check",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=DataResponse)
 async def health_check():
     """Health check endpoint for Playwright service"""
     try:
@@ -130,7 +131,7 @@ async def health_check():
     operation="web_search",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/search", response_model=None)
+@router.post("/search", response_model=DataResponse)
 async def web_search(request: SearchRequest):
     """
     Perform web search using embedded Playwright
@@ -171,7 +172,7 @@ async def web_search(request: SearchRequest):
     operation="test_frontend",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/test-frontend", response_model=None)
+@router.post("/test-frontend", response_model=DataResponse)
 async def test_frontend(request: FrontendTestRequest):
     """
     Test frontend functionality using embedded Playwright
@@ -205,7 +206,7 @@ async def test_frontend(request: FrontendTestRequest):
     operation="send_test_message",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/send-test-message", response_model=None)
+@router.post("/send-test-message", response_model=DataResponse)
 async def send_test_message(request: TestMessageRequest):
     """
     Send test message through frontend using embedded Playwright
@@ -243,7 +244,7 @@ async def send_test_message(request: TestMessageRequest):
     operation="capture_screenshot",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/screenshot", response_model=None)
+@router.post("/screenshot", response_model=DataResponse)
 async def capture_screenshot(request: ScreenshotRequest):
     """
     Capture screenshot of webpage using embedded Playwright
@@ -282,7 +283,7 @@ async def capture_screenshot(request: ScreenshotRequest):
     operation="quick_automation_test",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/automation/quick-test", response_model=None)
+@router.post("/automation/quick-test", response_model=DataResponse)
 async def quick_automation_test(background_tasks: BackgroundTasks):
     """
     Quick automation test to verify all Playwright functionality
@@ -345,7 +346,7 @@ async def quick_automation_test(background_tasks: BackgroundTasks):
     operation="navigate",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/navigate", response_model=None)
+@router.post("/navigate", response_model=DataResponse)
 async def navigate_to_url(request: NavigateRequest):
     """
     Navigate to a URL using Playwright on Browser VM
@@ -390,7 +391,7 @@ async def navigate_to_url(request: NavigateRequest):
     operation="reload",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/reload", response_model=None)
+@router.post("/reload", response_model=DataResponse)
 async def reload_page(request: ReloadRequest):
     """
     Reload the current page using Playwright on Browser VM
@@ -431,7 +432,7 @@ async def reload_page(request: ReloadRequest):
     operation="go_back",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/back", response_model=None)
+@router.post("/back", response_model=DataResponse)
 async def go_back():
     """
     Navigate back in browser history using Playwright on Browser VM
@@ -473,7 +474,7 @@ async def go_back():
     operation="go_forward",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/forward", response_model=None)
+@router.post("/forward", response_model=DataResponse)
 async def go_forward():
     """
     Navigate forward in browser history using Playwright on Browser VM
@@ -517,7 +518,7 @@ async def go_forward():
     operation="worker_status",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.get("/worker-status", response_model=None)
+@router.get("/worker-status", response_model=DataResponse)
 async def get_worker_status():
     """
     Get browser worker connectivity status from Browser VM (#1130)
@@ -550,7 +551,7 @@ async def get_worker_status():
     operation="worker_screenshot",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/worker-screenshot", response_model=None)
+@router.post("/worker-screenshot", response_model=DataResponse)
 async def take_worker_screenshot():
     """
     Take screenshot of the persistent navigation page on Browser VM (#1130)
@@ -588,7 +589,7 @@ async def take_worker_screenshot():
     operation="interact",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/interact", response_model=None)
+@router.post("/interact", response_model=DataResponse)
 async def interact_with_page(request: InteractRequest):
     """Proxy interactive browser actions to Browser VM (#1416)"""
     allowed = {"click", "scroll", "type", "hover"}
@@ -639,7 +640,7 @@ async def interact_with_page(request: InteractRequest):
     operation="get_capabilities",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.get("/capabilities", response_model=None)
+@router.get("/capabilities", response_model=DataResponse)
 async def get_capabilities():
     """Get Playwright service capabilities and features"""
     return {

--- a/autobot-backend/api/registry.py
+++ b/autobot-backend/api/registry.py
@@ -503,7 +503,7 @@ async def list_endpoints():
     operation="list_routers",
     error_code_prefix="REGISTRY",
 )
-@router.get("/routers", response_model=None)
+@router.get("/routers", response_model=DataResponse)
 async def list_routers():
     """List all registered routers with full configuration"""
     routers_data = {}

--- a/autobot-backend/api/research_browser.py
+++ b/autobot-backend/api/research_browser.py
@@ -23,6 +23,7 @@ from autobot_shared.ssot_config import config as ssot_config
 from config.manager import get_config_manager
 from constants.error_constants import ERR_SESSION_NOT_FOUND
 from constants.network_constants import NetworkConstants
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +70,7 @@ def _require_browser():
     operation="health_check",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=DataResponse)
 async def health_check():
     """Health check endpoint for research browser service"""
     if not _BROWSER_AVAILABLE:
@@ -97,7 +98,7 @@ async def health_check():
     operation="research_url",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.post("/url", response_model=None)
+@router.post("/url", response_model=DataResponse)
 async def research_url(request: ResearchRequest):
     """Research a URL with automatic fallbacks and interaction handling"""
     _require_browser()
@@ -113,7 +114,7 @@ async def research_url(request: ResearchRequest):
     operation="handle_session_action",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.post("/session/action", response_model=None)
+@router.post("/session/action", response_model=DataResponse)
 async def handle_session_action(request: SessionAction):
     """Handle actions on a research session"""
     _require_browser()
@@ -163,7 +164,7 @@ async def handle_session_action(request: SessionAction):
     operation="get_session_status",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.get("/session/{session_id}/status", response_model=None)
+@router.get("/session/{session_id}/status", response_model=DataResponse)
 async def get_session_status(session_id: str):
     """Get the status of a research session"""
     _require_browser()
@@ -238,7 +239,7 @@ async def download_mhtml(session_id: str, filename: str):
     operation="cleanup_session",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.delete("/session/{session_id}", response_model=None)
+@router.delete("/session/{session_id}", response_model=DataResponse)
 async def cleanup_session(session_id: str):
     """Clean up a research session"""
     _require_browser()
@@ -255,7 +256,7 @@ async def cleanup_session(session_id: str):
     operation="list_sessions",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.get("/sessions", response_model=None)
+@router.get("/sessions", response_model=DataResponse)
 async def list_sessions():
     """List all active research sessions"""
     _require_browser()
@@ -289,7 +290,7 @@ class NavigationRequest(BaseModel):
     operation="navigate_session",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.post("/session/{session_id}/navigate", response_model=None)
+@router.post("/session/{session_id}/navigate", response_model=DataResponse)
 async def navigate_session(session_id: str, request: NavigationRequest):
     """Navigate a research session to a specific URL"""
     _require_browser()
@@ -308,7 +309,7 @@ async def navigate_session(session_id: str, request: NavigationRequest):
     operation="get_browser_info",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.get("/browser/{session_id}", response_model=None)
+@router.get("/browser/{session_id}", response_model=DataResponse)
 async def get_browser_info(session_id: str):
     """Get browser information for frontend integration (Issue #665: refactored)."""
     _require_browser()
@@ -417,7 +418,7 @@ class CreateChatBrowserRequest(BaseModel):
     operation="get_or_create_chat_browser_session",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.post("/chat-session", response_model=None)
+@router.post("/chat-session", response_model=DataResponse)
 async def get_or_create_chat_browser_session(request: CreateChatBrowserRequest):
     """
     Get existing or create new browser session for a chat conversation.
@@ -485,7 +486,7 @@ async def get_or_create_chat_browser_session(request: CreateChatBrowserRequest):
     operation="get_chat_browser_session",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.get("/chat-session/{conversation_id}", response_model=None)
+@router.get("/chat-session/{conversation_id}", response_model=DataResponse)
 async def get_chat_browser_session(conversation_id: str):
     """
     Get browser session info for a chat conversation.
@@ -536,7 +537,7 @@ async def get_chat_browser_session(conversation_id: str):
     operation="delete_chat_browser_session",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.delete("/chat-session/{conversation_id}", response_model=None)
+@router.delete("/chat-session/{conversation_id}", response_model=DataResponse)
 async def delete_chat_browser_session(conversation_id: str):
     """
     Close browser session for a chat conversation.

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -39,6 +39,7 @@ from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from middleware.proxy_utils import get_client_ip
 from type_defs.common import Metadata
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -690,7 +691,7 @@ def audit_log(
     operation="create_secret",
     error_code_prefix="SECRETS",
 )
-@router.post("/", response_model=None)
+@router.post("/", response_model=DataResponse)
 async def create_secret(
     request: SecretCreateRequest,
     http_request: Request,
@@ -735,7 +736,7 @@ async def create_secret(
     operation="list_secrets",
     error_code_prefix="SECRETS",
 )
-@router.get("/", response_model=None)
+@router.get("/", response_model=DataResponse)
 async def list_secrets(
     http_request: Request,
     chat_id: Optional[str] = Query(None),
@@ -768,7 +769,7 @@ async def list_secrets(
     operation="get_secret_types",
     error_code_prefix="SECRETS",
 )
-@router.get("/types", response_model=None)
+@router.get("/types", response_model=DataResponse)
 async def get_secret_types(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -792,7 +793,7 @@ async def get_secret_types(
     operation="get_secrets_status",
     error_code_prefix="SECRETS",
 )
-@router.get("/status", response_model=None)
+@router.get("/status", response_model=DataResponse)
 async def get_secrets_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -824,7 +825,7 @@ async def get_secrets_status(
     operation="get_secrets_stats",
     error_code_prefix="SECRETS",
 )
-@router.get("/stats", response_model=None)
+@router.get("/stats", response_model=DataResponse)
 async def get_secrets_stats(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -873,7 +874,7 @@ async def get_secrets_stats(
     operation="get_secret",
     error_code_prefix="SECRETS",
 )
-@router.get("/{secret_id}", response_model=None)
+@router.get("/{secret_id}", response_model=DataResponse)
 async def get_secret(
     secret_id: str,
     http_request: Request,
@@ -948,7 +949,7 @@ async def get_secret(
     operation="update_secret",
     error_code_prefix="SECRETS",
 )
-@router.put("/{secret_id}", response_model=None)
+@router.put("/{secret_id}", response_model=DataResponse)
 async def update_secret(
     secret_id: str,
     request: SecretUpdateRequest,
@@ -1011,7 +1012,7 @@ async def update_secret(
     operation="delete_secret",
     error_code_prefix="SECRETS",
 )
-@router.delete("/{secret_id}", response_model=None)
+@router.delete("/{secret_id}", response_model=DataResponse)
 async def delete_secret(
     secret_id: str,
     http_request: Request,
@@ -1060,7 +1061,7 @@ async def delete_secret(
     operation="transfer_secrets",
     error_code_prefix="SECRETS",
 )
-@router.post("/transfer", response_model=None)
+@router.post("/transfer", response_model=DataResponse)
 async def transfer_secrets(
     request: SecretTransferRequest,
     http_request: Request,
@@ -1102,7 +1103,7 @@ async def transfer_secrets(
     operation="get_chat_cleanup_info",
     error_code_prefix="SECRETS",
 )
-@router.get("/chat/{chat_id}/cleanup", response_model=None)
+@router.get("/chat/{chat_id}/cleanup", response_model=DataResponse)
 async def get_chat_cleanup_info(
     chat_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -1122,7 +1123,7 @@ async def get_chat_cleanup_info(
     operation="delete_chat_secrets",
     error_code_prefix="SECRETS",
 )
-@router.delete("/chat/{chat_id}", response_model=None)
+@router.delete("/chat/{chat_id}", response_model=DataResponse)
 async def delete_chat_secrets(
     chat_id: str,
     http_request: Request,

--- a/autobot-backend/api/security_assessment.py
+++ b/autobot-backend/api/security_assessment.py
@@ -30,6 +30,7 @@ from services.security_workflow_manager import (
 
 # Issue #756: Consolidated from src/utils/request_utils.py
 from utils.request_utils import generate_request_id
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +123,7 @@ async def get_workflow_manager() -> SecurityWorkflowManager:
 # API Endpoints
 
 
-@router.post("/assessments", response_model=None)
+@router.post("/assessments", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="create_assessment",
@@ -171,7 +172,7 @@ async def create_assessment(
     )
 
 
-@router.get("/assessments", response_model=None)
+@router.get("/assessments", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_assessments",
@@ -216,7 +217,7 @@ async def list_assessments(
     )
 
 
-@router.get("/assessments/{assessment_id}", response_model=None)
+@router.get("/assessments/{assessment_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="get_assessment",
@@ -256,7 +257,7 @@ async def get_assessment(
     )
 
 
-@router.get("/assessments/{assessment_id}/summary", response_model=None)
+@router.get("/assessments/{assessment_id}/summary", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="get_assessment_summary",
@@ -296,7 +297,7 @@ async def get_assessment_summary(
     )
 
 
-@router.delete("/assessments/{assessment_id}", response_model=None)
+@router.delete("/assessments/{assessment_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="delete_assessment",
@@ -336,7 +337,7 @@ async def delete_assessment(
     )
 
 
-@router.get("/assessments/{assessment_id}/phase", response_model=None)
+@router.get("/assessments/{assessment_id}/phase", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="get_phase",
@@ -386,7 +387,7 @@ async def get_current_phase(
     )
 
 
-@router.post("/assessments/{assessment_id}/phase", response_model=None)
+@router.post("/assessments/{assessment_id}/phase", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.VALIDATION,
     operation="advance_phase",
@@ -436,7 +437,7 @@ async def advance_phase(
     )
 
 
-@router.post("/assessments/{assessment_id}/hosts", response_model=None)
+@router.post("/assessments/{assessment_id}/hosts", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="add_host",
@@ -485,7 +486,7 @@ async def add_host(
     )
 
 
-@router.post("/assessments/{assessment_id}/ports", response_model=None)
+@router.post("/assessments/{assessment_id}/ports", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="add_port",
@@ -536,7 +537,7 @@ async def add_port(
     )
 
 
-@router.post("/assessments/{assessment_id}/vulnerabilities", response_model=None)
+@router.post("/assessments/{assessment_id}/vulnerabilities", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="add_vulnerability",
@@ -589,7 +590,7 @@ async def add_vulnerability(
     )
 
 
-@router.post("/assessments/{assessment_id}/findings", response_model=None)
+@router.post("/assessments/{assessment_id}/findings", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="add_finding",
@@ -641,7 +642,7 @@ async def add_finding(
     )
 
 
-@router.get("/assessments/{assessment_id}/findings", response_model=None)
+@router.get("/assessments/{assessment_id}/findings", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="get_findings",
@@ -789,7 +790,7 @@ async def _store_parsed_vulnerabilities(manager, assessment_id: str, parsed) -> 
     return vulns_added
 
 
-@router.post("/assessments/{assessment_id}/parse", response_model=None)
+@router.post("/assessments/{assessment_id}/parse", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.VALIDATION,
     operation="parse_tool_output",
@@ -857,7 +858,7 @@ async def parse_and_store_tool_output(
     )
 
 
-@router.post("/assessments/{assessment_id}/error", response_model=None)
+@router.post("/assessments/{assessment_id}/error", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="set_error",
@@ -899,7 +900,7 @@ async def set_error_state(
     )
 
 
-@router.post("/assessments/{assessment_id}/recover", response_model=None)
+@router.post("/assessments/{assessment_id}/recover", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.VALIDATION,
     operation="recover_from_error",
@@ -949,7 +950,7 @@ async def recover_from_error(
     )
 
 
-@router.get("/phases", response_model=None)
+@router.get("/phases", response_model=DataResponse)
 async def get_phase_definitions(
     admin_check: bool = Depends(check_admin_permission),
 ) -> JSONResponse:

--- a/autobot-backend/api/skills.py
+++ b/autobot-backend/api/skills.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field
 
 from skills.manager import SkillManager
 from skills.registry import get_skill_registry
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +75,7 @@ class SkillFeedbackRequest(BaseModel):
 # --- Endpoints ---
 
 
-@router.get("/", summary="List all skills", response_model=None)
+@router.get("/", summary="List all skills", response_model=DataResponse)
 async def list_skills(
     category: Optional[str] = Query(None, description="Filter by category"),
     search: Optional[str] = Query(None, description="Search query"),
@@ -101,7 +102,7 @@ async def list_skills(
     }
 
 
-@router.get("/categories", summary="List skill categories", response_model=None)
+@router.get("/categories", summary="List skill categories", response_model=DataResponse)
 async def list_categories() -> Dict[str, Any]:
     """List all available skill categories with counts."""
     manager = _get_manager()
@@ -109,14 +110,14 @@ async def list_categories() -> Dict[str, Any]:
     return {"categories": {cat: len(skills) for cat, skills in by_cat.items()}}
 
 
-@router.get("/health", summary="Get health of all skills", response_model=None)
+@router.get("/health", summary="Get health of all skills", response_model=DataResponse)
 async def get_all_health() -> Dict[str, Any]:
     """Get health status for all registered skills."""
     registry = get_skill_registry()
     return {"skills": registry.get_all_health()}
 
 
-@router.post("/initialize", summary="Initialize skills system", response_model=None)
+@router.post("/initialize", summary="Initialize skills system", response_model=DataResponse)
 async def initialize_skills() -> Dict[str, Any]:
     """Discover and load all builtin skills."""
     manager = _get_manager()
@@ -124,7 +125,7 @@ async def initialize_skills() -> Dict[str, Any]:
     return result
 
 
-@router.get("/{name}", summary="Get skill details", response_model=None)
+@router.get("/{name}", summary="Get skill details", response_model=DataResponse)
 async def get_skill(name: str) -> Dict[str, Any]:
     """Get detailed information about a specific skill."""
     registry = get_skill_registry()
@@ -134,7 +135,7 @@ async def get_skill(name: str) -> Dict[str, Any]:
     return detail
 
 
-@router.post("/{name}/enable", summary="Enable a skill", response_model=None)
+@router.post("/{name}/enable", summary="Enable a skill", response_model=DataResponse)
 async def enable_skill(name: str) -> Dict[str, Any]:
     """Enable a skill, checking dependencies. Persists state to Redis (Issue #993)."""
     registry = get_skill_registry()
@@ -146,7 +147,7 @@ async def enable_skill(name: str) -> Dict[str, Any]:
     return result
 
 
-@router.post("/{name}/disable", summary="Disable a skill", response_model=None)
+@router.post("/{name}/disable", summary="Disable a skill", response_model=DataResponse)
 async def disable_skill(name: str) -> Dict[str, Any]:
     """Disable a skill. Persists state to Redis (Issue #993)."""
     registry = get_skill_registry()
@@ -158,7 +159,7 @@ async def disable_skill(name: str) -> Dict[str, Any]:
     return result
 
 
-@router.put("/{name}/config", summary="Update skill config", response_model=None)
+@router.put("/{name}/config", summary="Update skill config", response_model=DataResponse)
 async def update_config(name: str, body: SkillConfigUpdate) -> Dict[str, Any]:
     """Update a skill's configuration values."""
     registry = get_skill_registry()
@@ -173,7 +174,7 @@ async def update_config(name: str, body: SkillConfigUpdate) -> Dict[str, Any]:
     return result
 
 
-@router.post("/{name}/execute", summary="Execute a skill action", response_model=None)
+@router.post("/{name}/execute", summary="Execute a skill action", response_model=DataResponse)
 async def execute_skill(name: str, body: SkillActionRequest) -> Dict[str, Any]:
     """Execute a specific action on a skill."""
     manager = _get_manager()
@@ -186,7 +187,7 @@ async def execute_skill(name: str, body: SkillActionRequest) -> Dict[str, Any]:
     return result
 
 
-@router.get("/{name}/health", summary="Get skill health", response_model=None)
+@router.get("/{name}/health", summary="Get skill health", response_model=DataResponse)
 async def get_skill_health(name: str) -> Dict[str, Any]:
     """Get health status for a specific skill."""
     registry = get_skill_registry()
@@ -196,7 +197,7 @@ async def get_skill_health(name: str) -> Dict[str, Any]:
     return health.model_dump()
 
 
-@router.get("/{name}/actions", summary="List skill actions", response_model=None)
+@router.get("/{name}/actions", summary="List skill actions", response_model=DataResponse)
 async def list_skill_actions(name: str) -> Dict[str, Any]:
     """List available actions for a skill."""
     registry = get_skill_registry()
@@ -209,7 +210,7 @@ async def list_skill_actions(name: str) -> Dict[str, Any]:
     }
 
 
-@router.get("/{name}/metrics", summary="Get skill metrics", response_model=None)
+@router.get("/{name}/metrics", summary="Get skill metrics", response_model=DataResponse)
 async def get_skill_metrics(
     name: str,
     days: int = Query(30, description="Number of days to analyze"),
@@ -231,7 +232,7 @@ async def get_skill_metrics(
         raise HTTPException(status_code=500, detail="Failed to retrieve metrics")
 
 
-@router.post("/{name}/feedback", summary="Submit skill feedback", response_model=None)
+@router.post("/{name}/feedback", summary="Submit skill feedback", response_model=DataResponse)
 async def submit_skill_feedback(
     name: str,
     body: SkillFeedbackRequest,
@@ -257,7 +258,7 @@ async def submit_skill_feedback(
         raise HTTPException(status_code=500, detail="Failed to log feedback")
 
 
-@router.get("/{name}/suggestions", summary="Get skill refinement suggestions", response_model=None)
+@router.get("/{name}/suggestions", summary="Get skill refinement suggestions", response_model=DataResponse)
 async def get_refinement_suggestions(name: str) -> Dict[str, Any]:
     """Get suggestions for improving a skill (Issue #4339)."""
     try:

--- a/autobot-backend/api/structured_thinking_mcp.py
+++ b/autobot-backend/api/structured_thinking_mcp.py
@@ -366,7 +366,7 @@ async def get_structured_thinking_mcp_tools() -> List[MCPTool]:
     operation="process_thought_mcp",
     error_code_prefix="STRUCTURED_THINKING_MCP",
 )
-@router.post("/mcp/process_thought", response_model=None)
+@router.post("/mcp/process_thought", response_model=DataResponse)
 async def process_thought_mcp(request: ProcessThoughtRequest) -> Metadata:
     """
     Process and record a thought within the structured cognitive framework.
@@ -437,7 +437,7 @@ async def process_thought_mcp(request: ProcessThoughtRequest) -> Metadata:
     operation="generate_summary_mcp",
     error_code_prefix="STRUCTURED_THINKING_MCP",
 )
-@router.post("/mcp/generate_summary", response_model=None)
+@router.post("/mcp/generate_summary", response_model=DataResponse)
 async def generate_summary_mcp(request: GenerateSummaryRequest) -> Metadata:
     """
     Generate a comprehensive summary of the thinking process.
@@ -531,7 +531,7 @@ async def clear_history_mcp(request: ClearHistoryRequest) -> Metadata:
     operation="get_structured_session",
     error_code_prefix="STRUCTURED_THINKING_MCP",
 )
-@router.get("/sessions/{session_id}", response_model=None)
+@router.get("/sessions/{session_id}", response_model=DataResponse)
 async def get_structured_session(session_id: str) -> Metadata:
     """Get complete structured thinking session"""
     async with _structured_sessions_lock:

--- a/autobot-backend/api/usage.py
+++ b/autobot-backend/api/usage.py
@@ -134,7 +134,7 @@ async def get_usage_by_user_all(
     operation="get_usage_by_user_single",
     error_code_prefix="USAGE",
 )
-@router.get("/by-user/{user_id}", response_model=None)
+@router.get("/by-user/{user_id}", response_model=DataResponse)
 async def get_usage_by_user_single(
     user_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -153,7 +153,7 @@ async def get_usage_by_user_single(
     operation="get_my_usage",
     error_code_prefix="USAGE",
 )
-@router.get("/me", response_model=None)
+@router.get("/me", response_model=DataResponse)
 async def get_my_usage(
     current_user: dict = Depends(get_current_user),
 ) -> dict[str, Any]:

--- a/autobot-backend/api/validation_dashboard.py
+++ b/autobot-backend/api/validation_dashboard.py
@@ -159,7 +159,7 @@ class DashboardGenerateRequest(BaseModel):
     operation="get_dashboard_status",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.get("/status", response_model=None)
+@router.get("/status", response_model=DataResponse)
 async def get_dashboard_status():
     """Get validation dashboard service status"""
     generator = get_dashboard_generator()
@@ -695,7 +695,7 @@ async def judge_agent_response(request: dict):
     operation="get_judge_status",
     error_code_prefix="VALIDATION_DASHBOARD",
 )
-@router.get("/judge_status", response_model=None)
+@router.get("/judge_status", response_model=DataResponse)
 async def get_judge_status():
     """Get status of validation judges"""
     judges = get_validation_judges()

--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -192,7 +192,7 @@ async def voice_clone_api(
 # ------------------------------------------------------------------
 
 
-@router.get("/voices", response_model=None)
+@router.get("/voices", response_model=DataResponse)
 async def voice_list_api():
     """List available voice profiles from TTS worker."""
     tts = get_tts_client()
@@ -205,7 +205,7 @@ async def voice_list_api():
     operation="voice_create_api",
     error_code_prefix="VOICE",
 )
-@router.post("/voices/create", response_model=None)
+@router.post("/voices/create", response_model=DataResponse)
 async def voice_create_api(
     name: str = Form(...),
     audio: UploadFile = File(...),

--- a/autobot-backend/api/web_research_settings.py
+++ b/autobot-backend/api/web_research_settings.py
@@ -15,6 +15,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from api.schemas_common import DataResponse, SuccessResponse
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,7 @@ class ResearchPreferences(BaseModel):
     operation="get_research_status",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.get("/status", response_model=None)
+@router.get("/status", response_model=DataResponse)
 async def get_research_status():
     """Get current web research status and configuration"""
     try:
@@ -99,7 +100,7 @@ async def get_research_status():
     operation="enable_web_research",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.post("/enable", response_model=None)
+@router.post("/enable", response_model=DataResponse)
 async def enable_web_research():
     """Enable web research functionality"""
     try:
@@ -151,7 +152,7 @@ async def enable_web_research():
     operation="disable_web_research",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.post("/disable", response_model=None)
+@router.post("/disable", response_model=DataResponse)
 async def disable_web_research():
     """Disable web research functionality"""
     try:
@@ -203,7 +204,7 @@ async def disable_web_research():
     operation="get_research_settings",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.get("/settings", response_model=None)
+@router.get("/settings", response_model=DataResponse)
 async def get_research_settings():
     """Get current web research settings"""
     try:
@@ -255,7 +256,7 @@ async def get_research_settings():
     operation="update_research_settings",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.put("/settings", response_model=None)
+@router.put("/settings", response_model=DataResponse)
 async def update_research_settings(settings: WebResearchSettings):
     """Update web research settings"""
     try:
@@ -317,7 +318,7 @@ async def update_research_settings(settings: WebResearchSettings):
     operation="test_web_research",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.post("/test", response_model=None)
+@router.post("/test", response_model=DataResponse)
 async def test_web_research(query: str = "test query"):
     """Test web research functionality"""
     try:
@@ -360,7 +361,7 @@ async def test_web_research(query: str = "test query"):
     operation="clear_research_cache",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.post("/clear-cache", response_model=None)
+@router.post("/clear-cache", response_model=DataResponse)
 async def clear_research_cache():
     """Clear web research cache"""
     try:
@@ -392,7 +393,7 @@ async def clear_research_cache():
     operation="reset_circuit_breakers",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.post("/reset-circuit-breakers", response_model=None)
+@router.post("/reset-circuit-breakers", response_model=DataResponse)
 async def reset_circuit_breakers():
     """Reset all circuit breakers for web research"""
     try:
@@ -424,7 +425,7 @@ async def reset_circuit_breakers():
     operation="get_usage_stats",
     error_code_prefix="WEB_RESEARCH_SETTINGS",
 )
-@router.get("/usage-stats", response_model=None)
+@router.get("/usage-stats", response_model=DataResponse)
 async def get_usage_stats():
     """Get web research usage statistics"""
     try:


### PR DESCRIPTION
## Summary

- Converts 291 route handlers that had `response_model=None` without justification to `response_model=DataResponse`
- Preserves 24 legitimately-justified `response_model=None` endpoints:
  - Streaming/SSE: `stream_task_events`, `stream_message`, `stream_enhanced_chat`, `compare_models`, `stream_log`, `chat_completions`, `download_mhtml`, `export_usage_csv`
  - File download: `download_file`, `download_conversation_file`, `get_dashboard_file`
  - Audio binary: `voice_synthesize_api`, `voice_clone_api`
  - Non-JSON content: `export_cost_csv`, `export_agent_csv`, `export_usage_csv` (CSV), `export_prometheus` (Prometheus text), `metrics_endpoint`, `get_process_logs` (PlainText), `get_dashboard_html` (HTML)
  - Proxy/assets: `get_vnc_client`, `proxy_vnc_assets`, `proxy_npu_health`
  - Graph export: `export_cfg_dot` (.dot format)
- 44 files changed; all syntax-validated with `python3 -m py_compile`

## Behavioral grep audit

Before:
```bash
$ grep -rn "response_model=None" autobot-backend/api/ --include="*.py" | wc -l
315
```

After (only justified streaming/binary endpoints remain):
```bash
$ grep -rn "response_model=None" autobot-backend/api/ --include="*.py" | wc -l
24
```

All 24 remaining `response_model=None` entries are non-JSON responses verified by code inspection and automated pattern matching.

## Test plan
- [ ] `python3 -m py_compile` all 44 modified files — all pass
- [ ] FastAPI app starts without import errors (DataResponse already in schemas_common.py)
- [ ] OpenAPI schema at `/openapi.json` shows DataResponse for previously-None endpoints
- [ ] Streaming endpoints (stream_message, etc.) unaffected

Closes #5843

🤖 Generated with [Claude Code](https://claude.com/claude-code)