### PR TITLE
refact(api): add SuccessMessageResponse and SuccessDataResponse base models (#5844)

### DIFF
--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -22,6 +22,21 @@ from pydantic import BaseModel
 # ---------------------------------------------------------------------------
 
 
+class SuccessMessageResponse(BaseModel):
+    """Base for endpoints that always return success: bool + message: str."""
+
+    success: bool
+    message: str
+
+
+class SuccessDataResponse(BaseModel):
+    """Base for endpoints that return success, message, and an optional data dict."""
+
+    success: bool
+    message: str
+    data: Optional[Dict[str, Any]] = None
+
+
 class SuccessResponse(BaseModel):
     """Minimal success/failure envelope used by several endpoints."""
 
@@ -1862,11 +1877,8 @@ class MetricsMonitoringStartResponse(BaseModel):
     collection_interval: Optional[Any] = None
 
 
-class MetricsMonitoringStopResponse(BaseModel):
+class MetricsMonitoringStopResponse(SuccessMessageResponse):
     """Response for POST /system/monitoring/stop."""
-
-    success: bool
-    message: str
 
 
 class MetricsDashboardResponse(BaseModel):
@@ -2285,28 +2297,16 @@ class FeatureFlagStatusResponse(BaseModel):
     data: Optional[Any] = None
 
 
-class FeatureFlagEnforcementModeResponse(BaseModel):
+class FeatureFlagEnforcementModeResponse(SuccessDataResponse):
     """Response for PUT /feature-flags/enforcement-mode."""
 
-    success: bool
-    message: str
-    data: Optional[Dict[str, Any]] = None
 
-
-class FeatureFlagEndpointSetResponse(BaseModel):
+class FeatureFlagEndpointSetResponse(SuccessDataResponse):
     """Response for PUT /feature-flags/endpoint/{endpoint:path}."""
 
-    success: bool
-    message: str
-    data: Optional[Dict[str, Any]] = None
 
-
-class FeatureFlagEndpointRemoveResponse(BaseModel):
+class FeatureFlagEndpointRemoveResponse(SuccessDataResponse):
     """Response for DELETE /feature-flags/endpoint/{endpoint:path}."""
-
-    success: bool
-    message: str
-    data: Optional[Dict[str, Any]] = None
 
 
 class AccessControlMetricsResponse(BaseModel):
@@ -2330,11 +2330,8 @@ class AccessControlUserMetricsResponse(BaseModel):
     data: Optional[Any] = None
 
 
-class AccessControlCleanupResponse(BaseModel):
+class AccessControlCleanupResponse(SuccessMessageResponse):
     """Response for POST /access-control/cleanup."""
-
-    success: bool
-    message: str
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds two new shared base models to `schemas_common.py`:
  - `SuccessMessageResponse(BaseModel)`: `{success: bool, message: str}` — for endpoints that always return a success flag and required message
  - `SuccessDataResponse(BaseModel)`: `{success: bool, message: str, data: Optional[Dict[str, Any]]}` — for endpoints returning success + message + optional data dict
- Migrates 5 exact-match schemas to inherit from the appropriate base, eliminating field repetition:
  - `MetricsMonitoringStopResponse`, `AccessControlCleanupResponse` → `SuccessMessageResponse`
  - `FeatureFlagEnforcementModeResponse`, `FeatureFlagEndpointSetResponse`, `FeatureFlagEndpointRemoveResponse` → `SuccessDataResponse`
- `PaginatedListResponse` deferred: grep for `items:` + `total:` across all schemas found 0 candidates — not filed as a gap
- `SuccessResponse` kept as-is (uses `Optional[str]` for message — semantically distinct; kept for backward compatibility)

## Verification

```python
from api.schemas_common import (SuccessMessageResponse, SuccessDataResponse,
    MetricsMonitoringStopResponse, AccessControlCleanupResponse,
    FeatureFlagEnforcementModeResponse)

assert issubclass(MetricsMonitoringStopResponse, SuccessMessageResponse)  # ✅
assert issubclass(AccessControlCleanupResponse, SuccessMessageResponse)   # ✅
assert issubclass(FeatureFlagEnforcementModeResponse, SuccessDataResponse) # ✅
MetricsMonitoringStopResponse(success=True, message="stopped")            # ✅
FeatureFlagEnforcementModeResponse(success=True, message="ok", data={"mode": "strict"})  # ✅
```

All 5 inheritance assertions pass. Fields preserved identically (field order unchanged).

Closes #5844

🤖 Generated with [Claude Code](https://claude.com/claude-code)