### PR TITLE
fix(planner): wire available_tools default + byte logging + name collision + template trim (#5870-5873)

### DIFF
--- a/autobot-backend/llm_interface_pkg/interface.py
+++ b/autobot-backend/llm_interface_pkg/interface.py
@@ -1405,26 +1405,29 @@ class LLMInterface:
         from prompt_manager import get_optimized_prompt
         from tools import get_tool_registry
 
+        # Issue #5870: default to full registry when caller omits available_tools
+        if available_tools is None:
+            available_tools = get_tool_registry().get_available_tools()
+
         tool_descriptions: dict | None = None
-        if available_tools:
-            try:
-                registry = get_tool_registry()
-                raw_descs = {
-                    name: desc
-                    for name, desc in (
-                        await registry.get_compressed_descriptions()
-                    ).items()
-                    if name in available_tools
-                }
-                before_bytes = sum(len(d) for d in raw_descs.values())
-                tool_descriptions = raw_descs
-                logger.debug(
-                    "[#5827] Compressed tool descriptions: %d tools, %d bytes",
-                    len(tool_descriptions),
-                    before_bytes,
-                )
-            except Exception:
-                logger.warning("[#5827] compress_description failed; falling back to tool names only", exc_info=True)
+        try:
+            registry = get_tool_registry()
+            tool_set = set(available_tools)
+            uncompressed = {n: d for n, d in registry.get_raw_descriptions().items() if n in tool_set}
+            compressed_map = await registry.get_compressed_descriptions()
+            tool_descriptions = {n: d for n, d in compressed_map.items() if n in tool_set}
+            uncompressed_bytes = sum(len(d) for d in uncompressed.values())
+            compressed_bytes = sum(len(d) for d in tool_descriptions.values())
+            saving_pct = (1 - compressed_bytes / uncompressed_bytes) * 100 if uncompressed_bytes else 0
+            logger.debug(
+                "[#5827] Tool desc savings: %d tools, %d → %d bytes (%.0f%% reduction)",
+                len(tool_descriptions),
+                uncompressed_bytes,
+                compressed_bytes,
+                saving_pct,
+            )
+        except Exception:
+            logger.warning("[#5827] compress_description failed; falling back to tool names only", exc_info=True)
 
         system_prompt = get_optimized_prompt(
             base_prompt_key=get_base_prompt_for_agent(agent_type),

--- a/autobot-backend/resources/prompts/default/agent.system.dynamic_context.md
+++ b/autobot-backend/resources/prompts/default/agent.system.dynamic_context.md
@@ -10,17 +10,17 @@
 - Role: {{ user_role | default("Standard User") }}
 
 **Available Tools:**
-{% if available_tools %}
-{% if tool_descriptions %}
-{% for tool in available_tools %}
+{%- if available_tools %}
+{%- if tool_descriptions %}
+{%- for tool in available_tools %}
 - {{ tool }}: {{ tool_descriptions.get(tool, tool) }}
-{% endfor %}
-{% else %}
+{%- endfor %}
+{%- else %}
 {{ available_tools | join(", ") }}
-{% endif %}
-{% else %}
+{%- endif %}
+{%- else %}
 All standard AutoBot tools
-{% endif %}
+{%- endif %}
 
 **Recent Context:**
 {% if recent_context %}

--- a/autobot-backend/tools/tool_registry.py
+++ b/autobot-backend/tools/tool_registry.py
@@ -489,9 +489,10 @@ class ToolRegistry:
             is not in the SDK registry.
         """
         try:
-            from tool_sdk.registry import ToolNotFoundError, get_tool_registry
+            from tool_sdk.registry import ToolNotFoundError  # noqa: PLC0415
+            from tool_sdk.registry import get_tool_registry as _get_sdk_registry  # noqa: PLC0415
 
-            registry = get_tool_registry()
+            registry = _get_sdk_registry()
             # Probe registry without instantiating — raises ToolNotFoundError if absent
             try:
                 registry.get(tool_name)
@@ -546,6 +547,30 @@ class ToolRegistry:
             "status": "error",
         }
 
+    def _tool_description(self, name: str) -> str:
+        """Return the raw (uncompressed) description for a single tool. Issue #5871."""
+        import inspect  # noqa: PLC0415
+
+        method = getattr(self, name, None)
+        if method is not None:
+            doc = inspect.getdoc(method)
+            if doc:
+                return doc.split("\n")[0]
+        try:
+            from chat_workflow.tool_handler import _BUILTIN_TOOL_SCHEMAS  # noqa: PLC0415
+
+            schema = _BUILTIN_TOOL_SCHEMAS.get(name, {})
+            desc = (schema or {}).get("description", "")
+            if desc:
+                return desc
+        except ImportError:
+            pass
+        return name
+
+    def get_raw_descriptions(self) -> Dict[str, str]:
+        """Return uncompressed descriptions for all registered tools. Issue #5871."""
+        return {name: self._tool_description(name) for name in self.get_available_tools()}
+
     async def get_compressed_descriptions(self) -> Dict[str, str]:
         """Return a mapping of tool_name -> compressed description for all registered tools.
 
@@ -553,38 +578,20 @@ class ToolRegistry:
         caching and Ollama LLM compression.  Falls back to the tool name string for
         any tool whose description cannot be resolved.
         """
-        import inspect  # noqa: PLC0415
-
         from tools.description_compressor import compress_description  # noqa: PLC0415
 
-        def _get_description(name: str) -> str:
-            # Registry tools: use method docstring first line
-            method = getattr(self, name, None)
-            if method is not None:
-                doc = inspect.getdoc(method)
-                if doc:
-                    return doc.split("\n")[0]
-            # Browser/builtin tools: use Anthropic schema description
-            try:
-                from chat_workflow.tool_handler import _BUILTIN_TOOL_SCHEMAS  # noqa: PLC0415
-
-                schema = _BUILTIN_TOOL_SCHEMAS.get(name, {})
-                desc = (schema or {}).get("description", "")
-                if desc:
-                    return desc
-            except ImportError:
-                pass
-            return name  # last resort
-
         tool_names = self.get_available_tools()
-        tasks = [compress_description(name, {"description": _get_description(name)}) for name in tool_names]
+        tasks = [
+            compress_description(name, {"description": self._tool_description(name)})
+            for name in tool_names
+        ]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         compressed: Dict[str, str] = {}
         for name, result in zip(tool_names, results):
             if isinstance(result, Exception):
                 logger.warning("compress_description failed for tool '%s': %s", name, result)
-                compressed[name] = name
+                compressed[name] = self._tool_description(name)
             else:
                 compressed[name] = result
         return compressed


### PR DESCRIPTION
## Summary

Fixes 4 discovery issues from #5827 post-merge audit.

- **#5870** — `chat_completion_optimized` now defaults `available_tools` to `get_tool_registry().get_available_tools()` when caller omits it — activates compression for all 7 specialized agents without touching each agent file
- **#5871** — Extract `_tool_description(name)` as a shared method; add `get_raw_descriptions()` that returns uncompressed descriptions; interface.py now logs `"Tool desc savings: N tools, U → C bytes (X% reduction)"` showing real before/after savings
- **#5872** — Rename SDK local import inside `execute_tool_sdk_tool()` to `_get_sdk_registry` — eliminates name collision with module-level `get_tool_registry = lazy_singleton(ToolRegistry)`
- **#5873** — Add `{%- / -%}` whitespace control to the Jinja2 tool loop in `agent.system.dynamic_context.md` — N tools now renders N lines instead of ~2N

## Test plan
- [ ] `python3 -m py_compile` passes on all modified Python files ✅
- [ ] Template renders `**Available Tools:**\n- tool: desc\n- tool2: desc2\n` with no blank lines ✅ (verified via `repr()` check)
- [ ] `available_tools is None` → defaults to full registry list; compression always fires
- [ ] `logger.debug("[#5827] Tool desc savings: ...")` includes uncompressed_bytes, compressed_bytes, saving_pct
- [ ] `_get_sdk_registry` correctly aliases `tool_sdk.registry.get_tool_registry` within `execute_tool_sdk_tool()`

Closes #5870, #5871, #5872, #5873

🤖 Generated with [Claude Code](https://claude.com/claude-code)