### PR TITLE
feat(tools): add ToolOutputFilter service with YAML config and integration (#5862)

### DIFF
--- a/autobot-backend/api/git_mcp.py
+++ b/autobot-backend/api/git_mcp.py
@@ -47,7 +47,10 @@ from autobot_shared.security.path_validator import validate_path
 from autobot_shared.ssot_config import PROJECT_ROOT
 from autobot_shared.time_utils import now_utc
 from constants.threshold_constants import QueryDefaults
+from services.tool_output_filter import ToolOutputFilter
 from type_defs.common import JSONObject, Metadata
+
+_output_filter = ToolOutputFilter()
 
 logger = logging.getLogger(__name__)
 
@@ -298,9 +301,10 @@ async def _run_git_process(cmd: List[str], repo_path: str, timeout: int) -> Meta
     stdout_str = stdout.decode("utf-8", errors="replace")
     stderr_str = stderr.decode("utf-8", errors="replace")
 
-    # Check output size
+    # Check output size, then apply semantic filter
     if len(stdout_str) > MAX_OUTPUT_SIZE:
-        stdout_str = stdout_str[:MAX_OUTPUT_SIZE] + "\n... (output truncated)"
+        stdout_str = stdout_str[:MAX_OUTPUT_SIZE]
+    stdout_str = _output_filter.filter(" ".join(cmd[:3]), stdout_str)
 
     return {
         "success": process.returncode == 0,

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -30,8 +30,10 @@ from .llm_handler import LLMHandlerMixin, _emit_after_continuation, _emit_before
 from .models import LLMIterationContext, StreamingMessage, WorkflowSession
 from .session_handler import SessionHandlerMixin, _emit_approval_received, _emit_approval_required
 from .tool_handler import ToolHandlerMixin
+from services.tool_output_filter import ToolOutputFilter
 
 logger = logging.getLogger(__name__)
+_output_filter = ToolOutputFilter()
 
 # Issue #380: Module-level frozenset for terminal message types
 _TERMINAL_MESSAGE_TYPES: FrozenSet[str] = frozenset(
@@ -1682,10 +1684,7 @@ class ChatWorkflowManager(
         if stderr:
             output_text += f"\nStderr: {stderr}"
 
-        # Issue #650: Increased from 500 to 2000 for better continuation context
-        max_output_len = 2000
-        if len(output_text) > max_output_len:
-            output_text = output_text[:max_output_len] + "\n... (output truncated)"
+        output_text = _output_filter.filter(cmd, output_text)
 
         return f"**Step {step_num}:** `{cmd}`\n- Status: {status}\n- Output:\n```\n{output_text}\n```"
 

--- a/autobot-backend/config/tool_output_filters.yaml
+++ b/autobot-backend/config/tool_output_filters.yaml
@@ -1,0 +1,67 @@
+# Tool output filter rules for ToolOutputFilter service.
+# Each key under `filters:` is a named rule; first match on match_command wins.
+#
+# Pipeline stages (applied in order when present):
+#   strip_ansi           — remove ANSI/VT100 escape codes
+#   match_output         — if output matches pattern, replace with short message
+#   strip_lines_matching — drop lines matching any regex
+#   keep_lines_matching  — keep only lines matching any regex
+#   dedup_consecutive    — collapse repeated consecutive lines into "line [×N]"
+#   max_lines            — keep last N lines
+#   on_empty             — message returned when filtered result is empty
+
+filters:
+  git_write:
+    match_command: "^git (add|push|pull|commit|fetch|merge|rebase|stash)"
+    strip_ansi: true
+    match_output:
+      - pattern: "Everything up-to-date"
+        message: "ok (already up-to-date)"
+      - pattern: "nothing to commit"
+        message: "ok (nothing to commit)"
+    max_lines: 15
+
+  pytest:
+    match_command: "^pytest"
+    strip_ansi: true
+    strip_lines_matching:
+      - "^test_.* PASSED"
+      - "^\\."
+      - "^s$"
+      - "^platform "
+      - "^rootdir:"
+      - "^plugins:"
+      - "^collecting \\.\\.\\."
+    max_lines: 150
+    on_empty: "All tests passed"
+
+  npm_test:
+    match_command: "^npm (test|run test|run lint|run build|run type-check)"
+    strip_ansi: true
+    strip_lines_matching:
+      - "^  ✓ "
+      - "^  ✔ "
+      - "^  pass "
+    max_lines: 150
+
+  ruff_eslint:
+    match_command: "^(ruff|eslint|flake8|mypy|black)"
+    strip_ansi: true
+    max_lines: 100
+
+  docker_logs:
+    match_command: "^docker (logs|compose logs)"
+    strip_ansi: true
+    dedup_consecutive: true
+    max_lines: 60
+
+  pip_install:
+    match_command: "^pip(3)? install"
+    strip_ansi: true
+    strip_lines_matching:
+      - "^Requirement already satisfied"
+      - "^Collecting "
+      - "^  Downloading "
+      - "^  Using cached "
+    max_lines: 20
+    on_empty: "ok (all requirements already satisfied)"

--- a/autobot-backend/services/tool_output_filter.py
+++ b/autobot-backend/services/tool_output_filter.py
@@ -1,0 +1,116 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+ToolOutputFilter — declarative pipeline for cleaning command stdout before it
+reaches the LLM.  Replaces naive byte-slice truncation at scattered sites.
+
+Usage::
+
+    from services.tool_output_filter import ToolOutputFilter
+    _filter = ToolOutputFilter()
+    clean = _filter.filter("pytest tests/", raw_output)
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CONFIG = os.path.join(
+    os.path.dirname(__file__), "..", "config", "tool_output_filters.yaml"
+)
+
+
+class ToolOutputFilter:
+    """Apply a rule-based pipeline to tool command output."""
+
+    def __init__(self, config_path: str | None = None) -> None:
+        path = config_path or _DEFAULT_CONFIG
+        try:
+            with open(path, encoding="utf-8") as fh:
+                cfg = yaml.safe_load(fh) or {}
+            self._rules: list[dict[str, Any]] = list(cfg.get("filters", {}).values())
+        except FileNotFoundError:
+            logger.warning("tool_output_filter: config not found at %s", path)
+            self._rules = []
+        except Exception:
+            logger.exception("tool_output_filter: failed to load config from %s", path)
+            self._rules = []
+
+    def filter(self, command: str, output: str) -> str:
+        """Return filtered *output* for *command*.  Passthrough if no rule matches."""
+        rule = self._match_rule(command)
+        if rule is None:
+            return output
+        return self._apply(rule, output)
+
+    def _match_rule(self, command: str) -> dict[str, Any] | None:
+        cmd = command.strip()
+        for rule in self._rules:
+            pattern = rule.get("match_command", "")
+            if pattern and re.search(pattern, cmd):
+                return rule
+        return None
+
+    def _apply(self, rule: dict[str, Any], text: str) -> str:
+        if rule.get("strip_ansi"):
+            text = _strip_ansi(text)
+
+        if "match_output" in rule:
+            for entry in rule["match_output"]:
+                if re.search(entry["pattern"], text, re.MULTILINE):
+                    return entry["message"]
+
+        if "strip_lines_matching" in rule:
+            patterns = [re.compile(p) for p in rule["strip_lines_matching"]]
+            text = "\n".join(
+                line for line in text.splitlines()
+                if not any(p.search(line) for p in patterns)
+            )
+
+        if "keep_lines_matching" in rule:
+            patterns = [re.compile(p) for p in rule["keep_lines_matching"]]
+            text = "\n".join(
+                line for line in text.splitlines()
+                if any(p.search(line) for p in patterns)
+            )
+
+        if rule.get("dedup_consecutive"):
+            text = _dedup_consecutive(text)
+
+        max_lines = rule.get("max_lines")
+        if max_lines and max_lines > 0:
+            lines = text.splitlines()
+            if len(lines) > max_lines:
+                text = "\n".join(lines[-max_lines:])
+
+        if not text.strip():
+            return rule.get("on_empty", "")
+
+        return text
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mGKHF]")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _dedup_consecutive(text: str) -> str:
+    lines = text.splitlines()
+    result: list[str] = []
+    count = 1
+    for i, line in enumerate(lines):
+        if i + 1 < len(lines) and lines[i + 1] == line:
+            count += 1
+        else:
+            result.append(f"{line} [×{count}]" if count > 1 else line)
+            count = 1
+    return "\n".join(result)

--- a/autobot-backend/tests/services/test_tool_output_filter.py
+++ b/autobot-backend/tests/services/test_tool_output_filter.py
@@ -1,0 +1,109 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for ToolOutputFilter pipeline stages."""
+import os
+import tempfile
+
+import yaml
+
+from services.tool_output_filter import ToolOutputFilter, _strip_ansi, _dedup_consecutive
+
+
+def _make_filter(rules: dict) -> ToolOutputFilter:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+    ) as fh:
+        yaml.dump({"filters": rules}, fh)
+        path = fh.name
+    try:
+        return ToolOutputFilter(config_path=path)
+    finally:
+        os.unlink(path)
+
+
+def test_strip_ansi_removes_color_codes():
+    assert _strip_ansi("\x1b[31mRED\x1b[0m") == "RED"
+
+
+def test_strip_ansi_passthrough_clean():
+    assert _strip_ansi("hello world") == "hello world"
+
+
+def test_dedup_consecutive_collapses():
+    assert _dedup_consecutive("a\na\na\nb\nb\nc") == "a [×3]\nb [×2]\nc"
+
+
+def test_dedup_consecutive_no_repeats():
+    assert _dedup_consecutive("a\nb\nc") == "a\nb\nc"
+
+
+def test_passthrough_when_no_rule():
+    f = _make_filter({})
+    output = "some\noutput\nhere"
+    assert f.filter("cat file.txt", output) == output
+
+
+def test_strip_ansi_stage():
+    f = _make_filter({"r": {"match_command": "^cmd", "strip_ansi": True}})
+    assert f.filter("cmd arg", "\x1b[32mgreen\x1b[0m text") == "green text"
+
+
+def test_match_output_short_circuit():
+    f = _make_filter({
+        "r": {"match_command": "^git", "match_output": [{"pattern": "Everything up-to-date", "message": "ok"}]},
+    })
+    assert f.filter("git push", "Everything up-to-date\nmore stuff") == "ok"
+
+
+def test_match_output_no_match_continues():
+    f = _make_filter({
+        "r": {"match_command": "^git", "match_output": [{"pattern": "Everything up-to-date", "message": "ok"}], "max_lines": 5},
+    })
+    assert "branch pushed" in f.filter("git push", "branch pushed\nremote updated")
+
+
+def test_strip_lines_matching():
+    f = _make_filter({"r": {"match_command": "^pytest", "strip_lines_matching": ["^test_.* PASSED"]}})
+    result = f.filter("pytest tests/", "test_foo PASSED\ntest_bar FAILED\ntest_baz PASSED")
+    assert "PASSED" not in result
+    assert "test_bar FAILED" in result
+
+
+def test_keep_lines_matching():
+    f = _make_filter({"r": {"match_command": "^ruff", "keep_lines_matching": ["error"]}})
+    result = f.filter("ruff check .", "info: checking\nerror: bad code L10\ninfo: done")
+    assert result.strip() == "error: bad code L10"
+
+
+def test_dedup_consecutive_stage():
+    f = _make_filter({"r": {"match_command": "^docker", "dedup_consecutive": True}})
+    result = f.filter("docker logs myapp", "log line\nlog line\nlog line\ndifferent")
+    assert "log line [×3]" in result
+    assert "different" in result
+
+
+def test_max_lines_truncates_to_last_n():
+    f = _make_filter({"r": {"match_command": "^cmd", "max_lines": 3}})
+    assert f.filter("cmd", "\n".join(str(i) for i in range(10))) == "7\n8\n9"
+
+
+def test_on_empty_returned_when_filtered_result_empty():
+    f = _make_filter({"r": {"match_command": "^pytest", "strip_lines_matching": [".*"], "on_empty": "All tests passed"}})
+    assert f.filter("pytest tests/", "test_foo PASSED\ntest_bar PASSED") == "All tests passed"
+
+
+def test_real_config_loads():
+    f = ToolOutputFilter()
+    assert isinstance(f._rules, list)
+
+
+def test_real_config_git_rule_matches():
+    f = ToolOutputFilter()
+    assert "already up-to-date" in f.filter("git push origin main", "Everything up-to-date")
+
+
+def test_real_config_passthrough_unknown_command():
+    f = ToolOutputFilter()
+    output = "hello\nworld"
+    assert f.filter("my_custom_script.sh", output) == output

--- a/autobot-backend/tools/code_interpreter.py
+++ b/autobot-backend/tools/code_interpreter.py
@@ -22,9 +22,12 @@ import sys
 import tempfile
 from typing import Dict, Any
 
+from services.tool_output_filter import ToolOutputFilter
+
 logger = logging.getLogger(__name__)
 
 MAX_OUTPUT_BYTES = 10 * 1024  # 10 KB per stream
+_output_filter = ToolOutputFilter()
 
 
 def execute_code(code: str, timeout_seconds: int = 30) -> Dict[str, Any]:
@@ -64,8 +67,11 @@ def execute_code(code: str, timeout_seconds: int = 30) -> Dict[str, Any]:
             len(raw_stdout) > MAX_OUTPUT_BYTES or len(raw_stderr) > MAX_OUTPUT_BYTES
         )
 
+        stdout_text = _output_filter.filter(
+            "python", raw_stdout[:MAX_OUTPUT_BYTES].decode("utf-8", errors="replace")
+        )
         return {
-            "stdout": raw_stdout[:MAX_OUTPUT_BYTES].decode("utf-8", errors="replace"),
+            "stdout": stdout_text,
             "stderr": raw_stderr[:MAX_OUTPUT_BYTES].decode("utf-8", errors="replace"),
             "exit_code": result.returncode,
             "truncated": truncated,


### PR DESCRIPTION
## Summary
- Creates `autobot-backend/services/tool_output_filter.py` — declarative 7-stage pipeline (strip_ansi, match_output, strip_lines_matching, keep_lines_matching, dedup_consecutive, max_lines, on_empty)
- Creates `autobot-backend/config/tool_output_filters.yaml` — rules for git, pytest, npm, ruff/eslint, docker, pip
- Creates `autobot-backend/tests/services/test_tool_output_filter.py` — 16 unit tests, all passing
- Wires into 3 existing truncation sites: `tools/code_interpreter.py`, `chat_workflow/manager.py`, `api/git_mcp.py`
- `secure_command_executor.py` already calls `strip_ansi_codes` via `execute_shell_command` — no change needed

## Test Plan
- [x] 16 unit tests: all pipeline stages tested independently + real config smoke tests
- [x] Syntax check on all modified Python files

Closes #5862

🤖 Generated with Claude Code