### PR TITLE
docs(composables): document counter-based loading in useCodeIntelligence (#5880)

### DIFF
--- a/autobot-frontend/src/composables/useCodeIntelligence.ts
+++ b/autobot-frontend/src/composables/useCodeIntelligence.ts
@@ -145,6 +145,9 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
   const trends = ref<AnalysisTrend[]>([])
   const securityScoreCached = ref<SecurityScoreCached | null>(null)
   const isLoading = ref(false)
+  // Counter-based concurrency: isLoading clears only when all concurrent analysis
+  // operations finish. useLoadingState.wrap() does not support this — it clears
+  // loading per-call, not per-set. Skip migrating this composable (#5880).
   const loadingCount = ref(0)
   const errors = ref<string[]>([])
   const error = computed<string | null>(() =>


### PR DESCRIPTION
## Summary
- Added comment to `useCodeIntelligence.ts` explaining why the counter-based `loadingCount` pattern is intentionally not migrated to `useLoadingState`
- Counter tracks concurrent operations (isLoading stays true until ALL finish); `useLoadingState.wrap()` clears per-call and cannot replicate this

## Related
Closes #5880

🤖 Generated with [Claude Code](https://claude.com/claude-code)