### PR TITLE
docs(workflow): add squash-duplicate detection gate to pre-merge-validate (#5841)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,7 @@ When spawning multiple agents for batch work with `/batch-implement`:
 
 After agents complete:
 
+0. **Gate 0 — Squash-duplicate check:** For each PR branch, run the squash-duplicate detection command (see `docs/developer/CLAUDE_WORKFLOW.md` "Gate 0") to verify no commits are already in `Dev_new_gui`. If all commits are duplicates, close the issue without merging.
 1. **Enumerate ALL open PRs:** `gh pr list --state open` to count expected PRs before starting review.
 2. **Track in checklist:** One line per PR to verify nothing is skipped.
 3. **Review each PR:**
@@ -279,6 +280,7 @@ Sub-agents without Bash permissions cannot complete git operations and will stal
 
 **Use `/pre-merge-validate <PR>` before merging any code:**
 
+0. **Squash-Duplicate Detection:** Run Gate 0 (see `docs/developer/CLAUDE_WORKFLOW.md`) to detect commits already squash-merged to `Dev_new_gui` — avoids wasted merge work on already-landed changes.
 1. **Syntax + Imports:** Catches SyntaxError, ImportError
 2. **Call-Site Impact:** Finds removed functions with live callers (prevents `_init_redis()` incidents)
 3. **Function Signatures:** Detects signature changes with existing callers

--- a/docs/developer/CLAUDE_WORKFLOW.md
+++ b/docs/developer/CLAUDE_WORKFLOW.md
@@ -159,3 +159,65 @@ Subagents cannot autonomously acquire Bash permission. Run batch file-manipulati
 **Self-Improvement:** After corrections, update `tasks/lessons.md`.
 
 **Elegance Gate:** For non-trivial changes, pause and ask "Is there a more elegant way?" — but elegance means the simplest correct solution.
+
+---
+
+## Pre-Merge Validation
+
+Run these gates before creating a PR or merging any branch. Gates are ordered by cost — cheapest first.
+
+### Gate 0: Squash-Duplicate Detection
+
+Before running any other validation, check whether the branch contains commits that are already squash-merged to `Dev_new_gui`. A squash merge collapses N commits into one, so the individual commit SHAs differ even though the diff is identical. `git log --cherry-pick` detects this by comparing patch IDs rather than SHAs.
+
+```bash
+# Gate 0: Squash-Duplicate Detection
+DUPES=$(git log --cherry-pick --right-only origin/Dev_new_gui...$BRANCH --oneline 2>/dev/null | wc -l)
+TOTAL=$(git log origin/Dev_new_gui...$BRANCH --oneline 2>/dev/null | wc -l)
+NEW=$((TOTAL - DUPES))
+if [ "$DUPES" -gt 0 ]; then
+  echo "WARNING: $DUPES of $TOTAL commit(s) already squash-merged to Dev_new_gui — $NEW truly new"
+  git log --cherry-pick --right-only origin/Dev_new_gui...$BRANCH --format="  %H %s"
+fi
+```
+
+**If DUPES == TOTAL:** The entire branch is already in `Dev_new_gui`. Close the issue without creating a PR — the work is done.
+
+**If DUPES > 0 but < TOTAL:** Some commits are new. Rebase the branch onto `origin/Dev_new_gui` to drop the duplicate patches before opening a PR. This prevents merge conflicts and duplicate hunks in the diff.
+
+**If DUPES == 0:** No duplicates — proceed to Gate 1.
+
+### Gate 1: Syntax and Imports
+
+```bash
+# Backend
+python -m py_compile <changed_files>
+python -c 'import <module>' for each modified file
+
+# Frontend
+npx tsc --noEmit -p autobot-vue/tsconfig.app.json
+```
+
+### Gate 2: Call-Site Impact
+
+For every function removed or renamed, grep all callers and verify none are broken:
+
+```bash
+grep -r "old_function_name" --include="*.py" src/
+grep -r "oldFunctionName" --include="*.ts" --include="*.vue" autobot-vue/src/
+```
+
+### Gate 3: Targeted Tests
+
+Run tests only for changed files to keep validation fast:
+
+```bash
+python -m pytest tests/$(dirname <changed_file>) -x -q
+```
+
+### Gate 4: Linting
+
+```bash
+python -m black --check <changed_files>
+npm run lint --prefix autobot-vue 2>&1 | grep "error"
+```


### PR DESCRIPTION
## Summary
- Added Gate 0 (squash-duplicate detection) to `CLAUDE_WORKFLOW.md` Pre-Merge Validation section
- Added Gate 0 one-liner to `CLAUDE.md` PR Review checklist and Validation Gates sections
- Uses `git log --cherry-pick --right-only` to detect commits already squash-merged under a different SHA

## Related
Closes #5841

🤖 Generated with [Claude Code](https://claude.com/claude-code)