### PR TITLE
fix(composables): add _pending counter to useLoadingState + unit tests (#5881 #5883)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useLoadingState.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useLoadingState.test.ts
@@ -1,0 +1,122 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+//
+// Tests for useLoadingState (#5881, #5883)
+
+import { describe, it, expect } from 'vitest'
+import { nextTick } from 'vue'
+import { useLoadingState } from '../useLoadingState'
+
+function deferred<T>() {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('useLoadingState', () => {
+  it('initializes isLoading=false by default', () => {
+    const { isLoading } = useLoadingState()
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('initializes isLoading=true when initial=true', () => {
+    const { isLoading } = useLoadingState(true)
+    expect(isLoading.value).toBe(true)
+  })
+
+  it('sets isLoading=true while wrap is running', async () => {
+    const { isLoading, wrap } = useLoadingState()
+    const d = deferred<number>()
+    const resultPromise = wrap(() => d.promise)
+    await nextTick()
+    expect(isLoading.value).toBe(true)
+    d.resolve(42)
+    await resultPromise
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('returns the resolved value from wrap', async () => {
+    const { wrap } = useLoadingState()
+    const result = await wrap(() => Promise.resolve('hello'))
+    expect(result).toBe('hello')
+  })
+
+  it('clears isLoading=false after wrap completes', async () => {
+    const { isLoading, wrap } = useLoadingState()
+    await wrap(() => Promise.resolve(1))
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('clears isLoading=false even when wrap throws', async () => {
+    const { isLoading, wrap } = useLoadingState()
+    await wrap(() => Promise.reject(new Error('boom'))).catch(() => {})
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('propagates errors thrown inside wrap', async () => {
+    const { wrap } = useLoadingState()
+    await expect(wrap(() => Promise.reject(new Error('fail')))).rejects.toThrow('fail')
+  })
+
+  it('does NOT clear isLoading prematurely when two calls overlap (#5883)', async () => {
+    const { isLoading, wrap } = useLoadingState()
+    const d1 = deferred<number>()
+    const d2 = deferred<number>()
+
+    const p1 = wrap(() => d1.promise)
+    const p2 = wrap(() => d2.promise)
+    await nextTick()
+
+    expect(isLoading.value).toBe(true)
+
+    // op1 finishes first — isLoading must stay true because op2 is still running
+    d1.resolve(1)
+    await p1
+    expect(isLoading.value).toBe(true)
+
+    // op2 finishes — now isLoading can clear
+    d2.resolve(2)
+    await p2
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('handles many concurrent calls and only clears after last one', async () => {
+    const { isLoading, wrap } = useLoadingState()
+    const defers = Array.from({ length: 5 }, () => deferred<number>())
+    const promises = defers.map((d) => wrap(() => d.promise))
+
+    await nextTick()
+    expect(isLoading.value).toBe(true)
+
+    // resolve first 4 — still loading
+    for (let i = 0; i < 4; i++) {
+      defers[i].resolve(i)
+      await promises[i]
+      expect(isLoading.value).toBe(true)
+    }
+
+    // resolve last one — now done
+    defers[4].resolve(4)
+    await promises[4]
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('resets correctly for sequential calls', async () => {
+    const { isLoading, wrap } = useLoadingState()
+    await wrap(() => Promise.resolve(1))
+    expect(isLoading.value).toBe(false)
+
+    const d = deferred<number>()
+    const p = wrap(() => d.promise)
+    await nextTick()
+    expect(isLoading.value).toBe(true)
+    d.resolve(2)
+    await p
+    expect(isLoading.value).toBe(false)
+  })
+})

--- a/autobot-frontend/src/composables/useLoadingState.ts
+++ b/autobot-frontend/src/composables/useLoadingState.ts
@@ -20,14 +20,15 @@ export function useLoadingState(initial = false): {
   isLoading: Ref<boolean>
   wrap: <T>(fn: () => Promise<T>) => Promise<T>
 } {
+  let _pending = 0
   const isLoading = ref(initial)
 
   async function wrap<T>(fn: () => Promise<T>): Promise<T> {
-    isLoading.value = true
+    if (++_pending === 1) isLoading.value = true
     try {
       return await fn()
     } finally {
-      isLoading.value = false
+      if (--_pending === 0) isLoading.value = false
     }
   }
 


### PR DESCRIPTION
## Summary

- Fixes #5883: `wrap()` now uses a `_pending` counter — only the last concurrent call to finish clears `isLoading`
- Fixes #5881: adds 9 unit tests covering initialization, in-flight state, return values, error propagation, concurrent overlap (the key race), and sequential reuse

## The bug

Before: first of N concurrent ops finishing would set `isLoading=false` while others ran.
After: `_pending` counts in-flight calls; `isLoading` clears only when `_pending` reaches 0.

## Test plan

- [ ] `npm test` — 9 new tests pass, existing suite unaffected

Closes #5881
Closes #5883

🤖 Generated with [Claude Code](https://claude.ai/claude-code)