### PR TITLE
fix(api): revert response_model=DataResponse to None for plain-dict endpoints (#5896)

### DIFF
--- a/autobot-backend/api/a2a.py
+++ b/autobot-backend/api/a2a.py
@@ -202,7 +202,7 @@ async def get_signed_agent_card(request: Request) -> Dict[str, Any]:
     summary="Submit A2A task",
     tags=["a2a"],
     status_code=202,
-    response_model=DataResponse,
+    response_model=None,
 )
 async def submit_task(
     body: TaskSendRequest,
@@ -403,7 +403,7 @@ async def stream_task_events(task_id: str) -> StreamingResponse:
     "/tasks/{task_id}/trace",
     summary="Get A2A task audit trace",
     tags=["a2a"],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def get_task_trace(task_id: str) -> Dict[str, Any]:
     """
@@ -429,7 +429,7 @@ async def get_task_trace(task_id: str) -> Dict[str, Any]:
     "/tasks/{task_id}",
     summary="Cancel A2A task",
     tags=["a2a"],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def cancel_task(task_id: str) -> Dict[str, str]:
     """Cancel a pending or in-progress task."""
@@ -449,7 +449,7 @@ async def cancel_task(task_id: str) -> Dict[str, str]:
     "/stats",
     summary="A2A task statistics",
     tags=["a2a"],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def task_stats() -> Dict[str, Any]:
     """Return task counts broken down by state."""

--- a/autobot-backend/api/analytics_architecture.py
+++ b/autobot-backend/api/analytics_architecture.py
@@ -1271,7 +1271,7 @@ async def analyze_architecture(
     )
 
 
-@router.get("/patterns", response_model=DataResponse, summary="List available pattern types")
+@router.get("/patterns", response_model=None, summary="List available pattern types")
 async def list_pattern_types(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
@@ -1294,7 +1294,7 @@ async def list_pattern_types(
     return {"patterns": patterns, "total": len(patterns)}
 
 
-@router.get("/quick-scan", response_model=DataResponse, summary="Quick architecture scan")
+@router.get("/quick-scan", response_model=None, summary="Quick architecture scan")
 async def quick_scan(
     admin_check: bool = Depends(check_admin_permission),
     path: str = Query("backend/api/", description="Path to scan"),
@@ -1327,7 +1327,7 @@ async def quick_scan(
     }
 
 
-@router.get("/layers", response_model=DataResponse, summary="Get architecture layers")
+@router.get("/layers", response_model=None, summary="Get architecture layers")
 async def get_layers(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
@@ -1351,7 +1351,7 @@ async def get_layers(
     }
 
 
-@router.get("/diagram", response_model=DataResponse, summary="Generate architecture diagram")
+@router.get("/diagram", response_model=None, summary="Generate architecture diagram")
 async def get_diagram(
     admin_check: bool = Depends(check_admin_permission),
     format: str = Query("mermaid", description="Diagram format"),
@@ -1376,7 +1376,7 @@ async def get_diagram(
     }
 
 
-@router.get("/consistency", response_model=DataResponse, summary="Check pattern consistency")
+@router.get("/consistency", response_model=None, summary="Check pattern consistency")
 async def check_consistency(
     admin_check: bool = Depends(check_admin_permission),
     pattern: Optional[PatternType] = Query(None, description="Specific pattern"),
@@ -1405,7 +1405,7 @@ async def check_consistency(
     }
 
 
-@router.get("/health", response_model=DataResponse, summary="Health check")
+@router.get("/health", response_model=None, summary="Health check")
 async def health_check(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:

--- a/autobot-backend/api/analytics_bug_prediction.py
+++ b/autobot-backend/api/analytics_bug_prediction.py
@@ -1042,7 +1042,7 @@ async def get_cached_bug_prediction():
     return _no_data_response("No cached bug prediction available")
 
 
-@router.post("/analyze", response_model=DataResponse)
+@router.post("/analyze", response_model=None)
 async def start_bug_analysis(
     background_tasks: BackgroundTasks,
     admin_check: bool = Depends(check_admin_permission),
@@ -1072,7 +1072,7 @@ async def get_bug_prediction_status(
     return task
 
 
-@router.post("/tasks/clear-stuck", response_model=DataResponse)
+@router.post("/tasks/clear-stuck", response_model=None)
 async def clear_stuck_bug_tasks(
     force: bool = Query(default=False, description="Force clear ALL running tasks"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1472,7 +1472,7 @@ async def get_prediction_summary(
         return _no_data_response("Summary generation failed")
 
 
-@router.get("/factors", response_model=DataResponse)
+@router.get("/factors", response_model=None)
 async def get_risk_factors(
     admin_check: bool = Depends(check_admin_permission),
 ) -> dict[str, Any]:
@@ -1519,7 +1519,7 @@ def _get_factor_description(factor: RiskFactor) -> str:
     return descriptions.get(factor, "Unknown factor")
 
 
-@router.post("/record-bug", response_model=DataResponse)
+@router.post("/record-bug", response_model=None)
 async def record_bug(
     admin_check: bool = Depends(check_admin_permission),
     file_path: str = None,

--- a/autobot-backend/api/analytics_code.py
+++ b/autobot-backend/api/analytics_code.py
@@ -50,7 +50,7 @@ def set_analytics_dependencies(controller, state):
     operation="index_codebase",
     error_code_prefix="ANALYTICS",
 )
-@router.post("/code/index", response_model=DataResponse)
+@router.post("/code/index", response_model=None)
 async def index_codebase(
     request: CodeAnalysisRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -210,7 +210,7 @@ async def get_code_quality_assessment(
     operation="get_code_quality_metrics",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/code/quality-metrics", response_model=DataResponse)
+@router.get("/code/quality-metrics", response_model=None)
 async def get_code_quality_metrics(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -320,7 +320,7 @@ def _build_chain_insights(static_endpoints: list, runtime_patterns: dict) -> lis
     operation="get_communication_chains",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/code/communication-chains", response_model=DataResponse)
+@router.get("/code/communication-chains", response_model=None)
 async def get_communication_chains(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -592,7 +592,7 @@ def _score_to_grade(score: float) -> str:
     operation="get_code_quality_score",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/code/metrics/quality-score", response_model=DataResponse)
+@router.get("/code/metrics/quality-score", response_model=None)
 async def get_code_quality_score(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/analytics_continuous_learning.py
+++ b/autobot-backend/api/analytics_continuous_learning.py
@@ -1139,7 +1139,7 @@ async def trigger_retrain(
     return await engine.trigger_retrain(request)
 
 
-@router.get("/insights", summary="Get generated insights", response_model=DataResponse)
+@router.get("/insights", summary="Get generated insights", response_model=None)
 async def get_insights(
     admin_check: bool = Depends(check_admin_permission),
     active_only: bool = Query(True, description="Only active insights"),
@@ -1158,7 +1158,7 @@ async def get_insights(
     }
 
 
-@router.post("/insights/generate", summary="Generate insights now", response_model=DataResponse)
+@router.post("/insights/generate", summary="Generate insights now", response_model=None)
 async def generate_insights_now(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
@@ -1188,7 +1188,7 @@ async def get_monitoring_status(
     return engine.monitor.get_status()
 
 
-@router.put("/config", summary="Update learning config", response_model=DataResponse)
+@router.put("/config", summary="Update learning config", response_model=None)
 async def update_config(
     admin_check: bool = Depends(check_admin_permission),
     config: LearningConfig = None,
@@ -1216,7 +1216,7 @@ async def get_config(
     return engine.config
 
 
-@router.get("/health", summary="Health check", response_model=DataResponse)
+@router.get("/health", summary="Health check", response_model=None)
 async def health_check(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:

--- a/autobot-backend/api/analytics_export.py
+++ b/autobot-backend/api/analytics_export.py
@@ -605,7 +605,7 @@ async def export_grafana_dashboard(
     operation="get_export_formats",
     error_code_prefix="EXPORT",
 )
-@router.get("/formats", response_model=DataResponse)
+@router.get("/formats", response_model=None)
 async def get_export_formats(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/analytics_maintenance.py
+++ b/autobot-backend/api/analytics_maintenance.py
@@ -109,7 +109,7 @@ class CustomReportRequest(BaseModel):
     operation="get_maintenance_recommendations",
     error_code_prefix="MAINT",
 )
-@router.get("/maintenance", response_model=DataResponse)
+@router.get("/maintenance", response_model=None)
 async def get_maintenance_recommendations(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -150,7 +150,7 @@ async def get_maintenance_recommendations(
     operation="get_maintenance_by_category",
     error_code_prefix="MAINT",
 )
-@router.get("/maintenance/category/{category}", response_model=DataResponse)
+@router.get("/maintenance/category/{category}", response_model=None)
 async def get_maintenance_by_category(
     category: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -179,7 +179,7 @@ async def get_maintenance_by_category(
     operation="get_maintenance_summary",
     error_code_prefix="MAINT",
 )
-@router.get("/maintenance/summary", response_model=DataResponse)
+@router.get("/maintenance/summary", response_model=None)
 async def get_maintenance_summary(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -245,7 +245,7 @@ async def get_maintenance_summary(
     operation="get_resource_optimizations",
     error_code_prefix="OPT",
 )
-@router.get("/optimization", response_model=DataResponse)
+@router.get("/optimization", response_model=None)
 async def get_resource_optimizations(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -287,7 +287,7 @@ async def get_resource_optimizations(
     operation="get_optimization_by_type",
     error_code_prefix="OPT",
 )
-@router.get("/optimization/type/{resource_type}", response_model=DataResponse)
+@router.get("/optimization/type/{resource_type}", response_model=None)
 async def get_optimization_by_type(
     resource_type: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -316,7 +316,7 @@ async def get_optimization_by_type(
     operation="get_quick_wins",
     error_code_prefix="OPT",
 )
-@router.get("/optimization/quick-wins", response_model=DataResponse)
+@router.get("/optimization/quick-wins", response_model=None)
 async def get_quick_wins(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -381,7 +381,7 @@ async def get_unified_dashboard(
     operation="get_health_status",
     error_code_prefix="HEALTH",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def get_health_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -492,7 +492,7 @@ async def get_executive_summary(
     operation="get_insights",
     error_code_prefix="INSIGHT",
 )
-@router.get("/insights", response_model=DataResponse)
+@router.get("/insights", response_model=None)
 async def get_insights(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -560,7 +560,7 @@ async def get_insights(
     operation="get_trends_analysis",
     error_code_prefix="TREND",
 )
-@router.get("/trends", response_model=DataResponse)
+@router.get("/trends", response_model=None)
 async def get_trends_analysis(
     days: int = Query(default=30, ge=7, le=90, description="Days to analyze"),
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/analytics_pattern_learning.py
+++ b/autobot-backend/api/analytics_pattern_learning.py
@@ -1070,7 +1070,7 @@ async def submit_pattern_feedback(feedback: PatternFeedback) -> Dict[str, Any]:
     return await engine.submit_feedback(feedback)
 
 
-@router.get("/confidence", response_model=DataResponse, summary="Get pattern confidence scores")
+@router.get("/confidence", response_model=None, summary="Get pattern confidence scores")
 async def get_pattern_confidence(
     pattern_ids: Optional[str] = Query(None, description="Comma-separated pattern IDs"),
 ) -> Dict[str, Any]:
@@ -1093,7 +1093,7 @@ async def get_learning_metrics() -> LearningMetrics:
     return await engine.get_learning_metrics()
 
 
-@router.get("/active-learning", response_model=DataResponse, summary="Get active learning queries")
+@router.get("/active-learning", response_model=None, summary="Get active learning queries")
 async def get_active_learning_queries(
     limit: int = Query(10, ge=1, le=50, description="Maximum queries to return"),
 ) -> Dict[str, Any]:
@@ -1119,7 +1119,7 @@ async def register_pattern(pattern: PatternDefinition) -> Dict[str, Any]:
     return await engine.register_pattern(pattern)
 
 
-@router.get("/patterns/{pattern_id}/history", response_model=DataResponse, summary="Get pattern feedback history")
+@router.get("/patterns/{pattern_id}/history", response_model=None, summary="Get pattern feedback history")
 async def get_pattern_history(
     pattern_id: str,
     limit: int = Query(50, ge=1, le=200, description="Maximum records to return"),
@@ -1152,7 +1152,7 @@ async def run_learning_cycle() -> Dict[str, Any]:
     return await engine.run_learning_cycle()
 
 
-@router.get("/health", response_model=DataResponse, summary="Health check")
+@router.get("/health", response_model=None, summary="Health check")
 async def health_check() -> Dict[str, Any]:
     """Check the health of the pattern learning system."""
     try:

--- a/autobot-backend/api/analytics_performance.py
+++ b/autobot-backend/api/analytics_performance.py
@@ -644,7 +644,7 @@ async def get_pattern(
     return PERFORMANCE_PATTERNS[pattern_id]
 
 
-@router.post("/patterns/{pattern_id}/toggle", response_model=DataResponse)
+@router.post("/patterns/{pattern_id}/toggle", response_model=None)
 async def toggle_pattern(
     pattern_id: str,
     enabled: bool,
@@ -678,7 +678,7 @@ async def get_history(
         return list(_analysis_history[:limit])
 
 
-@router.get("/summary", response_model=DataResponse)
+@router.get("/summary", response_model=None)
 async def get_summary(
     admin_check: bool = Depends(check_admin_permission),
 ) -> dict:

--- a/autobot-backend/api/log_forwarding.py
+++ b/autobot-backend/api/log_forwarding.py
@@ -381,7 +381,7 @@ async def list_destinations(
     operation="get_destination",
     error_code_prefix="LOGFWD",
 )
-@router.get("/destinations/{name}", response_model=DataResponse)
+@router.get("/destinations/{name}", response_model=None)
 async def get_destination(
     name: str,
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/playwright.py
+++ b/autobot-backend/api/playwright.py
@@ -81,7 +81,7 @@ BROWSER_VM_URL = (
     operation="get_playwright_status",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=None)
 async def get_playwright_status():
     """Get Playwright service status and capabilities"""
     try:
@@ -104,7 +104,7 @@ async def get_playwright_status():
     operation="health_check",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def health_check():
     """Health check endpoint for Playwright service"""
     try:
@@ -283,7 +283,7 @@ async def capture_screenshot(request: ScreenshotRequest):
     operation="quick_automation_test",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/automation/quick-test", response_model=DataResponse)
+@router.post("/automation/quick-test", response_model=None)
 async def quick_automation_test(background_tasks: BackgroundTasks):
     """
     Quick automation test to verify all Playwright functionality
@@ -518,7 +518,7 @@ async def go_forward():
     operation="worker_status",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.get("/worker-status", response_model=DataResponse)
+@router.get("/worker-status", response_model=None)
 async def get_worker_status():
     """
     Get browser worker connectivity status from Browser VM (#1130)
@@ -640,7 +640,7 @@ async def interact_with_page(request: InteractRequest):
     operation="get_capabilities",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.get("/capabilities", response_model=DataResponse)
+@router.get("/capabilities", response_model=None)
 async def get_capabilities():
     """Get Playwright service capabilities and features"""
     return {

--- a/autobot-backend/api/research_browser.py
+++ b/autobot-backend/api/research_browser.py
@@ -70,7 +70,7 @@ def _require_browser():
     operation="health_check",
     error_code_prefix="RESEARCH_BROWSER",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def health_check():
     """Health check endpoint for research browser service"""
     if not _BROWSER_AVAILABLE:

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -793,7 +793,7 @@ async def get_secret_types(
     operation="get_secrets_status",
     error_code_prefix="SECRETS",
 )
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=None)
 async def get_secrets_status(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/skills.py
+++ b/autobot-backend/api/skills.py
@@ -75,7 +75,7 @@ class SkillFeedbackRequest(BaseModel):
 # --- Endpoints ---
 
 
-@router.get("/", summary="List all skills", response_model=DataResponse)
+@router.get("/", summary="List all skills", response_model=None)
 async def list_skills(
     category: Optional[str] = Query(None, description="Filter by category"),
     search: Optional[str] = Query(None, description="Search query"),
@@ -102,7 +102,7 @@ async def list_skills(
     }
 
 
-@router.get("/categories", summary="List skill categories", response_model=DataResponse)
+@router.get("/categories", summary="List skill categories", response_model=None)
 async def list_categories() -> Dict[str, Any]:
     """List all available skill categories with counts."""
     manager = _get_manager()
@@ -110,7 +110,7 @@ async def list_categories() -> Dict[str, Any]:
     return {"categories": {cat: len(skills) for cat, skills in by_cat.items()}}
 
 
-@router.get("/health", summary="Get health of all skills", response_model=DataResponse)
+@router.get("/health", summary="Get health of all skills", response_model=None)
 async def get_all_health() -> Dict[str, Any]:
     """Get health status for all registered skills."""
     registry = get_skill_registry()
@@ -197,7 +197,7 @@ async def get_skill_health(name: str) -> Dict[str, Any]:
     return health.model_dump()
 
 
-@router.get("/{name}/actions", summary="List skill actions", response_model=DataResponse)
+@router.get("/{name}/actions", summary="List skill actions", response_model=None)
 async def list_skill_actions(name: str) -> Dict[str, Any]:
     """List available actions for a skill."""
     registry = get_skill_registry()

--- a/autobot-backend/api/structured_thinking_mcp.py
+++ b/autobot-backend/api/structured_thinking_mcp.py
@@ -531,7 +531,7 @@ async def clear_history_mcp(request: ClearHistoryRequest) -> Metadata:
     operation="get_structured_session",
     error_code_prefix="STRUCTURED_THINKING_MCP",
 )
-@router.get("/sessions/{session_id}", response_model=DataResponse)
+@router.get("/sessions/{session_id}", response_model=None)
 async def get_structured_session(session_id: str) -> Metadata:
     """Get complete structured thinking session"""
     async with _structured_sessions_lock:

--- a/autobot-backend/api/usage.py
+++ b/autobot-backend/api/usage.py
@@ -153,7 +153,7 @@ async def get_usage_by_user_single(
     operation="get_my_usage",
     error_code_prefix="USAGE",
 )
-@router.get("/me", response_model=DataResponse)
+@router.get("/me", response_model=None)
 async def get_my_usage(
     current_user: dict = Depends(get_current_user),
 ) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- 52 endpoints changed in #5843 returned plain dicts **without** a `success` field, which `DataResponse` requires (`success: bool`, no default)
- FastAPI validates responses via `model_validate()` at runtime — missing required `success` raises `ValidationError` → **HTTP 500**
- Reverts those 52 endpoints from `response_model=DataResponse` back to `response_model=None` across 16 files
- Endpoints that safely use `DataResponse` (call `create_success_response()` or check `result["success"]`) are left unchanged

## Files changed (16)

`a2a.py`, `analytics_architecture.py`, `analytics_bug_prediction.py`, `analytics_code.py`, `analytics_continuous_learning.py`, `analytics_export.py`, `analytics_maintenance.py`, `analytics_pattern_learning.py`, `analytics_performance.py`, `log_forwarding.py`, `playwright.py`, `research_browser.py`, `secrets.py`, `skills.py`, `structured_thinking_mcp.py`, `usage.py`

## Root cause

`DataResponse.success: bool` has no default — it is a required field. Endpoints returning `{"skills": [...], "total": 5}` (no `success`) fail response validation with `pydantic.ValidationError`, which FastAPI converts to HTTP 500.

The fix script used `return {` detection + absence of `"success"` key as the classifier. Endpoints using `result["success"]` checks before returning were correctly kept as `DataResponse`.

## Test plan

- [x] `python3 -m py_compile` passes for all 16 files
- [x] `git diff --stat` shows exactly 52 insertions + 52 deletions (symmetric change)
- [x] No `create_success_response` callers were reverted (verified by grep)

Fixes #5896

🤖 Generated with [Claude Code](https://claude.com/claude-code)