### PR TITLE
fix(tool_output_filter): wire dead code, singleton, prepare_and_filter, pytest summary (#5891-#5895)

### DIFF
--- a/autobot-backend/api/git_mcp.py
+++ b/autobot-backend/api/git_mcp.py
@@ -47,10 +47,8 @@ from autobot_shared.security.path_validator import validate_path
 from autobot_shared.ssot_config import PROJECT_ROOT
 from autobot_shared.time_utils import now_utc
 from constants.threshold_constants import QueryDefaults
-from services.tool_output_filter import ToolOutputFilter
+from services.tool_output_filter import get_tool_output_filter
 from type_defs.common import JSONObject, Metadata
-
-_output_filter = ToolOutputFilter()
 
 logger = logging.getLogger(__name__)
 
@@ -304,7 +302,9 @@ async def _run_git_process(cmd: List[str], repo_path: str, timeout: int) -> Meta
     # Check output size, then apply semantic filter
     if len(stdout_str) > MAX_OUTPUT_SIZE:
         stdout_str = stdout_str[:MAX_OUTPUT_SIZE]
-    stdout_str = _output_filter.filter(" ".join(cmd[:3]), stdout_str)
+    stdout_str = get_tool_output_filter().prepare_and_filter(
+        " ".join(cmd[:3]), stdout_str, exit_code=process.returncode
+    )
 
     return {
         "success": process.returncode == 0,

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -30,10 +30,9 @@ from .llm_handler import LLMHandlerMixin, _emit_after_continuation, _emit_before
 from .models import LLMIterationContext, StreamingMessage, WorkflowSession
 from .session_handler import SessionHandlerMixin, _emit_approval_received, _emit_approval_required
 from .tool_handler import ToolHandlerMixin
-from services.tool_output_filter import ToolOutputFilter
+from services.tool_output_filter import get_tool_output_filter
 
 logger = logging.getLogger(__name__)
-_output_filter = ToolOutputFilter()
 
 # Issue #380: Module-level frozenset for terminal message types
 _TERMINAL_MESSAGE_TYPES: FrozenSet[str] = frozenset(
@@ -1684,7 +1683,7 @@ class ChatWorkflowManager(
         if stderr:
             output_text += f"\nStderr: {stderr}"
 
-        output_text = _output_filter.filter(cmd, output_text)
+        output_text = get_tool_output_filter().prepare_and_filter(cmd, output_text)
 
         return f"**Step {step_num}:** `{cmd}`\n- Status: {status}\n- Output:\n```\n{output_text}\n```"
 

--- a/autobot-backend/config/tool_output_filters.yaml
+++ b/autobot-backend/config/tool_output_filters.yaml
@@ -15,6 +15,8 @@ filters:
   git_write:
     match_command: "^git (add|push|pull|commit|fetch|merge|rebase|stash)"
     strip_ansi: true
+    # apply_no_op_detection() and short_circuit_git() handle these patterns before
+    # _apply() is reached. Kept as documentation and fallback if pre-filters change.
     match_output:
       - pattern: "Everything up-to-date"
         message: "ok (already up-to-date)"

--- a/autobot-backend/secure_command_executor.py
+++ b/autobot-backend/secure_command_executor.py
@@ -24,7 +24,7 @@ from security.command_patterns import (
     SYSTEM_PATHS,
     check_dangerous_patterns,
 )
-from services.tool_output_filter import ToolOutputFilter
+from services.tool_output_filter import get_tool_output_filter
 from utils.command_utils import execute_shell_command
 
 # Permission system imports (lazy to avoid circular imports)
@@ -33,8 +33,6 @@ if TYPE_CHECKING:
     from services.permission_matcher import PermissionMatcher
 
 logger = logging.getLogger(__name__)
-
-_output_filter = ToolOutputFilter()
 
 # Issue #765: Path constants now imported from security.command_patterns
 
@@ -875,14 +873,15 @@ class SecureCommandExecutor:
         Returns:
             Execution result dictionary
         """
-        prepared_command = _output_filter.prepare_command(command)
+        _filter = get_tool_output_filter()
+        prepared_command = _filter.prepare_command(command)
         actual_command = self._prepare_command_for_execution(prepared_command, risk)
 
         try:
             result = await execute_shell_command(actual_command)
             log_entry["executed"] = True
             log_entry["return_code"] = result["return_code"]
-            result["stdout"] = _output_filter.filter(
+            result["stdout"] = _filter.filter(
                 prepared_command,
                 result.get("stdout", ""),
                 exit_code=result["return_code"],

--- a/autobot-backend/services/tool_output_filter.py
+++ b/autobot-backend/services/tool_output_filter.py
@@ -7,9 +7,8 @@ reaches the LLM.  Replaces naive byte-slice truncation at scattered sites.
 
 Usage::
 
-    from services.tool_output_filter import ToolOutputFilter
-    _filter = ToolOutputFilter()
-    clean = _filter.filter("pytest tests/", raw_output, exit_code=exit_code)
+    from services.tool_output_filter import get_tool_output_filter
+    clean = get_tool_output_filter().prepare_and_filter("pytest tests/", raw, exit_code)
 """
 from __future__ import annotations
 
@@ -40,6 +39,7 @@ _BADGE_RE = re.compile(r"^\[!\[.*?\]\(.*?\)\]\(.*?\)\s*$")
 _IMAGE_ONLY_RE = re.compile(r"^!\[.*?\]\(.*?\)\s*$")
 _HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 _HR_RE = re.compile(r"^[-*_]{3,}\s*$")
+_SHORT_SUMMARY_RE = re.compile(r"^=+ short test summary info =+", re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------
@@ -105,11 +105,14 @@ def apply_no_op_detection(command: str, stdout: str, exit_code: int) -> str | No
 
 def filter_pytest(output: str, exit_code: int = 0) -> str:
     """
-    4-state machine that extracts only failures + summary from pytest output.
+    5-state machine that extracts only failures + summary from pytest output.
 
-    States: HEADER → PROGRESS → FAILURES → SUMMARY
+    States: HEADER → PROGRESS → FAILURES → SUMMARY_INFO → SUMMARY
+
+    SUMMARY_INFO handles the ``=== short test summary info ===`` section that
+    pytest emits with ``-q``, which would otherwise be silently dropped.
     """
-    HEADER, PROGRESS, FAILURES, SUMMARY = range(4)
+    HEADER, PROGRESS, FAILURES, SUMMARY_INFO, SUMMARY = range(5)
     state = HEADER
     result: list[str] = []
     failure_block: list[str] = []
@@ -125,17 +128,29 @@ def filter_pytest(output: str, exit_code: int = 0) -> str:
             if re.match(r"^(=+ FAILURES =+|=+ ERRORS =+|_+ \S)", line):
                 state = FAILURES
                 failure_block.append(line)
+            elif _SHORT_SUMMARY_RE.match(line):
+                state = SUMMARY_INFO
+                result.append(line)
             elif re.match(r"^=+ \d+ (passed|failed|error)", line):
                 state = SUMMARY
                 result.append(line)
         elif state == FAILURES:
-            if re.match(r"^=+ \d+ (passed|failed|error)", line):
+            if _SHORT_SUMMARY_RE.match(line):
+                state = SUMMARY_INFO
+                result.extend(failure_block)
+                failure_block = []
+                result.append(line)
+            elif re.match(r"^=+ \d+ (passed|failed|error)", line):
                 state = SUMMARY
                 result.extend(failure_block)
                 failure_block = []
                 result.append(line)
             else:
                 failure_block.append(line)
+        elif state == SUMMARY_INFO:
+            result.append(line)
+            if re.match(r"^=+ \d+ (passed|failed|error)", line):
+                state = SUMMARY
         elif state == SUMMARY:
             result.append(line)
 
@@ -167,6 +182,9 @@ def filter_ruff_json(stdout: str) -> str:
         by_rule.setdefault(code, []).append(f"  {filename}:{row}  {msg}")
 
     lines: list[str] = []
+    if len(by_rule) > 1:
+        rule_names = sorted(by_rule.keys())
+        lines.append(f"ruff violations: {join_with_overflow(rule_names, 5, 'more rules')}")
     for rule, entries in sorted(by_rule.items()):
         plural = "s" if len(entries) != 1 else ""
         lines.append(f"{rule} ({len(entries)} occurrence{plural}):")
@@ -179,6 +197,9 @@ def filter_ruff_json(stdout: str) -> str:
 def short_circuit_git(subcmd: str, stdout: str, stderr: str, exit_code: int) -> str | None:
     """
     Return a short message for git write operations with known no-op exit codes.
+
+    Complements ``apply_no_op_detection`` by also checking *stderr*, which git
+    uses for progress/status messages (e.g. ``Everything up-to-date`` on push).
     Returns None when the output should be processed normally.
     """
     if exit_code != 0:
@@ -378,19 +399,39 @@ class ToolOutputFilter:
         """Inject compact-output flags before execution."""
         return inject_compact_flags(command)
 
+    def prepare_and_filter(
+        self, command: str, output: str, exit_code: int = 0, stderr: str = ""
+    ) -> str:
+        """Inject compact flags and filter output in a single call.
+
+        Use this at sites that do not execute the command themselves (e.g. sites
+        that receive pre-run output).  Sites that *execute* the command should call
+        ``prepare_command()`` before execution and ``filter()`` after.
+        """
+        return self.filter(self.prepare_command(command), output, exit_code, stderr)
+
     def filter(self, command: str, output: str, exit_code: int = 0, stderr: str = "") -> str:
         """Return filtered *output* for *command*.  Passthrough if no rule matches."""
         no_op = apply_no_op_detection(command, output, exit_code)
         if no_op is not None:
             return no_op
 
+        # Git-specific: also check stderr for no-op signals (git writes to stderr)
+        if stderr and re.match(r"^git\s+", command.strip()):
+            parts = command.strip().split()
+            subcmd = parts[1] if len(parts) > 1 else ""
+            git_sc = short_circuit_git(subcmd, output, stderr, exit_code)
+            if git_sc is not None:
+                return git_sc
+
         rule = self._match_rule(command)
         if rule is None:
             return output
 
         filtered = self._apply(rule, output, exit_code)
+        pre_hint_filtered = filtered  # snapshot before tee hint for accurate savings
 
-        savings = len(output) - len(filtered)
+        savings = len(output) - len(pre_hint_filtered)
         if savings > 200:
             hint = tee_and_hint(output, command.strip().split()[0], exit_code)
             if hint and filtered:
@@ -398,12 +439,16 @@ class ToolOutputFilter:
 
         try:
             asyncio.get_running_loop().create_task(
-                record_filter_savings(command, output, filtered)
+                record_filter_savings(command, output, pre_hint_filtered)
             )
         except RuntimeError:
             pass
 
         return filtered
+
+    def filter_blocks(self, output: str, handler: BlockHandler, exit_code: int = 0) -> str:
+        """Filter structured block output using *handler* (ESLint, mypy, docker build, etc.)."""
+        return filter_by_blocks(output, handler, exit_code)
 
     def _match_rule(self, command: str) -> dict[str, Any] | None:
         cmd = command.strip()
@@ -457,3 +502,8 @@ class ToolOutputFilter:
             return rule.get("on_empty", "")
 
         return text
+
+
+# Singleton accessor — use this instead of ToolOutputFilter() at call sites.
+from autobot_shared.singleton_factory import lazy_singleton  # noqa: E402
+get_tool_output_filter = lazy_singleton(ToolOutputFilter)

--- a/autobot-backend/tests/services/test_tool_output_filter.py
+++ b/autobot-backend/tests/services/test_tool_output_filter.py
@@ -19,6 +19,7 @@ from services.tool_output_filter import (
     filter_markdown_body,
     filter_pytest,
     filter_ruff_json,
+    get_tool_output_filter,
     inject_compact_flags,
     join_with_overflow,
     short_circuit_git,
@@ -520,3 +521,190 @@ def test_prepare_command_injects_flags():
     f = ToolOutputFilter()
     result = f.prepare_command("pytest tests/")
     assert "--tb=short" in result
+
+
+# ---------------------------------------------------------------------------
+# filter_pytest — SUMMARY_INFO state (#5892)
+# ---------------------------------------------------------------------------
+
+_PYTEST_Q_FAIL_OUTPUT = (
+    ".F.\n"
+    "=========================== short test summary info ===========================\n"
+    "FAILED tests/test_foo.py::test_bar - AssertionError: expected 1\n"
+    "=========================== 1 failed, 2 passed in 0.5s ==========================="
+)
+
+_PYTEST_Q_FAIL_WITH_DETAILS = (
+    ".F.\n"
+    "=========================== FAILURES ===========================\n"
+    "___ test_bar ___\n"
+    "AssertionError: expected 1\n"
+    "=========================== short test summary info ===========================\n"
+    "FAILED tests/test_foo.py::test_bar - AssertionError\n"
+    "=========================== 1 failed in 0.5s ==========================="
+)
+
+
+def test_filter_pytest_preserves_short_summary_info_section():
+    result = filter_pytest(_PYTEST_Q_FAIL_OUTPUT, exit_code=1)
+    assert "FAILED tests/test_foo.py::test_bar" in result
+    assert "1 failed" in result
+
+
+def test_filter_pytest_summary_info_header_preserved():
+    result = filter_pytest(_PYTEST_Q_FAIL_OUTPUT, exit_code=1)
+    assert "short test summary info" in result
+
+
+def test_filter_pytest_summary_info_after_failures_block():
+    result = filter_pytest(_PYTEST_Q_FAIL_WITH_DETAILS, exit_code=1)
+    assert "AssertionError" in result
+    assert "FAILED tests/test_foo.py::test_bar" in result
+
+
+def test_filter_pytest_summary_info_final_line_preserved():
+    result = filter_pytest(_PYTEST_Q_FAIL_OUTPUT, exit_code=1)
+    assert "1 failed" in result
+    assert "2 passed" in result
+
+
+# ---------------------------------------------------------------------------
+# filter_ruff_json — join_with_overflow header (#5894)
+# ---------------------------------------------------------------------------
+
+def test_filter_ruff_json_multi_rule_summary_header():
+    data = (
+        '[{"code":"F401","filename":"a.py","location":{"row":1},"message":"unused"},'
+        '{"code":"E501","filename":"b.py","location":{"row":2},"message":"long"}]'
+    )
+    result = filter_ruff_json(data)
+    assert "ruff violations:" in result
+    assert "E501" in result
+    assert "F401" in result
+
+
+def test_filter_ruff_json_single_rule_no_summary_header():
+    result = filter_ruff_json(_RUFF_JSON)
+    assert "ruff violations:" not in result
+    assert "E501" in result
+
+
+# ---------------------------------------------------------------------------
+# short_circuit_git wired in filter() (#5894)
+# ---------------------------------------------------------------------------
+
+def test_filter_short_circuit_git_via_stderr():
+    f = ToolOutputFilter()
+    # exit_code=0, stderr contains no-op phrase; apply_no_op_detection won't
+    # catch it (only checks stdout), but short_circuit_git will check stderr
+    result = f.filter("git push origin main", "", exit_code=0, stderr="Everything up-to-date")
+    assert "up-to-date" in result.lower() or "up to date" in result.lower()
+
+
+def test_filter_short_circuit_git_not_triggered_when_no_stderr():
+    f = ToolOutputFilter()
+    # With empty stderr and stdout that has no no-op pattern, short_circuit_git
+    # and apply_no_op_detection both return None → passthrough to rule pipeline.
+    result = f.filter("git push origin main", "branch pushed successfully", exit_code=0)
+    assert result  # non-empty, processed normally
+
+
+# ---------------------------------------------------------------------------
+# prepare_and_filter (#5891)
+# ---------------------------------------------------------------------------
+
+def test_prepare_and_filter_injects_and_filters():
+    f = ToolOutputFilter()
+    # ruff check without --output-format=json: prepare_and_filter injects it,
+    # but filter_ruff_json gets non-JSON and falls back to raw.
+    # The key check: command is rewritten before rule matching.
+    result = f.prepare_and_filter("ruff check .", "ok: no issues")
+    assert result  # passes through (non-JSON, no rule match → raw)
+
+
+def test_prepare_and_filter_injects_pytest_flags():
+    f = ToolOutputFilter()
+    # The prepared command "pytest --tb=short -q ..." still matches the pytest rule
+    result = f.prepare_and_filter("pytest tests/", _PYTEST_PASS_OUTPUT, exit_code=0)
+    assert result  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# filter_blocks instance method (#5894)
+# ---------------------------------------------------------------------------
+
+class _MockBlockHandler:
+    """Concrete BlockHandler for testing."""
+    def __init__(self):
+        self._in_error = False
+
+    def start_block(self, line: str) -> bool:
+        self._in_error = "ERROR:" in line
+        return "BLOCK_START:" in line
+
+    def end_block(self, line: str) -> bool:
+        return "BLOCK_END" in line
+
+    def is_error_block(self) -> bool:
+        return self._in_error
+
+
+def test_filter_blocks_instance_method_keeps_error_blocks():
+    f = ToolOutputFilter()
+    output = (
+        "preamble\n"
+        "BLOCK_START: ERROR: bad thing\n"
+        "detail line\n"
+        "BLOCK_END\n"
+        "footer"
+    )
+    result = f.filter_blocks(output, _MockBlockHandler())
+    assert "detail line" in result
+
+
+# ---------------------------------------------------------------------------
+# get_tool_output_filter singleton (#5893)
+# ---------------------------------------------------------------------------
+
+def test_get_tool_output_filter_returns_instance():
+    instance = get_tool_output_filter()
+    assert isinstance(instance, ToolOutputFilter)
+
+
+def test_get_tool_output_filter_same_object_on_repeated_calls():
+    assert get_tool_output_filter() is get_tool_output_filter()
+
+
+# ---------------------------------------------------------------------------
+# record_filter_savings uses pre-hint bytes (#5895)
+# ---------------------------------------------------------------------------
+
+def test_filter_savings_not_inflated_by_tee_hint(tmp_path, monkeypatch):
+    import services.tool_output_filter as mod
+    # Override tee dir to tmp so tee_and_hint actually writes
+    monkeypatch.setattr(mod, "_TEE_DIR", tmp_path)
+    saved_args: list = []
+
+    import asyncio
+
+    async def _capture(command, original, filtered):
+        saved_args.append((len(original), len(filtered)))
+
+    monkeypatch.setattr(mod, "record_filter_savings", _capture)
+
+    f = ToolOutputFilter()
+    # Build output that will trigger savings > 200 so tee_and_hint fires.
+    # Use a rule with max_lines=1 to compress heavily.
+    big_output = "\n".join(["x" * 40] * 30)  # ~1200 bytes
+    rule_cfg = {"r": {"match_command": "^cmd", "max_lines": 1}}
+    f2 = _make_filter(rule_cfg)
+
+    async def _run():
+        return f2.filter("cmd", big_output)
+
+    result = asyncio.get_event_loop().run_until_complete(_run())
+    # If savings were tracked, verify filtered length does NOT include tee hint
+    if saved_args:
+        orig_len, filt_len = saved_args[0]
+        # filt_len must NOT include "[full output saved: ...]" line
+        assert "[full output saved:" not in result[:filt_len] or filt_len < len(result)

--- a/autobot-backend/tools/code_interpreter.py
+++ b/autobot-backend/tools/code_interpreter.py
@@ -22,12 +22,11 @@ import sys
 import tempfile
 from typing import Dict, Any
 
-from services.tool_output_filter import ToolOutputFilter
+from services.tool_output_filter import get_tool_output_filter
 
 logger = logging.getLogger(__name__)
 
 MAX_OUTPUT_BYTES = 10 * 1024  # 10 KB per stream
-_output_filter = ToolOutputFilter()
 
 
 def execute_code(code: str, timeout_seconds: int = 30) -> Dict[str, Any]:
@@ -67,7 +66,7 @@ def execute_code(code: str, timeout_seconds: int = 30) -> Dict[str, Any]:
             len(raw_stdout) > MAX_OUTPUT_BYTES or len(raw_stderr) > MAX_OUTPUT_BYTES
         )
 
-        stdout_text = _output_filter.filter(
+        stdout_text = get_tool_output_filter().prepare_and_filter(
             "python", raw_stdout[:MAX_OUTPUT_BYTES].decode("utf-8", errors="replace")
         )
         return {


### PR DESCRIPTION
## Summary
- **#5891** `prepare_and_filter()` added; `git_mcp`, `manager`, `code_interpreter` now use it so `inject_compact_flags` activates at all non-executor sites
- **#5892** `filter_pytest` 5-state machine — new `SUMMARY_INFO` state preserves `=== short test summary info ===` section (pytest `-q`)
- **#5893** All 4 `ToolOutputFilter()` module instances replaced with `get_tool_output_filter()` (lazy_singleton)
- **#5894** `short_circuit_git` wired into `filter()` for stderr checks; `filter_blocks()` instance method exposed; `join_with_overflow` used in `filter_ruff_json` multi-rule header
- **#5895** `record_filter_savings` uses pre-hint bytes; YAML dead `match_output` entries documented

## Test plan
- [ ] 82 unit tests pass: `python3 -m pytest tests/services/test_tool_output_filter.py -q`
- [ ] Syntax clean on all 5 modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)