### PR TITLE
refact(services): add lazy_singleton for ToolOutputFilter (#5893)

### DIFF
--- a/autobot-backend/api/git_mcp.py
+++ b/autobot-backend/api/git_mcp.py
@@ -47,10 +47,8 @@ from autobot_shared.security.path_validator import validate_path
 from autobot_shared.ssot_config import PROJECT_ROOT
 from autobot_shared.time_utils import now_utc
 from constants.threshold_constants import QueryDefaults
-from services.tool_output_filter import ToolOutputFilter
+from services.tool_output_filter import get_tool_output_filter
 from type_defs.common import JSONObject, Metadata
-
-_output_filter = ToolOutputFilter()
 
 logger = logging.getLogger(__name__)
 
@@ -304,7 +302,7 @@ async def _run_git_process(cmd: List[str], repo_path: str, timeout: int) -> Meta
     # Check output size, then apply semantic filter
     if len(stdout_str) > MAX_OUTPUT_SIZE:
         stdout_str = stdout_str[:MAX_OUTPUT_SIZE]
-    stdout_str = _output_filter.filter(" ".join(cmd[:3]), stdout_str)
+    stdout_str = get_tool_output_filter().filter(" ".join(cmd[:3]), stdout_str)
 
     return {
         "success": process.returncode == 0,

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -30,10 +30,9 @@ from .llm_handler import LLMHandlerMixin, _emit_after_continuation, _emit_before
 from .models import LLMIterationContext, StreamingMessage, WorkflowSession
 from .session_handler import SessionHandlerMixin, _emit_approval_received, _emit_approval_required
 from .tool_handler import ToolHandlerMixin
-from services.tool_output_filter import ToolOutputFilter
+from services.tool_output_filter import get_tool_output_filter
 
 logger = logging.getLogger(__name__)
-_output_filter = ToolOutputFilter()
 
 # Issue #380: Module-level frozenset for terminal message types
 _TERMINAL_MESSAGE_TYPES: FrozenSet[str] = frozenset(
@@ -1684,7 +1683,7 @@ class ChatWorkflowManager(
         if stderr:
             output_text += f"\nStderr: {stderr}"
 
-        output_text = _output_filter.filter(cmd, output_text)
+        output_text = get_tool_output_filter().filter(cmd, output_text)
 
         return f"**Step {step_num}:** `{cmd}`\n- Status: {status}\n- Output:\n```\n{output_text}\n```"
 

--- a/autobot-backend/secure_command_executor.py
+++ b/autobot-backend/secure_command_executor.py
@@ -24,7 +24,7 @@ from security.command_patterns import (
     SYSTEM_PATHS,
     check_dangerous_patterns,
 )
-from services.tool_output_filter import ToolOutputFilter
+from services.tool_output_filter import get_tool_output_filter
 from utils.command_utils import execute_shell_command
 
 # Permission system imports (lazy to avoid circular imports)
@@ -33,8 +33,6 @@ if TYPE_CHECKING:
     from services.permission_matcher import PermissionMatcher
 
 logger = logging.getLogger(__name__)
-
-_output_filter = ToolOutputFilter()
 
 # Issue #765: Path constants now imported from security.command_patterns
 
@@ -875,14 +873,14 @@ class SecureCommandExecutor:
         Returns:
             Execution result dictionary
         """
-        prepared_command = _output_filter.prepare_command(command)
+        prepared_command = get_tool_output_filter().prepare_command(command)
         actual_command = self._prepare_command_for_execution(prepared_command, risk)
 
         try:
             result = await execute_shell_command(actual_command)
             log_entry["executed"] = True
             log_entry["return_code"] = result["return_code"]
-            result["stdout"] = _output_filter.filter(
+            result["stdout"] = get_tool_output_filter().filter(
                 prepared_command,
                 result.get("stdout", ""),
                 exit_code=result["return_code"],

--- a/autobot-backend/services/__init__.py
+++ b/autobot-backend/services/__init__.py
@@ -10,6 +10,7 @@ including AI Stack integration, database connections, and external service clien
 Issue #640: Added NPU worker client for compute offload.
 """
 
+from .tool_output_filter import ToolOutputFilter, get_tool_output_filter
 from .ai_stack_client import (
     AIStackClient,
     AIStackError,
@@ -27,6 +28,9 @@ from .npu_client import (
 )
 
 __all__ = [
+    # ToolOutputFilter (Issue #5893)
+    "ToolOutputFilter",
+    "get_tool_output_filter",
     # AI Stack
     "AIStackClient",
     "AIStackError",

--- a/autobot-backend/services/tool_output_filter.py
+++ b/autobot-backend/services/tool_output_filter.py
@@ -457,3 +457,8 @@ class ToolOutputFilter:
             return rule.get("on_empty", "")
 
         return text
+
+
+from autobot_shared.singleton_factory import lazy_singleton  # noqa: E402
+
+get_tool_output_filter = lazy_singleton(ToolOutputFilter)

--- a/autobot-backend/tools/code_interpreter.py
+++ b/autobot-backend/tools/code_interpreter.py
@@ -22,12 +22,11 @@ import sys
 import tempfile
 from typing import Dict, Any
 
-from services.tool_output_filter import ToolOutputFilter
+from services.tool_output_filter import get_tool_output_filter
 
 logger = logging.getLogger(__name__)
 
 MAX_OUTPUT_BYTES = 10 * 1024  # 10 KB per stream
-_output_filter = ToolOutputFilter()
 
 
 def execute_code(code: str, timeout_seconds: int = 30) -> Dict[str, Any]:
@@ -67,7 +66,7 @@ def execute_code(code: str, timeout_seconds: int = 30) -> Dict[str, Any]:
             len(raw_stdout) > MAX_OUTPUT_BYTES or len(raw_stderr) > MAX_OUTPUT_BYTES
         )
 
-        stdout_text = _output_filter.filter(
+        stdout_text = get_tool_output_filter().filter(
             "python", raw_stdout[:MAX_OUTPUT_BYTES].decode("utf-8", errors="replace")
         )
         return {


### PR DESCRIPTION
## Summary
- Adds `get_tool_output_filter = lazy_singleton(ToolOutputFilter)` to `services/tool_output_filter.py`
- Removes 4 module-level `ToolOutputFilter()` constructions from `git_mcp.py`, `manager.py`, `code_interpreter.py`, and `secure_command_executor.py`
- All call sites now use `get_tool_output_filter()` — single instance, config loaded once
- Exports `ToolOutputFilter` and `get_tool_output_filter` from `services/__init__.py`

## Test Plan
- [x] Singleton identity verified: `get_tool_output_filter() is get_tool_output_filter()` → True
- [x] All 4 call sites updated consistently
- [x] `services/__init__.py` exports updated

Closes #5893

🤖 Generated with Claude Code