### PR TITLE
refactor(services): wire short_circuit_git + join_with_overflow into _apply dispatch (#5894)

### DIFF
--- a/autobot-backend/config/tool_output_filters.yaml
+++ b/autobot-backend/config/tool_output_filters.yaml
@@ -15,6 +15,7 @@ filters:
   git_write:
     match_command: "^git (add|push|pull|commit|fetch|merge|rebase|stash)"
     strip_ansi: true
+    filter_type: git
     match_output:
       - pattern: "Everything up-to-date"
         message: "ok (already up-to-date)"

--- a/autobot-backend/services/tool_output_filter.py
+++ b/autobot-backend/services/tool_output_filter.py
@@ -172,7 +172,9 @@ def filter_ruff_json(stdout: str) -> str:
         lines.append(f"{rule} ({len(entries)} occurrence{plural}):")
         lines.extend(entries[:10])
         if len(entries) > 10:
-            lines.append(f"  … and {len(entries) - 10} more")
+            # Show which files the extra occurrences are in via join_with_overflow.
+            extra_files = [e.strip().split("  ")[0] for e in entries[10:]]
+            lines.append("  … " + join_with_overflow(extra_files, 3, "more occurrences"))
     return "\n".join(lines)
 
 
@@ -387,6 +389,13 @@ class ToolOutputFilter:
         rule = self._match_rule(command)
         if rule is None:
             return output
+
+        # filter_type: git — precise no-op detection for git write subcommands.
+        if rule.get("filter_type") == "git":
+            subcmd = " ".join(command.strip().split()[1:]) if command.strip() else ""
+            git_result = short_circuit_git(subcmd, output, stderr, exit_code)
+            if git_result is not None:
+                return git_result
 
         filtered = self._apply(rule, output, exit_code)
 

--- a/docs/developer/ARCHITECTURE_EXCEPTIONS.md
+++ b/docs/developer/ARCHITECTURE_EXCEPTIONS.md
@@ -127,3 +127,29 @@ silently swallowed. Narrowing the catch would add fragility without improving
 observability.
 
 **Grep check:** `grep -n "except Exception" autobot-backend/api/skills_governance.py`
+
+---
+
+## `services/tool_output_filter.py` — `filter_by_blocks` + `BlockHandler` are stubs
+
+**File:** `autobot-backend/services/tool_output_filter.py`
+**Issue:** #5894
+
+**Pattern bypassed:** All filter pipeline functions should be reachable via `_apply()` dispatch.
+
+**Reason:** `filter_by_blocks(output, handler, exit_code)` requires a concrete
+`BlockHandler` implementation that knows how to identify block boundaries for a
+specific tool (e.g. ESLint, mypy, docker build). No such implementation exists yet
+in the codebase. Adding a `filter_type: blocks` dispatch case without a handler
+would raise `NotImplementedError` at runtime and provide no value.
+
+`BlockHandler` is defined as a `@runtime_checkable` `Protocol` — it is the correct
+abstraction. Once a tool-specific handler is implemented (e.g. `MypyBlockHandler`,
+`EslintBlockHandler`), the dispatch case and a corresponding YAML rule should be
+added together in the same PR.
+
+**How to complete:** Implement a concrete `BlockHandler` subclass for the target
+tool, add `filter_type: blocks` to `_apply()` with a handler lookup, and add a YAML
+rule with `filter_type: blocks` for the matching command pattern.
+
+**Grep check:** `grep -n "filter_by_blocks\|BlockHandler" autobot-backend/services/tool_output_filter.py`


### PR DESCRIPTION
## Summary
- **short_circuit_git** wired: added `filter_type: git` to the `git_write` YAML rule; `filter()` now calls `short_circuit_git(subcmd, ...)` for more precise git no-op detection
- **join_with_overflow** wired: replaced hard-coded overflow notice in `filter_ruff_json` with `join_with_overflow(extra_files, 3, "more occurrences")`
- **filter_by_blocks / BlockHandler** documented: added entry to `docs/developer/ARCHITECTURE_EXCEPTIONS.md` explaining these are intentional stubs awaiting a concrete handler implementation (ESLint, mypy, docker); no `_apply()` dispatch added since no handler exists yet

All 68 existing tests pass.

## Related
Closes #5894

🤖 Generated with [Claude Code](https://claude.com/claude-code)