### PR TITLE
fix(chat): reset showMobileSidebar on desktop viewport resize (#4446)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -1043,6 +1043,12 @@ const initializeChatInterface = async () => {
 }
 
 // Lifecycle
+let _lgMediaQuery: MediaQueryList | null = null
+
+function _onLgBreakpoint(e: MediaQueryListEvent): void {
+  if (e.matches) showMobileSidebar.value = false
+}
+
 onMounted(async () => {
   // Initialize chat interface with streamlined loading
   await initializeChatInterface()
@@ -1061,11 +1067,17 @@ onMounted(async () => {
   // Add keyboard shortcuts
   document.addEventListener('keydown', handleKeyboardShortcuts)
 
+  // Reset mobile sidebar when viewport reaches desktop width (#4446)
+  _lgMediaQuery = window.matchMedia('(min-width: 1024px)')
+  _lgMediaQuery.addEventListener('change', _onLgBreakpoint)
+
 })
 
 onUnmounted(() => {
   // Clean up event listeners
   document.removeEventListener('keydown', handleKeyboardShortcuts)
+  _lgMediaQuery?.removeEventListener('change', _onLgBreakpoint)
+  _lgMediaQuery = null
 
   // Clean up intervals
   heartbeatPoller.stop()


### PR DESCRIPTION
## Summary
- Adds `window.matchMedia('(min-width: 1024px)')` listener in `onMounted`
- Resets `showMobileSidebar.value = false` when viewport crosses the lg breakpoint
- Removes listener in `onUnmounted` to prevent memory leaks

## Test Plan
- [x] Open mobile sidebar on narrow viewport
- [x] Resize to desktop width → sidebar closes automatically
- [x] No listener leak: component cleanup verified via onUnmounted removal

Closes #4446

🤖 Generated with Claude Code