### PR TITLE
fix(agents): rename live event channel agent: → heartbeat: (#4444)

### DIFF
--- a/autobot-backend/services/heartbeat_scheduler.py
+++ b/autobot-backend/services/heartbeat_scheduler.py
@@ -194,7 +194,7 @@ class HeartbeatScheduler:
             await session.commit()
         logger.info("Heartbeat run %s started for agent %s", run_id, agent_id)
         await publish_live_event(
-            f"agent:{agent_id}",
+            f"heartbeat:{agent_id}",
             HEARTBEAT_RUN_STARTED,
             {"run_id": str(run_id), "agent_id": agent_id, "trigger": trigger.value},
         )
@@ -259,7 +259,7 @@ class HeartbeatScheduler:
             )
             await session.commit()
         await publish_live_event(
-            f"agent:{agent_id}",
+            f"heartbeat:{agent_id}",
             HEARTBEAT_RUN_COMPLETED,
             {
                 "run_id": str(run_id),

--- a/autobot-frontend/src/components/agents/HeartbeatPanel.vue
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.vue
@@ -244,7 +244,7 @@ function _onLiveEvent(event: LiveEvent): void {
 
 watch(agentId, (newId: string, oldId: string) => {
   if (oldId) {
-    const oldChannel = `agent:${oldId}`
+    const oldChannel = `heartbeat:${oldId}`
     if (_liveUnsub) {
       _liveUnsub()
       _liveUnsub = null
@@ -252,7 +252,7 @@ watch(agentId, (newId: string, oldId: string) => {
     unsubscribe(oldChannel, _onLiveEvent)
   }
   if (newId) {
-    _liveUnsub = subscribe(`agent:${newId}`, _onLiveEvent)
+    _liveUnsub = subscribe(`heartbeat:${newId}`, _onLiveEvent)
     logger.debug('Subscribed to live events for agent', { agentId: newId })
   }
 }, { immediate: true })


### PR DESCRIPTION
## Summary
- Renames live event channel from `agent:{agent_id}` to `heartbeat:{agent_id}` in both backend and frontend
- Backend: `heartbeat_scheduler.py` — 2 `publish_live_event()` calls (run_started + run_completed)
- Frontend: `HeartbeatPanel.vue` — subscribe, unsubscribe, and oldChannel references

## Test Plan
- [x] Backend publishes to `heartbeat:{id}` — verified by grep
- [x] Frontend subscribes to `heartbeat:{id}` — verified by grep
- [x] Both sides agree on channel name — coordinated change

Closes #4444

🤖 Generated with Claude Code