### PR TITLE
migrate(composables): useVncControls/useVncConnection/usePlugins to useLoadingState (#5909 #5910)

### DIFF
--- a/autobot-frontend/src/composables/usePlugins.ts
+++ b/autobot-frontend/src/composables/usePlugins.ts
@@ -13,6 +13,7 @@ import { ref } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
+import { useLoadingState } from '@/composables/useLoadingState'
 
 const logger = createLogger('usePlugins')
 
@@ -49,36 +50,30 @@ export interface DiscoveredPlugin {
 export function usePlugins() {
   const plugins = ref<PluginInfo[]>([])
   const discovered = ref<PluginManifest[]>([])
-  const loading = ref(false)
+  const { isLoading: loading, wrap } = useLoadingState()
   const error = ref<string | null>(null)
 
   async function listPlugins(): Promise<void> {
-    loading.value = true
     error.value = null
     try {
-      const data = await ApiClient.get(`${getApiBase()}/plugins`)
+      const data = await wrap(() => ApiClient.get(`${getApiBase()}/plugins`))
       plugins.value = data.plugins ?? []
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Failed to list plugins'
       error.value = msg
       logger.error('listPlugins error: %s', msg)
-    } finally {
-      loading.value = false
     }
   }
 
   async function discoverPlugins(): Promise<void> {
-    loading.value = true
     error.value = null
     try {
-      const data = await ApiClient.get(`${getApiBase()}/plugins/discover`)
+      const data = await wrap(() => ApiClient.get(`${getApiBase()}/plugins/discover`))
       discovered.value = data.discovered ?? []
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Failed to discover plugins'
       error.value = msg
       logger.error('discoverPlugins error: %s', msg)
-    } finally {
-      loading.value = false
     }
   }
 

--- a/autobot-frontend/src/composables/useVncConnection.ts
+++ b/autobot-frontend/src/composables/useVncConnection.ts
@@ -10,6 +10,7 @@
 import { ref, computed } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { useLoadingState } from '@/composables/useLoadingState'
 
 const logger = createLogger('useVncConnection')
 
@@ -36,7 +37,7 @@ export interface ConnectionMetrics {
 }
 
 export function useVncConnection(sessionId: string = 'default') {
-  const loading = ref(false)
+  const { isLoading: loading, wrap } = useLoadingState()
   const errors = ref<string[]>([])
   const error = computed<string | null>(() =>
     errors.value.length > 0 ? errors.value.join('; ') : null,
@@ -45,30 +46,23 @@ export function useVncConnection(sessionId: string = 'default') {
   const metrics = ref<ConnectionMetrics | null>(null)
 
   async function loadSettings(): Promise<void> {
-    loading.value = true
     errors.value = []
-
     try {
-      const data = await ApiClient.get<ConnectionSettings>(
-        `/vnc/connection/settings?session_id=${sessionId}`
+      const data = await wrap(() =>
+        ApiClient.get<ConnectionSettings>(`/vnc/connection/settings?session_id=${sessionId}`)
       )
       settings.value = data
     } catch (err: unknown) {
       logger.error('Failed to load connection settings:', err)
       errors.value = [...errors.value, 'Failed to load connection settings']
-    } finally {
-      loading.value = false
     }
   }
 
   async function updateSettings(newSettings: ConnectionSettings): Promise<boolean> {
-    loading.value = true
     errors.value = []
-
     try {
-      await ApiClient.post(
-        `/vnc/connection/settings?session_id=${sessionId}`,
-        newSettings
+      await wrap(() =>
+        ApiClient.post(`/vnc/connection/settings?session_id=${sessionId}`, newSettings)
       )
       settings.value = newSettings
       return true
@@ -76,8 +70,6 @@ export function useVncConnection(sessionId: string = 'default') {
       logger.error('Failed to update connection settings:', err)
       errors.value = [...errors.value, 'Failed to update connection settings']
       return false
-    } finally {
-      loading.value = false
     }
   }
 

--- a/autobot-frontend/src/composables/useVncControls.ts
+++ b/autobot-frontend/src/composables/useVncControls.ts
@@ -10,6 +10,7 @@
 import { ref } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { useLoadingState } from '@/composables/useLoadingState'
 
 const logger = createLogger('useVncControls')
 
@@ -44,140 +45,83 @@ function extractErrorMessage(err: unknown, fallback: string): string {
 }
 
 export function useVncControls() {
-  const loading = ref(false)
+  const { isLoading: loading, wrap } = useLoadingState()
   const error = ref<string | null>(null)
 
   async function mouseClick(params: MouseClickParams): Promise<VncActionResponse> {
-    loading.value = true
     error.value = null
-
     try {
-      const response = await ApiClient.post<VncActionResponse>('/vnc/click', params)
-      return response
+      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/click', params))
     } catch (err: unknown) {
       logger.error('Mouse click failed:', err)
       error.value = extractErrorMessage(err, 'Mouse click failed')
-      return {
-        status: 'error',
-        message: error.value ?? 'Mouse click failed'
-      }
-    } finally {
-      loading.value = false
+      return { status: 'error', message: error.value ?? 'Mouse click failed' }
     }
   }
 
   async function keyboardType(text: string): Promise<VncActionResponse> {
-    loading.value = true
     error.value = null
-
     try {
-      const response = await ApiClient.post<VncActionResponse>('/vnc/type', { text })
-      return response
+      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/type', { text }))
     } catch (err: unknown) {
       logger.error('Keyboard type failed:', err)
       error.value = extractErrorMessage(err, 'Keyboard type failed')
-      return {
-        status: 'error',
-        message: error.value ?? 'Keyboard type failed'
-      }
-    } finally {
-      loading.value = false
+      return { status: 'error', message: error.value ?? 'Keyboard type failed' }
     }
   }
 
   async function specialKey(key: string): Promise<VncActionResponse> {
-    loading.value = true
     error.value = null
-
     try {
-      const response = await ApiClient.post<VncActionResponse>('/vnc/key', { key })
-      return response
+      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/key', { key }))
     } catch (err: unknown) {
       logger.error('Special key failed:', err)
       error.value = extractErrorMessage(err, 'Special key failed')
-      return {
-        status: 'error',
-        message: error.value ?? 'Special key failed'
-      }
-    } finally {
-      loading.value = false
+      return { status: 'error', message: error.value ?? 'Special key failed' }
     }
   }
 
   async function mouseScroll(params: MouseScrollParams): Promise<VncActionResponse> {
-    loading.value = true
     error.value = null
-
     try {
-      const response = await ApiClient.post<VncActionResponse>('/vnc/scroll', params)
-      return response
+      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/scroll', params))
     } catch (err: unknown) {
       logger.error('Mouse scroll failed:', err)
       error.value = extractErrorMessage(err, 'Mouse scroll failed')
-      return {
-        status: 'error',
-        message: error.value ?? 'Mouse scroll failed'
-      }
-    } finally {
-      loading.value = false
+      return { status: 'error', message: error.value ?? 'Mouse scroll failed' }
     }
   }
 
   async function mouseDrag(params: MouseDragParams): Promise<VncActionResponse> {
-    loading.value = true
     error.value = null
-
     try {
-      const response = await ApiClient.post<VncActionResponse>('/vnc/drag', params)
-      return response
+      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/drag', params))
     } catch (err: unknown) {
       logger.error('Mouse drag failed:', err)
       error.value = extractErrorMessage(err, 'Mouse drag failed')
-      return {
-        status: 'error',
-        message: error.value ?? 'Mouse drag failed'
-      }
-    } finally {
-      loading.value = false
+      return { status: 'error', message: error.value ?? 'Mouse drag failed' }
     }
   }
 
   async function captureScreenshot(): Promise<VncActionResponse> {
-    loading.value = true
     error.value = null
-
     try {
-      const response = await ApiClient.get<VncActionResponse>('/vnc/screenshot')
-      return response
+      return await wrap(() => ApiClient.get<VncActionResponse>('/vnc/screenshot'))
     } catch (err: unknown) {
       logger.error('Screenshot capture failed:', err)
       error.value = extractErrorMessage(err, 'Screenshot capture failed')
-      return {
-        status: 'error',
-        message: error.value ?? 'Screenshot capture failed',
-        image_data: ''
-      }
-    } finally {
-      loading.value = false
+      return { status: 'error', message: error.value ?? 'Screenshot capture failed', image_data: '' }
     }
   }
 
   async function syncClipboard(content: string): Promise<VncActionResponse> {
-    loading.value = true
     error.value = null
-
     try {
-      const response = await ApiClient.post<VncActionResponse>('/vnc/clipboard', { content })
-      return response
+      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/clipboard', { content }))
     } catch (err: unknown) {
       logger.error('Clipboard sync failed:', err)
       error.value = extractErrorMessage(err, 'Clipboard sync failed')
-      return {
-        status: 'error',
-        message: error.value ?? 'Clipboard sync failed'
-      }
-    } finally {
-      loading.value = false
+      return { status: 'error', message: error.value ?? 'Clipboard sync failed' }
     }
   }
 

--- a/docs/developer/COMPOSABLE_HTTP_PATTERNS.md
+++ b/docs/developer/COMPOSABLE_HTTP_PATTERNS.md
@@ -78,11 +78,11 @@ Each `useLoadingState()` call is independent. Concurrent calls through the *same
 
 ## Long-term consolidation path
 
-The split is deliberate and low-risk today. `ApiClient` is well-tested for mutations; `useFetchEndpoint` is the right abstraction for reads. The gap tracked in issue #5884 is:
+The split is deliberate and low-risk today. `ApiClient` is well-tested for mutations; `useFetchEndpoint` is the right abstraction for reads.
 
 1. **`ApiClient` does not expose an `AbortSignal` externally.** Until it does, mutation composables cannot participate in lifecycle teardown. For short-lived one-shot POSTs this is not a problem in practice — the call completes before the component unmounts in the normal case.
 
-2. **Reads on `ApiClient`** (there are a few — `useAvailableModels`, `useCodeIntelligence`, `useDocumentChanges`) could migrate to `useFetchEndpoint` for abort + race safety. Each migration is independent and low-risk. File a follow-up issue when you encounter one.
+2. **Reads on `ApiClient`** (there are a few — `useAvailableModels`, `useDocumentChanges`) could migrate to `useFetchEndpoint` for abort + race safety. Each migration is independent and low-risk. File a follow-up issue when you encounter one rather than doing it inline.
 
 3. **No forced migration.** Do not rewrite working mutation composables to `useFetchEndpoint` unless the composable also needs reactive `data`, abort safety, or `fallbackData`. The ergonomics of `wrap()` are intentionally better for mutations.
 
@@ -105,6 +105,9 @@ The split is deliberate and low-risk today. `ApiClient` is well-tested for mutat
 | `useMachineKnowledge` | GET facts, inline result |
 | `useManPages` | GET man page, inline result |
 | `useKnowledgeCategories` | GET categories, inline result |
+| `useVncControls` | 7 desktop-control commands — click, type, key, scroll, drag, screenshot, clipboard |
+| `useVncConnection` | Load/update connection settings; `loadMetrics` has no loading flag |
+| `usePlugins` | Load and discover plugins; lifecycle mutations call `listPlugins()` after |
 | `useCodeIntelligence` | Counter-based `loadingCount` — not migrated; see #5880 |
 
 ### Pattern B — `useFetchEndpoint` / `useApiResource`


### PR DESCRIPTION
## Summary

- Migrates 11 manual `loading.value = true/finally false` pairs in three composables missed by the #5869 sweep: `useVncControls` (7 pairs), `useVncConnection` (2 pairs), `usePlugins` (2 pairs)
- Uses `const { isLoading: loading, wrap } = useLoadingState()` pattern — identical to the 12 composables already migrated
- Updates `COMPOSABLE_HTTP_PATTERNS.md`: adds all three to the Pattern A inventory table and removes the stale self-reference to closed issue #5884 in the consolidation-path section

## Test plan

- [ ] TypeScript: `npm run type-check` in `autobot-frontend/`
- [ ] Public API unchanged — all three composables still export `loading` (aliased from `isLoading`)
- [ ] `useVncControls`: catch blocks still set `error.value` and return `{ status: 'error' }` — behavior identical to before
- [ ] `useVncConnection`: `loadMetrics` and `setQualityPreset` untouched — no loading flag, correct

Closes #5909
Closes #5910

🤖 Generated with [Claude Code](https://claude.com/claude-code)