### PR TITLE
fix(api): revert response_model=DataResponse to None for 61 variable-return endpoints (#5904)

### DIFF
--- a/autobot-backend/api/a2a.py
+++ b/autobot-backend/api/a2a.py
@@ -146,7 +146,7 @@ def _remote_addr(request: Request) -> str:
     "/agent-card",
     summary="A2A Agent Card",
     tags=["a2a"],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def get_agent_card(request: Request) -> Dict[str, Any]:
     """
@@ -162,7 +162,7 @@ async def get_agent_card(request: Request) -> Dict[str, Any]:
     "/agent-card/signed",
     summary="Signed A2A Agent Card",
     tags=["a2a"],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def get_signed_agent_card(request: Request) -> Dict[str, Any]:
     """
@@ -262,7 +262,7 @@ async def submit_task(
     "/tasks",
     summary="List A2A tasks",
     tags=["a2a"],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def list_tasks() -> list:
     """Return all A2A tasks with their current state and artifacts."""
@@ -274,7 +274,7 @@ async def list_tasks() -> list:
     "/tasks/{task_id}",
     summary="Get A2A task",
     tags=["a2a"],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def get_task(task_id: str) -> Dict[str, Any]:
     """Return a specific task by ID, including state and any artifacts."""
@@ -471,7 +471,7 @@ async def task_stats() -> Dict[str, Any]:
     "/capabilities",
     summary="Verify local capability claims",
     tags=["a2a"],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def local_capabilities() -> Dict[str, Any]:
     """
@@ -489,7 +489,7 @@ async def local_capabilities() -> Dict[str, Any]:
     "/capabilities/verify",
     summary="Verify a remote agent's capabilities",
     tags=["a2a"],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def verify_remote_capabilities(body: RemoteVerifyRequest) -> Dict[str, Any]:
     """

--- a/autobot-backend/api/agent_terminal.py
+++ b/autobot-backend/api/agent_terminal.py
@@ -595,7 +595,7 @@ async def execute_agent_command(
     operation="approve_agent_command",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/approve", response_model=DataResponse)
+@router.post("/sessions/{session_id}/approve", response_model=None)
 async def approve_agent_command(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -675,7 +675,7 @@ async def submit_tool_approval(
     operation="interrupt_agent_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/interrupt", response_model=DataResponse)
+@router.post("/sessions/{session_id}/interrupt", response_model=None)
 async def interrupt_agent_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -706,7 +706,7 @@ async def interrupt_agent_session(
     operation="resume_agent_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/resume", response_model=DataResponse)
+@router.post("/sessions/{session_id}/resume", response_model=None)
 async def resume_agent_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/ai_stack_integration.py
+++ b/autobot-backend/api/ai_stack_integration.py
@@ -726,7 +726,7 @@ async def multi_agent_query(
     operation="legacy_rag_search",
     error_code_prefix="AI_STACK",
 )
-@router.post("/legacy/rag-search", response_model=DataResponse)
+@router.post("/legacy/rag-search", response_model=None)
 async def legacy_rag_search(
     query: str,
     max_results: int = 10,
@@ -746,7 +746,7 @@ async def legacy_rag_search(
     operation="legacy_enhanced_chat",
     error_code_prefix="AI_STACK",
 )
-@router.post("/legacy/enhanced-chat", response_model=DataResponse)
+@router.post("/legacy/enhanced-chat", response_model=None)
 async def legacy_enhanced_chat(
     message: str,
     context: Optional[str] = None,

--- a/autobot-backend/api/analytics_bug_prediction.py
+++ b/autobot-backend/api/analytics_bug_prediction.py
@@ -1060,7 +1060,7 @@ async def start_bug_analysis(
     return {"task_id": task_id, "status": "pending"}
 
 
-@router.get("/status/{task_id}", response_model=DataResponse)
+@router.get("/status/{task_id}", response_model=None)
 async def get_bug_prediction_status(
     task_id: str,
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/analytics_code.py
+++ b/autobot-backend/api/analytics_code.py
@@ -85,7 +85,7 @@ async def index_codebase(
     operation="get_code_analysis_status",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/code/status", response_model=DataResponse)
+@router.get("/code/status", response_model=None)
 async def get_code_analysis_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -141,7 +141,7 @@ async def get_code_analysis_status(
     operation="get_code_quality_assessment",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/quality/assessment", response_model=DataResponse)
+@router.get("/quality/assessment", response_model=None)
 async def get_code_quality_assessment(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/analytics_code_review.py
+++ b/autobot-backend/api/analytics_code_review.py
@@ -670,7 +670,7 @@ async def review_file(
     }
 
 
-@router.get("/patterns", response_model=DataResponse)
+@router.get("/patterns", response_model=None)
 async def get_review_patterns(
     admin_check: bool = Depends(check_admin_permission),
 ) -> list[dict[str, Any]]:
@@ -842,7 +842,7 @@ async def get_review_summary(
     )
 
 
-@router.get("/categories", response_model=DataResponse)
+@router.get("/categories", response_model=None)
 async def get_review_categories(
     admin_check: bool = Depends(check_admin_permission),
 ) -> list[dict[str, Any]]:

--- a/autobot-backend/api/analytics_continuous_learning.py
+++ b/autobot-backend/api/analytics_continuous_learning.py
@@ -1056,7 +1056,7 @@ async def get_engine() -> ContinuousLearningEngine:
 # =============================================================================
 
 
-@router.post("/start", summary="Start continuous learning", response_model=DataResponse)
+@router.post("/start", summary="Start continuous learning", response_model=None)
 async def start_learning(
     admin_check: bool = Depends(check_admin_permission),
     background_tasks: BackgroundTasks = None,
@@ -1070,7 +1070,7 @@ async def start_learning(
     return await engine.start()
 
 
-@router.post("/stop", summary="Stop continuous learning", response_model=DataResponse)
+@router.post("/stop", summary="Stop continuous learning", response_model=None)
 async def stop_learning(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
@@ -1083,7 +1083,7 @@ async def stop_learning(
     return await engine.stop()
 
 
-@router.get("/status", summary="Get learning status", response_model=DataResponse)
+@router.get("/status", summary="Get learning status", response_model=None)
 async def get_status(
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
@@ -1109,7 +1109,7 @@ async def get_metrics(
     return engine.get_metrics()
 
 
-@router.post("/feedback", summary="Submit pattern feedback", response_model=DataResponse)
+@router.post("/feedback", summary="Submit pattern feedback", response_model=None)
 async def submit_feedback(
     admin_check: bool = Depends(check_admin_permission),
     pattern_id: str = None,
@@ -1125,7 +1125,7 @@ async def submit_feedback(
     return await engine.submit_feedback(pattern_id, is_correct, details)
 
 
-@router.post("/retrain", summary="Trigger model retraining", response_model=DataResponse)
+@router.post("/retrain", summary="Trigger model retraining", response_model=None)
 async def trigger_retrain(
     admin_check: bool = Depends(check_admin_permission),
     request: RetrainingRequest = None,

--- a/autobot-backend/api/analytics_maintenance.py
+++ b/autobot-backend/api/analytics_maintenance.py
@@ -358,7 +358,7 @@ async def get_quick_wins(
     operation="get_unified_dashboard",
     error_code_prefix="DASH",
 )
-@router.get("/dashboard", response_model=DataResponse)
+@router.get("/dashboard", response_model=None)
 async def get_unified_dashboard(
     days: int = Query(default=30, ge=1, le=365, description="Days to analyze"),
     admin_check: bool = Depends(check_admin_permission),
@@ -419,7 +419,7 @@ async def get_health_status(
     operation="generate_custom_report",
     error_code_prefix="REPORT",
 )
-@router.post("/report", response_model=DataResponse)
+@router.post("/report", response_model=None)
 async def generate_custom_report(
     request: CustomReportRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -455,7 +455,7 @@ async def generate_custom_report(
     operation="get_executive_summary",
     error_code_prefix="REPORT",
 )
-@router.get("/report/executive", response_model=DataResponse)
+@router.get("/report/executive", response_model=None)
 async def get_executive_summary(
     days: int = Query(default=30, ge=7, le=90, description="Days to summarize"),
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/analytics_pattern_learning.py
+++ b/autobot-backend/api/analytics_pattern_learning.py
@@ -1059,7 +1059,7 @@ async def get_learning_engine() -> PatternLearningEngine:
 # =============================================================================
 
 
-@router.post("/feedback", response_model=DataResponse, summary="Submit pattern feedback")
+@router.post("/feedback", response_model=None, summary="Submit pattern feedback")
 async def submit_pattern_feedback(feedback: PatternFeedback) -> Dict[str, Any]:
     """
     Submit developer feedback for a pattern match.
@@ -1112,7 +1112,7 @@ async def get_active_learning_queries(
     }
 
 
-@router.post("/patterns", response_model=DataResponse, summary="Register a new pattern")
+@router.post("/patterns", response_model=None, summary="Register a new pattern")
 async def register_pattern(pattern: PatternDefinition) -> Dict[str, Any]:
     """Register a new pattern for learning."""
     engine = await get_learning_engine()
@@ -1138,7 +1138,7 @@ async def get_pattern_history(
     }
 
 
-@router.post("/learn", response_model=DataResponse, summary="Run learning cycle")
+@router.post("/learn", response_model=None, summary="Run learning cycle")
 async def run_learning_cycle() -> Dict[str, Any]:
     """
     Trigger a learning cycle to analyze feedback and update patterns.

--- a/autobot-backend/api/analytics_performance.py
+++ b/autobot-backend/api/analytics_performance.py
@@ -595,7 +595,7 @@ async def analyze_path(
     return result
 
 
-@router.post("/analyze-content", response_model=DataResponse)
+@router.post("/analyze-content", response_model=None)
 async def analyze_content(
     content: str,
     filename: str = Query("code.py", description="Filename for context"),
@@ -619,7 +619,7 @@ async def analyze_content(
     return issues
 
 
-@router.get("/patterns", response_model=DataResponse)
+@router.get("/patterns", response_model=None)
 async def list_patterns(
     admin_check: bool = Depends(check_admin_permission),
 ) -> list[PatternDefinition]:
@@ -630,7 +630,7 @@ async def list_patterns(
     return list(PERFORMANCE_PATTERNS.values())
 
 
-@router.get("/patterns/{pattern_id}", response_model=DataResponse)
+@router.get("/patterns/{pattern_id}", response_model=None)
 async def get_pattern(
     pattern_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -665,7 +665,7 @@ async def toggle_pattern(
     }
 
 
-@router.get("/history", response_model=DataResponse)
+@router.get("/history", response_model=None)
 async def get_history(
     limit: int = Query(20, ge=1, le=100),
     admin_check: bool = Depends(check_admin_permission),
@@ -738,7 +738,7 @@ async def get_summary(
         }
 
 
-@router.get("/categories", response_model=DataResponse)
+@router.get("/categories", response_model=None)
 async def get_categories(
     admin_check: bool = Depends(check_admin_permission),
 ) -> list[dict]:
@@ -779,7 +779,7 @@ async def get_categories(
     ]
 
 
-@router.get("/hotspots", response_model=DataResponse)
+@router.get("/hotspots", response_model=None)
 async def get_hotspots(
     limit: int = Query(10, ge=1, le=50),
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -1179,7 +1179,7 @@ def _validate_workflow_manager(chat_workflow_manager) -> None:
     operation="send_chat_message_by_id",
     error_code_prefix="CHAT",
 )
-@router.post("/chats/{chat_id}/message", response_model=DataResponse)
+@router.post("/chats/{chat_id}/message", response_model=None)
 async def send_chat_message_by_id(
     chat_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1254,7 +1254,7 @@ async def _stream_graph_resume(
     operation="resume_chat_graph",
     error_code_prefix="CHAT",
 )
-@router.post("/chats/{chat_id}/resume", response_model=DataResponse)
+@router.post("/chats/{chat_id}/resume", response_model=None)
 async def resume_chat_graph(
     chat_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1491,7 +1491,7 @@ async def delete_chat_by_id(
     operation="send_direct_chat_response",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/direct", response_model=DataResponse)
+@router.post("/chat/direct", response_model=None)
 async def send_direct_chat_response(
     current_user: dict = Depends(get_current_user),
     request: Request = None,

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -1350,7 +1350,7 @@ def _build_delete_session_response(
     operation="delete_session",
     error_code_prefix="CHAT",
 )
-@router.delete("/chat/sessions/{session_id}", response_model=DataResponse)
+@router.delete("/chat/sessions/{session_id}", response_model=None)
 async def delete_session(
     session_id: str,
     request: Request,

--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -1523,7 +1523,7 @@ async def get_security_score(
     operation="security_report",
     error_code_prefix="SECURITY",
 )
-@router.get("/security/report", response_model=DataResponse)
+@router.get("/security/report", response_model=None)
 async def get_security_report(
     path: str = Query(..., description="Directory path to analyze"),
     format: str = Query(default="json", description="Report format: json or markdown"),
@@ -1798,7 +1798,7 @@ async def get_performance_score(
     operation="performance_report",
     error_code_prefix="PERFORMANCE",
 )
-@router.get("/performance/report", response_model=DataResponse)
+@router.get("/performance/report", response_model=None)
 async def get_performance_report(
     path: str = Query(..., description="Directory path to analyze"),
     format: str = Query(default="json", description="Report format: json or markdown"),

--- a/autobot-backend/api/code_search.py
+++ b/autobot-backend/api/code_search.py
@@ -285,7 +285,7 @@ async def search_code(request: SearchRequest):
     operation="search_code_get",
     error_code_prefix="CODE_SEARCH",
 )
-@router.get("/search", response_model=DataResponse)
+@router.get("/search", response_model=None)
 async def search_code_get(
     q: str = Query(..., description="Search query"),
     type: str = Query("semantic", description="Search type"),

--- a/autobot-backend/api/development_speedup.py
+++ b/autobot-backend/api/development_speedup.py
@@ -148,7 +148,7 @@ async def analyze_codebase_endpoint(request: AnalysisRequest):
     operation="analyze_codebase_get",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/analyze", response_model=DataResponse)
+@router.get("/analyze", response_model=None)
 async def analyze_codebase_get(
     path: str = Query(..., description="Root path to analyze"),
     type: str = Query("comprehensive", description="Analysis type"),

--- a/autobot-backend/api/llm.py
+++ b/autobot-backend/api/llm.py
@@ -50,7 +50,7 @@ def _get_llm_interface():
     operation="get_llm_config",
     error_code_prefix="LLM",
 )
-@router.get("/config", response_model=DataResponse)
+@router.get("/config", response_model=None)
 async def get_llm_config(
     current_user: dict = Depends(get_current_user),
 ):
@@ -515,7 +515,7 @@ async def get_comprehensive_llm_status(
     operation="get_llm_status",
     error_code_prefix="LLM",
 )
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=None)
 async def get_llm_status(
     current_user: dict = Depends(get_current_user),
 ):

--- a/autobot-backend/api/log_forwarding.py
+++ b/autobot-backend/api/log_forwarding.py
@@ -349,7 +349,7 @@ def _destination_to_response(dest) -> DestinationResponse:
     operation="list_destinations",
     error_code_prefix="LOGFWD",
 )
-@router.get("/destinations", response_model=DataResponse)
+@router.get("/destinations", response_model=None)
 async def list_destinations(
     admin_check: bool = Depends(check_admin_permission),
 ) -> List[Dict[str, Any]]:

--- a/autobot-backend/api/logs.py
+++ b/autobot-backend/api/logs.py
@@ -515,7 +515,7 @@ async def get_recent_logs(
     operation="list_logs",
     error_code_prefix="LOGS",
 )
-@router.get("/list", response_model=DataResponse)
+@router.get("/list", response_model=None)
 async def list_logs(
     admin_check: bool = Depends(check_admin_permission),
 ) -> List[Metadata]:

--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -104,7 +104,7 @@ def _build_single_task_response(result: dict) -> JSONResponse:
     )
 
 
-@router.post("/workflow/execute", response_model=DataResponse)
+@router.post("/workflow/execute", response_model=None)
 async def execute_workflow(
     request: WorkflowRequest,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/playwright.py
+++ b/autobot-backend/api/playwright.py
@@ -346,7 +346,7 @@ async def quick_automation_test(background_tasks: BackgroundTasks):
     operation="navigate",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/navigate", response_model=DataResponse)
+@router.post("/navigate", response_model=None)
 async def navigate_to_url(request: NavigateRequest):
     """
     Navigate to a URL using Playwright on Browser VM
@@ -391,7 +391,7 @@ async def navigate_to_url(request: NavigateRequest):
     operation="reload",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/reload", response_model=DataResponse)
+@router.post("/reload", response_model=None)
 async def reload_page(request: ReloadRequest):
     """
     Reload the current page using Playwright on Browser VM
@@ -432,7 +432,7 @@ async def reload_page(request: ReloadRequest):
     operation="go_back",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/back", response_model=DataResponse)
+@router.post("/back", response_model=None)
 async def go_back():
     """
     Navigate back in browser history using Playwright on Browser VM
@@ -474,7 +474,7 @@ async def go_back():
     operation="go_forward",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/forward", response_model=DataResponse)
+@router.post("/forward", response_model=None)
 async def go_forward():
     """
     Navigate forward in browser history using Playwright on Browser VM
@@ -551,7 +551,7 @@ async def get_worker_status():
     operation="worker_screenshot",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/worker-screenshot", response_model=DataResponse)
+@router.post("/worker-screenshot", response_model=None)
 async def take_worker_screenshot():
     """
     Take screenshot of the persistent navigation page on Browser VM (#1130)
@@ -589,7 +589,7 @@ async def take_worker_screenshot():
     operation="interact",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/interact", response_model=DataResponse)
+@router.post("/interact", response_model=None)
 async def interact_with_page(request: InteractRequest):
     """Proxy interactive browser actions to Browser VM (#1416)"""
     allowed = {"click", "scroll", "type", "hover"}

--- a/autobot-backend/api/registry.py
+++ b/autobot-backend/api/registry.py
@@ -503,7 +503,7 @@ async def list_endpoints():
     operation="list_routers",
     error_code_prefix="REGISTRY",
 )
-@router.get("/routers", response_model=DataResponse)
+@router.get("/routers", response_model=None)
 async def list_routers():
     """List all registered routers with full configuration"""
     routers_data = {}

--- a/autobot-backend/api/skills.py
+++ b/autobot-backend/api/skills.py
@@ -117,7 +117,7 @@ async def get_all_health() -> Dict[str, Any]:
     return {"skills": registry.get_all_health()}
 
 
-@router.post("/initialize", summary="Initialize skills system", response_model=DataResponse)
+@router.post("/initialize", summary="Initialize skills system", response_model=None)
 async def initialize_skills() -> Dict[str, Any]:
     """Discover and load all builtin skills."""
     manager = _get_manager()
@@ -125,7 +125,7 @@ async def initialize_skills() -> Dict[str, Any]:
     return result
 
 
-@router.get("/{name}", summary="Get skill details", response_model=DataResponse)
+@router.get("/{name}", summary="Get skill details", response_model=None)
 async def get_skill(name: str) -> Dict[str, Any]:
     """Get detailed information about a specific skill."""
     registry = get_skill_registry()
@@ -187,7 +187,7 @@ async def execute_skill(name: str, body: SkillActionRequest) -> Dict[str, Any]:
     return result
 
 
-@router.get("/{name}/health", summary="Get skill health", response_model=DataResponse)
+@router.get("/{name}/health", summary="Get skill health", response_model=None)
 async def get_skill_health(name: str) -> Dict[str, Any]:
     """Get health status for a specific skill."""
     registry = get_skill_registry()
@@ -210,7 +210,7 @@ async def list_skill_actions(name: str) -> Dict[str, Any]:
     }
 
 
-@router.get("/{name}/metrics", summary="Get skill metrics", response_model=DataResponse)
+@router.get("/{name}/metrics", summary="Get skill metrics", response_model=None)
 async def get_skill_metrics(
     name: str,
     days: int = Query(30, description="Number of days to analyze"),
@@ -258,7 +258,7 @@ async def submit_skill_feedback(
         raise HTTPException(status_code=500, detail="Failed to log feedback")
 
 
-@router.get("/{name}/suggestions", summary="Get skill refinement suggestions", response_model=DataResponse)
+@router.get("/{name}/suggestions", summary="Get skill refinement suggestions", response_model=None)
 async def get_refinement_suggestions(name: str) -> Dict[str, Any]:
     """Get suggestions for improving a skill (Issue #4339)."""
     try:

--- a/autobot-backend/api/usage.py
+++ b/autobot-backend/api/usage.py
@@ -134,7 +134,7 @@ async def get_usage_by_user_all(
     operation="get_usage_by_user_single",
     error_code_prefix="USAGE",
 )
-@router.get("/by-user/{user_id}", response_model=DataResponse)
+@router.get("/by-user/{user_id}", response_model=None)
 async def get_usage_by_user_single(
     user_id: str,
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -192,7 +192,7 @@ async def voice_clone_api(
 # ------------------------------------------------------------------
 
 
-@router.get("/voices", response_model=DataResponse)
+@router.get("/voices", response_model=None)
 async def voice_list_api():
     """List available voice profiles from TTS worker."""
     tts = get_tts_client()
@@ -205,7 +205,7 @@ async def voice_list_api():
     operation="voice_create_api",
     error_code_prefix="VOICE",
 )
-@router.post("/voices/create", response_model=DataResponse)
+@router.post("/voices/create", response_model=None)
 async def voice_create_api(
     name: str = Form(...),
     audio: UploadFile = File(...),


### PR DESCRIPTION
## Summary

- Second pass of the #5896 runtime-500 fix (#5843 regression)
- The first classifier only caught `return {` literal-dict patterns — missed 61 endpoints returning **variables** (`return result`, `return detail`, `return model.model_dump()`) where the variable has no `success` field
- `DataResponse.success: bool` is required (no default); FastAPI's `model_validate()` raises `ValidationError` → HTTP 500
- Reverts all 61 from `response_model=DataResponse` → `response_model=None` across 24 files

## Confirmed broken examples

| File | Function | What it returns |
|------|----------|-----------------|
| `skills.py` | `initialize_skills` | `{"skills_discovered": N, "total_registered": N, "categories": [...]}` |
| `skills.py` | `get_skill` | `get_skill_detail()` dict — `{name, version, status, ...}` |
| `skills.py` | `get_skill_health` | `SkillHealth.model_dump()` — model has no `success` field |
| `llm.py` | `get_llm_config` | `Metadata` Pydantic model — no `success` field |
| `logs.py` | `list_logs` | `list` — a list can never satisfy `DataResponse` |

## Files changed (24)

`a2a.py`, `agent_terminal.py`, `ai_stack_integration.py`, `analytics_bug_prediction.py`, `analytics_code.py`, `analytics_code_review.py`, `analytics_continuous_learning.py`, `analytics_maintenance.py`, `analytics_pattern_learning.py`, `analytics_performance.py`, `chat.py`, `chat_sessions.py`, `code_intelligence.py`, `code_search.py`, `development_speedup.py`, `llm.py`, `log_forwarding.py`, `logs.py`, `orchestration.py`, `playwright.py`, `registry.py`, `skills.py`, `usage.py`, `voice.py`

## Test plan

- [x] `python3 -m py_compile` passes for all 24 files
- [x] `git diff --stat` shows exactly 61 insertions + 61 deletions (symmetric)
- [x] No `create_success_response` callers were reverted (verified by classifier logic)
- [x] Proper named schemas for these endpoints tracked in #5912

Fixes #5904

🤖 Generated with [Claude Code](https://claude.com/claude-code)