### PR TITLE
docs(api): add response schema selection guide (#5914)

### DIFF
--- a/docs/developer/API_RESPONSE_MIGRATION.md
+++ b/docs/developer/API_RESPONSE_MIGRATION.md
@@ -628,3 +628,122 @@ return success_response(data=result)
 5. **Track progress** - Update migration checklist
 
 **Migration Status**: Ready to begin - utility tested and functional ✅
+
+---
+
+## Response Schema Selection Guide
+
+*Added 2026-04-26 — addresses the root cause of the #5843 → #5896 → #5904 runtime-500
+cascade where developers defaulted to `response_model=DataResponse` for all endpoints
+without guidance. (#5914)*
+
+### Decision Tree
+
+```
+New endpoint — which response_model to use?
+│
+├── Returns streaming / binary / SSE / WebSocket?
+│   └─► response_model=None
+│       FastAPI MUST NOT validate streaming or binary responses.
+│       Also use None for file downloads (FileResponse) and plain-text
+│       status pages.
+│
+├── Returns JSONResponse / Response / StreamingResponse / FileResponse
+│   directly (not a plain dict or Pydantic model)?
+│   └─► response_model=None
+│       FastAPI skips model validation when the return value is already
+│       a Response subclass. Annotating with a schema is misleading and
+│       adds no enforcement — use None to be explicit.
+│
+├── Uses create_success_response() exclusively?
+│   └─► response_model=DataResponse
+│       DataResponse requires success: bool (no default).
+│       create_success_response() always sets it. Any endpoint that does
+│       NOT call create_success_response() on every return path will
+│       produce a runtime HTTP 500 (see #5843 / #5896 / #5904).
+│       The tools/lint/check_response_models.py pre-commit hook enforces
+│       this invariant. (#5913)
+│
+├── Always returns {success: bool, message: str} with no extra fields?
+│   └─► response_model=SuccessMessageResponse
+│       Imported from autobot-backend/api/schemas_common.py.
+│       Use for simple acknowledge / toggle / clear endpoints where no
+│       payload beyond success+message is needed.
+│
+├── Returns {success: bool, message: str, <domain-key>: ...}?
+│   ├── The extra data has no fixed schema (generic dict / list)?
+│   │   └─► response_model=SuccessDataResponse
+│   │       Provides success + message + data: Any.
+│   │
+│   └── The extra fields have a specific shape (known keys + types)?
+│       └─► Define a named schema in schemas_common.py
+│           class MyDomainResponse(SuccessMessageResponse):
+│               field_one: str
+│               field_two: int
+│           Inheriting from SuccessMessageResponse avoids redeclaring
+│           success and message.  After #5799, place domain schemas in
+│           per-domain files instead of schemas_common.py.
+│
+└── Returns a fully custom shape (no success/message convention)?
+    └─► Define a standalone Pydantic BaseModel in schemas_common.py
+        (or domain schema file after #5799) and use that directly.
+        Preferred for domain-rich responses where success/message
+        semantics don't apply (e.g. query results, config snapshots).
+```
+
+### Quick Reference
+
+| Situation | response_model |
+|-----------|---------------|
+| Streaming / SSE / WebSocket | `None` |
+| Binary / file download | `None` |
+| Returns `JSONResponse` / `Response` directly | `None` |
+| Uses `create_success_response()` | `DataResponse` |
+| Simple OK/fail, no payload | `SuccessMessageResponse` |
+| Success + generic extra data dict | `SuccessDataResponse` |
+| Success + typed domain fields | `class X(SuccessMessageResponse): ...` |
+| Domain-specific shape, no success convention | Custom `BaseModel` |
+
+### Common Mistakes
+
+**❌ Defaulting to DataResponse for everything**
+
+```python
+# WRONG — runtime HTTP 500 if function returns a plain dict
+@router.post("/stop", response_model=DataResponse)
+async def stop():
+    return {"stopped": True}   # missing 'success' key → ValidationError
+```
+
+**✅ Use SuccessMessageResponse for simple acknowledgements**
+
+```python
+@router.post("/stop", response_model=SuccessMessageResponse)
+async def stop():
+    return {"success": True, "message": "Stopped"}
+```
+
+**❌ Annotating streaming responses with a schema**
+
+```python
+# WRONG — FastAPI will attempt to validate the StreamingResponse body
+@router.get("/stream", response_model=DataResponse)
+async def stream():
+    return StreamingResponse(generate())
+```
+
+**✅ Use None for streaming**
+
+```python
+@router.get("/stream", response_model=None)
+async def stream():
+    return StreamingResponse(generate())
+```
+
+### Enforcement
+
+The `tools/lint/check_response_models.py` pre-commit hook (added in #5913) blocks any
+`response_model=DataResponse` endpoint whose body does not call
+`create_success_response()`, return a dict literal with a `'success'` key, or return a
+bypass response type.  This prevents a recurrence of the #5843/5896/5904 runtime-500
+cascade at the point of commit rather than at runtime in production.


### PR DESCRIPTION
## Summary
- Appends a "Response Schema Selection Guide" section to `docs/developer/API_RESPONSE_MIGRATION.md`
- Includes a full decision tree, quick-reference table, common-mistake examples, and enforcement callout for the #5913 pre-commit hook

## Motivation
Without guidance, developers defaulted to `response_model=DataResponse` for all endpoints — the direct cause of the #5843 → #5896 → #5904 runtime-500 cascade. This doc section gives a single authoritative reference for which schema to choose.

## Test Plan
- [x] Decision tree covers all actual schemas: `None`, `DataResponse`, `SuccessMessageResponse`, `SuccessDataResponse`, custom `BaseModel`
- [x] Common-mistake examples mirror the actual patterns that caused #5843
- [x] References the #5799 future direction (per-domain schema split) and the #5913 enforcement hook

Closes #5914

🤖 Generated with Claude Code