### PR TITLE
fix(frontend): replace DefineComponent<{},{},any> stubs with proper prop types (#5020)

### DIFF
--- a/autobot-frontend/src/components/CodebaseAnalytics.vue.d.ts
+++ b/autobot-frontend/src/components/CodebaseAnalytics.vue.d.ts
@@ -1,4 +1,0 @@
-// Issue #156 Fix: TypeScript declaration for ${file}.vue
-import { DefineComponent } from 'vue'
-declare const component: DefineComponent<{}, {}, any>
-export default component

--- a/autobot-frontend/src/components/KnowledgePersistenceDialog.vue.d.ts
+++ b/autobot-frontend/src/components/KnowledgePersistenceDialog.vue.d.ts
@@ -1,3 +1,0 @@
-import { DefineComponent } from 'vue';
-declare const KnowledgePersistenceDialog: DefineComponent<{}, {}, any>;
-export default KnowledgePersistenceDialog;

--- a/autobot-frontend/src/components/RumDashboard.vue.d.ts
+++ b/autobot-frontend/src/components/RumDashboard.vue.d.ts
@@ -1,4 +1,0 @@
-// Issue #156 Fix: TypeScript declaration for ${file}.vue
-import { DefineComponent } from 'vue'
-declare const component: DefineComponent<{}, {}, any>
-export default component

--- a/autobot-frontend/src/components/ValidationDashboard.vue.d.ts
+++ b/autobot-frontend/src/components/ValidationDashboard.vue.d.ts
@@ -1,4 +1,0 @@
-// Issue #156 Fix: TypeScript declaration for ${file}.vue
-import { DefineComponent } from 'vue'
-declare const component: DefineComponent<{}, {}, any>
-export default component

--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue.d.ts
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue.d.ts
@@ -1,4 +1,5 @@
-// Issue #156 Fix: TypeScript declaration for DesktopInterface.vue
-import { DefineComponent } from 'vue'
-declare const component: DefineComponent<{}, {}, any>
-export default component
+import type { DefineComponent } from 'vue'
+
+declare const DesktopInterface: DefineComponent<{}, {}, unknown>
+
+export default DesktopInterface

--- a/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue.d.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue.d.ts
@@ -1,18 +1,19 @@
-import { DefineComponent } from 'vue';
+import type { DefineComponent } from 'vue'
 
 export interface KnowledgeChatContext {
-  topic?: string;
-  keywords?: string[];
-  file_count?: number;
+  topic?: string
+  keywords?: string[]
+  file_count?: number
 }
 
 declare const KnowledgePersistenceDialog: DefineComponent<
   {
-    visible: { type: BooleanConstructor; default: false };
-    chatId: { type: StringConstructor; required: false; default: null };
-    chatContext: { type: ObjectConstructor; default: null };
+    visible?: boolean
+    chatId?: string | null
+    chatContext?: KnowledgeChatContext | null
   },
   {},
-  any
->;
-export default KnowledgePersistenceDialog;
+  unknown
+>
+
+export default KnowledgePersistenceDialog

--- a/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue.d.ts
+++ b/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue.d.ts
@@ -1,4 +1,5 @@
-import { DefineComponent } from 'vue';
+import type { DefineComponent } from 'vue'
 
-declare const SystemKnowledgeManager: DefineComponent<{}, {}, any>;
-export default SystemKnowledgeManager;
+declare const SystemKnowledgeManager: DefineComponent<{}, {}, unknown>
+
+export default SystemKnowledgeManager

--- a/autobot-frontend/src/components/manpage/ManPageManager.vue.d.ts
+++ b/autobot-frontend/src/components/manpage/ManPageManager.vue.d.ts
@@ -1,4 +1,5 @@
-import { DefineComponent } from 'vue';
+import type { DefineComponent } from 'vue'
 
-declare const ManPageManager: DefineComponent<{}, {}, any>;
-export default ManPageManager;
+declare const ManPageManager: DefineComponent<{}, {}, unknown>
+
+export default ManPageManager

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue.d.ts
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue.d.ts
@@ -1,4 +1,5 @@
-import { DefineComponent } from 'vue';
+import type { DefineComponent } from 'vue'
 
-declare const TerminalWindow: DefineComponent<{}, {}, any>;
-export default TerminalWindow;
+declare const TerminalWindow: DefineComponent<{}, {}, unknown>
+
+export default TerminalWindow

--- a/autobot-frontend/src/components/ui/CommandPermissionDialog.vue.d.ts
+++ b/autobot-frontend/src/components/ui/CommandPermissionDialog.vue.d.ts
@@ -1,3 +1,0 @@
-import { DefineComponent } from 'vue';
-declare const CommandPermissionDialog: DefineComponent<{}, {}, any>;
-export default CommandPermissionDialog;

--- a/autobot-frontend/src/components/workflow/WorkflowProgressWidget.vue.d.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowProgressWidget.vue.d.ts
@@ -1,3 +1,11 @@
-import { DefineComponent } from 'vue';
-declare const WorkflowProgressWidget: DefineComponent<{}, {}, any>;
-export default WorkflowProgressWidget;
+import type { DefineComponent } from 'vue'
+
+declare const WorkflowProgressWidget: DefineComponent<
+  {
+    workflowId?: string
+  },
+  {},
+  unknown
+>
+
+export default WorkflowProgressWidget


### PR DESCRIPTION
## Summary

Fixed 10 `.vue.d.ts` stub files that used `DefineComponent<{}, {}, any>`, silencing TS7016 without providing real type safety.

### Per-file actions

| File | Action |
|------|--------|
| `components/CodebaseAnalytics.vue.d.ts` | Deleted — orphaned root stub (actual component is `analytics/CodebaseAnalytics.vue` with `<script setup lang="ts">`) |
| `components/KnowledgePersistenceDialog.vue.d.ts` | Deleted — duplicate root stub (actual stub in `knowledge/`) |
| `components/RumDashboard.vue.d.ts` | Deleted — no corresponding `.vue` file exists |
| `components/ValidationDashboard.vue.d.ts` | Deleted — no corresponding `.vue` file exists |
| `components/ui/CommandPermissionDialog.vue.d.ts` | Deleted — component uses `<script setup lang="ts">`, vue-tsc auto-generates correct types |
| `knowledge/KnowledgePersistenceDialog.vue.d.ts` | Rewritten — proper typed props (`visible`, `chatId`, `chatContext`) + `KnowledgeChatContext` interface |
| `workflow/WorkflowProgressWidget.vue.d.ts` | Rewritten — proper typed `workflowId?: string` prop |
| `desktop/DesktopInterface.vue.d.ts` | Rewritten — proper typed component, `any` → `unknown` |
| `knowledge/SystemKnowledgeManager.vue.d.ts` | Rewritten — Options API, `any` → `unknown` |
| `manpage/ManPageManager.vue.d.ts` | Rewritten — Options API, `any` → `unknown` |
| `terminal/TerminalWindow.vue.d.ts` | Rewritten — Options API, `any` → `unknown` |

### Verification
`npx vue-tsc --noEmit -p tsconfig.app.json` exits 0 after all changes.

## Related
Closes #5020

🤖 Generated with [Claude Code](https://claude.com/claude-code)