### PR TITLE
test+feat(lint): add tests and extend check_response_models to SuccessMessageResponse/SuccessDataResponse (#5924 #5925)

### DIFF
--- a/tools/lint/check_response_models.py
+++ b/tools/lint/check_response_models.py
@@ -2,28 +2,32 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Pre-commit hook: verify response_model=DataResponse endpoints return compatible shapes.
+"""Pre-commit hook: verify response_model= endpoints return compatible shapes.
 
-Any FastAPI endpoint annotated with response_model=DataResponse will raise an HTTP 500
-ValidationError at runtime unless it returns a dict with a 'success' key (required, no
-default).  Static type checkers (mypy/pyright) do not validate response_model= decorator
+Any FastAPI endpoint annotated with response_model=<Schema> will raise an HTTP 500
+ValidationError at runtime unless it returns a dict satisfying all required fields.
+Static type checkers (mypy/pyright) do not validate response_model= decorator
 arguments against actual return shapes — this hook fills that gap.
 
-Implements the minimum viable check from issue #5913:
+Checked schemas and their required fields:
+  DataResponse              — requires 'success'
+  SuccessMessageResponse    — requires 'success' + 'message'
+  SuccessDataResponse       — requires 'success' + 'message'
 
-  For every route decorated with response_model=DataResponse, at least one of:
-    1. The function body calls create_success_response()
-    2. A return statement contains a dict literal with key 'success'
-    3. The function returns a bypass type (JSONResponse, Response, StreamingResponse,
-       FileResponse, PlainTextResponse, RedirectResponse) that skips FastAPI validation
+For each, at least one of the following must be true:
+  1. The function body calls create_success_response() [DataResponse only]
+  2. A return statement contains a dict literal with all required keys
+  3. The function returns a bypass type (JSONResponse, Response, StreamingResponse,
+     FileResponse, PlainTextResponse, RedirectResponse) that skips FastAPI validation
 
 Exit codes:
   0 — clean
   1 — violations found
   2 — usage error
 
-Background: #5843 → #5896 → #5904 cascade — 52 runtime-500 bugs introduced by
+Background: #5843 → #5896 → #5904 cascade — 52+61 runtime-500 bugs introduced by
 response_model=DataResponse on endpoints that returned plain dicts without 'success'.
+Extended in #5925 to cover SuccessMessageResponse and SuccessDataResponse.
 """
 from __future__ import annotations
 
@@ -56,6 +60,14 @@ ROUTE_METHODS = frozenset(
     {"get", "post", "put", "delete", "patch", "head", "options", "route", "api_route"}
 )
 
+# Schemas with required fields (no defaults) that this hook validates.
+# Maps schema name → frozenset of required key names that must appear in return dicts.
+CHECKED_SCHEMAS: dict[str, frozenset[str]] = {
+    "DataResponse": frozenset({"success"}),
+    "SuccessMessageResponse": frozenset({"success", "message"}),
+    "SuccessDataResponse": frozenset({"success", "message"}),
+}
+
 ALLOWLIST = {
     "tools/lint/check_response_models.py",
     "tools/lint/check_response_models_test.py",
@@ -64,23 +76,23 @@ ALLOWLIST = {
 _FuncNode = Union[ast.FunctionDef, ast.AsyncFunctionDef]
 
 
-def _has_data_response_model(decorator: ast.expr) -> bool:
-    """Return True if *decorator* is a route call with response_model=DataResponse."""
+def _checked_schema(decorator: ast.expr) -> str | None:
+    """Return the schema name if *decorator* is a route with a checked response_model."""
     if not isinstance(decorator, ast.Call):
-        return False
+        return None
     func = decorator.func
     if not isinstance(func, ast.Attribute):
-        return False
+        return None
     if func.attr not in ROUTE_METHODS:
-        return False
+        return None
     for kw in decorator.keywords:
         if (
             kw.arg == "response_model"
             and isinstance(kw.value, ast.Name)
-            and kw.value.id == "DataResponse"
+            and kw.value.id in CHECKED_SCHEMAS
         ):
-            return True
-    return False
+            return kw.value.id
+    return None
 
 
 def _calls_create_success_response(node: _FuncNode) -> bool:
@@ -95,16 +107,17 @@ def _calls_create_success_response(node: _FuncNode) -> bool:
     return False
 
 
-def _returns_success_dict(node: _FuncNode) -> bool:
-    """Return True if any return statement yields a dict literal with key 'success'."""
+def _return_dict_keys(node: _FuncNode) -> set[str]:
+    """Return the set of string keys found in any return dict literal in *node*."""
+    keys: set[str] = set()
     for child in ast.walk(node):
         if isinstance(child, ast.Return) and child.value is not None:
             val = child.value
             if isinstance(val, ast.Dict):
                 for key in val.keys:
-                    if isinstance(key, ast.Constant) and key.value == "success":
-                        return True
-    return False
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                        keys.add(key.value)
+    return keys
 
 
 def _returns_bypass_type(node: _FuncNode) -> bool:
@@ -140,13 +153,15 @@ def _check_file(path: Path, repo_root: Path) -> List[Tuple[int, str]]:
         if not isinstance(func_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
         for dec in func_node.decorator_list:
-            if not _has_data_response_model(dec):
+            schema = _checked_schema(dec)
+            if schema is None:
                 continue
-            if (
-                _calls_create_success_response(func_node)
-                or _returns_success_dict(func_node)
-                or _returns_bypass_type(func_node)
-            ):
+            required_keys = CHECKED_SCHEMAS[schema]
+            if _returns_bypass_type(func_node):
+                break
+            if schema == "DataResponse" and _calls_create_success_response(func_node):
+                break
+            if required_keys.issubset(_return_dict_keys(func_node)):
                 break
             violations.append((func_node.lineno, func_node.name))
             break
@@ -167,8 +182,8 @@ def main(argv: List[str]) -> int:
             rel = path
         for line_no, func_name in hits:
             print(
-                f"[{HOOK_ID}] {rel}:{line_no}: {func_name}() has response_model=DataResponse "
-                f"but body lacks create_success_response() or a return dict with 'success'. "
+                f"[{HOOK_ID}] {rel}:{line_no}: {func_name}() uses a checked response_model "
+                f"but body lacks the required return keys or a safe bypass. "
                 f"Use create_success_response() or a named schema instead. (#5913)",
                 file=sys.stderr,
             )

--- a/tools/lint/check_response_models_test.py
+++ b/tools/lint/check_response_models_test.py
@@ -197,6 +197,74 @@ async def get_attr():
 
 
 # ---------------------------------------------------------------------------
+# SuccessMessageResponse / SuccessDataResponse — extended coverage (#5925)
+# ---------------------------------------------------------------------------
+
+
+def test_detects_success_message_response_missing_required_keys(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.post("/msg", response_model=SuccessMessageResponse)
+async def post_msg():
+    return {"success": True}  # missing 'message'
+""",
+    )
+    violations = hook._check_file(f, tmp_path)
+    assert len(violations) == 1
+    assert violations[0][1] == "post_msg"
+
+
+def test_safe_success_message_response_with_both_keys(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.post("/msg", response_model=SuccessMessageResponse)
+async def post_msg():
+    return {"success": True, "message": "done"}
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_detects_success_data_response_missing_message(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.post("/data", response_model=SuccessDataResponse)
+async def post_data():
+    return {"success": True, "data": {}}  # missing 'message'
+""",
+    )
+    violations = hook._check_file(f, tmp_path)
+    assert len(violations) == 1
+
+
+def test_safe_success_data_response_with_required_keys(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.post("/data", response_model=SuccessDataResponse)
+async def post_data():
+    return {"success": True, "message": "ok", "data": None}
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_safe_success_message_response_with_bypass(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/stream", response_model=SuccessMessageResponse)
+async def stream():
+    return StreamingResponse(iter([b"x"]))
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
 # Exit-code integration
 # ---------------------------------------------------------------------------
 

--- a/tools/lint/check_response_models_test.py
+++ b/tools/lint/check_response_models_test.py
@@ -1,0 +1,237 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for tools/lint/check_response_models.py — see #5924.
+
+Covers detection, safe predicates, and exit codes for the hook that
+prevents response_model=DataResponse on endpoints that would produce
+HTTP 500 ValidationError at runtime (#5913).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_HOOK_PATH = Path(__file__).parent / "check_response_models.py"
+_spec = importlib.util.spec_from_file_location("_hook_under_test", _HOOK_PATH)
+assert _spec is not None and _spec.loader is not None
+hook = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hook)
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "case.py"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Positive cases — should FAIL (exit 1)
+# ---------------------------------------------------------------------------
+
+
+def test_detects_missing_success_in_return_dict(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+from fastapi import APIRouter
+router = APIRouter()
+
+@router.get("/foo", response_model=DataResponse)
+async def get_foo():
+    return {"data": "bar"}
+""",
+    )
+    repo = tmp_path
+    violations = hook._check_file(f, repo)
+    assert len(violations) == 1
+    assert violations[0][1] == "get_foo"
+
+
+def test_detects_plain_dict_return_no_success(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.post("/submit", response_model=DataResponse)
+def submit():
+    return {"result": 42, "count": 1}
+""",
+    )
+    violations = hook._check_file(f, tmp_path)
+    assert len(violations) == 1
+
+
+def test_detects_multiple_violations_in_one_file(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/a", response_model=DataResponse)
+async def get_a():
+    return {"items": []}
+
+@router.get("/b", response_model=DataResponse)
+async def get_b():
+    return {"count": 0}
+""",
+    )
+    violations = hook._check_file(f, tmp_path)
+    assert len(violations) == 2
+    assert {v[1] for v in violations} == {"get_a", "get_b"}
+
+
+def test_detects_async_def_route(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.delete("/item", response_model=DataResponse)
+async def delete_item():
+    return {"removed": True}
+""",
+    )
+    violations = hook._check_file(f, tmp_path)
+    assert len(violations) == 1
+    assert violations[0][1] == "delete_item"
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — should PASS (no violations)
+# ---------------------------------------------------------------------------
+
+
+def test_safe_with_create_success_response(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/ok", response_model=DataResponse)
+async def get_ok():
+    return create_success_response(data={"key": "value"})
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_safe_with_success_key_in_literal(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.post("/manual", response_model=DataResponse)
+def manual():
+    return {"success": True, "data": None}
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_safe_with_jsonresponse(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+from fastapi.responses import JSONResponse
+
+@router.get("/raw", response_model=DataResponse)
+async def raw():
+    return JSONResponse(content={"key": "val"})
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_safe_with_streamingresponse(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/stream", response_model=DataResponse)
+async def stream():
+    return StreamingResponse(iter([b"data"]))
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_safe_response_model_none(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/none", response_model=None)
+async def get_none():
+    return {"items": []}
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_safe_no_response_model_annotation(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/unannotated")
+async def get_unannotated():
+    return {"items": []}
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_safe_custom_schema(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/typed", response_model=MySchema)
+async def get_typed():
+    return {"items": []}
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_safe_create_success_response_via_attribute(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/attr", response_model=DataResponse)
+async def get_attr():
+    return helpers.create_success_response(data={})
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Exit-code integration
+# ---------------------------------------------------------------------------
+
+
+def test_main_returns_0_for_clean_file(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/clean", response_model=DataResponse)
+async def clean():
+    return create_success_response()
+""",
+    )
+    assert hook.main(["hook", str(f)]) == 0
+
+
+def test_main_returns_1_for_violation(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/bad", response_model=DataResponse)
+async def bad():
+    return {"no_success": True}
+""",
+    )
+    assert hook.main(["hook", str(f)]) == 1
+
+
+def test_main_returns_0_for_file_with_no_dataresponse(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/clean", response_model=None)
+async def clean():
+    return {"items": []}
+""",
+    )
+    assert hook.main(["hook", str(f)]) == 0


### PR DESCRIPTION
## Summary

- Adds a 20-test suite for `tools/lint/check_response_models.py` covering detection, safe predicates, and exit codes (`#5924`)
- Extends the CI hook to validate `SuccessMessageResponse` and `SuccessDataResponse` in addition to `DataResponse`, preventing the same HTTP 500 runtime failures for those schemas (`#5925`)

## Changes

### `tools/lint/check_response_models_test.py` (new — #5924)
- Loaded via `importlib.util.spec_from_file_location` to avoid package-path requirements
- 4 positive cases (violations detected), 9 negative cases (safe patterns pass), 3 exit-code integration tests
- Covers: `create_success_response()`, `JSONResponse`/`StreamingResponse` bypass, `{"success": True}` literal, `response_model=None`, `response_model=MySchema` (custom schema)

### `tools/lint/check_response_models.py` (extended — #5925)
- `CHECKED_SCHEMAS: dict[str, frozenset[str]]` maps each schema name to its required keys:
  - `DataResponse` → `{"success"}`
  - `SuccessMessageResponse` → `{"success", "message"}`
  - `SuccessDataResponse` → `{"success", "message"}`
- `_checked_schema()` now returns the schema name (not just bool) for dispatch
- `_return_dict_keys()` extracted to return all string keys across all return dict literals
- `_check_file()` uses `required_keys.issubset(return_dict_keys)` — one check covers all schemas
- 5 new tests added for SuccessMessageResponse/SuccessDataResponse (20 total pass)

## Test evidence

```
tools/lint/check_response_models_test.py ....................  [100%]
20 passed in 0.43s
```

## Discovery issues filed

- `#5928` — 306 more DataResponse endpoints outside FILES_5843 scope still annotated with `response_model=DataResponse` but returning plain dicts without `success` — same HTTP 500 risk, wider file set

Closes #5924
Closes #5925