### PR TITLE
fix(api): revert response_model=DataResponse to None for 309 variable-return endpoints (#5928)

### DIFF
--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -137,7 +137,7 @@ async def terminate_streaming_session(
     operation="list_streaming_sessions",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/streaming/sessions", response_model=DataResponse)
+@router.get("/streaming/sessions", response_model=None)
 async def list_streaming_sessions(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -155,7 +155,7 @@ async def list_streaming_sessions(
     operation="get_streaming_capabilities",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/streaming/capabilities", response_model=DataResponse)
+@router.get("/streaming/capabilities", response_model=None)
 async def get_streaming_capabilities(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -368,7 +368,7 @@ async def complete_takeover_session(
     operation="get_pending_takeovers",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/takeover/pending", response_model=DataResponse)
+@router.get("/takeover/pending", response_model=None)
 async def get_pending_takeovers(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -386,7 +386,7 @@ async def get_pending_takeovers(
     operation="get_active_takeovers",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/takeover/active", response_model=DataResponse)
+@router.get("/takeover/active", response_model=None)
 async def get_active_takeovers(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -404,7 +404,7 @@ async def get_active_takeovers(
     operation="get_takeover_status",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/takeover/status", response_model=DataResponse)
+@router.get("/takeover/status", response_model=None)
 async def get_takeover_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -503,7 +503,7 @@ async def emergency_system_stop(
     operation="get_system_health",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/system/health", response_model=DataResponse)
+@router.get("/system/health", response_model=None)
 async def get_system_health(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -599,7 +599,7 @@ async def desktop_streaming_websocket(websocket: WebSocket, session_id: str):
     operation="advanced_control_info",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/", response_model=DataResponse)
+@router.get("/", response_model=None)
 async def advanced_control_info(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -986,7 +986,7 @@ async def command_approval(
     operation="execute_command",
     error_code_prefix="AGENT",
 )
-@router.post("/execute_command", response_model=DataResponse)
+@router.post("/execute_command", response_model=None)
 async def execute_command(
     request: Request,
     command_data: dict,

--- a/autobot-backend/api/agent_terminal.py
+++ b/autobot-backend/api/agent_terminal.py
@@ -557,7 +557,7 @@ async def delete_agent_terminal_session(
     operation="execute_agent_command",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/execute", response_model=DataResponse)
+@router.post("/execute", response_model=None)
 async def execute_agent_command(
     current_user: dict = Depends(get_current_user),
     session_id: str = None,

--- a/autobot-backend/api/alertmanager_webhook.py
+++ b/autobot-backend/api/alertmanager_webhook.py
@@ -67,7 +67,7 @@ class AlertManagerWebhook(BaseModel):
     alerts: List[AlertInstance]
 
 
-@router.post("/alertmanager", response_model=DataResponse)
+@router.post("/alertmanager", response_model=None)
 async def receive_alertmanager_webhook(payload: AlertManagerWebhook, request: Request):
     """
     Receive alerts from Prometheus AlertManager
@@ -161,7 +161,7 @@ async def _process_alert(alert: AlertInstance, group_status: str):
         logger.error("Failed to process individual alert: %s", e, exc_info=True)
 
 
-@router.get("/alertmanager/health", response_model=DataResponse)
+@router.get("/alertmanager/health", response_model=None)
 async def alertmanager_webhook_health():
     """Health check endpoint for AlertManager webhook"""
     return {

--- a/autobot-backend/api/analytics.py
+++ b/autobot-backend/api/analytics.py
@@ -218,7 +218,7 @@ def _check_resource_alerts(system_resources: Dict) -> List[Dict[str, Any]]:
     operation="get_detailed_system_health",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/system/health-detailed", response_model=DataResponse)
+@router.get("/system/health-detailed", response_model=None)
 async def get_detailed_system_health(current_user: Dict = Depends(get_current_user)):
     """Get detailed system health with enhanced analytics (Issue #398: refactored)."""
     base_health = await hardware_monitor.get_system_health()
@@ -275,7 +275,7 @@ async def get_detailed_system_health(current_user: Dict = Depends(get_current_us
     operation="get_performance_metrics",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/performance/metrics", response_model=DataResponse)
+@router.get("/performance/metrics", response_model=None)
 async def get_performance_metrics(current_user: Dict = Depends(get_current_user)):
     """Get comprehensive performance metrics"""
     metrics = await analytics_controller.collect_performance_metrics()
@@ -321,7 +321,7 @@ async def get_performance_metrics(current_user: Dict = Depends(get_current_user)
     operation="get_communication_patterns",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/communication/patterns", response_model=DataResponse)
+@router.get("/communication/patterns", response_model=None)
 async def get_communication_patterns(current_user: Dict = Depends(get_current_user)):
     """Get detailed communication pattern analysis"""
     patterns = await analytics_controller.analyze_communication_patterns()
@@ -374,7 +374,7 @@ async def get_communication_patterns(current_user: Dict = Depends(get_current_us
     operation="get_usage_statistics",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/usage/statistics", response_model=DataResponse)
+@router.get("/usage/statistics", response_model=None)
 async def get_usage_statistics(current_user: Dict = Depends(get_current_user)):
     """Get comprehensive usage statistics"""
     stats = await analytics_controller.get_usage_statistics()
@@ -486,7 +486,7 @@ async def _collect_realtime_metrics_data() -> Dict[str, Any]:
     operation="get_realtime_metrics",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/realtime/metrics", response_model=DataResponse)
+@router.get("/realtime/metrics", response_model=None)
 async def get_realtime_metrics(current_user: Dict = Depends(get_current_user)):
     """Get current real-time metrics snapshot"""
     return await _collect_realtime_metrics_data()
@@ -497,7 +497,7 @@ async def get_realtime_metrics(current_user: Dict = Depends(get_current_user)):
     operation="track_analytics_event",
     error_code_prefix="ANALYTICS",
 )
-@router.post("/events/track", response_model=DataResponse)
+@router.post("/events/track", response_model=None)
 async def track_analytics_event(
     event: RealTimeEvent, current_user: Dict = Depends(get_current_user)
 ):
@@ -602,7 +602,7 @@ def _compute_hourly_stats(historical_calls: list) -> dict:
     operation="get_historical_trends",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/trends/historical", response_model=DataResponse)
+@router.get("/trends/historical", response_model=None)
 async def get_historical_trends(
     hours: int = Query(24, description="Number of hours to analyze", ge=1, le=168),
     current_user: Dict = Depends(get_current_user),
@@ -735,7 +735,7 @@ async def websocket_realtime_analytics(websocket: WebSocket):
     operation="start_analytics_collection",
     error_code_prefix="ANALYTICS",
 )
-@router.post("/collection/start", response_model=DataResponse)
+@router.post("/collection/start", response_model=None)
 async def start_analytics_collection(current_user: Dict = Depends(get_current_user)):
     """Start continuous analytics collection"""
     # Initialize session tracking
@@ -761,7 +761,7 @@ async def start_analytics_collection(current_user: Dict = Depends(get_current_us
     operation="stop_analytics_collection",
     error_code_prefix="ANALYTICS",
 )
-@router.post("/collection/stop", response_model=DataResponse)
+@router.post("/collection/stop", response_model=None)
 async def stop_analytics_collection(current_user: Dict = Depends(get_current_user)):
     """Stop continuous analytics collection"""
     # Stop metrics collection
@@ -821,7 +821,7 @@ async def _check_analytics_redis_connectivity() -> Dict[str, str]:
     operation="get_analytics_status",
     error_code_prefix="ANALYTICS",
 )
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=None)
 async def get_analytics_status(current_user: Dict = Depends(get_current_user)):
     """Get comprehensive analytics system status (Issue #398: refactored)."""
     status = _build_analytics_status_base(analytics_controller.metrics_collector)
@@ -1207,7 +1207,7 @@ async def websocket_live_analytics(websocket: WebSocket):
 # ------------------------------------------------------------------
 
 
-@router.get("/root-cause/{task_id}", response_model=DataResponse)
+@router.get("/root-cause/{task_id}", response_model=None)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="analyze_root_cause",
@@ -1312,7 +1312,7 @@ async def _run_dashboard_analysis(task_id: str) -> None:
         await _dash_manager.fail_task(task_id, str(e))
 
 
-@router.post("/dashboard/overview/analyze", response_model=DataResponse)
+@router.post("/dashboard/overview/analyze", response_model=None)
 async def start_dashboard_analysis(
     background_tasks: BackgroundTasks,
     current_user: Dict = Depends(get_current_user),
@@ -1323,7 +1323,7 @@ async def start_dashboard_analysis(
     return {"task_id": task_id, "status": "pending"}
 
 
-@router.get("/dashboard/overview/status/{task_id}", response_model=DataResponse)
+@router.get("/dashboard/overview/status/{task_id}", response_model=None)
 async def get_dashboard_status(task_id: str):
     """Get dashboard overview task status (#1304)."""
     task = await _dash_manager.get_status(task_id)
@@ -1332,7 +1332,7 @@ async def get_dashboard_status(task_id: str):
     return task
 
 
-@router.post("/dashboard/overview/tasks/clear-stuck", response_model=DataResponse)
+@router.post("/dashboard/overview/tasks/clear-stuck", response_model=None)
 async def clear_stuck_dashboard_tasks(
     force: bool = Query(
         default=False,

--- a/autobot-backend/api/analytics_agents.py
+++ b/autobot-backend/api/analytics_agents.py
@@ -98,7 +98,7 @@ class CompleteTaskRequest(BaseModel):
     operation="get_all_agents_performance",
     error_code_prefix="AGENT",
 )
-@router.get("/performance", response_model=DataResponse)
+@router.get("/performance", response_model=None)
 async def get_all_agents_performance(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -176,7 +176,7 @@ async def get_agent_performance(
     operation="get_agent_history",
     error_code_prefix="AGENT",
 )
-@router.get("/{agent_id}/history", response_model=DataResponse)
+@router.get("/{agent_id}/history", response_model=None)
 async def get_agent_history(
     agent_id: str,
     limit: int = Query(default=100, ge=1, le=1000, description="Max records to return"),
@@ -204,7 +204,7 @@ async def get_agent_history(
     operation="get_recent_tasks",
     error_code_prefix="AGENT",
 )
-@router.get("/tasks/recent", response_model=DataResponse)
+@router.get("/tasks/recent", response_model=None)
 async def get_recent_tasks(
     limit: int = Query(default=100, ge=1, le=1000, description="Max records to return"),
     admin_check: bool = Depends(check_admin_permission),
@@ -235,7 +235,7 @@ async def get_recent_tasks(
     operation="compare_agents",
     error_code_prefix="AGENT",
 )
-@router.get("/comparison", response_model=DataResponse)
+@router.get("/comparison", response_model=None)
 async def compare_agents(
     agent_ids: Optional[str] = Query(
         None, description="Comma-separated agent IDs to compare (all if not specified)"
@@ -326,7 +326,7 @@ def _check_agent_metrics(metrics) -> list:
     operation="get_agent_recommendations",
     error_code_prefix="AGENT",
 )
-@router.get("/recommendations", response_model=DataResponse)
+@router.get("/recommendations", response_model=None)
 async def get_agent_recommendations(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -379,7 +379,7 @@ async def get_agent_recommendations(
     operation="get_performance_trends",
     error_code_prefix="AGENT",
 )
-@router.get("/trends", response_model=DataResponse)
+@router.get("/trends", response_model=None)
 async def get_performance_trends(
     agent_id: Optional[str] = Query(
         None, description="Specific agent ID (all if not specified)"
@@ -405,7 +405,7 @@ async def get_performance_trends(
     operation="get_agent_types",
     error_code_prefix="AGENT",
 )
-@router.get("/types", response_model=DataResponse)
+@router.get("/types", response_model=None)
 async def get_agent_types(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -432,7 +432,7 @@ async def get_agent_types(
     operation="track_task_start",
     error_code_prefix="AGENT",
 )
-@router.post("/tasks/start", response_model=DataResponse)
+@router.post("/tasks/start", response_model=None)
 async def track_task_start(
     request: TrackTaskRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -465,7 +465,7 @@ async def track_task_start(
     operation="track_task_complete",
     error_code_prefix="AGENT",
 )
-@router.post("/tasks/complete", response_model=DataResponse)
+@router.post("/tasks/complete", response_model=None)
 async def track_task_complete(
     request: CompleteTaskRequest,
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/analytics_behavior.py
+++ b/autobot-backend/api/analytics_behavior.py
@@ -91,7 +91,7 @@ class EngagementMetricsResponse(BaseModel):
     operation="track_user_event",
     error_code_prefix="BEHAVIOR",
 )
-@router.post("/track", response_model=DataResponse)
+@router.post("/track", response_model=None)
 async def track_user_event(
     request: TrackEventRequest,
     current_user: dict = Depends(get_current_user),
@@ -130,7 +130,7 @@ async def track_user_event(
     operation="get_recent_events",
     error_code_prefix="BEHAVIOR",
 )
-@router.get("/events/recent", response_model=DataResponse)
+@router.get("/events/recent", response_model=None)
 async def get_recent_events(
     limit: int = Query(
         default=100, ge=1, le=1000, description="Number of events to return"
@@ -163,7 +163,7 @@ async def get_recent_events(
     operation="get_feature_metrics",
     error_code_prefix="BEHAVIOR",
 )
-@router.get("/features", response_model=DataResponse)
+@router.get("/features", response_model=None)
 async def get_feature_metrics(
     feature: Optional[str] = Query(
         None, description="Specific feature to get metrics for"
@@ -188,7 +188,7 @@ async def get_feature_metrics(
     operation="get_feature_comparison",
     error_code_prefix="BEHAVIOR",
 )
-@router.get("/features/comparison", response_model=DataResponse)
+@router.get("/features/comparison", response_model=None)
 async def get_feature_comparison(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -273,7 +273,7 @@ async def get_user_journey(
     operation="get_engagement_metrics",
     error_code_prefix="BEHAVIOR",
 )
-@router.get("/engagement", response_model=DataResponse)
+@router.get("/engagement", response_model=None)
 async def get_engagement_metrics(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -301,7 +301,7 @@ async def get_engagement_metrics(
     operation="get_daily_stats",
     error_code_prefix="BEHAVIOR",
 )
-@router.get("/stats/daily", response_model=DataResponse)
+@router.get("/stats/daily", response_model=None)
 async def get_daily_stats(
     days: int = Query(
         default=30, ge=1, le=90, description="Number of days to retrieve"
@@ -326,7 +326,7 @@ async def get_daily_stats(
     operation="get_usage_heatmap",
     error_code_prefix="BEHAVIOR",
 )
-@router.get("/stats/heatmap", response_model=DataResponse)
+@router.get("/stats/heatmap", response_model=None)
 async def get_usage_heatmap(
     days: int = Query(default=7, ge=1, le=30, description="Number of days to include"),
     admin_check: bool = Depends(check_admin_permission),
@@ -349,7 +349,7 @@ async def get_usage_heatmap(
     operation="get_peak_usage",
     error_code_prefix="BEHAVIOR",
 )
-@router.get("/stats/peak", response_model=DataResponse)
+@router.get("/stats/peak", response_model=None)
 async def get_peak_usage(
     days: int = Query(default=7, ge=1, le=30, description="Number of days to analyze"),
     admin_check: bool = Depends(check_admin_permission),
@@ -404,7 +404,7 @@ async def get_peak_usage(
     operation="get_behavior_summary",
     error_code_prefix="BEHAVIOR",
 )
-@router.get("/summary", response_model=DataResponse)
+@router.get("/summary", response_model=None)
 async def get_behavior_summary(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/analytics_bug_prediction.py
+++ b/autobot-backend/api/analytics_bug_prediction.py
@@ -921,7 +921,7 @@ async def _run_bug_analysis(
     }
 
 
-@router.get("/analyze", response_model=DataResponse)
+@router.get("/analyze", response_model=None)
 async def analyze_codebase(
     admin_check: bool = Depends(check_admin_permission),
     path: str = Query(".", description="Path to analyze"),
@@ -1035,7 +1035,7 @@ async def _run_batched_bug_analysis(
         await _bg_manager.fail_task(task_id, str(e))
 
 
-@router.get("/cached", response_model=DataResponse)
+@router.get("/cached", response_model=None)
 async def get_cached_bug_prediction():
     """Return the latest completed bug prediction result (#1540)."""
     cached = await _bg_manager.get_latest_result()
@@ -1092,7 +1092,7 @@ async def clear_stuck_bug_tasks(
     }
 
 
-@router.get("/high-risk", response_model=DataResponse)
+@router.get("/high-risk", response_model=None)
 async def get_high_risk_files(
     admin_check: bool = Depends(check_admin_permission),
     threshold: float = Query(60, ge=0, le=100),
@@ -1160,7 +1160,7 @@ def _build_file_risk_response(file_path: str, factors: dict, bug_history: dict) 
     }
 
 
-@router.get("/file/{file_path:path}", response_model=DataResponse)
+@router.get("/file/{file_path:path}", response_model=None)
 async def get_file_risk(
     file_path: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -1257,7 +1257,7 @@ def _get_flat_heatmap_data(files: list) -> list:
     ]
 
 
-@router.get("/heatmap", response_model=DataResponse)
+@router.get("/heatmap", response_model=None)
 async def get_risk_heatmap(
     admin_check: bool = Depends(check_admin_permission),
     grouping: str = Query("directory", pattern="^(directory|module|flat)$"),
@@ -1306,7 +1306,7 @@ async def get_risk_heatmap(
         return _no_data_response("Heatmap generation failed")
 
 
-@router.get("/trends", response_model=DataResponse)
+@router.get("/trends", response_model=None)
 async def get_prediction_trends(
     admin_check: bool = Depends(check_admin_permission),
     period: str = Query("30d", pattern="^(7d|30d|90d)$"),
@@ -1419,7 +1419,7 @@ def _generate_summary_recommendations(
     return recommendations[:5]
 
 
-@router.get("/summary", response_model=DataResponse)
+@router.get("/summary", response_model=None)
 async def get_prediction_summary(
     admin_check: bool = Depends(check_admin_permission),
     path: str = Query(".", description="Path to analyze"),

--- a/autobot-backend/api/analytics_cfg.py
+++ b/autobot-backend/api/analytics_cfg.py
@@ -1201,7 +1201,7 @@ async def analyze_control_flow(
     operation="analyze_cfg_file",
     error_code_prefix="CFG",
 )
-@router.post("/analyze-file", response_model=DataResponse)
+@router.post("/analyze-file", response_model=None)
 async def analyze_file_control_flow(
     request: AnalyzeFileRequest,
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/analytics_code.py
+++ b/autobot-backend/api/analytics_code.py
@@ -456,7 +456,7 @@ def _generate_communication_chain_insights(
     operation="analyze_communication_chains_detailed",
     error_code_prefix="ANALYTICS",
 )
-@router.post("/code/analyze/communication-chains", response_model=DataResponse)
+@router.post("/code/analyze/communication-chains", response_model=None)
 async def analyze_communication_chains_detailed(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/analytics_code_generation.py
+++ b/autobot-backend/api/analytics_code_generation.py
@@ -954,7 +954,7 @@ get_code_generation_engine = lazy_singleton(CodeGenerationEngine)
 # =============================================================================
 
 
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def get_health(admin_check: bool = Depends(check_admin_permission)):
     """Get code generation service health status.
 
@@ -1017,7 +1017,7 @@ async def refactor_code(
     return await engine.refactor_code(request)
 
 
-@router.post("/validate", response_model=DataResponse)
+@router.post("/validate", response_model=None)
 async def validate_code(
     admin_check: bool = Depends(check_admin_permission),
     request: ValidationRequest = None,
@@ -1040,7 +1040,7 @@ async def validate_code(
     }
 
 
-@router.get("/versions/{file_path:path}", response_model=DataResponse)
+@router.get("/versions/{file_path:path}", response_model=None)
 async def get_versions(
     admin_check: bool = Depends(check_admin_permission), file_path: str = None
 ):
@@ -1088,7 +1088,7 @@ async def rollback_code(
     }
 
 
-@router.get("/stats", response_model=DataResponse)
+@router.get("/stats", response_model=None)
 async def get_stats(
     admin_check: bool = Depends(check_admin_permission),
     source_id: Optional[str] = Query(None, description="Project source ID to scope analysis"),
@@ -1109,7 +1109,7 @@ async def get_stats(
     return await engine.get_stats(source_id=source_id)
 
 
-@router.get("/refactoring-types", response_model=DataResponse)
+@router.get("/refactoring-types", response_model=None)
 async def get_refactoring_types(admin_check: bool = Depends(check_admin_permission)):
     """
     Get available refactoring types with descriptions.

--- a/autobot-backend/api/analytics_conversation.py
+++ b/autobot-backend/api/analytics_conversation.py
@@ -842,7 +842,7 @@ async def analyze_conversations(
     operation="get_intent_stats",
     error_code_prefix="CONVFLOW",
 )
-@router.get("/intents", response_model=DataResponse)
+@router.get("/intents", response_model=None)
 async def get_intent_stats(
     hours: int = Query(24, ge=1, le=168, description="Hours to analyze"),
     admin_check: bool = Depends(check_admin_permission),
@@ -905,7 +905,7 @@ async def get_intent_stats(
     operation="get_flow_paths",
     error_code_prefix="CONVFLOW",
 )
-@router.get("/flows", response_model=DataResponse)
+@router.get("/flows", response_model=None)
 async def get_flow_paths(
     hours: int = Query(24, ge=1, le=168, description="Hours to analyze"),
     min_frequency: int = Query(2, ge=1, description="Minimum flow frequency"),
@@ -973,7 +973,7 @@ async def get_flow_paths(
     operation="get_bottlenecks",
     error_code_prefix="CONVFLOW",
 )
-@router.get("/bottlenecks", response_model=DataResponse)
+@router.get("/bottlenecks", response_model=None)
 async def get_bottlenecks(
     hours: int = Query(24, ge=1, le=168, description="Hours to analyze"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1012,7 +1012,7 @@ async def get_bottlenecks(
     operation="get_hourly_distribution",
     error_code_prefix="CONVFLOW",
 )
-@router.get("/distribution", response_model=DataResponse)
+@router.get("/distribution", response_model=None)
 async def get_hourly_distribution(
     hours: int = Query(24, ge=1, le=168, description="Hours to analyze"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1056,7 +1056,7 @@ async def get_hourly_distribution(
     operation="detect_intent",
     error_code_prefix="CONVFLOW",
 )
-@router.post("/detect-intent", response_model=DataResponse)
+@router.post("/detect-intent", response_model=None)
 async def detect_intent(
     message: str = Query(..., description="Message to analyze"),
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/analytics_cost.py
+++ b/autobot-backend/api/analytics_cost.py
@@ -149,7 +149,7 @@ async def get_cost_summary(
     operation="get_cost_by_model",
     error_code_prefix="COST",
 )
-@router.get("/by-model", response_model=DataResponse)
+@router.get("/by-model", response_model=None)
 async def get_cost_by_model(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -264,7 +264,7 @@ async def get_cost_trends(
     operation="get_cost_forecast",
     error_code_prefix="COST",
 )
-@router.get("/forecast", response_model=DataResponse)
+@router.get("/forecast", response_model=None)
 async def get_cost_forecast(
     days_to_forecast: int = Query(
         default=30, ge=1, le=90, description="Days to forecast"
@@ -327,7 +327,7 @@ async def get_cost_forecast(
     operation="get_recent_usage",
     error_code_prefix="COST",
 )
-@router.get("/usage/recent", response_model=DataResponse)
+@router.get("/usage/recent", response_model=None)
 async def get_recent_usage(
     limit: int = Query(
         default=100, ge=1, le=1000, description="Number of records to return"
@@ -360,7 +360,7 @@ async def get_recent_usage(
     operation="get_model_pricing",
     error_code_prefix="COST",
 )
-@router.get("/pricing", response_model=DataResponse)
+@router.get("/pricing", response_model=None)
 async def get_model_pricing(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -412,7 +412,7 @@ async def get_model_pricing(
     operation="calculate_cost_estimate",
     error_code_prefix="COST",
 )
-@router.get("/estimate", response_model=DataResponse)
+@router.get("/estimate", response_model=None)
 async def calculate_cost_estimate(
     model: str = Query(..., description="Model name"),
     input_tokens: int = Query(..., ge=0, description="Number of input tokens"),
@@ -448,7 +448,7 @@ async def calculate_cost_estimate(
     operation="set_budget_alert",
     error_code_prefix="COST",
 )
-@router.post("/budget-alert", response_model=DataResponse)
+@router.post("/budget-alert", response_model=None)
 async def set_budget_alert(
     alert: BudgetAlertRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -485,7 +485,7 @@ async def set_budget_alert(
     operation="get_budget_alerts",
     error_code_prefix="COST",
 )
-@router.get("/budget-alerts", response_model=DataResponse)
+@router.get("/budget-alerts", response_model=None)
 async def get_budget_alerts(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -579,7 +579,7 @@ async def _get_current_costs(tracker, today: datetime) -> dict:
     operation="get_budget_status",
     error_code_prefix="COST",
 )
-@router.get("/budget-status", response_model=DataResponse)
+@router.get("/budget-status", response_model=None)
 async def get_budget_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -636,7 +636,7 @@ class AgentCostResponse(BaseModel):
     operation="get_cost_by_agent_all",
     error_code_prefix="COST",
 )
-@router.get("/by-agent", response_model=DataResponse)
+@router.get("/by-agent", response_model=None)
 async def get_cost_by_agent_all(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -681,7 +681,7 @@ async def get_cost_by_agent_all(
     operation="get_cost_by_agent_single",
     error_code_prefix="COST",
 )
-@router.get("/by-agent/{agent_id}", response_model=DataResponse)
+@router.get("/by-agent/{agent_id}", response_model=None)
 async def get_cost_by_agent_single(
     agent_id: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -706,7 +706,7 @@ async def get_cost_by_agent_single(
     operation="set_agent_budget",
     error_code_prefix="COST",
 )
-@router.put("/by-agent/{agent_id}/budget", response_model=DataResponse)
+@router.put("/by-agent/{agent_id}/budget", response_model=None)
 async def set_agent_budget(
     agent_id: str,
     request: AgentBudgetRequest,
@@ -727,7 +727,7 @@ async def set_agent_budget(
     operation="get_agent_budget_status",
     error_code_prefix="COST",
 )
-@router.get("/by-agent/{agent_id}/budget", response_model=DataResponse)
+@router.get("/by-agent/{agent_id}/budget", response_model=None)
 async def get_agent_budget_status(
     agent_id: str,
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/analytics_dfa.py
+++ b/autobot-backend/api/analytics_dfa.py
@@ -1181,7 +1181,7 @@ async def analyze_file(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/vulnerabilities", response_model=DataResponse)
+@router.post("/vulnerabilities", response_model=None)
 async def get_vulnerabilities(
     request: AnalyzeRequest, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -1285,7 +1285,7 @@ async def get_taint_summary(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/sources", response_model=DataResponse)
+@router.get("/sources", response_model=None)
 async def list_taint_sources(admin_check: bool = Depends(check_admin_permission)):
     """
     List all recognized taint sources.
@@ -1304,7 +1304,7 @@ async def list_taint_sources(admin_check: bool = Depends(check_admin_permission)
     }
 
 
-@router.get("/sinks", response_model=DataResponse)
+@router.get("/sinks", response_model=None)
 async def list_taint_sinks(admin_check: bool = Depends(check_admin_permission)):
     """
     List all recognized security-sensitive sinks.
@@ -1324,7 +1324,7 @@ async def list_taint_sinks(admin_check: bool = Depends(check_admin_permission)):
     }
 
 
-@router.get("/sanitizers", response_model=DataResponse)
+@router.get("/sanitizers", response_model=None)
 async def list_sanitizers(admin_check: bool = Depends(check_admin_permission)):
     """
     List all recognized sanitizer functions.
@@ -1334,7 +1334,7 @@ async def list_sanitizers(admin_check: bool = Depends(check_admin_permission)):
     return {"sanitizers": sorted(SANITIZERS)}
 
 
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def health_check(admin_check: bool = Depends(check_admin_permission)):
     """
     Health check endpoint.

--- a/autobot-backend/api/analytics_log_patterns.py
+++ b/autobot-backend/api/analytics_log_patterns.py
@@ -922,7 +922,7 @@ def _analyze_pattern_lines(
     operation="get_pattern_details",
     error_code_prefix="LOGPAT",
 )
-@router.get("/pattern/{pattern_id}", response_model=DataResponse)
+@router.get("/pattern/{pattern_id}", response_model=None)
 async def get_pattern_details(
     pattern_id: str,
     hours: int = Query(24, ge=1, le=168, description="Hours of logs to search"),
@@ -971,7 +971,7 @@ async def get_pattern_details(
     operation="get_error_hotspots",
     error_code_prefix="LOGPAT",
 )
-@router.get("/hotspots", response_model=DataResponse)
+@router.get("/hotspots", response_model=None)
 async def get_error_hotspots(
     hours: int = Query(24, ge=1, le=168, description="Hours to analyze"),
     limit: int = Query(10, ge=1, le=50, description="Number of hotspots to return"),
@@ -1049,7 +1049,7 @@ def _aggregate_log_stats(
     operation="get_log_stats",
     error_code_prefix="LOGPAT",
 )
-@router.get("/stats", response_model=DataResponse)
+@router.get("/stats", response_model=None)
 async def get_log_stats(
     hours: int = Query(24, ge=1, le=168, description="Hours to analyze"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1093,7 +1093,7 @@ async def get_log_stats(
     operation="get_realtime_summary",
     error_code_prefix="LOGPAT",
 )
-@router.get("/realtime", response_model=DataResponse)
+@router.get("/realtime", response_model=None)
 async def get_realtime_summary(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/analytics_quality.py
+++ b/autobot-backend/api/analytics_quality.py
@@ -966,7 +966,7 @@ manager = ConnectionManager()
 # ============================================================================
 
 
-@router.get("/health-score", response_model=DataResponse)
+@router.get("/health-score", response_model=None)
 async def get_health_score(
     admin_check: bool = Depends(check_admin_permission),
     source_id: Optional[str] = Query(None, description="Project source ID to scope analysis"),
@@ -1004,7 +1004,7 @@ async def get_health_score(
     }
 
 
-@router.get("/metrics", response_model=DataResponse)
+@router.get("/metrics", response_model=None)
 async def get_quality_metrics(
     category: Optional[MetricCategory] = Query(None, description="Filter by category"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1063,7 +1063,7 @@ async def get_quality_metrics(
     }
 
 
-@router.get("/patterns", response_model=DataResponse)
+@router.get("/patterns", response_model=None)
 async def get_pattern_distribution(
     severity: Optional[str] = Query(None, description="Filter by severity"),
     limit: int = Query(20, ge=1, le=100),
@@ -1116,7 +1116,7 @@ async def get_pattern_distribution(
     return {"status": "success", "patterns": result}
 
 
-@router.get("/complexity", response_model=DataResponse)
+@router.get("/complexity", response_model=None)
 async def get_complexity_metrics(
     top_n: int = Query(10, ge=1, le=50, description="Number of hotspots to return"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1233,7 +1233,7 @@ def _calculate_trend_statistics(scores: list) -> dict:
     }
 
 
-@router.get("/trends", response_model=DataResponse)
+@router.get("/trends", response_model=None)
 async def get_quality_trends(
     period: str = Query("30d", pattern="^(7d|14d|30d|90d)$"),
     metric: Optional[str] = Query(None, description="Specific metric to trend"),
@@ -1268,7 +1268,7 @@ async def get_quality_trends(
     }
 
 
-@router.get("/snapshot", response_model=DataResponse)
+@router.get("/snapshot", response_model=None)
 async def get_quality_snapshot(
     admin_check: bool = Depends(check_admin_permission),
     source_id: Optional[str] = Query(None, description="Project source ID to scope analysis"),
@@ -1336,7 +1336,7 @@ async def get_quality_snapshot(
     }
 
 
-@router.get("/drill-down/{category}", response_model=DataResponse)
+@router.get("/drill-down/{category}", response_model=None)
 async def drill_down_category(
     category: str,
     file_filter: Optional[str] = Query(None, description="Filter by file path"),

--- a/autobot-backend/api/approval_gates.py
+++ b/autobot-backend/api/approval_gates.py
@@ -426,7 +426,7 @@ async def link_task(
 @router.delete(
     "/approval-gates/{approval_id}/tasks/{task_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    response_model=DataResponse,
+    response_model=None,
 )
 async def unlink_task(
     approval_id: uuid.UUID,

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -357,7 +357,7 @@ async def logout(request: Request, logout_data: LogoutRequest):
     operation="get_current_user_info",
     error_code_prefix="AUTH",
 )
-@router.get("/me", response_model=DataResponse)
+@router.get("/me", response_model=None)
 async def get_current_user_info(request: Request):
     """
     Get current authenticated user information.
@@ -406,7 +406,7 @@ async def get_current_user_info(request: Request):
     operation="check_authentication",
     error_code_prefix="AUTH",
 )
-@router.get("/check", response_model=DataResponse)
+@router.get("/check", response_model=None)
 async def check_authentication(request: Request):
     """
     Quick authentication check endpoint.
@@ -450,7 +450,7 @@ async def check_authentication(request: Request):
     operation="check_permission",
     error_code_prefix="AUTH",
 )
-@router.get("/permissions/{operation}", response_model=DataResponse)
+@router.get("/permissions/{operation}", response_model=None)
 async def check_permission(request: Request, operation: str):
     """
     Check if current user has permission for specific operation

--- a/autobot-backend/api/batch_jobs.py
+++ b/autobot-backend/api/batch_jobs.py
@@ -310,7 +310,7 @@ async def get_batch_job(
     operation="delete_batch_job",
     error_code_prefix="BATCH_JOBS",
 )
-@router.delete("/{job_id}", response_model=DataResponse)
+@router.delete("/{job_id}", response_model=None)
 async def delete_batch_job(
     job_id: str,
     current_user: dict = Depends(get_current_user),
@@ -503,7 +503,7 @@ async def get_batch_template(
     operation="delete_batch_template",
     error_code_prefix="BATCH_JOBS",
 )
-@router.delete("/templates/{template_id}", response_model=DataResponse)
+@router.delete("/templates/{template_id}", response_model=None)
 async def delete_batch_template(
     template_id: str,
     current_user: dict = Depends(get_current_user),
@@ -613,7 +613,7 @@ async def create_batch_schedule(
     operation="delete_batch_schedule",
     error_code_prefix="BATCH_JOBS",
 )
-@router.delete("/schedules/{schedule_id}", response_model=DataResponse)
+@router.delete("/schedules/{schedule_id}", response_model=None)
 async def delete_batch_schedule(
     schedule_id: str,
     current_user: dict = Depends(get_current_user),
@@ -648,7 +648,7 @@ async def delete_batch_schedule(
     operation="get_batch_jobs_health",
     error_code_prefix="BATCH_JOBS",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def get_batch_jobs_health(
     current_user: dict = Depends(get_current_user),
 ):
@@ -741,7 +741,7 @@ class BatchResponse(BaseModel):
     operation="get_batch_status",
     error_code_prefix="BATCH",
 )
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=None)
 async def get_batch_status():
     """Get batch processing service status"""
     return {
@@ -759,7 +759,7 @@ async def get_batch_status():
     operation="batch_load",
     error_code_prefix="BATCH",
 )
-@router.post("/load", response_model=DataResponse)
+@router.post("/load", response_model=None)
 async def batch_load(batch_request: BatchRequest):
     """Execute multiple API calls in parallel and return combined results."""
     import time
@@ -813,8 +813,8 @@ async def batch_load(batch_request: BatchRequest):
     operation="batch_chat_initialization",
     error_code_prefix="BATCH",
 )
-@router.get("/chat-init", response_model=DataResponse)
-@router.post("/chat-init", response_model=DataResponse)
+@router.get("/chat-init", response_model=None)
+@router.post("/chat-init", response_model=None)
 async def batch_chat_initialization():
     """
     Optimized endpoint for chat interface initialization.

--- a/autobot-backend/api/bi_export_endpoints.py
+++ b/autobot-backend/api/bi_export_endpoints.py
@@ -42,7 +42,7 @@ class SavedReportRequest(BaseModel):
 # =========================================================================
 
 
-@router.post("/reports/save", response_model=DataResponse)
+@router.post("/reports/save", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="save_report",
@@ -67,7 +67,7 @@ async def save_report(
 # =========================================================================
 
 
-@router.get("/reports/saved", response_model=DataResponse)
+@router.get("/reports/saved", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_saved_reports",

--- a/autobot-backend/api/chat_knowledge.py
+++ b/autobot-backend/api/chat_knowledge.py
@@ -848,7 +848,7 @@ async def get_chat_context(chat_id: str):
     operation="health_check",
     error_code_prefix="CHAT_KNOWLEDGE",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def health_check():
     """Health check endpoint for chat knowledge system"""
     try:
@@ -875,7 +875,7 @@ class MarkFactsPreservedRequest(BaseModel):
     preserve: bool = True
 
 
-@router.get("/chat/sessions/{session_id}/facts", response_model=DataResponse)
+@router.get("/chat/sessions/{session_id}/facts", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_session_facts",
@@ -1000,7 +1000,7 @@ def _count_preserve_results(results: list, session_id: str) -> tuple[int, int, l
     return updated_count, failed_count, errors
 
 
-@router.post("/chat/sessions/{session_id}/facts/preserve", response_model=DataResponse)
+@router.post("/chat/sessions/{session_id}/facts/preserve", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="preserve_session_facts",

--- a/autobot-backend/api/collaboration.py
+++ b/autobot-backend/api/collaboration.py
@@ -438,7 +438,7 @@ async def share_secret_with_session(
         )
 
 
-@router.get("/{session_id}/presence", response_model=DataResponse)
+@router.get("/{session_id}/presence", response_model=None)
 async def get_presence(
     session_id: str,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/conversation_export.py
+++ b/autobot-backend/api/conversation_export.py
@@ -160,7 +160,7 @@ def _build_export_response(
     operation="export_conversation",
     error_code_prefix="CONVEXPORT",
 )
-@router.get("/conversations/{session_id}/export", response_model=DataResponse)
+@router.get("/conversations/{session_id}/export", response_model=None)
 async def export_conversation(
     session_id: str,
     request: Request,
@@ -228,7 +228,7 @@ async def export_all_conversations(
     operation="import_conversation",
     error_code_prefix="CONVEXPORT",
 )
-@router.post("/conversations/import", response_model=DataResponse)
+@router.post("/conversations/import", response_model=None)
 async def import_conversation_endpoint(
     body: ConversationImportRequest,
     request: Request,

--- a/autobot-backend/api/conversation_files.py
+++ b/autobot-backend/api/conversation_files.py
@@ -837,7 +837,7 @@ def _build_delete_response(session_id: str, file_id: str) -> JSONResponse:
     operation="delete_conversation_file",
     error_code_prefix="CONVERSATION_FILES",
 )
-@router.delete("/conversation/{session_id}/files/{file_id}", response_model=DataResponse)
+@router.delete("/conversation/{session_id}/files/{file_id}", response_model=None)
 async def delete_conversation_file(request: Request, session_id: str, file_id: str):
     """
     Delete a specific file from a conversation.

--- a/autobot-backend/api/data_storage.py
+++ b/autobot-backend/api/data_storage.py
@@ -327,7 +327,7 @@ async def get_storage_stats():
     operation="get_database_files",
     error_code_prefix="STORAGE",
 )
-@router.get("/databases", response_model=DataResponse)
+@router.get("/databases", response_model=None)
 async def get_database_files_endpoint():
     """Get information about database files in the data directory."""
     try:
@@ -351,7 +351,7 @@ async def get_database_files_endpoint():
     operation="get_category_details",
     error_code_prefix="STORAGE",
 )
-@router.get("/category/{category_path}", response_model=DataResponse)
+@router.get("/category/{category_path}", response_model=None)
 async def get_category_details(
     category_path: str,
     limit: int = Query(default=100, le=1000),
@@ -498,7 +498,7 @@ async def cleanup_category(
     operation="cleanup_old_backups",
     error_code_prefix="STORAGE",
 )
-@router.post("/cleanup/old-backups", response_model=DataResponse)
+@router.post("/cleanup/old-backups", response_model=None)
 async def cleanup_old_backups(
     dry_run: bool = Query(default=True),
     _: None = Depends(check_admin_permission),
@@ -608,7 +608,7 @@ async def delete_conversation(
     operation="get_conversations_summary",
     error_code_prefix="STORAGE",
 )
-@router.get("/conversations/summary", response_model=DataResponse)
+@router.get("/conversations/summary", response_model=None)
 async def get_conversations_summary():
     """Get summary of stored conversations."""
     try:

--- a/autobot-backend/api/developer.py
+++ b/autobot-backend/api/developer.py
@@ -93,7 +93,7 @@ api_registry = APIRegistry()
     operation="get_api_endpoints",
     error_code_prefix="DEVELOPER",
 )
-@router.get("/endpoints", response_model=DataResponse)
+@router.get("/endpoints", response_model=None)
 async def get_api_endpoints():
     """Get all registered API endpoints (developer mode)"""
     developer_mode = unified_config_manager.get_nested("developer.enabled", False)
@@ -109,7 +109,7 @@ async def get_api_endpoints():
     operation="get_developer_config",
     error_code_prefix="DEVELOPER",
 )
-@router.get("/config", response_model=DataResponse)
+@router.get("/config", response_model=None)
 async def get_developer_config():
     """Get developer mode configuration"""
     developer_config = unified_config_manager.get_nested("developer", {})
@@ -126,7 +126,7 @@ async def get_developer_config():
     operation="update_developer_config",
     error_code_prefix="DEVELOPER",
 )
-@router.post("/config", response_model=DataResponse)
+@router.post("/config", response_model=None)
 async def update_developer_config(config: dict):
     """Update developer mode configuration"""
     # Update the configuration
@@ -147,7 +147,7 @@ async def update_developer_config(config: dict):
     operation="get_system_info",
     error_code_prefix="DEVELOPER",
 )
-@router.get("/system-info", response_model=DataResponse)
+@router.get("/system-info", response_model=None)
 async def get_system_info():
     """Get system information for debugging"""
     developer_mode = unified_config_manager.get_nested("developer.enabled", False)

--- a/autobot-backend/api/diagnostics.py
+++ b/autobot-backend/api/diagnostics.py
@@ -139,7 +139,7 @@ async def health_check():
         return HealthCheckResponse(status="error", engine_ready=False)
 
 
-@router.get("/analyze-failure", response_model=DataResponse)
+@router.get("/analyze-failure", response_model=None)
 async def analyze_failure_get(
     task_id: str = Query(..., description="Task ID to analyze"),
     error_description: Optional[str] = Query(

--- a/autobot-backend/api/documents.py
+++ b/autobot-backend/api/documents.py
@@ -133,7 +133,7 @@ async def _assert_ownership(doc: AIDocument, user_id: str) -> None:
 # ============================================================================
 
 
-@router.post("/documents", status_code=201, response_model=DataResponse)
+@router.post("/documents", status_code=201, response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="create_ai_document",
@@ -164,7 +164,7 @@ async def create_document(
     return doc.model_dump()
 
 
-@router.get("/documents", response_model=DataResponse)
+@router.get("/documents", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_ai_documents",
@@ -205,7 +205,7 @@ async def list_documents(
     return {"documents": [d.model_dump() for d in page], "total": total}
 
 
-@router.get("/documents/{doc_id}", response_model=DataResponse)
+@router.get("/documents/{doc_id}", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_ai_document",
@@ -225,7 +225,7 @@ async def get_document(
     return doc.model_dump()
 
 
-@router.put("/documents/{doc_id}", response_model=DataResponse)
+@router.put("/documents/{doc_id}", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_ai_document",
@@ -261,7 +261,7 @@ async def update_document(
     return doc.model_dump()
 
 
-@router.delete("/documents/{doc_id}", status_code=204, response_model=DataResponse)
+@router.delete("/documents/{doc_id}", status_code=204, response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="delete_ai_document",
@@ -286,7 +286,7 @@ async def delete_document(
     logger.info("Deleted AI document %s for user %s", doc_id, uid)
 
 
-@router.post("/documents/{doc_id}/refine", response_model=DataResponse)
+@router.post("/documents/{doc_id}/refine", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="refine_ai_document",

--- a/autobot-backend/api/enhanced_search.py
+++ b/autobot-backend/api/enhanced_search.py
@@ -197,7 +197,7 @@ async def enhanced_semantic_search(request: SearchRequest):
     operation="get_hardware_status",
     error_code_prefix="ENHANCED_SEARCH",
 )
-@router.get("/hardware/status", response_model=DataResponse)
+@router.get("/hardware/status", response_model=None)
 async def get_hardware_status():
     """
     Get current hardware status and utilization metrics.
@@ -226,7 +226,7 @@ async def get_hardware_status():
     operation="benchmark_search_performance",
     error_code_prefix="ENHANCED_SEARCH",
 )
-@router.post("/benchmark", response_model=DataResponse)
+@router.post("/benchmark", response_model=None)
 async def benchmark_search_performance(request: BenchmarkRequest):
     """
     Benchmark search performance across different hardware configurations.
@@ -257,7 +257,7 @@ async def benchmark_search_performance(request: BenchmarkRequest):
     operation="optimize_search_engine",
     error_code_prefix="ENHANCED_SEARCH",
 )
-@router.post("/optimize", response_model=DataResponse)
+@router.post("/optimize", response_model=None)
 async def optimize_search_engine(request: OptimizationRequest):
     """
     Optimize search engine for specific workload types.
@@ -289,7 +289,7 @@ async def optimize_search_engine(request: OptimizationRequest):
     operation="get_performance_analytics",
     error_code_prefix="ENHANCED_SEARCH",
 )
-@router.get("/performance/analytics", response_model=DataResponse)
+@router.get("/performance/analytics", response_model=None)
 async def get_performance_analytics():
     """
     Get comprehensive performance analytics and recommendations.
@@ -337,7 +337,7 @@ async def get_performance_analytics():
     operation="test_npu_connectivity",
     error_code_prefix="ENHANCED_SEARCH",
 )
-@router.get("/test/connectivity", response_model=DataResponse)
+@router.get("/test/connectivity", response_model=None)
 async def test_npu_connectivity():
     """
     Test NPU Worker connectivity and capabilities.
@@ -532,7 +532,7 @@ def _generate_system_recommendations(
     operation="health_check",
     error_code_prefix="ENHANCED_SEARCH",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def health_check():
     """Health check for enhanced search service."""
     try:

--- a/autobot-backend/api/error_resilience.py
+++ b/autobot-backend/api/error_resilience.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/resilience", tags=["resilience"])
 
 
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def get_resilience_health() -> Dict[str, Any]:
     """
     Get overall system resilience health.
@@ -49,7 +49,7 @@ async def get_resilience_health() -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail="Failed to get resilience health")
 
 
-@router.get("/circuit-breakers", response_model=DataResponse)
+@router.get("/circuit-breakers", response_model=None)
 async def get_circuit_breaker_status() -> Dict[str, Any]:
     """
     Get status of all circuit breakers.
@@ -67,7 +67,7 @@ async def get_circuit_breaker_status() -> Dict[str, Any]:
         )
 
 
-@router.get("/error-budgets", response_model=DataResponse)
+@router.get("/error-budgets", response_model=None)
 async def get_error_budget_status() -> Dict[str, Any]:
     """
     Get status of all error budgets.
@@ -85,7 +85,7 @@ async def get_error_budget_status() -> Dict[str, Any]:
         )
 
 
-@router.post("/circuit-breakers/{service_name}/reset", response_model=DataResponse)
+@router.post("/circuit-breakers/{service_name}/reset", response_model=None)
 async def reset_circuit_breaker(service_name: str) -> Dict[str, str]:
     """
     Manually reset circuit breaker for service.
@@ -107,7 +107,7 @@ async def reset_circuit_breaker(service_name: str) -> Dict[str, str]:
         )
 
 
-@router.post("/error-budgets/{component}/reset", response_model=DataResponse)
+@router.post("/error-budgets/{component}/reset", response_model=None)
 async def reset_error_budget(component: str) -> Dict[str, str]:
     """
     Manually reset error budget for component.

--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -799,7 +799,7 @@ async def download_file(request: Request, path: str):
     operation="view_file",
     error_code_prefix="FILES",
 )
-@router.get("/view/{path:path}", response_model=DataResponse)
+@router.get("/view/{path:path}", response_model=None)
 async def view_file(request: Request, path: str):
     """
     View file content (for text files) or get file info.
@@ -923,7 +923,7 @@ async def _validate_rename_paths(source_path: Path, new_name: str) -> Path:
     operation="rename_file_or_directory",
     error_code_prefix="FILES",
 )
-@router.post("/rename", response_model=DataResponse)
+@router.post("/rename", response_model=None)
 async def rename_file_or_directory(
     request: Request, path: str = Form(...), new_name: str = Form(...)
 ):
@@ -1013,7 +1013,7 @@ async def _read_text_content(target_file: Path) -> tuple:
     operation="preview_file",
     error_code_prefix="FILES",
 )
-@router.get("/preview", response_model=DataResponse)
+@router.get("/preview", response_model=None)
 async def preview_file(request: Request, path: str):
     """
     Get file preview with content and download URL.
@@ -1061,7 +1061,7 @@ async def preview_file(request: Request, path: str):
     operation="delete_file",
     error_code_prefix="FILES",
 )
-@router.delete("/delete", response_model=DataResponse)
+@router.delete("/delete", response_model=None)
 async def delete_file(request: Request, path: str):
     """
     Delete a file or directory within the sandbox.
@@ -1136,7 +1136,7 @@ def _log_directory_create_audit(
     operation="create_directory",
     error_code_prefix="FILES",
 )
-@router.post("/create_directory", response_model=DataResponse)
+@router.post("/create_directory", response_model=None)
 async def create_directory(
     request: Request, path: str = Form(...), name: str = Form(...)
 ):
@@ -1180,7 +1180,7 @@ async def create_directory(
     operation="get_directory_tree",
     error_code_prefix="FILES",
 )
-@router.get("/tree", response_model=DataResponse)
+@router.get("/tree", response_model=None)
 async def get_directory_tree(request: Request, path: str = ""):
     """Get directory tree structure for file browser"""
     # SECURITY FIX: Enable proper authentication and authorization
@@ -1248,7 +1248,7 @@ async def get_directory_tree(request: Request, path: str = ""):
     operation="get_file_stats",
     error_code_prefix="FILES",
 )
-@router.get("/stats", response_model=DataResponse)
+@router.get("/stats", response_model=None)
 async def get_file_stats(request: Request):
     """Get file system statistics for the sandbox"""
     # SECURITY FIX: Enable proper authentication and authorization
@@ -1344,7 +1344,7 @@ def _entry_to_file_item(entry: Path) -> dict:
         }
 
 
-@router.get("", summary="List directory for SLM admin file browser", response_model=DataResponse)
+@router.get("", summary="List directory for SLM admin file browser", response_model=None)
 async def admin_list_directory(path: str = "/home/autobot") -> dict:  # noqa: ssot-path
     """List directory contents at an absolute path.
 
@@ -1365,7 +1365,7 @@ async def admin_list_directory(path: str = "/home/autobot") -> dict:  # noqa: ss
         raise HTTPException(status_code=403, detail="Permission denied")
 
 
-@router.get("/read", summary="Read file content for SLM admin file browser", response_model=DataResponse)
+@router.get("/read", summary="Read file content for SLM admin file browser", response_model=None)
 async def admin_read_file(path: str) -> dict:
     """Return text content of a file at an absolute path.
 

--- a/autobot-backend/api/frontend_config.py
+++ b/autobot-backend/api/frontend_config.py
@@ -161,7 +161,7 @@ def _build_fallback_config() -> Dict[str, Any]:
     operation="get_frontend_config",
     error_code_prefix="FRONTEND_CONFIG",
 )
-@router.get("/frontend-config", response_model=DataResponse)
+@router.get("/frontend-config", response_model=None)
 async def get_frontend_config():
     """
     Get frontend-specific configuration.

--- a/autobot-backend/api/heartbeat.py
+++ b/autobot-backend/api/heartbeat.py
@@ -226,7 +226,7 @@ async def get_run(
     return _run_to_response(run)
 
 
-@router.post("/{agent_id}/wakeup", status_code=status.HTTP_202_ACCEPTED, response_model=DataResponse)
+@router.post("/{agent_id}/wakeup", status_code=status.HTTP_202_ACCEPTED, response_model=None)
 async def request_wakeup(
     agent_id: str,
     body: WakeupRequestCreate,
@@ -258,7 +258,7 @@ async def list_wakeup_requests(
     return [_wakeup_to_response(r) for r in result.scalars().all()]
 
 
-@router.post("/{agent_id}/trigger", status_code=status.HTTP_202_ACCEPTED, response_model=DataResponse)
+@router.post("/{agent_id}/trigger", status_code=status.HTTP_202_ACCEPTED, response_model=None)
 async def trigger_manual(
     agent_id: str,
     scheduler: HeartbeatScheduler = Depends(_get_scheduler),

--- a/autobot-backend/api/hot_reload.py
+++ b/autobot-backend/api/hot_reload.py
@@ -211,7 +211,7 @@ async def stop_hot_reload():
     operation="hot_reload_health",
     error_code_prefix="HOT_RELOAD",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def hot_reload_health():
     """
     Health check for hot reload functionality

--- a/autobot-backend/api/infrastructure.py
+++ b/autobot-backend/api/infrastructure.py
@@ -56,7 +56,7 @@ def _load_secrets_hosts() -> List[Dict[str, Any]]:
         return []
 
 
-@router.get("/hosts", response_model=DataResponse)
+@router.get("/hosts", response_model=None)
 async def get_infrastructure_hosts(
     capability: Optional[str] = Query(
         None, description="Filter by capability (ssh, vnc)"

--- a/autobot-backend/api/integration_cicd.py
+++ b/autobot-backend/api/integration_cicd.py
@@ -57,7 +57,7 @@ class ProviderInfo(BaseModel):
     auth_type: str = Field(..., description="Authentication type")
 
 
-@router.post("/test-connection", response_model=DataResponse)
+@router.post("/test-connection", response_model=None)
 async def test_connection(request: ConnectionTestRequest) -> Dict[str, Any]:
     """Test connection to a CI/CD provider.
 
@@ -85,7 +85,7 @@ async def test_connection(request: ConnectionTestRequest) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/providers", response_model=DataResponse)
+@router.get("/providers", response_model=None)
 async def list_providers() -> List[ProviderInfo]:
     """List supported CI/CD providers.
 
@@ -114,7 +114,7 @@ async def list_providers() -> List[ProviderInfo]:
     ]
 
 
-@router.get("/{provider}/pipelines", response_model=DataResponse)
+@router.get("/{provider}/pipelines", response_model=None)
 async def list_pipelines(
     provider: CICDProvider,
     base_url: str = Query(..., description="CI/CD service base URL"),
@@ -155,7 +155,7 @@ async def list_pipelines(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/{provider}/pipelines/{pipeline_id}/status", response_model=DataResponse)
+@router.get("/{provider}/pipelines/{pipeline_id}/status", response_model=None)
 async def get_pipeline_status(
     provider: CICDProvider,
     pipeline_id: str,
@@ -195,7 +195,7 @@ async def get_pipeline_status(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/{provider}/pipelines/{pipeline_id}/trigger", response_model=DataResponse)
+@router.post("/{provider}/pipelines/{pipeline_id}/trigger", response_model=None)
 async def trigger_pipeline(
     provider: CICDProvider,
     pipeline_id: str,
@@ -238,7 +238,7 @@ async def trigger_pipeline(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/{provider}/pipelines/{pipeline_id}/logs", response_model=DataResponse)
+@router.get("/{provider}/pipelines/{pipeline_id}/logs", response_model=None)
 async def get_pipeline_logs(
     provider: CICDProvider,
     pipeline_id: str,

--- a/autobot-backend/api/integration_cloud.py
+++ b/autobot-backend/api/integration_cloud.py
@@ -94,7 +94,7 @@ async def list_providers():
     ]
 
 
-@router.post("/test-connection", response_model=DataResponse)
+@router.post("/test-connection", response_model=None)
 async def test_connection(request: ConnectionTestRequest):
     """Test connection to a cloud provider."""
     try:
@@ -123,7 +123,7 @@ async def test_connection(request: ConnectionTestRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/{provider}/resources", response_model=DataResponse)
+@router.get("/{provider}/resources", response_model=None)
 async def list_resources(
     provider: str,
     api_key: Optional[str] = None,
@@ -162,7 +162,7 @@ async def list_resources(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/{provider}/storage", response_model=DataResponse)
+@router.get("/{provider}/storage", response_model=None)
 async def list_storage(
     provider: str,
     api_key: Optional[str] = None,
@@ -200,7 +200,7 @@ async def list_storage(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/{provider}/account", response_model=DataResponse)
+@router.get("/{provider}/account", response_model=None)
 async def get_account_info(
     provider: str,
     api_key: Optional[str] = None,

--- a/autobot-backend/api/integration_database.py
+++ b/autobot-backend/api/integration_database.py
@@ -161,7 +161,7 @@ def _get_integration_class(provider: str):
     return integration_class
 
 
-@router.post("/test-connection", response_model=DataResponse)
+@router.post("/test-connection", response_model=None)
 async def test_database_connection(request: DatabaseConnectionRequest):
     """
     Test connection to a database.
@@ -196,7 +196,7 @@ async def test_database_connection(request: DatabaseConnectionRequest):
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
-@router.get("/providers", response_model=DataResponse)
+@router.get("/providers", response_model=None)
 async def list_database_providers() -> Dict[str, List[Dict[str, Any]]]:
     """
     List all supported database providers.
@@ -228,7 +228,7 @@ async def list_database_providers() -> Dict[str, List[Dict[str, Any]]]:
     return {"providers": providers, "count": len(providers)}
 
 
-@router.post("/{provider}/query", response_model=DataResponse)
+@router.post("/{provider}/query", response_model=None)
 async def execute_database_query(provider: str, request: QueryRequest):
     """
     Execute a read-only query on a database.
@@ -276,7 +276,7 @@ async def execute_database_query(provider: str, request: QueryRequest):
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
-@router.post("/mongodb/query-collection", response_model=DataResponse)
+@router.post("/mongodb/query-collection", response_model=None)
 async def query_mongodb_collection(request: MongoQueryRequest):
     """
     Query a MongoDB collection.
@@ -319,7 +319,7 @@ async def query_mongodb_collection(request: MongoQueryRequest):
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
-@router.post("/{provider}/databases", response_model=DataResponse)
+@router.post("/{provider}/databases", response_model=None)
 async def list_databases(provider: str, request: DatabaseListRequest):
     """
     List all databases for a provider.
@@ -355,7 +355,7 @@ async def list_databases(provider: str, request: DatabaseListRequest):
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
-@router.post("/{provider}/tables", response_model=DataResponse)
+@router.post("/{provider}/tables", response_model=None)
 async def list_tables(provider: str, request: DatabaseListRequest):
     """
     List all tables/collections in a database.

--- a/autobot-backend/api/integration_github.py
+++ b/autobot-backend/api/integration_github.py
@@ -106,7 +106,7 @@ async def test_connection(
         raise HTTPException(status_code=500, detail="Connection test failed")
 
 
-@router.get("/{owner}/{repo}/pull-requests", response_model=DataResponse)
+@router.get("/{owner}/{repo}/pull-requests", response_model=None)
 async def list_pull_requests(
     owner: str,
     repo: str,
@@ -135,7 +135,7 @@ async def list_pull_requests(
         raise HTTPException(status_code=500, detail="Failed to list pull requests")
 
 
-@router.get("/{owner}/{repo}/pull-requests/{pull_number}", response_model=DataResponse)
+@router.get("/{owner}/{repo}/pull-requests/{pull_number}", response_model=None)
 async def get_pull_request(
     owner: str,
     repo: str,
@@ -159,7 +159,7 @@ async def get_pull_request(
         raise HTTPException(status_code=500, detail="Failed to get pull request")
 
 
-@router.get("/{owner}/{repo}/pull-requests/{pull_number}/diff", response_model=DataResponse)
+@router.get("/{owner}/{repo}/pull-requests/{pull_number}/diff", response_model=None)
 async def get_pull_request_diff(
     owner: str,
     repo: str,
@@ -183,7 +183,7 @@ async def get_pull_request_diff(
         raise HTTPException(status_code=500, detail="Failed to get pull request diff")
 
 
-@router.get("/{owner}/{repo}/pull-requests/{pull_number}/comments", response_model=DataResponse)
+@router.get("/{owner}/{repo}/pull-requests/{pull_number}/comments", response_model=None)
 async def list_pr_review_comments(
     owner: str,
     repo: str,
@@ -207,7 +207,7 @@ async def list_pr_review_comments(
         raise HTTPException(status_code=500, detail="Failed to list PR comments")
 
 
-@router.post("/{owner}/{repo}/pull-requests/{pull_number}/comments", response_model=DataResponse)
+@router.post("/{owner}/{repo}/pull-requests/{pull_number}/comments", response_model=None)
 async def post_pr_comment(request: GitHubCommentRequest) -> Dict[str, Any]:
     """Post an issue-level comment to a pull request.
 
@@ -234,7 +234,7 @@ async def post_pr_comment(request: GitHubCommentRequest) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail="Failed to post PR comment")
 
 
-@router.post("/{owner}/{repo}/pull-requests/{pull_number}/reviews", response_model=DataResponse)
+@router.post("/{owner}/{repo}/pull-requests/{pull_number}/reviews", response_model=None)
 async def submit_pr_review(request: GitHubReviewRequest) -> Dict[str, Any]:
     """Submit a formal pull request review.
 
@@ -271,7 +271,7 @@ async def submit_pr_review(request: GitHubReviewRequest) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail="Failed to submit PR review")
 
 
-@router.get("/{owner}/{repo}/issues", response_model=DataResponse)
+@router.get("/{owner}/{repo}/issues", response_model=None)
 async def list_issues(
     owner: str,
     repo: str,
@@ -300,7 +300,7 @@ async def list_issues(
         raise HTTPException(status_code=500, detail="Failed to list issues")
 
 
-@router.get("/{owner}/{repo}/issues/{issue_number}", response_model=DataResponse)
+@router.get("/{owner}/{repo}/issues/{issue_number}", response_model=None)
 async def get_issue(
     owner: str,
     repo: str,
@@ -324,7 +324,7 @@ async def get_issue(
         raise HTTPException(status_code=500, detail="Failed to get issue")
 
 
-@router.get("/{owner}/{repo}", response_model=DataResponse)
+@router.get("/{owner}/{repo}", response_model=None)
 async def get_repository(
     owner: str,
     repo: str,
@@ -346,7 +346,7 @@ async def get_repository(
         raise HTTPException(status_code=500, detail="Failed to get repository")
 
 
-@router.get("/{owner}/{repo}/commits", response_model=DataResponse)
+@router.get("/{owner}/{repo}/commits", response_model=None)
 async def list_commits(
     owner: str,
     repo: str,
@@ -372,7 +372,7 @@ async def list_commits(
         raise HTTPException(status_code=500, detail="Failed to list commits")
 
 
-@router.get("/{owner}/{repo}/commits/{ref}", response_model=DataResponse)
+@router.get("/{owner}/{repo}/commits/{ref}", response_model=None)
 async def get_commit(
     owner: str,
     repo: str,
@@ -395,7 +395,7 @@ async def get_commit(
         raise HTTPException(status_code=500, detail="Failed to get commit")
 
 
-@router.get("/{owner}/{repo}/tree/{tree_sha}", response_model=DataResponse)
+@router.get("/{owner}/{repo}/tree/{tree_sha}", response_model=None)
 async def get_repository_tree(
     owner: str,
     repo: str,
@@ -420,7 +420,7 @@ async def get_repository_tree(
         raise HTTPException(status_code=500, detail="Failed to get repository tree")
 
 
-@router.get("/{owner}/{repo}/contents/{path:path}", response_model=DataResponse)
+@router.get("/{owner}/{repo}/contents/{path:path}", response_model=None)
 async def get_file_contents(
     owner: str,
     repo: str,
@@ -445,7 +445,7 @@ async def get_file_contents(
         raise HTTPException(status_code=500, detail="Failed to get file contents")
 
 
-@router.get("/providers", response_model=DataResponse)
+@router.get("/providers", response_model=None)
 async def get_providers() -> List[Dict[str, Any]]:
     """List supported GitHub integration providers.
 

--- a/autobot-backend/api/integration_monitoring.py
+++ b/autobot-backend/api/integration_monitoring.py
@@ -99,7 +99,7 @@ class MonitorCreateRequest(BaseModel):
     message: str = Field(..., description="Notification message")
 
 
-@router.post("/test-connection", response_model=DataResponse)
+@router.post("/test-connection", response_model=None)
 async def test_connection(request: ConnectionTestRequest) -> Dict[str, Any]:
     """Test connection to a monitoring provider.
 
@@ -128,7 +128,7 @@ async def test_connection(request: ConnectionTestRequest) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail="Connection test failed")
 
 
-@router.get("/providers", response_model=DataResponse)
+@router.get("/providers", response_model=None)
 async def list_providers() -> Dict[str, List[Dict[str, str]]]:
     """List supported monitoring providers.
 
@@ -151,7 +151,7 @@ async def list_providers() -> Dict[str, List[Dict[str, str]]]:
     }
 
 
-@router.get("/{provider}/hosts", response_model=DataResponse)
+@router.get("/{provider}/hosts", response_model=None)
 async def list_hosts(
     provider: str,
     api_key: str = Query(..., description="API key"),
@@ -188,7 +188,7 @@ async def list_hosts(
         raise HTTPException(status_code=500, detail="Failed to list hosts")
 
 
-@router.post("/{provider}/metrics", response_model=DataResponse)
+@router.post("/{provider}/metrics", response_model=None)
 async def query_metrics(
     provider: str,
     request: MetricsQueryRequest,
@@ -227,7 +227,7 @@ async def query_metrics(
         raise HTTPException(status_code=500, detail="Failed to query metrics")
 
 
-@router.get("/{provider}/alerts", response_model=DataResponse)
+@router.get("/{provider}/alerts", response_model=None)
 async def list_alerts(
     provider: str,
     api_key: str = Query(..., description="API key"),
@@ -264,7 +264,7 @@ async def list_alerts(
         raise HTTPException(status_code=500, detail="Failed to list alerts")
 
 
-@router.post("/{provider}/events", response_model=DataResponse)
+@router.post("/{provider}/events", response_model=None)
 async def get_events(
     provider: str,
     request: EventsQueryRequest,

--- a/autobot-backend/api/integration_project_management.py
+++ b/autobot-backend/api/integration_project_management.py
@@ -201,7 +201,7 @@ async def list_providers() -> List[ProviderInfo]:
     return list(SUPPORTED_PROVIDERS.values())
 
 
-@router.get("/{provider}/projects", response_model=DataResponse)
+@router.get("/{provider}/projects", response_model=None)
 async def list_projects(
     provider: str,
     base_url: Optional[str] = Query(None),
@@ -241,7 +241,7 @@ async def list_projects(
         return await integration.execute_action("list_workspaces", {})
 
 
-@router.get("/{provider}/issues", response_model=DataResponse)
+@router.get("/{provider}/issues", response_model=None)
 async def list_issues(
     provider: str,
     base_url: Optional[str] = Query(None),
@@ -340,7 +340,7 @@ def _build_create_params(provider: str, request: IssueCreateRequest) -> tuple:
         return "create_task", params
 
 
-@router.post("/{provider}/issues", response_model=DataResponse)
+@router.post("/{provider}/issues", response_model=None)
 async def create_issue(
     provider: str,
     request: IssueCreateRequest,
@@ -402,7 +402,7 @@ def _build_update_params(
         return "update_task", params
 
 
-@router.patch("/{provider}/issues/{issue_id}", response_model=DataResponse)
+@router.patch("/{provider}/issues/{issue_id}", response_model=None)
 async def update_issue(
     provider: str,
     issue_id: str,
@@ -429,7 +429,7 @@ async def update_issue(
     return await integration.execute_action(action, params)
 
 
-@router.get("/{provider}/search", response_model=DataResponse)
+@router.get("/{provider}/search", response_model=None)
 async def search_issues(
     provider: str,
     query: str = Query(..., description="Search query or JQL"),

--- a/autobot-backend/api/integration_version_control.py
+++ b/autobot-backend/api/integration_version_control.py
@@ -166,7 +166,7 @@ async def get_providers() -> List[ProviderInfo]:
     return providers
 
 
-@router.get("/{provider}/repositories", response_model=DataResponse)
+@router.get("/{provider}/repositories", response_model=None)
 async def list_repositories(
     provider: str,
     api_key: str = Query(..., description="API key or access token"),
@@ -207,7 +207,7 @@ async def list_repositories(
         raise HTTPException(status_code=500, detail="Failed to list repositories")
 
 
-@router.get("/{provider}/repositories/{repo_id}/branches", response_model=DataResponse)
+@router.get("/{provider}/repositories/{repo_id}/branches", response_model=None)
 async def list_branches(
     provider: str,
     repo_id: str,
@@ -274,7 +274,7 @@ def _build_pr_params(
         return "list_pull_requests", params
 
 
-@router.get("/{provider}/repositories/{repo_id}/pull-requests", response_model=DataResponse)
+@router.get("/{provider}/repositories/{repo_id}/pull-requests", response_model=None)
 async def list_pull_requests(
     provider: str,
     repo_id: str,
@@ -297,7 +297,7 @@ async def list_pull_requests(
         raise HTTPException(status_code=500, detail="Failed to list pull requests")
 
 
-@router.get("/{provider}/repositories/{repo_id}/commits", response_model=DataResponse)
+@router.get("/{provider}/repositories/{repo_id}/commits", response_model=None)
 async def get_commit_info(
     provider: str,
     repo_id: str,

--- a/autobot-backend/api/intelligent_agent.py
+++ b/autobot-backend/api/intelligent_agent.py
@@ -287,7 +287,7 @@ async def health_check(
     operation="reload_agent",
     error_code_prefix="INTELLIGENT_AGENT",
 )
-@router.post("/reload", response_model=DataResponse)
+@router.post("/reload", response_model=None)
 async def reload_agent(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/kb_librarian.py
+++ b/autobot-backend/api/kb_librarian.py
@@ -129,7 +129,7 @@ async def query_knowledge_base(
     operation="get_kb_librarian_status",
     error_code_prefix="KB_LIBRARIAN",
 )
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=None)
 async def get_kb_librarian_status(
     current_user: dict = Depends(get_current_user),
 ):
@@ -160,7 +160,7 @@ async def get_kb_librarian_status(
     operation="configure_kb_librarian",
     error_code_prefix="KB_LIBRARIAN",
 )
-@router.put("/configure", response_model=DataResponse)
+@router.put("/configure", response_model=None)
 async def configure_kb_librarian(
     enabled: Optional[bool] = None,
     similarity_threshold: Optional[float] = None,

--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -398,7 +398,7 @@ async def update_connector(connector_id: str, request: UpdateConnectorRequest):
     return {"connector_id": connector_id, "config": _cfg_to_dict(cfg)}
 
 
-@router.delete("/knowledge_base/connectors/{connector_id}", status_code=204, response_model=DataResponse)
+@router.delete("/knowledge_base/connectors/{connector_id}", status_code=204, response_model=None)
 async def delete_connector(connector_id: str):
     """Remove a connector, stop its schedule, and delete its Redis keys."""
     cfg = await _load_connector(connector_id)

--- a/autobot-backend/api/knowledge_graph_routes.py
+++ b/autobot-backend/api/knowledge_graph_routes.py
@@ -106,7 +106,7 @@ async def run_pipeline(
 # --- Entity Endpoints ---
 
 
-@router.get("/entities", response_model=DataResponse)
+@router.get("/entities", response_model=None)
 async def list_entities(
     entity_type: Optional[str] = Query(None),
     query: Optional[str] = Query(None),
@@ -128,7 +128,7 @@ async def list_entities(
         raise HTTPException(status_code=500, detail="Entity listing failed")
 
 
-@router.get("/entities/{entity_id}/relationships", response_model=DataResponse)
+@router.get("/entities/{entity_id}/relationships", response_model=None)
 async def get_entity_relationships(
     entity_id: str,
     relationship_type: Optional[str] = Query(None),
@@ -157,7 +157,7 @@ async def get_entity_relationships(
 # --- Temporal Event Endpoints ---
 
 
-@router.get("/events", response_model=DataResponse)
+@router.get("/events", response_model=None)
 async def search_events(
     start_date: Optional[str] = Query(None),
     end_date: Optional[str] = Query(None),
@@ -195,7 +195,7 @@ async def search_events(
         raise HTTPException(status_code=500, detail="Event search failed")
 
 
-@router.get("/events/{entity_name}/timeline", response_model=DataResponse)
+@router.get("/events/{entity_name}/timeline", response_model=None)
 async def get_event_timeline(
     entity_name: str,
     limit: int = Query(50, ge=1, le=200),
@@ -228,7 +228,7 @@ async def get_event_timeline(
 # --- Summary Endpoints ---
 
 
-@router.get("/summaries/search", response_model=DataResponse)
+@router.get("/summaries/search", response_model=None)
 async def search_summaries(
     query: str = Query(..., description="Search query"),
     level: Optional[str] = Query(
@@ -256,7 +256,7 @@ async def search_summaries(
         raise HTTPException(status_code=500, detail="Summary search failed")
 
 
-@router.get("/documents/{document_id}/overview", response_model=DataResponse)
+@router.get("/documents/{document_id}/overview", response_model=None)
 async def get_document_overview(
     document_id: str,
     current_user: dict = Depends(get_current_user),
@@ -277,7 +277,7 @@ async def get_document_overview(
         raise HTTPException(status_code=500, detail="Document overview failed")
 
 
-@router.get("/summaries/{summary_id}/drill-down", response_model=DataResponse)
+@router.get("/summaries/{summary_id}/drill-down", response_model=None)
 async def drill_down_summary(
     summary_id: str,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/long_running_operations.py
+++ b/autobot-backend/api/long_running_operations.py
@@ -417,7 +417,7 @@ async def start_security_scan(
     operation="migrate_existing_operation",
     error_code_prefix="LONG_RUNNING_OPERATIONS",
 )
-@router.post("/migrate/existing", response_model=DataResponse)
+@router.post("/migrate/existing", response_model=None)
 async def migrate_existing_operation(
     operation_name: str,
     timeout_seconds: int,
@@ -462,7 +462,7 @@ async def migrate_existing_operation(
     operation="get_operation_status",
     error_code_prefix="LONG_RUNNING_OPERATIONS",
 )
-@router.get("/{operation_id}", response_model=DataResponse)
+@router.get("/{operation_id}", response_model=None)
 async def get_operation_status(
     operation_id: str, manager=Depends(get_operation_manager)
 ):
@@ -483,7 +483,7 @@ async def get_operation_status(
     operation="list_operations",
     error_code_prefix="LONG_RUNNING_OPERATIONS",
 )
-@router.get("/", response_model=DataResponse)
+@router.get("/", response_model=None)
 async def list_operations(
     status: Optional[str] = None,
     operation_type: Optional[str] = None,
@@ -537,7 +537,7 @@ async def list_operations(
     operation="cancel_operation",
     error_code_prefix="LONG_RUNNING_OPERATIONS",
 )
-@router.post("/{operation_id}/cancel", response_model=DataResponse)
+@router.post("/{operation_id}/cancel", response_model=None)
 async def cancel_operation(operation_id: str, manager=Depends(get_operation_manager)):
     """Cancel a running operation"""
     try:
@@ -559,7 +559,7 @@ async def cancel_operation(operation_id: str, manager=Depends(get_operation_mana
     operation="resume_operation",
     error_code_prefix="LONG_RUNNING_OPERATIONS",
 )
-@router.post("/{operation_id}/resume", response_model=DataResponse)
+@router.post("/{operation_id}/resume", response_model=None)
 async def resume_operation(operation_id: str, manager=Depends(get_operation_manager)):
     """Resume operation from latest checkpoint"""
     try:

--- a/autobot-backend/api/manual_mcp.py
+++ b/autobot-backend/api/manual_mcp.py
@@ -323,7 +323,7 @@ def _doc_index_tool_schema() -> dict:
     operation="manual_mcp_tools",
     error_code_prefix="MANUAL_MCP",
 )
-@router.get("/mcp/tools", response_model=DataResponse)
+@router.get("/mcp/tools", response_model=None)
 async def get_manual_mcp_tools(
     current_user: dict = Depends(get_current_user),
 ) -> List[dict]:

--- a/autobot-backend/api/marketplace.py
+++ b/autobot-backend/api/marketplace.py
@@ -258,7 +258,7 @@ async def get_catalog_entry(plugin_name: str) -> MarketplaceEntry:
     return MarketplaceEntry(**entry)
 
 
-@router.get("/categories", response_model=DataResponse)
+@router.get("/categories", response_model=None)
 async def list_categories() -> dict[str, list[str]]:
     """
     List valid plugin categories and sort options.
@@ -293,7 +293,7 @@ async def _get_installed() -> set[str]:
         return set()
 
 
-@router.get("/installed", response_model=DataResponse)
+@router.get("/installed", response_model=None)
 async def list_installed() -> dict[str, list[str]]:
     """
     List names of installed marketplace plugins.
@@ -304,7 +304,7 @@ async def list_installed() -> dict[str, list[str]]:
     return {"installed": sorted(installed)}
 
 
-@router.post("/install", status_code=status.HTTP_201_CREATED, response_model=DataResponse)
+@router.post("/install", status_code=status.HTTP_201_CREATED, response_model=None)
 async def install_plugin(body: InstallRequest) -> dict[str, str]:
     """
     Mark a catalog plugin as installed.
@@ -344,7 +344,7 @@ async def install_plugin(body: InstallRequest) -> dict[str, str]:
     return {"status": "installed", "plugin": body.plugin_name}
 
 
-@router.delete("/install/{plugin_name}", response_model=DataResponse)
+@router.delete("/install/{plugin_name}", response_model=None)
 async def uninstall_plugin(plugin_name: str) -> dict[str, str]:
     """
     Remove a marketplace plugin from the installed set.

--- a/autobot-backend/api/memory.py
+++ b/autobot-backend/api/memory.py
@@ -541,7 +541,7 @@ async def create_entity(
     operation="list_all_entities",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities/all", response_model=DataResponse)
+@router.get("/entities/all", response_model=None)
 async def list_all_entities(
     admin_check: bool = Depends(check_admin_permission),
     entity_type: Optional[str] = Query(None, description="Filter by entity type"),
@@ -586,7 +586,7 @@ async def list_all_entities(
     operation="find_orphaned_conversation_entities",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities/orphans", response_model=DataResponse)
+@router.get("/entities/orphans", response_model=None)
 async def find_orphaned_conversation_entities(
     admin_check: bool = Depends(check_admin_permission),
     request: Request = None,
@@ -903,7 +903,7 @@ async def _detect_orphaned_entities(
     operation="cleanup_orphaned_conversation_entities",
     error_code_prefix="MEMORY",
 )
-@router.delete("/entities/orphans", response_model=DataResponse)
+@router.delete("/entities/orphans", response_model=None)
 async def cleanup_orphaned_conversation_entities(
     admin_check: bool = Depends(check_admin_permission),
     request: Request = None,
@@ -1130,7 +1130,7 @@ async def add_observations(
     operation="delete_entity",
     error_code_prefix="MEMORY",
 )
-@router.delete("/entities/{entity_id}", response_model=DataResponse)
+@router.delete("/entities/{entity_id}", response_model=None)
 async def delete_entity(
     entity_id: str = Path(..., description="Entity UUID"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1262,7 +1262,7 @@ async def create_relation(
     operation="get_related_entities",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities/{entity_id}/relations", response_model=DataResponse)
+@router.get("/entities/{entity_id}/relations", response_model=None)
 async def get_related_entities(
     entity_id: str = Path(..., description="Entity UUID"),
     admin_check: bool = Depends(check_admin_permission),
@@ -1317,7 +1317,7 @@ async def get_related_entities(
     operation="delete_relation",
     error_code_prefix="MEMORY",
 )
-@router.delete("/relations", response_model=DataResponse)
+@router.delete("/relations", response_model=None)
 async def delete_relation(
     admin_check: bool = Depends(check_admin_permission),
     from_entity: str = Query(..., description="Source entity name"),
@@ -1656,7 +1656,7 @@ def _build_invalidate_relation_response(
     operation="invalidate_entity",
     error_code_prefix="MEMORY",
 )
-@router.patch("/entities/{entity_id}/invalidate", response_model=DataResponse)
+@router.patch("/entities/{entity_id}/invalidate", response_model=None)
 async def invalidate_entity(
     entity_id: str = Path(..., description="UUID of the entity to invalidate"),
     body: InvalidateEntityRequest = Body(default_factory=InvalidateEntityRequest),
@@ -1720,7 +1720,7 @@ async def invalidate_entity(
     operation="invalidate_relation",
     error_code_prefix="MEMORY",
 )
-@router.patch("/relations/invalidate", response_model=DataResponse)
+@router.patch("/relations/invalidate", response_model=None)
 async def invalidate_relation(
     body: InvalidateRelationRequest = Body(...),
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -1088,7 +1088,7 @@ async def update_performance_threshold(
     operation="export_metrics",
     error_code_prefix="MONITORING",
 )
-@router.get("/export/metrics", response_model=DataResponse)
+@router.get("/export/metrics", response_model=None)
 async def export_metrics(
     admin_check: bool = Depends(check_admin_permission),
     format: str = Query("json", pattern="^(json|csv)$"),

--- a/autobot-backend/api/multimodal.py
+++ b/autobot-backend/api/multimodal.py
@@ -858,7 +858,7 @@ async def update_batch_size(
     operation="health_check",
     error_code_prefix="MULTIMODAL",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def health_check(
     current_user: dict = Depends(get_current_user),
 ):

--- a/autobot-backend/api/natural_language_search.py
+++ b/autobot-backend/api/natural_language_search.py
@@ -1185,7 +1185,7 @@ async def parse_query(query: str):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/suggestions", response_model=DataResponse)
+@router.get("/suggestions", response_model=None)
 async def get_query_suggestions(query: str):
     """
     Get query suggestions for a given query.
@@ -1214,7 +1214,7 @@ async def get_query_suggestions(query: str):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/explain", response_model=DataResponse)
+@router.post("/explain", response_model=None)
 async def explain_code_snippet(
     code: str, file_path: str = "<unknown>", line_number: int = 0
 ):
@@ -1241,7 +1241,7 @@ async def explain_code_snippet(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/intents", response_model=DataResponse)
+@router.get("/intents", response_model=None)
 async def list_supported_intents():
     """List all supported query intents with examples."""
     return {
@@ -1282,7 +1282,7 @@ async def list_supported_intents():
     }
 
 
-@router.get("/domains", response_model=DataResponse)
+@router.get("/domains", response_model=None)
 async def list_supported_domains():
     """List all supported query domains with keywords."""
     return {
@@ -1293,7 +1293,7 @@ async def list_supported_domains():
     }
 
 
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def health_check():
     """Health check endpoint.
 

--- a/autobot-backend/api/nl_database.py
+++ b/autobot-backend/api/nl_database.py
@@ -215,7 +215,7 @@ async def nl_query(
     summary="Get trained database schema information",
     description="Returns metadata about databases the NL service has been trained on.",
     tags=["nl-database"],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def get_schema(
     _auth=Depends(get_current_user),
@@ -263,7 +263,7 @@ async def train_on_db(
     summary="Get query history",
     description="Retrieve the history of natural language queries executed by the current user.",
     tags=["nl-database"],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def get_history(
     request: Request,

--- a/autobot-backend/api/overseer_handlers.py
+++ b/autobot-backend/api/overseer_handlers.py
@@ -516,7 +516,7 @@ async def submit_query(
         return {"success": False, "error": "Internal server error"}
 
 
-@router.get("/status/{session_id}", response_model=DataResponse)
+@router.get("/status/{session_id}", response_model=None)
 async def get_status(
     session_id: str,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/permissions.py
+++ b/autobot-backend/api/permissions.py
@@ -303,7 +303,7 @@ async def get_permission_rules(admin_check: bool = Depends(check_admin_permissio
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/rules", response_model=DataResponse)
+@router.post("/rules", response_model=None)
 async def add_permission_rule(
     request: AddRuleRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -351,7 +351,7 @@ async def add_permission_rule(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.delete("/rules", response_model=DataResponse)
+@router.delete("/rules", response_model=None)
 async def remove_permission_rule(
     request: RemoveRuleRequest, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -442,7 +442,7 @@ async def get_project_approvals(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.delete("/memory/{project_path:path}", response_model=DataResponse)
+@router.delete("/memory/{project_path:path}", response_model=None)
 async def clear_project_approvals(
     project_path: str,
     admin_check: bool = Depends(check_admin_permission),
@@ -478,7 +478,7 @@ async def clear_project_approvals(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/memory", response_model=DataResponse)
+@router.post("/memory", response_model=None)
 async def store_approval(
     admin_check: bool = Depends(check_admin_permission),
     project_path: str = Query(..., description="Project path"),
@@ -521,7 +521,7 @@ async def store_approval(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/memory/stats", response_model=DataResponse)
+@router.get("/memory/stats", response_model=None)
 async def get_memory_stats(admin_check: bool = Depends(check_admin_permission)):
     """
     Get approval memory statistics.

--- a/autobot-backend/api/personality.py
+++ b/autobot-backend/api/personality.py
@@ -187,7 +187,7 @@ async def get_status() -> StatusResponse:
     )
 
 
-@router.get("/languages", response_model=DataResponse)
+@router.get("/languages", response_model=None)
 async def list_languages() -> Dict[str, str]:
     """Return the supported language codes and their display names."""
     return SUPPORTED_LANGUAGES
@@ -238,7 +238,7 @@ async def update_profile(pid: str, body: ProfileUpdate) -> ProfileDetail:
     "/profiles/{pid}",
     status_code=status.HTTP_204_NO_CONTENT,
     dependencies=[Depends(check_admin_permission)],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def delete_profile(pid: str) -> None:
     """Delete a user-created profile. System profiles cannot be deleted."""
@@ -257,7 +257,7 @@ async def delete_profile(pid: str) -> None:
     "/profiles/{pid}/activate",
     status_code=status.HTTP_204_NO_CONTENT,
     dependencies=[Depends(check_admin_permission)],
-    response_model=DataResponse,
+    response_model=None,
 )
 async def activate_profile(pid: str) -> None:
     """Set a profile as the active personality."""

--- a/autobot-backend/api/playwright.py
+++ b/autobot-backend/api/playwright.py
@@ -139,7 +139,7 @@ async def health_check():
     operation="web_search",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/search", response_model=DataResponse)
+@router.post("/search", response_model=None)
 async def web_search(request: SearchRequest):
     """
     Perform web search using embedded Playwright
@@ -180,7 +180,7 @@ async def web_search(request: SearchRequest):
     operation="test_frontend",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/test-frontend", response_model=DataResponse)
+@router.post("/test-frontend", response_model=None)
 async def test_frontend(request: FrontendTestRequest):
     """
     Test frontend functionality using embedded Playwright
@@ -214,7 +214,7 @@ async def test_frontend(request: FrontendTestRequest):
     operation="send_test_message",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/send-test-message", response_model=DataResponse)
+@router.post("/send-test-message", response_model=None)
 async def send_test_message(request: TestMessageRequest):
     """
     Send test message through frontend using embedded Playwright
@@ -252,7 +252,7 @@ async def send_test_message(request: TestMessageRequest):
     operation="capture_screenshot",
     error_code_prefix="PLAYWRIGHT",
 )
-@router.post("/screenshot", response_model=DataResponse)
+@router.post("/screenshot", response_model=None)
 async def capture_screenshot(request: ScreenshotRequest):
     """
     Capture screenshot of webpage using embedded Playwright

--- a/autobot-backend/api/project_state.py
+++ b/autobot-backend/api/project_state.py
@@ -302,7 +302,7 @@ async def auto_progress_phases():
     operation="health_check",
     error_code_prefix="PROJECT_STATE",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def health_check():
     """Health check for project state API"""
     try:

--- a/autobot-backend/api/prometheus_mcp.py
+++ b/autobot-backend/api/prometheus_mcp.py
@@ -156,7 +156,7 @@ PROMETHEUS_MCP_TOOL_DEFINITIONS = (
     operation="get_prometheus_mcp_tools",
     error_code_prefix="PROMETHEUS_MCP",
 )
-@router.get("/mcp/tools", response_model=DataResponse)
+@router.get("/mcp/tools", response_model=None)
 async def get_prometheus_mcp_tools() -> List[MCPTool]:
     """
     Get available MCP tools for Prometheus metrics.
@@ -416,7 +416,7 @@ TOOL_HANDLERS = {
     operation="execute_prometheus_tool",
     error_code_prefix="PROMETHEUS_MCP",
 )
-@router.post("/mcp/{tool_name}", response_model=DataResponse)
+@router.post("/mcp/{tool_name}", response_model=None)
 async def execute_prometheus_tool(tool_name: str, request: Metadata) -> Metadata:
     """
     Execute a Prometheus MCP tool

--- a/autobot-backend/api/prompts.py
+++ b/autobot-backend/api/prompts.py
@@ -227,7 +227,7 @@ async def _collect_prompt_files(
     operation="get_prompts",
     error_code_prefix="PROMPTS",
 )
-@router.get("/", response_model=DataResponse)
+@router.get("/", response_model=None)
 async def get_prompts(admin_check: bool = Depends(check_admin_permission)):
     """Get all prompts from filesystem with caching.
 
@@ -289,7 +289,7 @@ async def get_prompts(admin_check: bool = Depends(check_admin_permission)):
     operation="clear_prompts_cache",
     error_code_prefix="PROMPTS",
 )
-@router.post("/cache/clear", response_model=DataResponse)
+@router.post("/cache/clear", response_model=None)
 async def clear_prompts_cache(admin_check: bool = Depends(check_admin_permission)):
     """Clear the prompts cache to force reload on next request.
 
@@ -331,8 +331,8 @@ def _build_prompt_save_response(
     operation="save_prompt",
     error_code_prefix="PROMPTS",
 )
-@router.post("/{prompt_id}", response_model=DataResponse)
-@router.put("/{prompt_id}", response_model=DataResponse)  # Issue #570: Support PUT for frontend compatibility
+@router.post("/{prompt_id}", response_model=None)
+@router.put("/{prompt_id}", response_model=None)  # Issue #570: Support PUT for frontend compatibility
 async def save_prompt(
     prompt_id: str, request: dict, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -438,7 +438,7 @@ async def _write_prompt_from_default(
     operation="revert_prompt",
     error_code_prefix="PROMPTS",
 )
-@router.post("/{prompt_id}/revert", response_model=DataResponse)
+@router.post("/{prompt_id}/revert", response_model=None)
 async def revert_prompt(
     prompt_id: str, admin_check: bool = Depends(check_admin_permission)
 ):

--- a/autobot-backend/api/redis.py
+++ b/autobot-backend/api/redis.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
     operation="get_redis_config",
     error_code_prefix="REDIS",
 )
-@router.get("/config", response_model=DataResponse)
+@router.get("/config", response_model=None)
 async def get_redis_config():
     """Get current Redis configuration"""
     try:
@@ -35,7 +35,7 @@ async def get_redis_config():
     operation="update_redis_config",
     error_code_prefix="REDIS",
 )
-@router.post("/config", response_model=DataResponse)
+@router.post("/config", response_model=None)
 async def update_redis_config(config_data: dict):
     """Update Redis configuration"""
     try:
@@ -51,7 +51,7 @@ async def update_redis_config(config_data: dict):
     operation="get_redis_status",
     error_code_prefix="REDIS",
 )
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=None)
 async def get_redis_status():
     """Get Redis connection status"""
     try:
@@ -70,7 +70,7 @@ async def get_redis_status():
     operation="test_redis_connection",
     error_code_prefix="REDIS",
 )
-@router.post("/test_connection", response_model=DataResponse)
+@router.post("/test_connection", response_model=None)
 async def test_redis_connection():
     """Test Redis connection with current configuration"""
     try:
@@ -89,7 +89,7 @@ async def test_redis_connection():
     operation="get_redis_health",
     error_code_prefix="REDIS",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def get_redis_health():
     """Get Redis health status for frontend health checks"""
     try:

--- a/autobot-backend/api/rum.py
+++ b/autobot-backend/api/rum.py
@@ -435,7 +435,7 @@ async def clear_rum_data():
     operation="export_rum_data",
     error_code_prefix="RUM",
 )
-@router.get("/export", response_model=DataResponse)
+@router.get("/export", response_model=None)
 async def export_rum_data():
     """Export RUM data for analysis"""
 

--- a/autobot-backend/api/sandbox.py
+++ b/autobot-backend/api/sandbox.py
@@ -64,7 +64,7 @@ class SandboxBatchRequest(BaseModel):
     operation="execute_command",
     error_code_prefix="SANDBOX",
 )
-@router.post("/execute", response_model=DataResponse)
+@router.post("/execute", response_model=None)
 async def execute_command(
     request: SandboxExecuteRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -125,7 +125,7 @@ async def execute_command(
     operation="execute_script",
     error_code_prefix="SANDBOX",
 )
-@router.post("/execute/script", response_model=DataResponse)
+@router.post("/execute/script", response_model=None)
 async def execute_script(
     request: SandboxScriptRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -186,7 +186,7 @@ async def execute_script(
     operation="execute_batch",
     error_code_prefix="SANDBOX",
 )
-@router.post("/execute/batch", response_model=DataResponse)
+@router.post("/execute/batch", response_model=None)
 async def execute_batch(
     request: SandboxBatchRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -316,7 +316,7 @@ def _build_batch_result_data(commands: List[str], result: Any) -> Dict[str, Any]
     operation="get_sandbox_stats",
     error_code_prefix="SANDBOX",
 )
-@router.get("/stats", response_model=DataResponse)
+@router.get("/stats", response_model=None)
 async def get_sandbox_stats(
     current_user: dict = Depends(get_current_user),
 ):
@@ -371,7 +371,7 @@ async def get_sandbox_stats(
     operation="get_security_levels",
     error_code_prefix="SANDBOX",
 )
-@router.get("/security-levels", response_model=DataResponse)
+@router.get("/security-levels", response_model=None)
 async def get_security_levels(
     current_user: dict = Depends(get_current_user),
 ):
@@ -440,7 +440,7 @@ async def get_security_levels(
     operation="get_sandbox_examples",
     error_code_prefix="SANDBOX",
 )
-@router.get("/examples", response_model=DataResponse)
+@router.get("/examples", response_model=None)
 async def get_sandbox_examples(
     current_user: dict = Depends(get_current_user),
 ):

--- a/autobot-backend/api/self_capabilities.py
+++ b/autobot-backend/api/self_capabilities.py
@@ -218,7 +218,7 @@ async def discover_endpoints(app: Any) -> Dict[str, Any]:
         f"{TTL_5_MINUTES // 60}-minute TTL that resets on route changes."
     ),
     tags=["self", "capabilities"],
-    response_model=DataResponse,
+    response_model=None,
 )
 @with_error_handling(category=ErrorCategory.SYSTEM)
 async def get_capabilities(request: Request) -> Dict[str, Any]:

--- a/autobot-backend/api/sequential_thinking_mcp.py
+++ b/autobot-backend/api/sequential_thinking_mcp.py
@@ -220,7 +220,7 @@ class SequentialThinkingRequest(BaseModel):
     operation="get_sequential_thinking_mcp_tools",
     error_code_prefix="SEQUENTIAL_THINKING_MCP",
 )
-@router.get("/mcp/tools", response_model=DataResponse)
+@router.get("/mcp/tools", response_model=None)
 async def get_sequential_thinking_mcp_tools() -> List[MCPTool]:
     """
     Get available MCP tools for sequential thinking.
@@ -271,7 +271,7 @@ def _calculate_session_summary(session_thoughts: list, thought_number: int) -> d
     operation="sequential_thinking_mcp",
     error_code_prefix="SEQUENTIAL_THINKING_MCP",
 )
-@router.post("/mcp/sequential_thinking", response_model=DataResponse)
+@router.post("/mcp/sequential_thinking", response_model=None)
 async def sequential_thinking_mcp(request: SequentialThinkingRequest) -> Metadata:
     """Execute sequential thinking tool (Issue #398: refactored)."""
     session_id = request.get_session_key()
@@ -333,7 +333,7 @@ async def sequential_thinking_mcp(request: SequentialThinkingRequest) -> Metadat
     operation="get_thinking_session",
     error_code_prefix="SEQUENTIAL_THINKING_MCP",
 )
-@router.get("/sessions/{session_id}", response_model=DataResponse)
+@router.get("/sessions/{session_id}", response_model=None)
 async def get_thinking_session(session_id: str) -> Metadata:
     """Get complete thinking session history"""
     async with _thinking_sessions_lock:
@@ -388,7 +388,7 @@ async def clear_thinking_session(session_id: str) -> Metadata:
     operation="list_thinking_sessions",
     error_code_prefix="SEQUENTIAL_THINKING_MCP",
 )
-@router.get("/sessions", response_model=DataResponse)
+@router.get("/sessions", response_model=None)
 async def list_thinking_sessions() -> Metadata:
     """List all active thinking sessions"""
     async with _thinking_sessions_lock:

--- a/autobot-backend/api/service_monitor.py
+++ b/autobot-backend/api/service_monitor.py
@@ -65,7 +65,7 @@ async def _check_redis_health() -> Tuple[str, str]:
         return "offline", "Unreachable"
 
 
-@router.get("/services", response_model=DataResponse)
+@router.get("/services", response_model=None)
 async def get_service_statuses() -> Dict[str, Any]:
     """Return health status for each AutoBot supporting service.
 
@@ -109,7 +109,7 @@ async def get_service_statuses() -> Dict[str, Any]:
     }
 
 
-@router.get("/vms/status", response_model=DataResponse)
+@router.get("/vms/status", response_model=None)
 async def get_vm_statuses() -> Dict[str, Any]:
     """Return status for AutoBot VMs as a list.
 

--- a/autobot-backend/api/services.py
+++ b/autobot-backend/api/services.py
@@ -226,7 +226,7 @@ async def get_services(admin_check: bool = Depends(check_admin_permission)):
     operation="get_health",
     error_code_prefix="SERVICES",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def get_health(admin_check: bool = Depends(check_admin_permission)):
     """Simple health check endpoint.
 
@@ -252,7 +252,7 @@ async def get_health(admin_check: bool = Depends(check_admin_permission)):
     operation="get_services_health",
     error_code_prefix="SERVICES",
 )
-@router.get("/services/health", response_model=DataResponse)
+@router.get("/services/health", response_model=None)
 async def get_services_health(admin_check: bool = Depends(check_admin_permission)):
     """Get service health status - alias to monitoring endpoint
 
@@ -348,7 +348,7 @@ def _build_vm_status_list(vm_definitions: list) -> list:
     operation="get_vms_status",
     error_code_prefix="SERVICES",
 )
-@router.get("/vms/status", response_model=DataResponse)
+@router.get("/vms/status", response_model=None)
 async def get_vms_status(admin_check: bool = Depends(check_admin_permission)):
     """
     Get VM status for distributed infrastructure.

--- a/autobot-backend/api/skills.py
+++ b/autobot-backend/api/skills.py
@@ -146,7 +146,7 @@ async def get_skill(name: str) -> Dict[str, Any]:
     return detail
 
 
-@router.post("/{name}/enable", summary="Enable a skill", response_model=DataResponse)
+@router.post("/{name}/enable", summary="Enable a skill", response_model=None)
 async def enable_skill(name: str) -> Dict[str, Any]:
     """Enable a skill, checking dependencies. Persists state to Redis (Issue #993)."""
     registry = get_skill_registry()
@@ -158,7 +158,7 @@ async def enable_skill(name: str) -> Dict[str, Any]:
     return result
 
 
-@router.post("/{name}/disable", summary="Disable a skill", response_model=DataResponse)
+@router.post("/{name}/disable", summary="Disable a skill", response_model=None)
 async def disable_skill(name: str) -> Dict[str, Any]:
     """Disable a skill. Persists state to Redis (Issue #993)."""
     registry = get_skill_registry()
@@ -170,7 +170,7 @@ async def disable_skill(name: str) -> Dict[str, Any]:
     return result
 
 
-@router.put("/{name}/config", summary="Update skill config", response_model=DataResponse)
+@router.put("/{name}/config", summary="Update skill config", response_model=None)
 async def update_config(name: str, body: SkillConfigUpdate) -> Dict[str, Any]:
     """Update a skill's configuration values."""
     registry = get_skill_registry()
@@ -185,7 +185,7 @@ async def update_config(name: str, body: SkillConfigUpdate) -> Dict[str, Any]:
     return result
 
 
-@router.post("/{name}/execute", summary="Execute a skill action", response_model=DataResponse)
+@router.post("/{name}/execute", summary="Execute a skill action", response_model=None)
 async def execute_skill(name: str, body: SkillActionRequest) -> Dict[str, Any]:
     """Execute a specific action on a skill."""
     manager = _get_manager()

--- a/autobot-backend/api/skills_repos.py
+++ b/autobot-backend/api/skills_repos.py
@@ -58,7 +58,7 @@ async def _get_repo_by_id(session: AsyncSession, repo_id: str) -> SkillRepo:
     return repo
 
 
-@router.post("/", summary="Register a new skill repository", response_model=DataResponse)
+@router.post("/", summary="Register a new skill repository", response_model=None)
 async def add_repo(
     body: AddRepoRequest,
     _: None = Depends(check_admin_permission),
@@ -87,8 +87,8 @@ async def add_repo(
     return {"id": repo.id, "name": repo.name, "status": "registered"}
 
 
-@router.get("", summary="List all registered skill repositories", response_model=DataResponse)
-@router.get("/", include_in_schema=False, response_model=DataResponse)
+@router.get("", summary="List all registered skill repositories", response_model=None)
+@router.get("/", include_in_schema=False, response_model=None)
 async def list_repos() -> List[Dict[str, Any]]:
     """Return all registered skill repositories."""
     engine = get_skills_engine()
@@ -111,7 +111,7 @@ async def list_repos() -> List[Dict[str, Any]]:
     ]
 
 
-@router.post("/{repo_id}/sync", summary="Sync packages from a repository", response_model=DataResponse)
+@router.post("/{repo_id}/sync", summary="Sync packages from a repository", response_model=None)
 async def sync_repo(
     repo_id: str,
     _: None = Depends(check_admin_permission),
@@ -135,7 +135,7 @@ async def sync_repo(
     return {"synced": len(packages), "repo": repo.name}
 
 
-@router.get("/{repo_id}/browse", summary="Browse packages in a repository", response_model=DataResponse)
+@router.get("/{repo_id}/browse", summary="Browse packages in a repository", response_model=None)
 async def browse_repo(repo_id: str) -> Dict[str, Any]:
     """List the skill package names available in the specified repository."""
     engine = get_skills_engine()

--- a/autobot-backend/api/startup.py
+++ b/autobot-backend/api/startup.py
@@ -126,7 +126,7 @@ async def broadcast_startup_message(message: StartupMessage):
     operation="get_startup_status",
     error_code_prefix="STARTUP",
 )
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=None)
 async def get_startup_status():
     """Get current startup status"""
     with _startup_lock:

--- a/autobot-backend/api/structured_thinking_mcp.py
+++ b/autobot-backend/api/structured_thinking_mcp.py
@@ -368,7 +368,7 @@ async def get_structured_thinking_mcp_tools() -> List[MCPTool]:
     operation="process_thought_mcp",
     error_code_prefix="STRUCTURED_THINKING_MCP",
 )
-@router.post("/mcp/process_thought", response_model=DataResponse)
+@router.post("/mcp/process_thought", response_model=None)
 async def process_thought_mcp(request: ProcessThoughtRequest) -> Metadata:
     """
     Process and record a thought within the structured cognitive framework.

--- a/autobot-backend/api/system_validation.py
+++ b/autobot-backend/api/system_validation.py
@@ -51,7 +51,7 @@ class ValidationResult(BaseModel):
     operation="validation_health",
     error_code_prefix="SYSTEM_VALIDATION",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=None)
 async def validation_health():
     """Health check for validation system"""
     try:
@@ -110,7 +110,7 @@ async def run_comprehensive_validation(
     operation="run_quick_validation",
     error_code_prefix="SYSTEM_VALIDATION",
 )
-@router.get("/validate/quick", response_model=DataResponse)
+@router.get("/validate/quick", response_model=None)
 async def run_quick_validation():
     """Run quick system validation check"""
     try:
@@ -177,7 +177,7 @@ async def run_quick_validation():
     operation="validate_component",
     error_code_prefix="SYSTEM_VALIDATION",
 )
-@router.get("/validate/component/{component_name}", response_model=DataResponse)
+@router.get("/validate/component/{component_name}", response_model=None)
 async def validate_component(component_name: str):
     """Validate specific component"""
     try:
@@ -225,7 +225,7 @@ async def validate_component(component_name: str):
     operation="get_optimization_recommendations",
     error_code_prefix="SYSTEM_VALIDATION",
 )
-@router.get("/validate/recommendations", response_model=DataResponse)
+@router.get("/validate/recommendations", response_model=None)
 async def get_optimization_recommendations():
     """Get system optimization recommendations"""
     try:
@@ -290,7 +290,7 @@ async def get_optimization_recommendations():
     operation="get_validation_status",
     error_code_prefix="SYSTEM_VALIDATION",
 )
-@router.get("/validate/status", response_model=DataResponse)
+@router.get("/validate/status", response_model=None)
 async def get_validation_status():
     """Get current validation system status"""
     try:
@@ -322,7 +322,7 @@ async def get_validation_status():
     operation="run_performance_benchmark",
     error_code_prefix="SYSTEM_VALIDATION",
 )
-@router.post("/validate/benchmark", response_model=DataResponse)
+@router.post("/validate/benchmark", response_model=None)
 async def run_performance_benchmark():
     """Run performance benchmarking tests"""
     try:

--- a/autobot-backend/api/triggers.py
+++ b/autobot-backend/api/triggers.py
@@ -166,7 +166,7 @@ async def list_triggers(
     "/triggers/{trigger_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Unregister a trigger",
-    response_model=DataResponse,
+    response_model=None,
 )
 async def delete_trigger(
     trigger_id: str,
@@ -198,7 +198,7 @@ async def delete_trigger(
     "/triggers/webhook/{trigger_id}",
     status_code=status.HTTP_200_OK,
     summary="Receive an external webhook event",
-    response_model=DataResponse,
+    response_model=None,
 )
 async def receive_webhook(
     trigger_id: str,

--- a/autobot-backend/api/vision.py
+++ b/autobot-backend/api/vision.py
@@ -232,7 +232,7 @@ async def analyze_screen(
     operation="detect_elements",
     error_code_prefix="VISION",
 )
-@router.post("/elements", response_model=DataResponse)
+@router.post("/elements", response_model=None)
 async def detect_elements(
     request: ElementDetectionRequest,
     current_user: dict = Depends(get_current_user),
@@ -294,7 +294,7 @@ async def detect_elements(
     operation="extract_text_ocr",
     error_code_prefix="VISION",
 )
-@router.post("/ocr", response_model=DataResponse)
+@router.post("/ocr", response_model=None)
 async def extract_text_ocr(
     request: OCRRequest,
     current_user: dict = Depends(get_current_user),
@@ -350,7 +350,7 @@ async def extract_text_ocr(
     operation="get_automation_opportunities",
     error_code_prefix="VISION",
 )
-@router.get("/automation-opportunities", response_model=DataResponse)
+@router.get("/automation-opportunities", response_model=None)
 async def get_automation_opportunities(
     session_id: Optional[str] = None,
     current_user: dict = Depends(get_current_user),
@@ -382,7 +382,7 @@ async def get_automation_opportunities(
     operation="get_element_types",
     error_code_prefix="VISION",
 )
-@router.get("/element-types", response_model=DataResponse)
+@router.get("/element-types", response_model=None)
 async def get_element_types(
     current_user: dict = Depends(get_current_user),
 ):
@@ -409,7 +409,7 @@ async def get_element_types(
     operation="get_interaction_types",
     error_code_prefix="VISION",
 )
-@router.get("/interaction-types", response_model=DataResponse)
+@router.get("/interaction-types", response_model=None)
 async def get_interaction_types(
     current_user: dict = Depends(get_current_user),
 ):
@@ -436,7 +436,7 @@ async def get_interaction_types(
     operation="get_layout_analysis",
     error_code_prefix="VISION",
 )
-@router.get("/layout", response_model=DataResponse)
+@router.get("/layout", response_model=None)
 async def get_layout_analysis(
     session_id: Optional[str] = None,
     current_user: dict = Depends(get_current_user),
@@ -467,7 +467,7 @@ async def get_layout_analysis(
     operation="vision_service_status",
     error_code_prefix="VISION",
 )
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=None)
 async def get_vision_status(
     current_user: dict = Depends(get_current_user),
 ):

--- a/autobot-backend/api/wake_word.py
+++ b/autobot-backend/api/wake_word.py
@@ -99,7 +99,7 @@ async def check_wake_word(request: WakeWordCheckRequest) -> WakeWordCheckRespons
     operation="get_wake_words",
     error_code_prefix="WAKE_WORD",
 )
-@router.get("/words", response_model=DataResponse)
+@router.get("/words", response_model=None)
 async def get_wake_words() -> Metadata:
     """Get list of configured wake words"""
     detector = get_wake_word_detector()
@@ -168,7 +168,7 @@ async def remove_wake_word(wake_word: str) -> Metadata:
     operation="get_wake_word_config",
     error_code_prefix="WAKE_WORD",
 )
-@router.get("/config", response_model=DataResponse)
+@router.get("/config", response_model=None)
 async def get_wake_word_config() -> Metadata:
     """Get current wake word detection configuration"""
     detector = get_wake_word_detector()
@@ -216,7 +216,7 @@ async def update_wake_word_config(request: WakeWordConfigRequest) -> Metadata:
     operation="get_wake_word_stats",
     error_code_prefix="WAKE_WORD",
 )
-@router.get("/stats", response_model=DataResponse)
+@router.get("/stats", response_model=None)
 async def get_wake_word_stats() -> Metadata:
     """Get wake word detection statistics"""
     detector = get_wake_word_detector()
@@ -349,7 +349,7 @@ async def stop_listening() -> Metadata:
     operation="get_listening_status",
     error_code_prefix="WAKE_WORD",
 )
-@router.get("/listening/status", response_model=DataResponse)
+@router.get("/listening/status", response_model=None)
 async def get_listening_status() -> Metadata:
     """
     Get background listening status including real-time CPU metrics.

--- a/autobot-backend/api/workflow_permissions.py
+++ b/autobot-backend/api/workflow_permissions.py
@@ -174,7 +174,7 @@ async def grant_workflow_permission(
     "/workflows/{workflow_id}/permissions/{user_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Revoke a workflow permission",
-    response_model=DataResponse,
+    response_model=None,
 )
 async def revoke_workflow_permission(
     workflow_id: str,

--- a/autobot-backend/api/workflow_secrets.py
+++ b/autobot-backend/api/workflow_secrets.py
@@ -231,7 +231,7 @@ async def update_workflow_secret(
     )
 
 
-@router.delete("/{name}", status_code=204, response_model=DataResponse)
+@router.delete("/{name}", status_code=204, response_model=None)
 async def delete_workflow_secret(
     name: str,
     current_user: dict = Depends(get_current_user),


### PR DESCRIPTION
## Summary

- Extends the DataResponse runtime-500 fix (#5896, #5904) to cover **all 79 API files**, not just the 44 in FILES_5843
- Reverts `response_model=DataResponse` → `response_model=None` for **309 endpoints** that return variables without guaranteed `success` field
- This is the third and final pass — all 307 violations reported by the CI hook are now resolved

## Background

Three-pass cascade:
| Pass | Issue | Endpoints | Pattern |
|------|-------|-----------|---------|
| 1 | #5896 | 52 | `return {` literals without `"success"` key |
| 2 | #5904 | 61 | variable returns in FILES_5843 only |
| 3 | **#5928** (this PR) | **309** | All API files — first text-based (253), then AST-based (56 missed due to "success" in docstrings) |

## Why two sub-passes

Pass 3 first ran a text-based classifier (`"success" in func_src`). This missed 56 functions that had `"success"` in their **docstrings** (e.g. `analysis_status: "success", "partial", or "failed"`) but not as a return dict key. A second AST pass using the exact same logic as the CI hook caught and fixed all remaining 56.

## Verification

```
$ python3 tools/lint/check_response_models.py autobot-backend/api/*.py 2>&1 | grep "^\[response-model" | wc -l
0
```

78 files changed, 309 endpoints reverted. CI hook reports 0 violations.

## Files changed

67 files in first pass, 23 files in second pass, 78 unique files total across both passes.

Closes #5928