### PR TITLE
refact(composables): replace axios with ApiClient + useLoadingState in useEvolution (#5922)

### DIFF
--- a/autobot-frontend/src/composables/useEvolution.ts
+++ b/autobot-frontend/src/composables/useEvolution.ts
@@ -8,9 +8,10 @@
  */
 
 import { ref, computed, isRef, type ComputedRef } from 'vue'
-import axios from 'axios'
+import ApiClient from '@/utils/ApiClient'
+import { useLoadingState } from '@/composables/useLoadingState'
 import { createLogger } from '@/utils/debugUtils'
-import { extractApiErrorMessage, extractErrorMessage } from '@/utils/errorExtract'
+import { extractApiErrorMessage } from '@/utils/errorExtract'
 import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useEvolution')
@@ -81,7 +82,7 @@ export interface EvolutionSummary {
 }
 
 export function useEvolution(sourceId?: string | ComputedRef<string | undefined>) {
-  const loading = ref(false)
+  const { isLoading: loading, wrap } = useLoadingState()
   const error = ref<string | null>(null)
 
   const analysisResult = ref<EvolutionAnalysisResponse | null>(null)
@@ -89,15 +90,6 @@ export function useEvolution(sourceId?: string | ComputedRef<string | undefined>
   const patternData = ref<PatternEvolutionData>({})
   const trendsData = ref<TrendsData>({})
   const summary = ref<EvolutionSummary | null>(null)
-
-  // API client with auth token
-  const api = axios.create({
-    baseURL: `${getApiBase()}/evolution`,
-    timeout: 120000, // 2 minutes for long-running analysis
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  })
 
   /**
    * Merge source_id into params when sourceId is provided (Issue #3436).
@@ -110,38 +102,31 @@ export function useEvolution(sourceId?: string | ComputedRef<string | undefined>
     return { ...params, source_id: id }
   }
 
-  // Add auth token to requests
-  api.interceptors.request.use((config) => {
-    const token = localStorage.getItem('access_token')
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
   /**
    * Trigger code evolution analysis
    */
   async function analyzeEvolution(request: EvolutionAnalysisRequest): Promise<boolean> {
-    loading.value = true
     error.value = null
-
     try {
-      const response = await api.post<EvolutionAnalysisResponse>('/analyze', request)
-      analysisResult.value = response.data
+      const data = await wrap(() =>
+        ApiClient.post<EvolutionAnalysisResponse>(
+          `${getApiBase()}/evolution/analyze`,
+          request,
+          { timeout: 120000 }
+        )
+      )
+      analysisResult.value = data
 
       // After analysis, fetch timeline and pattern data
       await fetchTimeline()
       await fetchPatternEvolution()
 
-      logger.info('Evolution analysis complete', response.data)
+      logger.info('Evolution analysis complete', data)
       return true
     } catch (e: unknown) {
       error.value = extractApiErrorMessage(e, 'Analysis failed')
       logger.error('Evolution analysis failed:', e)
       return false
-    } finally {
-      loading.value = false
     }
   }
 
@@ -154,27 +139,29 @@ export function useEvolution(sourceId?: string | ComputedRef<string | undefined>
     granularity: string = 'daily',
     metrics: string = 'overall_score,complexity,maintainability'
   ): Promise<void> {
-    loading.value = true
     error.value = null
-
     try {
       const params: Record<string, string> = { granularity, metrics }
       if (start_date) params.start_date = start_date
       if (end_date) params.end_date = end_date
 
       // Issue #3436: scope to project when sourceId is provided
-      const response = await api.get<{ timeline: TimelineData[] }>('/timeline', { params: withSourceId(params) })
+      const qs = new URLSearchParams(withSourceId(params)).toString()
+      const data = await wrap(() =>
+        ApiClient.get<{ timeline: TimelineData[] }>(
+          `${getApiBase()}/evolution/timeline?${qs}`,
+          { timeout: 120000 }
+        )
+      )
 
-      if (response.data.timeline) {
-        timelineData.value = response.data.timeline
+      if (data.timeline) {
+        timelineData.value = data.timeline
       }
 
       logger.info('Timeline data fetched', { count: timelineData.value.length })
     } catch (e: unknown) {
       error.value = extractApiErrorMessage(e, 'Failed to fetch timeline')
       logger.error('Failed to fetch timeline:', e)
-    } finally {
-      loading.value = false
     }
   }
 
@@ -186,9 +173,7 @@ export function useEvolution(sourceId?: string | ComputedRef<string | undefined>
     start_date?: string,
     end_date?: string
   ): Promise<void> {
-    loading.value = true
     error.value = null
-
     try {
       const params: Record<string, string> = {}
       if (pattern_type) params.pattern_type = pattern_type
@@ -196,18 +181,22 @@ export function useEvolution(sourceId?: string | ComputedRef<string | undefined>
       if (end_date) params.end_date = end_date
 
       // Issue #3436: scope to project when sourceId is provided
-      const response = await api.get<{ patterns: PatternEvolutionData }>('/patterns', { params: withSourceId(params) })
+      const qs = new URLSearchParams(withSourceId(params)).toString()
+      const data = await wrap(() =>
+        ApiClient.get<{ patterns: PatternEvolutionData }>(
+          `${getApiBase()}/evolution/patterns?${qs}`,
+          { timeout: 120000 }
+        )
+      )
 
-      if (response.data.patterns) {
-        patternData.value = response.data.patterns
+      if (data.patterns) {
+        patternData.value = data.patterns
       }
 
       logger.info('Pattern evolution data fetched', { count: Object.keys(patternData.value).length })
     } catch (e: unknown) {
       error.value = extractApiErrorMessage(e, 'Failed to fetch pattern data')
       logger.error('Failed to fetch pattern evolution:', e)
-    } finally {
-      loading.value = false
     }
   }
 
@@ -217,9 +206,12 @@ export function useEvolution(sourceId?: string | ComputedRef<string | undefined>
   async function fetchTrends(days: number = 30): Promise<void> {
     try {
       // Issue #3436: scope to project when sourceId is provided
-      const response = await api.get<{ trends: TrendsData }>('/trends', { params: withSourceId({ days: String(days) }) })
-      if (response.data.trends) {
-        trendsData.value = response.data.trends
+      const qs = new URLSearchParams(withSourceId({ days: String(days) })).toString()
+      const data = await ApiClient.get<{ trends: TrendsData }>(
+        `${getApiBase()}/evolution/trends?${qs}`
+      )
+      if (data.trends) {
+        trendsData.value = data.trends
       }
       logger.info('Trends data fetched', { count: Object.keys(trendsData.value).length })
     } catch (e: unknown) {
@@ -233,9 +225,12 @@ export function useEvolution(sourceId?: string | ComputedRef<string | undefined>
   async function fetchSummary(): Promise<void> {
     try {
       // Issue #3436: scope to project when sourceId is provided
-      const response = await api.get<{ summary: EvolutionSummary }>('/summary', { params: withSourceId() })
-      if (response.data.summary) {
-        summary.value = response.data.summary
+      const params = withSourceId()
+      const qs = new URLSearchParams(params).toString()
+      const url = `${getApiBase()}/evolution/summary${qs ? `?${qs}` : ''}`
+      const data = await ApiClient.get<{ summary: EvolutionSummary }>(url)
+      if (data.summary) {
+        summary.value = data.summary
       }
       logger.info('Evolution summary fetched')
     } catch (e: unknown) {
@@ -256,30 +251,24 @@ export function useEvolution(sourceId?: string | ComputedRef<string | undefined>
       if (start_date) params.start_date = start_date
       if (end_date) params.end_date = end_date
 
-      const response = await api.get('/export', {
-        params,
-        responseType: format === 'csv' ? 'blob' : 'json',
-      })
+      const qs = new URLSearchParams(params).toString()
+      const response = await ApiClient.rawRequest(
+        `${getApiBase()}/evolution/export?${qs}`
+      )
 
+      let blob: Blob
       if (format === 'csv') {
-        const blob = new Blob([response.data], { type: 'text/csv' })
-        const url = URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = url
-        a.download = `evolution_data_${new Date().toISOString().slice(0, 10)}.csv`
-        a.click()
-        URL.revokeObjectURL(url)
+        blob = await response.blob()
       } else {
-        const blob = new Blob([JSON.stringify(response.data, null, 2)], {
-          type: 'application/json',
-        })
-        const url = URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = url
-        a.download = `evolution_data_${new Date().toISOString().slice(0, 10)}.json`
-        a.click()
-        URL.revokeObjectURL(url)
+        const data = await response.json()
+        blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
       }
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `evolution_data_${new Date().toISOString().slice(0, 10)}.${format}`
+      a.click()
+      URL.revokeObjectURL(url)
       logger.info('Evolution data exported as', format)
     } catch (e: unknown) {
       error.value = extractApiErrorMessage(e, 'Export failed')


### PR DESCRIPTION
## Summary
- Removes the only remaining `axios` import in the composable layer
- Migrates 3 loading pairs (`analyzeEvolution`, `fetchTimeline`, `fetchPatternEvolution`) to `useLoadingState.wrap()`
- `fetchTrends` and `fetchSummary` use `ApiClient.get` directly (no loading state needed)
- `exportData` uses `ApiClient.rawRequest()` for blob support (CSV/JSON download)
- `URLSearchParams` replaces axios `params` object for GET query strings

## Test plan
- [ ] Verify `useEvolution.ts` type-checks with `npm run type-check`
- [ ] Check that `loading` ref updates correctly during analysis and data fetches
- [ ] Confirm `exportData` still triggers download for both JSON and CSV formats

Closes #5922

🤖 Generated with [Claude Code](https://claude.com/claude-code)