### PR TITLE
refact(composables): migrate useEnvironmentAnalysis to useLoadingState (#5923)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useEnvironmentAnalysis.ts
+++ b/autobot-frontend/src/composables/analytics/useEnvironmentAnalysis.ts
@@ -10,6 +10,7 @@
  */
 
 import { ref } from 'vue'
+import { useLoadingState } from '@/composables/useLoadingState'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { getConfig } from '@/config/ssot-config'
@@ -28,7 +29,7 @@ export function useEnvironmentAnalysis(
 
   const environmentAnalysis =
     ref<EnvironmentAnalysisResult | null>(null)
-  const loadingEnvAnalysis = ref(false)
+  const { isLoading: loadingEnvAnalysis, wrap } = useLoadingState()
   const envAnalysisError = ref('')
   const useAiFiltering = ref(false)
   const aiFilteringModel = ref(getConfig().llm.defaultModel)
@@ -44,57 +45,58 @@ export function useEnvironmentAnalysis(
 
   const loadEnvironmentAnalysis = async () => {
     if (!rootPath.value) return
-    loadingEnvAnalysis.value = true
     envAnalysisError.value = ''
     llmFilteringResult.value = null
     try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      let url = `${backendUrl}/api/analytics/codebase/env-analysis?path=${encodeURIComponent(rootPath.value)}`
-      if (useAiFiltering.value) {
-        url += `&use_llm_filter=true`
-        url += `&llm_model=${encodeURIComponent(aiFilteringModel.value)}`
-        url += `&filter_priority=${encodeURIComponent(aiFilteringPriority.value)}`
-      }
-      url = withSourceId(url)
-      const response = await fetchWithAuth(url, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      })
-      if (!response.ok) {
-        throw new Error(
-          `Environment analysis endpoint returned ${response.status}`,
-        )
-      }
-      const data = await response.json()
-      if (data.status === 'success') {
-        environmentAnalysis.value = {
-          total_hardcoded_values:
-            data.total_hardcoded_values || 0,
-          high_priority_count: data.high_priority_count || 0,
-          recommendations_count:
-            data.recommendations_count || 0,
-          categories: data.categories || {},
-          analysis_time_seconds:
-            data.analysis_time_seconds || 0,
-          hardcoded_values: data.hardcoded_values || [],
-          recommendations: data.recommendations || [],
+      await wrap(async () => {
+        const backendUrl = await appConfig.getServiceUrl('backend')
+        let url = `${backendUrl}/api/analytics/codebase/env-analysis?path=${encodeURIComponent(rootPath.value)}`
+        if (useAiFiltering.value) {
+          url += `&use_llm_filter=true`
+          url += `&llm_model=${encodeURIComponent(aiFilteringModel.value)}`
+          url += `&filter_priority=${encodeURIComponent(aiFilteringPriority.value)}`
         }
-        if (data.llm_filtering) {
-          llmFilteringResult.value = data.llm_filtering
-          logger.info(
-            'LLM filtering applied:',
-            data.llm_filtering,
+        url = withSourceId(url)
+        const response = await fetchWithAuth(url, {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+          },
+        })
+        if (!response.ok) {
+          throw new Error(
+            `Environment analysis endpoint returned ${response.status}`,
           )
         }
-      } else if (data.status === 'no_data') {
-        environmentAnalysis.value = null
-        logger.debug(
-          'No environment analysis data - run indexing first',
-        )
-      }
+        const data = await response.json()
+        if (data.status === 'success') {
+          environmentAnalysis.value = {
+            total_hardcoded_values:
+              data.total_hardcoded_values || 0,
+            high_priority_count: data.high_priority_count || 0,
+            recommendations_count:
+              data.recommendations_count || 0,
+            categories: data.categories || {},
+            analysis_time_seconds:
+              data.analysis_time_seconds || 0,
+            hardcoded_values: data.hardcoded_values || [],
+            recommendations: data.recommendations || [],
+          }
+          if (data.llm_filtering) {
+            llmFilteringResult.value = data.llm_filtering
+            logger.info(
+              'LLM filtering applied:',
+              data.llm_filtering,
+            )
+          }
+        } else if (data.status === 'no_data') {
+          environmentAnalysis.value = null
+          logger.debug(
+            'No environment analysis data - run indexing first',
+          )
+        }
+      })
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : String(error)
@@ -103,8 +105,6 @@ export function useEnvironmentAnalysis(
         error,
       )
       envAnalysisError.value = errorMessage
-    } finally {
-      loadingEnvAnalysis.value = false
     }
   }
 


### PR DESCRIPTION
## Summary
- Migrates `useEnvironmentAnalysis.loadEnvironmentAnalysis` from manual `loadingEnvAnalysis.value = true/finally false` to `useLoadingState.wrap()`
- `usePatternAnalysis` and `useVoiceProfiles` were already migrated in batch 3 PR (#5921) so are unchanged here
- `useLoadingState` import was already present in both files; this PR closes out the tracking issue

## Test plan
- [ ] Verify `useEnvironmentAnalysis.ts` type-checks with `npm run type-check`
- [ ] Confirm `loadingEnvAnalysis` correctly goes true/false during env analysis fetch

Closes #5923

🤖 Generated with [Claude Code](https://claude.com/claude-code)