### PR TITLE
feat(lint): add single-assignment variable tracking to check_response_models (#5926)

### DIFF
--- a/tools/lint/check_response_models.py
+++ b/tools/lint/check_response_models.py
@@ -19,6 +19,12 @@ For each, at least one of the following must be true:
   2. A return statement contains a dict literal with all required keys
   3. The function returns a bypass type (JSONResponse, Response, StreamingResponse,
      FileResponse, PlainTextResponse, RedirectResponse) that skips FastAPI validation
+  4. A local variable is assigned a dict literal containing all required keys and
+     that variable is returned (single-assignment pattern — #5926)
+
+Known limitation: multi-step variable builds (e.g. result = {}; result["success"] = True)
+and pass-through returns of function-call results are not analyzed. Use
+create_success_response() for those cases to satisfy the hook.
 
 Exit codes:
   0 — clean
@@ -134,6 +140,38 @@ def _returns_bypass_type(node: _FuncNode) -> bool:
     return False
 
 
+def _var_dict_keys(node: _FuncNode) -> dict[str, set[str]]:
+    """Map local variable names to the union of keys from their dict literal assignments.
+
+    Covers the single-assignment pattern:
+        result = {"success": True, "data": ...}
+        return result
+    """
+    var_keys: dict[str, set[str]] = {}
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Assign):
+            continue
+        if not isinstance(child.value, ast.Dict):
+            continue
+        keys: set[str] = set()
+        for key in child.value.keys:
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                keys.add(key.value)
+        for target in child.targets:
+            if isinstance(target, ast.Name):
+                var_keys.setdefault(target.id, set()).update(keys)
+    return var_keys
+
+
+def _returned_var_names(node: _FuncNode) -> set[str]:
+    """Return the set of local variable names that appear in bare return statements."""
+    names: set[str] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Return) and isinstance(child.value, ast.Name):
+            names.add(child.value.id)
+    return names
+
+
 def _check_file(path: Path, repo_root: Path) -> List[Tuple[int, str]]:
     """Return [(line_no, func_name)] for each DataResponse violation in *path*."""
     try:
@@ -162,6 +200,15 @@ def _check_file(path: Path, repo_root: Path) -> List[Tuple[int, str]]:
             if schema == "DataResponse" and _calls_create_success_response(func_node):
                 break
             if required_keys.issubset(_return_dict_keys(func_node)):
+                break
+            # Single-assignment variable pattern: result = {"success": ...}; return result
+            var_keys = _var_dict_keys(func_node)
+            returned_vars = _returned_var_names(func_node)
+            if any(
+                required_keys.issubset(var_keys[name])
+                for name in returned_vars
+                if name in var_keys
+            ):
                 break
             violations.append((func_node.lineno, func_node.name))
             break

--- a/tools/lint/check_response_models_test.py
+++ b/tools/lint/check_response_models_test.py
@@ -303,3 +303,63 @@ async def clean():
 """,
     )
     assert hook.main(["hook", str(f)]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Variable-assignment pattern (#5926) — single-assignment tracking
+# ---------------------------------------------------------------------------
+
+
+def test_safe_variable_assigned_dict_with_success(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/var", response_model=DataResponse)
+async def get_var():
+    result = {"success": True, "data": []}
+    return result
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_detects_variable_assigned_dict_missing_success(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/var", response_model=DataResponse)
+async def get_var():
+    result = {"data": [], "count": 0}
+    return result
+""",
+    )
+    violations = hook._check_file(f, tmp_path)
+    assert len(violations) == 1
+    assert violations[0][1] == "get_var"
+
+
+def test_safe_success_message_response_variable_assignment(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.post("/msg", response_model=SuccessMessageResponse)
+async def post_msg():
+    response = {"success": True, "message": "done"}
+    return response
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_detects_success_message_response_variable_missing_message(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.post("/msg", response_model=SuccessMessageResponse)
+async def post_msg():
+    response = {"success": True}
+    return response
+""",
+    )
+    violations = hook._check_file(f, tmp_path)
+    assert len(violations) == 1


### PR DESCRIPTION
## Summary

Fixes the variable-return blind spot in `tools/lint/check_response_models.py` by adding a fourth safe predicate that detects the single-assignment pattern:

```python
result = {"success": True, "data": ...}
return result
```

Previously the hook only detected `return {"success": ...}` literals directly. This extended check prevents false negatives when developers write the common variable-assignment style.

## Changes

### `tools/lint/check_response_models.py`

New helpers:
- `_var_dict_keys(node)` — walks `Assign` nodes, maps local variable names to the union of string keys from their dict literal values
- `_returned_var_names(node)` — collects variable names from bare `return <name>` statements

`_check_file()` now tries predicate 4 after the existing literal-dict check (predicate 2).

Module docstring updated to:
- Document predicate 4 explicitly
- Document the known limitation: multi-step dict builds (`result = {}; result["success"] = True`) and pass-through function-call returns are still not analyzed

### `tools/lint/check_response_models_test.py`

4 new tests:
- `test_safe_variable_assigned_dict_with_success` — DataResponse + `result = {"success": ...}; return result` → passes
- `test_detects_variable_assigned_dict_missing_success` — DataResponse + `result = {"data": ...}; return result` → violation
- `test_safe_success_message_response_variable_assignment` — SuccessMessageResponse + both required keys → passes
- `test_detects_success_message_response_variable_missing_message` — missing `message` → violation

## Test evidence

```
tools/lint/check_response_models_test.py ........................  [100%]
24 passed in 0.34s
```

Codebase-wide check still reports 0 violations:
```
$ python3 tools/lint/check_response_models.py autobot-backend/api/*.py 2>&1 | grep "^\[response-model" | wc -l
0
```

Closes #5926