### PR TITLE
refact(api): resolve schema name collisions from domain split (#5935 #5936 #5937)

### DIFF
--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -36,8 +36,8 @@ from type_defs.common import Metadata
 from utils.chat_exceptions import InternalError, SubprocessError
 from utils.response_helpers import create_success_response, handle_ai_stack_error
 
-from api.schemas_common import DataResponse
-from api.schemas_agent import AgentCommandApprovalResponse, AgentHealthResponse, AgentMessageResponse
+from api.schemas_common import AgentMessageResponse, DataResponse
+from api.schemas_agent import AgentCommandApprovalResponse, AgentHealthResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/autobot-backend/api/analytics_cost.py
+++ b/autobot-backend/api/analytics_cost.py
@@ -92,19 +92,6 @@ class ModelPricingInfo(BaseModel):
     provider: str
 
 
-class UsageRecordResponse(BaseModel):
-    """Usage record response model"""
-
-    provider: str
-    model: str
-    input_tokens: int
-    output_tokens: int
-    cost_usd: float
-    timestamp: str
-    session_id: Optional[str]
-    success: bool
-
-
 # ============================================================================
 # COST SUMMARY ENDPOINTS
 # ============================================================================

--- a/autobot-backend/api/intelligent_agent.py
+++ b/autobot-backend/api/intelligent_agent.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from monitoring.prometheus_metrics import get_metrics_manager
+from api.schemas_agent import AgentSystemCapabilitiesResponse
 from api.schemas_common import DataResponse
 
 # CRITICAL FIX: Use lazy loading to prevent startup deadlock
@@ -123,16 +124,6 @@ class GoalResponse(BaseModel):
     metadata: Metadata = {}
 
 
-class SystemInfoResponse(BaseModel):
-    """Response model for system information."""
-
-    os_type: str
-    distro: str = ""
-    user: str
-    capabilities: List[str]
-    available_tools: List[str]
-
-
 class HealthResponse(BaseModel):
     """Response model for health check."""
 
@@ -208,7 +199,7 @@ async def process_natural_language_goal(
     operation="get_system_info",
     error_code_prefix="INTELLIGENT_AGENT",
 )
-@router.get("/system-info", response_model=SystemInfoResponse)
+@router.get("/system-info", response_model=AgentSystemCapabilitiesResponse)
 async def get_system_info(
     current_user: dict = Depends(get_current_user),
 ):
@@ -222,7 +213,7 @@ async def get_system_info(
 
     # Handle both initialized and uninitialized states
     if system_info.get("status") == "not_initialized":
-        return SystemInfoResponse(
+        return AgentSystemCapabilitiesResponse(
             os_type="unknown",
             distro="",
             user="",
@@ -234,7 +225,7 @@ async def get_system_info(
     os_info = system_info.get("os_info", {})
     capabilities_info = system_info.get("capabilities", {})
 
-    return SystemInfoResponse(
+    return AgentSystemCapabilitiesResponse(
         os_type=os_info.get("os_type", "unknown"),
         distro=os_info.get("distro", ""),
         user=os_info.get("user", ""),

--- a/autobot-backend/api/logs.py
+++ b/autobot-backend/api/logs.py
@@ -21,7 +21,7 @@ import aiofiles
 from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket
 from fastapi.responses import StreamingResponse
 
-from api.schemas_agent import AgentMessageResponse
+from api.schemas_common import AgentMessageResponse
 from api.schemas_code import (
     LogContainerResponse,
     LogReadResponse,

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -14,13 +14,6 @@ from pydantic import BaseModel
 # Agent schemas
 # ---------------------------------------------------------------------------
 
-class AgentMessageResponse(BaseModel):
-    """Response for /goal, /pause, /resume — plain {"message": str}."""
-
-    message: str
-
-
-
 class AgentCommandApprovalResponse(BaseModel):
     """Response for POST /command_approval."""
 
@@ -675,6 +668,22 @@ class LLMPatternsCostBreakdownResponse(BaseModel):
     by_model: List[Any]
     by_category: List[Any]
     daily_trend: List[Any]
+
+
+# ---------------------------------------------------------------------------
+# intelligent_agent.py schemas  (Issue #5937)
+# ---------------------------------------------------------------------------
+
+
+
+class AgentSystemCapabilitiesResponse(BaseModel):
+    """Response for GET /intelligent-agent/system-info — OS, user, and tool capabilities."""
+
+    os_type: str
+    distro: str = ""
+    user: str
+    capabilities: List[str]
+    available_tools: List[str]
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -823,3 +823,21 @@ class UsageMyUsageResponse(BaseModel):
 # ---------------------------------------------------------------------------
 # files.py schemas  (Issue #5317)
 # ---------------------------------------------------------------------------
+
+
+
+class CostTrackingRecordResponse(BaseModel):
+    """Per-request cost tracking record returned by cost analytics endpoints (#5936).
+
+    Renamed from analytics_cost.UsageRecordResponse to avoid collision with
+    schemas_common.UsageRecordResponse (which is the POST /usage/record confirmation).
+    """
+
+    provider: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    timestamp: str
+    session_id: Optional[str]
+    success: bool

--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -81,6 +81,16 @@ class UsageRecordResponse(BaseModel):
     record_id: Optional[str] = None
 
 
+class AgentMessageResponse(BaseModel):
+    """Response for /goal, /pause, /resume — plain {"message": str}.
+
+    Moved from schemas_agent.py (#5935): used by both agent.py and logs.py,
+    making it cross-domain.
+    """
+
+    message: str
+
+
 # ---------------------------------------------------------------------------
 # structured_thinking_mcp.py schemas  (Issue #5317)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **#5935**: `AgentMessageResponse` moved from `schemas_agent.py` to `schemas_common.py` — it was used by both `agent.py` and `logs.py`, making it cross-domain; imports updated in both callers
- **#5936**: Dead local `UsageRecordResponse` class removed from `analytics_cost.py` (never used as `response_model=` or constructor); proper `CostTrackingRecordResponse` added to `schemas_analytics.py` with correct fields (provider, model, tokens, cost_usd, timestamp, session_id, success)
- **#5937**: Local `SystemInfoResponse` in `intelligent_agent.py` renamed to `AgentSystemCapabilitiesResponse` and moved to `schemas_agent.py`; all 3 usages updated (`response_model=` + 2 constructors)

## Test Plan
- [x] `python3 -m py_compile` passes on all 7 modified files
- [x] No remaining `SystemInfoResponse` references in intelligent_agent.py
- [x] `AgentMessageResponse` resolves from `schemas_common` in both callers
- [x] `CostTrackingRecordResponse` has distinct name from `UsageRecordResponse` in schemas_common

Closes #5935
Closes #5936
Closes #5937

🤖 Generated with Claude Code