### PR TITLE
migrate(composables): useWorkflowBuilder/usePatternAnalysis/useVoiceProfiles/useWorkflowTemplates to useLoadingState (#5942)

### DIFF
--- a/autobot-frontend/src/composables/usePatternAnalysis.ts
+++ b/autobot-frontend/src/composables/usePatternAnalysis.ts
@@ -17,6 +17,7 @@ import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 import { extractErrorMessage } from '@/utils/errorExtract'
 import { useBackgroundTask } from '@/composables/useBackgroundTask'
+import { useLoadingState } from '@/composables/useLoadingState'
 
 const logger = createLogger('usePatternAnalysis')
 
@@ -162,7 +163,7 @@ export function usePatternAnalysis() {
   )
 
   // Reactive state
-  const loading = ref(false)
+  const { isLoading: loading, wrap } = useLoadingState()
   const analyzing = ref(false)
   const error = ref<string | null>(null)
   const wasInterrupted = ref(false)  // #1250: orphaned task detection
@@ -522,14 +523,11 @@ export function usePatternAnalysis() {
    * First tries cached data, falls back to full analysis if no cache
    */
   const getSummary = async (path?: string): Promise<void> => {
-    loading.value = true
     error.value = null
-
-    try {
+    await wrap(async () => {
       // First try to get cached summary (fast path)
       const hasCached = await getCachedSummary()
       if (hasCached) {
-        loading.value = false
         return
       }
 
@@ -565,12 +563,10 @@ export function usePatternAnalysis() {
           other_patterns: []
         }
       }
-    } catch (e: unknown) {
+    }).catch((e: unknown) => {
       error.value = extractErrorMessage(e, 'Summary fetch failed')
       logger.error('Pattern summary fetch failed:', e)
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   /**
@@ -581,10 +577,8 @@ export function usePatternAnalysis() {
     minSimilarity: number = 0.8,
     limit: number = 50
   ): Promise<void> => {
-    loading.value = true
     error.value = null
-
-    try {
+    await wrap(async () => {
       const backendUrl = await getBackendUrl()
       const params = new URLSearchParams({
         min_similarity: minSimilarity.toString(),
@@ -602,12 +596,10 @@ export function usePatternAnalysis() {
       if (data.status === 'success') {
         duplicatePatterns.value = data.duplicates || []
       }
-    } catch (e: unknown) {
+    }).catch((e: unknown) => {
       error.value = extractErrorMessage(e, 'Duplicates fetch failed')
       logger.error('Duplicate patterns fetch failed:', e)
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   /**
@@ -617,10 +609,8 @@ export function usePatternAnalysis() {
     path?: string,
     limit: number = 50
   ): Promise<void> => {
-    loading.value = true
     error.value = null
-
-    try {
+    await wrap(async () => {
       const backendUrl = await getBackendUrl()
       const params = new URLSearchParams({ limit: limit.toString() })
       if (path) params.append('path', path)
@@ -635,12 +625,10 @@ export function usePatternAnalysis() {
       if (data.status === 'success') {
         regexOpportunities.value = data.opportunities || []
       }
-    } catch (e: unknown) {
+    }).catch((e: unknown) => {
       error.value = extractErrorMessage(e, 'Regex opportunities fetch failed')
       logger.error('Regex opportunities fetch failed:', e)
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   /**
@@ -651,10 +639,8 @@ export function usePatternAnalysis() {
     minComplexity: number = 10,
     limit: number = 50
   ): Promise<void> => {
-    loading.value = true
     error.value = null
-
-    try {
+    await wrap(async () => {
       const backendUrl = await getBackendUrl()
       const params = new URLSearchParams({
         min_complexity: minComplexity.toString(),
@@ -672,12 +658,10 @@ export function usePatternAnalysis() {
       if (data.status === 'success') {
         complexityHotspots.value = data.hotspots || []
       }
-    } catch (e: unknown) {
+    }).catch((e: unknown) => {
       error.value = extractErrorMessage(e, 'Complexity hotspots fetch failed')
       logger.error('Complexity hotspots fetch failed:', e)
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   /**
@@ -687,10 +671,8 @@ export function usePatternAnalysis() {
     path?: string,
     maxSuggestions: number = 20
   ): Promise<void> => {
-    loading.value = true
     error.value = null
-
-    try {
+    await wrap(async () => {
       const backendUrl = await getBackendUrl()
       const params = new URLSearchParams({ max_suggestions: maxSuggestions.toString() })
       if (path) params.append('path', path)
@@ -705,21 +687,17 @@ export function usePatternAnalysis() {
       if (data.status === 'success') {
         refactoringSuggestions.value = data.suggestions || []
       }
-    } catch (e: unknown) {
+    }).catch((e: unknown) => {
       error.value = extractErrorMessage(e, 'Refactoring suggestions fetch failed')
       logger.error('Refactoring suggestions fetch failed:', e)
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   /**
    * Get pattern storage stats
    */
   const getStorageStats = async (): Promise<void> => {
-    loading.value = true
-
-    try {
+    await wrap(async () => {
       const backendUrl = await getBackendUrl()
       const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/storage/stats`)
 
@@ -731,20 +709,16 @@ export function usePatternAnalysis() {
       if (data.status === 'success') {
         storageStats.value = data.stats
       }
-    } catch (e: unknown) {
+    }).catch((e: unknown) => {
       logger.error('Storage stats fetch failed:', e)
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   /**
    * Clear pattern storage
    */
   const clearStorage = async (): Promise<boolean> => {
-    loading.value = true
-
-    try {
+    return wrap(async () => {
       const backendUrl = await getBackendUrl()
       const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/storage/clear`, {
         method: 'DELETE'
@@ -760,21 +734,17 @@ export function usePatternAnalysis() {
         return true
       }
       return false
-    } catch (e: unknown) {
+    }).catch((e: unknown) => {
       logger.error('Clear storage failed:', e)
       return false
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   /**
    * Get markdown report
    */
   const getReport = async (path?: string): Promise<string | null> => {
-    loading.value = true
-
-    try {
+    return wrap(async () => {
       const backendUrl = await getBackendUrl()
       const params = path ? `?path=${encodeURIComponent(path)}` : ''
       const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/report${params}`)
@@ -788,19 +758,16 @@ export function usePatternAnalysis() {
         return data.report
       }
       return null
-    } catch (e: unknown) {
+    }).catch((e: unknown) => {
       logger.error('Report fetch failed:', e)
       return null
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   /**
    * Reset all state
    */
   const reset = (): void => {
-    loading.value = false
     analyzing.value = false
     error.value = null
     wasInterrupted.value = false
@@ -819,10 +786,8 @@ export function usePatternAnalysis() {
    * Issue #208: Optimized loading for already indexed data
    */
   const loadCachedData = async (): Promise<boolean> => {
-    loading.value = true
     error.value = null
-
-    try {
+    return wrap(async () => {
       // Load summary and stats in parallel from cache
       const [hasCachedSummary] = await Promise.all([
         getCachedSummary(),
@@ -830,12 +795,10 @@ export function usePatternAnalysis() {
       ])
 
       return hasCachedSummary
-    } catch (e: unknown) {
+    }).catch((e: unknown) => {
       logger.error('Failed to load cached data:', e)
       return false
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   /**

--- a/autobot-frontend/src/composables/useVoiceProfiles.ts
+++ b/autobot-frontend/src/composables/useVoiceProfiles.ts
@@ -12,6 +12,7 @@ import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { usePreferences } from '@/composables/usePreferences'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
+import { useLoadingState } from '@/composables/useLoadingState'
 
 const logger = createLogger('useVoiceProfiles')
 
@@ -29,7 +30,8 @@ const voices = ref<VoiceProfile[]>([])
 const selectedVoiceId = ref<string>(
   localStorage.getItem(STORAGE_KEY) || ''
 )
-const loading = ref(false)
+// loading and wrap are module-level to preserve the singleton pattern
+const { isLoading: loading, wrap } = useLoadingState()
 const error = ref<string | null>(null)
 // Personality-assigned voice — overrides user selection when set (#1135)
 const personalityVoiceId = ref<string>('')
@@ -50,9 +52,8 @@ const effectiveVoiceId = computed<string>(() => {
 
 export function useVoiceProfiles() {
   async function fetchVoices(): Promise<void> {
-    loading.value = true
     error.value = null
-    try {
+    await wrap(async () => {
       const res = await fetchWithAuth(`${getApiBase()}/voice/voices`)
       if (!res.ok) {
         error.value = `Failed to fetch voices: ${res.status}`
@@ -60,12 +61,10 @@ export function useVoiceProfiles() {
       }
       const data = await res.json()
       voices.value = Array.isArray(data) ? data : (data.voices || [])
-    } catch (e) {
+    }).catch((e) => {
       logger.error('fetchVoices error:', e)
       error.value = String(e)
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   function selectVoice(voiceId: string): void {
@@ -79,9 +78,8 @@ export function useVoiceProfiles() {
     audioBlob: Blob,
     filename: string,
   ): Promise<boolean> {
-    loading.value = true
     error.value = null
-    try {
+    return wrap(async () => {
       const formData = new FormData()
       formData.append('name', name)
       formData.append('audio', audioBlob, filename)
@@ -96,19 +94,16 @@ export function useVoiceProfiles() {
       }
       await fetchVoices()
       return true
-    } catch (e) {
+    }).catch((e) => {
       logger.error('createVoice error:', e)
       error.value = String(e)
       return false
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   async function deleteVoice(voiceId: string): Promise<boolean> {
-    loading.value = true
     error.value = null
-    try {
+    return wrap(async () => {
       const res = await fetchWithAuth(`${getApiBase()}/voice/voices/${voiceId}`, {
         method: 'DELETE',
       })
@@ -121,13 +116,11 @@ export function useVoiceProfiles() {
       }
       await fetchVoices()
       return true
-    } catch (e) {
+    }).catch((e) => {
       logger.error('deleteVoice error:', e)
       error.value = String(e)
       return false
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   function setPersonalityVoice(voiceId: string): void {

--- a/autobot-frontend/src/composables/useWorkflowBuilder.ts
+++ b/autobot-frontend/src/composables/useWorkflowBuilder.ts
@@ -20,6 +20,7 @@ import type { ApiResponse } from '@/types/api';
 import { useWorkflowTemplates } from '@/composables/useWorkflowTemplates';
 import type { WorkflowTemplateDetail } from '@/types/workflowTemplates';
 import { useWebSocket } from '@/composables/useWebSocket';
+import { useLoadingState } from '@/composables/useLoadingState';
 
 const logger = createLogger('useWorkflowBuilder');
 
@@ -576,12 +577,12 @@ export function useWorkflowBuilder() {
   // STATE
   // ==================================================================================
 
-  // Loading states
-  const loading = ref(false);
-  const executingWorkflow = ref(false);
-  const loadingStrategies = ref(false);
-  const loadingCapabilities = ref(false);
-  const loadingExamples = ref(false);
+  // Loading states — each managed by its own useLoadingState instance
+  const { isLoading: loading, wrap: wrapLoading } = useLoadingState();
+  const { isLoading: executingWorkflow, wrap: wrapExecuting } = useLoadingState();
+  const { isLoading: loadingStrategies, wrap: wrapStrategies } = useLoadingState();
+  const { isLoading: loadingCapabilities, wrap: wrapCapabilities } = useLoadingState();
+  const { isLoading: loadingExamples, wrap: wrapExamples } = useLoadingState();
 
   // Error state — accumulated to prevent race conditions (#2626)
   const errors = ref<string[]>([]);
@@ -733,48 +734,42 @@ export function useWorkflowBuilder() {
 
   /** Load orchestration system status */
   async function loadOrchestrationStatus(): Promise<void> {
-    loading.value = true;
-
-    const response = await apiClient.getOrchestrationStatus();
-    if (response.success && response.data) {
-      orchestrationStatus.value = response.data;
-      logger.debug('Orchestration status loaded:', response.data);
-    } else {
-      // Non-blocking: status badge shows "Services Offline" when null
-      logger.warn('Orchestration status unavailable:', response.error);
-    }
-
-    loading.value = false;
+    await wrapLoading(async () => {
+      const response = await apiClient.getOrchestrationStatus();
+      if (response.success && response.data) {
+        orchestrationStatus.value = response.data;
+        logger.debug('Orchestration status loaded:', response.data);
+      } else {
+        // Non-blocking: status badge shows "Services Offline" when null
+        logger.warn('Orchestration status unavailable:', response.error);
+      }
+    });
   }
 
   /** Load execution strategies */
   async function loadExecutionStrategies(): Promise<void> {
-    loadingStrategies.value = true;
-
-    const response = await apiClient.getExecutionStrategies();
-    if (response.success && response.data) {
-      executionStrategies.value = response.data.strategies;
-      logger.debug('Strategies loaded:', response.data);
-    } else {
-      logger.error('Failed to load strategies:', response.error);
-    }
-
-    loadingStrategies.value = false;
+    await wrapStrategies(async () => {
+      const response = await apiClient.getExecutionStrategies();
+      if (response.success && response.data) {
+        executionStrategies.value = response.data.strategies;
+        logger.debug('Strategies loaded:', response.data);
+      } else {
+        logger.error('Failed to load strategies:', response.error);
+      }
+    });
   }
 
   /** Load agent capabilities */
   async function loadAgentCapabilities(): Promise<void> {
-    loadingCapabilities.value = true;
-
-    const response = await apiClient.getAgentCapabilities();
-    if (response.success && response.data) {
-      agentCapabilities.value = response.data.agents;
-      logger.debug('Agent capabilities loaded:', response.data);
-    } else {
-      logger.error('Failed to load agent capabilities:', response.error);
-    }
-
-    loadingCapabilities.value = false;
+    await wrapCapabilities(async () => {
+      const response = await apiClient.getAgentCapabilities();
+      if (response.success && response.data) {
+        agentCapabilities.value = response.data.agents;
+        logger.debug('Agent capabilities loaded:', response.data);
+      } else {
+        logger.error('Failed to load agent capabilities:', response.error);
+      }
+    });
   }
 
   /** Load agent performance metrics */
@@ -790,17 +785,15 @@ export function useWorkflowBuilder() {
 
   /** Load example workflows */
   async function loadExampleWorkflows(): Promise<void> {
-    loadingExamples.value = true;
-
-    const response = await apiClient.getExampleWorkflows();
-    if (response.success && response.data) {
-      exampleWorkflows.value = response.data.examples;
-      logger.debug('Example workflows loaded:', response.data);
-    } else {
-      logger.error('Failed to load example workflows:', response.error);
-    }
-
-    loadingExamples.value = false;
+    await wrapExamples(async () => {
+      const response = await apiClient.getExampleWorkflows();
+      if (response.success && response.data) {
+        exampleWorkflows.value = response.data.examples;
+        logger.debug('Example workflows loaded:', response.data);
+      } else {
+        logger.error('Failed to load example workflows:', response.error);
+      }
+    });
   }
 
   /** Execute workflow with orchestration */
@@ -809,20 +802,18 @@ export function useWorkflowBuilder() {
     strategy?: ExecutionStrategy,
     context?: Record<string, unknown>
   ): Promise<WorkflowExecutionResult | null> {
-    executingWorkflow.value = true;
     errors.value = [];
-
-    const response = await apiClient.executeWorkflow(goal, strategy, context);
-    executingWorkflow.value = false;
-
-    if (response.success && response.data) {
-      logger.info('Workflow executed:', response.data);
-      return response.data;
-    } else {
-      errors.value = [...errors.value, response.error || 'Failed to execute workflow'];
-      logger.error('Workflow execution failed:', response.error);
-      return null;
-    }
+    return wrapExecuting(async () => {
+      const response = await apiClient.executeWorkflow(goal, strategy, context);
+      if (response.success && response.data) {
+        logger.info('Workflow executed:', response.data);
+        return response.data;
+      } else {
+        errors.value = [...errors.value, response.error || 'Failed to execute workflow'];
+        logger.error('Workflow execution failed:', response.error);
+        return null;
+      }
+    });
   }
 
   /** Create workflow plan without executing */
@@ -830,21 +821,19 @@ export function useWorkflowBuilder() {
     goal: string,
     context?: Record<string, unknown>
   ): Promise<WorkflowPlan | null> {
-    loading.value = true;
     errors.value = [];
-
-    const response = await apiClient.createWorkflowPlan(goal, context);
-    loading.value = false;
-
-    if (response.success && response.data) {
-      workflowPlan.value = response.data.plan;
-      logger.info('Workflow plan created:', response.data);
-      return response.data.plan;
-    } else {
-      errors.value = [...errors.value, response.error || 'Failed to create workflow plan'];
-      logger.error('Plan creation failed:', response.error);
-      return null;
-    }
+    return wrapLoading(async () => {
+      const response = await apiClient.createWorkflowPlan(goal, context);
+      if (response.success && response.data) {
+        workflowPlan.value = response.data.plan;
+        logger.info('Workflow plan created:', response.data);
+        return response.data.plan;
+      } else {
+        errors.value = [...errors.value, response.error || 'Failed to create workflow plan'];
+        logger.error('Plan creation failed:', response.error);
+        return null;
+      }
+    });
   }
 
   // ==================================================================================
@@ -853,18 +842,16 @@ export function useWorkflowBuilder() {
 
   /** Load active workflows */
   async function loadActiveWorkflows(): Promise<void> {
-    loading.value = true;
-
-    const response = await apiClient.getActiveWorkflows();
-    if (response.success && response.data) {
-      activeWorkflows.value = response.data.workflows;
-      logger.debug('Active workflows loaded:', response.data);
-    } else {
-      // Non-blocking: empty list is a valid state; log but don't block the UI
-      logger.warn('Active workflows unavailable:', response.error);
-    }
-
-    loading.value = false;
+    await wrapLoading(async () => {
+      const response = await apiClient.getActiveWorkflows();
+      if (response.success && response.data) {
+        activeWorkflows.value = response.data.workflows;
+        logger.debug('Active workflows loaded:', response.data);
+      } else {
+        // Non-blocking: empty list is a valid state; log but don't block the UI
+        logger.warn('Active workflows unavailable:', response.error);
+      }
+    });
   }
 
   /** Load completed workflow history (#1367) */
@@ -893,28 +880,25 @@ export function useWorkflowBuilder() {
     sessionId: string,
     automationMode: AutomationMode = 'semi_automatic'
   ): Promise<string | null> {
-    loading.value = true;
     errors.value = [];
-
-    const response = await apiClient.createWorkflow(
-      template.name,
-      template.description,
-      template.steps,
-      sessionId,
-      automationMode
-    );
-
-    loading.value = false;
-
-    if (response.success && response.data) {
-      logger.info('Workflow created from template:', response.data);
-      await loadActiveWorkflows();
-      return response.data.workflow_id;
-    } else {
-      errors.value = [...errors.value, response.error || 'Failed to create workflow'];
-      logger.error('Workflow creation failed:', response.error);
-      return null;
-    }
+    return wrapLoading(async () => {
+      const response = await apiClient.createWorkflow(
+        template.name,
+        template.description,
+        template.steps,
+        sessionId,
+        automationMode
+      );
+      if (response.success && response.data) {
+        logger.info('Workflow created from template:', response.data);
+        await loadActiveWorkflows();
+        return response.data.workflow_id;
+      } else {
+        errors.value = [...errors.value, response.error || 'Failed to create workflow'];
+        logger.error('Workflow creation failed:', response.error);
+        return null;
+      }
+    });
   }
 
   /** Create workflow from natural language */
@@ -923,48 +907,43 @@ export function useWorkflowBuilder() {
     sessionId: string,
     requireApproval: boolean = true
   ): Promise<string | null> {
-    loading.value = true;
     errors.value = [];
-
-    const response = await apiClient.createWorkflowFromChat(
-      request,
-      sessionId,
-      !requireApproval,
-      requireApproval
-    );
-
-    loading.value = false;
-
-    if (response.success && response.data?.workflow_id) {
-      if (response.data.plan) {
-        pendingApproval.value = response.data.plan;
+    return wrapLoading(async () => {
+      const response = await apiClient.createWorkflowFromChat(
+        request,
+        sessionId,
+        !requireApproval,
+        requireApproval
+      );
+      if (response.success && response.data?.workflow_id) {
+        if (response.data.plan) {
+          pendingApproval.value = response.data.plan;
+        }
+        await loadActiveWorkflows();
+        return response.data.workflow_id;
+      } else {
+        errors.value = [...errors.value, response.error || response.data?.message || 'Failed to create workflow'];
+        logger.error('Workflow creation from chat failed:', response.error);
+        return null;
       }
-      await loadActiveWorkflows();
-      return response.data.workflow_id;
-    } else {
-      errors.value = [...errors.value, response.error || response.data?.message || 'Failed to create workflow'];
-      logger.error('Workflow creation from chat failed:', response.error);
-      return null;
-    }
+    });
   }
 
   /** Start workflow execution */
   async function startWorkflow(workflowId: string): Promise<boolean> {
-    executingWorkflow.value = true;
     errors.value = [];
-
-    const response = await apiClient.startWorkflow(workflowId);
-    executingWorkflow.value = false;
-
-    if (response.success) {
-      logger.info('Workflow started:', workflowId);
-      await getWorkflowStatus(workflowId);
-      return true;
-    } else {
-      errors.value = [...errors.value, response.error || 'Failed to start workflow'];
-      logger.error('Workflow start failed:', response.error);
-      return false;
-    }
+    return wrapExecuting(async () => {
+      const response = await apiClient.startWorkflow(workflowId);
+      if (response.success) {
+        logger.info('Workflow started:', workflowId);
+        await getWorkflowStatus(workflowId);
+        return true;
+      } else {
+        errors.value = [...errors.value, response.error || 'Failed to start workflow'];
+        logger.error('Workflow start failed:', response.error);
+        return false;
+      }
+    });
   }
 
   /** Pause workflow */

--- a/autobot-frontend/src/composables/useWorkflowTemplates.ts
+++ b/autobot-frontend/src/composables/useWorkflowTemplates.ts
@@ -23,6 +23,7 @@ import appConfig from '@/config/AppConfig.js'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
+import { useLoadingState } from '@/composables/useLoadingState'
 import type {
   WorkflowTemplateSummary,
   WorkflowTemplateDetail,
@@ -98,6 +99,9 @@ export function useWorkflowTemplates() {
     onError: () => { /* logger.error already fired inside endpoint */ },
   })
 
+  // Loading state for POST mutations
+  const { isLoading: mutationLoading, wrap: wrapMutation } = useLoadingState()
+
   // Bridge per-endpoint loading flags into the composable-level `loading` ref
   // so the public API (consumers reading `loading.value`) is preserved.
   // Endpoints that only set state (templates/categories/stats) AND on-demand
@@ -110,6 +114,7 @@ export function useWorkflowTemplates() {
       categoriesEndpoint.loading,
       statsEndpoint.loading,
       ondemandLoading,
+      mutationLoading,
     ],
     (flags: boolean[]) => {
       loading.value = flags.some(Boolean)
@@ -215,9 +220,8 @@ export function useWorkflowTemplates() {
     templateId: string,
     variables?: Record<string, string>
   ): Promise<CreateWorkflowResponse | null> {
-    loading.value = true
     error.value = null
-    try {
+    return wrapMutation(async () => {
       const backendUrl = await getBackendUrl()
       const response = await fetchWithAuth(
         `${backendUrl}/api/templates/templates/${templateId}/create-workflow`,
@@ -233,13 +237,11 @@ export function useWorkflowTemplates() {
       )
       if (!response.ok) throw new Error(`HTTP ${response.status}`)
       return await response.json()
-    } catch (e) {
+    }).catch((e) => {
       error.value = `Failed to create workflow: ${e}`
       logger.error('createWorkflowFromTemplate failed:', e)
       return null
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   async function executeTemplate(
@@ -247,9 +249,8 @@ export function useWorkflowTemplates() {
     variables?: Record<string, string>,
     autoApprove = false
   ): Promise<CreateWorkflowResponse | null> {
-    loading.value = true
     error.value = null
-    try {
+    return wrapMutation(async () => {
       const backendUrl = await getBackendUrl()
       const response = await fetchWithAuth(
         `${backendUrl}/api/templates/templates/${templateId}/execute`,
@@ -265,13 +266,11 @@ export function useWorkflowTemplates() {
       )
       if (!response.ok) throw new Error(`HTTP ${response.status}`)
       return await response.json()
-    } catch (e) {
+    }).catch((e) => {
       error.value = `Failed to execute template: ${e}`
       logger.error('executeTemplate failed:', e)
       return null
-    } finally {
-      loading.value = false
-    }
+    })
   }
 
   async function initializeTemplates(): Promise<void> {


### PR DESCRIPTION
## Summary
Migrates 4 remaining composables from manual `isLoading.value = true / try-finally / false` boilerplate to `useLoadingState().wrap()`:

- **useWorkflowBuilder**: 5 independent loading states (`loading`, `executingWorkflow`, `loadingStrategies`, `loadingCapabilities`, `loadingExamples`) — each using a separate `useLoadingState()` instance with destructured alias
- **usePatternAnalysis**: 1 instance, 9 async methods wrapped
- **useVoiceProfiles**: module-level singleton `useLoadingState()` (preserves existing singleton semantics); 3 loading pairs replaced
- **useWorkflowTemplates**: `mutationLoading` for 2 POST mutations; `loading` (bridge ref driven by watch) intentionally not migrated

## Test Plan
- [x] TypeScript syntax valid (no compile errors introduced)
- [x] Multiple loading states use separate `useLoadingState()` instances with alias destructuring
- [x] `useVoiceProfiles` singleton pattern preserved
- [x] `useWorkflowTemplates` bridge `loading` ref left intact (watch-driven, not manual boilerplate)

Closes #5942

🤖 Generated with Claude Code