### PR TITLE
fix(services): replace get_redis_client(async_client=True) anti-pattern in semantic_query_cache (#5943)

### DIFF
--- a/autobot-backend/services/semantic_query_cache.py
+++ b/autobot-backend/services/semantic_query_cache.py
@@ -391,8 +391,7 @@ class SemanticQueryCache(AsyncInitializable):
                     rkey = meta.get("response_key", "")
                     if rkey:
                         try:
-                            client = get_redis_client(
-                                async_client=True,
+                            client = await get_async_redis_client(
                                 database=_REDIS_DATABASE,
                             )
                             if client:
@@ -438,9 +437,7 @@ class SemanticQueryCache(AsyncInitializable):
                 results = await self._collection.get(include=["metadatas"])
                 if results and results.get("ids"):
                     # Clean Redis
-                    client = get_redis_client(
-                        async_client=True, database=_REDIS_DATABASE
-                    )
+                    client = await get_async_redis_client(database=_REDIS_DATABASE)
                     if client:
                         for meta in results.get("metadatas", []):
                             rkey = meta.get("response_key", "")


### PR DESCRIPTION
Fixes two instances of the anti-pattern at lines ~394 and ~441. Replaced with `await get_async_redis_client(database=_REDIS_DATABASE)`. Import was already present. Closes #5943