### PR TITLE
fix(api): add @with_error_handling to skills_repos, integration_database, integration_cloud (#5947)

### DIFF
--- a/autobot-backend/api/integration_cloud.py
+++ b/autobot-backend/api/integration_cloud.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from integrations.base import IntegrationConfig
 from integrations.cloud_integration import (
     AWSIntegration,
@@ -65,6 +66,11 @@ class ResourceListRequest(BaseModel):
     )
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_providers",
+    error_code_prefix="INTEGRATION_CLOUD",
+)
 @router.get("/providers", response_model=List[CloudProviderInfo])
 async def list_providers():
     """List all supported cloud providers."""
@@ -94,6 +100,11 @@ async def list_providers():
     ]
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="test_connection",
+    error_code_prefix="INTEGRATION_CLOUD",
+)
 @router.post("/test-connection", response_model=None)
 async def test_connection(request: ConnectionTestRequest):
     """Test connection to a cloud provider."""
@@ -123,6 +134,11 @@ async def test_connection(request: ConnectionTestRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_resources",
+    error_code_prefix="INTEGRATION_CLOUD",
+)
 @router.get("/{provider}/resources", response_model=None)
 async def list_resources(
     provider: str,
@@ -162,6 +178,11 @@ async def list_resources(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_storage",
+    error_code_prefix="INTEGRATION_CLOUD",
+)
 @router.get("/{provider}/storage", response_model=None)
 async def list_storage(
     provider: str,
@@ -200,6 +221,11 @@ async def list_storage(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_account_info",
+    error_code_prefix="INTEGRATION_CLOUD",
+)
 @router.get("/{provider}/account", response_model=None)
 async def get_account_info(
     provider: str,

--- a/autobot-backend/api/integration_database.py
+++ b/autobot-backend/api/integration_database.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from integrations.base import IntegrationConfig
 from integrations.database_integration import (
     MongoDBIntegration,
@@ -161,6 +162,11 @@ def _get_integration_class(provider: str):
     return integration_class
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="test_database_connection",
+    error_code_prefix="INTEGRATION_DATABASE",
+)
 @router.post("/test-connection", response_model=None)
 async def test_database_connection(request: DatabaseConnectionRequest):
     """
@@ -196,6 +202,11 @@ async def test_database_connection(request: DatabaseConnectionRequest):
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_database_providers",
+    error_code_prefix="INTEGRATION_DATABASE",
+)
 @router.get("/providers", response_model=None)
 async def list_database_providers() -> Dict[str, List[Dict[str, Any]]]:
     """
@@ -228,6 +239,11 @@ async def list_database_providers() -> Dict[str, List[Dict[str, Any]]]:
     return {"providers": providers, "count": len(providers)}
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="execute_database_query",
+    error_code_prefix="INTEGRATION_DATABASE",
+)
 @router.post("/{provider}/query", response_model=None)
 async def execute_database_query(provider: str, request: QueryRequest):
     """
@@ -276,6 +292,11 @@ async def execute_database_query(provider: str, request: QueryRequest):
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="query_mongodb_collection",
+    error_code_prefix="INTEGRATION_DATABASE",
+)
 @router.post("/mongodb/query-collection", response_model=None)
 async def query_mongodb_collection(request: MongoQueryRequest):
     """
@@ -319,6 +340,11 @@ async def query_mongodb_collection(request: MongoQueryRequest):
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_databases",
+    error_code_prefix="INTEGRATION_DATABASE",
+)
 @router.post("/{provider}/databases", response_model=None)
 async def list_databases(provider: str, request: DatabaseListRequest):
     """
@@ -355,6 +381,11 @@ async def list_databases(provider: str, request: DatabaseListRequest):
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_tables",
+    error_code_prefix="INTEGRATION_DATABASE",
+)
 @router.post("/{provider}/tables", response_model=None)
 async def list_tables(provider: str, request: DatabaseListRequest):
     """

--- a/autobot-backend/api/skills_repos.py
+++ b/autobot-backend/api/skills_repos.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth_middleware import check_admin_permission
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from skills.db import get_skills_engine
 from skills.models import RepoType, SkillRepo
 from api.schemas_common import DataResponse
@@ -58,6 +59,11 @@ async def _get_repo_by_id(session: AsyncSession, repo_id: str) -> SkillRepo:
     return repo
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="add_repo",
+    error_code_prefix="SKILLS_REPOS",
+)
 @router.post("/", summary="Register a new skill repository", response_model=None)
 async def add_repo(
     body: AddRepoRequest,
@@ -87,6 +93,11 @@ async def add_repo(
     return {"id": repo.id, "name": repo.name, "status": "registered"}
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_repos",
+    error_code_prefix="SKILLS_REPOS",
+)
 @router.get("", summary="List all registered skill repositories", response_model=None)
 @router.get("/", include_in_schema=False, response_model=None)
 async def list_repos() -> List[Dict[str, Any]]:
@@ -111,6 +122,11 @@ async def list_repos() -> List[Dict[str, Any]]:
     ]
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="sync_repo",
+    error_code_prefix="SKILLS_REPOS",
+)
 @router.post("/{repo_id}/sync", summary="Sync packages from a repository", response_model=None)
 async def sync_repo(
     repo_id: str,
@@ -135,6 +151,11 @@ async def sync_repo(
     return {"synced": len(packages), "repo": repo.name}
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="browse_repo",
+    error_code_prefix="SKILLS_REPOS",
+)
 @router.get("/{repo_id}/browse", summary="Browse packages in a repository", response_model=None)
 async def browse_repo(repo_id: str) -> Dict[str, Any]:
     """List the skill package names available in the specified repository."""


### PR DESCRIPTION
15 routes decorated across 3 files. All use ErrorCategory.SERVER_ERROR with file-matching error_code_prefix. Closes #5947