### PR TITLE
fix(backend): replace hardcoded /opt/autobot/code_source with env var (#5953)

### DIFF
--- a/autobot-backend/api/branch_health.py
+++ b/autobot-backend/api/branch_health.py
@@ -9,13 +9,14 @@ and file conflict density for branch management and alerts.
 """
 
 import logging
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.ssot_config import config
 from utils.branch_metrics import BranchMetrics, BranchMetricsCollector
 
 router = APIRouter(
@@ -52,7 +53,7 @@ class BranchHealthResponse(BaseModel):
     context="Fetch all branch health metrics",
 )
 async def get_all_branch_health(
-    repo_path: str = "/opt/autobot/code_source",
+    repo_path: Optional[str] = None,
     base_branch: str = "Dev_new_gui",
 ) -> List[BranchHealthResponse]:
     """
@@ -62,13 +63,14 @@ async def get_all_branch_health(
     Requires admin permission.
 
     Args:
-        repo_path: Git repository path
+        repo_path: Git repository path (defaults to AUTOBOT_CODE_SOURCE env var)
         base_branch: Base branch for divergence calculation
 
     Returns:
         List of branch health metrics
     """
-    collector = BranchMetricsCollector(repo_path, base_branch)
+    resolved_path = repo_path if repo_path is not None else str(config.path.code_source_path)
+    collector = BranchMetricsCollector(resolved_path, base_branch)
     metrics = await collector.analyze_all_branches()
 
     return [_metrics_to_response(m) for m in metrics]
@@ -80,7 +82,7 @@ async def get_all_branch_health(
     context="Fetch unhealthy branches",
 )
 async def get_unhealthy_branch_health(
-    repo_path: str = "/opt/autobot/code_source",
+    repo_path: Optional[str] = None,
     base_branch: str = "Dev_new_gui",
     threshold: float = 50.0,
 ) -> List[BranchHealthResponse]:
@@ -91,14 +93,15 @@ async def get_unhealthy_branch_health(
     Requires admin permission.
 
     Args:
-        repo_path: Git repository path
+        repo_path: Git repository path (defaults to AUTOBOT_CODE_SOURCE env var)
         base_branch: Base branch for divergence calculation
         threshold: Health score threshold (0-100, default 50)
 
     Returns:
         List of unhealthy branches
     """
-    collector = BranchMetricsCollector(repo_path, base_branch)
+    resolved_path = repo_path if repo_path is not None else str(config.path.code_source_path)
+    collector = BranchMetricsCollector(resolved_path, base_branch)
     all_metrics = await collector.analyze_all_branches()
 
     unhealthy = [m for m in all_metrics if m.health_score < threshold]
@@ -112,7 +115,7 @@ async def get_unhealthy_branch_health(
     context="Fetch highly diverged branches",
 )
 async def get_diverged_branch_health(
-    repo_path: str = "/opt/autobot/code_source",
+    repo_path: Optional[str] = None,
     base_branch: str = "Dev_new_gui",
     threshold: int = 20,
 ) -> List[BranchHealthResponse]:
@@ -123,14 +126,15 @@ async def get_diverged_branch_health(
     Requires admin permission.
 
     Args:
-        repo_path: Git repository path
+        repo_path: Git repository path (defaults to AUTOBOT_CODE_SOURCE env var)
         base_branch: Base branch for divergence calculation
         threshold: Minimum commits diverged (default 20)
 
     Returns:
         List of highly diverged branches sorted by divergence
     """
-    collector = BranchMetricsCollector(repo_path, base_branch)
+    resolved_path = repo_path if repo_path is not None else str(config.path.code_source_path)
+    collector = BranchMetricsCollector(resolved_path, base_branch)
     all_metrics = await collector.analyze_all_branches()
 
     diverged = [
@@ -149,7 +153,7 @@ async def get_diverged_branch_health(
     context="Fetch stale branches",
 )
 async def get_stale_branch_health(
-    repo_path: str = "/opt/autobot/code_source",
+    repo_path: Optional[str] = None,
     base_branch: str = "Dev_new_gui",
     threshold_days: int = 30,
 ) -> List[BranchHealthResponse]:
@@ -160,14 +164,15 @@ async def get_stale_branch_health(
     Requires admin permission.
 
     Args:
-        repo_path: Git repository path
+        repo_path: Git repository path (defaults to AUTOBOT_CODE_SOURCE env var)
         base_branch: Base branch for divergence calculation
         threshold_days: Staleness threshold in days (default 30)
 
     Returns:
         List of stale branches sorted by age (oldest first)
     """
-    collector = BranchMetricsCollector(repo_path, base_branch, threshold_days)
+    resolved_path = repo_path if repo_path is not None else str(config.path.code_source_path)
+    collector = BranchMetricsCollector(resolved_path, base_branch, threshold_days)
     all_metrics = await collector.analyze_all_branches()
 
     stale = [m for m in all_metrics if m.is_stale]

--- a/autobot-backend/utils/branch_metrics.py
+++ b/autobot-backend/utils/branch_metrics.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 
+from autobot_shared.ssot_config import config
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 
 logger = logging.getLogger(__name__)
@@ -49,12 +50,12 @@ class BranchMetricsCollector:
 
     def __init__(
         self,
-        repo_path: str = "/opt/autobot/code_source",
+        repo_path: Optional[str] = None,
         base_branch: str = "Dev_new_gui",
         stale_threshold_days: int = 30,
     ):
         """Initialize branch metrics collector."""
-        self.repo_path = repo_path
+        self.repo_path = repo_path if repo_path is not None else str(config.path.code_source_path)
         self.base_branch = base_branch
         self.stale_threshold_days = stale_threshold_days
 
@@ -175,7 +176,7 @@ class BranchMetricsCollector:
 
 
 async def get_unhealthy_branches(
-    repo_path: str = "/opt/autobot/code_source",
+    repo_path: Optional[str] = None,
     base_branch: str = "Dev_new_gui",
     health_threshold: float = 50.0,
 ) -> List[BranchMetrics]:
@@ -186,7 +187,7 @@ async def get_unhealthy_branches(
 
 
 async def get_highly_diverged_branches(
-    repo_path: str = "/opt/autobot/code_source",
+    repo_path: Optional[str] = None,
     base_branch: str = "Dev_new_gui",
     threshold: int = 20,
 ) -> List[BranchMetrics]:

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1099,6 +1099,7 @@ class PathConfig(BaseSettings):
     logs_dir: str = Field(default="logs", alias="AUTOBOT_LOG_DIR")
     models_dir: str = Field(default="models", alias="AUTOBOT_MODELS_DIR")
     docs_dir: str = Field(default="docs", alias="AUTOBOT_DOCS_DIR")
+    code_source_dir: str = Field(default="code_source", alias="AUTOBOT_CODE_SOURCE")
 
     def resolve(self, relative: str) -> Path:
         """Resolve a path relative to base_dir."""
@@ -1131,6 +1132,11 @@ class PathConfig(BaseSettings):
     def docs_path(self) -> Path:
         """Absolute path to the docs directory."""
         return self.resolve(self.docs_dir)
+
+    @property
+    def code_source_path(self) -> Path:
+        """Absolute path to the code source directory (git repo root on deployment)."""
+        return self.resolve(self.code_source_dir)
 
 
 class FeatureConfig(BaseSettings):


### PR DESCRIPTION
Added code_source_path property to PathConfig in ssot_config.py. Updated 7 function defaults across branch_metrics.py and branch_health.py to use Optional[str]=None + config.path.code_source_path. Closes #5953