### PR TITLE
fix(backend): derive service registry hostnames from deployment.domain config (#5955)

### DIFF
--- a/autobot-backend/utils/service_registry.py
+++ b/autobot-backend/utils/service_registry.py
@@ -181,9 +181,9 @@ class ServiceRegistry:
             },
             DeploymentMode.DISTRIBUTED: {
                 "default": "{service}.{domain}",
-                "redis": "redis.autobot.local",
-                "ai-stack": "ai-stack.autobot.local",
-                "npu-worker": "npu-worker.autobot.local",
+                "redis": "redis.{domain}",
+                "ai-stack": "ai-stack.{domain}",
+                "npu-worker": "npu-worker.{domain}",
             },
         }
         return cls._cached_host_patterns


### PR DESCRIPTION
## Summary
- Replaces 3 hardcoded `*.autobot.local` literals in `service_registry.py` with format-string patterns that the existing `_resolve_host()` interpolation already handles
- All three now correctly inherit from `config.get("deployment.domain", "autobot.local")`

## Files changed
- `autobot-backend/utils/service_registry.py` — 3 insertions, 3 deletions

Closes #5955