### PR TITLE
fix(services): extract concurrent_limiter timeout to AUTOBOT_CONCURRENT_LIMITER_TIMEOUT env var (#5959)

### DIFF
--- a/autobot-backend/services/workflow_automation/concurrent_limiter.py
+++ b/autobot-backend/services/workflow_automation/concurrent_limiter.py
@@ -10,11 +10,14 @@ workflows and providing configurable overflow handling (reject/queue/drop-oldest
 
 import asyncio
 import logging
+import os
 import time
 from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Awaitable, Callable, Deque, Dict, Optional
+
+_ACQUIRE_TIMEOUT_SECONDS = float(os.environ.get("AUTOBOT_CONCURRENT_LIMITER_TIMEOUT", "300"))
 
 from constants.threshold_constants import TimingConstants
 
@@ -203,7 +206,11 @@ class ConcurrentWorkflowLimiter:
         raise ConcurrencyLimitError(workflow_id, self._max_concurrent)
 
     async def _enqueue(self, workflow_id: str) -> None:
-        """Block until a slot opens, then claim it. Timeout after 300s."""
+        """Block until a slot opens, then claim it.
+
+        Timeout controlled by AUTOBOT_CONCURRENT_LIMITER_TIMEOUT env var
+        (default 300 s).
+        """
         entry = _QueuedEntry(workflow_id=workflow_id)
         self._queue.append(entry)
         logger.info(
@@ -212,7 +219,7 @@ class ConcurrentWorkflowLimiter:
             len(self._queue),
         )
         try:
-            await asyncio.wait_for(entry.ready_event.wait(), timeout=300.0)
+            await asyncio.wait_for(entry.ready_event.wait(), timeout=_ACQUIRE_TIMEOUT_SECONDS)
         except asyncio.TimeoutError:
             self._queue.remove(entry)
             raise ConcurrencyLimitError(workflow_id, self._max_concurrent)


### PR DESCRIPTION
## Summary
- Adds `import os` and module-level `_ACQUIRE_TIMEOUT_SECONDS` constant backed by `AUTOBOT_CONCURRENT_LIMITER_TIMEOUT` env var (default `300`)
- Replaces bare `timeout=300.0` at the `asyncio.wait_for` call site with the named constant

## Files changed
- `autobot-backend/services/workflow_automation/concurrent_limiter.py` — 9 insertions, 2 deletions

Closes #5959