### PR TITLE
fix(auth): replace hardcoded @autobot.local with AUTOBOT_AUTH_DOMAIN env var (#5954)

### DIFF
--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, validator
 
 from auth_middleware import auth_middleware
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.ssot_config import config as ssot_config
 from constants.error_constants import ERR_INVALID_CREDENTIALS, ERR_INVALID_TOKEN
 from user_management.database import db_session_context
 from user_management.services.user_service import UserService
@@ -277,11 +278,11 @@ async def login(request: Request, login_data: LoginRequest):
                 "username": "admin",
                 "user_id": "admin",
                 "role": "admin",
-                "email": "admin@autobot.local",
+                "email": f"admin@{ssot_config.auth.domain}",
                 "last_login": None,
             }
             jwt_token = auth_middleware.create_jwt_token(
-                {"username": "admin", "role": "admin", "email": "admin@autobot.local"}
+                {"username": "admin", "role": "admin", "email": f"admin@{ssot_config.auth.domain}"}
             )
             session_id = auth_middleware.create_session(
                 {"username": "admin", "role": "admin"}, request
@@ -373,7 +374,7 @@ async def get_current_user_info(request: Request):
             return {
                 "username": "admin",
                 "role": "admin",
-                "email": "admin@autobot.local",
+                "email": f"admin@{ssot_config.auth.domain}",
                 "auth_method": "single_user",
                 "authenticated": True,
                 "deployment_mode": "single_user",

--- a/autobot-backend/api/user_management/dependencies.py
+++ b/autobot-backend/api/user_management/dependencies.py
@@ -13,6 +13,7 @@ from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth_middleware import auth_middleware
+from autobot_shared.ssot_config import config as ssot_config
 from user_management.config import DeploymentMode, get_deployment_config
 from user_management.database import get_async_session
 from user_management.services import (
@@ -54,7 +55,7 @@ def get_current_user(request: Request) -> dict:
     if config.mode == DeploymentMode.SINGLE_USER:
         return {
             "username": "admin",
-            "email": "admin@autobot.local",
+            "email": f"admin@{ssot_config.auth.domain}",
             "role": "admin",
             "is_platform_admin": True,
             "auth_disabled": True,

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -188,7 +188,7 @@ class AuthenticationMiddleware:
         return {
             "username": "admin",
             "role": "admin",
-            "email": "admin@autobot.local",
+            "email": f"admin@{ssot_config.auth.domain}",
             "auth_disabled": True,
         }
 
@@ -241,7 +241,7 @@ class AuthenticationMiddleware:
         return {
             "username": username,
             "role": user_config.get("role", "user"),
-            "email": user_config.get("email", f"{username}@autobot.local"),
+            "email": user_config.get("email", f"{username}@{ssot_config.auth.domain}"),
             "last_login": user_config["last_login"],
         }
 
@@ -474,7 +474,7 @@ class AuthenticationMiddleware:
         return {
             "username": f"dev_{user_role}",
             "role": user_role,
-            "email": f"dev_{user_role}@autobot.local",
+            "email": f"dev_{user_role}@{ssot_config.auth.domain}",
             "auth_method": "development",
         }
 
@@ -744,7 +744,7 @@ async def authenticate_websocket(websocket) -> Optional[dict]:
             return {
                 "username": "admin",
                 "role": "admin",
-                "email": "admin@autobot.local",
+                "email": f"admin@{ssot_config.auth.domain}",
                 "source": "single_user_mode",
             }
     except Exception:

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -855,6 +855,30 @@ class CacheConfig(BaseSettings):
     l2: CacheL2Config = Field(default_factory=CacheL2Config)
 
 
+class AuthConfig(BaseSettings):
+    """Authentication domain configuration.
+
+    Controls auth-level defaults that are shared across middleware and API layers.
+    Override via environment variable (e.g. AUTOBOT_AUTH_DOMAIN=corp.example.com).
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=str(PROJECT_ROOT / ".env"),
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    domain: str = Field(
+        default="autobot.local",
+        alias="AUTOBOT_AUTH_DOMAIN",
+        description=(
+            "Email domain used for synthetic/fallback user accounts. "
+            "Default 'autobot.local' is used for auth-disabled, single-user, "
+            "and dev-mode synthetic accounts."
+        ),
+    )
+
+
 class PermissionMode(str, Enum):
     """
     Permission modes for command execution control.
@@ -1225,6 +1249,7 @@ class AutoBotConfig(BaseSettings):
     feature: FeatureConfig = Field(default_factory=FeatureConfig)
     permission: PermissionConfig = Field(default_factory=PermissionConfig)
     database_pool: DatabasePoolConfig = Field(default_factory=DatabasePoolConfig)
+    auth: AuthConfig = Field(default_factory=AuthConfig)
     path: PathConfig = Field(
         default_factory=PathConfig, alias="AUTOBOT_PATH_CONFIG"
     )  # Issue #3397; alias avoids collision with system PATH env var
@@ -1793,6 +1818,7 @@ __all__ = [
     "CacheL1Config",
     "CacheL2Config",
     "DatabasePoolConfig",
+    "AuthConfig",
     "FeatureConfig",
     "get_config",
     "reload_config",


### PR DESCRIPTION
Added AuthConfig.domain to ssot_config.py. Replaced 8 hardcoded @autobot.local occurrences across auth_middleware.py, api/auth.py, user_management/dependencies.py. Closes #5954