### PR TITLE
fix(api): replace hardcoded localhost:1234 LM Studio URL with LMSTUDIO_HOST env var (#5957)

### DIFF
--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -4,6 +4,7 @@
 import asyncio
 import importlib
 import logging
+import os
 import sys
 from datetime import datetime, timezone
 
@@ -120,7 +121,7 @@ def _build_frontend_services_config(ollama_url: str, redis_config: dict) -> dict
         "lmstudio": {
             "url": config.get(
                 "backend.llm.local.providers.lmstudio.endpoint",
-                f"http://localhost:1234",
+                os.getenv("LMSTUDIO_HOST", "http://127.0.0.1:1234"),
             ),
         },
     }


### PR DESCRIPTION
Replaced f'http://localhost:1234' in system.py with os.getenv('LMSTUDIO_HOST', 'http://127.0.0.1:1234'), matching the pattern in provider_health/providers.py. Closes #5957