### PR TITLE
fix(lint): restrict scope traversal + attribute bypass tests (#5964 #5965)

### DIFF
--- a/tools/lint/check_response_models.py
+++ b/tools/lint/check_response_models.py
@@ -82,6 +82,15 @@ ALLOWLIST = {
 _FuncNode = Union[ast.FunctionDef, ast.AsyncFunctionDef]
 
 
+def _scope_walk(node: ast.AST):
+    """Walk AST descendants without entering nested function/class definitions."""
+    yield node
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        yield from _scope_walk(child)
+
+
 def _checked_schema(decorator: ast.expr) -> str | None:
     """Return the schema name if *decorator* is a route with a checked response_model."""
     if not isinstance(decorator, ast.Call):
@@ -148,7 +157,7 @@ def _var_dict_keys(node: _FuncNode) -> dict[str, set[str]]:
         return result
     """
     var_keys: dict[str, set[str]] = {}
-    for child in ast.walk(node):
+    for child in _scope_walk(node):
         if not isinstance(child, ast.Assign):
             continue
         if not isinstance(child.value, ast.Dict):
@@ -166,7 +175,7 @@ def _var_dict_keys(node: _FuncNode) -> dict[str, set[str]]:
 def _returned_var_names(node: _FuncNode) -> set[str]:
     """Return the set of local variable names that appear in bare return statements."""
     names: set[str] = set()
-    for child in ast.walk(node):
+    for child in _scope_walk(node):
         if isinstance(child, ast.Return) and isinstance(child.value, ast.Name):
             names.add(child.value.id)
     return names

--- a/tools/lint/check_response_models_test.py
+++ b/tools/lint/check_response_models_test.py
@@ -363,3 +363,54 @@ async def post_msg():
     )
     violations = hook._check_file(f, tmp_path)
     assert len(violations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Attribute-access bypass (#5965) — responses.JSONResponse / module.StreamingResponse
+# ---------------------------------------------------------------------------
+
+
+def test_safe_with_jsonresponse_via_attribute(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/raw", response_model=DataResponse)
+async def raw():
+    return responses.JSONResponse(content={"key": "val"})
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_safe_with_streamingresponse_via_attribute(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/stream", response_model=DataResponse)
+async def stream():
+    return some_module.StreamingResponse(iter([b"data"]))
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Nested-function scope isolation (#5964) — inner dict must not bleed out
+# ---------------------------------------------------------------------------
+
+
+def test_detects_violation_when_only_nested_function_has_success_dict(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        """
+@router.get("/bad", response_model=DataResponse)
+async def bad_endpoint():
+    async def _build():
+        result = {"success": True, "data": []}
+        return result
+    return {"items": [], "count": 0}
+""",
+    )
+    violations = hook._check_file(f, tmp_path)
+    assert len(violations) == 1
+    assert violations[0][1] == "bad_endpoint"


### PR DESCRIPTION
## Summary

- Fixes `_var_dict_keys`/`_returned_var_names` to stop traversal at nested function/class definitions (`_scope_walk()`), eliminating false negatives where an inner helper's `{"success": ...}` dict masked an unsafe outer return
- Adds 3 new tests: nested-function false-negative now detected, `JSONResponse`/`StreamingResponse` via attribute access confirmed safe (27 total pass)

Closes #5964, closes #5965

🤖 Generated with [Claude Code](https://claude.ai/claude-code)