### PR TITLE
fix(config): correct code_source_dir path + add new env vars to Ansible backend template

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -120,3 +120,10 @@ AUTOBOT_PLANNING_MODEL={{ backend_llm_model }}
 AUTOBOT_{{ agent | upper }}_PROVIDER={{ backend_llm_provider | default('ollama') }}
 AUTOBOT_{{ agent | upper }}_ENDPOINT={{ backend_llm_endpoint | default('http://127.0.0.1:11434') }}
 {% endfor %}
+
+# Deployment paths and tunables (Issues #5953–#5959)
+AUTOBOT_CODE_SOURCE={{ code_source_dir | default('/opt/autobot/code_source') }}
+AUTOBOT_AUTH_DOMAIN={{ auth_domain | default('autobot.local') }}
+AUTOBOT_VNC_PASSWD_FILE=/home/{{ vnc_user | default('autobot') }}/.vnc/x11vnc.passwd
+AUTOBOT_CONCURRENT_LIMITER_TIMEOUT={{ concurrent_limiter_timeout | default(300) }}
+LMSTUDIO_HOST={{ lmstudio_host | default('http://localhost:1234') }}

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1123,7 +1123,10 @@ class PathConfig(BaseSettings):
     logs_dir: str = Field(default="logs", alias="AUTOBOT_LOG_DIR")
     models_dir: str = Field(default="models", alias="AUTOBOT_MODELS_DIR")
     docs_dir: str = Field(default="docs", alias="AUTOBOT_DOCS_DIR")
-    code_source_dir: str = Field(default="code_source", alias="AUTOBOT_CODE_SOURCE")
+    # code_source lives at /opt/autobot/code_source, a sibling of autobot-backend/ —
+    # NOT inside base_dir. Absolute default ensures correct resolution regardless
+    # of what AUTOBOT_BASE_DIR is set to.
+    code_source_dir: str = Field(default="/opt/autobot/code_source", alias="AUTOBOT_CODE_SOURCE")
 
     def resolve(self, relative: str) -> Path:
         """Resolve a path relative to base_dir."""


### PR DESCRIPTION
## Problem

Issue #5953 added `code_source_dir: str = Field(default="code_source", alias="AUTOBOT_CODE_SOURCE")` to `PathConfig`. This assumed `AUTOBOT_BASE_DIR=/opt/autobot`, but Ansible actually sets it to `AUTOBOT_BASE_DIR=/opt/autobot/autobot-backend` (via `backend_code_dir`). The relative default `"code_source"` therefore resolved to `/opt/autobot/autobot-backend/code_source` — the wrong path. The correct path is the sibling directory `/opt/autobot/code_source`.

Additionally, the 5 new env vars introduced in #5953-#5959 were never added to `backend.env.j2`, leaving them invisible to Ansible operators.

## Changes

**`autobot_shared/ssot_config.py`**
- Change `code_source_dir` default from `"code_source"` (relative) to `"/opt/autobot/code_source"` (absolute)
- `resolve()` already short-circuits on absolute paths (`p.is_absolute() → return p`) so this is safe regardless of `AUTOBOT_BASE_DIR`
- Verified: resolves to `/opt/autobot/code_source` even when `AUTOBOT_BASE_DIR=/opt/autobot/autobot-backend`

**`autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2`**
- Add `AUTOBOT_CODE_SOURCE`, `AUTOBOT_AUTH_DOMAIN`, `AUTOBOT_VNC_PASSWD_FILE`, `AUTOBOT_CONCURRENT_LIMITER_TIMEOUT`, `LMSTUDIO_HOST` with Jinja2 `default()` fallbacks matching the code defaults

## Verification

```python
import os; os.environ['AUTOBOT_BASE_DIR'] = '/opt/autobot/autobot-backend'
from autobot_shared.ssot_config import PathConfig
assert str(PathConfig().code_source_path) == '/opt/autobot/code_source'  # ✅
```