### PR TITLE
refact(api): move GoalRequest/GoalResponse/HealthResponse to schemas_agent (#5977)

### DIFF
--- a/autobot-backend/api/intelligent_agent.py
+++ b/autobot-backend/api/intelligent_agent.py
@@ -10,20 +10,18 @@ Provides REST and WebSocket endpoints for the intelligent agent system.
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
-from pydantic import BaseModel
 
 from auth_middleware import check_admin_permission, get_current_user
-from type_defs.common import Metadata
 
 if TYPE_CHECKING:
     from intelligence.intelligent_agent import IntelligentAgent
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from monitoring.prometheus_metrics import get_metrics_manager
-from api.schemas_agent import AgentSystemCapabilitiesResponse
+from api.schemas_agent import AgentSystemCapabilitiesResponse, GoalRequest, GoalResponse, HealthResponse
 from api.schemas_common import DataResponse
 
 # CRITICAL FIX: Use lazy loading to prevent startup deadlock
@@ -105,31 +103,6 @@ async def get_agent() -> "IntelligentAgent":
                 status_code=503,
                 detail="Intelligent agent initialization failed",
             )
-
-
-# Pydantic models for API
-class GoalRequest(BaseModel):
-    """Request model for natural language goals."""
-
-    goal: str
-    context: Metadata = {}
-
-
-class GoalResponse(BaseModel):
-    """Response model for processed goals."""
-
-    success: bool
-    result: str
-    execution_time: float
-    metadata: Metadata = {}
-
-
-class HealthResponse(BaseModel):
-    """Response model for health check."""
-
-    status: str
-    components: Dict[str, str]
-    uptime: float
 
 
 # Router - no prefix needed as it's added when mounting

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -686,6 +686,30 @@ class AgentSystemCapabilitiesResponse(BaseModel):
     available_tools: List[str]
 
 
+class GoalRequest(BaseModel):
+    """Request body for POST /intelligent-agent/process."""
+
+    goal: str
+    context: Dict[str, Any] = {}
+
+
+class GoalResponse(BaseModel):
+    """Response for POST /intelligent-agent/process."""
+
+    success: bool
+    result: str
+    execution_time: float
+    metadata: Dict[str, Any] = {}
+
+
+class HealthResponse(BaseModel):
+    """Response for GET /intelligent-agent/health."""
+
+    status: str
+    components: Dict[str, str]
+    uptime: float
+
+
 # ---------------------------------------------------------------------------
 # voice.py schemas  (Issue #5317)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Completes the `intelligent_agent.py` schema migration started in #5937:
- Moves `GoalRequest`, `GoalResponse`, `HealthResponse` from `intelligent_agent.py` into `schemas_agent.py`
- Removes now-unused `BaseModel`, `Dict`, `List`, and `Metadata` imports from `intelligent_agent.py`
- `context`/`metadata` fields typed as `Dict[str, Any]` (equivalent to `Metadata` alias from `type_defs.common`)

## Test Plan
- [x] `python3 -m py_compile` passes on both modified files
- [x] No remaining local `BaseModel` subclasses in `intelligent_agent.py`
- [x] All 3 endpoint handlers resolve types from `schemas_agent` import

Closes #5977

🤖 Generated with Claude Code