### PR TITLE
fix(deploy): wire env vars from #5953-#5959 into backend.env.j2, fix PathConfig default (#5979)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -120,3 +120,10 @@ AUTOBOT_PLANNING_MODEL={{ backend_llm_model }}
 AUTOBOT_{{ agent | upper }}_PROVIDER={{ backend_llm_provider | default('ollama') }}
 AUTOBOT_{{ agent | upper }}_ENDPOINT={{ backend_llm_endpoint | default('http://127.0.0.1:11434') }}
 {% endfor %}
+
+# Path / infrastructure overrides (Issues #5953–#5959)
+AUTOBOT_CODE_SOURCE={{ autobot_code_source | default('/opt/autobot/code_source') }}
+AUTOBOT_AUTH_DOMAIN={{ autobot_auth_domain | default('autobot.local') }}
+AUTOBOT_VNC_PASSWD_FILE={{ autobot_vnc_passwd_file | default('/etc/autobot/vnc.passwd') }}
+AUTOBOT_CONCURRENT_LIMITER_TIMEOUT={{ autobot_concurrent_limiter_timeout | default('300') }}
+LMSTUDIO_HOST={{ lmstudio_host | default('http://127.0.0.1:1234') }}

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1123,7 +1123,7 @@ class PathConfig(BaseSettings):
     logs_dir: str = Field(default="logs", alias="AUTOBOT_LOG_DIR")
     models_dir: str = Field(default="models", alias="AUTOBOT_MODELS_DIR")
     docs_dir: str = Field(default="docs", alias="AUTOBOT_DOCS_DIR")
-    code_source_dir: str = Field(default="code_source", alias="AUTOBOT_CODE_SOURCE")
+    code_source_dir: str = Field(default="/opt/autobot/code_source", alias="AUTOBOT_CODE_SOURCE")
 
     def resolve(self, relative: str) -> Path:
         """Resolve a path relative to base_dir."""


### PR DESCRIPTION
## Summary
- Adds `AUTOBOT_CODE_SOURCE`, `AUTOBOT_AUTH_DOMAIN`, `AUTOBOT_VNC_PASSWD_FILE`, `AUTOBOT_CONCURRENT_LIMITER_TIMEOUT`, `LMSTUDIO_HOST` to `backend.env.j2` with correct Ansible defaults
- Fixes `PathConfig.code_source_path` default from relative `"code_source"` to absolute `"/opt/autobot/code_source"` (consistent with other absolute paths in the class)

Closes #5979

🤖 Generated with [Claude Code](https://claude.com/claude-code)