### PR TITLE
fix(api): add 6 missing fields to CostTrackingRecordResponse (#5995)

### DIFF
--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -839,8 +839,14 @@ class CostTrackingRecordResponse(BaseModel):
     output_tokens: int
     cost_usd: float
     timestamp: str
-    session_id: Optional[str]
-    success: bool
+    session_id: Optional[str] = None
+    user_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    endpoint: Optional[str] = None
+    latency_ms: Optional[float] = None
+    success: bool = True
+    error_message: Optional[str] = None
+    metadata: Dict[str, Any] = {}
 
 
 


### PR DESCRIPTION
## Summary

`CostTrackingRecordResponse` was introduced in #5936 and wired to `GET /cost/usage/recent` in #5976, but only declared 8 of the 14 fields that `LLMUsageRecord.to_dict()` actually stores. FastAPI silently dropped the other 6 during serialization — a data regression vs the previous `response_model=None` behaviour.

**Fields added:**
| Field | Type |
|-------|------|
| `user_id` | `Optional[str]` |
| `agent_id` | `Optional[str]` |
| `endpoint` | `Optional[str]` |
| `latency_ms` | `Optional[float]` |
| `error_message` | `Optional[str]` |
| `metadata` | `Dict[str, Any]` |

Also tightened existing `session_id: Optional[str]` and `success: bool` to carry default values matching `LLMUsageRecord` field defaults.

## Test Plan
- [x] `python3 -m py_compile` passes
- [x] All 14 fields in `LLMUsageRecord.to_dict()` are now covered by the schema
- [x] No required fields without defaults — no new 500 risk

Closes #5995

🤖 Generated with Claude Code