### PR TITLE
fix(api): add 6 missing fields to CostTrackingRecordResponse (#5995)

### DIFF
--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -839,8 +839,14 @@ class CostTrackingRecordResponse(BaseModel):
     output_tokens: int
     cost_usd: float
     timestamp: str
-    session_id: Optional[str]
-    success: bool
+    session_id: Optional[str] = None
+    user_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    endpoint: Optional[str] = None
+    latency_ms: Optional[float] = None
+    success: bool = True
+    error_message: Optional[str] = None
+    metadata: Dict[str, Any] = {}
 
 
 


### PR DESCRIPTION
## Summary
- Adds `user_id`, `agent_id`, `endpoint`, `latency_ms`, `error_message`, `metadata` to `CostTrackingRecordResponse`
- FastAPI was silently dropping these 6 fields on `GET /usage/recent` because they existed in `LLMUsageRecord.to_dict()` but were absent from the schema
- Fixes optional/default declarations for `session_id` and `success` to match actual nullability

Closes #5995

🤖 Generated with [Claude Code](https://claude.com/claude-code)