### PR TITLE
refact(config): move VNC_PASSWD_FILE into PathConfig.vnc_passwd_file in ssot_config (#6001)

### DIFF
--- a/autobot-backend/desktop_streaming_manager.py
+++ b/autobot-backend/desktop_streaming_manager.py
@@ -26,6 +26,7 @@ from typing import Any, Optional
 
 import websockets
 
+from autobot_shared.ssot_config import config
 from config import config_manager
 from constants.threshold_constants import TimingConstants
 from task_execution_tracker import TaskPriority, task_tracker
@@ -41,11 +42,6 @@ ALL_VNC_PROCESS_KEYS: frozenset[str] = frozenset(
     {"novnc_process", "vnc_process", "xvfb_process"}
 )
 CORE_VNC_PROCESS_KEYS: frozenset[str] = frozenset({"xvfb_process", "vnc_process"})
-
-# VNC password file path — override with AUTOBOT_VNC_PASSWD_FILE env var (#5956)
-VNC_PASSWD_FILE: str = os.environ.get(
-    "AUTOBOT_VNC_PASSWD_FILE", "/home/autobot/.vnc/x11vnc.passwd"
-)
 
 
 def _get_x_lock_directory() -> Path:
@@ -553,7 +549,7 @@ class VNCServerManager:
             "-rfbport",
             str(vnc_port),
             "-rfbauth",
-            VNC_PASSWD_FILE,
+            str(config.path.vnc_passwd_path),
             "-shared",
             "-forever",
             "-noxdamage",

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1128,6 +1128,12 @@ class PathConfig(BaseSettings):
     # of what AUTOBOT_BASE_DIR is set to.
     code_source_dir: str = Field(default="/opt/autobot/code_source", alias="AUTOBOT_CODE_SOURCE")
 
+    # VNC password file — absolute path, not relative to base_dir.
+    # Override via AUTOBOT_VNC_PASSWD_FILE env var.
+    vnc_passwd_file: str = Field(
+        default="/home/autobot/.vnc/x11vnc.passwd", alias="AUTOBOT_VNC_PASSWD_FILE"
+    )
+
     def resolve(self, relative: str) -> Path:
         """Resolve a path relative to base_dir."""
         p = Path(relative)
@@ -1164,6 +1170,11 @@ class PathConfig(BaseSettings):
     def code_source_path(self) -> Path:
         """Absolute path to the code source directory (git repo root on deployment)."""
         return self.resolve(self.code_source_dir)
+
+    @property
+    def vnc_passwd_path(self) -> Path:
+        """Absolute path to the x11vnc password file."""
+        return Path(self.vnc_passwd_file)
 
 
 class FeatureConfig(BaseSettings):


### PR DESCRIPTION
## Summary
- Adds `vnc_passwd_file` field and `vnc_passwd_path` property to `PathConfig` in `ssot_config.py`
- Removes raw `os.environ.get("AUTOBOT_VNC_PASSWD_FILE", ...)` from `desktop_streaming_manager.py`; uses `config.path.vnc_passwd_path` instead

Closes #6001

🤖 Generated with [Claude Code](https://claude.com/claude-code)