### PR TITLE
refact(config): consolidate LMSTUDIO_HOST into ssot_config.LLMConfig (#6000)

### DIFF
--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -121,7 +121,7 @@ def _build_frontend_services_config(ollama_url: str, redis_config: dict) -> dict
         "lmstudio": {
             "url": config.get(
                 "backend.llm.local.providers.lmstudio.endpoint",
-                os.getenv("LMSTUDIO_HOST", "http://127.0.0.1:1234"),
+                ssot_config.llm.lmstudio_host,
             ),
         },
     }

--- a/autobot-backend/config/service_config.py
+++ b/autobot-backend/config/service_config.py
@@ -9,12 +9,19 @@ Service, host, port, and URL configuration management.
 import logging
 import os
 from typing import Any, Dict
+from urllib.parse import urlparse
 
+from autobot_shared.ssot_config import config as ssot_config
 from config.registry import ConfigRegistry
 from constants.network_constants import NetworkConstants
 from constants.path_constants import PATH
 
 logger = logging.getLogger(__name__)
+
+# Parse lmstudio host/port from ssot_config once at module load (#6000).
+_lmstudio_parsed = urlparse(ssot_config.llm.lmstudio_host)
+_LMSTUDIO_HOST = _lmstudio_parsed.hostname or "127.0.0.1"
+_LMSTUDIO_PORT = _lmstudio_parsed.port or 1234
 
 # Issue #380: Module-level cached maps to avoid repeated dictionary creation
 # Issue #1214: Ollama host resolved via ConfigRegistry (SLM-managed, not
@@ -32,7 +39,7 @@ _HOST_SERVICE_MAP = {
     "openai": "api.openai.com",
     "anthropic": "api.anthropic.com",
     "vllm": "localhost",
-    "lmstudio": "localhost",
+    "lmstudio": _LMSTUDIO_HOST,
 }
 
 _PORT_SERVICE_MAP = {
@@ -48,7 +55,7 @@ _PORT_SERVICE_MAP = {
     "openai": 443,
     "anthropic": 443,
     "vllm": 8000,
-    "lmstudio": 1234,
+    "lmstudio": _LMSTUDIO_PORT,
 }
 
 

--- a/autobot-backend/services/provider_health/providers.py
+++ b/autobot-backend/services/provider_health/providers.py
@@ -12,7 +12,7 @@ import time
 import aiohttp
 
 from autobot_shared.http_client import get_http_client
-from autobot_shared.ssot_config import get_ollama_url
+from autobot_shared.ssot_config import config as ssot_config, get_ollama_url
 from constants.model_constants import ANTHROPIC_CLAUDE3_HAIKU_DATED
 
 from .base import BaseProviderHealth, ProviderHealthResult, ProviderStatus
@@ -425,7 +425,7 @@ class LMStudioHealth(BaseProviderHealth):
         """Initialize LM Studio health checker with host configuration."""
         super().__init__("lmstudio")
         # LM Studio default port is 1234
-        self.lmstudio_host = os.getenv("LMSTUDIO_HOST", "http://127.0.0.1:1234")
+        self.lmstudio_host = ssot_config.llm.lmstudio_host
 
     async def check_health(self, timeout: float = 5.0) -> ProviderHealthResult:
         """Check LM Studio service health"""

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -213,6 +213,9 @@ class LLMConfig(BaseSettings):
         default="https://api.anthropic.com/v1", alias="AUTOBOT_ANTHROPIC_ENDPOINT"
     )
     custom_endpoint: str = Field(default="", alias="AUTOBOT_CUSTOM_LLM_ENDPOINT")
+    lmstudio_host: str = Field(
+        default="http://127.0.0.1:1234", alias="LMSTUDIO_HOST"
+    )
 
     # GPU Ollama endpoint for model-to-endpoint routing (#1070)
     ollama_gpu_endpoint: str = Field(default="", alias="AUTOBOT_OLLAMA_GPU_ENDPOINT")
@@ -419,6 +422,7 @@ class LLMConfig(BaseSettings):
             "openai": self.openai_endpoint,
             "anthropic": self.anthropic_endpoint,
             "custom": self.custom_endpoint,
+            "lmstudio": self.lmstudio_host,
         }
         return endpoints.get(provider.lower(), self.ollama_endpoint)
 


### PR DESCRIPTION
## Summary
- Adds `lmstudio_host` field to `LLMConfig` in `ssot_config.py` (alias: `LMSTUDIO_HOST`, default: `http://127.0.0.1:1234`)
- Replaces `os.getenv("LMSTUDIO_HOST", ...)` in `api/system.py` and `services/provider_health/providers.py` with `ssot_config.llm.lmstudio_host`
- Fixes `config/service_config.py` — derives port and hostname from ssot config via `urlparse` instead of bare hardcoded `1234`

Closes #6000

🤖 Generated with [Claude Code](https://claude.com/claude-code)