### PR TITLE
refact(services): migrate 9 services from manual _get_redis to AsyncRedisClientMixin (#5946)

### DIFF
--- a/autobot-backend/services/access_control_metrics.py
+++ b/autobot-backend/services/access_control_metrics.py
@@ -22,13 +22,13 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
-from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from type_defs.common import Metadata
 
 logger = logging.getLogger(__name__)
 
 
-class AccessControlMetrics:
+class AccessControlMetrics(AsyncRedisClientMixin):
     """
     Track and analyze access control violations for safe rollout
 
@@ -40,6 +40,8 @@ class AccessControlMetrics:
     - Time-series data for trending
     """
 
+    _redis_database = "metrics"
+
     def __init__(self, retention_days: int = 7):
         """
         Initialize metrics collection service
@@ -48,14 +50,6 @@ class AccessControlMetrics:
             retention_days: How long to keep detailed metrics (default: 7 days)
         """
         self.retention_days = retention_days
-        self._redis = None
-
-    async def _get_redis(self):
-        """Get Redis metrics database (DB 4)"""
-        if not self._redis:
-            # Get async Redis client for metrics database (returns coroutine, must await)
-            self._redis = await get_async_redis_client(database="metrics")
-        return self._redis
 
     async def record_violation(
         self,

--- a/autobot-backend/services/autoresearch/auto_research_agent.py
+++ b/autobot-backend/services/autoresearch/auto_research_agent.py
@@ -45,6 +45,7 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from constants.ttl_constants import TTL_7_DAYS, TTL_24_HOURS
 
 from .config import AutoResearchConfig
@@ -192,7 +193,7 @@ class CheckpointResult:
     redirect_instructions: Optional[str] = None
 
 
-class ResearchCheckpointGate:
+class ResearchCheckpointGate(AsyncRedisClientMixin):
     """
     Redis-backed gate that pauses a research session at defined checkpoints
     and waits for a human to approve, redirect, or cancel.
@@ -217,17 +218,7 @@ class ResearchCheckpointGate:
         from .config import AutoResearchConfig as _Cfg
 
         self.config = config or _Cfg()
-        self._redis = None
-
-    async def _get_redis(self):
-        if self._redis is None:
-            from autobot_shared.redis_client import get_redis_client
-
-            self._redis = get_redis_client(
-                async_client=True,
-                database=self.config.redis_database,
-            )
-        return self._redis
+        self._redis_database = self.config.redis_database
 
     def _keys(self, session_id: str, cp_type: str):
         ctx_key = self._CONTEXT_KEY.format(session_id=session_id, cp_type=cp_type)
@@ -327,7 +318,7 @@ class ResearchCheckpointGate:
 # ---------------------------------------------------------------------------
 
 
-class ApprovalGate:
+class ApprovalGate(AsyncRedisClientMixin):
     """
     Lightweight Redis-backed gate for autoresearch significant improvements.
 
@@ -346,17 +337,7 @@ class ApprovalGate:
 
     def __init__(self, config: Optional[AutoResearchConfig] = None):
         self.config = config or AutoResearchConfig()
-        self._redis = None
-
-    async def _get_redis(self):
-        if self._redis is None:
-            from autobot_shared.redis_client import get_redis_client
-
-            self._redis = get_redis_client(
-                async_client=True,
-                database=self.config.redis_database,
-            )
-        return self._redis
+        self._redis_database = self.config.redis_database
 
     def check_approval_needed(
         self, improvement_pct: Optional[float], threshold: float
@@ -578,7 +559,7 @@ def _parse_github_results(data: Dict[str, Any]) -> List[SearchResult]:
 # ---------------------------------------------------------------------------
 
 
-class AutoResearchAgent:
+class AutoResearchAgent(AsyncRedisClientMixin):
     """
     Orchestrator for the AutoResearch M2 loop.
 
@@ -606,13 +587,13 @@ class AutoResearchAgent:
         http_client: Optional[httpx.AsyncClient] = None,
     ):
         self.config = config or AutoResearchConfig()
+        self._redis_database = self.config.redis_database
         self.store = store or ExperimentStore(self.config)
         self.runner = runner or ExperimentRunner(config=self.config, store=self.store)
         self.approval_gate = approval_gate or ApprovalGate(self.config)
         self.checkpoint_gate = checkpoint_gate or ResearchCheckpointGate(self.config)
         self._http_client = http_client
         self._cancel_event: asyncio.Event = asyncio.Event()
-        self._redis = None
 
     # ------------------------------------------------------------------
     # Public API
@@ -1201,16 +1182,6 @@ class AutoResearchAgent:
     # ------------------------------------------------------------------
     # Private: session persistence
     # ------------------------------------------------------------------
-
-    async def _get_redis(self):
-        if self._redis is None:
-            from autobot_shared.redis_client import get_redis_client
-
-            self._redis = get_redis_client(
-                async_client=True,
-                database=self.config.redis_database,
-            )
-        return self._redis
 
     async def _save_session(self, session: ExperimentSession) -> None:
         """Persist an ExperimentSession to Redis.

--- a/autobot-backend/services/autoresearch/store.py
+++ b/autobot-backend/services/autoresearch/store.py
@@ -15,33 +15,24 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
+
 from .config import AutoResearchConfig
 from .models import Experiment, ExperimentState, ExperimentStats
 
 logger = logging.getLogger(__name__)
 
 
-class ExperimentStore:
+class ExperimentStore(AsyncRedisClientMixin):
     """Persist and query experiments across Redis and ChromaDB."""
 
     def __init__(self, config: Optional[AutoResearchConfig] = None):
         self.config = config or AutoResearchConfig()
-        self._redis = None
+        self._redis_database = self.config.redis_database
         self._chromadb_collection = None
 
     def _redis_key(self, *parts: str) -> str:
         return ":".join([self.config.redis_prefix, *parts])
-
-    async def _get_redis(self):
-        """Lazy-init async Redis client."""
-        if self._redis is None:
-            from autobot_shared.redis_client import get_redis_client
-
-            self._redis = get_redis_client(
-                async_client=True,
-                database=self.config.redis_database,
-            )
-        return self._redis
 
     async def _get_chromadb(self):
         """Lazy-init ChromaDB collection."""

--- a/autobot-backend/services/feature_flags.py
+++ b/autobot-backend/services/feature_flags.py
@@ -33,7 +33,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
 
-from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from constants.threshold_constants import StringParsingConstants
 from type_defs.common import Metadata
 
@@ -48,7 +48,7 @@ class EnforcementMode(str, Enum):
     ENFORCED = "enforced"  # Full enforcement, block violations
 
 
-class FeatureFlags:
+class FeatureFlags(AsyncRedisClientMixin):
     """
     Redis-backed feature flags for access control rollout
 
@@ -56,20 +56,14 @@ class FeatureFlags:
     Supports real-time updates across distributed VMs
     """
 
+    _redis_database = "cache"
+
     def __init__(self):
         """Initialize feature flags service"""
-        self.redis = None
         self._cache = {}
         self._cache_ttl = 5  # seconds
         self._last_refresh = {}
         self._enforcement_default_logged = False
-
-    async def _get_redis(self):
-        """Get Redis connection for feature flags (uses cache DB)"""
-        if not self.redis:
-            # Get async Redis client for cache database (returns coroutine, must await)
-            self.redis = await get_async_redis_client(database="cache")
-        return self.redis
 
     async def get_enforcement_mode(self) -> EnforcementMode:
         """

--- a/autobot-backend/services/knowledge/org_knowledge_config.py
+++ b/autobot-backend/services/knowledge/org_knowledge_config.py
@@ -30,7 +30,7 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 
 logger = logging.getLogger(__name__)
 
@@ -71,20 +71,14 @@ def _key(org_id: Optional[str]) -> str:
     return f"{_KEY_PREFIX}{org_id or DEFAULT_ORG_ID}"
 
 
-class OrgKnowledgeConfigService:
+class OrgKnowledgeConfigService(AsyncRedisClientMixin):
     """Persisted per-org knowledge model config with SSOT fallback."""
 
-    def __init__(self, redis_client=None) -> None:
-        # Injected client (for tests) or lazy-fetched from the knowledge DB.
-        self._redis = redis_client
+    _redis_database = "knowledge"
 
-    async def _get_redis(self):
-        if self._redis is not None:
-            return self._redis
-        self._redis = await get_redis_client(
-            database="knowledge", async_client=True
-        )
-        return self._redis
+    def __init__(self, redis_client=None) -> None:
+        # Injected client (for tests) or lazy-fetched from the knowledge DB via mixin.
+        self._redis = redis_client
 
     async def get(self, org_id: Optional[str] = None) -> Optional[OrgKnowledgeConfig]:
         """Return the persisted config for ``org_id`` or None if unset."""

--- a/autobot-backend/services/security_workflow_manager.py
+++ b/autobot-backend/services/security_workflow_manager.py
@@ -25,7 +25,7 @@ from typing import Any, List, Optional
 
 from redis.exceptions import RedisError
 
-from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
@@ -262,7 +262,7 @@ class SecurityAssessment:
         )
 
 
-class SecurityWorkflowManager:
+class SecurityWorkflowManager(AsyncRedisClientMixin):
     """
     Manages security assessment workflows with Redis persistence.
 
@@ -298,16 +298,7 @@ class SecurityWorkflowManager:
     REDIS_KEY_PREFIX = "workflow:assessment"
     REDIS_ACTIVE_INDEX = "workflow:assessments:active"
     REDIS_TTL_DAYS = 30  # Keep assessments for 30 days
-
-    def __init__(self) -> None:
-        """Initialize security workflow manager with Redis client placeholder."""
-        self._redis_client: Any = None
-
-    async def _get_redis(self) -> Any:
-        """Get Redis client for workflow database."""
-        if self._redis_client is None:
-            self._redis_client = await get_async_redis_client(database="workflows")
-        return self._redis_client
+    _redis_database = "workflows"
 
     def _assessment_key(self, assessment_id: str) -> str:
         """Generate Redis key for an assessment."""

--- a/autobot-backend/services/skill_management/skill_feedback.py
+++ b/autobot-backend/services/skill_management/skill_feedback.py
@@ -11,10 +11,10 @@ provide refinement recommendations.
 import json
 import logging
 from collections import Counter
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from autobot_shared.time_utils import now_utc
 
 from .skill_metrics import SkillMetrics, REDIS_SKILL_METRICS_PREFIX
@@ -22,21 +22,13 @@ from .skill_metrics import SkillMetrics, REDIS_SKILL_METRICS_PREFIX
 logger = logging.getLogger(__name__)
 
 
-class SkillFeedbackAnalyzer:
+class SkillFeedbackAnalyzer(AsyncRedisClientMixin):
     """Analyzes skill feedback to identify patterns and recommend improvements."""
+
+    _redis_database = "analytics"
 
     def __init__(self) -> None:
         self._metrics = SkillMetrics()
-        self._redis: Optional[Any] = None
-
-    async def _get_redis(self) -> Optional[Any]:
-        """Get Redis client (analytics database)."""
-        if self._redis is None:
-            try:
-                self._redis = get_redis_client(RedisDatabase.ANALYTICS)
-            except Exception as e:
-                logger.error("Failed to get Redis client: %s", e)
-        return self._redis
 
     async def log_user_feedback(
         self,
@@ -68,8 +60,8 @@ class SkillFeedbackAnalyzer:
             }
 
             key = f"skill_feedback:{skill_id}:{now.strftime('%Y-%m-%d')}"
-            redis.lpush(key, json.dumps(feedback_entry, default=str))
-            redis.expire(key, 90 * 86400)  # Keep 90 days
+            await redis.lpush(key, json.dumps(feedback_entry, default=str))
+            await redis.expire(key, 90 * 86400)  # Keep 90 days
 
             logger.debug("Logged feedback for %s: rating=%d", skill_id, rating)
 
@@ -106,7 +98,7 @@ class SkillFeedbackAnalyzer:
             for i in range(days):
                 date = (now - timedelta(days=i)).strftime("%Y-%m-%d")
                 key = f"skill_feedback:{skill_id}:{date}"
-                feedback_entries = redis.lrange(key, 0, -1)
+                feedback_entries = await redis.lrange(key, 0, -1)
 
                 for entry_raw in feedback_entries:
                     try:
@@ -124,9 +116,7 @@ class SkillFeedbackAnalyzer:
                         continue
 
             # Calculate statistics
-            avg_rating = (
-                (sum(ratings) / len(ratings)) if ratings else 0.0
-            )
+            avg_rating = (sum(ratings) / len(ratings)) if ratings else 0.0
 
             # Find most common failure patterns
             pattern_counter = Counter(failure_patterns)

--- a/autobot-backend/services/skill_management/skill_metrics.py
+++ b/autobot-backend/services/skill_management/skill_metrics.py
@@ -11,10 +11,10 @@ auto-deprecation of underperforming skills.
 
 import json
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
@@ -26,20 +26,10 @@ REDIS_SKILL_ERROR_PREFIX = "skill_error:"
 REDIS_SKILL_HEALTH_PREFIX = "skill_health:"
 
 
-class SkillMetrics:
+class SkillMetrics(AsyncRedisClientMixin):
     """Tracks and stores skill invocation metrics in Redis."""
 
-    def __init__(self) -> None:
-        self._redis: Optional[Any] = None
-
-    async def _get_redis(self) -> Optional[Any]:
-        """Get Redis client (analytics database)."""
-        if self._redis is None:
-            try:
-                self._redis = get_redis_client(RedisDatabase.ANALYTICS)
-            except Exception as e:
-                logger.error("Failed to get Redis client: %s", e)
-        return self._redis
+    _redis_database = "analytics"
 
     async def log_invocation(
         self,
@@ -71,19 +61,19 @@ class SkillMetrics:
 
         try:
             # Increment invocation counter
-            redis.incr(f"{day_prefix}:total")
+            await redis.incr(f"{day_prefix}:total")
 
             if success:
-                redis.incr(f"{day_prefix}:success")
+                await redis.incr(f"{day_prefix}:success")
             else:
-                redis.incr(f"{day_prefix}:failures")
+                await redis.incr(f"{day_prefix}:failures")
 
             # Track error type
             if error_type:
-                redis.incr(f"{day_prefix}:error:{error_type}")
+                await redis.incr(f"{day_prefix}:error:{error_type}")
 
             # Record duration (for percentile calculations)
-            redis.lpush(f"{day_prefix}:durations", str(duration_ms))
+            await redis.lpush(f"{day_prefix}:durations", str(duration_ms))
 
             # Store feedback if provided
             if user_feedback:
@@ -93,21 +83,21 @@ class SkillMetrics:
                     "success": success,
                     "feedback": user_feedback,
                 }
-                redis.lpush(
+                await redis.lpush(
                     f"{day_prefix}:feedback",
                     json.dumps(feedback_entry, default=str),
                 )
 
             # Trim old data (keep last 100 feedbacks per day)
-            redis.ltrim(f"{day_prefix}:feedback", 0, 99)
-            redis.ltrim(f"{day_prefix}:durations", 0, 999)
+            await redis.ltrim(f"{day_prefix}:feedback", 0, 99)
+            await redis.ltrim(f"{day_prefix}:durations", 0, 999)
 
             # Set key expiry (keep 90 days of metrics)
-            redis.expire(f"{day_prefix}:total", 90 * 86400)
-            redis.expire(f"{day_prefix}:success", 90 * 86400)
-            redis.expire(f"{day_prefix}:failures", 90 * 86400)
-            redis.expire(f"{day_prefix}:feedback", 90 * 86400)
-            redis.expire(f"{day_prefix}:durations", 90 * 86400)
+            await redis.expire(f"{day_prefix}:total", 90 * 86400)
+            await redis.expire(f"{day_prefix}:success", 90 * 86400)
+            await redis.expire(f"{day_prefix}:failures", 90 * 86400)
+            await redis.expire(f"{day_prefix}:feedback", 90 * 86400)
+            await redis.expire(f"{day_prefix}:durations", 90 * 86400)
 
         except Exception as e:
             logger.error("Failed to log skill metrics: %s", e)
@@ -147,21 +137,21 @@ class SkillMetrics:
                 day_prefix = f"{REDIS_SKILL_METRICS_PREFIX}{skill_id}:{date}"
 
                 # Get counts for this day
-                invocations = int(redis.get(f"{day_prefix}:total") or 0)
-                successes = int(redis.get(f"{day_prefix}:success") or 0)
+                invocations = int(await redis.get(f"{day_prefix}:total") or 0)
+                successes = int(await redis.get(f"{day_prefix}:success") or 0)
                 total_invocations += invocations
                 total_successes += successes
 
                 # Aggregate error patterns
-                error_keys = redis.keys(f"{day_prefix}:error:*")
+                error_keys = await redis.keys(f"{day_prefix}:error:*")
                 for key in error_keys:
                     key_str = key.decode() if isinstance(key, bytes) else key
                     error_type = key_str.split(":")[-1]
-                    count = int(redis.get(key) or 0)
+                    count = int(await redis.get(key) or 0)
                     error_patterns[error_type] = error_patterns.get(error_type, 0) + count
 
                 # Collect durations
-                durations_raw = redis.lrange(f"{day_prefix}:durations", 0, -1)
+                durations_raw = await redis.lrange(f"{day_prefix}:durations", 0, -1)
                 for d in durations_raw:
                     try:
                         duration_str = d.decode() if isinstance(d, bytes) else d
@@ -262,12 +252,12 @@ class SkillMetrics:
             for i in range(30):
                 date = (now - timedelta(days=i)).strftime("%Y-%m-%d")
                 day_prefix = f"{REDIS_SKILL_METRICS_PREFIX}{skill_id}:{date}"
-                count = int(redis.get(f"{day_prefix}:total") or 0)
+                count = int(await redis.get(f"{day_prefix}:total") or 0)
                 recent_invocations += count
 
             if recent_invocations == 0:
                 # Mark as stale
-                redis.set(
+                await redis.set(
                     f"{REDIS_SKILL_HEALTH_PREFIX}{skill_id}:stale",
                     "true",
                     ex=90 * 86400,
@@ -291,7 +281,7 @@ class SkillMetrics:
             return []
 
         try:
-            stale_keys = redis.keys(f"{REDIS_SKILL_HEALTH_PREFIX}*:stale")
+            stale_keys = await redis.keys(f"{REDIS_SKILL_HEALTH_PREFIX}*:stale")
             return [
                 key.decode().replace(f"{REDIS_SKILL_HEALTH_PREFIX}", "").replace(
                     ":stale", ""


### PR DESCRIPTION
## Summary
- Replaces manual `self._redis = None` / `_get_redis()` pattern with `AsyncRedisClientMixin` in 8 files covering 10 classes
- Classes now inherit `AsyncRedisClientMixin`, set `_redis_database`, and call `await self.redis()` instead of the bespoke getter
- Eliminates the re-initialization race condition from the manual pattern

## Files Changed
- `services/access_control_metrics.py` — AccessControlMetrics
- `services/security_workflow_manager.py` — SecurityWorkflowManager
- `services/feature_flags.py` — FeatureFlags
- `services/autoresearch/store.py` — ExperimentStore, ResearchCheckpointGate, ApprovalGate
- `services/autoresearch/auto_research_agent.py` — AutoResearchAgent
- `services/skill_management/skill_metrics.py` — SkillMetrics (sync→async redis calls)
- `services/skill_management/skill_feedback.py` — SkillFeedbackAnalyzer
- `services/knowledge/org_knowledge_config.py` — OrgKnowledgeConfigService

## Behavioral grep audit
Before:
```bash
$ grep -rn "def _get_redis\|self\._redis = None\|self\._redis_client = None" autobot-backend/services/ --include="*.py" | grep -v __pycache__
# 9+ hits across the 8 files
```
After:
```bash
$ grep -rn "def _get_redis\|self\._redis = None\|self\._redis_client = None" autobot-backend/services/ --include="*.py" | grep -v __pycache__
# 0 hits in all migrated files
```

## Test plan
- [ ] `python3 -m py_compile` passes for all 8 modified files ✅
- [ ] No `_get_redis` or `self._redis = None` patterns remain in migrated files ✅

Closes #5946