### PR TITLE
feat(composables): add AbortController race protection to 7 fetchWithAuth composables (#5944)

### DIFF
--- a/autobot-frontend/src/composables/useBackgroundTask.ts
+++ b/autobot-frontend/src/composables/useBackgroundTask.ts
@@ -13,7 +13,7 @@
  * Author: mrveiss
  */
 
-import { ref, type Ref } from 'vue'
+import { ref, onUnmounted, type Ref } from 'vue'
 import appConfig from '@/config/AppConfig.js'
 import { getConfig } from '@/config/ssot-config'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
@@ -50,11 +50,11 @@ async function getBackendUrl(): Promise<string> {
  * Clear stuck tasks for a given endpoint.
  * Shared helper used by both 409 recovery and orphan auto-retry.
  */
-async function clearStuckTasks(clearUrl: string): Promise<void> {
+async function clearStuckTasks(clearUrl: string, signal?: AbortSignal): Promise<void> {
   const backendUrl = await getBackendUrl()
   await fetchWithAuth(
     `${backendUrl}${clearUrl}?force=true`,
-    { method: 'POST' },
+    { method: 'POST', signal },
   )
 }
 
@@ -91,6 +91,10 @@ export function useBackgroundTask(baseUrl: string, clearStuckUrl?: string) {
 
   const resolvedClearUrl = clearStuckUrl ?? `${baseUrl}/tasks/clear-stuck`
 
+  // AbortControllers for in-flight requests
+  let _startController: AbortController | null = null
+  let _pollController: AbortController | null = null
+
   /**
    * POST to start the analysis, then poll until done.
    * Handles 409 conflict and orphaned tasks by auto-clearing and retrying once.
@@ -109,6 +113,10 @@ export function useBackgroundTask(baseUrl: string, clearStuckUrl?: string) {
       return false
     }
 
+    _startController?.abort()
+    _startController = new AbortController()
+    const signal = _startController.signal
+
     running.value = true
     progress.value = 0
     currentStep.value = null
@@ -117,7 +125,7 @@ export function useBackgroundTask(baseUrl: string, clearStuckUrl?: string) {
     result.value = null
 
     try {
-      const fetchOpts: RequestInit = { method: 'POST' }
+      const fetchOpts: RequestInit = { method: 'POST', signal }
       if (body) {
         fetchOpts.headers = { 'Content-Type': 'application/json' }
         fetchOpts.body = JSON.stringify(body)
@@ -132,7 +140,7 @@ export function useBackgroundTask(baseUrl: string, clearStuckUrl?: string) {
       // Auto-clear stuck tasks on 409 and retry once
       if (response.status === 409 && resolvedClearUrl) {
         logger.info('Task conflict (409), clearing stuck tasks…')
-        await clearStuckTasks(resolvedClearUrl)
+        await clearStuckTasks(resolvedClearUrl, signal)
         response = await postAnalyze(baseUrl, qs, fetchOpts)
       }
 
@@ -160,8 +168,16 @@ export function useBackgroundTask(baseUrl: string, clearStuckUrl?: string) {
         error.value = null
         progress.value = 0
 
-        await clearStuckTasks(resolvedClearUrl)
-        const retryResp = await postAnalyze(baseUrl, qs, fetchOpts)
+        // Check abort before retry
+        if (signal.aborted) return false
+
+        await clearStuckTasks(resolvedClearUrl, signal)
+        const retryOpts: RequestInit = { method: 'POST', signal }
+        if (body) {
+          retryOpts.headers = { 'Content-Type': 'application/json' }
+          retryOpts.body = JSON.stringify(body)
+        }
+        const retryResp = await postAnalyze(baseUrl, qs, retryOpts)
         if (!retryResp.ok) {
           throw new Error(`Retry failed: ${retryResp.statusText}`)
         }
@@ -176,6 +192,10 @@ export function useBackgroundTask(baseUrl: string, clearStuckUrl?: string) {
 
       return !error.value
     } catch (e: unknown) {
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        running.value = false
+        return false
+      }
       error.value = e instanceof Error ? e.message : String(e)
       logger.error('Background task start failed:', e)
       running.value = false
@@ -194,6 +214,10 @@ export function useBackgroundTask(baseUrl: string, clearStuckUrl?: string) {
     let consecutiveErrors = 0
     let resolved = false
 
+    _pollController?.abort()
+    _pollController = new AbortController()
+    const pollSignal = _pollController.signal
+
     type PollResult = { done: boolean; outcome: 'completed' | 'failed' | 'orphaned' | 'error' | 'running' }
 
     return new Promise<'completed' | 'failed' | 'orphaned' | 'error'>((resolve) => {
@@ -205,7 +229,10 @@ export function useBackgroundTask(baseUrl: string, clearStuckUrl?: string) {
         async () => {
           try {
             const backendUrl = await getBackendUrl()
-            const resp = await fetchWithAuth(`${backendUrl}${baseUrl}/status/${id}`)
+            const resp = await fetchWithAuth(
+              `${backendUrl}${baseUrl}/status/${id}`,
+              { signal: pollSignal },
+            )
             if (!resp.ok) throw new Error(`Status ${resp.status}`)
 
             const data: TaskStatus = await resp.json()
@@ -235,6 +262,10 @@ export function useBackgroundTask(baseUrl: string, clearStuckUrl?: string) {
 
             return { done: false, outcome: 'running' }
           } catch (e: unknown) {
+            if (e instanceof DOMException && e.name === 'AbortError') {
+              running.value = false
+              return { done: true, outcome: 'error' }
+            }
             consecutiveErrors++
             const msg = e instanceof Error ? e.message : String(e)
             logger.warn(`Poll error (${consecutiveErrors}/${MAX_CONSECUTIVE_ERRORS}): ${msg}`)
@@ -269,6 +300,11 @@ export function useBackgroundTask(baseUrl: string, clearStuckUrl?: string) {
     taskId.value = null
     taskStatus.value = null
   }
+
+  onUnmounted(() => {
+    _startController?.abort()
+    _pollController?.abort()
+  })
 
   return {
     running,

--- a/autobot-frontend/src/composables/useMultiModelCompare.ts
+++ b/autobot-frontend/src/composables/useMultiModelCompare.ts
@@ -11,7 +11,7 @@
  *   const { responses, selectedModels, isComparing, compare, reset } = useMultiModelCompare()
  */
 
-import { ref, type Ref } from 'vue'
+import { ref, onUnmounted, type Ref } from 'vue'
 import { getBackendUrl, getApiBase } from '@/config/ssot-config'
 import { getAuthToken } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
@@ -75,6 +75,7 @@ export function useMultiModelCompare(): UseMultiModelCompareReturn {
   const responses = ref<Map<string, ModelResponse>>(new Map())
   const selectedModels = ref<string[]>(loadStoredModels())
   const isComparing = ref(false)
+  let compareController: AbortController | null = null
 
   // Persist selected models whenever they change (caller is responsible for
   // updating selectedModels; we expose a watcher-free API for simplicity)
@@ -83,6 +84,8 @@ export function useMultiModelCompare(): UseMultiModelCompareReturn {
   }
 
   function reset(): void {
+    compareController?.abort()
+    compareController = null
     responses.value = new Map()
     isComparing.value = false
   }
@@ -94,6 +97,9 @@ export function useMultiModelCompare(): UseMultiModelCompareReturn {
     _persistModels()
     reset()
     isComparing.value = true
+
+    compareController = new AbortController()
+    const signal = compareController.signal
 
     // Initialise placeholders so the UI can render empty cards immediately
     const initial = new Map<string, ModelResponse>()
@@ -113,8 +119,13 @@ export function useMultiModelCompare(): UseMultiModelCompareReturn {
         method: 'POST',
         headers,
         body: JSON.stringify({ prompt, models: targetModels }),
+        signal,
       })
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        isComparing.value = false
+        return
+      }
       logger.error('compare fetch failed:', err)
       for (const m of targetModels) {
         responses.value.set(m, { content: '', done: true, error: String(err) })
@@ -177,12 +188,17 @@ export function useMultiModelCompare(): UseMultiModelCompareReturn {
         }
       }
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return
       logger.error('compare stream read error:', err)
     } finally {
       reader.releaseLock()
       isComparing.value = false
     }
   }
+
+  onUnmounted(() => {
+    compareController?.abort()
+  })
 
   return { responses, selectedModels, isComparing, compare, reset }
 }

--- a/autobot-frontend/src/composables/usePatternAnalysis.ts
+++ b/autobot-frontend/src/composables/usePatternAnalysis.ts
@@ -8,7 +8,7 @@
  * Author: mrveiss
  */
 
-import { ref, computed } from 'vue'
+import { ref, computed, onUnmounted } from 'vue'
 import { usePollingJob } from '@/composables/usePollingJob'
 import { useExpansion } from '@/composables/useExpansion'
 import appConfig from '@/config/AppConfig.js'
@@ -178,6 +178,11 @@ export function usePatternAnalysis() {
   const refactoringSuggestions = ref<RefactoringSuggestion[]>([])
   const storageStats = ref<PatternStorageStats | null>(null)
 
+  // AbortControllers — replaced (aborting previous) before each new fetch
+  let _analyzeController: AbortController | null = null
+  let _actionController: AbortController | null = null
+  let _pollController: AbortController | null = null
+
   // UI state
   type Section = 'duplicates' | 'regex' | 'complexity' | 'refactoring'
   const { isExpanded: isSectionExpanded, toggle: toggleSection } = useExpansion<Section>()
@@ -232,6 +237,10 @@ export function usePatternAnalysis() {
     error.value = null
     wasInterrupted.value = false
 
+    _analyzeController?.abort()
+    _analyzeController = new AbortController()
+    const _analyzeSignal = _analyzeController.signal
+
     try {
       const backendUrl = await getBackendUrl()
       let response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/analyze`, {
@@ -244,7 +253,8 @@ export function usePatternAnalysis() {
           enable_duplicate_detection: enableDuplicates,
           similarity_threshold: similarityThreshold,
           run_in_background: runInBackground
-        })
+        }),
+        signal: _analyzeSignal,
       })
 
       // Issue #647: Handle 409 Conflict by clearing stuck tasks and retrying
@@ -253,7 +263,8 @@ export function usePatternAnalysis() {
 
         // Try to clear stuck tasks with force=true
         const clearResponse = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/tasks/clear-stuck?force=true`, {
-          method: 'POST'
+          method: 'POST',
+          signal: _analyzeSignal,
         })
 
         if (clearResponse.ok) {
@@ -271,7 +282,8 @@ export function usePatternAnalysis() {
               enable_duplicate_detection: enableDuplicates,
               similarity_threshold: similarityThreshold,
               run_in_background: runInBackground
-            })
+            }),
+            signal: _analyzeSignal,
           })
         }
       }
@@ -302,7 +314,7 @@ export function usePatternAnalysis() {
 
           await fetchWithAuth(
             `${backendUrl}/api/analytics/codebase/patterns/tasks/clear-stuck?force=true`,
-            { method: 'POST' },
+            { method: 'POST', signal: _analyzeSignal },
           )
           const retryResp = await fetchWithAuth(
             `${backendUrl}/api/analytics/codebase/patterns/analyze`,
@@ -317,6 +329,7 @@ export function usePatternAnalysis() {
                 similarity_threshold: similarityThreshold,
                 run_in_background: true,
               }),
+              signal: _analyzeSignal,
             },
           )
           if (retryResp.ok) {
@@ -341,6 +354,7 @@ export function usePatternAnalysis() {
 
       throw new Error('Unexpected response format')
     } catch (e: unknown) {
+      if (e instanceof DOMException && e.name === 'AbortError') { analyzing.value = false; return false }
       error.value = extractErrorMessage(e, 'Analysis failed')
       logger.error('Pattern analysis failed:', e)
       analyzing.value = false
@@ -376,8 +390,11 @@ export function usePatternAnalysis() {
         async () => {
           try {
             const backendUrl = await getBackendUrl()
+            _pollController?.abort()
+            _pollController = new AbortController()
             const response = await fetchWithAuth(
-              `${backendUrl}/api/analytics/codebase/patterns/status/${taskId}`
+              `${backendUrl}/api/analytics/codebase/patterns/status/${taskId}`,
+              { signal: _pollController.signal },
             )
             if (!response.ok) {
               throw new Error(`Status check failed: ${response.statusText}`)
@@ -448,6 +465,10 @@ export function usePatternAnalysis() {
 
             return { done: false, outcome: 'running' }
           } catch (e: unknown) {
+            if (e instanceof DOMException && e.name === 'AbortError') {
+              analyzing.value = false
+              return { done: true, outcome: 'error' }
+            }
             consecutiveErrors++
             const msg = extractErrorMessage(e, 'Unknown poll error')
             logger.warn(
@@ -480,8 +501,13 @@ export function usePatternAnalysis() {
    */
   const getCachedSummary = async (): Promise<boolean> => {
     try {
+      _actionController?.abort()
+      _actionController = new AbortController()
       const backendUrl = await getBackendUrl()
-      const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/cached-summary`)
+      const response = await fetchWithAuth(
+        `${backendUrl}/api/analytics/codebase/patterns/cached-summary`,
+        { signal: _actionController.signal },
+      )
 
       if (!response.ok) {
         return false
@@ -513,6 +539,7 @@ export function usePatternAnalysis() {
       }
       return false
     } catch (e: unknown) {
+      if (e instanceof DOMException && e.name === 'AbortError') return false
       logger.debug('Cached summary not available:', extractErrorMessage(e, 'unknown'))
       return false
     }
@@ -586,7 +613,12 @@ export function usePatternAnalysis() {
       })
       if (path) params.append('path', path)
 
-      const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/duplicates?${params}`)
+      _actionController?.abort()
+      _actionController = new AbortController()
+      const response = await fetchWithAuth(
+        `${backendUrl}/api/analytics/codebase/patterns/duplicates?${params}`,
+        { signal: _actionController.signal },
+      )
 
       if (!response.ok) {
         throw new Error(`Duplicates fetch failed: ${response.statusText}`)
@@ -597,6 +629,7 @@ export function usePatternAnalysis() {
         duplicatePatterns.value = data.duplicates || []
       }
     }).catch((e: unknown) => {
+      if (e instanceof DOMException && e.name === 'AbortError') return
       error.value = extractErrorMessage(e, 'Duplicates fetch failed')
       logger.error('Duplicate patterns fetch failed:', e)
     })
@@ -615,7 +648,12 @@ export function usePatternAnalysis() {
       const params = new URLSearchParams({ limit: limit.toString() })
       if (path) params.append('path', path)
 
-      const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/regex-opportunities?${params}`)
+      _actionController?.abort()
+      _actionController = new AbortController()
+      const response = await fetchWithAuth(
+        `${backendUrl}/api/analytics/codebase/patterns/regex-opportunities?${params}`,
+        { signal: _actionController.signal },
+      )
 
       if (!response.ok) {
         throw new Error(`Regex opportunities fetch failed: ${response.statusText}`)
@@ -626,6 +664,7 @@ export function usePatternAnalysis() {
         regexOpportunities.value = data.opportunities || []
       }
     }).catch((e: unknown) => {
+      if (e instanceof DOMException && e.name === 'AbortError') return
       error.value = extractErrorMessage(e, 'Regex opportunities fetch failed')
       logger.error('Regex opportunities fetch failed:', e)
     })
@@ -648,7 +687,12 @@ export function usePatternAnalysis() {
       })
       if (path) params.append('path', path)
 
-      const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/complexity-hotspots?${params}`)
+      _actionController?.abort()
+      _actionController = new AbortController()
+      const response = await fetchWithAuth(
+        `${backendUrl}/api/analytics/codebase/patterns/complexity-hotspots?${params}`,
+        { signal: _actionController.signal },
+      )
 
       if (!response.ok) {
         throw new Error(`Complexity hotspots fetch failed: ${response.statusText}`)
@@ -659,6 +703,7 @@ export function usePatternAnalysis() {
         complexityHotspots.value = data.hotspots || []
       }
     }).catch((e: unknown) => {
+      if (e instanceof DOMException && e.name === 'AbortError') return
       error.value = extractErrorMessage(e, 'Complexity hotspots fetch failed')
       logger.error('Complexity hotspots fetch failed:', e)
     })
@@ -677,7 +722,12 @@ export function usePatternAnalysis() {
       const params = new URLSearchParams({ max_suggestions: maxSuggestions.toString() })
       if (path) params.append('path', path)
 
-      const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/refactoring-suggestions?${params}`)
+      _actionController?.abort()
+      _actionController = new AbortController()
+      const response = await fetchWithAuth(
+        `${backendUrl}/api/analytics/codebase/patterns/refactoring-suggestions?${params}`,
+        { signal: _actionController.signal },
+      )
 
       if (!response.ok) {
         throw new Error(`Refactoring suggestions fetch failed: ${response.statusText}`)
@@ -688,6 +738,7 @@ export function usePatternAnalysis() {
         refactoringSuggestions.value = data.suggestions || []
       }
     }).catch((e: unknown) => {
+      if (e instanceof DOMException && e.name === 'AbortError') return
       error.value = extractErrorMessage(e, 'Refactoring suggestions fetch failed')
       logger.error('Refactoring suggestions fetch failed:', e)
     })
@@ -699,7 +750,12 @@ export function usePatternAnalysis() {
   const getStorageStats = async (): Promise<void> => {
     await wrap(async () => {
       const backendUrl = await getBackendUrl()
-      const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/storage/stats`)
+      _actionController?.abort()
+      _actionController = new AbortController()
+      const response = await fetchWithAuth(
+        `${backendUrl}/api/analytics/codebase/patterns/storage/stats`,
+        { signal: _actionController.signal },
+      )
 
       if (!response.ok) {
         throw new Error(`Storage stats fetch failed: ${response.statusText}`)
@@ -710,6 +766,7 @@ export function usePatternAnalysis() {
         storageStats.value = data.stats
       }
     }).catch((e: unknown) => {
+      if (e instanceof DOMException && e.name === 'AbortError') return
       logger.error('Storage stats fetch failed:', e)
     })
   }
@@ -720,8 +777,11 @@ export function usePatternAnalysis() {
   const clearStorage = async (): Promise<boolean> => {
     return wrap(async () => {
       const backendUrl = await getBackendUrl()
+      _actionController?.abort()
+      _actionController = new AbortController()
       const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/storage/clear`, {
-        method: 'DELETE'
+        method: 'DELETE',
+        signal: _actionController.signal,
       })
 
       if (!response.ok) {
@@ -735,6 +795,7 @@ export function usePatternAnalysis() {
       }
       return false
     }).catch((e: unknown) => {
+      if (e instanceof DOMException && e.name === 'AbortError') return false
       logger.error('Clear storage failed:', e)
       return false
     })
@@ -747,7 +808,12 @@ export function usePatternAnalysis() {
     return wrap(async () => {
       const backendUrl = await getBackendUrl()
       const params = path ? `?path=${encodeURIComponent(path)}` : ''
-      const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/report${params}`)
+      _actionController?.abort()
+      _actionController = new AbortController()
+      const response = await fetchWithAuth(
+        `${backendUrl}/api/analytics/codebase/patterns/report${params}`,
+        { signal: _actionController.signal },
+      )
 
       if (!response.ok) {
         throw new Error(`Report fetch failed: ${response.statusText}`)
@@ -759,6 +825,7 @@ export function usePatternAnalysis() {
       }
       return null
     }).catch((e: unknown) => {
+      if (e instanceof DOMException && e.name === 'AbortError') return null
       logger.error('Report fetch failed:', e)
       return null
     })
@@ -767,6 +834,12 @@ export function usePatternAnalysis() {
   /**
    * Reset all state
    */
+  onUnmounted(() => {
+    _analyzeController?.abort()
+    _actionController?.abort()
+    _pollController?.abort()
+  })
+
   const reset = (): void => {
     analyzing.value = false
     error.value = null
@@ -822,9 +895,11 @@ export function usePatternAnalysis() {
   const clearStuckTasks = async (force: boolean = false): Promise<{ cleared: number; message: string }> => {
     try {
       const backendUrl = await getBackendUrl()
+      _actionController?.abort()
+      _actionController = new AbortController()
       const response = await fetchWithAuth(
         `${backendUrl}/api/analytics/codebase/patterns/tasks/clear-stuck?force=${force}`,
-        { method: 'POST' }
+        { method: 'POST', signal: _actionController.signal },
       )
 
       if (!response.ok) {
@@ -835,6 +910,7 @@ export function usePatternAnalysis() {
       logger.info('Cleared stuck tasks:', result)
       return { cleared: result.cleared_count, message: result.message }
     } catch (e: unknown) {
+      if (e instanceof DOMException && e.name === 'AbortError') throw e
       logger.error('Failed to clear stuck tasks:', e)
       throw e
     }
@@ -847,7 +923,12 @@ export function usePatternAnalysis() {
   const listTasks = async (): Promise<{ total: number; running: number; tasks: AnalysisTaskEntry[] }> => {
     try {
       const backendUrl = await getBackendUrl()
-      const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/tasks`)
+      _actionController?.abort()
+      _actionController = new AbortController()
+      const response = await fetchWithAuth(
+        `${backendUrl}/api/analytics/codebase/patterns/tasks`,
+        { signal: _actionController.signal },
+      )
 
       if (!response.ok) {
         throw new Error(`Failed to list tasks: ${response.statusText}`)
@@ -855,6 +936,7 @@ export function usePatternAnalysis() {
 
       return await response.json()
     } catch (e: unknown) {
+      if (e instanceof DOMException && e.name === 'AbortError') throw e
       logger.error('Failed to list tasks:', e)
       throw e
     }

--- a/autobot-frontend/src/composables/useToolApproval.ts
+++ b/autobot-frontend/src/composables/useToolApproval.ts
@@ -62,6 +62,7 @@ export interface UseToolApprovalReturn {
 export function useToolApproval(): UseToolApprovalReturn {
   const pendingToolApproval = ref<PendingToolApproval | null>(null)
   const submittingApproval = ref(false)
+  let submitController: AbortController | null = null
 
   // Subscribe to the global channel for APPROVAL_REQUIRED events (#4952).
   // The agent loop publishes on the global channel with EventType.APPROVAL_REQUIRED
@@ -92,6 +93,8 @@ export function useToolApproval(): UseToolApprovalReturn {
       logger.warn('submitToolApproval called with no pending approval')
       return
     }
+    submitController?.abort()
+    submitController = new AbortController()
     submittingApproval.value = true
     try {
       const url = await appConfig.getApiUrl(
@@ -106,6 +109,7 @@ export function useToolApproval(): UseToolApprovalReturn {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
+        signal: submitController.signal,
       })
       if (!response.ok) {
         const text = await response.text().catch(() => '')
@@ -114,6 +118,7 @@ export function useToolApproval(): UseToolApprovalReturn {
       logger.debug('Tool approval submitted', { approval_id: approval.approval_id, approved })
       pendingToolApproval.value = null
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return
       logger.error('Failed to submit tool approval:', err)
       throw err
     } finally {
@@ -128,7 +133,10 @@ export function useToolApproval(): UseToolApprovalReturn {
   // Auto-cleanup on component unmount
   const instance = getCurrentInstance()
   if (instance) {
-    onUnmounted(() => unsub())
+    onUnmounted(() => {
+      unsub()
+      submitController?.abort()
+    })
   } else {
     logger.warn('useToolApproval: not inside a Vue component, cleanup must be manual')
   }

--- a/autobot-frontend/src/composables/useVoiceConversation.ts
+++ b/autobot-frontend/src/composables/useVoiceConversation.ts
@@ -67,6 +67,8 @@ let _sileroVad: any = null
 let _whisperFallback = false // #1329: true when browser STT unavailable (airgapped)
 let _fallbackRecorder: MediaRecorder | null = null
 let _fallbackStream: MediaStream | null = null
+// AbortController for transcription requests — aborts in-flight call when new recording starts.
+let _transcribeController: AbortController | null = null
 
 // Issue #1371: Cooldown timer to prevent TTS echo from triggering VAD
 let _ttsCooldownTimer: ReturnType<typeof setTimeout> | null = null
@@ -347,6 +349,7 @@ async function _startWhisperFallback(): Promise<void> {
           }
         })
         .catch((err) => {
+          if (err instanceof DOMException && err.name === 'AbortError') { state.value = 'idle'; return }
           logger.error('Whisper fallback transcription error:', err)
           errorMessage.value = 'Transcription failed. Try again.'
           state.value = 'idle'
@@ -626,9 +629,12 @@ async function _transcribeAudioWithLanguage(
   form.append('audio', blob, filename)
   const lang = _getShortLanguage()
   if (lang) form.append('language', lang)
+  _transcribeController?.abort()
+  _transcribeController = new AbortController()
   const res = await fetchWithAuth(`${getApiBase()}/voice/transcribe`, {
     method: 'POST',
     body: form,
+    signal: _transcribeController.signal,
   })
   if (!res.ok) {
     logger.warn('Transcribe failed:', res.status)
@@ -722,6 +728,7 @@ function _handleVadSpeechEnd(audio: Float32Array): void {
       _dispatchTranscript(text)
     })
     .catch((err) => {
+      if (err instanceof DOMException && err.name === 'AbortError') { state.value = 'idle'; return }
       logger.error('Hands-free transcription error:', err)
       errorMessage.value = 'Transcription failed. Try again.'
       state.value = 'idle'

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -42,6 +42,10 @@ let _ttsWsConnecting: Promise<WebSocket> | null = null
 let _ttsWsIdleTimer: ReturnType<typeof setTimeout> | null = null
 const _TTS_WS_IDLE_TIMEOUT = 30_000
 
+// AbortController for the current in-flight speak() HTTP request.
+// Module-level so a new speak() call can abort the previous one.
+let _speakController: AbortController | null = null
+
 function _getOrCreateContext(): AudioContext {
   if (!_audioContext) {
     _audioContext = new AudioContext()
@@ -247,6 +251,10 @@ export function useVoiceOutput() {
     if ((!force && !voiceOutputEnabled.value) || !text.trim()) return
     if (isSpeaking.value) _stopCurrentAudio()
 
+    _speakController?.abort()
+    _speakController = new AbortController()
+    const signal = _speakController.signal
+
     try {
       const { effectiveVoiceId } = useVoiceProfiles()
       const { language: prefLang } = usePreferences()
@@ -262,6 +270,7 @@ export function useVoiceOutput() {
       const response = await fetchWithAuth(`${getApiBase()}/voice/synthesize`, {
         method: 'POST',
         body: formData,
+        signal,
       })
       if (!response.ok) {
         logger.warn('TTS synthesize failed:', response.status)
@@ -273,6 +282,7 @@ export function useVoiceOutput() {
       // Issue #1146: clear isSpeaking so watch(isSpeaking) in useVoiceConversation fires
       isSpeaking.value = false
     } catch (e) {
+      if (e instanceof DOMException && (e as DOMException).name === 'AbortError') return
       logger.error('speak() error:', e)
       isSpeaking.value = false
     }

--- a/autobot-frontend/src/composables/useVoiceProfiles.ts
+++ b/autobot-frontend/src/composables/useVoiceProfiles.ts
@@ -50,11 +50,22 @@ const effectiveVoiceId = computed<string>(() => {
   return selectedVoiceId.value
 })
 
+// Module-level controllers — singleton state shared across all instances.
+// Each controller is replaced (aborting the previous) before a new call.
+// No onUnmounted is used because the singleton outlives individual components.
+let _fetchVoicesController: AbortController | null = null
+let _createVoiceController: AbortController | null = null
+let _deleteVoiceController: AbortController | null = null
+let _fetchPersonalityController: AbortController | null = null
+
 export function useVoiceProfiles() {
   async function fetchVoices(): Promise<void> {
     error.value = null
+    _fetchVoicesController?.abort()
+    _fetchVoicesController = new AbortController()
+    const signal = _fetchVoicesController.signal
     await wrap(async () => {
-      const res = await fetchWithAuth(`${getApiBase()}/voice/voices`)
+      const res = await fetchWithAuth(`${getApiBase()}/voice/voices`, { signal })
       if (!res.ok) {
         error.value = `Failed to fetch voices: ${res.status}`
         return
@@ -62,6 +73,7 @@ export function useVoiceProfiles() {
       const data = await res.json()
       voices.value = Array.isArray(data) ? data : (data.voices || [])
     }).catch((e) => {
+      if (e instanceof DOMException && e.name === 'AbortError') return
       logger.error('fetchVoices error:', e)
       error.value = String(e)
     })
@@ -79,6 +91,9 @@ export function useVoiceProfiles() {
     filename: string,
   ): Promise<boolean> {
     error.value = null
+    _createVoiceController?.abort()
+    _createVoiceController = new AbortController()
+    const signal = _createVoiceController.signal
     return wrap(async () => {
       const formData = new FormData()
       formData.append('name', name)
@@ -86,6 +101,7 @@ export function useVoiceProfiles() {
       const res = await fetchWithAuth(`${getApiBase()}/voice/voices/create`, {
         method: 'POST',
         body: formData,
+        signal,
       })
       if (!res.ok) {
         const body = await res.text()
@@ -95,6 +111,7 @@ export function useVoiceProfiles() {
       await fetchVoices()
       return true
     }).catch((e) => {
+      if (e instanceof DOMException && e.name === 'AbortError') return false
       logger.error('createVoice error:', e)
       error.value = String(e)
       return false
@@ -103,9 +120,13 @@ export function useVoiceProfiles() {
 
   async function deleteVoice(voiceId: string): Promise<boolean> {
     error.value = null
+    _deleteVoiceController?.abort()
+    _deleteVoiceController = new AbortController()
+    const signal = _deleteVoiceController.signal
     return wrap(async () => {
       const res = await fetchWithAuth(`${getApiBase()}/voice/voices/${voiceId}`, {
         method: 'DELETE',
+        signal,
       })
       if (!res.ok) {
         error.value = `Delete voice failed: ${res.status}`
@@ -117,6 +138,7 @@ export function useVoiceProfiles() {
       await fetchVoices()
       return true
     }).catch((e) => {
+      if (e instanceof DOMException && e.name === 'AbortError') return false
       logger.error('deleteVoice error:', e)
       error.value = String(e)
       return false
@@ -129,8 +151,11 @@ export function useVoiceProfiles() {
   }
 
   async function fetchPersonalityVoice(): Promise<void> {
+    _fetchPersonalityController?.abort()
+    _fetchPersonalityController = new AbortController()
+    const signal = _fetchPersonalityController.signal
     try {
-      const res = await fetchWithAuth(`${getApiBase()}/personality/active`)
+      const res = await fetchWithAuth(`${getApiBase()}/personality/active`, { signal })
       if (res.ok) {
         const profile = await res.json()
         personalityVoiceId.value = profile?.voice_id ?? ''
@@ -139,7 +164,8 @@ export function useVoiceProfiles() {
         personalityVoiceId.value = ''
         personalityVoiceIds.value = {}
       }
-    } catch {
+    } catch (e) {
+      if (e instanceof DOMException && (e as DOMException).name === 'AbortError') return
       personalityVoiceId.value = ''
       personalityVoiceIds.value = {}
     }


### PR DESCRIPTION
Adds AbortController + signal to 7 composables using bare fetchWithAuth calls, providing lifecycle teardown and race condition protection. Closes #5944.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)