### PR TITLE
refact(api): add named schemas for 12 agent/auth/chat endpoints (#5985)

### DIFF
--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -37,7 +37,7 @@ from utils.chat_exceptions import InternalError, SubprocessError
 from utils.response_helpers import create_success_response, handle_ai_stack_error
 
 from api.schemas_common import AgentMessageResponse, DataResponse
-from api.schemas_agent import AgentCommandApprovalResponse, AgentHealthResponse
+from api.schemas_agent import AgentCommandApprovalResponse, AgentCommandExecuteResponse, AgentHealthResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -1011,7 +1011,7 @@ async def command_approval(
     operation="execute_command",
     error_code_prefix="AGENT",
 )
-@router.post("/execute_command", response_model=None)
+@router.post("/execute_command", response_model=AgentCommandExecuteResponse)
 async def execute_command(
     request: Request,
     command_data: dict,

--- a/autobot-backend/api/agent_terminal.py
+++ b/autobot-backend/api/agent_terminal.py
@@ -238,6 +238,12 @@ from autobot_shared.redis_client import get_redis_client
 from services.agent_terminal import AgentSessionState, AgentTerminalService
 from services.command_approval_manager import AgentRole
 from services.command_execution_queue import get_command_queue
+from api.schemas_agent import (
+    AgentTerminalApproveResponse,
+    AgentTerminalExecuteResponse,
+    AgentTerminalInterruptResponse,
+    AgentTerminalResumeResponse,
+)
 from api.schemas_terminal import (
     AgentTerminalCommandStateResponse,
     AgentTerminalHostSelectionCancelResponse,
@@ -582,7 +588,7 @@ async def delete_agent_terminal_session(
     operation="execute_agent_command",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/execute", response_model=None)
+@router.post("/execute", response_model=AgentTerminalExecuteResponse)
 async def execute_agent_command(
     current_user: dict = Depends(get_current_user),
     session_id: str = None,
@@ -625,7 +631,7 @@ async def execute_agent_command(
     operation="approve_agent_command",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/approve", response_model=None)
+@router.post("/sessions/{session_id}/approve", response_model=AgentTerminalApproveResponse)
 async def approve_agent_command(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -715,7 +721,7 @@ async def submit_tool_approval(
     operation="interrupt_agent_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/interrupt", response_model=None)
+@router.post("/sessions/{session_id}/interrupt", response_model=AgentTerminalInterruptResponse)
 async def interrupt_agent_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),
@@ -751,7 +757,7 @@ async def interrupt_agent_session(
     operation="resume_agent_session",
     error_code_prefix="AGENT_TERMINAL",
 )
-@router.post("/sessions/{session_id}/resume", response_model=None)
+@router.post("/sessions/{session_id}/resume", response_model=AgentTerminalResumeResponse)
 async def resume_agent_session(
     session_id: str,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -22,6 +22,7 @@ from autobot_shared.ssot_config import config as ssot_config
 from constants.error_constants import ERR_INVALID_CREDENTIALS, ERR_INVALID_TOKEN
 from user_management.database import db_session_context
 from user_management.services.user_service import UserService
+from api.schemas_agent import AuthCheckResponse, AuthPermissionResponse, AuthUserInfoResponse
 from api.schemas_common import DataResponse
 
 router = APIRouter()
@@ -373,7 +374,7 @@ async def logout(request: Request, logout_data: LogoutRequest):
     operation="get_current_user_info",
     error_code_prefix="AUTH",
 )
-@router.get("/me", response_model=None)
+@router.get("/me", response_model=AuthUserInfoResponse)
 async def get_current_user_info(request: Request):
     """
     Get current authenticated user information.
@@ -427,7 +428,7 @@ async def get_current_user_info(request: Request):
     operation="check_authentication",
     error_code_prefix="AUTH",
 )
-@router.get("/check", response_model=None)
+@router.get("/check", response_model=AuthCheckResponse)
 async def check_authentication(request: Request):
     """
     Quick authentication check endpoint.
@@ -476,7 +477,7 @@ async def check_authentication(request: Request):
     operation="check_permission",
     error_code_prefix="AUTH",
 )
-@router.get("/permissions/{operation}", response_model=None)
+@router.get("/permissions/{operation}", response_model=AuthPermissionResponse)
 async def check_permission(request: Request, operation: str):
     """
     Check if current user has permission for specific operation

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -1375,7 +1375,7 @@ def _build_delete_session_response(
     operation="delete_session",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.delete("/chat/sessions/{session_id}", response_model=None)
+@router.delete("/chat/sessions/{session_id}", response_model=DataResponse)
 async def delete_session(
     session_id: str,
     request: Request,

--- a/autobot-backend/api/llm.py
+++ b/autobot-backend/api/llm.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.schemas_agent import (
+    LLMConfigResponse,
     LLMConnectionTestResponse,
     LLMCurrentResponse,
     LLMEmbeddingModelsResponse,
@@ -55,7 +56,7 @@ def _get_llm_interface():
     operation="get_llm_config",
     error_code_prefix="LLM",
 )
-@router.get("/config", response_model=None)
+@router.get("/config", response_model=LLMConfigResponse)
 async def get_llm_config(
     current_user: dict = Depends(get_current_user),
 ):

--- a/autobot-backend/api/logs.py
+++ b/autobot-backend/api/logs.py
@@ -15,12 +15,13 @@ import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 import aiofiles
 from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket
 from fastapi.responses import StreamingResponse
 
+from api.schemas_agent import LogFileMetadata
 from api.schemas_common import AgentMessageResponse
 from api.schemas_code import (
     LogContainerResponse,
@@ -530,7 +531,7 @@ async def get_recent_logs(
     operation="list_logs",
     error_code_prefix="LOGS",
 )
-@router.get("/list", response_model=None)
+@router.get("/list", response_model=List[LogFileMetadata])
 async def list_logs(
     admin_check: bool = Depends(check_admin_permission),
 ) -> List[Metadata]:

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -711,5 +711,113 @@ class HealthResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# auth.py schemas  (Issue #5985)
+# ---------------------------------------------------------------------------
+
+
+class AuthUserInfoResponse(BaseModel):
+    """Response for GET /auth/me."""
+
+    username: str
+    role: str
+    email: str
+    auth_method: str
+    authenticated: bool
+    deployment_mode: str
+
+
+class AuthCheckResponse(BaseModel):
+    """Response for GET /auth/check."""
+
+    authenticated: bool
+    role: Optional[str] = None
+    auth_enabled: bool
+    deployment_mode: Optional[str] = None
+    error: Optional[str] = None
+
+
+class AuthPermissionResponse(BaseModel):
+    """Response for GET /auth/permissions/{operation}."""
+
+    permitted: bool
+    operation: str
+    user_role: Optional[str] = None
+    username: Optional[str] = None
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# agent_terminal.py schemas  (Issue #5985)
+# ---------------------------------------------------------------------------
+
+
+class AgentTerminalExecuteResponse(BaseModel):
+    """Response for POST /agent-terminal/execute — shape varies, extra fields allowed."""
+
+    model_config = {"extra": "allow"}
+    status: str
+
+
+class AgentTerminalApproveResponse(BaseModel):
+    """Response for POST /agent-terminal/sessions/{session_id}/approve."""
+
+    model_config = {"extra": "allow"}
+    status: str
+
+
+class AgentTerminalInterruptResponse(BaseModel):
+    """Response for POST /agent-terminal/sessions/{session_id}/interrupt."""
+
+    status: str
+    message: Optional[str] = None
+    previous_state: Optional[str] = None
+    current_state: Optional[str] = None
+    pending_approval: Optional[Any] = None
+    error: Optional[str] = None
+
+
+class AgentTerminalResumeResponse(BaseModel):
+    """Response for POST /agent-terminal/sessions/{session_id}/resume."""
+
+    status: str
+    message: Optional[str] = None
+    current_state: Optional[str] = None
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# voice.py schemas  (Issue #5985)
+# ---------------------------------------------------------------------------
+
+
+class VoiceCreateResponse(BaseModel):
+    """Response for POST /voice/voices/create — shape from tts.create_voice(), extra fields allowed."""
+
+    model_config = {"extra": "allow"}
+
+
+# ---------------------------------------------------------------------------
+# llm.py schemas  (Issue #5985)
+# ---------------------------------------------------------------------------
+
+
+class LLMConfigResponse(BaseModel):
+    """Response for GET /llm/config — provider-specific shape, extra fields allowed."""
+
+    model_config = {"extra": "allow"}
+
+
+# ---------------------------------------------------------------------------
+# logs.py schemas  (Issue #5985)
+# ---------------------------------------------------------------------------
+
+
+class LogFileMetadata(BaseModel):
+    """Single log file entry for GET /logs/list — shape from log sources, extra fields allowed."""
+
+    model_config = {"extra": "allow"}
+
+
+# ---------------------------------------------------------------------------
 # voice.py schemas  (Issue #5317)
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -9,6 +9,9 @@ import tempfile
 from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
 from fastapi.responses import JSONResponse, Response
 
+from typing import Any, Dict, List
+
+from api.schemas_agent import VoiceCreateResponse
 from api.schemas_code import (
     VoiceDeleteResponse,
     VoiceListenResponse,
@@ -217,7 +220,7 @@ async def voice_clone_api(
     operation="voice_list_api",
     error_code_prefix="VOICE",
 )
-@router.get("/voices", response_model=None)
+@router.get("/voices", response_model=List[Dict[str, Any]])
 async def voice_list_api():
     """List available voice profiles from TTS worker."""
     tts = get_tts_client()
@@ -235,7 +238,7 @@ async def voice_list_api():
     operation="voice_create_api",
     error_code_prefix="VOICE",
 )
-@router.post("/voices/create", response_model=None)
+@router.post("/voices/create", response_model=VoiceCreateResponse)
 async def voice_create_api(
     name: str = Form(...),
     audio: UploadFile = File(...),


### PR DESCRIPTION
## Summary

- Adds 10 new Pydantic schemas to `schemas_agent.py` for auth, agent-terminal, voice, LLM, and log endpoints
- Updates 8 endpoint files to use named `response_model=` instead of `None`
- 4 bypass endpoints correctly kept as `response_model=None` (audio Response, JSONResponse-delegation, StreamingResponse)

## Files changed

- `schemas_agent.py` — adds AuthUserInfoResponse, AuthCheckResponse, AuthPermissionResponse, AgentTerminalExecute/Approve/Interrupt/ResumeResponse, VoiceCreateResponse, LLMConfigResponse, LogFileMetadata
- `auth.py` — /me, /check, /permissions/{op}
- `agent.py` — /execute_command
- `agent_terminal.py` — /execute, /sessions/{id}/approve, /sessions/{id}/interrupt, /sessions/{id}/resume
- `voice.py` — /voices (List[Dict]), /voices/create
- `llm.py` — /config
- `logs.py` — /list
- `chat_sessions.py` — DELETE /sessions/{id}

## Test Plan

- [x] `py_compile` passes on all 8 modified files
- [x] `schemas_agent` importable (NameError check)
- [x] `check_response_models.py` lint hook: 0 violations
- [x] Audio bypass (/synthesize, /clone-voice), JSONResponse bypass (/llm/status), StreamingResponse bypass (/logs/stream) correctly preserved as `response_model=None`

Closes #5985
Part of #5960

🤖 Generated with Claude Code