### PR TITLE
fix(frontend): replace 29 direct fetch() calls with fetchWithAuth (#5945)

### DIFF
--- a/autobot-frontend/src/components/agents/HeartbeatPanel.vue
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.vue
@@ -153,6 +153,7 @@
 import { computed, onUnmounted, ref, watch } from 'vue'
 
 import { getBackendUrl } from '@/config/ssot-config'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 import { useLiveEvents } from '@/composables/useLiveEvents'
 import { useExpansion } from '@/composables/useExpansion'
@@ -271,11 +272,9 @@ function apiBase(): string {
 }
 
 async function apiFetch(path: string, init?: RequestInit): Promise<unknown> {
-  const token = localStorage.getItem('access_token')
-  const resp = await fetch(`${apiBase()}${path}`, {
+  const resp = await fetchWithAuth(`${apiBase()}${path}`, {
     headers: {
       'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
     ...init,
   })

--- a/autobot-frontend/src/components/examples/AsyncOperationExample.vue
+++ b/autobot-frontend/src/components/examples/AsyncOperationExample.vue
@@ -643,6 +643,7 @@ import { ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 import { useAsyncOperation, createAsyncOperations } from '@/composables/useAsyncOperation'
 import { networkConfig } from '@/constants/network.ts'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
 
 const logger = createLogger('AsyncOperationExample')
 
@@ -658,7 +659,7 @@ const health = useAsyncOperation({
 })
 
 const checkHealth = () => health.execute(async () => {
-  const response = await fetch(`${BACKEND_URL}/api/health`)
+  const response = await fetchWithAuth(`${BACKEND_URL}/api/health`)
   return response.json()
 })
 
@@ -682,7 +683,7 @@ const saveOp = useAsyncOperation({
 })
 
 const saveSettings = () => saveOp.execute(async () => {
-  await fetch(`${BACKEND_URL}/api/settings`, {
+  await fetchWithAuth(`${BACKEND_URL}/api/settings`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ value: settingValue.value })
@@ -707,7 +708,7 @@ const validateOp = useAsyncOperation({
 })
 
 const validateConfig = () => validateOp.execute(async () => {
-  const response = await fetch(`${BACKEND_URL}/api/validate`)
+  const response = await fetchWithAuth(`${BACKEND_URL}/api/validate`)
   if (!response.ok) throw new Error('Validation failed')
   return response.json()
 })
@@ -722,12 +723,12 @@ const ops = createAsyncOperations({
 })
 
 const loadUsers = () => ops.users.execute(async () => {
-  const response = await fetch(`${BACKEND_URL}/api/llm/models`)
+  const response = await fetchWithAuth(`${BACKEND_URL}/api/llm/models`)
   return response.json()
 })
 
 const loadSystemInfo = () => ops.systemInfo.execute(async () => {
-  const response = await fetch(`${BACKEND_URL}/api/system/info`)
+  const response = await fetchWithAuth(`${BACKEND_URL}/api/system/info`)
   return response.json()
 })
 
@@ -754,7 +755,7 @@ const analytics = useAsyncOperation<AnalyticsData>({
 })
 
 const loadAnalytics = () => analytics.execute(async () => {
-  const response = await fetch(`${BACKEND_URL}/api/analytics`)
+  const response = await fetchWithAuth(`${BACKEND_URL}/api/analytics`)
   const rawData = await response.json()
 
   // Transform data inline - composable handles state management

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -1013,7 +1013,7 @@ const loadSecrets = async () => {
       secretsApiClient.getSecrets({}) as Promise<Record<string, any>>,
       secretsApiClient.getSecretsStats() as Promise<Record<string, any>>,
       // Also fetch legacy hosts for backwards compatibility (will be migrated eventually)
-      fetch(`${backendUrl}/api/infrastructure/hosts`).then(r => r.ok ? r.json() : { hosts: [] }).catch(() => ({ hosts: [] }))
+      fetchWithAuth(`${backendUrl}/api/infrastructure/hosts`).then(r => r.ok ? r.json() : { hosts: [] }).catch(() => ({ hosts: [] }))
     ]);
 
     // Convert legacy infrastructure hosts to secret-like format for unified display

--- a/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
+++ b/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
@@ -151,6 +151,7 @@ import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 import BaseModal from '@/components/ui/BaseModal.vue'
 import { getBackendUrl } from '@/config/ssot-config'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
 
 const logger = createLogger('ApiKeySetupWizard')
 const { t } = useI18n()
@@ -280,7 +281,7 @@ async function saveAndClose(): Promise<void> {
 async function saveKeys(keys: KeyEntry[]): Promise<void> {
   const baseUrl = getBackendUrl()
   for (const key of keys) {
-    const response = await fetch(`${baseUrl}/api/secrets/`, {
+    const response = await fetchWithAuth(`${baseUrl}/api/secrets/`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/autobot-frontend/src/components/ui/HostSelectionDialog.vue
+++ b/autobot-frontend/src/components/ui/HostSelectionDialog.vue
@@ -185,6 +185,7 @@ import { ref, onMounted, onUnmounted, watch, useId, toRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { secretsApiClient } from '@/utils/SecretsApiClient';
 import { getBackendUrl } from '@/config/ssot-config';
+import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import { createLogger } from '@/utils/debugUtils';
 import Icon, { type IconName } from '@/components/ui/Icon.vue';
 import LoadingSpinner from '@/components/ui/LoadingSpinner.vue';
@@ -272,7 +273,7 @@ const loadHosts = async () => {
     // Fetch both secrets (infrastructure_host type) and legacy hosts
     const [secretsResponse, legacyHostsResponse] = await Promise.all([
       secretsApiClient.getSecrets({}) as Promise<Record<string, any>>,
-      fetch(`${backendUrl}/api/infrastructure/hosts`)
+      fetchWithAuth(`${backendUrl}/api/infrastructure/hosts`)
         .then(r => r.ok ? r.json() : { hosts: [] })
         .catch(() => ({ hosts: [] }))
     ]);

--- a/autobot-frontend/src/composables/useHostSelection.ts
+++ b/autobot-frontend/src/composables/useHostSelection.ts
@@ -12,6 +12,7 @@ import { ref, computed, readonly } from 'vue';
 import { getBackendUrl } from '@/config/ssot-config';
 import { createLogger } from '@/utils/debugUtils';
 import { useLoadingState } from '@/composables/useLoadingState';
+import { fetchWithAuth } from '@/utils/fetchWithAuth';
 
 const logger = createLogger('useHostSelection');
 
@@ -69,7 +70,7 @@ const loadHosts = async (): Promise<InfrastructureHost[]> => {
 
       // Issue #1310: Single source — only user-configured hosts from secrets.
       // Fleet/system VMs no longer included (they belong in SLM).
-      const response = await fetch(`${backendUrl}/api/infrastructure/hosts`);
+      const response = await fetchWithAuth(`${backendUrl}/api/infrastructure/hosts`);
       const data = response.ok ? await response.json() : { hosts: [] };
 
       hosts.value = (data.hosts || []).map((h: any) => ({

--- a/autobot-frontend/src/composables/useMultiModelCompare.ts
+++ b/autobot-frontend/src/composables/useMultiModelCompare.ts
@@ -13,7 +13,7 @@
 
 import { ref, onUnmounted, type Ref } from 'vue'
 import { getBackendUrl, getApiBase } from '@/config/ssot-config'
-import { getAuthToken } from '@/utils/fetchWithAuth'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useMultiModelCompare')
@@ -109,15 +109,12 @@ export function useMultiModelCompare(): UseMultiModelCompareReturn {
     responses.value = initial
 
     const url = `${getBackendUrl()}${getApiBase()}/chat/compare`
-    const token = getAuthToken()
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-    if (token) headers['Authorization'] = `Bearer ${token}`
 
     let fetchResponse: Response
     try {
-      fetchResponse = await fetch(url, {
+      fetchResponse = await fetchWithAuth(url, {
         method: 'POST',
-        headers,
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ prompt, models: targetModels }),
         signal,
       })

--- a/autobot-frontend/src/composables/useNotificationConfig.ts
+++ b/autobot-frontend/src/composables/useNotificationConfig.ts
@@ -12,6 +12,7 @@ import { ref } from 'vue';
 import { getApiBase } from '@/config/ssot-config';
 import { createLogger } from '@/utils/debugUtils';
 import { useLoadingState } from '@/composables/useLoadingState';
+import { fetchWithAuth } from '@/utils/fetchWithAuth';
 
 const logger = createLogger('NotificationConfig');
 
@@ -52,13 +53,6 @@ function emptyConfig(): NotificationConfigData {
   };
 }
 
-function getAuthHeaders(): Record<string, string> {
-  const token = localStorage.getItem('token') || localStorage.getItem('access_token');
-  return {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  };
-}
 
 export function useNotificationConfig() {
   const config = ref<NotificationConfigData>(emptyConfig());
@@ -71,7 +65,7 @@ export function useNotificationConfig() {
     await wrap(async () => {
       try {
         const url = `${getApiBase()}/workflow-automation/notification_config/${workflowId}`;
-        const resp = await fetch(url, { headers: getAuthHeaders() });
+        const resp = await fetchWithAuth(url);
         if (!resp.ok) {
           throw new Error(`HTTP ${resp.status}`);
         }
@@ -91,9 +85,9 @@ export function useNotificationConfig() {
     return wrapSaving(async () => {
       try {
         const url = `${getApiBase()}/workflow-automation/notification_config/${workflowId}`;
-        const resp = await fetch(url, {
+        const resp = await fetchWithAuth(url, {
           method: 'PUT',
-          headers: getAuthHeaders(),
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(config.value),
         });
         if (!resp.ok) {

--- a/autobot-frontend/src/composables/useWorkflowBuilder.ts
+++ b/autobot-frontend/src/composables/useWorkflowBuilder.ts
@@ -15,7 +15,7 @@
 import { ref, computed, reactive } from 'vue';
 import { getBackendUrl, getBackendWsUrl, getApiBase } from '@/config/ssot-config';
 import { createLogger } from '@/utils/debugUtils';
-import { getAuthToken } from '@/utils/fetchWithAuth';
+import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import type { ApiResponse } from '@/types/api';
 import { useWorkflowTemplates } from '@/composables/useWorkflowTemplates';
 import type { WorkflowTemplateDetail } from '@/types/workflowTemplates';
@@ -259,13 +259,11 @@ class WorkflowBuilderApiClient {
     const timeoutId = setTimeout(() => controller.abort(), this.timeout);
 
     try {
-      const token = getAuthToken();
-      const response = await fetch(url, {
+      const response = await fetchWithAuth(url, {
         ...options,
         signal: controller.signal,
         headers: {
           'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
           ...options.headers,
         },
       });

--- a/autobot-frontend/src/composables/useWorkflowNotificationConfig.ts
+++ b/autobot-frontend/src/composables/useWorkflowNotificationConfig.ts
@@ -11,7 +11,7 @@
 import { ref } from 'vue';
 import { getApiBase } from '@/config/ssot-config';
 import { createLogger } from '@/utils/debugUtils';
-import { getAuthToken } from '@/utils/fetchWithAuth';
+import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import type { ApiResponse } from '@/types/api';
 
 const logger = createLogger('useWorkflowNotificationConfig');
@@ -82,13 +82,11 @@ async function apiRequest<T>(
   const timeoutId = setTimeout(() => controller.abort(), 30_000);
 
   try {
-    const token = getAuthToken();
-    const response = await fetch(url, {
+    const response = await fetchWithAuth(url, {
       ...options,
       signal: controller.signal,
       headers: {
         'Content-Type': 'application/json',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
         ...options.headers,
       },
     });

--- a/autobot-frontend/src/models/repositories/ChatRepository.ts
+++ b/autobot-frontend/src/models/repositories/ChatRepository.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import type { AxiosInstance, AxiosResponse, AxiosRequestConfig } from 'axios'
 import { getBackendUrl, getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import type { ChatMessage } from '@/types/api'
 
 // Create scoped logger for ChatRepository
@@ -227,12 +228,9 @@ export class ChatRepository {
 
       // Use native fetch API for proper SSE streaming support
       const url = `${this.baseURL}${getApiBase()}/chats/${chatId}/message`
-      const fetchHeaders: Record<string, string> = { 'Content-Type': 'application/json' }
-      const authToken = this._getAuthToken()
-      if (authToken) fetchHeaders['Authorization'] = `Bearer ${authToken}`
-      const response = await fetch(url, {
+      const response = await fetchWithAuth(url, {
         method: 'POST',
-        headers: fetchHeaders,
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           message: message,
           context: metadata

--- a/autobot-frontend/src/stores/useUserStore.ts
+++ b/autobot-frontend/src/stores/useUserStore.ts
@@ -2,6 +2,7 @@ import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
 
 const logger = createLogger('useUserStore')
 
@@ -319,11 +320,11 @@ export const useUserStore = defineStore('user', () => {
       const controller = new AbortController()
       const timeoutId = setTimeout(() => controller.abort(), 5000) // 5s timeout
 
-      const response = await fetch(`${getApiBase()}/auth/me`, {
+      const response = await fetchWithAuth(`${getApiBase()}/auth/me`, {
         signal: controller.signal,
         headers: {
-          'Accept': 'application/json'
-        }
+          'Accept': 'application/json',
+        },
       })
       clearTimeout(timeoutId)
 
@@ -374,18 +375,9 @@ export const useUserStore = defineStore('user', () => {
     newPassword: string
   ): Promise<{ success: boolean; message: string }> {
     try {
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json'
-      }
-
-      // Add authorization header if we have a token
-      if (authState.value.token && authState.value.token !== 'single_user_mode') {
-        headers['Authorization'] = `Bearer ${authState.value.token}`
-      }
-
-      const response = await fetch(`${getApiBase()}/auth/change-password`, {
+      const response = await fetchWithAuth(`${getApiBase()}/auth/change-password`, {
         method: 'POST',
-        headers,
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           current_password: currentPassword,
           new_password: newPassword

--- a/autobot-frontend/src/utils/AdvancedControlApiClient.ts
+++ b/autobot-frontend/src/utils/AdvancedControlApiClient.ts
@@ -9,6 +9,7 @@
  */
 
 import { getConfig, getApiBase } from '@/config/ssot-config';
+import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import { createLogger } from '@/utils/debugUtils';
 import type { ApiResponse } from '@/types/api';
 
@@ -203,7 +204,7 @@ class AdvancedControlApiClient {
     };
 
     try {
-      const response = await fetch(url, {
+      const response = await fetchWithAuth(url, {
         ...options,
         headers: { ...defaultHeaders, ...options.headers },
       });

--- a/autobot-frontend/src/utils/FeatureFlagsApiClient.ts
+++ b/autobot-frontend/src/utils/FeatureFlagsApiClient.ts
@@ -12,6 +12,7 @@ import appConfig from '@/config/AppConfig.js';
 import { NetworkConstants } from '@/constants/network';
 import { createLogger } from '@/utils/debugUtils';
 import { getApiBase } from '@/config/ssot-config';
+import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import type { ApiResponse } from '@/types/api';
 
 const logger = createLogger('FeatureFlagsApiClient');
@@ -119,7 +120,7 @@ class FeatureFlagsApiClient {
     };
 
     try {
-      const response = await fetch(url, {
+      const response = await fetchWithAuth(url, {
         ...options,
         headers: { ...defaultHeaders, ...options.headers },
       });

--- a/autobot-frontend/src/utils/VisionMultimodalApiClient.ts
+++ b/autobot-frontend/src/utils/VisionMultimodalApiClient.ts
@@ -11,7 +11,7 @@
 import appConfig from '@/config/AppConfig.js';
 import { NetworkConstants } from '@/constants/network';
 import { createLogger } from '@/utils/debugUtils';
-import { getAuthToken } from '@/utils/fetchWithAuth';
+import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import { getApiBase } from '@/config/ssot-config';
 import type { ApiResponse } from '@/types/api';
 
@@ -356,14 +356,8 @@ class VisionMultimodalApiClient {
       'Content-Type': 'application/json',
     };
 
-    // Inject auth token if available (#1236)
-    const authToken = getAuthToken();
-    if (authToken) {
-      defaultHeaders['Authorization'] = `Bearer ${authToken}`;
-    }
-
     try {
-      const response = await fetch(url, {
+      const response = await fetchWithAuth(url, {
         ...options,
         headers: { ...defaultHeaders, ...options.headers },
       });
@@ -395,18 +389,10 @@ class VisionMultimodalApiClient {
     const baseUrl = await this.ensureBaseUrl();
     const url = `${baseUrl}${endpoint}`;
 
-    // Inject auth token if available (#1236)
-    const headers: Record<string, string> = {};
-    const authToken = getAuthToken();
-    if (authToken) {
-      headers['Authorization'] = `Bearer ${authToken}`;
-    }
-
     try {
-      const response = await fetch(url, {
+      const response = await fetchWithAuth(url, {
         method: 'POST',
         body: formData,
-        headers,
         // Don't set Content-Type - browser will set it with boundary for multipart
       });
 

--- a/autobot-frontend/src/views/AdminUsersView.vue
+++ b/autobot-frontend/src/views/AdminUsersView.vue
@@ -180,8 +180,8 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { getBackendUrl } from '@/config/ssot-config'
-import { useUserStore } from '@/stores/useUserStore'
 import { createLogger } from '@/utils/debugUtils'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
 
 const logger = createLogger('AdminUsersView')
 
@@ -202,7 +202,6 @@ interface NewUserForm {
   display_name: string
 }
 
-const userStore = useUserStore()
 
 const users = ref<UserRecord[]>([])
 const total = ref(0)
@@ -221,15 +220,6 @@ const deleteTarget = ref<UserRecord | null>(null)
 
 const totalPages = computed(() => Math.ceil(total.value / pageSize))
 
-function authHeaders(): Record<string, string> {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-  const token = userStore.authState.token
-  if (token && token !== 'single_user_mode') {
-    headers['Authorization'] = `Bearer ${token}`
-  }
-  return headers
-}
-
 function primaryRole(user: UserRecord): string {
   if (user.is_platform_admin) return 'admin'
   const sysRole = user.roles.find(r => r.is_system)
@@ -247,9 +237,7 @@ async function loadUsers(): Promise<void> {
     if (searchQuery.value.trim()) {
       params.set('search', searchQuery.value.trim())
     }
-    const res = await fetch(`${getBackendUrl()}/user-management/users?${params}`, {
-      headers: authHeaders(),
-    })
+    const res = await fetchWithAuth(`${getBackendUrl()}/user-management/users?${params}`)
     if (!res.ok) {
       const body = await res.json().catch(() => ({}))
       throw new Error((body as { detail?: string }).detail ?? `HTTP ${res.status}`)
@@ -281,9 +269,9 @@ function changePage(delta: number): void {
 
 async function onRoleChange(user: UserRecord, role: string): Promise<void> {
   try {
-    const res = await fetch(`${getBackendUrl()}/user-management/users/${user.id}/role`, {
+    const res = await fetchWithAuth(`${getBackendUrl()}/user-management/users/${user.id}/role`, {
       method: 'PUT',
-      headers: authHeaders(),
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ role }),
     })
     if (!res.ok) {
@@ -300,9 +288,8 @@ async function onRoleChange(user: UserRecord, role: string): Promise<void> {
 async function toggleActive(user: UserRecord, activate: boolean): Promise<void> {
   const action = activate ? 'activate' : 'deactivate'
   try {
-    const res = await fetch(`${getBackendUrl()}/user-management/users/${user.id}/${action}`, {
+    const res = await fetchWithAuth(`${getBackendUrl()}/user-management/users/${user.id}/${action}`, {
       method: 'POST',
-      headers: authHeaders(),
     })
     if (!res.ok) {
       const body = await res.json().catch(() => ({}))
@@ -322,9 +309,8 @@ function confirmDelete(user: UserRecord): void {
 async function deleteUser(): Promise<void> {
   if (!deleteTarget.value) return
   try {
-    const res = await fetch(`${getBackendUrl()}/user-management/users/${deleteTarget.value.id}`, {
+    const res = await fetchWithAuth(`${getBackendUrl()}/user-management/users/${deleteTarget.value.id}`, {
       method: 'DELETE',
-      headers: authHeaders(),
     })
     if (!res.ok) {
       const body = await res.json().catch(() => ({}))
@@ -343,9 +329,9 @@ async function createUser(): Promise<void> {
   creating.value = true
   createError.value = null
   try {
-    const res = await fetch(`${getBackendUrl()}/user-management/users`, {
+    const res = await fetchWithAuth(`${getBackendUrl()}/user-management/users`, {
       method: 'POST',
-      headers: authHeaders(),
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         email: newUser.value.email,
         username: newUser.value.username,

--- a/autobot-frontend/src/views/UsageView.vue
+++ b/autobot-frontend/src/views/UsageView.vue
@@ -174,6 +174,7 @@ import { getApiBase } from '@/config/ssot-config'
 import { useApi } from '@/composables/useApi'
 import { useUserStore } from '@/stores/useUserStore'
 import { createLogger } from '@/utils/debugUtils'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
 
 const logger = createLogger('UsageView')
 const api = useApi()
@@ -250,10 +251,7 @@ async function load() {
 async function downloadCsv() {
   csvLoading.value = true
   try {
-    const token = localStorage.getItem('authToken') || ''
-    const res = await fetch(`${getApiBase()}/usage/export/csv?days=${days.value}`, {
-      headers: { Authorization: `Bearer ${token}` },
-    })
+    const res = await fetchWithAuth(`${getApiBase()}/usage/export/csv?days=${days.value}`)
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
     const blob = await res.blob()
     const url = URL.createObjectURL(blob)


### PR DESCRIPTION
Replaces raw fetch() in 17 frontend files with fetchWithAuth() so all non-SLM/non-Prometheus requests carry the Bearer auth header automatically. Closes #5945.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)