### PR TITLE
refact(backend): replace 20+ module-level singletons with lazy_singleton (#5948)

### DIFF
--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -17,10 +17,10 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.error_constants import ERR_SESSION_NOT_FOUND
 from constants.threshold_constants import TimingConstants
-from desktop_streaming_manager import desktop_streaming
+from desktop_streaming_manager import get_desktop_streaming
 from enhanced_memory_manager_async import TaskPriority
-from takeover_manager import TakeoverTrigger, takeover_manager
-from task_execution_tracker import task_tracker
+from takeover_manager import TakeoverTrigger, get_takeover_manager
+from task_execution_tracker import get_task_tracker
 from type_defs.common import Metadata
 from api.schemas_common import DataResponse
 
@@ -94,7 +94,7 @@ async def create_streaming_session(
 
     Issue #744: Requires admin authentication.
     """
-    async with task_tracker.track_task(
+    async with get_task_tracker().track_task(
         "Create Desktop Streaming Session",
         f"Creating streaming session for user {request.user_id}",
         agent_type="advanced_control",
@@ -103,7 +103,7 @@ async def create_streaming_session(
     ) as task_context:
         session_config = {"resolution": request.resolution, "depth": request.depth}
 
-        result = await desktop_streaming.create_streaming_session(
+        result = await get_desktop_streaming().create_streaming_session(
             user_id=request.user_id, session_config=session_config
         )
 
@@ -134,7 +134,7 @@ async def terminate_streaming_session(
 
     Issue #744: Requires admin authentication.
     """
-    success = await desktop_streaming.terminate_streaming_session(session_id)
+    success = await get_desktop_streaming().terminate_streaming_session(session_id)
     if success:
         logger.info("Desktop streaming session terminated: %s", session_id)
         return {"success": True, "session_id": session_id}
@@ -161,7 +161,7 @@ async def list_streaming_sessions(
 
     Issue #744: Requires admin authentication.
     """
-    sessions = desktop_streaming.vnc_manager.list_active_sessions()
+    sessions = get_desktop_streaming().vnc_manager.list_active_sessions()
     return {"sessions": sessions, "count": len(sessions)}
 
 
@@ -184,7 +184,7 @@ async def get_streaming_capabilities(
 
     Issue #744: Requires admin authentication.
     """
-    capabilities = desktop_streaming.get_system_capabilities()
+    capabilities = get_desktop_streaming().get_system_capabilities()
     return capabilities
 
 
@@ -236,7 +236,7 @@ async def request_takeover(
 
     priority = priority_mapping.get(request.priority.upper(), TaskPriority.HIGH)
 
-    request_id = await takeover_manager.request_takeover(
+    request_id = await get_takeover_manager().request_takeover(
         trigger=trigger,
         reason=request.reason,
         requesting_agent=request.requesting_agent,
@@ -272,7 +272,7 @@ async def approve_takeover(
     Issue #744: Requires admin authentication.
     """
     try:
-        session_id = await takeover_manager.approve_takeover(
+        session_id = await get_takeover_manager().approve_takeover(
             request_id=request_id,
             human_operator=approval.human_operator,
             takeover_scope=approval.takeover_scope,
@@ -309,7 +309,7 @@ async def execute_takeover_action(
     Issue #744: Requires admin authentication.
     """
     try:
-        result = await takeover_manager.execute_takeover_action(
+        result = await get_takeover_manager().execute_takeover_action(
             session_id=session_id,
             action_type=action.action_type,
             action_data=action.action_data,
@@ -344,7 +344,7 @@ async def pause_takeover_session(
 
     Issue #744: Requires admin authentication.
     """
-    success = await takeover_manager.pause_takeover_session(session_id)
+    success = await get_takeover_manager().pause_takeover_session(session_id)
     if success:
         return {"success": True, "session_id": session_id, "status": "paused"}
     else:
@@ -371,7 +371,7 @@ async def resume_takeover_session(
 
     Issue #744: Requires admin authentication.
     """
-    success = await takeover_manager.resume_takeover_session(session_id)
+    success = await get_takeover_manager().resume_takeover_session(session_id)
     if success:
         return {"success": True, "session_id": session_id, "status": "active"}
     else:
@@ -401,7 +401,7 @@ async def complete_takeover_session(
 
     Issue #744: Requires admin authentication.
     """
-    success = await takeover_manager.complete_takeover_session(
+    success = await get_takeover_manager().complete_takeover_session(
         session_id=session_id,
         resolution=completion_data.get("resolution", "Session completed"),
         handback_notes=completion_data.get("handback_notes"),
@@ -432,7 +432,7 @@ async def get_pending_takeovers(
 
     Issue #744: Requires admin authentication.
     """
-    pending = takeover_manager.get_pending_requests()
+    pending = get_takeover_manager().get_pending_requests()
     return {"pending_requests": pending, "count": len(pending)}
 
 
@@ -455,7 +455,7 @@ async def get_active_takeovers(
 
     Issue #744: Requires admin authentication.
     """
-    active = takeover_manager.get_active_sessions()
+    active = get_takeover_manager().get_active_sessions()
     return {"active_sessions": active, "count": len(active)}
 
 
@@ -478,7 +478,7 @@ async def get_takeover_status(
 
     Issue #744: Requires admin authentication.
     """
-    status = takeover_manager.get_system_status()
+    status = get_takeover_manager().get_system_status()
     return status
 
 
@@ -514,16 +514,16 @@ async def get_system_status(
     }
 
     # Get streaming sessions
-    streaming_sessions = desktop_streaming.vnc_manager.list_active_sessions()
+    streaming_sessions = get_desktop_streaming().vnc_manager.list_active_sessions()
 
     # Get takeover data
-    pending_takeovers = takeover_manager.get_pending_requests()
-    active_takeovers = takeover_manager.get_active_sessions()
+    pending_takeovers = get_takeover_manager().get_pending_requests()
+    active_takeovers = get_takeover_manager().get_active_sessions()
     system_status = {
         "status": "healthy",
         "timestamp": psutil.boot_time(),
         "uptime_seconds": psutil.boot_time(),
-        "streaming_capabilities": desktop_streaming.get_system_capabilities(),
+        "streaming_capabilities": get_desktop_streaming().get_system_capabilities(),
     }
 
     response = SystemMonitoringResponse(
@@ -557,7 +557,7 @@ async def emergency_system_stop(
     Issue #744: Requires admin authentication.
     """
     # Request emergency takeover
-    request_id = await takeover_manager.request_takeover(
+    request_id = await get_takeover_manager().request_takeover(
         trigger=TakeoverTrigger.CRITICAL_ERROR,
         reason="Emergency stop activated",
         requesting_agent="emergency_system",
@@ -595,14 +595,14 @@ async def get_system_health(
     try:
         health_status = {
             "status": "healthy",
-            "desktop_streaming_available": desktop_streaming.vnc_manager.vnc_available,
-            "novnc_available": desktop_streaming.vnc_manager.novnc_available,
+            "desktop_streaming_available": get_desktop_streaming().vnc_manager.vnc_available,
+            "novnc_available": get_desktop_streaming().vnc_manager.novnc_available,
             "active_streaming_sessions": len(
-                desktop_streaming.vnc_manager.active_sessions
+                get_desktop_streaming().vnc_manager.active_sessions
             ),
-            "pending_takeovers": len(takeover_manager.pending_requests),
-            "active_takeovers": len(takeover_manager.active_sessions),
-            "paused_tasks": len(takeover_manager.paused_tasks),
+            "pending_takeovers": len(get_takeover_manager().pending_requests),
+            "active_takeovers": len(get_takeover_manager().active_sessions),
+            "paused_tasks": len(get_takeover_manager().paused_tasks),
         }
 
         return health_status
@@ -677,7 +677,7 @@ async def desktop_streaming_websocket(websocket: WebSocket, session_id: str):
 
     try:
         # Use the desktop streaming manager's WebSocket handler
-        await desktop_streaming.handle_websocket_client(
+        await get_desktop_streaming().handle_websocket_client(
             websocket, f"/ws/desktop/{session_id}"
         )
     except WebSocketDisconnect:

--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -792,7 +792,7 @@ async def receive_goal(
         JSONResponse: Returns a 403 error if permission is denied, or a 500
             error if an internal error occurs.
     """
-    from event_manager import event_manager
+    from event_manager import get_event_manager
 
     orchestrator = getattr(request.app.state, "orchestrator", None)
     if orchestrator is None:
@@ -814,7 +814,7 @@ async def receive_goal(
     logging.info(f"Received goal via API: {goal}")
 
     # Publish events (Issue #620: uses helper)
-    await _publish_goal_events(event_manager, goal, use_phi2)
+    await _publish_goal_events(get_event_manager(), goal, use_phi2)
 
     # Track task execution start time for Prometheus metrics
     task_start_time = time.time()
@@ -826,7 +826,7 @@ async def receive_goal(
 
     # Process and return result (Issue #620: uses helper)
     return await _handle_goal_result(
-        event_manager, security_layer, user_role, goal, result_dict, task_start_time
+        get_event_manager(), security_layer, user_role, goal, result_dict, task_start_time
     )
 
 
@@ -852,7 +852,7 @@ async def pause_agent_api(
     without actual functionality. Full implementation will be added with
     backend integration.
     """
-    from event_manager import event_manager
+    from event_manager import get_event_manager
 
     security_layer = request.app.state.security_layer
     orchestrator = getattr(request.app.state, "orchestrator", None)
@@ -884,7 +884,7 @@ async def pause_agent_api(
     security_layer.audit_log("agent_pause", user_role, "success", {})
     # Publish event (non-critical)
     try:
-        await event_manager.publish(
+        await get_event_manager().publish(
             "agent_paused", {"message": "Agent operation paused."}
         )
     except Exception as e:
@@ -914,7 +914,7 @@ async def resume_agent_api(
     actual functionality.
     Full implementation will be added with backend integration.
     """
-    from event_manager import event_manager
+    from event_manager import get_event_manager
 
     security_layer = request.app.state.security_layer
     orchestrator = getattr(request.app.state, "orchestrator", None)
@@ -946,7 +946,7 @@ async def resume_agent_api(
     security_layer.audit_log("agent_resume", user_role, "success", {})
     # Publish event (non-critical)
     try:
-        await event_manager.publish(
+        await get_event_manager().publish(
             "agent_resumed", {"message": "Agent operation resumed."}
         )
     except Exception as e:
@@ -1037,7 +1037,7 @@ async def execute_command(
                       a 403 error if permission is denied,
                       or a 500 error if an internal error occurs.
     """
-    from event_manager import event_manager
+    from event_manager import get_event_manager
 
     security_layer = request.app.state.security_layer
     command = command_data.get("command")
@@ -1047,7 +1047,7 @@ async def execute_command(
     if validation_error:
         if not command:
             await _publish_event_safe(
-                event_manager,
+                get_event_manager(),
                 "error",
                 {"message": "No command provided for execution."},
             )
@@ -1055,7 +1055,7 @@ async def execute_command(
 
     # Publish start event (Issue #281: uses helper)
     await _publish_event_safe(
-        event_manager, "command_execution_start", {"command": command}
+        get_event_manager(), "command_execution_start", {"command": command}
     )
     logging.info(f"Executing command: {command}")
 
@@ -1066,7 +1066,7 @@ async def execute_command(
 
     # Handle result and publish completion event (Issue #620: uses helper)
     return await _handle_command_result(
-        event_manager, security_layer, user_role, command, stdout, stderr, returncode
+        get_event_manager(), security_layer, user_role, command, stdout, stderr, returncode
     )
 
 

--- a/autobot-backend/api/audit.py
+++ b/autobot-backend/api/audit.py
@@ -24,7 +24,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
-from auth_middleware import auth_middleware
+from auth_middleware import get_auth_middleware
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.models.pagination import PaginationParams
 from services.audit_logger import AuditResult, get_audit_logger
@@ -82,7 +82,7 @@ def check_admin_permission(request: Request) -> bool:
     """Check if user has admin permission for audit log access"""
     try:
         # Get user from auth middleware
-        user_data = auth_middleware.get_user_from_request(request)
+        user_data = get_auth_middleware().get_user_from_request(request)
 
         if not user_data:
             raise_auth_error(

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -16,7 +16,7 @@ import jwt as pyjwt
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, validator
 
-from auth_middleware import auth_middleware
+from auth_middleware import get_auth_middleware
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.ssot_config import config as ssot_config
 from constants.error_constants import ERR_INVALID_CREDENTIALS, ERR_INVALID_TOKEN
@@ -287,10 +287,10 @@ async def login(request: Request, login_data: LoginRequest):
                 "email": f"admin@{ssot_config.auth.domain}",
                 "last_login": None,
             }
-            jwt_token = auth_middleware.create_jwt_token(
+            jwt_token = get_auth_middleware().create_jwt_token(
                 {"username": "admin", "role": "admin", "email": f"admin@{ssot_config.auth.domain}"}
             )
-            session_id = auth_middleware.create_session(
+            session_id = get_auth_middleware().create_session(
                 {"username": "admin", "role": "admin"}, request
             )
             return LoginResponse(
@@ -306,8 +306,8 @@ async def login(request: Request, login_data: LoginRequest):
             login_data.username, login_data.password, ip_address
         )
 
-        jwt_token = auth_middleware.create_jwt_token(user_data)
-        session_id = auth_middleware.create_session(user_data, request)
+        jwt_token = get_auth_middleware().create_jwt_token(user_data)
+        session_id = get_auth_middleware().create_session(user_data, request)
 
         safe_user_data = {
             "username": user_data["username"],
@@ -354,7 +354,7 @@ async def logout(request: Request, logout_data: LogoutRequest):
         session_id = logout_data.session_id or request.headers.get("X-Session-ID")
 
         if session_id:
-            auth_middleware.invalidate_session(session_id)
+            get_auth_middleware().invalidate_session(session_id)
 
         return {"success": True, "message": "Logged out successfully"}
 
@@ -396,7 +396,7 @@ async def get_current_user_info(request: Request):
                 "deployment_mode": "single_user",
             }
 
-        user_data = auth_middleware.get_user_from_request(request)
+        user_data = get_auth_middleware().get_user_from_request(request)
 
         if not user_data:
             raise HTTPException(status_code=401, detail="Not authenticated")
@@ -448,12 +448,12 @@ async def check_authentication(request: Request):
                 "deployment_mode": "single_user",
             }
 
-        user_data = auth_middleware.get_user_from_request(request)
+        user_data = get_auth_middleware().get_user_from_request(request)
 
         return {
             "authenticated": user_data is not None,
             "role": user_data["role"] if user_data else None,
-            "auth_enabled": auth_middleware.enable_auth,
+            "auth_enabled": get_auth_middleware().enable_auth,
             "deployment_mode": config.mode.value,
         }
 
@@ -462,7 +462,7 @@ async def check_authentication(request: Request):
         return {
             "authenticated": False,
             "role": None,
-            "auth_enabled": auth_middleware.enable_auth,
+            "auth_enabled": get_auth_middleware().enable_auth,
             "error": "Authentication check failed",
         }
 
@@ -483,7 +483,7 @@ async def check_permission(request: Request, operation: str):
     Check if current user has permission for specific operation
     """
     try:
-        has_permission, user_data = auth_middleware.check_file_permissions(
+        has_permission, user_data = get_auth_middleware().check_file_permissions(
             request, operation
         )
 
@@ -508,7 +508,7 @@ def _check_password_change_rate_limit(username: str, ip_address: str) -> None:
     client_id = f"{username}:{ip_address}"
     if not password_change_limiter.is_allowed(client_id):
         remaining_time = PASSWORD_CHANGE_RATE_WINDOW // 60
-        auth_middleware.security_layer.audit_log(
+        get_auth_middleware().security_layer.audit_log(
             action="password_change_rate_limited",
             user=username,
             outcome="denied",
@@ -524,15 +524,15 @@ def _verify_current_password(
     username: str, current_password: str, ip_address: str
 ) -> str:
     """Verify current password and return the hash. Raises HTTPException on failure."""
-    allowed_users = auth_middleware.security_config.get("allowed_users", {})
+    allowed_users = get_auth_middleware().security_config.get("allowed_users", {})
     if username not in allowed_users:
         raise HTTPException(status_code=404, detail="User not found in system")
 
     user_config = allowed_users[username]
     current_password_hash = user_config.get("password_hash", "")
 
-    if not auth_middleware.verify_password(current_password, current_password_hash):
-        auth_middleware.security_layer.audit_log(
+    if not get_auth_middleware().verify_password(current_password, current_password_hash):
+        get_auth_middleware().security_layer.audit_log(
             action="password_change_failed",
             user=username,
             outcome="denied",
@@ -548,7 +548,7 @@ def _persist_password_change(username: str, new_password_hash: str) -> None:
     from config.manager import get_config_manager
 
     # Update in-memory config
-    allowed_users = auth_middleware.security_config.get("allowed_users", {})
+    allowed_users = get_auth_middleware().security_config.get("allowed_users", {})
     allowed_users[username]["password_hash"] = new_password_hash
 
     # Persist to disk
@@ -589,7 +589,7 @@ async def change_password(request: Request, password_data: ChangePasswordRequest
                 detail="Password change is not available in single-user mode",
             )
 
-        user_data = auth_middleware.get_user_from_request(request)
+        user_data = get_auth_middleware().get_user_from_request(request)
         if not user_data or user_data.get("auth_method") == "guest":
             raise HTTPException(status_code=401, detail="Authentication required")
 
@@ -602,10 +602,10 @@ async def change_password(request: Request, password_data: ChangePasswordRequest
         _check_password_change_rate_limit(username, ip_address)
         _verify_current_password(username, password_data.current_password, ip_address)
 
-        new_password_hash = auth_middleware.hash_password(password_data.new_password)
+        new_password_hash = get_auth_middleware().hash_password(password_data.new_password)
         _persist_password_change(username, new_password_hash)
 
-        auth_middleware.security_layer.audit_log(
+        get_auth_middleware().security_layer.audit_log(
             action="password_changed",
             user=username,
             outcome="success",
@@ -688,8 +688,8 @@ def _decode_refresh_token(token: str) -> Dict:
     try:
         payload = pyjwt.decode(
             token,
-            auth_middleware.jwt_secret,
-            algorithms=[auth_middleware.jwt_algorithm],
+            get_auth_middleware().jwt_secret,
+            algorithms=[get_auth_middleware().jwt_algorithm],
             options={"verify_exp": False},
         )
     except pyjwt.InvalidTokenError as exc:
@@ -751,8 +751,8 @@ async def refresh_token(request: Request):
         user_data["user_id"] = payload["user_id"]
     if payload.get("org_id"):
         user_data["org_id"] = payload["org_id"]
-    new_token = auth_middleware.create_jwt_token(user_data)
-    expiry_seconds = auth_middleware.jwt_expiry_hours * 3600
+    new_token = get_auth_middleware().create_jwt_token(user_data)
+    expiry_seconds = get_auth_middleware().jwt_expiry_hours * 3600
 
     return {
         "success": True,

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
-from auth_middleware import auth_middleware, get_current_user
+from auth_middleware import get_auth_middleware, get_current_user
 from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
@@ -538,7 +538,7 @@ async def _list_scoped_sessions(
 
     Helper for list_sessions (#684).
     """
-    user_data = auth_middleware.get_user_from_request(request)
+    user_data = get_auth_middleware().get_user_from_request(request)
     if not user_data:
         (
             AutoBotError,
@@ -658,7 +658,7 @@ async def _list_shared_sessions(
 
     Helper for list_sessions.
     """
-    user_data = auth_middleware.get_user_from_request(request)
+    user_data = get_auth_middleware().get_user_from_request(request)
     if not user_data:
         return create_success_response(
             data={"sessions": [], "count": 0, "scope": "shared"},
@@ -809,7 +809,7 @@ async def create_session(session_data: SessionCreate, request: Request):
     session_title = session_data.title or DEFAULT_SESSION_TITLE
 
     # SECURITY: Extract authenticated user and add to metadata as owner
-    user_data = auth_middleware.get_user_from_request(request)
+    user_data = get_auth_middleware().get_user_from_request(request)
     metadata = session_data.metadata or {}
     if user_data and user_data.get("username"):
         metadata["owner"] = user_data["username"]

--- a/autobot-backend/api/conversation_files.py
+++ b/autobot-backend/api/conversation_files.py
@@ -21,7 +21,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, Uplo
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel, Field, field_validator
 
-from auth_middleware import auth_middleware, check_admin_permission
+from auth_middleware import check_admin_permission, get_auth_middleware
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from security_layer import SecurityLayer
 from utils.catalog_http_exceptions import raise_internal_error, raise_invalid_input, raise_not_found
@@ -208,7 +208,7 @@ async def _authorize_file_operation(
     request: Request, session_id: str, operation: str
 ) -> dict:
     """Authorize file operation and return user data (Issue #398: extracted)."""
-    has_permission, user_data = auth_middleware.check_file_permissions(
+    has_permission, user_data = get_auth_middleware().check_file_permissions(
         request, operation
     )
     if not has_permission:
@@ -782,7 +782,7 @@ async def preview_conversation_file(request: Request, session_id: str, file_id: 
         500: Server error
     """
     # Authenticate and authorize
-    has_permission, user_data = auth_middleware.check_file_permissions(request, "view")
+    has_permission, user_data = get_auth_middleware().check_file_permissions(request, "view")
     if not has_permission:
         raise HTTPException(
             status_code=403, detail="Insufficient permissions for file preview"

--- a/autobot-backend/api/enhanced_memory.py
+++ b/autobot-backend/api/enhanced_memory.py
@@ -39,7 +39,7 @@ from enhanced_memory_manager_async import (
     get_async_enhanced_memory_manager,
 )
 from markdown_reference_system import MarkdownReferenceSystem
-from task_execution_tracker import task_tracker
+from task_execution_tracker import get_task_tracker
 from type_defs.common import Metadata
 
 logger = logging.getLogger(__name__)
@@ -155,8 +155,8 @@ async def get_memory_statistics(days_back: int = Query(30, ge=1, le=365)):
         task_stats, markdown_stats, active_tasks, insights = await asyncio.gather(
             memory_manager.get_task_statistics(),
             asyncio.to_thread(markdown_system.get_markdown_statistics),
-            asyncio.to_thread(task_tracker.get_active_tasks),
-            task_tracker.analyze_task_patterns(days_back),
+            asyncio.to_thread(get_task_tracker().get_active_tasks),
+            get_task_tracker().analyze_task_patterns(days_back),
         )
 
         return {
@@ -199,7 +199,7 @@ async def get_task_history(
             except ValueError:
                 raise HTTPException(status_code=400, detail=f"Invalid status: {status}")
 
-        history = task_tracker.get_task_history(
+        history = get_task_tracker().get_task_history(
             agent_type=agent_type, status=status_enum, limit=limit, days_back=days_back
         )
 
@@ -570,7 +570,7 @@ async def cleanup_old_data(days_to_keep: int = Query(90, ge=30, le=365)):
 async def get_active_tasks():
     """Get currently active tasks"""
     try:
-        active_tasks = task_tracker.get_active_tasks()
+        active_tasks = get_task_tracker().get_active_tasks()
 
         return {
             "count": len(active_tasks),

--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -24,7 +24,7 @@ from fastapi.responses import FileResponse
 from fastapi.security import HTTPBearer
 from pydantic import BaseModel, field_validator
 
-from auth_middleware import auth_middleware
+from auth_middleware import get_auth_middleware
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_relative_path
 from constants.error_constants import (
@@ -246,7 +246,7 @@ def _check_file_permission(request: Request, permission: str) -> dict:
 
     Issue #620.
     """
-    has_permission, user_data = auth_middleware.check_file_permissions(
+    has_permission, user_data = get_auth_middleware().check_file_permissions(
         request, permission
     )
     if not has_permission:
@@ -713,7 +713,7 @@ async def upload_file(
         overwrite: Whether to overwrite existing files
     """
     # SECURITY FIX: Enable proper authentication and authorization
-    has_permission, user_data = auth_middleware.check_file_permissions(
+    has_permission, user_data = get_auth_middleware().check_file_permissions(
         request, "upload"
     )
     if not has_permission:
@@ -775,7 +775,7 @@ async def download_file(request: Request, path: str):
         path: File path within the sandbox
     """
     # SECURITY FIX: Enable proper authentication and authorization
-    has_permission, user_data = auth_middleware.check_file_permissions(
+    has_permission, user_data = get_auth_middleware().check_file_permissions(
         request, "download"
     )
     if not has_permission:
@@ -839,7 +839,7 @@ async def view_file(request: Request, path: str):
         path: File path within the sandbox
     """
     # SECURITY FIX: Use modern auth_middleware instead of deprecated function
-    has_permission, user_data = auth_middleware.check_file_permissions(request, "view")
+    has_permission, user_data = get_auth_middleware().check_file_permissions(request, "view")
     if not has_permission:
         raise HTTPException(
             status_code=403, detail="Insufficient permissions for file viewing"
@@ -1117,7 +1117,7 @@ async def delete_file(request: Request, path: str):
     Args:
         path: Path to the file/directory to delete (query parameter)
     """
-    has_permission, user_data = auth_middleware.check_file_permissions(
+    has_permission, user_data = get_auth_middleware().check_file_permissions(
         request, "delete"
     )
     if not has_permission:
@@ -1240,7 +1240,7 @@ async def create_directory(
 async def get_directory_tree(request: Request, path: str = ""):
     """Get directory tree structure for file browser"""
     # SECURITY FIX: Enable proper authentication and authorization
-    has_permission, user_data = auth_middleware.check_file_permissions(request, "view")
+    has_permission, user_data = get_auth_middleware().check_file_permissions(request, "view")
     if not has_permission:
         raise HTTPException(
             status_code=403,
@@ -1313,7 +1313,7 @@ async def get_directory_tree(request: Request, path: str = ""):
 async def get_file_stats(request: Request):
     """Get file system statistics for the sandbox"""
     # SECURITY FIX: Enable proper authentication and authorization
-    has_permission, user_data = auth_middleware.check_file_permissions(request, "view")
+    has_permission, user_data = get_auth_middleware().check_file_permissions(request, "view")
     if not has_permission:
         raise HTTPException(
             status_code=403, detail="Insufficient permissions for file statistics"

--- a/autobot-backend/api/live_events.py
+++ b/autobot-backend/api/live_events.py
@@ -27,7 +27,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from live_event_manager import live_event_manager
+from live_event_manager import get_live_event_manager
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -40,9 +40,9 @@ def _verify_token(token: str) -> dict | None:
     if not token:
         return None
     try:
-        from auth_middleware import auth_middleware
+        from auth_middleware import get_auth_middleware
 
-        return auth_middleware.verify_jwt_token(token)
+        return get_auth_middleware().verify_jwt_token(token)
     except Exception as exc:
         logger.warning("Token verification failed: %s", exc)
         return None
@@ -51,9 +51,9 @@ def _verify_token(token: str) -> dict | None:
 def _auth_required() -> bool:
     """Return True when JWT auth is enabled in app config."""
     try:
-        from auth_middleware import auth_middleware
+        from auth_middleware import get_auth_middleware
 
-        return auth_middleware.enable_auth
+        return get_auth_middleware().enable_auth
     except Exception:
         return True
 
@@ -78,7 +78,7 @@ async def _handle_subscribe(
         if not is_admin and claimed_id not in (user_id, username):
             await _send_error(ws, f"Not authorized to subscribe to {channel}")
             return
-    ok = await live_event_manager.subscribe(ws, channel)
+    ok = await get_live_event_manager().subscribe(ws, channel)
     if ok:
         await ws.send_json({"type": "subscribed", "channel": channel})
     else:
@@ -87,7 +87,7 @@ async def _handle_subscribe(
 
 async def _handle_unsubscribe(ws: WebSocket, channel: str) -> None:
     """Process an unsubscribe action from the client."""
-    await live_event_manager.unsubscribe(ws, channel)
+    await get_live_event_manager().unsubscribe(ws, channel)
     await ws.send_json({"type": "unsubscribed", "channel": channel})
 
 
@@ -176,5 +176,5 @@ async def live_events_endpoint(websocket: WebSocket):
             await keepalive_task
         except asyncio.CancelledError:
             pass
-        await live_event_manager.remove_client(websocket)
+        await get_live_event_manager().remove_client(websocket)
         logger.info("Live events WebSocket connection cleaned up")

--- a/autobot-backend/api/redis_service.py
+++ b/autobot-backend/api/redis_service.py
@@ -19,7 +19,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from auth_middleware import auth_middleware
+from auth_middleware import get_auth_middleware
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.redis_service_manager import RedisConnectionError, RedisServiceManager
 
@@ -77,7 +77,7 @@ def check_admin_permission(request: Request) -> str:
     Raises:
         HTTPException: If user lacks admin permissions
     """
-    user_data = auth_middleware.get_user_from_request(request)
+    user_data = get_auth_middleware().get_user_from_request(request)
 
     if not user_data:
         raise HTTPException(status_code=401, detail="Authentication required")
@@ -101,7 +101,7 @@ def check_operator_permission(request: Request) -> str:
     Raises:
         HTTPException: If user lacks operator/admin permissions
     """
-    user_data = auth_middleware.get_user_from_request(request)
+    user_data = get_auth_middleware().get_user_from_request(request)
 
     if not user_data:
         raise HTTPException(status_code=401, detail="Authentication required")

--- a/autobot-backend/api/research_browser.py
+++ b/autobot-backend/api/research_browser.py
@@ -30,11 +30,11 @@ logger = logging.getLogger(__name__)
 
 # Issue #1009: Graceful fallback when playwright is not installed
 try:
-    from research_browser_manager import research_browser_manager
+    from research_browser_manager import get_research_browser_manager
 
     _BROWSER_AVAILABLE = True
 except ImportError:
-    research_browser_manager = None
+    get_research_browser_manager = None  # type: ignore[assignment]
     _BROWSER_AVAILABLE = False
     logger.warning("research_browser_manager unavailable (playwright not installed)")
 
@@ -113,7 +113,7 @@ async def health_check():
 async def research_url(request: ResearchRequest):
     """Research a URL with automatic fallbacks and interaction handling"""
     _require_browser()
-    result = await research_browser_manager.research_url(
+    result = await get_research_browser_manager().research_url(
         request.conversation_id, request.url, request.extract_content
     )
 
@@ -134,7 +134,7 @@ async def research_url(request: ResearchRequest):
 async def handle_session_action(request: SessionAction):
     """Handle actions on a research session"""
     _require_browser()
-    session = research_browser_manager.get_session(request.session_id)
+    session = get_research_browser_manager().get_session(request.session_id)
     if not session:
         raise HTTPException(status_code=404, detail=ERR_SESSION_NOT_FOUND)
 
@@ -189,7 +189,7 @@ async def handle_session_action(request: SessionAction):
 async def get_session_status(session_id: str):
     """Get the status of a research session"""
     _require_browser()
-    session = research_browser_manager.get_session(session_id)
+    session = get_research_browser_manager().get_session(session_id)
     if not session:
         raise HTTPException(status_code=404, detail=ERR_SESSION_NOT_FOUND)
 
@@ -223,7 +223,7 @@ async def get_session_status(session_id: str):
 async def download_mhtml(session_id: str, filename: str):
     """Download an MHTML file from a research session"""
     _require_browser()
-    session = research_browser_manager.get_session(session_id)
+    session = get_research_browser_manager().get_session(session_id)
     if not session:
         raise HTTPException(status_code=404, detail=ERR_SESSION_NOT_FOUND)
 
@@ -274,7 +274,7 @@ async def download_mhtml(session_id: str, filename: str):
 async def cleanup_session(session_id: str):
     """Clean up a research session"""
     _require_browser()
-    await research_browser_manager.cleanup_session(session_id)
+    await get_research_browser_manager().cleanup_session(session_id)
 
     return JSONResponse(
         status_code=200,
@@ -298,7 +298,7 @@ async def list_sessions():
     _require_browser()
     sessions_info = []
 
-    for session_id, session in research_browser_manager.sessions.items():
+    for session_id, session in get_research_browser_manager().sessions.items():
         sessions_info.append(
             {
                 "session_id": session_id,
@@ -335,7 +335,7 @@ class NavigationRequest(BaseModel):
 async def navigate_session(session_id: str, request: NavigationRequest):
     """Navigate a research session to a specific URL"""
     _require_browser()
-    session = research_browser_manager.get_session(session_id)
+    session = get_research_browser_manager().get_session(session_id)
     if not session:
         raise HTTPException(status_code=404, detail=ERR_SESSION_NOT_FOUND)
 
@@ -383,12 +383,12 @@ async def get_browser_info(session_id: str):
 
 def _get_or_create_browser_session(session_id: str):
     """Get existing session or create default for chat-browser (Issue #665: extracted helper)."""
-    session = research_browser_manager.get_session(session_id)
+    session = get_research_browser_manager().get_session(session_id)
 
     # Special handling for chat-browser - create default session if needed
     if not session and session_id == "chat-browser":
         logger.info("Creating default chat-browser session for frontend integration")
-        session = research_browser_manager.create_session(
+        session = get_research_browser_manager().create_session(
             conversation_id="default-chat",
             interaction_settings={
                 "captcha": False,
@@ -481,7 +481,7 @@ async def get_or_create_chat_browser_session(request: CreateChatBrowserRequest):
     """
     _require_browser()
     # Check for existing session for this conversation
-    existing_session = research_browser_manager.get_session_by_conversation(
+    existing_session = get_research_browser_manager().get_session_by_conversation(
         request.conversation_id
     )
 
@@ -506,14 +506,14 @@ async def get_or_create_chat_browser_session(request: CreateChatBrowserRequest):
     logger.info(
         f"Creating new browser session for conversation {request.conversation_id}"
     )
-    session_id = await research_browser_manager.create_session(
+    session_id = await get_research_browser_manager().create_session(
         request.conversation_id, headless=request.headless
     )
 
     if not session_id:
         raise HTTPException(status_code=500, detail="Failed to create browser session")
 
-    session = research_browser_manager.get_session(session_id)
+    session = get_research_browser_manager().get_session(session_id)
 
     # Navigate to initial URL if provided
     if request.initial_url and session:
@@ -550,7 +550,7 @@ async def get_chat_browser_session(conversation_id: str):
     Issue #73: Browser sessions tied to chat like terminal
     """
     _require_browser()
-    session = research_browser_manager.get_session_by_conversation(conversation_id)
+    session = get_research_browser_manager().get_session_by_conversation(conversation_id)
 
     if not session:
         raise HTTPException(
@@ -606,7 +606,7 @@ async def delete_chat_browser_session(conversation_id: str):
     Issue #73: Browser sessions tied to chat like terminal
     """
     _require_browser()
-    session = research_browser_manager.get_session_by_conversation(conversation_id)
+    session = get_research_browser_manager().get_session_by_conversation(conversation_id)
 
     if not session:
         raise HTTPException(
@@ -615,7 +615,7 @@ async def delete_chat_browser_session(conversation_id: str):
         )
 
     session_id = session.session_id
-    await research_browser_manager.cleanup_session(session_id)
+    await get_research_browser_manager().cleanup_session(session_id)
 
     return JSONResponse(
         status_code=200,

--- a/autobot-backend/api/scheduler.py
+++ b/autobot-backend/api/scheduler.py
@@ -23,7 +23,7 @@ from constants.threshold_constants import RetryConfig
 from type_defs.common import Metadata
 from workflow_scheduler import WorkflowPriority
 from workflow_scheduler import WorkflowScheduleRequest as InternalScheduleRequest
-from workflow_scheduler import WorkflowStatus, workflow_scheduler
+from workflow_scheduler import WorkflowStatus, get_workflow_scheduler
 
 router = APIRouter(dependencies=[Depends(check_admin_permission)])
 
@@ -227,10 +227,10 @@ async def schedule_workflow(request: ScheduleWorkflowRequest):
         timeout_minutes=request.timeout_minutes,
         max_retries=request.max_retries,
     )
-    workflow_id = workflow_scheduler.schedule_workflow(request=internal_request)
+    workflow_id = get_workflow_scheduler().schedule_workflow(request=internal_request)
 
     # Get the created workflow for response (Issue #372 - use model method)
-    workflow = workflow_scheduler.get_workflow(workflow_id)
+    workflow = get_workflow_scheduler().get_workflow(workflow_id)
 
     return {
         "success": True,
@@ -269,7 +269,7 @@ async def list_scheduled_workflows(
         tags_filter = [tag.strip() for tag in tags.split(",")]
 
     # Get workflows
-    workflows = workflow_scheduler.list_scheduled_workflows(
+    workflows = get_workflow_scheduler().list_scheduled_workflows(
         status=status_filter, user_id=user_id, tags=tags_filter
     )
 
@@ -296,7 +296,7 @@ async def list_scheduled_workflows(
 @router.get("/workflows/{workflow_id}", response_model=SchedulerWorkflowDetailResponse)
 async def get_workflow_details(workflow_id: str):
     """Get detailed information about a specific scheduled workflow (Issue #372)"""
-    workflow = workflow_scheduler.get_workflow(workflow_id)
+    workflow = get_workflow_scheduler().get_workflow(workflow_id)
     if not workflow:
         raise HTTPException(status_code=404, detail=ERR_WORKFLOW_NOT_FOUND)
 
@@ -330,7 +330,7 @@ async def reschedule_workflow(workflow_id: str, request: RescheduleRequest):
                 status_code=400, detail=f"Invalid priority: {request.new_priority}"
             )
 
-    success = workflow_scheduler.reschedule_workflow(
+    success = get_workflow_scheduler().reschedule_workflow(
         workflow_id, request.new_scheduled_time, new_priority
     )
 
@@ -340,7 +340,7 @@ async def reschedule_workflow(workflow_id: str, request: RescheduleRequest):
         )
 
     # Get updated workflow
-    workflow = workflow_scheduler.get_workflow(workflow_id)
+    workflow = get_workflow_scheduler().get_workflow(workflow_id)
 
     return {
         "success": True,
@@ -368,7 +368,7 @@ async def reschedule_workflow(workflow_id: str, request: RescheduleRequest):
 @router.delete("/workflows/{workflow_id}", response_model=SchedulerCancelResponse)
 async def cancel_workflow(workflow_id: str):
     """Cancel a scheduled or queued workflow"""
-    success = workflow_scheduler.cancel_workflow(workflow_id)
+    success = get_workflow_scheduler().cancel_workflow(workflow_id)
 
     if not success:
         raise HTTPException(
@@ -395,7 +395,7 @@ async def cancel_workflow(workflow_id: str):
 @router.get("/status", response_model=SchedulerStatusResponse)
 async def get_scheduler_status():
     """Get current scheduler and queue status"""
-    status = workflow_scheduler.get_scheduler_status()
+    status = get_workflow_scheduler().get_scheduler_status()
 
     return {"success": True, "scheduler_status": status}
 
@@ -413,9 +413,9 @@ async def get_scheduler_status():
 @router.get("/queue", response_model=SchedulerQueueResponse)
 async def get_queue_status():
     """Get current queue status and workflows"""
-    queue_status = workflow_scheduler.queue.get_queue_status()
-    queued_workflows = workflow_scheduler.queue.list_queued()
-    running_workflows = workflow_scheduler.queue.list_running()
+    queue_status = get_workflow_scheduler().queue.get_queue_status()
+    queued_workflows = get_workflow_scheduler().queue.list_queued()
+    running_workflows = get_workflow_scheduler().queue.list_running()
 
     # Convert to response format
     queued_list = []
@@ -464,10 +464,10 @@ async def get_queue_status():
 async def control_queue(request: QueueControlRequest):
     """Control queue operations (pause, resume, set max concurrent)"""
     if request.action == "pause":
-        workflow_scheduler.queue.pause_queue()
+        get_workflow_scheduler().queue.pause_queue()
         message = "Queue paused"
     elif request.action == "resume":
-        workflow_scheduler.queue.resume_queue()
+        get_workflow_scheduler().queue.resume_queue()
         message = "Queue resumed"
     elif request.action == "set_max_concurrent":
         if request.value is None:
@@ -475,7 +475,7 @@ async def control_queue(request: QueueControlRequest):
                 status_code=400,
                 detail="value required for set_max_concurrent action",
             )
-        workflow_scheduler.queue.set_max_concurrent(request.value)
+        get_workflow_scheduler().queue.set_max_concurrent(request.value)
         message = f"Max concurrent workflows set to {request.value}"
     else:
         raise HTTPException(status_code=400, detail=f"Invalid action: {request.action}")
@@ -483,7 +483,7 @@ async def control_queue(request: QueueControlRequest):
     return {
         "success": True,
         "message": message,
-        "queue_status": workflow_scheduler.queue.get_queue_status(),
+        "queue_status": get_workflow_scheduler().queue.get_queue_status(),
     }
 
 
@@ -500,12 +500,12 @@ async def control_queue(request: QueueControlRequest):
 @router.post("/start", response_model=SchedulerStartResponse)
 async def start_scheduler():
     """Start the workflow scheduler"""
-    await workflow_scheduler.start()
+    await get_workflow_scheduler().start()
 
     return {
         "success": True,
         "message": "Workflow scheduler started",
-        "status": workflow_scheduler.get_scheduler_status(),
+        "status": get_workflow_scheduler().get_scheduler_status(),
     }
 
 
@@ -522,7 +522,7 @@ async def start_scheduler():
 @router.post("/stop", response_model=SchedulerStopResponse)
 async def stop_scheduler():
     """Stop the workflow scheduler"""
-    await workflow_scheduler.stop()
+    await get_workflow_scheduler().stop()
 
     return {"success": True, "message": "Workflow scheduler stopped"}
 
@@ -640,8 +640,8 @@ async def schedule_template_workflow(
         auto_approve,
         user_id,
     )
-    workflow_id = workflow_scheduler.schedule_workflow(request=internal_request)
-    workflow = workflow_scheduler.get_workflow(workflow_id)
+    workflow_id = get_workflow_scheduler().schedule_workflow(request=internal_request)
+    workflow = get_workflow_scheduler().get_workflow(workflow_id)
 
     return {
         "success": True,
@@ -675,10 +675,10 @@ async def schedule_template_workflow(
 @router.get("/stats", response_model=SchedulerStatsResponse)
 async def get_scheduler_statistics():
     """Get detailed scheduler statistics"""
-    status = workflow_scheduler.get_scheduler_status()
+    status = get_workflow_scheduler().get_scheduler_status()
 
     # Get additional statistics
-    all_workflows = workflow_scheduler.list_scheduled_workflows()
+    all_workflows = get_workflow_scheduler().list_scheduled_workflows()
 
     # Priority distribution
     priority_stats = {}
@@ -759,7 +759,7 @@ async def batch_schedule_workflows(workflows: List[ScheduleWorkflowRequest]):
                 timeout_minutes=request.timeout_minutes,
                 max_retries=request.max_retries,
             )
-            workflow_id = workflow_scheduler.schedule_workflow(request=internal_request)
+            workflow_id = get_workflow_scheduler().schedule_workflow(request=internal_request)
 
             scheduled_workflows.append(workflow_id)
 

--- a/autobot-backend/api/service_messages.py
+++ b/autobot-backend/api/service_messages.py
@@ -18,7 +18,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
-from auth_middleware import auth_middleware
+from auth_middleware import get_auth_middleware
 from autobot_shared.message_bus import get_message_bus
 from utils.catalog_http_exceptions import raise_auth_error, raise_server_error
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -78,7 +78,7 @@ class CorrelationChainResponse(BaseModel):
 def _check_admin(request: Request) -> bool:
     """Require admin role for service-message access."""
     try:
-        user_data = auth_middleware.get_user_from_request(request)
+        user_data = get_auth_middleware().get_user_from_request(request)
         if not user_data:
             raise_auth_error(
                 "AUTH_0002",

--- a/autobot-backend/api/user_management/dependencies.py
+++ b/autobot-backend/api/user_management/dependencies.py
@@ -12,7 +12,7 @@ import uuid
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth_middleware import auth_middleware
+from auth_middleware import get_auth_middleware
 from autobot_shared.ssot_config import config as ssot_config
 from user_management.config import DeploymentMode, get_deployment_config
 from user_management.database import get_async_session
@@ -61,7 +61,7 @@ def get_current_user(request: Request) -> dict:
             "auth_disabled": True,
         }
 
-    user_data = auth_middleware.get_user_from_request(request)
+    user_data = get_auth_middleware().get_user_from_request(request)
     if not user_data:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/autobot-backend/api/websockets.py
+++ b/autobot-backend/api/websockets.py
@@ -527,9 +527,9 @@ def _register_event_manager_broadcast(broadcast_event: Callable) -> None:
         broadcast_event: Broadcast callback function
     """
     try:
-        from event_manager import event_manager
+        from event_manager import get_event_manager
 
-        event_manager.register_websocket_broadcast(broadcast_event)
+        get_event_manager().register_websocket_broadcast(broadcast_event)
         logger.info("Successfully registered WebSocket broadcast with event manager")
     except ImportError as e:
         logger.warning("Event manager not available, continuing without it: %s", e)
@@ -544,9 +544,9 @@ def _unregister_event_manager_broadcast() -> None:
     Issue #665: Extracted from websocket_endpoint to reduce function length.
     """
     try:
-        from event_manager import event_manager
+        from event_manager import get_event_manager
 
-        event_manager.register_websocket_broadcast(None)
+        get_event_manager().register_websocket_broadcast(None)
         logger.info("WebSocket broadcast unregistered from event manager")
     except ImportError:
         logger.debug("Event manager not available for cleanup")
@@ -862,16 +862,16 @@ def init_npu_worker_websocket():
             return
 
         try:
-            from event_manager import event_manager
+            from event_manager import get_event_manager
 
             # Subscribe to all NPU worker events
-            event_manager.subscribe(
+            get_event_manager().subscribe(
                 "npu.worker.status.changed", broadcast_npu_worker_event
             )
-            event_manager.subscribe("npu.worker.added", broadcast_npu_worker_event)
-            event_manager.subscribe("npu.worker.updated", broadcast_npu_worker_event)
-            event_manager.subscribe("npu.worker.removed", broadcast_npu_worker_event)
-            event_manager.subscribe(
+            get_event_manager().subscribe("npu.worker.added", broadcast_npu_worker_event)
+            get_event_manager().subscribe("npu.worker.updated", broadcast_npu_worker_event)
+            get_event_manager().subscribe("npu.worker.removed", broadcast_npu_worker_event)
+            get_event_manager().subscribe(
                 "npu.worker.metrics.updated", broadcast_npu_worker_event
             )
 

--- a/autobot-backend/async_chat_workflow.py
+++ b/autobot-backend/async_chat_workflow.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.singleton_factory import lazy_singleton
 from constants.threshold_constants import TimingConstants
 from dependency_container import inject_services
 from llm_interface import ChatMessage, LLMResponse
@@ -366,8 +367,7 @@ class WorkflowManager:
         return self._instance
 
 
-# Global workflow manager
-workflow_manager = WorkflowManager()
+get_workflow_manager = lazy_singleton(WorkflowManager)
 
 
 # Convenience function
@@ -377,7 +377,7 @@ async def process_chat_message(
     """Process chat message through async workflow"""
     try:
         # Add timeout protection to prevent hanging - maximum 25 seconds
-        workflow = await workflow_manager.get_workflow()
+        workflow = await get_workflow_manager().get_workflow()
         result = await asyncio.wait_for(
             workflow.process_chat_message(user_message, chat_id), timeout=25.0
         )

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -23,6 +23,7 @@ from autobot_shared.auth.jwt_core import (
     hash_password,
     verify_password,
 )
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config as ssot_config
 from config.manager import get_config_manager
 from security_layer import SecurityLayer
@@ -631,8 +632,7 @@ class AuthenticationMiddleware:
             return False, None
 
 
-# Global authentication middleware instance
-auth_middleware = AuthenticationMiddleware()
+get_auth_middleware = lazy_singleton(AuthenticationMiddleware)
 
 
 def get_current_user(request: Request) -> Dict:
@@ -650,7 +650,7 @@ def get_current_user(request: Request) -> Dict:
     if _internal_key and request.headers.get("X-Internal-API-Key") == _internal_key:
         return {"username": "service:slm", "role": "admin", "service": True}
 
-    user_data = auth_middleware.get_user_from_request(request)
+    user_data = get_auth_middleware().get_user_from_request(request)
     if not user_data:
         raise_auth_error("AUTH_0002", "Authentication required")
     return user_data
@@ -687,7 +687,7 @@ def check_admin_permission(request: Request) -> bool:
         logger.debug("Single user mode: granting admin access")
         return True
 
-    user_data = auth_middleware.get_user_from_request(request)
+    user_data = get_auth_middleware().get_user_from_request(request)
 
     if not user_data:
         raise_auth_error("AUTH_0002", "Authentication required")

--- a/autobot-backend/auth_rbac.py
+++ b/autobot-backend/auth_rbac.py
@@ -34,14 +34,14 @@ from typing import Callable, List, Union
 
 from fastapi import Request
 
-from auth_middleware import auth_middleware
+from autobot_shared.singleton_factory import lazy_singleton
+from auth_middleware import get_auth_middleware
 from security_layer import SecurityLayer
 from utils.catalog_http_exceptions import raise_auth_error
 
 logger = logging.getLogger(__name__)
 
-# Initialize security layer for permission checks
-_security_layer = SecurityLayer()
+_get_security_layer = lazy_singleton(SecurityLayer)
 
 
 class Permission(str, Enum):
@@ -294,7 +294,7 @@ def _get_user_permissions(user_role: str) -> List[str]:
         pass
 
     # Also get permissions from SecurityLayer (for backward compatibility)
-    security_perms = _security_layer._get_default_role_permissions(user_role)
+    security_perms = _get_security_layer()._get_default_role_permissions(user_role)
     permissions.extend(security_perms)
 
     return list(set(permissions))  # Remove duplicates
@@ -322,7 +322,7 @@ def has_permission(user_data: dict, permission: Union[Permission, str]) -> bool:
     perm_str = permission.value if isinstance(permission, Permission) else permission
 
     # Check using SecurityLayer for audit logging
-    return _security_layer.check_permission(user_role, perm_str)
+    return _get_security_layer().check_permission(user_role, perm_str)
 
 
 def _check_single_user_bypass(permission: Union[Permission, str]) -> bool:
@@ -359,7 +359,7 @@ def _deny_permission_access(user_data: dict, perm_str: str, request: Request) ->
     Raises:
         HTTPException via raise_auth_error
     """
-    _security_layer.audit_log(
+    _get_security_layer().audit_log(
         action="permission_denied",
         user=user_data.get("username", "unknown"),
         outcome="denied",
@@ -405,7 +405,7 @@ def require_permission(
         if allow_single_user_bypass and _check_single_user_bypass(permission):
             return True
 
-        user_data = auth_middleware.get_user_from_request(request)
+        user_data = get_auth_middleware().get_user_from_request(request)
         if not user_data:
             raise_auth_error("AUTH_0002", "Authentication required")
 
@@ -435,7 +435,7 @@ def _deny_role_access(
     Raises:
         HTTPException via raise_auth_error
     """
-    _security_layer.audit_log(
+    _get_security_layer().audit_log(
         action="role_denied",
         user=user_data.get("username", "unknown"),
         outcome="denied",
@@ -465,7 +465,7 @@ def _deny_any_permission_access(
     Raises:
         HTTPException via raise_auth_error
     """
-    _security_layer.audit_log(
+    _get_security_layer().audit_log(
         action="permission_denied",
         user=user_data.get("username", "unknown"),
         outcome="denied",
@@ -510,7 +510,7 @@ def require_role(
         if allow_single_user_bypass and _check_single_user_bypass("role_check"):
             return True
 
-        user_data = auth_middleware.get_user_from_request(request)
+        user_data = get_auth_middleware().get_user_from_request(request)
         if not user_data:
             raise_auth_error("AUTH_0002", "Authentication required")
 
@@ -556,7 +556,7 @@ def require_any_permission(
         if allow_single_user_bypass and _check_single_user_bypass("any_permission"):
             return True
 
-        user_data = auth_middleware.get_user_from_request(request)
+        user_data = get_auth_middleware().get_user_from_request(request)
         if not user_data:
             raise_auth_error("AUTH_0002", "Authentication required")
 

--- a/autobot-backend/chat_workflow/cot_events.py
+++ b/autobot-backend/chat_workflow/cot_events.py
@@ -191,11 +191,11 @@ def _try_publish(event_type: str, payload: dict) -> None:
         payload:    Dict payload that will be broadcast to WebSocket clients.
     """
     try:
-        from event_manager import event_manager
+        from event_manager import get_event_manager
 
         try:
             loop = asyncio.get_running_loop()
-            task = loop.create_task(event_manager.publish(event_type, payload))
+            task = loop.create_task(get_event_manager().publish(event_type, payload))
             task.add_done_callback(
                 lambda t: logger.debug("cot_events: publish error: %s", t.exception())
                 if not t.cancelled() and t.exception()

--- a/autobot-backend/circuit_breaker.py
+++ b/autobot-backend/circuit_breaker.py
@@ -17,6 +17,7 @@ from functools import wraps
 from threading import Lock
 from typing import Any, Callable, Dict, List, Optional
 
+from autobot_shared.singleton_factory import lazy_singleton
 from constants import CircuitBreakerDefaults
 
 logger = logging.getLogger(__name__)
@@ -494,8 +495,7 @@ class CircuitBreakerManager:
             cb.reset()
 
 
-# Global circuit breaker manager
-circuit_breaker_manager = CircuitBreakerManager()
+get_circuit_breaker_manager = lazy_singleton(CircuitBreakerManager)
 
 
 def circuit_breaker_async(
@@ -530,7 +530,7 @@ def circuit_breaker_async(
         if monitored_exceptions:
             config.monitored_exceptions = monitored_exceptions
 
-        circuit_breaker = circuit_breaker_manager.get_circuit_breaker(
+        circuit_breaker = get_circuit_breaker_manager().get_circuit_breaker(
             service_name, config
         )
 
@@ -577,7 +577,7 @@ def circuit_breaker_sync(
         if monitored_exceptions:
             config.monitored_exceptions = monitored_exceptions
 
-        circuit_breaker = circuit_breaker_manager.get_circuit_breaker(
+        circuit_breaker = get_circuit_breaker_manager().get_circuit_breaker(
             service_name, config
         )
 
@@ -603,7 +603,7 @@ async def protected_llm_call(func: Callable, *args, **kwargs) -> Any:
         monitored_exceptions=(ConnectionError, TimeoutError, OSError),
     )
 
-    circuit_breaker = circuit_breaker_manager.get_circuit_breaker("llm_service", config)
+    circuit_breaker = get_circuit_breaker_manager().get_circuit_breaker("llm_service", config)
     return await circuit_breaker.call_async(func, *args, **kwargs)
 
 
@@ -618,7 +618,7 @@ async def protected_database_call(func: Callable, *args, **kwargs) -> Any:
         monitored_exceptions=(ConnectionError, TimeoutError, OSError),
     )
 
-    circuit_breaker = circuit_breaker_manager.get_circuit_breaker(
+    circuit_breaker = get_circuit_breaker_manager().get_circuit_breaker(
         "database_service", config
     )
     return await circuit_breaker.call_async(func, *args, **kwargs)
@@ -634,7 +634,7 @@ async def protected_network_call(func: Callable, *args, **kwargs) -> Any:
         monitored_exceptions=(ConnectionError, TimeoutError, OSError),
     )
 
-    circuit_breaker = circuit_breaker_manager.get_circuit_breaker(
+    circuit_breaker = get_circuit_breaker_manager().get_circuit_breaker(
         "network_service", config
     )
     return await circuit_breaker.call_async(func, *args, **kwargs)

--- a/autobot-backend/computer_vision/phase9_multimodal_ai_test.py
+++ b/autobot-backend/computer_vision/phase9_multimodal_ai_test.py
@@ -23,7 +23,7 @@ from context_aware_decision_system import (  # noqa: E402
     DecisionType,
     context_aware_decision_system,
 )
-from modern_ai_integration import AIProvider, modern_ai_integration  # noqa: E402
+from modern_ai_integration import AIProvider, get_modern_ai_integration  # noqa: E402
 from multimodal_processor import (  # noqa: E402
     ModalInput,
     ModalityType,
@@ -338,7 +338,7 @@ async def test_modern_ai_integration():
     # Test 1: Provider Status
     print("\n1. Testing AI Provider Status...")  # noqa: print
     try:
-        status = modern_ai_integration.get_provider_status()
+        status = get_modern_ai_integration().get_provider_status()
         print("✅ AI providers status:")  # noqa: print
         for provider, info in status.items():
             availability = "✅" if info.get("available") else "❌"
@@ -354,7 +354,7 @@ async def test_modern_ai_integration():
     # Test 2: Local Model Processing (safe fallback)
     print("\n2. Testing Local Model Processing...")  # noqa: print
     try:
-        response = await modern_ai_integration.process_with_ai(
+        response = await get_modern_ai_integration().process_with_ai(
             provider=AIProvider.LOCAL_MODEL,
             prompt="Describe the capabilities of AutoBot Phase 9",
             task_type="description_generation",
@@ -368,7 +368,7 @@ async def test_modern_ai_integration():
     # Test 3: Natural Language Processing
     print("\n3. Testing Natural Language to Actions...")  # noqa: print
     try:
-        actions = await modern_ai_integration.natural_language_to_actions(
+        actions = await get_modern_ai_integration().natural_language_to_actions(
             user_command=(
                 "Click the submit button and then navigate to the " "settings page"
             ),
@@ -389,7 +389,7 @@ async def test_modern_ai_integration():
     # Test 4: Usage Statistics
     print("\n4. Testing Usage Statistics...")  # noqa: print
     try:
-        stats = modern_ai_integration.get_usage_statistics()
+        stats = get_modern_ai_integration().get_usage_statistics()
         print("✅ AI usage statistics:")  # noqa: print
         print(f"   Total requests: {stats.get('total_requests', 0)}")  # noqa: print
         print(f"   Success rate: {stats.get('success_rate', 0):.2f}")  # noqa: print
@@ -449,7 +449,7 @@ async def test_integration():
         )
 
         # Use AI to elaborate on the decision
-        ai_response = await modern_ai_integration.process_with_ai(
+        ai_response = await get_modern_ai_integration().process_with_ai(
             provider=AIProvider.LOCAL_MODEL,
             prompt=(
                 f"Elaborate on this automation decision: "
@@ -483,7 +483,7 @@ async def test_integration():
         )
 
         print("   → Processing with AI integration...")  # noqa: print
-        ai_insight = await modern_ai_integration.process_with_ai(
+        ai_insight = await get_modern_ai_integration().process_with_ai(
             provider=AIProvider.LOCAL_MODEL,
             prompt="Provide insights on workflow optimization opportunities",
             task_type="workflow_analysis",

--- a/autobot-backend/computer_vision/screen_analyzer.py
+++ b/autobot-backend/computer_vision/screen_analyzer.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import numpy as np
 
-from desktop_streaming_manager import desktop_streaming
+from desktop_streaming_manager import get_desktop_streaming
 from memory import TaskPriority
 from multimodal_processor import (
     ModalityType,
@@ -27,7 +27,7 @@ from multimodal_processor import (
     ProcessingIntent,
     unified_processor,
 )
-from task_execution_tracker import task_tracker
+from task_execution_tracker import get_task_tracker
 
 from .classifiers import ContextAnalyzer, ElementClassifier, TemplateMatchingEngine
 from .collections import ProcessingResultExtractor, UIElementCollection
@@ -149,7 +149,7 @@ class ScreenAnalyzer:
         Issue #281: Refactored from 141 lines to use extracted helper methods.
         Issue #620: Further refactored to reduce function length.
         """
-        async with task_tracker.track_task(
+        async with get_task_tracker().track_task(
             "Screen Analysis",
             "Comprehensive analysis of current screen state",
             agent_type="computer_vision",
@@ -303,10 +303,10 @@ class ScreenAnalyzer:
         cv2 = _get_cv2()
         PILImage = _get_pil_image()
 
-        session_info = desktop_streaming.vnc_manager.get_session_info(session_id)
+        session_info = get_desktop_streaming().vnc_manager.get_session_info(session_id)
         if not session_info:
             return None
-        screenshot_base64 = await desktop_streaming._get_session_screenshot(session_id)
+        screenshot_base64 = await get_desktop_streaming()._get_session_screenshot(session_id)
         if not screenshot_base64:
             return None
         screenshot_bytes = base64.b64decode(screenshot_base64)

--- a/autobot-backend/computer_vision/system.py
+++ b/autobot-backend/computer_vision/system.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 
 from memory import EnhancedMemoryManager, TaskPriority
-from task_execution_tracker import task_tracker
+from task_execution_tracker import get_task_tracker
 
 from .screen_analyzer import ScreenAnalyzer
 from .types import ScreenState
@@ -72,7 +72,7 @@ class ComputerVisionSystem:
     ) -> Dict[str, Any]:
         """Comprehensive screen analysis and understanding"""
 
-        async with task_tracker.track_task(
+        async with get_task_tracker().track_task(
             "Computer Vision Analysis",
             "Complete screen understanding and element detection",
             agent_type="computer_vision_system",

--- a/autobot-backend/context_aware_decision/collectors/audio.py
+++ b/autobot-backend/context_aware_decision/collectors/audio.py
@@ -29,9 +29,9 @@ class AudioContextCollector:
     async def collect(self) -> List[ContextElement]:
         """Collect audio/voice context."""
         try:
-            from voice_processing_system import voice_processing_system
+            from voice_processing_system import get_voice_processing_system
 
-            voice_status = voice_processing_system.get_system_status()
+            voice_status = get_voice_processing_system().get_system_status()
             audio_elements = []
 
             # Recent voice commands context
@@ -41,7 +41,7 @@ class AudioContextCollector:
                 )
 
             # Command history context
-            command_history = voice_processing_system.get_command_history(limit=5)
+            command_history = get_voice_processing_system().get_command_history(limit=5)
             if command_history:
                 audio_elements.append(
                     self._create_command_history_context(command_history)

--- a/autobot-backend/context_aware_decision/collectors/main.py
+++ b/autobot-backend/context_aware_decision/collectors/main.py
@@ -15,7 +15,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from enhanced_memory_manager_async import TaskPriority
-from task_execution_tracker import task_tracker
+from task_execution_tracker import get_task_tracker
 
 from ..models import ContextElement, DecisionContext
 from ..time_provider import TimeProvider
@@ -104,7 +104,7 @@ class ContextCollector:
         self, decision_type: DecisionType, primary_goal: str
     ) -> DecisionContext:
         """Collect comprehensive context for decision making."""
-        async with task_tracker.track_task(
+        async with get_task_tracker().track_task(
             "Context Collection",
             f"Collecting context for {decision_type.value} decision",
             agent_type="context_collector",

--- a/autobot-backend/context_aware_decision/collectors/system.py
+++ b/autobot-backend/context_aware_decision/collectors/system.py
@@ -29,7 +29,7 @@ class SystemContextCollector:
     async def collect(self) -> List[ContextElement]:
         """Collect system state context."""
         try:
-            from takeover_manager import takeover_manager
+            from takeover_manager import get_takeover_manager
 
             system_elements = []
 
@@ -37,7 +37,7 @@ class SystemContextCollector:
             system_elements.append(self._create_takeover_status_context())
 
             # Active takeovers
-            active_takeovers = takeover_manager.get_active_sessions()
+            active_takeovers = get_takeover_manager().get_active_sessions()
             if active_takeovers:
                 system_elements.append(
                     self._create_active_takeovers_context(active_takeovers)
@@ -56,9 +56,9 @@ class SystemContextCollector:
 
     def _create_takeover_status_context(self) -> ContextElement:
         """Create context element for takeover system status."""
-        from takeover_manager import takeover_manager
+        from takeover_manager import get_takeover_manager
 
-        takeover_status = takeover_manager.get_system_status()
+        takeover_status = get_takeover_manager().get_system_status()
         return ContextElement(
             context_id=f"takeover_status_{self.time_provider.current_timestamp_millis()}",
             context_type=ContextType.SYSTEM_STATE,

--- a/autobot-backend/context_aware_decision/decision_engine.py
+++ b/autobot-backend/context_aware_decision/decision_engine.py
@@ -15,7 +15,7 @@ import logging
 from typing import Any, Callable, Dict, List
 
 from enhanced_memory_manager_async import TaskPriority
-from task_execution_tracker import task_tracker
+from task_execution_tracker import get_task_tracker
 
 from .models import Decision, DecisionContext
 from .time_provider import TimeProvider
@@ -52,7 +52,7 @@ class DecisionEngine:
     async def make_decision(self, decision_context: DecisionContext) -> Decision:
         """Make a decision based on provided context."""
 
-        async with task_tracker.track_task(
+        async with get_task_tracker().track_task(
             "Decision Making",
             f"Making {decision_context.decision_type.value} decision",
             agent_type="decision_engine",

--- a/autobot-backend/context_aware_decision/system.py
+++ b/autobot-backend/context_aware_decision/system.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from enhanced_memory_manager_async import TaskPriority
 from memory import EnhancedMemoryManager
-from task_execution_tracker import task_tracker
+from task_execution_tracker import get_task_tracker
 
 from .collectors import ContextCollector
 from .decision_engine import DecisionEngine
@@ -50,7 +50,7 @@ class ContextAwareDecisionSystem:
     ) -> Decision:
         """Make a decision considering comprehensive context."""
 
-        async with task_tracker.track_task(
+        async with get_task_tracker().track_task(
             "Contextual Decision Making",
             f"Making contextual {decision_type.value} decision: {primary_goal}",
             agent_type="context_aware_decision_system",

--- a/autobot-backend/dependency_container.py
+++ b/autobot-backend/dependency_container.py
@@ -16,6 +16,7 @@ from typing import Any, AsyncGenerator, Callable, Dict, Optional, Type, TypeVar
 import redis.asyncio as async_redis
 
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.singleton_factory import lazy_singleton
 from config.manager import ConfigManager, get_config_manager
 from llm_interface import LLMInterface, get_llm_interface
 
@@ -363,25 +364,25 @@ class AsyncServiceContainer:
         return info
 
 
-# Global container instance
-container = AsyncServiceContainer()
+get_container = lazy_singleton(AsyncServiceContainer)
 
 
 # Convenience functions for common services
 async def get_config() -> ConfigManager:
     """Get config manager"""
-    return await container.get_service("config")
+    return await get_container().get_service("config")
 
 
 async def get_llm() -> LLMInterface:
     """Get LLM interface"""
-    return await container.get_service("llm")
+    return await get_container().get_service("llm")
 
 
 # Context manager for service lifecycle
 @asynccontextmanager
 async def service_context():
     """Context manager for automatic service lifecycle management"""
+    container = get_container()
     try:
         # Initialize all services
         initialization_results = await container.initialize_all_services()
@@ -418,7 +419,7 @@ def inject_service(service_name: str):
 
         async def wrapper(*args, **kwargs):
             """Async wrapper that injects requested service before calling function."""
-            service = await container.get_service(service_name)
+            service = await get_container().get_service(service_name)
             return await func(service, *args, **kwargs)
 
         return wrapper
@@ -436,7 +437,7 @@ def inject_services(**service_mapping):
             """Async wrapper that injects all mapped services before calling function."""
             services = {}
             for param_name, service_name in service_mapping.items():
-                services[param_name] = await container.get_service(service_name)
+                services[param_name] = await get_container().get_service(service_name)
 
             return await func(*args, **services, **kwargs)
 

--- a/autobot-backend/desktop_streaming_manager.py
+++ b/autobot-backend/desktop_streaming_manager.py
@@ -26,6 +26,7 @@ from typing import Any, Optional
 
 import websockets
 
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config
 from config import config_manager
 from constants.threshold_constants import TimingConstants
@@ -1106,5 +1107,4 @@ class DesktopStreamingManager:
         }
 
 
-# Global instance
-desktop_streaming = DesktopStreamingManager()
+get_desktop_streaming = lazy_singleton(DesktopStreamingManager)

--- a/autobot-backend/diagnostics.py
+++ b/autobot-backend/diagnostics.py
@@ -20,12 +20,13 @@ import psutil
 
 try:
     from autobot_shared.redis_client import get_redis_client
+    from autobot_shared.singleton_factory import lazy_singleton
     from constants.threshold_constants import (
         ResourceThresholds,
         RetryConfig,
         TimingConstants,
     )
-    from event_manager import event_manager
+    from event_manager import get_event_manager
 except ImportError as e:
     logging.warning(f"Import error in diagnostics: {e}")
 
@@ -136,7 +137,7 @@ class PerformanceOptimizedDiagnostics:
     ) -> asyncio.Future:
         """Publish permission request and return future (Issue #315 - extracted helper)."""
         permission_future = asyncio.Future()
-        await event_manager.publish(
+        await get_event_manager().publish(
             "log_message",
             {
                 "task_id": task_id,
@@ -173,7 +174,7 @@ class PerformanceOptimizedDiagnostics:
         )
 
         if attempt < self.permission_retry_attempts - 1:
-            await event_manager.publish(
+            await get_event_manager().publish(
                 "log_message",
                 {
                     "level": "WARNING",
@@ -241,7 +242,7 @@ class PerformanceOptimizedDiagnostics:
         self, task_id: str, elapsed_time: float
     ):
         """Handle user permission timeout with intelligent fallback"""
-        await event_manager.publish(
+        await get_event_manager().publish(
             "log_message",
             {
                 "level": "WARNING",
@@ -496,37 +497,36 @@ class PerformanceOptimizedDiagnostics:
             return {"error": "Memory cleanup failed"}
 
 
-# Global instance with performance optimization
-performance_diagnostics = PerformanceOptimizedDiagnostics()
+get_performance_diagnostics = lazy_singleton(PerformanceOptimizedDiagnostics)
 
 
 # Legacy compatibility functions (with performance improvements)
 async def request_user_permission(task_id: str, report: Dict[str, Any]) -> bool:
     """PERFORMANCE OPTIMIZED: Legacy wrapper with new timeout handling"""
-    return await performance_diagnostics.request_user_permission_optimized(
+    return await get_performance_diagnostics().request_user_permission_optimized(
         task_id, report
     )
 
 
 def get_system_info() -> Dict[str, Any]:
     """Get system information with performance insights"""
-    return performance_diagnostics.check_system_resources()
+    return get_performance_diagnostics().check_system_resources()
 
 
 def force_memory_cleanup() -> Dict[str, Any]:
     """Force system-wide memory cleanup"""
-    return performance_diagnostics.cleanup_and_optimize_memory()
+    return get_performance_diagnostics().cleanup_and_optimize_memory()
 
 
 # Additional performance monitoring functions
 def get_performance_metrics() -> Dict[str, Any]:
     """Get current performance metrics"""
     return {
-        "system_resources": performance_diagnostics.check_system_resources(),
+        "system_resources": get_performance_diagnostics().check_system_resources(),
         "memory_cleanup_available": True,
         "timeout_optimizations_active": True,
         "max_user_permission_timeout": (
-            performance_diagnostics.max_user_permission_timeout
+            get_performance_diagnostics().max_user_permission_timeout
         ),
         "performance_mode": "optimized",
     }
@@ -550,6 +550,5 @@ if __name__ == "__main__":
     logger.info("Performance Metrics: {json.dumps(metrics, indent=2)}")
 
 
-# Backward compatibility aliases
+# Backward compatibility alias
 Diagnostics = PerformanceOptimizedDiagnostics
-performance_diagnostics = PerformanceOptimizedDiagnostics()

--- a/autobot-backend/elevation_wrapper.py
+++ b/autobot-backend/elevation_wrapper.py
@@ -13,6 +13,8 @@ import re
 import subprocess  # nosec B404 - elevation wrapper requires subprocess
 from typing import Dict, Tuple
 
+from autobot_shared.singleton_factory import lazy_singleton
+
 logger = logging.getLogger(__name__)
 
 # Pattern to detect sudo commands
@@ -204,8 +206,7 @@ class ElevationWrapper:
         self.session_commands.clear()
 
 
-# Global instance
-elevation_wrapper = ElevationWrapper()
+get_elevation_wrapper = lazy_singleton(ElevationWrapper)
 
 
 def wrap_sudo_command(command: str) -> str:
@@ -218,7 +219,7 @@ def wrap_sudo_command(command: str) -> str:
 
 async def execute_with_elevation(command: str, **kwargs):
     """Convenience function to execute command with elevation if needed"""
-    return await elevation_wrapper.execute_command(command, **kwargs)
+    return await get_elevation_wrapper().execute_command(command, **kwargs)
 
 
 # Monkey-patch subprocess to intercept sudo calls

--- a/autobot-backend/event_manager.py
+++ b/autobot-backend/event_manager.py
@@ -8,6 +8,7 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 
 import yaml
 
+from autobot_shared.singleton_factory import lazy_singleton
 from constants.path_constants import PATH
 
 logger = logging.getLogger(__name__)
@@ -98,8 +99,7 @@ class EventManager:
             self._listeners[event_type].remove(listener)
 
 
-# Global instance of EventManager
-event_manager = EventManager()
+get_event_manager = lazy_singleton(EventManager)
 
 if __name__ == "__main__":
 
@@ -109,17 +109,17 @@ if __name__ == "__main__":
 
     async def main():
         """Main test function demonstrating EventManager usage."""
-        event_manager.subscribe("task_update", test_listener)
-        event_manager.subscribe("log_message", test_listener)
+        get_event_manager().subscribe("task_update", test_listener)
+        get_event_manager().subscribe("log_message", test_listener)
 
         # Simulate WebSocket broadcast callback
         async def mock_websocket_broadcast(event):
             """Mock callback that simulates WebSocket event broadcast."""
             print(f"WebSocket Broadcast: {event}")  # noqa: print
 
-        event_manager.register_websocket_broadcast(mock_websocket_broadcast)
+        get_event_manager().register_websocket_broadcast(mock_websocket_broadcast)
 
-        await event_manager.publish(
+        await get_event_manager().publish(
             "task_update",
             {
                 "task_id": "123",
@@ -127,10 +127,10 @@ if __name__ == "__main__":
                 "description": "Doing something",
             },
         )
-        await event_manager.publish(
+        await get_event_manager().publish(
             "log_message", {"level": "INFO", "message": "Agent started."}
         )
-        await event_manager.publish(
+        await get_event_manager().publish(
             "task_update",
             {
                 "task_id": "123",
@@ -140,7 +140,7 @@ if __name__ == "__main__":
         )
 
         # Test debug publish
-        await event_manager.debug_publish(
+        await get_event_manager().debug_publish(
             "debug_info", {"message": "This is a debug message."}
         )
 

--- a/autobot-backend/initialization/endpoints.py
+++ b/autobot-backend/initialization/endpoints.py
@@ -15,7 +15,7 @@ from typing import Any, Dict
 from fastapi import FastAPI, Request
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from circuit_breaker import circuit_breaker_manager
+from circuit_breaker import get_circuit_breaker_manager
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 def _get_circuit_breaker_states() -> Dict[str, Any]:
     """Return all registered circuit breaker states for health reporting."""
     try:
-        return circuit_breaker_manager.get_all_states()
+        return get_circuit_breaker_manager().get_all_states()
     except Exception:
         logger.debug("Could not retrieve circuit breaker states", exc_info=True)
         return {}

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1232,7 +1232,7 @@ async def _wire_scheduler_executor() -> None:
     logger.info("[ 98%%] Scheduler: Wiring orchestration executor...")
     try:
         from orchestrator import get_orchestrator_sync
-        from workflow_scheduler import ScheduledWorkflow, workflow_scheduler
+        from workflow_scheduler import ScheduledWorkflow, get_workflow_scheduler
 
         orchestrator = get_orchestrator_sync()
 
@@ -1264,7 +1264,7 @@ async def _wire_scheduler_executor() -> None:
             succeeded = result.get("status") in ("completed", "partially_completed")
             return {"success": succeeded, **result}
 
-        workflow_scheduler.set_workflow_executor(_orchestration_executor)
+        get_workflow_scheduler().set_workflow_executor(_orchestration_executor)
         logger.info("[ 98%%] Scheduler: Orchestration executor wired")
     except Exception as e:
         logger.warning(

--- a/autobot-backend/live_event_manager.py
+++ b/autobot-backend/live_event_manager.py
@@ -15,6 +15,8 @@ from typing import Dict, Set
 from fastapi import WebSocket
 from starlette.websockets import WebSocketState
 
+from autobot_shared.singleton_factory import lazy_singleton
+
 logger = logging.getLogger(__name__)
 
 _VALID_PREFIXES = {"agent", "task", "workflow", "global"}
@@ -128,7 +130,7 @@ class LiveEventManager:
         return sent
 
 
-live_event_manager = LiveEventManager()
+get_live_event_manager = lazy_singleton(LiveEventManager)
 
 
 async def publish_live_event(channel: str, event_type: str, payload: dict) -> int:
@@ -138,4 +140,4 @@ async def publish_live_event(channel: str, event_type: str, payload: dict) -> in
         await publish_live_event("task:abc123", "task_progress", {"pct": 50})
         await publish_live_event("global", "cost_warning", {"threshold": 10.0})
     """
-    return await live_event_manager.publish(channel, event_type, payload)
+    return await get_live_event_manager().publish(channel, event_type, payload)

--- a/autobot-backend/modern_ai_integration.py
+++ b/autobot-backend/modern_ai_integration.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.singleton_factory import lazy_singleton
 from constants.model_constants import (
     ANTHROPIC_CLAUDE3_OPUS_DATED,
     GOOGLE_GEMINI_PRO,
@@ -1226,5 +1227,4 @@ class ModernAIIntegration:
         }
 
 
-# Global instance
-modern_ai_integration = ModernAIIntegration()
+get_modern_ai_integration = lazy_singleton(ModernAIIntegration)

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -41,7 +41,7 @@ from orchestration import (
     WorkflowPlanner,
 )
 from orchestration.primitives import bounded_gather
-from task_execution_tracker import Priority, TaskType, task_tracker
+from task_execution_tracker import Priority, TaskType, get_task_tracker
 
 # Import shared agent selection utilities (Issue #292 - Eliminate duplicate code)
 from utils.agent_selection import find_best_agent_for_task as _find_best_agent
@@ -51,7 +51,7 @@ from utils.agent_selection import update_agent_performance as _update_performanc
 
 # Issue #5040: Imports for merged EnhancedMultiAgentOrchestrator functionality
 from autobot_shared.redis_client import get_async_redis_client, get_redis_client
-from event_manager import event_manager as _event_manager
+from event_manager import get_event_manager as _get_event_manager
 
 from enhanced_orchestration.execution_strategies import ExecutionStrategyHandler
 from enhanced_orchestration.success_criteria import SuccessCriteriaEvaluator
@@ -542,7 +542,7 @@ class Orchestrator:
         context: Optional[Dict[str, Any]],
     ) -> None:
         """Start task tracking for user request. Issue #620."""
-        task_tracker.start_task(
+        get_task_tracker().start_task(
             task_id=task_id,
             task_type=TaskType.USER_REQUEST,
             description=user_message[:200],
@@ -587,7 +587,7 @@ class Orchestrator:
 
             processing_time = time.time() - start_time
             self._update_success_metrics(processing_time)
-            task_tracker.complete_task(task_id, result)
+            get_task_tracker().complete_task(task_id, result)
             logger.info("✅ Request %s completed in %.2fs", task_id, processing_time)
 
             return self._build_success_response(
@@ -602,7 +602,7 @@ class Orchestrator:
         except Exception as e:
             processing_time = time.time() - start_time
             self.metrics["tasks_failed"] += 1
-            task_tracker.fail_task(task_id, str(e))
+            get_task_tracker().fail_task(task_id, str(e))
             logger.error(
                 "❌ Request %s failed after %.2fs: %s", task_id, processing_time, e
             )
@@ -1664,7 +1664,7 @@ class Orchestrator:
         self, workflow_id: str, event_type: str, data: Dict[str, Any]
     ) -> None:
         """Publish a workflow lifecycle event via the event manager."""
-        await _event_manager.publish(
+        await _get_event_manager().publish(
             "workflow_event",
             {
                 "workflow_id": workflow_id,

--- a/autobot-backend/prompt_manager.py
+++ b/autobot-backend/prompt_manager.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List, Optional
 import yaml
 from jinja2 import Environment, FileSystemLoader, Template
 
+from autobot_shared.singleton_factory import lazy_singleton
 from constants.ttl_constants import TTL_24_HOURS
 
 logger = logging.getLogger(__name__)
@@ -1202,8 +1203,7 @@ class PromptManager:
             logger.debug("Redis prompts cache save failed: %s", e)
 
 
-# Global prompt manager instance
-prompt_manager = PromptManager()
+get_prompt_manager = lazy_singleton(PromptManager)
 
 
 def get_prompt(prompt_key: str, **kwargs) -> str:
@@ -1217,7 +1217,7 @@ def get_prompt(prompt_key: str, **kwargs) -> str:
     Returns:
         Rendered prompt content
     """
-    return prompt_manager.get(prompt_key, **kwargs)
+    return get_prompt_manager().get(prompt_key, **kwargs)
 
 
 def _build_dynamic_context(
@@ -1249,7 +1249,7 @@ def _build_dynamic_context(
     """
     try:
         dynamic_template_key = "default.agent.system.dynamic_context"
-        return prompt_manager.get(
+        return get_prompt_manager().get(
             dynamic_template_key,
             session_id=session_id or "N/A",
             current_date=datetime.now(tz=timezone.utc).strftime("%Y-%m-%d"),
@@ -1302,7 +1302,7 @@ def get_optimized_prompt(
         Combined prompt with static prefix + dynamic suffix
     """
     # Get static base prompt with includes rendered (will be cached by vLLM)
-    base_prompt = prompt_manager.get(base_prompt_key)
+    base_prompt = get_prompt_manager().get(base_prompt_key)
 
     # Build dynamic context section (Issue #620: extracted helper)
     dynamic_context = _build_dynamic_context(
@@ -1329,14 +1329,14 @@ def list_available_prompts(filter_pattern: Optional[str] = None) -> List[str]:
     Returns:
         List of matching prompt keys
     """
-    return prompt_manager.list_prompts(filter_pattern)
+    return get_prompt_manager().list_prompts(filter_pattern)
 
 
 def reload_prompts() -> None:
     """
     Convenience function to reload all prompts.
     """
-    prompt_manager.reload()
+    get_prompt_manager().reload()
 
 
 # Issue #1327: Supported languages for prompt language injection.

--- a/autobot-backend/research_browser_manager.py
+++ b/autobot-backend/research_browser_manager.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Optional
 
 import aiofiles
 
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config as ssot_config
 from config.manager import get_config_manager
 
@@ -684,5 +685,4 @@ class ResearchBrowserManager:
             await self.cleanup_session(session_id)
 
 
-# Global research browser manager
-research_browser_manager = ResearchBrowserManager()
+get_research_browser_manager = lazy_singleton(ResearchBrowserManager)

--- a/autobot-backend/retry_mechanism.py
+++ b/autobot-backend/retry_mechanism.py
@@ -17,6 +17,7 @@ from enum import Enum
 from functools import wraps
 from typing import Any, Callable, Dict, Optional
 
+from autobot_shared.singleton_factory import lazy_singleton
 from constants.threshold_constants import RetryConfig as ThresholdRetryConfig
 from constants.threshold_constants import TimingConstants
 
@@ -351,8 +352,7 @@ class RetryMechanism:
             }
 
 
-# Global retry mechanism instance
-default_retry_mechanism = RetryMechanism()
+get_default_retry_mechanism = lazy_singleton(RetryMechanism)
 
 
 def retry_async(

--- a/autobot-backend/routers/code_completion.py
+++ b/autobot-backend/routers/code_completion.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import create_engine, desc, func
 from sqlalchemy.orm import sessionmaker
 
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config
 from models.code_pattern import CodePattern
 from services.context_analyzer import ContextAnalyzer
@@ -24,8 +25,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["code-completion"])
 
-# Initialize context analyzer
-context_analyzer = ContextAnalyzer()
+get_context_analyzer = lazy_singleton(ContextAnalyzer)
 
 # Database setup — deferred to avoid crash when config.database is unavailable
 _engine = None
@@ -385,7 +385,7 @@ async def analyze_context(request: ContextAnalysisRequest):
     start_time = time.time()
 
     try:
-        context = context_analyzer.analyze(
+        context = get_context_analyzer().analyze(
             file_content=request.file_content,
             cursor_line=request.cursor_line,
             cursor_position=request.cursor_position,
@@ -412,7 +412,7 @@ async def get_context(context_id: str):
     - **context_id**: Context identifier from previous analysis
     """
     try:
-        cached = context_analyzer._get_cached_context(context_id)
+        cached = get_context_analyzer()._get_cached_context(context_id)
 
         if not cached:
             raise HTTPException(

--- a/autobot-backend/security/session_ownership.py
+++ b/autobot-backend/security/session_ownership.py
@@ -19,7 +19,7 @@ from typing import Dict, Optional
 
 from fastapi import HTTPException, Request
 
-from auth_middleware import auth_middleware
+from auth_middleware import get_auth_middleware
 
 logger = logging.getLogger(__name__)
 
@@ -175,7 +175,7 @@ class SessionOwnershipValidator:
         Raises:
             HTTPException: 401 if not authenticated
         """
-        user_data = auth_middleware.get_user_from_request(request)
+        user_data = get_auth_middleware().get_user_from_request(request)
 
         if not user_data:
             logger.warning(
@@ -228,7 +228,7 @@ class SessionOwnershipValidator:
             enforcement_mode: Current enforcement mode
         """
         try:
-            auth_middleware.security_layer.audit_log(
+            get_auth_middleware().security_layer.audit_log(
                 action="unauthorized_conversation_access",
                 user=username,
                 outcome="log_only" if enforcement_mode == "log_only" else "denied",
@@ -293,7 +293,7 @@ class SessionOwnershipValidator:
             enforcement_mode: Current enforcement mode
         """
         try:
-            auth_middleware.security_layer.audit_log(
+            get_auth_middleware().security_layer.audit_log(
                 action="conversation_accessed",
                 user=username,
                 outcome="success",
@@ -443,7 +443,7 @@ class SessionOwnershipValidator:
         Returns the result dict when a fast path applies, or None to signal
         that the caller should proceed to the full ownership check.
         """
-        if user_data.get("auth_disabled") or not auth_middleware.enable_auth:
+        if user_data.get("auth_disabled") or not get_auth_middleware().enable_auth:
             logger.debug(
                 f"Auth disabled - allowing access to session {session_id[:8]}..."
             )

--- a/autobot-backend/source_attribution.py
+++ b/autobot-backend/source_attribution.py
@@ -14,6 +14,8 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
+from autobot_shared.singleton_factory import lazy_singleton
+
 logger = logging.getLogger(__name__)
 
 
@@ -251,20 +253,19 @@ class SourceAttributionManager:
         return json.dumps([s.to_dict() for s in self.current_response_sources], indent=2)
 
 
-# Global instance
-source_manager = SourceAttributionManager()
+get_source_manager = lazy_singleton(SourceAttributionManager)
 
 
 def track_source(source_type: Union[SourceType, str], content: str, **kwargs) -> Source:
     """Convenience function to track a source"""
-    return source_manager.add_source(source_type, content, **kwargs)
+    return get_source_manager().add_source(source_type, content, **kwargs)
 
 
 def get_attribution() -> str:
     """Get formatted attribution for current response"""
-    return source_manager.format_attribution_block()
+    return get_source_manager().format_attribution_block()
 
 
 def clear_sources():
     """Clear current response sources"""
-    source_manager.clear_current_sources()
+    get_source_manager().clear_current_sources()

--- a/autobot-backend/takeover_manager.py
+++ b/autobot-backend/takeover_manager.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Set
 
+from autobot_shared.singleton_factory import lazy_singleton
 from memory import EnhancedMemoryManager, TaskPriority
 
 logger = logging.getLogger(__name__)
@@ -699,5 +700,4 @@ class TakeoverManager:
         }
 
 
-# Global instance
-takeover_manager = TakeoverManager()
+get_takeover_manager = lazy_singleton(TakeoverManager)

--- a/autobot-backend/task_execution_tracker.py
+++ b/autobot-backend/task_execution_tracker.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 
+from autobot_shared.singleton_factory import lazy_singleton
 from enhanced_memory_manager_async import Priority  # Import Priority for backward compatibility
 from enhanced_memory_manager_async import (
     AsyncEnhancedMemoryManager,
@@ -471,5 +472,4 @@ class TaskExecutionContext:
         return self.tracker.store_task_embedding(self.task_id, content, embedding_model, embedding_vector)
 
 
-# Global instance for easy access across the application
-task_tracker = TaskExecutionTracker()
+get_task_tracker = lazy_singleton(TaskExecutionTracker)

--- a/autobot-backend/voice_processing/nlp_processor.py
+++ b/autobot-backend/voice_processing/nlp_processor.py
@@ -15,7 +15,7 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from enhanced_memory_manager_async import TaskPriority
-from task_execution_tracker import task_tracker
+from task_execution_tracker import get_task_tracker
 from voice_processing.constants import (
     APP_PATTERNS_RE,
     AUTOMATION_INTENT_PATTERNS,
@@ -258,7 +258,7 @@ class NaturalLanguageProcessor:
     ) -> VoiceCommandAnalysis:
         """Analyze voice command for intent and parameters"""
 
-        async with task_tracker.track_task(
+        async with get_task_tracker().track_task(
             "Voice Command Analysis",
             f"Analyzing command: {transcription[:50]}...",
             agent_type="voice_processing",

--- a/autobot-backend/voice_processing/speech_recognition.py
+++ b/autobot-backend/voice_processing/speech_recognition.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List
 import numpy as np
 
 from enhanced_memory_manager_async import TaskPriority
-from task_execution_tracker import task_tracker
+from task_execution_tracker import get_task_tracker
 from voice_processing.models import AudioInput, SpeechRecognitionResult
 from voice_processing.types import SpeechQuality
 
@@ -129,7 +129,7 @@ class SpeechRecognitionEngine:
             language: BCP-47 language code (e.g. "en", "de"). Defaults to "en".
         """
 
-        async with task_tracker.track_task(
+        async with get_task_tracker().track_task(
             "Speech Recognition",
             f"Transcribing audio: {audio_input.audio_id}",
             agent_type="voice_processing",

--- a/autobot-backend/voice_processing/system.py
+++ b/autobot-backend/voice_processing/system.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from enhanced_memory_manager_async import TaskPriority
 from memory import EnhancedMemoryManager
-from task_execution_tracker import task_tracker
+from task_execution_tracker import get_task_tracker
 
 from .constants import HIGH_RISK_COMMAND_TYPES, HIGH_RISK_INTENTS, SCREEN_STATE_INTENTS
 from .models import AudioInput, SpeechSynthesisRequest, VoiceCommandAnalysis
@@ -86,7 +86,7 @@ class VoiceProcessingSystem:
         self, audio_input: AudioInput, context: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """Complete voice command processing pipeline."""
-        async with task_tracker.track_task(
+        async with get_task_tracker().track_task(
             "Voice Command Processing",
             f"Processing voice command: {audio_input.audio_id}",
             agent_type="voice_processing_system",

--- a/autobot-backend/voice_processing/tts_engine.py
+++ b/autobot-backend/voice_processing/tts_engine.py
@@ -13,7 +13,7 @@ import logging
 
 import aiofiles
 
-from task_execution_tracker import task_tracker
+from task_execution_tracker import get_task_tracker
 from voice_processing.models import SpeechSynthesisRequest
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class TextToSpeechEngine:
     async def synthesize_speech(self, request: SpeechSynthesisRequest) -> bytes:
         """Convert text to speech audio"""
 
-        async with task_tracker.track_task(
+        async with get_task_tracker().track_task(
             "Speech Synthesis",
             f"Converting text to speech: {request.text[:50]}...",
             agent_type="voice_processing",

--- a/autobot-backend/voice_processing_system.py
+++ b/autobot-backend/voice_processing_system.py
@@ -14,6 +14,8 @@ For new code, import directly from voice_processing:
     from voice_processing import VoiceProcessingSystem, VoiceCommand, AudioInput
 """
 
+from autobot_shared.singleton_factory import lazy_singleton
+
 # Re-export everything from the refactored package
 from voice_processing import (  # Types; Models; Constants; Engines; Main system
     APP_PATTERNS_RE,
@@ -56,8 +58,7 @@ _DIRECTION_RE = DIRECTION_RE
 _APP_PATTERNS_RE = APP_PATTERNS_RE
 _match_intent_from_patterns = match_intent_from_patterns
 
-# Global instance for backward compatibility
-voice_processing_system = VoiceProcessingSystem()
+get_voice_processing_system = lazy_singleton(VoiceProcessingSystem)
 
 # Logging
 import logging
@@ -93,6 +94,6 @@ __all__ = [
     "TextToSpeechEngine",
     # Main system
     "VoiceProcessingSystem",
-    # Global instance
-    "voice_processing_system",
+    # Global instance factory
+    "get_voice_processing_system",
 ]

--- a/autobot-backend/worker_node.py
+++ b/autobot-backend/worker_node.py
@@ -34,7 +34,7 @@ from autobot_shared.redis_client import get_redis_client
 
 # Import the centralized ConfigManager and Redis client utility
 from config import config as global_config_manager
-from event_manager import event_manager
+from event_manager import get_event_manager
 from knowledge_base import KnowledgeBase
 from llm_interface import LLMInterface
 from security_layer import SecurityLayer
@@ -254,7 +254,7 @@ class WorkerNode:
             logger.info("Worker capabilities reported to Redis channel '%s'.", channel)
         else:
             logger.debug("Worker capabilities detected (local mode): %s", capabilities)
-            await event_manager.publish("worker_capability_report", capabilities)
+            await get_event_manager().publish("worker_capability_report", capabilities)
 
     def _validate_user_role(self, task_type: str, task_id: str, user_role: Optional[str]) -> Optional[Dict[str, Any]]:
         """Validate that user_role is provided for task execution.
@@ -351,7 +351,7 @@ class WorkerNode:
 
     async def _publish_task_start(self, task_id: str, task_type: str, user_role: str) -> None:
         """Publish task start event and log execution start. Issue #620."""
-        await event_manager.publish(
+        await get_event_manager().publish(
             "worker_task_start",
             {"worker_id": self.worker_id, "task_id": task_id, "type": task_type},
         )
@@ -365,7 +365,7 @@ class WorkerNode:
 
     async def _publish_task_completion(self, task_id: str, result: Dict[str, Any]) -> None:
         """Publish task completion event and log result. Issue #620."""
-        await event_manager.publish(
+        await get_event_manager().publish(
             "worker_task_end",
             {"worker_id": self.worker_id, "task_id": task_id, "result": result},
         )

--- a/autobot-backend/workflow_scheduler.py
+++ b/autobot-backend/workflow_scheduler.py
@@ -22,6 +22,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Union
 from uuid import uuid4
 
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.time_utils import parse_utc_iso
 from autobot_types import TaskComplexity
 from constants.threshold_constants import RetryConfig, WorkflowConfig
@@ -950,8 +951,7 @@ async def _default_template_executor(
     return result
 
 
-# Global scheduler instance
-workflow_scheduler = WorkflowScheduler()
+get_workflow_scheduler = lazy_singleton(WorkflowScheduler)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces module-level singleton instantiation with `lazy_singleton()` across 20 backend modules
- Eliminates constructor I/O and config reads at import time
- Enables proper test mocking of these singletons
- Updates all API callers from `from module import singleton` to `from module import get_singleton()`

## Modules migrated

`live_event_manager`, `auth_middleware`, `prompt_manager`, `event_manager`, `circuit_breaker`, `elevation_wrapper`, `async_chat_workflow`, `workflow_scheduler`, `dependency_container`, `voice_processing_system`, `modern_ai_integration`, `takeover_manager`, `auth_rbac`, `task_execution_tracker`, `retry_mechanism`, `research_browser_manager`, `desktop_streaming_manager`, `source_attribution`, `routers/code_completion`, `diagnostics`

## Validation

- All 53 modified files pass `py_compile`
- API callers updated in: `agent.py`, `auth.py`, `advanced_control.py`, `chat_sessions.py`, `audit.py`, `conversation_files.py`, `enhanced_memory.py`, `files.py`, `live_events.py`, `redis_service.py`, `research_browser.py`, `service_messages.py`, `scheduler.py`, `websockets.py`, `user_management/dependencies.py`, and 10 backend service files

Closes #5948

🤖 Generated with [Claude Code](https://claude.com/claude-code)