### PR TITLE
refact(api): complete 19 agent/auth/chat response_model=None endpoints (#5985)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -944,7 +944,7 @@ async def send_message(
     operation="stream_message",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/stream", response_model=None)
+@router.post("/chat/stream", response_model=None)  # StreamingResponse — no Pydantic schema
 async def stream_message(
     current_user: dict = Depends(get_current_user),
     message: ChatMessage = None,
@@ -1219,7 +1219,7 @@ def _validate_workflow_manager(chat_workflow_manager) -> None:
     operation="send_chat_message_by_id",
     error_code_prefix="CHAT",
 )
-@router.post("/chats/{chat_id}/message", response_model=None)
+@router.post("/chats/{chat_id}/message", response_model=None)  # StreamingResponse — no Pydantic schema
 async def send_chat_message_by_id(
     chat_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1299,7 +1299,7 @@ async def _stream_graph_resume(
     operation="resume_chat_graph",
     error_code_prefix="CHAT",
 )
-@router.post("/chats/{chat_id}/resume", response_model=None)
+@router.post("/chats/{chat_id}/resume", response_model=None)  # StreamingResponse — no Pydantic schema
 async def resume_chat_graph(
     chat_id: str,
     current_user: dict = Depends(get_current_user),
@@ -1551,7 +1551,7 @@ async def delete_chat_by_id(
     operation="send_direct_chat_response",
     error_code_prefix="CHAT",
 )
-@router.post("/chat/direct", response_model=None)
+@router.post("/chat/direct", response_model=None)  # StreamingResponse — no Pydantic schema
 async def send_direct_chat_response(
     current_user: dict = Depends(get_current_user),
     request: Request = None,
@@ -2094,7 +2094,7 @@ async def enhanced_chat(
     operation="stream_enhanced_chat",
     error_code_prefix="CHAT",
 )
-@router.post("/stream-enhanced", response_model=None)
+@router.post("/stream-enhanced", response_model=None)  # StreamingResponse — no Pydantic schema
 async def stream_enhanced_chat(
     current_user: dict = Depends(get_current_user),
     message: EnhancedChatMessage = None,

--- a/autobot-backend/api/intelligent_agent.py
+++ b/autobot-backend/api/intelligent_agent.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from monitoring.prometheus_metrics import get_metrics_manager
-from api.schemas_agent import AgentSystemCapabilitiesResponse, GoalRequest, GoalResponse, HealthResponse
+from api.schemas_agent import AgentReloadResponse, AgentSystemCapabilitiesResponse, GoalRequest, GoalResponse, HealthResponse
 from api.schemas_common import DataResponse
 
 # CRITICAL FIX: Use lazy loading to prevent startup deadlock
@@ -271,7 +271,7 @@ async def health_check(
     operation="reload_agent",
     error_code_prefix="INTELLIGENT_AGENT",
 )
-@router.post("/reload", response_model=None)
+@router.post("/reload", response_model=AgentReloadResponse)
 async def reload_agent(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/llm.py
+++ b/autobot-backend/api/llm.py
@@ -14,6 +14,7 @@ from api.schemas_agent import (
     LLMEmbeddingModelsResponse,
     LLMModelsResponse,
 )
+from api.schemas_common import DataResponse
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.ssot_config import config as ssot_config
@@ -566,7 +567,7 @@ async def get_comprehensive_llm_status(
     operation="get_llm_status",
     error_code_prefix="LLM",
 )
-@router.get("/status", response_model=None)
+@router.get("/status", response_model=DataResponse)
 async def get_llm_status(
     current_user: dict = Depends(get_current_user),
 ):

--- a/autobot-backend/api/logs.py
+++ b/autobot-backend/api/logs.py
@@ -879,7 +879,7 @@ def parse_file_log_line(line: str, source: str) -> Metadata:
     operation="stream_log",
     error_code_prefix="LOGS",
 )
-@router.get("/stream/{filename}", response_model=None)
+@router.get("/stream/{filename}", response_model=None)  # StreamingResponse — no Pydantic schema
 async def stream_log(
     filename: str,
     admin_check: bool = Depends(check_admin_permission),

--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -109,7 +109,7 @@ def _build_single_task_response(result: dict) -> JSONResponse:
     operation="execute_workflow",
     error_code_prefix="ORCHESTRATION",
 )
-@router.post("/workflow/execute", response_model=None)
+@router.post("/workflow/execute", response_model=None)  # Returns JSONResponse directly — no Pydantic schema
 async def execute_workflow(
     request: WorkflowRequest,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -819,5 +819,18 @@ class LogFileMetadata(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# intelligent_agent.py reload schema  (Issue #5985)
+# ---------------------------------------------------------------------------
+
+
+
+class AgentReloadResponse(BaseModel):
+    """Response for POST /intelligent-agent/reload."""
+
+    status: str
+    message: str
+
+
+# ---------------------------------------------------------------------------
 # voice.py schemas  (Issue #5317)
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -138,7 +138,7 @@ async def voice_speak_api(
     operation="voice_synthesize_api",
     error_code_prefix="VOICE",
 )
-@router.post("/synthesize", response_model=None)
+@router.post("/synthesize", response_model=None)  # Returns audio/wav Response — no Pydantic schema
 async def voice_synthesize_api(
     request: Request,
     text: str = Form(...),
@@ -179,7 +179,7 @@ async def voice_synthesize_api(
     operation="voice_clone_api",
     error_code_prefix="VOICE",
 )
-@router.post("/clone-voice", response_model=None)
+@router.post("/clone-voice", response_model=None)  # Returns audio/wav Response — no Pydantic schema
 async def voice_clone_api(
     request: Request,
     text: str = Form(...),


### PR DESCRIPTION
## Summary
Completes batch 3/7 of #5960 — the remaining 2 endpoints not covered by the first partial pass:
- `intelligent_agent.py /reload` → `AgentReloadResponse`
- `llm.py /status` → `DataResponse` (also adds missing `DataResponse` import)

9 legitimately streaming endpoints documented with inline comments explaining `response_model=None`.

Closes #5985

🤖 Generated with [Claude Code](https://claude.com/claude-code)