### PR TITLE
refact(api): add named Pydantic schemas to system endpoints (#5990)

### DIFF
--- a/autobot-backend/api/alertmanager_webhook.py
+++ b/autobot-backend/api/alertmanager_webhook.py
@@ -15,7 +15,10 @@ from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel
 
 from api.monitoring import ws_manager
-from api.schemas_common import DataResponse
+from api.schemas_system import (
+    AlertManagerWebhookHealthResponse,
+    AlertManagerWebhookReceiveResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
@@ -73,7 +76,7 @@ class AlertManagerWebhook(BaseModel):
     operation="receive_alertmanager_webhook",
     error_code_prefix="ALERTMANAGER_WEBHOOK",
 )
-@router.post("/alertmanager", response_model=None)
+@router.post("/alertmanager", response_model=AlertManagerWebhookReceiveResponse)
 async def receive_alertmanager_webhook(payload: AlertManagerWebhook, request: Request):
     """
     Receive alerts from Prometheus AlertManager
@@ -172,7 +175,7 @@ async def _process_alert(alert: AlertInstance, group_status: str):
     operation="alertmanager_webhook_health",
     error_code_prefix="ALERTMANAGER_WEBHOOK",
 )
-@router.get("/alertmanager/health", response_model=None)
+@router.get("/alertmanager/health", response_model=AlertManagerWebhookHealthResponse)
 async def alertmanager_webhook_health():
     """Health check endpoint for AlertManager webhook"""
     return {

--- a/autobot-backend/api/developer.py
+++ b/autobot-backend/api/developer.py
@@ -20,7 +20,12 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from config import unified_config_manager
 from services.config_service import ConfigService
 from type_defs.common import Metadata
-from api.schemas_common import DataResponse
+from api.schemas_system import (
+    DeveloperConfigResponse,
+    DeveloperConfigUpdateResponse,
+    DeveloperEndpointsResponse,
+    DeveloperSystemInfoResponse,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -98,7 +103,7 @@ api_registry = APIRegistry()
     operation="get_api_endpoints",
     error_code_prefix="DEVELOPER",
 )
-@router.get("/endpoints", response_model=None)
+@router.get("/endpoints", response_model=DeveloperEndpointsResponse)
 async def get_api_endpoints():
     """Get all registered API endpoints (developer mode)"""
     developer_mode = unified_config_manager.get_nested("developer.enabled", False)
@@ -119,7 +124,7 @@ async def get_api_endpoints():
     operation="get_developer_config",
     error_code_prefix="DEVELOPER",
 )
-@router.get("/config", response_model=None)
+@router.get("/config", response_model=DeveloperConfigResponse)
 async def get_developer_config():
     """Get developer mode configuration"""
     developer_config = unified_config_manager.get_nested("developer", {})
@@ -141,7 +146,7 @@ async def get_developer_config():
     operation="update_developer_config",
     error_code_prefix="DEVELOPER",
 )
-@router.post("/config", response_model=None)
+@router.post("/config", response_model=DeveloperConfigUpdateResponse)
 async def update_developer_config(config: dict):
     """Update developer mode configuration"""
     # Update the configuration
@@ -167,7 +172,7 @@ async def update_developer_config(config: dict):
     operation="get_system_info",
     error_code_prefix="DEVELOPER",
 )
-@router.get("/system-info", response_model=None)
+@router.get("/system-info", response_model=DeveloperSystemInfoResponse)
 async def get_system_info():
     """Get system information for debugging"""
     developer_mode = unified_config_manager.get_nested("developer.enabled", False)

--- a/autobot-backend/api/diagnostics.py
+++ b/autobot-backend/api/diagnostics.py
@@ -155,7 +155,7 @@ async def health_check():
     operation="analyze_failure_get",
     error_code_prefix="DIAGNOSTICS",
 )
-@router.get("/analyze-failure", response_model=None)
+@router.get("/analyze-failure", response_model=FailureAnalysisResponse)
 async def analyze_failure_get(
     task_id: str = Query(..., description="Task ID to analyze"),
     error_description: Optional[str] = Query(

--- a/autobot-backend/api/heartbeat.py
+++ b/autobot-backend/api/heartbeat.py
@@ -29,7 +29,10 @@ from models.heartbeat import (
     WakeupTrigger,
 )
 from services.heartbeat_scheduler import HeartbeatScheduler, _get_or_create_state
-from api.schemas_common import DataResponse
+from api.schemas_system import (
+    HeartbeatTriggerResponse,
+    HeartbeatWakeupQueuedResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
@@ -257,7 +260,7 @@ async def get_run(
     operation="request_wakeup",
     error_code_prefix="HEARTBEAT",
 )
-@router.post("/{agent_id}/wakeup", status_code=status.HTTP_202_ACCEPTED, response_model=None)
+@router.post("/{agent_id}/wakeup", status_code=status.HTTP_202_ACCEPTED, response_model=HeartbeatWakeupQueuedResponse)
 async def request_wakeup(
     agent_id: str,
     body: WakeupRequestCreate,
@@ -299,7 +302,7 @@ async def list_wakeup_requests(
     operation="trigger_manual",
     error_code_prefix="HEARTBEAT",
 )
-@router.post("/{agent_id}/trigger", status_code=status.HTTP_202_ACCEPTED, response_model=None)
+@router.post("/{agent_id}/trigger", status_code=status.HTTP_202_ACCEPTED, response_model=HeartbeatTriggerResponse)
 async def trigger_manual(
     agent_id: str,
     scheduler: HeartbeatScheduler = Depends(_get_scheduler),

--- a/autobot-backend/api/hot_reload.py
+++ b/autobot-backend/api/hot_reload.py
@@ -15,6 +15,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from type_defs.common import Metadata
 from api.schemas_common import DataResponse
+from api.schemas_system import HotReloadHealthResponse
 
 logger = logging.getLogger(__name__)
 
@@ -241,7 +242,7 @@ async def stop_hot_reload():
     operation="hot_reload_health",
     error_code_prefix="HOT_RELOAD",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=HotReloadHealthResponse)
 async def hot_reload_health():
     """
     Health check for hot reload functionality

--- a/autobot-backend/api/infrastructure.py
+++ b/autobot-backend/api/infrastructure.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, Query
 
 from auth_middleware import get_current_user
-from api.schemas_common import DataResponse
+from api.schemas_system import InfrastructureHostsResponse
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
@@ -62,7 +62,7 @@ def _load_secrets_hosts() -> List[Dict[str, Any]]:
     operation="get_infrastructure_hosts",
     error_code_prefix="INFRASTRUCTURE",
 )
-@router.get("/hosts", response_model=None)
+@router.get("/hosts", response_model=InfrastructureHostsResponse)
 async def get_infrastructure_hosts(
     capability: Optional[str] = Query(
         None, description="Filter by capability (ssh, vnc)"

--- a/autobot-backend/api/overseer_handlers.py
+++ b/autobot-backend/api/overseer_handlers.py
@@ -27,6 +27,7 @@ from agents.overseer.types import (
 from auth_middleware import get_current_user
 from chat_history import ChatHistoryManager
 from api.schemas_common import DataResponse
+from api.schemas_system import OverseerStatusResponse
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
@@ -532,7 +533,7 @@ async def submit_query(
     operation="get_status",
     error_code_prefix="OVERSEER_HANDLERS",
 )
-@router.get("/status/{session_id}", response_model=None)
+@router.get("/status/{session_id}", response_model=OverseerStatusResponse)
 async def get_status(
     session_id: str,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/project_state.py
+++ b/autobot-backend/api/project_state.py
@@ -17,6 +17,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from project_state_manager import DevelopmentPhase, get_project_state_manager
 from utils.advanced_cache_manager import smart_cache
 from api.schemas_common import DataResponse
+from api.schemas_system import ProjectStateHealthResponse
 
 logger = logging.getLogger(__name__)
 
@@ -337,7 +338,7 @@ async def auto_progress_phases():
     operation="health_check",
     error_code_prefix="PROJECT_STATE",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=ProjectStateHealthResponse)
 async def health_check():
     """Health check for project state API"""
     try:

--- a/autobot-backend/api/redis.py
+++ b/autobot-backend/api/redis.py
@@ -8,7 +8,11 @@ from fastapi import APIRouter, HTTPException
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.config_service import ConfigService
 from utils.connection_utils import ConnectionTester
-from api.schemas_common import DataResponse
+from api.schemas_system import (
+    RedisConfigResponse,
+    RedisConnectionStatusResponse,
+    RedisHealthResponse,
+)
 
 router = APIRouter()
 
@@ -25,7 +29,7 @@ logger = logging.getLogger(__name__)
     operation="get_redis_config",
     error_code_prefix="REDIS",
 )
-@router.get("/config", response_model=None)
+@router.get("/config", response_model=RedisConfigResponse)
 async def get_redis_config():
     """Get current Redis configuration"""
     try:
@@ -45,7 +49,7 @@ async def get_redis_config():
     operation="update_redis_config",
     error_code_prefix="REDIS",
 )
-@router.post("/config", response_model=None)
+@router.post("/config", response_model=RedisConfigResponse)
 async def update_redis_config(config_data: dict):
     """Update Redis configuration"""
     try:
@@ -66,7 +70,7 @@ async def update_redis_config(config_data: dict):
     operation="get_redis_status",
     error_code_prefix="REDIS",
 )
-@router.get("/status", response_model=None)
+@router.get("/status", response_model=RedisConnectionStatusResponse)
 async def get_redis_status():
     """Get Redis connection status"""
     try:
@@ -90,7 +94,7 @@ async def get_redis_status():
     operation="test_redis_connection",
     error_code_prefix="REDIS",
 )
-@router.post("/test_connection", response_model=None)
+@router.post("/test_connection", response_model=RedisConnectionStatusResponse)
 async def test_redis_connection():
     """Test Redis connection with current configuration"""
     try:
@@ -114,7 +118,7 @@ async def test_redis_connection():
     operation="get_redis_health",
     error_code_prefix="REDIS",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=RedisHealthResponse)
 async def get_redis_health():
     """Get Redis health status for frontend health checks"""
     try:

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -556,3 +556,352 @@ class GitHubProviderInfo(BaseModel):
     description: str
     required_settings: List[str]
     optional_settings: List[str]
+
+
+# ---------------------------------------------------------------------------
+# redis.py schemas  (Issue #5990)
+# ---------------------------------------------------------------------------
+
+
+class RedisConfigResponse(BaseModel):
+    """Response for GET /config and POST /config in redis.py.
+
+    ConfigService.get_redis_config() returns these fields; extra fields
+    allowed for additional redis_config keys.
+    """
+
+    model_config = {"extra": "allow"}
+
+    type: Optional[str] = None
+    host: Optional[str] = None
+    port: Optional[int] = None
+
+
+class RedisConnectionStatusResponse(BaseModel):
+    """Response for GET /status, POST /test_connection in redis.py.
+
+    ConnectionTester.test_redis_connection() returns status + message at minimum;
+    connected path adds host/port/redis_search_module_loaded. Extra fields allowed.
+    """
+
+    model_config = {"extra": "allow"}
+
+    status: str
+    message: Optional[str] = None
+
+
+class RedisHealthResponse(BaseModel):
+    """Response for GET /health in redis.py."""
+
+    status: str
+    redis_status: Optional[str] = None
+    message: Optional[str] = None
+    host: Optional[str] = None
+    port: Optional[int] = None
+    redis_search_module_loaded: bool = False
+
+
+# ---------------------------------------------------------------------------
+# services.py schemas  (Issue #5990)
+# ---------------------------------------------------------------------------
+
+
+class ServicesHealthDeprecatedResponse(BaseModel):
+    """Response for GET /health (deprecated) in services.py."""
+
+    status: str
+    deprecated: bool
+    use_instead: str
+    timestamp: Any
+
+
+class ServicesHealthAggregateResponse(BaseModel):
+    """Response for GET /services/health in services.py.
+
+    Shape is either from monitoring (opaque) or the fallback dict built
+    from ServicesResponse. Extra fields allowed for monitoring pass-through.
+    """
+
+    model_config = {"extra": "allow"}
+
+    timestamp: Optional[float] = None
+    overall_status: Optional[str] = None
+    total_services: Optional[int] = None
+    healthy_services: Optional[int] = None
+    degraded_services: Optional[int] = None
+    critical_services: Optional[int] = None
+
+
+class VMStatusItem(BaseModel):
+    """A single VM entry in ServicesVMsStatusResponse."""
+
+    name: str
+    ip: str
+    status: str
+    services: List[Any] = []
+    last_check: Optional[Any] = None
+
+
+class ServicesVMsStatusResponse(BaseModel):
+    """Response for GET /vms/status in services.py."""
+
+    vms: List[VMStatusItem]
+    total_count: int
+    online_count: int
+    offline_count: int
+    overall_status: str
+    last_updated: Any
+
+
+# ---------------------------------------------------------------------------
+# wake_word.py schemas  (Issue #5990)
+# ---------------------------------------------------------------------------
+
+
+class WakeWordGetWordsResponse(BaseModel):
+    """Response for GET /words in wake_word.py."""
+
+    wake_words: List[str]
+    total: int
+
+
+class WakeWordGetConfigResponse(BaseModel):
+    """Response for GET /config in wake_word.py.
+
+    WakeWordDetector.get_config() returns these fields.
+    """
+
+    enabled: bool
+    wake_words: List[str]
+    confidence_threshold: float
+    cooldown_seconds: float
+    max_false_positive_rate: float
+    adaptive_threshold: bool
+    noise_tolerance: Optional[float] = None
+    max_cpu_percent: Optional[float] = None
+
+
+class WakeWordStatsResponse(BaseModel):
+    """Response for GET /stats in wake_word.py.
+
+    WakeWordDetector.get_stats() return shape.
+    """
+
+    total_detections: int
+    true_positives: int
+    false_positives: int
+    accuracy: float
+    average_confidence: float
+    total_listening_time: float
+    cpu_usage_percent: float
+
+
+class WakeWordListeningStatusResponse(BaseModel):
+    """Response for GET /listening/status in wake_word.py."""
+
+    active: bool
+    duty_cycle_ms: float
+    sleep_ms: float
+    chunks_processed: int
+    throttle_events: int
+    current_cpu_percent: float
+    max_cpu_percent: float
+
+
+# ---------------------------------------------------------------------------
+# developer.py schemas  (Issue #5990)
+# ---------------------------------------------------------------------------
+
+
+class DeveloperEndpointsResponse(BaseModel):
+    """Response for GET /endpoints in developer.py."""
+
+    total_endpoints: int
+    routers: List[str]
+    endpoints: Dict[str, Any]
+
+
+class DeveloperConfigResponse(BaseModel):
+    """Response for GET /config in developer.py."""
+
+    enabled: bool
+    enhanced_errors: bool
+    endpoint_suggestions: bool
+    debug_logging: bool
+
+
+class DeveloperConfigUpdateResponse(BaseModel):
+    """Response for POST /config in developer.py."""
+
+    status: str
+    config: Dict[str, Any]
+
+
+class DeveloperSystemInfoResponse(BaseModel):
+    """Response for GET /system-info in developer.py.
+
+    Returns opaque config sections from unified_config_manager. Extra fields allowed.
+    """
+
+    model_config = {"extra": "allow"}
+
+    config_loaded: bool
+    available_routers: List[str]
+
+
+# ---------------------------------------------------------------------------
+# startup.py schemas  (Issue #5990)
+# ---------------------------------------------------------------------------
+
+
+class StartupStatusResponse(BaseModel):
+    """Response for GET /status in startup.py."""
+
+    current_phase: str
+    progress: int
+    messages: List[Any]
+    elapsed_time: float
+    is_ready: bool
+
+
+# ---------------------------------------------------------------------------
+# hot_reload.py schemas  (Issue #5990)
+# ---------------------------------------------------------------------------
+
+
+class HotReloadHealthResponse(BaseModel):
+    """Response for GET /health in hot_reload.py."""
+
+    status: str
+    running: bool
+    watched_modules: int
+    watched_paths: int
+    service: str
+
+
+# ---------------------------------------------------------------------------
+# service_monitor.py schemas  (Issue #5990)
+# ---------------------------------------------------------------------------
+
+
+class ServiceStatusItem(BaseModel):
+    """A single service entry in ServiceMonitorServicesResponse."""
+
+    status: str
+    health: str
+
+
+class ServiceMonitorServicesResponse(BaseModel):
+    """Response for GET /services in service_monitor.py."""
+
+    services: Dict[str, ServiceStatusItem]
+
+
+class VMStatusListItem(BaseModel):
+    """A single VM entry in ServiceMonitorVMsResponse."""
+
+    name: str
+    status: str
+    message: str
+
+
+class ServiceMonitorVMsResponse(BaseModel):
+    """Response for GET /vms/status in service_monitor.py."""
+
+    vms: List[VMStatusListItem]
+
+
+# ---------------------------------------------------------------------------
+# infrastructure.py schemas  (Issue #5990)
+# ---------------------------------------------------------------------------
+
+
+class InfrastructureHostItem(BaseModel):
+    """A single infrastructure host entry.
+
+    Derived from _load_secrets_hosts() in infrastructure.py.
+    """
+
+    id: str
+    name: str
+    host: str
+    ssh_port: int
+    vnc_port: Optional[int] = None
+    username: str
+    os: Optional[str] = None
+    description: str
+    capabilities: List[str]
+
+
+class InfrastructureHostsResponse(BaseModel):
+    """Response for GET /hosts in infrastructure.py."""
+
+    hosts: List[InfrastructureHostItem]
+
+
+# ---------------------------------------------------------------------------
+# heartbeat.py schemas  (Issue #5990)
+# ---------------------------------------------------------------------------
+
+
+class HeartbeatWakeupQueuedResponse(BaseModel):
+    """Response for POST /{agent_id}/wakeup in heartbeat.py."""
+
+    id: str
+    agent_id: str
+    status: str
+
+
+class HeartbeatTriggerResponse(BaseModel):
+    """Response for POST /{agent_id}/trigger in heartbeat.py."""
+
+    agent_id: str
+    status: str
+
+
+# ---------------------------------------------------------------------------
+# alertmanager_webhook.py schemas  (Issue #5990)
+# ---------------------------------------------------------------------------
+
+
+class AlertManagerWebhookReceiveResponse(BaseModel):
+    """Response for POST /alertmanager in alertmanager_webhook.py."""
+
+    status: str
+    processed: int
+    timestamp: str
+
+
+class AlertManagerWebhookHealthResponse(BaseModel):
+    """Response for GET /alertmanager/health in alertmanager_webhook.py."""
+
+    status: str
+    endpoint: str
+    websocket_manager: str
+    timestamp: str
+
+
+# ---------------------------------------------------------------------------
+# overseer_handlers.py schemas  (Issue #5990)
+# ---------------------------------------------------------------------------
+
+
+class OverseerStatusResponse(BaseModel):
+    """Response for GET /status/{session_id} in overseer_handlers.py."""
+
+    active: bool
+    summary: Optional[Any] = None
+
+
+# ---------------------------------------------------------------------------
+# project_state.py schemas  (Issue #5990)
+# ---------------------------------------------------------------------------
+
+
+class ProjectStateHealthResponse(BaseModel):
+    """Response for GET /health in project_state.py."""
+
+    status: str
+    current_phase: str
+    overall_completion: float
+    timestamp: Optional[str] = None

--- a/autobot-backend/api/service_monitor.py
+++ b/autobot-backend/api/service_monitor.py
@@ -18,7 +18,10 @@ import aiohttp
 from fastapi import APIRouter
 
 from autobot_shared.ssot_config import config as _ssot
-from api.schemas_common import DataResponse
+from api.schemas_system import (
+    ServiceMonitorServicesResponse,
+    ServiceMonitorVMsResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
@@ -71,7 +74,7 @@ async def _check_redis_health() -> Tuple[str, str]:
     operation="get_service_statuses",
     error_code_prefix="SERVICE_MONITOR",
 )
-@router.get("/services", response_model=None)
+@router.get("/services", response_model=ServiceMonitorServicesResponse)
 async def get_service_statuses() -> Dict[str, Any]:
     """Return health status for each AutoBot supporting service.
 
@@ -120,7 +123,7 @@ async def get_service_statuses() -> Dict[str, Any]:
     operation="get_vm_statuses",
     error_code_prefix="SERVICE_MONITOR",
 )
-@router.get("/vms/status", response_model=None)
+@router.get("/vms/status", response_model=ServiceMonitorVMsResponse)
 async def get_vm_statuses() -> Dict[str, Any]:
     """Return status for AutoBot VMs as a list.
 

--- a/autobot-backend/api/services.py
+++ b/autobot-backend/api/services.py
@@ -16,7 +16,11 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from api.schemas_common import DataResponse
+from api.schemas_system import (
+    ServicesHealthAggregateResponse,
+    ServicesHealthDeprecatedResponse,
+    ServicesVMsStatusResponse,
+)
 
 # Import existing monitoring functionality
 try:
@@ -236,7 +240,7 @@ async def get_services(admin_check: bool = Depends(check_admin_permission)):
     operation="get_health",
     error_code_prefix="SERVICES",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=ServicesHealthDeprecatedResponse)
 async def get_health(admin_check: bool = Depends(check_admin_permission)):
     """Simple health check endpoint.
 
@@ -267,7 +271,7 @@ async def get_health(admin_check: bool = Depends(check_admin_permission)):
     operation="get_services_health",
     error_code_prefix="SERVICES",
 )
-@router.get("/services/health", response_model=None)
+@router.get("/services/health", response_model=ServicesHealthAggregateResponse)
 async def get_services_health(admin_check: bool = Depends(check_admin_permission)):
     """Get service health status - alias to monitoring endpoint
 
@@ -368,7 +372,7 @@ def _build_vm_status_list(vm_definitions: list) -> list:
     operation="get_vms_status",
     error_code_prefix="SERVICES",
 )
-@router.get("/vms/status", response_model=None)
+@router.get("/vms/status", response_model=ServicesVMsStatusResponse)
 async def get_vms_status(admin_check: bool = Depends(check_admin_permission)):
     """
     Get VM status for distributed infrastructure.

--- a/autobot-backend/api/startup.py
+++ b/autobot-backend/api/startup.py
@@ -25,6 +25,7 @@ router = APIRouter(tags=["startup", "status"])
 # Thread lock for synchronous access to startup_state
 import threading
 from api.schemas_common import DataResponse
+from api.schemas_system import StartupStatusResponse
 
 _startup_lock = threading.Lock()
 
@@ -131,7 +132,7 @@ async def broadcast_startup_message(message: StartupMessage):
     operation="get_startup_status",
     error_code_prefix="STARTUP",
 )
-@router.get("/status", response_model=None)
+@router.get("/status", response_model=StartupStatusResponse)
 async def get_startup_status():
     """Get current startup status"""
     with _startup_lock:

--- a/autobot-backend/api/wake_word.py
+++ b/autobot-backend/api/wake_word.py
@@ -16,6 +16,12 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.wake_word_service import WakeWordDetector, get_wake_word_detector
 from type_defs.common import Metadata
 from api.schemas_common import DataResponse
+from api.schemas_system import (
+    WakeWordGetConfigResponse,
+    WakeWordGetWordsResponse,
+    WakeWordListeningStatusResponse,
+    WakeWordStatsResponse,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["wake_word", "voice"])
@@ -109,7 +115,7 @@ async def check_wake_word(request: WakeWordCheckRequest) -> WakeWordCheckRespons
     operation="get_wake_words",
     error_code_prefix="WAKE_WORD",
 )
-@router.get("/words", response_model=None)
+@router.get("/words", response_model=WakeWordGetWordsResponse)
 async def get_wake_words() -> Metadata:
     """Get list of configured wake words"""
     detector = get_wake_word_detector()
@@ -193,7 +199,7 @@ async def remove_wake_word(wake_word: str) -> Metadata:
     operation="get_wake_word_config",
     error_code_prefix="WAKE_WORD",
 )
-@router.get("/config", response_model=None)
+@router.get("/config", response_model=WakeWordGetConfigResponse)
 async def get_wake_word_config() -> Metadata:
     """Get current wake word detection configuration"""
     detector = get_wake_word_detector()
@@ -251,7 +257,7 @@ async def update_wake_word_config(request: WakeWordConfigRequest) -> Metadata:
     operation="get_wake_word_stats",
     error_code_prefix="WAKE_WORD",
 )
-@router.get("/stats", response_model=None)
+@router.get("/stats", response_model=WakeWordStatsResponse)
 async def get_wake_word_stats() -> Metadata:
     """Get wake word detection statistics"""
     detector = get_wake_word_detector()
@@ -419,7 +425,7 @@ async def stop_listening() -> Metadata:
     operation="get_listening_status",
     error_code_prefix="WAKE_WORD",
 )
-@router.get("/listening/status", response_model=None)
+@router.get("/listening/status", response_model=WakeWordListeningStatusResponse)
 async def get_listening_status() -> Metadata:
     """
     Get background listening status including real-time CPU metrics.


### PR DESCRIPTION
## Summary

Adds named Pydantic response schemas to 29 system management API endpoints (#5960 batch 6/7).

**Files updated:**
- `redis.py` — 5 endpoints: `RedisConfigResponse`, `RedisConnectionStatusResponse`, etc.
- `services.py` — 3 endpoints: `ServicesHealthDeprecatedResponse`, etc.
- `wake_word.py` — 4 endpoints: `WakeWordGetWordsResponse`, etc.
- `developer.py` — 4 endpoints: `DeveloperEndpointsResponse`, etc.
- `startup.py`, `hot_reload.py`, `infrastructure.py`, `service_monitor.py` — 5 more
- `monitoring.py` GET /export/metrics intentionally remains `None` (returns JSONResponse/StreamingResponse)

All new schemas added to `schemas_system.py`.

Closes #5990

🤖 Generated with [Claude Code](https://claude.com/claude-code)