### PR TITLE
refact(api): add named Pydantic schemas for 51 workflow endpoints (#5989)

### DIFF
--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -23,6 +23,15 @@ from takeover_manager import TakeoverTrigger, get_takeover_manager
 from task_execution_tracker import get_task_tracker
 from type_defs.common import Metadata
 from api.schemas_common import DataResponse
+from api.schemas_workflows import (
+    AdvancedControlActiveTakeoversListResponse,
+    AdvancedControlHealthResponse,
+    AdvancedControlInfoResponse,
+    AdvancedControlPendingTakeoversListResponse,
+    AdvancedControlStreamingCapabilitiesResponse,
+    AdvancedControlStreamingSessionListResponse,
+    AdvancedControlTakeoverSystemStatusResponse,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["advanced_control"])
@@ -152,7 +161,7 @@ async def terminate_streaming_session(
     operation="list_streaming_sessions",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/streaming/sessions", response_model=None)
+@router.get("/streaming/sessions", response_model=AdvancedControlStreamingSessionListResponse)
 async def list_streaming_sessions(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -175,7 +184,7 @@ async def list_streaming_sessions(
     operation="get_streaming_capabilities",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/streaming/capabilities", response_model=None)
+@router.get("/streaming/capabilities", response_model=AdvancedControlStreamingCapabilitiesResponse)
 async def get_streaming_capabilities(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -423,7 +432,7 @@ async def complete_takeover_session(
     operation="get_pending_takeovers",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/takeover/pending", response_model=None)
+@router.get("/takeover/pending", response_model=AdvancedControlPendingTakeoversListResponse)
 async def get_pending_takeovers(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -446,7 +455,7 @@ async def get_pending_takeovers(
     operation="get_active_takeovers",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/takeover/active", response_model=None)
+@router.get("/takeover/active", response_model=AdvancedControlActiveTakeoversListResponse)
 async def get_active_takeovers(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -469,7 +478,7 @@ async def get_active_takeovers(
     operation="get_takeover_status",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/takeover/status", response_model=None)
+@router.get("/takeover/status", response_model=AdvancedControlTakeoverSystemStatusResponse)
 async def get_takeover_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -583,7 +592,7 @@ async def emergency_system_stop(
     operation="get_system_health",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/system/health", response_model=None)
+@router.get("/system/health", response_model=AdvancedControlHealthResponse)
 async def get_system_health(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -694,7 +703,7 @@ async def desktop_streaming_websocket(websocket: WebSocket, session_id: str):
     operation="advanced_control_info",
     error_code_prefix="ADVANCED_CONTROL",
 )
-@router.get("/", response_model=None)
+@router.get("/", response_model=AdvancedControlInfoResponse)
 async def advanced_control_info(
     admin_check: bool = Depends(check_admin_permission),
 ):

--- a/autobot-backend/api/batch_jobs.py
+++ b/autobot-backend/api/batch_jobs.py
@@ -27,7 +27,15 @@ from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.models.pagination import PaginationParams
 from autobot_shared.redis_client import get_redis_client
-from api.schemas_common import DataResponse
+from api.schemas_workflows import (
+    BatchChatInitResponse,
+    BatchJobDeleteResponse,
+    BatchJobsHealthResponse,
+    BatchLoadResponse,
+    BatchScheduleDeleteResponse,
+    BatchStatusResponse,
+    BatchTemplateDeleteResponse,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["batch-jobs", "management"])
@@ -330,7 +338,7 @@ async def get_batch_job(
     operation="delete_batch_job",
     error_code_prefix="BATCH_JOBS",
 )
-@router.delete("/{job_id}", response_model=None)
+@router.delete("/{job_id}", response_model=BatchJobDeleteResponse)
 async def delete_batch_job(
     job_id: str,
     current_user: dict = Depends(get_current_user),
@@ -548,7 +556,7 @@ async def get_batch_template(
     operation="delete_batch_template",
     error_code_prefix="BATCH_JOBS",
 )
-@router.delete("/templates/{template_id}", response_model=None)
+@router.delete("/templates/{template_id}", response_model=BatchTemplateDeleteResponse)
 async def delete_batch_template(
     template_id: str,
     current_user: dict = Depends(get_current_user),
@@ -673,7 +681,7 @@ async def create_batch_schedule(
     operation="delete_batch_schedule",
     error_code_prefix="BATCH_JOBS",
 )
-@router.delete("/schedules/{schedule_id}", response_model=None)
+@router.delete("/schedules/{schedule_id}", response_model=BatchScheduleDeleteResponse)
 async def delete_batch_schedule(
     schedule_id: str,
     current_user: dict = Depends(get_current_user),
@@ -713,7 +721,7 @@ async def delete_batch_schedule(
     operation="get_batch_jobs_health",
     error_code_prefix="BATCH_JOBS",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=BatchJobsHealthResponse)
 async def get_batch_jobs_health(
     current_user: dict = Depends(get_current_user),
 ):
@@ -811,7 +819,7 @@ class BatchResponse(BaseModel):
     operation="get_batch_status",
     error_code_prefix="BATCH_JOBS",
 )
-@router.get("/status", response_model=None)
+@router.get("/status", response_model=BatchStatusResponse)
 async def get_batch_status():
     """Get batch processing service status"""
     return {
@@ -834,7 +842,7 @@ async def get_batch_status():
     operation="batch_load",
     error_code_prefix="BATCH_JOBS",
 )
-@router.post("/load", response_model=None)
+@router.post("/load", response_model=BatchLoadResponse)
 async def batch_load(batch_request: BatchRequest):
     """Execute multiple API calls in parallel and return combined results."""
     import time
@@ -893,13 +901,13 @@ async def batch_load(batch_request: BatchRequest):
     operation="batch_chat_initialization",
     error_code_prefix="BATCH_JOBS",
 )
-@router.get("/chat-init", response_model=None)
+@router.get("/chat-init", response_model=BatchChatInitResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="batch_chat_initialization",
     error_code_prefix="BATCH_JOBS",
 )
-@router.post("/chat-init", response_model=None)
+@router.post("/chat-init", response_model=BatchChatInitResponse)
 async def batch_chat_initialization():
     """
     Optimized endpoint for chat interface initialization.

--- a/autobot-backend/api/collaboration.py
+++ b/autobot-backend/api/collaboration.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth_middleware import get_current_user
 from models.session_collaboration import PermissionLevel, SessionCollaboration
 from user_management.database import get_async_session
-from api.schemas_common import DataResponse
+from api.schemas_workflows import SessionPresenceResponse, SessionShareSecretResponse
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
@@ -403,7 +403,7 @@ async def get_participants(
     operation="share_secret_with_session",
     error_code_prefix="COLLABORATION",
 )
-@router.post("/{session_id}/secrets/share", response_model=DataResponse)
+@router.post("/{session_id}/secrets/share", response_model=SessionShareSecretResponse)
 async def share_secret_with_session(
     session_id: str,
     share: ShareSecretRequest,
@@ -464,7 +464,7 @@ async def share_secret_with_session(
     operation="get_presence",
     error_code_prefix="COLLABORATION",
 )
-@router.get("/{session_id}/presence", response_model=None)
+@router.get("/{session_id}/presence", response_model=SessionPresenceResponse)
 async def get_presence(
     session_id: str,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/data_storage.py
+++ b/autobot-backend/api/data_storage.py
@@ -24,7 +24,13 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_relative_path
 from utils.catalog_http_exceptions import raise_server_error
-from api.schemas_common import DataResponse
+from api.schemas_workflows import (
+    DataStorageCategoryDetailResponse,
+    DataStorageConversationsSummaryResponse,
+    DataStorageDatabasesResponse,
+    DataStorageDeleteConversationResponse,
+    DataStorageOldBackupsResponse,
+)
 
 router = APIRouter(prefix="/data-storage", tags=["Data Storage"])
 logger = logging.getLogger(__name__)
@@ -337,7 +343,7 @@ async def get_storage_stats():
     operation="get_database_files_endpoint",
     error_code_prefix="DATA_STORAGE",
 )
-@router.get("/databases", response_model=None)
+@router.get("/databases", response_model=DataStorageDatabasesResponse)
 async def get_database_files_endpoint():
     """Get information about database files in the data directory."""
     try:
@@ -366,7 +372,7 @@ async def get_database_files_endpoint():
     operation="get_category_details",
     error_code_prefix="DATA_STORAGE",
 )
-@router.get("/category/{category_path}", response_model=None)
+@router.get("/category/{category_path}", response_model=DataStorageCategoryDetailResponse)
 async def get_category_details(
     category_path: str,
     limit: int = Query(default=100, le=1000),
@@ -523,7 +529,7 @@ async def cleanup_category(
     operation="cleanup_old_backups",
     error_code_prefix="DATA_STORAGE",
 )
-@router.post("/cleanup/old-backups", response_model=None)
+@router.post("/cleanup/old-backups", response_model=DataStorageOldBackupsResponse)
 async def cleanup_old_backups(
     dry_run: bool = Query(default=True),
     _: None = Depends(check_admin_permission),
@@ -579,7 +585,7 @@ async def cleanup_old_backups(
     operation="delete_conversation",
     error_code_prefix="DATA_STORAGE",
 )
-@router.delete("/conversations/{conversation_id}", response_model=DataResponse)
+@router.delete("/conversations/{conversation_id}", response_model=DataStorageDeleteConversationResponse)
 async def delete_conversation(
     conversation_id: str,
     _: None = Depends(check_admin_permission),
@@ -643,7 +649,7 @@ async def delete_conversation(
     operation="get_conversations_summary",
     error_code_prefix="DATA_STORAGE",
 )
-@router.get("/conversations/summary", response_model=None)
+@router.get("/conversations/summary", response_model=DataStorageConversationsSummaryResponse)
 async def get_conversations_summary():
     """Get summary of stored conversations."""
     try:

--- a/autobot-backend/api/error_resilience.py
+++ b/autobot-backend/api/error_resilience.py
@@ -18,7 +18,13 @@ from services.resilience.circuit_breaker_manager import (
 )
 from services.resilience.error_budget import get_error_budget_tracker
 from services.resilience.fallback_manager import get_fallback_manager
-from api.schemas_common import DataResponse
+from api.schemas_workflows import (
+    CircuitBreakerResetResponse,
+    CircuitBreakerStatusResponse,
+    ErrorBudgetResetResponse,
+    ErrorBudgetStatusResponse,
+    ResilienceHealthResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
@@ -31,7 +37,7 @@ router = APIRouter(prefix="/api/resilience", tags=["resilience"])
     operation="get_resilience_health",
     error_code_prefix="ERROR_RESILIENCE",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=ResilienceHealthResponse)
 async def get_resilience_health() -> Dict[str, Any]:
     """
     Get overall system resilience health.
@@ -60,7 +66,7 @@ async def get_resilience_health() -> Dict[str, Any]:
     operation="get_circuit_breaker_status",
     error_code_prefix="ERROR_RESILIENCE",
 )
-@router.get("/circuit-breakers", response_model=None)
+@router.get("/circuit-breakers", response_model=CircuitBreakerStatusResponse)
 async def get_circuit_breaker_status() -> Dict[str, Any]:
     """
     Get status of all circuit breakers.
@@ -83,7 +89,7 @@ async def get_circuit_breaker_status() -> Dict[str, Any]:
     operation="get_error_budget_status",
     error_code_prefix="ERROR_RESILIENCE",
 )
-@router.get("/error-budgets", response_model=None)
+@router.get("/error-budgets", response_model=ErrorBudgetStatusResponse)
 async def get_error_budget_status() -> Dict[str, Any]:
     """
     Get status of all error budgets.
@@ -106,7 +112,7 @@ async def get_error_budget_status() -> Dict[str, Any]:
     operation="reset_circuit_breaker",
     error_code_prefix="ERROR_RESILIENCE",
 )
-@router.post("/circuit-breakers/{service_name}/reset", response_model=None)
+@router.post("/circuit-breakers/{service_name}/reset", response_model=CircuitBreakerResetResponse)
 async def reset_circuit_breaker(service_name: str) -> Dict[str, str]:
     """
     Manually reset circuit breaker for service.
@@ -133,7 +139,7 @@ async def reset_circuit_breaker(service_name: str) -> Dict[str, str]:
     operation="reset_error_budget",
     error_code_prefix="ERROR_RESILIENCE",
 )
-@router.post("/error-budgets/{component}/reset", response_model=None)
+@router.post("/error-budgets/{component}/reset", response_model=ErrorBudgetResetResponse)
 async def reset_error_budget(component: str) -> Dict[str, str]:
     """
     Manually reset error budget for component.

--- a/autobot-backend/api/long_running_operations.py
+++ b/autobot-backend/api/long_running_operations.py
@@ -38,7 +38,14 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_path
 from constants.path_constants import PATH
 from constants.threshold_constants import TimingConstants
-from api.schemas_common import DataResponse
+from api.schemas_workflows import (
+    LongRunningOperationCancelResponse,
+    LongRunningOperationHealthResponse,
+    LongRunningOperationListResponse,
+    LongRunningOperationMigrateResponse,
+    LongRunningOperationResumeResponse,
+    LongRunningOperationStatusResponse,
+)
 
 # Add AutoBot paths
 sys.path.append(str(PATH.PROJECT_ROOT))
@@ -442,7 +449,7 @@ async def start_security_scan(
     operation="migrate_existing_operation",
     error_code_prefix="LONG_RUNNING_OPERATIONS",
 )
-@router.post("/migrate/existing", response_model=None)
+@router.post("/migrate/existing", response_model=LongRunningOperationMigrateResponse)
 async def migrate_existing_operation(
     operation_name: str,
     timeout_seconds: int,
@@ -492,7 +499,7 @@ async def migrate_existing_operation(
     operation="get_operation_status",
     error_code_prefix="LONG_RUNNING_OPERATIONS",
 )
-@router.get("/{operation_id}", response_model=None)
+@router.get("/{operation_id}", response_model=LongRunningOperationStatusResponse)
 async def get_operation_status(
     operation_id: str, manager=Depends(get_operation_manager)
 ):
@@ -518,7 +525,7 @@ async def get_operation_status(
     operation="list_operations",
     error_code_prefix="LONG_RUNNING_OPERATIONS",
 )
-@router.get("/", response_model=None)
+@router.get("/", response_model=LongRunningOperationListResponse)
 async def list_operations(
     status: Optional[str] = None,
     operation_type: Optional[str] = None,
@@ -577,7 +584,7 @@ async def list_operations(
     operation="cancel_operation",
     error_code_prefix="LONG_RUNNING_OPERATIONS",
 )
-@router.post("/{operation_id}/cancel", response_model=None)
+@router.post("/{operation_id}/cancel", response_model=LongRunningOperationCancelResponse)
 async def cancel_operation(operation_id: str, manager=Depends(get_operation_manager)):
     """Cancel a running operation"""
     try:
@@ -604,7 +611,7 @@ async def cancel_operation(operation_id: str, manager=Depends(get_operation_mana
     operation="resume_operation",
     error_code_prefix="LONG_RUNNING_OPERATIONS",
 )
-@router.post("/{operation_id}/resume", response_model=None)
+@router.post("/{operation_id}/resume", response_model=LongRunningOperationResumeResponse)
 async def resume_operation(operation_id: str, manager=Depends(get_operation_manager)):
     """Resume operation from latest checkpoint"""
     try:
@@ -704,7 +711,7 @@ async def websocket_progress_updates(websocket: WebSocket, operation_id: str):
     operation="operations_health",
     error_code_prefix="LONG_RUNNING_OPERATIONS",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=LongRunningOperationHealthResponse)
 async def operations_health():
     """Health check for long-running operations service"""
     if operation_integration_manager is None:

--- a/autobot-backend/api/prompts.py
+++ b/autobot-backend/api/prompts.py
@@ -14,7 +14,12 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_relative_path
 from constants.ttl_constants import TTL_5_MINUTES
-from api.schemas_common import DataResponse
+from api.schemas_workflows import (
+    PromptRevertResponse,
+    PromptSaveResponse,
+    PromptsCacheClearResponse,
+    PromptsListResponse,
+)
 
 router = APIRouter()
 
@@ -232,7 +237,7 @@ async def _collect_prompt_files(
     operation="get_prompts",
     error_code_prefix="PROMPTS",
 )
-@router.get("/", response_model=None)
+@router.get("/", response_model=PromptsListResponse)
 async def get_prompts(admin_check: bool = Depends(check_admin_permission)):
     """Get all prompts from filesystem with caching.
 
@@ -299,7 +304,7 @@ async def get_prompts(admin_check: bool = Depends(check_admin_permission)):
     operation="clear_prompts_cache",
     error_code_prefix="PROMPTS",
 )
-@router.post("/cache/clear", response_model=None)
+@router.post("/cache/clear", response_model=PromptsCacheClearResponse)
 async def clear_prompts_cache(admin_check: bool = Depends(check_admin_permission)):
     """Clear the prompts cache to force reload on next request.
 
@@ -346,13 +351,13 @@ def _build_prompt_save_response(
     operation="save_prompt",
     error_code_prefix="PROMPTS",
 )
-@router.post("/{prompt_id}", response_model=None)
+@router.post("/{prompt_id}", response_model=PromptSaveResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="save_prompt",
     error_code_prefix="PROMPTS",
 )
-@router.put("/{prompt_id}", response_model=None)  # Issue #570: Support PUT for frontend compatibility
+@router.put("/{prompt_id}", response_model=PromptSaveResponse)  # Issue #570: Support PUT for frontend compatibility
 async def save_prompt(
     prompt_id: str, request: dict, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -463,7 +468,7 @@ async def _write_prompt_from_default(
     operation="revert_prompt",
     error_code_prefix="PROMPTS",
 )
-@router.post("/{prompt_id}/revert", response_model=None)
+@router.post("/{prompt_id}/revert", response_model=PromptRevertResponse)
 async def revert_prompt(
     prompt_id: str, admin_check: bool = Depends(check_admin_permission)
 ):

--- a/autobot-backend/api/registry.py
+++ b/autobot-backend/api/registry.py
@@ -16,6 +16,7 @@ from api.schemas_workflows import (
     RegistryEndpointsResponse,
     RegistryHealthResponse,
     RegistryRouterDetailResponse,
+    RegistryRoutersResponse,
     RegistryTagRoutersResponse,
     RegistryTagsResponse,
     RegistryValidateResponse,
@@ -513,7 +514,7 @@ async def list_endpoints():
     operation="list_routers",
     error_code_prefix="REGISTRY",
 )
-@router.get("/routers", response_model=None)
+@router.get("/routers", response_model=RegistryRoutersResponse)
 async def list_routers():
     """List all registered routers with full configuration"""
     routers_data = {}

--- a/autobot-backend/api/rum.py
+++ b/autobot-backend/api/rum.py
@@ -16,12 +16,12 @@ from typing import List, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from api.schemas_common import DataResponse
 from api.schemas_workflows import (
     RUMClearResponse,
     RUMConfigResponse,
     RUMDisableResponse,
     RUMEventResponse,
+    RUMExportResponse,
     RUMMetricsResponse,
     RUMStatusResponse,
 )
@@ -460,7 +460,7 @@ async def clear_rum_data():
     operation="export_rum_data",
     error_code_prefix="RUM",
 )
-@router.get("/export", response_model=None)
+@router.get("/export", response_model=RUMExportResponse)
 async def export_rum_data():
     """Export RUM data for analysis"""
 

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -698,5 +698,500 @@ class StructuredThinkingSessionDetailResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# batch_jobs.py schemas  (Issue #5989)
+# ---------------------------------------------------------------------------
+
+
+class BatchJobDeleteResponse(BaseModel):
+    """Response for DELETE /{job_id} — cancel and delete a batch job."""
+
+    status: str
+    job_id: str
+    message: str
+
+
+class BatchTemplateDeleteResponse(BaseModel):
+    """Response for DELETE /templates/{template_id}."""
+
+    status: str
+    template_id: str
+
+
+class BatchScheduleDeleteResponse(BaseModel):
+    """Response for DELETE /schedules/{schedule_id}."""
+
+    status: str
+    schedule_id: str
+
+
+class BatchJobsHealthResponse(BaseModel):
+    """Response for GET /health — batch jobs service health."""
+
+    status: str
+    service: str
+    redis_connected: bool
+    timestamp: str
+    capabilities: List[str]
+
+
+class BatchStatusResponse(BaseModel):
+    """Response for GET /status — legacy batch processor status."""
+
+    status: str
+    service: str
+    capabilities: List[str]
+    max_batch_size: int
+    timeout: int
+    timestamp: str
+
+
+class BatchLoadResponse(BaseModel):
+    """Response for POST /load — multi-endpoint batch execution."""
+
+    responses: Any
+    errors: Any
+    timing: Any
+
+
+class BatchChatInitResponse(BaseModel):
+    """Response for GET/POST /chat-init — optimized chat initialization."""
+
+    chat_sessions: Any
+    system_health: Any
+    service_health: Any
+    settings: Any
+    timing: Any
+
+
+# ---------------------------------------------------------------------------
+# advanced_control.py schemas  (Issue #5989)
+# ---------------------------------------------------------------------------
+
+
+class AdvancedControlStreamingSessionListResponse(BaseModel):
+    """Response for GET /streaming/sessions."""
+
+    sessions: List[Any]
+    count: int
+
+
+class AdvancedControlStreamingCapabilitiesResponse(BaseModel):
+    """Response for GET /streaming/capabilities.
+
+    Shape is opaque (from get_system_capabilities()) — extra fields allowed.
+    """
+
+    model_config = {"extra": "allow"}
+
+
+class AdvancedControlPendingTakeoversListResponse(BaseModel):
+    """Response for GET /takeover/pending."""
+
+    pending_requests: List[Any]
+    count: int
+
+
+class AdvancedControlActiveTakeoversListResponse(BaseModel):
+    """Response for GET /takeover/active."""
+
+    active_sessions: List[Any]
+    count: int
+
+
+class AdvancedControlTakeoverSystemStatusResponse(BaseModel):
+    """Response for GET /takeover/status.
+
+    Shape is opaque (from get_system_status()) — extra fields allowed.
+    """
+
+    model_config = {"extra": "allow"}
+
+
+class AdvancedControlHealthResponse(BaseModel):
+    """Response for GET /system/health."""
+
+    status: str
+    desktop_streaming_available: bool
+    novnc_available: bool
+    active_streaming_sessions: int
+    pending_takeovers: int
+    active_takeovers: int
+    paused_tasks: int
+
+
+class AdvancedControlInfoResponse(BaseModel):
+    """Response for GET / — advanced control capabilities info."""
+
+    name: str
+    version: str
+    features: List[str]
+    endpoints: Any
+
+
+# ---------------------------------------------------------------------------
+# long_running_operations.py schemas  (Issue #5989)
+# ---------------------------------------------------------------------------
+
+
+class LongRunningOperationMigrateResponse(BaseModel):
+    """Response for POST /migrate/existing."""
+
+    operation_id: str
+    status: str
+
+
+class LongRunningOperationStatusResponse(BaseModel):
+    """Response for GET /{operation_id} — opaque shape from _convert_operation_to_response."""
+
+    model_config = {"extra": "allow"}
+
+
+class LongRunningOperationListResponse(BaseModel):
+    """Response for GET / — list operations."""
+
+    operations: List[Any]
+    total_count: int
+    active_count: int
+    completed_count: int
+    failed_count: int
+
+
+class LongRunningOperationCancelResponse(BaseModel):
+    """Response for POST /{operation_id}/cancel."""
+
+    status: str
+    operation_id: str
+
+
+class LongRunningOperationResumeResponse(BaseModel):
+    """Response for POST /{operation_id}/resume."""
+
+    status: str
+    new_operation_id: str
+    resumed_from: str
+    original_operation_id: str
+
+
+class LongRunningOperationHealthResponse(BaseModel):
+    """Response for GET /health — long-running operations service health.
+
+    JSONResponse(503/500) paths bypass response_model; success path only.
+    """
+
+    status: str
+    active_operations: int
+    total_operations: int
+    redis_connected: bool
+    background_processor_running: bool
+
+
+# ---------------------------------------------------------------------------
+# error_resilience.py schemas  (Issue #5989)
+# ---------------------------------------------------------------------------
+
+
+class ResilienceHealthResponse(BaseModel):
+    """Response for GET /health — system resilience health."""
+
+    status: str
+    circuit_breakers: Any
+    error_budgets: Any
+    fallback_chains: Any
+
+
+class CircuitBreakerStatusResponse(BaseModel):
+    """Response for GET /circuit-breakers — opaque shape from manager.get_status()."""
+
+    model_config = {"extra": "allow"}
+
+
+class ErrorBudgetStatusResponse(BaseModel):
+    """Response for GET /error-budgets — opaque shape from tracker.get_status()."""
+
+    model_config = {"extra": "allow"}
+
+
+class CircuitBreakerResetResponse(BaseModel):
+    """Response for POST /circuit-breakers/{service_name}/reset."""
+
+    message: str
+
+
+class ErrorBudgetResetResponse(BaseModel):
+    """Response for POST /error-budgets/{component}/reset."""
+
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# system_validation.py schemas  (Issue #5989)
+# ---------------------------------------------------------------------------
+
+
+class SystemValidationHealthResponse(BaseModel):
+    """Response for GET /health — validation system health."""
+
+    status: str
+    message: str
+    validator_initialized: bool
+    timestamp: Optional[str] = None
+
+
+class SystemValidationQuickResponse(BaseModel):
+    """Response for GET /validate/quick."""
+
+    status: str
+    overall_score: float
+    components: Any
+    timestamp: str
+
+
+class SystemValidationComponentResponse(BaseModel):
+    """Response for GET /validate/component/{component_name}."""
+
+    component: str
+    status: str
+    score: float
+    details: Any
+    timestamp: str
+
+
+class SystemValidationRecommendationsResponse(BaseModel):
+    """Response for GET /validate/recommendations."""
+
+    total_recommendations: int
+    recommendations: List[Any]
+    timestamp: str
+
+
+class SystemValidationStatusResponse(BaseModel):
+    """Response for GET /validate/status."""
+
+    validation_system: str
+    available_validations: List[str]
+    last_validation: Optional[Any] = None
+    system_health: str
+    timestamp: str
+
+
+class SystemValidationBenchmarkResponse(BaseModel):
+    """Response for POST /validate/benchmark."""
+
+    benchmark_status: str
+    benchmarks: Any
+    overall_performance_score: float
+    timestamp: str
+
+
+# ---------------------------------------------------------------------------
+# sequential_thinking_mcp.py schemas  (Issue #5989)
+# ---------------------------------------------------------------------------
+
+
+class SequentialThinkingMCPToolsResponse(BaseModel):
+    """Response for GET /mcp/tools — list of MCP tools (each has name/description/input_schema)."""
+
+    model_config = {"extra": "allow"}
+
+
+class SequentialThinkingResponse(BaseModel):
+    """Response for POST /mcp/sequential_thinking."""
+
+    success: bool
+    session_id: str
+    thought_number: int
+    total_thoughts: int
+    progress_percentage: float
+    thinking_complete: bool
+    session_thought_count: int
+    message: str
+    revision_info: Optional[Any] = None
+    branch_info: Optional[Any] = None
+    summary: Optional[Any] = None
+
+
+class SequentialThinkingSessionResponse(BaseModel):
+    """Response for GET /sessions/{session_id}."""
+
+    session_id: str
+    thought_count: int
+    thoughts: List[Any]
+    revisions: List[Any]
+    branches: List[Any]
+    started_at: Optional[str] = None
+    last_thought_at: Optional[str] = None
+
+
+class SequentialThinkingSessionListResponse(BaseModel):
+    """Response for GET /sessions — list all thinking sessions."""
+
+    session_count: int
+    sessions: List[Any]
+
+
+# ---------------------------------------------------------------------------
+# structured_thinking_mcp.py schemas  (Issue #5989)
+# ---------------------------------------------------------------------------
+
+
+class StructuredThinkingProcessThoughtResponse(BaseModel):
+    """Response for POST /mcp/process_thought."""
+
+    success: bool
+    session_id: str
+    thought_number: int
+    total_thoughts: int
+    progress_percentage: float
+    current_stage: str
+    thinking_complete: bool
+    stage_distribution: Any
+    session_thought_count: int
+    message: str
+    related_thoughts: Optional[List[Any]] = None
+    completion_summary: Optional[Any] = None
+
+
+# ---------------------------------------------------------------------------
+# prompts.py schemas  (Issue #5989)
+# ---------------------------------------------------------------------------
+
+
+class PromptsListResponse(BaseModel):
+    """Response for GET / — list all prompts with defaults."""
+
+    prompts: List[Any]
+    defaults: Any
+
+
+class PromptsCacheClearResponse(BaseModel):
+    """Response for POST /cache/clear."""
+
+    status: str
+    message: str
+
+
+class PromptSaveResponse(BaseModel):
+    """Response for POST/{PUT /{prompt_id} — save or update prompt."""
+
+    id: str
+    name: str
+    type: str
+    path: str
+    content: str
+
+
+class PromptRevertResponse(BaseModel):
+    """Response for POST /{prompt_id}/revert."""
+
+    id: str
+    name: str
+    type: str
+    path: str
+    content: str
+
+
+# ---------------------------------------------------------------------------
+# registry.py schemas  (Issue #5989)
+# ---------------------------------------------------------------------------
+
+
+class RegistryRoutersResponse(BaseModel):
+    """Response for GET /routers — all registered routers with full config.
+
+    Keyed by router name; each value is a router config dict.
+    """
+
+    model_config = {"extra": "allow"}
+
+
+# ---------------------------------------------------------------------------
+# rum.py schemas  (Issue #5989)
+# ---------------------------------------------------------------------------
+
+
+class RUMExportResponse(BaseModel):
+    """Response for GET /export — export RUM data for analysis."""
+
+    status: str
+    data: Any
+
+
+# ---------------------------------------------------------------------------
+# data_storage.py schemas  (Issue #5989)
+# ---------------------------------------------------------------------------
+
+
+class DataStorageDeleteConversationResponse(BaseModel):
+    """Response for DELETE /conversations/{conversation_id}."""
+
+    conversation_id: str
+    files_deleted: List[str]
+    errors: List[str]
+    success: bool
+
+
+class DataStorageDatabasesResponse(BaseModel):
+    """Response for GET /databases — database files in data directory."""
+
+    databases: List[Any]
+    total_count: int
+    total_size_bytes: int
+    total_size_human: str
+
+
+class DataStorageCategoryDetailResponse(BaseModel):
+    """Response for GET /category/{category_path}."""
+
+    category: str
+    total_size_bytes: int
+    total_size_human: str
+    total_files: int
+    files: List[Any]
+    showing: int
+
+
+class DataStorageOldBackupsResponse(BaseModel):
+    """Response for POST /cleanup/old-backups."""
+
+    directories_found: List[Any]
+    total_count: int
+    bytes_freed: int
+    bytes_freed_human: str
+    dry_run: bool
+    message: str
+
+
+class DataStorageConversationsSummaryResponse(BaseModel):
+    """Response for GET /conversations/summary."""
+
+    unique_conversations: int
+    transcripts: Any
+    chats: Any
+    total_size_bytes: int
+    total_size_human: str
+
+
+# ---------------------------------------------------------------------------
+# collaboration.py schemas  (Issue #5989)
+# ---------------------------------------------------------------------------
+
+
+class SessionPresenceResponse(BaseModel):
+    """Response for GET /{session_id}/presence."""
+
+    session_id: str
+    online_users: List[Any]
+    count: int
+
+
+class SessionShareSecretResponse(BaseModel):
+    """Response for POST /{session_id}/secrets/share."""
+
+    success: bool
+    secret_id: str
+    shared_with_count: int
+
+
+# ---------------------------------------------------------------------------
 # analytics.py schemas  (Issue #5317)
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/sequential_thinking_mcp.py
+++ b/autobot-backend/api/sequential_thinking_mcp.py
@@ -26,6 +26,12 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from type_defs.common import Metadata
 from api.schemas_common import DataResponse
+from api.schemas_workflows import (
+    SequentialThinkingMCPToolsResponse,
+    SequentialThinkingResponse,
+    SequentialThinkingSessionListResponse,
+    SequentialThinkingSessionResponse,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(
@@ -225,7 +231,7 @@ class SequentialThinkingRequest(BaseModel):
     operation="get_sequential_thinking_mcp_tools",
     error_code_prefix="SEQUENTIAL_THINKING_MCP",
 )
-@router.get("/mcp/tools", response_model=None)
+@router.get("/mcp/tools", response_model=SequentialThinkingMCPToolsResponse)
 async def get_sequential_thinking_mcp_tools() -> List[MCPTool]:
     """
     Get available MCP tools for sequential thinking.
@@ -281,7 +287,7 @@ def _calculate_session_summary(session_thoughts: list, thought_number: int) -> d
     operation="sequential_thinking_mcp",
     error_code_prefix="SEQUENTIAL_THINKING_MCP",
 )
-@router.post("/mcp/sequential_thinking", response_model=None)
+@router.post("/mcp/sequential_thinking", response_model=SequentialThinkingResponse)
 async def sequential_thinking_mcp(request: SequentialThinkingRequest) -> Metadata:
     """Execute sequential thinking tool (Issue #398: refactored)."""
     session_id = request.get_session_key()
@@ -348,7 +354,7 @@ async def sequential_thinking_mcp(request: SequentialThinkingRequest) -> Metadat
     operation="get_thinking_session",
     error_code_prefix="SEQUENTIAL_THINKING_MCP",
 )
-@router.get("/sessions/{session_id}", response_model=None)
+@router.get("/sessions/{session_id}", response_model=SequentialThinkingSessionResponse)
 async def get_thinking_session(session_id: str) -> Metadata:
     """Get complete thinking session history"""
     async with _thinking_sessions_lock:
@@ -413,7 +419,7 @@ async def clear_thinking_session(session_id: str) -> Metadata:
     operation="list_thinking_sessions",
     error_code_prefix="SEQUENTIAL_THINKING_MCP",
 )
-@router.get("/sessions", response_model=None)
+@router.get("/sessions", response_model=SequentialThinkingSessionListResponse)
 async def list_thinking_sessions() -> Metadata:
     """List all active thinking sessions"""
     async with _thinking_sessions_lock:

--- a/autobot-backend/api/structured_thinking_mcp.py
+++ b/autobot-backend/api/structured_thinking_mcp.py
@@ -33,8 +33,9 @@ from pydantic import BaseModel, Field
 from api.schemas_common import DataResponse
 from api.schemas_workflows import (
     StructuredThinkingClearResponse,
-    StructuredThinkingSessionsResponse,
+    StructuredThinkingProcessThoughtResponse,
     StructuredThinkingSessionDetailResponse,
+    StructuredThinkingSessionsResponse,
 )
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -378,7 +379,7 @@ async def get_structured_thinking_mcp_tools() -> List[MCPTool]:
     operation="process_thought_mcp",
     error_code_prefix="STRUCTURED_THINKING_MCP",
 )
-@router.post("/mcp/process_thought", response_model=None)
+@router.post("/mcp/process_thought", response_model=StructuredThinkingProcessThoughtResponse)
 async def process_thought_mcp(request: ProcessThoughtRequest) -> Metadata:
     """
     Process and record a thought within the structured cognitive framework.

--- a/autobot-backend/api/system_validation.py
+++ b/autobot-backend/api/system_validation.py
@@ -16,7 +16,14 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from type_defs.common import Metadata
 from utils.catalog_http_exceptions import raise_catalog_error_simple, raise_server_error
 from utils.system_validator import get_system_validator
-from api.schemas_common import DataResponse
+from api.schemas_workflows import (
+    SystemValidationBenchmarkResponse,
+    SystemValidationComponentResponse,
+    SystemValidationHealthResponse,
+    SystemValidationQuickResponse,
+    SystemValidationRecommendationsResponse,
+    SystemValidationStatusResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +63,7 @@ class ValidationResult(BaseModel):
     operation="validation_health",
     error_code_prefix="SYSTEM_VALIDATION",
 )
-@router.get("/health", response_model=None)
+@router.get("/health", response_model=SystemValidationHealthResponse)
 async def validation_health():
     """Health check for validation system"""
     try:
@@ -125,7 +132,7 @@ async def run_comprehensive_validation(
     operation="run_quick_validation",
     error_code_prefix="SYSTEM_VALIDATION",
 )
-@router.get("/validate/quick", response_model=None)
+@router.get("/validate/quick", response_model=SystemValidationQuickResponse)
 async def run_quick_validation():
     """Run quick system validation check"""
     try:
@@ -197,7 +204,7 @@ async def run_quick_validation():
     operation="validate_component",
     error_code_prefix="SYSTEM_VALIDATION",
 )
-@router.get("/validate/component/{component_name}", response_model=None)
+@router.get("/validate/component/{component_name}", response_model=SystemValidationComponentResponse)
 async def validate_component(component_name: str):
     """Validate specific component"""
     try:
@@ -250,7 +257,7 @@ async def validate_component(component_name: str):
     operation="get_optimization_recommendations",
     error_code_prefix="SYSTEM_VALIDATION",
 )
-@router.get("/validate/recommendations", response_model=None)
+@router.get("/validate/recommendations", response_model=SystemValidationRecommendationsResponse)
 async def get_optimization_recommendations():
     """Get system optimization recommendations"""
     try:
@@ -320,7 +327,7 @@ async def get_optimization_recommendations():
     operation="get_validation_status",
     error_code_prefix="SYSTEM_VALIDATION",
 )
-@router.get("/validate/status", response_model=None)
+@router.get("/validate/status", response_model=SystemValidationStatusResponse)
 async def get_validation_status():
     """Get current validation system status"""
     try:
@@ -357,7 +364,7 @@ async def get_validation_status():
     operation="run_performance_benchmark",
     error_code_prefix="SYSTEM_VALIDATION",
 )
-@router.post("/validate/benchmark", response_model=None)
+@router.post("/validate/benchmark", response_model=SystemValidationBenchmarkResponse)
 async def run_performance_benchmark():
     """Run performance benchmarking tests"""
     try:


### PR DESCRIPTION
## Summary
- Wire pre-created schemas from `schemas_workflows.py` to 13 endpoint files
- Cover batch_jobs, advanced_control, long_running_operations, error_resilience, system_validation, sequential/structured thinking MCP, prompts, registry, rum, data_storage, collaboration
- Keep `response_model=None` for 3 HTTP 204 DELETE bypasses

## Test Plan
- [x] `python3 -c "from api import schemas_workflows"` passes
- [x] `python3 -m py_compile` passes for all 13 modified files
- [x] Zero `response_model=None` in target files except proven bypasses

Closes #5989 (batch 5/7 of #5960)

🤖 Generated with Claude Code