### PR TITLE
fix(api): add response_model=DataResponse to development_speedup GET /analyze (#6112)

### DIFF
--- a/autobot-backend/api/development_speedup.py
+++ b/autobot-backend/api/development_speedup.py
@@ -158,7 +158,7 @@ async def analyze_codebase_endpoint(request: AnalysisRequest):
     operation="analyze_codebase_get",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-@router.get("/analyze", response_model=None)
+@router.get("/analyze", response_model=DataResponse)
 async def analyze_codebase_get(
     path: str = Query(..., description="Root path to analyze"),
     type: str = Query("comprehensive", description="Analysis type"),


### PR DESCRIPTION
## Summary
- `GET /analyze` in `development_speedup.py` had `response_model=None` but delegates to the `POST /analyze` handler which uses `response_model=DataResponse`
- Single-line fix: `response_model=None` → `response_model=DataResponse`

Closes #6112

🤖 Generated with [Claude Code](https://claude.com/claude-code)