### PR TITLE
refact(composables): migrate useEnvironmentAnalysis fetchWithAuth GET to useFetchEndpoint (#6022)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useEnvironmentAnalysis.ts
+++ b/autobot-frontend/src/composables/analytics/useEnvironmentAnalysis.ts
@@ -7,12 +7,13 @@
  *
  * Environment variable scanning with optional AI-powered filtering.
  * Extracted from useSpecializedAnalysis (Issue #2372).
+ *
+ * Migrated from raw fetchWithAuth to useFetchEndpoint (#6022) for
+ * AbortController, race protection, and consistent error handling.
  */
 
 import { ref } from 'vue'
-import { useLoadingState } from '@/composables/useLoadingState'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import appConfig from '@/config/AppConfig.js'
+import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import { getConfig } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import type {
@@ -22,15 +23,30 @@ import type {
 
 const logger = createLogger('useEnvironmentAnalysis')
 
+interface EnvAnalysisRaw {
+  status: string
+  total_hardcoded_values?: number
+  high_priority_count?: number
+  recommendations_count?: number
+  categories?: Record<string, number>
+  analysis_time_seconds?: number
+  hardcoded_values?: unknown[]
+  recommendations?: unknown[]
+  llm_filtering?: {
+    enabled: boolean
+    model: string
+    original_count: number
+    filtered_count: number
+    reduction_percent: number
+    filter_priority: string | null
+  }
+}
+
 export function useEnvironmentAnalysis(
   deps: UseCodeIntelAnalysisDeps,
 ) {
   const { rootPath, withSourceId } = deps
 
-  const environmentAnalysis =
-    ref<EnvironmentAnalysisResult | null>(null)
-  const { isLoading: loadingEnvAnalysis, wrap } = useLoadingState()
-  const envAnalysisError = ref('')
   const useAiFiltering = ref(false)
   const aiFilteringModel = ref(getConfig().llm.defaultModel)
   const aiFilteringPriority = ref('high')
@@ -43,75 +59,63 @@ export function useEnvironmentAnalysis(
     filter_priority: string | null
   } | null>(null)
 
-  const loadEnvironmentAnalysis = async () => {
-    if (!rootPath.value) return
-    envAnalysisError.value = ''
-    llmFilteringResult.value = null
-    try {
-      await wrap(async () => {
-        const backendUrl = await appConfig.getServiceUrl('backend')
-        let url = `${backendUrl}/api/analytics/codebase/env-analysis?path=${encodeURIComponent(rootPath.value)}`
-        if (useAiFiltering.value) {
-          url += `&use_llm_filter=true`
-          url += `&llm_model=${encodeURIComponent(aiFilteringModel.value)}`
-          url += `&filter_priority=${encodeURIComponent(aiFilteringPriority.value)}`
-        }
-        url = withSourceId(url)
-        const response = await fetchWithAuth(url, {
-          method: 'GET',
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-          },
-        })
-        if (!response.ok) {
-          throw new Error(
-            `Environment analysis endpoint returned ${response.status}`,
-          )
-        }
-        const data = await response.json()
-        if (data.status === 'success') {
-          environmentAnalysis.value = {
-            total_hardcoded_values:
-              data.total_hardcoded_values || 0,
-            high_priority_count: data.high_priority_count || 0,
-            recommendations_count:
-              data.recommendations_count || 0,
-            categories: data.categories || {},
-            analysis_time_seconds:
-              data.analysis_time_seconds || 0,
-            hardcoded_values: data.hardcoded_values || [],
-            recommendations: data.recommendations || [],
-          }
-          if (data.llm_filtering) {
-            llmFilteringResult.value = data.llm_filtering
-            logger.info(
-              'LLM filtering applied:',
-              data.llm_filtering,
-            )
-          }
-        } else if (data.status === 'no_data') {
-          environmentAnalysis.value = null
+  const endpoint = useFetchEndpoint<EnvAnalysisRaw, EnvironmentAnalysisResult>(
+    {
+      path: '/api/analytics/codebase/env-analysis',
+      scopeToSource: true,
+      pickData: (raw) => {
+        if (raw.status === 'no_data') {
           logger.debug(
             'No environment analysis data - run indexing first',
           )
+          return null
         }
-      })
-    } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error)
-      logger.error(
-        'Failed to load environment analysis:',
-        error,
-      )
-      envAnalysisError.value = errorMessage
+        if (raw.status !== 'success') return null
+        return {
+          total_hardcoded_values: raw.total_hardcoded_values ?? 0,
+          high_priority_count: raw.high_priority_count ?? 0,
+          recommendations_count: raw.recommendations_count ?? 0,
+          categories: raw.categories ?? {},
+          analysis_time_seconds: raw.analysis_time_seconds ?? 0,
+          hardcoded_values: (raw.hardcoded_values ?? []) as EnvironmentAnalysisResult['hardcoded_values'],
+          recommendations: (raw.recommendations ?? []) as EnvironmentAnalysisResult['recommendations'],
+        }
+      },
+      onSuccess: (_data, raw) => {
+        if (raw.llm_filtering) {
+          llmFilteringResult.value = raw.llm_filtering
+          logger.info('LLM filtering applied:', raw.llm_filtering)
+        }
+      },
+      onError: (message, err) => {
+        logger.error('Failed to load environment analysis:', err)
+        // error surface is handled by endpoint.error
+      },
+      label: 'Environment analysis',
+    },
+    { withSourceId },
+  )
+
+  const loadEnvironmentAnalysis = async () => {
+    if (!rootPath.value) return
+    llmFilteringResult.value = null
+
+    const queryExtras: Record<string, string> = {
+      path: rootPath.value,
     }
+    if (useAiFiltering.value) {
+      queryExtras['use_llm_filter'] = 'true'
+      queryExtras['llm_model'] = aiFilteringModel.value
+      queryExtras['filter_priority'] = aiFilteringPriority.value
+    }
+
+    await endpoint.load(queryExtras)
   }
 
   return {
-    environmentAnalysis,
-    loadingEnvAnalysis,
-    envAnalysisError,
+    environmentAnalysis: endpoint.data,
+    loadingEnvAnalysis: endpoint.loading,
+    envAnalysisError: endpoint.error,
     useAiFiltering,
     aiFilteringModel,
     aiFilteringPriority,


### PR DESCRIPTION
## Summary

- Replace raw `fetchWithAuth` GET call in `useEnvironmentAnalysis.ts` with `useFetchEndpoint`
- Gains AbortController + race safety from `useApiResource` inside `useFetchEndpoint`
- Added `EnvAnalysisRaw` interface for typed transform
- Dynamic query params (`path`, `use_llm_filter`, `llm_model`, `filter_priority`) passed as `queryExtras` to `endpoint.load()`
- `scopeToSource: true` handles `withSourceId(url)` automatically via deps injection
- `no_data` status maps to `null`; `llmFilteringResult` populated via `onSuccess`
- Public API unchanged: `environmentAnalysis`, `loadingEnvAnalysis`, `envAnalysisError`, `loadEnvironmentAnalysis`

Part of tracker #6006 · Closes #6022

🤖 Generated with [Claude Code](https://claude.com/claude-code)