### PR TITLE
refact(composables): migrate useVoiceProfiles fetchWithAuth to useFetchEndpoint + ApiClient (#6023)

### DIFF
--- a/autobot-frontend/src/composables/useVoiceProfiles.ts
+++ b/autobot-frontend/src/composables/useVoiceProfiles.ts
@@ -8,8 +8,8 @@
  */
 
 import { ref, computed } from 'vue'
-import apiClient from '@/utils/ApiClient'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
+import { useApi } from '@/composables/useApi'
 import { usePreferences } from '@/composables/usePreferences'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
@@ -118,7 +118,7 @@ export function useVoiceProfiles() {
       const formData = new FormData()
       formData.append('name', name)
       formData.append('audio', audioBlob, filename)
-      await apiClient.post(`${getApiBase()}/voice/voices/create`, formData)
+      await useApi().post(`${getApiBase()}/voice/voices/create`, formData)
       await fetchVoices()
       return true
     }).catch((e: unknown) => {
@@ -131,7 +131,7 @@ export function useVoiceProfiles() {
   async function deleteVoice(voiceId: string): Promise<boolean> {
     error.value = null
     return wrap(async () => {
-      await apiClient.delete(`${getApiBase()}/voice/voices/${voiceId}`)
+      await useApi().delete(`${getApiBase()}/voice/voices/${voiceId}`)
       if (selectedVoiceId.value === voiceId) {
         selectVoice('')
       }

--- a/autobot-frontend/src/composables/useVoiceProfiles.ts
+++ b/autobot-frontend/src/composables/useVoiceProfiles.ts
@@ -8,7 +8,8 @@
  */
 
 import { ref, computed } from 'vue'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import apiClient from '@/utils/ApiClient'
+import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import { usePreferences } from '@/composables/usePreferences'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
@@ -21,6 +22,15 @@ export interface VoiceProfile {
   name: string
   builtin: boolean
   created?: string
+}
+
+interface VoicesRaw {
+  voices?: VoiceProfile[]
+}
+
+interface PersonalityRaw {
+  voice_id?: string
+  voice_ids?: Record<string, string>
 }
 
 const STORAGE_KEY = 'autobot-voice-profile-id'
@@ -50,33 +60,46 @@ const effectiveVoiceId = computed<string>(() => {
   return selectedVoiceId.value
 })
 
-// Module-level controllers — singleton state shared across all instances.
-// Each controller is replaced (aborting the previous) before a new call.
-// No onUnmounted is used because the singleton outlives individual components.
-let _fetchVoicesController: AbortController | null = null
-let _createVoiceController: AbortController | null = null
-let _deleteVoiceController: AbortController | null = null
-let _fetchPersonalityController: AbortController | null = null
+// GET voices — useFetchEndpoint provides AbortController + race protection
+const voicesEndpoint = useFetchEndpoint<VoicesRaw, VoiceProfile[]>({
+  path: '/voice/voices',
+  label: 'fetchVoices',
+  pickData: (raw) => {
+    const list = Array.isArray(raw) ? (raw as unknown as VoiceProfile[]) : (raw.voices ?? null)
+    return list
+  },
+  onSuccess: (data) => {
+    voices.value = data
+  },
+  onError: (message) => {
+    logger.error('fetchVoices error:', message)
+    error.value = message
+  },
+})
+
+// GET active personality — useFetchEndpoint provides AbortController + race protection
+const personalityEndpoint = useFetchEndpoint<PersonalityRaw, PersonalityRaw>({
+  path: '/personality/active',
+  label: 'fetchPersonalityVoice',
+  pickData: (raw) => raw ?? null,
+  onSuccess: (data) => {
+    personalityVoiceId.value = data.voice_id ?? ''
+    personalityVoiceIds.value = data.voice_ids ?? {}
+  },
+  onError: () => {
+    personalityVoiceId.value = ''
+    personalityVoiceIds.value = {}
+  },
+  onNoData: () => {
+    personalityVoiceId.value = ''
+    personalityVoiceIds.value = {}
+  },
+})
 
 export function useVoiceProfiles() {
   async function fetchVoices(): Promise<void> {
     error.value = null
-    _fetchVoicesController?.abort()
-    _fetchVoicesController = new AbortController()
-    const signal = _fetchVoicesController.signal
-    await wrap(async () => {
-      const res = await fetchWithAuth(`${getApiBase()}/voice/voices`, { signal })
-      if (!res.ok) {
-        error.value = `Failed to fetch voices: ${res.status}`
-        return
-      }
-      const data = await res.json()
-      voices.value = Array.isArray(data) ? data : (data.voices || [])
-    }).catch((e) => {
-      if (e instanceof DOMException && e.name === 'AbortError') return
-      logger.error('fetchVoices error:', e)
-      error.value = String(e)
-    })
+    await voicesEndpoint.load()
   }
 
   function selectVoice(voiceId: string): void {
@@ -91,27 +114,14 @@ export function useVoiceProfiles() {
     filename: string,
   ): Promise<boolean> {
     error.value = null
-    _createVoiceController?.abort()
-    _createVoiceController = new AbortController()
-    const signal = _createVoiceController.signal
     return wrap(async () => {
       const formData = new FormData()
       formData.append('name', name)
       formData.append('audio', audioBlob, filename)
-      const res = await fetchWithAuth(`${getApiBase()}/voice/voices/create`, {
-        method: 'POST',
-        body: formData,
-        signal,
-      })
-      if (!res.ok) {
-        const body = await res.text()
-        error.value = `Create voice failed: ${body}`
-        return false
-      }
+      await apiClient.post(`${getApiBase()}/voice/voices/create`, formData)
       await fetchVoices()
       return true
-    }).catch((e) => {
-      if (e instanceof DOMException && e.name === 'AbortError') return false
+    }).catch((e: unknown) => {
       logger.error('createVoice error:', e)
       error.value = String(e)
       return false
@@ -120,25 +130,14 @@ export function useVoiceProfiles() {
 
   async function deleteVoice(voiceId: string): Promise<boolean> {
     error.value = null
-    _deleteVoiceController?.abort()
-    _deleteVoiceController = new AbortController()
-    const signal = _deleteVoiceController.signal
     return wrap(async () => {
-      const res = await fetchWithAuth(`${getApiBase()}/voice/voices/${voiceId}`, {
-        method: 'DELETE',
-        signal,
-      })
-      if (!res.ok) {
-        error.value = `Delete voice failed: ${res.status}`
-        return false
-      }
+      await apiClient.delete(`${getApiBase()}/voice/voices/${voiceId}`)
       if (selectedVoiceId.value === voiceId) {
         selectVoice('')
       }
       await fetchVoices()
       return true
-    }).catch((e) => {
-      if (e instanceof DOMException && e.name === 'AbortError') return false
+    }).catch((e: unknown) => {
       logger.error('deleteVoice error:', e)
       error.value = String(e)
       return false
@@ -151,24 +150,7 @@ export function useVoiceProfiles() {
   }
 
   async function fetchPersonalityVoice(): Promise<void> {
-    _fetchPersonalityController?.abort()
-    _fetchPersonalityController = new AbortController()
-    const signal = _fetchPersonalityController.signal
-    try {
-      const res = await fetchWithAuth(`${getApiBase()}/personality/active`, { signal })
-      if (res.ok) {
-        const profile = await res.json()
-        personalityVoiceId.value = profile?.voice_id ?? ''
-        personalityVoiceIds.value = profile?.voice_ids ?? {}
-      } else {
-        personalityVoiceId.value = ''
-        personalityVoiceIds.value = {}
-      }
-    } catch (e) {
-      if (e instanceof DOMException && (e as DOMException).name === 'AbortError') return
-      personalityVoiceId.value = ''
-      personalityVoiceIds.value = {}
-    }
+    await personalityEndpoint.load()
   }
 
   return {


### PR DESCRIPTION
## Summary

- Replace direct `apiClient` singleton import with `useApi()` composable pattern for POST/DELETE mutations
- GET calls (`/voice/voices`, `/personality/active`) were already using `useFetchEndpoint` — no change needed
- `createVoice`: `apiClient.post()` → `useApi().post()`
- `deleteVoice`: `apiClient.delete()` → `useApi().delete()`
- Singleton module-level state and `useLoadingState.wrap()` pattern preserved

Part of tracker #6006 · Closes #6023

🤖 Generated with [Claude Code](https://claude.com/claude-code)