### PR TITLE
docs(composables): document useIndexingJob fetchWithAuth intentional exemption (#6024)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useIndexingJob.ts
+++ b/autobot-frontend/src/composables/analytics/useIndexingJob.ts
@@ -307,11 +307,16 @@ export function useIndexingJob(deps: UseIndexingJobDeps) {
   /**
    * Send an index request with retry on 502/503.
    *
-   * #5257: intentionally NOT migrated to useFetchEndpoint. The composable
-   * has no retry hook today (adding one for a single consumer would be
-   * speculative surface area), and the 502/503 handling here is
-   * domain-specific (backend-warmup vs real error). Keeping this one
-   * hand-rolled; the other 4 fetchers in this file migrated cleanly.
+   * #5257: intentionally NOT migrated to useFetchEndpoint — the composable
+   * has no retry hook, and the 502/503 handling is domain-specific
+   * (backend-warmup vs real error).
+   *
+   * #6024: assessed for useBackgroundTask migration — not applicable.
+   * useBackgroundTask hard-codes POST {baseUrl}/analyze + GET {baseUrl}/status/{id};
+   * this endpoint is POST /index (no /analyze suffix). The indexing API also
+   * exposes domain-specific statuses (syncing, already_running, queued),
+   * intermediate result polling, cancellation, and resume-on-mount that
+   * useBackgroundTask does not support. See discovery #6126 for full analysis.
    */
   const _sendIndexRequest = async (
     endpoint: string,


### PR DESCRIPTION
## Summary

After audit, `_sendIndexRequest`'s `fetchWithAuth` **cannot** be migrated to `useBackgroundTask`:

1. `useBackgroundTask` hardcodes `{baseUrl}/analyze` suffix — incompatible with `/api/analytics/codebase/index`
2. `useBackgroundTask` has no 502/503 retry logic — the hand-rolled retries exist for backend warm-up scenarios
3. Polling contract is incompatible (`TaskStatus: pending|running|completed|failed` vs domain-specific `syncing|already_running|queued` + `phases`/`batches`/`stats`)
4. No equivalent for cancellation (`/index/cancel`) or resume-on-mount (`checkCurrentIndexingJob`)

Updated comment at line 307 documents the #6024 assessment and references discovery #6126 for full analysis trail. The fetchWithAuth stays as intentional technical debt.

Part of tracker #6006 · Closes #6024

🤖 Generated with [Claude Code](https://claude.com/claude-code)