### PR TITLE
refact(composables): migrate useBugPrediction loadCachedBugPrediction fetchWithAuth to ApiClient (#6026)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useBugPrediction.ts
+++ b/autobot-frontend/src/composables/analytics/useBugPrediction.ts
@@ -11,8 +11,7 @@
 
 import { ref, computed } from 'vue'
 import { useExpansion } from '@/composables/useExpansion'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import appConfig from '@/config/AppConfig.js'
+import apiClient from '@/utils/ApiClient'
 import { useBackgroundTask } from '@/composables/useBackgroundTask'
 import type {
   UseCodeIntelAnalysisDeps,
@@ -62,15 +61,15 @@ export function useBugPrediction(deps: UseCodeIntelAnalysisDeps) {
   const loadBugPrediction = () => bugPredictionTask.start()
 
   const loadCachedBugPrediction = async () => {
-    const backendUrl = await appConfig.getServiceUrl('backend')
-    const resp = await fetchWithAuth(
-      `${backendUrl}/api/analytics/bug-prediction/cached`,
-    )
-    if (!resp.ok) return
-    const data = await resp.json()
-    if (data.status === 'success' && data.files) {
-      bugPredictionTask.result.value =
-        data as Record<string, unknown>
+    try {
+      const data = await apiClient.get<Record<string, unknown>>(
+        '/api/analytics/bug-prediction/cached',
+      )
+      if (data.status === 'success' && data.files) {
+        bugPredictionTask.result.value = data
+      }
+    } catch {
+      // Cached data not available — silently ignore
     }
   }
 


### PR DESCRIPTION
## Summary
- Replaces single `fetchWithAuth` GET in `loadCachedBugPrediction` with `apiClient.get()`
- Removes unused `fetchWithAuth` and `appConfig` imports
- Non-2xx responses now throw (caught silently) — same effective behavior as original `if (!resp.ok) return`
- Already uses `useBackgroundTask` for main task; this completes the migration

## Behavioral grep audit
Before: 1 `fetchWithAuth` call in `useBugPrediction.ts`
After: 0 `fetchWithAuth` calls in `useBugPrediction.ts`

Closes #6026. Part of tracker #6006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)