### PR TITLE
fix(deps): downgrade typescript 6.0.3→5.8.3 to satisfy openapi-typescript peer dep (#6139)

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -87,7 +87,7 @@
         "prettier": "3.8.1",
         "start-server-and-test": "^3.0.2",
         "tailwindcss": "^4.2.2",
-        "typescript": "~6.0.3",
+        "typescript": "~5.8.3",
         "vite": "^8.0.9",
         "vite-plugin-vue-devtools": "^8.1.1",
         "vitest": "^4.1.4",
@@ -11810,10 +11810,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -127,7 +127,7 @@
     "prettier": "3.8.1",
     "start-server-and-test": "^3.0.2",
     "tailwindcss": "^4.2.2",
-    "typescript": "~6.0.3",
+    "typescript": "~5.8.3",
     "vite": "^8.0.9",
     "vite-plugin-vue-devtools": "^8.1.1",
     "vitest": "^4.1.4",


### PR DESCRIPTION
## Summary

- Downgrades `typescript` from `~6.0.3` to `~5.8.3` in `autobot-frontend/package.json`
- Regenerates `package-lock.json` with clean peer dependency resolution
- Fixes `npm ci` ERESOLVE in the Docker frontend build (`openapi-typescript@7.13.0` requires `typescript@^5.x`)

## Root Cause

`openapi-typescript@7.13.0` declares `peerDependencies: { typescript: "^5.x" }`. With TypeScript 6, npm 10 strict peer dep enforcement rejects the install. No TypeScript 6-specific features (`isolatedDeclarations`, `using`, `noUncheckedSideEffectImports`, etc.) are used anywhere in the codebase — the version bump was unnecessary.

All other tools are compatible with 5.8.x:
- `vue-tsc@3.2.6`: requires `>=5.0.0` ✅
- `@vue/tsconfig@0.9.1`: requires `>=5.8` ✅
- `openapi-typescript@7.13.0`: requires `^5.x` ✅ (was failing with 6.0.3)

## Verification

- `npm install` succeeded with zero ERESOLVE errors
- `npm run type-check` exits 0 — no regressions introduced
- TypeScript 5.8.3 confirmed in lockfile

Closes #6139