### PR TITLE
fix(deps): restore typescript 6.0.3, use npm overrides to satisfy openapi-typescript peer dep

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -87,7 +87,7 @@
         "prettier": "3.8.1",
         "start-server-and-test": "^3.0.2",
         "tailwindcss": "^4.2.2",
-        "typescript": "~5.8.3",
+        "typescript": "~6.0.3",
         "vite": "^8.0.9",
         "vite-plugin-vue-devtools": "^8.1.1",
         "vitest": "^4.1.4",
@@ -11810,9 +11810,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -72,7 +72,10 @@
   },
   "overrides": {
     "minimatch": ">=9.0.7",
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "openapi-typescript": {
+      "typescript": "$typescript"
+    }
   },
   "devDependencies": {
     "@pinia/testing": "^1.0.3",
@@ -127,7 +130,7 @@
     "prettier": "3.8.1",
     "start-server-and-test": "^3.0.2",
     "tailwindcss": "^4.2.2",
-    "typescript": "~5.8.3",
+    "typescript": "~6.0.3",
     "vite": "^8.0.9",
     "vite-plugin-vue-devtools": "^8.1.1",
     "vitest": "^4.1.4",


### PR DESCRIPTION
## Summary

Follows up on #6144 (which downgraded TypeScript to 5.8.3). Restores TypeScript to the latest `~6.0.3` while properly resolving the peer dep conflict via npm `overrides`.

- Reverts `typescript` from `~5.8.3` back to `~6.0.3`
- Adds `overrides` entry so npm accepts TypeScript 6 for `openapi-typescript@7.13.0`'s `^5.x` peer dep
- Regenerates lockfile — TypeScript 6.0.3 confirmed installed, zero ERESOLVE

## Why overrides, not downgrade

`openapi-typescript@7.13.0` is a codegen tool — it generates `.ts` files from an OpenAPI spec, it does not invoke the TypeScript compiler. The `^5.x` peer dep is a conservative declaration that was never updated for TypeScript 6. The override tells npm's resolver to accept our TypeScript 6 installation rather than rejecting it.

## Verification

- `npm install` → clean, no ERESOLVE
- `package-lock.json` lockfile shows `typescript: 6.0.3`
- All peer deps satisfied: `vue-tsc` (≥5.0), `@vue/tsconfig` (≥5.8), `openapi-typescript` (overridden)