### PR TITLE
refact(composables): extract fetchWithAuth from CodeGenerationDashboard to useCodeGenerationData (#6060)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
@@ -329,10 +329,17 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 import { escapeHtml } from '@/utils/sanitize'
-import { getApiBase } from '@/config/ssot-config'
+import { useCodeGenerationData } from '@/composables/analytics/useCodeGenerationData'
+import type {
+  GenerateRequest,
+  RefactorRequest,
+  GenerationResult,
+  ValidationInfo,
+  CodeGenerationStats,
+  RefactoringType,
+} from '@/composables/analytics/useCodeGenerationData'
 
 const logger = createLogger('CodeGenerationDashboard')
 
@@ -348,51 +355,13 @@ function withSourceId(url: string): string {
   return `${url}${sep}source_id=${encodeURIComponent(id)}`
 }
 
-
-// Types
-interface GenerateRequest {
-  description: string
-  language: string
-  context: string
-  existing_code: string
-}
-
-interface RefactorRequest {
-  code: string
-  language: string
-  refactoring_type: string
-  preserve_comments: boolean
-}
-
-interface ValidationInfo {
-  is_valid: boolean
-  errors: string[]
-  warnings: string[]
-  ast_info: Record<string, unknown>
-}
-
-interface GenerationResult {
-  success: boolean
-  generated_code?: string
-  refactored_code?: string
-  diff?: string
-  changes?: string[]
-  validation?: ValidationInfo
-  tokens_used: number
-  processing_time: number
-  error?: string
-}
-
-interface Stats {
-  generation: { total: number; success: number; tokens: number }
-  refactoring: { total: number; success: number; tokens: number }
-}
-
-interface RefactoringType {
-  id: string
-  name: string
-  description: string
-}
+const {
+  generateCode: apiGenerateCode,
+  refactorCode: apiRefactorCode,
+  validateCode: apiValidateCode,
+  fetchStats: apiFetchStats,
+  fetchRefactoringTypes: apiFetchRefactoringTypes,
+} = useCodeGenerationData(withSourceId)
 
 // State
 const mode = ref<'generate' | 'refactor'>('generate')
@@ -415,7 +384,7 @@ const refactorRequest = ref<RefactorRequest>({
   preserve_comments: true
 })
 
-const stats = ref<Stats>({
+const stats = ref<CodeGenerationStats>({
   generation: { total: 0, success: 0, tokens: 0 },
   refactoring: { total: 0, success: 0, tokens: 0 }
 })
@@ -489,15 +458,8 @@ const generateCode = async () => {
   result.value = null
 
   try {
-    const response = await fetchWithAuth(`${getApiBase()}/code-generation/generate`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(generateRequest.value)
-    })
-
-    if (!response.ok) throw new Error('Generation failed')
-
-    result.value = await response.json()
+    const data = await apiGenerateCode(generateRequest.value)
+    result.value = data ?? { success: false, error: 'Generation failed', tokens_used: 0, processing_time: 0 }
     await fetchStats()
   } catch (err) {
     logger.error('Generation error:', err)
@@ -517,15 +479,8 @@ const refactorCode = async () => {
   result.value = null
 
   try {
-    const response = await fetchWithAuth(`${getApiBase()}/code-generation/refactor`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(refactorRequest.value)
-    })
-
-    if (!response.ok) throw new Error('Refactoring failed')
-
-    result.value = await response.json()
+    const data = await apiRefactorCode(refactorRequest.value)
+    result.value = data ?? { success: false, error: 'Refactoring failed', tokens_used: 0, processing_time: 0 }
     await fetchStats()
   } catch (err) {
     logger.error('Refactoring error:', err)
@@ -541,46 +496,24 @@ const refactorCode = async () => {
 }
 
 const validateCodeSubmit = async () => {
-  try {
-    const response = await fetchWithAuth(`${getApiBase()}/code-generation/validate`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        code: validateCode.value,
-        language: validateLanguage.value
-      })
-    })
-
-    if (!response.ok) throw new Error('Validation failed')
-
-    validationResult.value = await response.json()
-  } catch (err) {
-    logger.error('Validation error:', err)
+  const data = await apiValidateCode(validateCode.value, validateLanguage.value)
+  if (data !== null) {
+    validationResult.value = data
   }
 }
 
 const fetchStats = async () => {
-  try {
-    // Issue #3436: scope to project when sourceId is present
-    const response = await fetchWithAuth(withSourceId(`${getApiBase()}/code-generation/stats`))
-    if (response.ok) {
-      const data = await response.json()
-      stats.value = data
-    }
-  } catch (err) {
-    logger.error('Failed to fetch stats:', err)
+  // Issue #3436: scope to project when sourceId is present
+  const data = await apiFetchStats()
+  if (data !== null) {
+    stats.value = data
   }
 }
 
 const fetchRefactoringTypes = async () => {
-  try {
-    const response = await fetchWithAuth(`${getApiBase()}/code-generation/refactoring-types`)
-    if (response.ok) {
-      const data = await response.json()
-      refactoringTypes.value = data.types
-    }
-  } catch (err) {
-    logger.error('Failed to fetch refactoring types:', err)
+  const types = await apiFetchRefactoringTypes()
+  if (types.length > 0) {
+    refactoringTypes.value = types
   }
 }
 

--- a/autobot-frontend/src/composables/analytics/useCodeGenerationData.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeGenerationData.ts
@@ -1,0 +1,152 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Composable: useCodeGenerationData
+ *
+ * Encapsulates all fetchWithAuth calls for the Code Generation Dashboard.
+ * Extracted from CodeGenerationDashboard.vue (Issue #6060).
+ *
+ * Endpoints (all under /api/code-generation/*):
+ *   POST GET  /code-generation/generate
+ *   POST      /code-generation/refactor
+ *   POST      /code-generation/validate
+ *   GET       /code-generation/stats
+ *   GET       /code-generation/refactoring-types
+ */
+
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { getApiBase } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useCodeGenerationData')
+
+export interface GenerateRequest {
+  description: string
+  language: string
+  context: string
+  existing_code: string
+}
+
+export interface RefactorRequest {
+  code: string
+  language: string
+  refactoring_type: string
+  preserve_comments: boolean
+}
+
+export interface ValidationInfo {
+  is_valid: boolean
+  errors: string[]
+  warnings: string[]
+  ast_info: Record<string, unknown>
+}
+
+export interface GenerationResult {
+  success: boolean
+  generated_code?: string
+  refactored_code?: string
+  diff?: string
+  changes?: string[]
+  validation?: ValidationInfo
+  tokens_used: number
+  processing_time: number
+  error?: string
+}
+
+export interface CodeGenerationStats {
+  generation: { total: number; success: number; tokens: number }
+  refactoring: { total: number; success: number; tokens: number }
+}
+
+export interface RefactoringType {
+  id: string
+  name: string
+  description: string
+}
+
+export function useCodeGenerationData(withSourceId: (url: string) => string) {
+  async function generateCode(request: GenerateRequest): Promise<GenerationResult | null> {
+    try {
+      const response = await fetchWithAuth(`${getApiBase()}/code-generation/generate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+      })
+      if (!response.ok) throw new Error('Generation failed')
+      return (await response.json()) as GenerationResult
+    } catch (err) {
+      logger.error('Generation error:', err)
+      return null
+    }
+  }
+
+  async function refactorCode(request: RefactorRequest): Promise<GenerationResult | null> {
+    try {
+      const response = await fetchWithAuth(`${getApiBase()}/code-generation/refactor`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+      })
+      if (!response.ok) throw new Error('Refactoring failed')
+      return (await response.json()) as GenerationResult
+    } catch (err) {
+      logger.error('Refactoring error:', err)
+      return null
+    }
+  }
+
+  async function validateCode(code: string, language: string): Promise<ValidationInfo | null> {
+    try {
+      const response = await fetchWithAuth(`${getApiBase()}/code-generation/validate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code, language }),
+      })
+      if (!response.ok) throw new Error('Validation failed')
+      return (await response.json()) as ValidationInfo
+    } catch (err) {
+      logger.error('Validation error:', err)
+      return null
+    }
+  }
+
+  async function fetchStats(): Promise<CodeGenerationStats | null> {
+    try {
+      // Issue #3436: scope to project when sourceId is present
+      const response = await fetchWithAuth(withSourceId(`${getApiBase()}/code-generation/stats`))
+      if (!response.ok) {
+        logger.warn('Failed to fetch stats: HTTP', response.status)
+        return null
+      }
+      return (await response.json()) as CodeGenerationStats
+    } catch (err) {
+      logger.error('Failed to fetch stats:', err)
+      return null
+    }
+  }
+
+  async function fetchRefactoringTypes(): Promise<RefactoringType[]> {
+    try {
+      const response = await fetchWithAuth(`${getApiBase()}/code-generation/refactoring-types`)
+      if (!response.ok) {
+        logger.warn('Failed to fetch refactoring types: HTTP', response.status)
+        return []
+      }
+      const data = await response.json()
+      return (data.types as RefactoringType[]) || []
+    } catch (err) {
+      logger.error('Failed to fetch refactoring types:', err)
+      return []
+    }
+  }
+
+  return {
+    generateCode,
+    refactorCode,
+    validateCode,
+    fetchStats,
+    fetchRefactoringTypes,
+  }
+}


### PR DESCRIPTION
## Summary
- Created `autobot-frontend/src/composables/analytics/useCodeGenerationData.ts` with 5 functions (generateCode, refactorCode, validateCode, fetchStats, fetchRefactoringTypes)
- Removed all inline `fetchWithAuth` calls from `CodeGenerationDashboard.vue`; interfaces moved to composable

## Behavioral grep audit
Before: 5 fetchWithAuth hits in component
After: 0 hits

## Test plan
- [ ] No fetchWithAuth/apiClient in component
- [ ] Type-check ≤ 244 errors

Closes #6060
🤖 Generated with [Claude Code](https://claude.com/claude-code)