### PR TITLE
refact(composables): extract fetchWithAuth from LogPatternDashboard to useLogPatternData (#6064)

### DIFF
--- a/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
@@ -227,72 +227,17 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
-import { getApiBase } from '@/config/ssot-config'
 import { getCssVar } from '@/composables/useCssVars'
 import { usePollingJob } from '@/composables/usePollingJob'
+import { useLogPatternData } from '@/composables/analytics/useLogPatternData'
+import type { LogPattern, LogAnomaly, LogTrend, MiningResult, RealtimeData } from '@/composables/analytics/useLogPatternData'
 
 const { t } = useI18n()
 
 const logger = createLogger('LogPatternDashboard')
 
-// Types
-interface LogPattern {
-  pattern_id: string
-  pattern_template: string
-  occurrences: number
-  first_seen: string
-  last_seen: string
-  log_levels: string[]
-  sources: string[]
-  sample_messages: string[]
-  frequency_per_hour: number
-  is_error_pattern: boolean
-  is_anomaly: boolean
-}
-
-interface LogAnomaly {
-  anomaly_id: string
-  anomaly_type: string
-  severity: string
-  description: string
-  timestamp: string
-  affected_sources: string[]
-  metric_before: number
-  metric_after: number
-  confidence: number
-}
-
-interface LogTrend {
-  trend_id: string
-  metric_name: string
-  direction: string
-  change_percent: number
-  time_period: string
-  data_points: Array<Record<string, unknown>>
-}
-
-interface MiningResult {
-  patterns: LogPattern[]
-  anomalies: LogAnomaly[]
-  trends: LogTrend[]
-  summary: {
-    total_logs: number
-    unique_patterns: number
-    error_patterns: number
-    anomalies_detected: number
-  }
-  analysis_time_ms: number
-  logs_analyzed: number
-}
-
-interface RealtimeData {
-  logs_last_5min: number
-  error_count: number
-  level_counts: Record<string, number>
-  recent_errors: Array<Record<string, unknown>>
-}
+const { fetchMiningResult, fetchRealtimeData: _fetchRealtimeData } = useLogPatternData()
 
 // State
 const timeRange = ref(24)
@@ -337,28 +282,14 @@ const filteredPatterns = computed(() => {
 const runAnalysis = async () => {
   isAnalyzing.value = true
   try {
-    const response = await fetchWithAuth(
-      `${getApiBase()}/log-patterns/mine?hours=${timeRange.value}&include_anomalies=true&include_trends=true`
-    )
-    if (response.ok) {
-      miningResult.value = await response.json()
-    }
-  } catch (error) {
-    logger.error('Failed to run log analysis:', error)
+    miningResult.value = await fetchMiningResult(timeRange.value)
   } finally {
     isAnalyzing.value = false
   }
 }
 
 const fetchRealtimeData = async () => {
-  try {
-    const response = await fetchWithAuth(`${getApiBase()}/log-patterns/realtime`)
-    if (response.ok) {
-      realtimeData.value = await response.json()
-    }
-  } catch (error) {
-    logger.error('Failed to fetch realtime data:', error)
-  }
+  realtimeData.value = await _fetchRealtimeData()
 }
 
 const truncate = (text: string, length: number): string => {

--- a/autobot-frontend/src/composables/analytics/useLogPatternData.ts
+++ b/autobot-frontend/src/composables/analytics/useLogPatternData.ts
@@ -1,0 +1,106 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Composable: useLogPatternData
+ *
+ * Encapsulates all log-pattern API calls: mining patterns and fetching
+ * real-time log summary data.
+ *
+ * Issue #6064: Extracted from LogPatternDashboard.vue.
+ */
+
+import { createLogger } from '@/utils/debugUtils'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { getApiBase } from '@/config/ssot-config'
+
+const logger = createLogger('useLogPatternData')
+
+export interface LogPattern {
+  pattern_id: string
+  pattern_template: string
+  occurrences: number
+  first_seen: string
+  last_seen: string
+  log_levels: string[]
+  sources: string[]
+  sample_messages: string[]
+  frequency_per_hour: number
+  is_error_pattern: boolean
+  is_anomaly: boolean
+}
+
+export interface LogAnomaly {
+  anomaly_id: string
+  anomaly_type: string
+  severity: string
+  description: string
+  timestamp: string
+  affected_sources: string[]
+  metric_before: number
+  metric_after: number
+  confidence: number
+}
+
+export interface LogTrend {
+  trend_id: string
+  metric_name: string
+  direction: string
+  change_percent: number
+  time_period: string
+  data_points: Array<Record<string, unknown>>
+}
+
+export interface MiningResult {
+  patterns: LogPattern[]
+  anomalies: LogAnomaly[]
+  trends: LogTrend[]
+  summary: {
+    total_logs: number
+    unique_patterns: number
+    error_patterns: number
+    anomalies_detected: number
+  }
+  analysis_time_ms: number
+  logs_analyzed: number
+}
+
+export interface RealtimeData {
+  logs_last_5min: number
+  error_count: number
+  level_counts: Record<string, number>
+  recent_errors: Array<Record<string, unknown>>
+}
+
+export function useLogPatternData() {
+  async function fetchMiningResult(hours: number): Promise<MiningResult | null> {
+    try {
+      const response = await fetchWithAuth(
+        `${getApiBase()}/log-patterns/mine?hours=${hours}&include_anomalies=true&include_trends=true`
+      )
+      if (response.ok) {
+        return (await response.json()) as MiningResult
+      }
+      return null
+    } catch (error) {
+      logger.error('Failed to run log analysis:', error)
+      return null
+    }
+  }
+
+  async function fetchRealtimeData(): Promise<RealtimeData | null> {
+    try {
+      const response = await fetchWithAuth(`${getApiBase()}/log-patterns/realtime`)
+      if (response.ok) {
+        return (await response.json()) as RealtimeData
+      }
+      return null
+    } catch (error) {
+      logger.error('Failed to fetch realtime data:', error)
+      return null
+    }
+  }
+
+  return { fetchMiningResult, fetchRealtimeData }
+}


### PR DESCRIPTION
## Summary
- Created `autobot-frontend/src/composables/analytics/useLogPatternData.ts` with 2 functions (fetchMiningResult, fetchRealtimeData); exports 5 interfaces
- Removed all inline `fetchWithAuth` calls from `LogPatternDashboard.vue`

## Behavioral grep audit
Before: 2 fetchWithAuth hits in component
After: 0 hits

## Test plan
- [ ] No fetchWithAuth/apiClient in component
- [ ] Type-check ≤ 244 errors

Closes #6064
🤖 Generated with [Claude Code](https://claude.com/claude-code)