### PR TITLE
refact(chat): extract fetchWithAuth from ChatMessages to useCommandApproval (#6078)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -526,12 +526,9 @@ import BaseModal from '@/components/ui/BaseModal.vue'
 import OverseerPlanMessage from '@/components/chat/OverseerPlanMessage.vue'
 import OverseerStepMessage from '@/components/chat/OverseerStepMessage.vue'
 import CitationsDisplay from '@/components/chat/CitationsDisplay.vue'
-import appConfig from '@/config/AppConfig.js'
-import { getApiBase } from '@/config/ssot-config'
 import { formatFileSize, formatTime } from '@/utils/formatHelpers'
-import { useToast } from '@/composables/useToast'
 import { createLogger } from '@/utils/debugUtils'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { useCommandApproval } from '@/composables/useCommandApproval'
 import { sanitizeChatHtml } from '@/utils/sanitize'
 
 const logger = createLogger('ChatMessages')
@@ -558,10 +555,47 @@ const controller = useChatController()
 const { displaySettings } = useDisplaySettings()
 const permissionStore = usePermissionStore()
 
-// Toast notifications
-const { showToast } = useToast()
-const notify = (message: string, type: 'info' | 'success' | 'warning' | 'error' = 'info') => {
-  showToast(message, type, type === 'error' ? 5000 : 3000)
+// Command Approval composable — replaces all inline fetchWithAuth calls
+const {
+  processingApproval,
+  showCommentInput,
+  activeCommentSessionId,
+  approvalComment,
+  pendingApprovalDecision,
+  autoApproveFuture,
+  rememberForProject,
+  currentProjectPath,
+  approveCommand: _approveCommand,
+  promptForComment,
+  submitApprovalWithComment,
+  cancelComment,
+  getRiskClass,
+} = useCommandApproval()
+
+/**
+ * Thin wrapper: calls the composable's approveCommand with the store's
+ * message-update callback wired in.
+ */
+const approveCommand = (
+  terminal_session_id: string,
+  approved: boolean,
+  comment?: string,
+  command_id?: string,
+  commandInfo?: { command: string; risk_level: string }
+) => {
+  const onMessageUpdate = (sessionId: string, status: string, updateComment?: string) => {
+    const targetMessage = store.currentMessages.find(
+      msg => msg.metadata?.terminal_session_id === sessionId &&
+             msg.metadata?.requires_approval === true
+    )
+    if (targetMessage && targetMessage.metadata) {
+      targetMessage.metadata.approval_status = status
+      targetMessage.metadata.approval_comment = updateComment
+    } else {
+      logger.warn('Could not find message to update approval status')
+    }
+  }
+  return _approveCommand(terminal_session_id, approved, comment, command_id, onMessageUpdate, commandInfo)
 }
 
 // Refs
@@ -583,22 +617,6 @@ const estimatedResponseTime = ref<number | null>(null)
 // Issue #249: Citation display state
 const citationExpansion = useExpansion<string>()
 const expandedCitations = citationExpansion.expanded
-
-// Approval state
-const processingApproval = ref(false)
-
-// Comment functionality state
-const showCommentInput = ref(false)
-const activeCommentSessionId = ref<string | null>(null)
-const approvalComment = ref('')
-const pendingApprovalDecision = ref<boolean | null>(null)
-
-// Auto-approve functionality state
-const autoApproveFuture = ref(false)
-
-// Permission v2: Project memory state
-const rememberForProject = ref(false)
-const currentProjectPath = ref<string | null>(null)
 
 // CRITICAL FIX: Prevent EmptyState from flashing during polling/reactivity updates
 // Once messages have been loaded, never show EmptyState again (prevents flicker)
@@ -1036,248 +1054,6 @@ const detectToolCalls = (message: ChatMessage) => {
       logger.error('Failed to parse TOOL_CALL:', error)
     }
   }
-}
-
-// Poll command state from queue (event-driven, no timeouts!)
-const pollCommandState = async (command_id: string, callback: (result: any) => void) => {
-  const maxAttempts = 100  // 100 * 500ms = 50 seconds max
-  let attempt = 0
-
-  const poll = async () => {
-    try {
-      const backendUrl = await appConfig.getApiUrl(`${getApiBase()}/agent-terminal/commands/${command_id}`)
-      const response = await fetchWithAuth(backendUrl)
-
-      if (!response.ok) {
-        logger.error('Failed to get command state:', response.status)
-        if (attempt < maxAttempts) {
-          attempt++
-          setTimeout(poll, 500)
-        } else {
-          callback({ state: 'error', error: 'HTTP error' })
-        }
-        return
-      }
-
-      const command = await response.json()
-      logger.debug(`Command state (attempt ${attempt + 1}):`, command.state)
-
-      // Check if command is finished
-      if (command.state === 'completed' || command.state === 'failed' || command.state === 'denied') {
-        logger.debug('Command finished:', {
-          state: command.state,
-          output_length: command.output?.length || 0,
-          return_code: command.return_code
-        })
-        callback({
-          state: command.state,
-          output: command.output,
-          stderr: command.stderr,
-          return_code: command.return_code,
-          command: command.command
-        })
-        return  // Stop polling
-      }
-
-      // Command still running - poll again
-      if (attempt < maxAttempts) {
-        attempt++
-        setTimeout(poll, 500)  // Poll every 500ms
-      } else {
-        logger.error('Polling timed out after 50 seconds')
-        callback({ state: 'timeout', error: 'Polling timeout' })
-      }
-    } catch (error) {
-      logger.error('Polling error:', error)
-      if (attempt < maxAttempts) {
-        attempt++
-        setTimeout(poll, 500)
-      } else {
-        callback({ state: 'error', error: (error as Error).message })
-      }
-    }
-  }
-
-  // Start polling
-  logger.debug('Starting command state polling for:', command_id)
-  poll()
-}
-
-// Command Approval - Use HTTP POST to agent-terminal API with dynamic URL
-// Permission v2: Enhanced with project memory support
-const approveCommand = async (
-  terminal_session_id: string,
-  approved: boolean,
-  comment?: string,
-  command_id?: string,
-  commandInfo?: { command: string; risk_level: string }  // Permission v2: Command details for memory
-) => {
-  if (!terminal_session_id) {
-    logger.error('No terminal_session_id provided for approval')
-    return
-  }
-
-  processingApproval.value = true
-  logger.debug(`${approved ? 'Approving' : 'Denying'} command for session:`, terminal_session_id)
-  if (comment) {
-    logger.debug('With comment:', comment)
-  }
-  if (autoApproveFuture.value) {
-    logger.debug('Auto-approve similar commands in future:', autoApproveFuture.value)
-  }
-  if (rememberForProject.value) {
-    logger.debug('Remember for project:', currentProjectPath.value)
-  }
-
-  try {
-    // Get backend URL from appConfig
-    const backendUrl = await appConfig.getApiUrl(`${getApiBase()}/agent-terminal/sessions/${terminal_session_id}/approve`)
-
-    const response = await fetchWithAuth(backendUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        approved,
-        user_id: 'web_user',
-        comment: comment || null,
-        auto_approve_future: autoApproveFuture.value,  // Send auto-approve preference
-        remember_for_project: rememberForProject.value,  // Permission v2
-        project_path: currentProjectPath.value  // Permission v2
-      })
-    })
-
-    const result = await response.json()
-    logger.debug('Approval response:', result)
-
-    if (result.status === 'approved' || result.status === 'denied') {
-      logger.debug(`Command ${approved ? 'approved' : 'denied'} successfully`)
-      notify(`Command ${approved ? 'approved' : 'denied'}`, approved ? 'success' : 'warning')
-
-      // Update the message metadata to reflect approval status
-      const targetMessage = store.currentMessages.find(
-        msg => msg.metadata?.terminal_session_id === terminal_session_id &&
-               msg.metadata?.requires_approval === true
-      )
-
-      if (targetMessage && targetMessage.metadata) {
-        targetMessage.metadata.approval_status = result.status
-        targetMessage.metadata.approval_comment = comment || result.comment
-        logger.debug('Updated message approval status:', targetMessage.metadata)
-      } else {
-        logger.warn('Could not find message to update approval status')
-      }
-
-      // START POLLING: If approved and we have command_id, poll for completion
-      if (result.status === 'approved' && approved && command_id) {
-        logger.debug('Starting polling for approved command:', command_id)
-
-        pollCommandState(command_id, (pollResult) => {
-          logger.debug('Command execution complete:', pollResult)
-
-          if (pollResult.state === 'completed') {
-            logger.debug('Command completed successfully')
-            logger.debug('Output:', pollResult.output)
-            // Note: Backend already handles LLM interpretation and sends it to chat
-            // The output will appear naturally through the WebSocket/streaming flow
-          } else if (pollResult.state === 'failed') {
-            logger.error('Command failed:', pollResult.stderr)
-            notify('Command execution failed', 'error')
-          } else if (pollResult.state === 'timeout') {
-            logger.warn('Polling timed out')
-            notify('Command execution timed out', 'warning')
-          } else if (pollResult.state === 'error') {
-            logger.error('Polling error:', pollResult.error)
-            notify('Command polling error', 'error')
-          }
-        })
-      } else if (!command_id && approved) {
-        logger.warn('No command_id available for polling (legacy approval flow)')
-      }
-
-      // Permission v2: Store approval in project memory if requested
-      if (
-        rememberForProject.value &&
-        approved &&
-        currentProjectPath.value &&
-        commandInfo &&
-        permissionStore.isEnabled
-      ) {
-        const stored = await permissionStore.storeApproval(
-          currentProjectPath.value,
-          'web_user',
-          commandInfo.command,
-          commandInfo.risk_level,
-          'Bash',
-          comment
-        )
-        if (stored) {
-          logger.info('Approval stored in project memory')
-          notify('Approval remembered for this project', 'info')
-        }
-      }
-
-      // Reset checkboxes after submission
-      autoApproveFuture.value = false
-      rememberForProject.value = false
-    } else if (result.status === 'error') {
-      logger.error('Approval error:', result.error)
-      notify(`Approval failed: ${result.error}`, 'error')
-    }
-
-    processingApproval.value = false
-  } catch (error) {
-    logger.error('Error sending approval:', error)
-    notify('Failed to process command approval', 'error')
-    processingApproval.value = false
-  }
-}
-
-const getRiskClass = (riskLevel: string): string => {
-  const riskClasses: Record<string, string> = {
-    'LOW': 'text-green-600',
-    'MODERATE': 'text-yellow-600',
-    'HIGH': 'text-orange-600',
-    'DANGEROUS': 'text-red-600'
-  }
-  return riskClasses[riskLevel] || 'text-autobot-text-secondary'
-}
-
-// Comment functionality methods
-const promptForComment = (sessionId: string) => {
-  showCommentInput.value = true
-  activeCommentSessionId.value = sessionId
-  approvalComment.value = ''
-  pendingApprovalDecision.value = null
-}
-
-const submitApprovalWithComment = async (sessionId: string, approved: boolean | null) => {
-  if (!approvalComment.value.trim()) {
-    logger.warn('Cannot submit approval with empty comment')
-    return
-  }
-
-  // Determine approval decision
-  const finalDecision = approved !== null ? approved : pendingApprovalDecision.value
-
-  if (finalDecision === null) {
-    logger.error('No approval decision provided')
-    return
-  }
-
-  // Call existing approveCommand with comment
-  await approveCommand(sessionId, finalDecision, approvalComment.value)
-
-  // Reset state
-  cancelComment()
-}
-
-const cancelComment = () => {
-  showCommentInput.value = false
-  activeCommentSessionId.value = null
-  approvalComment.value = ''
-  pendingApprovalDecision.value = null
 }
 
 // Issue #1312: Consolidated watcher — auto-scroll + screen reader announcement


### PR DESCRIPTION
## Summary
- Wired `useCommandApproval` composable (already existed) into `ChatMessages.vue`
- Removed inline `pollCommandState` and `approveCommand` plus associated state (266 lines deleted, 42 added)
- `approveCommand` wrapper retains component-side `onMessageUpdate` callback for chat history mutation

## Behavioral grep audit

Before:
```bash
$ grep -n "fetchWithAuth\|apiClient" autobot-frontend/src/components/chat/ChatMessages.vue
# 2 hits — pollCommandState GET, approveCommand POST
```

After:
```bash
$ grep -n "fetchWithAuth\|apiClient" autobot-frontend/src/components/chat/ChatMessages.vue
# 0 hits
```

## Test plan
- [ ] Type-check passes (`npx vue-tsc --noEmit -p tsconfig.app.json`)
- [ ] Command approval flow works end-to-end

Closes #6078

🤖 Generated with [Claude Code](https://claude.com/claude-code)