### PR TITLE
refact(composables): create useSourceRegistry and migrate AddSourceModal fetchWithAuth (#6069)

### DIFF
--- a/autobot-frontend/src/components/analytics/AddSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/AddSourceModal.vue
@@ -212,8 +212,8 @@ import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
 import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import appConfig from '@/config/AppConfig.js'
+import { fetchSourceSecrets, saveCodeSource } from '@/composables/analytics/useSourceRegistry'
+import type { RegistrySecret } from '@/composables/analytics/useSourceRegistry'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('AddSourceModal')
@@ -222,13 +222,6 @@ const { t } = useI18n()
 // ---- Types ----------------------------------------------------------------
 
 import type { CodeSource } from '@/types/analytics'
-
-interface Secret {
-  id: string
-  name: string
-  type: string
-  scope: string
-}
 
 interface FormErrors {
   name?: string
@@ -298,7 +291,7 @@ const errors = ref<FormErrors>({})
 const submitError = ref<string | null>(null)
 const submitting = ref(false)
 
-const secrets = ref<Secret[]>([])
+const secrets = ref<RegistrySecret[]>([])
 const secretsLoadError = ref<string | null>(null)
 
 // ---- Computed -------------------------------------------------------------
@@ -311,19 +304,9 @@ const filteredSecrets = computed(() =>
 
 // ---- API ------------------------------------------------------------------
 
-async function getBackendUrl(): Promise<string> {
-  return appConfig.getServiceUrl('backend')
-}
-
 async function loadSecrets() {
   try {
-    const backendUrl = await getBackendUrl()
-    const response = await fetchWithAuth(`${backendUrl}/api/secrets`)
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`)
-    }
-    const data = await response.json()
-    secrets.value = data.secrets ?? []
+    secrets.value = await fetchSourceSecrets()
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
     logger.warn('Failed to load secrets:', msg)
@@ -379,39 +362,19 @@ async function handleSubmit() {
   submitting.value = true
   submitError.value = null
 
-  const payload: Record<string, unknown> = {
+  const payload = {
     name: form.value.name.trim(),
     source_type: form.value.source_type,
+    repo: form.value.source_type === 'github'
+      ? form.value.repo.trim()
+      : form.value.local_path.trim(),
     branch: form.value.branch.trim() || 'main',
     access: form.value.access,
     credential_id: form.value.credential_id || null
   }
 
-  if (form.value.source_type === 'github') {
-    payload.repo = form.value.repo.trim()
-  } else {
-    payload.repo = form.value.local_path.trim()
-  }
-
   try {
-    const backendUrl = await getBackendUrl()
-    const url = isEditMode.value
-      ? `${backendUrl}/api/analytics/codebase/sources/${props.source!.id}`
-      : `${backendUrl}/api/analytics/codebase/sources`
-    const method = isEditMode.value ? 'PUT' : 'POST'
-
-    const response = await fetchWithAuth(url, {
-      method,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    })
-
-    if (!response.ok) {
-      const text = await response.text()
-      throw new Error(`HTTP ${response.status}: ${text}`)
-    }
-
-    const saved: CodeSource = await response.json()
+    const saved = await saveCodeSource(payload, props.source?.id)
     logger.info(isEditMode.value ? 'Source updated:' : 'Source created:', saved.name)
     emit('saved', saved)
   } catch (err: unknown) {

--- a/autobot-frontend/src/composables/analytics/useSourceRegistry.ts
+++ b/autobot-frontend/src/composables/analytics/useSourceRegistry.ts
@@ -15,6 +15,8 @@ import { ref, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import { useSourcesListEndpoint } from '@/composables/analytics/useSourcesListEndpoint'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
 import type { ToastType } from '@/composables/useToast'
 
@@ -23,6 +25,68 @@ const logger = createLogger('useSourceRegistry')
 // Issue #1133 / #2238: CodeSource type extracted to shared types
 import type { CodeSource } from '@/types/analytics'
 export type { CodeSource }
+
+/** Secret credential entry returned by GET /api/secrets */
+export interface RegistrySecret {
+  id: string
+  name: string
+  type: string
+  scope: string
+}
+
+/** Payload shape for POST/PUT /api/analytics/codebase/sources */
+export interface SourceSavePayload {
+  name: string
+  source_type: 'github' | 'local'
+  repo: string
+  branch: string
+  access: 'private' | 'shared' | 'public'
+  credential_id: string | null
+}
+
+async function _getBackendUrl(): Promise<string> {
+  return appConfig.getServiceUrl('backend')
+}
+
+/**
+ * Load credentials available for source authentication.
+ * Extracted from AddSourceModal.vue (#6069).
+ */
+export async function fetchSourceSecrets(): Promise<RegistrySecret[]> {
+  const backendUrl = await _getBackendUrl()
+  const response = await fetchWithAuth(`${backendUrl}/api/secrets`)
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`)
+  }
+  const data = await response.json()
+  return (data.secrets ?? []) as RegistrySecret[]
+}
+
+/**
+ * Create or update a code source entry in the registry.
+ * Uses POST for new entries, PUT for existing ones (when `id` is provided).
+ * Extracted from AddSourceModal.vue (#6069).
+ */
+export async function saveCodeSource(
+  payload: SourceSavePayload,
+  id?: string,
+): Promise<CodeSource> {
+  const backendUrl = await _getBackendUrl()
+  const url = id
+    ? `${backendUrl}/api/analytics/codebase/sources/${id}`
+    : `${backendUrl}/api/analytics/codebase/sources`
+  const method = id ? 'PUT' : 'POST'
+  const response = await fetchWithAuth(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`HTTP ${response.status}: ${text}`)
+  }
+  return (await response.json()) as CodeSource
+}
 
 export interface UseSourceRegistryDeps {
   t: (key: string, params?: Record<string, unknown>) => string


### PR DESCRIPTION
## Summary
- Extended `autobot-frontend/src/composables/analytics/useSourceRegistry.ts` with `fetchSourceSecrets()` and `saveCodeSource()` functions
- Removed all inline `fetchWithAuth` calls from `AddSourceModal.vue`
- Exported `RegistrySecret` and `SourceSavePayload` interfaces from composable

## Behavioral grep audit
Before: 2 fetchWithAuth hits in AddSourceModal.vue
After: 0 hits

## Test plan
- [ ] No fetchWithAuth/apiClient in component
- [ ] Type-check ≤ 244 errors

Closes #6069
🤖 Generated with [Claude Code](https://claude.com/claude-code)