### PR TITLE
refact(composables): extract fetchWithAuth from CodebaseAnalytics to useSourceRegistry (#6068)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -444,8 +444,6 @@
 import { ref, computed, onMounted, onUnmounted, type Ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import appConfig from '@/config/AppConfig.js'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import PatternAnalysis from '@/components/analytics/PatternAnalysis.vue'
 import { useToast } from '@/composables/useToast'
@@ -525,6 +523,7 @@ const {
   sourceIdQuery,
   withSourceId,
   loadSources,
+  loadSourceById,
   handleSelectSource,
   handleSourceSaved,
   handleShareSaved,
@@ -621,6 +620,7 @@ const {
   codeSmellsProgressTitle,
   exportingReport,
   clearingCache,
+  clearCache: clearCache_composable,
   runCodeSmellAnalysis,
   getCodeHealthScore,
   securityScore,
@@ -853,38 +853,17 @@ const handleStop = () => {
   }
 }
 
-// Clear analysis cache
-const clearCache = async () => {
-  clearingCache.value = true
-  progressStatus.value = t('analytics.codebase.status.clearingCache')
-  try {
-    const backendUrl = await appConfig.getServiceUrl('backend')
-    const response = await fetchWithAuth(withSourceId(`${backendUrl}/api/analytics/codebase/cache`), {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' }
-    })
-    if (!response.ok) {
-      const errorText = await response.text()
-      throw new Error(`Status ${response.status}: ${errorText}`)
-    }
-    const result = await response.json()
+// Clear analysis cache — delegates to useCodeIntelAnalysis.clearCache (#6068)
+const clearCache = () =>
+  clearCache_composable(withSourceId, () => {
     codebaseStats.value = null
     problemsReport.value = []
     declarationAnalysis.value = []
     duplicateAnalysis.value = []
     hardcodeAnalysis.value = []
     chartData.value = null
-    notify(t('analytics.codebase.notify.cacheCleared', { count: result.deleted_keys || 0 }), 'success')
     progressStatus.value = t('analytics.codebase.status.cacheCleared')
-  } catch (error: unknown) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
-    logger.error('Cache clear failed:', error)
-    notify(t('analytics.codebase.notify.cacheClearFailed', { error: errorMessage }), 'error')
-    progressStatus.value = t('analytics.codebase.status.cacheClearFailed')
-  } finally {
-    clearingCache.value = false
-  }
-}
+  })
 
 // Run full analysis with scan runner
 const runFullAnalysis = async () => {
@@ -943,26 +922,9 @@ onMounted(async () => {
     return
   }
 
-  // Load source metadata from backend
-  try {
-    const backendUrl = await appConfig.getServiceUrl('backend')
-    const resp = await fetchWithAuth(
-      `${backendUrl}/api/analytics/codebase/sources/${sourceId}`,
-    )
-    if (resp.ok) {
-      const source = await resp.json()
-      selectedSource.value = source
-      rootPath.value = source.clone_path || ''
-      localStorage.setItem(STORAGE_KEY_PATH, rootPath.value)
-    } else {
-      notify(t('analytics.codebase.notify.sourceNotFound'), 'error')
-      analyticsRouter.replace({ name: 'analytics-codebase' })
-      return
-    }
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
-    logger.error('Failed to load source metadata:', msg)
-    notify(t('analytics.codebase.notify.sourceNotFound'), 'error')
+  // Load source metadata from backend (#6068: extracted to useSourceRegistry)
+  const loaded = await loadSourceById(sourceId)
+  if (!loaded) {
     analyticsRouter.replace({ name: 'analytics-codebase' })
     return
   }

--- a/autobot-frontend/src/composables/analytics/useSourceRegistry.ts
+++ b/autobot-frontend/src/composables/analytics/useSourceRegistry.ts
@@ -188,6 +188,34 @@ export function useSourceRegistry(deps: UseSourceRegistryDeps) {
     showShareSourceModal.value = true
   }
 
+  // Issue #6068: Load a single source by ID and populate selectedSource +
+  // rootPath. Returns true on success, false on failure (caller handles
+  // navigation).
+  async function loadSourceById(sourceId: string): Promise<boolean> {
+    try {
+      const endpoint = useFetchEndpoint<CodeSource, CodeSource>({
+        path: `/api/analytics/codebase/sources/${encodeURIComponent(sourceId)}`,
+        pickData: (raw) => raw,
+        label: 'Load source by ID',
+      })
+      await endpoint.load()
+      if (endpoint.error.value || !endpoint.data.value) {
+        notify(t('analytics.codebase.notify.sourceNotFound'), 'error')
+        return false
+      }
+      const source = endpoint.data.value
+      selectedSource.value = source
+      rootPath.value = source.clone_path || ''
+      localStorage.setItem(STORAGE_KEY_PATH, rootPath.value)
+      return true
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err)
+      logger.error('Failed to load source metadata:', msg)
+      notify(t('analytics.codebase.notify.sourceNotFound'), 'error')
+      return false
+    }
+  }
+
   // #5153 B: migrated to useFetchEndpoint with POST body factory.
   // onError surfaces the user-visible toast; onSuccess hides the opt-in
   // banner and emits the success toast.
@@ -242,6 +270,7 @@ export function useSourceRegistry(deps: UseSourceRegistryDeps) {
     // Functions
     withSourceId,
     loadSources,
+    loadSourceById,
     handleSelectSource,
     handleClearSource,
     handleSourceSaved,


### PR DESCRIPTION
## Summary
- Extended `useSourceRegistry.ts` with `loadSourceById()` function
- Replaced `clearCache()` inline fetch with delegation to `useCodeIntelAnalysis.clearCache()`
- Removed all inline `fetchWithAuth` calls from `CodebaseAnalytics.vue`

## Behavioral grep audit
Before: 2 fetchWithAuth hits in CodebaseAnalytics.vue
After: 0 hits

## Test plan
- [ ] No fetchWithAuth/apiClient in component
- [ ] Type-check ≤ 244 errors

Closes #6068
🤖 Generated with [Claude Code](https://claude.com/claude-code)