### PR TITLE
refact(composables): migrate useToolApproval fetchWithAuth POST to ApiClient (#6028)

### DIFF
--- a/autobot-frontend/src/composables/useToolApproval.ts
+++ b/autobot-frontend/src/composables/useToolApproval.ts
@@ -19,8 +19,7 @@
 import { ref, type Ref, onUnmounted, getCurrentInstance } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 import liveEventService from '@/services/LiveEventService'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import appConfig from '@/config/AppConfig.js'
+import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useToolApproval')
@@ -62,7 +61,6 @@ export interface UseToolApprovalReturn {
 export function useToolApproval(): UseToolApprovalReturn {
   const pendingToolApproval = ref<PendingToolApproval | null>(null)
   const submittingApproval = ref(false)
-  let submitController: AbortController | null = null
 
   // Subscribe to the global channel for APPROVAL_REQUIRED events (#4952).
   // The agent loop publishes on the global channel with EventType.APPROVAL_REQUIRED
@@ -93,28 +91,12 @@ export function useToolApproval(): UseToolApprovalReturn {
       logger.warn('submitToolApproval called with no pending approval')
       return
     }
-    submitController?.abort()
-    submitController = new AbortController()
     submittingApproval.value = true
     try {
-      const url = await appConfig.getApiUrl(
-        `${getApiBase()}/agent-terminal/tools/approve/${encodeURIComponent(approval.approval_id)}`
+      await apiClient.post(
+        `${getApiBase()}/agent-terminal/tools/approve/${encodeURIComponent(approval.approval_id)}`,
+        { approved, comment: comment ?? null, task_id: approval.task_id ?? null }
       )
-      const body: Record<string, unknown> = {
-        approved,
-        comment: comment ?? null,
-        task_id: approval.task_id ?? null,
-      }
-      const response = await fetchWithAuth(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-        signal: submitController.signal,
-      })
-      if (!response.ok) {
-        const text = await response.text().catch(() => '')
-        throw new Error(`Tool approval POST returned ${response.status}: ${text}`)
-      }
       logger.debug('Tool approval submitted', { approval_id: approval.approval_id, approved })
       pendingToolApproval.value = null
     } catch (err) {
@@ -135,7 +117,6 @@ export function useToolApproval(): UseToolApprovalReturn {
   if (instance) {
     onUnmounted(() => {
       unsub()
-      submitController?.abort()
     })
   } else {
     logger.warn('useToolApproval: not inside a Vue component, cleanup must be manual')


### PR DESCRIPTION
## Summary
- Replaces single `fetchWithAuth` POST in `submitToolApproval` with `apiClient.post()`
- Removes `submitController` AbortController (only used for the POST)
- Removes `appConfig` and `fetchWithAuth` imports (now unused)
- Path built with `getApiBase()` directly — eliminates `appConfig.getApiUrl()` lookup
- Manual headers, JSON.stringify, response.ok check replaced by apiClient

## Behavioral grep audit
Before: 1 `fetchWithAuth` call in `useToolApproval.ts`
After: 0 `fetchWithAuth` calls

Closes #6028. Part of tracker #6006.
🤖 Generated with [Claude Code](https://claude.com/claude-code)