### PR TITLE
docs(composables): document useVoiceOutput fetchWithAuth binary exemption (#6030)

### DIFF
--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -267,6 +267,8 @@ export function useVoiceOutput() {
       if (language) {
         formData.append('language', language)
       }
+      // fetchWithAuth retained: binary audio response (blob → arrayBuffer) and FormData
+      // body cannot be handled by apiClient.post(). Exempt per composable-weakness-remediation design.
       const response = await fetchWithAuth(`${getApiBase()}/voice/synthesize`, {
         method: 'POST',
         body: formData,


### PR DESCRIPTION
## Summary
- Documents the `fetchWithAuth` call in `speak()` as an intentional exemption
- Binary audio response (blob → arrayBuffer) cannot be handled by `apiClient.post()`
- FormData body is also incompatible with `apiClient.post()`'s JSON serialization
- Per composable-weakness-remediation design spec: binary responses are explicitly exempt

## Behavioral grep audit
`fetchWithAuth` in `useVoiceOutput.ts`: 1 call (intentional exemption, documented with comment)

Closes #6030. Part of tracker #6006.
🤖 Generated with [Claude Code](https://claude.com/claude-code)