### PR TITLE
refact(composables): migrate ShareSourceModal fetchWithAuth to useSourceRegistry (#6070)

### DIFF
--- a/autobot-frontend/src/components/analytics/ShareSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/ShareSourceModal.vue
@@ -131,8 +131,7 @@ import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
 import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import appConfig from '@/config/AppConfig.js'
+import { shareCodeSource } from '@/composables/analytics/useSourceRegistry'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('ShareSourceModal')
@@ -208,12 +207,6 @@ const parsedUserIds = computed<string[]>(() =>
     .filter(s => s.length > 0)
 )
 
-// ---- API ------------------------------------------------------------------
-
-async function getBackendUrl(): Promise<string> {
-  return appConfig.getServiceUrl('backend')
-}
-
 // ---- Actions --------------------------------------------------------------
 
 async function handleSubmit() {
@@ -221,28 +214,11 @@ async function handleSubmit() {
   submitting.value = true
   submitError.value = null
 
-  const payload = {
-    user_ids: parsedUserIds.value,
-    access: form.value.access
-  }
-
   try {
-    const backendUrl = await getBackendUrl()
-    const response = await fetchWithAuth(
-      `${backendUrl}/api/analytics/codebase/sources/${props.source.id}/share`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-      }
-    )
-
-    if (!response.ok) {
-      const text = await response.text()
-      throw new Error(`HTTP ${response.status}: ${text}`)
-    }
-
-    const saved: CodeSource = await response.json()
+    const saved = await shareCodeSource(props.source.id, {
+      access: form.value.access,
+      user_ids: parsedUserIds.value
+    })
     logger.info('Access updated for source:', saved.name)
     emit('saved', saved)
   } catch (err: unknown) {

--- a/autobot-frontend/src/composables/analytics/useSourceRegistry.ts
+++ b/autobot-frontend/src/composables/analytics/useSourceRegistry.ts
@@ -62,6 +62,36 @@ export async function fetchSourceSecrets(): Promise<RegistrySecret[]> {
   return (data.secrets ?? []) as RegistrySecret[]
 }
 
+/** Payload shape for POST /api/analytics/codebase/sources/:id/share */
+export interface SourceSharePayload {
+  access: 'private' | 'shared' | 'public'
+  user_ids: string[]
+}
+
+/**
+ * Update access control for a code source.
+ * Extracted from ShareSourceModal.vue (#6070).
+ */
+export async function shareCodeSource(
+  sourceId: string,
+  payload: SourceSharePayload,
+): Promise<CodeSource> {
+  const backendUrl = await _getBackendUrl()
+  const response = await fetchWithAuth(
+    `${backendUrl}/api/analytics/codebase/sources/${sourceId}/share`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    },
+  )
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`HTTP ${response.status}: ${text}`)
+  }
+  return (await response.json()) as CodeSource
+}
+
 /**
  * Create or update a code source entry in the registry.
  * Uses POST for new entries, PUT for existing ones (when `id` is provided).


### PR DESCRIPTION
## Summary
- Extended `useSourceRegistry.ts` with `shareCodeSource()` function and `SourceSharePayload` interface
- Removed all inline `fetchWithAuth` calls from `ShareSourceModal.vue`

## Behavioral grep audit
Before: 1 fetchWithAuth hit in ShareSourceModal.vue
After: 0 hits

## Test plan
- [ ] No fetchWithAuth/apiClient in component
- [ ] Type-check ≤ 244 errors

Closes #6070
🤖 Generated with [Claude Code](https://claude.com/claude-code)