### PR TITLE
refact(analytics): extract fetchWithAuth from ConversationFlowDashboard to useConversationFlowData (#6071)

### DIFF
--- a/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
+++ b/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
@@ -262,67 +262,17 @@
  * Issue #704: Migrated to design tokens for centralized theming
  */
 import { ref, onMounted, computed } from 'vue'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
-import { getApiBase } from '@/config/ssot-config'
-import { useLoadingState } from '@/composables/useLoadingState'
+import {
+  useConversationFlowData,
+  type IntentPattern,
+} from '@/composables/analytics/useConversationFlowData'
 
 const logger = createLogger('ConversationFlowDashboard')
 
-
-// Types
-interface IntentPattern {
-  intent_id: string
-  intent_name: string
-  pattern_regex: string
-  occurrences: number
-  success_rate: number
-  avg_turns_to_resolve: number
-  sample_queries: string[]
-}
-
-interface ConversationFlow {
-  flow_id: string
-  path: string[]
-  frequency: number
-  avg_duration_seconds: number
-  completion_rate: number
-  drop_off_point: string | null
-}
-
-interface FlowBottleneck {
-  bottleneck_id: string
-  location: string
-  description: string
-  impact_score: number
-  affected_conversations: number
-  suggested_improvements: string[]
-}
-
-interface ConversationMetrics {
-  total_conversations: number
-  total_messages: number
-  avg_messages_per_conversation: number
-  avg_conversation_duration_seconds: number
-  user_satisfaction_estimate: number
-  resolution_rate: number
-  escalation_rate: number
-}
-
-interface AnalysisResult {
-  metrics: ConversationMetrics
-  intent_patterns: IntentPattern[]
-  common_flows: ConversationFlow[]
-  bottlenecks: FlowBottleneck[]
-  hourly_distribution: Record<string, number>
-  analysis_period: string
-  conversations_analyzed: number
-}
-
 // State
 const timeRange = ref(24)
-const { isLoading, wrap } = useLoadingState()
-const analysisResult = ref<AnalysisResult | null>(null)
+const { isLoading, analysisResult, runAnalysis: fetchAnalysis } = useConversationFlowData()
 const selectedIntent = ref<IntentPattern | null>(null)
 
 // Computed
@@ -333,16 +283,7 @@ const maxHourlyCount = computed(() => {
 
 // Methods
 const runAnalysis = async () => {
-  await wrap(async () => {
-  try {
-    const response = await fetchWithAuth(`${getApiBase()}/conversation-flow/analyze?hours=${timeRange.value}`)
-    if (response.ok) {
-      analysisResult.value = await response.json()
-    }
-  } catch (error) {
-    logger.error('Failed to analyze conversations:', error)
-  }
-  })
+  await fetchAnalysis(timeRange.value)
 }
 
 const formatIntentName = (intentId: string): string => {

--- a/autobot-frontend/src/composables/analytics/useConversationFlowData.ts
+++ b/autobot-frontend/src/composables/analytics/useConversationFlowData.ts
@@ -1,0 +1,85 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Composable: useConversationFlowData
+ *
+ * Encapsulates all API data fetching for ConversationFlowDashboard.
+ * Extracted from ConversationFlowDashboard.vue — Issue #6071.
+ * Migrated from fetchWithAuth to useFetchEndpoint — Issue #6071.
+ */
+
+import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useConversationFlowData')
+
+export interface IntentPattern {
+  intent_id: string
+  intent_name: string
+  pattern_regex: string
+  occurrences: number
+  success_rate: number
+  avg_turns_to_resolve: number
+  sample_queries: string[]
+}
+
+export interface ConversationFlow {
+  flow_id: string
+  path: string[]
+  frequency: number
+  avg_duration_seconds: number
+  completion_rate: number
+  drop_off_point: string | null
+}
+
+export interface FlowBottleneck {
+  bottleneck_id: string
+  location: string
+  description: string
+  impact_score: number
+  affected_conversations: number
+  suggested_improvements: string[]
+}
+
+export interface ConversationMetrics {
+  total_conversations: number
+  total_messages: number
+  avg_messages_per_conversation: number
+  avg_conversation_duration_seconds: number
+  user_satisfaction_estimate: number
+  resolution_rate: number
+  escalation_rate: number
+}
+
+export interface AnalysisResult {
+  metrics: ConversationMetrics
+  intent_patterns: IntentPattern[]
+  common_flows: ConversationFlow[]
+  bottlenecks: FlowBottleneck[]
+  hourly_distribution: Record<string, number>
+  analysis_period: string
+  conversations_analyzed: number
+}
+
+export function useConversationFlowData() {
+  const endpoint = useFetchEndpoint<AnalysisResult, AnalysisResult>({
+    path: '/api/conversation-flow/analyze',
+    label: 'conversation-flow/analyze',
+    pickData: (raw) => raw ?? null,
+    onError: (message, err) => {
+      logger.error('Failed to analyze conversations:', err)
+    },
+  })
+
+  const runAnalysis = async (hours: number): Promise<void> => {
+    await endpoint.load({ hours: String(hours) })
+  }
+
+  return {
+    isLoading: endpoint.loading,
+    analysisResult: endpoint.data,
+    runAnalysis,
+  }
+}


### PR DESCRIPTION
## Summary
- Extracted inline `fetchWithAuth` GET call from `ConversationFlowDashboard.vue` to new `useConversationFlowData.ts`
- Moved interface types (`IntentPattern`, `ConversationFlow`, `FlowBottleneck`, etc.) to composable
- Component now imports `useConversationFlowData` and `IntentPattern` from the composable; no direct `fetchWithAuth` remains

Closes #6071

🤖 Generated with [Claude Code](https://claude.com/claude-code)