### PR TITLE
refact(analytics): extract fetchWithAuth from CodeEvolutionTimeline to useCodeEvolutionData (#6072)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
+++ b/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
@@ -212,41 +212,14 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 // @ts-ignore - Component may not have type declarations
 import BaseButton from '@/components/base/BaseButton.vue'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { useToast } from '@/composables/useToast'
-import { getApiBase } from '@/config/ssot-config'
+import { useCodeEvolutionData } from '@/composables/analytics/useCodeEvolutionData'
+import type { TimelinePoint, TrendData, PatternPoint } from '@/composables/analytics/useCodeEvolutionData'
 
 const { t } = useI18n()
 
-interface TimelinePoint {
-  timestamp: string
-  overall_score?: number
-  maintainability?: number
-  testability?: number
-  documentation?: number
-  complexity?: number
-  security?: number
-  performance?: number
-  total_files?: number
-  total_lines?: number
-}
-
-interface TrendData {
-  first_value: number
-  last_value: number
-  change: number
-  percent_change: number
-  direction: 'improving' | 'declining' | 'stable'
-  data_points: number
-}
-
-interface PatternPoint {
-  timestamp: string
-  count: number
-  pattern_type: string
-}
-
 const { showToast } = useToast()
+const { fetchTimeline: apiFetchTimeline, fetchTrends: apiFetchTrends, fetchPatterns: apiFetchPatterns, fetchExport: apiFetchExport } = useCodeEvolutionData()
 
 // State
 const loading = ref(false)
@@ -324,33 +297,21 @@ async function fetchTimeline() {
     const startDate = new Date(Date.now() - parseInt(selectedDays.value) * 24 * 60 * 60 * 1000)
       .toISOString().split('T')[0]
 
-    const params = new URLSearchParams({
-      start_date: startDate,
-      end_date: endDate,
-      granularity: selectedGranularity.value,
-      metrics: selectedMetrics.value.join(',')
-    })
-
-    // Issue #552: Fixed path - backend uses /api/evolution/* not /api/analytics/evolution/*
-    const [timelineRes, trendsRes, patternsRes] = await Promise.all([
-      fetchWithAuth(`${getApiBase()}/evolution/timeline?${params}`),
-      fetchWithAuth(`${getApiBase()}/evolution/trends?days=${selectedDays.value}`),
-      fetchWithAuth(`${getApiBase()}/evolution/patterns`)
+    const [timelineResult, trendsResult, patternsResult] = await Promise.all([
+      apiFetchTimeline(startDate, endDate, selectedGranularity.value, selectedMetrics.value),
+      apiFetchTrends(selectedDays.value),
+      apiFetchPatterns()
     ])
 
-    if (!timelineRes.ok || !trendsRes.ok) {
+    if (!timelineResult || !trendsResult) {
       throw new Error('Failed to fetch evolution data')
     }
 
-    const timelineJson = await timelineRes.json()
-    const trendsJson = await trendsRes.json()
-    const patternsJson = await patternsRes.json()
+    timelineData.value = timelineResult.timeline || []
+    trends.value = trendsResult.trends || {}
+    patterns.value = patternsResult?.patterns || {}
 
-    timelineData.value = timelineJson.timeline || []
-    trends.value = trendsJson.trends || {}
-    patterns.value = patternsJson.patterns || {}
-
-    if (timelineJson.status === 'demo') {
+    if (timelineResult.status === 'demo') {
       showToast(t('analytics.codeEvolution.demoDataWarning'), 'warning')
     }
 
@@ -367,14 +328,9 @@ async function exportData() {
       .toISOString().split('T')[0]
     const endDate = new Date().toISOString().split('T')[0]
 
-    // Issue #552: Fixed path - backend uses /api/evolution/* not /api/analytics/evolution/*
-    const response = await fetchWithAuth(
-      `${getApiBase()}/evolution/export?format=csv&start_date=${startDate}&end_date=${endDate}`
-    )
+    const blob = await apiFetchExport(startDate, endDate)
+    if (!blob) throw new Error('Export failed')
 
-    if (!response.ok) throw new Error('Export failed')
-
-    const blob = await response.blob()
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url

--- a/autobot-frontend/src/composables/analytics/useCodeEvolutionData.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeEvolutionData.ts
@@ -1,0 +1,159 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Composable: useCodeEvolutionData
+ *
+ * Encapsulates all fetchWithAuth calls for the Code Evolution Timeline.
+ * Extracted from CodeEvolutionTimeline.vue (Issue #6072).
+ *
+ * Endpoints (all under /api/evolution/*):
+ *   GET  /evolution/timeline?start_date=<d>&end_date=<d>&granularity=<g>&metrics=<m>
+ *   GET  /evolution/trends?days=<n>
+ *   GET  /evolution/patterns
+ *   GET  /evolution/export?format=csv&start_date=<d>&end_date=<d>
+ */
+
+import { ref } from 'vue'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { getApiBase } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useCodeEvolutionData')
+
+export interface TimelinePoint {
+  timestamp: string
+  overall_score?: number
+  maintainability?: number
+  testability?: number
+  documentation?: number
+  complexity?: number
+  security?: number
+  performance?: number
+  total_files?: number
+  total_lines?: number
+}
+
+export interface TrendData {
+  first_value: number
+  last_value: number
+  change: number
+  percent_change: number
+  direction: 'improving' | 'declining' | 'stable'
+  data_points: number
+}
+
+export interface PatternPoint {
+  timestamp: string
+  count: number
+  pattern_type: string
+}
+
+export interface TimelineResult {
+  timeline: TimelinePoint[]
+  status?: string
+}
+
+export interface TrendsResult {
+  trends: Record<string, TrendData>
+}
+
+export interface PatternsResult {
+  patterns: Record<string, PatternPoint[]>
+}
+
+export function useCodeEvolutionData() {
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchTimeline(
+    startDate: string,
+    endDate: string,
+    granularity: string,
+    metrics: string[]
+  ): Promise<TimelineResult | null> {
+    error.value = null
+    try {
+      const params = new URLSearchParams({
+        start_date: startDate,
+        end_date: endDate,
+        granularity,
+        metrics: metrics.join(','),
+      })
+      // Issue #552: backend uses /api/evolution/* not /api/analytics/evolution/*
+      const response = await fetchWithAuth(`${getApiBase()}/evolution/timeline?${params}`)
+      if (!response.ok) {
+        logger.warn('Failed to load evolution timeline: HTTP', response.status)
+        return null
+      }
+      return await response.json()
+    } catch (e) {
+      logger.error('Failed to load evolution timeline:', e)
+      error.value = e instanceof Error ? e.message : 'Unknown error'
+      return null
+    }
+  }
+
+  async function fetchTrends(days: string): Promise<TrendsResult | null> {
+    error.value = null
+    try {
+      // Issue #552: backend uses /api/evolution/* not /api/analytics/evolution/*
+      const response = await fetchWithAuth(`${getApiBase()}/evolution/trends?days=${days}`)
+      if (!response.ok) {
+        logger.warn('Failed to load evolution trends: HTTP', response.status)
+        return null
+      }
+      return await response.json()
+    } catch (e) {
+      logger.error('Failed to load evolution trends:', e)
+      error.value = e instanceof Error ? e.message : 'Unknown error'
+      return null
+    }
+  }
+
+  async function fetchPatterns(): Promise<PatternsResult | null> {
+    error.value = null
+    try {
+      // Issue #552: backend uses /api/evolution/* not /api/analytics/evolution/*
+      const response = await fetchWithAuth(`${getApiBase()}/evolution/patterns`)
+      if (!response.ok) {
+        logger.warn('Failed to load evolution patterns: HTTP', response.status)
+        return null
+      }
+      return await response.json()
+    } catch (e) {
+      logger.error('Failed to load evolution patterns:', e)
+      error.value = e instanceof Error ? e.message : 'Unknown error'
+      return null
+    }
+  }
+
+  async function fetchExport(startDate: string, endDate: string): Promise<Blob | null> {
+    error.value = null
+    try {
+      // Issue #552: backend uses /api/evolution/* not /api/analytics/evolution/*
+      const response = await fetchWithAuth(
+        `${getApiBase()}/evolution/export?format=csv&start_date=${startDate}&end_date=${endDate}`
+      )
+      if (!response.ok) {
+        logger.warn('Failed to export evolution data: HTTP', response.status)
+        return null
+      }
+      return await response.blob()
+    } catch (e) {
+      logger.error('Failed to export evolution data:', e)
+      error.value = e instanceof Error ? e.message : 'Unknown error'
+      return null
+    }
+  }
+
+  return {
+    isLoading,
+    error,
+    fetchTimeline,
+    fetchTrends,
+    fetchPatterns,
+    fetchExport,
+  }
+}


### PR DESCRIPTION
## Summary
- Extracted 4 inline `fetchWithAuth` calls from `CodeEvolutionTimeline.vue` to new `useCodeEvolutionData.ts`
- Composable exposes `fetchTimeline`, `fetchTrends`, `fetchPatterns`, `fetchExport`
- Component's inline type definitions (`TimelinePoint`, `TrendData`, `PatternPoint`) moved to composable

Closes #6072

🤖 Generated with [Claude Code](https://claude.com/claude-code)