### PR TITLE
docs(composables): document useVoiceConversation fetchWithAuth FormData exemption (#6031)

### DIFF
--- a/autobot-frontend/src/composables/useVoiceConversation.ts
+++ b/autobot-frontend/src/composables/useVoiceConversation.ts
@@ -631,6 +631,8 @@ async function _transcribeAudioWithLanguage(
   if (lang) form.append('language', lang)
   _transcribeController?.abort()
   _transcribeController = new AbortController()
+  // fetchWithAuth retained: FormData audio body (multipart) and AbortController signal
+  // are incompatible with apiClient.post(). Exempt per composable-weakness-remediation design.
   const res = await fetchWithAuth(`${getApiBase()}/voice/transcribe`, {
     method: 'POST',
     body: form,


### PR DESCRIPTION
## Summary
- Documents FormData + AbortController exemption in `useVoiceConversation._transcribeAudioWithLanguage()`
- No functional change — adds inline comment explaining why `fetchWithAuth` is intentionally retained
- Exemption reason: FormData audio body (multipart) and AbortController signal are incompatible with `apiClient.post()`

## Behavioral grep audit
N/A — documentation-only change, no behavior changed

## Test plan
- [ ] TypeScript type-check passes
- [ ] No functional regression in voice transcription

Closes #6031