### PR TITLE
fix(docker): match autobot-shared hyphen in requirements filter regex

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -34,7 +34,7 @@ COPY requirements.txt /app/requirements-root.txt
 
 # Install backend dependencies (filter out local refs, install root deps separately)
 COPY autobot-backend/requirements.txt /tmp/requirements.txt
-RUN grep -v -E "(autobot_shared|^-r )" /tmp/requirements.txt > /app/requirements-filtered.txt \
+RUN grep -v -E "(autobot.shared|^-r )" /tmp/requirements.txt > /app/requirements-filtered.txt \
     && python3.12 -m pip install --no-cache-dir -r /app/requirements-root.txt \
     && python3.12 -m pip install --no-cache-dir -r /app/requirements-filtered.txt
 


### PR DESCRIPTION
## Summary

Fixes the backend Docker build failing with:

\`\`\`
ERROR: ../autobot-shared is not a valid editable requirement
\`\`\`

## Root Cause

\`autobot-backend/requirements.txt\` line 1 is \`-e ../autobot-shared\` (hyphen). The Dockerfile filter used \`autobot_shared\` (underscore), so \`../autobot-shared\` slipped through and hit \`pip install\` as an unresolvable local path.

**Before:** \`grep -v -E "(autobot_shared|^-r )"\`
**After:** \`grep -v -E "(autobot.shared|^-r )"\` — dot matches both \`-\` and \`_\`

Discovered while tracking down smoke test failures after the \`--build\` fix landed.