### PR TITLE
refact(composables): extract fetchWithAuth from SecretsManager to useSecretsAuditApi (#6081)

### DIFF
--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -791,8 +791,7 @@ import { useAppStore } from '@/stores/useAppStore';
 import { createLogger } from '@/utils/debugUtils';
 import { formatDateTime } from '@/utils/formatHelpers';
 import { useDebounce } from '@/composables/useDebounce';
-import { getBackendUrl } from '@/config/ssot-config';
-import { fetchWithAuth } from '@/utils/fetchWithAuth';
+import { useSecretsAuditApi } from '@/composables/security/useSecretsAuditApi';
 import EmptyState from '@/components/ui/EmptyState.vue';
 import LoadingSpinner from '@/components/ui/LoadingSpinner.vue';
 import BaseModal from '@/components/ui/BaseModal.vue';
@@ -800,6 +799,7 @@ import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n();
 const logger = createLogger('SecretsManager');
+const { fetchInfraHosts, fetchSecretsUsage, deleteInfraHost } = useSecretsAuditApi();
 
 // Credential type categories with icons and colors (using design tokens)
 const credentialCategories = computed(() => [
@@ -1006,14 +1006,12 @@ const isFormValid = computed(() => {
 const loadSecrets = async () => {
   loading.value = true;
   try {
-    const backendUrl = getBackendUrl();
-
     // Fetch secrets and stats - infrastructure_host is now a regular secret type
     const [secretsResponse, statsResponse, legacyHostsResponse] = await Promise.all([
       secretsApiClient.getSecrets({}) as Promise<Record<string, any>>,
       secretsApiClient.getSecretsStats() as Promise<Record<string, any>>,
       // Also fetch legacy hosts for backwards compatibility (will be migrated eventually)
-      fetchWithAuth(`${backendUrl}/api/infrastructure/hosts`).then(r => r.ok ? r.json() : { hosts: [] }).catch(() => ({ hosts: [] }))
+      fetchInfraHosts()
     ]);
 
     // Convert legacy infrastructure hosts to secret-like format for unified display
@@ -1065,14 +1063,8 @@ const loadSecrets = async () => {
 // Load workflow usage for secrets (#1415)
 const loadWorkflowUsage = async () => {
   try {
-    const backendUrl = getBackendUrl();
-    const response = await fetchWithAuth(
-      `${backendUrl}/api/templates/templates/secrets-usage`
-    );
-    if (response.ok) {
-      const data = await response.json();
-      workflowUsage.value = data.secrets_usage || {};
-    }
+    const data = await fetchSecretsUsage();
+    workflowUsage.value = data.secrets_usage || {};
   } catch (error) {
     logger.error('Failed to load workflow usage:', error);
   }
@@ -1283,13 +1275,7 @@ const deleteSecret = async () => {
   try {
     // Handle legacy infrastructure hosts differently (they use old API)
     if (deletingSecret.value._isLegacyHost) {
-      const backendUrl = getBackendUrl();
-      const response = await fetchWithAuth(`${backendUrl}/api/infrastructure/hosts/${deletingSecret.value.id}`, {
-        method: 'DELETE'
-      });
-      if (!response.ok) {
-        throw new Error('Failed to delete infrastructure host');
-      }
+      await deleteInfraHost(deletingSecret.value.id);
     } else {
       // All secrets (including new infrastructure_host type) use unified secrets API
       await secretsApiClient.deleteSecret(deletingSecret.value.id, { chatId: deletingSecret.value.chat_id });

--- a/autobot-frontend/src/composables/security/useSecretsAuditApi.ts
+++ b/autobot-frontend/src/composables/security/useSecretsAuditApi.ts
@@ -1,0 +1,67 @@
+/**
+ * useSecretsAuditApi — thin fetch wrappers for infrastructure-host and
+ * workflow-usage endpoints used by SecretsManager.
+ *
+ * Extracted from SecretsManager.vue (issue #6081).
+ */
+
+import { getBackendUrl } from '@/config/ssot-config';
+import { fetchWithAuth } from '@/utils/fetchWithAuth';
+
+export interface InfraHost {
+  id: string;
+  name: string;
+  scope?: string;
+  chat_id?: string;
+  description?: string;
+  tags?: string[];
+  created_at?: string;
+  updated_at?: string;
+  host: string;
+  ssh_port: number;
+  vnc_port?: number | null;
+  username: string;
+  auth_type: string;
+  capabilities?: Record<string, unknown>;
+}
+
+export interface InfraHostsResponse {
+  hosts: InfraHost[];
+}
+
+export interface SecretsUsageResponse {
+  secrets_usage: Record<string, unknown[]>;
+}
+
+export function useSecretsAuditApi() {
+  /** Fetch legacy infrastructure hosts from the old API. */
+  async function fetchInfraHosts(): Promise<InfraHostsResponse> {
+    const backendUrl = getBackendUrl();
+    return fetchWithAuth(`${backendUrl}/api/infrastructure/hosts`)
+      .then(r => (r.ok ? r.json() : { hosts: [] }))
+      .catch(() => ({ hosts: [] }));
+  }
+
+  /** Fetch workflow-usage mapping for secrets (#1415). */
+  async function fetchSecretsUsage(): Promise<SecretsUsageResponse> {
+    const backendUrl = getBackendUrl();
+    const response = await fetchWithAuth(`${backendUrl}/api/templates/templates/secrets-usage`);
+    if (!response.ok) {
+      return { secrets_usage: {} };
+    }
+    return response.json();
+  }
+
+  /** Delete a legacy infrastructure host by id. */
+  async function deleteInfraHost(id: string): Promise<void> {
+    const backendUrl = getBackendUrl();
+    const response = await fetchWithAuth(`${backendUrl}/api/infrastructure/hosts/${id}`, {
+      method: 'DELETE',
+    });
+    if (!response.ok) {
+      throw new Error('Failed to delete infrastructure host');
+    }
+  }
+
+  return { fetchInfraHosts, fetchSecretsUsage, deleteInfraHost };
+}


### PR DESCRIPTION
## Summary
- Created `autobot-frontend/src/composables/security/useSecretsAuditApi.ts` with fetchInfraHosts, fetchSecretsUsage, deleteInfraHost functions
- Removed all inline fetchWithAuth calls from SecretsManager.vue

## Behavioral grep audit
Before: 3 fetchWithAuth hits in component. After: 0 hits.

## Test plan
- [ ] No fetchWithAuth/apiClient in component. Type-check ≤ 244 errors (237).

Closes #6081
🤖 Generated with [Claude Code](https://claude.com/claude-code)