### PR TITLE
refact(composables): extract fetchWithAuth from SystemArchitectureDiagram to useSystemArchitectureData (#6085)

### DIFF
--- a/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
+++ b/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
@@ -511,12 +511,12 @@
 
 import { ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import apiClient from '@/utils/ApiClient'
-import { getConfig, getApiBase } from '@/config/ssot-config'
+import { getConfig } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import { getCssVar } from '@/composables/useCssVars'
 import { usePollingJob } from '@/composables/usePollingJob'
 import { useLoadingState } from '@/composables/useLoadingState'
+import { useSystemArchitectureData } from '@/composables/visualizations/useSystemArchitectureData'
 
 const { t } = useI18n()
 
@@ -599,6 +599,7 @@ const props = withDefaults(defineProps<Props>(), {
 // ============================================================================
 
 const { isLoading, wrap } = useLoadingState()
+const { fetchArchitectureHealth } = useSystemArchitectureData()
 const allComponents = ref<Component[]>([])
 const connections = ref<Connection[]>([])
 const componentGroups = ref<ComponentGroup[]>([])
@@ -702,18 +703,8 @@ const visibleConnections = computed(() => {
 
 async function refreshArchitecture() {
   await wrap(async () => {
-  try {
-    // Issue #552: Fixed path - backend uses /api/monitoring/services/health
-    const healthData = await apiClient.get<Record<string, any>>(`${getApiBase()}/monitoring/services/health`)
-
-    // Generate architecture based on known infrastructure
-    generateArchitecture(healthData?.data?.services || healthData?.services || {})
-
-  } catch (error) {
-    logger.error('Failed to fetch architecture data:', error)
-    // Generate default architecture on error
-    generateArchitecture({})
-  }
+    const serviceHealth = await fetchArchitectureHealth()
+    generateArchitecture(serviceHealth)
   })
 }
 

--- a/autobot-frontend/src/composables/visualizations/useSystemArchitectureData.ts
+++ b/autobot-frontend/src/composables/visualizations/useSystemArchitectureData.ts
@@ -1,0 +1,43 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Composable: useSystemArchitectureData
+ *
+ * Encapsulates the backend fetch for the SystemArchitectureDiagram component
+ * (#6085).
+ *
+ * Responsibilities:
+ *  - Fetch `/monitoring/services/health` via apiClient
+ *  - Expose `fetchArchitectureHealth` so the component owns zero API logic
+ *  - Fall back to an empty service map on error, logging the failure
+ */
+
+import apiClient from '@/utils/ApiClient'
+import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
+
+const logger = createLogger('useSystemArchitectureData')
+
+export interface ServiceHealthMap {
+  [key: string]: { status?: string } | undefined
+}
+
+interface HealthApiResponse {
+  services?: ServiceHealthMap
+}
+
+export function useSystemArchitectureData() {
+  async function fetchArchitectureHealth(): Promise<ServiceHealthMap> {
+    try {
+      const response = await apiClient.get<HealthApiResponse>(`${getApiBase()}/monitoring/services/health`)
+      return response?.data?.services ?? (response?.services as ServiceHealthMap | undefined) ?? {}
+    } catch (error) {
+      logger.error('Failed to fetch architecture data:', error)
+      return {}
+    }
+  }
+
+  return { fetchArchitectureHealth }
+}


### PR DESCRIPTION
## Summary
- Created `autobot-frontend/src/composables/visualizations/useSystemArchitectureData.ts` with fetchArchitectureHealth
- Removed all inline apiClient calls from SystemArchitectureDiagram.vue

## Behavioral grep audit
Before: 1 apiClient hit in component. After: 0 hits.

## Test plan
- [ ] No fetchWithAuth/apiClient in component. Type-check ≤ 244 errors (237).

Closes #6085
🤖 Generated with [Claude Code](https://claude.com/claude-code)