### PR TITLE
refact(composables): migrate KnowledgeCategories fetchWithAuth to useKnowledgeCategories (#6049)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -168,10 +168,9 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter, useRoute } from 'vue-router'
-import apiClient from '@/utils/ApiClient'
-import { getApiBase } from '@/config/ssot-config'
 import { useKnowledgeStats } from '@/composables/knowledge/useKnowledgeStats'
 import { useKnowledgeIcons } from '@/composables/knowledge/useKnowledgeIcons'
+import { useKnowledgeCategories } from '@/composables/knowledge/useKnowledgeCategories'
 import { formatDate, formatCategoryName, formatFileSize } from '@/utils/formatHelpers'
 import KnowledgeBrowser from './KnowledgeBrowser.vue'
 import DocumentChangeFeed from './DocumentChangeFeed.vue'
@@ -190,6 +189,7 @@ import '@/styles/document-feed-wrapper.css'
 // Domain composables (migrated from useKnowledgeBase BC shim in #5193)
 const { fetchBasicStats } = useKnowledgeStats()
 const { getCategoryIcon, getTypeIcon } = useKnowledgeIcons()
+const { fetchMainCategories, fetchCategoryDocuments } = useKnowledgeCategories()
 
 // Router
 const router = useRouter()
@@ -248,8 +248,7 @@ const viewCategoryDocuments = async (category: any) => {
   selectedCategoryPath.value = category.path
 
   try {
-    const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/categories/${encodeURIComponent(category.path)}`)
-    categoryDocuments.value = data?.documents || []
+    categoryDocuments.value = await fetchCategoryDocuments(category.path)
     showCategoryDocuments.value = true
   } catch (error) {
     logger.error('Error loading category documents:', error)
@@ -280,17 +279,10 @@ const loadMainCategories = async () => {
   isLoadingCategories.value = true
   categoriesError.value = null
   try {
-    // apiClient.get<T> returns parsed JSON or throws on HTTP error — it
-    // never returns a Response-like object with a `status` field. The
-    // previous `if (response && 'status' in response)` guard was dead code
-    // left over from the parseApiResponse wrapper pattern (#5033); the 401 /
-    // 403 handling now lives in the catch below via the thrown error.
-    const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/categories/main`)
-    if (!data?.categories || !Array.isArray(data.categories)) {
-      categoriesError.value = t('knowledge.categories.invalidResponse')
-      return
-    }
-    mainCategories.value = data.categories
+    // fetchMainCategories delegates to apiClient.get<T> which returns parsed
+    // JSON or throws on HTTP error — 401/403 handling lives in the catch
+    // below via the thrown error (#5033).
+    mainCategories.value = await fetchMainCategories()
   } catch (error: unknown) {
     logger.error('Failed to load main categories:', error)
     const status = (error as { status?: number; response?: { status?: number } })?.status

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeCategories.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeCategories.ts
@@ -156,6 +156,46 @@ export const buildCategoryFilterOptions = (
 
 // ==================== Reactive composable ====================
 
+export interface MainCategoryItem {
+  id: string
+  name: string
+  description: string
+  examples: string
+  icon: string
+  color: string
+  count: number
+  [key: string]: unknown
+}
+
+export interface CategoryDocumentsResponse {
+  documents: Record<string, unknown>[]
+  [key: string]: unknown
+}
+
+/**
+ * Fetch the main category cards shown on the KnowledgeCategories landing page.
+ * Returns the validated categories array or throws.
+ */
+export const fetchMainCategories = async (): Promise<MainCategoryItem[]> => {
+  const data = await apiClient.get<Record<string, unknown>>(`${getApiBase()}/knowledge_base/categories/main`)
+  if (!data?.categories || !Array.isArray(data.categories)) {
+    throw new Error('Invalid main categories response format')
+  }
+  return data.categories as MainCategoryItem[]
+}
+
+/**
+ * Fetch all documents for a specific category path.
+ */
+export const fetchCategoryDocuments = async (
+  categoryPath: string
+): Promise<Record<string, unknown>[]> => {
+  const data = await apiClient.get<CategoryDocumentsResponse>(
+    `${getApiBase()}/knowledge_base/categories/${encodeURIComponent(categoryPath)}`
+  )
+  return data?.documents ?? []
+}
+
 export interface UseKnowledgeCategoriesReturn {
   /** Latest categories list. */
   categories: Readonly<Ref<KnowledgeCategoryItem[]>>
@@ -175,6 +215,8 @@ export interface UseKnowledgeCategoriesReturn {
   // Imperative passthroughs — BC with pre-#5149 callers
   fetchCategories: typeof fetchCategories
   fetchCategory: typeof fetchCategory
+  fetchMainCategories: typeof fetchMainCategories
+  fetchCategoryDocuments: typeof fetchCategoryDocuments
   getCategorizedFacts: typeof getCategorizedFacts
   buildCategoryFilterOptions: typeof buildCategoryFilterOptions
   getCategoryIcon: typeof getCategoryIcon
@@ -226,6 +268,8 @@ export function useKnowledgeCategories(): UseKnowledgeCategoriesReturn {
     refreshCategorizedFacts,
     fetchCategories,
     fetchCategory,
+    fetchMainCategories,
+    fetchCategoryDocuments,
     getCategorizedFacts,
     buildCategoryFilterOptions,
     getCategoryIcon,


### PR DESCRIPTION
## Summary
- Extended `useKnowledgeCategories.ts` with `fetchMainCategories()` and `fetchCategoryDocuments()` functions
- Removed all inline `apiClient` calls from `KnowledgeCategories.vue`

## Behavioral grep audit
Before: 2 apiClient hits in component. After: 0 hits.

## Test plan
- [ ] No fetchWithAuth/apiClient in component. Type-check ≤ 244 errors (234).

Closes #6049
🤖 Generated with [Claude Code](https://claude.com/claude-code)