### PR TITLE
fix(knowledge): resolve TS2339 type errors in useKnowledgeGraph

### DIFF
--- a/autobot-frontend/src/composables/knowledge/useKnowledgeGraph.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeGraph.ts
@@ -155,11 +155,14 @@ export function useKnowledgeGraph(): UseKnowledgeGraphReturn {
           ),
         ])
 
+        const unifiedBody = (unifiedData as Record<string, unknown>)?.data as Record<string, unknown> | undefined
+        const memoryBody = (memoryData as Record<string, unknown>)?.data as Record<string, unknown> | undefined
+
         const unifiedEntities: GraphEntity[] =
-          (unifiedData as Record<string, unknown>)?.data?.entities as GraphEntity[] ?? []
+          (unifiedBody?.entities as GraphEntity[] | undefined) ?? []
         const memoryEntities: GraphEntity[] =
-          (memoryData as Record<string, unknown>)?.data?.entities as GraphEntity[]
-          ?? (memoryData as Record<string, unknown>)?.entities as GraphEntity[]
+          (memoryBody?.entities as GraphEntity[] | undefined)
+          ?? ((memoryData as Record<string, unknown>)?.entities as GraphEntity[] | undefined)
           ?? []
 
         // Merge entities, avoiding duplicates by ID
@@ -172,8 +175,7 @@ export function useKnowledgeGraph(): UseKnowledgeGraphReturn {
         entities.value = Array.from(entityMap.values())
 
         // Seed relations from the unified endpoint
-        relations.value =
-          (unifiedData as Record<string, unknown>)?.data?.relations as GraphRelation[] ?? []
+        relations.value = (unifiedBody?.relations as GraphRelation[] | undefined) ?? []
 
         // Augment with per-entity memory relations when memory has entries
         if (memoryEntities.length > 0) {


### PR DESCRIPTION
## Summary
- Fixes 3 TS2339 errors in `useKnowledgeGraph.ts` introduced by PR #6180
- Adds intermediate `unifiedBody`/`memoryBody` variables cast to `Record<string,unknown>` so TypeScript can resolve `.entities` and `.relations` property chains

## Test plan
- [ ] `npx vue-tsc --noEmit -p tsconfig.app.json` shows 0 errors for `knowledge/useKnowledgeGraph.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)