### PR TITLE
fix(deps): correct -e path from autobot-shared to autobot_shared in 3 requirements files (#6191)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -1,4 +1,4 @@
--e ../autobot-shared
+-e ../autobot_shared
 
 # Core
 fastapi>=0.135.2                # SECURITY UPDATE - requires starlette >=0.52.1

--- a/autobot-browser-worker/requirements.txt
+++ b/autobot-browser-worker/requirements.txt
@@ -1,4 +1,4 @@
--e ../autobot-shared
+-e ../autobot_shared
 
 # Browser automation
 playwright>=1.58.0

--- a/autobot-npu-worker/requirements.txt
+++ b/autobot-npu-worker/requirements.txt
@@ -1,4 +1,4 @@
--e ../autobot-shared
+-e ../autobot_shared
 
 # NPU/AI
 openvino>=2026.0.0


### PR DESCRIPTION
## Summary
- Changes `-e ../autobot-shared` to `-e ../autobot_shared` in 3 service requirements files
- Fixes local development `pip install -r requirements.txt` which fails with `ERROR: ../autobot-shared is not a valid editable requirement` because the directory is `autobot_shared/` (underscore)
- Docker builds are unaffected (Dockerfile filters this line), but local dev setups were broken

## Files changed
- `autobot-backend/requirements.txt`
- `autobot-browser-worker/requirements.txt`
- `autobot-npu-worker/requirements.txt`

## Closes
Fixes #6191

🤖 Generated with [Claude Code](https://claude.com/claude-code)