### PR TITLE
refact(orchestration): consolidate duplicate AgentCapability enum (#6192)

### DIFF
--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -287,7 +287,7 @@ async def recommend_agents(
     if not _ORCHESTRATOR_AVAILABLE:
         raise HTTPException(status_code=503, detail="Orchestrator module not available")
     try:
-        from enhanced_orchestration import AgentCapability  # noqa: PLC0415
+        from orchestration import AgentCapability  # noqa: PLC0415
 
         # Convert capability strings to enums
         capabilities_needed = set()

--- a/autobot-backend/enhanced_orchestration/__init__.py
+++ b/autobot-backend/enhanced_orchestration/__init__.py
@@ -24,9 +24,9 @@ from .success_criteria import (
     SuccessCriteriaEvaluator,
     SuccessCriteriaType,
 )
+from orchestration.types import AgentCapability  # canonical definition (#6192)
 from .types import (
     FALLBACK_TIERS,
-    AgentCapability,
     AgentPerformance,
     AgentTask,
     ExecutionStrategy,

--- a/autobot-backend/enhanced_orchestration/types.py
+++ b/autobot-backend/enhanced_orchestration/types.py
@@ -18,22 +18,10 @@ if TYPE_CHECKING:
 
 from constants.status_enums import TaskStatus
 from constants.threshold_constants import RetryConfig, TimingConstants
+from orchestration.types import AgentCapability  # single canonical definition (#6192)
 
 # Module-level frozenset for fallback tier checks
 FALLBACK_TIERS: FrozenSet[str] = frozenset({"basic", "emergency"})
-
-
-class AgentCapability(Enum):
-    """Core agent capabilities"""
-
-    RESEARCH = "research"
-    ANALYSIS = "analysis"
-    EXECUTION = "execution"
-    MONITORING = "monitoring"
-    SYNTHESIS = "synthesis"
-    VALIDATION = "validation"
-    OPTIMIZATION = "optimization"
-    SECURITY = "security"
 
 
 class ExecutionStrategy(Enum):


### PR DESCRIPTION
## Summary
- Removes the duplicate `AgentCapability` definition from `enhanced_orchestration/types.py` (8-member subset)
- Adds `from orchestration.types import AgentCapability` in its place — `orchestration/types.py` already has the complete 14-member merged set (workaround from commit `7ea249690`)
- Updates `enhanced_orchestration/__init__.py` to re-export `AgentCapability` from `orchestration.types`
- Updates `api/orchestration.py` to import from `orchestration` instead of `enhanced_orchestration`

## Closes
Fixes #6192

🤖 Generated with [Claude Code](https://claude.com/claude-code)