### PR TITLE
fix(deploy): add Ansible task to clear stale .pyc files after source sync (#6193)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -250,6 +250,14 @@
       - "--exclude=archives"
   tags: ['backend', 'deploy']
 
+- name: "Backend | Clear stale .pyc files after source sync (#6193)"
+  ansible.builtin.shell: |
+    find "{{ backend_code_dir }}" -name '*.pyc' -delete
+    find "{{ backend_install_dir }}/autobot_shared" -name '*.pyc' -delete 2>/dev/null || true
+    find "{{ backend_shared_standalone_dir }}" -name '*.pyc' -delete 2>/dev/null || true
+  changed_when: false
+  tags: ['backend', 'deploy']
+
 - name: Create backend symlink for imports
   ansible.builtin.file:
     src: "{{ backend_code_dir }}"


### PR DESCRIPTION
## Summary
- Adds a new task after all rsync sync tasks in `autobot-slm-backend/ansible/roles/backend/tasks/main.yml`
- Task runs `find -name '*.pyc' -delete` across `backend_code_dir`, `backend_install_dir/autobot_shared`, and `backend_shared_standalone_dir`
- Prevents stale compiled bytecode from masking fixed import bugs after deployment

## Closes
Fixes #6193

🤖 Generated with [Claude Code](https://claude.com/claude-code)