### PR TITLE
fix(backend): replace bare singleton aliases with get_*() pattern at all call sites (#6196)

### DIFF
--- a/autobot-backend/agents/interactive_terminal_agent.py
+++ b/autobot-backend/agents/interactive_terminal_agent.py
@@ -19,7 +19,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from constants.threshold_constants import TimingConstants
-from event_manager import event_manager
+from event_manager import get_event_manager
 
 from .base_agent import AgentRequest
 from .standardized_agent import ActionHandler, StandardizedAgent
@@ -180,7 +180,7 @@ class InteractiveTerminalAgent(StandardizedAgent):
 
     async def _notify_session_started(self, command: str) -> None:
         """Publish session started event. Issue #620."""
-        await event_manager.publish(
+        await get_event_manager().publish(
             "terminal_session",
             {
                 "chat_id": self.chat_id,
@@ -314,7 +314,7 @@ class InteractiveTerminalAgent(StandardizedAgent):
 
     async def _handle_sudo_prompt(self, prompt_data: str):
         """Handle sudo password prompts"""
-        await event_manager.publish(
+        await get_event_manager().publish(
             "terminal_output",
             {
                 "chat_id": self.chat_id,
@@ -334,7 +334,7 @@ class InteractiveTerminalAgent(StandardizedAgent):
 
     async def _handle_input_prompt(self, prompt_data: str):
         """Handle interactive prompts"""
-        await event_manager.publish(
+        await get_event_manager().publish(
             "terminal_output",
             {
                 "chat_id": self.chat_id,
@@ -348,7 +348,7 @@ class InteractiveTerminalAgent(StandardizedAgent):
 
     async def _send_to_chat(self, output: str):
         """Send regular output to chat"""
-        await event_manager.publish(
+        await get_event_manager().publish(
             "terminal_output",
             {
                 "chat_id": self.chat_id,
@@ -360,7 +360,7 @@ class InteractiveTerminalAgent(StandardizedAgent):
 
     async def _send_error(self, error: str):
         """Send error message to chat"""
-        await event_manager.publish(
+        await get_event_manager().publish(
             "terminal_output",
             {
                 "chat_id": self.chat_id,
@@ -401,7 +401,7 @@ class InteractiveTerminalAgent(StandardizedAgent):
     async def take_control(self):
         """Allow user to take full control of terminal"""
         self.input_mode = "user"
-        await event_manager.publish(
+        await get_event_manager().publish(
             "terminal_control",
             {
                 "chat_id": self.chat_id,
@@ -416,7 +416,7 @@ class InteractiveTerminalAgent(StandardizedAgent):
     async def return_control(self):
         """Return control to agent"""
         self.input_mode = "agent"
-        await event_manager.publish(
+        await get_event_manager().publish(
             "terminal_control",
             {
                 "chat_id": self.chat_id,
@@ -472,7 +472,7 @@ class InteractiveTerminalAgent(StandardizedAgent):
         async with self._buffer_lock:
             output_lines = len(self.output_buffer)
 
-        await event_manager.publish(
+        await get_event_manager().publish(
             "terminal_session",
             {
                 "chat_id": self.chat_id,

--- a/autobot-backend/agents/kb_librarian/librarian.py
+++ b/autobot-backend/agents/kb_librarian/librarian.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from agents.web_researcher import WebResearcher as WebResearchAssistant
-from event_manager import event_manager
+from event_manager import get_event_manager
 from knowledge_base import KnowledgeBase
 
 from .formatters import ToolInfoFormatter
@@ -349,7 +349,7 @@ class EnhancedKBLibrarian:
         await self.knowledge_base.store_fact(document_content, metadata=metadata)
         logger.info("Stored knowledge for tool: %s", tool_name)
 
-        await event_manager.publish(
+        await get_event_manager().publish(
             "knowledge_update",
             {
                 "type": "new_tool",

--- a/autobot-backend/agents/system_command_agent.py
+++ b/autobot-backend/agents/system_command_agent.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional
 
 from agents.interactive_terminal_agent import InteractiveTerminalAgent
 from constants.threshold_constants import TimingConstants
-from event_manager import event_manager
+from event_manager import get_event_manager
 from security.command_patterns import (
     SENSITIVE_REDIRECT_PATHS,
     UNRESTRICTED_ROOT_COMMANDS,
@@ -374,7 +374,7 @@ class SystemCommandAgent(StandardizedAgent):
         elif result:
             event_data["exit_code"] = result["exit_code"]
             event_data["duration"] = result["duration"]
-        await event_manager.publish("command_execution", event_data)
+        await get_event_manager().publish("command_execution", event_data)
 
     def _build_execution_result(self, result: dict) -> Dict[str, Any]:
         """Build execution result dict (Issue #398: extracted)."""
@@ -470,7 +470,7 @@ class SystemCommandAgent(StandardizedAgent):
 
     async def _request_user_confirmation(self, command: str, chat_id: str) -> bool:
         """Request user confirmation for dangerous commands"""
-        await event_manager.publish(
+        await get_event_manager().publish(
             "command_confirmation",
             {
                 "chat_id": chat_id,

--- a/autobot-backend/event_manager.py
+++ b/autobot-backend/event_manager.py
@@ -100,7 +100,6 @@ class EventManager:
 
 
 get_event_manager = lazy_singleton(EventManager)
-event_manager = get_event_manager()
 
 if __name__ == "__main__":
 

--- a/autobot-backend/phase8_control_panel_test.py
+++ b/autobot-backend/phase8_control_panel_test.py
@@ -243,9 +243,9 @@ async def test_integration():
 
     # Test 1: Memory system integration
     print("\n1. Testing Memory System Integration...")  # noqa: print
-    from task_execution_tracker import task_tracker
+    from task_execution_tracker import get_task_tracker
 
-    async with task_tracker.track_task(
+    async with get_task_tracker().track_task(
         "Phase 8 Integration Test",
         "Testing integration between Phase 8 components",
         agent_type="phase8_test",

--- a/autobot-backend/services/agent_terminal/approval_handler.py
+++ b/autobot-backend/services/agent_terminal/approval_handler.py
@@ -171,9 +171,9 @@ class ApprovalHandler:
 
             # IMPLEMENTED: Real-time WebSocket broadcasting via event_manager
             try:
-                from event_manager import event_manager
+                from event_manager import get_event_manager
 
-                await event_manager.publish(
+                await get_event_manager().publish(
                     event_type="command_approval_status",
                     payload={
                         "conversation_id": session.conversation_id,

--- a/autobot-backend/services/approval_gate_service.py
+++ b/autobot-backend/services/approval_gate_service.py
@@ -347,11 +347,11 @@ class ApprovalGateService:
         event_type: str,
         approval: Approval,
     ) -> None:
-        """Publish WebSocket notification via event_manager."""
+        """Publish WebSocket notification via get_event_manager()."""
         try:
-            from event_manager import event_manager
+            from event_manager import get_event_manager
 
-            await event_manager.publish(
+            await get_event_manager().publish(
                 event_type=event_type,
                 payload={
                     "approval_id": str(approval.id),

--- a/autobot-backend/services/autoresearch/auto_research_agent.py
+++ b/autobot-backend/services/autoresearch/auto_research_agent.py
@@ -1136,9 +1136,9 @@ class AutoResearchAgent(AsyncRedisClientMixin):
         )
 
         try:
-            from event_manager import event_manager
+            from event_manager import get_event_manager
 
-            await event_manager.publish(
+            await get_event_manager().publish(
                 event_type="research_checkpoint_pending",
                 payload={
                     "session_id": session.id,

--- a/autobot-backend/services/captcha_human_loop.py
+++ b/autobot-backend/services/captcha_human_loop.py
@@ -50,7 +50,7 @@ from playwright.async_api import Page
 
 from constants.network_constants import NetworkConstants
 from constants.threshold_constants import TimingConstants
-from event_manager import event_manager
+from event_manager import get_event_manager
 
 logger = logging.getLogger(__name__)
 
@@ -507,7 +507,7 @@ class CaptchaHumanLoop:
         screenshot_b64: str,
     ) -> None:
         """Send WebSocket notification that CAPTCHA was detected."""
-        await event_manager.publish(
+        await get_event_manager().publish(
             "captcha_detected",
             {
                 "captcha_id": captcha_id,
@@ -523,7 +523,7 @@ class CaptchaHumanLoop:
 
     async def _notify_captcha_timeout(self, captcha_id: str, url: str) -> None:
         """Send WebSocket notification that CAPTCHA resolution timed out."""
-        await event_manager.publish(
+        await get_event_manager().publish(
             "captcha_timeout",
             {
                 "captcha_id": captcha_id,
@@ -537,7 +537,7 @@ class CaptchaHumanLoop:
         self, captcha_id: str, url: str, status: CaptchaResolutionStatus
     ) -> None:
         """Send WebSocket notification that CAPTCHA was resolved."""
-        await event_manager.publish(
+        await get_event_manager().publish(
             "captcha_resolved",
             {
                 "captcha_id": captcha_id,

--- a/autobot-backend/services/load_balancer.py
+++ b/autobot-backend/services/load_balancer.py
@@ -31,7 +31,7 @@ from enum import Enum
 from typing import Dict, List, Optional
 
 from constants.threshold_constants import RetryConfig, TimingConstants
-from event_manager import event_manager
+from event_manager import get_event_manager
 from npu_integration import NPUWorkerClient
 from type_defs.common import Metadata
 
@@ -683,7 +683,7 @@ class NPULoadBalancer:
             reason: Reason for status change
         """
         try:
-            await event_manager.publish(
+            await get_event_manager().publish(
                 "npu_worker_status_change",
                 worker.to_status_event_dict(reason),
             )

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -20,7 +20,7 @@ import yaml
 
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.threshold_constants import TimingConstants
-from event_manager import event_manager
+from event_manager import get_event_manager
 from models.npu_models import (
     LoadBalancingConfig,
     NPUWorkerConfig,
@@ -398,7 +398,7 @@ class NPUWorkerManager(AsyncInitializable):
             if event_type in _WORKER_FULL_DATA_EVENTS:
                 event_data["worker"] = worker_details.to_event_dict()
 
-            await event_manager.publish(f"npu.{event_type}", event_data)
+            await get_event_manager().publish(f"npu.{event_type}", event_data)
             logger.debug(f"Emitted event {event_type} for worker {worker_details.config.id}")
 
         except Exception as e:
@@ -577,7 +577,7 @@ class NPUWorkerManager(AsyncInitializable):
         await self._save_workers_to_config()
 
         # Emit worker removed event
-        await event_manager.publish(
+        await get_event_manager().publish(
             "npu.worker.removed",
             {
                 "event": "worker.removed",

--- a/autobot-backend/task_execution_tracker.py
+++ b/autobot-backend/task_execution_tracker.py
@@ -473,4 +473,3 @@ class TaskExecutionContext:
 
 
 get_task_tracker = lazy_singleton(TaskExecutionTracker)
-task_tracker = get_task_tracker()

--- a/autobot-backend/task_handlers/communication_handlers.py
+++ b/autobot-backend/task_handlers/communication_handlers.py
@@ -11,7 +11,7 @@ import logging
 from typing import Any, Dict
 
 from autobot_shared.models.task_result import task_pending_approval, task_success
-from event_manager import event_manager
+from event_manager import get_event_manager
 from models.task_context import TaskExecutionContext
 
 from .base import TaskHandler
@@ -26,7 +26,7 @@ class RespondConversationallyHandler(TaskHandler):
         """Execute conversational response task and publish via event manager."""
         response_text = ctx.get_payload_value("response_text", "No response provided.")
 
-        await event_manager.publish("llm_response", {"response": response_text})
+        await get_event_manager().publish("llm_response", {"response": response_text})
 
         result = task_success(
             "Responded conversationally.",
@@ -50,7 +50,7 @@ class AskUserForManualHandler(TaskHandler):
         program_name = ctx.require_payload_value("program_name")
         question_text = ctx.require_payload_value("question_text")
 
-        await event_manager.publish(
+        await get_event_manager().publish(
             "ask_user_for_manual",
             {
                 "task_id": ctx.task_id,
@@ -77,7 +77,7 @@ class AskUserCommandApprovalHandler(TaskHandler):
         """Execute command approval request task requiring user confirmation."""
         command_to_approve = ctx.require_payload_value("command")
 
-        await event_manager.publish(
+        await get_event_manager().publish(
             "ask_user_command_approval",
             {"task_id": ctx.task_id, "command": command_to_approve},
         )


### PR DESCRIPTION
## Summary
- Replaces `from event_manager import event_manager` with `from event_manager import get_event_manager` in 10 files; replaces `event_manager.X()` with `get_event_manager().X()`
- Replaces `from task_execution_tracker import task_tracker` with `from task_execution_tracker import get_task_tracker` in the test file
- Removes module-level aliases `event_manager = get_event_manager()` from `event_manager.py` and `task_tracker = get_task_tracker()` from `task_execution_tracker.py`
- Restores lazy initialization of both singletons — deferred until first `get_*()` call

## Files changed
- `event_manager.py` — removed alias
- `task_execution_tracker.py` — removed alias
- 9 service/agent/handler files — updated `event_manager.*` calls to `get_event_manager().*`
- `phase8_control_panel_test.py` — updated `task_tracker.*` to `get_task_tracker().*`

## Closes
Fixes #6196

🤖 Generated with [Claude Code](https://claude.com/claude-code)