### PR TITLE
fix(tooling): extend check_response_models hook for import-after-decorator ordering (#6143)

### DIFF
--- a/tools/lint/check_response_models.py
+++ b/tools/lint/check_response_models.py
@@ -22,6 +22,10 @@ For each, at least one of the following must be true:
   4. A local variable is assigned a dict literal containing all required keys and
      that variable is returned (single-assignment pattern — #5926)
 
+Additionally, any schema name used in response_model= must be imported at a line
+that appears BEFORE the decorator line. Import-after-use causes NameError at startup
+(#6143).
+
 Known limitation: multi-step variable builds (e.g. result = {}; result["success"] = True)
 and pass-through returns of function-call results are not analyzed. Use
 create_success_response() for those cases to satisfy the hook.
@@ -34,13 +38,14 @@ Exit codes:
 Background: #5843 → #5896 → #5904 cascade — 52+61 runtime-500 bugs introduced by
 response_model=DataResponse on endpoints that returned plain dicts without 'success'.
 Extended in #5925 to cover SuccessMessageResponse and SuccessDataResponse.
+Extended in #6143 to catch import-after-decorator ordering bugs.
 """
 from __future__ import annotations
 
 import ast
 import sys
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -107,6 +112,48 @@ def _checked_schema(decorator: ast.expr) -> str | None:
             and kw.value.id in CHECKED_SCHEMAS
         ):
             return kw.value.id
+    return None
+
+
+def _collect_import_line_map(tree: ast.Module) -> Dict[str, int]:
+    """Return a mapping of imported name → first import line number.
+
+    Covers all standard import forms:
+      import foo                       → {"foo": line}
+      import foo.bar as baz            → {"baz": line}
+      from foo import Bar, Baz         → {"Bar": line, "Baz": line}
+      from foo import Bar as B         → {"B": line}
+    """
+    name_to_line: Dict[str, int] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                bound_name = alias.asname if alias.asname else alias.name.split(".")[0]
+                if bound_name not in name_to_line:
+                    name_to_line[bound_name] = node.lineno
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                bound_name = alias.asname if alias.asname else alias.name
+                if bound_name not in name_to_line:
+                    name_to_line[bound_name] = node.lineno
+    return name_to_line
+
+
+def _import_order_violation(
+    schema: str, decorator_line: int, import_line_map: Dict[str, int]
+) -> Optional[str]:
+    """Return an error message if *schema* is not imported before *decorator_line*.
+
+    Returns None when the import is present and precedes the decorator.
+    """
+    if schema not in import_line_map:
+        return f"{schema} used in response_model= at line {decorator_line} but never imported"
+    import_line = import_line_map[schema]
+    if import_line > decorator_line:
+        return (
+            f"{schema} imported at line {import_line} but used in response_model= "
+            f"at line {decorator_line} (import must come first)"
+        )
     return None
 
 
@@ -181,8 +228,22 @@ def _returned_var_names(node: _FuncNode) -> set[str]:
     return names
 
 
-def _check_file(path: Path, repo_root: Path) -> List[Tuple[int, str]]:
-    """Return [(line_no, func_name)] for each DataResponse violation in *path*."""
+# Violation tuple: (line_no, func_name, error_message).
+# ``error_message`` is None for return-shape violations (message is assembled in main).
+_Violation = Tuple[int, str, Optional[str]]
+
+_SHAPE_VIOLATION_MSG = None  # sentinel: use the standard return-shape message in main
+
+
+def _check_file(path: Path, repo_root: Path) -> List[_Violation]:
+    """Return [_Violation] for each problem found in *path*.
+
+    Two classes of violations are detected:
+      1. Return-shape mismatch — endpoint body lacks required keys for the schema.
+         Tuple: (line_no, func_name, None)
+      2. Import-order — schema name is imported after (or never before) its decorator.
+         Tuple: (line_no, func_name, "<detail message>")
+    """
     try:
         rel = str(path.resolve().relative_to(repo_root)).replace("\\", "/")
     except ValueError:
@@ -195,7 +256,8 @@ def _check_file(path: Path, repo_root: Path) -> List[Tuple[int, str]]:
     except (SyntaxError, UnicodeDecodeError, OSError):
         return []
 
-    violations: List[Tuple[int, str]] = []
+    import_line_map = _collect_import_line_map(tree)
+    violations: List[_Violation] = []
     for func_node in ast.walk(tree):
         if not isinstance(func_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
@@ -203,6 +265,12 @@ def _check_file(path: Path, repo_root: Path) -> List[Tuple[int, str]]:
             schema = _checked_schema(dec)
             if schema is None:
                 continue
+            # Check 1: import ordering — schema must be imported before the decorator.
+            order_err = _import_order_violation(schema, dec.lineno, import_line_map)
+            if order_err is not None:
+                violations.append((func_node.lineno, func_node.name, order_err))
+                break
+            # Check 2: return-shape — body must satisfy required keys.
             required_keys = CHECKED_SCHEMAS[schema]
             if _returns_bypass_type(func_node):
                 break
@@ -219,7 +287,7 @@ def _check_file(path: Path, repo_root: Path) -> List[Tuple[int, str]]:
                 if name in var_keys
             ):
                 break
-            violations.append((func_node.lineno, func_node.name))
+            violations.append((func_node.lineno, func_node.name, _SHAPE_VIOLATION_MSG))
             break
     return violations
 
@@ -236,13 +304,21 @@ def main(argv: List[str]) -> int:
             rel = path.resolve().relative_to(repo_root)
         except ValueError:
             rel = path
-        for line_no, func_name in hits:
-            print(
-                f"[{HOOK_ID}] {rel}:{line_no}: {func_name}() uses a checked response_model "
-                f"but body lacks the required return keys or a safe bypass. "
-                f"Use create_success_response() or a named schema instead. (#5913)",
-                file=sys.stderr,
-            )
+        for line_no, func_name, detail in hits:
+            if detail is not None:
+                # Import-order violation — detail carries the specific message.
+                print(
+                    f"[{HOOK_ID}] {rel}:{line_no}: {func_name}(): {detail} (#6143)",
+                    file=sys.stderr,
+                )
+            else:
+                # Return-shape violation.
+                print(
+                    f"[{HOOK_ID}] {rel}:{line_no}: {func_name}() uses a checked response_model "
+                    f"but body lacks the required return keys or a safe bypass. "
+                    f"Use create_success_response() or a named schema instead. (#5913)",
+                    file=sys.stderr,
+                )
             total += 1
     if total:
         print(

--- a/tools/lint/check_response_models_test.py
+++ b/tools/lint/check_response_models_test.py
@@ -6,6 +6,9 @@
 Covers detection, safe predicates, and exit codes for the hook that
 prevents response_model=DataResponse on endpoints that would produce
 HTTP 500 ValidationError at runtime (#5913).
+
+Extended in #6143: import-order checks — schema name must be imported
+before the decorator line that references it.
 """
 from __future__ import annotations
 
@@ -17,6 +20,12 @@ _spec = importlib.util.spec_from_file_location("_hook_under_test", _HOOK_PATH)
 assert _spec is not None and _spec.loader is not None
 hook = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(hook)
+
+# Reusable import preamble — added to all test snippets that use checked schemas
+# so that import-order checks do not fire (only shape checks are tested).
+_DR = "from schemas import DataResponse\n"
+_SMR = "from schemas import SuccessMessageResponse\n"
+_SDR = "from schemas import SuccessDataResponse\n"
 
 
 def _write(tmp_path: Path, content: str) -> Path:
@@ -33,7 +42,8 @@ def _write(tmp_path: Path, content: str) -> Path:
 def test_detects_missing_success_in_return_dict(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 from fastapi import APIRouter
 router = APIRouter()
 
@@ -46,12 +56,15 @@ async def get_foo():
     violations = hook._check_file(f, repo)
     assert len(violations) == 1
     assert violations[0][1] == "get_foo"
+    # Shape violation: detail is None
+    assert violations[0][2] is None
 
 
 def test_detects_plain_dict_return_no_success(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.post("/submit", response_model=DataResponse)
 def submit():
     return {"result": 42, "count": 1}
@@ -59,12 +72,14 @@ def submit():
     )
     violations = hook._check_file(f, tmp_path)
     assert len(violations) == 1
+    assert violations[0][2] is None  # shape violation
 
 
 def test_detects_multiple_violations_in_one_file(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.get("/a", response_model=DataResponse)
 async def get_a():
     return {"items": []}
@@ -82,7 +97,8 @@ async def get_b():
 def test_detects_async_def_route(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.delete("/item", response_model=DataResponse)
 async def delete_item():
     return {"removed": True}
@@ -101,7 +117,8 @@ async def delete_item():
 def test_safe_with_create_success_response(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.get("/ok", response_model=DataResponse)
 async def get_ok():
     return create_success_response(data={"key": "value"})
@@ -113,7 +130,8 @@ async def get_ok():
 def test_safe_with_success_key_in_literal(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.post("/manual", response_model=DataResponse)
 def manual():
     return {"success": True, "data": None}
@@ -125,7 +143,8 @@ def manual():
 def test_safe_with_jsonresponse(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 from fastapi.responses import JSONResponse
 
 @router.get("/raw", response_model=DataResponse)
@@ -139,7 +158,8 @@ async def raw():
 def test_safe_with_streamingresponse(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.get("/stream", response_model=DataResponse)
 async def stream():
     return StreamingResponse(iter([b"data"]))
@@ -173,6 +193,7 @@ async def get_unannotated():
 
 
 def test_safe_custom_schema(tmp_path: Path) -> None:
+    """Non-checked schema names are not validated at all (no import-order check)."""
     f = _write(
         tmp_path,
         """
@@ -187,7 +208,8 @@ async def get_typed():
 def test_safe_create_success_response_via_attribute(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.get("/attr", response_model=DataResponse)
 async def get_attr():
     return helpers.create_success_response(data={})
@@ -204,7 +226,8 @@ async def get_attr():
 def test_detects_success_message_response_missing_required_keys(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _SMR
+        + """
 @router.post("/msg", response_model=SuccessMessageResponse)
 async def post_msg():
     return {"success": True}  # missing 'message'
@@ -218,7 +241,8 @@ async def post_msg():
 def test_safe_success_message_response_with_both_keys(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _SMR
+        + """
 @router.post("/msg", response_model=SuccessMessageResponse)
 async def post_msg():
     return {"success": True, "message": "done"}
@@ -230,7 +254,8 @@ async def post_msg():
 def test_detects_success_data_response_missing_message(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _SDR
+        + """
 @router.post("/data", response_model=SuccessDataResponse)
 async def post_data():
     return {"success": True, "data": {}}  # missing 'message'
@@ -243,7 +268,8 @@ async def post_data():
 def test_safe_success_data_response_with_required_keys(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _SDR
+        + """
 @router.post("/data", response_model=SuccessDataResponse)
 async def post_data():
     return {"success": True, "message": "ok", "data": None}
@@ -255,7 +281,8 @@ async def post_data():
 def test_safe_success_message_response_with_bypass(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _SMR
+        + """
 @router.get("/stream", response_model=SuccessMessageResponse)
 async def stream():
     return StreamingResponse(iter([b"x"]))
@@ -272,7 +299,8 @@ async def stream():
 def test_main_returns_0_for_clean_file(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.get("/clean", response_model=DataResponse)
 async def clean():
     return create_success_response()
@@ -284,7 +312,8 @@ async def clean():
 def test_main_returns_1_for_violation(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.get("/bad", response_model=DataResponse)
 async def bad():
     return {"no_success": True}
@@ -313,7 +342,8 @@ async def clean():
 def test_safe_variable_assigned_dict_with_success(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.get("/var", response_model=DataResponse)
 async def get_var():
     result = {"success": True, "data": []}
@@ -326,7 +356,8 @@ async def get_var():
 def test_detects_variable_assigned_dict_missing_success(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.get("/var", response_model=DataResponse)
 async def get_var():
     result = {"data": [], "count": 0}
@@ -341,7 +372,8 @@ async def get_var():
 def test_safe_success_message_response_variable_assignment(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _SMR
+        + """
 @router.post("/msg", response_model=SuccessMessageResponse)
 async def post_msg():
     response = {"success": True, "message": "done"}
@@ -354,7 +386,8 @@ async def post_msg():
 def test_detects_success_message_response_variable_missing_message(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _SMR
+        + """
 @router.post("/msg", response_model=SuccessMessageResponse)
 async def post_msg():
     response = {"success": True}
@@ -373,7 +406,8 @@ async def post_msg():
 def test_safe_with_jsonresponse_via_attribute(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.get("/raw", response_model=DataResponse)
 async def raw():
     return responses.JSONResponse(content={"key": "val"})
@@ -385,7 +419,8 @@ async def raw():
 def test_safe_with_streamingresponse_via_attribute(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.get("/stream", response_model=DataResponse)
 async def stream():
     return some_module.StreamingResponse(iter([b"data"]))
@@ -402,7 +437,8 @@ async def stream():
 def test_detects_violation_when_only_nested_function_has_success_dict(tmp_path: Path) -> None:
     f = _write(
         tmp_path,
-        """
+        _DR
+        + """
 @router.get("/bad", response_model=DataResponse)
 async def bad_endpoint():
     async def _build():
@@ -414,3 +450,148 @@ async def bad_endpoint():
     violations = hook._check_file(f, tmp_path)
     assert len(violations) == 1
     assert violations[0][1] == "bad_endpoint"
+
+
+# ---------------------------------------------------------------------------
+# Import-order checks (#6143) — schema must be imported before its decorator
+# ---------------------------------------------------------------------------
+
+
+def test_safe_import_before_decorator(tmp_path: Path) -> None:
+    """Import appears before decorator — no import-order violation."""
+    f = _write(
+        tmp_path,
+        """
+from schemas import DataResponse
+
+@router.get("/ok", response_model=DataResponse)
+async def get_ok():
+    return {"success": True}
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_detects_import_after_decorator(tmp_path: Path) -> None:
+    """Import appears after decorator line — import-order violation."""
+    f = _write(
+        tmp_path,
+        """
+@router.get("/bad", response_model=DataResponse)
+async def get_bad():
+    return {"success": True}
+
+from schemas import DataResponse
+""",
+    )
+    violations = hook._check_file(f, tmp_path)
+    assert len(violations) == 1
+    assert violations[0][1] == "get_bad"
+    # Third element is the detail message, not None (import-order violation)
+    detail = violations[0][2]
+    assert detail is not None
+    assert "DataResponse" in detail
+    assert "import" in detail.lower()
+
+
+def test_detects_missing_import_for_checked_schema(tmp_path: Path) -> None:
+    """Schema name never imported at all — missing-import violation."""
+    f = _write(
+        tmp_path,
+        """
+@router.get("/bad", response_model=DataResponse)
+async def get_bad():
+    return {"success": True}
+""",
+    )
+    violations = hook._check_file(f, tmp_path)
+    assert len(violations) == 1
+    assert violations[0][1] == "get_bad"
+    detail = violations[0][2]
+    assert detail is not None
+    assert "DataResponse" in detail
+    assert "import" in detail.lower()
+
+
+def test_safe_import_via_alias_before_decorator(tmp_path: Path) -> None:
+    """Schema imported with alias — the alias name is what matters for the decorator."""
+    f = _write(
+        tmp_path,
+        """
+from schemas import DataResponse as DataResponse
+
+@router.get("/ok", response_model=DataResponse)
+async def get_ok():
+    return {"success": True}
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_safe_success_message_response_import_before_decorator(tmp_path: Path) -> None:
+    """SuccessMessageResponse imported before decorator — no import-order violation."""
+    f = _write(
+        tmp_path,
+        """
+from schemas import SuccessMessageResponse
+
+@router.post("/msg", response_model=SuccessMessageResponse)
+async def post_msg():
+    return {"success": True, "message": "done"}
+""",
+    )
+    assert hook._check_file(f, tmp_path) == []
+
+
+def test_detects_import_after_decorator_with_line_numbers_in_message(tmp_path: Path) -> None:
+    """Error message includes both the import line and the decorator line."""
+    f = _write(
+        tmp_path,
+        """
+@router.get("/bad", response_model=DataResponse)
+async def get_bad():
+    return {"success": True}
+
+from schemas import DataResponse
+""",
+    )
+    violations = hook._check_file(f, tmp_path)
+    assert len(violations) == 1
+    detail = violations[0][2]
+    assert detail is not None
+    # Both line numbers should appear in the message
+    assert "2" in detail  # decorator line
+    assert "6" in detail  # import line
+
+
+def test_return_shape_violation_has_none_detail(tmp_path: Path) -> None:
+    """Return-shape violations carry None as the detail (not an import-order message)."""
+    f = _write(
+        tmp_path,
+        _DR
+        + """
+@router.get("/bad", response_model=DataResponse)
+async def get_bad():
+    return {"data": "bar"}
+""",
+    )
+    violations = hook._check_file(f, tmp_path)
+    assert len(violations) == 1
+    assert violations[0][1] == "get_bad"
+    # Shape violation: detail is None
+    assert violations[0][2] is None
+
+
+def test_import_order_violation_reported_in_main(tmp_path: Path) -> None:
+    """main() reports import-order violations with exit code 1."""
+    f = _write(
+        tmp_path,
+        """
+@router.get("/bad", response_model=DataResponse)
+async def get_bad():
+    return {"success": True}
+
+from schemas import DataResponse
+""",
+    )
+    assert hook.main(["hook", str(f)]) == 1


### PR DESCRIPTION
## Summary
- Added `_collect_import_line_map(tree)` to map each imported name to its first import line
- Added `_import_order_violation()` to detect when a `response_model=` class is imported *after* the decorator that uses it
- 8 new tests (35 total, all pass)

Prevents startup crashes like those found in #6143 where the schema-split migration appended imports after route decorators.

Closes #6143

🤖 Generated with [Claude Code](https://claude.com/claude-code)