### PR TITLE
fix(ci): catch RuntimeError in ML optional-dep guards — 19 files (#6219)

### DIFF
--- a/autobot-backend/ai_hardware_accelerator.py
+++ b/autobot-backend/ai_hardware_accelerator.py
@@ -44,7 +44,7 @@ try:
     from transformers import CLIPModel, CLIPProcessor, Wav2Vec2Model, Wav2Vec2Processor
 
     MULTIMODAL_MODELS_AVAILABLE = True
-except ImportError:
+except (ImportError, RuntimeError):
     MULTIMODAL_MODELS_AVAILABLE = False
 
 logger = get_llm_logger("ai_hardware_accelerator")

--- a/autobot-backend/llm_interface_pkg/hardware.py
+++ b/autobot-backend/llm_interface_pkg/hardware.py
@@ -19,7 +19,7 @@ try:
     import torch
 
     TORCH_AVAILABLE = True
-except ImportError:
+except (ImportError, RuntimeError):
     logger.warning("PyTorch not available or CUDA libraries missing")
     TORCH_AVAILABLE = False
 

--- a/autobot-backend/llm_interface_pkg/optimization/attention_backend.py
+++ b/autobot-backend/llm_interface_pkg/optimization/attention_backend.py
@@ -42,7 +42,7 @@ def _import_torch() -> Any:
         import torch  # noqa: PLC0415
 
         return torch
-    except ImportError as exc:
+    except (ImportError, RuntimeError) as exc:
         raise ImportError(
             "torch is required for attention backend selection. "
             "Install with: pip install torch>=2.0.0"
@@ -55,7 +55,7 @@ def _import_better_transformer() -> Any:
         from optimum.bettertransformer import BetterTransformer  # noqa: PLC0415
 
         return BetterTransformer
-    except ImportError:
+    except (ImportError, RuntimeError):
         return None
 
 
@@ -252,7 +252,7 @@ class AttentionBackendSelector:
         try:
             torch = _import_torch()
             return hasattr(torch.nn.functional, "scaled_dot_product_attention")
-        except ImportError:
+        except (ImportError, RuntimeError):
             return False
 
     def _try_apply_better_transformer(self, model: Any) -> Optional[Any]:
@@ -304,7 +304,7 @@ def _free_memory() -> None:
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
             logger.debug("CUDA cache cleared after backend fallback")
-    except ImportError:
+    except (ImportError, RuntimeError):
         pass
 
 

--- a/autobot-backend/llm_interface_pkg/optimization/flash_attention.py
+++ b/autobot-backend/llm_interface_pkg/optimization/flash_attention.py
@@ -121,7 +121,7 @@ def _probe_flash_attn() -> bool:
         _flash_attn_modules["pad_input"] = pad_input
         _flash_attn_available = True
         logger.info("Flash Attention v2 loaded successfully")
-    except ImportError:
+    except (ImportError, RuntimeError):
         _flash_attn_available = False
         logger.info("flash_attn not available, will use fallback backends")
 
@@ -136,7 +136,7 @@ def _try_load_fused_rope() -> None:
 
         _flash_attn_modules["fused_rope"] = fused_rope
         logger.info("Fused RoPE kernel loaded from flash_attn")
-    except ImportError:
+    except (ImportError, RuntimeError):
         logger.debug("Fused RoPE kernel not available, using standard implementation")
 
 

--- a/autobot-backend/llm_interface_pkg/optimization/inference_utils.py
+++ b/autobot-backend/llm_interface_pkg/optimization/inference_utils.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 # Conditional torch import — module degrades gracefully without it
 try:
     import torch
-except ImportError:
+except (ImportError, RuntimeError):
     torch = None  # type: ignore[assignment]
 
 

--- a/autobot-backend/llm_interface_pkg/optimization/kv_cache.py
+++ b/autobot-backend/llm_interface_pkg/optimization/kv_cache.py
@@ -42,7 +42,7 @@ def _get_torch():
             import torch as _t
 
             _torch = _t
-        except ImportError:
+        except (ImportError, RuntimeError):
             _torch = None
     return _torch
 

--- a/autobot-backend/llm_interface_pkg/optimization/layer_inference.py
+++ b/autobot-backend/llm_interface_pkg/optimization/layer_inference.py
@@ -44,7 +44,7 @@ def _get_torch() -> Any:
             import torch as _t
 
             _torch = _t
-        except ImportError:
+        except (ImportError, RuntimeError):
             _torch = None
     return _torch
 
@@ -419,7 +419,7 @@ class LayerInferenceEngine:
 
         try:
             from transformers import AutoTokenizer  # noqa: PLC0415
-        except ImportError as exc:
+        except (ImportError, RuntimeError) as exc:
             raise ImportError(
                 "transformers is required for generate. "
                 "Install with: pip install transformers>=4.40.0"

--- a/autobot-backend/llm_interface_pkg/optimization/meta_eviction.py
+++ b/autobot-backend/llm_interface_pkg/optimization/meta_eviction.py
@@ -40,7 +40,7 @@ def _import_torch() -> Any:
         import torch  # noqa: PLC0415
 
         return torch
-    except ImportError as exc:
+    except (ImportError, RuntimeError) as exc:
         raise RuntimeError(
             "PyTorch is required for meta-device eviction. "
             "Install with: pip install torch"
@@ -53,7 +53,7 @@ def _import_accelerate() -> Any:
         import accelerate  # noqa: PLC0415
 
         return accelerate
-    except ImportError as exc:
+    except (ImportError, RuntimeError) as exc:
         raise ImportError(
             "accelerate is required for per-parameter meta-device eviction. "
             "Install with: pip install accelerate"

--- a/autobot-backend/llm_interface_pkg/optimization/profiler.py
+++ b/autobot-backend/llm_interface_pkg/optimization/profiler.py
@@ -102,7 +102,7 @@ class _VRAMTracker:
                 import torch
 
                 self._cuda_available = torch.cuda.is_available()
-            except ImportError:
+            except (ImportError, RuntimeError):
                 self._cuda_available = False
         return self._cuda_available
 

--- a/autobot-backend/llm_providers/vllm_provider.py
+++ b/autobot-backend/llm_providers/vllm_provider.py
@@ -239,7 +239,7 @@ class VLLMProvider:
 
                     if torch.cuda.is_available():
                         torch.cuda.empty_cache()
-                except ImportError:
+                except (ImportError, RuntimeError):
                     pass
                 logger.info("vLLM model %s cleaned up", self.model_name)
             except Exception as e:

--- a/autobot-backend/multimodal_processor/processor.py
+++ b/autobot-backend/multimodal_processor/processor.py
@@ -52,7 +52,7 @@ def _get_torch_nn():
 
             _torch_nn = nn
             _TORCH_NN_AVAILABLE = True
-        except ImportError:
+        except (ImportError, RuntimeError):
             _TORCH_NN_AVAILABLE = False
     return _torch_nn, _TORCH_NN_AVAILABLE
 

--- a/autobot-backend/utils/multimodal_performance_monitor.py
+++ b/autobot-backend/utils/multimodal_performance_monitor.py
@@ -25,7 +25,7 @@ try:
     import torch.cuda
 
     TORCH_AVAILABLE = True
-except ImportError:
+except (ImportError, RuntimeError):
     TORCH_AVAILABLE = False
     torch = None
 

--- a/autobot-backend/worker_node.py
+++ b/autobot-backend/worker_node.py
@@ -25,7 +25,7 @@ try:
     import torch
 
     TORCH_AVAILABLE = True
-except ImportError:
+except (ImportError, RuntimeError):
     logger.warning("PyTorch not available or CUDA libraries missing")
     TORCH_AVAILABLE = False
     torch = None


### PR DESCRIPTION
## Summary
- Changes `except ImportError` → `except (ImportError, RuntimeError)` in 19 torch/CUDA optional-dep guards across 13 files
- `RuntimeError` is raised at torch import time when there is a CUDA version mismatch (e.g., torchvision CUDA 12.8 vs torch CUDA 13.0), not `ImportError`; the old guards propagated the crash to callers

## Files changed
`ai_hardware_accelerator.py`, `worker_node.py`, `llm_interface_pkg/hardware.py`, `llm_interface_pkg/optimization/{attention_backend,flash_attention,inference_utils,kv_cache,layer_inference,meta_eviction,profiler}.py`, `llm_providers/vllm_provider.py`, `multimodal_processor/processor.py`, `utils/multimodal_performance_monitor.py`

## Behavioral grep audit

Before:
```bash
$ grep -c 'except ImportError' autobot-backend/llm_interface_pkg/hardware.py autobot-backend/worker_node.py autobot-backend/ai_hardware_accelerator.py
# 1 + 1 + 1 = 3 unguarded torch ImportError handlers (of 19 total)
```

After:
```bash
$ grep -c 'except (ImportError, RuntimeError)' autobot-backend/llm_interface_pkg/optimization/flash_attention.py
# 2 — both torch guards updated
```

## Test plan
- [ ] Backend starts cleanly when torch is absent or has mismatched CUDA
- [ ] CI smoke test no longer crashes on `RuntimeError: operator torchvision::nms does not exist`

Closes #6219

🤖 Generated with [Claude Code](https://claude.com/claude-code)