### PR TITLE
feat(frontend): migrate multi-value spacing shorthands to design tokens (#4947)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -920,7 +920,7 @@ export default {
   left: 0;
   background: #000;
   color: #fff;
-  padding: 8px 16px;
+  padding: var(--spacing-2) var(--spacing-4);
   text-decoration: none;
   border-radius: 0 0 var(--radius-default) 0;
   font-size: var(--text-sm);

--- a/autobot-frontend/src/components/agents/HeartbeatPanel.vue
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.vue
@@ -426,7 +426,7 @@ function statusClass(status: string): string {
   border: 1px solid var(--border, #334155);
   border-radius: var(--radius-default);
   color: inherit;
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-2);
   width: 200px;
 }
 .error-banner {
@@ -434,7 +434,7 @@ function statusClass(status: string): string {
   border: 1px solid rgba(239, 68, 68, 0.4);
   border-radius: var(--radius-md);
   color: #fca5a5;
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
 }
 .card {
   background: var(--bg-card, #1e293b);
@@ -529,7 +529,7 @@ function statusClass(status: string): string {
   padding: var(--spacing-0);
 }
 .events-container {
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-1);
@@ -558,7 +558,7 @@ function statusClass(status: string): string {
 .empty-state {
   color: var(--text-secondary, #94a3b8);
   font-style: italic;
-  padding: 0.5rem 0;
+  padding: var(--spacing-2) var(--spacing-0);
 }
 .count-badge {
   background: var(--bg-input, #0f172a);

--- a/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
@@ -557,7 +557,7 @@ onMounted(() => {
 }
 
 .tab-btn {
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-2) var(--spacing-4);
   border: none;
   background: none;
   color: var(--text-secondary);
@@ -640,7 +640,7 @@ onMounted(() => {
 
 .badge {
   display: inline-block;
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-2);
   background: var(--bg-tertiary);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
@@ -669,12 +669,12 @@ onMounted(() => {
 }
 
 .recommendation-item ul {
-  margin: 0.5rem 0 0 1.5rem;
+  margin: var(--spacing-2) var(--spacing-0) var(--spacing-0) var(--spacing-6);
   padding: var(--spacing-0);
 }
 
 .recommendation-item li {
-  margin: 0.25rem 0;
+  margin: var(--spacing-1) var(--spacing-0);
 }
 
 .severity-high {
@@ -697,7 +697,7 @@ onMounted(() => {
 
 .export-card p {
   color: var(--text-secondary);
-  margin: 0.5rem 0 1rem;
+  margin: var(--spacing-2) var(--spacing-0) var(--spacing-4);
 }
 
 .export-actions {

--- a/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.vue
+++ b/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.vue
@@ -121,7 +121,7 @@ const emit = defineEmits<{
 }
 
 .header-content h2 {
-  margin: 0 0 16px 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-4) var(--spacing-0);
   color: var(--text-on-primary);
   font-size: 1.5em;
   font-weight: var(--font-semibold);
@@ -135,7 +135,7 @@ const emit = defineEmits<{
 }
 
 .btn-primary, .btn-secondary, .btn-debug {
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   border: none;
   border-radius: var(--radius-lg);
   font-weight: var(--font-semibold);
@@ -176,7 +176,7 @@ const emit = defineEmits<{
 .btn-cancel {
   background: var(--color-error-hover);
   color: var(--text-on-error);
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   border: none;
   border-radius: var(--radius-lg);
   font-weight: var(--font-semibold);

--- a/autobot-frontend/src/components/analytics/AnalyticsProgressSection.vue
+++ b/autobot-frontend/src/components/analytics/AnalyticsProgressSection.vue
@@ -300,7 +300,7 @@ function getPhaseIcon(status: string): string {
   display: flex;
   align-items: center;
   gap: var(--spacing-1-5);
-  padding: 6px 12px;
+  padding: var(--spacing-1-5) var(--spacing-3);
   background: var(--bg-secondary);
   border-radius: var(--radius-default);
   font-size: 0.85em;

--- a/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
+++ b/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
@@ -504,7 +504,7 @@ watch([selectedGranularity, selectedDays], () => {
 }
 
 .control-select {
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);

--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -818,7 +818,7 @@ onMounted(() => {
 
 .subtitle {
   color: var(--text-secondary);
-  margin: 0.25rem 0 0 0;
+  margin: var(--spacing-1) var(--spacing-0) var(--spacing-0) var(--spacing-0);
   font-size: var(--text-sm);
 }
 
@@ -832,7 +832,7 @@ onMounted(() => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-2) var(--spacing-4);
   border: none;
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
@@ -863,7 +863,7 @@ onMounted(() => {
 .action-btn.text {
   background: transparent;
   color: var(--accent-color);
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-2);
 }
 
 .action-btn:disabled {
@@ -910,7 +910,7 @@ onMounted(() => {
 }
 
 .input-group input {
-  padding: 0.625rem 0.875rem;
+  padding: var(--spacing-2-5) var(--spacing-3-5);
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
@@ -934,7 +934,7 @@ onMounted(() => {
 }
 
 .chip {
-  padding: 0.375rem 0.75rem;
+  padding: var(--spacing-1-5) var(--spacing-3);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-2xl);
@@ -1040,7 +1040,7 @@ onMounted(() => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1);
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-2);
   background: transparent;
   border: none;
   border-radius: var(--radius-default);
@@ -1056,7 +1056,7 @@ onMounted(() => {
 
 .filter-tab .count {
   background: rgba(0,0,0,0.2);
-  padding: 0.125rem 0.375rem;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-lg);
   font-size: 0.625rem;
 }
@@ -1115,7 +1115,7 @@ onMounted(() => {
 
 .severity-badge.small {
   font-size: 0.625rem;
-  padding: 0.125rem 0.375rem;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
   background: var(--bg-quaternary);
 }
@@ -1125,7 +1125,7 @@ onMounted(() => {
   font-weight: 600;
   color: var(--accent-color);
   background: var(--bg-quaternary);
-  padding: 0.125rem 0.375rem;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
 }
 
@@ -1249,7 +1249,7 @@ onMounted(() => {
 .donut-chart-container {
   display: flex;
   justify-content: center;
-  padding: 1rem 0;
+  padding: var(--spacing-4) var(--spacing-0);
 }
 
 .donut-chart {
@@ -1281,7 +1281,7 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2);
-  padding: 0 1rem;
+  padding: var(--spacing-0) var(--spacing-4);
 }
 
 .legend-item {
@@ -1322,7 +1322,7 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -1356,7 +1356,7 @@ onMounted(() => {
 }
 
 .stat {
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: 0.6875rem;
   font-weight: 600;
@@ -1383,12 +1383,12 @@ onMounted(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 1rem;
+  padding: var(--spacing-12) var(--spacing-4);
   color: var(--text-secondary);
 }
 
 .empty-state.small {
-  padding: 1.5rem 1rem;
+  padding: var(--spacing-6) var(--spacing-4);
 }
 
 .empty-icon {
@@ -1427,7 +1427,7 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem 1.25rem;
+  padding: var(--spacing-4) var(--spacing-5);
   border-bottom: 1px solid var(--border-color);
 }
 
@@ -1446,7 +1446,7 @@ onMounted(() => {
 }
 
 .pattern-category h4 {
-  margin: 0 0 0.75rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3) var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-primary);
 }
@@ -1461,7 +1461,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 0.625rem 0.875rem;
+  padding: var(--spacing-2-5) var(--spacing-3-5);
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   opacity: 0.6;

--- a/autobot-frontend/src/components/analytics/CodeSmellsSection.vue
+++ b/autobot-frontend/src/components/analytics/CodeSmellsSection.vue
@@ -422,7 +422,7 @@ const getItemSeverityClass = (severity: string): string => {
 }
 
 .export-btn {
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   border: 1px solid var(--border-primary);
   border-radius: var(--radius-md);
   background: var(--bg-tertiary);

--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -996,7 +996,7 @@ onUnmounted(() => {
 .project-meta-item.status-error { color: var(--color-error, #ef4444); }
 
 .btn-primary {
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   border: none;
   border-radius: var(--radius-lg);
   font-weight: var(--font-semibold);
@@ -1095,7 +1095,7 @@ onUnmounted(() => {
   background: var(--chart-indigo);
   color: var(--text-on-primary);
   border: none;
-  padding: 8px 16px;
+  padding: var(--spacing-2) var(--spacing-4);
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all var(--duration-200);
@@ -1149,7 +1149,7 @@ onUnmounted(() => {
 }
 
 .kb-optin-btn {
-  padding: 8px 14px;
+  padding: var(--spacing-2) var(--spacing-3-5);
   background: var(--color-success);
   border: none;
   border-radius: var(--radius-lg);
@@ -1201,7 +1201,7 @@ onUnmounted(() => {
 .project-sub-tabs {
   display: flex;
   gap: var(--spacing-0-5);
-  padding: 0 0 0 0;
+  padding: var(--spacing-0) var(--spacing-0) var(--spacing-0) var(--spacing-0);
   overflow-x: auto;
   border-bottom: 1px solid var(--border-default);
   background-color: var(--bg-secondary);
@@ -1211,7 +1211,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-1-5);
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--text-secondary);

--- a/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.vue
@@ -328,7 +328,7 @@ const emit = defineEmits<{
 <style scoped>
 /* Shared button styles */
 .btn-primary {
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   border: none;
   border-radius: var(--radius-lg);
   font-weight: var(--font-semibold);
@@ -370,7 +370,7 @@ const emit = defineEmits<{
   background: var(--bg-tertiary);
   border: 1px solid var(--bg-hover);
   color: var(--text-secondary);
-  padding: 6px 8px;
+  padding: var(--spacing-1-5) var(--spacing-2);
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all var(--duration-200);
@@ -570,7 +570,7 @@ const emit = defineEmits<{
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-default);
   font-family: 'JetBrains Mono', monospace;
@@ -604,7 +604,7 @@ const emit = defineEmits<{
 }
 
 .external-deps-table h4 {
-  margin: 0 0 16px 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-4) var(--spacing-0);
   color: var(--text-secondary);
   font-size: var(--text-base);
   font-weight: 600;
@@ -627,7 +627,7 @@ const emit = defineEmits<{
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: rgba(51, 65, 85, 0.4);
   border-radius: var(--radius-default);
   transition: background var(--duration-200) var(--ease-out);
@@ -647,7 +647,7 @@ const emit = defineEmits<{
   font-size: 0.8rem;
   color: var(--text-muted);
   background: rgba(59, 130, 246, 0.2);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
 }
 

--- a/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
@@ -280,7 +280,7 @@ const getQualityClass = (score: number): string => {
   background: var(--bg-tertiary);
   border: 1px solid var(--bg-hover);
   color: var(--text-secondary);
-  padding: 6px 8px;
+  padding: var(--spacing-1-5) var(--spacing-2);
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all var(--duration-200);
@@ -302,7 +302,7 @@ const getQualityClass = (score: number): string => {
   background: var(--bg-secondary);
   border: 1px solid var(--bg-tertiary);
   color: var(--text-muted);
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
   cursor: pointer;
@@ -363,7 +363,7 @@ const getQualityClass = (score: number): string => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 0;
+  padding: var(--spacing-2) var(--spacing-0);
   border-bottom: 1px solid var(--bg-tertiary);
 }
 
@@ -501,7 +501,7 @@ const getQualityClass = (score: number): string => {
   background: var(--chart-indigo);
   color: var(--text-on-primary);
   border: none;
-  padding: 8px 16px;
+  padding: var(--spacing-2) var(--spacing-4);
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all var(--duration-200);

--- a/autobot-frontend/src/components/analytics/CodebaseSecurityPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseSecurityPanel.vue
@@ -178,7 +178,7 @@ const getTabCount = (tabId: string): number => {
 }
 
 .code-intelligence-section .action-btn {
-  padding: 6px 12px;
+  padding: var(--spacing-1-5) var(--spacing-3);
   border: 1px solid var(--border-primary);
   border-radius: var(--radius-md);
   background: var(--bg-tertiary);
@@ -224,7 +224,7 @@ const getTabCount = (tabId: string): number => {
 }
 
 .code-intel-tabs .tab-btn {
-  padding: 8px 16px;
+  padding: var(--spacing-2) var(--spacing-4);
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
@@ -248,7 +248,7 @@ const getTabCount = (tabId: string): number => {
 
 .code-intel-tabs .tab-count {
   background: var(--bg-tertiary);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-full);
   font-size: 0.8em;
 }

--- a/autobot-frontend/src/components/analytics/DeclarationsSection.vue
+++ b/autobot-frontend/src/components/analytics/DeclarationsSection.vue
@@ -370,7 +370,7 @@ const getDeclarationTypeClass = (type: string): string => {
 }
 
 .export-btn {
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   border: 1px solid var(--border-primary);
   border-radius: var(--radius-md);
   background: var(--bg-tertiary);

--- a/autobot-frontend/src/components/analytics/DuplicatesSection.vue
+++ b/autobot-frontend/src/components/analytics/DuplicatesSection.vue
@@ -374,7 +374,7 @@ const formatSimilarityGroup = (similarity: string): string => {
 }
 
 .export-btn {
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   border: 1px solid var(--border-primary);
   border-radius: var(--radius-md);
   background: var(--bg-tertiary);

--- a/autobot-frontend/src/components/analytics/HardcodesSection.vue
+++ b/autobot-frontend/src/components/analytics/HardcodesSection.vue
@@ -398,7 +398,7 @@ const formatSeverityGroup = (severity: string): string => {
 }
 
 .export-btn {
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   border: 1px solid var(--border-primary);
   border-radius: var(--radius-md);
   background: var(--bg-tertiary);

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
@@ -513,7 +513,7 @@ onMounted(() => {
 .subtitle {
   color: var(--text-secondary);
   font-size: var(--text-sm);
-  margin: 0.25rem 0 0 0;
+  margin: var(--spacing-1) var(--spacing-0) var(--spacing-0) var(--spacing-0);
 }
 
 /* Stats Grid */
@@ -671,7 +671,7 @@ onMounted(() => {
 }
 
 .analyze-btn {
-  padding: 0.75rem 1.5rem;
+  padding: var(--spacing-3) var(--spacing-6);
   background: var(--color-info);
   border: none;
   border-radius: var(--radius-md);
@@ -709,7 +709,7 @@ onMounted(() => {
 .category-badge,
 .tokens-badge,
 .cost-badge {
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
 }
@@ -811,13 +811,13 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--text-primary);
-  margin: 0 0 0.5rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2) var(--spacing-0);
 }
 
 .recommendation-card p {
   font-size: 0.8125rem;
   color: var(--text-secondary);
-  margin: 0 0 0.5rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2) var(--spacing-0);
 }
 
 .rec-meta {
@@ -832,7 +832,7 @@ onMounted(() => {
   border-radius: var(--radius-default);
   color: var(--text-secondary);
   font-size: var(--text-xs);
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-2);
   cursor: pointer;
 }
 
@@ -918,7 +918,7 @@ onMounted(() => {
 }
 
 .category-item {
-  padding: 0.5rem 0;
+  padding: var(--spacing-2) var(--spacing-0);
 }
 
 .category-header {

--- a/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
@@ -626,7 +626,7 @@ onMounted(() => {
 
 .subtitle {
   color: var(--text-secondary);
-  margin: 0.25rem 0 0 0;
+  margin: var(--spacing-1) var(--spacing-0) var(--spacing-0) var(--spacing-0);
   font-size: var(--text-sm);
 }
 
@@ -640,7 +640,7 @@ onMounted(() => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-2) var(--spacing-4);
   border: none;
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
@@ -705,7 +705,7 @@ onMounted(() => {
 }
 
 .input-group input {
-  padding: 0.625rem 0.875rem;
+  padding: var(--spacing-2-5) var(--spacing-3-5);
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
@@ -729,7 +729,7 @@ onMounted(() => {
 }
 
 .quick-path-btn {
-  padding: 0.375rem 0.75rem;
+  padding: var(--spacing-1-5) var(--spacing-3);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-default);
@@ -866,7 +866,7 @@ onMounted(() => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1);
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-2);
   background: transparent;
   border: none;
   border-radius: var(--radius-default);
@@ -882,7 +882,7 @@ onMounted(() => {
 
 .cat-tab .count {
   background: rgba(0,0,0,0.2);
-  padding: 0.125rem 0.25rem;
+  padding: var(--spacing-0-5) var(--spacing-1);
   border-radius: var(--radius-default);
 }
 
@@ -928,7 +928,7 @@ onMounted(() => {
 
 .impact-badge.small {
   font-size: 0.625rem;
-  padding: 0.125rem 0.375rem;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
   background: var(--bg-quaternary);
 }
@@ -939,7 +939,7 @@ onMounted(() => {
   font-family: monospace;
   color: var(--accent-color);
   background: var(--bg-quaternary);
-  padding: 0.125rem 0.375rem;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
 }
 
@@ -957,7 +957,7 @@ onMounted(() => {
 }
 
 .issue-desc {
-  margin: 0 0 0.5rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2) var(--spacing-0);
   font-size: 0.8125rem;
   color: var(--text-secondary);
 }
@@ -1108,7 +1108,7 @@ onMounted(() => {
 }
 
 .hotspot-stats .stat {
-  padding: 0.125rem 0.375rem;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
   font-size: 0.625rem;
   font-weight: 600;
@@ -1194,7 +1194,7 @@ onMounted(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 1rem;
+  padding: var(--spacing-12) var(--spacing-4);
   color: var(--text-secondary);
 }
 
@@ -1233,7 +1233,7 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem 1.25rem;
+  padding: var(--spacing-4) var(--spacing-5);
   border-bottom: 1px solid var(--border-color);
 }
 
@@ -1247,7 +1247,7 @@ onMounted(() => {
 }
 
 .pattern-category h4 {
-  margin: 0 0 0.75rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3) var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-primary);
 }
@@ -1262,7 +1262,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   opacity: 0.6;

--- a/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
@@ -642,7 +642,7 @@ onMounted(() => {
 
 .subtitle {
   color: var(--text-secondary);
-  margin: 0.25rem 0 0 0;
+  margin: var(--spacing-1) var(--spacing-0) var(--spacing-0) var(--spacing-0);
   font-size: var(--text-sm);
 }
 
@@ -656,7 +656,7 @@ onMounted(() => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-2) var(--spacing-4);
   border: none;
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
@@ -696,7 +696,7 @@ onMounted(() => {
 .action-btn.text {
   background: transparent;
   color: var(--accent-color);
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-2);
 }
 
 .action-btn:disabled {
@@ -722,7 +722,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-4);
-  padding: 1rem 1.25rem;
+  padding: var(--spacing-4) var(--spacing-5);
   border-radius: var(--radius-lg);
   border: 1px solid;
 }
@@ -847,7 +847,7 @@ onMounted(() => {
 }
 
 .filter-btn {
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-2);
   background: transparent;
   border: none;
   border-radius: var(--radius-default);
@@ -903,7 +903,7 @@ onMounted(() => {
   font-weight: 600;
   color: var(--accent-color);
   background: var(--bg-quaternary);
-  padding: 0.125rem 0.375rem;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
 }
 
@@ -920,7 +920,7 @@ onMounted(() => {
 }
 
 .result-message {
-  margin: 0 0 0.5rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2) var(--spacing-0);
   font-size: 0.8125rem;
   color: var(--text-secondary);
 }
@@ -988,14 +988,14 @@ onMounted(() => {
 }
 
 .category-checks {
-  padding: 0.5rem 0 0 1.5rem;
+  padding: var(--spacing-2) var(--spacing-0) var(--spacing-0) var(--spacing-6);
 }
 
 .check-item {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 0.5rem 0;
+  padding: var(--spacing-2) var(--spacing-0);
   opacity: 0.6;
 }
 
@@ -1063,7 +1063,7 @@ onMounted(() => {
 
 .severity-indicator {
   font-size: 0.625rem;
-  padding: 0.125rem 0.375rem;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
   text-transform: uppercase;
 }
@@ -1098,7 +1098,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 0.625rem 0.875rem;
+  padding: var(--spacing-2-5) var(--spacing-3-5);
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -1143,7 +1143,7 @@ onMounted(() => {
 }
 
 .stat {
-  padding: 0.125rem 0.375rem;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
   font-size: 0.625rem;
   font-weight: 600;
@@ -1188,7 +1188,7 @@ onMounted(() => {
 }
 
 .common-issues h4 {
-  margin: 0 0 0.75rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3) var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-primary);
 }
@@ -1241,12 +1241,12 @@ onMounted(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 1rem;
+  padding: var(--spacing-12) var(--spacing-4);
   color: var(--text-secondary);
 }
 
 .empty-state.small {
-  padding: 1.5rem 1rem;
+  padding: var(--spacing-6) var(--spacing-4);
 }
 
 .empty-icon {

--- a/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
@@ -266,7 +266,7 @@ function copyPath(finding: Finding): void {
 
 /* Issue #901: Technical Precision severity badges */
 .severity-badge {
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-xs);
   font-size: var(--text-xs);
   font-weight: 500;
@@ -406,7 +406,7 @@ code {
 /* Issue #901: Electric blue for OWASP tags */
 .owasp-tag {
   display: inline-block;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--color-info-bg);
   color: var(--color-info-dark);
   border-radius: var(--radius-xs);
@@ -425,7 +425,7 @@ code {
 
 /* Issue #901: Technical Precision button styling */
 .btn-small {
-  padding: 6px 12px;
+  padding: var(--spacing-1-5) var(--spacing-3);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xs);

--- a/autobot-frontend/src/components/analytics/code-intelligence/PerformanceFindingsPanel.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/PerformanceFindingsPanel.vue
@@ -53,7 +53,7 @@ defineProps<{
 
 .count-badge {
   background: var(--bg-tertiary);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-full);
   font-size: var(--text-xs);
   color: var(--text-secondary);

--- a/autobot-frontend/src/components/analytics/code-intelligence/RedisFindingsPanel.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/RedisFindingsPanel.vue
@@ -53,7 +53,7 @@ defineProps<{
 
 .count-badge {
   background: var(--bg-tertiary);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-full);
   font-size: var(--text-xs);
   color: var(--text-secondary);

--- a/autobot-frontend/src/components/analytics/code-intelligence/SecurityFindingsPanel.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/SecurityFindingsPanel.vue
@@ -53,7 +53,7 @@ defineProps<{
 
 .count-badge {
   background: var(--bg-tertiary);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-full);
   font-size: var(--text-xs);
   color: var(--text-secondary);

--- a/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
@@ -321,7 +321,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 14px 16px;
+  padding: var(--spacing-3-5) var(--spacing-4);
   cursor: pointer;
   background: var(--bg-secondary);
   transition: background var(--duration-200) var(--ease-out);
@@ -362,7 +362,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 /* Unified Severity Badges */
 .severity-badge {
   font-size: 0.7em;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-xl);
   font-weight: 500;
 }
@@ -406,7 +406,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .list-item {
   background: var(--bg-card);
   border-radius: var(--radius-lg);
-  padding: 14px 16px;
+  padding: var(--spacing-3-5) var(--spacing-4);
   border-left: 4px solid var(--text-tertiary);
   transition: all var(--duration-200) var(--ease-out);
 }
@@ -453,7 +453,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 
 .item-severity {
   font-size: 0.75em;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
   font-weight: 600;
   text-transform: uppercase;
@@ -491,7 +491,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 /* Duplicate-specific Styles */
 .item-similarity {
   font-size: 0.75em;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
   font-weight: 600;
 }
@@ -588,7 +588,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   display: flex;
   align-items: center;
   gap: var(--spacing-2-5);
-  margin: 0 0 20px 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-5) var(--spacing-0);
   color: var(--text-secondary);
   font-size: 1.1rem;
   font-weight: 600;
@@ -621,7 +621,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 
 /* Coverage Bar */
 .coverage-bar-container {
-  margin: 20px 0;
+  margin: var(--spacing-5) var(--spacing-0);
   padding: var(--spacing-4);
   background: rgba(30, 41, 59, 0.8);
   border-radius: var(--radius-lg);
@@ -667,7 +667,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 /* HTTP Method Badges */
 .method-badge {
   display: inline-block;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
   font-weight: 600;
@@ -692,7 +692,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 /* Call Count Badge */
 .call-count-badge {
   display: inline-block;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   margin-left: auto;
   background: rgba(59, 130, 246, 0.2);
   color: var(--color-info-light);
@@ -704,7 +704,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 /* Item Details */
 .item-details {
   margin-top: var(--spacing-1);
-  padding: 6px 10px;
+  padding: var(--spacing-1-5) var(--spacing-2-5);
   background: rgba(0, 0, 0, 0.2);
   border-radius: var(--radius-default);
   color: var(--text-muted);
@@ -772,7 +772,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 /* Scan Timestamp */
 .scan-timestamp {
   margin-top: var(--spacing-4);
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: rgba(30, 41, 59, 0.8);
   border-radius: var(--radius-md);
   color: var(--text-tertiary);

--- a/autobot-frontend/src/components/analytics/panels/CodebaseBugPredictionPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseBugPredictionPanel.vue
@@ -605,7 +605,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 }
 
 .bug-prediction-section .risk-badge {
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   border-radius: var(--radius-default);
   font-weight: 600;
   font-size: 0.85em;
@@ -642,7 +642,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 }
 
 .bug-prediction-section .risk-level-badge {
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: 0.75em;
   text-transform: uppercase;
@@ -686,7 +686,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   display: flex;
   align-items: flex-start;
   gap: var(--spacing-2);
-  padding: 10px 12px;
+  padding: var(--spacing-2-5) var(--spacing-3);
   background: rgba(59, 130, 246, 0.1);
   border-radius: var(--radius-md);
   border: 1px solid rgba(59, 130, 246, 0.2);
@@ -716,7 +716,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Enhanced Bug Prediction Styles */
 .summary-card.clickable { cursor: pointer; transition: transform 0.2s; }
 .summary-card.clickable:hover { transform: translateY(-2px); }
-.top-risk-factors-summary { margin: 20px 0; padding: var(--spacing-4); background: rgba(17, 24, 39, 0.6); border-radius: var(--radius-xl); border: 1px solid rgba(239, 68, 68, 0.2); }
+.top-risk-factors-summary { margin: var(--spacing-5) var(--spacing-0); padding: var(--spacing-4); background: rgba(17, 24, 39, 0.6); border-radius: var(--radius-xl); border: 1px solid rgba(239, 68, 68, 0.2); }
 .top-risk-factors-summary h4 { color: var(--color-error-light); font-size: 1em; margin-bottom: var(--spacing-4); display: flex; align-items: center; gap: var(--spacing-2); }
 .top-risk-factors-summary h4 i { color: var(--color-error); }
 .risk-factors-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: var(--spacing-3); }
@@ -732,8 +732,8 @@ function formatTimestamp(timestamp: string | undefined): string {
 .risk-factor-card .factor-name { color: var(--text-primary); font-weight: 600; font-size: 0.95em; margin-bottom: var(--spacing-1); }
 .risk-factor-card .factor-count { color: var(--color-warning-light); font-size: 0.85em; font-weight: 500; margin-bottom: var(--spacing-1); }
 .risk-factor-card .factor-description { color: var(--text-muted); font-size: 0.8em; line-height: 1.4; }
-.risk-filter-tabs { display: flex; gap: var(--spacing-2); margin: 20px 0 16px; flex-wrap: wrap; }
-.risk-filter-tabs button { padding: 8px 16px; border: 1px solid rgba(71, 85, 105, 0.5); background: rgba(30, 41, 59, 0.5); color: var(--text-muted); border-radius: var(--radius-md); font-size: 0.85em; cursor: pointer; transition: all 0.2s; }
+.risk-filter-tabs { display: flex; gap: var(--spacing-2); margin: var(--spacing-5) var(--spacing-0) var(--spacing-4); flex-wrap: wrap; }
+.risk-filter-tabs button { padding: var(--spacing-2) var(--spacing-4); border: 1px solid rgba(71, 85, 105, 0.5); background: rgba(30, 41, 59, 0.5); color: var(--text-muted); border-radius: var(--radius-md); font-size: 0.85em; cursor: pointer; transition: all 0.2s; }
 .risk-filter-tabs button:hover:not(:disabled) { background: rgba(71, 85, 105, 0.5); color: var(--text-secondary); }
 .risk-filter-tabs button.active { background: rgba(59, 130, 246, 0.2); border-color: rgba(59, 130, 246, 0.5); color: var(--color-info-light); }
 .risk-filter-tabs button:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -746,21 +746,21 @@ function formatTimestamp(timestamp: string | undefined): string {
 .risk-file-item.item-info { border-left-color: var(--chart-blue); }
 .risk-file-item.item-success { border-left-color: var(--chart-green); }
 .risk-file-item.expanded { background: rgba(17, 24, 39, 0.8); }
-.risk-file-item .file-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; cursor: pointer; transition: background 0.2s; }
+.risk-file-item .file-header { display: flex; align-items: center; justify-content: space-between; padding: var(--spacing-3) var(--spacing-4); cursor: pointer; transition: background 0.2s; }
 .risk-file-item .file-header:hover { background: rgba(71, 85, 105, 0.2); }
 .risk-file-item .file-info { display: flex; align-items: center; gap: var(--spacing-2-5); flex: 1; flex-wrap: wrap; }
-.risk-file-item .risk-score-badge { padding: 4px 10px; border-radius: var(--radius-default); font-weight: 700; font-size: 0.85em; min-width: 40px; text-align: center; }
+.risk-file-item .risk-score-badge { padding: var(--spacing-1) var(--spacing-2-5); border-radius: var(--radius-default); font-weight: 700; font-size: 0.85em; min-width: 40px; text-align: center; }
 .risk-file-item .risk-score-badge.item-critical { background: rgba(239, 68, 68, 0.3); color: var(--color-error-light); }
 .risk-file-item .risk-score-badge.item-warning { background: rgba(245, 158, 11, 0.3); color: var(--color-warning-light); }
 .risk-file-item .risk-score-badge.item-info { background: rgba(59, 130, 246, 0.3); color: var(--color-info-light); }
 .risk-file-item .risk-score-badge.item-success { background: rgba(34, 197, 94, 0.3); color: var(--color-success-light); }
 .risk-file-item .file-path { color: var(--text-secondary); font-family: monospace; font-size: 0.85em; flex: 1; word-break: break-all; }
-.risk-file-item .risk-level-tag { padding: 2px 8px; border-radius: var(--radius-default); font-size: 0.7em; text-transform: uppercase; font-weight: 600; }
+.risk-file-item .risk-level-tag { padding: var(--spacing-0-5) var(--spacing-2); border-radius: var(--radius-default); font-size: 0.7em; text-transform: uppercase; font-weight: 600; }
 .risk-file-item .risk-level-tag.high, .risk-file-item .risk-level-tag.critical { background: rgba(239, 68, 68, 0.2); color: var(--color-error-light); }
 .risk-file-item .risk-level-tag.medium { background: rgba(245, 158, 11, 0.2); color: var(--color-warning-light); }
 .risk-file-item .risk-level-tag.low, .risk-file-item .risk-level-tag.minimal { background: rgba(34, 197, 94, 0.2); color: var(--color-success-light); }
-.risk-file-item .expand-icon { color: var(--text-tertiary); padding: 4px 8px; }
-.quick-risk-indicators { display: flex; flex-wrap: wrap; gap: var(--spacing-1-5); padding: 0 16px 12px; }
+.risk-file-item .expand-icon { color: var(--text-tertiary); padding: var(--spacing-1) var(--spacing-2); }
+.quick-risk-indicators { display: flex; flex-wrap: wrap; gap: var(--spacing-1-5); padding: var(--spacing-0) var(--spacing-4) var(--spacing-3); }
 .quick-risk-indicators .indicator { display: flex; align-items: center; gap: var(--spacing-1); padding: 3px 8px; border-radius: var(--radius-default); font-size: 0.75em; font-weight: 500; }
 .quick-risk-indicators .indicator.critical { background: rgba(239, 68, 68, 0.2); color: var(--color-error-light); }
 .quick-risk-indicators .indicator.high { background: rgba(249, 115, 22, 0.2); color: var(--chart-orange-light); }
@@ -788,13 +788,13 @@ function formatTimestamp(timestamp: string | undefined): string {
 .factor-row.high-value .factor-value { color: var(--color-error-light); }
 .factor-row.medium-value .factor-value { color: var(--color-warning-light); }
 .tips-list, .tests-list { list-style: none; padding: var(--spacing-0); margin: var(--spacing-0); }
-.tips-list li, .tests-list li { display: flex; align-items: flex-start; gap: var(--spacing-2-5); padding: 10px 12px; background: rgba(30, 41, 59, 0.5); border-radius: var(--radius-md); margin-bottom: var(--spacing-1-5); font-size: 0.85em; line-height: 1.4; }
+.tips-list li, .tests-list li { display: flex; align-items: flex-start; gap: var(--spacing-2-5); padding: var(--spacing-2-5) var(--spacing-3); background: rgba(30, 41, 59, 0.5); border-radius: var(--radius-md); margin-bottom: var(--spacing-1-5); font-size: 0.85em; line-height: 1.4; }
 .tips-list li i { color: var(--color-warning-light); margin-top: var(--spacing-0-5); }
 .tips-list li { color: var(--text-secondary); border-left: 3px solid var(--color-warning-light); }
 .tests-list li i { color: var(--chart-purple-light); margin-top: var(--spacing-0-5); }
 .tests-list li { color: var(--chart-purple-light); border-left: 3px solid var(--chart-purple-light); }
 .show-more-container { text-align: center; margin-top: var(--spacing-4); }
-.show-more-btn { padding: 10px 24px; background: rgba(59, 130, 246, 0.2); border: 1px solid rgba(59, 130, 246, 0.4); color: var(--color-info-light); border-radius: var(--radius-md); cursor: pointer; font-size: 0.9em; display: inline-flex; align-items: center; gap: var(--spacing-2); transition: all 0.2s; }
+.show-more-btn { padding: var(--spacing-2-5) var(--spacing-6); background: rgba(59, 130, 246, 0.2); border: 1px solid rgba(59, 130, 246, 0.4); color: var(--color-info-light); border-radius: var(--radius-md); cursor: pointer; font-size: 0.9em; display: inline-flex; align-items: center; gap: var(--spacing-2); transition: all 0.2s; }
 .show-more-btn:hover { background: rgba(59, 130, 246, 0.3); }
 
 /* Issue #538: Code Intelligence Scores Section */

--- a/autobot-frontend/src/components/analytics/panels/CodebaseChartsSection.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseChartsSection.vue
@@ -331,7 +331,7 @@ function getCategoryIcon(categoryId: string): string {
   contain: layout style;}
 
 .stats-section h3 {
-  margin: 0 0 20px 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-5) var(--spacing-0);
   color: var(--text-secondary);
   font-size: var(--text-xl);
   font-weight: 600;
@@ -362,7 +362,7 @@ function getCategoryIcon(categoryId: string): string {
   border: 1px solid rgba(71, 85, 105, 0.5);
   border-radius: var(--radius-md);
   color: var(--text-muted);
-  padding: 6px 12px;
+  padding: var(--spacing-1-5) var(--spacing-3);
   font-size: 0.85rem;
   font-weight: 500;
   cursor: pointer;
@@ -449,7 +449,7 @@ function getCategoryIcon(categoryId: string): string {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 8px 16px;
+  padding: var(--spacing-2) var(--spacing-4);
   background: rgba(51, 65, 85, 0.5);
   border: 1px solid rgba(71, 85, 105, 0.5);
   border-radius: var(--radius-md);
@@ -482,7 +482,7 @@ function getCategoryIcon(categoryId: string): string {
   justify-content: center;
   min-width: 20px;
   height: 20px;
-  padding: 0 6px;
+  padding: var(--spacing-0) var(--spacing-1-5);
   background: rgba(0, 0, 0, 0.2);
   border-radius: var(--radius-xl);
   font-size: var(--text-xs);
@@ -687,7 +687,7 @@ function getCategoryIcon(categoryId: string): string {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-default);
   font-family: 'JetBrains Mono', monospace;
@@ -708,7 +708,7 @@ function getCategoryIcon(categoryId: string): string {
 }
 
 .external-deps-table h4 {
-  margin: 0 0 16px 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-4) var(--spacing-0);
   color: var(--text-secondary);
   font-size: var(--text-base);
   font-weight: 600;
@@ -731,7 +731,7 @@ function getCategoryIcon(categoryId: string): string {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: rgba(51, 65, 85, 0.4);
   border-radius: var(--radius-default);
   transition: background var(--duration-200) var(--ease-out);
@@ -751,7 +751,7 @@ function getCategoryIcon(categoryId: string): string {
   font-size: 0.8rem;
   color: var(--text-muted);
   background: rgba(59, 130, 246, 0.2);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
 }
 

--- a/autobot-frontend/src/components/analytics/panels/CodebaseConfigDuplicatesPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseConfigDuplicatesPanel.vue
@@ -217,7 +217,7 @@ function truncateValue(value: string, maxLength = 50): string {
 .config-duplicates-section .config-value-badge {
   background: rgba(245, 158, 11, 0.2);
   color: var(--color-warning-light);
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   border-radius: var(--radius-default);
   font-family: 'Monaco', 'Menlo', monospace;
   font-size: 0.85em;
@@ -236,7 +236,7 @@ function truncateValue(value: string, maxLength = 50): string {
 .config-duplicates-section .location-item {
   color: var(--text-muted);
   font-size: 0.85em;
-  padding: 2px 0;
+  padding: var(--spacing-0-5) var(--spacing-0);
 }
 
 .config-duplicates-section .more-locations {
@@ -248,7 +248,7 @@ function truncateValue(value: string, maxLength = 50): string {
 
 .config-duplicates-section .recommendation-box {
   margin-top: var(--spacing-5);
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   background: rgba(59, 130, 246, 0.1);
   border: 1px solid rgba(59, 130, 246, 0.3);
   border-radius: var(--radius-lg);
@@ -264,7 +264,7 @@ function truncateValue(value: string, maxLength = 50): string {
 
 .config-duplicates-section .recommendation-box code {
   background: rgba(30, 41, 59, 0.8);
-  padding: 2px 6px;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
   font-size: 0.9em;
 }

--- a/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
@@ -425,7 +425,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 14px 16px;
+  padding: var(--spacing-3-5) var(--spacing-4);
   cursor: pointer;
   background: var(--bg-secondary);
   transition: background var(--duration-200) var(--ease-out);
@@ -466,7 +466,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Unified Severity Badges */
 .severity-badge {
   font-size: 0.7em;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-xl);
   font-weight: 500;
 }
@@ -510,7 +510,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .list-item {
   background: var(--bg-card);
   border-radius: var(--radius-lg);
-  padding: 14px 16px;
+  padding: var(--spacing-3-5) var(--spacing-4);
   border-left: 4px solid var(--text-tertiary);
   transition: all var(--duration-200) var(--ease-out);
 }
@@ -557,7 +557,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 
 .item-severity {
   font-size: 0.75em;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
   font-weight: 600;
   text-transform: uppercase;
@@ -595,7 +595,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Duplicate-specific Styles */
 .item-similarity {
   font-size: 0.75em;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
   font-weight: 600;
 }
@@ -692,7 +692,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   display: flex;
   align-items: center;
   gap: var(--spacing-2-5);
-  margin: 0 0 20px 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-5) var(--spacing-0);
   color: var(--text-secondary);
   font-size: 1.1rem;
   font-weight: 600;
@@ -728,7 +728,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   display: flex;
   flex-wrap: wrap;
   gap: var(--spacing-3);
-  margin: 16px 0;
+  margin: var(--spacing-4) var(--spacing-0);
   padding: var(--spacing-3);
   background: rgba(30, 41, 59, 0.8);
   border-radius: var(--radius-lg);
@@ -738,7 +738,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1-5);
-  padding: 6px 12px;
+  padding: var(--spacing-1-5) var(--spacing-3);
   border-radius: var(--radius-md);
   font-size: 0.85rem;
   font-weight: 500;
@@ -765,7 +765,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Cross-language Type Badges */
 .type-badge {
   display: inline-block;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
   font-weight: 500;
@@ -791,7 +791,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Validation Type Badge */
 .validation-type-badge {
   display: inline-block;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
   font-weight: 500;
@@ -804,7 +804,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Similarity Score */
 .similarity-score {
   display: inline-block;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
   font-weight: 600;
@@ -822,7 +822,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Match Type */
 .match-type {
   display: inline-block;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   margin-left: var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
@@ -868,7 +868,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 }
 
 .item-field code {
-  padding: 2px 6px;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   background: rgba(0, 0, 0, 0.3);
   border-radius: var(--radius-default);
   color: var(--text-secondary);
@@ -884,7 +884,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Item Recommendation */
 .item-recommendation {
   margin-top: var(--spacing-1-5);
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: rgba(59, 130, 246, 0.1);
   border-radius: var(--radius-md);
   color: var(--color-info-light);
@@ -901,7 +901,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 
 /* Scan Button */
 .btn-scan {
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   background: var(--chart-purple);
   color: white;
   border: none;

--- a/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
@@ -346,7 +346,7 @@ function formatFactorName(factor: string): string {
 }
 
 .environment-analysis-section .category-badge {
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   background: rgba(71, 85, 105, 0.4);
   border-radius: var(--radius-default);
   font-size: 0.85em;
@@ -394,13 +394,13 @@ function formatFactorName(factor: string): string {
 .environment-analysis-section .env-var-name {
   background: rgba(34, 197, 94, 0.2);
   color: var(--color-success-light);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: 0.9em;
 }
 
 .environment-analysis-section .priority-badge {
-  padding: 2px 6px;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
   font-size: 0.7em;
   text-transform: uppercase;
@@ -503,7 +503,7 @@ function formatFactorName(factor: string): string {
 .environment-analysis-section .hv-value code {
   background: rgba(245, 158, 11, 0.1);
   color: var(--color-warning-light);
-  padding: 2px 6px;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
   font-size: 0.85em;
 }
@@ -518,7 +518,7 @@ function formatFactorName(factor: string): string {
   display: flex;
   align-items: center;
   gap: var(--spacing-1-5);
-  padding: 6px 10px;
+  padding: var(--spacing-1-5) var(--spacing-2-5);
   background: rgba(59, 130, 246, 0.1);
   border-radius: var(--radius-default);
   font-size: 0.85em;

--- a/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
@@ -822,7 +822,7 @@ function formatTimestamp(timestamp: string): string {
 
 .score-card .score-header .card-refresh-btn {
   margin-left: auto;
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
   background: rgba(59, 130, 246, 0.1);
   border: 1px solid rgba(59, 130, 246, 0.3);
   border-radius: var(--radius-default);
@@ -889,7 +889,7 @@ function formatTimestamp(timestamp: string): string {
   display: flex;
   align-items: center;
   gap: var(--spacing-1);
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   border-radius: var(--radius-default);
   font-size: 0.8em;
 }
@@ -964,7 +964,7 @@ function formatTimestamp(timestamp: string): string {
 
 .quality-trend {
   margin-top: var(--spacing-2);
-  padding: 4px 12px;
+  padding: var(--spacing-1) var(--spacing-3);
   border-radius: var(--radius-default);
   font-size: 0.8em;
   font-weight: 500;
@@ -1010,7 +1010,7 @@ function formatTimestamp(timestamp: string): string {
 .suggestions-section h4 i { color: var(--color-warning); }
 
 .suggestions-count {
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: rgba(245, 158, 11, 0.2);
   border-radius: var(--radius-xl);
   font-size: 0.75em;
@@ -1024,7 +1024,7 @@ function formatTimestamp(timestamp: string): string {
 }
 
 .suggestion-item {
-  padding: 14px 16px;
+  padding: var(--spacing-3-5) var(--spacing-4);
   background: rgba(17, 24, 39, 0.5);
   border-radius: var(--radius-lg);
   border-left: 4px solid var(--text-tertiary);
@@ -1042,7 +1042,7 @@ function formatTimestamp(timestamp: string): string {
 }
 
 .suggestion-type-badge {
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: rgba(99, 102, 241, 0.2);
   border-radius: var(--radius-default);
   font-size: 0.75em;
@@ -1051,7 +1051,7 @@ function formatTimestamp(timestamp: string): string {
 }
 
 .suggestion-priority {
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: 0.7em;
   font-weight: 600;
@@ -1130,7 +1130,7 @@ function formatTimestamp(timestamp: string): string {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 10px 14px;
+  padding: var(--spacing-2-5) var(--spacing-3-5);
   background: rgba(17, 24, 39, 0.5);
   border-radius: var(--radius-md);
   transition: background var(--duration-200) var(--ease-out);
@@ -1181,7 +1181,7 @@ function formatTimestamp(timestamp: string): string {
 .view-details-btn {
   width: 100%;
   margin-top: var(--spacing-3);
-  padding: 8px 16px;
+  padding: var(--spacing-2) var(--spacing-4);
   background: rgba(99, 102, 241, 0.2);
   border: 1px solid rgba(99, 102, 241, 0.4);
   border-radius: var(--radius-md);
@@ -1234,7 +1234,7 @@ function formatTimestamp(timestamp: string): string {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   background: rgba(30, 41, 59, 0.8);
   border-bottom: 1px solid rgba(71, 85, 105, 0.5);
 }
@@ -1254,7 +1254,7 @@ function formatTimestamp(timestamp: string): string {
 .redis-findings-panel .findings-header h4 i { color: var(--color-info); }
 
 .findings-count {
-  padding: 4px 12px;
+  padding: var(--spacing-1) var(--spacing-3);
   background: rgba(71, 85, 105, 0.5);
   border-radius: var(--radius-2xl);
   color: var(--text-muted);
@@ -1268,7 +1268,7 @@ function formatTimestamp(timestamp: string): string {
   align-items: center;
   justify-content: center;
   gap: var(--spacing-2-5);
-  padding: 40px 20px;
+  padding: var(--spacing-10) var(--spacing-5);
   color: var(--text-muted);
   font-size: 0.95em;
 }
@@ -1287,7 +1287,7 @@ function formatTimestamp(timestamp: string): string {
 .finding-item {
   background: rgba(15, 23, 42, 0.6);
   border-radius: var(--radius-lg);
-  padding: 14px 16px;
+  padding: var(--spacing-3-5) var(--spacing-4);
   margin-bottom: var(--spacing-2-5);
   border-left: 4px solid var(--text-tertiary);
   transition: all var(--duration-200) var(--ease-out);
@@ -1330,7 +1330,7 @@ function formatTimestamp(timestamp: string): string {
 }
 
 .finding-severity {
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: 0.75em;
   font-weight: 600;
@@ -1370,7 +1370,7 @@ function formatTimestamp(timestamp: string): string {
 }
 
 .finding-category {
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: rgba(71, 85, 105, 0.5);
   border-radius: var(--radius-default);
   font-size: 0.75em;
@@ -1402,7 +1402,7 @@ function formatTimestamp(timestamp: string): string {
 
 .finding-recommendation {
   margin-top: var(--spacing-2-5);
-  padding: 10px 12px;
+  padding: var(--spacing-2-5) var(--spacing-3);
   background: rgba(34, 197, 94, 0.1);
   border-radius: var(--radius-md);
   border-left: 3px solid var(--chart-green);

--- a/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
@@ -498,7 +498,7 @@ function formatFactorName(factor: string): string {
 }
 
 .ownership-tabs .tab-btn {
-  padding: 8px 16px;
+  padding: var(--spacing-2) var(--spacing-4);
   background: rgba(71, 85, 105, 0.3);
   border: 1px solid rgba(71, 85, 105, 0.5);
   border-radius: var(--radius-md);
@@ -525,7 +525,7 @@ function formatFactorName(factor: string): string {
 .ownership-tabs .gap-badge {
   background: rgba(239, 68, 68, 0.3);
   color: var(--color-error-light);
-  padding: 2px 6px;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-xl);
   font-size: 0.75em;
 }
@@ -616,7 +616,7 @@ function formatFactorName(factor: string): string {
   display: grid;
   grid-template-columns: 40px 1fr 120px 80px;
   align-items: center;
-  padding: 10px 14px;
+  padding: var(--spacing-2-5) var(--spacing-3-5);
   background: rgba(17, 24, 39, 0.5);
   border-radius: var(--radius-lg);
   border: 1px solid rgba(71, 85, 105, 0.3);
@@ -665,7 +665,7 @@ function formatFactorName(factor: string): string {
 }
 
 .risk-badge {
-  padding: 6px 12px;
+  padding: var(--spacing-1-5) var(--spacing-3);
   border-radius: var(--radius-md);
   font-size: 0.85em;
   font-weight: 500;
@@ -731,7 +731,7 @@ function formatFactorName(factor: string): string {
 .expert-score {
   background: var(--chart-purple);
   color: var(--text-on-primary);
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   border-radius: var(--radius-xl);
   font-weight: 700;
   font-size: 0.9em;
@@ -843,7 +843,7 @@ function formatFactorName(factor: string): string {
 
 .directory-item,
 .file-item {
-  padding: 12px 14px;
+  padding: var(--spacing-3) var(--spacing-3-5);
   background: rgba(17, 24, 39, 0.5);
   border-radius: var(--radius-lg);
   border-left: 3px solid var(--color-success-light);

--- a/autobot-frontend/src/components/base/BaseBadge.vue
+++ b/autobot-frontend/src/components/base/BaseBadge.vue
@@ -85,28 +85,28 @@ const handleRemove = (event: MouseEvent) => {
 /* Size Variants */
 .badge-xs {
   height: 16px;
-  padding: 0 6px;
+  padding: var(--spacing-0) var(--spacing-1-5);
   font-size: var(--text-xs);
   border-radius: var(--radius-lg);
 }
 
 .badge-sm {
   height: 20px;
-  padding: 0 8px;
+  padding: var(--spacing-0) var(--spacing-2);
   font-size: var(--text-xs);
   border-radius: var(--radius-xl);
 }
 
 .badge-md {
   height: 24px;
-  padding: 0 10px;
+  padding: var(--spacing-0) var(--spacing-2-5);
   font-size: var(--text-xs);
   border-radius: var(--radius-xl);
 }
 
 .badge-lg {
   height: 28px;
-  padding: 0 12px;
+  padding: var(--spacing-0) var(--spacing-3);
   font-size: var(--text-sm);
   border-radius: var(--radius-2xl);
 }

--- a/autobot-frontend/src/components/base/BaseButton.vue
+++ b/autobot-frontend/src/components/base/BaseButton.vue
@@ -166,35 +166,35 @@ const createRipple = (event: TouchEvent) => {
 /* Size variants - Issue #901: Technical Precision sizing */
 .btn-xs {
   height: 28px;
-  padding: 0 8px;
+  padding: var(--spacing-0) var(--spacing-2);
   font-size: var(--text-xs);
   border-radius: var(--radius-xs);
 }
 
 .btn-sm {
   height: 32px;
-  padding: 0 12px;
+  padding: var(--spacing-0) var(--spacing-3);
   font-size: var(--text-sm);
   border-radius: var(--radius-xs);
 }
 
 .btn-md {
   height: 40px;
-  padding: 0 16px;
+  padding: var(--spacing-0) var(--spacing-4);
   font-size: var(--text-sm);
   border-radius: var(--radius-xs);
 }
 
 .btn-lg {
   height: 48px;
-  padding: 0 24px;
+  padding: var(--spacing-0) var(--spacing-6);
   font-size: var(--text-base);
   border-radius: var(--radius-default);
 }
 
 .btn-xl {
   height: 56px;
-  padding: 0 32px;
+  padding: var(--spacing-0) var(--spacing-8);
   font-size: var(--text-lg);
   border-radius: var(--radius-default);
 }
@@ -371,12 +371,12 @@ const createRipple = (event: TouchEvent) => {
 /* Responsive adjustments */
 @media (max-width: 640px) {
   .btn-lg {
-    padding: 0.5rem 1rem;
+    padding: var(--spacing-2) var(--spacing-4);
     font-size: var(--text-base);
   }
 
   .btn-xl {
-    padding: 0.75rem 1.5rem;
+    padding: var(--spacing-3) var(--spacing-6);
     font-size: var(--text-base);
   }
 }

--- a/autobot-frontend/src/components/base/BaseCard.vue
+++ b/autobot-frontend/src/components/base/BaseCard.vue
@@ -156,7 +156,7 @@ const footerClasses = computed(() => ({
 }
 
 .card-subtitle {
-  margin: 4px 0 0 0;
+  margin: var(--spacing-1) var(--spacing-0) var(--spacing-0) var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-secondary);
   line-height: 1.4;
@@ -181,7 +181,7 @@ const footerClasses = computed(() => ({
 
 /* Card Footer */
 .card-footer {
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   border-top: 1px solid var(--border-default);
   background-color: var(--bg-secondary);
   display: flex;
@@ -238,7 +238,7 @@ const footerClasses = computed(() => ({
   }
 
   .card-footer {
-    padding: 10px 12px;
+    padding: var(--spacing-2-5) var(--spacing-3);
     flex-wrap: wrap;
   }
 }

--- a/autobot-frontend/src/components/base/BaseInput.vue
+++ b/autobot-frontend/src/components/base/BaseInput.vue
@@ -238,7 +238,7 @@ defineExpose({
 /* Size Variants */
 .input-size-sm .input-container {
   height: 32px;
-  padding: 0 8px;
+  padding: var(--spacing-0) var(--spacing-2);
 }
 
 .input-size-sm .base-input {
@@ -247,7 +247,7 @@ defineExpose({
 
 .input-size-md .input-container {
   height: 40px;
-  padding: 0 12px;
+  padding: var(--spacing-0) var(--spacing-3);
 }
 
 .input-size-md .base-input {
@@ -256,7 +256,7 @@ defineExpose({
 
 .input-size-lg .input-container {
   height: 48px;
-  padding: 0 16px;
+  padding: var(--spacing-0) var(--spacing-4);
 }
 
 .input-size-lg .base-input {

--- a/autobot-frontend/src/components/base/BaseTable.vue
+++ b/autobot-frontend/src/components/base/BaseTable.vue
@@ -259,7 +259,7 @@ const formatCellValue = (value: any, column: TableColumn) => {
 
 /* Table Controls */
 .table-controls {
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   border-bottom: 1px solid var(--border-default);
   background-color: var(--bg-secondary);
 }
@@ -295,7 +295,7 @@ const formatCellValue = (value: any, column: TableColumn) => {
 }
 
 .table-header-cell {
-  padding: 12px 8px;
+  padding: var(--spacing-3) var(--spacing-2);
   font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
@@ -375,7 +375,7 @@ const formatCellValue = (value: any, column: TableColumn) => {
 }
 
 .table-cell {
-  padding: 12px 8px;
+  padding: var(--spacing-3) var(--spacing-2);
   color: var(--text-primary);
   vertical-align: middle;
 }
@@ -423,7 +423,7 @@ const formatCellValue = (value: any, column: TableColumn) => {
 }
 
 .empty-cell {
-  padding: 48px 16px;
+  padding: var(--spacing-12) var(--spacing-4);
   text-align: center;
 }
 
@@ -442,7 +442,7 @@ const formatCellValue = (value: any, column: TableColumn) => {
 
 /* Table Footer */
 .table-footer {
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   border-top: 1px solid var(--border-default);
   background-color: var(--bg-secondary);
 }
@@ -450,17 +450,17 @@ const formatCellValue = (value: any, column: TableColumn) => {
 /* Size Variants */
 .table-compact .table-header-cell,
 .table-compact .table-cell {
-  padding: 8px 8px;
+  padding: var(--spacing-2) var(--spacing-2);
 }
 
 .table-comfortable .table-header-cell,
 .table-comfortable .table-cell {
-  padding: 12px 8px;
+  padding: var(--spacing-3) var(--spacing-2);
 }
 
 .table-spacious .table-header-cell,
 .table-spacious .table-cell {
-  padding: 16px 12px;
+  padding: var(--spacing-4) var(--spacing-3);
 }
 
 /* Variant Styles */

--- a/autobot-frontend/src/components/browser/BrowserSessionManager.vue
+++ b/autobot-frontend/src/components/browser/BrowserSessionManager.vue
@@ -567,7 +567,7 @@ export default {
 }
 
 .persistent-badge {
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
   background: var(--color-primary-bg);
   color: var(--color-primary);
   border-radius: var(--radius-sm);

--- a/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
+++ b/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
@@ -243,7 +243,7 @@ function submitType() {
 .toolbar {
   display: flex;
   gap: var(--spacing-1);
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
   background: var(--color-surface, #1e1e2e);
   border-top: 1px solid var(--color-border, #333);
 }
@@ -276,14 +276,14 @@ function submitType() {
 .type-overlay {
   display: flex;
   gap: var(--spacing-1);
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
   background: var(--color-surface, #1e1e2e);
   border-top: 1px solid var(--color-border, #333);
 }
 
 .type-input {
   flex: 1;
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
   border: 1px solid var(--color-border, #333);
   border-radius: var(--radius-default);
   background: var(--color-bg, #121212);

--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -1399,7 +1399,7 @@ watch(viewMode, async (newMode) => {
   cursor: pointer;
   text-decoration: underline;
   font-size: var(--text-sm);
-  padding: 0;
+  padding: var(--spacing-0);
 }
 
 .loading-spinner {
@@ -2063,7 +2063,7 @@ watch(viewMode, async (newMode) => {
 }
 
 .orphaned-item-header .async-badge {
-  padding: 2px 6px;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   font-size: var(--text-xs);
   background: var(--color-info-bg);
   color: var(--color-info);
@@ -2071,7 +2071,7 @@ watch(viewMode, async (newMode) => {
 }
 
 .orphaned-item-header .class-badge {
-  padding: 2px 6px;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   font-size: var(--text-xs);
   background: var(--color-secondary-bg, rgba(139, 92, 246, 0.1));
   color: var(--color-secondary, #8b5cf6);

--- a/autobot-frontend/src/components/charts/ImportTreeChart.vue
+++ b/autobot-frontend/src/components/charts/ImportTreeChart.vue
@@ -1132,7 +1132,7 @@ onUnmounted(() => {
   font-family: monospace;
   font-size: 0.8rem;
   background: var(--bg-secondary);
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
   border-radius: var(--radius-sm);
   overflow-x: auto;
 }
@@ -1275,7 +1275,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-1);
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
   font-size: 0.8rem;
   border-radius: var(--radius-sm);
   background: var(--bg-primary);

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -1330,13 +1330,13 @@ function _extractCompleteSentences(text: string): string[] {
   border-bottom: 1px solid var(--color-warning-border);
 }
 .tool-approval-header i { color: var(--color-warning); font-size: 1.25rem; }
-.tool-approval-header h3 { @apply text-sm font-semibold; color: var(--text-primary); margin: 0; }
+.tool-approval-header h3 { @apply text-sm font-semibold; color: var(--text-primary); margin: var(--spacing-0); }
 .tool-approval-body { @apply flex flex-col gap-3 px-5 py-4; }
 .tool-approval-row { @apply flex flex-col gap-1; }
 .tool-approval-label { @apply text-xs font-medium; color: var(--text-tertiary); text-transform: uppercase; letter-spacing: 0.05em; }
 .tool-approval-value { @apply text-sm; color: var(--text-primary); }
 .tool-approval-value code { @apply font-mono text-xs px-2 py-0.5 rounded; background: var(--bg-tertiary); }
-.tool-approval-args { @apply text-xs font-mono p-2 rounded overflow-auto max-h-32; background: var(--bg-tertiary); color: var(--text-primary); margin: 0; }
+.tool-approval-args { @apply text-xs font-mono p-2 rounded overflow-auto max-h-32; background: var(--bg-tertiary); color: var(--text-primary); margin: var(--spacing-0); }
 .risk-low    { color: var(--color-success); font-weight: 600; }
 .risk-medium { color: var(--color-warning); font-weight: 600; }
 .risk-high   { color: var(--color-error); font-weight: 600; }

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -1139,7 +1139,7 @@ onMounted(async () => {
 .message-wrapper {
   @apply rounded-lg shadow-sm border transition-all duration-200 relative;
   max-width: 85%;
-  padding: 6px 10px;
+  padding: var(--spacing-1-5) var(--spacing-2-5);
 }
 
 .message-wrapper:hover {

--- a/autobot-frontend/src/components/chat/MessageItem.vue
+++ b/autobot-frontend/src/components/chat/MessageItem.vue
@@ -349,7 +349,7 @@ const formattedContent = computed(() => {
 .message-wrapper {
   @apply rounded-lg shadow-sm border transition-all duration-200;
   max-width: 85%;
-  padding: 6px 10px;
+  padding: var(--spacing-1-5) var(--spacing-2-5);
   animation: slideInFromBottom 0.25s ease-out;
 }
 

--- a/autobot-frontend/src/components/chat/MultiModelChat.vue
+++ b/autobot-frontend/src/components/chat/MultiModelChat.vue
@@ -307,7 +307,7 @@ defineExpose({ reset })
 }
 
 .multi-model-chat__response-text {
-  margin: 0;
+  margin: var(--spacing-0);
   font-family: ui-monospace, monospace;
   font-size: 0.8125rem;
   color: var(--color-text-primary, #e5e7eb);
@@ -319,7 +319,7 @@ defineExpose({ reset })
 .multi-model-chat__error-msg {
   font-size: 0.8125rem;
   color: var(--color-error, #ef4444);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .multi-model-chat__cursor {

--- a/autobot-frontend/src/components/chat/ReasoningTrace.vue
+++ b/autobot-frontend/src/components/chat/ReasoningTrace.vue
@@ -176,7 +176,7 @@ function formatDuration(ms: number): string {
   border-top: 1px solid var(--color-border, #334155);
   max-height: 18rem;
   overflow-y: auto;
-  padding: 0.25rem 0;
+  padding: var(--spacing-1) var(--spacing-0);
 }
 
 /* Entries */

--- a/autobot-frontend/src/components/chat/TypingIndicator.vue
+++ b/autobot-frontend/src/components/chat/TypingIndicator.vue
@@ -141,7 +141,7 @@ onUnmounted(() => {
   border-color: var(--border-default);
   border-radius: 18px 18px 18px 4px;
   max-width: 85%;
-  padding: 6px 10px;
+  padding: var(--spacing-1-5) var(--spacing-2-5);
 }
 
 .message-header {

--- a/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
+++ b/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
@@ -372,7 +372,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-bottom: 1px solid var(--border-default);
 }
 
@@ -538,7 +538,7 @@ onUnmounted(() => {
 
 .option-group select,
 .option-group input {
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -559,7 +559,7 @@ onUnmounted(() => {
 
 /* Analyze button */
 .btn-analyze {
-  padding: 10px 24px;
+  padding: var(--spacing-2-5) var(--spacing-6);
   background: var(--color-primary);
   color: var(--text-on-primary, #fff);
   border: none;
@@ -588,7 +588,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 10px 14px;
+  padding: var(--spacing-2-5) var(--spacing-3-5);
   background: var(--color-error-bg);
   border: 1px solid var(--color-error-border, var(--color-error));
   border-radius: var(--radius-lg);
@@ -615,7 +615,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   background: var(--color-success-bg);
 }
 
@@ -692,7 +692,7 @@ onUnmounted(() => {
 .object-row {
   display: flex;
   justify-content: space-between;
-  padding: 6px 10px;
+  padding: var(--spacing-1-5) var(--spacing-2-5);
   background: var(--bg-secondary);
   border-radius: var(--radius-default);
   font-size: var(--text-sm);
@@ -705,7 +705,7 @@ onUnmounted(() => {
 }
 
 .btn-toggle-json {
-  padding: 6px 10px;
+  padding: var(--spacing-1-5) var(--spacing-2-5);
   background: none;
   border: none;
   color: var(--text-tertiary);
@@ -736,7 +736,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 20px;
+  padding: var(--spacing-3-5) var(--spacing-5);
   border-top: 1px solid var(--border-default);
 }
 
@@ -746,7 +746,7 @@ onUnmounted(() => {
 }
 
 .btn-primary {
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   background: var(--color-primary);
   color: var(--text-on-primary, #fff);
   border: none;
@@ -769,7 +769,7 @@ onUnmounted(() => {
 }
 
 .btn-secondary {
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);

--- a/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
@@ -398,7 +398,7 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.25rem;
+  padding: var(--spacing-4) var(--spacing-5);
   border-bottom: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.1));
   background: var(--bg-elevated, rgba(15, 23, 42, 0.8));
 }
@@ -417,7 +417,7 @@ onBeforeUnmount(() => {
 
 .voice-overlay__mode-select {
   appearance: none;
-  padding: 0.25rem 1.75rem 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-7) var(--spacing-1) var(--spacing-2);
   border-radius: var(--radius-md);
   border: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.15));
   background: var(--bg-tertiary, #1e293b)
@@ -545,7 +545,7 @@ onBeforeUnmount(() => {
 
 .voice-overlay__bubble-content {
   max-width: 80%;
-  padding: 0.625rem 0.875rem;
+  padding: var(--spacing-2-5) var(--spacing-3-5);
   border-radius: 0.875rem;
   font-size: var(--text-sm);
   line-height: 1.5;
@@ -577,7 +577,7 @@ onBeforeUnmount(() => {
 /* Live transcript */
 .voice-overlay__live-transcript {
   margin-top: var(--spacing-3);
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
   border-radius: var(--radius-lg);
   background: rgba(37, 99, 235, 0.06);
   border: 1px dashed rgba(37, 99, 235, 0.2);
@@ -588,8 +588,8 @@ onBeforeUnmount(() => {
 
 /* Error banner */
 .voice-overlay__error {
-  margin: 0 1.25rem;
-  padding: 0.5rem 0.75rem;
+  margin: var(--spacing-0) var(--spacing-5);
+  padding: var(--spacing-2) var(--spacing-3);
   border-radius: var(--radius-lg);
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.2);
@@ -599,8 +599,8 @@ onBeforeUnmount(() => {
 
 /* Insecure-context cert warning (#1059) */
 .voice-overlay__cert-warning {
-  margin: 0 1.25rem;
-  padding: 0.75rem 1rem;
+  margin: var(--spacing-0) var(--spacing-5);
+  padding: var(--spacing-3) var(--spacing-4);
   border-radius: var(--radius-lg);
   background: rgba(245, 158, 11, 0.08);
   border: 1px solid rgba(245, 158, 11, 0.25);
@@ -648,7 +648,7 @@ onBeforeUnmount(() => {
   flex-direction: column;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 1.5rem 1.25rem 2rem;
+  padding: var(--spacing-6) var(--spacing-5) var(--spacing-8);
   border-top: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.08));
   background: linear-gradient(
     to top,
@@ -771,7 +771,7 @@ onBeforeUnmount(() => {
    ============================================ */
 
 .voice-overlay__hf-controls {
-  padding: 0.75rem 1.25rem 0;
+  padding: var(--spacing-3) var(--spacing-5) var(--spacing-0);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2-5);

--- a/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
@@ -372,7 +372,7 @@ onBeforeUnmount(() => {
 /* Live transcript */
 .voice-panel__transcript {
   width: 100%;
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
   border-radius: var(--radius-md);
   background: rgba(37, 99, 235, 0.06);
   border: 1px dashed rgba(37, 99, 235, 0.2);
@@ -384,8 +384,8 @@ onBeforeUnmount(() => {
 
 /* Error */
 .voice-panel__error {
-  margin: 0 0.75rem;
-  padding: 0.375rem 0.5rem;
+  margin: var(--spacing-0) var(--spacing-3);
+  padding: var(--spacing-1-5) var(--spacing-2);
   border-radius: var(--radius-md);
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.2);
@@ -395,8 +395,8 @@ onBeforeUnmount(() => {
 
 /* Cert warning */
 .voice-panel__cert-warning {
-  margin: 0 0.75rem;
-  padding: 0.5rem 0.625rem;
+  margin: var(--spacing-0) var(--spacing-3);
+  padding: var(--spacing-2) var(--spacing-2-5);
   border-radius: var(--radius-md);
   background: rgba(245, 158, 11, 0.08);
   border: 1px solid rgba(245, 158, 11, 0.25);
@@ -409,7 +409,7 @@ onBeforeUnmount(() => {
 
 /* Hands-free controls */
 .voice-panel__hf-controls {
-  padding: 0.5rem 0.75rem 0;
+  padding: var(--spacing-2) var(--spacing-3) var(--spacing-0);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2);
@@ -468,7 +468,7 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1rem 0.75rem 1.25rem;
+  padding: var(--spacing-4) var(--spacing-3) var(--spacing-5);
   border-top: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.08));
 }
 

--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -470,7 +470,7 @@ onUnmounted(() => {
 }
 
 .desktop-header {
-  padding: 1rem 1.5rem;
+  padding: var(--spacing-4) var(--spacing-6);
   background-color: var(--bg-card);
   border-bottom: 1px solid var(--border-default);
 }
@@ -496,7 +496,7 @@ onUnmounted(() => {
 /* Loading and error styles moved to UnifiedLoadingView */
 
 .desktop-controls {
-  padding: 0.75rem 1.5rem;
+  padding: var(--spacing-3) var(--spacing-6);
   background-color: var(--bg-card);
   border-top: 1px solid var(--border-default);
   display: flex;
@@ -505,7 +505,7 @@ onUnmounted(() => {
 }
 
 .control-btn {
-  padding: 0.375rem 0.75rem;
+  padding: var(--spacing-1-5) var(--spacing-3);
   font-size: var(--text-sm);
   background-color: var(--bg-secondary);
   color: var(--text-secondary);
@@ -526,7 +526,7 @@ onUnmounted(() => {
 
 /* Desktop Actions Toolbar (Issue #74) */
 .desktop-actions {
-  padding: 0.75rem 1.5rem;
+  padding: var(--spacing-3) var(--spacing-6);
   background-color: var(--bg-card);
   border-top: 1px solid var(--border-default);
   display: flex;
@@ -546,7 +546,7 @@ onUnmounted(() => {
 }
 
 .action-btn {
-  padding: 0.375rem 0.75rem;
+  padding: var(--spacing-1-5) var(--spacing-3);
   font-size: var(--text-sm);
   background-color: var(--color-primary-bg);
   color: var(--color-primary);
@@ -587,7 +587,7 @@ onUnmounted(() => {
 }
 
 .screenshot-header {
-  padding: 1rem 1.5rem;
+  padding: var(--spacing-4) var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
   display: flex;
   align-items: center;
@@ -608,7 +608,7 @@ onUnmounted(() => {
 }
 
 .screenshot-footer {
-  padding: 1rem 1.5rem;
+  padding: var(--spacing-4) var(--spacing-6);
   border-top: 1px solid var(--border-default);
   display: flex;
   align-items: center;
@@ -617,7 +617,7 @@ onUnmounted(() => {
 }
 
 .download-btn {
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-2) var(--spacing-4);
   background-color: var(--color-primary);
   color: white;
   border: none;
@@ -631,7 +631,7 @@ onUnmounted(() => {
 }
 
 .cancel-btn {
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-2) var(--spacing-4);
   background-color: var(--bg-secondary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
@@ -677,7 +677,7 @@ onUnmounted(() => {
 }
 
 .type-dialog-header {
-  padding: 1rem 1.5rem;
+  padding: var(--spacing-4) var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
   display: flex;
   align-items: center;
@@ -690,7 +690,7 @@ onUnmounted(() => {
 
 .type-textarea {
   width: 100%;
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   background-color: var(--bg-secondary);
@@ -710,7 +710,7 @@ onUnmounted(() => {
 }
 
 .type-dialog-footer {
-  padding: 1rem 1.5rem;
+  padding: var(--spacing-4) var(--spacing-6);
   border-top: 1px solid var(--border-default);
   display: flex;
   align-items: center;
@@ -719,7 +719,7 @@ onUnmounted(() => {
 }
 
 .type-btn {
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-2) var(--spacing-4);
   background-color: var(--color-primary);
   color: white;
   border: none;

--- a/autobot-frontend/src/components/documents/AIDocumentEditor.vue
+++ b/autobot-frontend/src/components/documents/AIDocumentEditor.vue
@@ -270,7 +270,7 @@ const formattedUpdatedAt = computed(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   border-bottom: 1px solid var(--color-border, #333);
   gap: var(--spacing-3);
 }
@@ -289,7 +289,7 @@ const formattedUpdatedAt = computed(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   outline: none;
-  padding: 2px 4px;
+  padding: var(--spacing-0-5) var(--spacing-1);
   border-radius: var(--radius-default);
   transition: background var(--duration-150);
 }
@@ -310,7 +310,7 @@ const formattedUpdatedAt = computed(() => {
   border-radius: var(--radius-default);
   font-size: 1.1rem;
   font-weight: 600;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   outline: none;
 }
 .title-input:focus-visible {
@@ -327,13 +327,13 @@ const formattedUpdatedAt = computed(() => {
 .error-banner {
   background: var(--color-error-bg, #3c1515);
   color: var(--color-error, #f87171);
-  padding: 8px 16px;
+  padding: var(--spacing-2) var(--spacing-4);
   font-size: 0.85rem;
   border-bottom: 1px solid var(--color-error, #f87171);
 }
 
 .refine-panel {
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   border-bottom: 1px solid var(--color-border, #333);
   background: var(--color-background-secondary, #252525);
   display: flex;
@@ -397,7 +397,7 @@ const formattedUpdatedAt = computed(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-4);
-  padding: 6px 16px;
+  padding: var(--spacing-1-5) var(--spacing-4);
   font-size: var(--text-xs);
   color: var(--color-text-muted, #888);
   border-top: 1px solid var(--color-border, #333);

--- a/autobot-frontend/src/components/feature-flags/AccessMetrics.vue
+++ b/autobot-frontend/src/components/feature-flags/AccessMetrics.vue
@@ -324,7 +324,7 @@ const formatTime = (timestamp: number) => {
 }
 
 .header-info h3 {
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
@@ -350,7 +350,7 @@ const formatTime = (timestamp: number) => {
 }
 
 .days-selector {
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   background: var(--bg-input);
@@ -407,7 +407,7 @@ const formatTime = (timestamp: number) => {
 }
 
 .no-data-state h4 {
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
@@ -529,7 +529,7 @@ const formatTime = (timestamp: number) => {
 }
 
 .breakdown-section h4 {
-  margin: 0 0 16px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-4);
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-secondary);
@@ -667,7 +667,7 @@ code.item-label {
   display: grid;
   grid-template-columns: 120px 100px 1fr 100px;
   gap: var(--spacing-4);
-  padding: 10px 12px;
+  padding: var(--spacing-2-5) var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   font-weight: 600;
@@ -679,7 +679,7 @@ code.item-label {
   display: grid;
   grid-template-columns: 120px 100px 1fr 100px;
   gap: var(--spacing-4);
-  padding: 10px 12px;
+  padding: var(--spacing-2-5) var(--spacing-3);
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -691,7 +691,7 @@ code.item-label {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   background: var(--bg-tertiary);
-  padding: 2px 6px;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
 }
 

--- a/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
+++ b/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
@@ -286,7 +286,7 @@ const closeModal = () => {
 }
 
 .header-info h3 {
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
@@ -307,7 +307,7 @@ const closeModal = () => {
 }
 
 .btn-add {
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
@@ -328,7 +328,7 @@ const closeModal = () => {
 /* Empty State */
 .empty-state {
   text-align: center;
-  padding: 40px 20px;
+  padding: var(--spacing-10) var(--spacing-5);
 }
 
 .empty-icon {
@@ -345,14 +345,14 @@ const closeModal = () => {
 }
 
 .empty-state h4 {
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .empty-state p {
-  margin: 0 0 20px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-5);
   font-size: var(--text-sm);
   color: var(--text-secondary);
 }
@@ -368,7 +368,7 @@ const closeModal = () => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2-5);
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
@@ -406,7 +406,7 @@ const closeModal = () => {
   font-size: var(--text-sm);
   color: var(--text-primary);
   background: var(--bg-tertiary);
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
   border-radius: var(--radius-default);
 }
 
@@ -420,7 +420,7 @@ const closeModal = () => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1-5);
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
   font-weight: 500;
@@ -606,7 +606,7 @@ const closeModal = () => {
 /* Remove Modal */
 .remove-content {
   text-align: center;
-  padding: 20px 0;
+  padding: var(--spacing-5) var(--spacing-0);
 }
 
 .remove-icon {
@@ -623,7 +623,7 @@ const closeModal = () => {
 }
 
 .remove-content h4 {
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
@@ -637,13 +637,13 @@ const closeModal = () => {
 .remove-content code {
   font-family: var(--font-mono);
   background: var(--bg-tertiary);
-  padding: 2px 6px;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
 }
 
 /* Buttons */
 .btn-primary {
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
@@ -668,7 +668,7 @@ const closeModal = () => {
 }
 
 .btn-secondary {
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: none;

--- a/autobot-frontend/src/components/feature-flags/EnforcementModeSelector.vue
+++ b/autobot-frontend/src/components/feature-flags/EnforcementModeSelector.vue
@@ -141,7 +141,7 @@ const selectMode = (mode: EnforcementMode) => {
 }
 
 .selector-header h3 {
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
@@ -237,7 +237,7 @@ const selectMode = (mode: EnforcementMode) => {
 
 .current-badge {
   font-size: var(--text-xs);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--color-primary);
   color: var(--text-on-primary);
   border-radius: var(--radius-default);
@@ -245,7 +245,7 @@ const selectMode = (mode: EnforcementMode) => {
 }
 
 .option-description {
-  margin: 0 0 10px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2-5);
   font-size: var(--text-sm);
   color: var(--text-secondary);
   line-height: 1.4;

--- a/autobot-frontend/src/components/feature-flags/FlagChangeHistory.vue
+++ b/autobot-frontend/src/components/feature-flags/FlagChangeHistory.vue
@@ -169,7 +169,7 @@ const formatRelativeTime = (timestamp: string) => {
 }
 
 .section-header h3 {
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
@@ -213,7 +213,7 @@ const formatRelativeTime = (timestamp: string) => {
 }
 
 .empty-state h4 {
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
@@ -273,7 +273,7 @@ const formatRelativeTime = (timestamp: string) => {
   width: 2px;
   flex: 1;
   background: var(--border-default);
-  margin: 8px 0;
+  margin: var(--spacing-2) var(--spacing-0);
 }
 
 .timeline-content {
@@ -295,7 +295,7 @@ const formatRelativeTime = (timestamp: string) => {
 .mode-badge {
   display: inline-flex;
   align-items: center;
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
   font-weight: 600;
@@ -329,7 +329,7 @@ const formatRelativeTime = (timestamp: string) => {
 }
 
 .action-text {
-  margin: 0 0 10px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2-5);
   font-size: var(--text-sm);
   color: var(--text-primary);
 }

--- a/autobot-frontend/src/components/file-browser/FileBrowser.vue
+++ b/autobot-frontend/src/components/file-browser/FileBrowser.vue
@@ -552,7 +552,7 @@ onMounted(() => {
 }
 
 .modal-header {
-  padding: 16px 24px;
+  padding: var(--spacing-4) var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
   display: flex;
   justify-content: space-between;
@@ -676,7 +676,7 @@ onMounted(() => {
 }
 
 .file-info p {
-  margin: 8px 0;
+  margin: var(--spacing-2) var(--spacing-0);
   font-size: var(--text-base);
   color: var(--text-primary);
 }
@@ -687,7 +687,7 @@ onMounted(() => {
 
 .download-btn {
   margin-top: var(--spacing-5);
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   background-color: var(--color-electric-600, #2563eb);
   color: white;
   border: none;
@@ -709,7 +709,7 @@ onMounted(() => {
   }
 
   .modal-header {
-    padding: 12px 16px;
+    padding: var(--spacing-3) var(--spacing-4);
   }
 
   .modal-header h3 {

--- a/autobot-frontend/src/components/knowledge/DocumentChangeFeed.vue
+++ b/autobot-frontend/src/components/knowledge/DocumentChangeFeed.vue
@@ -357,7 +357,7 @@ onUnmounted(() => {
 }
 
 .badge {
-  padding: 0.25rem 0.75rem;
+  padding: var(--spacing-1) var(--spacing-3);
   border-radius: var(--radius-full);
   font-size: var(--text-sm);
   font-weight: 500;
@@ -411,7 +411,7 @@ onUnmounted(() => {
 }
 
 .section-select {
-  padding: 0.375rem 0.5rem;
+  padding: var(--spacing-1-5) var(--spacing-2);
   font-size: var(--text-sm);
   border: 1px solid var(--border-light);
   border-radius: var(--radius-default);
@@ -466,7 +466,7 @@ onUnmounted(() => {
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   margin-bottom: var(--spacing-4);
 }
 

--- a/autobot-frontend/src/components/knowledge/KBSearchResultPanel.vue
+++ b/autobot-frontend/src/components/knowledge/KBSearchResultPanel.vue
@@ -620,7 +620,7 @@ async function copyContent(): Promise<void> {
   background-color: #fef08a;
   color: #713f12;
   border-radius: var(--radius-xs);
-  padding: 0 1px;
+  padding: var(--spacing-0) var(--spacing-px);
   font-weight: 600;
 }
 </style>

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -1172,7 +1172,7 @@ watch(() => props.mode, () => {
   justify-content: center;
   min-width: 1.5rem;
   height: 1.25rem;
-  padding: 0 0.375rem;
+  padding: var(--spacing-0) var(--spacing-1-5);
   background: rgba(0, 0, 0, 0.1);
   border-radius: var(--radius-xl);
   font-size: var(--text-xs);
@@ -1190,7 +1190,7 @@ watch(() => props.mode, () => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 0.375rem 0.75rem;
+  padding: var(--spacing-1-5) var(--spacing-3);
   background: var(--color-primary-bg);
   border: 1px solid var(--color-primary-light);
   border-radius: var(--radius-2xl);
@@ -1277,7 +1277,7 @@ watch(() => props.mode, () => {
   z-index: 100;
   background: var(--color-primary);
   box-shadow: 0 4px 12px var(--color-primary-alpha-30);
-  padding: 0.75rem 1.5rem;
+  padding: var(--spacing-3) var(--spacing-6);
   border-bottom: 1px solid rgba(255, 255, 255, 0.2);
 }
 
@@ -1347,7 +1347,7 @@ watch(() => props.mode, () => {
 
 .search-input {
   width: 100%;
-  padding: 0.625rem 2.5rem 0.625rem 2.5rem;
+  padding: var(--spacing-2-5) var(--spacing-10) var(--spacing-2-5) var(--spacing-10);
   border: 1px solid var(--border-light);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
@@ -1374,7 +1374,7 @@ watch(() => props.mode, () => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 0.75rem 1.5rem;
+  padding: var(--spacing-3) var(--spacing-6);
   background: var(--bg-card);
   border-bottom: 1px solid var(--border-default);
   font-size: var(--text-sm);
@@ -1446,7 +1446,7 @@ watch(() => props.mode, () => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem 1.5rem;
+  padding: var(--spacing-12) var(--spacing-6);
   text-align: center;
   color: var(--text-tertiary);
 }

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -365,7 +365,7 @@ onUnmounted(() => {
 
 /* Category Selection View */
 .category-selection {
-  padding: 2rem 0;
+  padding: var(--spacing-8) var(--spacing-0);
 }
 
 .selection-header {
@@ -600,7 +600,7 @@ onUnmounted(() => {
 }
 
 .tab-btn {
-  padding: 0.75rem 1.5rem;
+  padding: var(--spacing-3) var(--spacing-6);
   border: none;
   background: none;
   color: var(--text-secondary);
@@ -650,7 +650,7 @@ onUnmounted(() => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 0.625rem 1.25rem;
+  padding: var(--spacing-2-5) var(--spacing-5);
   background: var(--color-info);
   color: var(--text-on-primary);
   text-decoration: none;
@@ -834,7 +834,7 @@ onUnmounted(() => {
 
 .action-button {
   flex: 1;
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   border: none;
   border-radius: var(--radius-md);
   font-weight: 500;
@@ -911,7 +911,7 @@ onUnmounted(() => {
 
 /* KB Message */
 .kb-message {
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
 }
@@ -951,7 +951,7 @@ onUnmounted(() => {
 
 .categories-error-state {
   text-align: center;
-  padding: 3rem 2rem;
+  padding: var(--spacing-12) var(--spacing-8);
   color: var(--color-error-dark);
   background: var(--color-error-bg);
   border: 1px solid var(--color-error-border);
@@ -972,7 +972,7 @@ onUnmounted(() => {
 }
 
 .retry-btn {
-  padding: 0.5rem 1.25rem;
+  padding: var(--spacing-2) var(--spacing-5);
   background: var(--color-error-dark);
   color: #fff;
   border: none;
@@ -1204,7 +1204,7 @@ onUnmounted(() => {
 /* View Documents Button */
 .view-docs-button {
   margin-top: var(--spacing-3);
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-2) var(--spacing-4);
   background: var(--color-success);
   color: var(--text-on-success);
   border: none;
@@ -1256,7 +1256,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem 2rem;
+  padding: var(--spacing-6) var(--spacing-8);
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-secondary);
   border-radius: var(--radius-xl) 0.75rem 0 0;
@@ -1272,7 +1272,7 @@ onUnmounted(() => {
 .modal-content {
   flex: 1;
   overflow-y: auto;
-  padding: 1.5rem 2rem;
+  padding: var(--spacing-6) var(--spacing-8);
 }
 
 .documents-grid {
@@ -1389,7 +1389,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem 2rem;
+  padding: var(--spacing-6) var(--spacing-8);
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-secondary);
   border-radius: var(--radius-xl) 0.75rem 0 0;
@@ -1413,7 +1413,7 @@ onUnmounted(() => {
   color: var(--color-info);
   font-family: var(--font-mono);
   background: var(--color-info-bg);
-  padding: 0.25rem 0.75rem;
+  padding: var(--spacing-1) var(--spacing-3);
   border-radius: var(--radius-md);
 }
 
@@ -1444,7 +1444,7 @@ onUnmounted(() => {
 }
 
 .system-tab-btn {
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-2) var(--spacing-4);
   border: none;
   background: transparent;
   border-radius: var(--radius-md);

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
@@ -1554,7 +1554,7 @@ watch(layoutMode, () => {
   cursor: pointer;
   text-decoration: underline;
   font-size: var(--text-sm);
-  padding: 0;
+  padding: var(--spacing-0);
 }
 
 /* Zoom Controls */
@@ -1995,7 +1995,7 @@ watch(layoutMode, () => {
 .control-separator {
   color: var(--border-default);
   font-size: var(--text-sm);
-  margin: 0 4px;
+  margin: var(--spacing-0) var(--spacing-1);
 }
 
 /* 3D Graph Loading Skeleton */

--- a/autobot-frontend/src/components/knowledge/KnowledgeMainCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeMainCategories.vue
@@ -293,7 +293,7 @@ const showEmptyStateHint = computed(
 }
 
 .kb-status-panel__text:last-child {
-  margin-bottom: 0;
+  margin-bottom: var(--spacing-0);
 }
 
 .kb-status-panel--info {

--- a/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.vue
@@ -303,7 +303,7 @@ onMounted(() => {
   font-size: 1.75rem;
   font-weight: 700;
   color: var(--text-primary);
-  margin: 0 0 0.5rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2) var(--spacing-0);
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
@@ -346,7 +346,7 @@ onMounted(() => {
 }
 
 .health-status-badge {
-  padding: 0.375rem 0.75rem;
+  padding: var(--spacing-1-5) var(--spacing-3);
   border-radius: var(--radius-full);
   font-size: var(--text-xs);
   font-weight: 600;
@@ -472,7 +472,7 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-secondary);
-  margin: 0 0 1rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-4) var(--spacing-0);
 }
 
 .dimension-bars {
@@ -539,7 +539,7 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-secondary);
-  margin: 0 0 0.75rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3) var(--spacing-0);
 }
 
 .issues-counts {
@@ -576,7 +576,7 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--color-info-dark);
-  margin: 0 0 0.75rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3) var(--spacing-0);
 }
 
 .recommendation-list {
@@ -654,7 +654,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-4);
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
   border-left: 3px solid var(--border-light);

--- a/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
@@ -508,7 +508,7 @@ onBeforeUnmount(() => {
 
 .search-input {
   width: 100%;
-  padding: 0.5rem 0.75rem 0.5rem 2.25rem;
+  padding: var(--spacing-2) var(--spacing-3) var(--spacing-2) var(--spacing-9);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
@@ -517,7 +517,7 @@ onBeforeUnmount(() => {
 }
 
 .category-filter {
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
@@ -530,7 +530,7 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   font-size: var(--text-sm);
 }
 
@@ -582,7 +582,7 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 0.5rem 0;
+  padding: var(--spacing-2) var(--spacing-0);
   font-size: var(--text-xs);
   font-weight: 600;
   color: var(--text-secondary);
@@ -593,7 +593,7 @@ onBeforeUnmount(() => {
 .category-header .count {
   margin-left: auto;
   background: var(--bg-card);
-  padding: 0.125rem 0.5rem;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-2xl);
   font-weight: 500;
 }
@@ -605,7 +605,7 @@ onBeforeUnmount(() => {
 }
 
 .prompt-item {
-  padding: 0.625rem 0.75rem;
+  padding: var(--spacing-2-5) var(--spacing-3);
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all var(--duration-150);
@@ -663,7 +663,7 @@ onBeforeUnmount(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.875rem 1.5rem;
+  padding: var(--spacing-3-5) var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-card);
 }
@@ -681,7 +681,7 @@ onBeforeUnmount(() => {
 }
 
 .version-badge {
-  padding: 0.125rem 0.5rem;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--bg-secondary);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
@@ -689,7 +689,7 @@ onBeforeUnmount(() => {
 }
 
 .unsaved-badge {
-  padding: 0.125rem 0.5rem;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--color-warning-bg);
   color: var(--color-warning-dark);
   border-radius: var(--radius-default);
@@ -735,7 +735,7 @@ onBeforeUnmount(() => {
 
 /* Editor Footer */
 .editor-footer {
-  padding: 0.75rem 1.5rem;
+  padding: var(--spacing-3) var(--spacing-6);
   border-top: 1px solid var(--border-default);
   background: var(--bg-secondary);
   display: flex;
@@ -769,7 +769,7 @@ onBeforeUnmount(() => {
 }
 
 .variable-tag {
-  padding: 0.125rem 0.5rem;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--color-info-bg);
   color: var(--color-info);
   border-radius: var(--radius-default);
@@ -803,7 +803,7 @@ onBeforeUnmount(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   cursor: pointer;

--- a/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
@@ -516,7 +516,7 @@ onMounted(() => {
 
 .search-input {
   width: 100%;
-  padding: 0.5rem 0.875rem 0.5rem 2.5rem;
+  padding: var(--spacing-2) var(--spacing-3-5) var(--spacing-2) var(--spacing-10);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
@@ -561,7 +561,7 @@ onMounted(() => {
   align-items: center;
   gap: var(--spacing-2);
   width: 100%;
-  padding: 0.625rem 1rem;
+  padding: var(--spacing-2-5) var(--spacing-4);
   border: none;
   background: none;
   color: var(--text-primary);
@@ -579,7 +579,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   background: var(--color-error-bg);
   color: var(--color-error-dark);
   border-bottom: 1px solid var(--color-error-border);
@@ -606,11 +606,11 @@ onMounted(() => {
 .docs-sidebar {
   border-right: 1px solid var(--border-default);
   overflow-y: auto;
-  padding: 1rem 0;
+  padding: var(--spacing-4) var(--spacing-0);
 }
 
 .category-tree {
-  padding: 0 0.5rem;
+  padding: var(--spacing-0) var(--spacing-2);
 }
 
 .category-item {
@@ -621,7 +621,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: background var(--duration-150);
@@ -669,7 +669,7 @@ onMounted(() => {
   font-size: var(--text-xs);
   color: var(--text-muted);
   background: var(--bg-secondary);
-  padding: 0.125rem 0.5rem;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-2xl);
 }
 
@@ -777,7 +777,7 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem 1.5rem;
+  padding: var(--spacing-4) var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-card);
 }
@@ -800,7 +800,7 @@ onMounted(() => {
 .preview-meta {
   display: flex;
   gap: var(--spacing-6);
-  padding: 0.75rem 1.5rem;
+  padding: var(--spacing-3) var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-card);
 }

--- a/autobot-frontend/src/components/knowledge/KnowledgeUpload.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeUpload.vue
@@ -1030,7 +1030,7 @@ onMounted(() => {
   color: var(--text-on-primary);
   font-size: var(--text-xs);
   font-weight: var(--font-bold);
-  padding: 0.125rem 0.5rem;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-full);
   min-width: 1.25rem;
   text-align: center;

--- a/autobot-frontend/src/components/knowledge/QualityScoreBadge.vue
+++ b/autobot-frontend/src/components/knowledge/QualityScoreBadge.vue
@@ -27,7 +27,7 @@ const qualityClass = computed(() => {
 <style scoped>
 .quality-badge {
   display: inline-block;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-xs);
   font-size: var(--text-xs);
   font-weight: 600;

--- a/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
+++ b/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
@@ -223,7 +223,7 @@ const cleanupSessionOrphans = async () => {
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0 0 0.25rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-1) var(--spacing-0);
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
@@ -292,7 +292,7 @@ const cleanupSessionOrphans = async () => {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--color-warning-darker);
-  margin: 0 0 0.75rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3) var(--spacing-0);
 }
 
 .orphan-list {
@@ -318,7 +318,7 @@ const cleanupSessionOrphans = async () => {
 
 .orphan-category {
   font-size: var(--text-xs);
-  padding: 0.125rem 0.5rem;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--color-primary-bg);
   color: var(--color-primary-dark);
   border-radius: var(--radius-full);
@@ -326,7 +326,7 @@ const cleanupSessionOrphans = async () => {
 
 .orphan-important {
   font-size: var(--text-xs);
-  padding: 0.125rem 0.5rem;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--color-warning-bg);
   color: var(--color-warning-dark);
   border-radius: var(--radius-full);
@@ -335,7 +335,7 @@ const cleanupSessionOrphans = async () => {
 .orphan-content-text {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0 0 0.25rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-1) var(--spacing-0);
   line-height: 1.4;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -351,7 +351,7 @@ const cleanupSessionOrphans = async () => {
   font-size: var(--text-sm);
   color: var(--text-tertiary);
   font-style: italic;
-  margin: 0.75rem 0 0 0;
+  margin: var(--spacing-3) var(--spacing-0) var(--spacing-0) var(--spacing-0);
   text-align: center;
 }
 
@@ -415,12 +415,12 @@ const cleanupSessionOrphans = async () => {
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0 0 0.5rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2) var(--spacing-0);
 }
 
 .action-card p {
   color: var(--text-tertiary);
-  margin: 0 0 1rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-4) var(--spacing-0);
   line-height: 1.5;
 }
 

--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
@@ -452,7 +452,7 @@ const closeDialog = () => {
 
 .search-input {
   width: 100%;
-  padding: 0.5rem 0.75rem 0.5rem 2.5rem;
+  padding: var(--spacing-2) var(--spacing-3) var(--spacing-2) var(--spacing-10);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
@@ -523,7 +523,7 @@ const closeDialog = () => {
 }
 
 .current-access h4 {
-  margin: 0 0 1rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-4) var(--spacing-0);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
@@ -582,7 +582,7 @@ const closeDialog = () => {
 }
 
 .permission-select {
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-2);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-default);
   font-size: var(--text-sm);
@@ -614,7 +614,7 @@ const closeDialog = () => {
 }
 
 .btn {
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-2) var(--spacing-4);
   border-radius: var(--radius-md);
   font-weight: 500;
   cursor: pointer;

--- a/autobot-frontend/src/components/knowledge/VectorizationProgressModal.vue
+++ b/autobot-frontend/src/components/knowledge/VectorizationProgressModal.vue
@@ -477,7 +477,7 @@ const allCompleted = computed(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 0.625rem 1.25rem;
+  padding: var(--spacing-2-5) var(--spacing-5);
   border-radius: var(--radius-lg);
   font-weight: 500;
   cursor: pointer;

--- a/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
@@ -440,7 +440,7 @@ function selectIcon(icon: string): void {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 0.875rem 1rem;
+  padding: var(--spacing-3-5) var(--spacing-4);
   border-radius: var(--radius-lg);
   margin-bottom: var(--spacing-6);
   font-size: var(--text-sm);
@@ -461,7 +461,7 @@ function selectIcon(icon: string): void {
 /* Category Path */
 .category-path {
   background: var(--bg-secondary);
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   border-radius: var(--radius-lg);
   margin-bottom: var(--spacing-6);
 }
@@ -497,7 +497,7 @@ function selectIcon(icon: string): void {
 .form-input,
 .form-textarea {
   width: 100%;
-  padding: 0.625rem 0.875rem;
+  padding: var(--spacing-2-5) var(--spacing-3-5);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);

--- a/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
@@ -291,7 +291,7 @@ watch(() => props.modelValue, (isOpen) => {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   border-radius: var(--radius-md);
   margin-bottom: var(--spacing-4);
   font-size: var(--text-sm);
@@ -345,7 +345,7 @@ watch(() => props.modelValue, (isOpen) => {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 0.875rem 1rem;
+  padding: var(--spacing-3-5) var(--spacing-4);
   border: 2px solid var(--border-default);
   border-radius: var(--radius-lg);
   cursor: pointer;

--- a/autobot-frontend/src/components/knowledge/panels/SourcePreviewPanel.vue
+++ b/autobot-frontend/src/components/knowledge/panels/SourcePreviewPanel.vue
@@ -319,7 +319,7 @@ onUnmounted(() => {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  padding: 1.25rem 1.5rem;
+  padding: var(--spacing-5) var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-secondary);
 }
@@ -417,7 +417,7 @@ onUnmounted(() => {
   display: flex;
   flex-wrap: wrap;
   gap: var(--spacing-4);
-  padding: 0.75rem 1.5rem;
+  padding: var(--spacing-3) var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-secondary);
 }
@@ -464,7 +464,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   gap: var(--spacing-3);
-  padding: 1rem 1.5rem;
+  padding: var(--spacing-4) var(--spacing-6);
   border-top: 1px solid var(--border-default);
   background: var(--bg-card);
 }

--- a/autobot-frontend/src/components/manpage/IntegrationStatusPanel.vue
+++ b/autobot-frontend/src/components/manpage/IntegrationStatusPanel.vue
@@ -210,7 +210,7 @@ defineEmits<Emits>()
 .command-tag {
   background: var(--color-primary);
   color: var(--text-inverse);
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   border-radius: var(--radius-2xl);
   font-size: 0.8rem;
   font-family: 'Courier New', monospace;

--- a/autobot-frontend/src/components/operations/OperationDetail.vue
+++ b/autobot-frontend/src/components/operations/OperationDetail.vue
@@ -323,7 +323,7 @@ async function copyId() {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0 0 0.5rem 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2) var(--spacing-0);
 }
 
 .progress-section,
@@ -448,7 +448,7 @@ async function copyId() {
   display: flex;
   align-items: center;
   gap: var(--spacing-1-5);
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-2) var(--spacing-4);
   font-size: var(--text-sm);
   font-weight: 500;
   border-radius: var(--radius-md);
@@ -506,7 +506,7 @@ async function copyId() {
 }
 
 .copy-id-btn {
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-2);
   font-size: var(--text-xs);
   background: none;
   border: 1px solid var(--border-default);

--- a/autobot-frontend/src/components/operations/OperationFilters.vue
+++ b/autobot-frontend/src/components/operations/OperationFilters.vue
@@ -165,7 +165,7 @@ function clearFilters() {
 }
 
 .filter-select {
-  padding: 0.5rem 2rem 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-8) var(--spacing-2) var(--spacing-3);
   font-size: var(--text-sm);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -197,7 +197,7 @@ function clearFilters() {
   display: flex;
   align-items: center;
   gap: var(--spacing-1-5);
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--text-secondary);

--- a/autobot-frontend/src/components/operations/OperationsList.vue
+++ b/autobot-frontend/src/components/operations/OperationsList.vue
@@ -343,7 +343,7 @@ function canResumeOperation(operation: Operation): boolean {
 }
 
 .list-footer {
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   border-top: 1px solid var(--border-default);
   background-color: var(--bg-secondary);
 }

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -418,14 +418,14 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   display: flex;
   gap: var(--spacing-0);
   border-bottom: 1px solid var(--border-default);
-  padding: 0 24px;
+  padding: var(--spacing-0) var(--spacing-6);
 }
 
 .tab-btn {
   display: flex;
   align-items: center;
   gap: var(--spacing-1-5);
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   border: none;
   background: none;
   color: var(--text-muted);
@@ -494,7 +494,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 }
 
 .role-badge {
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-xl);
   font-size: var(--text-xs);
   font-weight: 600;
@@ -525,7 +525,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 }
 
 .option-btn {
-  padding: 6px 16px;
+  padding: var(--spacing-1-5) var(--spacing-4);
   border-radius: var(--radius-md);
   border: 1px solid var(--border-default);
   background: var(--bg-secondary);
@@ -569,7 +569,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 
 .save-btn {
   margin-top: var(--spacing-4);
-  padding: 8px 20px;
+  padding: var(--spacing-2) var(--spacing-5);
   background: var(--color-primary, #6366f1);
   color: white;
   border: none;
@@ -596,7 +596,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 }
 
 .pw-input {
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   background: var(--bg-secondary);
@@ -620,7 +620,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   position: fixed;
   bottom: 24px;
   right: 24px;
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
   font-weight: 500;

--- a/autobot-frontend/src/components/research/CaptchaNotification.vue
+++ b/autobot-frontend/src/components/research/CaptchaNotification.vue
@@ -142,7 +142,7 @@ const {
 }
 
 .captcha-type {
-  margin: 0.125rem 0 0;
+  margin: var(--spacing-0-5) var(--spacing-0) var(--spacing-0);
   font-size: var(--text-xs);
   opacity: 0.9;
 }

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -1628,7 +1628,7 @@ watch(selectedScope, () => {
 }
 
 .sidebar-search {
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-bottom: 1px solid var(--border-default);
 }
 
@@ -1647,7 +1647,7 @@ watch(selectedScope, () => {
 
 .search-wrapper .search-input {
   width: 100%;
-  padding: 10px 36px 10px 36px;
+  padding: var(--spacing-2-5) var(--spacing-9) var(--spacing-2-5) var(--spacing-9);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
@@ -1679,11 +1679,11 @@ watch(selectedScope, () => {
 .category-nav {
   flex: 1;
   overflow-y: auto;
-  padding: 12px 0;
+  padding: var(--spacing-3) var(--spacing-0);
 }
 
 .category-divider {
-  padding: 12px 20px 8px;
+  padding: var(--spacing-3) var(--spacing-5) var(--spacing-2);
   font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
@@ -1695,7 +1695,7 @@ watch(selectedScope, () => {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   cursor: pointer;
   transition: all var(--duration-150);
   color: var(--text-secondary);
@@ -1724,7 +1724,7 @@ watch(selectedScope, () => {
 .category-item .count {
   font-size: var(--text-xs);
   background: var(--bg-tertiary);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-xl);
   color: var(--text-tertiary);
 }
@@ -1744,7 +1744,7 @@ watch(selectedScope, () => {
 }
 
 .sidebar-actions {
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-top: 1px solid var(--border-default);
 }
 
@@ -1782,7 +1782,7 @@ watch(selectedScope, () => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px 24px;
+  padding: var(--spacing-5) var(--spacing-6);
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-default);
 }
@@ -1831,7 +1831,7 @@ watch(selectedScope, () => {
 .stats-bar {
   display: flex;
   gap: var(--spacing-6);
-  padding: 16px 24px;
+  padding: var(--spacing-4) var(--spacing-6);
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-default);
 }
@@ -1966,7 +1966,7 @@ watch(selectedScope, () => {
 
 .badge {
   font-size: var(--text-xs);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-default);
   font-weight: 500;
   text-transform: capitalize;
@@ -2023,7 +2023,7 @@ watch(selectedScope, () => {
 }
 
 .card-description {
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
   font-size: var(--text-sm);
   color: var(--text-tertiary);
   line-height: 1.4;
@@ -2055,7 +2055,7 @@ watch(selectedScope, () => {
 
 .tag {
   font-size: var(--text-xs);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--bg-tertiary);
   border-radius: var(--radius-default);
   color: var(--text-secondary);
@@ -2083,7 +2083,7 @@ watch(selectedScope, () => {
 
 .usage-tag {
   font-size: var(--text-xs);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--color-primary-bg);
   color: var(--color-primary);
   border-radius: var(--radius-xl);
@@ -2131,7 +2131,7 @@ watch(selectedScope, () => {
 }
 
 .templates-section h3 {
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
@@ -2145,7 +2145,7 @@ watch(selectedScope, () => {
 }
 
 .templates-subtitle {
-  margin: 0 0 20px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-5);
   font-size: var(--text-sm);
   color: var(--text-tertiary);
 }
@@ -2192,7 +2192,7 @@ watch(selectedScope, () => {
 }
 
 .template-info p {
-  margin: 2px 0 0;
+  margin: var(--spacing-0-5) var(--spacing-0) var(--spacing-0);
   font-size: var(--text-xs);
   color: var(--text-tertiary);
 }
@@ -2205,7 +2205,7 @@ watch(selectedScope, () => {
 }
 
 .template-selection h4 {
-  margin: 0 0 16px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-4);
   font-size: 15px;
   font-weight: 600;
   color: var(--text-secondary);
@@ -2325,7 +2325,7 @@ watch(selectedScope, () => {
 }
 
 .form-input {
-  padding: 10px 12px;
+  padding: var(--spacing-2-5) var(--spacing-3);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
@@ -2555,7 +2555,7 @@ watch(selectedScope, () => {
 .transfer-content,
 .delete-content {
   text-align: center;
-  padding: 20px 0;
+  padding: var(--spacing-5) var(--spacing-0);
 }
 
 .transfer-icon,
@@ -2582,7 +2582,7 @@ watch(selectedScope, () => {
 
 .transfer-content h4,
 .delete-content h4 {
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
@@ -2590,7 +2590,7 @@ watch(selectedScope, () => {
 
 .transfer-content p,
 .delete-content p {
-  margin: 0 0 16px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-4);
   color: var(--text-secondary);
 }
 
@@ -2599,7 +2599,7 @@ watch(selectedScope, () => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
 }
@@ -2616,7 +2616,7 @@ watch(selectedScope, () => {
 
 /* Buttons */
 .btn-primary {
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
@@ -2641,7 +2641,7 @@ watch(selectedScope, () => {
 }
 
 .btn-secondary {
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: none;
@@ -2657,7 +2657,7 @@ watch(selectedScope, () => {
 }
 
 .btn-danger {
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   background: var(--color-error);
   color: var(--text-on-error);
   border: none;
@@ -2692,7 +2692,7 @@ watch(selectedScope, () => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);

--- a/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
+++ b/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
@@ -455,7 +455,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
 
 .key-badge {
   font-size: 0.7rem;
-  padding: 2px 6px;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-default);
   text-transform: uppercase;
 }

--- a/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.vue
@@ -316,7 +316,7 @@ onMounted(() => {
 }
 
 .error-state p {
-  margin: 0 0 16px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-4);
   font-size: var(--text-sm);
 }
 
@@ -324,7 +324,7 @@ onMounted(() => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--color-error);
   color: var(--text-on-error);
   border: none;

--- a/autobot-frontend/src/components/settings/VoiceSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/VoiceSettingsPanel.vue
@@ -286,7 +286,7 @@ async function handleDelete(voiceId: string, name: string) {
 
 .voice-badge {
   font-size: var(--text-xs);
-  padding: 2px 6px;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   border-radius: var(--radius-sm, 4px);
   font-weight: 500;
 }

--- a/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
+++ b/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
@@ -442,7 +442,7 @@ function resetEdit(): void {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1);
-  padding: 0.125rem 0.5rem;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--color-warning-bg, rgba(245, 158, 11, 0.15));
   color: var(--color-warning, #f59e0b);
   border-radius: var(--radius-full);
@@ -458,7 +458,7 @@ function resetEdit(): void {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1);
-  padding: 0.125rem 0.5rem;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: transparent;
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm, 0.25rem);

--- a/autobot-frontend/src/components/terminal/CompletionSuggestions.vue
+++ b/autobot-frontend/src/components/terminal/CompletionSuggestions.vue
@@ -72,7 +72,7 @@ const typeIcon = (type: string): string => {
 .completion-item {
   display: flex;
   align-items: center;
-  padding: 4px 12px;
+  padding: var(--spacing-1) var(--spacing-3);
   cursor: pointer;
   gap: var(--spacing-2);
   transition: background-color var(--duration-100);
@@ -111,7 +111,7 @@ const typeIcon = (type: string): string => {
 }
 
 .completion-hint {
-  padding: 2px 12px;
+  padding: var(--spacing-0-5) var(--spacing-3);
   font-size: var(--text-xs);
   color: #555;
   border-top: 1px solid #333;

--- a/autobot-frontend/src/components/terminal/SSHTerminal.vue
+++ b/autobot-frontend/src/components/terminal/SSHTerminal.vue
@@ -309,7 +309,7 @@ defineExpose({
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 6px 12px;
+  padding: var(--spacing-1-5) var(--spacing-3);
   font-size: var(--text-xs);
   border-bottom: 1px solid #333;
 }
@@ -355,7 +355,7 @@ defineExpose({
 }
 
 .reconnect-btn {
-  padding: 4px 12px;
+  padding: var(--spacing-1) var(--spacing-3);
   background: rgba(255, 255, 255, 0.1);
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: var(--radius-default);

--- a/autobot-frontend/src/components/terminal/Terminal.vue
+++ b/autobot-frontend/src/components/terminal/Terminal.vue
@@ -773,7 +773,7 @@ onUnmounted(() => {
   }
 
   .terminal-header {
-    padding: 8px 12px;
+    padding: var(--spacing-2) var(--spacing-3);
   }
 
   .terminal-header h3 {
@@ -781,7 +781,7 @@ onUnmounted(() => {
   }
 
   .terminal-controls button {
-    padding: 4px 8px;
+    padding: var(--spacing-1) var(--spacing-2);
     font-size: var(--text-xs);
   }
 

--- a/autobot-frontend/src/components/terminal/TerminalInput.vue
+++ b/autobot-frontend/src/components/terminal/TerminalInput.vue
@@ -343,7 +343,7 @@ defineExpose({
 /* Responsive */
 @media (max-width: 768px) {
   .terminal-input-line {
-    padding: 0 12px 12px 12px;
+    padding: var(--spacing-0) var(--spacing-3) var(--spacing-3) var(--spacing-3);
   }
 
   .footer-info {

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue
@@ -1501,7 +1501,7 @@ export default {
   justify-content: space-between;
   align-items: center;
   background-color: #2d2d2d;
-  padding: 8px 16px;
+  padding: var(--spacing-2) var(--spacing-4);
   border-bottom: 1px solid #333;
   user-select: none;
 }
@@ -1527,7 +1527,7 @@ export default {
   background-color: #444;
   border: 1px solid #666;
   color: #fff;
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
   border-radius: var(--radius-default);
   cursor: pointer;
   font-size: var(--text-xs);
@@ -1553,7 +1553,7 @@ export default {
   justify-content: space-between;
   align-items: center;
   background-color: #1e1e1e;
-  padding: 4px 16px;
+  padding: var(--spacing-1) var(--spacing-4);
   border-bottom: 1px solid #333;
   font-size: var(--text-xs);
   color: #888;
@@ -1643,7 +1643,7 @@ export default {
 .terminal-input-line {
   display: flex;
   align-items: center;
-  padding: 0 16px 16px 16px;
+  padding: var(--spacing-0) var(--spacing-4) var(--spacing-4) var(--spacing-4);
   background-color: #000;
 }
 
@@ -1684,7 +1684,7 @@ export default {
   justify-content: space-between;
   align-items: center;
   background-color: #2d2d2d;
-  padding: 6px 16px;
+  padding: var(--spacing-1-5) var(--spacing-4);
   border-top: 1px solid #333;
   font-size: var(--text-xs);
 }
@@ -1761,7 +1761,7 @@ export default {
 }
 
 .btn {
-  padding: 8px 16px;
+  padding: var(--spacing-2) var(--spacing-4);
   border: none;
   border-radius: var(--radius-default);
   cursor: pointer;
@@ -1876,7 +1876,7 @@ export default {
 }
 
 .modal-header {
-  padding: 20px 24px 16px 24px;
+  padding: var(--spacing-5) var(--spacing-6) var(--spacing-4) var(--spacing-6);
   border-bottom: 1px solid #444;
   background: var(--bg-secondary);
   border-radius: var(--radius-xl) 12px 0 0;
@@ -1933,7 +1933,7 @@ export default {
 }
 
 .risk-level {
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
   font-weight: 600;
@@ -1983,7 +1983,7 @@ export default {
 }
 
 .confirmation-message ul {
-  margin: 12px 0;
+  margin: var(--spacing-3) var(--spacing-0);
   padding-left: var(--spacing-5);
 }
 
@@ -2003,7 +2003,7 @@ export default {
 
 .process-item {
   background-color: #1e1e1e;
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   border-radius: var(--radius-default);
   margin-bottom: var(--spacing-1);
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
@@ -2015,7 +2015,7 @@ export default {
   display: flex;
   gap: var(--spacing-3);
   justify-content: flex-end;
-  padding: 20px 24px;
+  padding: var(--spacing-5) var(--spacing-6);
   border-top: 1px solid #444;
   background-color: #252525;
   border-radius: 0 0 var(--radius-xl) var(--radius-xl);
@@ -2065,7 +2065,7 @@ export default {
 .step-counter {
   background-color: #17a2b8;
   color: white;
-  padding: 8px 16px;
+  padding: var(--spacing-2) var(--spacing-4);
   border-radius: var(--radius-2xl);
   display: inline-block;
   font-size: var(--text-xs);
@@ -2076,14 +2076,14 @@ export default {
 }
 
 .step-description h4 {
-  margin: 0 0 8px 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2) var(--spacing-0);
   color: #17a2b8;
   font-size: var(--text-base);
   font-weight: 600;
 }
 
 .step-description p {
-  margin: 0 0 16px 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-4) var(--spacing-0);
   color: #ccc;
   font-size: var(--text-sm);
   line-height: 1.5;
@@ -2098,7 +2098,7 @@ export default {
 }
 
 .option-info p {
-  margin: 0 0 12px 0;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3) var(--spacing-0);
   color: #17a2b8;
   font-weight: 600;
 }
@@ -2121,7 +2121,7 @@ export default {
 
 .workflow-actions {
   justify-content: space-between;
-  padding: 20px 24px;
+  padding: var(--spacing-5) var(--spacing-6);
 }
 
 .btn-success {
@@ -2218,7 +2218,7 @@ export default {
 /* Responsive */
 @media (max-width: 768px) {
   .window-header {
-    padding: 6px 12px;
+    padding: var(--spacing-1-5) var(--spacing-3);
   }
 
   .terminal-status-bar {
@@ -2231,7 +2231,7 @@ export default {
   }
 
   .terminal-input-line {
-    padding: 0 12px 12px 12px;
+    padding: var(--spacing-0) var(--spacing-3) var(--spacing-3) var(--spacing-3);
   }
 
   .footer-info {

--- a/autobot-frontend/src/components/ui/BaseAlert.vue
+++ b/autobot-frontend/src/components/ui/BaseAlert.vue
@@ -119,7 +119,7 @@ onMounted(() => {
   display: flex;
   align-items: flex-start;
   gap: var(--spacing-3);
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
   line-height: 1.25rem;

--- a/autobot-frontend/src/components/ui/DataTable.vue
+++ b/autobot-frontend/src/components/ui/DataTable.vue
@@ -265,7 +265,7 @@ const formatCell = (value: any, column: Column) => {
   position: absolute;
   width: 1px;
   height: 1px;
-  padding: 0;
+  padding: var(--spacing-0);
   margin: var(--spacing-neg-px);
   overflow: hidden;
   clip: rect(0, 0, 0, 0);

--- a/autobot-frontend/src/components/ui/HostSelector.vue
+++ b/autobot-frontend/src/components/ui/HostSelector.vue
@@ -282,7 +282,7 @@ defineExpose({
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
@@ -372,7 +372,7 @@ defineExpose({
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   border-bottom: 1px solid var(--border-default);
 }
 
@@ -403,13 +403,13 @@ defineExpose({
 .capability-filter {
   display: flex;
   gap: var(--spacing-1);
-  padding: 8px 16px;
+  padding: var(--spacing-2) var(--spacing-4);
   border-bottom: 1px solid var(--border-default);
 }
 
 .filter-btn {
   flex: 1;
-  padding: 6px 12px;
+  padding: var(--spacing-1-5) var(--spacing-3);
   background: var(--bg-tertiary);
   border: 1px solid transparent;
   border-radius: var(--radius-md);
@@ -439,7 +439,7 @@ defineExpose({
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 10px 12px;
+  padding: var(--spacing-2-5) var(--spacing-3);
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all var(--duration-150);
@@ -501,7 +501,7 @@ defineExpose({
 }
 
 .capability-badge {
-  padding: 2px 6px;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   font-size: var(--text-xs);
   font-weight: 600;
   border-radius: var(--radius-default);
@@ -524,7 +524,7 @@ defineExpose({
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 32px 16px;
+  padding: var(--spacing-8) var(--spacing-4);
   text-align: center;
   color: var(--text-muted);
 }
@@ -544,14 +544,14 @@ defineExpose({
 .selector-actions {
   display: flex;
   gap: var(--spacing-2);
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   border-top: 1px solid var(--border-default);
 }
 
 .btn-secondary,
 .btn-primary {
   flex: 1;
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   border: none;
   border-radius: var(--radius-md);
   font-size: var(--text-sm);

--- a/autobot-frontend/src/components/ui/LoadingSpinner.vue
+++ b/autobot-frontend/src/components/ui/LoadingSpinner.vue
@@ -230,7 +230,7 @@ const customStyle = computed(() => ({
   position: absolute;
   width: 1px;
   height: 1px;
-  padding: 0;
+  padding: var(--spacing-0);
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);

--- a/autobot-frontend/src/components/vision/GUIAutomationControls.vue
+++ b/autobot-frontend/src/components/vision/GUIAutomationControls.vue
@@ -332,7 +332,7 @@ onMounted(() => {
 }
 
 .header-info h3 {
-  margin: 0 0 4px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-1);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
@@ -345,7 +345,7 @@ onMounted(() => {
 }
 
 .btn-refresh {
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
@@ -446,7 +446,7 @@ onMounted(() => {
 }
 
 .confidence-badge {
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   border-radius: var(--radius-xl);
   font-size: var(--text-xs);
   font-weight: 500;
@@ -482,7 +482,7 @@ onMounted(() => {
 .btn-execute,
 .btn-details {
   flex: 1;
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   border-radius: var(--radius-md);
   font-size: var(--text-xs);
   font-weight: 500;
@@ -563,7 +563,7 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   cursor: pointer;
   transition: background var(--duration-200);
 }
@@ -587,7 +587,7 @@ onMounted(() => {
 }
 
 .reference-content {
-  padding: 0 20px 20px;
+  padding: var(--spacing-0) var(--spacing-5) var(--spacing-5);
 }
 
 .types-grid {
@@ -600,7 +600,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 10px 12px;
+  padding: var(--spacing-2-5) var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
 }
@@ -644,7 +644,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2-5);
-  padding: 10px 12px;
+  padding: var(--spacing-2-5) var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
 }
@@ -684,7 +684,7 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-bottom: 1px solid var(--border-default);
 }
 
@@ -735,7 +735,7 @@ onMounted(() => {
 .modal-actions {
   display: flex;
   gap: var(--spacing-3);
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-top: 1px solid var(--border-default);
 }
 
@@ -760,7 +760,7 @@ onMounted(() => {
 }
 
 .btn-secondary {
-  padding: 12px 20px;
+  padding: var(--spacing-3) var(--spacing-5);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);

--- a/autobot-frontend/src/components/vision/MediaGallery.vue
+++ b/autobot-frontend/src/components/vision/MediaGallery.vue
@@ -319,7 +319,7 @@ onUnmounted(() => {
 }
 
 .header-info h3 {
-  margin: 0 0 4px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-1);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
@@ -338,7 +338,7 @@ onUnmounted(() => {
 }
 
 .filter-group select {
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
@@ -347,7 +347,7 @@ onUnmounted(() => {
 }
 
 .btn-clear-all {
-  padding: 8px 16px;
+  padding: var(--spacing-2) var(--spacing-4);
   background: var(--color-error-bg);
   color: var(--color-error);
   border: 1px solid var(--color-error);
@@ -451,7 +451,7 @@ onUnmounted(() => {
 .item-actions {
   display: flex;
   gap: var(--spacing-1);
-  padding: 0 12px 12px;
+  padding: var(--spacing-0) var(--spacing-3) var(--spacing-3);
 }
 
 .btn-action {
@@ -482,7 +482,7 @@ onUnmounted(() => {
   align-items: center;
   justify-content: center;
   gap: var(--spacing-4);
-  padding: 80px 20px;
+  padding: var(--spacing-20) var(--spacing-5);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
@@ -543,7 +543,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-bottom: 1px solid var(--border-default);
 }
 
@@ -628,7 +628,7 @@ onUnmounted(() => {
 }
 
 .analysis-section h5 {
-  margin: 0 0 12px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3);
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
@@ -645,7 +645,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
 }
@@ -662,7 +662,7 @@ onUnmounted(() => {
 }
 
 .btn-toggle {
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: none;
   border: none;
   color: var(--text-tertiary);
@@ -691,13 +691,13 @@ onUnmounted(() => {
 .modal-actions {
   display: flex;
   gap: var(--spacing-3);
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-top: 1px solid var(--border-default);
 }
 
 .btn-primary {
   flex: 1;
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
@@ -716,7 +716,7 @@ onUnmounted(() => {
 }
 
 .btn-secondary {
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
@@ -734,7 +734,7 @@ onUnmounted(() => {
 }
 
 .btn-danger {
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--color-error-bg);
   color: var(--color-error);
   border: 1px solid var(--color-error);
@@ -790,14 +790,14 @@ onUnmounted(() => {
 }
 
 .confirm-modal h4 {
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .confirm-modal p {
-  margin: 0 0 20px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-5);
   font-size: var(--text-sm);
   color: var(--text-secondary);
 }
@@ -809,7 +809,7 @@ onUnmounted(() => {
 
 .btn-cancel {
   flex: 1;
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
@@ -825,7 +825,7 @@ onUnmounted(() => {
 
 .btn-confirm {
   flex: 1;
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--color-error);
   color: white;
   border: none;

--- a/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
+++ b/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
@@ -388,7 +388,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
@@ -404,7 +404,7 @@ onUnmounted(() => {
 }
 
 .btn-capture {
-  padding: 12px 24px;
+  padding: var(--spacing-3) var(--spacing-6);
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
@@ -477,7 +477,7 @@ onUnmounted(() => {
 }
 
 .interval-select {
-  padding: 6px 10px;
+  padding: var(--spacing-1-5) var(--spacing-2-5);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -497,7 +497,7 @@ onUnmounted(() => {
 }
 
 .filter-group select {
-  padding: 6px 10px;
+  padding: var(--spacing-1-5) var(--spacing-2-5);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -536,7 +536,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-bottom: 1px solid var(--border-default);
   flex-wrap: wrap;
   gap: var(--spacing-3);
@@ -566,14 +566,14 @@ onUnmounted(() => {
 .elements-section,
 .text-section,
 .layout-section {
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-bottom: 1px solid var(--border-default);
 }
 
 .elements-section h5,
 .text-section h5,
 .layout-section h5 {
-  margin: 0 0 12px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3);
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-secondary);
@@ -591,7 +591,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 10px 12px;
+  padding: var(--spacing-2-5) var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
   cursor: pointer;
@@ -643,7 +643,7 @@ onUnmounted(() => {
 .element-confidence {
   font-size: var(--text-xs);
   color: var(--text-tertiary);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--bg-secondary);
   border-radius: var(--radius-default);
 }
@@ -670,7 +670,7 @@ onUnmounted(() => {
 }
 
 .text-region {
-  padding: 10px 12px;
+  padding: var(--spacing-2-5) var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
 }
@@ -758,7 +758,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-bottom: 1px solid var(--border-default);
 }
 
@@ -815,7 +815,7 @@ onUnmounted(() => {
 
 .interaction-tag {
   font-size: var(--text-xs);
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   background: var(--color-primary-bg);
   color: var(--color-primary);
   border-radius: var(--radius-xl);

--- a/autobot-frontend/src/components/vision/VideoProcessor.vue
+++ b/autobot-frontend/src/components/vision/VideoProcessor.vue
@@ -658,7 +658,7 @@ onUnmounted(() => {
 
 .option-group select,
 .option-group input {
-  padding: 10px 12px;
+  padding: var(--spacing-2-5) var(--spacing-3);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
@@ -673,7 +673,7 @@ onUnmounted(() => {
 }
 
 .btn-process {
-  padding: 14px 32px;
+  padding: var(--spacing-3-5) var(--spacing-8);
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
@@ -736,7 +736,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   background: var(--color-success-bg);
   border-bottom: 1px solid var(--border-default);
 }
@@ -801,7 +801,7 @@ onUnmounted(() => {
 }
 
 .selected-frame h5 {
-  margin: 0 0 12px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3);
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
@@ -832,7 +832,7 @@ onUnmounted(() => {
 }
 
 .btn-toggle {
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: none;
   border: none;
   color: var(--text-tertiary);
@@ -857,12 +857,12 @@ onUnmounted(() => {
 .results-actions {
   display: flex;
   gap: var(--spacing-3);
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-top: 1px solid var(--border-default);
 }
 
 .btn-secondary {
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
@@ -884,7 +884,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   background: var(--color-error-bg);
   border: 1px solid var(--color-error);
   border-radius: var(--radius-lg);
@@ -898,7 +898,7 @@ onUnmounted(() => {
 }
 
 .btn-dismiss {
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
   background: none;
   border: none;
   color: var(--color-error);

--- a/autobot-frontend/src/components/visualizations/ServiceMessageTimeline.vue
+++ b/autobot-frontend/src/components/visualizations/ServiceMessageTimeline.vue
@@ -160,16 +160,16 @@ onMounted(() => refresh())
 
 <style scoped>
 .smt { display:flex; flex-direction:column; height:100%; background:var(--bg-primary,#1a1a2e); border-radius: var(--radius-lg); overflow:hidden; }
-.smt-header { display:flex; justify-content:space-between; align-items:center; padding:12px 16px; border-bottom:1px solid var(--border-color,#2a2a4a); }
+.smt-header { display:flex; justify-content:space-between; align-items:center; padding:var(--spacing-3) var(--spacing-4); border-bottom:1px solid var(--border-color,#2a2a4a); }
 .smt-header h3 { margin:var(--spacing-0); font-size: var(--text-sm); font-weight:600; color:var(--text-primary,#e0e0ff); }
 .smt-controls { display:flex; gap:var(--spacing-1); align-items:center; }
-.smt-select { background:var(--bg-secondary,#16213e); color:var(--text-secondary,#a0a0c0); border:1px solid var(--border-color,#2a2a4a); border-radius: var(--radius-default); padding:4px 8px; font-size: var(--text-xs); }
-.smt-btn { background:none; border:1px solid var(--border-color,#2a2a4a); color:var(--text-secondary,#a0a0c0); border-radius: var(--radius-default); padding:4px 8px; cursor:pointer; font-size: var(--text-xs); transition:all .2s; }
+.smt-select { background:var(--bg-secondary,#16213e); color:var(--text-secondary,#a0a0c0); border:1px solid var(--border-color,#2a2a4a); border-radius: var(--radius-default); padding:var(--spacing-1) var(--spacing-2); font-size: var(--text-xs); }
+.smt-btn { background:none; border:1px solid var(--border-color,#2a2a4a); color:var(--text-secondary,#a0a0c0); border-radius: var(--radius-default); padding:var(--spacing-1) var(--spacing-2); cursor:pointer; font-size: var(--text-xs); transition:all .2s; }
 .smt-btn:hover { background:var(--bg-hover,#2a2a4a); color:var(--text-primary,#e0e0ff); }
 .smt-btn.active { background:var(--accent-color,#4a90d9); color:#fff; border-color:var(--accent-color,#4a90d9); }
 .smt-empty { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:var(--spacing-10); color:var(--text-secondary,#a0a0c0); gap:var(--spacing-2); }
-.smt-body { flex:1; overflow-y:auto; padding:4px 12px; }
-.smt-entry { display:flex; gap:var(--spacing-2-5); padding:8px 4px; cursor:pointer; border-radius: var(--radius-default); transition:background .15s; align-items:flex-start; }
+.smt-body { flex:1; overflow-y:auto; padding:var(--spacing-1) var(--spacing-3); }
+.smt-entry { display:flex; gap:var(--spacing-2-5); padding:var(--spacing-2) var(--spacing-1); cursor:pointer; border-radius: var(--radius-default); transition:background .15s; align-items:flex-start; }
 .smt-entry:hover { background:rgba(255,255,255,.03); }
 .smt-entry.selected { background:rgba(74,144,217,.1); }
 .smt-dot { width:10px; height:10px; border-radius:50%; margin-top:var(--spacing-1); flex-shrink:0; }
@@ -180,20 +180,20 @@ onMounted(() => refresh())
 .smt-route { display:flex; align-items:center; gap:var(--spacing-1); font-size: var(--text-sm); font-weight:500; color:var(--text-primary,#e0e0ff); }
 .smt-route i { font-size: var(--text-xs); color:var(--text-secondary,#a0a0c0); }
 .smt-meta { font-size: var(--text-xs); color:var(--text-muted,#707090); margin-top:var(--spacing-0-5); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-.smt-badge { font-size: var(--text-xs); padding:1px 6px; border-radius: var(--radius-default); font-weight:500; margin-left:auto; }
+.smt-badge { font-size: var(--text-xs); padding:var(--spacing-px) var(--spacing-1-5); border-radius: var(--radius-default); font-weight:500; margin-left:auto; }
 .smt-badge.t-task { background:rgba(74,144,217,.2); color:#4a90d9; } .smt-badge.t-result { background:rgba(76,175,80,.2); color:#4caf50; }
 .smt-badge.t-error { background:rgba(244,67,54,.2); color:#f44336; } .smt-badge.t-health { background:rgba(139,195,74,.2); color:#8bc34a; }
 .smt-badge.t-deploy { background:rgba(255,152,0,.2); color:#ff9800; } .smt-badge.t-workflow_step { background:rgba(156,39,176,.2); color:#9c27b0; }
 .smt-badge.t-notification { background:rgba(0,188,212,.2); color:#00bcd4; }
-.smt-detail { border-top:1px solid var(--border-color,#2a2a4a); background:var(--bg-secondary,#16213e); max-height:50%; overflow-y:auto; padding:12px 16px; }
+.smt-detail { border-top:1px solid var(--border-color,#2a2a4a); background:var(--bg-secondary,#16213e); max-height:50%; overflow-y:auto; padding:var(--spacing-3) var(--spacing-4); }
 .smt-detail-head { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--spacing-2); color:var(--text-primary,#e0e0ff); font-size: var(--text-sm); }
 .smt-table { width:100%; font-size: var(--text-xs); border-collapse:collapse; }
 .smt-table td { padding:3px 0; }
 .smt-table td:first-child { color:var(--text-muted,#707090); font-weight:500; width:120px; }
 .smt-table td:last-child { color:var(--text-primary,#e0e0ff); }
-.smt-table code { font-family:'JetBrains Mono',monospace; font-size: var(--text-xs); background:var(--bg-primary,#1a1a2e); padding:2px 6px; border-radius: var(--radius-default); }
+.smt-table code { font-family:'JetBrains Mono',monospace; font-size: var(--text-xs); background:var(--bg-primary,#1a1a2e); padding:var(--spacing-0-5) var(--spacing-1-5); border-radius: var(--radius-default); }
 .smt-link { cursor:pointer; } .smt-link:hover { color:var(--accent-color,#4a90d9)!important; }
-.smt-pre { background:var(--bg-primary,#1a1a2e); padding:8px 12px; border-radius: var(--radius-default); font-size: var(--text-xs); font-family:'JetBrains Mono',monospace; color:var(--text-secondary,#a0a0c0); overflow-x:auto; max-height:120px; margin:8px 0 0; }
+.smt-pre { background:var(--bg-primary,#1a1a2e); padding:var(--spacing-2) var(--spacing-3); border-radius: var(--radius-default); font-size: var(--text-xs); font-family:'JetBrains Mono',monospace; color:var(--text-secondary,#a0a0c0); overflow-x:auto; max-height:120px; margin:var(--spacing-2) var(--spacing-0) var(--spacing-0); }
 .smt-chain { margin-top:var(--spacing-3); border-top:1px solid var(--border-color,#2a2a4a); padding-top:var(--spacing-2); }
 .smt-chain strong { font-size: var(--text-sm); color:var(--text-primary,#e0e0ff); }
 .smt-chain-row { display:flex; align-items:center; gap:var(--spacing-2); padding:3px 8px; font-size: var(--text-xs); border-radius: var(--radius-default); color:var(--text-primary,#e0e0ff); }

--- a/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
@@ -624,7 +624,7 @@ defineExpose({
   display: flex;
   align-items: center;
   gap: var(--spacing-1-5);
-  padding: 6px 12px;
+  padding: var(--spacing-1-5) var(--spacing-3);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
   font-weight: 500;
@@ -652,7 +652,7 @@ defineExpose({
 
 .layout-btn,
 .fit-btn {
-  padding: 8px 10px;
+  padding: var(--spacing-2) var(--spacing-2-5);
   background: transparent;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
@@ -953,7 +953,7 @@ defineExpose({
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  padding: 8px 0;
+  padding: var(--spacing-2) var(--spacing-0);
   border-bottom: 1px solid rgba(71, 85, 105, 0.3);
 }
 

--- a/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
+++ b/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
@@ -230,7 +230,7 @@ function formatDuration(seconds: number): string {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 40px 24px;
+  padding: var(--spacing-10) var(--spacing-6);
   color: var(--text-tertiary);
   text-align: center;
 }
@@ -242,7 +242,7 @@ function formatDuration(seconds: number): string {
 }
 
 .empty-state h4 {
-  margin: 0 0 4px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-1);
   color: var(--text-primary);
   font-size: var(--text-sm);
 }
@@ -370,7 +370,7 @@ function formatDuration(seconds: number): string {
   flex-direction: column;
   align-items: center;
   flex: 1;
-  padding: 8px 0;
+  padding: var(--spacing-2) var(--spacing-0);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
 }
@@ -394,7 +394,7 @@ function formatDuration(seconds: number): string {
 
 /* Reliability Bar */
 .reliability-bar-container {
-  padding: 0 2px;
+  padding: var(--spacing-0) var(--spacing-0-5);
 }
 
 .reliability-bar {
@@ -422,7 +422,7 @@ function formatDuration(seconds: number): string {
 }
 
 .capability-tag {
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--bg-tertiary);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
@@ -430,7 +430,7 @@ function formatDuration(seconds: number): string {
 }
 
 .capability-overflow {
-  padding: 2px 6px;
+  padding: var(--spacing-0-5) var(--spacing-1-5);
   font-size: var(--text-xs);
   color: var(--text-muted);
 }

--- a/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
+++ b/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
@@ -286,7 +286,7 @@ async function handleSave(): Promise<void> {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-bottom: 1px solid var(--border-default);
 }
 
@@ -302,7 +302,7 @@ async function handleSave(): Promise<void> {
 .notif-header h3 i { color: var(--color-primary); }
 
 .btn-close {
-  padding: 6px 8px;
+  padding: var(--spacing-1-5) var(--spacing-2);
   background: transparent;
   border: none;
   color: var(--text-tertiary);
@@ -331,7 +331,7 @@ async function handleSave(): Promise<void> {
 }
 
 .notif-error {
-  padding: 10px 14px;
+  padding: var(--spacing-2-5) var(--spacing-3-5);
   background: var(--color-error-bg);
   color: var(--color-error);
   border-radius: var(--radius-md);
@@ -352,12 +352,12 @@ async function handleSave(): Promise<void> {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
-  padding: 0 6px;
+  padding: var(--spacing-0) var(--spacing-1-5);
 }
 
 .notif-input {
   width: 100%;
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -384,7 +384,7 @@ async function handleSave(): Promise<void> {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1-5);
-  padding: 4px 10px;
+  padding: var(--spacing-1) var(--spacing-2-5);
   background: var(--color-primary-bg);
   color: var(--color-primary);
   border-radius: var(--radius-2xl);
@@ -405,7 +405,7 @@ async function handleSave(): Promise<void> {
 
 .tag-input {
   width: 100%;
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -417,13 +417,13 @@ async function handleSave(): Promise<void> {
 .tag-input:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 
 .field-error {
-  margin: 6px 0 0;
+  margin: var(--spacing-1-5) var(--spacing-0) var(--spacing-0);
   font-size: var(--text-xs);
   color: var(--color-error);
 }
 
 .field-hint {
-  margin: 0 0 10px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2-5);
   font-size: var(--text-xs);
   color: var(--text-tertiary);
 }
@@ -447,13 +447,13 @@ async function handleSave(): Promise<void> {
 .event-label {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  padding: 6px 4px;
+  padding: var(--spacing-1-5) var(--spacing-1);
 }
 
 .channel-cell {
   display: flex;
   justify-content: center;
-  padding: 6px 4px;
+  padding: var(--spacing-1-5) var(--spacing-1);
 }
 
 .channel-cell input[type="checkbox"] {
@@ -467,12 +467,12 @@ async function handleSave(): Promise<void> {
   display: flex;
   justify-content: flex-end;
   gap: var(--spacing-2-5);
-  padding: 14px 20px;
+  padding: var(--spacing-3-5) var(--spacing-5);
   border-top: 1px solid var(--border-default);
 }
 
 .btn-primary {
-  padding: 8px 20px;
+  padding: var(--spacing-2) var(--spacing-5);
   background: var(--color-primary);
   color: white;
   border: none;
@@ -488,7 +488,7 @@ async function handleSave(): Promise<void> {
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .btn-secondary {
-  padding: 8px 20px;
+  padding: var(--spacing-2) var(--spacing-5);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);

--- a/autobot-frontend/src/components/workflow/OrchestrationVisualizer.vue
+++ b/autobot-frontend/src/components/workflow/OrchestrationVisualizer.vue
@@ -174,7 +174,7 @@ function getStrategyIcon(strategy: string): string {
 .orchestration-visualizer { display: flex; flex-direction: column; gap: var(--spacing-6); height: 100%; overflow-y: auto; }
 
 .status-panel h3, .capabilities-panel h4, .strategies-panel h4, .visualization-panel h4 {
-  margin: 0 0 16px; font-size: 15px; color: var(--text-primary); display: flex; align-items: center; gap: var(--spacing-2-5);
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-4); font-size: 15px; color: var(--text-primary); display: flex; align-items: center; gap: var(--spacing-2-5);
 }
 .status-panel h3 i, .capabilities-panel h4 i, .strategies-panel h4 i, .visualization-panel h4 i { color: var(--color-primary); }
 
@@ -188,7 +188,7 @@ function getStrategyIcon(strategy: string): string {
 
 .capabilities-panel { background: var(--bg-secondary); border-radius: var(--radius-xl); padding: var(--spacing-5); }
 .capabilities-list { display: flex; flex-wrap: wrap; gap: var(--spacing-3); }
-.capability-item { display: flex; align-items: center; gap: var(--spacing-2); padding: 8px 14px; background: var(--bg-tertiary); border-radius: var(--radius-2xl); font-size: var(--text-sm); color: var(--text-muted); }
+.capability-item { display: flex; align-items: center; gap: var(--spacing-2); padding: var(--spacing-2) var(--spacing-3-5); background: var(--bg-tertiary); border-radius: var(--radius-2xl); font-size: var(--text-sm); color: var(--text-muted); }
 .capability-item.enabled { background: var(--color-success-bg); color: var(--color-success); }
 .capability-item i { font-size: var(--text-sm); }
 
@@ -200,12 +200,12 @@ function getStrategyIcon(strategy: string): string {
 .strategy-icon { width: 36px; height: 36px; border-radius: var(--radius-lg); background: var(--bg-secondary); display: flex; align-items: center; justify-content: center; color: var(--text-secondary); flex-shrink: 0; }
 .strategy-card.active .strategy-icon { background: var(--color-primary); color: white; }
 .strategy-name { display: block; font-size: var(--text-sm); font-weight: 500; color: var(--text-primary); margin-bottom: var(--spacing-1); }
-.strategy-desc { margin: 0 0 6px; font-size: var(--text-xs); color: var(--text-secondary); line-height: 1.4; }
+.strategy-desc { margin: var(--spacing-0) var(--spacing-0) var(--spacing-1-5); font-size: var(--text-xs); color: var(--text-secondary); line-height: 1.4; }
 .strategy-best { font-size: var(--text-xs); color: var(--text-muted); font-style: italic; }
 
 .visualization-panel { background: var(--bg-secondary); border-radius: var(--radius-xl); padding: var(--spacing-5); }
 .workflow-viz { display: flex; flex-direction: column; gap: var(--spacing-5); }
-.viz-timeline { display: flex; align-items: flex-start; gap: var(--spacing-0); overflow-x: auto; padding: 16px 0; }
+.viz-timeline { display: flex; align-items: flex-start; gap: var(--spacing-0); overflow-x: auto; padding: var(--spacing-4) var(--spacing-0); }
 .viz-step { display: flex; align-items: center; }
 .viz-node { display: flex; flex-direction: column; align-items: center; gap: var(--spacing-2); min-width: 80px; }
 .node-circle { width: 40px; height: 40px; border-radius: 50%; background: var(--bg-tertiary); display: flex; align-items: center; justify-content: center; font-size: var(--text-sm); font-weight: 600; color: var(--text-tertiary); border: 2px solid var(--border-default); }
@@ -220,7 +220,7 @@ function getStrategyIcon(strategy: string): string {
 .detail-item { display: flex; flex-direction: column; gap: var(--spacing-1); }
 .detail-item .label { font-size: var(--text-xs); color: var(--text-tertiary); text-transform: uppercase; }
 .detail-item .value { font-size: var(--text-sm); font-weight: 500; color: var(--text-primary); }
-.status-badge { padding: 2px 10px; border-radius: var(--radius-xl); font-size: var(--text-xs); }
+.status-badge { padding: var(--spacing-0-5) var(--spacing-2-5); border-radius: var(--radius-xl); font-size: var(--text-xs); }
 .status-badge.running { background: var(--color-success-bg); color: var(--color-success); }
 .status-badge.paused { background: var(--color-warning-bg); color: var(--color-warning); }
 .status-badge.completed { background: var(--color-info-bg); color: var(--color-info); }
@@ -229,6 +229,6 @@ function getStrategyIcon(strategy: string): string {
 .no-workflow { flex: 1; display: flex; align-items: center; justify-content: center; }
 .empty-viz { text-align: center; padding: var(--spacing-10); }
 .empty-viz i { font-size: var(--text-5xl); color: var(--text-muted); margin-bottom: var(--spacing-4); }
-.empty-viz h3 { margin: 0 0 8px; color: var(--text-primary); }
+.empty-viz h3 { margin: var(--spacing-0) var(--spacing-0) var(--spacing-2); color: var(--text-primary); }
 .empty-viz p { margin: var(--spacing-0); color: var(--text-tertiary); }
 </style>

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -349,16 +349,16 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 
 <style scoped>
 .workflow-canvas-container { display: flex; flex-direction: column; height: 100%; background: var(--bg-primary); border-radius: var(--radius-lg); overflow: hidden; }
-.canvas-toolbar { display: flex; justify-content: space-between; padding: 12px 16px; background: var(--bg-secondary); border-bottom: 1px solid var(--border-default); }
+.canvas-toolbar { display: flex; justify-content: space-between; padding: var(--spacing-3) var(--spacing-4); background: var(--bg-secondary); border-bottom: 1px solid var(--border-default); }
 .toolbar-left, .toolbar-right { display: flex; align-items: center; gap: var(--spacing-2); }
-.tool-btn { display: flex; align-items: center; gap: var(--spacing-1-5); padding: 8px 12px; background: var(--bg-tertiary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-secondary); font-size: var(--text-sm); cursor: pointer; transition: all 0.15s; }
+.tool-btn { display: flex; align-items: center; gap: var(--spacing-1-5); padding: var(--spacing-2) var(--spacing-3); background: var(--bg-tertiary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-secondary); font-size: var(--text-sm); cursor: pointer; transition: all 0.15s; }
 .tool-btn:hover:not(:disabled) { background: var(--bg-hover); color: var(--text-primary); }
 .tool-btn.primary { background: var(--color-primary); color: var(--text-on-primary); border-color: var(--color-primary); }
 .tool-btn.primary:hover:not(:disabled) { filter: brightness(1.1); }
 .tool-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .tool-btn.btn-experimental { opacity: 0.85; position: relative; }
-.badge-experimental { font-size: 9px; padding: 1px 4px; background: var(--color-warning); color: #000; border-radius: var(--radius-default); font-weight: 700; text-transform: uppercase; line-height: 1; }
-.toolbar-divider { width: 1px; height: 24px; background: var(--border-default); margin: 0 4px; }
+.badge-experimental { font-size: 9px; padding: var(--spacing-px) var(--spacing-1); background: var(--color-warning); color: #000; border-radius: var(--radius-default); font-weight: 700; text-transform: uppercase; line-height: 1; }
+.toolbar-divider { width: 1px; height: 24px; background: var(--border-default); margin: var(--spacing-0) var(--spacing-1); }
 
 .canvas-area { flex: 1; position: relative; overflow: hidden; background: linear-gradient(var(--border-subtle) 1px, transparent 1px), linear-gradient(90deg, var(--border-subtle) 1px, transparent 1px); background-size: 20px 20px; cursor: grab; }
 .canvas-area:active { cursor: grabbing; }
@@ -376,19 +376,19 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .workflow-node[class*="vision-"] .node-header { background: linear-gradient(135deg, #7c3aed, #6d28d9); }
 
 .dropdown-container { position: relative; display: inline-block; }
-.dropdown-menu { position: absolute; top: 100%; left: 0; z-index: 10; background: var(--bg-secondary, #1e293b); border: 1px solid var(--border-color, #334155); border-radius: var(--radius-md); padding: 4px 0; min-width: 180px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
-.dropdown-menu button { display: flex; align-items: center; gap: var(--spacing-2); width: 100%; padding: 8px 12px; border: none; background: none; color: var(--text-primary, #e2e8f0); cursor: pointer; font-size: 0.85rem; }
+.dropdown-menu { position: absolute; top: 100%; left: 0; z-index: 10; background: var(--bg-secondary, #1e293b); border: 1px solid var(--border-color, #334155); border-radius: var(--radius-md); padding: var(--spacing-1) var(--spacing-0); min-width: 180px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
+.dropdown-menu button { display: flex; align-items: center; gap: var(--spacing-2); width: 100%; padding: var(--spacing-2) var(--spacing-3); border: none; background: none; color: var(--text-primary, #e2e8f0); cursor: pointer; font-size: 0.85rem; }
 .dropdown-menu button:hover { background: var(--bg-tertiary, #334155); }
 .target-label { font-size: var(--text-xs); color: var(--text-secondary, #94a3b8); }
 .hint { font-size: var(--text-xs); color: var(--text-secondary, #94a3b8); font-style: italic; }
 
-.node-header { display: flex; align-items: center; gap: var(--spacing-2); padding: 8px 12px; color: var(--text-on-primary); border-radius: var(--radius-lg) 8px 0 0; font-size: var(--text-sm); font-weight: 600; }
+.node-header { display: flex; align-items: center; gap: var(--spacing-2); padding: var(--spacing-2) var(--spacing-3); color: var(--text-on-primary); border-radius: var(--radius-lg) 8px 0 0; font-size: var(--text-sm); font-weight: 600; }
 .node-header span { flex: 1; }
 .delete-btn { padding: var(--spacing-1); background: transparent; border: none; color: inherit; cursor: pointer; opacity: 0.7; border-radius: var(--radius-default); }
 .delete-btn:hover { opacity: 1; background: rgba(255,255,255,0.2); }
 
 .node-body { padding: var(--spacing-3); display: flex; flex-direction: column; gap: var(--spacing-2); }
-.node-body input, .node-body select { width: 100%; padding: 6px 8px; background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: var(--radius-default); color: var(--text-primary); font-size: var(--text-xs); }
+.node-body input, .node-body select { width: 100%; padding: var(--spacing-1-5) var(--spacing-2); background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: var(--radius-default); color: var(--text-primary); font-size: var(--text-xs); }
 .node-body input:focus, .node-body select:focus { outline: none; border-color: var(--color-primary); }
 .node-body input:focus-visible, .node-body select:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .node-body input.mono { font-family: monospace; }
@@ -404,21 +404,21 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 
 .empty-state { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; padding: var(--spacing-10); }
 .empty-state i { font-size: var(--text-5xl); color: var(--text-muted); margin-bottom: var(--spacing-4); }
-.empty-state h3 { margin: 0 0 8px; color: var(--text-primary); }
-.empty-state p { margin: 0 0 20px; color: var(--text-tertiary); }
+.empty-state h3 { margin: var(--spacing-0) var(--spacing-0) var(--spacing-2); color: var(--text-primary); }
+.empty-state p { margin: var(--spacing-0) var(--spacing-0) var(--spacing-5); color: var(--text-tertiary); }
 
 .dialog-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: var(--z-modal-backdrop); }
 .dialog { width: 400px; background: var(--bg-secondary); border-radius: var(--radius-xl); padding: var(--spacing-6); }
-.dialog h3 { margin: 0 0 20px; display: flex; align-items: center; gap: var(--spacing-2-5); color: var(--text-primary); }
+.dialog h3 { margin: var(--spacing-0) var(--spacing-0) var(--spacing-5); display: flex; align-items: center; gap: var(--spacing-2-5); color: var(--text-primary); }
 .dialog h3 i { color: var(--color-primary); }
-.dialog input, .dialog textarea { width: 100%; padding: 10px 12px; margin-bottom: var(--spacing-3); background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-primary); font-size: var(--text-sm); font-family: inherit; }
+.dialog input, .dialog textarea { width: 100%; padding: var(--spacing-2-5) var(--spacing-3); margin-bottom: var(--spacing-3); background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-primary); font-size: var(--text-sm); font-family: inherit; }
 .dialog input:focus, .dialog textarea:focus { outline: none; border-color: var(--color-primary); }
 .dialog input:focus-visible, .dialog textarea:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .dialog-actions { display: flex; justify-content: flex-end; gap: var(--spacing-3); margin-top: var(--spacing-3); }
 
-.btn-primary { padding: 10px 20px; background: var(--color-primary); color: var(--text-on-primary); border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-2); }
+.btn-primary { padding: var(--spacing-2-5) var(--spacing-5); background: var(--color-primary); color: var(--text-on-primary); border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-2); }
 .btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
-.btn-secondary { padding: 10px 20px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; }
+.btn-secondary { padding: var(--spacing-2-5) var(--spacing-5); background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; }
 .btn-secondary:hover { background: var(--bg-hover); }
 </style>

--- a/autobot-frontend/src/components/workflow/WorkflowHistory.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowHistory.vue
@@ -185,16 +185,16 @@ function formatDate(date?: string): string {
 .workflow-history { height: 100%; display: flex; flex-direction: column; }
 
 .history-filters { display: flex; justify-content: space-between; align-items: center; gap: var(--spacing-4); margin-bottom: var(--spacing-5); flex-wrap: wrap; }
-.search-box { display: flex; align-items: center; gap: var(--spacing-2-5); padding: 10px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); flex: 1; min-width: 200px; }
+.search-box { display: flex; align-items: center; gap: var(--spacing-2-5); padding: var(--spacing-2-5) var(--spacing-3-5); background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); flex: 1; min-width: 200px; }
 .search-box i { color: var(--text-muted); }
 .search-box input { flex: 1; background: none; border: none; color: var(--text-primary); font-size: var(--text-sm); outline: none; }
 .search-box input:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .filter-group { display: flex; gap: var(--spacing-2); }
-.filter-group select { padding: 10px 12px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); color: var(--text-primary); font-size: var(--text-sm); cursor: pointer; }
+.filter-group select { padding: var(--spacing-2-5) var(--spacing-3); background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); color: var(--text-primary); font-size: var(--text-sm); cursor: pointer; }
 
 .empty-state { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-tertiary); padding: var(--spacing-10); }
 .empty-state i { font-size: var(--text-5xl); margin-bottom: var(--spacing-4); }
-.empty-state h3 { margin: 0 0 8px; color: var(--text-primary); }
+.empty-state h3 { margin: var(--spacing-0) var(--spacing-0) var(--spacing-2); color: var(--text-primary); }
 
 .history-list { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: var(--spacing-3); }
 .history-item { display: flex; align-items: center; gap: var(--spacing-4); padding: var(--spacing-4); background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-xl); cursor: pointer; transition: all 0.2s; }
@@ -212,7 +212,7 @@ function formatDate(date?: string): string {
 .item-meta span { display: flex; align-items: center; gap: var(--spacing-1); }
 
 .item-stats { display: flex; gap: var(--spacing-3); }
-.item-stats .stat { font-size: var(--text-xs); padding: 4px 10px; border-radius: var(--radius-xl); }
+.item-stats .stat { font-size: var(--text-xs); padding: var(--spacing-1) var(--spacing-2-5); border-radius: var(--radius-xl); }
 .item-stats .stat span { font-weight: 600; }
 .item-stats .success { background: var(--color-success-bg); color: var(--color-success); }
 .item-stats .failed { background: var(--color-error-bg); color: var(--color-error); }
@@ -222,8 +222,8 @@ function formatDate(date?: string): string {
 .btn-icon { width: 32px; height: 32px; background: var(--bg-tertiary); border: none; border-radius: var(--radius-md); color: var(--text-secondary); cursor: pointer; transition: all 0.15s; }
 .btn-icon:hover { background: var(--bg-hover); color: var(--text-primary); }
 
-.pagination { display: flex; justify-content: center; align-items: center; gap: var(--spacing-4); padding: 16px 0; margin-top: auto; }
-.pagination button { padding: 8px 12px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-secondary); cursor: pointer; }
+.pagination { display: flex; justify-content: center; align-items: center; gap: var(--spacing-4); padding: var(--spacing-4) var(--spacing-0); margin-top: auto; }
+.pagination button { padding: var(--spacing-2) var(--spacing-3); background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-secondary); cursor: pointer; }
 .pagination button:hover:not(:disabled) { background: var(--bg-hover); }
 .pagination button:disabled { opacity: 0.5; cursor: not-allowed; }
 .pagination span { font-size: var(--text-sm); color: var(--text-tertiary); }

--- a/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
@@ -340,7 +340,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 8px 14px;
+  padding: var(--spacing-2) var(--spacing-3-5);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
   font-weight: 500;
@@ -366,7 +366,7 @@ onUnmounted(() => {
 
 .btn-reconnect {
   margin-left: auto;
-  padding: 4px 12px;
+  padding: var(--spacing-1) var(--spacing-3);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -398,7 +398,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
@@ -478,7 +478,7 @@ onUnmounted(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 48px 24px;
+  padding: var(--spacing-12) var(--spacing-6);
   color: var(--text-tertiary);
   text-align: center;
 }
@@ -490,7 +490,7 @@ onUnmounted(() => {
 }
 
 .empty-state h4 {
-  margin: 0 0 6px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-1-5);
   color: var(--text-primary);
   font-size: 15px;
 }
@@ -695,7 +695,7 @@ onUnmounted(() => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--bg-tertiary);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);

--- a/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
@@ -355,7 +355,7 @@ watch(saveSuccess, (val) => {
 }
 
 .field-input {
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
   border: 1px solid var(--color-border, #374151);
   border-radius: var(--radius-md);
   background: var(--color-bg-secondary, #1e293b);
@@ -453,7 +453,7 @@ watch(saveSuccess, (val) => {
 
 .matrix-cell {
   flex: 1;
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
   text-align: center;
   font-size: 0.8125rem;
 }
@@ -488,7 +488,7 @@ watch(saveSuccess, (val) => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1-5);
-  padding: 0.5rem 1.25rem;
+  padding: var(--spacing-2) var(--spacing-5);
   border: none;
   border-radius: var(--radius-md);
   background: var(--color-primary, #3b82f6);
@@ -519,7 +519,7 @@ watch(saveSuccess, (val) => {
   gap: var(--spacing-2);
   font-size: var(--text-sm);
   color: var(--color-text-secondary, #94a3b8);
-  padding: 0.75rem 0;
+  padding: var(--spacing-3) var(--spacing-0);
 }
 
 .spinner {
@@ -538,7 +538,7 @@ watch(saveSuccess, (val) => {
 }
 
 .error-banner {
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
   border-radius: var(--radius-md);
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);

--- a/autobot-frontend/src/components/workflow/WorkflowRunner.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowRunner.vue
@@ -239,24 +239,24 @@ function formatResult(result: Record<string, unknown>): string {
 .runner-main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
 .no-selection { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-tertiary); padding: var(--spacing-10); }
 .no-selection i { font-size: var(--text-5xl); margin-bottom: var(--spacing-4); }
-.no-selection h3 { margin: 0 0 8px; color: var(--text-primary); }
+.no-selection h3 { margin: var(--spacing-0) var(--spacing-0) var(--spacing-2); color: var(--text-primary); }
 
 .workflow-header { display: flex; justify-content: space-between; align-items: flex-start; padding: var(--spacing-5); background: var(--bg-secondary); border-bottom: 1px solid var(--border-default); }
-.header-info h2 { margin: 0 0 4px; font-size: var(--text-lg); color: var(--text-primary); }
-.header-info p { margin: 0 0 10px; font-size: var(--text-sm); color: var(--text-secondary); }
+.header-info h2 { margin: var(--spacing-0) var(--spacing-0) var(--spacing-1); font-size: var(--text-lg); color: var(--text-primary); }
+.header-info p { margin: var(--spacing-0) var(--spacing-0) var(--spacing-2-5); font-size: var(--text-sm); color: var(--text-secondary); }
 .header-meta { display: flex; gap: var(--spacing-4); font-size: var(--text-xs); color: var(--text-tertiary); flex-wrap: wrap; }
 .header-meta span { display: flex; align-items: center; gap: var(--spacing-1-5); }
-.phase-badge { padding: 2px 8px; border-radius: var(--radius-xl); font-weight: 500; background: var(--bg-tertiary); }
+.phase-badge { padding: var(--spacing-0-5) var(--spacing-2); border-radius: var(--radius-xl); font-weight: 500; background: var(--bg-tertiary); }
 .phase-badge.planning { background: var(--color-info-bg); color: var(--color-info); }
 .phase-badge.executing { background: var(--color-primary-bg); color: var(--color-primary); }
 .phase-badge.validating { background: var(--color-warning-bg); color: var(--color-warning); }
 .phase-badge.complete { background: var(--color-success-bg); color: var(--color-success); }
 .phase-badge.failed { background: var(--color-error-bg); color: var(--color-error); }
-.service-badge { padding: 2px 8px; border-radius: var(--radius-xl); background: var(--bg-tertiary); color: var(--text-secondary); font-family: monospace; }
+.service-badge { padding: var(--spacing-0-5) var(--spacing-2); border-radius: var(--radius-xl); background: var(--bg-tertiary); color: var(--text-secondary); font-family: monospace; }
 .header-actions { display: flex; gap: var(--spacing-2-5); align-items: center; }
 
 .btn-notif {
-  padding: 8px 10px;
+  padding: var(--spacing-2) var(--spacing-2-5);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -278,7 +278,7 @@ function formatResult(result: Record<string, unknown>): string {
 .progress-stats .label { font-size: var(--text-xs); color: var(--text-tertiary); }
 
 .steps-container { flex: 1; overflow-y: auto; padding: var(--spacing-5); }
-.steps-container h4 { margin: 0 0 16px; font-size: var(--text-sm); color: var(--text-primary); display: flex; align-items: center; gap: var(--spacing-2); }
+.steps-container h4 { margin: var(--spacing-0) var(--spacing-0) var(--spacing-4); font-size: var(--text-sm); color: var(--text-primary); display: flex; align-items: center; gap: var(--spacing-2); }
 .steps-container h4 i { color: var(--color-primary); }
 
 .steps-list { display: flex; flex-direction: column; }
@@ -293,7 +293,7 @@ function formatResult(result: Record<string, unknown>): string {
 .step-line { width: 2px; flex: 1; min-height: 20px; background: var(--border-default); margin-top: var(--spacing-1); }
 .step-line.completed { background: var(--color-success); }
 
-.step-content { flex: 1; padding: 8px 16px; background: var(--bg-secondary); border-radius: var(--radius-lg); border-left: 3px solid var(--border-default); }
+.step-content { flex: 1; padding: var(--spacing-2) var(--spacing-4); background: var(--bg-secondary); border-radius: var(--radius-lg); border-left: 3px solid var(--border-default); }
 .step-item.completed .step-content { border-left-color: var(--color-success); }
 .step-item.failed .step-content { border-left-color: var(--color-error); }
 .step-item.executing .step-content { border-left-color: var(--color-primary); }
@@ -301,16 +301,16 @@ function formatResult(result: Record<string, unknown>): string {
 
 .step-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--spacing-2); }
 .step-desc { font-size: var(--text-sm); font-weight: 500; color: var(--text-primary); }
-.step-status { font-size: var(--text-xs); padding: 2px 8px; border-radius: var(--radius-xl); background: var(--bg-tertiary); color: var(--text-tertiary); }
+.step-status { font-size: var(--text-xs); padding: var(--spacing-0-5) var(--spacing-2); border-radius: var(--radius-xl); background: var(--bg-tertiary); color: var(--text-tertiary); }
 .step-status.completed { background: var(--color-success-bg); color: var(--color-success); }
 .step-status.failed { background: var(--color-error-bg); color: var(--color-error); }
 .step-status.executing { background: var(--color-primary-bg); color: var(--color-primary); }
 .step-status.waiting_approval { background: var(--color-warning-bg); color: var(--color-warning); }
 
-.step-command { display: block; padding: 8px 10px; background: var(--bg-tertiary); border-radius: var(--radius-default); font-size: var(--text-xs); color: var(--text-secondary); margin-bottom: var(--spacing-2); overflow-x: auto; }
+.step-command { display: block; padding: var(--spacing-2) var(--spacing-2-5); background: var(--bg-tertiary); border-radius: var(--radius-default); font-size: var(--text-xs); color: var(--text-secondary); margin-bottom: var(--spacing-2); overflow-x: auto; }
 .step-meta { display: flex; gap: var(--spacing-3); font-size: var(--text-xs); color: var(--text-tertiary); }
 .step-meta span { display: flex; align-items: center; gap: var(--spacing-1); }
-.step-meta .risk { padding: 2px 6px; border-radius: var(--radius-lg); }
+.step-meta .risk { padding: var(--spacing-0-5) var(--spacing-1-5); border-radius: var(--radius-lg); }
 .step-meta .risk.low { background: var(--color-success-bg); color: var(--color-success); }
 .step-meta .risk.medium { background: var(--color-warning-bg); color: var(--color-warning); }
 .step-meta .risk.high { background: var(--color-error-bg); color: var(--color-error); }
@@ -320,13 +320,13 @@ function formatResult(result: Record<string, unknown>): string {
 .step-result.error { background: var(--color-error-bg); }
 .step-result pre { margin: var(--spacing-0); font-size: var(--text-xs); color: var(--text-secondary); white-space: pre-wrap; word-break: break-all; max-height: 150px; overflow-y: auto; }
 
-.btn-success { padding: 8px 16px; background: var(--color-success); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
+.btn-success { padding: var(--spacing-2) var(--spacing-4); background: var(--color-success); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
 .btn-success:hover { filter: brightness(1.1); }
-.btn-warning { padding: 8px 16px; background: var(--color-warning); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
+.btn-warning { padding: var(--spacing-2) var(--spacing-4); background: var(--color-warning); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
 .btn-warning:hover { filter: brightness(1.1); }
-.btn-danger { padding: 8px 16px; background: var(--color-error); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
+.btn-danger { padding: var(--spacing-2) var(--spacing-4); background: var(--color-error); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
 .btn-danger:hover { filter: brightness(1.1); }
-.btn-secondary { padding: 8px 16px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
+.btn-secondary { padding: var(--spacing-2) var(--spacing-4); background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
 .btn-secondary:hover { background: var(--bg-hover); }
-.btn-sm { padding: 6px 12px; font-size: var(--text-xs); }
+.btn-sm { padding: var(--spacing-1-5) var(--spacing-3); font-size: var(--text-xs); }
 </style>

--- a/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
@@ -321,16 +321,16 @@ onMounted(async () => {
 
 <style scoped>
 .template-gallery { height: 100%; display: flex; flex-direction: column; }
-.gallery-header { padding: 0 0 20px; display: flex; flex-direction: column; gap: var(--spacing-4); }
-.search-box { display: flex; align-items: center; gap: var(--spacing-2-5); padding: 10px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); }
+.gallery-header { padding: var(--spacing-0) var(--spacing-0) var(--spacing-5); display: flex; flex-direction: column; gap: var(--spacing-4); }
+.search-box { display: flex; align-items: center; gap: var(--spacing-2-5); padding: var(--spacing-2-5) var(--spacing-3-5); background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); }
 .search-box i { color: var(--text-muted); }
 .search-box input { flex: 1; background: none; border: none; color: var(--text-primary); font-size: var(--text-sm); outline: none; }
 .search-box input:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .category-filters { display: flex; gap: var(--spacing-2); flex-wrap: wrap; }
-.filter-btn { padding: 6px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-2xl); color: var(--text-secondary); font-size: var(--text-sm); cursor: pointer; transition: all 0.15s; display: flex; align-items: center; gap: var(--spacing-1-5); }
+.filter-btn { padding: var(--spacing-1-5) var(--spacing-3-5); background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-2xl); color: var(--text-secondary); font-size: var(--text-sm); cursor: pointer; transition: all 0.15s; display: flex; align-items: center; gap: var(--spacing-1-5); }
 .filter-btn:hover { background: var(--bg-hover); }
 .filter-btn.active { background: var(--color-primary); color: var(--text-on-primary); border-color: var(--color-primary); }
-.count-badge { font-size: var(--text-xs); padding: 1px 6px; background: rgba(255,255,255,0.2); border-radius: var(--radius-xl); }
+.count-badge { font-size: var(--text-xs); padding: var(--spacing-px) var(--spacing-1-5); background: rgba(255,255,255,0.2); border-radius: var(--radius-xl); }
 
 .loading-state, .empty-state, .error-state { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--spacing-3); color: var(--text-tertiary); }
 .empty-state i, .error-state i { font-size: var(--text-5xl); }
@@ -351,10 +351,10 @@ onMounted(async () => {
 .template-icon.community { background: var(--color-success-bg); color: var(--color-success); }
 
 .template-info { flex: 1; min-width: 0; }
-.template-info h4 { margin: 0 0 4px; font-size: 15px; color: var(--text-primary); }
-.template-info p { margin: 0 0 10px; font-size: var(--text-sm); color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.template-info h4 { margin: var(--spacing-0) var(--spacing-0) var(--spacing-1); font-size: 15px; color: var(--text-primary); }
+.template-info p { margin: var(--spacing-0) var(--spacing-0) var(--spacing-2-5); font-size: var(--text-sm); color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .template-meta { display: flex; gap: var(--spacing-3); font-size: var(--text-xs); flex-wrap: wrap; }
-.category-badge { padding: 2px 8px; background: var(--bg-tertiary); color: var(--text-tertiary); border-radius: var(--radius-xl); }
+.category-badge { padding: var(--spacing-0-5) var(--spacing-2); background: var(--bg-tertiary); color: var(--text-tertiary); border-radius: var(--radius-xl); }
 .steps-count, .duration { color: var(--text-tertiary); display: flex; align-items: center; gap: var(--spacing-1); }
 
 .template-actions { display: flex; flex-direction: column; gap: var(--spacing-2); }
@@ -368,21 +368,21 @@ onMounted(async () => {
 .preview-header h3 { margin: var(--spacing-0); font-size: var(--text-base); color: var(--text-primary); }
 .preview-header button { padding: var(--spacing-1-5); background: transparent; border: none; color: var(--text-tertiary); cursor: pointer; }
 .preview-body { flex: 1; overflow-y: auto; padding: var(--spacing-5); }
-.preview-desc { margin: 0 0 20px; color: var(--text-secondary); }
-.preview-body h4 { margin: 0 0 12px; font-size: var(--text-sm); color: var(--text-tertiary); text-transform: uppercase; }
+.preview-desc { margin: var(--spacing-0) var(--spacing-0) var(--spacing-5); color: var(--text-secondary); }
+.preview-body h4 { margin: var(--spacing-0) var(--spacing-0) var(--spacing-3); font-size: var(--text-sm); color: var(--text-tertiary); text-transform: uppercase; }
 
 .preview-agents { margin-bottom: var(--spacing-5); }
 .agent-tags { display: flex; flex-wrap: wrap; gap: var(--spacing-1-5); }
-.agent-tag { padding: 4px 10px; background: var(--color-primary-bg); color: var(--color-primary); border-radius: var(--radius-xl); font-size: var(--text-xs); }
+.agent-tag { padding: var(--spacing-1) var(--spacing-2-5); background: var(--color-primary-bg); color: var(--color-primary); border-radius: var(--radius-xl); font-size: var(--text-xs); }
 
 .preview-secrets { margin-bottom: var(--spacing-5); }
 .secret-items { display: flex; flex-direction: column; gap: var(--spacing-2); }
-.secret-item { display: flex; align-items: center; gap: var(--spacing-2-5); padding: 8px 12px; background: var(--bg-tertiary); border-radius: var(--radius-lg); font-size: var(--text-sm); }
+.secret-item { display: flex; align-items: center; gap: var(--spacing-2-5); padding: var(--spacing-2) var(--spacing-3); background: var(--bg-tertiary); border-radius: var(--radius-lg); font-size: var(--text-sm); }
 .secret-item i { color: var(--text-tertiary); font-size: var(--text-xs); }
 .secret-info { flex: 1; min-width: 0; display: flex; flex-direction: column; }
 .secret-name { font-weight: 600; color: var(--text-primary); font-size: var(--text-xs); }
 .secret-desc { color: var(--text-tertiary); font-size: var(--text-xs); }
-.secret-scope { padding: 2px 6px; border-radius: var(--radius-lg); font-size: var(--text-xs); background: var(--bg-secondary); color: var(--text-tertiary); }
+.secret-scope { padding: var(--spacing-0-5) var(--spacing-1-5); border-radius: var(--radius-lg); font-size: var(--text-xs); background: var(--bg-secondary); color: var(--text-tertiary); }
 .secret-scope.write { background: var(--color-warning-bg); color: var(--color-warning); }
 .secret-scope.read { background: var(--color-success-bg); color: var(--color-success); }
 
@@ -391,19 +391,19 @@ onMounted(async () => {
 .step-num { width: 24px; height: 24px; background: var(--color-primary); color: white; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: var(--text-xs); font-weight: 600; flex-shrink: 0; }
 .step-content { flex: 1; min-width: 0; }
 .step-desc { display: block; font-size: var(--text-sm); color: var(--text-primary); margin-bottom: var(--spacing-1); }
-.step-content code { display: block; padding: 6px 8px; background: var(--bg-primary); border-radius: var(--radius-default); font-size: var(--text-xs); color: var(--text-secondary); overflow-x: auto; }
+.step-content code { display: block; padding: var(--spacing-1-5) var(--spacing-2); background: var(--bg-primary); border-radius: var(--radius-default); font-size: var(--text-xs); color: var(--text-secondary); overflow-x: auto; }
 .step-meta { display: flex; gap: var(--spacing-2-5); margin-top: var(--spacing-2); font-size: var(--text-xs); }
-.step-meta .risk { padding: 2px 6px; border-radius: var(--radius-lg); }
+.step-meta .risk { padding: var(--spacing-0-5) var(--spacing-1-5); border-radius: var(--radius-lg); }
 .step-meta .risk.low { background: var(--color-success-bg); color: var(--color-success); }
 .step-meta .risk.medium { background: var(--color-warning-bg); color: var(--color-warning); }
 .step-meta .risk.high, .step-meta .risk.critical { background: var(--color-error-bg); color: var(--color-error); }
 .step-meta span { color: var(--text-tertiary); display: flex; align-items: center; gap: var(--spacing-1); }
-.preview-actions { padding: 16px 20px; border-top: 1px solid var(--border-default); display: flex; gap: var(--spacing-3); }
+.preview-actions { padding: var(--spacing-4) var(--spacing-5); border-top: 1px solid var(--border-default); display: flex; gap: var(--spacing-3); }
 .preview-actions .btn-secondary, .preview-actions .btn-primary { flex: 1; justify-content: center; }
 
-.btn-primary { padding: 10px 16px; background: var(--color-primary); color: var(--text-on-primary); border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-2); }
+.btn-primary { padding: var(--spacing-2-5) var(--spacing-4); background: var(--color-primary); color: var(--text-on-primary); border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-2); }
 .btn-primary:hover { filter: brightness(1.1); }
-.btn-secondary { padding: 10px 16px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-2); }
+.btn-secondary { padding: var(--spacing-2-5) var(--spacing-4); background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-2); }
 .btn-secondary:hover { background: var(--bg-hover); }
 
 .slide-enter-active, .slide-leave-active { transition: transform 0.25s ease; }

--- a/autobot-frontend/src/views/AdminUsersView.vue
+++ b/autobot-frontend/src/views/AdminUsersView.vue
@@ -376,7 +376,7 @@ onMounted(loadUsers)
 .page-title {
   font-size: var(--text-2xl);
   font-weight: 600;
-  margin: 0 0 0.25rem;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-1);
 }
 
 .page-subtitle {
@@ -394,7 +394,7 @@ onMounted(loadUsers)
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   background: var(--color-error-bg, #fef2f2);
   border: 1px solid var(--color-error-border, #fca5a5);
   border-radius: var(--radius-lg);
@@ -425,7 +425,7 @@ onMounted(loadUsers)
 
 .search-input {
   width: 100%;
-  padding: 0.5rem 0.75rem 0.5rem 2.25rem;
+  padding: var(--spacing-2) var(--spacing-3) var(--spacing-2) var(--spacing-9);
   border: 1px solid var(--color-border, #d1d5db);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
@@ -452,7 +452,7 @@ onMounted(loadUsers)
 
 .data-table th {
   text-align: left;
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
@@ -463,7 +463,7 @@ onMounted(loadUsers)
 }
 
 .data-table td {
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   border-bottom: 1px solid var(--color-border, #f3f4f6);
   font-size: var(--text-sm);
 }
@@ -484,7 +484,7 @@ onMounted(loadUsers)
 
 .badge {
   display: inline-block;
-  padding: 0.125rem 0.5rem;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-full);
   font-size: 0.7rem;
   font-weight: 600;
@@ -506,7 +506,7 @@ onMounted(loadUsers)
 }
 
 .role-select {
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-1) var(--spacing-2);
   border: 1px solid var(--color-border, #d1d5db);
   border-radius: var(--radius-md);
   font-size: 0.8125rem;
@@ -561,7 +561,7 @@ onMounted(loadUsers)
 }
 
 .btn-page {
-  padding: 0.375rem 0.75rem;
+  padding: var(--spacing-1-5) var(--spacing-3);
   border: 1px solid var(--color-border, #d1d5db);
   border-radius: var(--radius-md);
   background: transparent;
@@ -584,7 +584,7 @@ onMounted(loadUsers)
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1-5);
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-2) var(--spacing-4);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
   font-weight: 500;
@@ -640,7 +640,7 @@ onMounted(loadUsers)
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.25rem;
+  padding: var(--spacing-4) var(--spacing-5);
   border-bottom: 1px solid var(--color-border, #e5e7eb);
 }
 
@@ -675,7 +675,7 @@ onMounted(loadUsers)
 
 .form-input {
   width: 100%;
-  padding: 0.5rem 0.75rem;
+  padding: var(--spacing-2) var(--spacing-3);
   border: 1px solid var(--color-border, #d1d5db);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);

--- a/autobot-frontend/src/views/AgentRegistryView.vue
+++ b/autobot-frontend/src/views/AgentRegistryView.vue
@@ -431,7 +431,7 @@ onMounted(async () => {
   .p-6 > .flex.items-center.justify-between:first-child {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.75rem;
+    gap: var(--spacing-3);
   }
 
   /* Scrollable tab nav instead of wrapping */
@@ -455,7 +455,7 @@ onMounted(async () => {
 
   /* Category filter buttons: allow wrap on mobile */
   .mb-4.flex.flex-wrap {
-    gap: 0.5rem;
+    gap: var(--spacing-2);
   }
 }
 </style>

--- a/autobot-frontend/src/views/AnalyticsView.vue
+++ b/autobot-frontend/src/views/AnalyticsView.vue
@@ -146,7 +146,7 @@ const isDevToolsActive = computed(() => {
 
 /* Header Section */
 .analytics-header {
-  padding: 24px 32px 20px;
+  padding: var(--spacing-6) var(--spacing-8) var(--spacing-5);
   border-bottom: 1px solid var(--border-default);
   background-color: var(--bg-primary);
 }
@@ -166,7 +166,7 @@ const isDevToolsActive = computed(() => {
 }
 
 .page-subtitle {
-  margin: 6px 0 0 0;
+  margin: var(--spacing-1-5) var(--spacing-0) var(--spacing-0) var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-secondary);
   line-height: 1.5;
@@ -184,7 +184,7 @@ const isDevToolsActive = computed(() => {
 .nav-tabs {
   display: flex;
   gap: var(--spacing-0-5);
-  padding: 0 32px;
+  padding: var(--spacing-0) var(--spacing-8);
   max-width: 1400px;
   margin: 0 auto;
   overflow-x: auto;
@@ -194,7 +194,7 @@ const isDevToolsActive = computed(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--text-secondary);
@@ -232,13 +232,13 @@ const isDevToolsActive = computed(() => {
 .analytics-router-view {
   flex: 1;
   overflow-y: auto;
-  padding: 24px 32px;
+  padding: var(--spacing-6) var(--spacing-8);
 }
 
 /* Responsive Adjustments */
 @media (max-width: 768px) {
   .analytics-header {
-    padding: 20px 16px 16px;
+    padding: var(--spacing-5) var(--spacing-4) var(--spacing-4);
   }
 
   .page-title {
@@ -250,12 +250,12 @@ const isDevToolsActive = computed(() => {
   }
 
   .nav-tabs {
-    padding: 0 16px;
+    padding: var(--spacing-0) var(--spacing-4);
     gap: var(--spacing-0);
   }
 
   .nav-tab {
-    padding: 10px 12px;
+    padding: var(--spacing-2-5) var(--spacing-3);
     font-size: var(--text-sm);
     gap: var(--spacing-1-5);
   }

--- a/autobot-frontend/src/views/ComponentShowcaseView.vue
+++ b/autobot-frontend/src/views/ComponentShowcaseView.vue
@@ -332,7 +332,7 @@ const handleRemove = () => {
 <style scoped>
 .showcase-container { padding: var(--spacing-6); max-width: 1400px; margin: 0 auto; background-color: var(--bg-primary); min-height: 100%; overflow-y: auto; }
 .showcase-header { margin-bottom: var(--spacing-8); }
-.showcase-title { font-size: 32px; font-weight: 600; color: var(--text-primary); margin: 0 0 8px 0; font-family: var(--font-sans); }
+.showcase-title { font-size: 32px; font-weight: 600; color: var(--text-primary); margin: var(--spacing-0) var(--spacing-0) var(--spacing-2) var(--spacing-0); font-family: var(--font-sans); }
 .showcase-subtitle { font-size: var(--text-base); color: var(--text-secondary); margin: var(--spacing-0); }
 .showcase-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: var(--spacing-6); }
 .showcase-full-width { grid-column: 1 / -1; }

--- a/autobot-frontend/src/views/CustomDashboard.vue
+++ b/autobot-frontend/src/views/CustomDashboard.vue
@@ -634,7 +634,7 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem 2rem;
+  padding: var(--spacing-6) var(--spacing-8);
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-default);
 }
@@ -668,7 +668,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 0.625rem 1rem;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   color: var(--text-primary);
@@ -706,7 +706,7 @@ onMounted(() => {
 }
 
 .dashboard-selector select {
-  padding: 0.625rem 1rem;
+  padding: var(--spacing-2-5) var(--spacing-4);
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
@@ -736,7 +736,7 @@ onMounted(() => {
 
 /* Widget Palette */
 .widget-palette {
-  padding: 1rem 2rem;
+  padding: var(--spacing-4) var(--spacing-8);
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-default);
 }
@@ -758,7 +758,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-2) var(--spacing-4);
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
@@ -783,7 +783,7 @@ onMounted(() => {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: var(--spacing-6);
-  padding: 1.5rem 2rem;
+  padding: var(--spacing-6) var(--spacing-8);
   overflow-y: auto;
 }
 
@@ -837,7 +837,7 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.75rem 1rem;
+  padding: var(--spacing-3) var(--spacing-4);
   background: var(--bg-tertiary);
   border-bottom: 1px solid var(--border-default);
 }
@@ -956,7 +956,7 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem 1.5rem;
+  padding: var(--spacing-4) var(--spacing-6);
   background: var(--bg-tertiary);
   border-bottom: 1px solid var(--border-default);
 }
@@ -1007,7 +1007,7 @@ onMounted(() => {
 .form-group input,
 .form-group select {
   width: 100%;
-  padding: 0.625rem 0.75rem;
+  padding: var(--spacing-2-5) var(--spacing-3);
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
@@ -1030,7 +1030,7 @@ onMounted(() => {
   display: flex;
   justify-content: flex-end;
   gap: var(--spacing-3);
-  padding: 1rem 1.5rem;
+  padding: var(--spacing-4) var(--spacing-6);
   background: var(--bg-primary);
   border-top: 1px solid var(--border-default);
 }

--- a/autobot-frontend/src/views/DocumentsView.vue
+++ b/autobot-frontend/src/views/DocumentsView.vue
@@ -295,7 +295,7 @@ function showError(msg: string) {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 16px;
+  padding: var(--spacing-3-5) var(--spacing-4);
   border-bottom: 1px solid var(--color-border, #333);
   flex-shrink: 0;
 }
@@ -353,7 +353,7 @@ function showError(msg: string) {
 .document-item {
   display: flex;
   flex-direction: column;
-  padding: 10px 16px;
+  padding: var(--spacing-2-5) var(--spacing-4);
   cursor: pointer;
   border-bottom: 1px solid var(--color-border, #2a2a2a);
   gap: var(--spacing-0-5);
@@ -403,7 +403,7 @@ function showError(msg: string) {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   border-top: 1px solid var(--color-border, #333);
   font-size: 0.8rem;
   flex-shrink: 0;
@@ -463,13 +463,13 @@ function showError(msg: string) {
 }
 
 .modal-title {
-  margin: 0 0 12px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3);
   font-size: var(--text-base);
   font-weight: 600;
 }
 
 .modal-body {
-  margin: 0 0 20px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-5);
   font-size: 0.9rem;
   color: var(--color-text-muted, #bbb);
   line-height: 1.5;
@@ -491,7 +491,7 @@ function showError(msg: string) {
   color: var(--color-error, #f87171);
   border: 1px solid var(--color-error, #f87171);
   border-radius: var(--radius-md);
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   font-size: var(--text-sm);
   z-index: var(--z-popover);
   max-width: 90vw;

--- a/autobot-frontend/src/views/KnowledgeView.vue
+++ b/autobot-frontend/src/views/KnowledgeView.vue
@@ -242,11 +242,11 @@
 .category-nav {
   flex: 1;
   overflow-y: auto;
-  padding: 12px 0;
+  padding: var(--spacing-3) var(--spacing-0);
 }
 
 .category-divider {
-  padding: 12px 20px 8px;
+  padding: var(--spacing-3) var(--spacing-5) var(--spacing-2);
   font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
@@ -259,7 +259,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   cursor: pointer;
   transition: all var(--duration-150) var(--ease-in-out);
   color: var(--text-secondary);
@@ -335,7 +335,7 @@
   }
 
   .category-item {
-    padding: 12px 16px;
+    padding: var(--spacing-3) var(--spacing-4);
     min-height: 44px;
   }
 
@@ -344,7 +344,7 @@
   }
 
   .category-divider {
-    padding: 10px 16px 6px;
+    padding: var(--spacing-2-5) var(--spacing-4) var(--spacing-1-5);
   }
 }
 </style>

--- a/autobot-frontend/src/views/MarketplaceView.vue
+++ b/autobot-frontend/src/views/MarketplaceView.vue
@@ -437,7 +437,7 @@ onMounted(async () => {
 
 .search-input {
   width: 100%;
-  padding: 6px 12px 6px 32px;
+  padding: var(--spacing-1-5) var(--spacing-3) var(--spacing-1-5) var(--spacing-8);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -456,7 +456,7 @@ onMounted(async () => {
 }
 
 .filter-select {
-  padding: 6px 10px;
+  padding: var(--spacing-1-5) var(--spacing-2-5);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -478,7 +478,7 @@ onMounted(async () => {
   display: flex;
   align-items: center;
   gap: var(--spacing-xs);
-  padding: 6px 12px;
+  padding: var(--spacing-1-5) var(--spacing-3);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -501,7 +501,7 @@ onMounted(async () => {
 
 .count-badge {
   font-size: var(--text-xs);
-  padding: 1px 6px;
+  padding: var(--spacing-px) var(--spacing-1-5);
   border-radius: var(--radius-xl);
   min-width: 20px;
   text-align: center;
@@ -613,7 +613,7 @@ onMounted(async () => {
 .status-badge {
   font-size: var(--text-xs);
   font-weight: 600;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-xl);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -687,7 +687,7 @@ onMounted(async () => {
 .category-tag {
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  padding: 1px 6px;
+  padding: var(--spacing-px) var(--spacing-1-5);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
   color: var(--text-secondary);
@@ -704,7 +704,7 @@ onMounted(async () => {
   font-size: var(--text-xs);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
-  padding: 1px 6px;
+  padding: var(--spacing-px) var(--spacing-1-5);
   border-radius: var(--radius-default);
   border: 1px solid var(--border-default);
 }
@@ -724,7 +724,7 @@ onMounted(async () => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1);
-  padding: 4px 12px;
+  padding: var(--spacing-1) var(--spacing-3);
   border-radius: var(--radius-sm);
   font-size: var(--text-sm);
   font-weight: 500;

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -642,7 +642,7 @@ onMounted(async () => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   font-size: var(--text-xs);
-  padding: 1px 6px;
+  padding: var(--spacing-px) var(--spacing-1-5);
   border-radius: var(--radius-xl);
   min-width: 20px;
   text-align: center;
@@ -757,7 +757,7 @@ onMounted(async () => {
 .status-badge {
   font-size: var(--text-xs);
   font-weight: 600;
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-xl);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -837,7 +837,7 @@ onMounted(async () => {
   font-size: var(--text-xs);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
-  padding: 1px 6px;
+  padding: var(--spacing-px) var(--spacing-1-5);
   border-radius: var(--radius-default);
   border: 1px solid var(--border-default);
 }
@@ -857,7 +857,7 @@ onMounted(async () => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1);
-  padding: 4px 12px;
+  padding: var(--spacing-1) var(--spacing-3);
   border-radius: var(--radius-sm);
   font-size: var(--text-sm);
   font-weight: 500;
@@ -900,7 +900,7 @@ onMounted(async () => {
   background: var(--color-info-bg);
   color: var(--color-info);
   border-color: var(--color-info-border, rgba(59, 130, 246, 0.3));
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
 }
 
 .action-reload:hover:not(:disabled) {
@@ -911,7 +911,7 @@ onMounted(async () => {
   background: var(--color-error-bg);
   color: var(--color-error);
   border-color: var(--color-error-border);
-  padding: 4px 8px;
+  padding: var(--spacing-1) var(--spacing-2);
 }
 
 .action-unload:hover:not(:disabled) {
@@ -1050,7 +1050,7 @@ onMounted(async () => {
   background: transparent;
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
-  padding: 2px 10px;
+  padding: var(--spacing-0-5) var(--spacing-2-5);
   font-size: var(--text-sm);
   color: var(--text-secondary);
   cursor: pointer;

--- a/autobot-frontend/src/views/SettingsView.vue
+++ b/autobot-frontend/src/views/SettingsView.vue
@@ -378,7 +378,7 @@ function onApiKeysSaved(): void {
     overflow-x: auto;
     flex-wrap: nowrap;
     -webkit-overflow-scrolling: touch;
-    gap: 0;
+    gap: var(--spacing-0);
   }
 
   .settings-tab {

--- a/autobot-frontend/src/views/WorkflowBuilderView.vue
+++ b/autobot-frontend/src/views/WorkflowBuilderView.vue
@@ -1216,11 +1216,11 @@ watch(hasActiveWorkflows, (hasActive) => {
 .category-nav {
   flex: 1;
   overflow-y: auto;
-  padding: 12px 0;
+  padding: var(--spacing-3) var(--spacing-0);
 }
 
 .category-divider {
-  padding: 12px 20px 8px;
+  padding: var(--spacing-3) var(--spacing-5) var(--spacing-2);
   font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
@@ -1237,7 +1237,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 
 .health-indicator {
   font-size: 0.65rem;
-  padding: 1px 6px;
+  padding: var(--spacing-px) var(--spacing-1-5);
   border-radius: var(--radius-lg);
   text-transform: uppercase;
   font-weight: 600;
@@ -1262,7 +1262,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   cursor: pointer;
   transition: all var(--duration-150) var(--ease-in-out);
   color: var(--text-secondary);
@@ -1304,7 +1304,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   font-size: var(--text-xs);
   font-family: var(--font-mono);
   background: var(--bg-tertiary);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-xl);
   color: var(--text-tertiary);
   font-weight: 500;
@@ -1321,14 +1321,14 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .sidebar-actions {
-  padding: 16px 20px;
+  padding: var(--spacing-4) var(--spacing-5);
   border-top: 1px solid var(--border-default);
 }
 
 .btn-refresh {
   width: 100%;
   height: 36px;
-  padding: 0 12px;
+  padding: var(--spacing-0) var(--spacing-3);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
@@ -1385,7 +1385,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px 24px;
+  padding: var(--spacing-5) var(--spacing-6);
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-default);
 }
@@ -1412,7 +1412,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  padding: 8px 14px;
+  padding: var(--spacing-2) var(--spacing-3-5);
   border-radius: var(--radius-2xl);
   font-size: var(--text-sm);
   font-weight: 500;
@@ -1551,7 +1551,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .overview-card h4 {
-  margin: 0 0 16px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-4);
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
@@ -1632,7 +1632,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .strategy-description {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
 }
 
 .strategy-best-for {
@@ -1649,7 +1649,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .example-item {
-  padding: 12px 16px;
+  padding: var(--spacing-3) var(--spacing-4);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
   cursor: pointer;
@@ -1675,7 +1675,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 
 .example-strategy {
   font-size: var(--text-xs);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--color-primary-bg);
   color: var(--color-primary);
   border-radius: var(--radius-xl);
@@ -1714,7 +1714,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .nl-header p {
-  margin: 8px 0 0;
+  margin: var(--spacing-2) var(--spacing-0) var(--spacing-0);
   color: var(--text-secondary);
 }
 
@@ -1754,7 +1754,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin: 16px 0;
+  margin: var(--spacing-4) var(--spacing-0);
 }
 
 .checkbox-option {
@@ -1772,7 +1772,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .strategy-select {
-  padding: 8px 12px;
+  padding: var(--spacing-2) var(--spacing-3);
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -1812,7 +1812,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .approval-summary p {
-  margin: 0 0 8px;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-2);
   color: var(--text-secondary);
 }
 
@@ -1830,7 +1830,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .approval-steps {
-  margin: 16px 0;
+  margin: var(--spacing-4) var(--spacing-0);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2);
@@ -1861,7 +1861,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 
 .risk-badge {
   font-size: var(--text-xs);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-xl);
   text-transform: uppercase;
 }
@@ -1992,7 +1992,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 
 .capability-tag {
   font-size: var(--text-xs);
-  padding: 2px 8px;
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--bg-secondary);
   color: var(--text-secondary);
   border-radius: var(--radius-xl);
@@ -2041,7 +2041,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 
 /* Buttons */
 .btn-primary {
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
@@ -2066,7 +2066,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .btn-success {
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   background: var(--color-success);
   color: var(--text-on-primary);
   border: none;
@@ -2085,7 +2085,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .btn-danger {
-  padding: 10px 20px;
+  padding: var(--spacing-2-5) var(--spacing-5);
   background: var(--color-error);
   color: var(--text-on-primary);
   border: none;

--- a/scripts/migrate_spacing_tokens.py
+++ b/scripts/migrate_spacing_tokens.py
@@ -2,8 +2,14 @@
 """
 Migrate hardcoded padding/margin/gap values in Vue <style> blocks to spacing design tokens.
 
-Covers only single-value declarations (e.g. `padding: 16px`) — multi-value shorthands
-(e.g. `padding: 8px 16px`) are skipped per issue #4651 scope.
+Pass 1 (single-value, issue #4651) handled `padding: 16px` etc.
+This pass (issue #4947) adds multi-value shorthand support:
+  - Two-value:   padding: 8px 16px
+  - Three-value: padding: 12px 20px 8px
+  - Four-value:  padding: 4px 8px 4px 8px
+  - Mixed zero:  padding: 0 12px
+
+Values with no token equivalent are left unchanged (e.g. padding: 15px 30px).
 
 Usage:
     python scripts/migrate_spacing_tokens.py <src_dir>
@@ -64,48 +70,64 @@ SPACING_MAP = {
     "0": "var(--spacing-0)",
 }
 
-# Properties to migrate
-SPACING_PROPS = [
-    "padding",
-    "padding-top",
-    "padding-right",
-    "padding-bottom",
-    "padding-left",
-    "margin",
-    "margin-top",
-    "margin-right",
-    "margin-bottom",
-    "margin-left",
-    "gap",
-    "row-gap",
-    "column-gap",
+# Shorthand-only properties (can take 2–4 values)
+_SHORTHAND_PROPS = ["padding", "margin", "gap", "row-gap", "column-gap"]
+# All properties including directional variants (always single-value)
+_ALL_PROPS = [
+    "padding", "padding-top", "padding-right", "padding-bottom", "padding-left",
+    "margin", "margin-top", "margin-right", "margin-bottom", "margin-left",
+    "gap", "row-gap", "column-gap",
 ]
 
-_PROPS_RE = "|".join(re.escape(p) for p in SPACING_PROPS)
+_SHORTHAND_PROPS_RE = "|".join(re.escape(p) for p in _SHORTHAND_PROPS)
+_ALL_PROPS_RE = "|".join(re.escape(p) for p in _ALL_PROPS)
 
-# Matches single-value spacing declarations only (no multi-value shorthands).
-# Value must be a single token (digits + optional unit), nothing after before `;`.
-DECL_RE = re.compile(
-    r"(?P<indent>[ \t]*)(?P<prop>" + _PROPS_RE + r")(?P<colon>\s*:\s*)"
-    r"(?P<value>-?[\d.]+(?:px|rem)|0)(?P<tail>\s*;)",
+# Single raw CSS value: digit-based with optional unit, or bare zero
+_VAL = r"(?:-?[\d.]+(?:px|rem)|0(?:px|rem)?)"
+
+# Multi-value declarations: 2–4 space-separated raw values immediately before `;`
+# Only matches shorthand properties (padding, margin, gap) — not directional variants
+MULTI_DECL_RE = re.compile(
+    r"(?P<indent>[ \t]*)(?P<prop>" + _SHORTHAND_PROPS_RE + r")(?P<colon>\s*:\s*)"
+    r"(?P<values>" + _VAL + r"(?:\s+" + _VAL + r"){1,3})(?P<tail>\s*;)",
+    re.MULTILINE,
+)
+
+# Single-value declarations (all properties)
+SINGLE_DECL_RE = re.compile(
+    r"(?P<indent>[ \t]*)(?P<prop>" + _ALL_PROPS_RE + r")(?P<colon>\s*:\s*)"
+    r"(?P<value>" + _VAL + r")(?P<tail>\s*;)",
     re.MULTILINE,
 )
 
 
 def migrate_style_block(style_block: str) -> tuple[str, int]:
-    """Replace single-value spacing declarations inside a <style> block."""
+    """Replace multi-value then single-value spacing declarations inside a <style> block."""
     replacements = 0
 
-    def replacer(m: re.Match) -> str:
+    def multi_replacer(m: re.Match) -> str:
         nonlocal replacements
-        raw_val = m.group("value")
-        token = SPACING_MAP.get(raw_val)
+        parts = m.group("values").split()
+        mapped = [SPACING_MAP.get(p) for p in parts]
+        if any(t is None for t in mapped):
+            return m.group(0)  # at least one value has no token — leave unchanged
+        replacements += 1
+        return (
+            m.group("indent") + m.group("prop") + m.group("colon")
+            + " ".join(mapped) + m.group("tail")  # type: ignore[arg-type]
+        )
+
+    def single_replacer(m: re.Match) -> str:
+        nonlocal replacements
+        token = SPACING_MAP.get(m.group("value"))
         if token is None:
-            return m.group(0)  # no mapping — leave unchanged
+            return m.group(0)
         replacements += 1
         return m.group("indent") + m.group("prop") + m.group("colon") + token + m.group("tail")
 
-    new_block = DECL_RE.sub(replacer, style_block)
+    # Multi-value first — prevents single-value regex from partially matching
+    new_block = MULTI_DECL_RE.sub(multi_replacer, style_block)
+    new_block = SINGLE_DECL_RE.sub(single_replacer, new_block)
     return new_block, replacements
 
 


### PR DESCRIPTION
## Summary

- Extends `scripts/migrate_spacing_tokens.py` with multi-value shorthand support (issue #4947)
- Migrates ~890 multi-value `padding`/`margin`/`gap` declarations in Vue `<style>` blocks to `--spacing-*` tokens
- 119 files changed, 739 tokenised lines across all component/view/composable tree

## Behavioral grep audit

**Before:**
```
grep -rE 'padding:\s+[0-9]+(px|rem)\s+[0-9]' autobot-frontend/src --include="*.vue" | wc -l
```
~890 raw multi-value shorthand declarations (baseline from #4947)

**After:**
```
grep -rE 'padding:\s+[0-9]+(px|rem)\s+[0-9]' autobot-frontend/src --include="*.vue" | wc -l
```
Remaining = declarations where at least one component value has no token mapping (e.g. `padding: 15px 30px`) — intentionally left unchanged per issue scope.

## Script changes

`MULTI_DECL_RE` matches 2–4 raw values on `padding`, `margin`, `gap`; `SINGLE_DECL_RE` kept for directional variants (`padding-top` etc.). Multi-value pass runs first to prevent single-value pass from partially matching shorthand lines.

## Test plan

- [ ] Vue type-check passes
- [ ] Sample diff shows raw values → token values (no untokenised multi-value lines that have full mappings)
- [ ] Remaining raw multi-value lines are legitimately unmapped (e.g. `padding: 15px 30px`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)