### PR TITLE
fix(composables): add ApprovalResponse type to useCommandApproval apiClient.post calls (#6221)

### DIFF
--- a/autobot-frontend/src/composables/useCommandApproval.ts
+++ b/autobot-frontend/src/composables/useCommandApproval.ts
@@ -47,6 +47,12 @@ export interface CommandResult {
   error?: string
 }
 
+export interface ApprovalResponse {
+  status: 'approved' | 'denied' | 'error' | string
+  comment?: string
+  error?: string
+}
+
 export function useCommandApproval() {
   const { showToast } = useToast()
   const chatStore = useChatStore()
@@ -220,7 +226,7 @@ export function useCommandApproval() {
     }
 
     try {
-      const result = await apiClient.post(
+      const result = await apiClient.post<ApprovalResponse>(
         `${getApiBase()}/agent-terminal/sessions/${terminal_session_id}/approve`,
         {
           approved,
@@ -389,11 +395,11 @@ export function useCommandApproval() {
     terminalSessionId: string,
     approved: boolean,
     userId = 'web_user'
-  ): Promise<{ status: string; error?: string; [key: string]: unknown }> => {
-    const result = await apiClient.post(
+  ): Promise<ApprovalResponse> => {
+    const result = await apiClient.post<ApprovalResponse>(
       `${getApiBase()}/agent-terminal/sessions/${terminalSessionId}/approve`,
       { approved, user_id: userId }
-    ) as { status: string; error?: string; [key: string]: unknown }
+    )
     return result
   }
 


### PR DESCRIPTION
## Summary
- Adds new `ApprovalResponse` interface (`status`, `comment?`, `error?`) to match the actual approval endpoint response shape
- Changes both `apiClient.post()` calls to `apiClient.post<ApprovalResponse>()` to eliminate TS18046 "Object is of type unknown" errors at lines 236, 242, 246, 299, 300, 301
- Removes the inline `as { status: string; error?: string; [key: string]: unknown }` cast in `approveCommandForDialog` — now redundant with proper typing

## Root cause
Wave 2/3 migrations (#6032, #6088) moved `approveCommand` and `approveCommandForDialog` to `apiClient.post()` but forgot the `<ReturnType>` generic, leaving `result` as `unknown`.

## Test plan
- [ ] `npx vue-tsc --noEmit -p tsconfig.app.json` — zero TS18046 errors in useCommandApproval.ts
- [ ] Command approval flow works in dev

Closes #6221

🤖 Generated with [Claude Code](https://claude.com/claude-code)