### PR TITLE
fix(composables): use intermediate unknown cast for QualityDrillDown in useCodeQualityData (#6222)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useCodeQualityData.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeQualityData.ts
@@ -281,7 +281,7 @@ export function useCodeQualityData(withSourceId: (url: string) => string) {
         {
           path: `/api/quality/drill-down/${encodeURIComponent(category)}`,
           scopeToSource: true,
-          pickData: (raw) => raw as QualityDrillDown,
+          pickData: (raw) => raw as unknown as QualityDrillDown,
           onError: (message, err) => {
             logger.warn('Failed to load drill-down data:', err)
             error.value = message


### PR DESCRIPTION
## Summary
- Fixes TS2352 in `useCodeQualityData.ts` by changing `raw as QualityDrillDown` to `raw as unknown as QualityDrillDown` in the `pickData` callback
- Required because `raw` is `TRaw` (generic) and TypeScript requires an intermediate cast through `unknown` when the types don't overlap sufficiently

## Root cause
`#6152` regression — `useFetchEndpoint` extraction made `raw` strongly-typed as `TRaw`, so direct cross-type assertions now require the `unknown` bridge.

## Test plan
- [ ] `npx vue-tsc --noEmit -p tsconfig.app.json` — zero TS2352 errors in useCodeQualityData.ts

Closes #6222

🤖 Generated with [Claude Code](https://claude.com/claude-code)