### PR TITLE
fix(composables): make AbortSignal required in useFetchEndpoint fetcher callback (#6226)

### DIFF
--- a/autobot-frontend/src/composables/api/useFetchEndpoint.ts
+++ b/autobot-frontend/src/composables/api/useFetchEndpoint.ts
@@ -216,7 +216,7 @@ export function useFetchEndpoint<TRaw, TOut, Ctx = undefined>(
   //
   // fallbackData is handled by catching inside the fetcher and returning the
   // fallback value rather than re-throwing, so useApiResource sees a success.
-  const resource = useApiResource<TOut | null>(async (signal?: AbortSignal) => {
+  const resource = useApiResource<TOut | null>(async (signal: AbortSignal) => {
     const ctx = pendingCtx
     const queryExtras = pendingExtras
 
@@ -264,7 +264,7 @@ export function useFetchEndpoint<TRaw, TOut, Ctx = undefined>(
       if (
         (err instanceof DOMException && err.name === 'AbortError') ||
         (err as Error)?.name === 'AbortError'
-      ) return
+      ) return null
       const message = err instanceof Error ? err.message : String(err)
       logger.error(`Failed to load ${label}:`, err)
       opts.onError?.(message, err, ctx)


### PR DESCRIPTION
## Summary
- Changes `async (signal?: AbortSignal)` to `async (signal: AbortSignal)` in the inner fetcher to satisfy the `useApiResource` overload union which expects a non-optional signal
- Changes `return` to `return null` on AbortError to satisfy the `Promise<TOut | null>` return type

## Root cause
TS2345 — `useFetchEndpoint` passes the fetcher to `useApiResource` but the optional `signal?` parameter type doesn't match the overload union that expects `AbortSignal` (required). `useApiResource` always provides the signal.

## Test plan
- [ ] `npx vue-tsc --noEmit -p tsconfig.app.json` — zero TS2345 errors in useFetchEndpoint.ts

Closes #6226

🤖 Generated with [Claude Code](https://claude.com/claude-code)