### PR TITLE
fix(backend): register long_running_operations router — fixes HTTP 500 on /api/long-running/* (#6227)

### DIFF
--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -59,6 +59,7 @@ from api.knowledge_search_aggregator import (
 from api.knowledge_sync_queue import router as knowledge_sync_queue_router  # Issue #4453
 from api.knowledge_vectorization import router as knowledge_vectorization_router
 from api.llm import router as llm_router
+from api.long_running_operations import router as long_running_operations_router  # Issue #6227
 from api.llm_providers import router as llm_providers_router
 from api.manual_mcp import router as manual_mcp_router
 from api.mcp_registry import router as mcp_registry_router
@@ -377,6 +378,12 @@ def _get_agent_routers() -> list:
             "",
             ["process-management"],
             "process_management",
+        ),
+        (  # Issue #6227: register long-running operations router
+            long_running_operations_router,
+            "/long-running",
+            ["long-running-operations"],
+            "long_running_operations",
         ),
     ]
 

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -240,12 +240,7 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         "heartbeat",
     ),
     # Long-running and validation
-    (
-        "api.long_running_operations",
-        "/long-running",
-        ["long-running"],
-        "long_running_operations",
-    ),
+    # api.long_running_operations promoted to core_routers.py (Issue #6227)
     (
         "api.system_validation",
         "/system-validation",


### PR DESCRIPTION
## Summary
- Removed silent optional registration from `feature_routers.py` (graceful degradation was hiding errors)
- Added hard import + RouterEntry in `core_routers.py` `_get_agent_routers()` at prefix `/long-running`
- Startup now fails fast if the router can't load, rather than silently returning 500 on every request

Closes #6227

🤖 Generated with [Claude Code](https://claude.com/claude-code)