### PR TITLE
fix(backend): replace None-stubs with sentinel in training/__init__.py (#6223)

### DIFF
--- a/autobot-backend/training/__init__.py
+++ b/autobot-backend/training/__init__.py
@@ -11,6 +11,31 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
+class _MissingDep:
+    """Sentinel for optional ML dependencies that are not installed.
+
+    Raises a clear ImportError (instead of a misleading TypeError) when the
+    missing symbol is called or attribute-accessed at runtime.
+    """
+
+    def __init__(self, name: str, error: Exception) -> None:
+        self._name = name
+        self._error = error
+
+    def __call__(self, *args: object, **kwargs: object) -> None:
+        raise ImportError(
+            f"{self._name} is not available — install the optional ML dependencies "
+            f"(original error: {self._error})"
+        )
+
+    def __getattr__(self, item: str) -> None:  # type: ignore[override]
+        raise ImportError(
+            f"{self._name} is not available — install the optional ML dependencies "
+            f"(original error: {self._error})"
+        )
+
+
 try:
     from training.completion_model import CompletionModel
     from training.completion_trainer import CompletionTrainer
@@ -27,12 +52,12 @@ try:
     ]
 except (ImportError, RuntimeError) as e:
     logger.warning("ML training dependencies unavailable: %s", e)
-    CompletionModel = None  # type: ignore
-    CompletionTrainer = None  # type: ignore
-    PatternDataset = None  # type: ignore
-    Tokenizer = None  # type: ignore
-    create_dataloaders = None  # type: ignore
-    CompletionEvaluator = None  # type: ignore
+    CompletionModel = _MissingDep("CompletionModel", e)  # type: ignore[assignment]
+    CompletionTrainer = _MissingDep("CompletionTrainer", e)  # type: ignore[assignment]
+    PatternDataset = _MissingDep("PatternDataset", e)  # type: ignore[assignment]
+    Tokenizer = _MissingDep("Tokenizer", e)  # type: ignore[assignment]
+    create_dataloaders = _MissingDep("create_dataloaders", e)  # type: ignore[assignment]
+    CompletionEvaluator = _MissingDep("CompletionEvaluator", e)  # type: ignore[assignment]
 
     __all__ = [
         "CompletionModel",


### PR DESCRIPTION
Fixes #6223.

Replaces module-level None stubs with proper lazy-sentinel pattern in `training/__init__.py`.

🤖 Generated with Claude Code