### PR TITLE
fix(frontend): add missing usePollingJob import to ResourceHeatmap.vue (#6251)

### DIFF
--- a/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
+++ b/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
@@ -83,6 +83,7 @@ import { useI18n } from 'vue-i18n'
 import VueApexCharts from 'vue3-apexcharts'
 import type { ApexOptions } from 'apexcharts'
 import { useResourceMetrics } from '@/composables/visualizations/useResourceMetrics'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 const { t } = useI18n()
 


### PR DESCRIPTION
Fixes #6251.

Adds missing `usePollingJob` import to `ResourceHeatmap.vue` — same class of bug as #6231 in CustomDashboard.

🤖 Generated with Claude Code