### PR TITLE
fix(backend): surface specific error type/message in AI Stack client error messages (#6234)

### DIFF
--- a/autobot-backend/services/ai_stack_client.py
+++ b/autobot-backend/services/ai_stack_client.py
@@ -258,13 +258,13 @@ class AIStackClient:
                     continue
 
                 raise AIStackError(
-                    "Failed to connect to AI Stack",
+                    f"AI Stack unreachable: {type(e).__name__} connecting to {url}",
                     details={"error": type(e).__name__, "url": url},
                 )
             except Exception as e:
                 logger.warning("Unexpected error in AI Stack request: %s", e)
                 raise AIStackError(
-                    "Unexpected error during AI Stack request",
+                    f"AI Stack error: {type(e).__name__}: {e}",
                     details={"error": type(e).__name__, "url": url},
                 )
 


### PR DESCRIPTION
## Summary
- Changes generic `"Unexpected error during AI Stack request"` to `f"AI Stack error: {type(e).__name__}: {e}"` in the catch-all `except Exception` block
- Changes `"Failed to connect to AI Stack"` to `f"AI Stack unreachable: {type(e).__name__} connecting to {url}"` in the `aiohttp.ClientError` block
- Gives operators actionable diagnostic: connection class (ConnectionRefusedError, TimeoutError) + URL instead of an opaque generic message

## Test plan
- [ ] `GET /api/ai-stack/health` with unreachable VM returns message like `"AI Stack unreachable: ConnectionRefusedError connecting to http://..."` instead of generic string
- [ ] Backend logs show specific exception class and message

Closes #6234

🤖 Generated with [Claude Code](https://claude.com/claude-code)