### PR TITLE
fix(composables): move fetchWithAuth exemption comments inline across 6 files (#6256)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useIndexingJob.ts
+++ b/autobot-frontend/src/composables/analytics/useIndexingJob.ts
@@ -325,7 +325,7 @@ export function useIndexingJob(deps: UseIndexingJobDeps) {
     const maxRetries = 2
     let response: Response | null = null
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
-      response = await fetchWithAuth(endpoint, {
+      response = await fetchWithAuth(endpoint, { // fetchWithAuth retained: raw Response needed for 502/503 retry status inspection — exempt (#6256)
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body,

--- a/autobot-frontend/src/composables/useBackgroundTask.ts
+++ b/autobot-frontend/src/composables/useBackgroundTask.ts
@@ -70,7 +70,7 @@ async function postAnalyze(
   fetchOpts: RequestInit,
 ): Promise<Response> {
   const backendUrl = await getBackendUrl()
-  return fetchWithAuth(`${backendUrl}${baseUrl}/analyze${qs}`, fetchOpts)
+  return fetchWithAuth(`${backendUrl}${baseUrl}/analyze${qs}`, fetchOpts) // fetchWithAuth retained: callers inspect response.status === 409 — exempt (#6256)
 }
 
 /**
@@ -230,9 +230,8 @@ export function useBackgroundTask(baseUrl: string, clearStuckUrl?: string) {
       const poller = usePollingJob<PollResult>(
         async () => {
           try {
-            // fetchWithAuth retained: AbortController signal required for polling abort. Exempt.
             const backendUrl = await getBackendUrl()
-            const resp = await fetchWithAuth(
+            const resp = await fetchWithAuth( // fetchWithAuth retained: AbortController signal for polling abort — exempt (#6256)
               `${backendUrl}${baseUrl}/status/${id}`,
               { signal: pollSignal },
             )

--- a/autobot-frontend/src/composables/useCommandApproval.ts
+++ b/autobot-frontend/src/composables/useCommandApproval.ts
@@ -128,8 +128,7 @@ export function useCommandApproval() {
         const backendUrl = await appConfig.getApiUrl(
           `${getApiBase()}/agent-terminal/commands/${command_id}`
         )
-        // fetchWithAuth retained: AbortController signal required for polling abort. Exempt.
-        const response = await fetchWithAuth(backendUrl, { signal })
+        const response = await fetchWithAuth(backendUrl, { signal }) // fetchWithAuth retained: AbortController signal for polling abort — exempt (#6256)
 
         if (!response.ok) {
           logger.error('Failed to get command state:', response.status)

--- a/autobot-frontend/src/composables/usePatternAnalysis.ts
+++ b/autobot-frontend/src/composables/usePatternAnalysis.ts
@@ -213,8 +213,6 @@ export function usePatternAnalysis() {
 
   // API Methods
 
-  // fetchWithAuth retained: 409 conflict detection requires raw response.status,
-  // and partial-results streaming during polling cannot be replicated with ApiClient/useBackgroundTask.
   /**
    * Run full pattern analysis on a directory
    */
@@ -246,7 +244,7 @@ export function usePatternAnalysis() {
 
     try {
       const backendUrl = await getBackendUrl()
-      let response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/analyze`, {
+      let response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/analyze`, { // fetchWithAuth retained: AbortController signal + response.status === 409 — exempt (#6256)
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -265,7 +263,7 @@ export function usePatternAnalysis() {
         logger.info('Another analysis is running, attempting to clear stuck tasks...')
 
         // Try to clear stuck tasks with force=true
-        const clearResponse = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/tasks/clear-stuck?force=true`, {
+        const clearResponse = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/tasks/clear-stuck?force=true`, { // fetchWithAuth retained: AbortController signal — exempt (#6256)
           method: 'POST',
           signal: _analyzeSignal,
         })
@@ -275,7 +273,7 @@ export function usePatternAnalysis() {
           logger.info('Cleared stuck tasks:', clearResult)
 
           // Retry the analysis
-          response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/analyze`, {
+          response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/patterns/analyze`, { // fetchWithAuth retained: AbortController signal + response.status === 409 — exempt (#6256)
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -315,11 +313,11 @@ export function usePatternAnalysis() {
           wasInterrupted.value = false
           error.value = null
 
-          await fetchWithAuth(
+          await fetchWithAuth( // fetchWithAuth retained: AbortController signal — exempt (#6256)
             `${backendUrl}/api/analytics/codebase/patterns/tasks/clear-stuck?force=true`,
             { method: 'POST', signal: _analyzeSignal },
           )
-          const retryResp = await fetchWithAuth(
+          const retryResp = await fetchWithAuth( // fetchWithAuth retained: AbortController signal + response.status check — exempt (#6256)
             `${backendUrl}/api/analytics/codebase/patterns/analyze`,
             {
               method: 'POST',
@@ -365,8 +363,6 @@ export function usePatternAnalysis() {
     }
   }
 
-  // fetchWithAuth retained: partial-results streaming updates reactive state (regexOpportunities,
-  // complexityHotspots, etc.) on every poll tick — this pattern cannot be replicated with ApiClient.
   /**
    * Poll for background task status using usePollingJob for resilience.
    * Returns a Promise that resolves when the task completes or fails.
@@ -397,7 +393,7 @@ export function usePatternAnalysis() {
             const backendUrl = await getBackendUrl()
             _pollController?.abort()
             _pollController = new AbortController()
-            const response = await fetchWithAuth(
+            const response = await fetchWithAuth( // fetchWithAuth retained: AbortController signal + partial-results streaming — exempt (#6256)
               `${backendUrl}/api/analytics/codebase/patterns/status/${taskId}`,
               { signal: _pollController.signal },
             )

--- a/autobot-frontend/src/composables/useVoiceConversation.ts
+++ b/autobot-frontend/src/composables/useVoiceConversation.ts
@@ -631,9 +631,7 @@ async function _transcribeAudioWithLanguage(
   if (lang) form.append('language', lang)
   _transcribeController?.abort()
   _transcribeController = new AbortController()
-  // fetchWithAuth retained: FormData audio body (multipart) and AbortController signal
-  // are incompatible with apiClient.post(). Exempt per composable-weakness-remediation design.
-  const res = await fetchWithAuth(`${getApiBase()}/voice/transcribe`, {
+  const res = await fetchWithAuth(`${getApiBase()}/voice/transcribe`, { // fetchWithAuth retained: FormData audio body + AbortController signal — exempt (#6256)
     method: 'POST',
     body: form,
     signal: _transcribeController.signal,

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -267,9 +267,7 @@ export function useVoiceOutput() {
       if (language) {
         formData.append('language', language)
       }
-      // fetchWithAuth retained: binary audio response (blob → arrayBuffer) and FormData
-      // body cannot be handled by apiClient.post(). Exempt per composable-weakness-remediation design.
-      const response = await fetchWithAuth(`${getApiBase()}/voice/synthesize`, {
+      const response = await fetchWithAuth(`${getApiBase()}/voice/synthesize`, { // fetchWithAuth retained: binary audio blob + FormData body — exempt (#6256)
         method: 'POST',
         body: formData,
         signal,


### PR DESCRIPTION
## Summary

- Moves `// fetchWithAuth retained: ...` comments from the line above the call to **inline on the same line** as the `fetchWithAuth(` call in 6 composables
- Adds a missing exemption comment to `useIndexingJob.ts` (502/503 retry loop)
- Removes now-redundant off-line comment blocks (net −10 lines)

## Behavioral grep audit

Before:
```bash
$ grep -rn "fetchWithAuth(" autobot-frontend/src/composables/ --include="*.ts" \
  | grep -v "useFetchEndpoint.ts|\.test\.ts|// fetchWithAuth retained"
# 12 hits across 6 files
```

After:
```bash
$ grep -rn "fetchWithAuth(" autobot-frontend/src/composables/ --include="*.ts" \
  | grep -v "useFetchEndpoint.ts|\.test\.ts|// fetchWithAuth retained"
# 0 hits — all exempt calls documented inline
```

## Files changed

| File | Calls | Action |
|---|---|---|
| `useCommandApproval.ts` | 1 | Moved comment inline |
| `useVoiceOutput.ts` | 1 | Replaced 2-line comment block with inline |
| `useVoiceConversation.ts` | 1 | Replaced 2-line comment block with inline |
| `useBackgroundTask.ts` | 2 | Moved comments inline (JSDoc kept for context) |
| `usePatternAnalysis.ts` | 6 | Removed section comments, added inline on each call |
| `useIndexingJob.ts` | 1 | Added new inline comment (no prior comment existed) |

No logic changes — comment placement only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)