### PR TITLE
feat(frontend): add signal?: AbortSignal to apiClient.RequestOptions (#6257)

### DIFF
--- a/autobot-frontend/src/utils/ApiClient.ts
+++ b/autobot-frontend/src/utils/ApiClient.ts
@@ -19,6 +19,7 @@ export interface RequestOptions {
   maxRetries?: number;
   onUploadProgress?: (progressEvent: UploadProgressEvent) => void;
   responseType?: string;
+  signal?: AbortSignal;
 }
 
 export interface ChatMessageOptions {
@@ -254,15 +255,36 @@ export class ApiClient {
       headers = {},
       body,
       timeout = options.timeout || this.defaultTimeout,
+      signal: externalSignal,
     } = options;
 
     const baseUrl = await this.ensureBaseUrl();
     const url = baseUrl ? `${baseUrl}${endpoint}` : endpoint;
 
     const controller = new AbortController();
-    const timeoutId = window.setTimeout(
-      () => controller.abort(), timeout
-    );
+    let timedOut = false;
+    const timeoutId = window.setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeout);
+
+    // Forward external cancellation into the internal controller (#6257)
+    let externalAbortHandler: (() => void) | null = null;
+    if (externalSignal) {
+      if (externalSignal.aborted) {
+        controller.abort();
+      } else {
+        externalAbortHandler = () => controller.abort();
+        externalSignal.addEventListener('abort', externalAbortHandler);
+      }
+    }
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      if (externalSignal && externalAbortHandler) {
+        externalSignal.removeEventListener('abort', externalAbortHandler);
+      }
+    };
 
     try {
       const fetchOptions: RequestInit = {
@@ -288,7 +310,7 @@ export class ApiClient {
       }
 
       const response = await fetch(url, fetchOptions);
-      clearTimeout(timeoutId);
+      cleanup();
 
       // Handle 401 — redirect to login (skip for auth endpoints)
       if (
@@ -300,9 +322,10 @@ export class ApiClient {
 
       return response;
     } catch (error) {
-      clearTimeout(timeoutId);
+      cleanup();
       if (error instanceof Error && error.name === 'AbortError') {
-        throw new Error(`Request timeout after ${timeout}ms`);
+        if (timedOut) throw new Error(`Request timeout after ${timeout}ms`);
+        throw error;
       }
       throw error;
     }


### PR DESCRIPTION
## Summary

- Adds `signal?: AbortSignal` to `RequestOptions` interface in `ApiClient.ts`
- Wires the external signal through `rawRequest` by forwarding abort events into the internal timeout controller
- Distinguishes timeout aborts (throws `Request timeout after Xms`) from caller-initiated aborts (re-throws the original `AbortError`)
- Zero behaviour change for callers that don't pass a signal

## Implementation

`rawRequest` now:
1. Extracts `signal: externalSignal` from options
2. If provided and already aborted → immediately aborts internal controller
3. Otherwise attaches a listener to forward the abort event
4. Tracks `timedOut` flag to distinguish timeout vs. external abort in the catch block
5. Extracts cleanup into a local function to avoid double-calling in happy/error paths

## Acceptance criterion

```ts
// useCommandApproval can now be migrated in a follow-up:
const response = await apiClient.get(url, { signal: pollingAbortController.signal })
```

All call sites currently using `fetchWithAuth` for AbortSignal support can be migrated once this lands (tracked in #6256 as Wave 6 scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)