### PR TITLE
fix(backend): extract MissingDep sentinel to autobot_shared, use NoReturn typing (#6261, #6264)

### DIFF
--- a/autobot-backend/background_vectorization.py
+++ b/autobot-backend/background_vectorization.py
@@ -16,6 +16,7 @@ import time
 from datetime import datetime, timezone
 from typing import Optional
 
+from autobot_shared.missing_dep import MissingDep as _MissingDep
 from autobot_shared.ssot_config import DEFAULT_EMBEDDING_MODEL
 from autobot_shared.singleton_factory import lazy_singleton
 from constants.threshold_constants import TimingConstants
@@ -28,9 +29,9 @@ try:
     )
 
     EMBEDDING_ANALYTICS_AVAILABLE = True
-except ImportError:
+except ImportError as _e:
     EMBEDDING_ANALYTICS_AVAILABLE = False
-    EmbeddingUsageRequest = None
+    EmbeddingUsageRequest = _MissingDep("EmbeddingUsageRequest", _e)  # type: ignore[assignment]
     logger = logging.getLogger(__name__)
     logger.debug("Embedding analytics not available - usage tracking disabled")
 

--- a/autobot-backend/llm_interface.py
+++ b/autobot-backend/llm_interface.py
@@ -15,6 +15,7 @@ For new code, import directly from llm_interface_pkg:
 """
 
 # Import additional dependencies that may be expected by consumers
+from autobot_shared.missing_dep import MissingDep as _MissingDep
 from config.manager import get_config_manager
 
 # Re-export everything from the refactored package
@@ -47,8 +48,8 @@ config = get_config_manager()
 # Optional imports for backward compatibility
 try:
     from prompt_manager import prompt_manager
-except ImportError:
-    prompt_manager = None
+except ImportError as _e:
+    prompt_manager = _MissingDep("prompt_manager", _e)  # type: ignore[assignment]
 
 try:
     from autobot_shared.logging_manager import get_llm_logger
@@ -64,10 +65,10 @@ try:
     from api.analytics_llm_patterns import UsageRecordRequest, get_pattern_analyzer
 
     PATTERN_ANALYZER_AVAILABLE = True
-except ImportError:
+except ImportError as _e:
     PATTERN_ANALYZER_AVAILABLE = False
-    UsageRecordRequest = None
-    get_pattern_analyzer = None
+    UsageRecordRequest = _MissingDep("UsageRecordRequest", _e)  # type: ignore[assignment]
+    get_pattern_analyzer = _MissingDep("get_pattern_analyzer", _e)  # type: ignore[assignment]
 
 # OpenAI availability flag
 try:

--- a/autobot-backend/training/__init__.py
+++ b/autobot-backend/training/__init__.py
@@ -9,31 +9,9 @@ ML model training infrastructure for code completion.
 
 import logging
 
+from autobot_shared.missing_dep import MissingDep as _MissingDep
+
 logger = logging.getLogger(__name__)
-
-
-class _MissingDep:
-    """Sentinel for optional ML dependencies that are not installed.
-
-    Raises a clear ImportError (instead of a misleading TypeError) when the
-    missing symbol is called or attribute-accessed at runtime.
-    """
-
-    def __init__(self, name: str, error: Exception) -> None:
-        self._name = name
-        self._error = error
-
-    def __call__(self, *args: object, **kwargs: object) -> None:
-        raise ImportError(
-            f"{self._name} is not available — install the optional ML dependencies "
-            f"(original error: {self._error})"
-        )
-
-    def __getattr__(self, item: str) -> None:  # type: ignore[override]
-        raise ImportError(
-            f"{self._name} is not available — install the optional ML dependencies "
-            f"(original error: {self._error})"
-        )
 
 
 try:

--- a/autobot-backend/voice_interface.py
+++ b/autobot-backend/voice_interface.py
@@ -20,6 +20,8 @@ from typing import Any, Dict, Optional
 
 import yaml
 
+from autobot_shared.missing_dep import MissingDep as _MissingDep
+
 logger = logging.getLogger(__name__)
 
 # Check speech recognition availability
@@ -27,8 +29,8 @@ try:
     import speech_recognition as sr
 
     SPEECH_RECOGNITION_AVAILABLE = True
-except ImportError:
-    sr = None
+except ImportError as _e:
+    sr = _MissingDep("speech_recognition", _e)  # type: ignore[assignment]
     SPEECH_RECOGNITION_AVAILABLE = False
 
 # Check pyttsx3 availability
@@ -36,8 +38,8 @@ try:
     import pyttsx3
 
     PYTTSX3_AVAILABLE = True
-except ImportError:
-    pyttsx3 = None
+except ImportError as _e:
+    pyttsx3 = _MissingDep("pyttsx3", _e)  # type: ignore[assignment]
     PYTTSX3_AVAILABLE = False
 
 # Check Vosk availability
@@ -45,9 +47,9 @@ try:
     from vosk import KaldiRecognizer, Model
 
     VOSK_AVAILABLE = True
-except ImportError:
-    KaldiRecognizer = None
-    Model = None
+except ImportError as _e:
+    KaldiRecognizer = _MissingDep("KaldiRecognizer", _e)  # type: ignore[assignment]
+    Model = _MissingDep("Model", _e)  # type: ignore[assignment]
     VOSK_AVAILABLE = False
 
 # Check Coqui TTS availability
@@ -55,8 +57,8 @@ try:
     from TTS.api import TTS as CoquiTTS
 
     COQUI_TTS_AVAILABLE = True
-except ImportError:
-    CoquiTTS = None
+except ImportError as _e:
+    CoquiTTS = _MissingDep("CoquiTTS", _e)  # type: ignore[assignment]
     COQUI_TTS_AVAILABLE = False
 
 # Check gTTS availability (Google Text-to-Speech - online fallback)
@@ -64,8 +66,8 @@ try:
     from gtts import gTTS
 
     GTTS_AVAILABLE = True
-except ImportError:
-    gTTS = None
+except ImportError as _e:
+    gTTS = _MissingDep("gTTS", _e)  # type: ignore[assignment]
     GTTS_AVAILABLE = False
 
 # Check sounddevice for audio playback
@@ -74,9 +76,9 @@ try:
     import soundfile as sf
 
     SOUNDDEVICE_AVAILABLE = True
-except ImportError:
-    sd = None
-    sf = None
+except ImportError as _e:
+    sd = _MissingDep("sounddevice", _e)  # type: ignore[assignment]
+    sf = _MissingDep("soundfile", _e)  # type: ignore[assignment]
     SOUNDDEVICE_AVAILABLE = False
 
 

--- a/autobot_shared/missing_dep.py
+++ b/autobot_shared/missing_dep.py
@@ -18,6 +18,8 @@ Usage::
         some_optional_lib = _MissingDep("some_optional_lib", e)
 """
 
+from typing import NoReturn
+
 
 class MissingDep:
     """Sentinel for optional dependencies that are not installed.
@@ -30,13 +32,13 @@ class MissingDep:
         self._name = name
         self._error = error
 
-    def __call__(self, *args: object, **kwargs: object) -> None:
+    def __call__(self, *args: object, **kwargs: object) -> NoReturn:
         raise ImportError(
             f"{self._name} is not available — install the optional dependencies "
             f"(original error: {self._error})"
         )
 
-    def __getattr__(self, item: str) -> None:  # type: ignore[override]
+    def __getattr__(self, item: str) -> NoReturn:
         raise ImportError(
             f"{self._name} is not available — install the optional dependencies "
             f"(original error: {self._error})"

--- a/autobot_shared/missing_dep.py
+++ b/autobot_shared/missing_dep.py
@@ -1,0 +1,43 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Shared sentinel for optional dependencies that are not installed.
+
+Issue #6264: Centralise the _MissingDep pattern so every module that has an
+optional import raises a clear ImportError instead of a misleading TypeError
+or AttributeError when the missing symbol is accidentally called.
+
+Usage::
+
+    from autobot_shared.missing_dep import MissingDep as _MissingDep
+
+    try:
+        import some_optional_lib
+    except ImportError as e:
+        some_optional_lib = _MissingDep("some_optional_lib", e)
+"""
+
+
+class MissingDep:
+    """Sentinel for optional dependencies that are not installed.
+
+    Raises a clear ImportError (instead of a misleading TypeError) when the
+    missing symbol is called or attribute-accessed at runtime.
+    """
+
+    def __init__(self, name: str, error: Exception) -> None:
+        self._name = name
+        self._error = error
+
+    def __call__(self, *args: object, **kwargs: object) -> None:
+        raise ImportError(
+            f"{self._name} is not available — install the optional dependencies "
+            f"(original error: {self._error})"
+        )
+
+    def __getattr__(self, item: str) -> None:  # type: ignore[override]
+        raise ImportError(
+            f"{self._name} is not available — install the optional dependencies "
+            f"(original error: {self._error})"
+        )


### PR DESCRIPTION
## Summary

- Creates `autobot_shared/missing_dep.py` with `MissingDep` sentinel class (#6264)
- Updates `training/__init__.py`, `voice_interface.py`, `llm_interface.py`, `background_vectorization.py` to import from shared location
- Fixes `__call__` and `__getattr__` return types from `-> None` to `-> NoReturn` (#6261)
- 12 `None`-stubs across 4 files now raise `ImportError` with clear diagnostic message on call

## Behavioral grep audit

Before:
```bash
$ grep -rn "= None$" autobot-backend/voice_interface.py autobot-backend/llm_interface.py autobot-backend/background_vectorization.py autobot-backend/training/__init__.py
# 12 None-stubs found
```

After:
```bash
$ grep -rn "= None$" autobot-backend/voice_interface.py autobot-backend/llm_interface.py autobot-backend/background_vectorization.py autobot-backend/training/__init__.py
# 0 hits — all replaced with _MissingDep(...)
```

## Test plan

- [ ] `python3 -m py_compile autobot_shared/missing_dep.py` — OK
- [ ] `python3 -m py_compile autobot-backend/training/__init__.py autobot-backend/voice_interface.py autobot-backend/llm_interface.py autobot-backend/background_vectorization.py` — all OK
- [ ] Calling a missing dep raises `ImportError` with clear message, not `TypeError`

Closes #6264
Closes #6261

🤖 Generated with [Claude Code](https://claude.com/claude-code)