### PR TITLE
fix(backend): define __all__ once outside try/except in training/__init__.py (#6265)

### DIFF
--- a/autobot-backend/training/__init__.py
+++ b/autobot-backend/training/__init__.py
@@ -13,21 +13,20 @@ from autobot_shared.missing_dep import MissingDep as _MissingDep
 
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    "CompletionModel",
+    "CompletionTrainer",
+    "PatternDataset",
+    "Tokenizer",
+    "create_dataloaders",
+    "CompletionEvaluator",
+]
 
 try:
     from training.completion_model import CompletionModel
     from training.completion_trainer import CompletionTrainer
     from training.data_loader import PatternDataset, Tokenizer, create_dataloaders
     from training.evaluator import CompletionEvaluator
-
-    __all__ = [
-        "CompletionModel",
-        "CompletionTrainer",
-        "PatternDataset",
-        "Tokenizer",
-        "create_dataloaders",
-        "CompletionEvaluator",
-    ]
 except (ImportError, RuntimeError) as e:
     logger.warning("ML training dependencies unavailable: %s", e)
     CompletionModel = _MissingDep("CompletionModel", e)  # type: ignore[assignment]
@@ -36,12 +35,3 @@ except (ImportError, RuntimeError) as e:
     Tokenizer = _MissingDep("Tokenizer", e)  # type: ignore[assignment]
     create_dataloaders = _MissingDep("create_dataloaders", e)  # type: ignore[assignment]
     CompletionEvaluator = _MissingDep("CompletionEvaluator", e)  # type: ignore[assignment]
-
-    __all__ = [
-        "CompletionModel",
-        "CompletionTrainer",
-        "PatternDataset",
-        "Tokenizer",
-        "create_dataloaders",
-        "CompletionEvaluator",
-    ]


### PR DESCRIPTION
## Summary

- Moves `__all__` outside the try/except block in `training/__init__.py`
- Both branches defined the identical list; now defined once, eliminating the maintenance hazard where adding a new export requires updating two places

## Test plan

- [ ] `python3 -m py_compile autobot-backend/training/__init__.py` — OK
- [ ] `__all__` appears once in the file (grep confirms line 16 only)

Closes #6265

🤖 Generated with [Claude Code](https://claude.com/claude-code)