### PR TITLE
fix(frontend/backend): unify WebSocket URL to /api/ws in ssot-config and frontend-config endpoint (#6232)

### DIFF
--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -124,6 +124,11 @@ def _build_frontend_services_config(ollama_url: str, redis_config: dict) -> dict
                 ssot_config.llm.lmstudio_host,
             ),
         },
+        # Issue #6232: Expose canonical WebSocket base URL so the frontend
+        # can validate/override the build-time ssot-config value at runtime.
+        "websocket": {
+            "url": ssot_config.websocket_url,
+        },
     }
 
 

--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -455,7 +455,7 @@ function buildConfig(): AutoBotConfig {
 
     get websocketUrl(): string {
       const wsProtocol = httpProtocol === 'https' ? 'wss' : 'ws';
-      return `${wsProtocol}://${vm.main}:${port.backend}/ws`;
+      return `${wsProtocol}://${vm.main}:${port.backend}/api/ws`;
     },
 
     get aistackUrl(): string {

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1412,8 +1412,14 @@ class AutoBotConfig(BaseSettings):
 
     @property
     def websocket_url(self) -> str:
-        """Get the WebSocket URL for real-time communication."""
-        return f"ws://{self.vm.main}:{self.port.backend}/ws"
+        """Get the WebSocket URL for real-time communication.
+
+        Issue #6232: Path corrected to /api/ws to match backend route /api/ws/live.
+        Uses wss:// when backend TLS is enabled.
+        """
+        if self.tls.backend_tls_enabled:
+            return f"wss://{self.vm.main}:{self.tls.backend_tls_port}/api/ws"
+        return f"ws://{self.vm.main}:{self.port.backend}/api/ws"
 
     @property
     def aistack_url(self) -> str:


### PR DESCRIPTION
## Summary
- Fix `ssot-config.ts` `websocketUrl` getter: `/ws` → `/api/ws` (matches backend route `/api/ws/live`)
- Fix `ssot_config.py` `websocket_url` property: same path correction + add `wss://` support when TLS is enabled
- Expose canonical WebSocket URL via `_build_frontend_services_config` in `system.py` so frontend can validate its build-time value at runtime

## Test plan
- [ ] Frontend WebSocket connections use correct `/api/ws` path (not bare `/ws` which 404s)
- [ ] `GET /api/frontend-config` response includes `services.websocket.url`
- [ ] TLS path returns `wss://` URL when `backend_tls_enabled=True`

Closes #6232

🤖 Generated with [Claude Code](https://claude.com/claude-code)