### PR TITLE
fix(docker): remove redundant /var/log/nginx tmpfs mount (#6254)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -358,7 +358,6 @@ services:
       - /var/run
       - /var/cache/nginx
       - /var/lib/nginx
-      - /var/log/nginx
     security_opt:
       - no-new-privileges:true
     networks:


### PR DESCRIPTION
## Summary

- Removes `- /var/log/nginx` from the `autobot-frontend` tmpfs block in `docker-compose.yml`
- nginx no longer writes to `/var/log/nginx` after log redirect to stdout/stderr (commit `8a08191e7`); the tmpfs mount allocates memory for a path nginx never uses

## Test plan

- [ ] `docker compose up autobot-frontend` starts without errors
- [ ] nginx logs appear on stdout/stderr (unchanged)

Closes #6254

🤖 Generated with [Claude Code](https://claude.com/claude-code)