### PR TITLE
fix(ci): correct smoke test timeout message to 7.5 min (#6255)

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -58,7 +58,7 @@ jobs:
             sleep 10
           done
 
-          echo "Services failed to become healthy within 7 minutes"
+          echo "Services failed to become healthy within 7.5 minutes (450s)"
           echo ""
           echo "=== Docker Compose Logs ==="
           docker compose --env-file docker/.env.docker logs


### PR DESCRIPTION
## Summary

- Changes smoke test failure message from "7 minutes" to "7.5 minutes (450s)" to match the actual `max_attempts=45 × 10s = 450s` poll window

## Test plan

- [ ] Failure path message now reads "7.5 minutes (450s)"

Closes #6255

🤖 Generated with [Claude Code](https://claude.com/claude-code)