### PR TITLE
fix(docker): install CPU-only torch/torchvision in backend Dockerfile (#6220)

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -31,6 +31,9 @@ COPY requirements.txt /app/requirements-root.txt
 COPY autobot-backend/requirements.txt /tmp/requirements.txt
 RUN grep -v -E "(autobot.shared|^-r )" /tmp/requirements.txt > /app/requirements-filtered.txt \
     && python3 -m pip install --no-cache-dir -r /app/requirements-root.txt \
+    && python3 -m pip install --no-cache-dir \
+        "torch>=2.11.0" "torchvision>=0.26.0" \
+        --index-url https://download.pytorch.org/whl/cpu \
     && python3 -m pip install --no-cache-dir -r /app/requirements-filtered.txt
 
 


### PR DESCRIPTION
## Summary

- Adds explicit torch/torchvision install step using the CPU-only PyTorch wheel index before the general requirements install
- Eliminates CUDA-enabled wheels (~2 GB) on CPU-only CI runners and production containers
- Reduces torch install size from ~2-2.5 GB to ~250 MB
- Prevents CUDA version mismatch between torch and torchvision

## Mechanism

PyTorch's CPU-only wheel index (`https://download.pytorch.org/whl/cpu`) provides the same version numbers as the CUDA wheels but without GPU libraries. Installing from there first means the subsequent `pip install -r requirements-filtered.txt` finds the version constraint already satisfied and skips reinstallation.

## Test plan

- [ ] `docker build -f docker/backend/Dockerfile .` completes without CUDA version conflict
- [ ] `python3 -c "import torch; print(torch.__version__)"` works in the built image
- [ ] Backend starts cleanly: `curl http://localhost:8001/api/system/health` → `{"status":"ok"}`

Closes #6220

🤖 Generated with [Claude Code](https://claude.com/claude-code)