### PR TITLE
fix(backend): promote websockets and live_events routers to core_routers (#6229)

### DIFF
--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -59,8 +59,10 @@ from api.knowledge_search_aggregator import (
 from api.knowledge_sync_queue import router as knowledge_sync_queue_router  # Issue #4453
 from api.knowledge_vectorization import router as knowledge_vectorization_router
 from api.llm import router as llm_router
+from api.live_events import router as live_events_router  # Issue #6229
 from api.long_running_operations import router as long_running_operations_router  # Issue #6227
 from api.llm_providers import router as llm_providers_router
+from api.websockets import router as websockets_router  # Issue #6229
 from api.manual_mcp import router as manual_mcp_router
 from api.mcp_registry import router as mcp_registry_router
 from api.memory import router as memory_router
@@ -304,6 +306,8 @@ def _get_service_routers() -> list:
         (voice_router, "/voice", ["voice"], "voice"),
         (voice_stream_router, "/voice", ["voice", "websocket"], "voice_stream"),
         (wake_word_router, "/wake_word", ["wake_word", "voice"], "wake_word"),
+        (websockets_router, "", ["websockets"], "websockets"),  # Issue #6229
+        (live_events_router, "", ["live-events"], "live_events"),  # Issue #6229
         (vnc_router, "/vnc", ["vnc"], "vnc"),
         (vnc_proxy_router, "/vnc-proxy", ["vnc-proxy"], "vnc_proxy"),
         # Issue #729: infrastructure_hosts removed - now served by slm-server

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -23,9 +23,7 @@ logger = logging.getLogger(__name__)
 # Format: (module_path, prefix, tags, name)
 FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
     # Core workflow and batch processing
-    ("api.websockets", "", ["websockets"], "websockets"),
-    # Issue #1408: scoped real-time event channels
-    ("api.live_events", "", ["live-events"], "live_events"),
+    # Issue #6229: api.websockets and api.live_events promoted to core_routers
     ("api.workflow", "/workflow", ["workflow"], "workflow"),
     # Issue #1287: batch.py consolidated into batch_jobs.py
     (


### PR DESCRIPTION
## Summary

- Moves `api.websockets` and `api.live_events` from `feature_routers.py` (lazy/optional loading) to `core_routers.py` (always loaded)
- Eliminates the root cause of ~7 s LiveEventService reconnect loops on all pages — the WebSocket endpoint was silently absent when feature router loading was skipped or delayed

## Root cause

`feature_routers.py` entries are loaded dynamically with import-error suppression. If any upstream dependency of the feature router module failed to import at startup, the WebSocket and live-events endpoints were never registered. The frontend's `LiveEventService` would then attempt to reconnect every ~7 s indefinitely.

Moving these two routers to `core_routers.py` makes them fail-fast (startup crash) rather than silently absent — WebSocket connectivity is a core transport, not an optional feature.

## Files changed

| File | Change |
|---|---|
| `initialization/router_registry/core_routers.py` | Added `live_events_router` + `websockets_router` imports and registrations |
| `initialization/router_registry/feature_routers.py` | Removed the two entries (replaced with comment referencing #6229) |

## Validation

- `python3 -m py_compile` passes for both changed files
- No logic changes — router registration only

🤖 Generated with [Claude Code](https://claude.com/claude-code)