### PR TITLE
lint(frontend): add vue/no-undef-components error rule to catch missing imports (#6236)

### DIFF
--- a/autobot-frontend/eslint.config.ts
+++ b/autobot-frontend/eslint.config.ts
@@ -51,6 +51,9 @@ export default defineConfigWithVueTs(
       'vue/no-deprecated-filter': 'warn',
       'vue/no-parsing-error': 'warn',
       'prefer-const': 'warn',
+      'vue/no-undef-components': ['error', {
+        ignorePatterns: ['RouterLink', 'RouterView', 'Transition', 'TransitionGroup', 'KeepAlive', 'Teleport', 'Suspense'],
+      }],
     },
   },
   ...pluginOxlint.configs['flat/recommended'],


### PR DESCRIPTION
## Summary

Closes #6236. Adds `vue/no-undef-components: 'error'` to `autobot-frontend/eslint.config.ts` to catch undefined component usage in Vue templates at lint time.

- **Why not `no-undef`?** `typescript-eslint` intentionally sets `no-undef: 'off'` for TypeScript projects because TypeScript's compiler already catches undefined identifiers via `ts(2304)`. Re-enabling it produces 118 false positives from TypeScript built-in types (`RequestInit`, `EventListener`, `ScrollBehavior`, etc.) and browser globals. The rule is not appropriate for TS codebases.
- **Why not `vue/script-setup-uses-vars`?** This rule was removed in `eslint-plugin-vue` v10. The project uses v10.8.0.
- **What covers composable missing imports** (the original #6231 bug class)? TypeScript via `vue-tsc --noEmit -p tsconfig.app.json`, which CI already runs. A missing composable import is `ts(2304): Cannot find name 'usePollingJob'`.
- `vue/no-undef-components` catches the _template_ side: components used without being imported or registered. Vue built-ins (`Transition`, `KeepAlive`, `Teleport`, `Suspense`) and Vue Router components (`RouterLink`, `RouterView`) are excluded via `ignorePatterns`.

## Verification

```bash
# Rule fires on undefined component:
$ echo '<template><MissingComponent/></template><script setup lang="ts"></script>' > src/t.vue
$ npx eslint src/t.vue
# → error  The '<MissingComponent>' component has been used, but not defined  vue/no-undef-components

# Zero new errors on existing codebase:
$ npx eslint src/ 2>&1 | grep -c vue/no-undef-components
# → 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)