### PR TITLE
fix(backend): deeper AI Stack diagnostic improvements — error boundaries + health check (#6234)

### DIFF
--- a/autobot-backend/api/ai_stack_integration.py
+++ b/autobot-backend/api/ai_stack_integration.py
@@ -152,13 +152,13 @@ async def ai_stack_health_check(admin_check: bool = Depends(check_admin_permissi
             ),
         )
     except Exception as e:
-        logger.error("AI Stack health check failed: %s", e)
+        logger.error("AI Stack health check failed: %s: %s", type(e).__name__, e)
         return JSONResponse(
             status_code=503,
             content={
                 "success": False,
                 "error": "AI Stack unavailable",
-                "details": "Internal server error",
+                "details": f"{type(e).__name__}: {e}",
                 "timestamp": utc_timestamp(),
             },
         )

--- a/autobot-backend/services/ai_stack_client.py
+++ b/autobot-backend/services/ai_stack_client.py
@@ -93,9 +93,9 @@ async def _process_ai_stack_response(
             None,
             False,
             AIStackError(
-                f"AI Stack request failed: {response.status}",
+                f"AI Stack error: upstream HTTP {response.status}",
                 status_code=response.status,
-                details={"response": response_text, "url": url},
+                details={"response": response_text[:500], "url": url},
             ),
         )
 
@@ -251,20 +251,37 @@ class AIStackClient:
                         raise error
                     return result
 
+            except asyncio.TimeoutError as e:
+                _log_connection_error(attempt + 1, e)
+                if attempt < self.retry_attempts - 1:
+                    await asyncio.sleep(self.retry_delay * (attempt + 1))
+                    continue
+                raise AIStackError(
+                    f"AI Stack unreachable: connection timed out ({self.timeout.total}s) to {url}",
+                    details={"error": type(e).__name__, "url": url},
+                )
+            except aiohttp.ClientConnectorError as e:
+                _log_connection_error(attempt + 1, e)
+                if attempt < self.retry_attempts - 1:
+                    await asyncio.sleep(self.retry_delay * (attempt + 1))
+                    continue
+                raise AIStackError(
+                    f"AI Stack unreachable: connection refused at {url}",
+                    details={"error": type(e).__name__, "url": url, "os_error": str(e.os_error) if e.os_error else None},
+                )
             except aiohttp.ClientError as e:
                 _log_connection_error(attempt + 1, e)
                 if attempt < self.retry_attempts - 1:
                     await asyncio.sleep(self.retry_delay * (attempt + 1))
                     continue
-
                 raise AIStackError(
-                    f"AI Stack unreachable: {type(e).__name__} connecting to {url}",
+                    f"AI Stack connection error: {type(e).__name__}: {e}",
                     details={"error": type(e).__name__, "url": url},
                 )
             except Exception as e:
-                logger.warning("Unexpected error in AI Stack request: %s", e)
+                logger.warning("Unexpected error in AI Stack request: %s: %s", type(e).__name__, e)
                 raise AIStackError(
-                    f"AI Stack error: {type(e).__name__}: {e}",
+                    f"Unexpected error during AI Stack request: {type(e).__name__}: {e}",
                     details={"error": type(e).__name__, "url": url},
                 )
 

--- a/autobot-backend/utils/error_boundaries/decorators.py
+++ b/autobot-backend/utils/error_boundaries/decorators.py
@@ -242,12 +242,20 @@ def _create_api_error_response(
     error_code = f"{error_code_prefix}_{abs(hash(type(e).__name__)) % 10000:04d}"
     status_code = APIErrorResponse.get_status_code_for_category(category)
 
+    exc_type = type(e).__name__
+    exc_msg = str(e)
+    message = (
+        f"Operation failed ({func_operation}): {exc_type}: {exc_msg}"
+        if exc_msg
+        else f"Operation failed ({func_operation}): {exc_type}"
+    )
+
     return APIErrorResponse(
         category=category,
-        message="Operation failed",
+        message=message,
         code=error_code,
         status_code=status_code,
-        details={"operation": func_operation},
+        details={"operation": func_operation, "exception_type": exc_type, "exception_message": exc_msg},
         trace_id=trace_id,
     )
 


### PR DESCRIPTION
## Summary

Extends the partial fix from PR #6262 with broader AI Stack diagnostic improvements:

- **`ai_stack_client._make_request`**: split `aiohttp.ClientError` into three specific handlers — `asyncio.TimeoutError` ('connection timed out with duration'), `aiohttp.ClientConnectorError` ('connection refused' + OS error detail), and residual `aiohttp.ClientError` fallback; each surfaces exception type and URL
- **`ai_stack_client._process_ai_stack_response`**: change `'AI Stack request failed: N'` → `'AI Stack error: upstream HTTP N'`; cap response body in details at 500 chars to prevent log flooding
- **`ai_stack_integration.ai_stack_health_check`**: replace static `'details: Internal server error'` with `f'{type(e).__name__}: {e}'` so operators see the actual exception
- **`error_boundaries.decorators._create_api_error_response`**: replace static `'Operation failed'` with `f'Operation failed ({operation}): {ExcType}: {exc_msg}'` and add `exception_type`/`exception_message` to details dict — affects every decorated endpoint

Relates to #6234 (first part merged in #6262 touched only `ai_stack_client.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)