### PR TITLE
fix(backend): replace callable None-stubs with MissingDep in 5 files (#6276)

### DIFF
--- a/autobot-backend/api/analytics_code_generation.py
+++ b/autobot-backend/api/analytics_code_generation.py
@@ -44,14 +44,16 @@ from api.schemas_analytics import (
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
+from autobot_shared.missing_dep import MissingDep as _MissingDep
+
 # LLM Interface for real code generation
 try:
     from llm_interface import LLMInterface
 
     LLM_INTERFACE_AVAILABLE = True
-except ImportError:
+except ImportError as _e:
     LLM_INTERFACE_AVAILABLE = False
-    LLMInterface = None
+    LLMInterface = _MissingDep("LLMInterface", _e)  # type: ignore[assignment]
     logging.warning("LLMInterface not available - code generation will fail")
 
 # Issue #552: Prefix set in router_registry to match frontend calls at /api/code-generation/*

--- a/autobot-backend/llm_interface_pkg/interface.py
+++ b/autobot-backend/llm_interface_pkg/interface.py
@@ -53,21 +53,23 @@ from .streaming import StreamingManager
 from .tiered_routing import TierConfig, TieredModelRouter
 from .types import ProviderType
 
+from autobot_shared.missing_dep import MissingDep as _MissingDep
+
 # Issue #756: Import provider health checking to prevent stalls
 try:
     from services.provider_health import ProviderHealthManager, ProviderStatus
 
     HEALTH_CHECK_AVAILABLE = True
-except ImportError:
+except ImportError as _e:
     HEALTH_CHECK_AVAILABLE = False
-    ProviderHealthManager = None
-    ProviderStatus = None
+    ProviderHealthManager = _MissingDep("ProviderHealthManager", _e)  # type: ignore[assignment]
+    ProviderStatus = _MissingDep("ProviderStatus", _e)  # type: ignore[assignment]
 
 # Optional imports
 try:
     from prompt_manager import prompt_manager
-except ImportError:
-    prompt_manager = None
+except ImportError as _e:
+    prompt_manager = _MissingDep("prompt_manager", _e)  # type: ignore[assignment]
 
 try:
     from autobot_shared.logging_manager import get_llm_logger
@@ -81,9 +83,9 @@ try:
     from api.analytics_llm_patterns import UsageRecordRequest, get_pattern_analyzer
 
     PATTERN_ANALYZER_AVAILABLE = True
-except ImportError:
+except ImportError as _e:
     PATTERN_ANALYZER_AVAILABLE = False
-    UsageRecordRequest = None
+    UsageRecordRequest = _MissingDep("UsageRecordRequest", _e)  # type: ignore[assignment]
     logger.debug("LLM Pattern Analyzer not available - usage tracking disabled")
 
 config = get_config_manager()

--- a/autobot-backend/llm_interface_pkg/optimization/connection_pool.py
+++ b/autobot-backend/llm_interface_pkg/optimization/connection_pool.py
@@ -16,13 +16,15 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
+from autobot_shared.missing_dep import MissingDep as _MissingDep
+
 try:
     import httpx
 
     HTTPX_AVAILABLE = True
-except ImportError:
+except ImportError as _e:
     HTTPX_AVAILABLE = False
-    httpx = None
+    httpx = _MissingDep("httpx", _e)  # type: ignore[assignment]
 
 from autobot_shared.ssot_config import config as _ssot_config
 

--- a/autobot-backend/utils/gpu_vector_search.py
+++ b/autobot-backend/utils/gpu_vector_search.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 
+from autobot_shared.missing_dep import MissingDep as _MissingDep
 from knowledge.backends import BaseClient, BaseCollection
 from utils.async_initializable import AsyncInitializable
 
@@ -40,19 +41,19 @@ try:
     else:
         FAISS_GPU_AVAILABLE = False
         FAISS_AVAILABLE = True
-except ImportError:
+except ImportError as _e:
     FAISS_AVAILABLE = False
     FAISS_GPU_AVAILABLE = False
-    faiss = None
+    faiss = _MissingDep("faiss", _e)  # type: ignore[assignment]
 
 # ChromaDB import
 try:
     import chromadb
 
     CHROMADB_AVAILABLE = True
-except ImportError:
+except ImportError as _e:
     CHROMADB_AVAILABLE = False
-    chromadb = None
+    chromadb = _MissingDep("chromadb", _e)  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/utils/task_queue.py
+++ b/autobot-backend/utils/task_queue.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 
+from autobot_shared.missing_dep import MissingDep as _MissingDep
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.time_utils import parse_utc_iso
 
@@ -26,9 +27,9 @@ try:
     from redis.exceptions import RedisError
 
     from autobot_shared.redis_client import get_redis_client
-except ImportError:
+except ImportError as _e:
     RedisError = Exception  # Fallback if redis not available
-    get_redis_client = None
+    get_redis_client = _MissingDep("get_redis_client", _e)  # type: ignore[assignment]
 
 from constants.threshold_constants import RetryConfig, TimingConstants
 
@@ -175,7 +176,7 @@ class TaskQueue:
             enable_scheduler: Whether to enable scheduled task processing
         """
         self.queue_name = queue_name
-        self.redis = redis_client or (get_redis_client() if get_redis_client else None)
+        self.redis = redis_client or get_redis_client()
         self.max_workers = max_workers
         self.enable_scheduler = enable_scheduler
 


### PR DESCRIPTION
## Summary

Closes #6276. Applies `MissingDep` sentinel pattern to 9 remaining `except ImportError: x = None` callable stubs, as a follow-up to #6264 (PR #6269).

**Files changed:**
- `utils/gpu_vector_search.py`: `faiss`, `chromadb`
- `llm_interface_pkg/interface.py`: `ProviderHealthManager`, `ProviderStatus`, `prompt_manager`, `UsageRecordRequest`
- `llm_interface_pkg/optimization/connection_pool.py`: `httpx`
- `api/analytics_code_generation.py`: `LLMInterface`
- `utils/task_queue.py`: `get_redis_client` + removes the `if get_redis_client else None` guard at call site (L178)

**Behavioral change:** If any of these optional dependencies is absent and code calls into the stub, callers now get `ImportError: X is not available — install the optional dependencies` instead of `TypeError: 'NoneType' object is not callable`.

## Verification

```bash
$ python3 -m py_compile \
    autobot-backend/utils/gpu_vector_search.py \
    autobot-backend/llm_interface_pkg/interface.py \
    autobot-backend/llm_interface_pkg/optimization/connection_pool.py \
    autobot-backend/api/analytics_code_generation.py \
    autobot-backend/utils/task_queue.py
# → (no output = clean)

$ grep -n "except ImportError" <5 files> -A3 | grep "= None"
# → error_handler = None / ErrorCategory = None (unconditional, not in except block — OK)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)