### PR TITLE
fix(frontend/backend): correct WebSocket URL path and HTTPS port (#6232)

### DIFF
--- a/autobot-backend/api/frontend_config.py
+++ b/autobot-backend/api/frontend_config.py
@@ -144,7 +144,7 @@ def _build_fallback_config() -> Dict[str, Any]:
             "timeouts": _build_timeouts_config(api_config.get("timeouts", {})),
         },
         "websocket": {
-            "url": f"ws://{backend_config.get('host')}:{backend_config.get('port')}/ws",
+            "url": f"ws://{backend_config.get('host')}:{backend_config.get('port')}/api/ws",
             "reconnect_attempts": websocket_config.get("reconnect_attempts", 5),
             "reconnect_delay": websocket_config.get("reconnect_delay", 1000),
         },

--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -454,8 +454,10 @@ function buildConfig(): AutoBotConfig {
     },
 
     get websocketUrl(): string {
-      const wsProtocol = httpProtocol === 'https' ? 'wss' : 'ws';
-      return `${wsProtocol}://${vm.main}:${port.backend}/api/ws`;
+      if (httpProtocol === 'https') {
+        return `wss://${vm.main}/api/ws`;
+      }
+      return `ws://${vm.main}:${port.backend}/api/ws`;
     },
 
     get aistackUrl(): string {

--- a/autobot_shared/network_constants.py
+++ b/autobot_shared/network_constants.py
@@ -219,7 +219,7 @@ class NetworkConstants:
     @classmethod
     def get_websocket_url(cls) -> str:
         """Get WebSocket URL for frontend (Issue #372 - reduces feature envy)."""
-        return f"ws://{cls.MAIN_MACHINE_IP}:{cls.BACKEND_PORT}/ws"
+        return f"ws://{cls.MAIN_MACHINE_IP}:{cls.BACKEND_PORT}/api/ws"
 
 
 class ServiceURLs:


### PR DESCRIPTION
## Summary

Closes #6232. Three targeted fixes to align WebSocket URL configuration with the actual backend path.

**Root cause:** The backend registers all WebSocket routes under the `/api` prefix (via `app_factory`), so the live-events endpoint is `/api/ws/live`. But two backend config values were returning `/ws` (wrong), and the frontend `ssot-config.ts` was building `wss://host:8001/ws` — wrong path AND in HTTPS production, port 8001 bypasses nginx TLS termination, causing a mixed-content block.

**Changes:**
1. `ssot-config.ts` `websocketUrl` getter: HTTPS builds `wss://host/api/ws` (no port, through nginx); HTTP dev builds `ws://host:8001/api/ws`
2. `autobot_shared/network_constants.py`: `/ws` → `/api/ws`  
3. `api/frontend_config.py`: `/ws` → `/api/ws`

🤖 Generated with [Claude Code](https://claude.com/claude-code)