### PR TITLE
fix(backend): apply MissingDep to remaining callable None-stubs in 6 API/analysis modules (#6285)

### DIFF
--- a/autobot-backend/api/codebase_analytics/analyzers.py
+++ b/autobot-backend/api/codebase_analytics/analyzers.py
@@ -36,11 +36,13 @@ try:
     _bug_predictor: Optional[BugPredictor] = None
     _analyzers_available = True
 except ImportError as e:
+    from autobot_shared.missing_dep import MissingDep as _MissingDep
+
     logger.warning("Code intelligence analyzers not available: %s", e)
     _analyzers_available = False
-    _anti_pattern_detector = None
-    _performance_analyzer = None
-    _bug_predictor = None
+    _anti_pattern_detector = _MissingDep("AntiPatternDetector", e)  # type: ignore[assignment]
+    _performance_analyzer = _MissingDep("PerformanceAnalyzer", e)  # type: ignore[assignment]
+    _bug_predictor = _MissingDep("BugPredictor", e)  # type: ignore[assignment]
 
 
 # =============================================================================

--- a/autobot-backend/api/long_running_operations.py
+++ b/autobot-backend/api/long_running_operations.py
@@ -58,20 +58,24 @@ try:
         OperationMigrator,
         operation_integration_manager,
     )
-except ImportError as e:
-    logging.warning(f"Long-running operations framework not available: {e}")
-    # Provide fallback implementations
-    operation_integration_manager = None
+except ImportError as _e:
+    from autobot_shared.missing_dep import MissingDep as _MissingDep
+
+    logging.warning(f"Long-running operations framework not available: {_e}")
+    OperationStatus = _MissingDep("OperationStatus", _e)  # type: ignore[assignment]
+    OperationType = _MissingDep("OperationType", _e)  # type: ignore[assignment]
+    CreateOperationRequest = _MissingDep("CreateOperationRequest", _e)  # type: ignore[assignment]
+    OperationMigrator = _MissingDep("OperationMigrator", _e)  # type: ignore[assignment]
+    operation_integration_manager = _MissingDep("operation_integration_manager", _e)  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["long-running-operations"])
 
 # Performance optimization: O(1) lookup for failed operation statuses (Issue #326)
-FAILED_OPERATION_STATUSES = (
-    {OperationStatus.FAILED, OperationStatus.TIMEOUT}
-    if operation_integration_manager
-    else set()
-)
+try:
+    FAILED_OPERATION_STATUSES = {OperationStatus.FAILED, OperationStatus.TIMEOUT}
+except ImportError:
+    FAILED_OPERATION_STATUSES = set()
 
 
 # Additional models specific to AutoBot integration

--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -24,13 +24,13 @@ try:
     # get_performance_report, get_agent_recommendations, etc.).
     orchestrator = get_orchestrator_sync()
     _ORCHESTRATOR_AVAILABLE = True
-except ImportError:
+except ImportError as _e:
+    from autobot_shared.missing_dep import MissingDep as _MissingDep
+
     _ORCHESTRATOR_AVAILABLE = False
-    create_and_execute_workflow = None
-    orchestrator = None
-    logging.getLogger(__name__).warning(
-        "orchestrator module not available"
-    )
+    create_and_execute_workflow = _MissingDep("create_and_execute_workflow", _e)  # type: ignore[assignment]
+    orchestrator = _MissingDep("orchestrator", _e)  # type: ignore[assignment]
+    logging.getLogger(__name__).warning("orchestrator module not available")
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from api.schemas_common import DataResponse, SuccessResponse

--- a/autobot-backend/api/services.py
+++ b/autobot-backend/api/services.py
@@ -25,8 +25,10 @@ from api.schemas_system import (
 # Import existing monitoring functionality
 try:
     from api.monitoring import get_services_health as monitoring_services_health
-except ImportError:
-    monitoring_services_health = None
+except ImportError as _e:
+    from autobot_shared.missing_dep import MissingDep as _MissingDep
+
+    monitoring_services_health = _MissingDep("monitoring_services_health", _e)  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Services"])

--- a/autobot-backend/api/validation_dashboard.py
+++ b/autobot-backend/api/validation_dashboard.py
@@ -43,7 +43,9 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 try:
     from scripts.validation_dashboard_generator import ValidationDashboardGenerator
 except ImportError as e:
-    ValidationDashboardGenerator = None
+    from autobot_shared.missing_dep import MissingDep as _MissingDep
+
+    ValidationDashboardGenerator = _MissingDep("ValidationDashboardGenerator", e)  # type: ignore[assignment]
     import_error = str(e)
 
 # Import LLM judges for validation enhancement

--- a/autobot-backend/code_analysis/src/ownership_analyzer.py
+++ b/autobot-backend/code_analysis/src/ownership_analyzer.py
@@ -34,8 +34,10 @@ try:
 
     _REDIS_AVAILABLE = True
     _CONFIG_AVAILABLE = True
-except ImportError:
-    get_redis_client = None
+except ImportError as _e:
+    from autobot_shared.missing_dep import MissingDep as _MissingDep
+
+    get_redis_client = _MissingDep("get_redis_client", _e)  # type: ignore[assignment]
     TTL_1_HOUR = 3_600
     _REDIS_AVAILABLE = False
     _CONFIG_AVAILABLE = False


### PR DESCRIPTION
## Summary

Applies the `MissingDep` sentinel (established in #6223, #6264, #6276) to 9 remaining callable `None` stubs across 6 backend files. Callers now receive a clear `ImportError` with context instead of a misleading `TypeError: 'NoneType' object is not callable` or `AttributeError`.

## Files Changed

| File | Symbols replaced |
|------|-----------------|
| `api/validation_dashboard.py` | `ValidationDashboardGenerator` |
| `api/long_running_operations.py` | `OperationStatus`, `OperationType`, `CreateOperationRequest`, `OperationMigrator`, `operation_integration_manager` |
| `api/services.py` | `monitoring_services_health` |
| `api/orchestration.py` | `create_and_execute_workflow`, `orchestrator` |
| `api/codebase_analytics/analyzers.py` | `_anti_pattern_detector`, `_performance_analyzer`, `_bug_predictor` |
| `code_analysis/src/ownership_analyzer.py` | `get_redis_client` |

## Notable: `long_running_operations.py`

`FAILED_OPERATION_STATUSES` was computed via a ternary `if operation_integration_manager else set()`. With MissingDep (truthy), `OperationStatus.FAILED` would be evaluated at module load time, raising `ImportError`. Fixed by wrapping in `try/except ImportError` instead.

## Test plan

- [x] All 6 modified files pass `python3 -m py_compile`
- [x] Pattern consistent with #6276 (same `_MissingDep` alias, `# type: ignore[assignment]`)

Closes #6285