### PR TITLE
chore(backend): wire IsolatedBridgeRegistry graceful shutdown on backend exit (#4107)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1532,6 +1532,15 @@ async def cleanup_services(app: FastAPI):
         except Exception as pm_err:
             logger.warning("Plugin manager shutdown failed: %s", pm_err)
 
+        # Issue #4107: Stop isolated MCP bridge worker processes
+        try:
+            from services.mcp_isolated_runtime import get_isolated_registry
+
+            await get_isolated_registry().shutdown_all()
+            logger.info("✅ Isolated MCP bridge workers shutdown")
+        except Exception as mcp_err:
+            logger.warning("Isolated MCP bridge shutdown failed: %s", mcp_err)
+
         # Redis connections automatically managed by get_redis_client()
         logger.info("✅ Cleanup completed successfully")
     except Exception as e:


### PR DESCRIPTION
## Summary

- Calls `get_isolated_registry().shutdown_all()` in `lifespan.py`'s cleanup sequence so isolated MCP bridge worker subprocesses receive `SIGTERM` before the backend process exits.
- Wrapped in `try/except Exception` consistent with the surrounding shutdown hooks so a misbehaving registry never prevents other cleanup from running.

## Test plan

- [x] `python3 -m py_compile autobot-backend/initialization/lifespan.py` passes
- [x] `shutdown_all()` logs `"✅ Isolated MCP bridge workers shutdown"` on clean exit
- [x] Failures in `shutdown_all()` produce a warning but don't abort the remaining cleanup

Closes #4107