### PR TITLE
fix(api/orchestration): remove unused SuccessResponse import (#6290)

### DIFF
--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -33,7 +33,7 @@ except ImportError as _e:
     logging.getLogger(__name__).warning("orchestrator module not available")
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- Removes `SuccessResponse` from the `api.schemas_common` import in `api/orchestration.py` — it was imported but never used, leaving a dead import and a false dependency signal.

## Root Cause
`SuccessResponse` was present in the import line from before the MissingDep refactor; no route in the file uses it.

## Test plan
- [x] `python3 -m py_compile autobot-backend/api/orchestration.py` passes
- [x] `grep SuccessResponse autobot-backend/api/orchestration.py` returns no hits post-removal

Closes #6290