### PR TITLE
fix(code_analysis): remove dead self.config assignment in OwnershipAnalyzer (#6288)

### DIFF
--- a/autobot-backend/code_analysis/src/ownership_analyzer.py
+++ b/autobot-backend/code_analysis/src/ownership_analyzer.py
@@ -156,7 +156,6 @@ class OwnershipAnalyzer:
         else:
             self.redis_client = None
             logger.info("Redis not available - caching disabled for OwnershipAnalyzer")
-        self.config = config
 
         # Caching keys
         self.OWNERSHIP_KEY = "ownership_analysis:files"


### PR DESCRIPTION
## Summary
- Removes `self.config = config` from `OwnershipAnalyzer.__init__` in `code_analysis/src/ownership_analyzer.py`.
- `config` is never imported in this file and `self.config` is never read anywhere in the class — the assignment would raise `NameError` at runtime whenever `OwnershipAnalyzer` is instantiated.

## Root Cause
Dead assignment left from an earlier refactor; the `config` name was removed from imports but the assignment line was not cleaned up.

## Test plan
- [x] `python3 -m py_compile autobot-backend/code_analysis/src/ownership_analyzer.py` passes
- [x] `grep 'self\.config' autobot-backend/code_analysis/src/ownership_analyzer.py` returns no hits

Closes #6288