### PR TITLE
fix(api/long_running_operations): restore HTTP 503 guards bypassed by MissingDep (#6289)

### DIFF
--- a/autobot-backend/api/long_running_operations.py
+++ b/autobot-backend/api/long_running_operations.py
@@ -58,6 +58,7 @@ try:
         OperationMigrator,
         operation_integration_manager,
     )
+    _OPERATIONS_AVAILABLE = True
 except ImportError as _e:
     from autobot_shared.missing_dep import MissingDep as _MissingDep
 
@@ -67,6 +68,7 @@ except ImportError as _e:
     CreateOperationRequest = _MissingDep("CreateOperationRequest", _e)  # type: ignore[assignment]
     OperationMigrator = _MissingDep("OperationMigrator", _e)  # type: ignore[assignment]
     operation_integration_manager = _MissingDep("operation_integration_manager", _e)  # type: ignore[assignment]
+    _OPERATIONS_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["long-running-operations"])
@@ -153,7 +155,7 @@ class SecurityScanRequest(BaseModel):
 
 async def get_operation_manager():
     """Dependency to get the operation integration manager"""
-    if operation_integration_manager is None:
+    if not _OPERATIONS_AVAILABLE:
         raise HTTPException(
             status_code=503, detail="Long-running operations service not available"
         )
@@ -652,7 +654,7 @@ async def resume_operation(operation_id: str, manager=Depends(get_operation_mana
 @router.websocket("/{operation_id}/progress")
 async def websocket_progress_updates(websocket: WebSocket, operation_id: str):
     """WebSocket endpoint for real-time progress updates"""
-    if operation_integration_manager is None:
+    if not _OPERATIONS_AVAILABLE:
         await websocket.close(code=1003, reason="Service not available")
         return
 
@@ -718,7 +720,7 @@ async def websocket_progress_updates(websocket: WebSocket, operation_id: str):
 @router.get("/health", response_model=LongRunningOperationHealthResponse)
 async def operations_health():
     """Health check for long-running operations service"""
-    if operation_integration_manager is None:
+    if not _OPERATIONS_AVAILABLE:
         return JSONResponse(
             status_code=503,
             content={


### PR DESCRIPTION
## Summary
- Adds `_OPERATIONS_AVAILABLE` flag to the try/except block in `api/long_running_operations.py` (same pattern as `_ORCHESTRATOR_AVAILABLE` in `api/orchestration.py`).
- Updates three `get_operation_manager` guards from `if operation_integration_manager is None:` to `if not _OPERATIONS_AVAILABLE:` so the HTTP 503 response is correctly raised when the framework is unavailable.

## Root Cause
PR #6285 replaced `None` stubs with `MissingDep` sentinels. `MissingDep` is truthy, so the existing `is None` guards at lines 156, 655, 721 were silently bypassed. When any dependent route called `get_operation_manager()`, it returned the MissingDep object instead of raising HTTP 503 — callers then hit `MissingDep.__getattr__` → `ImportError` → HTTP 500 via `@with_error_handling`.

## Fix
```python
# try block
_OPERATIONS_AVAILABLE = True
# except block  
_OPERATIONS_AVAILABLE = False

# guards
if not _OPERATIONS_AVAILABLE:   # was: if operation_integration_manager is None:
    raise HTTPException(503, ...)
```

## Test plan
- [x] `python3 -m py_compile autobot-backend/api/long_running_operations.py` passes
- [x] Three guards confirmed changed via `grep 'not _OPERATIONS_AVAILABLE' long_running_operations.py` (3 hits)

Closes #6289