### PR TITLE
fix(pki): implement certificate renewal with key preservation option (#4312)

### DIFF
--- a/autobot-backend/pki/generator.py
+++ b/autobot-backend/pki/generator.py
@@ -382,6 +382,59 @@ class CertificateGenerator:
         logger.info(f"Certificate generated for {vm_info.name}: {cert_path}")
         return True
 
+    def _renew_service_cert(self, vm_info: VMCertificateInfo) -> bool:
+        """
+        Renew a service certificate while preserving the existing private key.
+
+        Reuses the existing key at ``vm_info.key_path``, regenerates only the
+        CSR and the signed certificate.  The certificate at ``vm_info.cert_path``
+        is replaced in-place so callers that already hold the path do not need
+        updating.
+
+        Args:
+            vm_info: VM certificate information (name, paths, SANs).
+
+        Returns:
+            True if renewal succeeded.
+        """
+        cert_path = vm_info.cert_path
+        key_path = vm_info.key_path
+
+        if not key_path.exists():
+            logger.error(
+                f"Cannot renew certificate for {vm_info.name}: "
+                f"existing key not found at {key_path}"
+            )
+            return False
+
+        logger.info(
+            f"Renewing certificate for {vm_info.name} (preserving existing key)"
+        )
+
+        conf_path = cert_path.parent / "server.conf"
+        _write_openssl_config(conf_path, self.config, vm_info)
+
+        csr_path = cert_path.parent / "server.csr"
+        if not _generate_csr(key_path, csr_path, conf_path, vm_info.name):
+            return False
+
+        if not _sign_certificate(
+            csr_path,
+            cert_path,
+            self.config.ca_cert_path,
+            self.config.ca_key_path,
+            conf_path,
+            self.config.cert_validity_days,
+            vm_info.name,
+        ):
+            return False
+
+        csr_path.unlink()
+        logger.info(
+            f"Certificate renewed for {vm_info.name} (key preserved): {cert_path}"
+        )
+        return True
+
     def _parse_certificate_output(
         self, output: str
     ) -> Tuple[Optional[str], Optional[str], Optional[str]]:

--- a/autobot-backend/pki/manager.py
+++ b/autobot-backend/pki/manager.py
@@ -247,16 +247,29 @@ class PKIManager:
         """Get list of certificates needing renewal."""
         return self.generator.needs_renewal()
 
-    async def renew(self, certificates: Optional[List[str]] = None) -> bool:
+    async def renew(
+        self,
+        certificates: Optional[List[str]] = None,
+        preserve_keys: bool = True,
+    ) -> bool:
         """
         Renew certificates.
 
         Args:
             certificates: List of certificate names to renew.
                          If None, renews all that need renewal.
+            preserve_keys: When True (default), reuses the existing private key
+                          and only regenerates the certificate.  When False,
+                          regenerates both the private key and the certificate
+                          (full key rotation).
 
         Returns:
-            True if renewal successful
+            True if all renewals succeeded.
+
+        Raises:
+            ValueError: If "ca" is included in the certificates list.  CA
+                       renewal requires manual steps (re-signing all service
+                       certificates) and cannot be performed automatically.
         """
         if certificates is None:
             certificates = self.generator.needs_renewal()
@@ -265,26 +278,40 @@ class PKIManager:
             logger.info("No certificates need renewal")
             return True
 
-        logger.info(f"Renewing certificates: {certificates}")
+        if "ca" in certificates:
+            raise ValueError(
+                "CA certificate renewal requires manual steps: the CA key and "
+                "certificate must be rotated offline, and all service certificates "
+                "must then be re-signed against the new CA.  Remove 'ca' from the "
+                "renewal list and follow the PKI CA-rotation runbook."
+            )
 
-        # For now, regenerate and redistribute
-        # TODO: Implement proper renewal that preserves keys if desired
+        logger.info(
+            "Renewing certificates: %s (preserve_keys=%s)", certificates, preserve_keys
+        )
 
+        success = True
         for cert_name in certificates:
-            if cert_name == "ca":
-                # CA renewal is more complex - would need to re-sign all certs
-                logger.warning("CA renewal not yet implemented")
+            vm_ip = VM_DEFINITIONS.get(cert_name)
+            if not vm_ip:
+                logger.warning("Unknown certificate name '%s', skipping", cert_name)
                 continue
 
-            vm_ip = VM_DEFINITIONS.get(cert_name)
-            if vm_ip:
-                vm_info = self.config.get_vm_cert_info(cert_name, vm_ip)
-                # Regenerate
-                self.generator._generate_service_cert(vm_info, force=True)
-                # Redistribute
-                await self.distributor._distribute_to_vm(vm_info)
+            vm_info = self.config.get_vm_cert_info(cert_name, vm_ip)
 
-        return True
+            if preserve_keys:
+                renewed = self.generator._renew_service_cert(vm_info)
+            else:
+                renewed = self.generator._generate_service_cert(vm_info, force=True)
+
+            if not renewed:
+                logger.error("Failed to renew certificate for %s", cert_name)
+                success = False
+                continue
+
+            await self.distributor._distribute_to_vm(vm_info)
+
+        return success
 
     def get_certificate_details(self) -> Dict[str, dict]:
         """Get detailed certificate information."""

--- a/autobot-backend/pki/test_renewal.py
+++ b/autobot-backend/pki/test_renewal.py
@@ -1,0 +1,285 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for PKIManager.renew() — key preservation and key rotation paths.
+
+These tests mock all subprocess/SSH calls so they run without OpenSSL or
+a live CA on the test machine.
+"""
+
+import asyncio
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pki.config import TLSConfig, VMCertificateInfo
+from pki.generator import CertificateGenerator
+from pki.manager import PKIManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_vm_info(tmp_path: Path, name: str = "redis") -> VMCertificateInfo:
+    """Create a minimal VMCertificateInfo rooted under tmp_path."""
+    vm_dir = tmp_path / name
+    vm_dir.mkdir(parents=True, exist_ok=True)
+    return VMCertificateInfo(
+        name=name,
+        ip="192.168.1.10",
+        cert_path=vm_dir / "server-cert.pem",
+        key_path=vm_dir / "server-key.pem",
+        common_name=f"autobot-{name}",
+        san_entries=[f"DNS:autobot-{name}", "IP:192.168.1.10"],
+    )
+
+
+def _make_manager(tmp_path: Path) -> PKIManager:
+    """Build a PKIManager whose generator and distributor are fully mocked."""
+    config = MagicMock(spec=TLSConfig)
+    config.cert_dir_path = tmp_path / "certs"
+    config.ca_cert_path = tmp_path / "certs" / "ca" / "ca-cert.pem"
+    config.ca_key_path = tmp_path / "certs" / "ca" / "ca-key.pem"
+    config.cert_validity_days = 365
+    config.key_size = 2048
+    config.country = "US"
+    config.organization = "AutoBot"
+
+    manager = PKIManager.__new__(PKIManager)
+    manager.config = config
+    manager.generator = MagicMock(spec=CertificateGenerator)
+    manager.distributor = MagicMock()
+    manager.distributor._distribute_to_vm = AsyncMock(return_value=None)
+    manager.configurator = MagicMock()
+    manager._stage = MagicMock()
+    manager._errors = []
+    manager._warnings = []
+    return manager
+
+
+# ---------------------------------------------------------------------------
+# renew() — no-op when nothing needs renewal
+# ---------------------------------------------------------------------------
+
+def test_renew_no_certs_returns_true(tmp_path):
+    manager = _make_manager(tmp_path)
+    manager.generator.needs_renewal.return_value = []
+
+    result = asyncio.get_event_loop().run_until_complete(manager.renew())
+
+    assert result is True
+    manager.generator._renew_service_cert.assert_not_called()
+    manager.generator._generate_service_cert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# renew() — CA in list raises ValueError
+# ---------------------------------------------------------------------------
+
+def test_renew_ca_raises_value_error(tmp_path):
+    manager = _make_manager(tmp_path)
+
+    with pytest.raises(ValueError, match="CA certificate renewal requires manual steps"):
+        asyncio.get_event_loop().run_until_complete(
+            manager.renew(certificates=["ca"])
+        )
+
+    manager.generator._renew_service_cert.assert_not_called()
+    manager.generator._generate_service_cert.assert_not_called()
+
+
+def test_renew_ca_mixed_list_raises_before_any_cert(tmp_path):
+    """CA in a mixed list must raise before touching any service cert."""
+    manager = _make_manager(tmp_path)
+
+    with pytest.raises(ValueError):
+        asyncio.get_event_loop().run_until_complete(
+            manager.renew(certificates=["redis", "ca"])
+        )
+
+    manager.generator._renew_service_cert.assert_not_called()
+    manager.generator._generate_service_cert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# renew() — preserve_keys=True (default) path
+# ---------------------------------------------------------------------------
+
+def test_renew_preserve_keys_calls_renew_service_cert(tmp_path):
+    manager = _make_manager(tmp_path)
+    manager.generator._renew_service_cert.return_value = True
+
+    vm_info = _make_vm_info(tmp_path, "redis")
+    manager.config.get_vm_cert_info.return_value = vm_info
+
+    with patch("pki.manager.VM_DEFINITIONS", {"redis": "192.168.1.10"}):
+        result = asyncio.get_event_loop().run_until_complete(
+            manager.renew(certificates=["redis"], preserve_keys=True)
+        )
+
+    assert result is True
+    manager.generator._renew_service_cert.assert_called_once_with(vm_info)
+    manager.generator._generate_service_cert.assert_not_called()
+    manager.distributor._distribute_to_vm.assert_awaited_once_with(vm_info)
+
+
+def test_renew_default_preserve_keys_true(tmp_path):
+    """preserve_keys defaults to True — ensure _renew_service_cert is used."""
+    manager = _make_manager(tmp_path)
+    manager.generator._renew_service_cert.return_value = True
+
+    vm_info = _make_vm_info(tmp_path, "redis")
+    manager.config.get_vm_cert_info.return_value = vm_info
+
+    with patch("pki.manager.VM_DEFINITIONS", {"redis": "192.168.1.10"}):
+        result = asyncio.get_event_loop().run_until_complete(
+            manager.renew(certificates=["redis"])
+        )
+
+    assert result is True
+    manager.generator._renew_service_cert.assert_called_once()
+    manager.generator._generate_service_cert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# renew() — preserve_keys=False (key rotation) path
+# ---------------------------------------------------------------------------
+
+def test_renew_rotate_keys_calls_generate_service_cert(tmp_path):
+    manager = _make_manager(tmp_path)
+    manager.generator._generate_service_cert.return_value = True
+
+    vm_info = _make_vm_info(tmp_path, "redis")
+    manager.config.get_vm_cert_info.return_value = vm_info
+
+    with patch("pki.manager.VM_DEFINITIONS", {"redis": "192.168.1.10"}):
+        result = asyncio.get_event_loop().run_until_complete(
+            manager.renew(certificates=["redis"], preserve_keys=False)
+        )
+
+    assert result is True
+    manager.generator._generate_service_cert.assert_called_once_with(vm_info, force=True)
+    manager.generator._renew_service_cert.assert_not_called()
+    manager.distributor._distribute_to_vm.assert_awaited_once_with(vm_info)
+
+
+# ---------------------------------------------------------------------------
+# renew() — failure propagation
+# ---------------------------------------------------------------------------
+
+def test_renew_preserve_keys_failure_returns_false(tmp_path):
+    manager = _make_manager(tmp_path)
+    manager.generator._renew_service_cert.return_value = False
+
+    vm_info = _make_vm_info(tmp_path, "redis")
+    manager.config.get_vm_cert_info.return_value = vm_info
+
+    with patch("pki.manager.VM_DEFINITIONS", {"redis": "192.168.1.10"}):
+        result = asyncio.get_event_loop().run_until_complete(
+            manager.renew(certificates=["redis"], preserve_keys=True)
+        )
+
+    assert result is False
+    # Distribution must NOT be called when cert generation failed
+    manager.distributor._distribute_to_vm.assert_not_awaited()
+
+
+def test_renew_rotate_keys_failure_returns_false(tmp_path):
+    manager = _make_manager(tmp_path)
+    manager.generator._generate_service_cert.return_value = False
+
+    vm_info = _make_vm_info(tmp_path, "redis")
+    manager.config.get_vm_cert_info.return_value = vm_info
+
+    with patch("pki.manager.VM_DEFINITIONS", {"redis": "192.168.1.10"}):
+        result = asyncio.get_event_loop().run_until_complete(
+            manager.renew(certificates=["redis"], preserve_keys=False)
+        )
+
+    assert result is False
+    manager.distributor._distribute_to_vm.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# renew() — unknown cert name is skipped, not a hard failure
+# ---------------------------------------------------------------------------
+
+def test_renew_unknown_cert_name_skipped(tmp_path):
+    manager = _make_manager(tmp_path)
+
+    with patch("pki.manager.VM_DEFINITIONS", {}):
+        result = asyncio.get_event_loop().run_until_complete(
+            manager.renew(certificates=["unknown-vm"])
+        )
+
+    assert result is True
+    manager.generator._renew_service_cert.assert_not_called()
+    manager.generator._generate_service_cert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CertificateGenerator._renew_service_cert — unit tests
+# ---------------------------------------------------------------------------
+
+def test_renew_service_cert_missing_key_returns_false(tmp_path):
+    config = MagicMock(spec=TLSConfig)
+    config.ca_cert_path = tmp_path / "ca-cert.pem"
+    config.ca_key_path = tmp_path / "ca-key.pem"
+    config.cert_validity_days = 365
+    config.key_size = 2048
+    config.country = "US"
+    config.organization = "AutoBot"
+
+    gen = CertificateGenerator(config=config)
+    vm_info = _make_vm_info(tmp_path, "redis")
+    # key_path does NOT exist
+
+    result = gen._renew_service_cert(vm_info)
+
+    assert result is False
+
+
+def test_renew_service_cert_preserves_key_file(tmp_path):
+    """_renew_service_cert must NOT overwrite the existing key file."""
+    config = MagicMock(spec=TLSConfig)
+    config.ca_cert_path = tmp_path / "ca-cert.pem"
+    config.ca_key_path = tmp_path / "ca-key.pem"
+    config.cert_validity_days = 365
+    config.key_size = 2048
+    config.country = "US"
+    config.organization = "AutoBot"
+
+    gen = CertificateGenerator(config=config)
+    vm_info = _make_vm_info(tmp_path, "redis")
+
+    # Plant a sentinel key file
+    sentinel = b"EXISTING_KEY_CONTENT"
+    vm_info.key_path.write_bytes(sentinel)
+
+    # Stub out OpenSSL calls: CSR succeeds, signing succeeds, cert file created
+    def fake_generate_csr(key_path, csr_path, conf_path, vm_name):
+        csr_path.write_text("CSR", encoding="utf-8")
+        return True
+
+    def fake_sign_certificate(csr_path, cert_path, *args, **kwargs):
+        cert_path.write_text("CERT", encoding="utf-8")
+        import os
+        os.chmod(cert_path, 0o644)
+        return True
+
+    with (
+        patch("pki.generator._write_openssl_config"),
+        patch("pki.generator._generate_csr", side_effect=fake_generate_csr),
+        patch("pki.generator._sign_certificate", side_effect=fake_sign_certificate),
+    ):
+        result = gen._renew_service_cert(vm_info)
+
+    assert result is True
+    # The key file must be untouched
+    assert vm_info.key_path.read_bytes() == sentinel
+    # The cert file must have been written
+    assert vm_info.cert_path.read_text(encoding="utf-8") == "CERT"


### PR DESCRIPTION
## Summary
- Adds `preserve_keys: bool = True` parameter to `PKIManager.renew()`
- Default behavior now reuses existing private key, generates only a new cert via `_renew_service_cert()` — key continuity maintained
- `preserve_keys=False` triggers full key+cert rotation (previous behavior via `_generate_service_cert(force=True)`)
- CA renewal now raises `ValueError` with a clear runbook hint instead of silently skipping
- Unknown cert names logged at WARNING and skipped without aborting the rest of the list
- Returns `False` if any cert fails; distribution only attempted on successful certs
- Removes the TODO comment at line 271

## New method in generator.py: `_renew_service_cert(vm_info)`
- Reads existing key file, validates it present (returns `False` with ERROR log if missing)
- Generates new CSR + cert signed by CA; never writes to the key file path

## Tests (`pki/test_renewal.py`) — 11 passing
- No-op on empty renewal list
- CA alone and CA in mixed list → ValueError before any cert touched
- `preserve_keys=True`: calls `_renew_service_cert`, not `_generate_service_cert`
- `preserve_keys=False`: calls `_generate_service_cert(force=True)`, not `_renew_service_cert`
- Generation failure → `False` returned, distribution not called
- Unknown cert → skipped, returns `True`
- Missing key file → `_renew_service_cert` returns `False`
- Key file sentinel unchanged after `_renew_service_cert`

Closes #4312