### PR TITLE
feat(frontend): add useRequestQueue composable with priority queue and deduplication (#4415)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useRequestQueue.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useRequestQueue.test.ts
@@ -1,0 +1,256 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * Unit tests for useRequestQueue composable
+ * Issue #4415: Backpressure for concurrent LLM calls
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
+
+// Isolate module so each test gets a fresh singleton
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+function deferred<T>() {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('useRequestQueue', () => {
+  // Re-import per test to reset module state properly
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('executes a single request immediately', async () => {
+    const { useRequestQueue } = await import('../useRequestQueue')
+    const queue = useRequestQueue()
+    const fn = vi.fn().mockResolvedValue('ok')
+    const result = await queue.enqueue({ fn, priority: 'normal' })
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledOnce()
+  })
+
+  it('pending increments while queued and decrements after start', async () => {
+    const { useRequestQueue } = await import('../useRequestQueue')
+    const queue = useRequestQueue({ concurrency: 1 })
+
+    const d1 = deferred<string>()
+    const d2 = deferred<string>()
+
+    queue.enqueue({ fn: () => d1.promise, priority: 'normal' })
+    queue.enqueue({ fn: () => d2.promise, priority: 'normal' })
+
+    await nextTick()
+    // d1 is in-flight, d2 is pending
+    expect(queue.active.value).toBe(1)
+    expect(queue.pending.value).toBe(1)
+
+    d1.resolve('first')
+    await nextTick()
+    await nextTick()
+    // d2 now in-flight
+    expect(queue.active.value).toBe(1)
+    expect(queue.pending.value).toBe(0)
+
+    d2.resolve('second')
+    await nextTick()
+    expect(queue.active.value).toBe(0)
+    expect(queue.pending.value).toBe(0)
+  })
+
+  it('respects concurrency limit', async () => {
+    const { useRequestQueue } = await import('../useRequestQueue')
+    const queue = useRequestQueue({ concurrency: 2 })
+
+    const defers = [deferred<number>(), deferred<number>(), deferred<number>()]
+    const startOrder: number[] = []
+
+    defers.forEach((d, i) => {
+      queue.enqueue({
+        fn: () => { startOrder.push(i); return d.promise },
+        priority: 'normal',
+      })
+    })
+
+    await nextTick()
+    // Only 2 should have started
+    expect(queue.active.value).toBe(2)
+    expect(queue.pending.value).toBe(1)
+    expect(startOrder).toEqual([0, 1])
+
+    defers[0].resolve(0)
+    await nextTick()
+    await nextTick()
+    // Third should now start
+    expect(queue.active.value).toBe(2)
+    expect(startOrder).toEqual([0, 1, 2])
+
+    defers[1].resolve(1)
+    defers[2].resolve(2)
+    await Promise.allSettled(defers.map((d) => d.promise))
+    expect(queue.active.value).toBe(0)
+  })
+
+  it('executes high priority before normal before low', async () => {
+    const { useRequestQueue } = await import('../useRequestQueue')
+    // concurrency=1 so we can observe ordering
+    const queue = useRequestQueue({ concurrency: 1 })
+
+    const gate = deferred<void>()
+    const order: string[] = []
+
+    // Fill the single slot first to allow queueing
+    queue.enqueue({ fn: () => gate.promise, priority: 'normal' })
+
+    queue.enqueue({ fn: async () => { order.push('low') }, priority: 'low' })
+    queue.enqueue({ fn: async () => { order.push('high') }, priority: 'high' })
+    queue.enqueue({ fn: async () => { order.push('normal') }, priority: 'normal' })
+
+    await nextTick()
+    gate.resolve()
+    await nextTick()
+    await nextTick()
+    await nextTick()
+
+    expect(order).toEqual(['high', 'normal', 'low'])
+  })
+
+  it('deduplicates in-flight requests by dedupeKey', async () => {
+    const { useRequestQueue } = await import('../useRequestQueue')
+    const queue = useRequestQueue()
+
+    const fn = vi.fn().mockResolvedValue('data')
+    const p1 = queue.enqueue({ fn, priority: 'normal', dedupeKey: 'search-x' })
+    const p2 = queue.enqueue({ fn, priority: 'normal', dedupeKey: 'search-x' })
+
+    expect(p1).toBe(p2)
+    const [r1, r2] = await Promise.all([p1, p2])
+    expect(r1).toBe('data')
+    expect(r2).toBe('data')
+    expect(fn).toHaveBeenCalledOnce()
+  })
+
+  it('deduplicates queued (not-yet-started) requests by dedupeKey', async () => {
+    const { useRequestQueue } = await import('../useRequestQueue')
+    const queue = useRequestQueue({ concurrency: 1 })
+
+    const gate = deferred<void>()
+    queue.enqueue({ fn: () => gate.promise, priority: 'normal' })
+
+    const fn = vi.fn().mockResolvedValue('dedup')
+    const p1 = queue.enqueue({ fn, priority: 'normal', dedupeKey: 'key-q' })
+    const p2 = queue.enqueue({ fn, priority: 'normal', dedupeKey: 'key-q' })
+
+    expect(p1).toBe(p2)
+
+    gate.resolve()
+    const result = await p1
+    expect(result).toBe('dedup')
+    expect(fn).toHaveBeenCalledOnce()
+  })
+
+  it('cancel drops a pending request', async () => {
+    const { useRequestQueue } = await import('../useRequestQueue')
+    const queue = useRequestQueue({ concurrency: 1 })
+
+    const gate = deferred<void>()
+    queue.enqueue({ fn: () => gate.promise, priority: 'normal' })
+
+    const fn = vi.fn().mockResolvedValue('should-not-run')
+    const p = queue.enqueue({ fn, priority: 'normal', dedupeKey: 'cancel-me' })
+
+    queue.cancel('cancel-me')
+
+    gate.resolve()
+    await expect(p).rejects.toThrow('Request cancelled')
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('cancel does not affect in-flight requests', async () => {
+    const { useRequestQueue } = await import('../useRequestQueue')
+    const queue = useRequestQueue()
+
+    const d = deferred<string>()
+    const p = queue.enqueue({ fn: () => d.promise, priority: 'normal', dedupeKey: 'inflight' })
+
+    await nextTick()
+    expect(queue.active.value).toBe(1)
+
+    // cancel after it's already in-flight — should be a no-op
+    queue.cancel('inflight')
+
+    d.resolve('result')
+    const result = await p
+    expect(result).toBe('result')
+  })
+
+  it('propagates rejection from the underlying function', async () => {
+    const { useRequestQueue } = await import('../useRequestQueue')
+    const queue = useRequestQueue()
+
+    const err = new Error('boom')
+    const fn = vi.fn().mockRejectedValue(err)
+    await expect(queue.enqueue({ fn, priority: 'normal' })).rejects.toThrow('boom')
+    expect(queue.active.value).toBe(0)
+  })
+
+  it('active and pending stay consistent after errors', async () => {
+    const { useRequestQueue } = await import('../useRequestQueue')
+    const queue = useRequestQueue({ concurrency: 2 })
+
+    const d1 = deferred<string>()
+    const d2 = deferred<string>()
+
+    const p1 = queue.enqueue({ fn: () => d1.promise, priority: 'normal' })
+    const p2 = queue.enqueue({ fn: () => d2.promise, priority: 'normal' })
+
+    await nextTick()
+    expect(queue.active.value).toBe(2)
+
+    d1.reject(new Error('err1'))
+    d2.resolve('ok2')
+
+    await Promise.allSettled([p1, p2])
+    expect(queue.active.value).toBe(0)
+    expect(queue.pending.value).toBe(0)
+  })
+
+  it('different dedupeKeys are treated independently', async () => {
+    const { useRequestQueue } = await import('../useRequestQueue')
+    const queue = useRequestQueue()
+
+    const fn1 = vi.fn().mockResolvedValue('a')
+    const fn2 = vi.fn().mockResolvedValue('b')
+
+    const p1 = queue.enqueue({ fn: fn1, priority: 'normal', dedupeKey: 'key-a' })
+    const p2 = queue.enqueue({ fn: fn2, priority: 'normal', dedupeKey: 'key-b' })
+
+    expect(p1).not.toBe(p2)
+    const [r1, r2] = await Promise.all([p1, p2])
+    expect(r1).toBe('a')
+    expect(r2).toBe('b')
+  })
+
+  it('module-level requestQueue singleton is exported', async () => {
+    const mod = await import('../useRequestQueue')
+    expect(mod.requestQueue).toBeDefined()
+    expect(typeof mod.requestQueue.enqueue).toBe('function')
+    expect(typeof mod.requestQueue.cancel).toBe('function')
+    expect(mod.requestQueue.pending).toBeDefined()
+    expect(mod.requestQueue.active).toBeDefined()
+  })
+})

--- a/autobot-frontend/src/composables/useRequestQueue.ts
+++ b/autobot-frontend/src/composables/useRequestQueue.ts
@@ -1,0 +1,187 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * Request Queue Composable
+ *
+ * Issue #4415: Backpressure for concurrent LLM calls.
+ *
+ * Provides a priority-ordered queue with deduplication so that at most
+ * `concurrency` promises are in-flight at any time.  Callers sharing the
+ * same `dedupeKey` receive the same promise whether the request is still
+ * queued or already in-flight.
+ */
+
+import { ref, readonly } from 'vue'
+import type { Ref } from 'vue'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useRequestQueue')
+
+export type Priority = 'high' | 'normal' | 'low'
+
+const PRIORITY_ORDER: Record<Priority, number> = { high: 0, normal: 1, low: 2 }
+
+export interface QueuedRequest<T> {
+  fn: () => Promise<T>
+  priority: Priority
+  dedupeKey?: string
+}
+
+export interface UseRequestQueue {
+  enqueue<T>(req: QueuedRequest<T>): Promise<T>
+  readonly pending: Ref<number>
+  readonly active: Ref<number>
+  cancel(dedupeKey: string): void
+}
+
+interface QueueEntry<T = unknown> {
+  fn: () => Promise<T>
+  priority: Priority
+  dedupeKey?: string
+  /** The caller-facing promise returned by enqueue() */
+  callerPromise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: unknown) => void
+  cancelled: boolean
+}
+
+export function useRequestQueue(options?: { concurrency?: number }): UseRequestQueue {
+  const concurrency = options?.concurrency ?? 3
+
+  const _pending = ref(0)
+  const _active = ref(0)
+
+  // Queue entries sorted by priority on insertion
+  const _queue: QueueEntry[] = []
+
+  // Deduplication maps — keyed by dedupeKey, value is the caller-facing promise
+  const _inflightByKey = new Map<string, Promise<unknown>>()
+  const _pendingByKey = new Map<string, Promise<unknown>>()
+
+  function _insertSorted(entry: QueueEntry): void {
+    // Binary-insert to keep queue sorted by priority ascending (high=0 first)
+    const rank = PRIORITY_ORDER[entry.priority]
+    let lo = 0
+    let hi = _queue.length
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1
+      if (PRIORITY_ORDER[_queue[mid].priority] <= rank) lo = mid + 1
+      else hi = mid
+    }
+    _queue.splice(lo, 0, entry)
+    _pending.value++
+  }
+
+  function _tick(): void {
+    while (_active.value < concurrency && _queue.length > 0) {
+      const entry = _queue.shift()!
+      _pending.value--
+
+      if (entry.cancelled) {
+        // Already cancelled — clean up dedup and skip
+        if (entry.dedupeKey) _pendingByKey.delete(entry.dedupeKey)
+        entry.reject(new DOMException('Request cancelled', 'AbortError'))
+        continue
+      }
+
+      _active.value++
+      logger.debug(`Starting request (active=${_active.value}, pending=${_pending.value})`)
+
+      if (entry.dedupeKey) {
+        // Promote from pending→inflight using the same caller-facing promise
+        _pendingByKey.delete(entry.dedupeKey)
+        _inflightByKey.set(entry.dedupeKey, entry.callerPromise as Promise<unknown>)
+      }
+
+      entry.fn().then(
+        (value) => {
+          if (entry.dedupeKey) _inflightByKey.delete(entry.dedupeKey)
+          _active.value--
+          logger.debug(`Request resolved (active=${_active.value})`)
+          entry.resolve(value)
+          _tick()
+        },
+        (err) => {
+          if (entry.dedupeKey) _inflightByKey.delete(entry.dedupeKey)
+          _active.value--
+          logger.debug(`Request rejected (active=${_active.value})`)
+          entry.reject(err)
+          _tick()
+        },
+      )
+    }
+  }
+
+  function enqueue<T>(req: QueuedRequest<T>): Promise<T> {
+    const { fn, priority, dedupeKey } = req
+
+    // Dedup: already in-flight? Return the same caller-facing promise.
+    if (dedupeKey && _inflightByKey.has(dedupeKey)) {
+      logger.debug(`Dedupe hit (in-flight): ${dedupeKey}`)
+      return _inflightByKey.get(dedupeKey) as Promise<T>
+    }
+
+    // Dedup: already in the queue? Return the same caller-facing promise.
+    if (dedupeKey && _pendingByKey.has(dedupeKey)) {
+      logger.debug(`Dedupe hit (queued): ${dedupeKey}`)
+      return _pendingByKey.get(dedupeKey) as Promise<T>
+    }
+
+    // Build the caller-facing promise before inserting into the queue so that
+    // _tick() can immediately register it as the inflight dedup promise.
+    let resolve!: (value: T | PromiseLike<T>) => void
+    let reject!: (reason?: unknown) => void
+    const callerPromise = new Promise<T>((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+
+    const entry: QueueEntry<T> = {
+      fn,
+      priority,
+      dedupeKey,
+      callerPromise,
+      resolve,
+      reject,
+      cancelled: false,
+    }
+    _insertSorted(entry as QueueEntry)
+
+    if (dedupeKey) {
+      _pendingByKey.set(dedupeKey, callerPromise as Promise<unknown>)
+    }
+
+    // Kick the scheduler
+    _tick()
+
+    return callerPromise
+  }
+
+  function cancel(dedupeKey: string): void {
+    let cancelled = 0
+    for (const entry of _queue) {
+      if (entry.dedupeKey === dedupeKey && !entry.cancelled) {
+        entry.cancelled = true
+        cancelled++
+      }
+    }
+    if (cancelled > 0) {
+      logger.debug(`Cancelled ${cancelled} pending request(s) with key: ${dedupeKey}`)
+    }
+    // In-flight requests cannot be cancelled here — callers should use AbortSignal for that
+  }
+
+  return {
+    enqueue,
+    pending: readonly(_pending),
+    active: readonly(_active),
+    cancel,
+  }
+}
+
+/**
+ * Module-level singleton for shared use across composables.
+ * Concurrency defaults to 3 simultaneous in-flight requests.
+ */
+export const requestQueue = useRequestQueue()


### PR DESCRIPTION
## Summary
- Creates `autobot-frontend/src/composables/useRequestQueue.ts` with concurrency limiting, priority ordering, and deduplication
- Exports a module-level singleton `requestQueue` for app-wide use
- Adds 12-test suite at `__tests__/useRequestQueue.test.ts`

## Interface
```typescript
type Priority = 'high' | 'normal' | 'low'
interface QueuedRequest<T> { fn: () => Promise<T>; priority: Priority; dedupeKey?: string }
interface UseRequestQueue {
  enqueue<T>(req: QueuedRequest<T>): Promise<T>
  readonly pending: Ref<number>
  readonly active: Ref<number>
  cancel(dedupeKey: string): void
}
```

## Behaviour
- Default concurrency: 3 simultaneous in-flight requests
- Priority: `high` > `normal` > `low` (sorted on each tick)
- Deduplication: same `dedupeKey` in-flight or queued → callers receive the same `Promise` object
- `cancel(key)`: drops pending (not in-flight) entries matching the key

## Type check
Pre-existing errors in `useChatStore.ts`, `useWebResearchStore.ts`, `Welcome.stories.ts` exist in `Dev_new_gui` baseline — not introduced by this PR. `useRequestQueue.ts` itself is type-clean.

## Note on useChatStream integration
`useChatStream.ts` does not exist in the codebase; streaming is handled by `ChatController.ts` (400+ lines, complex state). Integration deferred to a follow-up issue scoped to that refactor.

Closes #4415