### PR TITLE
feat(skills): add builtin web_fetch, youtube_transcript, github_search, rss_reader skill entries (#4422)

### DIFF
--- a/autobot-backend/skills/builtin/github_search.md
+++ b/autobot-backend/skills/builtin/github_search.md
@@ -1,0 +1,139 @@
+---
+name: github-search
+version: 1.0.0
+description: Search GitHub repositories, issues, code, and PRs using the gh CLI
+author: mrveiss
+category: internet
+tools:
+  - search_repos
+  - search_issues
+  - search_code
+  - search_prs
+  - view_issue
+  - view_pr
+triggers:
+  - search GitHub
+  - find GitHub repo
+  - look up issue
+  - gh search
+  - GitHub PR
+  - GitHub issue
+  - find code on GitHub
+  - repository search
+  - open source library
+tags:
+  - github
+  - search
+  - gh
+  - cli
+  - repositories
+  - issues
+  - pull-requests
+  - code-search
+---
+
+## When to Use
+
+Use this skill when an agent needs to search or retrieve data from GitHub —
+finding repositories, reading issues, searching code, or listing pull requests.
+The `gh` CLI is the preferred tool because it handles authentication, pagination,
+and JSON output natively without requiring manual API key management.
+
+## Workflow
+
+### Search repositories
+
+```bash
+# Find repositories matching a query
+gh search repos '{query}' --limit {n}
+
+# Filter by language or topic
+gh search repos '{query}' --language python --limit 10
+gh search repos '{query}' --topic 'machine-learning' --limit 10
+
+# Sort by stars
+gh search repos '{query}' --sort stars --order desc --limit 10
+```
+
+### Search issues and pull requests
+
+```bash
+# Search issues across GitHub
+gh search issues '{query}' --limit 10
+
+# Search issues in a specific repo
+gh search issues '{query}' --repo {owner}/{repo} --state open
+
+# Search pull requests
+gh search prs '{query}' --repo {owner}/{repo} --state open
+```
+
+### Search code
+
+```bash
+# Full-text code search across GitHub
+gh search code '{query}'
+
+# Restrict to a single repository
+gh search code '{query}' --repo {owner}/{repo}
+```
+
+### View a specific issue or PR
+
+```bash
+gh issue view {number} --repo {owner}/{repo}
+gh pr view {number} --repo {owner}/{repo}
+```
+
+### Get JSON output for scripting
+
+```bash
+gh search repos '{query}' --json name,url,stargazerCount,description --limit 10
+gh issue view {number} --repo {owner}/{repo} --json number,title,body,labels
+```
+
+### Direct API access (for operations not covered by subcommands)
+
+```bash
+gh api repos/{owner}/{repo}/issues/{number}
+gh api --paginate repos/{owner}/{repo}/issues --jq '.[].number'
+```
+
+## Output Format
+
+- **Default:** Human-readable table (repo name, description, stars) or detail view.
+- **--json:** Machine-readable JSON; pipe through `jq` for field extraction.
+- **--jq:** Inline JQ filter applied to JSON output in a single command.
+- **--template:** Go template for custom formatting.
+
+## Parameters
+
+| Parameter | Type   | Required | Description                                     |
+|-----------|--------|----------|-------------------------------------------------|
+| query     | string | yes      | Search query (supports GitHub search qualifiers) |
+| owner     | string | no       | Repository owner for scoped searches            |
+| repo      | string | no       | Repository name for scoped searches             |
+| limit     | int    | no       | Max results to return (default 30, max 100)     |
+| state     | string | no       | `open`, `closed`, or `all` for issues/PRs       |
+
+## Limitations
+
+- Requires `gh auth login` or `GITHUB_TOKEN` environment variable to be set.
+- Code search API has a rate limit of 10 requests/minute for authenticated users.
+- Search results are limited to public repositories unless authenticated with
+  access to private repos.
+- `gh search code` returns file-level results, not line-level matches without
+  additional API calls.
+
+## Fallback Instructions
+
+If `gh` is not authenticated or returns a 401 error:
+1. Check `gh auth status` to confirm login state.
+2. If not logged in, run `gh auth login` (requires interactive session) or set
+   the `GITHUB_TOKEN` environment variable.
+3. If rate limited (403 with rate_limit message), check `gh api rate_limit` and
+   wait until the reset timestamp.
+4. For unauthenticated fallback, use the GitHub REST API via curl:
+   ```bash
+   curl -s 'https://api.github.com/search/repositories?q={query}&per_page=10'
+   ```

--- a/autobot-backend/skills/builtin/rss_reader.md
+++ b/autobot-backend/skills/builtin/rss_reader.md
@@ -1,0 +1,156 @@
+---
+name: rss-reader
+version: 1.0.0
+description: Parse and monitor RSS and Atom feeds using the feedparser Python library
+author: mrveiss
+category: internet
+tools:
+  - parse_feed
+  - list_entries
+  - get_entry_content
+  - check_feed_info
+triggers:
+  - read RSS feed
+  - parse RSS
+  - Atom feed
+  - subscribe to feed
+  - latest news from
+  - check blog updates
+  - feed URL
+  - RSS URL
+  - feedparser
+tags:
+  - rss
+  - atom
+  - feed
+  - feedparser
+  - news
+  - monitoring
+  - content-aggregation
+---
+
+## When to Use
+
+Use this skill when an agent needs to read news, blog posts, or any content
+published via an RSS or Atom feed. feedparser handles both feed formats
+automatically, tolerates malformed XML, and requires no authentication for
+public feeds.
+
+## Workflow
+
+### List entry titles from a feed
+
+```bash
+python3 -c "
+import feedparser
+d = feedparser.parse('{feed_url}')
+for e in d.entries[:10]:
+    print(e.title)
+"
+```
+
+### Get entries as JSON with metadata
+
+```bash
+python3 -c "
+import feedparser, json
+d = feedparser.parse('{feed_url}')
+entries = [
+    {
+        'title': e.title,
+        'link': e.link,
+        'published': e.get('published', ''),
+        'summary': e.get('summary', '')[:200],
+    }
+    for e in d.entries[:10]
+]
+print(json.dumps(entries, indent=2))
+"
+```
+
+### Check feed metadata (title, type, entry count)
+
+```bash
+python3 -c "
+import feedparser
+d = feedparser.parse('{feed_url}')
+print('Feed title:', d.feed.get('title', 'N/A'))
+print('Feed version:', d.version)
+print('Entry count:', len(d.entries))
+print('Bozo (parse error):', d.bozo)
+"
+```
+
+### Get full content of the first entry
+
+```bash
+python3 -c "
+import feedparser
+d = feedparser.parse('{feed_url}')
+e = d.entries[0]
+content = e.get('content', [{}])[0].get('value', e.get('summary', 'No content'))
+print(content)
+"
+```
+
+### Fallback — atoma (typed objects, Atom feeds only)
+
+```bash
+python3 -c "
+import atoma, requests
+feed = atoma.parse_atom_bytes(requests.get('{feed_url}').content)
+for e in feed.entries[:5]:
+    print(e.title.value)
+"
+```
+
+## Output Format
+
+- **List mode:** One entry title per line; suitable for quick enumeration.
+- **JSON mode:** Array of entry objects with `title`, `link`, `published`,
+  and `summary` fields.
+- **Content mode:** Raw HTML or plain text body of the selected entry; pass
+  through a markdown converter if needed.
+
+## Entry Fields Reference
+
+| Field                    | Description                              |
+|--------------------------|------------------------------------------|
+| `title`                  | Entry headline                           |
+| `link`                   | URL to the full article                  |
+| `summary` / `description`| Entry excerpt or full text               |
+| `published` / `updated`  | Date string (not always present)         |
+| `author`                 | Author name                              |
+| `tags`                   | List of category/tag objects             |
+| `content`                | Full content list (Atom feeds only)      |
+
+## Parameters
+
+| Parameter | Type   | Required | Description                                         |
+|-----------|--------|----------|-----------------------------------------------------|
+| feed_url  | string | yes      | Fully-qualified RSS or Atom feed URL                |
+| limit     | int    | no       | Maximum number of entries to return (default 10)    |
+| field     | string | no       | Specific field to extract (e.g., `title`, `link`)   |
+
+## Limitations
+
+- feedparser does not execute JavaScript; feeds served via JS redirects will
+  parse empty.
+- Entry dates are not guaranteed — use `e.get('published', e.get('updated', ''))`
+  for safe access.
+- Very large feeds (thousands of entries) may be slow; slice with `d.entries[:n]`.
+- Some feeds require an `Accept` header or specific `User-Agent`; pass a custom
+  handler if the default request is rejected.
+- feedparser does not validate feed signatures or SSL certificates beyond the
+  system trust store.
+
+## Fallback Instructions
+
+If feedparser returns an empty `entries` list:
+1. Check `d.bozo` — if `True`, inspect `d.bozo_exception` for the parse error.
+2. Try fetching the feed URL with `curl -s '{feed_url}'` to confirm the server
+   returns valid XML.
+3. If the feed is a Atom format and feedparser fails, try atoma as the fallback
+   parser.
+4. If the URL redirects to a login page or requires authentication, report the
+   feed as inaccessible and ask the user for credentials or an alternative URL.

--- a/autobot-backend/skills/builtin/web_fetch.md
+++ b/autobot-backend/skills/builtin/web_fetch.md
@@ -1,0 +1,99 @@
+---
+name: web-fetch
+version: 1.0.0
+description: Fetch and extract clean text content from any public URL using Jina Reader
+author: mrveiss
+category: internet
+tools:
+  - fetch_url
+  - fetch_url_json
+  - fetch_url_text
+triggers:
+  - fetch URL
+  - read webpage
+  - get content from URL
+  - open link
+  - browse to
+  - what does this page say
+  - summarize URL
+  - download webpage
+tags:
+  - web
+  - fetch
+  - jina
+  - url
+  - scraping
+  - content-extraction
+---
+
+## When to Use
+
+Use this skill whenever an agent needs to read the content of a public URL — news
+articles, documentation pages, blog posts, or any HTTP-accessible resource.
+Prefer this skill over raw curl or wget because Jina Reader returns clean,
+LLM-ready markdown without ads, navigation, or boilerplate HTML.
+
+## Workflow
+
+### Primary path — Jina Reader (preferred)
+
+```bash
+# Fetch as clean markdown (default)
+curl -s 'https://r.jina.ai/{url}'
+
+# Fetch as JSON with title, url, content, and description fields
+curl -s -H 'Accept: application/json' 'https://r.jina.ai/{url}'
+
+# Fetch as plain text only
+curl -s -H 'X-Return-Format: text' 'https://r.jina.ai/{url}'
+```
+
+Steps:
+1. Prepend `https://r.jina.ai/` to the target URL.
+2. Run the curl command and capture stdout.
+3. Pass the clean markdown directly to the LLM context.
+
+### Fallback path — wget (when Jina is unavailable or rate-limited)
+
+```bash
+wget -q -O - '{url}'
+```
+
+### Fallback path — httpx (async-capable alternative)
+
+```bash
+httpx '{url}'
+httpx '{url}' --json
+```
+
+## Output Format
+
+- **Default (markdown):** Clean article text in CommonMark markdown. Headings, code
+  blocks, and lists are preserved. Images are omitted.
+- **JSON mode:** Object with keys `title`, `url`, `content` (markdown), and
+  `description`. Use for structured extraction.
+- **Text mode:** Raw plain text without any markdown formatting.
+
+## Parameters
+
+| Parameter | Type   | Required | Description                        |
+|-----------|--------|----------|------------------------------------|
+| url       | string | yes      | Fully-qualified HTTP/HTTPS URL     |
+| format    | string | no       | `markdown` (default), `json`, `text` |
+| api_key   | string | no       | Jina API key for higher rate limits |
+
+## Limitations
+
+- JavaScript-heavy single-page apps may render incompletely; use a browser-based
+  tool for those cases.
+- Rate limited to ~20 requests/minute without a Jina API key.
+- Does not handle URLs that require authentication or session cookies.
+- Maximum response size is approximately 100 KB of extracted text.
+
+## Fallback Instructions
+
+If Jina Reader returns an empty response or HTTP 429:
+1. Wait 5 seconds and retry once.
+2. If still failing, fall back to `wget -q -O - '{url}'`.
+3. If wget also fails, report the URL as unreachable and ask the user for
+   alternative access (e.g., paste the content manually).

--- a/autobot-backend/skills/builtin/youtube_transcript.md
+++ b/autobot-backend/skills/builtin/youtube_transcript.md
@@ -1,0 +1,112 @@
+---
+name: youtube-transcript
+version: 1.0.0
+description: Extract timestamped transcripts and metadata from YouTube videos using yt-dlp
+author: mrveiss
+category: internet
+tools:
+  - get_transcript
+  - get_metadata
+  - search_videos
+triggers:
+  - youtube transcript
+  - video transcript
+  - get subtitles
+  - what does this video say
+  - summarize YouTube video
+  - extract captions
+  - YouTube URL
+  - watch video
+  - yt-dlp
+tags:
+  - youtube
+  - transcript
+  - captions
+  - subtitles
+  - video
+  - yt-dlp
+  - media
+---
+
+## When to Use
+
+Use this skill when an agent needs to read or summarize the spoken content of a
+YouTube video. yt-dlp downloads subtitle/caption files without downloading the
+video itself, making transcript extraction fast and bandwidth-efficient.
+
+## Workflow
+
+### Primary path — auto-generated English captions
+
+```bash
+# Download auto-generated English subtitles as VTT (no video download)
+yt-dlp --write-auto-sub --sub-lang en --skip-download '{youtube_url}'
+# Output file: <video_title>.en.vtt in current directory
+```
+
+Steps:
+1. Run the yt-dlp command with the target YouTube URL.
+2. Locate the generated `.vtt` file.
+3. Strip VTT timing tags to obtain plain text:
+   ```bash
+   grep -v '^WEBVTT\|^[0-9]\|^$\|-->' <file>.vtt | sort -u
+   ```
+4. Pass the plain text to the LLM context for summarization or Q&A.
+
+### Manual subtitles (preferred when available)
+
+```bash
+# Download manually uploaded English subtitles as SRT
+yt-dlp --write-sub --sub-lang en --sub-format srt --skip-download '{youtube_url}'
+```
+
+### Video metadata only (no transcript needed)
+
+```bash
+yt-dlp --dump-json --no-download '{youtube_url}'
+```
+
+Returns JSON with `title`, `description`, `duration`, `uploader`,
+`view_count`, `upload_date`, and `chapters`.
+
+### Search YouTube for video IDs
+
+```bash
+yt-dlp 'ytsearch{count}:{query}' --get-id
+# Example: yt-dlp 'ytsearch5:python asyncio tutorial' --get-id
+```
+
+## Output Format
+
+- **Transcript (VTT):** Timestamped caption blocks. Strip timing lines to get
+  plain text paragraphs.
+- **Transcript (SRT):** Numbered subtitle entries with start/end timestamps.
+- **Metadata (JSON):** Full video metadata object; use `jq` to extract specific
+  fields (e.g., `jq '.title'`).
+
+## Parameters
+
+| Parameter    | Type   | Required | Description                                |
+|--------------|--------|----------|--------------------------------------------|
+| youtube_url  | string | yes      | Full YouTube video URL or video ID         |
+| language     | string | no       | BCP-47 language code, default `en`         |
+| format       | string | no       | `vtt` (default) or `srt`                   |
+
+## Limitations
+
+- Auto-generated captions may have transcription errors, especially for
+  technical jargon, accents, or non-English speech.
+- Some videos disable captions entirely; no fallback transcript is available.
+- Age-gated or private videos require cookies (`--cookies-from-browser firefox`).
+- yt-dlp extractors may break after YouTube updates; run `yt-dlp -U` to
+  self-update before retrying.
+- Does not support live streams (use `--live-from-start` for ongoing streams).
+
+## Fallback Instructions
+
+If yt-dlp reports no subtitles available:
+1. Try `--write-auto-sub` in case only auto-generated captions exist.
+2. If still empty, fetch the video description via `--dump-json` and summarize
+   the description as a proxy for content.
+3. If the video is inaccessible, report the URL as unavailable and ask the user
+   to paste the transcript manually or provide an alternative source.


### PR DESCRIPTION
## Summary
- Creates `autobot-backend/skills/builtin/` directory with 4 skill markdown files
- Files use the YAML frontmatter format consumed by `BaseRepoSync._parse_skill_md()` and `SkillGenerator._parse_manifest()`
- No duplicate content with existing `resources/knowledge/tools/` YAML reference docs (different purpose: agent-routing skills vs. tool reference)

## Files Added
| File | Skill Name | Primary Tool |
|------|-----------|-------------|
| `web_fetch.md` | `web-fetch` | `curl https://r.jina.ai/{url}` |
| `youtube_transcript.md` | `youtube-transcript` | `yt-dlp --write-auto-sub --skip-download` |
| `github_search.md` | `github-search` | `gh search`, `gh issue view`, `gh api` |
| `rss_reader.md` | `rss-reader` | `python -c "import feedparser; ..."` |

## Validation
- All 4 files parse successfully via `yaml.safe_load(frontmatter)` — no YAML errors
- Trigger phrases, command patterns, output format descriptions, and fallback instructions included in each
- No new Python package dependencies — all tools are existing system CLIs

Closes #4422