### PR TITLE
feat(skills): add MCPSpan tracing per tool call with Redis storage and traces API (#4413)

### DIFF
--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -679,6 +679,28 @@ class SkillSuggestionsResponse(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class MCPSpanResponse(BaseModel):
+    """Single MCP tool-call span returned by the traces API (Issue #4413)."""
+
+    trace_id: str
+    skill_name: str
+    tool_name: str
+    started_at: float
+    ended_at: Optional[float]
+    input_params: Dict[str, Any]
+    output: Optional[Dict[str, Any]]
+    error: Optional[str]
+    pid: int
+
+
+class SkillTracesResponse(BaseModel):
+    """Response for GET /skills/traces (Issue #4413)."""
+
+    skill: Optional[str]
+    traces: List[MCPSpanResponse]
+    total: int
+
+
 # ---------------------------------------------------------------------------
 # structured_thinking_mcp.py schemas  (Issue #5912)
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/skills.py
+++ b/autobot-backend/api/skills.py
@@ -25,6 +25,7 @@ from api.schemas_code import (
 )
 from api.schemas_common import DataResponse
 from api.schemas_workflows import (
+    MCPSpanResponse,
     SkillsListResponse,
     SkillsCategoriesResponse,
     SkillsAllHealthResponse,
@@ -34,6 +35,7 @@ from api.schemas_workflows import (
     SkillActionsResponse,
     SkillMetricsResponse,
     SkillSuggestionsResponse,
+    SkillTracesResponse,
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
@@ -160,6 +162,63 @@ async def initialize_skills() -> Dict[str, Any]:
     manager = _get_manager()
     result = await manager.initialize()
     return result
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_skill_traces",
+    error_code_prefix="SKILLS",
+)
+@router.get("/traces", summary="Get recent MCP tool-call traces", response_model=SkillTracesResponse)
+async def get_skill_traces(
+    skill: Optional[str] = Query(None, description="Filter by skill name"),
+    limit: int = Query(50, ge=1, le=500, description="Maximum number of traces to return"),
+) -> Dict[str, Any]:
+    """Return recent MCP tool-call spans from Redis (Issue #4413).
+
+    Queries ``mcp_trace_idx:{skill}`` (sorted set, newest first) when a skill
+    name is provided, or iterates all ``mcp_trace_idx:*`` keys otherwise.
+    """
+    import json as _json
+
+    from autobot_shared.redis_client import get_async_redis_client
+
+    redis = await get_async_redis_client(database="main")
+    if redis is None:
+        return {"skill": skill, "traces": [], "total": 0}
+
+    if skill:
+        idx_keys = [f"mcp_trace_idx:{skill}"]
+    else:
+        idx_keys = [k.decode() if isinstance(k, bytes) else k async for k in redis.scan_iter("mcp_trace_idx:*")]
+
+    trace_ids: list = []
+    for idx_key in idx_keys:
+        ids = await redis.zrevrange(idx_key, 0, limit - 1)
+        trace_ids.extend(ids)
+
+    # Deduplicate while preserving insertion order
+    seen: set = set()
+    unique_ids = []
+    for tid in trace_ids:
+        tid_str = tid.decode() if isinstance(tid, bytes) else tid
+        if tid_str not in seen:
+            seen.add(tid_str)
+            unique_ids.append(tid_str)
+    unique_ids = unique_ids[:limit]
+
+    traces: list = []
+    for tid in unique_ids:
+        raw = await redis.get(f"mcp_trace:{tid}")
+        if raw is None:
+            continue
+        try:
+            data = _json.loads(raw)
+            traces.append(MCPSpanResponse(**data))
+        except Exception as exc:
+            logger.debug("mcp_trace: failed to deserialise span %s: %s", tid, exc)
+
+    return {"skill": skill, "traces": traces, "total": len(traces)}
 
 
 @with_error_handling(

--- a/autobot-backend/skills/mcp_process.py
+++ b/autobot-backend/skills/mcp_process.py
@@ -14,11 +14,13 @@ import logging
 import os
 import sys
 import tempfile
+import time
 from autobot_shared.singleton_factory import lazy_singleton
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.ssot_config import config
+from skills.mcp_trace import MCPSpan, new_span, write_span
 
 logger = logging.getLogger(__name__)
 
@@ -136,22 +138,46 @@ class MCPProcessManager:
         """Call a named tool on the skill server and return its result.
 
         Raises RuntimeError if the tool call returns an error.
+        Each call produces an MCPSpan written to Redis fire-and-forget (Issue #4413).
         """
         entry = self._get_entry(name)
-        async with entry._lock:
-            await self._send(
-                entry,
-                {
-                    "jsonrpc": "2.0",
-                    "id": 2,
-                    "method": "tools/call",
-                    "params": {"name": tool, "arguments": args},
-                },
-            )
-            resp = await asyncio.wait_for(self._recv(entry), timeout=CALL_TIMEOUT)
-        if "error" in resp:
-            raise RuntimeError(f"Tool call failed: {resp['error']}")
-        return resp.get("result")
+        span: MCPSpan = new_span(
+            skill_name=name,
+            tool_name=tool,
+            input_params=args,
+            pid=entry.proc.pid,
+        )
+        logger.debug("mcp_trace: starting trace_id=%s", span.trace_id)
+
+        result = None
+        error_str: Optional[str] = None
+        try:
+            async with entry._lock:
+                await self._send(
+                    entry,
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "tools/call",
+                        "params": {"name": tool, "arguments": args},
+                    },
+                )
+                resp = await asyncio.wait_for(self._recv(entry), timeout=CALL_TIMEOUT)
+            if "error" in resp:
+                error_str = str(resp["error"])
+                raise RuntimeError(f"Tool call failed: {resp['error']}")
+            result = resp.get("result")
+            return result
+        except RuntimeError:
+            raise
+        except Exception as exc:
+            error_str = str(exc)
+            raise
+        finally:
+            span.ended_at = time.time()
+            span.output = result if isinstance(result, dict) else ({"value": result} if result is not None else None)
+            span.error = error_str
+            asyncio.create_task(write_span(span))
 
     async def stop(self, name: str) -> None:
         """Terminate the skill subprocess and remove its temp file."""

--- a/autobot-backend/skills/mcp_trace.py
+++ b/autobot-backend/skills/mcp_trace.py
@@ -1,0 +1,95 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+MCP Span Tracing (Issue #4413)
+
+Lightweight span-level tracing for MCPProcessManager.  Every tool call
+produces an MCPSpan that is written asynchronously to Redis.
+
+Key schema
+----------
+- ``mcp_trace:{trace_id}``          → MCPSpan JSON, TTL 3600 s
+- ``mcp_trace_idx:{skill_name}``    → sorted-set of trace_ids scored by
+                                      started_at timestamp, TTL 3600 s
+
+The write is fire-and-forget (``asyncio.create_task``).  Redis errors are
+swallowed and logged at DEBUG level so tracing never disrupts tool calls.
+"""
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Optional
+
+from autobot_shared.redis_client import get_async_redis_client
+
+logger = logging.getLogger(__name__)
+
+_SPAN_TTL: int = 3600  # seconds
+
+
+@dataclass
+class MCPSpan:
+    """Immutable record of a single MCP tool-call invocation."""
+
+    trace_id: str
+    skill_name: str
+    tool_name: str
+    started_at: float
+    ended_at: Optional[float]
+    input_params: Dict[str, Any]
+    output: Optional[Dict[str, Any]]
+    error: Optional[str]
+    pid: int
+
+
+def new_span(
+    skill_name: str,
+    tool_name: str,
+    input_params: Dict[str, Any],
+    pid: int,
+) -> MCPSpan:
+    """Create a new MCPSpan with a fresh trace_id and current timestamp."""
+    return MCPSpan(
+        trace_id=str(uuid.uuid4()),
+        skill_name=skill_name,
+        tool_name=tool_name,
+        started_at=time.time(),
+        ended_at=None,
+        input_params=input_params,
+        output=None,
+        error=None,
+        pid=pid,
+    )
+
+
+async def write_span(span: MCPSpan) -> None:
+    """Write *span* to Redis.  Silently swallows all errors (DEBUG log only)."""
+    try:
+        redis = await get_async_redis_client(database="main")
+        if redis is None:
+            logger.debug("mcp_trace: Redis unavailable, dropping span %s", span.trace_id)
+            return
+
+        payload = json.dumps(asdict(span), ensure_ascii=False)
+        span_key = f"mcp_trace:{span.trace_id}"
+        idx_key = f"mcp_trace_idx:{span.skill_name}"
+
+        pipe = redis.pipeline()
+        pipe.set(span_key, payload, ex=_SPAN_TTL)
+        pipe.zadd(idx_key, {span.trace_id: span.started_at})
+        pipe.expire(idx_key, _SPAN_TTL)
+        await pipe.execute()
+
+        logger.debug(
+            "mcp_trace: wrote span trace_id=%s skill=%s tool=%s",
+            span.trace_id,
+            span.skill_name,
+            span.tool_name,
+        )
+    except Exception as exc:
+        logger.debug("mcp_trace: failed to write span %s: %s", span.trace_id, exc)


### PR DESCRIPTION
## Summary
- New `autobot-backend/skills/mcp_trace.py` — `MCPSpan` dataclass (trace_id, skill_name, tool_name, timestamps, input_params, output, error, pid) + async `write_span()` Redis writer
- `MCPProcessManager.call_tool()` instrumented with span creation (fire-and-forget via `asyncio.create_task`)
- `GET /api/skills/traces?skill=<name>&limit=50` endpoint returns recent spans from Redis

## Redis key schema
- `mcp_trace:{trace_id}` → MCPSpan JSON, TTL 3600s
- `mcp_trace_idx:{skill_name}` → sorted set of trace_ids by timestamp, TTL 3600s

## Design decisions
- Write is fire-and-forget: `asyncio.create_task(write_span(span))` — never adds latency to tool call
- Redis unavailability is silently swallowed (logged at DEBUG only) — tracing never blocks execution
- `trace_id` logged at DEBUG level for log correlation
- No changes to skill `.py` scripts — fully transparent to skill authors
- `MCPSpanResponse` + `SkillTracesResponse` added to `api/schemas_workflows.py`

## Validation
- `python3 -m py_compile` passes on all 4 modified/created files

Closes #4413