### PR TITLE
fix(frontend): update WEBSOCKET_LOCAL to /api/ws path

### DIFF
--- a/autobot-frontend/src/constants/network.ts
+++ b/autobot-frontend/src/constants/network.ts
@@ -104,7 +104,7 @@ export const ServiceURLs = Object.freeze({
 
   // WebSocket URLs
   WEBSOCKET_API: config.websocketUrl,
-  WEBSOCKET_LOCAL: `ws://${NetworkConstants.LOCALHOST_NAME}:${config.port.backend}/ws`
+  WEBSOCKET_LOCAL: `ws://${NetworkConstants.LOCALHOST_NAME}:${config.port.backend}/api/ws`
 })
 
 /**


### PR DESCRIPTION
## Summary

- Updates `WEBSOCKET_LOCAL` constant in `autobot-frontend/src/constants/network.ts` from `/ws` to `/api/ws`
- This constant was missed when #6232 fixed the WebSocket path in `ssot-config.ts` — the backend WebSocket endpoint is mounted at `/api/ws` (via `@router.websocket("/ws")` under the `/api` prefix)

## Test plan

- [ ] Local dev WebSocket connects to `ws://localhost:8001/api/ws` successfully
- [ ] No 404 on WebSocket connection in development mode

Closes #6301

🤖 Generated with [Claude Code](https://claude.com/claude-code)