### PR TITLE
fix(autobot_shared/ssot_config): omit TLS port from WebSocket URL

### DIFF
--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1415,10 +1415,12 @@ class AutoBotConfig(BaseSettings):
         """Get the WebSocket URL for real-time communication.
 
         Issue #6232: Path corrected to /api/ws to match backend route /api/ws/live.
-        Uses wss:// when backend TLS is enabled.
+        Issue #6302: When TLS is enabled the port is omitted so the connection
+        routes through nginx on 443 (TLS termination) rather than hitting the
+        uvicorn TLS listener on backend_tls_port directly.
         """
         if self.tls.backend_tls_enabled:
-            return f"wss://{self.vm.main}:{self.tls.backend_tls_port}/api/ws"
+            return f"wss://{self.vm.main}/api/ws"
         return f"ws://{self.vm.main}:{self.port.backend}/api/ws"
 
     @property


### PR DESCRIPTION
## Summary

- Fixes `ssot_config.py` `websocket_url` property: when TLS is enabled, returns `wss://host/api/ws` instead of `wss://host:8443/api/ws`
- The port 8443 caused the browser to connect directly to uvicorn's TLS port, bypassing nginx. Standard deployment uses nginx TLS termination on 443 with nginx proxying to uvicorn plaintext on 8001
- Now aligns with the TypeScript SSOT which already returns `wss://host/api/ws` (no port)

## Test plan

- [ ] On HTTPS deployment, WebSocket connects to `wss://host/api/ws` (port 443, through nginx)
- [ ] On HTTP deployment, WebSocket still connects to `ws://host:8001/api/ws` (unchanged)

Closes #6302

🤖 Generated with [Claude Code](https://claude.com/claude-code)