### PR TITLE
fix(autobot_shared/network_constants): get_websocket_url() returns wss:// when TLS enabled

### DIFF
--- a/autobot_shared/network_constants.py
+++ b/autobot_shared/network_constants.py
@@ -218,7 +218,15 @@ class NetworkConstants:
 
     @classmethod
     def get_websocket_url(cls) -> str:
-        """Get WebSocket URL for frontend (Issue #372 - reduces feature envy)."""
+        """Get WebSocket URL for frontend (Issue #372 - reduces feature envy).
+
+        Issue #6303: Returns wss:// when backend TLS is enabled; omits port
+        because nginx terminates TLS on 443 and proxies to the backend.
+        """
+        from autobot_shared.ssot_config import config  # lazy to avoid circular import
+
+        if config.tls.backend_tls_enabled:
+            return f"wss://{cls.MAIN_MACHINE_IP}/api/ws"
         return f"ws://{cls.MAIN_MACHINE_IP}:{cls.BACKEND_PORT}/api/ws"
 
 


### PR DESCRIPTION
## Summary

- `NetworkConstants.get_websocket_url()` previously always returned `ws://` regardless of TLS config
- Now reads `config.tls.backend_tls_enabled`: when True returns `wss://host/api/ws` (no port, through nginx 443); when False returns `ws://host:port/api/ws` (existing behavior)
- Fixes TLS deployments where plaintext `ws://` URLs are rejected by browsers as mixed-content

## Test plan

- [ ] `AUTOBOT_BACKEND_TLS_ENABLED=true python3 -c "from autobot_shared.network_constants import NetworkConstants; url = NetworkConstants.get_websocket_url(); assert url.startswith('wss://'), url"` passes
- [ ] Without TLS env var, returns original `ws://host:8001/api/ws` format

Closes #6303

🤖 Generated with [Claude Code](https://claude.com/claude-code)