### PR TITLE
fix(api/long_running_operations): move from core_routers to feature_routers

### DIFF
--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -60,7 +60,6 @@ from api.knowledge_sync_queue import router as knowledge_sync_queue_router  # Is
 from api.knowledge_vectorization import router as knowledge_vectorization_router
 from api.llm import router as llm_router
 from api.live_events import router as live_events_router  # Issue #6229
-from api.long_running_operations import router as long_running_operations_router  # Issue #6227
 from api.llm_providers import router as llm_providers_router
 from api.websockets import router as websockets_router  # Issue #6229
 from api.manual_mcp import router as manual_mcp_router
@@ -382,12 +381,6 @@ def _get_agent_routers() -> list:
             "",
             ["process-management"],
             "process_management",
-        ),
-        (  # Issue #6227: register long-running operations router
-            long_running_operations_router,
-            "/long-running",
-            ["long-running-operations"],
-            "long_running_operations",
         ),
     ]
 

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -238,7 +238,13 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         "heartbeat",
     ),
     # Long-running and validation
-    # api.long_running_operations promoted to core_routers.py (Issue #6227)
+    # Moved back from core_routers — has _OPERATIONS_AVAILABLE graceful degradation (Issue #6306)
+    (
+        "api.long_running_operations",
+        "/long-running",
+        ["long-running-operations"],
+        "long_running_operations",
+    ),
     (
         "api.system_validation",
         "/system-validation",


### PR DESCRIPTION
## Summary

- Moves `long_running_operations` from `core_routers.py` back to `feature_routers.py`
- The module was promoted to core_routers (#6227) to get fail-fast startup, but PR #6285 added MissingDep fallbacks and #6293 added `_OPERATIONS_AVAILABLE` graceful degradation — making it a fully-featured feature router already
- Having it in core_routers with MissingDep fallbacks defeats the fail-fast guarantee (import succeeds even when deps are missing, then requests degrade at runtime). Returning it to feature_routers is correct.

## Test plan

- [ ] Backend starts without errors
- [ ] `/api/long-running/health` returns 503 with clear message when deps missing, 200 when available
- [ ] `core_routers.py` no longer imports `long_running_operations_router`

Closes #6306

🤖 Generated with [Claude Code](https://claude.com/claude-code)