### PR TITLE
fix(integrations): wire github and slack to shared Redis rate limiter (#6311)

### DIFF
--- a/autobot-backend/integrations/communication_integration.py
+++ b/autobot-backend/integrations/communication_integration.py
@@ -29,10 +29,14 @@ from integrations.rate_limiter import (
     SLACK_REQUESTS_PER_HOUR,
     SLACK_REQUESTS_PER_MINUTE,
     IntegrationRateLimiter,
+    integration_rate_limiter as _shared_rate_limiter,
 )
 
 logger = logging.getLogger(__name__)
 
+# In-memory limiter retained solely for apply_response_headers() (Retry-After
+# header parsing on HTTP 429).  Distributed acquire() uses _shared_rate_limiter
+# so quota state is shared across all backend workers (Issue #6311).
 _SLACK_RATE_LIMITER = IntegrationRateLimiter(
     requests_per_minute=SLACK_REQUESTS_PER_MINUTE,
     requests_per_hour=SLACK_REQUESTS_PER_HOUR,
@@ -233,12 +237,16 @@ class SlackIntegration(BaseIntegration):
         retried once after the prescribed wait.  Never raises; returns
         ``{"ok": False, "error": "<reason>"}`` on failure.
         """
-        # Acquire a rate-limit slot (waits up to 120 s if near limit)
-        try:
-            await self._rate_limiter.acquire(self._token_key)
-        except asyncio.TimeoutError:
-            self.logger.error("Slack rate limit wait exceeded 120 s for %s", url)
-            return {"ok": False, "error": "rate_limit_timeout"}
+        # Acquire rate-limit slot via the shared Redis-backed limiter (Issue #6311).
+        # Falls back to allow-all when Redis is unavailable.
+        allowed = await _shared_rate_limiter.acquire(
+            self._token_key,
+            requests_per_minute=SLACK_REQUESTS_PER_MINUTE,
+            requests_per_hour=SLACK_REQUESTS_PER_HOUR,
+        )
+        if not allowed:
+            self.logger.error("Slack rate limit exceeded for %s", url)
+            return {"ok": False, "error": "rate_limit_exceeded"}
 
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)

--- a/autobot-backend/integrations/github_integration.py
+++ b/autobot-backend/integrations/github_integration.py
@@ -30,10 +30,14 @@ from integrations.rate_limiter import (
     GITHUB_REQUESTS_PER_HOUR,
     GITHUB_REQUESTS_PER_MINUTE,
     IntegrationRateLimiter,
+    integration_rate_limiter as _shared_rate_limiter,
 )
 
 logger = logging.getLogger(__name__)
 
+# In-memory limiter retained solely for apply_response_headers() (Retry-After /
+# X-RateLimit-* header parsing).  Distributed acquire() uses _shared_rate_limiter
+# so quota state is shared across all backend workers (Issue #6311).
 _GITHUB_RATE_LIMITER = IntegrationRateLimiter(
     requests_per_minute=GITHUB_REQUESTS_PER_MINUTE,
     requests_per_hour=GITHUB_REQUESTS_PER_HOUR,
@@ -277,15 +281,19 @@ class GitHubIntegration(BaseIntegration):
         """
         url = f"{self.base_url}{path}"
 
-        # Acquire rate-limit slot (waits up to 120 s if needed)
-        try:
-            await self._rate_limiter.acquire(self._token_key)
-        except asyncio.TimeoutError:
-            logger.error("GitHub rate limit wait exceeded 120 s for %s %s", method, path)
+        # Acquire rate-limit slot via the shared Redis-backed limiter (Issue #6311).
+        # Falls back to allow-all when Redis is unavailable.
+        allowed = await _shared_rate_limiter.acquire(
+            self._token_key,
+            requests_per_minute=GITHUB_REQUESTS_PER_MINUTE,
+            requests_per_hour=GITHUB_REQUESTS_PER_HOUR,
+        )
+        if not allowed:
+            logger.error("GitHub rate limit exceeded for %s %s", method, path)
             return {
                 "status_code": 429,
-                "body": {"message": "Rate limit wait exceeded"},
-                "error": "rate_limit_timeout",
+                "body": {"message": "Rate limit exceeded"},
+                "error": "rate_limit_exceeded",
             }
 
         last_result: Dict[str, Any] = {}


### PR DESCRIPTION
## Summary

- `integrations/github_integration.py` and `integrations/communication_integration.py` now use the shared Redis-backed `integration_rate_limiter` for `acquire()` calls, so quota state is shared across all backend workers.
- Per-module in-memory `IntegrationRateLimiter` instances retained solely for `apply_response_headers()` (Retry-After / X-RateLimit-* header parsing), which is not yet on the shared limiter.

## Before / After

**Before:** each worker had its own in-memory window — a burst on worker A didn't reduce quota on worker B.

**After:** `acquire()` checks a Redis sorted set shared across workers.

## API Note

`RateLimiter.acquire()` returns `bool` (no exception on timeout), so error paths changed from `except asyncio.TimeoutError` → `if not allowed`.

## Test plan
- [ ] `python3 -m py_compile autobot-backend/integrations/github_integration.py` — passes
- [ ] `python3 -m py_compile autobot-backend/integrations/communication_integration.py` — passes
- [ ] GitHub API calls respect per-token quota across workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)