### PR TITLE
perf(api/skills): replace N sequential redis.get() with mget() in traces endpoint (#6312)

### DIFF
--- a/autobot-backend/api/skills.py
+++ b/autobot-backend/api/skills.py
@@ -208,15 +208,15 @@ async def get_skill_traces(
     unique_ids = unique_ids[:limit]
 
     traces: list = []
-    for tid in unique_ids:
-        raw = await redis.get(f"mcp_trace:{tid}")
+    keys = [f"mcp_trace:{tid}" for tid in unique_ids]
+    raws = await redis.mget(*keys)
+    for raw in raws:
         if raw is None:
             continue
         try:
-            data = _json.loads(raw)
-            traces.append(MCPSpanResponse(**data))
+            traces.append(MCPSpanResponse(**_json.loads(raw)))
         except Exception as exc:
-            logger.debug("mcp_trace: failed to deserialise span %s: %s", tid, exc)
+            logger.debug("mcp_trace: failed to deserialise span: %s", exc)
 
     return {"skill": skill, "traces": traces, "total": len(traces)}
 


### PR DESCRIPTION
## Summary

Replaces a per-item `await redis.get()` loop in `GET /api/skills/traces` with a single `await redis.mget(*keys)`, reducing Redis round-trips from N to 1.

## Before / After

Before: 50 sequential `redis.get()` calls at the default `limit=50` — ~5 ms of serialized I/O at 0.1 ms/round-trip.

After: 1 `redis.mget()` call for all keys — constant latency regardless of limit.

## Test plan
- [ ] `python3 -m py_compile autobot-backend/api/skills.py` — passes
- [ ] `GET /api/skills/traces?skill=web-fetch&limit=50` returns same spans as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)