### PR TITLE
refactor(shared): extract fire-and-forget Redis write helper; wire into mcp_trace (#6335)

### DIFF
--- a/autobot-backend/skills/mcp_process.py
+++ b/autobot-backend/skills/mcp_process.py
@@ -19,6 +19,7 @@ from autobot_shared.singleton_factory import lazy_singleton
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.fire_and_forget import run_redis_write
 from autobot_shared.ssot_config import config
 from skills.mcp_trace import MCPSpan, new_span, write_span
 
@@ -177,7 +178,7 @@ class MCPProcessManager:
             span.ended_at = time.time()
             span.output = result if isinstance(result, dict) else ({"value": result} if result is not None else None)
             span.error = error_str
-            asyncio.create_task(write_span(span))
+            run_redis_write(write_span(span), label="mcp_trace")
 
     async def stop(self, name: str) -> None:
         """Terminate the skill subprocess and remove its temp file."""

--- a/autobot_shared/fire_and_forget.py
+++ b/autobot_shared/fire_and_forget.py
@@ -1,0 +1,38 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Fire-and-forget async task utilities.
+
+For observability/analytics writes that must never block the hot path.
+Errors are swallowed at DEBUG level.
+"""
+import asyncio
+import logging
+from typing import Any, Coroutine
+
+logger = logging.getLogger(__name__)
+
+
+def run_redis_write(coro: Coroutine[Any, Any, None], *, label: str) -> None:
+    """Schedule *coro* as a fire-and-forget asyncio task.
+
+    Swallows all exceptions from the coroutine at DEBUG level so observability
+    writes never propagate to the caller.
+
+    Args:
+        coro: Coroutine to run (typically a Redis write).
+        label: Identifies the call site in debug logs.
+    """
+
+    async def _wrapper() -> None:
+        try:
+            await coro
+        except Exception as exc:
+            logger.debug("%s: background write failed: %s", label, exc)
+
+    try:
+        asyncio.get_running_loop().create_task(_wrapper())
+    except RuntimeError:
+        logger.warning("%s: no running event loop — background write skipped", label)
+        coro.close()  # Prevent "coroutine never awaited" warning


### PR DESCRIPTION
## Summary

- Adds `autobot_shared/fire_and_forget.py` with `run_redis_write(coro, *, label)` — schedules a coroutine as fire-and-forget, swallowing all exceptions at DEBUG.
- Updates `skills/mcp_process.py` to use `run_redis_write` instead of inline `asyncio.create_task`.

## Motivation

The fire-and-forget Redis write pattern was duplicated per-site. This PR extracts it as a shared primitive so future sites don't re-implement the guard/swallow logic.

## Test plan
- [ ] `python3 -m py_compile autobot_shared/fire_and_forget.py` — passes
- [ ] `python3 -m py_compile autobot-backend/skills/mcp_process.py` — passes
- [ ] No-running-loop edge case logs warning + closes coro cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)