### PR TITLE
feat(frontend): wire useRequestQueue into ChatController.sendMessage for concurrency control (#6313)

### DIFF
--- a/autobot-frontend/src/models/controllers/ChatController.ts
+++ b/autobot-frontend/src/models/controllers/ChatController.ts
@@ -6,6 +6,7 @@ import type { ChatSession } from '@/stores/useChatStore'
 import { createLogger } from '@/utils/debugUtils'
 import { extractErrorMessage, extractApiErrorMessage } from '@/utils/errorExtract'
 import type { ChatMessageDisplayType } from '@/types/api'
+import { requestQueue } from '@/composables/useRequestQueue'
 
 const logger = createLogger('ChatController')
 
@@ -114,11 +115,17 @@ export class ChatController {
       for (let attempt = 1; attempt <= this.retryAttempts; attempt++) {
         try {
           // Send to backend with timeout and retry logic
-          const response = await this.sendMessageWithRetry({
-            message: content,
-            chatId: this.chatStore.currentSessionId!,
-            options: options || {}
-          }, attempt)
+          // Issue #6313: Route through requestQueue for concurrency backpressure
+          const chatId = this.chatStore.currentSessionId!
+          const response = await requestQueue.enqueue({
+            fn: () => this.sendMessageWithRetry({
+              message: content,
+              chatId,
+              options: options || {}
+            }, attempt),
+            priority: 'high',
+            dedupeKey: `chat-send-${chatId}-${attempt}`,
+          })
 
           // Update user message status to sent
           this.chatStore.updateMessage(userMessageId, { status: 'sent' })


### PR DESCRIPTION
## Summary

- Adds `import { requestQueue } from '@/composables/useRequestQueue'` to `ChatController.ts`
- Wraps the `sendMessageWithRetry()` call with `requestQueue.enqueue({ fn, priority: 'high', dedupeKey: 'chat-send-${chatId}-${attempt}' })`

This routes all LLM I/O through the shared request queue, providing concurrency backpressure (max 3 concurrent) and deduplication for the same session.

## Design

Only `sendMessageWithRetry()` is enqueued — not the full `sendMessage()` body. Error handling, retry loop, UI state (loading/typing), and user message persistence stay outside the queue where they belong.

The `dedupeKey` includes `attempt` so retries aren't deduplicated against the original failed call.

## Behavioral Grep Audit

Before:
```
grep -rn "requestQueue\|useRequestQueue" src/ --include="*.ts" --include="*.vue" | grep -v "__tests__"
# 1 hit — only the composable definition
```

After:
```
# 2 hits — composable definition + ChatController import
```

## Test plan
- [ ] `npx vue-tsc --noEmit -p tsconfig.app.json` — zero errors in touched files
- [ ] Sending a chat message still works end-to-end
- [ ] Rapid duplicate sends to the same session return the queued promise

🤖 Generated with [Claude Code](https://claude.com/claude-code)