### PR TITLE
fix(frontend): add /api prefix to useDocumentationSearch knowledge_base path (#6356)

### DIFF
--- a/autobot-frontend/src/composables/chat/useDocumentationSearch.ts
+++ b/autobot-frontend/src/composables/chat/useDocumentationSearch.ts
@@ -75,10 +75,10 @@ interface CategoriesResponse {
   categories?: DocCategory[]
 }
 
-// ---- GET /knowledge_base/docs/categories via useFetchEndpoint ----
+// ---- GET /api/knowledge_base/docs/categories via useFetchEndpoint ----
 
 const categoriesEndpoint = useFetchEndpoint<CategoriesResponse, DocCategory[]>({
-  path: '/knowledge_base/docs/categories',
+  path: '/api/knowledge_base/docs/categories',
   label: 'fetchDocCategories',
   pickData: (raw) => raw.categories ?? null,
   onError: (message) => {


### PR DESCRIPTION
## Summary

Adds `/api` prefix to `path: '/knowledge_base/docs/categories'` in `useDocumentationSearch.ts`. All backend routes mount under `/api`; the missing prefix caused 404 on documentation category fetches.

## Test plan
- [ ] `GET /api/knowledge_base/docs/categories` returns categories instead of 404
- [ ] No new vue-tsc errors in `useDocumentationSearch.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)