### PR TITLE
feat(frontend): wire DesktopInterface VNC into /slm/tools/novnc view and chat tab (#4977)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -821,6 +821,8 @@ export default {
       { to: '/plugins', labelKey: 'nav.plugins', icon: 'M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z', iconStroke: true },
       { to: '/secrets', labelKey: 'nav.secrets', icon: 'M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z', iconRule: 'evenodd' },
       { to: '/operations', labelKey: 'nav.operations', icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01', iconStroke: true },
+      // Issue #4977: Standalone Remote Desktop (noVNC) view
+      { to: '/slm/tools/novnc', labelKey: 'nav.remoteDesktop', icon: 'M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z', iconStroke: true },
       // Code Intelligence removed from main nav — merged into /analytics/codebase
       // Desktop nav removed — noVNC lives in the Chat tab. /desktop redirects to /chat.
       // Issue #902: Dev Tools moved into /analytics/dev-tools tab

--- a/autobot-frontend/src/components/chat/ChatTabContent.vue
+++ b/autobot-frontend/src/components/chat/ChatTabContent.vue
@@ -44,7 +44,7 @@
       <VisualBrowserPanel class="flex-1" />
     </div>
 
-    <!-- noVNC Tab Content (Issue #715: Dynamic hosts from user config) -->
+    <!-- noVNC Tab Content (Issue #715: Dynamic hosts from user config, Issue #4977: DesktopInterface) -->
     <div v-else-if="activeTab === 'novnc'" class="flex-1 flex flex-col min-h-0">
       <div class="flex-1 flex flex-col bg-black">
         <!-- Host selector header for VNC -->
@@ -60,27 +60,14 @@
               @open-secrets-manager="emit('open-secrets-manager')"
             />
           </div>
-          <a
-            v-if="selectedVncHost && dynamicVncUrl"
-            :href="dynamicVncUrl"
-            target="_blank"
-            class="text-autobot-text-muted hover:text-autobot-text-secondary underline"
-            :title="$t('chat.tabContent.openInNewWindow')"
-          >
-            <i class="fas fa-external-link-alt mr-1"></i>
-            {{ $t('chat.tabContent.openInNewWindow') }}
-          </a>
         </div>
-        <!-- VNC content - show iframe when host selected -->
-        <template v-if="selectedVncHost && dynamicVncUrl">
-          <iframe
-            :key="`vnc-${selectedVncHost.id}`"
-            :src="dynamicVncUrl"
-            class="flex-1 w-full border-0"
-            title="noVNC Remote Desktop"
-            allowfullscreen
-          ></iframe>
-        </template>
+        <!-- VNC content - DesktopInterface when host selected (Issue #4977) -->
+        <DesktopInterface
+          v-if="selectedVncHost"
+          :key="`vnc-${selectedVncHost.id}`"
+          :host="selectedVncHost"
+          class="flex-1"
+        />
         <!-- Empty state when no host selected -->
         <div v-else class="flex-1 flex items-center justify-center text-autobot-text-muted">
           <div class="text-center">
@@ -137,7 +124,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed, defineAsyncComponent } from 'vue'
+import { ref, watch, defineAsyncComponent } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -153,6 +140,7 @@ import FileBrowser from '@/components/file-browser/FileBrowser.vue'
 import VisualBrowserPanel from '@/components/chat/VisualBrowserPanel.vue'  // Issue #1130: screenshot-based browser
 import HostSelector from '@/components/ui/HostSelector.vue'  // Issue #715: Dynamic host selection
 import SSHTerminal from '@/components/terminal/SSHTerminal.vue'    // Issue #715: SSH terminal component
+import DesktopInterface from '@/components/desktop/DesktopInterface.vue'  // Issue #4977: full VNC component
 
 /**
  * Infrastructure host type for SSH/VNC connections.
@@ -188,15 +176,6 @@ const selectedSshHost = ref<InfrastructureHost | null>(null)
 const selectedVncHost = ref<InfrastructureHost | null>(null)
 const sshHostSelectorRef = ref<InstanceType<typeof HostSelector>>()
 const vncHostSelectorRef = ref<InstanceType<typeof HostSelector>>()
-
-// Dynamic VNC URL based on selected host
-const dynamicVncUrl = computed(() => {
-  if (!selectedVncHost.value) return null
-  const host = selectedVncHost.value
-  // noVNC websockify URL format: ws://host:vncport
-  // The backend VNC proxy will handle the connection
-  return `http://${host.host}:${host.vnc_port || 6080}/vnc.html?autoconnect=true`
-})
 
 // Host selection handlers
 const onSshHostSelected = (host: InfrastructureHost) => {

--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -169,8 +169,8 @@
   </div>
 </template>
 
-<script setup>
-import { ref, onMounted, onUnmounted, computed } from 'vue'
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 // MIGRATED: Removed environment.js, using AppConfig.js only
 import appConfig from '@/config/AppConfig.js'
@@ -181,6 +181,15 @@ import { useLoadingState } from '@/composables/useLoadingState'
 import { useVncControls } from '@/composables/useVncControls'
 import { usePollingJob } from '@/composables/usePollingJob'
 import { createLogger } from '@/utils/debugUtils'
+import type { SelectorHost } from '@/composables/useHostSelector'
+
+/** Optional host prop — when provided, drives the VNC URL directly from the
+ *  host record rather than fetching from AppConfig (Issue #4977). */
+interface Props {
+  host?: SelectorHost | null
+}
+
+const props = withDefaults(defineProps<Props>(), { host: null })
 
 const { t } = useI18n()
 const logger = createLogger('DesktopInterface')
@@ -199,9 +208,9 @@ const screenshotData = ref<string | null>(null)
 const textToType = ref('')
 const showTypeDialog = ref(false)
 
-const vncFrame = ref(null)
+const vncFrame = ref<HTMLIFrameElement | null>(null)
 const loading = ref(true)
-const error = ref(null)
+const error = ref<string | null>(null)
 const isFullscreen = ref(false)
 const connectionStatus = ref('Connecting...')
 
@@ -218,13 +227,24 @@ const connectionStatusDisplay = computed(() => {
   return statusMap[connectionStatus.value] || connectionStatus.value
 })
 
-// VNC connection URL - will be loaded asynchronously from AppConfig
+// VNC connection URL - will be loaded asynchronously from AppConfig or derived from host prop
 const vncUrl = ref('') // Will be loaded on mount
+
+/** Build VNC URL from a SelectorHost record (Issue #4977). */
+const buildHostVncUrl = (h: SelectorHost): string => {
+  const port = h.vnc_port || 6080
+  return `http://${h.host}:${port}/vnc.html?autoconnect=true`
+}
 
 // Load dynamic VNC URL on component mount
 const loadVncUrlFn = async () => {
-  const dynamicVncUrl = await appConfig.getVncUrl('desktop');
-  vncUrl.value = dynamicVncUrl;
+  // Issue #4977: when a host prop is supplied, derive URL directly — no AppConfig call needed
+  if (props.host) {
+    vncUrl.value = buildHostVncUrl(props.host)
+  } else {
+    const dynamicVncUrl = await appConfig.getVncUrl('desktop');
+    vncUrl.value = dynamicVncUrl;
+  }
   // Clear any previous errors and update status
   error.value = null;
   loading.value = false;
@@ -259,6 +279,16 @@ const loadVncUrl = async () => {
     logger.error('Desktop unavailable - no configuration loaded');
   });
 }
+
+// Issue #4977: when the host prop changes, reload the VNC URL
+watch(() => props.host, async (newHost: SelectorHost | null | undefined) => {
+  if (newHost !== undefined) {
+    loading.value = true
+    error.value = null
+    connectionStatus.value = 'Connecting...'
+    await loadVncUrl()
+  }
+})
 
 const connectionStatusClass = computed(() => {
   switch (connectionStatus.value) {

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -6963,6 +6963,7 @@
     "profile": "Profile",
     "systemStatus": "System Status",
     "operations": "العمليات",
+    "remoteDesktop": "Remote Desktop",
     "applicationError": "Application Error",
     "unexpectedError": "An unexpected error occurred",
     "loadingTimeout": "Loading Timed Out",
@@ -6999,5 +7000,11 @@
     "newCodeDesc": "Start a code analysis session",
     "newAnalysis": "New Analysis",
     "newAnalysisDesc": "Start an analysis session"
+  },
+  "slm": {
+    "novnc": {
+      "selectHost": "Select a host to connect",
+      "selectHostDesc": "Choose a VNC-capable host from the list to open a remote desktop session."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -6963,6 +6963,7 @@
     "profile": "Profile",
     "systemStatus": "System Status",
     "operations": "Operationen",
+    "remoteDesktop": "Remote Desktop",
     "applicationError": "Application Error",
     "unexpectedError": "An unexpected error occurred",
     "loadingTimeout": "Loading Timed Out",
@@ -6999,5 +7000,11 @@
     "newCodeDesc": "Start a code analysis session",
     "newAnalysis": "New Analysis",
     "newAnalysisDesc": "Start an analysis session"
+  },
+  "slm": {
+    "novnc": {
+      "selectHost": "Select a host to connect",
+      "selectHostDesc": "Choose a VNC-capable host from the list to open a remote desktop session."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -6818,6 +6818,12 @@
       "refresh": "Refresh"
     }
   },
+  "slm": {
+    "novnc": {
+      "selectHost": "Select a host to connect",
+      "selectHostDesc": "Choose a VNC-capable host from the list to open a remote desktop session."
+    }
+  },
   "desktop": {
     "connectionSettings": {
       "title": "Connection Quality",
@@ -7011,6 +7017,7 @@
     "marketplace": "Marketplace",
     "usage": "Usage & Costs",
     "operations": "Operations",
+    "remoteDesktop": "Remote Desktop",
     "applicationError": "Application Error",
     "unexpectedError": "An unexpected error occurred",
     "loadingTimeout": "Loading Timed Out",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -6963,6 +6963,7 @@
     "profile": "Profile",
     "systemStatus": "System Status",
     "operations": "Operaciones",
+    "remoteDesktop": "Remote Desktop",
     "applicationError": "Application Error",
     "unexpectedError": "An unexpected error occurred",
     "loadingTimeout": "Loading Timed Out",
@@ -6999,5 +7000,11 @@
     "newCodeDesc": "Start a code analysis session",
     "newAnalysis": "New Analysis",
     "newAnalysisDesc": "Start an analysis session"
+  },
+  "slm": {
+    "novnc": {
+      "selectHost": "Select a host to connect",
+      "selectHostDesc": "Choose a VNC-capable host from the list to open a remote desktop session."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -121,6 +121,7 @@
     "skipToNavigation": "Skip to navigation",
     "openMainMenu": "Open main menu",
     "operations": "عملیات",
+    "remoteDesktop": "Remote Desktop",
     "applicationError": "Application Error",
     "unexpectedError": "An unexpected error occurred",
     "loadingTimeout": "Loading Timed Out",
@@ -7104,5 +7105,11 @@
     "newCodeDesc": "Start a code analysis session",
     "newAnalysis": "New Analysis",
     "newAnalysisDesc": "Start an analysis session"
+  },
+  "slm": {
+    "novnc": {
+      "selectHost": "Select a host to connect",
+      "selectHostDesc": "Choose a VNC-capable host from the list to open a remote desktop session."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -6963,6 +6963,7 @@
     "profile": "Profile",
     "systemStatus": "System Status",
     "operations": "Opérations",
+    "remoteDesktop": "Remote Desktop",
     "applicationError": "Application Error",
     "unexpectedError": "An unexpected error occurred",
     "loadingTimeout": "Loading Timed Out",
@@ -6999,5 +7000,11 @@
     "newCodeDesc": "Start a code analysis session",
     "newAnalysis": "New Analysis",
     "newAnalysisDesc": "Start an analysis session"
+  },
+  "slm": {
+    "novnc": {
+      "selectHost": "Select a host to connect",
+      "selectHostDesc": "Choose a VNC-capable host from the list to open a remote desktop session."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -121,6 +121,7 @@
     "skipToNavigation": "Skip to navigation",
     "openMainMenu": "Open main menu",
     "operations": "פעולות",
+    "remoteDesktop": "Remote Desktop",
     "applicationError": "Application Error",
     "unexpectedError": "An unexpected error occurred",
     "loadingTimeout": "Loading Timed Out",
@@ -7104,5 +7105,11 @@
     "newCodeDesc": "Start a code analysis session",
     "newAnalysis": "New Analysis",
     "newAnalysisDesc": "Start an analysis session"
+  },
+  "slm": {
+    "novnc": {
+      "selectHost": "Select a host to connect",
+      "selectHostDesc": "Choose a VNC-capable host from the list to open a remote desktop session."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -6963,6 +6963,7 @@
     "profile": "Profile",
     "systemStatus": "System Status",
     "operations": "Darbības",
+    "remoteDesktop": "Remote Desktop",
     "applicationError": "Application Error",
     "unexpectedError": "An unexpected error occurred",
     "loadingTimeout": "Loading Timed Out",
@@ -6999,5 +7000,11 @@
     "newCodeDesc": "Start a code analysis session",
     "newAnalysis": "New Analysis",
     "newAnalysisDesc": "Start an analysis session"
+  },
+  "slm": {
+    "novnc": {
+      "selectHost": "Select a host to connect",
+      "selectHostDesc": "Choose a VNC-capable host from the list to open a remote desktop session."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -6963,6 +6963,7 @@
     "profile": "Profile",
     "systemStatus": "System Status",
     "operations": "Operacje",
+    "remoteDesktop": "Remote Desktop",
     "applicationError": "Application Error",
     "unexpectedError": "An unexpected error occurred",
     "loadingTimeout": "Loading Timed Out",
@@ -6999,5 +7000,11 @@
     "newCodeDesc": "Start a code analysis session",
     "newAnalysis": "New Analysis",
     "newAnalysisDesc": "Start an analysis session"
+  },
+  "slm": {
+    "novnc": {
+      "selectHost": "Select a host to connect",
+      "selectHostDesc": "Choose a VNC-capable host from the list to open a remote desktop session."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -6963,6 +6963,7 @@
     "profile": "Profile",
     "systemStatus": "System Status",
     "operations": "Operações",
+    "remoteDesktop": "Remote Desktop",
     "applicationError": "Application Error",
     "unexpectedError": "An unexpected error occurred",
     "loadingTimeout": "Loading Timed Out",
@@ -6999,5 +7000,11 @@
     "newCodeDesc": "Start a code analysis session",
     "newAnalysis": "New Analysis",
     "newAnalysisDesc": "Start an analysis session"
+  },
+  "slm": {
+    "novnc": {
+      "selectHost": "Select a host to connect",
+      "selectHostDesc": "Choose a VNC-capable host from the list to open a remote desktop session."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -121,6 +121,7 @@
     "skipToNavigation": "Skip to navigation",
     "openMainMenu": "Open main menu",
     "operations": "آپریشنز",
+    "remoteDesktop": "Remote Desktop",
     "applicationError": "Application Error",
     "unexpectedError": "An unexpected error occurred",
     "loadingTimeout": "Loading Timed Out",
@@ -7104,5 +7105,11 @@
     "newCodeDesc": "Start a code analysis session",
     "newAnalysis": "New Analysis",
     "newAnalysisDesc": "Start an analysis session"
+  },
+  "slm": {
+    "novnc": {
+      "selectHost": "Select a host to connect",
+      "selectHostDesc": "Choose a VNC-capable host from the list to open a remote desktop session."
+    }
   }
 }

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -647,6 +647,16 @@ const routes: RouteRecordRaw[] = [
   // /desktop removed from nav — noVNC is accessible via the Chat tab's noVNC tab.
   // Redirect any bookmarked /desktop URLs to /chat.
   { path: '/desktop', redirect: '/chat' },
+  // Issue #4977: Standalone noVNC view at /slm/tools/novnc (driven by HostSelector)
+  {
+    path: '/slm/tools/novnc',
+    name: 'SlmNoVnc',
+    component: () => import('@/views/SlmNoVncView.vue'),
+    meta: {
+      title: 'Remote Desktop',
+      requiresAuth: true,
+    },
+  },
   // Issue #3502: Custom Dashboard renamed to /home (see home route above)
 
   // Issue #729: Infrastructure routes redirected to slm-admin

--- a/autobot-frontend/src/views/SlmNoVncView.vue
+++ b/autobot-frontend/src/views/SlmNoVncView.vue
@@ -1,0 +1,80 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025 mrveiss -->
+<!-- Author: mrveiss -->
+<template>
+  <div class="slm-novnc-view view-container-full">
+    <div class="slm-novnc-header">
+      <HostSelector
+        v-model="selectedHost"
+        required-capability="vnc"
+        @host-selected="onHostSelected"
+      />
+    </div>
+    <DesktopInterface
+      v-if="selectedHost"
+      :key="`slm-vnc-${selectedHost.id}`"
+      :host="selectedHost"
+      class="slm-novnc-desktop"
+    />
+    <div v-else class="slm-novnc-empty">
+      <i class="fas fa-desktop slm-novnc-empty-icon"></i>
+      <p class="slm-novnc-empty-title">{{ $t('slm.novnc.selectHost') }}</p>
+      <p class="slm-novnc-empty-desc">{{ $t('slm.novnc.selectHostDesc') }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { createLogger } from '@/utils/debugUtils'
+import { useI18n } from 'vue-i18n'
+import type { SelectorHost } from '@/composables/useHostSelector'
+import HostSelector from '@/components/ui/HostSelector.vue'
+import DesktopInterface from '@/components/desktop/DesktopInterface.vue'
+
+const logger = createLogger('SlmNoVncView')
+const { t } = useI18n()
+
+const selectedHost = ref<SelectorHost | null>(null)
+
+const onHostSelected = (host: SelectorHost) => {
+  logger.info('VNC host selected:', { name: host.name, host: host.host })
+  selectedHost.value = host
+}
+</script>
+
+<style scoped>
+@reference "../assets/tailwind.css";
+
+.slm-novnc-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  @apply bg-autobot-bg-secondary;
+}
+
+.slm-novnc-header {
+  @apply flex items-center gap-3 px-4 py-2 bg-autobot-bg-secondary border-b border-autobot-border text-sm;
+}
+
+.slm-novnc-desktop {
+  flex: 1;
+  min-height: 0;
+}
+
+.slm-novnc-empty {
+  @apply flex-1 flex flex-col items-center justify-center text-autobot-text-muted;
+}
+
+.slm-novnc-empty-icon {
+  @apply text-5xl mb-4 opacity-50;
+}
+
+.slm-novnc-empty-title {
+  @apply text-lg mb-2;
+}
+
+.slm-novnc-empty-desc {
+  @apply text-sm text-autobot-text-muted;
+}
+</style>


### PR DESCRIPTION
## Summary

- Refactors `DesktopInterface.vue` to accept a `host?: SelectorHost` prop (falls back to existing appConfig behaviour when undefined)
- Replaces bare `<iframe>` in chat tab noVNC section (`ChatTabContent.vue`) with `<DesktopInterface :host="selectedVncHost" />`
- Adds new `SlmNoVncView.vue` — `HostSelector(required-capability="vnc")` + `DesktopInterface`
- Adds route `/slm/tools/novnc` → `SlmNoVncView`
- Adds "Remote Desktop" nav entry in `App.vue`
- Adds i18n keys to all 11 locale files (`nav.remoteDesktop`, `slm.novnc.selectHost`, `slm.novnc.selectHostDesc`)

## Behavioral Grep Audit

Before:
```bash
$ grep -rn "DesktopInterface" src/ --include="*.vue" | grep -v "DesktopInterface.vue"
# 0 hits — unreachable component
```

After:
```bash
# 2 hits — ChatTabContent.vue + SlmNoVncView.vue
```

## Test plan
- [ ] `/slm/tools/novnc` route renders `HostSelector` + `DesktopInterface`
- [ ] Chat noVNC tab shows `DesktopInterface` (not bare iframe)
- [ ] No new vue-tsc errors in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)