### PR TITLE
fix(frontend): use protocol-relative scheme in buildHostVncUrl (#6361)

### DIFF
--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -233,7 +233,8 @@ const vncUrl = ref('') // Will be loaded on mount
 /** Build VNC URL from a SelectorHost record (Issue #4977). */
 const buildHostVncUrl = (h: SelectorHost): string => {
   const port = h.vnc_port || 6080
-  return `http://${h.host}:${port}/vnc.html?autoconnect=true`
+  const scheme = window.location.protocol === 'https:' ? 'https' : 'http'
+  return `${scheme}://${h.host}:${port}/vnc.html?autoconnect=true`
 }
 
 // Load dynamic VNC URL on component mount


### PR DESCRIPTION
## Summary
- `buildHostVncUrl()` in `DesktopInterface.vue` was hardcoded to `http://`
- Now detects `window.location.protocol` and uses `https` when the app is served over HTTPS
- Prevents mixed-content browser blocks when AutoBot runs behind TLS

## Test plan
- [ ] Load AutoBot over HTTPS; open Remote Desktop panel — VNC URL should use `https://`
- [ ] Load over HTTP; confirm URL still uses `http://`

Closes #6361

🤖 Generated with [Claude Code](https://claude.com/claude-code)