### PR TITLE
refactor(api): DataResponse[T] generic — type 23 agent/ai_stack endpoints (#5772)

### DIFF
--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -37,7 +37,17 @@ from utils.chat_exceptions import InternalError, SubprocessError
 from utils.response_helpers import create_success_response, handle_ai_stack_error
 
 from api.schemas_common import AgentMessageResponse, DataResponse
-from api.schemas_agent import AgentCommandApprovalResponse, AgentCommandExecuteResponse, AgentHealthResponse
+from api.schemas_agent import (
+    AgentCommandApprovalResponse,
+    AgentCommandExecuteResponse,
+    AgentHealthResponse,
+    AgentAvailableData,
+    AgentResearchData,
+    AgentStatusData,
+    DevelopmentAnalysisData,
+    EnhancedGoalData,
+    MultiAgentCoordinationData,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -1201,7 +1211,7 @@ def _determine_coordination_mode(payload, selected_agents: list) -> str:
     operation="execute_enhanced_goal",
     error_code_prefix="AGENT",
 )
-@router.post("/goal/enhanced", response_model=DataResponse)
+@router.post("/goal/enhanced", response_model=DataResponse[EnhancedGoalData])
 async def execute_enhanced_goal(
     payload: EnhancedGoalPayload,
     request: Request,
@@ -1270,7 +1280,7 @@ async def execute_enhanced_goal(
     operation="coordinate_multi_agent_task",
     error_code_prefix="AGENT",
 )
-@router.post("/multi-agent/coordinate", response_model=DataResponse)
+@router.post("/multi-agent/coordinate", response_model=DataResponse[MultiAgentCoordinationData])
 async def coordinate_multi_agent_task(
     payload: MultiAgentTaskPayload,
     request: Request,
@@ -1341,7 +1351,7 @@ async def coordinate_multi_agent_task(
     operation="comprehensive_research_task",
     error_code_prefix="AGENT",
 )
-@router.post("/research/comprehensive", response_model=DataResponse)
+@router.post("/research/comprehensive", response_model=DataResponse[AgentResearchData])
 async def comprehensive_research_task(
     request_data: ResearchTaskRequest,
     knowledge_base=Depends(get_knowledge_base),
@@ -1411,7 +1421,7 @@ async def comprehensive_research_task(
     operation="analyze_development_task",
     error_code_prefix="AGENT",
 )
-@router.post("/development/analyze", response_model=DataResponse)
+@router.post("/development/analyze", response_model=DataResponse[DevelopmentAnalysisData])
 async def analyze_development_task(
     request_data: AgentAnalysisRequest,
     current_user: dict = Depends(get_current_user),
@@ -1455,7 +1465,7 @@ async def analyze_development_task(
     operation="list_available_agents",
     error_code_prefix="AGENT",
 )
-@router.get("/agents/available", response_model=DataResponse)
+@router.get("/agents/available", response_model=DataResponse[AgentAvailableData])
 async def list_available_agents():
     """
     List all available AI Stack agents with their capabilities.
@@ -1508,7 +1518,7 @@ async def list_available_agents():
     operation="get_agents_status",
     error_code_prefix="AGENT",
 )
-@router.get("/agents/status", response_model=DataResponse)
+@router.get("/agents/status", response_model=DataResponse[AgentStatusData])
 async def get_agents_status():
     """Get comprehensive status of all AI Stack agents.
 

--- a/autobot-backend/api/ai_stack_integration.py
+++ b/autobot-backend/api/ai_stack_integration.py
@@ -27,6 +27,11 @@ from type_defs.common import Metadata
 from utils.response_helpers import create_success_response
 
 from api.schemas_common import DataResponse
+from api.schemas_agent import (
+    ComprehensiveResearchData,
+    EnhancedKnowledgeSearchData,
+    MultiAgentQueryData,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +139,7 @@ class ContentClassificationRequest(BaseModel):
     operation="ai_stack_health_check",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.get("/health", response_model=DataResponse)
+@router.get("/health", response_model=DataResponse[Dict[str, Any]])
 async def ai_stack_health_check(admin_check: bool = Depends(check_admin_permission)):
     """
     Check AI Stack health and connectivity.
@@ -174,7 +179,7 @@ async def ai_stack_health_check(admin_check: bool = Depends(check_admin_permissi
     operation="list_ai_agents",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.get("/agents", response_model=DataResponse)
+@router.get("/agents", response_model=DataResponse[Dict[str, Any]])
 async def list_ai_agents(admin_check: bool = Depends(check_admin_permission)):
     """
     List all available AI agents.
@@ -202,7 +207,7 @@ async def list_ai_agents(admin_check: bool = Depends(check_admin_permission)):
     operation="rag_query",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/rag/query", response_model=DataResponse)
+@router.post("/rag/query", response_model=DataResponse[Dict[str, Any]])
 async def rag_query(
     request: RAGQueryRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -251,7 +256,7 @@ async def rag_query(
     operation="reformulate_query",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/rag/reformulate", response_model=DataResponse)
+@router.post("/rag/reformulate", response_model=DataResponse[Dict[str, Any]])
 async def reformulate_query(
     query: str,
     context: Optional[str] = None,
@@ -278,7 +283,7 @@ async def reformulate_query(
     operation="analyze_documents",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/rag/analyze-documents", response_model=DataResponse)
+@router.post("/rag/analyze-documents", response_model=DataResponse[Dict[str, Any]])
 async def analyze_documents(
     documents: List[Metadata], admin_check: bool = Depends(check_admin_permission)
 ):
@@ -308,7 +313,7 @@ async def analyze_documents(
     operation="enhanced_chat",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/chat/enhanced", response_model=DataResponse)
+@router.post("/chat/enhanced", response_model=DataResponse[Dict[str, Any]])
 async def enhanced_chat(
     request: EnhancedChatRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -365,7 +370,7 @@ async def enhanced_chat(
     operation="extract_knowledge",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/knowledge/extract", response_model=DataResponse)
+@router.post("/knowledge/extract", response_model=DataResponse[Dict[str, Any]])
 async def extract_knowledge(
     request: KnowledgeExtractionRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -397,7 +402,7 @@ async def extract_knowledge(
     operation="enhanced_knowledge_search",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/knowledge/enhanced-search", response_model=DataResponse)
+@router.post("/knowledge/enhanced-search", response_model=DataResponse[EnhancedKnowledgeSearchData])
 async def enhanced_knowledge_search(
     query: str,
     search_type: str = "comprehensive",
@@ -447,7 +452,7 @@ async def enhanced_knowledge_search(
     operation="get_system_knowledge",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.get("/knowledge/system", response_model=DataResponse)
+@router.get("/knowledge/system", response_model=DataResponse[Dict[str, Any]])
 async def get_system_knowledge(
     knowledge_category: Optional[str] = None,
     admin_check: bool = Depends(check_admin_permission),
@@ -478,7 +483,7 @@ async def get_system_knowledge(
     operation="comprehensive_research",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/research/comprehensive", response_model=DataResponse)
+@router.post("/research/comprehensive", response_model=DataResponse[ComprehensiveResearchData])
 async def comprehensive_research(
     request: ResearchRequest, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -524,7 +529,7 @@ async def comprehensive_research(
     operation="web_research",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/research/web", response_model=DataResponse)
+@router.post("/research/web", response_model=DataResponse[Dict[str, Any]])
 async def web_research(
     query: str,
     max_pages: int = 10,
@@ -559,7 +564,7 @@ async def web_research(
     operation="search_code",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/development/search-code", response_model=DataResponse)
+@router.post("/development/search-code", response_model=DataResponse[Dict[str, Any]])
 async def search_code(
     request: CodeSearchRequest, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -588,7 +593,7 @@ async def search_code(
     operation="analyze_development_speedup",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/development/analyze-speedup", response_model=DataResponse)
+@router.post("/development/analyze-speedup", response_model=DataResponse[Dict[str, Any]])
 async def analyze_development_speedup(
     request: DevelopmentAnalysisRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -623,7 +628,7 @@ async def analyze_development_speedup(
     operation="classify_content",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/classification/classify", response_model=DataResponse)
+@router.post("/classification/classify", response_model=DataResponse[Dict[str, Any]])
 async def classify_content(
     request: ContentClassificationRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -755,7 +760,7 @@ async def _execute_sequential_agents(
     operation="multi_agent_query",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/orchestrate/multi-agent-query", response_model=DataResponse)
+@router.post("/orchestrate/multi-agent-query", response_model=DataResponse[MultiAgentQueryData])
 async def multi_agent_query(
     query: str,
     agents: List[str],
@@ -806,7 +811,7 @@ async def multi_agent_query(
     operation="legacy_rag_search",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/legacy/rag-search", response_model=DataResponse)
+@router.post("/legacy/rag-search", response_model=DataResponse[Dict[str, Any]])
 async def legacy_rag_search(
     query: str,
     max_results: int = 10,
@@ -831,7 +836,7 @@ async def legacy_rag_search(
     operation="legacy_enhanced_chat",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/legacy/enhanced-chat", response_model=DataResponse)
+@router.post("/legacy/enhanced-chat", response_model=DataResponse[Dict[str, Any]])
 async def legacy_enhanced_chat(
     message: str,
     context: Optional[str] = None,

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -927,3 +927,111 @@ class SelfCapabilitiesResponse(BaseModel):
 
     total_endpoints: int
     unique_paths: int
+
+
+# ---------------------------------------------------------------------------
+# agent.py / ai_stack_integration.py — DataResponse[T] payload models (#5772)
+# ---------------------------------------------------------------------------
+
+
+class AgentCapabilityInfo(BaseModel):
+    """Single agent entry in the /agents/available response."""
+
+    name: str
+    description: str
+    capabilities: List[str]
+    status: str
+
+
+class AgentAvailableData(BaseModel):
+    """data payload for GET /agent/agents/available."""
+
+    total_agents: int
+    agents: List[AgentCapabilityInfo]
+    coordination_modes: List[str]
+    multi_agent_support: bool
+
+
+class AgentStatusData(BaseModel):
+    """data payload for GET /agent/agents/status."""
+
+    ai_stack_status: str
+    total_agents: int
+    available_agents: List[str]
+    multi_agent_coordination: bool
+    npu_acceleration: bool
+    research_capabilities: bool
+    development_tools: bool
+
+
+class EnhancedGoalData(BaseModel):
+    """data payload for POST /agent/goal/enhanced."""
+
+    goal: str
+    agents_used: List[str]
+    coordination_mode: str
+    execution_time: float
+    priority: Optional[str] = None
+    result: Optional[Dict[str, Any]] = None
+    enhanced_context_used: bool
+    knowledge_base_integrated: bool
+    timestamp: str
+
+
+class MultiAgentCoordinationData(BaseModel):
+    """data payload for POST /agent/multi-agent/coordinate."""
+
+    task: str
+    agents: List[str]
+    coordination_strategy: str
+    coordination_time: float
+    subtasks_count: int
+    dependencies_count: int
+    result: Optional[Dict[str, Any]] = None
+    timestamp: str
+
+
+class AgentResearchData(BaseModel):
+    """data payload for POST /agent/research/comprehensive."""
+
+    research_query: str
+    research_depth: Optional[str] = None
+    agents_used: List[str]
+    include_web: bool
+    include_code_search: bool
+    sources: Optional[List[str]] = None
+    result: Optional[Dict[str, Any]] = None
+
+
+class DevelopmentAnalysisData(BaseModel):
+    """data payload for POST /agent/development/analyze."""
+
+    analysis_type: str
+    target_path: str
+    include_performance: bool
+    include_optimization: bool
+    agents_used: List[str]
+    result: Optional[Dict[str, Any]] = None
+
+
+class MultiAgentQueryData(BaseModel):
+    """data payload for POST /ai-stack/orchestrate/multi-agent-query."""
+
+    query: str
+    coordination_mode: str
+    agents_used: List[str]
+    results: Dict[str, Any]
+
+
+class EnhancedKnowledgeSearchData(BaseModel):
+    """data payload for POST /ai-stack/knowledge/enhanced-search."""
+
+    local_kb: List[Dict[str, Any]]
+    enhanced: Dict[str, Any]
+
+
+class ComprehensiveResearchData(BaseModel):
+    """data payload for POST /ai-stack/research/comprehensive."""
+
+    research: Dict[str, Any]
+    web_research: Optional[Dict[str, Any]] = None

--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -15,9 +15,11 @@ Domain-specific schemas live in:
   schemas_code.py        - CodeReview*, Git*, Skills*, Database*, Template*, etc.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Generic, List, Optional, TypeVar
 
 from pydantic import BaseModel
+
+T = TypeVar("T")
 
 
 # ---------------------------------------------------------------------------
@@ -54,15 +56,18 @@ class SuccessResponse(BaseModel):
 
 
 
-class DataResponse(BaseModel):
+class DataResponse(BaseModel, Generic[T]):
     """Generic envelope returned by create_success_response() helpers.
 
     Covers all endpoints that delegate to utils.response_helpers.create_success_response,
     which always produces {"success": True, "data": ..., "message": ..., "timestamp": ...}.
+
+    Use DataResponse[ConcreteType] on endpoints where the data payload shape is known;
+    bare DataResponse (equivalent to DataResponse[Any]) remains valid for opaque payloads.
     """
 
     success: bool
-    data: Optional[Any] = None
+    data: Optional[T] = None
     message: Optional[str] = None
     timestamp: Optional[str] = None
 


### PR DESCRIPTION
## Summary

- Makes `DataResponse` a `Generic[T]` in `schemas_common.py` — fully backward-compatible, all existing bare `DataResponse` callers across the codebase are unaffected
- Adds 9 typed data payload models in `schemas_agent.py`: `AgentCapabilityInfo`, `AgentAvailableData`, `AgentStatusData`, `EnhancedGoalData`, `MultiAgentCoordinationData`, `AgentResearchData`, `DevelopmentAnalysisData`, `MultiAgentQueryData`, `EnhancedKnowledgeSearchData`, `ComprehensiveResearchData`
- 6 `agent.py` endpoints now use `DataResponse[ConcreteType]` — fully typed data payloads in OpenAPI
- 17 `ai_stack_integration.py` endpoints updated: 3 with domain-specific models, 14 AI Stack pass-through endpoints use `DataResponse[Dict[str, Any]]` (the data comes from an external AI Stack service with no fixed schema)

## Test Plan
- [x] `python3 -m py_compile` passes on all 4 modified files
- [x] `from api.schemas_common import DataResponse` and `from api.schemas_agent import ...` import cleanly
- [x] No bare `response_model=DataResponse` remain in the two endpoint files
- [x] 155 insertions, 27 deletions — no unrelated changes

Closes #5772

🤖 Generated with Claude Code