### PR TITLE
refact(api): migrate local BaseModel subclasses — analytics + knowledge domains (#6042)

### DIFF
--- a/autobot-backend/api/agent_org.py
+++ b/autobot-backend/api/agent_org.py
@@ -12,76 +12,25 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.schemas_agent import (
+    AgentDelegateRequest,
+    AgentSummary,
+    ChainOfCommandResponse,
+    DelegationResponse,
+    DelegationStatusUpdate,
+    OrgNodeResponse,
+    UpdateOrgRequest,
+    UpsertOrgRequest,
+)
 from api.user_management.dependencies import get_db_session
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.agent_org_service import AgentOrgService
 from services.delegation_service import DelegationService
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
-
-
-# -- Schemas ---------------------------------------------------------------
-
-
-class OrgNodeResponse(BaseModel):
-    """Single node in the org tree response (#1405)."""
-
-    agent_id: str
-    name: str
-    org_role: str
-    title: Optional[str] = None
-    capabilities: Optional[str] = None
-    direct_reports_count: int = 0
-    children: List["OrgNodeResponse"] = Field(default_factory=list)
-
-
-OrgNodeResponse.model_rebuild()
-
-
-class AgentSummary(BaseModel):
-    """Compact agent summary used in chain of command (#1405)."""
-
-    agent_id: str
-    name: str
-    org_role: str
-    title: Optional[str] = None
-
-
-class ChainOfCommandResponse(BaseModel):
-    """Ordered list from agent to org root (#1405)."""
-
-    chain: List[AgentSummary]
-
-
-class UpdateOrgRequest(BaseModel):
-    """Request body for PATCH /agents/{agent_id}/org (#1405)."""
-
-    reports_to: Optional[str] = Field(
-        default=None,
-        description="agent_id of the new manager, or null to clear",
-    )
-    org_role: Optional[str] = Field(
-        default=None,
-        description="One of: manager, coordinator, specialist, worker",
-    )
-    title: Optional[str] = Field(default=None, description="Human-readable job title")
-    capabilities: Optional[str] = Field(
-        default=None, description="Free-text capability description"
-    )
-
-
-class UpsertOrgRequest(BaseModel):
-    """Request body for PUT /agents/{agent_id}/org (#1405)."""
-
-    name: str
-    org_role: str = "worker"
-    reports_to: Optional[str] = None
-    title: Optional[str] = None
-    capabilities: Optional[str] = None
 
 
 # -- Endpoints -------------------------------------------------------------
@@ -261,38 +210,6 @@ async def get_role_defaults(
     return svc.get_role_defaults(role)
 
 
-# -- Delegation schemas (#1753) -------------------------------------------
-
-
-class DelegateRequest(BaseModel):
-    """Request body for POST /{manager_id}/delegate (#1753)."""
-
-    assignee_id: str = Field(..., description="Direct report to assign to")
-    task_description: str = Field(..., description="What the assignee should do")
-    context: Optional[Dict[str, Any]] = Field(
-        default=None, description="Extra context for the task"
-    )
-
-
-class DelegationResponse(BaseModel):
-    """Response for a task delegation (#1753)."""
-
-    id: str
-    delegator_id: str
-    assignee_id: str
-    task_description: str
-    status: str
-    escalated_to: Optional[str] = None
-    created_at: Optional[str] = None
-
-
-class DelegationStatusUpdate(BaseModel):
-    """Request body for PATCH /delegations/{id}/status (#1753)."""
-
-    status: str = Field(..., description="New status value")
-    result: Optional[Dict[str, Any]] = None
-
-
 def _delegation_to_response(d) -> DelegationResponse:
     """Convert TaskDelegation ORM row to response (#1753)."""
     return DelegationResponse(
@@ -322,7 +239,7 @@ def _delegation_to_response(d) -> DelegationResponse:
 )
 async def delegate_task(
     manager_id: str,
-    body: DelegateRequest,
+    body: AgentDelegateRequest,
     session: AsyncSession = Depends(get_db_session),
 ) -> DelegationResponse:
     """

--- a/autobot-backend/api/ai_stack_integration.py
+++ b/autobot-backend/api/ai_stack_integration.py
@@ -13,7 +13,15 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from api.schemas_knowledge import (
+    CodeSearchRequest,
+    ContentClassificationRequest,
+    DevelopmentAnalysisRequest,
+    EnhancedChatRequest,
+    KnowledgeExtractionRequest,
+    RAGQueryRequest,
+    ResearchRequest,
+)
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -43,79 +51,6 @@ AgentQueryHandler = Callable[[Any, str], Awaitable[Dict[str, Any]]]
 # ====================================================================
 
 router = APIRouter(tags=["ai-stack"])
-
-# ====================================================================
-# Request/Response Models
-# ====================================================================
-
-
-class RAGQueryRequest(BaseModel):
-    """RAG query request model."""
-
-    query: str = Field(..., min_length=1, max_length=10000, description="Search query")
-    documents: Optional[List[Metadata]] = Field(
-        None, description="Pre-retrieved documents"
-    )
-    context: Optional[str] = Field(None, description="Additional context")
-    max_results: int = Field(10, ge=1, le=50, description="Maximum results to return")
-
-
-class EnhancedChatRequest(BaseModel):
-    """Enhanced chat request model."""
-
-    message: str = Field(
-        ..., min_length=1, max_length=50000, description="Chat message"
-    )
-    context: Optional[str] = Field(None, description="Conversation context")
-    chat_history: Optional[List[Metadata]] = Field(
-        None, description="Previous messages"
-    )
-    use_knowledge_base: bool = Field(True, description="Whether to use knowledge base")
-    response_style: str = Field("conversational", description="Response style")
-
-
-class KnowledgeExtractionRequest(BaseModel):
-    """Knowledge extraction request model."""
-
-    content: str = Field(
-        ..., min_length=1, description="Content to extract knowledge from"
-    )
-    content_type: str = Field("text", description="Content type (text, document, url)")
-    extraction_mode: str = Field("comprehensive", description="Extraction detail level")
-
-
-class ResearchRequest(BaseModel):
-    """Research request model."""
-
-    query: str = Field(..., min_length=1, max_length=5000, description="Research query")
-    research_depth: str = Field("comprehensive", description="Research depth")
-    sources: Optional[List[str]] = Field(None, description="Specific sources")
-    include_web: bool = Field(True, description="Include web research")
-
-
-class CodeSearchRequest(BaseModel):
-    """Code search request model."""
-
-    query: str = Field(..., min_length=1, description="Code search query")
-    search_scope: str = Field("codebase", description="Search scope")
-    include_npu: bool = Field(True, description="Use NPU acceleration")
-
-
-class DevelopmentAnalysisRequest(BaseModel):
-    """Development analysis request model."""
-
-    code_path: Optional[str] = Field(None, description="Specific path to analyze")
-    analysis_type: str = Field("comprehensive", description="Analysis type")
-
-
-class ContentClassificationRequest(BaseModel):
-    """Content classification request model."""
-
-    content: str = Field(..., min_length=1, description="Content to classify")
-    classification_types: Optional[List[str]] = Field(
-        None, description="Classification types"
-    )
-
 
 # ====================================================================
 # Utility Functions (imported from backend.utils.response_helpers)

--- a/autobot-backend/api/analytics_cost.py
+++ b/autobot-backend/api/analytics_cost.py
@@ -17,93 +17,35 @@ Related Issues: #59 (Advanced Analytics & Business Intelligence)
 import asyncio
 import logging
 from datetime import datetime, timedelta
-from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from services.llm_cost_tracker import MODEL_PRICING, get_cost_tracker
-from api.schemas_common import DataResponse
 from api.schemas_analytics import (
+    AgentBudgetRequest,
     AgentBudgetSetResponse,
     AgentBudgetStatusResponse,
     AllAgentCostsResponse,
     BudgetAlertCreateResponse,
+    BudgetAlertRequest,
     BudgetAlertsListResponse,
     BudgetStatusResponse,
     CostByModelResponse,
     CostEstimateResponse,
     CostForecastResponse,
+    CostSummaryResponse,
+    CostTrendResponse,
     ModelPricingResponse,
+    SessionCostResponse,
     SingleAgentCostResponse,
     UsageRecentResponse,
 )
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/cost", tags=["analytics", "cost"])
-
-
-# ============================================================================
-# PYDANTIC MODELS
-# ============================================================================
-
-
-class CostSummaryResponse(BaseModel):
-    """Cost summary response model"""
-
-    period: dict
-    total_cost_usd: float
-    daily_costs: dict
-    by_model: dict
-    avg_daily_cost: float
-
-
-class CostTrendResponse(BaseModel):
-    """Cost trend response model"""
-
-    period_days: int
-    total_cost_usd: float
-    daily_costs: dict
-    trend: str
-    growth_rate_percent: float
-    avg_daily_cost: float
-
-
-class SessionCostResponse(BaseModel):
-    """Session cost response model"""
-
-    session_id: str
-    found: bool
-    cost_usd: Optional[float] = None
-    input_tokens: Optional[int] = None
-    output_tokens: Optional[int] = None
-    error: Optional[str] = None
-
-
-class BudgetAlertRequest(BaseModel):
-    """Budget alert configuration request"""
-
-    name: str = Field(..., description="Alert name")
-    threshold_usd: float = Field(..., gt=0, description="Budget threshold in USD")
-    period: str = Field(
-        ..., pattern="^(daily|weekly|monthly)$", description="Alert period"
-    )
-    notify_at_percent: List[int] = Field(
-        default=[50, 75, 90, 100], description="Percentages to notify at"
-    )
-    enabled: bool = Field(default=True, description="Whether alert is enabled")
-
-
-class ModelPricingInfo(BaseModel):
-    """Model pricing information"""
-
-    model: str
-    input_price_per_1m: float
-    output_price_per_1m: float
-    provider: str
 
 
 # ============================================================================
@@ -668,23 +610,6 @@ async def get_budget_status(
 # ============================================================================
 # PER-AGENT COST ENDPOINTS (#1401)
 # ============================================================================
-
-
-class AgentBudgetRequest(BaseModel):
-    """Per-agent budget configuration request (#1401)"""
-
-    budget_monthly_usd: float = Field(..., gt=0, description="Monthly budget in USD")
-
-
-class AgentCostResponse(BaseModel):
-    """Per-agent cost response (#1401)"""
-
-    agent_id: str
-    found: bool = False
-    cost_usd: float = 0.0
-    input_tokens: int = 0
-    output_tokens: int = 0
-    call_count: int = 0
 
 
 @with_error_handling(

--- a/autobot-backend/api/analytics_precommit.py
+++ b/autobot-backend/api/analytics_precommit.py
@@ -14,13 +14,25 @@ import re
 import subprocess  # nosec B404
 import threading
 from datetime import datetime, timezone
-from enum import Enum
 from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
 
+from api.schemas_analytics import (
+    CheckCategory,
+    CheckDefinition,
+    CheckResult,
+    CheckSeverity,
+    CheckToggleResponse,
+    CommitCheckResult,
+    HookConfig,
+    HookConfigUpdateResponse,
+    HookInstallResponse,
+    HookStatus,
+    PrecommitCategoryItem,
+    PrecommitSummaryResponse,
+)
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.network_constants import NetworkConstants
@@ -31,145 +43,6 @@ router = APIRouter(tags=["precommit", "analytics"])  # Prefix set in router_regi
 
 # Issue #380: Module-level frozenset for expensive checks to skip in fast mode
 _EXPENSIVE_CHECKS = frozenset({"QUA002", "DOC001"})
-
-
-# ============================================================================
-# Models
-# ============================================================================
-
-
-class CheckSeverity(str, Enum):
-    """Severity levels for pre-commit checks."""
-
-    BLOCK = "block"  # Prevents commit
-    WARN = "warn"  # Shows warning but allows commit
-    INFO = "info"  # Informational only
-
-
-class CheckCategory(str, Enum):
-    """Categories of pre-commit checks."""
-
-    SECURITY = "security"
-    QUALITY = "quality"
-    STYLE = "style"
-    DEBUG = "debug"
-    DOCS = "docs"
-
-
-class CheckResult(BaseModel):
-    """Result of a single check."""
-
-    check_id: str
-    name: str
-    category: CheckCategory
-    severity: CheckSeverity
-    passed: bool
-    message: str
-    file: Optional[str] = None
-    line: Optional[int] = None
-    snippet: Optional[str] = None
-    suggestion: Optional[str] = None
-
-
-class CommitCheckResult(BaseModel):
-    """Result of checking staged files."""
-
-    passed: bool
-    total_checks: int
-    passed_checks: int
-    failed_checks: int
-    warnings: int
-    blocked: bool
-    duration_ms: float
-    results: list[CheckResult]
-    files_checked: list[str]
-    timestamp: str
-
-
-class HookConfig(BaseModel):
-    """Configuration for pre-commit hooks."""
-
-    enabled: bool = True
-    fast_mode: bool = True  # Skip expensive checks
-    timeout_seconds: int = Field(default=5, ge=1, le=30)
-    bypass_keyword: str = "[skip-hooks]"
-    enabled_checks: list[str] = Field(default_factory=list)
-    disabled_checks: list[str] = Field(default_factory=list)
-
-
-class CheckDefinition(BaseModel):
-    """Definition of a check rule."""
-
-    id: str
-    name: str
-    category: CheckCategory
-    severity: CheckSeverity
-    pattern: str
-    description: str
-    suggestion: str
-    file_patterns: list[str] = Field(default_factory=lambda: ["*"])
-    enabled: bool = True
-
-
-class HookStatus(BaseModel):
-    """Status of installed hooks."""
-
-    installed: bool
-    path: Optional[str] = None
-    version: Optional[str] = None
-    last_run: Optional[str] = None
-    config: HookConfig
-
-
-class CheckToggleResponse(BaseModel):
-    """Response for POST /checks/{check_id}/toggle."""
-
-    check_id: str
-    enabled: bool
-    message: str
-
-
-class HookConfigUpdateResponse(BaseModel):
-    """Response for POST /config — echoes back the new config."""
-
-    message: str
-    config: HookConfig
-
-
-class HookInstallResponse(BaseModel):
-    """Response for POST /install and POST /uninstall."""
-
-    success: bool
-    message: str
-    path: Optional[str] = None
-
-
-class CommonIssueItem(BaseModel):
-    """Single issue entry in the summary common_issues list."""
-
-    check_id: str
-    count: int
-    name: str
-
-
-class PrecommitSummaryResponse(BaseModel):
-    """Response for GET /summary."""
-
-    total_runs: int
-    pass_rate: float
-    average_duration_ms: float
-    common_issues: list[CommonIssueItem]
-    checks_enabled: Optional[int] = None
-    total_checks: Optional[int] = None
-
-
-class CategoryItem(BaseModel):
-    """Single category entry for GET /categories."""
-
-    category: str
-    enabled: int
-    disabled: int
-    total: int
 
 
 # ============================================================================
@@ -993,7 +866,7 @@ async def get_summary(
     operation="get_categories",
     error_code_prefix="ANALYTICS_PRECOMMIT",
 )
-@router.get("/categories", response_model=list[CategoryItem])
+@router.get("/categories", response_model=list[PrecommitCategoryItem])
 async def get_categories(
     admin_check: bool = Depends(check_admin_permission),
 ) -> list[dict]:

--- a/autobot-backend/api/approval_gates.py
+++ b/autobot-backend/api/approval_gates.py
@@ -9,125 +9,41 @@ CRUD and lifecycle endpoints for human-in-the-loop approval gates.
 
 import logging
 import uuid
-from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.schemas_workflows import (
+    ApprovalAddCommentRequest,
+    ApprovalCommentResponse,
+    ApprovalGateResponse,
+    ApprovalLinkTaskRequest,
+    ApprovalResubmitRequest,
+    ApprovalTransitionRequest,
+    CreateApprovalRequest,
+    TaskApprovalLinkResponse,
+)
 from api.user_management.dependencies import get_db_session
 from auth_middleware import get_current_user
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.models.pagination import PaginationParams
 from models.approval import ApprovalStatus, ApprovalType
 from services.approval_gate_service import ApprovalGateService
-from api.schemas_common import DataResponse
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-# -- Request / Response schemas ----------------------------------------
-
-
-class AuthorTypeEnum(str, Enum):
-    """Valid author types for comments."""
-
-    HUMAN = "human"
-    AGENT = "agent"
-    SYSTEM = "system"
-
-
-class CreateApprovalRequest(BaseModel):
-    """Request body for creating an approval gate."""
-
-    title: str
-    approval_type: ApprovalType
-    description: Optional[str] = None
-    requested_by_agent: Optional[str] = None
-    workflow_id: Optional[str] = None
-    workflow_step: Optional[str] = None
-    context: Optional[Dict[str, Any]] = None
-    task_ids: Optional[List[str]] = None
-
-
-class TransitionRequest(BaseModel):
-    """Request body for approve / reject / request-revision."""
-
-    comment: Optional[str] = None
-
-
-class ResubmitRequest(BaseModel):
-    """Request body for resubmitting after revision."""
-
-    description: Optional[str] = None
-    context: Optional[Dict[str, Any]] = None
-
-
-class AddCommentRequest(BaseModel):
-    """Request body for adding a comment."""
-
-    body: str
-    author_type: AuthorTypeEnum = AuthorTypeEnum.HUMAN
-
-
-class LinkTaskRequest(BaseModel):
-    """Request body for linking a task."""
-
-    task_id: str
-    task_type: str = "github_issue"
-
-
-class TaskApprovalLinkResponse(BaseModel):
-    """Response for a task-approval link."""
-
-    id: str
-    approval_id: str
-    task_id: str
-    task_type: str
-
-
-class CommentResponse(BaseModel):
-    """Response for a comment."""
-
-    id: str
-    approval_id: str
-    author: str
-    author_type: str
-    body: str
-    created_at: Optional[str] = None
-
-
-class ApprovalResponse(BaseModel):
-    """Response for an approval."""
-
-    id: str
-    title: str
-    description: Optional[str] = None
-    approval_type: str
-    status: str
-    requested_by_agent: Optional[str] = None
-    decided_by_user: Optional[str] = None
-    workflow_id: Optional[str] = None
-    workflow_step: Optional[str] = None
-    context: Optional[Dict[str, Any]] = None
-    decided_at: Optional[str] = None
-    created_at: Optional[str] = None
-    updated_at: Optional[str] = None
-    comments: List[CommentResponse] = Field(default_factory=list)
-    task_links: List[TaskApprovalLinkResponse] = Field(default_factory=list)
-
-
 # -- Helpers -----------------------------------------------------------
 
 
-def _build_comments(approval) -> List[CommentResponse]:
+def _build_comments(approval) -> List[ApprovalCommentResponse]:
     """Build comment responses from approval ORM object (#1402)."""
     comments = []
     for c in getattr(approval, "comments", []) or []:
         comments.append(
-            CommentResponse(
+            ApprovalCommentResponse(
                 id=str(c.id),
                 approval_id=str(c.approval_id),
                 author=c.author,
@@ -154,9 +70,9 @@ def _build_task_links(approval) -> List[TaskApprovalLinkResponse]:
     return task_links
 
 
-def _to_response(approval) -> ApprovalResponse:
+def _to_response(approval) -> ApprovalGateResponse:
     """Convert an Approval ORM object to a response dict."""
-    return ApprovalResponse(
+    return ApprovalGateResponse(
         id=str(approval.id),
         title=approval.title,
         description=approval.description,
@@ -185,7 +101,7 @@ def _to_response(approval) -> ApprovalResponse:
 )
 @router.post(
     "/approval-gates",
-    response_model=ApprovalResponse,
+    response_model=ApprovalGateResponse,
     status_code=status.HTTP_201_CREATED,
 )
 async def create_approval(
@@ -215,7 +131,7 @@ async def create_approval(
 )
 @router.get(
     "/approval-gates",
-    response_model=List[ApprovalResponse],
+    response_model=List[ApprovalGateResponse],
 )
 async def list_approvals(
     status_filter: Optional[ApprovalStatus] = None,
@@ -246,7 +162,7 @@ async def list_approvals(
 )
 @router.get(
     "/approval-gates/{approval_id}",
-    response_model=ApprovalResponse,
+    response_model=ApprovalGateResponse,
 )
 async def get_approval(
     approval_id: uuid.UUID,
@@ -271,11 +187,11 @@ async def get_approval(
 )
 @router.post(
     "/approval-gates/{approval_id}/approve",
-    response_model=ApprovalResponse,
+    response_model=ApprovalGateResponse,
 )
 async def approve(
     approval_id: uuid.UUID,
-    body: TransitionRequest,
+    body: ApprovalTransitionRequest,
     current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
@@ -303,11 +219,11 @@ async def approve(
 )
 @router.post(
     "/approval-gates/{approval_id}/reject",
-    response_model=ApprovalResponse,
+    response_model=ApprovalGateResponse,
 )
 async def reject(
     approval_id: uuid.UUID,
-    body: TransitionRequest,
+    body: ApprovalTransitionRequest,
     current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
@@ -335,11 +251,11 @@ async def reject(
 )
 @router.post(
     "/approval-gates/{approval_id}/request-revision",
-    response_model=ApprovalResponse,
+    response_model=ApprovalGateResponse,
 )
 async def request_revision(
     approval_id: uuid.UUID,
-    body: TransitionRequest,
+    body: ApprovalTransitionRequest,
     current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
@@ -367,11 +283,11 @@ async def request_revision(
 )
 @router.post(
     "/approval-gates/{approval_id}/resubmit",
-    response_model=ApprovalResponse,
+    response_model=ApprovalGateResponse,
 )
 async def resubmit(
     approval_id: uuid.UUID,
-    body: ResubmitRequest,
+    body: ApprovalResubmitRequest,
     current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
@@ -398,12 +314,12 @@ async def resubmit(
 )
 @router.post(
     "/approval-gates/{approval_id}/comments",
-    response_model=CommentResponse,
+    response_model=ApprovalCommentResponse,
     status_code=status.HTTP_201_CREATED,
 )
 async def add_comment(
     approval_id: uuid.UUID,
-    body: AddCommentRequest,
+    body: ApprovalAddCommentRequest,
     current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
@@ -422,7 +338,7 @@ async def add_comment(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Internal server error",
         )
-    return CommentResponse(
+    return ApprovalCommentResponse(
         id=str(comment.id),
         approval_id=str(comment.approval_id),
         author=comment.author,
@@ -444,7 +360,7 @@ async def add_comment(
 )
 async def link_task(
     approval_id: uuid.UUID,
-    body: LinkTaskRequest,
+    body: ApprovalLinkTaskRequest,
     current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -10,11 +10,19 @@ import datetime
 import logging
 from collections import defaultdict
 from time import time
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import jwt as pyjwt
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, validator
+from api.schemas_agent import (
+    ChangePasswordRequest,
+    ChangePasswordResponse,
+    LoginRequest,
+    LoginResponse,
+    LogoutRequest,
+    SignupRequest,
+    SignupResponse,
+)
 
 from auth_middleware import get_auth_middleware
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -94,131 +102,6 @@ class PasswordChangeRateLimiter:
 
 # Global rate limiter for password changes
 password_change_limiter = PasswordChangeRateLimiter()
-
-
-class LoginRequest(BaseModel):
-    """Login request model"""
-
-    username: str
-    password: str
-
-    @validator("username")
-    def validate_username(cls, v):
-        """Validate and sanitize username format."""
-        if not v or len(v.strip()) == 0:
-            raise ValueError("Username cannot be empty")
-        if len(v) > 50:
-            raise ValueError("Username too long")
-        # Basic sanitization
-        v = v.strip().lower()
-        if not v.replace("_", "").replace("-", "").replace(".", "").isalnum():
-            raise ValueError("Username contains invalid characters")
-        return v
-
-    @validator("password")
-    def validate_password(cls, v):
-        """Validate password length constraints."""
-        if not v or len(v) < 1:
-            raise ValueError("Password cannot be empty")
-        if len(v) > 128:
-            raise ValueError("Password too long")
-        return v
-
-
-class LoginResponse(BaseModel):
-    """Login response model"""
-
-    success: bool
-    message: str
-    user: Optional[dict] = None
-    token: Optional[str] = None
-    session_id: Optional[str] = None
-
-
-class LogoutRequest(BaseModel):
-    """Logout request model"""
-
-    session_id: Optional[str] = None
-
-
-class ChangePasswordRequest(BaseModel):
-    """Change password request model"""
-
-    current_password: str
-    new_password: str
-
-    @validator("new_password")
-    def validate_new_password(cls, v):
-        """Validate password strength requirements."""
-        if len(v) < 8:
-            raise ValueError("Password must be at least 8 characters long")
-        if len(v) > 128:
-            raise ValueError("Password too long")
-        if not any(c.isupper() for c in v):
-            raise ValueError("Password must contain at least one uppercase letter")
-        if not any(c.islower() for c in v):
-            raise ValueError("Password must contain at least one lowercase letter")
-        if not any(c.isdigit() for c in v):
-            raise ValueError("Password must contain at least one digit")
-        return v
-
-
-class ChangePasswordResponse(BaseModel):
-    """Change password response model"""
-
-    success: bool
-    message: str
-
-
-class SignupRequest(BaseModel):
-    """Self-registration request model (#1801)."""
-
-    username: str
-    email: str
-    password: str
-    display_name: str | None = None
-
-    @validator("username")
-    def validate_username(cls, v):
-        """Validate username format."""
-        v = v.strip().lower()
-        if not v or len(v) < 3:
-            raise ValueError("Username must be at least 3 characters")
-        if len(v) > 50:
-            raise ValueError("Username too long")
-        if not v.replace("_", "").replace("-", "").isalnum():
-            raise ValueError("Username contains invalid characters")
-        return v
-
-    @validator("email")
-    def validate_email(cls, v):
-        """Minimal email sanity check."""
-        if "@" not in v or len(v) > 255:
-            raise ValueError("Invalid email address")
-        return v.strip().lower()
-
-    @validator("password")
-    def validate_password(cls, v):
-        """Password strength requirements."""
-        if len(v) < 8:
-            raise ValueError("Password must be at least 8 characters")
-        if len(v) > 128:
-            raise ValueError("Password too long")
-        if not any(c.isupper() for c in v):
-            raise ValueError("Password must contain at least one uppercase letter")
-        if not any(c.islower() for c in v):
-            raise ValueError("Password must contain at least one lowercase letter")
-        if not any(c.isdigit() for c in v):
-            raise ValueError("Password must contain at least one digit")
-        return v
-
-
-class SignupResponse(BaseModel):
-    """Self-registration response model (#1801)."""
-
-    success: bool
-    message: str
-    username: str | None = None
 
 
 async def _authenticate_and_build_user_data(

--- a/autobot-backend/api/browser_mcp.py
+++ b/autobot-backend/api/browser_mcp.py
@@ -28,19 +28,41 @@ import json
 import logging
 import re
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import List
 from urllib.parse import urlparse
 
 import aiohttp
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
-
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
 from autobot_shared.time_utils import now_utc
 from constants.network_constants import NetworkConstants
-from type_defs.common import JSONObject, Metadata
+from type_defs.common import Metadata
+from api.schemas_code import MCPTool
+from api.schemas_system import (
+    BrowserClickRequest,
+    BrowserClickResponse,
+    BrowserEvaluateRequest,
+    BrowserEvaluateResponse,
+    BrowserFillRequest,
+    BrowserFillResponse,
+    BrowserGetAttributeRequest,
+    BrowserGetAttributeResponse,
+    BrowserGetTextRequest,
+    BrowserGetTextResponse,
+    BrowserHoverRequest,
+    BrowserHoverResponse,
+    BrowserMcpStatusResponse,
+    BrowserNavigateRequest,
+    BrowserNavigateResponse,
+    BrowserScreenshotRequest,
+    BrowserScreenshotResponse,
+    BrowserSelectRequest,
+    BrowserSelectResponse,
+    BrowserWaitForSelectorRequest,
+    BrowserWaitForSelectorResponse,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(
@@ -170,201 +192,6 @@ async def check_rate_limit() -> bool:
 
         request_counter["count"] += 1
         return True
-
-
-class MCPTool(BaseModel):
-    """Standard MCP tool definition"""
-
-    name: str
-    description: str
-    input_schema: JSONObject
-
-
-# Request Models
-
-
-class NavigateRequest(BaseModel):
-    """Request model for browser navigation"""
-
-    url: str = Field(..., description="URL to navigate to")
-    wait_until: Optional[str] = Field(
-        "load", description="Wait condition: 'load', 'domcontentloaded', 'networkidle'"
-    )
-    timeout: Optional[int] = Field(30000, description="Timeout in milliseconds")
-
-
-class ClickRequest(BaseModel):
-    """Request model for clicking elements"""
-
-    selector: str = Field(..., description="CSS selector for element to click")
-    timeout: Optional[int] = Field(5000, description="Timeout in milliseconds")
-
-
-class FillRequest(BaseModel):
-    """Request model for filling form fields"""
-
-    selector: str = Field(..., description="CSS selector for input field")
-    value: str = Field(..., description="Value to fill")
-    timeout: Optional[int] = Field(5000, description="Timeout in milliseconds")
-
-
-class ScreenshotRequest(BaseModel):
-    """Request model for taking screenshots"""
-
-    selector: Optional[str] = Field(
-        None, description="CSS selector for element (full page if omitted)"
-    )
-    full_page: Optional[bool] = Field(False, description="Capture full scrollable page")
-
-
-class EvaluateRequest(BaseModel):
-    """Request model for executing JavaScript"""
-
-    script: str = Field(..., description="JavaScript code to execute")
-
-
-class WaitForSelectorRequest(BaseModel):
-    """Request model for waiting for elements"""
-
-    selector: str = Field(..., description="CSS selector to wait for")
-    timeout: Optional[int] = Field(30000, description="Timeout in milliseconds")
-    state: Optional[str] = Field(
-        "visible", description="State: 'attached', 'detached', 'visible', 'hidden'"
-    )
-
-
-class GetTextRequest(BaseModel):
-    """Request model for extracting text content"""
-
-    selector: str = Field(..., description="CSS selector for element")
-
-
-class GetAttributeRequest(BaseModel):
-    """Request model for getting element attributes"""
-
-    selector: str = Field(..., description="CSS selector for element")
-    attribute: str = Field(..., description="Attribute name to retrieve")
-
-
-class SelectRequest(BaseModel):
-    """Request model for selecting dropdown options"""
-
-    selector: str = Field(..., description="CSS selector for select element")
-    value: str = Field(..., description="Value to select")
-
-
-class HoverRequest(BaseModel):
-    """Request model for hovering over elements"""
-
-    selector: str = Field(..., description="CSS selector for element to hover")
-
-
-# Response models for Browser MCP endpoints
-class BrowserNavigateResponse(BaseModel):
-    """Response for navigate MCP action"""
-    success: bool
-    action: str
-    url: str
-    result: Optional[Any] = None
-    timestamp: str
-
-
-class BrowserClickResponse(BaseModel):
-    """Response for click MCP action"""
-    success: bool
-    action: str
-    selector: str
-    result: Optional[Any] = None
-    timestamp: str
-
-
-class BrowserFillResponse(BaseModel):
-    """Response for fill MCP action"""
-    success: bool
-    action: str
-    selector: str
-    value_length: int
-    result: Optional[Any] = None
-    timestamp: str
-
-
-class BrowserScreenshotResponse(BaseModel):
-    """Response for screenshot MCP action"""
-    success: bool
-    action: str
-    selector: Optional[str] = None
-    full_page: Optional[bool] = None
-    base64_image: Optional[str] = None
-    mime_type: str
-    timestamp: str
-
-
-class BrowserEvaluateResponse(BaseModel):
-    """Response for evaluate MCP action"""
-    success: bool
-    action: str
-    script_preview: str
-    result: Optional[Any] = None
-    timestamp: str
-
-
-class BrowserWaitForSelectorResponse(BaseModel):
-    """Response for wait_for_selector MCP action"""
-    success: bool
-    action: str
-    selector: str
-    state: Optional[str] = None
-    result: Optional[Any] = None
-    timestamp: str
-
-
-class BrowserGetTextResponse(BaseModel):
-    """Response for get_text MCP action"""
-    success: bool
-    action: str
-    selector: str
-    text: Optional[str] = None
-    timestamp: str
-
-
-class BrowserGetAttributeResponse(BaseModel):
-    """Response for get_attribute MCP action"""
-    success: bool
-    action: str
-    selector: str
-    attribute: str
-    value: Optional[str] = None
-    timestamp: str
-
-
-class BrowserSelectResponse(BaseModel):
-    """Response for select MCP action"""
-    success: bool
-    action: str
-    selector: str
-    value: str
-    result: Optional[Any] = None
-    timestamp: str
-
-
-class BrowserHoverResponse(BaseModel):
-    """Response for hover MCP action"""
-    success: bool
-    action: str
-    selector: str
-    result: Optional[Any] = None
-    timestamp: str
-
-
-class BrowserMcpStatusResponse(BaseModel):
-    """Response for Browser MCP status endpoint"""
-    success: bool
-    bridge: str
-    browser_vm: Dict[str, str]
-    security: Dict[str, Any]
-    rate_limit_status: Dict[str, Any]
-    tools_available: int
-    timestamp: str
 
 
 
@@ -715,7 +542,7 @@ async def send_to_browser_vm(action: str, params: Metadata) -> Metadata:
     error_code_prefix="BROWSER_MCP",
 )
 @router.post("/mcp/navigate", response_model=BrowserNavigateResponse)
-async def navigate_mcp(request: NavigateRequest) -> Metadata:
+async def navigate_mcp(request: BrowserNavigateRequest) -> Metadata:
     """Navigate browser to URL with security validation"""
     if not await check_rate_limit():
         raise HTTPException(status_code=429, detail="Rate limit exceeded")
@@ -757,7 +584,7 @@ async def navigate_mcp(request: NavigateRequest) -> Metadata:
     error_code_prefix="BROWSER_MCP",
 )
 @router.post("/mcp/click", response_model=BrowserClickResponse)
-async def click_mcp(request: ClickRequest) -> Metadata:
+async def click_mcp(request: BrowserClickRequest) -> Metadata:
     """Click on element by selector"""
     if not await check_rate_limit():
         raise HTTPException(status_code=429, detail="Rate limit exceeded")
@@ -789,7 +616,7 @@ async def click_mcp(request: ClickRequest) -> Metadata:
     error_code_prefix="BROWSER_MCP",
 )
 @router.post("/mcp/fill", response_model=BrowserFillResponse)
-async def fill_mcp(request: FillRequest) -> Metadata:
+async def fill_mcp(request: BrowserFillRequest) -> Metadata:
     """Fill form field with value"""
     if not await check_rate_limit():
         raise HTTPException(status_code=429, detail="Rate limit exceeded")
@@ -826,7 +653,7 @@ async def fill_mcp(request: FillRequest) -> Metadata:
     error_code_prefix="BROWSER_MCP",
 )
 @router.post("/mcp/screenshot", response_model=BrowserScreenshotResponse)
-async def screenshot_mcp(request: ScreenshotRequest) -> Metadata:
+async def screenshot_mcp(request: BrowserScreenshotRequest) -> Metadata:
     """Capture screenshot of page or element"""
     if not await check_rate_limit():
         raise HTTPException(status_code=429, detail="Rate limit exceeded")
@@ -862,7 +689,7 @@ async def screenshot_mcp(request: ScreenshotRequest) -> Metadata:
     error_code_prefix="BROWSER_MCP",
 )
 @router.post("/mcp/evaluate", response_model=BrowserEvaluateResponse)
-async def evaluate_mcp(request: EvaluateRequest) -> Metadata:
+async def evaluate_mcp(request: BrowserEvaluateRequest) -> Metadata:
     """Execute JavaScript with security validation"""
     if not await check_rate_limit():
         raise HTTPException(status_code=429, detail="Rate limit exceeded")
@@ -897,7 +724,7 @@ async def evaluate_mcp(request: EvaluateRequest) -> Metadata:
     error_code_prefix="BROWSER_MCP",
 )
 @router.post("/mcp/wait_for_selector", response_model=BrowserWaitForSelectorResponse)
-async def wait_for_selector_mcp(request: WaitForSelectorRequest) -> Metadata:
+async def wait_for_selector_mcp(request: BrowserWaitForSelectorRequest) -> Metadata:
     """Wait for element to reach specified state"""
     if not await check_rate_limit():
         raise HTTPException(status_code=429, detail="Rate limit exceeded")
@@ -934,7 +761,7 @@ async def wait_for_selector_mcp(request: WaitForSelectorRequest) -> Metadata:
     error_code_prefix="BROWSER_MCP",
 )
 @router.post("/mcp/get_text", response_model=BrowserGetTextResponse)
-async def get_text_mcp(request: GetTextRequest) -> Metadata:
+async def get_text_mcp(request: BrowserGetTextRequest) -> Metadata:
     """Extract text content from element"""
     if not await check_rate_limit():
         raise HTTPException(status_code=429, detail="Rate limit exceeded")
@@ -963,7 +790,7 @@ async def get_text_mcp(request: GetTextRequest) -> Metadata:
     error_code_prefix="BROWSER_MCP",
 )
 @router.post("/mcp/get_attribute", response_model=BrowserGetAttributeResponse)
-async def get_attribute_mcp(request: GetAttributeRequest) -> Metadata:
+async def get_attribute_mcp(request: BrowserGetAttributeRequest) -> Metadata:
     """Get attribute value from element"""
     if not await check_rate_limit():
         raise HTTPException(status_code=429, detail="Rate limit exceeded")
@@ -996,7 +823,7 @@ async def get_attribute_mcp(request: GetAttributeRequest) -> Metadata:
     error_code_prefix="BROWSER_MCP",
 )
 @router.post("/mcp/select", response_model=BrowserSelectResponse)
-async def select_mcp(request: SelectRequest) -> Metadata:
+async def select_mcp(request: BrowserSelectRequest) -> Metadata:
     """Select option from dropdown"""
     if not await check_rate_limit():
         raise HTTPException(status_code=429, detail="Rate limit exceeded")
@@ -1029,7 +856,7 @@ async def select_mcp(request: SelectRequest) -> Metadata:
     error_code_prefix="BROWSER_MCP",
 )
 @router.post("/mcp/hover", response_model=BrowserHoverResponse)
-async def hover_mcp(request: HoverRequest) -> Metadata:
+async def hover_mcp(request: BrowserHoverRequest) -> Metadata:
     """Hover mouse over element"""
     if not await check_rate_limit():
         raise HTTPException(status_code=429, detail="Rate limit exceeded")

--- a/autobot-backend/api/cache_management.py
+++ b/autobot-backend/api/cache_management.py
@@ -10,11 +10,23 @@ Consolidates all cache-related endpoints (Issue #1286).
 import asyncio
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
 
+from api.schemas_system import (
+    CacheClearTypeResponse,
+    CacheConfigResponse,
+    CacheHealthResponse,
+    CacheStatsResponse,
+    CacheWarmingRequest,
+    CacheWarmupResponse,
+    ClearAllResponse,
+    InvalidateCacheResponse,
+    RedisClearResponse,
+    RedisStatsResponse,
+    WarmCacheResponse,
+)
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_redis_client
@@ -90,118 +102,6 @@ def _clear_single_redis_database(db_name: str, db_number: int) -> dict:
             "keys_cleared": 0,
         }
 
-
-class CacheStatsResponse(BaseModel):
-    status: str
-    total_cache_keys: Optional[int] = None
-    total_hits: Optional[int] = None
-    total_misses: Optional[int] = None
-    global_hit_rate: Optional[str] = None
-    memory_usage: Optional[str] = None
-    configured_data_types: Optional[List[str]] = None
-    data_type_stats: Optional[Dict[str, Dict]] = None
-
-
-class CacheWarmingRequest(BaseModel):
-    data_types: List[str]
-    force_refresh: bool = False
-
-
-class RedisDbInfo(BaseModel):
-    """Per-database Redis info."""
-
-    database: int
-    key_count: int
-    memory_usage: str
-    connected: bool
-    error: Optional[str] = None
-
-
-class RedisClearEntry(BaseModel):
-    """Result for a single cleared database."""
-
-    name: str
-    database: int
-    keys_cleared: int
-    error: Optional[str] = None
-
-
-class RedisStatsResponse(BaseModel):
-    """Response for GET /stats."""
-
-    status: str
-    stats: Dict[str, Any]
-
-
-class RedisClearResponse(BaseModel):
-    """Response for POST /redis/clear/{database}."""
-
-    status: str
-    message: str
-    cleared_databases: List[Dict[str, Any]]
-
-
-class CacheClearTypeResponse(BaseModel):
-    """Response for POST /clear/{cache_type}."""
-
-    status: str
-    message: str
-    cache_type: str
-
-
-class CacheConfigResponse(BaseModel):
-    """Response for GET/POST /config."""
-
-    status: str
-    message: Optional[str] = None
-    config: Dict[str, Any]
-    source: Optional[str] = None
-
-
-class CacheWarmupResponse(BaseModel):
-    """Response for POST /warmup."""
-
-    status: str
-    message: str
-    warmed_caches: List[Dict[str, Any]]
-
-
-class WarmCacheResponse(BaseModel):
-    """Response for POST /warm."""
-
-    success: bool
-    warmed_types: List[str]
-    failed_types: List[str]
-    total_warmed: int
-
-
-class InvalidateCacheResponse(BaseModel):
-    """Response for DELETE /invalidate/{data_type}."""
-
-    success: bool
-    data_type: str
-    key_pattern: str
-    user_id: Optional[str] = None
-    deleted_count: int
-
-
-class ClearAllResponse(BaseModel):
-    """Response for POST /clear-all."""
-
-    success: bool
-    message: str
-    total_deleted: int
-
-
-class CacheHealthResponse(BaseModel):
-    """Response for GET /health."""
-
-    status: str
-    redis_status: Optional[str] = None
-    total_keys: Optional[int] = None
-    memory_usage: Optional[str] = None
-    global_hit_rate: Optional[str] = None
-    error: Optional[str] = None
 
 
 def _process_data_type_stats_results(

--- a/autobot-backend/api/chat_knowledge.py
+++ b/autobot-backend/api/chat_knowledge.py
@@ -40,12 +40,10 @@ import os
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from enum import Enum
 from typing import Dict, List, Optional
 
 import aiofiles
 from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
-from pydantic import BaseModel
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from chat_history import ChatHistoryManager
@@ -57,7 +55,16 @@ from type_defs.common import Metadata
 
 from api.schemas_common import DataResponse
 from api.schemas_knowledge import (
+    AddKnowledgeRequest,
+    AssociateFileRequest,
     ChatKnowledgeHealthResponse,
+    ChatKnowledgeSearchRequest,
+    CompileChatRequest,
+    CreateContextRequest,
+    FileAssociationType,
+    KnowledgeDecision,
+    KnowledgeDecisionRequest,
+    MarkFactsPreservedRequest,
     PreserveSessionFactsResponse,
     SessionFactsResponse,
 )
@@ -97,23 +104,6 @@ async def get_chat_knowledge_manager_instance(request: Request = None):
         )
 
     return new_manager
-
-
-class KnowledgeDecision(str, Enum):
-    """Decision for knowledge persistence"""
-
-    ADD_TO_KB = "add_to_kb"
-    KEEP_TEMPORARY = "keep_temporary"
-    DELETE = "delete"
-
-
-class FileAssociationType(str, Enum):
-    """Type of file association"""
-
-    REFERENCE = "reference"  # File referenced in chat
-    UPLOAD = "upload"  # File uploaded to chat
-    GENERATED = "generated"  # File generated during chat
-    MODIFIED = "modified"  # File modified during chat
 
 
 @dataclass
@@ -537,15 +527,6 @@ chat_knowledge_manager = None
 # API Endpoints
 
 
-class CreateContextRequest(BaseModel):
-    """Create chat context request (Issue #688: added user_id)."""
-
-    chat_id: str
-    topic: Optional[str] = None
-    keywords: Optional[List[str]] = None
-    user_id: Optional[str] = None  # Issue #688: Track user ownership
-
-
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="create_chat_context",
@@ -583,13 +564,6 @@ async def create_chat_context(request_data: CreateContextRequest, request: Reque
     except Exception as e:
         logger.error("Failed to create context: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error")
-
-
-class AssociateFileRequest(BaseModel):
-    chat_id: str
-    file_path: str
-    association_type: FileAssociationType
-    metadata: Optional[Metadata] = None
 
 
 @with_error_handling(
@@ -683,12 +657,6 @@ async def upload_file_to_chat(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-class AddKnowledgeRequest(BaseModel):
-    chat_id: str
-    content: str
-    metadata: Optional[Metadata] = None
-
-
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="add_temporary_knowledge",
@@ -741,12 +709,6 @@ async def get_pending_knowledge_decisions(chat_id: str):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-class KnowledgeDecisionRequest(BaseModel):
-    chat_id: str
-    knowledge_id: str
-    decision: KnowledgeDecision
-
-
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="apply_knowledge_decision",
@@ -777,12 +739,6 @@ async def apply_knowledge_decision(request: KnowledgeDecisionRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-class CompileChatRequest(BaseModel):
-    chat_id: str
-    title: Optional[str] = None
-    include_system_messages: bool = False
-
-
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="compile_chat_to_knowledge",
@@ -811,12 +767,6 @@ async def compile_chat_to_knowledge(request_data: CompileChatRequest, request: R
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-class SearchRequest(BaseModel):
-    query: str
-    chat_id: Optional[str] = None
-    include_temporary: bool = True
-
-
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="search_chat_knowledge",
@@ -828,7 +778,7 @@ class SearchRequest(BaseModel):
     error_code_prefix="CHAT_KNOWLEDGE",
 )
 @router.post("/search", response_model=DataResponse)
-async def search_chat_knowledge(request: SearchRequest):
+async def search_chat_knowledge(request: ChatKnowledgeSearchRequest):
     """Search knowledge across chats or within specific chat"""
     try:
         results = await chat_knowledge_manager.search_chat_knowledge(
@@ -921,13 +871,6 @@ async def health_check():
 # ============================================================================
 # Session Facts Endpoints (Issue #547)
 # ============================================================================
-
-
-class MarkFactsPreservedRequest(BaseModel):
-    """Request model for marking facts as preserved/important."""
-
-    fact_ids: List[str]
-    preserve: bool = True
 
 
 @with_error_handling(

--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -18,12 +18,20 @@ import logging
 import os
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
+from api.schemas_code import (
+    CachedSecurityScoreResponse,
+    ClearStuckResponse,
+    CodeIntelligenceTaskStatusResponse,
+    FindingsPlaceholderResponse,
+    StartTaskResponse,
+    SuggestionsResponse,
+)
 from api.schemas_common import DataResponse, SuccessResponse
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -50,66 +58,6 @@ from utils.catalog_http_exceptions import raise_internal_error, raise_invalid_in
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Response models (#5317)
-# ---------------------------------------------------------------------------
-
-
-class SuggestionItem(BaseModel):
-    id: str
-    type: str
-    priority: str
-    title: str
-    description: str
-    impact: str
-
-
-class SuggestionsResponse(BaseModel):
-    suggestions: List[SuggestionItem]
-
-
-class FindingsPlaceholderResponse(BaseModel):
-    findings: List[Any]
-    score: Optional[float]
-    message: str
-
-
-class TaskStatusResponse(BaseModel):
-    """Generic task status returned by BackgroundTaskManager."""
-
-    status: str
-    task_id: Optional[str] = None
-    progress: Optional[float] = None
-    message: Optional[str] = None
-    result: Optional[Dict[str, Any]] = None
-    error: Optional[str] = None
-
-
-class StartTaskResponse(BaseModel):
-    task_id: str
-    status: str
-
-
-class ClearStuckResponse(BaseModel):
-    cleared_count: int
-    message: str
-
-
-class CachedSecurityScoreResponse(BaseModel):
-    status: str
-    from_cache: Optional[bool] = None
-    completed_at: Optional[str] = None
-    security_score: Optional[float] = None
-    grade: Optional[str] = None
-    risk_level: Optional[str] = None
-    status_message: Optional[str] = None
-    total_findings: Optional[int] = None
-    critical_issues: Optional[int] = None
-    high_issues: Optional[int] = None
-    files_analyzed: Optional[int] = None
-    severity_breakdown: Optional[Dict[str, Any]] = None
-    owasp_breakdown: Optional[Dict[str, Any]] = None
-    message: Optional[str] = None
 
 
 router = APIRouter()
@@ -2353,7 +2301,7 @@ async def start_security_analysis(
     operation="get_security_score_status",
     error_code_prefix="CODE_INTELLIGENCE",
 )
-@router.get("/security/score/status/{task_id}", response_model=TaskStatusResponse)
+@router.get("/security/score/status/{task_id}", response_model=CodeIntelligenceTaskStatusResponse)
 async def get_security_score_status(task_id: str):
     """Get security score analysis task status (#1304)."""
     task = await _sec_manager.get_status(task_id)

--- a/autobot-backend/api/collaboration.py
+++ b/autobot-backend/api/collaboration.py
@@ -13,83 +13,26 @@ import uuid
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.schemas_agent import (
+    CollabInviteRequest,
+    CollabInviteResponse,
+    CollabParticipantResponse,
+    CollabRemoveRequest,
+    CollabRemoveResponse,
+    CollabShareSecretRequest,
+    SessionParticipantsResponse,
+)
+from api.schemas_workflows import SessionPresenceResponse, SessionShareSecretResponse
 from auth_middleware import get_current_user
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from models.session_collaboration import PermissionLevel, SessionCollaboration
 from user_management.database import get_async_session
-from api.schemas_workflows import SessionPresenceResponse, SessionShareSecretResponse
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/sessions", tags=["collaboration"])
-
-
-# ====================================================================
-# Request/Response Models
-# ====================================================================
-
-
-class InviteRequest(BaseModel):
-    """Request to invite user to session."""
-
-    user_id: str = Field(..., description="User ID to invite")
-    permission: PermissionLevel = Field(
-        ..., description="Permission level (owner/editor/viewer)"
-    )
-
-
-class RemoveRequest(BaseModel):
-    """Request to remove collaborator."""
-
-    user_id: str = Field(..., description="User ID to remove")
-
-
-class ShareSecretRequest(BaseModel):
-    """Request to share secret with session participants."""
-
-    secret_id: str = Field(..., description="Secret ID to share")
-    participant_ids: Optional[List[str]] = Field(
-        None,
-        description="Specific participants (None = all with editor+)",
-    )
-
-
-class ParticipantResponse(BaseModel):
-    """Participant information."""
-
-    user_id: str
-    permission: str
-    is_owner: bool
-    online: bool = False
-
-
-class SessionParticipantsResponse(BaseModel):
-    """Session participants list."""
-
-    session_id: str
-    owner_id: str
-    participants: List[ParticipantResponse]
-    total_count: int
-
-
-class InviteResponse(BaseModel):
-    """Invitation response."""
-
-    success: bool
-    session_id: str
-    invited_user_id: str
-    permission: str
-
-
-class RemoveResponse(BaseModel):
-    """Remove collaborator response."""
-
-    success: bool
-    session_id: str
-    removed_user_id: str
 
 
 # ====================================================================
@@ -182,7 +125,7 @@ async def _fetch_and_validate_secret(
 
 
 def _resolve_share_recipients(
-    share: ShareSecretRequest, user_id: uuid.UUID, collab: SessionCollaboration
+    share: CollabShareSecretRequest, user_id: uuid.UUID, collab: SessionCollaboration
 ) -> list:
     """Helper for share_secret_with_session. Ref: #1088."""
     if share.participant_ids:
@@ -208,10 +151,10 @@ def _resolve_share_recipients(
     operation="invite_user",
     error_code_prefix="COLLABORATION",
 )
-@router.post("/{session_id}/invite", response_model=InviteResponse)
+@router.post("/{session_id}/invite", response_model=CollabInviteResponse)
 async def invite_user(
     session_id: str,
-    invite: InviteRequest,
+    invite: CollabInviteRequest,
     db: AsyncSession = Depends(get_async_session),
     current_user: dict = Depends(get_current_user),
 ):
@@ -239,7 +182,7 @@ async def invite_user(
             f"to session {session_id} as {invite.permission.value}"
         )
 
-        return InviteResponse(
+        return CollabInviteResponse(
             success=True,
             session_id=session_id,
             invited_user_id=invite.user_id,
@@ -266,10 +209,10 @@ async def invite_user(
     operation="remove_collaborator",
     error_code_prefix="COLLABORATION",
 )
-@router.post("/{session_id}/remove", response_model=RemoveResponse)
+@router.post("/{session_id}/remove", response_model=CollabRemoveResponse)
 async def remove_collaborator(
     session_id: str,
-    remove: RemoveRequest,
+    remove: CollabRemoveRequest,
     db: AsyncSession = Depends(get_async_session),
     current_user: dict = Depends(get_current_user),
 ):
@@ -309,7 +252,7 @@ async def remove_collaborator(
             f"User {user_id} removed {remove_user_id} " f"from session {session_id}"
         )
 
-        return RemoveResponse(
+        return CollabRemoveResponse(
             success=True,
             session_id=session_id,
             removed_user_id=remove.user_id,
@@ -359,7 +302,7 @@ async def get_participants(
 
         # Add owner
         participants.append(
-            ParticipantResponse(
+            CollabParticipantResponse(
                 user_id=str(collab.owner_id),
                 permission=PermissionLevel.OWNER.value,
                 is_owner=True,
@@ -369,7 +312,7 @@ async def get_participants(
         # Add collaborators
         for user_id_str, perm in collab.list_collaborators().items():
             participants.append(
-                ParticipantResponse(
+                CollabParticipantResponse(
                     user_id=user_id_str,
                     permission=perm,
                     is_owner=False,
@@ -406,7 +349,7 @@ async def get_participants(
 @router.post("/{session_id}/secrets/share", response_model=SessionShareSecretResponse)
 async def share_secret_with_session(
     session_id: str,
-    share: ShareSecretRequest,
+    share: CollabShareSecretRequest,
     db: AsyncSession = Depends(get_async_session),
     current_user: dict = Depends(get_current_user),
 ):

--- a/autobot-backend/api/conversation_files.py
+++ b/autobot-backend/api/conversation_files.py
@@ -12,15 +12,26 @@ import asyncio
 import logging
 import secrets
 from datetime import datetime, timezone
-from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 import aiofiles
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, JSONResponse
-from pydantic import BaseModel, Field, field_validator
-
+from api.schemas_knowledge import (
+    AgentGenerateFileRequest,
+    ConvFileCopyRequest,
+    ConvFileCreateRequest,
+    ConvFileRenameRequest,
+    ConvFileUpdateContentRequest,
+    ConversationFileInfo,
+    ConversationFileListResponse,
+    FilePreviewResponse,
+    FileTransferRequest,
+    FileTransferResponse,
+    FileUploadResponse,
+    MCPToolCallRequest,
+)
 from auth_middleware import check_admin_permission, get_auth_middleware
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from security_layer import SecurityLayer
@@ -70,133 +81,6 @@ ALLOWED_EXTENSIONS = {
     ".xls",
     ".xlsx",
 }
-
-
-class FileDestination(str, Enum):
-    """File transfer destination options"""
-
-    KNOWLEDGE_BASE = "kb"
-    SHARED = "shared"
-
-
-class ConversationFileInfo(BaseModel):
-    """Conversation file information model"""
-
-    file_id: str
-    filename: str
-    original_filename: str
-    size: int
-    mime_type: Optional[str] = None
-    session_id: str
-    uploaded_at: datetime
-    uploaded_by: str
-    file_path: str
-    extension: Optional[str] = None
-
-
-class ConversationFileListResponse(BaseModel):
-    """Response model for listing conversation files"""
-
-    session_id: str
-    files: List[ConversationFileInfo]
-    total_files: int
-    total_size: int
-    page: int = 1
-    page_size: int = 50
-
-
-class FileUploadResponse(BaseModel):
-    """Response model for file upload"""
-
-    success: bool
-    message: str
-    file_info: Optional[ConversationFileInfo] = None
-    upload_id: str
-
-
-class FileTransferRequest(BaseModel):
-    """Request model for file transfer operation"""
-
-    file_ids: List[str] = Field(
-        ..., min_length=1, description="List of file IDs to transfer"
-    )
-    destination: FileDestination = Field(
-        ..., description="Transfer destination (kb or shared)"
-    )
-    target_path: Optional[str] = Field(None, description="Target path in destination")
-    # Renamed from 'copy' to avoid shadowing BaseModel.copy() method
-    copy_files: bool = Field(False, alias="copy", description="Copy instead of move")
-    tags: Optional[List[str]] = Field(None, description="Tags for KB indexing")
-
-    @field_validator("file_ids")
-    @classmethod
-    def validate_file_ids(cls, v):
-        """Validate that at least one file ID is provided."""
-        if not v:
-            raise ValueError("At least one file ID must be provided")
-        return v
-
-
-class FileTransferResponse(BaseModel):
-    """Response model for file transfer operation"""
-
-    success: bool
-    message: str
-    transferred_files: List[Dict[str, str]]
-    failed_files: List[Dict[str, str]]
-    total_transferred: int
-    total_failed: int
-
-
-class FilePreviewResponse(BaseModel):
-    """Response model for file preview"""
-
-    file_info: ConversationFileInfo
-    preview_available: bool
-    preview_content: Optional[str] = None
-    preview_type: Optional[str] = None  # "text", "image", "metadata_only"
-
-
-# Issue #70: New request/response models for file manager operations
-
-
-class CreateFileRequest(BaseModel):
-    """Request model for creating a new file"""
-
-    filename: str = Field(..., min_length=1, max_length=255)
-    content: str = Field(default="")
-    mime_type: str = Field(default="text/plain")
-
-
-class RenameFileRequest(BaseModel):
-    """Request model for renaming a file"""
-
-    new_filename: str = Field(..., min_length=1, max_length=255)
-
-
-class UpdateFileContentRequest(BaseModel):
-    """Request model for updating file content"""
-
-    content: str
-
-
-class CopyFileRequest(BaseModel):
-    """Request model for copying a file"""
-
-    new_filename: Optional[str] = Field(
-        None, max_length=255, description="Optional new name for the copy"
-    )
-
-
-class AgentGenerateFileRequest(BaseModel):
-    """Request model for agent file generation"""
-
-    filename: str = Field(..., min_length=1, max_length=255)
-    content: str
-    file_type: str = Field(default="generated", description="File type tag")
-    mime_type: str = Field(default="text/plain")
-    agent_name: Optional[str] = Field(None, description="Name of generating agent")
-    metadata: Optional[Dict[str, str]] = Field(None, description="Extra metadata")
 
 
 def get_security_layer(request: Request) -> SecurityLayer:
@@ -977,7 +861,7 @@ async def transfer_conversation_files(
 )
 @router.post("/conversation/{session_id}/files/create", response_model=DataResponse)
 async def create_conversation_file(
-    request: Request, session_id: str, body: CreateFileRequest
+    request: Request, session_id: str, body: ConvFileCreateRequest
 ):
     """Create a new file with content in a conversation session (Issue #70)."""
     try:
@@ -1025,7 +909,7 @@ async def create_conversation_file(
 )
 @router.put("/conversation/{session_id}/files/{file_id}/rename", response_model=DataResponse)
 async def rename_conversation_file(
-    request: Request, session_id: str, file_id: str, body: RenameFileRequest
+    request: Request, session_id: str, file_id: str, body: ConvFileRenameRequest
 ):
     """Rename a file in a conversation session (Issue #70)."""
     try:
@@ -1104,7 +988,7 @@ async def get_file_content(request: Request, session_id: str, file_id: str):
 )
 @router.put("/conversation/{session_id}/files/{file_id}/content", response_model=DataResponse)
 async def update_file_content(
-    request: Request, session_id: str, file_id: str, body: UpdateFileContentRequest
+    request: Request, session_id: str, file_id: str, body: ConvFileUpdateContentRequest
 ):
     """Update the text content of a file (Issue #70)."""
     try:
@@ -1148,7 +1032,7 @@ async def update_file_content(
 )
 @router.post("/conversation/{session_id}/files/{file_id}/copy", response_model=DataResponse)
 async def copy_conversation_file(
-    request: Request, session_id: str, file_id: str, body: CopyFileRequest
+    request: Request, session_id: str, file_id: str, body: ConvFileCopyRequest
 ):
     """Copy a file within a conversation session (Issue #70)."""
     try:
@@ -1332,13 +1216,6 @@ SESSION_MCP_TOOLS = [
         },
     },
 ]
-
-
-class MCPToolCallRequest(BaseModel):
-    """Request model for MCP tool call dispatch"""
-
-    tool_name: str = Field(..., description="Name of the MCP tool to call")
-    arguments: Dict = Field(default_factory=dict, description="Tool arguments")
 
 
 @with_error_handling(

--- a/autobot-backend/api/error_monitoring.py
+++ b/autobot-backend/api/error_monitoring.py
@@ -13,11 +13,20 @@ import json
 import logging
 import os
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Header, HTTPException, status
-from pydantic import BaseModel
 
+from api.schemas_analytics import (
+    AlertThresholdRequest,
+    ErrorMonitoringAlertThresholdResponse,
+    ErrorMonitoringClearResponse,
+    ErrorMonitoringCleanupResponse,
+    ErrorMonitoringDataResponse,
+    ErrorMonitoringResolveResponse,
+    ErrorMonitoringTestErrorResponse,
+    TestErrorRequest,
+)
 from autobot_shared.error_boundaries import (
     ErrorCategory,
     get_error_boundary_manager,
@@ -27,7 +36,6 @@ from autobot_shared.error_boundaries import (
 from config.manager import get_config_manager
 from type_defs.common import Metadata
 from utils.error_metrics import get_metrics_collector
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 config = get_config_manager()
 
@@ -43,56 +51,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Error Monitoring"])
 
 
-# ---------------------------------------------------------------------------
-# Response models for error_monitoring endpoints
-# ---------------------------------------------------------------------------
-
-
-class ErrorMonitoringDataResponse(BaseModel):
-    """Generic envelope for endpoints returning {"status": str, "data": Any}."""
-
-    status: str
-    data: Optional[Any] = None
-
-
-class ErrorMonitoringClearResponse(BaseModel):
-    """Response for POST /clear."""
-
-    status: str
-    message: str
-
-
-class ErrorMonitoringTestErrorResponse(BaseModel):
-    """Response for POST /test-error."""
-
-    status: str
-    message: str
-    error_caught: Optional[str] = None
-    error_type: Optional[str] = None
-
-
-class ErrorMonitoringResolveResponse(BaseModel):
-    """Response for POST /metrics/resolve/{trace_id}."""
-
-    status: str
-    message: str
-
-
-class ErrorMonitoringAlertThresholdResponse(BaseModel):
-    """Response for POST /metrics/alert-threshold."""
-
-    status: str
-    message: str
-    threshold_key: str
-    threshold: int
-
-
-class ErrorMonitoringCleanupResponse(BaseModel):
-    """Response for POST /metrics/cleanup."""
-
-    status: str
-    message: str
-    removed_count: int
 
 
 @with_error_handling(
@@ -365,11 +323,6 @@ async def clear_error_history(authorization: Optional[str] = Header(None)):
         )
 
 
-class TestErrorRequest(BaseModel):
-    error_type: str = "ValueError"
-    message: str = "Test error for error boundary system"
-
-
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="test_error_system",
@@ -621,12 +574,6 @@ async def mark_error_resolved_endpoint(trace_id: str):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Internal server error",
         )
-
-
-class AlertThresholdRequest(BaseModel):
-    component: str
-    error_code: Optional[str] = None
-    threshold: int
 
 
 @with_error_handling(

--- a/autobot-backend/api/filesystem_mcp.py
+++ b/autobot-backend/api/filesystem_mcp.py
@@ -29,11 +29,11 @@ import mimetypes
 import os
 import shutil
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import aiofiles
 
-from type_defs.common import JSONObject, Metadata
+from type_defs.common import Metadata
 from utils.io_executor import run_in_file_executor
 
 # Issue #514: Per-file locking to prevent concurrent write corruption
@@ -61,8 +61,35 @@ async def _get_file_lock(filepath: str) -> asyncio.Lock:
 
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
 
+from api.schemas_code import (
+    CreateDirectoryRequest,
+    DirectoryTreeRequest,
+    EditFileRequest,
+    FilesystemCreateDirectoryResponse,
+    FilesystemDirectoryTreeResponse,
+    FilesystemEditFileResponse,
+    FilesystemFileInfoResponse,
+    FilesystemListAllowedResponse,
+    FilesystemListDirectoryResponse,
+    FilesystemListDirectoryWithSizesResponse,
+    FilesystemMoveFileResponse,
+    FilesystemReadMediaResponse,
+    FilesystemReadMultipleResponse,
+    FilesystemReadTextResponse,
+    FilesystemSearchFilesResponse,
+    FilesystemWriteFileResponse,
+    GetFileInfoRequest,
+    ListDirectoryRequest,
+    ListDirectoryWithSizesRequest,
+    MCPTool,
+    MoveFileRequest,
+    ReadMediaFileRequest,
+    ReadMultipleFilesRequest,
+    ReadTextFileRequest,
+    SearchFilesRequest,
+    WriteFileRequest,
+)
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_path
@@ -72,144 +99,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["filesystem_mcp", "mcp"])
 
 
-# ---------------------------------------------------------------------------
-# Response models for filesystem_mcp endpoints
-# ---------------------------------------------------------------------------
-
-
-class FilesystemReadTextResponse(BaseModel):
-    """Response for POST /mcp/read_text_file."""
-
-    success: bool
-    path: str
-    content: str
-    lines: int
-    size_bytes: int
-
-
-class FilesystemReadMediaResponse(BaseModel):
-    """Response for POST /mcp/read_media_file."""
-
-    success: bool
-    path: str
-    mime_type: str
-    base64_data: str
-    size_bytes: int
-
-
-class FilesystemReadMultipleResponse(BaseModel):
-    """Response for POST /mcp/read_multiple_files."""
-
-    success: bool
-    files_read: int
-    files_failed: int
-    results: List[Dict]
-    errors: Optional[List[Dict]] = None
-
-
-class FilesystemWriteFileResponse(BaseModel):
-    """Response for POST /mcp/write_file."""
-
-    success: bool
-    path: str
-    size_bytes: int
-    message: str
-
-
-class FilesystemEditFileResponse(BaseModel):
-    """Response for POST /mcp/edit_file."""
-
-    success: bool
-    path: str
-    edits_applied: int
-    dry_run: bool
-    changes: List[Dict]
-    size_before: int
-    size_after: int
-
-
-class FilesystemCreateDirectoryResponse(BaseModel):
-    """Response for POST /mcp/create_directory."""
-
-    success: bool
-    path: str
-    message: str
-
-
-class FilesystemListDirectoryResponse(BaseModel):
-    """Response for POST /mcp/list_directory."""
-
-    success: bool
-    path: str
-    entry_count: int
-    entries: List[str]
-
-
-class FilesystemListDirectoryWithSizesResponse(BaseModel):
-    """Response for POST /mcp/list_directory_with_sizes."""
-
-    success: bool
-    path: str
-    entry_count: int
-    sorted_by: Optional[str] = None
-    entries: List[Dict]
-
-
-class FilesystemMoveFileResponse(BaseModel):
-    """Response for POST /mcp/move_file."""
-
-    success: bool
-    source: str
-    destination: str
-    message: str
-
-
-class FilesystemSearchFilesResponse(BaseModel):
-    """Response for POST /mcp/search_files."""
-
-    success: bool
-    search_path: str
-    pattern: str
-    matches_found: int
-    matches: List[str]
-
-
-class FilesystemDirectoryTreeResponse(BaseModel):
-    """Response for POST /mcp/directory_tree."""
-
-    success: bool
-    root_path: str
-    tree: Dict
-
-
-class FilesystemFileInfoResponse(BaseModel):
-    """Response for POST /mcp/get_file_info."""
-
-    success: bool
-    path: str
-    name: str
-    type: str
-    size_bytes: int
-    created: str
-    modified: str
-    accessed: str
-    permissions: str
-    mime_type: Optional[str] = None
-
-
-class FilesystemSecurityInfo(BaseModel):
-    path_traversal_blocked: bool
-    symlink_validation: bool
-    max_file_size_bytes: int
-
-
-class FilesystemListAllowedResponse(BaseModel):
-    """Response for GET /mcp/list_allowed_directories."""
-
-    success: bool
-    allowed_directories: List[str]
-    directory_count: int
-    security_info: FilesystemSecurityInfo
 
 # Security Configuration: Allowed Directories
 # Only paths within these directories are accessible
@@ -268,104 +157,6 @@ def _validated_path(path: str) -> str:
             status_code=403,
             detail="Access denied: Path not in allowed directories",
         )
-
-
-class MCPTool(BaseModel):
-    """Standard MCP tool definition"""
-
-    name: str
-    description: str
-    input_schema: JSONObject
-
-
-# Request Models
-
-
-class ReadTextFileRequest(BaseModel):
-    """Request model for reading text files"""
-
-    path: str = Field(..., description="Absolute path to file")
-    head: Optional[int] = Field(None, description="Read only first N lines")
-    tail: Optional[int] = Field(None, description="Read only last N lines")
-
-
-class ReadMediaFileRequest(BaseModel):
-    """Request model for reading media files (images, audio)"""
-
-    path: str = Field(..., description="Absolute path to media file")
-
-
-class ReadMultipleFilesRequest(BaseModel):
-    """Request model for reading multiple files"""
-
-    paths: List[str] = Field(..., description="List of absolute file paths")
-
-
-class WriteFileRequest(BaseModel):
-    """Request model for writing files"""
-
-    path: str = Field(..., description="Absolute path to file")
-    content: str = Field(..., description="File content to write")
-
-
-class EditFileRequest(BaseModel):
-    """Request model for editing files"""
-
-    path: str = Field(..., description="Absolute path to file")
-    edits: List[Dict[str, str]] = Field(
-        ..., description="List of {old_text, new_text} edits"
-    )
-    dry_run: Optional[bool] = Field(
-        False, description="Preview changes without applying"
-    )
-
-
-class CreateDirectoryRequest(BaseModel):
-    """Request model for creating directories"""
-
-    path: str = Field(..., description="Absolute path to directory")
-
-
-class ListDirectoryRequest(BaseModel):
-    """Request model for listing directory contents"""
-
-    path: str = Field(..., description="Absolute path to directory")
-
-
-class ListDirectoryWithSizesRequest(BaseModel):
-    """Request model for listing directory with sizes"""
-
-    path: str = Field(..., description="Absolute path to directory")
-    sort_by: Optional[str] = Field("name", description="Sort by 'name' or 'size'")
-
-
-class MoveFileRequest(BaseModel):
-    """Request model for moving/renaming files"""
-
-    source: str = Field(..., description="Source path")
-    destination: str = Field(..., description="Destination path")
-
-
-class SearchFilesRequest(BaseModel):
-    """Request model for searching files"""
-
-    path: str = Field(..., description="Directory to search")
-    pattern: str = Field(..., description="Search pattern (e.g., '*.py')")
-    exclude_patterns: Optional[List[str]] = Field(
-        None, description="Patterns to exclude"
-    )
-
-
-class DirectoryTreeRequest(BaseModel):
-    """Request model for directory tree"""
-
-    path: str = Field(..., description="Root directory path")
-
-
-class GetFileInfoRequest(BaseModel):
-    """Request model for file metadata"""
-
-    path: str = Field(..., description="File or directory path")
 
 
 def _create_read_text_file_tool() -> MCPTool:

--- a/autobot-backend/api/git_mcp.py
+++ b/autobot-backend/api/git_mcp.py
@@ -35,7 +35,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
-from api.schemas_code import GitMCPInfoResponse, GitMCPOperationResponse, GitMCPServiceStatusResponse
+from api.schemas_code import GitMCPInfoResponse, GitMCPOperationResponse, GitMCPServiceStatusResponse, MCPTool
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -44,7 +44,7 @@ from autobot_shared.ssot_config import PROJECT_ROOT
 from autobot_shared.time_utils import now_utc
 from constants.threshold_constants import QueryDefaults
 from services.tool_output_filter import get_tool_output_filter
-from type_defs.common import JSONObject, Metadata
+from type_defs.common import Metadata
 
 logger = logging.getLogger(__name__)
 
@@ -343,14 +343,6 @@ async def execute_git_command(
 
 
 # Pydantic Models
-
-
-class MCPTool(BaseModel):
-    """Standard MCP tool definition"""
-
-    name: str
-    description: str
-    input_schema: JSONObject
 
 
 class GitStatusRequest(BaseModel):

--- a/autobot-backend/api/ide_integration.py
+++ b/autobot-backend/api/ide_integration.py
@@ -28,6 +28,14 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
 
+from api.schemas_code import (
+    IDEBatchAnalyzeResponse,
+    IDECategoriesResponse,
+    IDEConfigUpdateResponse,
+    IDEHealthResponse,
+    IDERulesResponse,
+    IDESeveritiesResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.singleton_factory import lazy_optional_singleton, lazy_singleton
@@ -455,65 +463,6 @@ class CompletionResponse(BaseModel):
     completion_time_ms: float
     source: str  # "ml", "patterns", "hybrid"
     cached: bool = False
-
-
-class IDERulesResponse(BaseModel):
-    """Response for GET /rules."""
-
-    rules: List[Dict[str, Any]]
-    total: int
-    enabled: int
-
-
-class IDEConfigUpdateResponse(BaseModel):
-    """Response for PUT /config."""
-
-    updated: bool
-
-
-class IDECategoryItem(BaseModel):
-    """A single category entry."""
-
-    id: str
-    name: str
-
-
-class IDECategoriesResponse(BaseModel):
-    """Response for GET /categories."""
-
-    categories: List[IDECategoryItem]
-
-
-class IDESeverityItem(BaseModel):
-    """A single severity entry."""
-
-    id: str
-    name: str
-    lsp_code: int
-
-
-class IDESeveritiesResponse(BaseModel):
-    """Response for GET /severities."""
-
-    severities: List[IDESeverityItem]
-
-
-class IDEBatchAnalyzeResponse(BaseModel):
-    """Response for POST /batch-analyze."""
-
-    results: List[Any]
-    files_analyzed: int
-    total_issues: int
-    errors: int
-
-
-class IDEHealthResponse(BaseModel):
-    """Response for GET /health."""
-
-    status: str
-    rules_loaded: int
-    disabled_rules: int
-    cache_size: int
 
 
 # =============================================================================

--- a/autobot-backend/api/knowledge_tags.py
+++ b/autobot-backend/api/knowledge_tags.py
@@ -28,16 +28,27 @@ Related Issues: #77 (Tags), #185 (Split), #209 (Knowledge split), #409 (Tag CRUD
 
 import logging
 import re
-from typing import Any, Dict, List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
-from pydantic import BaseModel
 from starlette.requests import Request
 
 from api.schemas_knowledge import (
     AddTagsRequest,
     BulkTagRequest,
     FactIdValidator,
+    KnowledgeTagBulkResponse,
+    KnowledgeTagDeleteResponse,
+    KnowledgeTagDeleteStyleResponse,
+    KnowledgeTagFactsByTagResponse,
+    KnowledgeTagFactTagsResponse,
+    KnowledgeTagGetFactTagsResponse,
+    KnowledgeTagInfoResponse,
+    KnowledgeTagListResponse,
+    KnowledgeTagMergeResponse,
+    KnowledgeTagRenameResponse,
+    KnowledgeTagSearchResponse,
+    KnowledgeTagStyleResponse,
     MergeTagsRequest,
     RemoveTagsRequest,
     RenameTagRequest,
@@ -50,134 +61,6 @@ from constants.threshold_constants import QueryDefaults
 from knowledge_factory import get_or_create_knowledge_base
 
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Response models for knowledge_tags endpoints
-# ---------------------------------------------------------------------------
-
-
-class KnowledgeTagFactTagsResponse(BaseModel):
-    """Response for POST/DELETE/GET /fact/{fact_id}/tags."""
-
-    status: str
-    fact_id: str
-    tags: List[Any]
-    message: Optional[str] = None
-    added_count: Optional[int] = None
-    removed_count: Optional[int] = None
-
-
-class KnowledgeTagGetFactTagsResponse(BaseModel):
-    """Response for GET /fact/{fact_id}/tags."""
-
-    status: str
-    fact_id: str
-    tags: List[Any]
-
-
-class KnowledgeTagSearchResponse(BaseModel):
-    """Response for POST /tags/search."""
-
-    status: str
-    facts: List[Any]
-    total_count: int
-    tags_searched: List[str]
-    match_all: bool
-    limit: int
-    offset: int
-
-
-class KnowledgeTagListResponse(BaseModel):
-    """Response for GET /tags."""
-
-    status: str
-    tags: List[Any]
-    total_count: int
-
-
-class KnowledgeTagBulkResponse(BaseModel):
-    """Response for POST /tags/bulk."""
-
-    status: str
-    operation: str
-    processed_count: int
-    failed_count: int
-    results: List[Any]
-
-
-class KnowledgeTagRenameResponse(BaseModel):
-    """Response for PUT /tags/{tag_name}."""
-
-    status: str
-    old_tag: str
-    new_tag: str
-    affected_count: int
-    message: str
-
-
-class KnowledgeTagDeleteResponse(BaseModel):
-    """Response for DELETE /tags/{tag_name}."""
-
-    status: str
-    tag: str
-    affected_count: int
-    message: str
-
-
-class KnowledgeTagMergeResponse(BaseModel):
-    """Response for POST /tags/merge."""
-
-    status: str
-    source_tags: List[str]
-    target_tag: str
-    affected_count: int
-    message: str
-
-
-class KnowledgeTagFactsByTagResponse(BaseModel):
-    """Response for GET /tags/{tag_name}/facts."""
-
-    status: str
-    tag: str
-    facts: List[Any]
-    total_count: int
-    returned_count: int
-    limit: int
-    offset: int
-    has_more: bool
-
-
-class KnowledgeTagInfoResponse(BaseModel):
-    """Response for GET /tags/{tag_name}/info."""
-
-    status: str
-    tag: str
-    fact_count: int
-
-
-class KnowledgeTagStyleInfo(BaseModel):
-    color: Optional[str] = None
-    icon: Optional[str] = None
-    description: Optional[str] = None
-    is_default: bool
-
-
-class KnowledgeTagStyleResponse(BaseModel):
-    """Response for PATCH/GET /tags/{tag_name}/style."""
-
-    status: str
-    tag: str
-    style: Dict[str, Any]
-    message: Optional[str] = None
-
-
-class KnowledgeTagDeleteStyleResponse(BaseModel):
-    """Response for DELETE /tags/{tag_name}/style."""
-
-    status: str
-    tag: str
-    message: str
 
 
 # Issue #380: Pre-compiled regex for tag prefix validation

--- a/autobot-backend/api/log_forwarding.py
+++ b/autobot-backend/api/log_forwarding.py
@@ -23,8 +23,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
-
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.ssot_config import config
@@ -40,7 +38,20 @@ from scripts.logging.log_forwarder import (
     LogForwarder,
     SyslogProtocol,
 )
-from api.schemas_system import LogForwardingDestinationItem
+from api.schemas_system import (
+    LogForwardingDestinationItem,
+    LogFwdAutoStartResponse,
+    LogFwdCreateUpdateResponse,
+    LogFwdDestinationCreate,
+    LogFwdDestinationResponse,
+    LogFwdDestinationTypesResponse,
+    LogFwdDestinationUpdate,
+    LogFwdKnownHostsResponse,
+    LogFwdMessageResponse,
+    LogFwdStatusResponse,
+    LogFwdTestAllResponse,
+    LogFwdTestResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -61,184 +72,6 @@ async def _get_forwarder() -> LogForwarder:
 
 
 # Pydantic models for API
-class DestinationCreate(BaseModel):
-    """Model for creating a new destination."""
-
-    name: str = Field(..., description="Unique name for the destination")
-    type: str = Field(
-        ...,
-        description="Destination type: seq, elasticsearch, loki, syslog, webhook, file",
-    )
-    enabled: bool = Field(True, description="Whether the destination is enabled")
-    url: Optional[str] = Field(None, description="URL/host for the destination")
-    api_key: Optional[str] = Field(None, description="API key for authentication")
-    username: Optional[str] = Field(None, description="Username for authentication")
-    password: Optional[str] = Field(None, description="Password for authentication")
-    index: Optional[str] = Field(
-        "autobot-logs", description="Index name (Elasticsearch)"
-    )
-    file_path: Optional[str] = Field(None, description="File path (file destination)")
-    min_level: str = Field("Information", description="Minimum log level to forward")
-    batch_size: int = Field(10, ge=1, le=1000, description="Batch size for sending")
-    batch_timeout: float = Field(
-        5.0, ge=0.1, le=60.0, description="Batch timeout in seconds"
-    )
-    retry_count: int = Field(3, ge=0, le=10, description="Number of retries on failure")
-    retry_delay: float = Field(
-        1.0, ge=0.1, le=30.0, description="Delay between retries"
-    )
-    # Scope configuration
-    scope: str = Field("global", description="Scope: global (all hosts) or per_host")
-    target_hosts: List[str] = Field(
-        default_factory=list, description="Target hosts for per_host scope"
-    )
-    # Syslog-specific options
-    syslog_protocol: str = Field(
-        "udp", description="Syslog protocol: udp, tcp, tcp_tls"
-    )
-    ssl_verify: bool = Field(True, description="Verify SSL certificates for TLS")
-    ssl_ca_cert: Optional[str] = Field(None, description="Path to CA certificate")
-    ssl_client_cert: Optional[str] = Field(
-        None, description="Path to client certificate"
-    )
-    ssl_client_key: Optional[str] = Field(None, description="Path to client key")
-
-
-class DestinationUpdate(BaseModel):
-    """Model for updating an existing destination."""
-
-    enabled: Optional[bool] = None
-    url: Optional[str] = None
-    api_key: Optional[str] = None
-    username: Optional[str] = None
-    password: Optional[str] = None
-    index: Optional[str] = None
-    file_path: Optional[str] = None
-    min_level: Optional[str] = None
-    batch_size: Optional[int] = None
-    batch_timeout: Optional[float] = None
-    retry_count: Optional[int] = None
-    retry_delay: Optional[float] = None
-    scope: Optional[str] = None
-    target_hosts: Optional[List[str]] = None
-    syslog_protocol: Optional[str] = None
-    ssl_verify: Optional[bool] = None
-    ssl_ca_cert: Optional[str] = None
-    ssl_client_cert: Optional[str] = None
-    ssl_client_key: Optional[str] = None
-
-
-class DestinationResponse(BaseModel):
-    """Response model for a destination."""
-
-    name: str
-    type: str
-    enabled: bool
-    url: Optional[str]
-    index: Optional[str]
-    file_path: Optional[str]
-    min_level: str
-    batch_size: int
-    batch_timeout: float
-    scope: str
-    target_hosts: List[str]
-    syslog_protocol: str
-    ssl_verify: bool
-    # Status fields
-    healthy: bool
-    last_error: Optional[str]
-    sent_count: int
-    failed_count: int
-
-
-class LogFwdMessageResponse(BaseModel):
-    """Simple message-only response (start, stop, delete)."""
-
-    message: str
-
-
-class LogFwdCreateUpdateResponse(BaseModel):
-    """Response for create/update destination endpoints."""
-
-    message: str
-    destination: Dict[str, Any]
-
-
-class LogFwdTestResponse(BaseModel):
-    """Response for POST /destinations/{name}/test."""
-
-    name: str
-    healthy: bool
-    last_error: Optional[str] = None
-    message: str
-
-
-class LogFwdTestAllResponse(BaseModel):
-    """Response for POST /test-all."""
-
-    results: Dict[str, Any]
-    total: int
-    healthy: int
-    unhealthy: int
-
-
-class LogFwdDestinationStatusItem(BaseModel):
-    """Single entry in the destinations list within LogFwdStatusResponse."""
-
-    name: str
-    type: str
-    enabled: bool
-    healthy: bool
-    last_error: Optional[str] = None
-    sent_count: int
-    failed_count: int
-    scope: str
-
-
-class LogFwdStatusResponse(BaseModel):
-    """Response for GET /status."""
-
-    running: bool
-    hostname: str
-    queue_size: int
-    destinations: List[LogFwdDestinationStatusItem]
-    total_destinations: int
-    enabled_destinations: int
-    healthy_destinations: int
-    total_sent: int
-    total_failed: int
-
-
-class LogFwdDestinationTypesResponse(BaseModel):
-    """Response for GET /destination-types."""
-
-    types: List[Any]
-    scopes: List[Any]
-    log_levels: List[str]
-    syslog_protocols: List[Any]
-
-
-class LogFwdKnownHostItem(BaseModel):
-    """A single host entry in the known-hosts response."""
-
-    hostname: str
-    ip: Optional[str] = None
-    description: str
-
-
-class LogFwdKnownHostsResponse(BaseModel):
-    """Response for GET /known-hosts."""
-
-    hosts: List[LogFwdKnownHostItem]
-    current_hostname: str
-
-
-class LogFwdAutoStartResponse(BaseModel):
-    """Response for GET/PUT /auto-start."""
-
-    auto_start: bool
-    message: str
-
 
 def _build_updated_destination_config(
     name: str,
@@ -277,7 +110,7 @@ def _build_updated_destination_config(
     )
 
 
-def _config_to_destination_config(data: DestinationCreate) -> DestinationConfig:
+def _config_to_destination_config(data: LogFwdDestinationCreate) -> DestinationConfig:
     """Convert API model to DestinationConfig."""
     try:
         dest_type = DestinationType(data.type)
@@ -321,9 +154,9 @@ def _config_to_destination_config(data: DestinationCreate) -> DestinationConfig:
     )
 
 
-def _destination_to_response(dest) -> DestinationResponse:
+def _destination_to_response(dest) -> LogFwdDestinationResponse:
     """Convert LogDestination to API response."""
-    return DestinationResponse(
+    return LogFwdDestinationResponse(
         name=dest.config.name,
         type=dest.config.type.value,
         enabled=dest.config.enabled,
@@ -434,7 +267,7 @@ async def get_destination(
 )
 @router.post("/destinations", response_model=LogFwdCreateUpdateResponse)
 async def create_destination_endpoint(
-    data: DestinationCreate,
+    data: LogFwdDestinationCreate,
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
     """Create a new log forwarding destination.
@@ -487,7 +320,7 @@ async def create_destination_endpoint(
 @router.put("/destinations/{name}", response_model=LogFwdCreateUpdateResponse)
 async def update_destination(
     name: str,
-    data: DestinationUpdate,
+    data: LogFwdDestinationUpdate,
     admin_check: bool = Depends(check_admin_permission),
 ) -> Dict[str, Any]:
     """Update an existing destination.

--- a/autobot-backend/api/memory.py
+++ b/autobot-backend/api/memory.py
@@ -32,17 +32,18 @@ from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field, validator
 
 from auth_middleware import check_admin_permission
 from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.time_utils import utc_timestamp
 from autobot_shared.time_utils import now_utc
-from type_defs.common import Metadata
 from utils.request_utils import generate_request_id
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 from api.schemas_knowledge import (
+    EntityCreateRequest,
+    InvalidateEntityRequest,
+    InvalidateRelationRequest,
     MemoryDeleteEntityResponse,
     MemoryDeleteRelationResponse,
     MemoryEntityInvalidateResponse,
@@ -51,6 +52,8 @@ from api.schemas_knowledge import (
     MemoryOrphanScanResponse,
     MemoryRelatedEntitiesResponse,
     MemoryRelationInvalidateResponse,
+    ObservationAddRequest,
+    RelationCreateRequest,
 )
 
 # ====================================================================
@@ -59,151 +62,6 @@ from api.schemas_knowledge import (
 
 router = APIRouter(tags=["memory"])
 logger = logging.getLogger(__name__)
-
-# ====================================================================
-# Request/Response Models
-# ====================================================================
-
-
-class EntityCreateRequest(BaseModel):
-    """Request model for creating a new entity"""
-
-    entity_type: str = Field(
-        ..., description="Type of entity (conversation, bug_fix, feature, etc.)"
-    )
-    name: str = Field(
-        ..., min_length=1, max_length=200, description="Human-readable entity name"
-    )
-    observations: List[str] = Field(
-        ..., min_items=1, description="List of observation strings"
-    )
-    metadata: Optional[Metadata] = Field(
-        default_factory=dict, description="Additional metadata"
-    )
-    tags: Optional[List[str]] = Field(
-        default_factory=list, description="Classification tags"
-    )
-
-    @validator("entity_type")
-    def validate_entity_type(cls, v):
-        """Validate entity type against allowed values."""
-        valid_types = {
-            "conversation",
-            "bug_fix",
-            "feature",
-            "decision",
-            "task",
-            "user_preference",
-            "context",
-            "learning",
-            "research",
-            "implementation",
-        }
-        if v not in valid_types:
-            raise ValueError(f"entity_type must be one of: {valid_types}")
-        return v
-
-
-class ObservationAddRequest(BaseModel):
-    """Request model for adding observations to an entity"""
-
-    observations: List[str] = Field(
-        ..., min_items=1, description="New observations to add"
-    )
-
-
-class RelationCreateRequest(BaseModel):
-    """Request model for creating a relationship between entities"""
-
-    from_entity: str = Field(..., description="Source entity name")
-    to_entity: str = Field(..., description="Target entity name")
-    relation_type: str = Field(..., description="Type of relationship")
-    bidirectional: bool = Field(
-        default=False, description="Create reverse relation as well"
-    )
-    strength: float = Field(
-        default=1.0, ge=0.0, le=1.0, description="Relationship strength (0.0-1.0)"
-    )
-    metadata: Optional[Metadata] = Field(
-        default_factory=dict, description="Additional metadata"
-    )
-
-    @validator("relation_type")
-    def validate_relation_type(cls, v):
-        """Validate relation type against allowed values."""
-        valid_types = {
-            "relates_to",
-            "depends_on",
-            "implements",
-            "fixes",
-            "informs",
-            "guides",
-            "follows",
-            "contains",
-            "blocks",
-        }
-        if v not in valid_types:
-            raise ValueError(f"relation_type must be one of: {valid_types}")
-        return v
-
-
-class InvalidateEntityRequest(BaseModel):
-    """Request model for invalidating an entity (setting valid_to). Issue #3810."""
-
-    ended_at: Optional[str] = Field(
-        default=None,
-        description="ISO-8601 timestamp for valid_to. Defaults to now.",
-    )
-
-
-class InvalidateRelationRequest(BaseModel):
-    """Request model for invalidating a relation (setting valid_to). Issue #3810."""
-
-    from_id: str = Field(..., description="Source entity UUID")
-    relation_type: str = Field(..., description="Type of the relation")
-    to_id: str = Field(..., description="Target entity UUID")
-    ended_at: Optional[str] = Field(
-        default=None,
-        description="ISO-8601 timestamp for valid_to. Defaults to now.",
-    )
-
-
-class EntityResponse(BaseModel):
-    """Response model for entity data"""
-
-    id: str
-    type: str
-    name: str
-    created_at: int
-    updated_at: int
-    observations: List[str]
-    metadata: Metadata
-
-
-class RelationResponse(BaseModel):
-    """Response model for relation data"""
-
-    to: str
-    type: str
-    created_at: int
-    metadata: Metadata
-
-
-class GraphNodeResponse(BaseModel):
-    """Response model for graph node with relations"""
-
-    entity: EntityResponse
-    relations: Dict[str, List[RelationResponse]]
-
-
-class SearchResponse(BaseModel):
-    """Response model for search results"""
-
-    entities: List[EntityResponse]
-    total_count: int
-    query: str
-    filters: Metadata
-
 
 # ====================================================================
 # Dependency Injection

--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -24,7 +24,22 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel, Field
+from api.schemas_system import (
+    AlertCheckResponse,
+    AlertManagerResponse,
+    ClaudeApiStatusResponse,
+    CurrentMetricsResponse,
+    GitHubStatusResponse,
+    MetricsQuery,
+    MonitoringActionResponse,
+    MonitoringStatus,
+    OptimizationRecommendation,
+    PerformanceAlert,
+    ServicesSummaryResponse,
+    TestPerformanceResponse,
+    ThresholdUpdate,
+    ThresholdUpdateResponse,
+)
 
 # Hardware monitor moved to monitoring_hardware.py (Issue #213)
 from api.monitoring_hardware import hardware_monitor
@@ -257,177 +272,6 @@ router = APIRouter(tags=["AutoBot Monitoring"])
 # Performance optimization: O(1) lookup for critical service statuses (Issue #326)
 CRITICAL_SERVICE_STATUSES = {"critical", "offline"}
 
-
-class ServicesSummaryResponse(BaseModel):
-    """Response for GET /services/health."""
-
-    total_services: int
-    healthy_services: int
-    degraded_services: int
-    critical_services: int
-    overall_status: str
-    health_percentage: float
-    services: List[Dict[str, Any]]
-
-
-class MonitoringActionResponse(BaseModel):
-    """Response for monitoring start/stop endpoints."""
-
-    status: str
-    message: str
-    collection_interval: Optional[float] = None
-
-
-class CurrentMetricsResponse(BaseModel):
-    """Response for GET /metrics/current."""
-
-    timestamp: float
-    metrics: Dict[str, Any]
-    collection_successful: bool
-
-
-class ThresholdUpdateResponse(BaseModel):
-    """Response for POST /thresholds/update."""
-
-    status: str
-    threshold_key: str
-    new_value: float
-    comparison: str
-    old_value: Optional[float] = None
-
-
-class TestPerformanceResponse(BaseModel):
-    """Response for POST /test/performance."""
-
-    message: str
-    metrics_collected: bool
-    timestamp: float
-
-
-class ClaudeApiDetails(BaseModel):
-    """Claude API metrics from Prometheus."""
-
-    rate_limit_remaining: Optional[float] = None
-    requests_per_minute: Optional[float] = None
-    p95_latency_seconds: Optional[float] = None
-    failure_rate: Optional[float] = None
-
-
-class ClaudeApiStatusResponse(BaseModel):
-    """Response for GET /claude-api/status."""
-
-    success: bool
-    claude_api_status: ClaudeApiDetails
-    timestamp: str
-
-
-class GitHubApiDetails(BaseModel):
-    """GitHub API metrics from Prometheus."""
-
-    rate_limit_remaining: Optional[float] = None
-    total_operations: Optional[float] = None
-    p95_latency_seconds: Optional[float] = None
-
-
-class GitHubStatusResponse(BaseModel):
-    """Response for GET /github/status."""
-
-    success: bool
-    github_status: GitHubApiDetails
-    timestamp: str
-
-
-class AlertSources(BaseModel):
-    """Alert source counts."""
-
-    alertmanager: int
-    performance_monitor: int
-
-
-class AlertCheckResponse(BaseModel):
-    """Response for GET /alerts/check."""
-
-    timestamp: float
-    alerts: List[Dict[str, Any]]
-    total_count: int
-    critical_count: int
-    warning_count: int
-    high_count: int
-    sources: AlertSources
-
-
-class AlertManagerSeverityCounts(BaseModel):
-    """Severity breakdown for alertmanager response."""
-
-    critical: int
-    high: int
-    warning: int
-    info: int
-
-
-class AlertManagerResponse(BaseModel):
-    """Response for GET /alerts/alertmanager."""
-
-    timestamp: float
-    source: str
-    alertmanager_url: str
-    alerts: List[Dict[str, Any]]
-    total_count: int
-    by_severity: AlertManagerSeverityCounts
-    active_alerts: Dict[str, List[Dict[str, Any]]]
-
-
-class MonitoringStatus(BaseModel):
-    """Monitoring system status"""
-
-    active: bool
-    uptime_seconds: float
-    collection_interval: float
-    hardware_acceleration: Dict[str, bool]
-    metrics_collected: int
-    alerts_count: int
-
-
-class PerformanceAlert(BaseModel):
-    """Performance alert model"""
-
-    category: str
-    severity: str
-    message: str
-    recommendation: str
-    timestamp: float
-
-
-class OptimizationRecommendation(BaseModel):
-    """Performance optimization recommendation"""
-
-    category: str
-    priority: str
-    recommendation: str
-    action: str
-    expected_improvement: str
-
-
-class MetricsQuery(BaseModel):
-    """Query parameters for metrics retrieval"""
-
-    categories: Optional[List[str]] = Field(
-        None, description="Metric categories to include"
-    )
-    time_range_minutes: int = Field(
-        10, ge=1, le=1440, description="Time range in minutes"
-    )
-    include_trends: bool = Field(True, description="Include trend analysis")
-    include_alerts: bool = Field(True, description="Include recent alerts")
-
-
-class ThresholdUpdate(BaseModel):
-    """Performance threshold update"""
-
-    category: str
-    metric: str
-    threshold: float
-    comparison: str = Field(..., pattern="^(gt|lt|eq)$")
 
 
 # WebSocket connection manager for real-time updates

--- a/autobot-backend/api/openai_compat.py
+++ b/autobot-backend/api/openai_compat.py
@@ -26,8 +26,20 @@ from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
-
+from api.schemas_code import (
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    OAIChoice,
+    OAIChoiceMessage,
+    OAIDeltaMessage,
+    OAIMessage,
+    OAIModelCard,
+    OAIModelListResponse,
+    OAIStreamChoice,
+    OAIStreamOptions,
+    OAIUsage,
+)
 from auth_middleware import get_current_user
 from llm_interface_pkg.models import LLMRequest
 from llm_providers.provider_registry import get_provider_registry
@@ -80,94 +92,6 @@ def _remote_addr(request: Request) -> str:
     if forwarded:
         return forwarded.split(",")[0].strip()
     return request.client.host if request.client else "unknown"
-
-
-# ---------------------------------------------------------------------------
-# Request / response models (OpenAI wire format)
-# ---------------------------------------------------------------------------
-
-
-class OAIMessage(BaseModel):
-    role: str
-    content: str
-    name: Optional[str] = None
-
-
-class OAIStreamOptions(BaseModel):
-    include_usage: bool = False
-
-
-class ChatCompletionRequest(BaseModel):
-    model: str = "autobot-default"
-    messages: List[OAIMessage]
-    temperature: float = 0.7
-    max_tokens: Optional[int] = None
-    top_p: float = 1.0
-    frequency_penalty: float = 0.0
-    presence_penalty: float = 0.0
-    stop: Optional[List[str]] = None
-    stream: bool = False
-    stream_options: Optional[OAIStreamOptions] = None
-    n: int = Field(default=1, ge=1)
-    user: Optional[str] = None
-
-
-class OAIChoiceMessage(BaseModel):
-    role: str
-    content: str
-
-
-class OAIChoice(BaseModel):
-    index: int
-    message: OAIChoiceMessage
-    finish_reason: str = "stop"
-
-
-class OAIUsage(BaseModel):
-    prompt_tokens: int = 0
-    completion_tokens: int = 0
-    total_tokens: int = 0
-
-
-class ChatCompletionResponse(BaseModel):
-    id: str
-    object: str = "chat.completion"
-    created: int
-    model: str
-    choices: List[OAIChoice]
-    usage: OAIUsage
-
-
-class OAIDeltaMessage(BaseModel):
-    role: Optional[str] = None
-    content: Optional[str] = None
-
-
-class OAIStreamChoice(BaseModel):
-    index: int
-    delta: OAIDeltaMessage
-    finish_reason: Optional[str] = None
-
-
-class ChatCompletionChunk(BaseModel):
-    id: str
-    object: str = "chat.completion.chunk"
-    created: int
-    model: str
-    choices: List[OAIStreamChoice]
-    usage: Optional[OAIUsage] = None
-
-
-class OAIModelCard(BaseModel):
-    id: str
-    object: str = "model"
-    created: int = 0
-    owned_by: str = "autobot"
-
-
-class ModelListResponse(BaseModel):
-    object: str = "list"
-    data: List[OAIModelCard]
 
 
 # ---------------------------------------------------------------------------
@@ -403,8 +327,8 @@ async def chat_completions(
     operation="list_models",
     error_code_prefix="OPENAI_COMPAT",
 )
-@router.get("/models", response_model=ModelListResponse)
-async def list_models(request: Request) -> ModelListResponse:
+@router.get("/models", response_model=OAIModelListResponse)
+async def list_models(request: Request) -> OAIModelListResponse:
     """OpenAI-compatible models list endpoint (#4447).
 
     Returns all models available across registered providers.
@@ -436,4 +360,4 @@ async def list_models(request: Request) -> ModelListResponse:
     if not model_cards:
         model_cards.append(OAIModelCard(id="autobot-default", created=created))
 
-    return ModelListResponse(data=model_cards)
+    return OAIModelListResponse(data=model_cards)

--- a/autobot-backend/api/permissions.py
+++ b/autobot-backend/api/permissions.py
@@ -25,124 +25,35 @@ Usage:
 """
 
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
-
 from auth_middleware import check_admin_permission
 from autobot_shared.ssot_config import PermissionAction, PermissionMode, config
 from services.approval_memory import get_approval_memory
 from services.permission_matcher import get_permission_matcher
 from api.schemas_system import (
-    PermissionRuleMutateResponse,
+    ApprovalRecordResponse,
+    CheckCommandRequest,
+    CheckCommandResponse,
+    PermissionAddRuleRequest,
     PermissionClearApprovalsResponse,
-    PermissionStoreApprovalResponse,
     PermissionMemoryStatsResponse,
+    PermissionModeRequest,
+    PermissionModeResponse,
+    PermissionRemoveRuleRequest,
+    PermissionRuleMutateResponse,
+    PermissionRuleResponse,
+    PermissionRulesResponse,
+    PermissionStatusResponse,
+    ProjectApprovalsResponse,
+    PermissionStoreApprovalResponse,
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/permissions", tags=["permissions"])
-
-
-# =============================================================================
-# Request/Response Models
-# =============================================================================
-
-
-class PermissionModeResponse(BaseModel):
-    """Response model for permission mode."""
-
-    mode: str
-    enabled: bool
-    is_admin_only: bool
-    allowed_modes: List[str]
-
-
-class PermissionModeRequest(BaseModel):
-    """Request model for setting permission mode."""
-
-    mode: str = Field(..., description="Permission mode to set")
-
-
-class PermissionRuleResponse(BaseModel):
-    """Response model for a single rule."""
-
-    tool: str
-    pattern: str
-    action: str
-    description: str
-
-
-class PermissionRulesResponse(BaseModel):
-    """Response model for all rules."""
-
-    allow: List[PermissionRuleResponse]
-    ask: List[PermissionRuleResponse]
-    deny: List[PermissionRuleResponse]
-
-
-class AddRuleRequest(BaseModel):
-    """Request model for adding a rule."""
-
-    tool: str = Field(default="Bash", description="Tool name")
-    pattern: str = Field(..., description="Glob pattern")
-    action: str = Field(..., description="allow, ask, or deny")
-    description: str = Field(default="", description="Rule description")
-
-
-class RemoveRuleRequest(BaseModel):
-    """Request model for removing a rule."""
-
-    tool: str = Field(default="Bash", description="Tool name")
-    pattern: str = Field(..., description="Pattern to remove")
-
-
-class ApprovalRecordResponse(BaseModel):
-    """Response model for an approval record."""
-
-    pattern: str
-    tool: str
-    risk_level: str
-    user_id: str
-    created_at: float
-    original_command: str
-    comment: Optional[str] = None
-
-
-class ProjectApprovalsResponse(BaseModel):
-    """Response model for project approvals."""
-
-    project_path: str
-    approvals: List[ApprovalRecordResponse]
-
-
-class PermissionStatusResponse(BaseModel):
-    """Response model for permission system status."""
-
-    enabled: bool
-    mode: str
-    approval_memory_enabled: bool
-    approval_memory_ttl_days: int
-    rules_file: str
-    rules_count: dict
-
-
-class CheckCommandRequest(BaseModel):
-    """Request model for checking a command."""
-
-    command: str = Field(..., description="Command to check")
-    tool: str = Field(default="Bash", description="Tool name")
-
-
-class CheckCommandResponse(BaseModel):
-    """Response model for command check."""
-
-    result: str  # allow, ask, deny, default
-    pattern: Optional[str] = None
-    description: Optional[str] = None
 
 
 # =============================================================================
@@ -336,7 +247,7 @@ async def get_permission_rules(admin_check: bool = Depends(check_admin_permissio
 )
 @router.post("/rules", response_model=PermissionRuleMutateResponse)
 async def add_permission_rule(
-    request: AddRuleRequest,
+    request: PermissionAddRuleRequest,
     admin_check: bool = Depends(check_admin_permission),
     is_admin: bool = Query(default=False),
 ):
@@ -389,7 +300,7 @@ async def add_permission_rule(
 )
 @router.delete("/rules", response_model=PermissionRuleMutateResponse)
 async def remove_permission_rule(
-    request: RemoveRuleRequest, admin_check: bool = Depends(check_admin_permission)
+    request: PermissionRemoveRuleRequest, admin_check: bool = Depends(check_admin_permission)
 ):
     """
     Remove a permission rule.

--- a/autobot-backend/api/playwright.py
+++ b/autobot-backend/api/playwright.py
@@ -10,8 +10,6 @@ import logging
 
 import aiohttp
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
-from pydantic import BaseModel
-
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
@@ -26,23 +24,22 @@ from services.playwright_service import (
 )
 from api.schemas_common import DataResponse
 from api.schemas_code import (
-    PlaywrightStatusResponse,
-    PlaywrightHealthResponse,
-    PlaywrightQuickTestResponse,
     PlaywrightBrowserActionResponse,
-    PlaywrightWorkerStatusResponse,
     PlaywrightCapabilitiesResponse,
+    PlaywrightHealthResponse,
+    PlaywrightInteractRequest,
+    PlaywrightNavigateRequest,
+    PlaywrightQuickTestResponse,
+    PlaywrightReloadRequest,
+    PlaywrightScreenshotRequest,
+    PlaywrightSearchRequest,
+    PlaywrightStatusResponse,
+    PlaywrightWorkerStatusResponse,
 )
 from api.schemas_system import PlaywrightEmbeddedResultResponse
 
 router = APIRouter(dependencies=[Depends(check_admin_permission)])
 logger = logging.getLogger(__name__)
-
-
-class SearchRequest(BaseModel):
-    query: str
-    search_engine: str = "duckduckgo"
-    max_results: int = 5
 
 
 class TestMessageRequest(BaseModel):
@@ -52,31 +49,6 @@ class TestMessageRequest(BaseModel):
 
 class FrontendTestRequest(BaseModel):
     frontend_url: str = _ssot_config.frontend_url
-
-
-class ScreenshotRequest(BaseModel):
-    url: str
-    full_page: bool = True
-    wait_timeout: int = 5000
-
-
-class NavigateRequest(BaseModel):
-    url: str
-    wait_until: str = "networkidle"
-    timeout: int = 30000
-
-
-class ReloadRequest(BaseModel):
-    wait_until: str = "networkidle"
-
-
-class InteractRequest(BaseModel):
-    action: str  # click, scroll, type, hover
-    x: float | None = None
-    y: float | None = None
-    deltaX: float = 0
-    deltaY: float = 0
-    text: str | None = None
 
 
 # Browser VM connection
@@ -156,7 +128,7 @@ async def health_check():
     error_code_prefix="PLAYWRIGHT",
 )
 @router.post("/search", response_model=PlaywrightEmbeddedResultResponse)
-async def web_search(request: SearchRequest):
+async def web_search(request: PlaywrightSearchRequest):
     """
     Perform web search using embedded Playwright
 
@@ -284,7 +256,7 @@ async def send_test_message(request: TestMessageRequest):
     error_code_prefix="PLAYWRIGHT",
 )
 @router.post("/screenshot", response_model=PlaywrightEmbeddedResultResponse)
-async def capture_screenshot(request: ScreenshotRequest):
+async def capture_screenshot(request: PlaywrightScreenshotRequest):
     """
     Capture screenshot of webpage using embedded Playwright
 
@@ -396,7 +368,7 @@ async def quick_automation_test(background_tasks: BackgroundTasks):
     error_code_prefix="PLAYWRIGHT",
 )
 @router.post("/navigate", response_model=PlaywrightBrowserActionResponse)
-async def navigate_to_url(request: NavigateRequest):
+async def navigate_to_url(request: PlaywrightNavigateRequest):
     """
     Navigate to a URL using Playwright on Browser VM
 
@@ -446,7 +418,7 @@ async def navigate_to_url(request: NavigateRequest):
     error_code_prefix="PLAYWRIGHT",
 )
 @router.post("/reload", response_model=PlaywrightBrowserActionResponse)
-async def reload_page(request: ReloadRequest):
+async def reload_page(request: PlaywrightReloadRequest):
     """
     Reload the current page using Playwright on Browser VM
 
@@ -669,7 +641,7 @@ async def take_worker_screenshot():
     error_code_prefix="PLAYWRIGHT",
 )
 @router.post("/interact", response_model=PlaywrightBrowserActionResponse)
-async def interact_with_page(request: InteractRequest):
+async def interact_with_page(request: PlaywrightInteractRequest):
     """Proxy interactive browser actions to Browser VM (#1416)"""
     allowed = {"click", "scroll", "type", "hover"}
     if request.action not in allowed:

--- a/autobot-backend/api/rum.py
+++ b/autobot-backend/api/rum.py
@@ -14,8 +14,19 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
-
+from api.schemas_analytics import (
+    RumApiCallMetric,
+    RumConfig,
+    RumCriticalIssueMetric,
+    RumEvent,
+    RumJsErrorMetric,
+    RumMetrics,
+    RumPageMetrics,
+    RumResourceMetric,
+    RumSessionMetric,
+    RumUserActionMetric,
+    RumWebSocketMetric,
+)
 from api.schemas_workflows import (
     RUMClearResponse,
     RUMConfigResponse,
@@ -136,117 +147,6 @@ def _log_rum_event_by_type(
         return
 
     rum_logger.info(log_message)
-
-
-class RumEvent(BaseModel):
-    type: str
-    timestamp: str
-    sessionId: str
-    url: str
-    userAgent: str
-    data: Metadata = {}
-
-
-class RumConfig(BaseModel):
-    enabled: bool = False
-    error_tracking: bool = True
-    performance_monitoring: bool = True
-    interaction_tracking: bool = False
-    session_recording: bool = False
-    sample_rate: int = 100
-    max_events_per_session: int = 1000
-    debug_mode: bool = False
-    log_to_backend: bool = True
-    log_level: str = "info"
-
-
-# Issue #476: RUM Metrics models for Prometheus integration
-class PageMetrics(BaseModel):
-    """Page performance metrics from frontend."""
-
-    page: str
-    load_time_seconds: Optional[float] = None
-    fcp_seconds: Optional[float] = None  # First Contentful Paint
-    lcp_seconds: Optional[float] = None  # Largest Contentful Paint
-    tti_seconds: Optional[float] = None  # Time to Interactive
-    dom_loaded_seconds: Optional[float] = None
-
-
-class ApiCallMetric(BaseModel):
-    """Frontend API call metric."""
-
-    endpoint: str
-    method: str
-    status: str  # success, error, timeout
-    latency_seconds: float
-    is_slow: bool = False
-    is_timeout: bool = False
-    error_type: Optional[str] = None  # network, http, timeout
-
-
-class JsErrorMetric(BaseModel):
-    """JavaScript error metric."""
-
-    error_type: str  # syntax, reference, type, etc.
-    page: str
-    is_rejection: bool = False  # True for unhandled Promise rejections
-    component: Optional[str] = None  # Vue component name if applicable
-
-
-class UserActionMetric(BaseModel):
-    """User action/interaction metric."""
-
-    action_type: str  # click, submit, navigation, etc.
-    page: str
-    form_name: Optional[str] = None
-    form_status: Optional[str] = None  # success, validation_error, server_error
-
-
-class SessionMetric(BaseModel):
-    """Session metric."""
-
-    event: str  # start, end
-    duration_seconds: Optional[float] = None
-
-
-class WebSocketMetric(BaseModel):
-    """WebSocket event metric from frontend."""
-
-    event: str  # connect, disconnect, error, reconnect
-    direction: Optional[str] = None  # sent, received
-    event_type: Optional[str] = None  # message type
-
-
-class ResourceMetric(BaseModel):
-    """Resource load metric."""
-
-    resource_type: str  # script, stylesheet, image, font
-    load_time_seconds: float
-    is_slow: bool = False
-
-
-class CriticalIssueMetric(BaseModel):
-    """Critical issue from frontend."""
-
-    issue_type: str  # api_timeout, error, crash
-
-
-class RumMetrics(BaseModel):
-    """
-    Batch of RUM metrics from frontend.
-    Issue #476: Used for Prometheus metrics export.
-    """
-
-    session_id: str
-    timestamp: str
-    page_metrics: Optional[PageMetrics] = None
-    api_calls: Optional[List[ApiCallMetric]] = None
-    js_errors: Optional[List[JsErrorMetric]] = None
-    user_actions: Optional[List[UserActionMetric]] = None
-    session: Optional[SessionMetric] = None
-    websocket_events: Optional[List[WebSocketMetric]] = None
-    resources: Optional[List[ResourceMetric]] = None
-    critical_issues: Optional[List[CriticalIssueMetric]] = None
 
 
 def setup_rum_logger():
@@ -573,7 +473,7 @@ def format_rum_log_message(event_data: Metadata) -> str:
 # =============================================================================
 
 
-def _process_page_metrics(metrics_manager, page_metrics: PageMetrics) -> None:
+def _process_page_metrics(metrics_manager, page_metrics: RumPageMetrics) -> None:
     """Process page performance metrics."""
     if page_metrics.load_time_seconds is not None:
         metrics_manager.record_frontend_page_load(
@@ -591,7 +491,7 @@ def _process_page_metrics(metrics_manager, page_metrics: PageMetrics) -> None:
         )
 
 
-def _process_api_calls(metrics_manager, api_calls: List[ApiCallMetric]) -> None:
+def _process_api_calls(metrics_manager, api_calls: List[RumApiCallMetric]) -> None:
     """Process API call metrics."""
     for call in api_calls:
         metrics_manager.record_frontend_api_request(
@@ -608,7 +508,7 @@ def _process_api_calls(metrics_manager, api_calls: List[ApiCallMetric]) -> None:
             )
 
 
-def _process_js_errors(metrics_manager, js_errors: List[JsErrorMetric]) -> None:
+def _process_js_errors(metrics_manager, js_errors: List[RumJsErrorMetric]) -> None:
     """Process JavaScript error metrics."""
     for error in js_errors:
         if error.is_rejection:
@@ -622,7 +522,7 @@ def _process_js_errors(metrics_manager, js_errors: List[JsErrorMetric]) -> None:
 
 
 def _process_user_actions(
-    metrics_manager, user_actions: List[UserActionMetric]
+    metrics_manager, user_actions: List[RumUserActionMetric]
 ) -> None:
     """Process user action metrics."""
     for action in user_actions:
@@ -633,7 +533,7 @@ def _process_user_actions(
             )
 
 
-def _process_session_metric(metrics_manager, session: SessionMetric) -> None:
+def _process_session_metric(metrics_manager, session: RumSessionMetric) -> None:
     """Process session metrics."""
     if session.event == "start":
         metrics_manager.record_frontend_session_start()
@@ -642,7 +542,7 @@ def _process_session_metric(metrics_manager, session: SessionMetric) -> None:
 
 
 def _process_websocket_events(
-    metrics_manager, websocket_events: List[WebSocketMetric]
+    metrics_manager, websocket_events: List[RumWebSocketMetric]
 ) -> None:
     """Process WebSocket event metrics."""
     for ws_event in websocket_events:
@@ -653,7 +553,7 @@ def _process_websocket_events(
             )
 
 
-def _process_resources(metrics_manager, resources: List[ResourceMetric]) -> None:
+def _process_resources(metrics_manager, resources: List[RumResourceMetric]) -> None:
     """Process resource load metrics."""
     for resource in resources:
         metrics_manager.record_frontend_resource_load(
@@ -664,7 +564,7 @@ def _process_resources(metrics_manager, resources: List[ResourceMetric]) -> None
 
 
 def _process_critical_issues(
-    metrics_manager, critical_issues: List[CriticalIssueMetric]
+    metrics_manager, critical_issues: List[RumCriticalIssueMetric]
 ) -> None:
     """Process critical issue metrics."""
     for issue in critical_issues:

--- a/autobot-backend/api/scheduler.py
+++ b/autobot-backend/api/scheduler.py
@@ -10,184 +10,36 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from datetime import datetime
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
-
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.error_constants import ERR_TEMPLATE_NOT_FOUND, ERR_WORKFLOW_NOT_FOUND
-from constants.threshold_constants import RetryConfig
-from type_defs.common import Metadata
 from workflow_scheduler import WorkflowPriority
 from workflow_scheduler import WorkflowScheduleRequest as InternalScheduleRequest
 from workflow_scheduler import WorkflowStatus, get_workflow_scheduler
+from api.schemas_system import (
+    QueueControlRequest,
+    RescheduleRequest,
+    ScheduleWorkflowRequest,
+    SchedulerBatchScheduleResponse,
+    SchedulerCancelResponse,
+    SchedulerQueueControlResponse,
+    SchedulerQueueResponse,
+    SchedulerRescheduleResponse,
+    SchedulerStartResponse,
+    SchedulerStatsResponse,
+    SchedulerStatusResponse,
+    SchedulerStopResponse,
+    SchedulerTemplateScheduleResponse,
+    SchedulerWorkflowCreateResponse,
+    SchedulerWorkflowDetailResponse,
+    SchedulerWorkflowListResponse,
+)
 
 router = APIRouter(dependencies=[Depends(check_admin_permission)])
 
-
-# ---------------------------------------------------------------------------
-# Response models for scheduler endpoints
-# ---------------------------------------------------------------------------
-
-from typing import Any, Dict  # noqa: E402 — after logger init
-
-
-class SchedulerWorkflowCreateResponse(BaseModel):
-    """Response for POST /schedule."""
-
-    success: bool
-    workflow_id: str
-    scheduled_workflow: Any
-
-
-class SchedulerWorkflowListResponse(BaseModel):
-    """Response for GET /workflows."""
-
-    success: bool
-    workflows: List[Any]
-    total: int
-
-
-class SchedulerWorkflowDetailResponse(BaseModel):
-    """Response for GET /workflows/{workflow_id}."""
-
-    success: bool
-    workflow: Any
-
-
-class SchedulerRescheduleWorkflowItem(BaseModel):
-    id: str
-    scheduled_time: str
-    priority: str
-    status: str
-    complexity: str
-
-
-class SchedulerRescheduleResponse(BaseModel):
-    """Response for PUT /workflows/{workflow_id}/reschedule."""
-
-    success: bool
-    message: str
-    workflow: SchedulerRescheduleWorkflowItem
-
-
-class SchedulerCancelResponse(BaseModel):
-    """Response for DELETE /workflows/{workflow_id}."""
-
-    success: bool
-    message: str
-    workflow_id: str
-
-
-class SchedulerStatusResponse(BaseModel):
-    """Response for GET /status."""
-
-    success: bool
-    scheduler_status: Any
-
-
-class SchedulerQueueWorkflowItem(BaseModel):
-    id: str
-    name: str
-    priority: str
-    complexity: str
-    estimated_duration_minutes: int
-
-
-class SchedulerQueueResponse(BaseModel):
-    """Response for GET /queue."""
-
-    success: bool
-    queue_status: Any
-    queued_workflows: List[SchedulerQueueWorkflowItem]
-    running_workflows: List[SchedulerQueueWorkflowItem]
-
-
-class SchedulerQueueControlResponse(BaseModel):
-    """Response for POST /queue/control."""
-
-    success: bool
-    message: str
-    queue_status: Any
-
-
-class SchedulerStartResponse(BaseModel):
-    """Response for POST /start."""
-
-    success: bool
-    message: str
-    status: Any
-
-
-class SchedulerStopResponse(BaseModel):
-    """Response for POST /stop."""
-
-    success: bool
-    message: str
-
-
-class SchedulerTemplateWorkflowItem(BaseModel):
-    id: str
-    name: str
-    scheduled_time: str
-    priority: str
-    status: str
-    complexity: str
-
-
-class SchedulerTemplateScheduleResponse(BaseModel):
-    """Response for GET /templates/schedule/{template_id}."""
-
-    success: bool
-    workflow_id: str
-    template_info: Dict[str, Any]
-    scheduled_workflow: SchedulerTemplateWorkflowItem
-
-
-class SchedulerStatsResponse(BaseModel):
-    """Response for GET /stats."""
-
-    success: bool
-    statistics: Dict[str, Any]
-
-
-class SchedulerBatchScheduleResponse(BaseModel):
-    """Response for POST /batch-schedule."""
-
-    success: bool
-    scheduled_workflows: List[str]
-    errors: List[str]
-    total_scheduled: int
-    total_errors: int
-
-
-class ScheduleWorkflowRequest(BaseModel):
-    user_message: str
-    scheduled_time: Union[str, datetime]
-    priority: str = "normal"
-    complexity: str = "simple"
-    template_id: Optional[str] = None
-    variables: Optional[Metadata] = None
-    auto_approve: bool = False
-    tags: Optional[List[str]] = None
-    dependencies: Optional[List[str]] = None
-    user_id: Optional[str] = None
-    estimated_duration_minutes: int = 30
-    timeout_minutes: int = 120
-    max_retries: int = RetryConfig.DEFAULT_RETRIES
-
-
-class RescheduleRequest(BaseModel):
-    new_scheduled_time: Union[str, datetime]
-    new_priority: Optional[str] = None
-
-
-class QueueControlRequest(BaseModel):
-    action: str  # "pause", "resume", "set_max_concurrent"
-    value: Optional[int] = None
 
 
 @with_error_handling(

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -8,9 +8,10 @@ Agent config, memory, and LLM schemas.
 import uuid
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from models.session_collaboration import PermissionLevel
+from user_management.schemas import UserResponse as _UserResponse
 
 
 # ---------------------------------------------------------------------------
@@ -1266,3 +1267,164 @@ class MemberAddedResponse(BaseModel):
 class MemberRemovedResponse(BaseModel):
     success: bool = True
     message: str
+
+
+# user_management/users.py schemas (#6042)
+
+
+class UserCreatedResponse(BaseModel):
+    success: bool = True
+    message: str
+    user: _UserResponse
+
+
+class UserDeletedResponse(BaseModel):
+    success: bool = True
+    message: str
+
+
+class PasswordChangedResponse(BaseModel):
+    success: bool = True
+    message: str
+
+
+class RoleAssignmentResponse(BaseModel):
+    success: bool = True
+    message: str
+    role_id: uuid.UUID
+
+
+class RoleUpdateRequest(BaseModel):
+    role: str = Field(..., description="Role name: admin, user, or readonly",
+                     pattern="^(admin|user|readonly)$")
+
+
+class RoleUpdateResponse(BaseModel):
+    success: bool = True
+    message: str
+    username: str
+    role: str
+
+
+class UserSearchResult(BaseModel):
+    id: str
+    name: str
+    type: str = "user"
+
+
+class UserSearchResponse(BaseModel):
+    users: List[UserSearchResult]
+    available: bool
+
+
+# auth.py schemas (#6042)
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+    @field_validator("username")
+    @classmethod
+    def validate_username(cls, v):
+        if not v or len(v.strip()) == 0:
+            raise ValueError("Username cannot be empty")
+        if len(v) > 50:
+            raise ValueError("Username too long")
+        v = v.strip().lower()
+        if not v.replace("_", "").replace("-", "").replace(".", "").isalnum():
+            raise ValueError("Username contains invalid characters")
+        return v
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v):
+        if not v or len(v) < 1:
+            raise ValueError("Password cannot be empty")
+        if len(v) > 128:
+            raise ValueError("Password too long")
+        return v
+
+
+class LoginResponse(BaseModel):
+    success: bool
+    message: str
+    user: Optional[dict] = None
+    token: Optional[str] = None
+    session_id: Optional[str] = None
+
+
+class LogoutRequest(BaseModel):
+    session_id: Optional[str] = None
+
+
+class ChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def validate_new_password(cls, v):
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters long")
+        if len(v) > 128:
+            raise ValueError("Password too long")
+        if not any(c.isupper() for c in v):
+            raise ValueError("Password must contain at least one uppercase letter")
+        if not any(c.islower() for c in v):
+            raise ValueError("Password must contain at least one lowercase letter")
+        if not any(c.isdigit() for c in v):
+            raise ValueError("Password must contain at least one digit")
+        return v
+
+
+class ChangePasswordResponse(BaseModel):
+    success: bool
+    message: str
+
+
+class SignupRequest(BaseModel):
+    username: str
+    email: str
+    password: str
+    display_name: str | None = None
+
+    @field_validator("username")
+    @classmethod
+    def validate_username(cls, v):
+        v = v.strip().lower()
+        if not v or len(v) < 3:
+            raise ValueError("Username must be at least 3 characters")
+        if len(v) > 50:
+            raise ValueError("Username too long")
+        if not v.replace("_", "").replace("-", "").isalnum():
+            raise ValueError("Username contains invalid characters")
+        return v
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v):
+        if "@" not in v or len(v) > 255:
+            raise ValueError("Invalid email address")
+        return v.strip().lower()
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v):
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        if len(v) > 128:
+            raise ValueError("Password too long")
+        if not any(c.isupper() for c in v):
+            raise ValueError("Password must contain at least one uppercase letter")
+        if not any(c.islower() for c in v):
+            raise ValueError("Password must contain at least one lowercase letter")
+        if not any(c.isdigit() for c in v):
+            raise ValueError("Password must contain at least one digit")
+        return v
+
+
+class SignupResponse(BaseModel):
+    success: bool
+    message: str
+    username: str | None = None

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -1428,3 +1428,67 @@ class SignupResponse(BaseModel):
     success: bool
     message: str
     username: str | None = None
+
+
+# user_management/organizations.py schemas (#6042)
+
+
+class OrganizationCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    slug: Optional[str] = Field(None, max_length=100)
+    description: Optional[str] = Field(None, max_length=500)
+    settings: Optional[dict] = Field(default_factory=dict)
+    subscription_tier: str = Field("free")
+    max_users: int = Field(-1)
+
+
+class OrganizationUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    description: Optional[str] = Field(None, max_length=500)
+    settings: Optional[dict] = None
+    subscription_tier: Optional[str] = None
+    max_users: Optional[int] = None
+
+
+class OrganizationResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    slug: str
+    description: Optional[str]
+    settings: dict
+    subscription_tier: str
+    max_users: int
+    is_active: bool
+    created_at: str
+    updated_at: str
+
+    model_config = {"from_attributes": True}
+
+
+class OrganizationListResponse(BaseModel):
+    organizations: List[OrganizationResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class OrganizationCreatedResponse(BaseModel):
+    success: bool = True
+    message: str
+    organization: OrganizationResponse
+
+
+class OrganizationDeletedResponse(BaseModel):
+    success: bool = True
+    message: str
+
+
+class OrganizationStatsResponse(BaseModel):
+    organization_id: str
+    name: str
+    slug: str
+    subscription_tier: str
+    users: dict
+    teams: dict
+    is_active: bool
+    created_at: Optional[str]

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -7,7 +7,9 @@ Agent config, memory, and LLM schemas.
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from models.session_collaboration import PermissionLevel
 
 
 # ---------------------------------------------------------------------------
@@ -1033,3 +1035,159 @@ class ComprehensiveResearchData(BaseModel):
 
     research: Dict[str, Any]
     web_research: Optional[Dict[str, Any]] = None
+
+
+# ---------------------------------------------------------------------------
+# agent_org.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class OrgNodeResponse(BaseModel):
+    """Single node in the org tree response (#1405)."""
+
+    agent_id: str
+    name: str
+    org_role: str
+    title: Optional[str] = None
+    capabilities: Optional[str] = None
+    direct_reports_count: int = 0
+    children: List["OrgNodeResponse"] = Field(default_factory=list)
+
+
+OrgNodeResponse.model_rebuild()
+
+
+class AgentSummary(BaseModel):
+    """Compact agent summary used in chain of command (#1405)."""
+
+    agent_id: str
+    name: str
+    org_role: str
+    title: Optional[str] = None
+
+
+class ChainOfCommandResponse(BaseModel):
+    """Ordered list from agent to org root (#1405)."""
+
+    chain: List[AgentSummary]
+
+
+class UpdateOrgRequest(BaseModel):
+    """Request body for PATCH /agents/{agent_id}/org (#1405)."""
+
+    reports_to: Optional[str] = Field(
+        default=None,
+        description="agent_id of the new manager, or null to clear",
+    )
+    org_role: Optional[str] = Field(
+        default=None,
+        description="One of: manager, coordinator, specialist, worker",
+    )
+    title: Optional[str] = Field(default=None, description="Human-readable job title")
+    capabilities: Optional[str] = Field(
+        default=None, description="Free-text capability description"
+    )
+
+
+class UpsertOrgRequest(BaseModel):
+    """Request body for PUT /agents/{agent_id}/org (#1405)."""
+
+    name: str
+    org_role: str = "worker"
+    reports_to: Optional[str] = None
+    title: Optional[str] = None
+    capabilities: Optional[str] = None
+
+
+class AgentDelegateRequest(BaseModel):
+    """Request body for POST /{manager_id}/delegate (#1753)."""
+
+    assignee_id: str = Field(..., description="Direct report to assign to")
+    task_description: str = Field(..., description="What the assignee should do")
+    context: Optional[Dict[str, Any]] = Field(
+        default=None, description="Extra context for the task"
+    )
+
+
+class DelegationResponse(BaseModel):
+    """Response for a task delegation (#1753)."""
+
+    id: str
+    delegator_id: str
+    assignee_id: str
+    task_description: str
+    status: str
+    escalated_to: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+class DelegationStatusUpdate(BaseModel):
+    """Request body for PATCH /delegations/{id}/status (#1753)."""
+
+    status: str = Field(..., description="New status value")
+    result: Optional[Dict[str, Any]] = None
+
+
+# ---------------------------------------------------------------------------
+# collaboration.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class CollabInviteRequest(BaseModel):
+    """Request to invite user to session."""
+
+    user_id: str = Field(..., description="User ID to invite")
+    permission: PermissionLevel = Field(
+        ..., description="Permission level (owner/editor/viewer)"
+    )
+
+
+class CollabRemoveRequest(BaseModel):
+    """Request to remove collaborator."""
+
+    user_id: str = Field(..., description="User ID to remove")
+
+
+class CollabShareSecretRequest(BaseModel):
+    """Request to share secret with session participants."""
+
+    secret_id: str = Field(..., description="Secret ID to share")
+    participant_ids: Optional[List[str]] = Field(
+        None,
+        description="Specific participants (None = all with editor+)",
+    )
+
+
+class CollabParticipantResponse(BaseModel):
+    """Participant information."""
+
+    user_id: str
+    permission: str
+    is_owner: bool
+    online: bool = False
+
+
+class SessionParticipantsResponse(BaseModel):
+    """Session participants list."""
+
+    session_id: str
+    owner_id: str
+    participants: List[CollabParticipantResponse]
+    total_count: int
+
+
+class CollabInviteResponse(BaseModel):
+    """Invitation response."""
+
+    success: bool
+    session_id: str
+    invited_user_id: str
+    permission: str
+
+
+class CollabRemoveResponse(BaseModel):
+    """Remove collaborator response."""
+
+    success: bool
+    session_id: str
+    removed_user_id: str

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -5,6 +5,7 @@
 Agent config, memory, and LLM schemas.
 """
 
+import uuid
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
@@ -1191,3 +1192,77 @@ class CollabRemoveResponse(BaseModel):
     success: bool
     session_id: str
     removed_user_id: str
+
+
+# user_management/teams.py schemas (#6042)
+
+
+class TeamCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: Optional[str] = Field(None, max_length=500)
+    settings: Optional[dict] = Field(default_factory=dict)
+    is_default: bool = Field(False)
+
+
+class TeamUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    description: Optional[str] = Field(None, max_length=500)
+    settings: Optional[dict] = Field(None)
+
+
+class MembershipUpdate(BaseModel):
+    role: str = Field(..., description="New role (owner, admin, member)")
+
+
+class MemberResponse(BaseModel):
+    user_id: uuid.UUID
+    username: str
+    email: str
+    display_name: Optional[str]
+    role: str
+    joined_at: str
+
+    model_config = {"from_attributes": True}
+
+
+class TeamResponse(BaseModel):
+    id: uuid.UUID
+    org_id: uuid.UUID
+    name: str
+    description: Optional[str]
+    settings: dict
+    is_default: bool
+    member_count: int = 0
+    created_at: str
+    updated_at: str
+
+    model_config = {"from_attributes": True}
+
+
+class TeamListResponse(BaseModel):
+    teams: List[TeamResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class TeamCreatedResponse(BaseModel):
+    success: bool = True
+    message: str
+    team: TeamResponse
+
+
+class TeamDeletedResponse(BaseModel):
+    success: bool = True
+    message: str
+
+
+class MemberAddedResponse(BaseModel):
+    success: bool = True
+    message: str
+    member: MemberResponse
+
+
+class MemberRemovedResponse(BaseModel):
+    success: bool = True
+    message: str

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -1672,3 +1672,115 @@ class AlertThresholdRequest(BaseModel):
     component: str
     error_code: Optional[str] = None
     threshold: int
+
+
+# ---------------------------------------------------------------------------
+# rum.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class RumEvent(BaseModel):
+    type: str
+    timestamp: str
+    sessionId: str
+    url: str
+    userAgent: str
+    data: Metadata = {}
+
+
+class RumConfig(BaseModel):
+    enabled: bool = False
+    error_tracking: bool = True
+    performance_monitoring: bool = True
+    interaction_tracking: bool = False
+    session_recording: bool = False
+    sample_rate: int = 100
+    max_events_per_session: int = 1000
+    debug_mode: bool = False
+    log_to_backend: bool = True
+    log_level: str = "info"
+
+
+class RumPageMetrics(BaseModel):
+    """Page performance metrics from frontend."""
+
+    page: str
+    load_time_seconds: Optional[float] = None
+    fcp_seconds: Optional[float] = None
+    lcp_seconds: Optional[float] = None
+    tti_seconds: Optional[float] = None
+    dom_loaded_seconds: Optional[float] = None
+
+
+class RumApiCallMetric(BaseModel):
+    """Frontend API call metric."""
+
+    endpoint: str
+    method: str
+    status: str
+    latency_seconds: float
+    is_slow: bool = False
+    is_timeout: bool = False
+    error_type: Optional[str] = None
+
+
+class RumJsErrorMetric(BaseModel):
+    """JavaScript error metric."""
+
+    error_type: str
+    page: str
+    is_rejection: bool = False
+    component: Optional[str] = None
+
+
+class RumUserActionMetric(BaseModel):
+    """User action/interaction metric."""
+
+    action_type: str
+    page: str
+    form_name: Optional[str] = None
+    form_status: Optional[str] = None
+
+
+class RumSessionMetric(BaseModel):
+    """Session metric."""
+
+    event: str
+    duration_seconds: Optional[float] = None
+
+
+class RumWebSocketMetric(BaseModel):
+    """WebSocket event metric from frontend."""
+
+    event: str
+    direction: Optional[str] = None
+    event_type: Optional[str] = None
+
+
+class RumResourceMetric(BaseModel):
+    """Resource load metric."""
+
+    resource_type: str
+    load_time_seconds: float
+    is_slow: bool = False
+
+
+class RumCriticalIssueMetric(BaseModel):
+    """Critical issue from frontend."""
+
+    issue_type: str
+
+
+class RumMetrics(BaseModel):
+    """Batch of RUM metrics from frontend. Issue #476: Used for Prometheus metrics export."""
+
+    session_id: str
+    timestamp: str
+    page_metrics: Optional[RumPageMetrics] = None
+    api_calls: Optional[List[RumApiCallMetric]] = None
+    js_errors: Optional[List[RumJsErrorMetric]] = None
+    user_actions: Optional[List[RumUserActionMetric]] = None
+    session: Optional[RumSessionMetric] = None
+    websocket_events: Optional[List[RumWebSocketMetric]] = None
+    resources: Optional[List[RumResourceMetric]] = None
+    critical_issues: Optional[List[RumCriticalIssueMetric]] = None

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -5,6 +5,7 @@
 Analytics, cost, budget, usage, and metrics schemas.
 """
 
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
@@ -1469,3 +1470,205 @@ class QualityDrillDownResponse(BaseModel):
     """Response for GET /quality/drill-down/{category} — dual shape (success vs no_data)."""
 
     model_config = {"extra": "allow"}
+
+
+# ---------------------------------------------------------------------------
+# analytics_precommit schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class CheckSeverity(str, Enum):
+    """Severity levels for pre-commit checks."""
+
+    BLOCK = "block"
+    WARN = "warn"
+    INFO = "info"
+
+
+class CheckCategory(str, Enum):
+    """Categories of pre-commit checks."""
+
+    SECURITY = "security"
+    QUALITY = "quality"
+    STYLE = "style"
+    DEBUG = "debug"
+    DOCS = "docs"
+
+
+class CheckResult(BaseModel):
+    """Result of a single check."""
+
+    check_id: str
+    name: str
+    category: CheckCategory
+    severity: CheckSeverity
+    passed: bool
+    message: str
+    file: Optional[str] = None
+    line: Optional[int] = None
+    snippet: Optional[str] = None
+    suggestion: Optional[str] = None
+
+
+class CommitCheckResult(BaseModel):
+    """Result of checking staged files."""
+
+    passed: bool
+    total_checks: int
+    passed_checks: int
+    failed_checks: int
+    warnings: int
+    blocked: bool
+    duration_ms: float
+    results: List[CheckResult]
+    files_checked: List[str]
+    timestamp: str
+
+
+class HookConfig(BaseModel):
+    """Configuration for pre-commit hooks."""
+
+    enabled: bool = True
+    fast_mode: bool = True
+    timeout_seconds: int = Field(default=5, ge=1, le=30)
+    bypass_keyword: str = "[skip-hooks]"
+    enabled_checks: List[str] = Field(default_factory=list)
+    disabled_checks: List[str] = Field(default_factory=list)
+
+
+class CheckDefinition(BaseModel):
+    """Definition of a check rule."""
+
+    id: str
+    name: str
+    category: CheckCategory
+    severity: CheckSeverity
+    pattern: str
+    description: str
+    suggestion: str
+    file_patterns: List[str] = Field(default_factory=lambda: ["*"])
+    enabled: bool = True
+
+
+class HookStatus(BaseModel):
+    """Status of installed hooks."""
+
+    installed: bool
+    path: Optional[str] = None
+    version: Optional[str] = None
+    last_run: Optional[str] = None
+    config: HookConfig
+
+
+class CheckToggleResponse(BaseModel):
+    """Response for POST /checks/{check_id}/toggle."""
+
+    check_id: str
+    enabled: bool
+    message: str
+
+
+class HookConfigUpdateResponse(BaseModel):
+    """Response for POST /config — echoes back the new config."""
+
+    message: str
+    config: HookConfig
+
+
+class HookInstallResponse(BaseModel):
+    """Response for POST /install and POST /uninstall."""
+
+    success: bool
+    message: str
+    path: Optional[str] = None
+
+
+class CommonIssueItem(BaseModel):
+    """Single issue entry in the summary common_issues list."""
+
+    check_id: str
+    count: int
+    name: str
+
+
+class PrecommitSummaryResponse(BaseModel):
+    """Response for GET /summary."""
+
+    total_runs: int
+    pass_rate: float
+    average_duration_ms: float
+    common_issues: List[CommonIssueItem]
+    checks_enabled: Optional[int] = None
+    total_checks: Optional[int] = None
+
+
+class PrecommitCategoryItem(BaseModel):
+    """Single category entry for GET /categories."""
+
+    category: str
+    enabled: int
+    disabled: int
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# error_monitoring schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class ErrorMonitoringDataResponse(BaseModel):
+    """Generic envelope for endpoints returning {"status": str, "data": Any}."""
+
+    status: str
+    data: Optional[Any] = None
+
+
+class ErrorMonitoringClearResponse(BaseModel):
+    """Response for POST /clear."""
+
+    status: str
+    message: str
+
+
+class ErrorMonitoringTestErrorResponse(BaseModel):
+    """Response for POST /test-error."""
+
+    status: str
+    message: str
+    error_caught: Optional[str] = None
+    error_type: Optional[str] = None
+
+
+class ErrorMonitoringResolveResponse(BaseModel):
+    """Response for POST /metrics/resolve/{trace_id}."""
+
+    status: str
+    message: str
+
+
+class ErrorMonitoringAlertThresholdResponse(BaseModel):
+    """Response for POST /metrics/alert-threshold."""
+
+    status: str
+    message: str
+    threshold_key: str
+    threshold: int
+
+
+class ErrorMonitoringCleanupResponse(BaseModel):
+    """Response for POST /metrics/cleanup."""
+
+    status: str
+    message: str
+    removed_count: int
+
+
+class TestErrorRequest(BaseModel):
+    error_type: str = "ValueError"
+    message: str = "Test error for error boundary system"
+
+
+class AlertThresholdRequest(BaseModel):
+    component: str
+    error_code: Optional[str] = None
+    threshold: int

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -1784,3 +1784,60 @@ class RumMetrics(BaseModel):
     websocket_events: Optional[List[RumWebSocketMetric]] = None
     resources: Optional[List[RumResourceMetric]] = None
     critical_issues: Optional[List[RumCriticalIssueMetric]] = None
+
+
+# analytics_cost.py schemas (#6042)
+
+
+class CostSummaryResponse(BaseModel):
+    period: dict
+    total_cost_usd: float
+    daily_costs: dict
+    by_model: dict
+    avg_daily_cost: float
+
+
+class CostTrendResponse(BaseModel):
+    period_days: int
+    total_cost_usd: float
+    daily_costs: dict
+    trend: str
+    growth_rate_percent: float
+    avg_daily_cost: float
+
+
+class SessionCostResponse(BaseModel):
+    session_id: str
+    found: bool
+    cost_usd: Optional[float] = None
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    error: Optional[str] = None
+
+
+class BudgetAlertRequest(BaseModel):
+    name: str = Field(..., description="Alert name")
+    threshold_usd: float = Field(..., gt=0, description="Budget threshold in USD")
+    period: str = Field(..., pattern="^(daily|weekly|monthly)$", description="Alert period")
+    notify_at_percent: List[int] = Field(default=[50, 75, 90, 100])
+    enabled: bool = Field(default=True)
+
+
+class ModelPricingInfo(BaseModel):
+    model: str
+    input_price_per_1m: float
+    output_price_per_1m: float
+    provider: str
+
+
+class AgentBudgetRequest(BaseModel):
+    budget_monthly_usd: float = Field(..., gt=0, description="Monthly budget in USD")
+
+
+class AgentCostResponse(BaseModel):
+    agent_id: str
+    found: bool = False
+    cost_usd: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    call_count: int = 0

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -7,7 +7,9 @@ Code review, git, skills, database, template, log, voice, access-control, MCP, a
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from type_defs.common import JSONObject
 
 from api.schemas_common import SuccessMessageResponse
 
@@ -1302,3 +1304,397 @@ class SkillExternalSyncResponse(BaseModel):
 # permissions.py schemas are defined in schemas_system.py (PermissionRuleMutateResponse,
 # PermissionClearApprovalsResponse, PermissionStoreApprovalResponse,
 # PermissionMemoryStatsResponse) — already wired in permissions.py.
+
+
+# ---------------------------------------------------------------------------
+# filesystem_mcp schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class FilesystemReadTextResponse(BaseModel):
+    """Response for POST /mcp/read_text_file."""
+
+    success: bool
+    path: str
+    content: str
+    lines: int
+    size_bytes: int
+
+
+class FilesystemReadMediaResponse(BaseModel):
+    """Response for POST /mcp/read_media_file."""
+
+    success: bool
+    path: str
+    mime_type: str
+    base64_data: str
+    size_bytes: int
+
+
+class FilesystemReadMultipleResponse(BaseModel):
+    """Response for POST /mcp/read_multiple_files."""
+
+    success: bool
+    files_read: int
+    files_failed: int
+    results: List[Dict]
+    errors: Optional[List[Dict]] = None
+
+
+class FilesystemWriteFileResponse(BaseModel):
+    """Response for POST /mcp/write_file."""
+
+    success: bool
+    path: str
+    size_bytes: int
+    message: str
+
+
+class FilesystemEditFileResponse(BaseModel):
+    """Response for POST /mcp/edit_file."""
+
+    success: bool
+    path: str
+    edits_applied: int
+    dry_run: bool
+    changes: List[Dict]
+    size_before: int
+    size_after: int
+
+
+class FilesystemCreateDirectoryResponse(BaseModel):
+    """Response for POST /mcp/create_directory."""
+
+    success: bool
+    path: str
+    message: str
+
+
+class FilesystemListDirectoryResponse(BaseModel):
+    """Response for POST /mcp/list_directory."""
+
+    success: bool
+    path: str
+    entry_count: int
+    entries: List[str]
+
+
+class FilesystemListDirectoryWithSizesResponse(BaseModel):
+    """Response for POST /mcp/list_directory_with_sizes."""
+
+    success: bool
+    path: str
+    entry_count: int
+    sorted_by: Optional[str] = None
+    entries: List[Dict]
+
+
+class FilesystemMoveFileResponse(BaseModel):
+    """Response for POST /mcp/move_file."""
+
+    success: bool
+    source: str
+    destination: str
+    message: str
+
+
+class FilesystemSearchFilesResponse(BaseModel):
+    """Response for POST /mcp/search_files."""
+
+    success: bool
+    search_path: str
+    pattern: str
+    matches_found: int
+    matches: List[str]
+
+
+class FilesystemDirectoryTreeResponse(BaseModel):
+    """Response for POST /mcp/directory_tree."""
+
+    success: bool
+    root_path: str
+    tree: Dict
+
+
+class FilesystemFileInfoResponse(BaseModel):
+    """Response for POST /mcp/get_file_info."""
+
+    success: bool
+    path: str
+    name: str
+    type: str
+    size_bytes: int
+    created: str
+    modified: str
+    accessed: str
+    permissions: str
+    mime_type: Optional[str] = None
+
+
+class FilesystemSecurityInfo(BaseModel):
+    path_traversal_blocked: bool
+    symlink_validation: bool
+    max_file_size_bytes: int
+
+
+class FilesystemListAllowedResponse(BaseModel):
+    """Response for GET /mcp/list_allowed_directories."""
+
+    success: bool
+    allowed_directories: List[str]
+    directory_count: int
+    security_info: FilesystemSecurityInfo
+
+
+class MCPTool(BaseModel):
+    """Standard MCP tool definition (shared across all MCP endpoint files)."""
+
+    name: str
+    description: str
+    input_schema: JSONObject
+
+
+class ReadTextFileRequest(BaseModel):
+    """Request model for reading text files."""
+
+    path: str = Field(..., description="Absolute path to file")
+    head: Optional[int] = Field(None, description="Read only first N lines")
+    tail: Optional[int] = Field(None, description="Read only last N lines")
+
+
+class ReadMediaFileRequest(BaseModel):
+    """Request model for reading media files (images, audio)."""
+
+    path: str = Field(..., description="Absolute path to media file")
+
+
+class ReadMultipleFilesRequest(BaseModel):
+    """Request model for reading multiple files."""
+
+    paths: List[str] = Field(..., description="List of absolute file paths")
+
+
+class WriteFileRequest(BaseModel):
+    """Request model for writing files."""
+
+    path: str = Field(..., description="Absolute path to file")
+    content: str = Field(..., description="File content to write")
+
+
+class EditFileRequest(BaseModel):
+    """Request model for editing files."""
+
+    path: str = Field(..., description="Absolute path to file")
+    edits: List[Dict[str, str]] = Field(
+        ..., description="List of {old_text, new_text} edits"
+    )
+    dry_run: Optional[bool] = Field(False, description="Preview changes without applying")
+
+
+class CreateDirectoryRequest(BaseModel):
+    """Request model for creating directories."""
+
+    path: str = Field(..., description="Absolute path to directory")
+
+
+class ListDirectoryRequest(BaseModel):
+    """Request model for listing directory contents."""
+
+    path: str = Field(..., description="Absolute path to directory")
+
+
+class ListDirectoryWithSizesRequest(BaseModel):
+    """Request model for listing directory with sizes."""
+
+    path: str = Field(..., description="Absolute path to directory")
+    sort_by: Optional[str] = Field("name", description="Sort by 'name' or 'size'")
+
+
+class MoveFileRequest(BaseModel):
+    """Request model for moving/renaming files."""
+
+    source: str = Field(..., description="Source path")
+    destination: str = Field(..., description="Destination path")
+
+
+class SearchFilesRequest(BaseModel):
+    """Request model for searching files."""
+
+    path: str = Field(..., description="Directory to search")
+    pattern: str = Field(..., description="Search pattern (e.g., '*.py')")
+    exclude_patterns: Optional[List[str]] = Field(None, description="Patterns to exclude")
+
+
+class DirectoryTreeRequest(BaseModel):
+    """Request model for directory tree."""
+
+    path: str = Field(..., description="Root directory path")
+
+
+class GetFileInfoRequest(BaseModel):
+    """Request model for file metadata."""
+
+    path: str = Field(..., description="File or directory path")
+
+
+# ---------------------------------------------------------------------------
+# code_intelligence response schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class SuggestionItem(BaseModel):
+    id: str
+    type: str
+    priority: str
+    title: str
+    description: str
+    impact: str
+
+
+class SuggestionsResponse(BaseModel):
+    suggestions: List[SuggestionItem]
+
+
+class FindingsPlaceholderResponse(BaseModel):
+    findings: List[Any]
+    score: Optional[float]
+    message: str
+
+
+class CodeIntelligenceTaskStatusResponse(BaseModel):
+    """Generic task status returned by BackgroundTaskManager (code_intelligence)."""
+
+    status: str
+    task_id: Optional[str] = None
+    progress: Optional[float] = None
+    message: Optional[str] = None
+    result: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+
+class StartTaskResponse(BaseModel):
+    task_id: str
+    status: str
+
+
+class ClearStuckResponse(BaseModel):
+    cleared_count: int
+    message: str
+
+
+class CachedSecurityScoreResponse(BaseModel):
+    status: str
+    from_cache: Optional[bool] = None
+    completed_at: Optional[str] = None
+    security_score: Optional[float] = None
+    grade: Optional[str] = None
+    risk_level: Optional[str] = None
+    status_message: Optional[str] = None
+    total_findings: Optional[int] = None
+    critical_issues: Optional[int] = None
+    high_issues: Optional[int] = None
+    files_analyzed: Optional[int] = None
+    severity_breakdown: Optional[Dict[str, Any]] = None
+    owasp_breakdown: Optional[Dict[str, Any]] = None
+    message: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# playwright request schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class PlaywrightSearchRequest(BaseModel):
+    query: str
+    search_engine: str = "duckduckgo"
+    max_results: int = 5
+
+
+class PlaywrightScreenshotRequest(BaseModel):
+    url: str
+    full_page: bool = True
+    wait_timeout: int = 5000
+
+
+class PlaywrightNavigateRequest(BaseModel):
+    url: str
+    wait_until: str = "networkidle"
+    timeout: int = 30000
+
+
+class PlaywrightReloadRequest(BaseModel):
+    wait_until: str = "networkidle"
+
+
+class PlaywrightInteractRequest(BaseModel):
+    action: str
+    x: Optional[float] = None
+    y: Optional[float] = None
+    deltaX: float = 0
+    deltaY: float = 0
+    text: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# ide_integration response schemas (#6042) — clean IDE-prefixed classes only
+# (Generic LSP types Position/Range/Diagnostic etc. deferred to follow-up PR)
+# ---------------------------------------------------------------------------
+
+
+class IDERulesResponse(BaseModel):
+    """Response for GET /rules."""
+
+    rules: List[Dict[str, Any]]
+    total: int
+    enabled: int
+
+
+class IDEConfigUpdateResponse(BaseModel):
+    """Response for PUT /config."""
+
+    updated: bool
+
+
+class IDECategoryItem(BaseModel):
+    """A single category entry."""
+
+    id: str
+    name: str
+
+
+class IDECategoriesResponse(BaseModel):
+    """Response for GET /categories."""
+
+    categories: List[IDECategoryItem]
+
+
+class IDESeverityItem(BaseModel):
+    """A single severity entry."""
+
+    id: str
+    name: str
+    lsp_code: int
+
+
+class IDESeveritiesResponse(BaseModel):
+    """Response for GET /severities."""
+
+    severities: List[IDESeverityItem]
+
+
+class IDEBatchAnalyzeResponse(BaseModel):
+    """Response for POST /batch-analyze."""
+
+    results: List[Any]
+    files_analyzed: int
+    total_issues: int
+    errors: int
+
+
+class IDEHealthResponse(BaseModel):
+    """Response for GET /health."""
+
+    status: str
+    rules_loaded: int
+    disabled_rules: int
+    cache_size: int

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -1698,3 +1698,92 @@ class IDEHealthResponse(BaseModel):
     rules_loaded: int
     disabled_rules: int
     cache_size: int
+
+
+
+# ---------------------------------------------------------------------------
+# openai_compat.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class OAIMessage(BaseModel):
+    role: str
+    content: str
+    name: Optional[str] = None
+
+
+class OAIStreamOptions(BaseModel):
+    include_usage: bool = False
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str = "autobot-default"
+    messages: List[OAIMessage]
+    temperature: float = 0.7
+    max_tokens: Optional[int] = None
+    top_p: float = 1.0
+    frequency_penalty: float = 0.0
+    presence_penalty: float = 0.0
+    stop: Optional[List[str]] = None
+    stream: bool = False
+    stream_options: Optional[OAIStreamOptions] = None
+    n: int = Field(default=1, ge=1)
+    user: Optional[str] = None
+
+
+class OAIChoiceMessage(BaseModel):
+    role: str
+    content: str
+
+
+class OAIChoice(BaseModel):
+    index: int
+    message: OAIChoiceMessage
+    finish_reason: str = "stop"
+
+
+class OAIUsage(BaseModel):
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+class ChatCompletionResponse(BaseModel):
+    id: str
+    object: str = "chat.completion"
+    created: int
+    model: str
+    choices: List[OAIChoice]
+    usage: OAIUsage
+
+
+class OAIDeltaMessage(BaseModel):
+    role: Optional[str] = None
+    content: Optional[str] = None
+
+
+class OAIStreamChoice(BaseModel):
+    index: int
+    delta: OAIDeltaMessage
+    finish_reason: Optional[str] = None
+
+
+class ChatCompletionChunk(BaseModel):
+    id: str
+    object: str = "chat.completion.chunk"
+    created: int
+    model: str
+    choices: List[OAIStreamChoice]
+    usage: Optional[OAIUsage] = None
+
+
+class OAIModelCard(BaseModel):
+    id: str
+    object: str = "model"
+    created: int = 0
+    owned_by: str = "autobot"
+
+
+class OAIModelListResponse(BaseModel):
+    object: str = "list"
+    data: List[OAIModelCard]

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -5,9 +5,11 @@
 Knowledge base collection, category, fact, grounding, and audit schemas.
 """
 
+from datetime import datetime
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 
 
 # ---------------------------------------------------------------------------
@@ -3652,3 +3654,138 @@ class KnowledgeTagDeleteStyleResponse(BaseModel):
     status: str
     tag: str
     message: str
+
+
+# ---------------------------------------------------------------------------
+# conversation_files.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class FileDestination(str, Enum):
+    """File transfer destination options."""
+
+    KNOWLEDGE_BASE = "kb"
+    SHARED = "shared"
+
+
+class ConversationFileInfo(BaseModel):
+    """Conversation file information model."""
+
+    file_id: str
+    filename: str
+    original_filename: str
+    size: int
+    mime_type: Optional[str] = None
+    session_id: str
+    uploaded_at: datetime
+    uploaded_by: str
+    file_path: str
+    extension: Optional[str] = None
+
+
+class ConversationFileListResponse(BaseModel):
+    """Response model for listing conversation files."""
+
+    session_id: str
+    files: List[ConversationFileInfo]
+    total_files: int
+    total_size: int
+    page: int = 1
+    page_size: int = 50
+
+
+class FileUploadResponse(BaseModel):
+    """Response model for file upload."""
+
+    success: bool
+    message: str
+    file_info: Optional[ConversationFileInfo] = None
+    upload_id: str
+
+
+class FileTransferRequest(BaseModel):
+    """Request model for file transfer operation."""
+
+    file_ids: List[str] = Field(
+        ..., min_length=1, description="List of file IDs to transfer"
+    )
+    destination: FileDestination = Field(
+        ..., description="Transfer destination (kb or shared)"
+    )
+    target_path: Optional[str] = Field(None, description="Target path in destination")
+    copy_files: bool = Field(False, alias="copy", description="Copy instead of move")
+    tags: Optional[List[str]] = Field(None, description="Tags for KB indexing")
+
+    @field_validator("file_ids")
+    @classmethod
+    def validate_file_ids(cls, v):
+        """Validate that at least one file ID is provided."""
+        if not v:
+            raise ValueError("At least one file ID must be provided")
+        return v
+
+
+class FileTransferResponse(BaseModel):
+    """Response model for file transfer operation."""
+
+    success: bool
+    message: str
+    transferred_files: List[Dict[str, str]]
+    failed_files: List[Dict[str, str]]
+    total_transferred: int
+    total_failed: int
+
+
+class FilePreviewResponse(BaseModel):
+    """Response model for file preview."""
+
+    file_info: ConversationFileInfo
+    preview_available: bool
+    preview_content: Optional[str] = None
+    preview_type: Optional[str] = None
+
+
+class ConvFileCreateRequest(BaseModel):
+    """Request model for creating a new file."""
+
+    filename: str = Field(..., min_length=1, max_length=255)
+    content: str = Field(default="")
+    mime_type: str = Field(default="text/plain")
+
+
+class ConvFileRenameRequest(BaseModel):
+    """Request model for renaming a file."""
+
+    new_filename: str = Field(..., min_length=1, max_length=255)
+
+
+class ConvFileUpdateContentRequest(BaseModel):
+    """Request model for updating file content."""
+
+    content: str
+
+
+class ConvFileCopyRequest(BaseModel):
+    """Request model for copying a file."""
+
+    new_filename: Optional[str] = Field(
+        None, max_length=255, description="Optional new name for the copy"
+    )
+
+
+class AgentGenerateFileRequest(BaseModel):
+    """Request model for agent file generation."""
+
+    filename: str = Field(..., min_length=1, max_length=255)
+    content: str
+    file_type: str = Field(default="generated", description="File type tag")
+    mime_type: str = Field(default="text/plain")
+    agent_name: Optional[str] = Field(None, description="Name of generating agent")
+    metadata: Optional[Dict[str, str]] = Field(None, description="Extra metadata")
+
+
+class MCPToolCallRequest(BaseModel):
+    """Request model for MCP tool call dispatch."""
+
+    tool_name: str = Field(..., description="Name of the MCP tool to call")
+    arguments: Dict = Field(default_factory=dict, description="Tool arguments")

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -3524,3 +3524,131 @@ class NLSearchHealthResponse(BaseModel):
     use_instead: str
     features: List[str]
     llm_available: bool
+
+
+# ---------------------------------------------------------------------------
+# knowledge_tags schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeTagFactTagsResponse(BaseModel):
+    """Response for POST/DELETE/GET /fact/{fact_id}/tags."""
+
+    status: str
+    fact_id: str
+    tags: List[Any]
+    message: Optional[str] = None
+    added_count: Optional[int] = None
+    removed_count: Optional[int] = None
+
+
+class KnowledgeTagGetFactTagsResponse(BaseModel):
+    """Response for GET /fact/{fact_id}/tags."""
+
+    status: str
+    fact_id: str
+    tags: List[Any]
+
+
+class KnowledgeTagSearchResponse(BaseModel):
+    """Response for POST /tags/search."""
+
+    status: str
+    facts: List[Any]
+    total_count: int
+    tags_searched: List[str]
+    match_all: bool
+    limit: int
+    offset: int
+
+
+class KnowledgeTagListResponse(BaseModel):
+    """Response for GET /tags."""
+
+    status: str
+    tags: List[Any]
+    total_count: int
+
+
+class KnowledgeTagBulkResponse(BaseModel):
+    """Response for POST /tags/bulk."""
+
+    status: str
+    operation: str
+    processed_count: int
+    failed_count: int
+    results: List[Any]
+
+
+class KnowledgeTagRenameResponse(BaseModel):
+    """Response for PUT /tags/{tag_name}."""
+
+    status: str
+    old_tag: str
+    new_tag: str
+    affected_count: int
+    message: str
+
+
+class KnowledgeTagDeleteResponse(BaseModel):
+    """Response for DELETE /tags/{tag_name}."""
+
+    status: str
+    tag: str
+    affected_count: int
+    message: str
+
+
+class KnowledgeTagMergeResponse(BaseModel):
+    """Response for POST /tags/merge."""
+
+    status: str
+    source_tags: List[str]
+    target_tag: str
+    affected_count: int
+    message: str
+
+
+class KnowledgeTagFactsByTagResponse(BaseModel):
+    """Response for GET /tags/{tag_name}/facts."""
+
+    status: str
+    tag: str
+    facts: List[Any]
+    total_count: int
+    returned_count: int
+    limit: int
+    offset: int
+    has_more: bool
+
+
+class KnowledgeTagInfoResponse(BaseModel):
+    """Response for GET /tags/{tag_name}/info."""
+
+    status: str
+    tag: str
+    fact_count: int
+
+
+class KnowledgeTagStyleInfo(BaseModel):
+    color: Optional[str] = None
+    icon: Optional[str] = None
+    description: Optional[str] = None
+    is_default: bool
+
+
+class KnowledgeTagStyleResponse(BaseModel):
+    """Response for PATCH/GET /tags/{tag_name}/style."""
+
+    status: str
+    tag: str
+    style: Dict[str, Any]
+    message: Optional[str] = None
+
+
+class KnowledgeTagDeleteStyleResponse(BaseModel):
+    """Response for DELETE /tags/{tag_name}/style."""
+
+    status: str
+    tag: str
+    message: str

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+from type_defs.common import Metadata
+
 
 # ---------------------------------------------------------------------------
 # Knowledge schemas
@@ -3789,3 +3791,90 @@ class MCPToolCallRequest(BaseModel):
 
     tool_name: str = Field(..., description="Name of the MCP tool to call")
     arguments: Dict = Field(default_factory=dict, description="Tool arguments")
+
+
+# memory.py schemas (#6042)
+
+_VALID_ENTITY_TYPES = frozenset({
+    "conversation", "bug_fix", "feature", "decision", "task",
+    "user_preference", "context", "learning", "research", "implementation",
+})
+_VALID_RELATION_TYPES = frozenset({
+    "relates_to", "depends_on", "implements", "fixes", "informs",
+    "guides", "follows", "contains", "blocks",
+})
+
+
+class EntityCreateRequest(BaseModel):
+    entity_type: str = Field(..., description="Type of entity")
+    name: str = Field(..., min_length=1, max_length=200)
+    observations: List[str] = Field(..., min_length=1)
+    metadata: Optional[Metadata] = Field(default_factory=dict)
+    tags: Optional[List[str]] = Field(default_factory=list)
+
+    @field_validator("entity_type")
+    @classmethod
+    def validate_entity_type(cls, v):
+        if v not in _VALID_ENTITY_TYPES:
+            raise ValueError(f"entity_type must be one of: {_VALID_ENTITY_TYPES}")
+        return v
+
+
+class ObservationAddRequest(BaseModel):
+    observations: List[str] = Field(..., min_length=1)
+
+
+class RelationCreateRequest(BaseModel):
+    from_entity: str = Field(..., description="Source entity name")
+    to_entity: str = Field(..., description="Target entity name")
+    relation_type: str = Field(..., description="Type of relationship")
+    bidirectional: bool = Field(default=False)
+    strength: float = Field(default=1.0, ge=0.0, le=1.0)
+    metadata: Optional[Metadata] = Field(default_factory=dict)
+
+    @field_validator("relation_type")
+    @classmethod
+    def validate_relation_type(cls, v):
+        if v not in _VALID_RELATION_TYPES:
+            raise ValueError(f"relation_type must be one of: {_VALID_RELATION_TYPES}")
+        return v
+
+
+class InvalidateEntityRequest(BaseModel):
+    ended_at: Optional[str] = Field(default=None, description="ISO-8601 timestamp for valid_to")
+
+
+class InvalidateRelationRequest(BaseModel):
+    from_id: str = Field(..., description="Source entity UUID")
+    relation_type: str = Field(..., description="Type of the relation")
+    to_id: str = Field(..., description="Target entity UUID")
+    ended_at: Optional[str] = Field(default=None)
+
+
+class EntityResponse(BaseModel):
+    id: str
+    type: str
+    name: str
+    created_at: int
+    updated_at: int
+    observations: List[str]
+    metadata: Metadata
+
+
+class RelationResponse(BaseModel):
+    to: str
+    type: str
+    created_at: int
+    metadata: Metadata
+
+
+class GraphNodeResponse(BaseModel):
+    entity: EntityResponse
+    relations: Dict[str, List[RelationResponse]]
+
+
+class SearchResponse(BaseModel):
+    entities: List[EntityResponse]
+    total_count: int
+    query: str
+    filters: Metadata

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -3878,3 +3878,50 @@ class SearchResponse(BaseModel):
     total_count: int
     query: str
     filters: Metadata
+
+
+# ai_stack_integration.py schemas (#6042)
+
+
+class RAGQueryRequest(BaseModel):
+    query: str = Field(..., min_length=1, max_length=10000)
+    documents: Optional[List[Metadata]] = None
+    context: Optional[str] = None
+    max_results: int = Field(10, ge=1, le=50)
+
+
+class EnhancedChatRequest(BaseModel):
+    message: str = Field(..., min_length=1, max_length=50000)
+    context: Optional[str] = None
+    chat_history: Optional[List[Metadata]] = None
+    use_knowledge_base: bool = Field(True)
+    response_style: str = Field("conversational")
+
+
+class KnowledgeExtractionRequest(BaseModel):
+    content: str = Field(..., min_length=1)
+    content_type: str = Field("text")
+    extraction_mode: str = Field("comprehensive")
+
+
+class ResearchRequest(BaseModel):
+    query: str = Field(..., min_length=1, max_length=5000)
+    research_depth: str = Field("comprehensive")
+    sources: Optional[List[str]] = None
+    include_web: bool = Field(True)
+
+
+class CodeSearchRequest(BaseModel):
+    query: str = Field(..., min_length=1)
+    search_scope: str = Field("codebase")
+    include_npu: bool = Field(True)
+
+
+class DevelopmentAnalysisRequest(BaseModel):
+    code_path: Optional[str] = None
+    analysis_type: str = Field("comprehensive")
+
+
+class ContentClassificationRequest(BaseModel):
+    content: str = Field(..., min_length=1)
+    classification_types: Optional[List[str]] = None

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -5,13 +5,16 @@
 Knowledge base collection, category, fact, grounding, and audit schemas.
 """
 
+import re
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+from constants.threshold_constants import CategoryDefaults, QueryDefaults
 from type_defs.common import Metadata
+from utils.path_validation import contains_path_traversal
 
 
 # ---------------------------------------------------------------------------
@@ -1059,17 +1062,6 @@ class MemoryRelationInvalidateResponse(BaseModel):
 # ---------------------------------------------------------------------------
 # knowledge_models.py classes (merged from knowledge_models.py — Issue #5996)
 # ---------------------------------------------------------------------------
-
-import re
-from datetime import datetime
-from enum import Enum
-from typing import List, Optional
-
-from pydantic import Field, field_validator
-
-from constants.threshold_constants import CategoryDefaults, QueryDefaults
-from type_defs.common import Metadata
-from utils.path_validation import contains_path_traversal
 
 # Issue #380: Module-level frozenset for tag operations
 _VALID_TAG_OPERATIONS = frozenset({"add", "remove"})
@@ -3925,3 +3917,62 @@ class DevelopmentAnalysisRequest(BaseModel):
 class ContentClassificationRequest(BaseModel):
     content: str = Field(..., min_length=1)
     classification_types: Optional[List[str]] = None
+
+
+# chat_knowledge.py schemas (#6042)
+
+
+class KnowledgeDecision(str, Enum):
+    ADD_TO_KB = "add_to_kb"
+    KEEP_TEMPORARY = "keep_temporary"
+    DELETE = "delete"
+
+
+class FileAssociationType(str, Enum):
+    REFERENCE = "reference"
+    UPLOAD = "upload"
+    GENERATED = "generated"
+    MODIFIED = "modified"
+
+
+class CreateContextRequest(BaseModel):
+    chat_id: str
+    topic: Optional[str] = None
+    keywords: Optional[List[str]] = None
+    user_id: Optional[str] = None
+
+
+class AssociateFileRequest(BaseModel):
+    chat_id: str
+    file_path: str
+    association_type: FileAssociationType
+    metadata: Optional[Metadata] = None
+
+
+class AddKnowledgeRequest(BaseModel):
+    chat_id: str
+    content: str
+    metadata: Optional[Metadata] = None
+
+
+class KnowledgeDecisionRequest(BaseModel):
+    chat_id: str
+    knowledge_id: str
+    decision: KnowledgeDecision
+
+
+class CompileChatRequest(BaseModel):
+    chat_id: str
+    title: Optional[str] = None
+    include_system_messages: bool = False
+
+
+class ChatKnowledgeSearchRequest(BaseModel):
+    query: str
+    chat_id: Optional[str] = None
+    include_temporary: bool = True
+
+
+class MarkFactsPreservedRequest(BaseModel):
+    fact_ids: List[str]
+    preserve: bool = True

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -2244,3 +2244,62 @@ class LogFwdKnownHostsResponse(BaseModel):
 class LogFwdAutoStartResponse(BaseModel):
     auto_start: bool
     message: str
+
+
+# security_assessment.py schemas (#6042)
+
+
+class CreateAssessmentRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=200)
+    target: str = Field(..., min_length=1, description="Target IP, CIDR, or hostname")
+    scope: Optional[list[str]] = Field(None)
+    training_mode: bool = Field(False)
+    metadata: Optional[dict[str, Any]] = None
+
+
+class AdvancePhaseRequest(BaseModel):
+    reason: str = Field("", description="Reason for phase transition")
+    target_phase: Optional[str] = Field(None)
+
+
+class AddHostRequest(BaseModel):
+    ip: str = Field(..., description="Host IP address")
+    hostname: Optional[str] = None
+    status: str = Field("up")
+    metadata: Optional[dict[str, Any]] = None
+
+
+class AddPortRequest(BaseModel):
+    host_ip: str = Field(..., description="Host IP address")
+    port: int = Field(..., ge=1, le=65535)
+    protocol: str = Field("tcp")
+    state: str = Field("open")
+    service: Optional[str] = None
+    version: Optional[str] = None
+
+
+class AddVulnerabilityRequest(BaseModel):
+    host_ip: str = Field(..., description="Affected host IP")
+    cve_id: Optional[str] = None
+    title: str = Field("")
+    severity: str = Field("unknown")
+    description: str = ""
+    affected_service: Optional[str] = None
+    affected_port: Optional[int] = None
+    metadata: Optional[dict[str, Any]] = None
+
+
+class AddFindingRequest(BaseModel):
+    finding_type: str = Field(..., description="Type of finding")
+    description: str = ""
+    data: Optional[dict[str, Any]] = None
+
+
+class ParseToolOutputRequest(BaseModel):
+    output: str = Field(..., min_length=1, description="Raw tool output")
+    tool: Optional[str] = Field(None, description="Tool name (auto-detect if not provided)")
+
+
+class RecoverErrorRequest(BaseModel):
+    target_phase: str = Field(..., description="Phase to recover to")
+    reason: str = Field("Manual recovery")

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -2303,3 +2303,51 @@ class ParseToolOutputRequest(BaseModel):
 class RecoverErrorRequest(BaseModel):
     target_phase: str = Field(..., description="Phase to recover to")
     reason: str = Field("Manual recovery")
+
+
+# security.py schemas (#6042)
+
+
+class CommandApprovalRequest(BaseModel):
+    command_id: str
+    approved: bool
+
+
+class CommandApprovalResponse(BaseModel):
+    success: bool
+    message: str
+
+
+class SecurityStatusResponse(BaseModel):
+    security_enabled: bool
+    command_security_enabled: bool
+    docker_sandbox_enabled: bool
+    pending_approvals: List[Metadata]
+
+
+class URLCheckRequest(BaseModel):
+    url: str = Field(..., description="URL to check for threats")
+
+
+class URLCheckResponse(BaseModel):
+    success: bool
+    url: str
+    overall_score: float
+    threat_level: str
+    virustotal_score: Optional[float] = None
+    urlvoid_score: Optional[float] = None
+    sources_checked: int
+    cached: bool
+    message: Optional[str] = None
+
+
+class ThreatIntelStatusResponse(BaseModel):
+    any_service_configured: bool
+    virustotal: Dict[str, Any]
+    urlvoid: Dict[str, Any]
+    cache_stats: Dict[str, Any]
+
+
+class DomainSecurityStatsResponse(BaseModel):
+    success: bool
+    stats: Dict[str, Any]

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -5,11 +5,15 @@
 System health, cache, NPU worker, wake-word, and feature-flag schemas.
 """
 
-from typing import Any, Dict, List, Optional
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from api.schemas_common import SuccessDataResponse, SuccessMessageResponse
+from constants.threshold_constants import RetryConfig
+from type_defs.common import Metadata
 
 
 # ---------------------------------------------------------------------------
@@ -1084,3 +1088,1159 @@ class PermissionMemoryStatsResponse(BaseModel):
     ttl_seconds: Optional[int] = None
     ttl_days: Optional[int] = None
     error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# permissions.py remaining schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class PermissionModeResponse(BaseModel):
+    mode: str
+    enabled: bool
+    is_admin_only: bool
+    allowed_modes: List[str]
+
+
+class PermissionModeRequest(BaseModel):
+    mode: str = Field(..., description="Permission mode to set")
+
+
+class PermissionRuleResponse(BaseModel):
+    tool: str
+    pattern: str
+    action: str
+    description: str
+
+
+class PermissionRulesResponse(BaseModel):
+    allow: List[PermissionRuleResponse]
+    ask: List[PermissionRuleResponse]
+    deny: List[PermissionRuleResponse]
+
+
+class PermissionAddRuleRequest(BaseModel):
+    tool: str = Field(default="Bash", description="Tool name")
+    pattern: str = Field(..., description="Glob pattern")
+    action: str = Field(..., description="allow, ask, or deny")
+    description: str = Field(default="", description="Rule description")
+
+
+class PermissionRemoveRuleRequest(BaseModel):
+    tool: str = Field(default="Bash", description="Tool name")
+    pattern: str = Field(..., description="Pattern to remove")
+
+
+class ApprovalRecordResponse(BaseModel):
+    pattern: str
+    tool: str
+    risk_level: str
+    user_id: str
+    created_at: float
+    original_command: str
+    comment: Optional[str] = None
+
+
+class ProjectApprovalsResponse(BaseModel):
+    project_path: str
+    approvals: List[ApprovalRecordResponse]
+
+
+class PermissionStatusResponse(BaseModel):
+    enabled: bool
+    mode: str
+    approval_memory_enabled: bool
+    approval_memory_ttl_days: int
+    rules_file: str
+    rules_count: dict
+
+
+class CheckCommandRequest(BaseModel):
+    command: str = Field(..., description="Command to check")
+    tool: str = Field(default="Bash", description="Tool name")
+
+
+class CheckCommandResponse(BaseModel):
+    result: str
+    pattern: Optional[str] = None
+    description: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# vnc_manager.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class VncRunningResponse(BaseModel):
+    running: bool
+
+
+class VncStatusMessageResponse(BaseModel):
+    status: str
+    message: str
+
+
+class VncScreenshotResponse(BaseModel):
+    status: str
+    message: str
+    image_data: str
+
+
+class MacroStopResponse(BaseModel):
+    status: str
+    message: str
+    action_count: int
+
+
+class MacroListResponse(BaseModel):
+    macros: List[Dict[str, Any]]
+
+
+class VncQualityMetricsResponse(BaseModel):
+    vnc_running: bool
+    timestamp: str
+    vnc_port_reachable: Optional[bool] = None
+    latency_ms: Optional[float] = None
+    websockify_running: Optional[bool] = None
+    websockify_processes: Optional[int] = None
+
+
+class VncDesktopContextResponse(BaseModel):
+    system: Dict[str, str]
+    desktop: Dict[str, str]
+    processes: List[Dict[str, str]]
+    timestamp: str
+
+
+class VncOcrResponse(BaseModel):
+    status: str
+    text: str
+    message: str
+
+
+class VncFindImageResponse(BaseModel):
+    status: str
+    found: bool
+    message: str
+    x: Optional[int] = None
+    y: Optional[int] = None
+    confidence: Optional[float] = None
+
+
+class WaitForTextResponse(BaseModel):
+    status: str
+    found: bool
+    message: str
+
+
+class WaitForImageResponse(BaseModel):
+    status: str
+    found: bool
+    message: str
+    x: Optional[int] = None
+    y: Optional[int] = None
+    confidence: Optional[float] = None
+
+
+class RestoreStateResponse(BaseModel):
+    status: str
+    message: str
+    state: Optional[Dict[str, Any]] = None
+
+
+class SessionActionLogResponse(BaseModel):
+    status: str
+    actions: List[Dict[str, Any]]
+    message: str
+
+
+class SessionScreenshotsResponse(BaseModel):
+    status: str
+    screenshots: List[str]
+    message: str
+
+
+class SessionScreenshotSaveResponse(BaseModel):
+    status: str
+    message: str
+    screenshot_path: Optional[str] = None
+
+
+class MouseClickRequest(BaseModel):
+    x: int = Field(..., ge=0, description="X coordinate")
+    y: int = Field(..., ge=0, description="Y coordinate")
+    button: str = Field(default="left", description="Mouse button: left, middle, right")
+
+
+class KeyboardTypeRequest(BaseModel):
+    text: str = Field(..., description="Text to type")
+
+
+class SpecialKeyRequest(BaseModel):
+    key: str = Field(..., description="Special key name (e.g., Return, Escape, ctrl+c)")
+
+
+class MouseScrollRequest(BaseModel):
+    direction: str = Field(..., description="Scroll direction: up or down")
+    amount: int = Field(default=3, ge=1, le=10, description="Scroll amount (1-10)")
+
+
+class MouseDragRequest(BaseModel):
+    x1: int = Field(..., ge=0, description="Start X coordinate")
+    y1: int = Field(..., ge=0, description="Start Y coordinate")
+    x2: int = Field(..., ge=0, description="End X coordinate")
+    y2: int = Field(..., ge=0, description="End Y coordinate")
+
+
+class ClipboardSyncRequest(BaseModel):
+    content: str = Field(..., description="Text content to copy to clipboard")
+
+
+class ConnectionQualitySettings(BaseModel):
+    compression_level: int = Field(
+        default=6, ge=0, le=9, description="Compression level (0=none, 9=max)"
+    )
+    quality: int = Field(
+        default=6, ge=0, le=9, description="JPEG quality (0=poor, 9=best)"
+    )
+    encoding: str = Field(
+        default="tight", description="Encoding method: tight, hextile, raw"
+    )
+
+
+class ConnectionSettings(BaseModel):
+    auto_reconnect: bool = Field(
+        default=True, description="Enable auto-reconnect on disconnect"
+    )
+    reconnect_delay_ms: int = Field(
+        default=3000, ge=1000, le=30000, description="Delay before reconnect"
+    )
+    max_reconnect_attempts: int = Field(
+        default=10, ge=1, le=100, description="Max reconnect attempts"
+    )
+    quality: ConnectionQualitySettings = Field(
+        default_factory=ConnectionQualitySettings
+    )
+
+
+class MacroAction(BaseModel):
+    action_type: str = Field(
+        ..., description="Action type: click, type, key, scroll, drag"
+    )
+    params: Dict = Field(default_factory=dict, description="Action parameters")
+    timestamp: float = Field(..., description="Timestamp when action was recorded")
+
+
+class MacroRecording(BaseModel):
+    name: str = Field(..., description="Macro name")
+    actions: List[MacroAction] = Field(default_factory=list)
+    created_at: str = Field(default_factory=lambda: datetime.now(tz=timezone.utc).isoformat())
+
+
+# ---------------------------------------------------------------------------
+# scheduler.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class SchedulerWorkflowCreateResponse(BaseModel):
+    success: bool
+    workflow_id: str
+    scheduled_workflow: Any
+
+
+class SchedulerWorkflowListResponse(BaseModel):
+    success: bool
+    workflows: List[Any]
+    total: int
+
+
+class SchedulerWorkflowDetailResponse(BaseModel):
+    success: bool
+    workflow: Any
+
+
+class SchedulerRescheduleWorkflowItem(BaseModel):
+    id: str
+    scheduled_time: str
+    priority: str
+    status: str
+    complexity: str
+
+
+class SchedulerRescheduleResponse(BaseModel):
+    success: bool
+    message: str
+    workflow: SchedulerRescheduleWorkflowItem
+
+
+class SchedulerCancelResponse(BaseModel):
+    success: bool
+    message: str
+    workflow_id: str
+
+
+class SchedulerStatusResponse(BaseModel):
+    success: bool
+    scheduler_status: Any
+
+
+class SchedulerQueueWorkflowItem(BaseModel):
+    id: str
+    name: str
+    priority: str
+    complexity: str
+    estimated_duration_minutes: int
+
+
+class SchedulerQueueResponse(BaseModel):
+    success: bool
+    queue_status: Any
+    queued_workflows: List[SchedulerQueueWorkflowItem]
+    running_workflows: List[SchedulerQueueWorkflowItem]
+
+
+class SchedulerQueueControlResponse(BaseModel):
+    success: bool
+    message: str
+    queue_status: Any
+
+
+class SchedulerStartResponse(BaseModel):
+    success: bool
+    message: str
+    status: Any
+
+
+class SchedulerStopResponse(BaseModel):
+    success: bool
+    message: str
+
+
+class SchedulerTemplateWorkflowItem(BaseModel):
+    id: str
+    name: str
+    scheduled_time: str
+    priority: str
+    status: str
+    complexity: str
+
+
+class SchedulerTemplateScheduleResponse(BaseModel):
+    success: bool
+    workflow_id: str
+    template_info: Dict[str, Any]
+    scheduled_workflow: SchedulerTemplateWorkflowItem
+
+
+class SchedulerStatsResponse(BaseModel):
+    success: bool
+    statistics: Dict[str, Any]
+
+
+class SchedulerBatchScheduleResponse(BaseModel):
+    success: bool
+    scheduled_workflows: List[str]
+    errors: List[str]
+    total_scheduled: int
+    total_errors: int
+
+
+class ScheduleWorkflowRequest(BaseModel):
+    user_message: str
+    scheduled_time: Union[str, datetime]
+    priority: str = "normal"
+    complexity: str = "simple"
+    template_id: Optional[str] = None
+    variables: Optional[Metadata] = None
+    auto_approve: bool = False
+    tags: Optional[List[str]] = None
+    dependencies: Optional[List[str]] = None
+    user_id: Optional[str] = None
+    estimated_duration_minutes: int = 30
+    timeout_minutes: int = 120
+    max_retries: int = RetryConfig.DEFAULT_RETRIES
+
+
+class RescheduleRequest(BaseModel):
+    new_scheduled_time: Union[str, datetime]
+    new_priority: Optional[str] = None
+
+
+class QueueControlRequest(BaseModel):
+    action: str
+    value: Optional[int] = None
+
+
+# ---------------------------------------------------------------------------
+# monitoring.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class ServicesSummaryResponse(BaseModel):
+    total_services: int
+    healthy_services: int
+    degraded_services: int
+    critical_services: int
+    overall_status: str
+    health_percentage: float
+    services: List[Dict[str, Any]]
+
+
+class MonitoringActionResponse(BaseModel):
+    status: str
+    message: str
+    collection_interval: Optional[float] = None
+
+
+class CurrentMetricsResponse(BaseModel):
+    timestamp: float
+    metrics: Dict[str, Any]
+    collection_successful: bool
+
+
+class ThresholdUpdateResponse(BaseModel):
+    status: str
+    threshold_key: str
+    new_value: float
+    comparison: str
+    old_value: Optional[float] = None
+
+
+class TestPerformanceResponse(BaseModel):
+    message: str
+    metrics_collected: bool
+    timestamp: float
+
+
+class ClaudeApiDetails(BaseModel):
+    rate_limit_remaining: Optional[float] = None
+    requests_per_minute: Optional[float] = None
+    p95_latency_seconds: Optional[float] = None
+    failure_rate: Optional[float] = None
+
+
+class ClaudeApiStatusResponse(BaseModel):
+    success: bool
+    claude_api_status: ClaudeApiDetails
+    timestamp: str
+
+
+class GitHubApiDetails(BaseModel):
+    rate_limit_remaining: Optional[float] = None
+    total_operations: Optional[float] = None
+    p95_latency_seconds: Optional[float] = None
+
+
+class GitHubStatusResponse(BaseModel):
+    success: bool
+    github_status: GitHubApiDetails
+    timestamp: str
+
+
+class AlertSources(BaseModel):
+    alertmanager: int
+    performance_monitor: int
+
+
+class AlertCheckResponse(BaseModel):
+    timestamp: float
+    alerts: List[Dict[str, Any]]
+    total_count: int
+    critical_count: int
+    warning_count: int
+    high_count: int
+    sources: AlertSources
+
+
+class AlertManagerSeverityCounts(BaseModel):
+    critical: int
+    high: int
+    warning: int
+    info: int
+
+
+class AlertManagerResponse(BaseModel):
+    timestamp: float
+    source: str
+    alertmanager_url: str
+    alerts: List[Dict[str, Any]]
+    total_count: int
+    by_severity: AlertManagerSeverityCounts
+    active_alerts: Dict[str, List[Dict[str, Any]]]
+
+
+class MonitoringStatus(BaseModel):
+    active: bool
+    uptime_seconds: float
+    collection_interval: float
+    hardware_acceleration: Dict[str, bool]
+    metrics_collected: int
+    alerts_count: int
+
+
+class PerformanceAlert(BaseModel):
+    category: str
+    severity: str
+    message: str
+    recommendation: str
+    timestamp: float
+
+
+class OptimizationRecommendation(BaseModel):
+    category: str
+    priority: str
+    recommendation: str
+    action: str
+    expected_improvement: str
+
+
+class MetricsQuery(BaseModel):
+    categories: Optional[List[str]] = Field(
+        None, description="Metric categories to include"
+    )
+    time_range_minutes: int = Field(
+        10, ge=1, le=1440, description="Time range in minutes"
+    )
+    include_trends: bool = Field(True, description="Include trend analysis")
+    include_alerts: bool = Field(True, description="Include recent alerts")
+
+
+class ThresholdUpdate(BaseModel):
+    category: str
+    metric: str
+    threshold: float
+    comparison: str = Field(..., pattern="^(gt|lt|eq)$")
+
+
+# ---------------------------------------------------------------------------
+# vnc_mcp.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class VncMCPTool(BaseModel):
+    """VNC MCP tool definition (uses Metadata for input_schema)."""
+
+    name: str
+    description: str
+    input_schema: Metadata
+
+
+class VNCStatusRequest(BaseModel):
+    vnc_type: str = Field("browser", description="VNC type: 'desktop' or 'browser'")
+
+
+class VNCObservationRequest(BaseModel):
+    vnc_type: str = Field("browser", description="VNC type: 'desktop' or 'browser'")
+    duration_seconds: int = Field(
+        5, description="How many seconds of recent activity to return"
+    )
+
+
+class VncStatusMcpResponse(BaseModel):
+    success: bool
+    vnc_type: str
+    accessible: bool
+    endpoint: Optional[str] = None
+    status_code: Optional[int] = None
+    message: str
+    error: Optional[str] = None
+
+
+class VncObservationMcpResponse(BaseModel):
+    success: bool
+    vnc_type: str
+    duration_seconds: int
+    observation_count: int
+    observations: List[Dict[str, Any]]
+    last_check: Optional[str] = None
+    message: str
+
+
+class BrowserVncContextResponse(BaseModel):
+    success: bool
+    timestamp: str
+    playwright_state: Dict[str, Any]
+    vnc_state: Dict[str, Any]
+
+
+class VncRecordObservationResponse(BaseModel):
+    success: bool
+    recorded: bool
+
+
+class DesktopClickMcpResponse(BaseModel):
+    success: bool
+    message: str
+    action: str
+    coordinates: Dict[str, int]
+    button: str
+
+
+class DesktopKeyboardTypeMcpResponse(BaseModel):
+    success: bool
+    message: str
+    action: str
+    text_length: int
+
+
+class DesktopSpecialKeyMcpResponse(BaseModel):
+    success: bool
+    message: str
+    action: str
+    key: str
+
+
+class DesktopScreenshotMcpResponse(BaseModel):
+    success: bool
+    message: str
+    action: str
+    image_data: Optional[str] = None
+    format: Optional[str] = None
+
+
+class DesktopObserveStateMcpResponse(BaseModel):
+    success: bool
+    action: str
+    timestamp: str
+    resolution: Optional[str] = None
+    active_window: Optional[str] = None
+    screenshot: Optional[str] = None
+    screenshot_format: Optional[str] = None
+
+
+class DesktopMouseClickRequest(BaseModel):
+    x: int = Field(..., ge=0)
+    y: int = Field(..., ge=0)
+    button: str = Field(default="left")
+
+
+class DesktopKeyboardTypeRequest(BaseModel):
+    text: str
+
+
+class DesktopSpecialKeyRequest(BaseModel):
+    key: str
+
+
+class DesktopObserveStateRequest(BaseModel):
+    include_screenshot: bool = Field(default=True)
+
+
+# ---------------------------------------------------------------------------
+# cache_management.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class CacheStatsResponse(BaseModel):
+    status: str
+    total_cache_keys: Optional[int] = None
+    total_hits: Optional[int] = None
+    total_misses: Optional[int] = None
+    global_hit_rate: Optional[str] = None
+    memory_usage: Optional[str] = None
+    configured_data_types: Optional[List[str]] = None
+    data_type_stats: Optional[Dict[str, Dict]] = None
+
+
+class CacheWarmingRequest(BaseModel):
+    data_types: List[str]
+    force_refresh: bool = False
+
+
+class RedisDbInfo(BaseModel):
+    database: int
+    key_count: int
+    memory_usage: str
+    connected: bool
+    error: Optional[str] = None
+
+
+class RedisClearEntry(BaseModel):
+    name: str
+    database: int
+    keys_cleared: int
+    error: Optional[str] = None
+
+
+class RedisStatsResponse(BaseModel):
+    status: str
+    stats: Dict[str, Any]
+
+
+class RedisClearResponse(BaseModel):
+    status: str
+    message: str
+    cleared_databases: List[Dict[str, Any]]
+
+
+class CacheClearTypeResponse(BaseModel):
+    status: str
+    message: str
+    cache_type: str
+
+
+class CacheConfigResponse(BaseModel):
+    status: str
+    message: Optional[str] = None
+    config: Dict[str, Any]
+    source: Optional[str] = None
+
+
+class CacheWarmupResponse(BaseModel):
+    status: str
+    message: str
+    warmed_caches: List[Dict[str, Any]]
+
+
+class WarmCacheResponse(BaseModel):
+    success: bool
+    warmed_types: List[str]
+    failed_types: List[str]
+    total_warmed: int
+
+
+class InvalidateCacheResponse(BaseModel):
+    success: bool
+    data_type: str
+    key_pattern: str
+    user_id: Optional[str] = None
+    deleted_count: int
+
+
+class ClearAllResponse(BaseModel):
+    success: bool
+    message: str
+    total_deleted: int
+
+
+class CacheHealthResponse(BaseModel):
+    status: str
+    redis_status: Optional[str] = None
+    total_keys: Optional[int] = None
+    memory_usage: Optional[str] = None
+    global_hit_rate: Optional[str] = None
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# browser_mcp.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class BrowserNavigateRequest(BaseModel):
+    url: str = Field(..., description="URL to navigate to")
+    wait_until: Optional[str] = Field(
+        "load", description="Wait condition: 'load', 'domcontentloaded', 'networkidle'"
+    )
+    timeout: Optional[int] = Field(30000, description="Timeout in milliseconds")
+
+
+class BrowserClickRequest(BaseModel):
+    selector: str = Field(..., description="CSS selector for element to click")
+    timeout: Optional[int] = Field(5000, description="Timeout in milliseconds")
+
+
+class BrowserFillRequest(BaseModel):
+    selector: str = Field(..., description="CSS selector for input field")
+    value: str = Field(..., description="Value to fill")
+    timeout: Optional[int] = Field(5000, description="Timeout in milliseconds")
+
+
+class BrowserScreenshotRequest(BaseModel):
+    selector: Optional[str] = Field(
+        None, description="CSS selector for element (full page if omitted)"
+    )
+    full_page: Optional[bool] = Field(False, description="Capture full scrollable page")
+
+
+class BrowserEvaluateRequest(BaseModel):
+    script: str = Field(..., description="JavaScript code to execute")
+
+
+class BrowserWaitForSelectorRequest(BaseModel):
+    selector: str = Field(..., description="CSS selector to wait for")
+    timeout: Optional[int] = Field(30000, description="Timeout in milliseconds")
+    state: Optional[str] = Field(
+        "visible", description="State: 'attached', 'detached', 'visible', 'hidden'"
+    )
+
+
+class BrowserGetTextRequest(BaseModel):
+    selector: str = Field(..., description="CSS selector for element")
+
+
+class BrowserGetAttributeRequest(BaseModel):
+    selector: str = Field(..., description="CSS selector for element")
+    attribute: str = Field(..., description="Attribute name to retrieve")
+
+
+class BrowserSelectRequest(BaseModel):
+    selector: str = Field(..., description="CSS selector for select element")
+    value: str = Field(..., description="Value to select")
+
+
+class BrowserHoverRequest(BaseModel):
+    selector: str = Field(..., description="CSS selector for element to hover")
+
+
+class BrowserNavigateResponse(BaseModel):
+    success: bool
+    action: str
+    url: str
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserClickResponse(BaseModel):
+    success: bool
+    action: str
+    selector: str
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserFillResponse(BaseModel):
+    success: bool
+    action: str
+    selector: str
+    value_length: int
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserScreenshotResponse(BaseModel):
+    success: bool
+    action: str
+    selector: Optional[str] = None
+    full_page: Optional[bool] = None
+    base64_image: Optional[str] = None
+    mime_type: str
+    timestamp: str
+
+
+class BrowserEvaluateResponse(BaseModel):
+    success: bool
+    action: str
+    script_preview: str
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserWaitForSelectorResponse(BaseModel):
+    success: bool
+    action: str
+    selector: str
+    state: Optional[str] = None
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserGetTextResponse(BaseModel):
+    success: bool
+    action: str
+    selector: str
+    text: Optional[str] = None
+    timestamp: str
+
+
+class BrowserGetAttributeResponse(BaseModel):
+    success: bool
+    action: str
+    selector: str
+    attribute: str
+    value: Optional[str] = None
+    timestamp: str
+
+
+class BrowserSelectResponse(BaseModel):
+    success: bool
+    action: str
+    selector: str
+    value: str
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserHoverResponse(BaseModel):
+    success: bool
+    action: str
+    selector: str
+    result: Optional[Any] = None
+    timestamp: str
+
+
+class BrowserMcpStatusResponse(BaseModel):
+    success: bool
+    bridge: str
+    browser_vm: Dict[str, str]
+    security: Dict[str, Any]
+    rate_limit_status: Dict[str, Any]
+    tools_available: int
+    timestamp: str
+
+
+# ---------------------------------------------------------------------------
+# settings.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class SaveSettingsResponse(BaseModel):
+    status: Optional[str] = None
+    message: Optional[str] = None
+    success: Optional[bool] = None
+
+
+class ClearCacheResponse(BaseModel):
+    status: str
+    message: str
+    available_endpoints: Optional[dict] = None
+
+
+class SettingsTaskQueuedResponse(BaseModel):
+    task_id: str
+    status: str
+    message: str
+    dry_run: Optional[bool] = None
+
+
+class SettingsTaskStatusResponse(BaseModel):
+    task_id: str
+    status: str
+    message: Optional[str] = None
+    progress: Optional[Any] = None
+    result: Optional[Any] = None
+    error: Optional[str] = None
+
+
+class RBACStatusResponse(BaseModel):
+    initialized: bool
+    message: str
+
+
+class WorkerStatusResponse(BaseModel):
+    available: bool
+    message: str
+
+
+class UpdateStatusResponse(BaseModel):
+    last_update: Optional[str] = None
+    marker_exists: bool
+    message: str
+
+
+class RBACInitRequest(BaseModel):
+    create_admin: bool = False
+    admin_username: str = "admin"
+
+    @classmethod
+    def validate_admin_username(cls, v: str) -> str:
+        if len(v) < 3 or len(v) > 32:
+            raise ValueError("Username must be 3-32 characters")
+        if not re.match(r"^[a-zA-Z][a-zA-Z0-9_]*$", v):
+            raise ValueError(
+                "Username must start with a letter and contain only letters, numbers, and underscores"
+            )
+        return v
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        if self.create_admin:
+            self.admin_username = self.validate_admin_username(self.admin_username)
+
+
+class SystemUpdateRequest(BaseModel):
+    update_type: str = "dependencies"
+    target_groups: Optional[list] = None
+    dry_run: bool = False
+    force_update: bool = False
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        if self.update_type not in ("dependencies", "system"):
+            raise ValueError("update_type must be 'dependencies' or 'system'")
+
+
+class ConfigSyncRequest(BaseModel):
+    settings: dict
+
+
+class ConfigSyncResponse(BaseModel):
+    status: str
+    changed: dict
+    unchanged_keys: int
+
+
+_VALID_HARDWARE_TYPES = frozenset({"npu", "gpu", "cpu"})
+
+
+class HardwarePriorityRequest(BaseModel):
+    priority_order: List[str]
+
+    def model_post_init(self, __context) -> None:  # noqa: ANN001
+        given = set(self.priority_order)
+        if given != _VALID_HARDWARE_TYPES or len(self.priority_order) != 3:
+            raise ValueError(
+                f"priority_order must be a permutation of {sorted(_VALID_HARDWARE_TYPES)}, "
+                f"got {self.priority_order}"
+            )
+
+
+class HardwarePriorityResponse(BaseModel):
+    status: str
+    priority_order: List[str]
+    changed: dict
+
+
+# ---------------------------------------------------------------------------
+# log_forwarding.py remaining schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class LogFwdDestinationCreate(BaseModel):
+    name: str = Field(..., description="Unique name for the destination")
+    type: str = Field(
+        ...,
+        description="Destination type: seq, elasticsearch, loki, syslog, webhook, file",
+    )
+    enabled: bool = Field(True, description="Whether the destination is enabled")
+    url: Optional[str] = Field(None, description="URL/host for the destination")
+    api_key: Optional[str] = Field(None, description="API key for authentication")
+    username: Optional[str] = Field(None, description="Username for authentication")
+    password: Optional[str] = Field(None, description="Password for authentication")
+    index: Optional[str] = Field(
+        "autobot-logs", description="Index name (Elasticsearch)"
+    )
+    file_path: Optional[str] = Field(None, description="File path (file destination)")
+    min_level: str = Field("Information", description="Minimum log level to forward")
+    batch_size: int = Field(10, ge=1, le=1000, description="Batch size for sending")
+    batch_timeout: float = Field(
+        5.0, ge=0.1, le=60.0, description="Batch timeout in seconds"
+    )
+    retry_count: int = Field(3, ge=0, le=10, description="Number of retries on failure")
+    retry_delay: float = Field(
+        1.0, ge=0.1, le=30.0, description="Delay between retries"
+    )
+    scope: str = Field("global", description="Scope: global (all hosts) or per_host")
+    target_hosts: List[str] = Field(
+        default_factory=list, description="Target hosts for per_host scope"
+    )
+    syslog_protocol: str = Field(
+        "udp", description="Syslog protocol: udp, tcp, tcp_tls"
+    )
+    ssl_verify: bool = Field(True, description="Verify SSL certificates for TLS")
+    ssl_ca_cert: Optional[str] = Field(None, description="Path to CA certificate")
+    ssl_client_cert: Optional[str] = Field(
+        None, description="Path to client certificate"
+    )
+    ssl_client_key: Optional[str] = Field(None, description="Path to client key")
+
+
+class LogFwdDestinationUpdate(BaseModel):
+    enabled: Optional[bool] = None
+    url: Optional[str] = None
+    api_key: Optional[str] = None
+    username: Optional[str] = None
+    password: Optional[str] = None
+    index: Optional[str] = None
+    file_path: Optional[str] = None
+    min_level: Optional[str] = None
+    batch_size: Optional[int] = None
+    batch_timeout: Optional[float] = None
+    retry_count: Optional[int] = None
+    retry_delay: Optional[float] = None
+    scope: Optional[str] = None
+    target_hosts: Optional[List[str]] = None
+    syslog_protocol: Optional[str] = None
+    ssl_verify: Optional[bool] = None
+    ssl_ca_cert: Optional[str] = None
+    ssl_client_cert: Optional[str] = None
+    ssl_client_key: Optional[str] = None
+
+
+class LogFwdDestinationResponse(BaseModel):
+    name: str
+    type: str
+    enabled: bool
+    url: Optional[str]
+    index: Optional[str]
+    file_path: Optional[str]
+    min_level: str
+    batch_size: int
+    batch_timeout: float
+    scope: str
+    target_hosts: List[str]
+    syslog_protocol: str
+    ssl_verify: bool
+    healthy: bool
+    last_error: Optional[str]
+    sent_count: int
+    failed_count: int
+
+
+class LogFwdMessageResponse(BaseModel):
+    message: str
+
+
+class LogFwdCreateUpdateResponse(BaseModel):
+    message: str
+    destination: Dict[str, Any]
+
+
+class LogFwdTestResponse(BaseModel):
+    name: str
+    healthy: bool
+    last_error: Optional[str] = None
+    message: str
+
+
+class LogFwdTestAllResponse(BaseModel):
+    results: Dict[str, Any]
+    total: int
+    healthy: int
+    unhealthy: int
+
+
+class LogFwdDestinationStatusItem(BaseModel):
+    name: str
+    type: str
+    enabled: bool
+    healthy: bool
+    last_error: Optional[str] = None
+    sent_count: int
+    failed_count: int
+    scope: str
+
+
+class LogFwdStatusResponse(BaseModel):
+    running: bool
+    hostname: str
+    queue_size: int
+    destinations: List[LogFwdDestinationStatusItem]
+    total_destinations: int
+    enabled_destinations: int
+    healthy_destinations: int
+    total_sent: int
+    total_failed: int
+
+
+class LogFwdDestinationTypesResponse(BaseModel):
+    types: List[Any]
+    scopes: List[Any]
+    log_levels: List[str]
+    syslog_protocols: List[Any]
+
+
+class LogFwdKnownHostItem(BaseModel):
+    hostname: str
+    ip: Optional[str] = None
+    description: str
+
+
+class LogFwdKnownHostsResponse(BaseModel):
+    hosts: List[LogFwdKnownHostItem]
+    current_hostname: str
+
+
+class LogFwdAutoStartResponse(BaseModel):
+    auto_start: bool
+    message: str

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -5,11 +5,15 @@
 Workflow, registry, RUM, elevation, advanced-control, state-tracking, and validation schemas.
 """
 
+import re
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 
 from api.schemas_common import SuccessMessageResponse
+from autobot_shared.models.service_message import ServiceMessage
+from autobot_shared.time_utils import now_utc
+from type_defs.common import Metadata
 
 
 # ---------------------------------------------------------------------------
@@ -841,15 +845,6 @@ class AdvancedControlHealthResponse(BaseModel):
     paused_tasks: int
 
 
-class AdvancedControlInfoResponse(BaseModel):
-    """Response for GET / — advanced control capabilities info."""
-
-    name: str
-    version: str
-    features: List[str]
-    endpoints: Any
-
-
 # ---------------------------------------------------------------------------
 # long_running_operations.py schemas  (Issue #5989)
 # ---------------------------------------------------------------------------
@@ -1245,3 +1240,269 @@ class MarketplacePluginActionResponse(BaseModel):
 
     status: str
     plugin: str
+
+
+# ---------------------------------------------------------------------------
+# workflow.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class WorkflowApprovalRequest(BaseModel):
+    workflow_id: str
+    step_id: str
+    step_description: str
+    required_action: str
+    context: Metadata
+    timeout_seconds: int = 300
+
+
+class WorkflowApprovalResponse(BaseModel):
+    workflow_id: str
+    step_id: str
+    approved: bool
+    user_input: Optional[Metadata] = None
+    timestamp: float
+
+
+class WorkflowStatusUpdate(BaseModel):
+    workflow_id: str
+    step_id: str
+    status: str
+    progress: float
+    message: str
+    timestamp: float
+
+
+class WorkflowExecutionRequest(BaseModel):
+    user_message: str
+    workflow_id: Optional[str] = None
+    auto_approve: bool = False
+
+
+class WorkflowSummary(BaseModel):
+    """Summary of a single workflow as returned by list/detail endpoints."""
+
+    workflow_id: str
+    user_message: str
+    classification: str
+    status: str
+    total_steps: int
+    current_step: int
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+
+
+class WorkflowListResponse(BaseModel):
+    """Response shape for GET /workflows."""
+
+    success: bool
+    active_workflows: int
+    workflows: list[WorkflowSummary]
+
+
+class WorkflowDetailResponse(BaseModel):
+    """Response shape for GET /workflow/{workflow_id}."""
+
+    success: bool
+    workflow: Metadata
+
+
+class WorkflowStatusResponse(BaseModel):
+    """Response shape for GET /workflow/{workflow_id}/status."""
+
+    success: bool
+    workflow_id: str
+    status: str
+    current_step: int
+    total_steps: int
+    progress: float
+    current_step_info: Optional[Metadata] = None
+    estimated_remaining: Optional[str] = None
+
+
+class WorkflowApproveResponse(BaseModel):
+    """Response shape for POST /workflow/{workflow_id}/approve."""
+
+    success: bool
+    message: str
+    next_action: str
+
+
+class WorkflowCancelResponse(BaseModel):
+    """Response shape for DELETE /workflow/{workflow_id}."""
+
+    success: bool
+    message: str
+
+
+class PendingApprovalStep(BaseModel):
+    """A single step awaiting user approval."""
+
+    step_id: str
+    description: str
+    agent_type: str
+    action: str
+    context: Metadata
+
+
+class WorkflowPendingApprovalsResponse(BaseModel):
+    """Response shape for GET /workflow/{workflow_id}/pending_approvals."""
+
+    success: bool
+    workflow_id: str
+    pending_approvals: list[PendingApprovalStep]
+
+
+class WorkflowExecutionResponse(BaseModel):
+    """Response shape for POST /execute (covers both simple and complex paths)."""
+
+    success: bool
+    type: str
+    result: Optional[str] = None
+    routing_method: Optional[str] = None
+    workflow_id: Optional[str] = None
+    execution_started: Optional[bool] = None
+    status_endpoint: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# workflow_export.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class ShareWorkflowRequest(BaseModel):
+    """Request body for creating a workflow share (#2165)."""
+
+    workflow_id: str = Field(..., description="ID of the workflow to share.")
+    target_user_id: Optional[str] = Field(
+        default=None,
+        description="Share with a specific user.  Mutually optional with public.",
+    )
+    public: bool = Field(default=False, description="Make the share publicly accessible.")
+
+
+class ImportWorkflowRequest(BaseModel):
+    """Request body for importing a workflow from an export document (#2165)."""
+
+    export_document: dict = Field(
+        ...,
+        description="WorkflowExportFormat.to_dict() payload produced by the export endpoint.",
+    )
+    session_id: Optional[str] = Field(
+        default=None, description="Session to associate with the imported workflow."
+    )
+
+
+class CloneWorkflowRequest(BaseModel):
+    """Request body for cloning a shared workflow (#2165)."""
+
+    session_id: Optional[str] = Field(
+        default=None, description="Session to associate with the cloned workflow."
+    )
+
+
+# ---------------------------------------------------------------------------
+# workflow_permissions.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class GrantPermissionRequest(BaseModel):
+    """Request body for granting or updating a workflow role."""
+
+    user_id: str = Field(..., description="User receiving the role")
+    role: str = Field(..., description="owner | editor | runner | viewer")
+
+
+class WorkflowPermissionResponse(BaseModel):
+    """Serialised workflow permission entry."""
+
+    workflow_id: str
+    user_id: str
+    role: str
+    granted_by: Optional[str]
+    created_at: str
+    updated_at: str
+
+
+class WorkflowAuditLogEntry(BaseModel):
+    """Serialised workflow audit log entry."""
+
+    id: str
+    timestamp: str
+    user_id: str
+    workflow_id: str
+    action: str
+    details: Optional[dict]
+
+
+# ---------------------------------------------------------------------------
+# workflow_secrets.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+_WORKFLOW_SECRET_NAME_RE = re.compile(r"^[a-zA-Z0-9_\-\.]+$")
+
+
+def _validate_workflow_secret_name(name: str) -> str:
+    """Reject names containing characters outside the safe set. Issue #2153."""
+    if not _WORKFLOW_SECRET_NAME_RE.match(name):
+        raise ValueError(
+            "Secret name must contain only alphanumeric characters, "
+            "underscores, hyphens, and dots"
+        )
+    return name
+
+
+class WorkflowSecretCreateRequest(BaseModel):
+    """Request body for creating a workflow secret. Issue #2303: owner_id derived from auth."""
+
+    name: str = Field(..., min_length=1, max_length=256)
+    value: str = Field(..., min_length=1, max_length=65536)
+    secret_type: str = Field(default="api_key", max_length=50)
+    workflow_id: Optional[str] = Field(default=None, max_length=128)
+    description: Optional[str] = Field(default=None, max_length=1024)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Reject unsafe characters in the secret name."""
+        return _validate_workflow_secret_name(v)
+
+
+class WorkflowSecretUpdateRequest(BaseModel):
+    """Request body for updating a workflow secret's value. Issue #2303: owner_id from auth."""
+
+    value: str = Field(..., min_length=1, max_length=65536)
+
+
+class WorkflowSecretMetadata(BaseModel):
+    """Safe metadata response — no value field. Issue #2153."""
+
+    id: str
+    name: str
+    secret_type: str
+    scope: str
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    description: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# workflow_state.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class WorkflowState(BaseModel):
+    """Persistent workflow state with explicit routing."""
+
+    workflow_id: str
+    goal: str
+    current_step: str = "planning"
+    active_service: str = "main-backend"
+    steps_completed: List[str] = Field(default_factory=list)
+    steps_remaining: List[Dict] = Field(default_factory=list)
+    mailbox: List[ServiceMessage] = Field(default_factory=list)
+    done: bool = False
+    errors: List[str] = Field(default_factory=list)
+    created_at: str = Field(default_factory=lambda: now_utc().isoformat())
+    updated_at: str = Field(default_factory=lambda: now_utc().isoformat())
+    metadata: Dict = Field(default_factory=dict)

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -6,6 +6,7 @@ Workflow, registry, RUM, elevation, advanced-control, state-tracking, and valida
 """
 
 import re
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
@@ -13,6 +14,7 @@ from pydantic import BaseModel, Field, field_validator
 from api.schemas_common import SuccessMessageResponse
 from autobot_shared.models.service_message import ServiceMessage
 from autobot_shared.time_utils import now_utc
+from models.approval import ApprovalType
 from type_defs.common import Metadata
 
 
@@ -1506,3 +1508,96 @@ class WorkflowState(BaseModel):
     created_at: str = Field(default_factory=lambda: now_utc().isoformat())
     updated_at: str = Field(default_factory=lambda: now_utc().isoformat())
     metadata: Dict = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# approval_gates.py schemas (#6042)
+# ---------------------------------------------------------------------------
+
+
+class AuthorTypeEnum(str, Enum):
+    """Valid author types for approval comments."""
+
+    HUMAN = "human"
+    AGENT = "agent"
+    SYSTEM = "system"
+
+
+class CreateApprovalRequest(BaseModel):
+    """Request body for creating an approval gate."""
+
+    title: str
+    approval_type: ApprovalType
+    description: Optional[str] = None
+    requested_by_agent: Optional[str] = None
+    workflow_id: Optional[str] = None
+    workflow_step: Optional[str] = None
+    context: Optional[Dict[str, Any]] = None
+    task_ids: Optional[List[str]] = None
+
+
+class ApprovalTransitionRequest(BaseModel):
+    """Request body for approve / reject / request-revision."""
+
+    comment: Optional[str] = None
+
+
+class ApprovalResubmitRequest(BaseModel):
+    """Request body for resubmitting after revision."""
+
+    description: Optional[str] = None
+    context: Optional[Dict[str, Any]] = None
+
+
+class ApprovalAddCommentRequest(BaseModel):
+    """Request body for adding a comment to an approval gate."""
+
+    body: str
+    author_type: AuthorTypeEnum = AuthorTypeEnum.HUMAN
+
+
+class ApprovalLinkTaskRequest(BaseModel):
+    """Request body for linking a task to an approval gate."""
+
+    task_id: str
+    task_type: str = "github_issue"
+
+
+class TaskApprovalLinkResponse(BaseModel):
+    """Response for a task-approval link."""
+
+    id: str
+    approval_id: str
+    task_id: str
+    task_type: str
+
+
+class ApprovalCommentResponse(BaseModel):
+    """Response for an approval gate comment."""
+
+    id: str
+    approval_id: str
+    author: str
+    author_type: str
+    body: str
+    created_at: Optional[str] = None
+
+
+class ApprovalGateResponse(BaseModel):
+    """Response for an approval gate."""
+
+    id: str
+    title: str
+    description: Optional[str] = None
+    approval_type: str
+    status: str
+    requested_by_agent: Optional[str] = None
+    decided_by_user: Optional[str] = None
+    workflow_id: Optional[str] = None
+    workflow_step: Optional[str] = None
+    context: Optional[Dict[str, Any]] = None
+    decided_at: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    comments: List[ApprovalCommentResponse] = Field(default_factory=list)
+    task_links: List[TaskApprovalLinkResponse] = Field(default_factory=list)

--- a/autobot-backend/api/security.py
+++ b/autobot-backend/api/security.py
@@ -12,39 +12,30 @@ Includes:
 """
 
 import logging
-from typing import Any, Dict, List, Optional
 
 import aiofiles
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, Field
+from api.schemas_system import (
+    CommandApprovalRequest,
+    CommandApprovalResponse,
+    DomainSecurityStatsResponse,
+    SecurityStatusResponse,
+    ThreatIntelStatusResponse,
+    URLCheckRequest,
+    URLCheckResponse,
+)
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from enhanced_security_layer import EnhancedSecurityLayer
 from security.domain_security import get_domain_security_manager
 from security.threat_intelligence import ThreatLevel, get_threat_intelligence_service
-from type_defs.common import Metadata
 from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter(dependencies=[Depends(check_admin_permission)])
 
 
-class CommandApprovalRequest(BaseModel):
-    command_id: str
-    approved: bool
-
-
-class CommandApprovalResponse(BaseModel):
-    success: bool
-    message: str
-
-
-class SecurityStatusResponse(BaseModel):
-    security_enabled: bool
-    command_security_enabled: bool
-    docker_sandbox_enabled: bool
-    pending_approvals: List[Metadata]
 
 
 @with_error_handling(
@@ -249,42 +240,6 @@ async def get_audit_log(request: Request, limit: int = 100):
 # ============================================================================
 # THREAT INTELLIGENCE ENDPOINTS (Issue #67)
 # ============================================================================
-
-
-class URLCheckRequest(BaseModel):
-    """Request model for URL reputation check."""
-
-    url: str = Field(..., description="URL to check for threats")
-
-
-class URLCheckResponse(BaseModel):
-    """Response model for URL reputation check."""
-
-    success: bool
-    url: str
-    overall_score: float
-    threat_level: str
-    virustotal_score: Optional[float] = None
-    urlvoid_score: Optional[float] = None
-    sources_checked: int
-    cached: bool
-    message: Optional[str] = None
-
-
-class ThreatIntelStatusResponse(BaseModel):
-    """Response model for threat intelligence service status."""
-
-    any_service_configured: bool
-    virustotal: Dict[str, Any]
-    urlvoid: Dict[str, Any]
-    cache_stats: Dict[str, Any]
-
-
-class DomainSecurityStatsResponse(BaseModel):
-    """Response model for domain security statistics."""
-
-    success: bool
-    stats: Dict[str, Any]
 
 
 @with_error_handling(

--- a/autobot-backend/api/security_assessment.py
+++ b/autobot-backend/api/security_assessment.py
@@ -10,11 +10,20 @@ Issue: #260
 """
 
 import logging
-from typing import Any, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from api.schemas_system import (
+    AddFindingRequest,
+    AddHostRequest,
+    AddPortRequest,
+    AddVulnerabilityRequest,
+    AdvancePhaseRequest,
+    CreateAssessmentRequest,
+    ParseToolOutputRequest,
+    RecoverErrorRequest,
+)
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -30,88 +39,11 @@ from services.security_workflow_manager import (
 
 # Issue #756: Consolidated from src/utils/request_utils.py
 from utils.request_utils import generate_request_id
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/security", tags=["security"])
-
-
-# Pydantic models for request/response validation
-class CreateAssessmentRequest(BaseModel):
-    """Request to create a new security assessment."""
-
-    name: str = Field(..., min_length=1, max_length=200)
-    target: str = Field(..., min_length=1, description="Target IP, CIDR, or hostname")
-    scope: Optional[list[str]] = Field(None, description="In-scope targets")
-    training_mode: bool = Field(False, description="Enable exploitation phase")
-    metadata: Optional[dict[str, Any]] = None
-
-
-class AdvancePhaseRequest(BaseModel):
-    """Request to advance to the next phase."""
-
-    reason: str = Field("", description="Reason for phase transition")
-    target_phase: Optional[str] = Field(
-        None, description="Specific phase to transition to"
-    )
-
-
-class AddHostRequest(BaseModel):
-    """Request to add a host to the assessment."""
-
-    ip: str = Field(..., description="Host IP address")
-    hostname: Optional[str] = None
-    status: str = Field("up", description="Host status (up/down/unknown)")
-    metadata: Optional[dict[str, Any]] = None
-
-
-class AddPortRequest(BaseModel):
-    """Request to add a port to a host."""
-
-    host_ip: str = Field(..., description="Host IP address")
-    port: int = Field(..., ge=1, le=65535)
-    protocol: str = Field("tcp", description="Protocol (tcp/udp)")
-    state: str = Field("open", description="Port state")
-    service: Optional[str] = None
-    version: Optional[str] = None
-
-
-class AddVulnerabilityRequest(BaseModel):
-    """Request to add a vulnerability."""
-
-    host_ip: str = Field(..., description="Affected host IP")
-    cve_id: Optional[str] = None
-    title: str = Field("", description="Vulnerability title")
-    severity: str = Field("unknown", description="Severity level")
-    description: str = ""
-    affected_service: Optional[str] = None
-    affected_port: Optional[int] = None
-    metadata: Optional[dict[str, Any]] = None
-
-
-class AddFindingRequest(BaseModel):
-    """Request to add a general finding."""
-
-    finding_type: str = Field(..., description="Type of finding")
-    description: str = ""
-    data: Optional[dict[str, Any]] = None
-
-
-class ParseToolOutputRequest(BaseModel):
-    """Request to parse tool output."""
-
-    output: str = Field(..., min_length=1, description="Raw tool output")
-    tool: Optional[str] = Field(
-        None, description="Tool name (auto-detect if not provided)"
-    )
-
-
-class RecoverErrorRequest(BaseModel):
-    """Request to recover from error state."""
-
-    target_phase: str = Field(..., description="Phase to recover to")
-    reason: str = Field("Manual recovery", description="Recovery reason")
 
 
 # Dependency injection

--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -9,13 +9,26 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any
 
 import aiofiles
 from celery.result import AsyncResult
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
+from api.schemas_system import (
+    ClearCacheResponse,
+    ConfigSyncRequest,
+    ConfigSyncResponse,
+    HardwarePriorityRequest,
+    HardwarePriorityResponse,
+    RBACInitRequest,
+    RBACStatusResponse,
+    SettingsTaskQueuedResponse,
+    SettingsTaskStatusResponse,
+    SystemUpdateRequest,
+    UpdateStatusResponse,
+    WorkerStatusResponse,
+)
 
 from api.user_management.dependencies import get_db_session
 from auth_middleware import check_admin_permission
@@ -35,92 +48,9 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-# Issue #687: RBAC initialization request model
-import re
-
 # Issue #687: RBAC marker path constant
 RBAC_MARKER_PATH = Path("/etc/autobot/rbac-initialized")
 
-
-class SaveSettingsResponse(BaseModel):
-    """Response for save settings endpoints — passes through ConfigService result dict."""
-
-    status: Optional[str] = None
-    message: Optional[str] = None
-    success: Optional[bool] = None
-
-
-class ClearCacheResponse(BaseModel):
-    """Response for POST /clear-cache."""
-
-    status: str
-    message: str
-    available_endpoints: Optional[dict] = None
-
-
-class TaskQueuedResponse(BaseModel):
-    """Response when a Celery task is queued."""
-
-    task_id: str
-    status: str
-    message: str
-    dry_run: Optional[bool] = None
-
-
-class TaskStatusResponse(BaseModel):
-    """Response for Celery task status polling."""
-
-    task_id: str
-    status: str
-    message: Optional[str] = None
-    progress: Optional[Any] = None
-    result: Optional[Any] = None
-    error: Optional[str] = None
-
-
-class RBACStatusResponse(BaseModel):
-    """Response for GET /rbac/status."""
-
-    initialized: bool
-    message: str
-
-
-class WorkerStatusResponse(BaseModel):
-    """Response for GET /updates/worker-status."""
-
-    available: bool
-    message: str
-
-
-class UpdateStatusResponse(BaseModel):
-    """Response for GET /updates/status."""
-
-    last_update: Optional[str] = None
-    marker_exists: bool
-    message: str
-
-
-class RBACInitRequest(BaseModel):
-    """Request model for RBAC initialization."""
-
-    create_admin: bool = False
-    admin_username: str = "admin"
-
-    @classmethod
-    def validate_admin_username(cls, v: str) -> str:
-        """Validate admin username format."""
-        if len(v) < 3 or len(v) > 32:
-            raise ValueError("Username must be 3-32 characters")
-        if not re.match(r"^[a-zA-Z][a-zA-Z0-9_]*$", v):
-            raise ValueError(
-                "Username must start with a letter and contain only letters, numbers, and underscores"
-            )
-        return v
-
-    def __init__(self, **data):
-        super().__init__(**data)
-        if self.create_admin:
-            self.admin_username = self.validate_admin_username(self.admin_username)
 
 
 @with_error_handling(
@@ -414,7 +344,7 @@ async def clear_cache():
     operation="initialize_rbac_endpoint",
     error_code_prefix="SETTINGS",
 )
-@router.post("/rbac/initialize", response_model=TaskQueuedResponse)
+@router.post("/rbac/initialize", response_model=SettingsTaskQueuedResponse)
 async def initialize_rbac_endpoint(
     request: RBACInitRequest,
     _: None = Depends(check_admin_permission),
@@ -468,7 +398,7 @@ async def initialize_rbac_endpoint(
     operation="get_rbac_task_status",
     error_code_prefix="SETTINGS",
 )
-@router.get("/rbac/status/{task_id}", response_model=TaskStatusResponse)
+@router.get("/rbac/status/{task_id}", response_model=SettingsTaskStatusResponse)
 async def get_rbac_task_status(
     task_id: str,
     _: None = Depends(check_admin_permission),
@@ -557,19 +487,6 @@ async def get_rbac_status(
 UPDATES_MARKER_PATH = Path("/etc/autobot/last-update")
 
 
-class SystemUpdateRequest(BaseModel):
-    """Request model for system updates (Issue #544)."""
-
-    update_type: str = "dependencies"  # 'dependencies' or 'system'
-    target_groups: Optional[list] = None  # Host groups to update (None = all)
-    dry_run: bool = False  # Preview mode
-    force_update: bool = False  # Skip version checks
-
-    def __init__(self, **data):
-        super().__init__(**data)
-        if self.update_type not in ("dependencies", "system"):
-            raise ValueError("update_type must be 'dependencies' or 'system'")
-
 
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -581,7 +498,7 @@ class SystemUpdateRequest(BaseModel):
     operation="run_system_update_endpoint",
     error_code_prefix="SETTINGS",
 )
-@router.post("/updates/run", response_model=TaskQueuedResponse)
+@router.post("/updates/run", response_model=SettingsTaskQueuedResponse)
 async def run_system_update_endpoint(
     request: SystemUpdateRequest,
     _: None = Depends(check_admin_permission),
@@ -654,7 +571,7 @@ async def run_system_update_endpoint(
     operation="get_update_task_status",
     error_code_prefix="SETTINGS",
 )
-@router.get("/updates/status/{task_id}", response_model=TaskStatusResponse)
+@router.get("/updates/status/{task_id}", response_model=SettingsTaskStatusResponse)
 async def get_update_task_status(
     task_id: str,
     _: None = Depends(check_admin_permission),
@@ -776,7 +693,7 @@ async def check_celery_worker_status(
     operation="check_updates_endpoint",
     error_code_prefix="SETTINGS",
 )
-@router.post("/updates/check", response_model=TaskQueuedResponse)
+@router.post("/updates/check", response_model=SettingsTaskQueuedResponse)
 async def check_updates_endpoint(
     _: None = Depends(check_admin_permission),
 ):
@@ -914,23 +831,6 @@ def _exceeds_depth(obj: Any, current_depth: int = 0) -> bool:
         return any(_exceeds_depth(v, current_depth + 1) for v in obj.values())
     return False
 
-
-class ConfigSyncRequest(BaseModel):
-    """Request body for POST /api/settings/sync.
-
-    The *settings* dict is merged into the active settings.json so callers
-    can send partial payloads — only the provided keys are changed.
-    """
-
-    settings: dict
-
-
-class ConfigSyncResponse(BaseModel):
-    """Response body for POST /api/settings/sync."""
-
-    status: str
-    changed: dict  # keys that changed: {key: {"before": old, "after": new}}
-    unchanged_keys: int
 
 
 def _compute_flat_diff(before: dict, after: dict, prefix: str = "") -> dict:
@@ -1084,34 +984,6 @@ async def sync_config(
 
 
 # ==================== Hardware Priority Endpoint (Issue #3288) ====================
-
-_VALID_HARDWARE_TYPES = frozenset({"npu", "gpu", "cpu"})
-
-
-class HardwarePriorityRequest(BaseModel):
-    """Request body for PATCH /api/settings/hardware-priority.
-
-    priority_order must be a permutation of ["npu", "gpu", "cpu"] — all three
-    values required, no duplicates.
-    """
-
-    priority_order: List[str]
-
-    def model_post_init(self, __context) -> None:  # noqa: ANN001
-        given = set(self.priority_order)
-        if given != _VALID_HARDWARE_TYPES or len(self.priority_order) != 3:
-            raise ValueError(
-                f"priority_order must be a permutation of {sorted(_VALID_HARDWARE_TYPES)}, "
-                f"got {self.priority_order}"
-            )
-
-
-class HardwarePriorityResponse(BaseModel):
-    """Response body for PATCH /api/settings/hardware-priority."""
-
-    status: str
-    priority_order: List[str]
-    changed: dict
 
 
 @with_error_handling(

--- a/autobot-backend/api/user_management/organizations.py
+++ b/autobot-backend/api/user_management/organizations.py
@@ -10,10 +10,18 @@ Used in multi_company and provider deployment modes.
 
 import logging
 import uuid
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field
+from api.schemas_agent import (
+    OrganizationCreate,
+    OrganizationCreatedResponse,
+    OrganizationDeletedResponse,
+    OrganizationListResponse,
+    OrganizationResponse,
+    OrganizationStatsResponse,
+    OrganizationUpdate,
+)
 
 from api.user_management.dependencies import (
     get_organization_service,
@@ -29,95 +37,6 @@ from user_management.services.organization_service import (
 
 router = APIRouter(prefix="/organizations", tags=["Organizations"])
 logger = logging.getLogger(__name__)
-
-
-# -------------------------------------------------------------------------
-# Request/Response Models
-# -------------------------------------------------------------------------
-
-
-class OrganizationCreate(BaseModel):
-    """Request model for creating an organization."""
-
-    name: str = Field(
-        ..., min_length=1, max_length=255, description="Organization name"
-    )
-    slug: Optional[str] = Field(
-        None,
-        max_length=100,
-        description="URL-safe slug (auto-generated if not provided)",
-    )
-    description: Optional[str] = Field(None, max_length=500, description="Description")
-    settings: Optional[dict] = Field(
-        default_factory=dict, description="Organization settings"
-    )
-    subscription_tier: str = Field("free", description="Subscription tier")
-    max_users: int = Field(-1, description="Maximum users (-1 for unlimited)")
-
-
-class OrganizationUpdate(BaseModel):
-    """Request model for updating an organization."""
-
-    name: Optional[str] = Field(None, min_length=1, max_length=255, description="Name")
-    description: Optional[str] = Field(None, max_length=500, description="Description")
-    settings: Optional[dict] = Field(None, description="Settings")
-    subscription_tier: Optional[str] = Field(None, description="Subscription tier")
-    max_users: Optional[int] = Field(None, description="Maximum users")
-
-
-class OrganizationResponse(BaseModel):
-    """Response model for an organization."""
-
-    id: uuid.UUID
-    name: str
-    slug: str
-    description: Optional[str]
-    settings: dict
-    subscription_tier: str
-    max_users: int
-    is_active: bool
-    created_at: str
-    updated_at: str
-
-    class Config:
-        from_attributes = True
-
-
-class OrganizationListResponse(BaseModel):
-    """Response model for paginated organization list."""
-
-    organizations: List[OrganizationResponse]
-    total: int
-    limit: int
-    offset: int
-
-
-class OrganizationCreatedResponse(BaseModel):
-    """Response for organization creation."""
-
-    success: bool = True
-    message: str
-    organization: OrganizationResponse
-
-
-class OrganizationDeletedResponse(BaseModel):
-    """Response for organization deletion."""
-
-    success: bool = True
-    message: str
-
-
-class OrganizationStatsResponse(BaseModel):
-    """Response for organization statistics."""
-
-    organization_id: str
-    name: str
-    slug: str
-    subscription_tier: str
-    users: dict
-    teams: dict
-    is_active: bool
-    created_at: Optional[str]
 
 
 # -------------------------------------------------------------------------

--- a/autobot-backend/api/user_management/teams.py
+++ b/autobot-backend/api/user_management/teams.py
@@ -12,7 +12,18 @@ import uuid
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field
+from api.schemas_agent import (
+    MemberAddedResponse,
+    MemberRemovedResponse,
+    MemberResponse,
+    MembershipUpdate,
+    TeamCreate,
+    TeamCreatedResponse,
+    TeamDeletedResponse,
+    TeamListResponse,
+    TeamResponse,
+    TeamUpdate,
+)
 
 from api.user_management.dependencies import (
     get_team_service,
@@ -29,110 +40,6 @@ from user_management.services.team_service import (
 
 router = APIRouter(prefix="/teams", tags=["Teams"])
 logger = logging.getLogger(__name__)
-
-
-# -------------------------------------------------------------------------
-# Request/Response Models
-# -------------------------------------------------------------------------
-
-
-class TeamCreate(BaseModel):
-    """Request model for creating a team."""
-
-    name: str = Field(..., min_length=1, max_length=255, description="Team name")
-    description: Optional[str] = Field(
-        None, max_length=500, description="Team description"
-    )
-    settings: Optional[dict] = Field(default_factory=dict, description="Team settings")
-    is_default: bool = Field(False, description="Whether this is the default team")
-
-
-class TeamUpdate(BaseModel):
-    """Request model for updating a team."""
-
-    name: Optional[str] = Field(
-        None, min_length=1, max_length=255, description="Team name"
-    )
-    description: Optional[str] = Field(
-        None, max_length=500, description="Team description"
-    )
-    settings: Optional[dict] = Field(None, description="Team settings")
-
-
-class MembershipUpdate(BaseModel):
-    """Request model for updating membership."""
-
-    role: str = Field(..., description="New role (owner, admin, member)")
-
-
-class MemberResponse(BaseModel):
-    """Response model for team member."""
-
-    user_id: uuid.UUID
-    username: str
-    email: str
-    display_name: Optional[str]
-    role: str
-    joined_at: str
-
-    class Config:
-        from_attributes = True
-
-
-class TeamResponse(BaseModel):
-    """Response model for a team."""
-
-    id: uuid.UUID
-    org_id: uuid.UUID
-    name: str
-    description: Optional[str]
-    settings: dict
-    is_default: bool
-    member_count: int = 0
-    created_at: str
-    updated_at: str
-
-    class Config:
-        from_attributes = True
-
-
-class TeamListResponse(BaseModel):
-    """Response model for paginated team list."""
-
-    teams: List[TeamResponse]
-    total: int
-    limit: int
-    offset: int
-
-
-class TeamCreatedResponse(BaseModel):
-    """Response for team creation."""
-
-    success: bool = True
-    message: str
-    team: TeamResponse
-
-
-class TeamDeletedResponse(BaseModel):
-    """Response for team deletion."""
-
-    success: bool = True
-    message: str
-
-
-class MemberAddedResponse(BaseModel):
-    """Response for adding a member."""
-
-    success: bool = True
-    message: str
-    member: MemberResponse
-
-
-class MemberRemovedResponse(BaseModel):
-    """Response for removing a member."""
-
-    success: bool = True
-    message: str
 
 
 # -------------------------------------------------------------------------

--- a/autobot-backend/api/user_management/users.py
+++ b/autobot-backend/api/user_management/users.py
@@ -9,10 +9,19 @@ REST API for user management operations.
 
 import logging
 import uuid
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field
+from api.schemas_agent import (
+    PasswordChangedResponse,
+    RoleAssignmentResponse,
+    RoleUpdateRequest,
+    RoleUpdateResponse,
+    UserCreatedResponse,
+    UserDeletedResponse,
+    UserSearchResponse,
+    UserSearchResult,
+)
 
 from api.user_management.dependencies import (
     get_current_user,
@@ -41,81 +50,6 @@ from user_management.services.user_service import (
 
 router = APIRouter(prefix="/users", tags=["Users"])
 logger = logging.getLogger(__name__)
-
-
-# -------------------------------------------------------------------------
-# Response Models
-# -------------------------------------------------------------------------
-
-
-class UserCreatedResponse(BaseModel):
-    """Response for user creation."""
-
-    success: bool = True
-    message: str
-    user: UserResponse
-
-
-class UserDeletedResponse(BaseModel):
-    """Response for user deletion."""
-
-    success: bool = True
-    message: str
-
-
-class PasswordChangedResponse(BaseModel):
-    """Response for password change."""
-
-    success: bool = True
-    message: str
-
-
-class RoleAssignmentResponse(BaseModel):
-    """Response for role assignment."""
-
-    success: bool = True
-    message: str
-    role_id: uuid.UUID
-
-
-class RoleUpdateRequest(BaseModel):
-    """Request to set a user's role by name (#1801)."""
-
-    role: str = Field(
-        ...,
-        description="Role name: admin, user, or readonly",
-        pattern="^(admin|user|readonly)$",
-    )
-
-
-class RoleUpdateResponse(BaseModel):
-    """Response for role-by-name update (#1801)."""
-
-    success: bool = True
-    message: str
-    username: str
-    role: str
-
-
-class UserSearchResult(BaseModel):
-    """A single user result for the sharing dialog search."""
-
-    id: str
-    name: str
-    type: str = "user"
-
-
-class UserSearchResponse(BaseModel):
-    """Response for user search used by sharing features.
-
-    Issue #2072: Provides a search endpoint safe to call in all deployment
-    modes; returns an empty list with a message when user management is
-    unavailable rather than raising an error.
-    """
-
-    users: List[UserSearchResult]
-    available: bool
-    message: str
 
 
 # -------------------------------------------------------------------------

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -15,10 +15,34 @@ import subprocess  # nosec B404
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from api.schemas_system import (
+    ClipboardSyncRequest,
+    ConnectionSettings,
+    KeyboardTypeRequest,
+    MacroListResponse,
+    MacroRecording,
+    MacroStopResponse,
+    MouseClickRequest,
+    MouseDragRequest,
+    MouseScrollRequest,
+    RestoreStateResponse,
+    SessionActionLogResponse,
+    SessionScreenshotSaveResponse,
+    SessionScreenshotsResponse,
+    SpecialKeyRequest,
+    VncDesktopContextResponse,
+    VncFindImageResponse,
+    VncOcrResponse,
+    VncQualityMetricsResponse,
+    VncRunningResponse,
+    VncScreenshotResponse,
+    VncStatusMessageResponse,
+    WaitForImageResponse,
+    WaitForTextResponse,
+)
 
 # Issue #74 - Area 5: Human-like behavior helpers
 from api.vnc_humanization import (
@@ -38,192 +62,6 @@ from autobot_shared.error_boundaries import ErrorCategory
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-# Response models
-class VncRunningResponse(BaseModel):
-    """Response for VNC running status check"""
-    running: bool
-
-
-class VncStatusMessageResponse(BaseModel):
-    """Generic status + message response"""
-    status: str
-    message: str
-
-
-class VncScreenshotResponse(BaseModel):
-    """Response for screenshot capture"""
-    status: str
-    message: str
-    image_data: str
-
-
-class MacroStopResponse(BaseModel):
-    """Response for stop-macro-recording"""
-    status: str
-    message: str
-    action_count: int
-
-
-class MacroListResponse(BaseModel):
-    """Response for list-macros"""
-    macros: List[Dict[str, Any]]
-
-
-class VncQualityMetricsResponse(BaseModel):
-    """Response for connection quality metrics"""
-    vnc_running: bool
-    timestamp: str
-    vnc_port_reachable: Optional[bool] = None
-    latency_ms: Optional[float] = None
-    websockify_running: Optional[bool] = None
-    websockify_processes: Optional[int] = None
-
-
-class VncDesktopContextResponse(BaseModel):
-    """Response for desktop context info"""
-    system: Dict[str, str]
-    desktop: Dict[str, str]
-    processes: List[Dict[str, str]]
-    timestamp: str
-
-
-class VncOcrResponse(BaseModel):
-    """Response for OCR text recognition"""
-    status: str
-    text: str
-    message: str
-
-
-class VncFindImageResponse(BaseModel):
-    """Response for image template matching"""
-    status: str
-    found: bool
-    message: str
-    x: Optional[int] = None
-    y: Optional[int] = None
-    confidence: Optional[float] = None
-
-
-class WaitForTextResponse(BaseModel):
-    """Response for wait-for-text"""
-    status: str
-    found: bool
-    message: str
-
-
-class WaitForImageResponse(BaseModel):
-    """Response for wait-for-image"""
-    status: str
-    found: bool
-    message: str
-    x: Optional[int] = None
-    y: Optional[int] = None
-    confidence: Optional[float] = None
-
-
-class RestoreStateResponse(BaseModel):
-    """Response for restore-session-desktop-state"""
-    status: str
-    message: str
-    state: Optional[Dict[str, Any]] = None
-
-
-class SessionActionLogResponse(BaseModel):
-    """Response for get-session-action-log"""
-    status: str
-    actions: List[Dict[str, Any]]
-    message: str
-
-
-class SessionScreenshotsResponse(BaseModel):
-    """Response for get-session-screenshots"""
-    status: str
-    screenshots: List[str]
-    message: str
-
-
-class SessionScreenshotSaveResponse(BaseModel):
-    """Response for save-session-screenshot"""
-    status: str
-    message: str
-    screenshot_path: Optional[str] = None
-
-
-# Pydantic models for request bodies (Issue #74)
-class MouseClickRequest(BaseModel):
-    """Mouse click action request"""
-
-    x: int = Field(..., ge=0, description="X coordinate")
-    y: int = Field(..., ge=0, description="Y coordinate")
-    button: str = Field(default="left", description="Mouse button: left, middle, right")
-
-
-class KeyboardTypeRequest(BaseModel):
-    """Keyboard typing action request"""
-
-    text: str = Field(..., description="Text to type")
-
-
-class SpecialKeyRequest(BaseModel):
-    """Special key press request"""
-
-    key: str = Field(..., description="Special key name (e.g., Return, Escape, ctrl+c)")
-
-
-class MouseScrollRequest(BaseModel):
-    """Mouse scroll action request"""
-
-    direction: str = Field(..., description="Scroll direction: up or down")
-    amount: int = Field(default=3, ge=1, le=10, description="Scroll amount (1-10)")
-
-
-class MouseDragRequest(BaseModel):
-    """Mouse drag action request"""
-
-    x1: int = Field(..., ge=0, description="Start X coordinate")
-    y1: int = Field(..., ge=0, description="Start Y coordinate")
-    x2: int = Field(..., ge=0, description="End X coordinate")
-    y2: int = Field(..., ge=0, description="End Y coordinate")
-
-
-class ClipboardSyncRequest(BaseModel):
-    """Clipboard sync request"""
-
-    content: str = Field(..., description="Text content to copy to clipboard")
-
-
-# Issue #74 - Area 4: Advanced Session Management
-class ConnectionQualitySettings(BaseModel):
-    """VNC connection quality settings"""
-
-    compression_level: int = Field(
-        default=6, ge=0, le=9, description="Compression level (0=none, 9=max)"
-    )
-    quality: int = Field(
-        default=6, ge=0, le=9, description="JPEG quality (0=poor, 9=best)"
-    )
-    encoding: str = Field(
-        default="tight", description="Encoding method: tight, hextile, raw"
-    )
-
-
-class ConnectionSettings(BaseModel):
-    """VNC connection configuration"""
-
-    auto_reconnect: bool = Field(
-        default=True, description="Enable auto-reconnect on disconnect"
-    )
-    reconnect_delay_ms: int = Field(
-        default=3000, ge=1000, le=30000, description="Delay before reconnect"
-    )
-    max_reconnect_attempts: int = Field(
-        default=10, ge=1, le=100, description="Max reconnect attempts"
-    )
-    quality: ConnectionQualitySettings = Field(
-        default_factory=ConnectionQualitySettings
-    )
-
 
 # Global connection settings storage (in-memory for now)
 _connection_settings: Dict[str, ConnectionSettings] = {}
@@ -1128,24 +966,6 @@ async def get_desktop_context(
 
 
 # Area 5: Automation Features - Macro Recording/Playback
-
-
-class MacroAction(BaseModel):
-    """Single macro action"""
-
-    action_type: str = Field(
-        ..., description="Action type: click, type, key, scroll, drag"
-    )
-    params: Dict = Field(default_factory=dict, description="Action parameters")
-    timestamp: float = Field(..., description="Timestamp when action was recorded")
-
-
-class MacroRecording(BaseModel):
-    """Recorded macro sequence"""
-
-    name: str = Field(..., description="Macro name")
-    actions: List[MacroAction] = Field(default_factory=list)
-    created_at: str = Field(default_factory=lambda: datetime.now(tz=timezone.utc).isoformat())
 
 
 # Global macro storage (in-memory for now)

--- a/autobot-backend/api/vnc_mcp.py
+++ b/autobot-backend/api/vnc_mcp.py
@@ -11,17 +11,32 @@ import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from autobot_shared.time_utils import parse_utc_iso
-from typing import Any, Dict, List, Optional
+from typing import List
 
 import aiohttp
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
-
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
 from constants.network_constants import NetworkConstants
-from type_defs.common import Metadata
+from api.schemas_system import (
+    BrowserVncContextResponse,
+    DesktopClickMcpResponse,
+    DesktopKeyboardTypeMcpResponse,
+    DesktopKeyboardTypeRequest,
+    DesktopMouseClickRequest,
+    DesktopObserveStateMcpResponse,
+    DesktopObserveStateRequest,
+    DesktopScreenshotMcpResponse,
+    DesktopSpecialKeyMcpResponse,
+    DesktopSpecialKeyRequest,
+    VNCObservationRequest,
+    VNCStatusRequest,
+    VncMCPTool,
+    VncObservationMcpResponse,
+    VncRecordObservationResponse,
+    VncStatusMcpResponse,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(
@@ -199,112 +214,6 @@ VNC_MCP_TOOL_DEFINITIONS = (
 )
 
 
-class MCPTool(BaseModel):
-    """Standard MCP tool definition"""
-
-    name: str
-    description: str
-    input_schema: Metadata
-
-
-class VNCStatusRequest(BaseModel):
-    """Request model for VNC status check"""
-
-    vnc_type: str = Field("browser", description="VNC type: 'desktop' or 'browser'")
-
-
-class VNCObservationRequest(BaseModel):
-    """Request model for VNC observations"""
-
-    vnc_type: str = Field("browser", description="VNC type: 'desktop' or 'browser'")
-    duration_seconds: int = Field(
-        5, description="How many seconds of recent activity to return"
-    )
-
-
-# Response models for VNC MCP endpoints
-class VncStatusMcpResponse(BaseModel):
-    """Response for check_vnc_status MCP tool"""
-    success: bool
-    vnc_type: str
-    accessible: bool
-    endpoint: Optional[str] = None
-    status_code: Optional[int] = None
-    message: str
-    error: Optional[str] = None
-
-
-class VncObservationMcpResponse(BaseModel):
-    """Response for observe_vnc_activity MCP tool"""
-    success: bool
-    vnc_type: str
-    duration_seconds: int
-    observation_count: int
-    observations: List[Dict[str, Any]]
-    last_check: Optional[str] = None
-    message: str
-
-
-class BrowserVncContextResponse(BaseModel):
-    """Response for get_browser_vnc_context MCP tool"""
-    success: bool
-    timestamp: str
-    playwright_state: Dict[str, Any]
-    vnc_state: Dict[str, Any]
-
-
-class VncRecordObservationResponse(BaseModel):
-    """Response for record_vnc_observation"""
-    success: bool
-    recorded: bool
-
-
-class DesktopClickMcpResponse(BaseModel):
-    """Response for desktop_mouse_click MCP tool"""
-    success: bool
-    message: str
-    action: str
-    coordinates: Dict[str, int]
-    button: str
-
-
-class DesktopKeyboardTypeMcpResponse(BaseModel):
-    """Response for desktop_keyboard_type MCP tool"""
-    success: bool
-    message: str
-    action: str
-    text_length: int
-
-
-class DesktopSpecialKeyMcpResponse(BaseModel):
-    """Response for desktop_special_key MCP tool"""
-    success: bool
-    message: str
-    action: str
-    key: str
-
-
-class DesktopScreenshotMcpResponse(BaseModel):
-    """Response for desktop_screenshot MCP tool"""
-    success: bool
-    message: str
-    action: str
-    image_data: Optional[str] = None
-    format: Optional[str] = None
-
-
-class DesktopObserveStateMcpResponse(BaseModel):
-    """Response for desktop_observe_state MCP tool"""
-    success: bool
-    action: str
-    timestamp: str
-    resolution: Optional[str] = None
-    active_window: Optional[str] = None
-    screenshot: Optional[str] = None
-    screenshot_format: Optional[str] = None
-
-
-
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_vnc_mcp_tools",
@@ -315,8 +224,8 @@ class DesktopObserveStateMcpResponse(BaseModel):
     operation="get_vnc_mcp_tools",
     error_code_prefix="VNC_MCP",
 )
-@router.get("/mcp/tools", response_model=List[MCPTool])
-async def get_vnc_mcp_tools() -> List[MCPTool]:
+@router.get("/mcp/tools", response_model=List[VncMCPTool])
+async def get_vnc_mcp_tools() -> List[VncMCPTool]:
     """
     Get available MCP tools for VNC observation.
 
@@ -329,7 +238,7 @@ async def get_vnc_mcp_tools() -> List[MCPTool]:
     - Get real-time status of what humans are viewing
     """
     return [
-        MCPTool(name=name, description=desc, input_schema=schema)
+        VncMCPTool(name=name, description=desc, input_schema=schema)
         for name, desc, schema in VNC_MCP_TOOL_DEFINITIONS
     ]
 
@@ -563,32 +472,6 @@ async def record_vnc_observation(vnc_type: str, observation: Metadata):
 
 # Issue #74: Agent Desktop Interaction MCP Endpoints
 # These endpoints allow AI agents to interact with the desktop via MCP tools
-
-
-class DesktopMouseClickRequest(BaseModel):
-    """Agent mouse click request"""
-
-    x: int = Field(..., ge=0)
-    y: int = Field(..., ge=0)
-    button: str = Field(default="left")
-
-
-class DesktopKeyboardTypeRequest(BaseModel):
-    """Agent keyboard type request"""
-
-    text: str
-
-
-class DesktopSpecialKeyRequest(BaseModel):
-    """Agent special key request"""
-
-    key: str
-
-
-class DesktopObserveStateRequest(BaseModel):
-    """Agent desktop observation request"""
-
-    include_screenshot: bool = Field(default=True)
 
 
 @with_error_handling(

--- a/autobot-backend/api/workflow.py
+++ b/autobot-backend/api/workflow.py
@@ -14,8 +14,17 @@ from datetime import datetime, timezone
 from typing import Awaitable, Callable, Dict, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
-from pydantic import BaseModel
-
+from api.schemas_workflows import (
+    WorkflowApprovalResponse,
+    WorkflowApproveResponse,
+    WorkflowCancelResponse,
+    WorkflowDetailResponse,
+    WorkflowExecutionRequest,
+    WorkflowExecutionResponse,
+    WorkflowListResponse,
+    WorkflowPendingApprovalsResponse,
+    WorkflowStatusResponse,
+)
 from api.workflow_state import get_workflow_state_machine
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -354,130 +363,6 @@ def _convert_preview_to_steps(workflow_preview: list) -> list:
         }
         steps.append(step)
     return steps
-
-
-# Workflow models
-class WorkflowApprovalRequest(BaseModel):
-    workflow_id: str
-    step_id: str
-    step_description: str
-    required_action: str
-    context: Metadata
-    timeout_seconds: int = 300
-
-
-class WorkflowApprovalResponse(BaseModel):
-    workflow_id: str
-    step_id: str
-    approved: bool
-    user_input: Optional[Metadata] = None
-    timestamp: float
-
-
-class WorkflowStatusUpdate(BaseModel):
-    workflow_id: str
-    step_id: str
-    status: str  # "pending", "in_progress", "completed", "failed", "waiting_approval"
-    progress: float  # 0.0 to 1.0
-    message: str
-    timestamp: float
-
-
-class WorkflowExecutionRequest(BaseModel):
-    user_message: str
-    workflow_id: Optional[str] = None
-    auto_approve: bool = False
-
-
-# ---------------------------------------------------------------------------
-# Response models for response_model= annotations (#5317 — first batch)
-# ---------------------------------------------------------------------------
-
-
-class WorkflowSummary(BaseModel):
-    """Summary of a single workflow as returned by list/detail endpoints."""
-
-    workflow_id: str
-    user_message: str
-    classification: str
-    status: str
-    total_steps: int
-    current_step: int
-    started_at: Optional[str] = None
-    completed_at: Optional[str] = None
-
-
-class WorkflowListResponse(BaseModel):
-    """Response shape for GET /workflows."""
-
-    success: bool
-    active_workflows: int
-    workflows: list[WorkflowSummary]
-
-
-class WorkflowDetailResponse(BaseModel):
-    """Response shape for GET /workflow/{workflow_id}."""
-
-    success: bool
-    workflow: Metadata
-
-
-class WorkflowStatusResponse(BaseModel):
-    """Response shape for GET /workflow/{workflow_id}/status."""
-
-    success: bool
-    workflow_id: str
-    status: str
-    current_step: int
-    total_steps: int
-    progress: float
-    current_step_info: Optional[Metadata] = None
-    estimated_remaining: Optional[str] = None
-
-
-class WorkflowApproveResponse(BaseModel):
-    """Response shape for POST /workflow/{workflow_id}/approve."""
-
-    success: bool
-    message: str
-    next_action: str
-
-
-class WorkflowCancelResponse(BaseModel):
-    """Response shape for DELETE /workflow/{workflow_id}."""
-
-    success: bool
-    message: str
-
-
-class PendingApprovalStep(BaseModel):
-    """A single step awaiting user approval."""
-
-    step_id: str
-    description: str
-    agent_type: str
-    action: str
-    context: Metadata
-
-
-class WorkflowPendingApprovalsResponse(BaseModel):
-    """Response shape for GET /workflow/{workflow_id}/pending_approvals."""
-
-    success: bool
-    workflow_id: str
-    pending_approvals: list[PendingApprovalStep]
-
-
-class WorkflowExecutionResponse(BaseModel):
-    """Response shape for POST /execute (covers both simple and complex paths)."""
-
-    success: bool
-    type: str
-    result: Optional[str] = None
-    routing_method: Optional[str] = None
-    workflow_id: Optional[str] = None
-    execution_started: Optional[bool] = None
-    status_endpoint: Optional[str] = None
 
 
 # In-memory workflow storage (in production, use Redis or database)

--- a/autobot-backend/api/workflow_export.py
+++ b/autobot-backend/api/workflow_export.py
@@ -11,12 +11,12 @@ Registered in feature_routers.py as:
 """
 
 import logging
-from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
-
 from api.schemas_workflows import (
+    CloneWorkflowRequest,
+    ImportWorkflowRequest,
+    ShareWorkflowRequest,
     WorkflowExportResponse,
     WorkflowImportResponse,
     WorkflowListSharesResponse,
@@ -33,44 +33,6 @@ from services.workflow_sharing_service import WorkflowSharingService
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["workflow-export"])
-
-
-# ---------------------------------------------------------------------------
-# Request / response models
-# ---------------------------------------------------------------------------
-
-
-class ShareWorkflowRequest(BaseModel):
-    """Request body for creating a workflow share (#2165)."""
-
-    workflow_id: str = Field(..., description="ID of the workflow to share.")
-    target_user_id: Optional[str] = Field(
-        default=None,
-        description="Share with a specific user.  Mutually optional with public.",
-    )
-    public: bool = Field(
-        default=False, description="Make the share publicly accessible."
-    )
-
-
-class ImportWorkflowRequest(BaseModel):
-    """Request body for importing a workflow from an export document (#2165)."""
-
-    export_document: dict = Field(
-        ...,
-        description="WorkflowExportFormat.to_dict() payload produced by the export endpoint.",
-    )
-    session_id: Optional[str] = Field(
-        default=None, description="Session to associate with the imported workflow."
-    )
-
-
-class CloneWorkflowRequest(BaseModel):
-    """Request body for cloning a shared workflow (#2165)."""
-
-    session_id: Optional[str] = Field(
-        default=None, description="Session to associate with the cloned workflow."
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/workflow_permissions.py
+++ b/autobot-backend/api/workflow_permissions.py
@@ -14,59 +14,28 @@ Routes:
 """
 
 import logging
-from typing import List, Optional
+from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.schemas_workflows import (
+    GrantPermissionRequest,
+    WorkflowWorkflowAuditLogEntry,
+    WorkflowWorkflowPermissionResponse,
+)
 from api.user_management.dependencies import get_db_session
 from auth_middleware import get_current_user
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.workflow_permission_service import (
     ROLE_HIERARCHY,
     WorkflowPermissionService,
 )
 from services.workflow_rbac import require_workflow_permission
-from api.schemas_common import DataResponse
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["workflow-permissions"])
-
-
-# ---------------------------------------------------------------------------
-# Request / Response schemas
-# ---------------------------------------------------------------------------
-
-
-class GrantPermissionRequest(BaseModel):
-    """Request body for granting or updating a workflow role."""
-
-    user_id: str = Field(..., description="User receiving the role")
-    role: str = Field(..., description="owner | editor | runner | viewer")
-
-
-class PermissionResponse(BaseModel):
-    """Serialised workflow permission entry."""
-
-    workflow_id: str
-    user_id: str
-    role: str
-    granted_by: Optional[str]
-    created_at: str
-    updated_at: str
-
-
-class AuditLogEntry(BaseModel):
-    """Serialised workflow audit log entry."""
-
-    id: str
-    timestamp: str
-    user_id: str
-    workflow_id: str
-    action: str
-    details: Optional[dict]
 
 
 # ---------------------------------------------------------------------------
@@ -79,9 +48,9 @@ def _current_user_id(current_user: dict) -> str:
     return current_user.get("username") or current_user.get("user_id", "unknown")
 
 
-def _permission_to_response(perm) -> PermissionResponse:
+def _permission_to_response(perm) -> WorkflowWorkflowPermissionResponse:
     """Convert a WorkflowPermission ORM row to its response schema."""
-    return PermissionResponse(
+    return WorkflowWorkflowPermissionResponse(
         workflow_id=perm.workflow_id,
         user_id=perm.user_id,
         role=perm.role,
@@ -91,9 +60,9 @@ def _permission_to_response(perm) -> PermissionResponse:
     )
 
 
-def _audit_to_response(entry) -> AuditLogEntry:
+def _audit_to_response(entry) -> WorkflowWorkflowAuditLogEntry:
     """Convert a WorkflowAuditLog ORM row to its response schema."""
-    return AuditLogEntry(
+    return WorkflowWorkflowAuditLogEntry(
         id=str(entry.id),
         timestamp=entry.timestamp.isoformat() if entry.timestamp else "",
         user_id=entry.user_id,
@@ -115,7 +84,7 @@ def _audit_to_response(entry) -> AuditLogEntry:
 )
 @router.get(
     "/workflows/{workflow_id}/permissions",
-    response_model=List[PermissionResponse],
+    response_model=List[WorkflowPermissionResponse],
     summary="List workflow permissions",
 )
 async def list_workflow_permissions(
@@ -123,7 +92,7 @@ async def list_workflow_permissions(
     current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
     _: bool = Depends(require_workflow_permission("view")),
-) -> List[PermissionResponse]:
+) -> List[WorkflowPermissionResponse]:
     """Return all permission entries for the specified workflow (#2152)."""
     svc = WorkflowPermissionService(session)
     rows = await svc.get_permissions(workflow_id)
@@ -143,7 +112,7 @@ async def list_workflow_permissions(
 )
 @router.put(
     "/workflows/{workflow_id}/permissions",
-    response_model=PermissionResponse,
+    response_model=WorkflowPermissionResponse,
     summary="Grant or update a workflow permission",
 )
 async def grant_workflow_permission(
@@ -152,7 +121,7 @@ async def grant_workflow_permission(
     current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
     _: bool = Depends(require_workflow_permission("grant")),
-) -> PermissionResponse:
+) -> WorkflowPermissionResponse:
     """
     Grant (or update) a role for *body.user_id* on the workflow (#2152).
 
@@ -231,7 +200,7 @@ async def revoke_workflow_permission(
 )
 @router.get(
     "/workflows/{workflow_id}/audit",
-    response_model=List[AuditLogEntry],
+    response_model=List[WorkflowAuditLogEntry],
     summary="Get workflow audit log",
 )
 async def get_workflow_audit_log(
@@ -241,7 +210,7 @@ async def get_workflow_audit_log(
     current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
     _: bool = Depends(require_workflow_permission("view")),
-) -> List[AuditLogEntry]:
+) -> List[WorkflowAuditLogEntry]:
     """Return the audit trail for the specified workflow, newest first (#2152)."""
     svc = WorkflowPermissionService(session)
     entries = await svc.get_audit_log(workflow_id, limit=limit, offset=offset)

--- a/autobot-backend/api/workflow_secrets.py
+++ b/autobot-backend/api/workflow_secrets.py
@@ -19,75 +19,25 @@ Issue #2153 — Secret management for workflow credentials.
 """
 
 import logging
-import re
-from typing import List, Optional
+from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field, field_validator
 
+from api.schemas_workflows import (
+    WorkflowSecretCreateRequest,
+    WorkflowSecretMetadata,
+    WorkflowSecretUpdateRequest,
+)
 from auth_middleware import get_current_user
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.workflow_secret_service import (
     WorkflowSecretService,
     get_workflow_secret_service,
 )
-from api.schemas_common import DataResponse
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-# Allowed characters in a secret name — same rule as the general secrets API.
-_NAME_RE = re.compile(r"^[a-zA-Z0-9_\-\.]+$")
-
-
-# ---------------------------------------------------------------------------
-# Request / response schemas
-# ---------------------------------------------------------------------------
-
-
-def _validate_secret_name(name: str) -> str:
-    """Reject names containing characters outside the safe set. Issue #2153."""
-    if not _NAME_RE.match(name):
-        raise ValueError(
-            "Secret name must contain only alphanumeric characters, "
-            "underscores, hyphens, and dots"
-        )
-    return name
-
-
-class WorkflowSecretCreateRequest(BaseModel):
-    """Request body for creating a workflow secret. Issue #2303: owner_id derived from auth."""
-
-    name: str = Field(..., min_length=1, max_length=256)
-    value: str = Field(..., min_length=1, max_length=65536)
-    secret_type: str = Field(default="api_key", max_length=50)
-    workflow_id: Optional[str] = Field(default=None, max_length=128)
-    description: Optional[str] = Field(default=None, max_length=1024)
-
-    @field_validator("name")
-    @classmethod
-    def validate_name(cls, v: str) -> str:
-        """Reject unsafe characters in the secret name."""
-        return _validate_secret_name(v)
-
-
-class WorkflowSecretUpdateRequest(BaseModel):
-    """Request body for updating a workflow secret's value. Issue #2303: owner_id from auth."""
-
-    value: str = Field(..., min_length=1, max_length=65536)
-
-
-class WorkflowSecretMetadata(BaseModel):
-    """Safe metadata response — no value field. Issue #2153."""
-
-    id: str
-    name: str
-    secret_type: str
-    scope: str
-    created_at: Optional[str] = None
-    updated_at: Optional[str] = None
-    description: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/workflow_state.py
+++ b/autobot-backend/api/workflow_state.py
@@ -20,12 +20,9 @@ Usage::
 """
 
 import logging
-from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
-
-from autobot_shared.models.service_message import ServiceMessage
+from api.schemas_workflows import WorkflowState
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.time_utils import now_utc
 from constants.ttl_constants import TTL_7_DAYS
@@ -48,32 +45,6 @@ STEP_EXECUTING = "executing"
 STEP_VALIDATING = "validating"
 STEP_COMPLETE = "complete"
 STEP_FAILED = "failed"
-
-
-# ------------------------------------------------------------------ #
-# Pydantic model
-# ------------------------------------------------------------------ #
-
-
-class WorkflowState(BaseModel):
-    """Persistent workflow state with explicit routing."""
-
-    workflow_id: str
-    goal: str
-    current_step: str = STEP_PLANNING
-    active_service: str = "main-backend"
-    steps_completed: List[str] = Field(default_factory=list)
-    steps_remaining: List[Dict] = Field(default_factory=list)
-    mailbox: List[ServiceMessage] = Field(default_factory=list)
-    done: bool = False
-    errors: List[str] = Field(default_factory=list)
-    created_at: str = Field(
-        default_factory=lambda: now_utc().isoformat()
-    )
-    updated_at: str = Field(
-        default_factory=lambda: now_utc().isoformat()
-    )
-    metadata: Dict = Field(default_factory=dict)
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary

Phases 1–8 of #6042 — migrates local Pydantic BaseModel classes out of endpoint files into centralized domain schema files.

**Phase 1 (analytics + knowledge domains):**
- \`analytics_precommit.py\` → 12 classes to \`schemas_analytics.py\`
- \`error_monitoring.py\` → 8 classes to \`schemas_analytics.py\`
- \`knowledge_tags.py\` → 13 classes to \`schemas_knowledge.py\`

**Phase 2 (code domain):**
- \`filesystem_mcp.py\` → 27 classes to \`schemas_code.py\`
- \`git_mcp.py\` → shared \`MCPTool\` to \`schemas_code.py\`
- \`code_intelligence.py\` → 7 classes to \`schemas_code.py\`
- \`playwright.py\` → 5 renamed classes to \`schemas_code.py\`
- \`ide_integration.py\` → 8 classes to \`schemas_code.py\`

**Phase 3 (system domain):**
- \`permissions.py\` → 11 classes to \`schemas_system.py\`
- \`vnc_manager.py\` → 25 classes to \`schemas_system.py\`
- \`scheduler.py\` → 19 classes to \`schemas_system.py\`
- \`monitoring.py\` → 18 classes to \`schemas_system.py\`
- \`vnc_mcp.py\` → 16 classes (MCPTool→VncMCPTool) to \`schemas_system.py\`
- \`cache_management.py\` → 13 classes to \`schemas_system.py\`
- \`browser_mcp.py\` → 21 classes (request classes prefixed Browser*) to \`schemas_system.py\`
- \`settings.py\` → 13 classes (Task*Response renamed Settings*) to \`schemas_system.py\`
- \`log_forwarding.py\` → 13 classes (Destination* renamed LogFwdDestination*) to \`schemas_system.py\`

**Phase 4 (workflows domain):**
- \`workflow.py\` → 16 classes to \`schemas_workflows.py\`
- \`workflow_export.py\` → 9 classes to \`schemas_workflows.py\`
- \`workflow_permissions.py\` → 8 classes to \`schemas_workflows.py\`
- \`workflow_secrets.py\` → 7 classes to \`schemas_workflows.py\`
- \`workflow_state.py\` → 6 classes to \`schemas_workflows.py\`

**Phase 5 (agent domain):**
- \`agent_org.py\` → 8 classes to \`schemas_agent.py\`
- \`collaboration.py\` → 7 classes to \`schemas_agent.py\`
- \`approval_gates.py\` → 3 classes to \`schemas_agent.py\`
- \`orchestration.py\` → 4 classes to \`schemas_agent.py\`
- \`openai_compat.py\` → 5 classes (OAI* prefix) to \`schemas_agent.py\`
- \`rum.py\` → 4 classes to \`schemas_agent.py\`
- \`conversation_files.py\` → 4 classes (ConvFile* prefix) to \`schemas_knowledge.py\`

**Phase 6 (analytics cost + memory + teams):**
- \`analytics_cost.py\` → 7 classes to \`schemas_analytics.py\`
- \`memory.py\` → 5 classes to \`schemas_knowledge.py\`
- \`user_management/teams.py\` → 10 classes to \`schemas_agent.py\`

**Phase 7 (security_assessment + ai_stack_integration + auth + users):**
- \`security_assessment.py\` → 8 classes to \`schemas_system.py\`
- \`ai_stack_integration.py\` → 7 classes to \`schemas_knowledge.py\`
- \`auth.py\` → 7 classes to \`schemas_agent.py\` (pydantic v1→v2 validator conversion)
- \`user_management/users.py\` → 8 classes to \`schemas_agent.py\`

**Phase 8 (chat_knowledge + organizations + security):**
- \`chat_knowledge.py\` → 9 classes (2 Enums + 7 BaseModels) to \`schemas_knowledge.py\`
- \`user_management/organizations.py\` → 7 classes to \`schemas_agent.py\`
- \`security.py\` → 7 classes to \`schemas_system.py\`

**Deferred (follow-up PRs):** batch_jobs.py, analytics_dfa.py (Enum deps), codebase_analytics/models.py (17 classes)

## Test Plan
- [x] All modified endpoint files: \`python3 -m py_compile\` passes
- [x] All domain schema files: \`flake8 --select=F401,F811,F821\` clean
- [x] Rebased onto current Dev_new_gui
- [ ] Integration smoke test: start backend, verify /health endpoint

Closes #6042 (partial — phases 9+ in follow-up PR)

🤖 Generated with Claude Code