### PR TITLE
i18n(nav): translate nav.about key in all 10 non-English locales (#6366)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -6970,7 +6970,7 @@
     "loadingTimeout": "Loading Timed Out",
     "loadingTimeoutMessage": "Some content took too long to load. Try refreshing.",
     "home": "Home",
-    "about": "About",
+    "about": "حول",
     "experiments": "Experiments",
     "marketplace": "Marketplace",
     "usage": "Usage & Costs",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -6970,7 +6970,7 @@
     "loadingTimeout": "Loading Timed Out",
     "loadingTimeoutMessage": "Some content took too long to load. Try refreshing.",
     "home": "Home",
-    "about": "About",
+    "about": "Über",
     "experiments": "Experiments",
     "marketplace": "Marketplace",
     "usage": "Usage & Costs",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -6970,7 +6970,7 @@
     "loadingTimeout": "Loading Timed Out",
     "loadingTimeoutMessage": "Some content took too long to load. Try refreshing.",
     "home": "Home",
-    "about": "About",
+    "about": "Acerca de",
     "experiments": "Experiments",
     "marketplace": "Marketplace",
     "usage": "Usage & Costs",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -127,7 +127,7 @@
     "loadingTimeout": "Loading Timed Out",
     "loadingTimeoutMessage": "Some content took too long to load. Try refreshing.",
     "home": "Home",
-    "about": "About",
+    "about": "درباره",
     "experiments": "Experiments",
     "marketplace": "Marketplace",
     "usage": "Usage & Costs",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -6970,7 +6970,7 @@
     "loadingTimeout": "Loading Timed Out",
     "loadingTimeoutMessage": "Some content took too long to load. Try refreshing.",
     "home": "Home",
-    "about": "About",
+    "about": "À propos",
     "experiments": "Experiments",
     "marketplace": "Marketplace",
     "usage": "Usage & Costs",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -127,7 +127,7 @@
     "loadingTimeout": "Loading Timed Out",
     "loadingTimeoutMessage": "Some content took too long to load. Try refreshing.",
     "home": "Home",
-    "about": "About",
+    "about": "אודות",
     "experiments": "Experiments",
     "marketplace": "Marketplace",
     "usage": "Usage & Costs",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -6970,7 +6970,7 @@
     "loadingTimeout": "Loading Timed Out",
     "loadingTimeoutMessage": "Some content took too long to load. Try refreshing.",
     "home": "Home",
-    "about": "About",
+    "about": "Par",
     "experiments": "Experiments",
     "marketplace": "Marketplace",
     "usage": "Usage & Costs",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -6970,7 +6970,7 @@
     "loadingTimeout": "Loading Timed Out",
     "loadingTimeoutMessage": "Some content took too long to load. Try refreshing.",
     "home": "Home",
-    "about": "About",
+    "about": "O nas",
     "experiments": "Experiments",
     "marketplace": "Marketplace",
     "usage": "Usage & Costs",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -6970,7 +6970,7 @@
     "loadingTimeout": "Loading Timed Out",
     "loadingTimeoutMessage": "Some content took too long to load. Try refreshing.",
     "home": "Home",
-    "about": "About",
+    "about": "Sobre",
     "experiments": "Experiments",
     "marketplace": "Marketplace",
     "usage": "Usage & Costs",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -127,7 +127,7 @@
     "loadingTimeout": "Loading Timed Out",
     "loadingTimeoutMessage": "Some content took too long to load. Try refreshing.",
     "home": "Home",
-    "about": "About",
+    "about": "کے بارے میں",
     "experiments": "Experiments",
     "marketplace": "Marketplace",
     "usage": "Usage & Costs",


### PR DESCRIPTION
## Summary
- `nav.about` was showing "About" in all non-English locales
- Added proper translations for all 10 non-English locale files: ar, de, es, fa, fr, he, lv, pl, pt, ur

## Test plan
- [ ] Switch app language to German — nav "About" link shows "Über"
- [ ] Switch to Arabic — nav shows "حول"

Closes #6366

🤖 Generated with [Claude Code](https://claude.com/claude-code)