### PR TITLE
refactor(schemas): extract AgentTaskData base — reduce duplication in agent execution models (#6373)

### DIFF
--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -964,15 +964,20 @@ class AgentStatusData(BaseModel):
     development_tools: bool
 
 
-class EnhancedGoalData(BaseModel):
+class AgentTaskData(BaseModel):
+    """Base for agent execution payload models that invoke AI Stack multi-agent queries."""
+
+    agents_used: List[str]
+    result: Optional[Dict[str, Any]] = None
+
+
+class EnhancedGoalData(AgentTaskData):
     """data payload for POST /agent/goal/enhanced."""
 
     goal: str
-    agents_used: List[str]
     coordination_mode: str
     execution_time: float
     priority: Optional[str] = None
-    result: Optional[Dict[str, Any]] = None
     enhanced_context_used: bool
     knowledge_base_integrated: bool
     timestamp: str
@@ -991,27 +996,23 @@ class MultiAgentCoordinationData(BaseModel):
     timestamp: str
 
 
-class AgentResearchData(BaseModel):
+class AgentResearchData(AgentTaskData):
     """data payload for POST /agent/research/comprehensive."""
 
     research_query: str
     research_depth: Optional[str] = None
-    agents_used: List[str]
     include_web: bool
     include_code_search: bool
     sources: Optional[List[str]] = None
-    result: Optional[Dict[str, Any]] = None
 
 
-class DevelopmentAnalysisData(BaseModel):
+class DevelopmentAnalysisData(AgentTaskData):
     """data payload for POST /agent/development/analyze."""
 
     analysis_type: str
     target_path: str
     include_performance: bool
     include_optimization: bool
-    agents_used: List[str]
-    result: Optional[Dict[str, Any]] = None
 
 
 class MultiAgentQueryData(BaseModel):


### PR DESCRIPTION
## Summary

- Adds `AgentTaskData(BaseModel)` base class in `schemas_agent.py` with two shared fields: `agents_used: List[str]` and `result: Optional[Dict[str, Any]] = None`
- Three models now inherit from it: `EnhancedGoalData`, `AgentResearchData`, `DevelopmentAnalysisData`
- `MultiAgentCoordinationData` was intentionally NOT changed — it uses `agents: List[str]` (not `agents_used`) so the base doesn't apply
- No call-site changes needed — the 4 class names imported by `agent.py` are unchanged

## Benefit
When issue #6372 (AI Stack client typing) lands, the `result` field can be changed from `Optional[Dict[str, Any]]` to a concrete type in one place (`AgentTaskData`) and propagates to all 3 models.

## Test Plan
- [x] `python3 -m py_compile` passes on `schemas_agent.py`
- [x] MRO confirms `EnhancedGoalData`, `AgentResearchData`, `DevelopmentAnalysisData` all inherit through `AgentTaskData → BaseModel`

Closes #6373

🤖 Generated with Claude Code