### PR TITLE
refactor(api): add schemas_ai_stack.py — type 14 opaque AI Stack endpoint data payloads (#6372)

### DIFF
--- a/autobot-backend/api/ai_stack_integration.py
+++ b/autobot-backend/api/ai_stack_integration.py
@@ -26,6 +26,7 @@ from type_defs.common import Metadata
 # Import shared response utilities (Issue #292 - Eliminate duplicate code)
 from utils.response_helpers import create_success_response
 
+from api.schemas_ai_stack import AIStackAgentPayload, AIStackAgentsData, AIStackHealthData
 from api.schemas_common import DataResponse
 from api.schemas_agent import (
     ComprehensiveResearchData,
@@ -139,7 +140,7 @@ class ContentClassificationRequest(BaseModel):
     operation="ai_stack_health_check",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.get("/health", response_model=DataResponse[Dict[str, Any]])
+@router.get("/health", response_model=DataResponse[AIStackHealthData])
 async def ai_stack_health_check(admin_check: bool = Depends(check_admin_permission)):
     """
     Check AI Stack health and connectivity.
@@ -179,7 +180,7 @@ async def ai_stack_health_check(admin_check: bool = Depends(check_admin_permissi
     operation="list_ai_agents",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.get("/agents", response_model=DataResponse[Dict[str, Any]])
+@router.get("/agents", response_model=DataResponse[AIStackAgentsData])
 async def list_ai_agents(admin_check: bool = Depends(check_admin_permission)):
     """
     List all available AI agents.
@@ -207,7 +208,7 @@ async def list_ai_agents(admin_check: bool = Depends(check_admin_permission)):
     operation="rag_query",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/rag/query", response_model=DataResponse[Dict[str, Any]])
+@router.post("/rag/query", response_model=DataResponse[AIStackAgentPayload])
 async def rag_query(
     request: RAGQueryRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -256,7 +257,7 @@ async def rag_query(
     operation="reformulate_query",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/rag/reformulate", response_model=DataResponse[Dict[str, Any]])
+@router.post("/rag/reformulate", response_model=DataResponse[AIStackAgentPayload])
 async def reformulate_query(
     query: str,
     context: Optional[str] = None,
@@ -283,7 +284,7 @@ async def reformulate_query(
     operation="analyze_documents",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/rag/analyze-documents", response_model=DataResponse[Dict[str, Any]])
+@router.post("/rag/analyze-documents", response_model=DataResponse[AIStackAgentPayload])
 async def analyze_documents(
     documents: List[Metadata], admin_check: bool = Depends(check_admin_permission)
 ):
@@ -313,7 +314,7 @@ async def analyze_documents(
     operation="enhanced_chat",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/chat/enhanced", response_model=DataResponse[Dict[str, Any]])
+@router.post("/chat/enhanced", response_model=DataResponse[AIStackAgentPayload])
 async def enhanced_chat(
     request: EnhancedChatRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -370,7 +371,7 @@ async def enhanced_chat(
     operation="extract_knowledge",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/knowledge/extract", response_model=DataResponse[Dict[str, Any]])
+@router.post("/knowledge/extract", response_model=DataResponse[AIStackAgentPayload])
 async def extract_knowledge(
     request: KnowledgeExtractionRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -452,7 +453,7 @@ async def enhanced_knowledge_search(
     operation="get_system_knowledge",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.get("/knowledge/system", response_model=DataResponse[Dict[str, Any]])
+@router.get("/knowledge/system", response_model=DataResponse[AIStackAgentPayload])
 async def get_system_knowledge(
     knowledge_category: Optional[str] = None,
     admin_check: bool = Depends(check_admin_permission),
@@ -529,7 +530,7 @@ async def comprehensive_research(
     operation="web_research",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/research/web", response_model=DataResponse[Dict[str, Any]])
+@router.post("/research/web", response_model=DataResponse[AIStackAgentPayload])
 async def web_research(
     query: str,
     max_pages: int = 10,
@@ -564,7 +565,7 @@ async def web_research(
     operation="search_code",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/development/search-code", response_model=DataResponse[Dict[str, Any]])
+@router.post("/development/search-code", response_model=DataResponse[AIStackAgentPayload])
 async def search_code(
     request: CodeSearchRequest, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -593,7 +594,7 @@ async def search_code(
     operation="analyze_development_speedup",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/development/analyze-speedup", response_model=DataResponse[Dict[str, Any]])
+@router.post("/development/analyze-speedup", response_model=DataResponse[AIStackAgentPayload])
 async def analyze_development_speedup(
     request: DevelopmentAnalysisRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -628,7 +629,7 @@ async def analyze_development_speedup(
     operation="classify_content",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/classification/classify", response_model=DataResponse[Dict[str, Any]])
+@router.post("/classification/classify", response_model=DataResponse[AIStackAgentPayload])
 async def classify_content(
     request: ContentClassificationRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -811,7 +812,7 @@ async def multi_agent_query(
     operation="legacy_rag_search",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/legacy/rag-search", response_model=DataResponse[Dict[str, Any]])
+@router.post("/legacy/rag-search", response_model=DataResponse[AIStackAgentPayload])
 async def legacy_rag_search(
     query: str,
     max_results: int = 10,
@@ -836,7 +837,7 @@ async def legacy_rag_search(
     operation="legacy_enhanced_chat",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-@router.post("/legacy/enhanced-chat", response_model=DataResponse[Dict[str, Any]])
+@router.post("/legacy/enhanced-chat", response_model=DataResponse[AIStackAgentPayload])
 async def legacy_enhanced_chat(
     message: str,
     context: Optional[str] = None,

--- a/autobot-backend/api/schemas_ai_stack.py
+++ b/autobot-backend/api/schemas_ai_stack.py
@@ -1,0 +1,60 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+AI Stack integration Pydantic response schemas.
+
+Typed data payloads for the endpoints in api/ai_stack_integration.py.
+Where the external AI Stack service returns opaque JSON, models use
+``model_config = {"extra": "allow"}`` so any fields are accepted while
+still giving the OpenAPI schema a meaningful name.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# /health — structure known from AIStackClient.health_check()
+# ---------------------------------------------------------------------------
+
+
+class AIStackHealthData(BaseModel):
+    """Data payload for GET /ai-stack/health."""
+
+    status: str  # "healthy" or "unhealthy"
+    timestamp: str
+    ai_stack_response: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# /agents — structure known from AIStackClient.list_available_agents()
+# ---------------------------------------------------------------------------
+
+
+class AIStackAgentsData(BaseModel):
+    """Data payload for GET /ai-stack/agents."""
+
+    agents: List[str]
+    total: Optional[int] = None
+    source: Optional[str] = None  # "fallback_config" when stack unavailable
+
+
+# ---------------------------------------------------------------------------
+# External AI Stack agent endpoints — structure opaque (from remote service)
+# ---------------------------------------------------------------------------
+
+
+class AIStackAgentPayload(BaseModel):
+    """Generic payload returned by AI Stack agent endpoints.
+
+    Accepts any fields from the external AI Stack service response.
+    Used for: /rag/query, /rag/reformulate, /rag/analyze-documents,
+    /chat/enhanced, /knowledge/extract, /knowledge/system,
+    /research/web, /development/search-code, /development/analyze-speedup,
+    /classification/classify, /legacy/rag-search, /legacy/enhanced-chat.
+    """
+
+    model_config = {"extra": "allow"}


### PR DESCRIPTION
## Summary

- New file `api/schemas_ai_stack.py` with 3 Pydantic models:
  - `AIStackHealthData` — fully typed from known `health_check()` return structure: `status`, `timestamp`, `ai_stack_response`, `error`
  - `AIStackAgentsData` — fully typed from known `list_available_agents()` return: `agents`, `total`, `source`
  - `AIStackAgentPayload` — open model with `model_config = {"extra": "allow"}` for the 12 external AI Stack service endpoints where the response shape is determined by the external service
- Updates all 14 previously-`DataResponse[Dict[str, Any]]` annotations in `ai_stack_integration.py` to use named types
- Zero `DataResponse[Dict[str, Any]]` remain in `ai_stack_integration.py`

## Test Plan
- [x] `python3 -m py_compile` passes on both files
- [x] `from api.schemas_ai_stack import ...` imports cleanly
- [x] `grep "DataResponse\[Dict"` returns empty in ai_stack_integration.py

Closes #6372

🤖 Generated with Claude Code