### PR TITLE
refactor(utils): create_success_response() returns DataResponse[T] generic (#6371)

### DIFF
--- a/autobot-backend/api/ai_stack_integration.py
+++ b/autobot-backend/api/ai_stack_integration.py
@@ -154,7 +154,7 @@ async def ai_stack_health_check(admin_check: bool = Depends(check_admin_permissi
             status_code=200 if health_status["status"] == "healthy" else 503,
             content=create_success_response(
                 health_status, "AI Stack health check completed"
-            ),
+            ).model_dump(),
         )
     except Exception as e:
         logger.error("AI Stack health check failed: %s: %s", type(e).__name__, e)

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -2062,14 +2062,10 @@ async def enhanced_chat(
             preferences,
         )
 
-        return JSONResponse(
-            status_code=200,
-            media_type="application/json; charset=utf-8",
-            content=create_success_response(
-                response_data,
-                "Enhanced chat message processed successfully",
-                request_id,
-            ),
+        return create_success_response(
+            response_data,
+            "Enhanced chat message processed successfully",
+            request_id,
         )
 
     except HTTPException:

--- a/autobot-backend/utils/response_helpers.py
+++ b/autobot-backend/utils/response_helpers.py
@@ -14,40 +14,42 @@ Functions:
 """
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, TypeVar
 
 from autobot_shared.time_utils import utc_timestamp
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 
-from type_defs.common import Metadata
+from api.schemas_common import DataResponse
 
 if TYPE_CHECKING:
     from services.ai_stack_client import AIStackError
+
+T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
 
 
 def create_success_response(
-    data: Any = None,
+    data: T = None,
     message: str = "Operation successful",
-) -> Metadata:
+) -> DataResponse[T]:
     """
-    Create standardized success response dictionary.
+    Create standardized success response.
 
     Args:
         data: The response payload data
         message: Human-readable success message
 
     Returns:
-        Dict with success status, data, message, and timestamp
+        DataResponse with success status, data, message, and timestamp
     """
-    return {
-        "success": True,
-        "data": data,
-        "message": message,
-        "timestamp": utc_timestamp(),
-    }
+    return DataResponse(
+        success=True,
+        data=data,
+        message=message,
+        timestamp=utc_timestamp(),
+    )
 
 
 def create_error_response(


### PR DESCRIPTION
## Summary

- `create_success_response()` in `utils/response_helpers.py` now returns `DataResponse[T]` instead of `Metadata = Dict[str, Any]`
- Adds `TypeVar T`, function signature becomes `(data: T, ...) -> DataResponse[T]`
- Returns a `DataResponse` instance instead of a raw dict
- Fixes `ai_stack_integration.py` `/health` endpoint: adds `.model_dump()` so `JSONResponse(content=...)` receives a dict, not a Pydantic model
- Fixes `chat.py` pre-existing bug: original code wrapped `chat_utils.create_success_response()` (which returns `JSONResponse`) inside another `JSONResponse`, which would fail at render time — simplified to direct return

## Test Plan
- [x] `python3 -m py_compile` passes on all 3 modified files
- [x] Syntax clean; no import errors

Closes #6371

🤖 Generated with Claude Code