### PR TITLE
fix(workflow_runner): 5 targeted bug fixes from #5058 review (#6381 #6382 #6383 #6391 #6394)

### DIFF
--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -303,9 +303,7 @@ async def recommend_agents(
             )
 
         # Get recommendations
-        recommendations = await orchestrator.get_agent_recommendations(
-            request.task_type, capabilities_needed
-        )
+        recommendations = await orchestrator.get_agent_recommendations(capabilities_needed)
 
         return JSONResponse(
             status_code=200,

--- a/autobot-backend/enhanced_orchestration/workflow_runner.py
+++ b/autobot-backend/enhanced_orchestration/workflow_runner.py
@@ -74,7 +74,7 @@ class WorkflowRunner:
 
     # ----------------------------------------------------------------- public
 
-    async def execute_workflow(self, plan: WorkflowPlan) -> Dict[str, Any]:
+    async def execute_workflow(self, plan: WorkflowPlan, _depth: int = 0) -> Dict[str, Any]:
         """Execute a WorkflowPlan through the strategy handler."""
         logger.info("Executing workflow %s strategy=%s", plan.plan_id, plan.strategy.value)
         start_time = time.time()
@@ -88,10 +88,10 @@ class WorkflowRunner:
             results = await self._get_strategy_handler().execute_by_strategy(plan)
             return await self._handle_workflow_execution_success(plan, results, start_time)
         except Exception as e:
-            return await self._handle_workflow_execution_failure(plan, e, results)
+            return await self._handle_workflow_execution_failure(plan, e, results, _depth)
 
     async def get_agent_recommendations(
-        self, task_type: str, capabilities_needed: Set
+        self, capabilities_needed: Set
     ) -> List[str]:
         suitable = []
         for agent, caps in self.agent_capabilities.items():
@@ -162,12 +162,15 @@ class WorkflowRunner:
         }
 
     async def _handle_workflow_execution_failure(
-        self, plan: WorkflowPlan, error: Exception, results: Dict[str, Any]
+        self, plan: WorkflowPlan, error: Exception, results: Dict[str, Any], _depth: int = 0
     ) -> Dict[str, Any]:
         logger.error("Workflow execution failed: %s", error)
+        if _depth >= 5:
+            logger.error("Max fallback depth (5) reached, aborting fallback chain")
+            return {"plan_id": plan.plan_id, "success": False, "error": str(error), "results": results}
         for fallback in (plan.fallback_plans or []):
             try:
-                return await self.execute_workflow(fallback)
+                return await self.execute_workflow(fallback, _depth + 1)
             except Exception as fe:
                 logger.error("Fallback plan failed: %s", fe)
         return {"plan_id": plan.plan_id, "success": False, "error": str(error), "results": results}
@@ -183,7 +186,7 @@ class WorkflowRunner:
                 task.task_id, task.retry_count, task.max_retries,
             )
             return await self._execute_single_agent_task(task, context)
-        self._perf.update(task.agent_type, False, task.timeout)
+        self._perf.update(task.agent_type, False, time.time() - (task.start_time or time.time()))
         return task.to_failed_result("Task execution timed out")
 
     def _handle_task_exception(self, task: AgentTask, error: Exception) -> Dict[str, Any]:
@@ -227,14 +230,15 @@ class WorkflowRunner:
                     continue
                 try:
                     data = json.loads(message["data"])
-                    if data.get("type") == "share_insight":
-                        shared_context[f"{data.get('agent')}_insight"] = data.get("insight")
-                        await self._broadcast_to_agents(
-                            collab_channel,
-                            {"type": "context_update", "shared_context": shared_context},
-                        )
-                except Exception as e:
-                    logger.error("Collaboration coordination error: %s", e)
+                except json.JSONDecodeError as e:
+                    logger.error("Collaboration message decode error: %s", e)
+                    continue
+                if data.get("type") == "share_insight":
+                    shared_context[f"{data.get('agent')}_insight"] = data.get("insight")
+                    await self._broadcast_to_agents(
+                        collab_channel,
+                        {"type": "context_update", "shared_context": shared_context},
+                    )
         except asyncio.CancelledError:
             await pubsub.unsubscribe(collab_channel)
             raise

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -207,6 +207,7 @@ class Orchestrator:
         self.agent_interactions: List[AgentInteraction] = []
         self.knowledge_base = KnowledgeBase() if KNOWLEDGE_BASE_AVAILABLE else None
         self.knowledge_extraction_enabled = KNOWLEDGE_BASE_AVAILABLE
+        self.auto_doc_enabled = True
         self.workflow_metrics = {
             "total_workflows": 0,
             "successful_workflows": 0,
@@ -717,10 +718,10 @@ class Orchestrator:
         return await self._runner.execute_workflow(plan)
 
     async def get_agent_recommendations(
-        self, task_type: str, capabilities_needed: Set
+        self, capabilities_needed: Set
     ) -> List[str]:
         """Get recommended agents for a task. Delegates to WorkflowRunner (#5058)."""
-        return await self._runner.get_agent_recommendations(task_type, capabilities_needed)
+        return await self._runner.get_agent_recommendations(capabilities_needed)
 
     def get_performance_report(self) -> Dict[str, Any]:
         """Performance report. Delegates to WorkflowRunner (#5058)."""
@@ -747,12 +748,14 @@ class Orchestrator:
             "queued_tasks": len(self.task_queue),
             "metrics": self.metrics,
             "workflow_metrics": self.workflow_metrics,
+            "capabilities_coverage": self._runner._calculate_capability_coverage(),
             "configuration": {
                 "orchestrator_model": self.config.orchestrator_llm_model,
                 "task_model": self.config.task_llm_model,
                 "max_parallel_tasks": self.config.max_parallel_tasks,
                 "classification_enabled": self.classification_agent is not None,
                 "knowledge_extraction_enabled": self.knowledge_extraction_enabled,
+                "auto_doc_enabled": self.auto_doc_enabled,
             },
             "agent_registry": {
                 agent_id: {


### PR DESCRIPTION
## Summary
- #6381 `_handle_task_timeout` now records actual elapsed time, not the ceiling timeout value
- #6382 `_coordinate_collaboration` exception narrowed to `json.JSONDecodeError`; broadcast errors propagate instead of being swallowed
- #6394 `execute_workflow` / `_handle_workflow_execution_failure` cap fallback recursion at depth 5 via `_depth` parameter
- #6391 Dead `task_type` parameter removed from `get_agent_recommendations` across WorkflowRunner, Orchestrator wrapper, and `api/orchestration.py` call site
- #6383 `Orchestrator.get_status()` restores `capabilities_coverage` (from `_runner`) and `auto_doc_enabled` (from `self`) that were dropped in the #5058 refactor

## Test Plan
- [ ] `python3 -m py_compile` clean on all 3 modified files
- [ ] No remaining callers pass `task_type` to `get_agent_recommendations`
- [ ] `get_status()` response includes `capabilities_coverage` and `configuration.auto_doc_enabled`

Closes #6381
Closes #6382
Closes #6383
Closes #6391
Closes #6394