### PR TITLE
refactor(chat_utils): rename create_success_response → create_chat_response (#6388)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -45,8 +45,8 @@ from utils.chat_exceptions import get_exceptions_lazy
 
 # Import reusable chat utilities - Phase 1 Utility Extraction
 from utils.chat_utils import (
+    create_chat_response,
     create_error_response,
-    create_success_response,
     generate_chat_session_id,
     generate_message_id,
     generate_request_id,
@@ -832,7 +832,7 @@ async def list_chats(
     # Get sessions directly - decorator handles all errors
     # list_sessions_fast is async (uses asyncio.to_thread internally)
     sessions = await chat_history_manager.list_sessions_fast()
-    return create_success_response(
+    return create_chat_response(
         data=sessions,
         message="Chat sessions retrieved successfully",
         request_id=request_id,
@@ -1071,7 +1071,7 @@ async def chat_statistics(
     # Get basic statistics
     stats = await chat_history_manager.get_statistics()
 
-    return create_success_response(
+    return create_chat_response(
         data=stats,
         message="Statistics retrieved successfully",
         request_id=request_id,
@@ -2062,7 +2062,7 @@ async def enhanced_chat(
             preferences,
         )
 
-        return create_success_response(
+        return create_chat_response(
             response_data,
             "Enhanced chat message processed successfully",
             request_id,
@@ -2220,14 +2220,14 @@ async def get_enhanced_chat_capabilities(
             "context_window": 10,
         }
 
-        return create_success_response(
+        return create_chat_response(
             capabilities, "Enhanced chat capabilities retrieved successfully"
         )
 
     except Exception as e:
         logger.warning("Failed to get full capabilities: %s", e)
         # Return basic capabilities as fallback
-        return create_success_response(
+        return create_chat_response(
             {
                 "enhanced_chat": True,
                 "ai_stack_integration": False,

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -25,8 +25,8 @@ from utils.chat_exceptions import get_exceptions_lazy
 
 # Import reusable chat utilities
 from utils.chat_utils import (
+    create_chat_response,
     create_error_response,
-    create_success_response,
     generate_chat_session_id,
     generate_request_id,
     get_chat_history_manager,
@@ -410,7 +410,7 @@ async def get_session_messages(
     )
     total_count = await chat_history_manager.get_session_message_count(session_id)
 
-    return create_success_response(
+    return create_chat_response(
         data={
             "messages": messages,
             "session_id": session_id,
@@ -489,7 +489,7 @@ async def list_sessions(
     if len(sessions) == 0:
         response_data["intentional_empty"] = True
 
-    return create_success_response(
+    return create_chat_response(
         data=response_data,
         message="Sessions retrieved successfully",
         request_id=request_id,
@@ -590,7 +590,7 @@ async def _list_org_sessions(
     org_id = user_data.get("org_id")
     user_role = user_data.get("role", "")
     if not org_id:
-        return create_success_response(
+        return create_chat_response(
             data={"sessions": [], "count": 0, "scope": "org"},
             message="User has no organization",
             request_id=request_id,
@@ -610,7 +610,7 @@ async def _list_org_sessions(
     filtered = [s for s in all_sessions if s.get("id") in session_ids]
     filtered.sort(key=lambda x: x.get("lastModified", ""), reverse=True)
 
-    return create_success_response(
+    return create_chat_response(
         data={
             "sessions": filtered,
             "count": len(filtered),
@@ -637,7 +637,7 @@ async def _list_team_sessions(
     filtered = [s for s in all_sessions if s.get("id") in session_ids]
     filtered.sort(key=lambda x: x.get("lastModified", ""), reverse=True)
 
-    return create_success_response(
+    return create_chat_response(
         data={
             "sessions": filtered,
             "count": len(filtered),
@@ -660,7 +660,7 @@ async def _list_shared_sessions(
     """
     user_data = get_auth_middleware().get_user_from_request(request)
     if not user_data:
-        return create_success_response(
+        return create_chat_response(
             data={"sessions": [], "count": 0, "scope": "shared"},
             message="Authentication required",
             request_id=request_id,
@@ -676,7 +676,7 @@ async def _list_shared_sessions(
     session_ids = set(await validator.get_shared_sessions(user_id))
 
     if not session_ids:
-        return create_success_response(
+        return create_chat_response(
             data={"sessions": [], "count": 0, "scope": "shared"},
             message="No shared sessions",
             request_id=request_id,
@@ -686,7 +686,7 @@ async def _list_shared_sessions(
     filtered = [s for s in all_sessions if s.get("id") in session_ids]
     filtered.sort(key=lambda x: x.get("lastModified", ""), reverse=True)
 
-    return create_success_response(
+    return create_chat_response(
         data={
             "sessions": filtered,
             "count": len(filtered),
@@ -851,7 +851,7 @@ async def create_session(session_data: SessionCreate, request: Request):
     # Issue #4260: Wire SESSION_CREATE hook for extensions
     context = getattr(request.app.state, "context", {})
     await _emit_session_create(session_id, context)
-    return create_success_response(
+    return create_chat_response(
         data=session,
         message="Session created successfully",
         request_id=request_id,
@@ -919,7 +919,7 @@ async def update_session(
         {"title": session_data.title, "request_id": request_id},
     )
 
-    return create_success_response(
+    return create_chat_response(
         data=updated_session,
         message="Session updated successfully",
         request_id=request_id,
@@ -1351,7 +1351,7 @@ def _build_delete_session_response(
     Returns:
         Success response with deletion details
     """
-    return create_success_response(
+    return create_chat_response(
         data={
             "session_id": session_id,
             "deleted": True,
@@ -1581,7 +1581,7 @@ async def reset_chat(
         },
     )
 
-    return create_success_response(
+    return create_chat_response(
         data={
             "session_id": session_id,
             "reset": True,
@@ -1616,12 +1616,12 @@ def _create_activity_unavailable_response(
     Issue #665: Extracted helper for unavailable response.
     """
     if is_batch:
-        return create_success_response(
+        return create_chat_response(
             data={"total": activity_count, "stored": 0, "failed": activity_count},
             message="Activities received but memory graph unavailable",
             request_id=request_id,
         )
-    return create_success_response(
+    return create_chat_response(
         data={"activity_id": None, "stored": False},
         message="Activity received but memory graph unavailable",
         request_id=request_id,
@@ -1749,7 +1749,7 @@ async def add_session_activity(
             },
         )
 
-        return create_success_response(
+        return create_chat_response(
             data={
                 "activity_id": activity_data.activity_id,
                 "entity_id": activity_entity.get("entity_id"),
@@ -1762,7 +1762,7 @@ async def add_session_activity(
 
     except Exception as graph_error:
         logger.warning("[%s] Failed to store activity: %s", request_id, graph_error)
-        return create_success_response(
+        return create_chat_response(
             data={"activity_id": activity_data.activity_id, "stored": False},
             message="Activity received but storage failed",
             request_id=request_id,
@@ -1826,7 +1826,7 @@ async def add_session_activities_batch(
         },
     )
 
-    return create_success_response(
+    return create_chat_response(
         data={
             "total": total_activities,
             "stored": result["stored_count"],
@@ -1855,7 +1855,7 @@ async def _fetch_activities_from_graph(
             user_id=user_id,
             limit=limit,
         )
-        return create_success_response(
+        return create_chat_response(
             data={
                 "activities": activities,
                 "total": len(activities),
@@ -1870,7 +1870,7 @@ async def _fetch_activities_from_graph(
             request_id,
             graph_error,
         )
-        return create_success_response(
+        return create_chat_response(
             data={"activities": [], "total": 0},
             message="Failed to retrieve activities",
             request_id=request_id,
@@ -1922,7 +1922,7 @@ async def get_session_activities(
     )
 
     if not memory_graph:
-        return create_success_response(
+        return create_chat_response(
             data={"activities": [], "total": 0},
             message="Memory graph unavailable",
             request_id=request_id,
@@ -2009,7 +2009,7 @@ async def share_session(
             share_data.knowledge_facts,
         )
 
-    return create_success_response(
+    return create_chat_response(
         data={
             "session_id": session_id,
             "shared_with": share_data.share_with,
@@ -2057,7 +2057,7 @@ async def get_share_preview(
                     }
                 )
 
-    return create_success_response(
+    return create_chat_response(
         data={
             "session_id": session_id,
             "fact_count": len(facts),
@@ -2099,7 +2099,7 @@ async def clear_session_checkpoints(
 
         await delete_thread_checkpoints(session_id)
         logger.info("Cleared checkpoints for session %s (#1482)", session_id)
-        return create_success_response(
+        return create_chat_response(
             data={"session_id": session_id},
             message=f"Checkpoints cleared for session {session_id}",
         )

--- a/autobot-backend/utils/chat_utils.py
+++ b/autobot-backend/utils/chat_utils.py
@@ -11,13 +11,13 @@ code duplication and improve maintainability.
 Functions:
 - ID Generation: generate_request_id, generate_chat_session_id, generate_message_id
 - ID Validation: validate_chat_session_id
-- Response Formatting: create_success_response, create_error_response
+- Response Formatting: create_chat_response, create_error_response
 - Dependency Injection: get_chat_history_manager (FastAPI)
 
 Usage:
     from utils.chat_utils import (
         generate_request_id,
-        create_success_response,
+        create_chat_response,
         get_chat_history_manager
     )
 
@@ -181,14 +181,18 @@ def validate_message_content(content: str) -> bool:
 # Note: _canonical_create_error_response imported at top of file (Issue #292)
 
 
-def create_success_response(
+def create_chat_response(
     data: Any,
     message: str = "Success",
     request_id: Optional[str] = None,
     status_code: int = 200,
 ) -> JSONResponse:
     """
-    Create a standardized success response.
+    Create a standardized chat success response (returns JSONResponse with request_id).
+
+    Note: This is distinct from response_helpers.create_success_response which returns
+    DataResponse[T]. This function is specific to the chat subsystem and returns a
+    plain JSONResponse.
 
     Args:
         data: Response data (any JSON-serializable type)
@@ -200,7 +204,7 @@ def create_success_response(
         JSONResponse: Formatted success response
 
     Example:
-        >>> response = create_success_response(
+        >>> response = create_chat_response(
         ...     data={"chat_id": "123"},
         ...     message="Chat created",
         ...     request_id="abc-123"
@@ -379,7 +383,7 @@ __all__ = [
     "validate_chat_session_id",
     "validate_message_content",
     # Response Formatting
-    "create_success_response",
+    "create_chat_response",
     "create_error_response",
     # Dependency Injection
     "get_chat_history_manager",


### PR DESCRIPTION
## Summary
- Renames `create_success_response` in `utils/chat_utils.py` to `create_chat_response` to eliminate the naming collision with `utils/response_helpers.create_success_response` (which returns `DataResponse[T]`, a Pydantic model)
- Updates all callers: 5 sites in `api/chat.py`, ~25 sites in `api/chat_sessions.py`
- Adds clarifying docstring note distinguishing the two functions by purpose and return type

## Why
The two functions have the same name but incompatible return types — `chat_utils` returns `JSONResponse` (Starlette), `response_helpers` returns `DataResponse[T]` (Pydantic). A misimport silently breaks at render time. The rename makes the chat-specific variant unambiguous.

## Test Plan
- [x] All 3 changed files pass `python3 -m py_compile`
- [x] No remaining `create_success_response` references in `chat.py` or `chat_sessions.py`
- [x] All other callers of `create_success_response` import from `response_helpers` (unaffected)
- [x] Gate 5 linting: 0 flake8 errors

Closes #6388

🤖 Generated with Claude Code