### PR TITLE
refactor(schemas_agent): MultiAgentCoordinationData inherits AgentTaskData (#6389)

### DIFF
--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -1325,7 +1325,7 @@ async def coordinate_multi_agent_task(
         return create_success_response(
             {
                 "task": payload.task,
-                "agents": payload.agents,
+                "agents_used": payload.agents,
                 "coordination_strategy": payload.coordination_strategy,
                 "coordination_time": coordination_time,
                 "subtasks_count": len(payload.subtasks) if payload.subtasks else 0,

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -983,16 +983,14 @@ class EnhancedGoalData(AgentTaskData):
     timestamp: str
 
 
-class MultiAgentCoordinationData(BaseModel):
+class MultiAgentCoordinationData(AgentTaskData):
     """data payload for POST /agent/multi-agent/coordinate."""
 
     task: str
-    agents: List[str]
     coordination_strategy: str
     coordination_time: float
     subtasks_count: int
     dependencies_count: int
-    result: Optional[Dict[str, Any]] = None
     timestamp: str
 
 


### PR DESCRIPTION
## Summary
- Renames `MultiAgentCoordinationData.agents` → `agents_used` to match the `AgentTaskData` base class field name
- Makes `MultiAgentCoordinationData(AgentTaskData)` instead of `(BaseModel)`, completing the 4-model unification from issue #6373
- Removes now-redundant `agents` and `result` fields from the subclass (both inherited from `AgentTaskData`)
- Updates `api/agent.py` response dict key from `"agents"` to `"agents_used"` to match the renamed field

## Why
Three of four agent execution response models already inherit `AgentTaskData`. Only `MultiAgentCoordinationData` was left out because its field was named `agents` instead of `agents_used`. The rename aligns it with the convention and removes field duplication.

## Test Plan
- [x] Both changed files pass `python3 -m py_compile`
- [x] `schemas_agent` module imports cleanly (`from api import schemas_agent` succeeds)
- [x] No frontend code reads `MultiAgentCoordinationData.agents` outside generated types
- [x] Gate 5 linting: 0 flake8 errors

Closes #6389

🤖 Generated with Claude Code