### PR TITLE
refactor(orchestration): 5 targeted fixes from discovery audit (#6399 #6400 #6401 #6402 #6403)

### DIFF
--- a/autobot-backend/enhanced_orchestration/collaboration_coordinator.py
+++ b/autobot-backend/enhanced_orchestration/collaboration_coordinator.py
@@ -3,8 +3,9 @@
 # Author: mrveiss
 """Redis pub/sub collaboration coordinator extracted from WorkflowRunner (#6393)."""
 
+import asyncio
 import json
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
@@ -17,19 +18,22 @@ class CollaborationCoordinator:
 
     Extracted from WorkflowRunner (#6393) — owns all Redis lifecycle and
     pub/sub logic so WorkflowRunner remains focused on workflow execution.
+
+    Accept a redis_factory for testability (#6401); defaults to the production
+    async client so production callers need no changes.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, redis_factory: Callable = get_async_redis_client) -> None:
         self._redis_async = None
+        self._redis_factory = redis_factory
 
     async def _ensure_redis(self) -> None:
         if self._redis_async is None:
-            self._redis_async = await get_async_redis_client()
+            self._redis_async = await self._redis_factory()
         if self._redis_async is None:
             raise RuntimeError("Redis unavailable — collaboration channel requires Redis")
 
-    async def coordinate_collaboration(self, plan: Any, collab_channel: str) -> None:
-        import asyncio
+    async def coordinate_collaboration(self, collab_channel: str) -> None:
         await self._ensure_redis()
         pubsub = self._redis_async.pubsub()
         await pubsub.subscribe(collab_channel)

--- a/autobot-backend/enhanced_orchestration/execution_strategies.py
+++ b/autobot-backend/enhanced_orchestration/execution_strategies.py
@@ -174,7 +174,7 @@ class ExecutionStrategyHandler:
 
         # Start collaboration coordinator
         coordinator_task = asyncio.create_task(
-            self._coordinate_collaboration(plan, collab_channel)
+            self._coordinate_collaboration(collab_channel)
         )
 
         # Execute tasks with collaboration

--- a/autobot-backend/enhanced_orchestration/workflow_runner.py
+++ b/autobot-backend/enhanced_orchestration/workflow_runner.py
@@ -41,6 +41,7 @@ class WorkflowRunner:
         collaboration: CollaborationCoordinator,
         agent_router: AgentRouter,
         max_parallel_tasks: int = 5,
+        criteria_evaluator: Optional[SuccessCriteriaEvaluator] = None,
     ) -> None:
         self._strategy_planner = strategy_planner
         self._perf = performance_tracker
@@ -49,6 +50,7 @@ class WorkflowRunner:
         self._agent_router = agent_router
         self.max_parallel_tasks = max_parallel_tasks
         self.resource_semaphore: asyncio.Semaphore = asyncio.Semaphore(max_parallel_tasks)
+        self._criteria_evaluator = criteria_evaluator or SuccessCriteriaEvaluator()
         self._strategy_handler: Optional[ExecutionStrategyHandler] = None
 
     # ------------------------------------------------------------------ helpers
@@ -101,8 +103,7 @@ class WorkflowRunner:
         self, plan: WorkflowPlan, results: Dict[str, Any]
     ) -> Dict[str, Any]:
         if plan.structured_criteria:
-            evaluator = SuccessCriteriaEvaluator()
-            eval_result = await evaluator.evaluate(plan.structured_criteria, results)
+            eval_result = await self._criteria_evaluator.evaluate(plan.structured_criteria, results)
             return eval_result.to_dict()
         binary_pass = self._strategy_planner.check_success_criteria(plan, results)
         return {

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -80,6 +80,7 @@ except ImportError:
     logger.warning("KnowledgeBase not available - auto-documentation features disabled")
 
 from autobot_types import TaskComplexity
+from agents.agent_client import AgentRegistry as _AgentClientRegistry
 
 try:
     from agents.gemma_classification_agent import GemmaClassificationAgent
@@ -254,7 +255,6 @@ class Orchestrator:
         self._perf = PerformanceTracker(self.agent_capabilities)
 
         # Agent router — selection, resolution, capability coverage (#6393/#6392)
-        from agents.agent_client import AgentRegistry as _AgentClientRegistry
         self._agent_router = AgentRouter(
             agent_capabilities=self.agent_capabilities,
             performance_tracker=self._perf,


### PR DESCRIPTION
## Summary
- **#6399**: Move `asyncio` import to module level in `collaboration_coordinator.py` (was deferred inside method)
- **#6400**: Remove dead `plan: Any` parameter from `coordinate_collaboration` signature and its call site in `execution_strategies.py`
- **#6401**: Inject `redis_factory` callable into `CollaborationCoordinator.__init__` for testability; defaults to production `get_async_redis_client`
- **#6402**: Accept `criteria_evaluator: Optional[SuccessCriteriaEvaluator]` in `WorkflowRunner.__init__`; reuse injected instance instead of instantiating a new `SuccessCriteriaEvaluator` on every `_evaluate_workflow_criteria` call
- **#6403**: Move deferred `from agents.agent_client import AgentRegistry` from inside `_init_strategy_components` to module-level imports in `orchestrator.py`

## Test Plan
- [ ] `python3 -m py_compile` passes on all 4 modified files
- [ ] `CollaborationCoordinator(redis_factory=mock_factory)` injectable in unit tests
- [ ] `WorkflowRunner(criteria_evaluator=mock_evaluator)` injectable in unit tests
- [ ] `orchestrator.py` import-time check: `python3 -c 'import orchestrator'`

## Related Issues
Closes #6399
Closes #6400
Closes #6401
Closes #6402
Closes #6403