### PR TITLE
feat(schemas_chat): type chat_sessions DataResponse endpoints (#6405)

### DIFF
--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -19,6 +19,20 @@ from security.session_ownership import validate_session_ownership
 from type_defs.common import Metadata
 
 from api.schemas_common import DataResponse
+from api.schemas_chat import (
+    ActivityAddData,
+    ActivityBatchData,
+    ChatResetData,
+    SessionActivitiesData,
+    SessionCheckpointClearData,
+    SessionCreateData,
+    SessionDeleteData,
+    SessionListData,
+    SessionMessagesData,
+    SessionShareData,
+    SessionSharePreviewData,
+    SessionUpdateData,
+)
 
 # Import shared exception classes (Issue #292 - Eliminate duplicate code)
 from utils.chat_exceptions import get_exceptions_lazy
@@ -381,7 +395,7 @@ _EXPORT_CONTENT_TYPES = {
     operation="get_session_messages",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.get("/chat/sessions/{session_id}", response_model=DataResponse)
+@router.get("/chat/sessions/{session_id}", response_model=DataResponse[SessionMessagesData])
 async def get_session_messages(
     session_id: str,
     request: Request,
@@ -433,7 +447,7 @@ async def get_session_messages(
     operation="list_sessions",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.get("/chat/sessions", response_model=DataResponse)
+@router.get("/chat/sessions", response_model=DataResponse[SessionListData])
 async def list_sessions(
     request: Request,
     current_user: dict = Depends(get_current_user),
@@ -794,7 +808,7 @@ async def _track_session_in_memory_graph(
     operation="create_session",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.post("/chat/sessions", response_model=DataResponse)
+@router.post("/chat/sessions", response_model=DataResponse[SessionCreateData])
 async def create_session(session_data: SessionCreate, request: Request):
     """
     Create a new chat session.
@@ -869,7 +883,7 @@ async def create_session(session_data: SessionCreate, request: Request):
     operation="update_session",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.put("/chat/sessions/{session_id}", response_model=DataResponse)
+@router.put("/chat/sessions/{session_id}", response_model=DataResponse[SessionUpdateData])
 async def update_session(
     session_id: str,
     session_data: SessionUpdate,
@@ -1375,7 +1389,7 @@ def _build_delete_session_response(
     operation="delete_session",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.delete("/chat/sessions/{session_id}", response_model=DataResponse)
+@router.delete("/chat/sessions/{session_id}", response_model=DataResponse[SessionDeleteData])
 async def delete_session(
     session_id: str,
     request: Request,
@@ -1532,7 +1546,7 @@ def _clear_and_restore_session(
     operation="reset_chat",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.post("/chat/reset", response_model=DataResponse)
+@router.post("/chat/reset", response_model=DataResponse[ChatResetData])
 async def reset_chat(
     request: Request, reset_request: Optional[ChatResetRequest] = None
 ):
@@ -1710,7 +1724,7 @@ async def _process_activity_batch(
     operation="add_session_activity",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.post("/chat/sessions/{session_id}/activities", response_model=DataResponse)
+@router.post("/chat/sessions/{session_id}/activities", response_model=DataResponse[ActivityAddData])
 async def add_session_activity(
     session_id: str,
     activity_data: ActivityCreate,
@@ -1779,7 +1793,7 @@ async def add_session_activity(
     operation="add_session_activities_batch",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.post("/chat/sessions/{session_id}/activities/batch", response_model=DataResponse)
+@router.post("/chat/sessions/{session_id}/activities/batch", response_model=DataResponse[ActivityBatchData])
 async def add_session_activities_batch(
     session_id: str,
     batch_data: ActivityBatchCreate,
@@ -1887,7 +1901,7 @@ async def _fetch_activities_from_graph(
     operation="get_session_activities",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.get("/chat/sessions/{session_id}/activities", response_model=DataResponse)
+@router.get("/chat/sessions/{session_id}/activities", response_model=DataResponse[SessionActivitiesData])
 async def get_session_activities(
     session_id: str,
     request: Request,
@@ -1974,7 +1988,7 @@ async def _share_session_facts(
     operation="share_session",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.post("/chat/sessions/{session_id}/share", response_model=DataResponse)
+@router.post("/chat/sessions/{session_id}/share", response_model=DataResponse[SessionShareData])
 async def share_session(
     session_id: str,
     share_data: SessionShareRequest,
@@ -2031,7 +2045,7 @@ async def share_session(
     operation="get_share_preview",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.get("/chat/sessions/{session_id}/share/preview", response_model=DataResponse)
+@router.get("/chat/sessions/{session_id}/share/preview", response_model=DataResponse[SessionSharePreviewData])
 async def get_share_preview(
     session_id: str,
     request: Request,
@@ -2073,7 +2087,7 @@ async def get_share_preview(
     operation="clear_session_checkpoints",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.delete("/sessions/{session_id}/checkpoints", response_model=DataResponse)
+@router.delete("/sessions/{session_id}/checkpoints", response_model=DataResponse[SessionCheckpointClearData])
 async def clear_session_checkpoints(
     session_id: str,
     current_user: Dict = Depends(get_current_user),

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -1,0 +1,172 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Typed payload models for chat_sessions.py DataResponse endpoints.
+
+One model per endpoint, named <Noun>Data, used as DataResponse[<Noun>Data]
+to give FastAPI enough type information to generate correct OpenAPI schemas.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class SessionMessagesData(BaseModel):
+    """data payload for GET /chat/sessions/{session_id}."""
+
+    messages: List[Any]
+    session_id: str
+    total_count: int
+    page: int
+    per_page: int
+
+
+class SessionListData(BaseModel):
+    """data payload for GET /chat/sessions (all scope variants).
+
+    The ``scope``, ``org_id``, and ``team_id`` fields are only present when
+    the request uses scope=org or scope=team query params.
+    ``intentional_empty`` is set when the authenticated user has zero sessions.
+    """
+
+    sessions: List[Any]
+    count: int
+    scope: Optional[str] = None
+    org_id: Optional[str] = None
+    team_id: Optional[str] = None
+    intentional_empty: Optional[bool] = None
+
+
+class SessionCreateData(BaseModel):
+    """data payload for POST /chat/sessions."""
+
+    id: Optional[str] = None
+    title: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    created_at: Optional[str] = None
+    last_modified: Optional[str] = None
+
+
+class SessionUpdateData(BaseModel):
+    """data payload for PUT /chat/sessions/{session_id}."""
+
+    id: Optional[str] = None
+    title: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    created_at: Optional[str] = None
+    last_modified: Optional[str] = None
+
+
+class FileHandlingResult(BaseModel):
+    """Nested file-handling sub-payload within SessionDeleteData."""
+
+    files_handled: bool
+    action_taken: str
+    files_deleted: Optional[int] = None
+    files_transferred: Optional[int] = None
+    files_failed: Optional[int] = None
+    error: Optional[str] = None
+
+
+class TerminalCleanupResult(BaseModel):
+    """Nested terminal-cleanup sub-payload within SessionDeleteData."""
+
+    terminal_sessions_closed: int
+    pending_approvals_cleared: int
+    error: Optional[str] = None
+
+
+class KbCleanupResult(BaseModel):
+    """Nested KB-cleanup sub-payload within SessionDeleteData."""
+
+    facts_deleted: int
+    facts_preserved: int
+    cleanup_error: Optional[str] = None
+
+
+class TranscriptCleanupResult(BaseModel):
+    """Nested transcript-cleanup sub-payload within SessionDeleteData."""
+
+    transcript_deleted: bool
+    error: Optional[str] = None
+
+
+class SessionDeleteData(BaseModel):
+    """data payload for DELETE /chat/sessions/{session_id}."""
+
+    session_id: str
+    deleted: bool
+    file_handling: Optional[FileHandlingResult] = None
+    terminal_cleanup: Optional[TerminalCleanupResult] = None
+    kb_cleanup: Optional[KbCleanupResult] = None
+    transcript_cleanup: Optional[TranscriptCleanupResult] = None
+
+
+class ChatResetData(BaseModel):
+    """data payload for POST /chat/reset."""
+
+    session_id: str
+    reset: bool
+    clear_context: bool
+    keep_system_prompt: bool
+
+
+class ActivityAddData(BaseModel):
+    """data payload for POST /chat/sessions/{session_id}/activities."""
+
+    activity_id: Optional[str] = None
+    entity_id: Optional[str] = None
+    stored: bool
+
+
+class ActivityBatchData(BaseModel):
+    """data payload for POST /chat/sessions/{session_id}/activities/batch."""
+
+    total: int
+    stored: int
+    failed: int
+    stored_ids: Optional[List[str]] = None
+
+
+class SessionActivitiesData(BaseModel):
+    """data payload for GET /chat/sessions/{session_id}/activities."""
+
+    activities: List[Any]
+    total: int
+    session_id: Optional[str] = None
+
+
+class SessionShareData(BaseModel):
+    """data payload for POST /chat/sessions/{session_id}/share."""
+
+    session_id: str
+    shared_with: List[str]
+    include_knowledge: bool
+    facts_shared: Optional[Any] = None
+
+
+class FactPreview(BaseModel):
+    """Individual fact entry within SessionSharePreviewData."""
+
+    id: str
+    content: str
+    full_content: str
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class SessionSharePreviewData(BaseModel):
+    """data payload for GET /chat/sessions/{session_id}/share/preview."""
+
+    session_id: str
+    fact_count: int
+    facts: List[FactPreview]
+
+
+class SessionCheckpointClearData(BaseModel):
+    """data payload for DELETE /sessions/{session_id}/checkpoints."""
+
+    session_id: str


### PR DESCRIPTION
## Summary
- Creates `autobot-backend/api/schemas_chat.py` with 15 typed Pydantic models (12 endpoint models + 4 nested sub-models) for all bare `DataResponse` endpoints in `chat_sessions.py`
- Updates all 12 `response_model=DataResponse` declarations to `response_model=DataResponse[TypedModel]`
- FastAPI now generates typed OpenAPI schemas for all session management endpoints

## Models created
`SessionMessagesData`, `SessionListData`, `SessionCreateData`, `SessionUpdateData`, `SessionDeleteData` (+ `FileHandlingResult`, `TerminalCleanupResult`, `KbCleanupResult`, `TranscriptCleanupResult`), `ChatResetData`, `ActivityAddData`, `ActivityBatchData`, `SessionActivitiesData`, `SessionShareData`, `SessionSharePreviewData` (+ `FactPreview`), `SessionCheckpointClearData`

## Not touched
`GET /chat/sessions/{session_id}/export` — returns a raw file download `Response`, not a JSON payload; its `response_model=DataResponse` is pre-existing dead code (separate issue).

## Test Plan
- [x] Both files pass `python3 -m py_compile`
- [x] `schemas_chat` module imports cleanly
- [x] Gate 5: 0 flake8 errors
- [x] 12 endpoints now have typed `response_model=DataResponse[X]`

Closes #6405

🤖 Generated with Claude Code