### PR TITLE
refactor(schemas_agent): move execution_time to AgentTaskData base class (#6406)

### DIFF
--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -1327,7 +1327,7 @@ async def coordinate_multi_agent_task(
                 "task": payload.task,
                 "agents_used": payload.agents,
                 "coordination_strategy": payload.coordination_strategy,
-                "coordination_time": coordination_time,
+                "execution_time": coordination_time,
                 "subtasks_count": len(payload.subtasks) if payload.subtasks else 0,
                 "dependencies_count": (
                     len(payload.dependencies) if payload.dependencies else 0

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -968,6 +968,7 @@ class AgentTaskData(BaseModel):
     """Base for agent execution payload models that invoke AI Stack multi-agent queries."""
 
     agents_used: List[str]
+    execution_time: float
     result: Optional[Dict[str, Any]] = None
 
 
@@ -976,7 +977,6 @@ class EnhancedGoalData(AgentTaskData):
 
     goal: str
     coordination_mode: str
-    execution_time: float
     priority: Optional[str] = None
     enhanced_context_used: bool
     knowledge_base_integrated: bool
@@ -988,7 +988,6 @@ class MultiAgentCoordinationData(AgentTaskData):
 
     task: str
     coordination_strategy: str
-    coordination_time: float
     subtasks_count: int
     dependencies_count: int
     timestamp: str


### PR DESCRIPTION
## Summary
- Renames `MultiAgentCoordinationData.coordination_time` → `execution_time` to match the three other `AgentTaskData` subclasses
- Moves `execution_time: float` into `AgentTaskData` base class — all four execution-model subclasses now inherit it
- Removes the redundant `execution_time` declarations from `EnhancedGoalData`, `AgentResearchData`, `DevelopmentAnalysisData`
- Updates `agent.py` response dict key `"coordination_time"` → `"execution_time"`

## Test Plan
- [x] Both files pass `python3 -m py_compile`
- [x] `execution_time` verified in `AgentTaskData.model_fields`, absent from all subclass `__annotations__`
- [x] Zero `coordination_time` references remain in backend or frontend source
- [x] Gate 5: 0 flake8 errors

Closes #6406

🤖 Generated with Claude Code