### PR TITLE
fix(nav): remove noVNC nav item + make chat tabs separate routes (#6414 #6415)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -821,8 +821,6 @@ export default {
       { to: '/plugins', labelKey: 'nav.plugins', icon: 'M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z', iconStroke: true },
       { to: '/secrets', labelKey: 'nav.secrets', icon: 'M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z', iconRule: 'evenodd' },
       { to: '/operations', labelKey: 'nav.operations', icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01', iconStroke: true },
-      // Issue #4977: Standalone Remote Desktop (noVNC) view
-      { to: '/slm/tools/novnc', labelKey: 'nav.remoteDesktop', icon: 'M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z', iconStroke: true },
       // Code Intelligence removed from main nav — merged into /analytics/codebase
       // Desktop nav removed — noVNC lives in the Chat tab. /desktop redirects to /chat.
       // Issue #902: Dev Tools moved into /analytics/dev-tools tab

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -268,6 +268,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, onActivated, onDeactivated, watch, provide } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useBackoffPoller } from '@/composables/useBackoffPoller'
 import { usePollingJob } from '@/composables/usePollingJob'
@@ -318,6 +319,10 @@ import MultiModelChat from './MultiModelChat.vue'
 
 // i18n
 const { t } = useI18n()
+
+// Router — tab routes (#6415)
+const route = useRoute()
+const router = useRouter()
 
 // Stores and controller
 const store = useChatStore()
@@ -462,8 +467,9 @@ const pendingCommand = ref({
 })
 const currentWorkflowId = ref<string | null>(null)
 
-// Tab state
-const activeTab = ref<string>('chat')
+// Tab state — initialized from route meta so /chat/terminal and /chat/novnc deep-link correctly
+const activeTab = ref<string>((route.meta.chatTab as string) ?? 'chat')
+watch(() => route.meta.chatTab, (tab: unknown) => { activeTab.value = (tab as string) ?? 'chat' })
 
 // Issue #690: Overseer Agent State
 const overseerEnabled = ref(false)
@@ -680,15 +686,12 @@ const handleContentLoadingTimeout = () => {
   logger.warn('Content loading timed out')
 }
 
-// Tab change handler - ensures local tab state change without router navigation
+// Tab change handler — updates local state and syncs URL to the named tab route (#6415)
 const handleTabChange = (tabKey: string) => {
   logger.debug('Tab change requested:', tabKey)
-
-  // Prevent any router navigation and only update local state
-  // This fixes the Terminal tab issue where it was triggering unwanted navigation
   activeTab.value = tabKey
-
-  // Log successful tab change
+  const routeName = tabKey === 'chat' ? 'chat-default' : `chat-${tabKey}`
+  router.push({ name: routeName }).catch(() => {})
   logger.debug('Active tab changed to:', activeTab.value)
 }
 
@@ -814,7 +817,7 @@ const onCommandApproved = async (commandData: any) => {
   // The backend polling loop will detect the approval and execute the command.
 
   // Switch to terminal tab to show execution
-  activeTab.value = 'terminal'
+  handleTabChange('terminal')
 
   // Close dialog
   showCommandDialog.value = false

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -80,6 +80,18 @@ const routes: RouteRecordRaw[] = [
         component: () => import('@/components/chat/ChatInterface.vue')
       },
       {
+        path: 'terminal',
+        name: 'chat-terminal',
+        component: () => import('@/components/chat/ChatInterface.vue'),
+        meta: { chatTab: 'terminal', requiresAuth: true, title: 'Chat — Terminal' }
+      },
+      {
+        path: 'novnc',
+        name: 'chat-novnc',
+        component: () => import('@/components/chat/ChatInterface.vue'),
+        meta: { chatTab: 'novnc', requiresAuth: true, title: 'Chat — Remote Desktop' }
+      },
+      {
         path: ':sessionId',
         name: 'chat-session',
         component: () => import('@/components/chat/ChatInterface.vue'),


### PR DESCRIPTION
## Summary
- Removes `/slm/tools/novnc` nav item from `App.vue` — noVNC is in the Chat tab, not a top-level nav entry (#6414)
- Adds `terminal` and `novnc` as static named child routes of `/chat` in router, before the dynamic `:sessionId` child — so tabs are bookmarkable and deep-linkable (#6415)
- `ChatInterface.vue`: initializes `activeTab` from `route.meta.chatTab`; watches route changes; `handleTabChange` now calls `router.push` to sync URL

## Routes added
| Tab | Route | Name |
|-----|-------|------|
| Chat | `/chat` | `chat-default` |
| Terminal | `/chat/terminal` | `chat-terminal` |
| noVNC | `/chat/novnc` | `chat-novnc` |
| Session | `/chat/:sessionId` | `chat-session` (unchanged) |

## Test Plan
- [x] noVNC no longer appears in sidebar nav
- [x] Navigating to `/chat/terminal` opens Chat view with Terminal tab active
- [x] Navigating to `/chat/novnc` opens Chat view with noVNC tab active
- [x] Clicking tabs updates URL
- [x] Browser back/forward navigates between tabs
- [x] Existing `/chat/:sessionId` links unaffected (static routes matched before dynamic)
- [x] TypeScript: no new errors introduced (pre-existing `vue-router` module resolution issue in worktree, not related)

Closes #6414
Closes #6415

🤖 Generated with Claude Code