### PR TITLE
fix+refactor(enhanced_orchestration): 4 targeted fixes from discovery audit (#6419 #6420 #6421 #6422)

### DIFF
--- a/autobot-backend/enhanced_orchestration/collaboration_coordinator.py
+++ b/autobot-backend/enhanced_orchestration/collaboration_coordinator.py
@@ -54,8 +54,9 @@ class CollaborationCoordinator:
                         {"type": "context_update", "shared_context": shared_context},
                     )
         except asyncio.CancelledError:
-            await pubsub.unsubscribe(collab_channel)
             raise
+        finally:
+            await pubsub.unsubscribe(collab_channel)
 
     async def broadcast_to_agents(self, channel: str, data: Dict[str, Any]) -> None:
         await self._ensure_redis()

--- a/autobot-backend/enhanced_orchestration/collaboration_coordinator_test.py
+++ b/autobot-backend/enhanced_orchestration/collaboration_coordinator_test.py
@@ -1,0 +1,168 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for CollaborationCoordinator. Issue #6421."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from enhanced_orchestration.collaboration_coordinator import CollaborationCoordinator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_message(msg_type: str, data: dict) -> dict:
+    return {"type": msg_type, "data": json.dumps(data)}
+
+
+def _make_redis(messages: list):
+    """Build a minimal fake Redis client whose pubsub replays `messages`.
+
+    redis.pubsub() is synchronous in redis-py, so pubsub must be a MagicMock
+    returned from a MagicMock call (not an awaited AsyncMock).
+    """
+    pubsub = MagicMock()
+    pubsub.subscribe = AsyncMock()
+    pubsub.unsubscribe = AsyncMock()
+
+    async def _listen():
+        for msg in messages:
+            yield msg
+
+    pubsub.listen = _listen
+    redis = AsyncMock()
+    redis.pubsub = MagicMock(return_value=pubsub)
+    redis.publish = AsyncMock()
+    return redis, pubsub
+
+
+# ---------------------------------------------------------------------------
+# _ensure_redis
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_redis_calls_factory_once():
+    redis = AsyncMock()
+    factory = AsyncMock(return_value=redis)
+    coord = CollaborationCoordinator(redis_factory=factory)
+
+    await coord._ensure_redis()
+    await coord._ensure_redis()  # second call must not invoke factory again
+
+    factory.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ensure_redis_raises_when_factory_returns_none():
+    coord = CollaborationCoordinator(redis_factory=AsyncMock(return_value=None))
+    with pytest.raises(RuntimeError, match="Redis unavailable"):
+        await coord._ensure_redis()
+
+
+# ---------------------------------------------------------------------------
+# coordinate_collaboration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_coordinate_collaboration_broadcasts_share_insight():
+    insight_msg = _make_message(
+        "message", {"type": "share_insight", "agent": "agent_a", "insight": "foo"}
+    )
+    redis, pubsub = _make_redis([{"type": "subscribe"}, insight_msg])
+
+    coord = CollaborationCoordinator(redis_factory=AsyncMock(return_value=redis))
+    await coord.coordinate_collaboration("chan:test")
+
+    pubsub.subscribe.assert_awaited_once_with("chan:test")
+    redis.publish.assert_awaited_once()
+    published_payload = json.loads(redis.publish.call_args[0][1])
+    assert published_payload["type"] == "context_update"
+    assert "agent_a_insight" in published_payload["shared_context"]
+
+
+@pytest.mark.asyncio
+async def test_coordinate_collaboration_skips_non_message_type():
+    redis, pubsub = _make_redis([{"type": "subscribe"}, {"type": "psubscribe"}])
+    coord = CollaborationCoordinator(redis_factory=AsyncMock(return_value=redis))
+    await coord.coordinate_collaboration("chan:test")
+    redis.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_coordinate_collaboration_skips_bad_json():
+    bad_msg = {"type": "message", "data": "not-json{{{"}
+    redis, pubsub = _make_redis([bad_msg])
+    coord = CollaborationCoordinator(redis_factory=AsyncMock(return_value=redis))
+    await coord.coordinate_collaboration("chan:test")
+    redis.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_coordinate_collaboration_unsubscribes_on_cancellation():
+    """pubsub must be unsubscribed even when the task is cancelled (#6419)."""
+
+    async def _infinite_listen():
+        await asyncio.sleep(9999)
+        yield  # pragma: no cover
+
+    pubsub = MagicMock()
+    pubsub.subscribe = AsyncMock()
+    pubsub.unsubscribe = AsyncMock()
+    pubsub.listen = _infinite_listen
+    redis = AsyncMock()
+    redis.pubsub = MagicMock(return_value=pubsub)
+
+    coord = CollaborationCoordinator(redis_factory=AsyncMock(return_value=redis))
+    task = asyncio.create_task(coord.coordinate_collaboration("chan:test"))
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    pubsub.unsubscribe.assert_awaited_once_with("chan:test")
+
+
+@pytest.mark.asyncio
+async def test_coordinate_collaboration_unsubscribes_on_redis_error():
+    """pubsub must be unsubscribed when a non-CancelledError exception fires (#6419)."""
+
+    async def _error_listen():
+        raise ConnectionError("Redis dropped")
+        yield  # make this an async generator
+
+    pubsub = MagicMock()
+    pubsub.subscribe = AsyncMock()
+    pubsub.unsubscribe = AsyncMock()
+    pubsub.listen = _error_listen
+    redis = AsyncMock()
+    redis.pubsub = MagicMock(return_value=pubsub)
+
+    coord = CollaborationCoordinator(redis_factory=AsyncMock(return_value=redis))
+    with pytest.raises(ConnectionError):
+        await coord.coordinate_collaboration("chan:test")
+
+    pubsub.unsubscribe.assert_awaited_once_with("chan:test")
+
+
+# ---------------------------------------------------------------------------
+# broadcast_to_agents
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_agents_publishes_json():
+    redis = AsyncMock()
+    redis.pubsub.return_value = AsyncMock()
+    coord = CollaborationCoordinator(redis_factory=AsyncMock(return_value=redis))
+    await coord._ensure_redis()
+
+    await coord.broadcast_to_agents("chan:x", {"key": "val"})
+    redis.publish.assert_awaited_once_with("chan:x", json.dumps({"key": "val"}))

--- a/autobot-backend/enhanced_orchestration/execution_strategies.py
+++ b/autobot-backend/enhanced_orchestration/execution_strategies.py
@@ -10,11 +10,11 @@ Contains execution strategy implementations for workflow orchestration.
 
 import asyncio
 import logging
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Dict, Tuple
 
 from constants.threshold_constants import TimingConstants
 
-from .types import AgentTask, ExecutionStrategy, WorkflowPlan
+from .types import AgentTask, ExecutionStrategy, WorkflowDependencies, WorkflowPlan
 
 logger = logging.getLogger(__name__)
 
@@ -26,34 +26,16 @@ class ExecutionStrategyHandler:
         self,
         max_parallel_tasks: int,
         resource_semaphore: asyncio.Semaphore,
-        execute_single_task: Callable,
-        topological_sort_tasks: Callable,
-        dependencies_met: Callable,
-        group_pipeline_stages: Callable,
-        enhance_task_for_collaboration: Callable,
-        coordinate_collaboration: Callable,
-    ):
-        """
-        Initialize strategy handler with required dependencies.
-
-        Args:
-            max_parallel_tasks: Maximum concurrent tasks
-            resource_semaphore: Semaphore for resource management
-            execute_single_task: Function to execute a single task
-            topological_sort_tasks: Function to sort tasks by dependencies
-            dependencies_met: Function to check if dependencies are satisfied
-            group_pipeline_stages: Function to group tasks into pipeline stages
-            enhance_task_for_collaboration: Function to enhance tasks for collaboration
-            coordinate_collaboration: Coroutine for coordination
-        """
+        deps: WorkflowDependencies,
+    ) -> None:
         self.max_parallel_tasks = max_parallel_tasks
         self.resource_semaphore = resource_semaphore
-        self._execute_single_task = execute_single_task
-        self._topological_sort_tasks = topological_sort_tasks
-        self._dependencies_met = dependencies_met
-        self._group_pipeline_stages = group_pipeline_stages
-        self._enhance_task_for_collaboration = enhance_task_for_collaboration
-        self._coordinate_collaboration = coordinate_collaboration
+        self._execute_single_task = deps.execute_single_task
+        self._topological_sort_tasks = deps.topological_sort_tasks
+        self._dependencies_met = deps.dependencies_met
+        self._group_pipeline_stages = deps.group_pipeline_stages
+        self._enhance_task_for_collaboration = deps.enhance_task_for_collaboration
+        self._coordinate_collaboration = deps.coordinate_collaboration
         self.coordination_prefix = "autobot:orchestrator:coord:"
 
     async def execute_by_strategy(self, plan: WorkflowPlan) -> Dict[str, Any]:
@@ -130,9 +112,15 @@ class ExecutionStrategyHandler:
                         results[task.task_id] = result
                         running_tasks.remove((task, future))
                         logger.info("Completed parallel task %s", task.task_id)
-            else:
-                # No tasks running, wait a bit
-                await asyncio.sleep(TimingConstants.MICRO_DELAY)
+            elif pending_tasks:
+                # No running tasks but pending remain — dependency deadlock (#6420)
+                logger.error(
+                    "Dependency deadlock: %d tasks unresolvable, failing them",
+                    len(pending_tasks),
+                )
+                for task in pending_tasks:
+                    results[task.task_id] = task.to_failed_result("Dependency deadlock")
+                break
 
         return results
 

--- a/autobot-backend/enhanced_orchestration/execution_strategies_test.py
+++ b/autobot-backend/enhanced_orchestration/execution_strategies_test.py
@@ -1,0 +1,238 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for ExecutionStrategyHandler. Issue #6421."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from enhanced_orchestration.execution_strategies import ExecutionStrategyHandler
+from enhanced_orchestration.types import (
+    AgentTask,
+    ExecutionStrategy,
+    WorkflowDependencies,
+    WorkflowPlan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _task(task_id: str, deps: list = None) -> AgentTask:
+    return AgentTask(
+        task_id=task_id,
+        agent_type="test_agent",
+        action="test",
+        inputs={},
+        dependencies=deps or [],
+    )
+
+
+def _plan(tasks, strategy=ExecutionStrategy.SEQUENTIAL, deps_graph=None) -> WorkflowPlan:
+    return WorkflowPlan(
+        plan_id="plan-1",
+        goal="test",
+        strategy=strategy,
+        tasks=tasks,
+        dependencies_graph=deps_graph or {},
+        estimated_duration=1.0,
+        resource_requirements={},
+        success_criteria=[],
+    )
+
+
+def _completed(task_id: str) -> dict:
+    return {"status": "completed", "output": {}, "execution_time": 0.0, "agent": "test_agent"}
+
+
+def _failed(task_id: str) -> dict:
+    return {"status": "failed", "error": "err", "agent": "test_agent"}
+
+
+def _deps_met(task: AgentTask, results: dict) -> bool:
+    return all(
+        results.get(dep, {}).get("status") == "completed" for dep in task.dependencies
+    )
+
+
+def _make_handler(execute_fn=None, deps_met_fn=None, max_parallel=5):
+    execute_fn = execute_fn or (lambda task, ctx: asyncio.coroutine(lambda: _completed(task.task_id))())
+    deps_met_fn = deps_met_fn or _deps_met
+
+    async def _noop_coord(channel):
+        pass
+
+    deps = WorkflowDependencies(
+        execute_single_task=execute_fn,
+        topological_sort_tasks=lambda tasks, graph: tasks,
+        dependencies_met=deps_met_fn,
+        group_pipeline_stages=lambda tasks, graph: [tasks],
+        enhance_task_for_collaboration=lambda task, channel: task,
+        coordinate_collaboration=_noop_coord,
+    )
+    return ExecutionStrategyHandler(
+        max_parallel_tasks=max_parallel,
+        resource_semaphore=asyncio.Semaphore(max_parallel),
+        deps=deps,
+    )
+
+
+# ---------------------------------------------------------------------------
+# execute_sequential
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sequential_executes_all_tasks():
+    tasks = [_task("t1"), _task("t2"), _task("t3")]
+    executed = []
+
+    async def execute(task, ctx):
+        executed.append(task.task_id)
+        return _completed(task.task_id)
+
+    handler = _make_handler(execute_fn=execute)
+    results = await handler.execute_sequential(_plan(tasks))
+    assert executed == ["t1", "t2", "t3"]
+    assert all(results[tid]["status"] == "completed" for tid in ["t1", "t2", "t3"])
+
+
+@pytest.mark.asyncio
+async def test_sequential_stops_on_required_task_failure():
+    tasks = [_task("t1"), _task("t2"), _task("t3")]
+    executed = []
+
+    async def execute(task, ctx):
+        executed.append(task.task_id)
+        if task.task_id == "t2":
+            return _failed(task.task_id)
+        return _completed(task.task_id)
+
+    handler = _make_handler(execute_fn=execute)
+    results = await handler.execute_sequential(_plan(tasks))
+    assert "t3" not in executed
+    assert results["t2"]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_sequential_continues_after_optional_task_failure():
+    t2 = _task("t2")
+    t2.metadata["optional"] = True
+    tasks = [_task("t1"), t2, _task("t3")]
+    executed = []
+
+    async def execute(task, ctx):
+        executed.append(task.task_id)
+        if task.task_id == "t2":
+            return _failed(task.task_id)
+        return _completed(task.task_id)
+
+    handler = _make_handler(execute_fn=execute)
+    await handler.execute_sequential(_plan(tasks))
+    assert "t3" in executed
+
+
+# ---------------------------------------------------------------------------
+# execute_parallel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parallel_executes_independent_tasks():
+    tasks = [_task("t1"), _task("t2"), _task("t3")]
+    executed = []
+
+    async def execute(task, ctx):
+        executed.append(task.task_id)
+        return _completed(task.task_id)
+
+    handler = _make_handler(execute_fn=execute)
+    results = await handler.execute_parallel(_plan(tasks, ExecutionStrategy.PARALLEL))
+    assert set(executed) == {"t1", "t2", "t3"}
+    assert all(results[tid]["status"] == "completed" for tid in ["t1", "t2", "t3"])
+
+
+@pytest.mark.asyncio
+async def test_parallel_deadlock_detection(caplog):
+    """Tasks whose dependencies can never be satisfied must fail, not loop (#6420)."""
+    t1 = _task("t1", deps=["t_missing"])
+
+    async def execute(task, ctx):
+        return _completed(task.task_id)  # pragma: no cover
+
+    handler = _make_handler(execute_fn=execute)
+    results = await handler.execute_parallel(_plan([t1], ExecutionStrategy.PARALLEL))
+    assert results["t1"]["status"] == "failed"
+    assert "deadlock" in results["t1"]["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_parallel_respects_max_parallel_tasks():
+    tasks = [_task(f"t{i}") for i in range(10)]
+    concurrency_peak = 0
+    active = 0
+
+    async def execute(task, ctx):
+        nonlocal concurrency_peak, active
+        active += 1
+        concurrency_peak = max(concurrency_peak, active)
+        await asyncio.sleep(0)
+        active -= 1
+        return _completed(task.task_id)
+
+    handler = _make_handler(execute_fn=execute, max_parallel=3)
+    await handler.execute_parallel(_plan(tasks, ExecutionStrategy.PARALLEL))
+    assert concurrency_peak <= 3
+
+
+# ---------------------------------------------------------------------------
+# execute_adaptive — strategy switching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_adaptive_switches_to_sequential_on_high_failure():
+    tasks = [_task(f"t{i}") for i in range(4)]
+    call_count = 0
+
+    async def execute(task, ctx):
+        nonlocal call_count
+        call_count += 1
+        return _failed(task.task_id)
+
+    handler = _make_handler(execute_fn=execute)
+    results = await handler.execute_adaptive(_plan(tasks, ExecutionStrategy.ADAPTIVE))
+    assert all(results[t.task_id]["status"] == "failed" for t in tasks)
+
+
+# ---------------------------------------------------------------------------
+# WorkflowDependencies injection
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_dependencies_fields_wired_correctly():
+    """Ensure all 6 callables are accessible via named deps fields."""
+    sentinel = object()
+    deps = WorkflowDependencies(
+        execute_single_task=sentinel,
+        topological_sort_tasks=sentinel,
+        dependencies_met=sentinel,
+        group_pipeline_stages=sentinel,
+        enhance_task_for_collaboration=sentinel,
+        coordinate_collaboration=sentinel,
+    )
+    handler = ExecutionStrategyHandler(
+        max_parallel_tasks=1,
+        resource_semaphore=asyncio.Semaphore(1),
+        deps=deps,
+    )
+    assert handler._execute_single_task is sentinel
+    assert handler._topological_sort_tasks is sentinel
+    assert handler._dependencies_met is sentinel
+    assert handler._group_pipeline_stages is sentinel
+    assert handler._enhance_task_for_collaboration is sentinel
+    assert handler._coordinate_collaboration is sentinel

--- a/autobot-backend/enhanced_orchestration/types.py
+++ b/autobot-backend/enhanced_orchestration/types.py
@@ -11,7 +11,7 @@ Contains enums and dataclasses for the enhanced orchestration system.
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, FrozenSet, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Callable, Dict, FrozenSet, List, Optional, Set
 
 if TYPE_CHECKING:
     from .success_criteria import SuccessCriteria
@@ -128,6 +128,22 @@ class WorkflowPlan:
     structured_criteria: List["SuccessCriteria"] = field(default_factory=list)
     fallback_plans: List["WorkflowPlan"] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class WorkflowDependencies:
+    """Groups the callable dependencies injected into ExecutionStrategyHandler (#6422).
+
+    Replaces 6 positional Callable params with a single named container, making
+    the constructor testable and the dependency surface explicit.
+    """
+
+    execute_single_task: Callable
+    topological_sort_tasks: Callable
+    dependencies_met: Callable
+    group_pipeline_stages: Callable
+    enhance_task_for_collaboration: Callable
+    coordinate_collaboration: Callable
 
 
 @dataclass

--- a/autobot-backend/enhanced_orchestration/workflow_runner.py
+++ b/autobot-backend/enhanced_orchestration/workflow_runner.py
@@ -16,7 +16,7 @@ from enhanced_orchestration.agent_router import AgentRouter
 from enhanced_orchestration.collaboration_coordinator import CollaborationCoordinator
 from enhanced_orchestration.execution_strategies import ExecutionStrategyHandler
 from enhanced_orchestration.success_criteria import SuccessCriteriaEvaluator
-from enhanced_orchestration.types import AgentTask, WorkflowPlan
+from enhanced_orchestration.types import AgentTask, WorkflowDependencies, WorkflowPlan
 from enhanced_orchestration.workflow_planning import WorkflowPlanner as StrategyPlanner
 from event_manager import get_event_manager as _get_event_manager
 from orchestration.performance_tracker import PerformanceTracker
@@ -60,12 +60,14 @@ class WorkflowRunner:
             self._strategy_handler = ExecutionStrategyHandler(
                 max_parallel_tasks=self.max_parallel_tasks,
                 resource_semaphore=self.resource_semaphore,
-                execute_single_task=self._execute_single_agent_task,
-                topological_sort_tasks=self._strategy_planner.topological_sort_tasks,
-                dependencies_met=self._strategy_planner.dependencies_met,
-                group_pipeline_stages=self._strategy_planner.group_pipeline_stages,
-                enhance_task_for_collaboration=self._strategy_planner.enhance_task_for_collaboration,
-                coordinate_collaboration=self._collab.coordinate_collaboration,
+                deps=WorkflowDependencies(
+                    execute_single_task=self._execute_single_agent_task,
+                    topological_sort_tasks=self._strategy_planner.topological_sort_tasks,
+                    dependencies_met=self._strategy_planner.dependencies_met,
+                    group_pipeline_stages=self._strategy_planner.group_pipeline_stages,
+                    enhance_task_for_collaboration=self._strategy_planner.enhance_task_for_collaboration,
+                    coordinate_collaboration=self._collab.coordinate_collaboration,
+                ),
             )
         return self._strategy_handler
 

--- a/autobot-backend/enhanced_orchestration/workflow_runner_test.py
+++ b/autobot-backend/enhanced_orchestration/workflow_runner_test.py
@@ -1,0 +1,166 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for WorkflowRunner. Issue #6421."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from enhanced_orchestration.types import (
+    AgentTask,
+    ExecutionStrategy,
+    WorkflowPlan,
+)
+from enhanced_orchestration.workflow_runner import WorkflowRunner
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _task(task_id: str) -> AgentTask:
+    return AgentTask(
+        task_id=task_id,
+        agent_type="test_agent",
+        action="act",
+        inputs={},
+    )
+
+
+def _plan(tasks=None, strategy=ExecutionStrategy.SEQUENTIAL) -> WorkflowPlan:
+    tasks = tasks or [_task("t1")]
+    return WorkflowPlan(
+        plan_id="plan-test",
+        goal="test goal",
+        strategy=strategy,
+        tasks=tasks,
+        dependencies_graph={},
+        estimated_duration=1.0,
+        resource_requirements={},
+        success_criteria=[],
+    )
+
+
+def _make_runner(criteria_evaluator=None):
+    strategy_planner = MagicMock()
+    strategy_planner.topological_sort_tasks.return_value = []
+    strategy_planner.dependencies_met.return_value = True
+    strategy_planner.group_pipeline_stages.return_value = [[]]
+    strategy_planner.enhance_task_for_collaboration.side_effect = lambda t, c: t
+    strategy_planner.check_success_criteria.return_value = True
+    strategy_planner.summarize_results.return_value = {}
+
+    perf = MagicMock()
+    perf.update = MagicMock()
+    perf.update_from_plan = MagicMock()
+    perf.report = MagicMock(return_value={})
+
+    agent_router = AsyncMock()
+    agent_router.get_agent_recommendations = AsyncMock(return_value=[])
+    agent_router.calculate_capability_coverage.return_value = {}
+
+    collab = AsyncMock()
+    collab.coordinate_collaboration = AsyncMock()
+
+    return WorkflowRunner(
+        strategy_planner=strategy_planner,
+        performance_tracker=perf,
+        active_workflows={},
+        collaboration=collab,
+        agent_router=agent_router,
+        criteria_evaluator=criteria_evaluator,
+    )
+
+
+# ---------------------------------------------------------------------------
+# criteria_evaluator injection (#6402)
+# ---------------------------------------------------------------------------
+
+
+def test_default_criteria_evaluator_created_when_none():
+    from enhanced_orchestration.success_criteria import SuccessCriteriaEvaluator
+    runner = _make_runner()
+    assert isinstance(runner._criteria_evaluator, SuccessCriteriaEvaluator)
+
+
+def test_injected_criteria_evaluator_is_stored():
+    mock_evaluator = MagicMock()
+    runner = _make_runner(criteria_evaluator=mock_evaluator)
+    assert runner._criteria_evaluator is mock_evaluator
+
+
+@pytest.mark.asyncio
+async def test_evaluate_workflow_criteria_uses_injected_evaluator():
+    eval_result = MagicMock()
+    eval_result.to_dict.return_value = {"overall": "full", "score": 1.0, "results": []}
+    mock_evaluator = AsyncMock()
+    mock_evaluator.evaluate = AsyncMock(return_value=eval_result)
+
+    runner = _make_runner(criteria_evaluator=mock_evaluator)
+    plan = _plan()
+    plan.structured_criteria = [MagicMock()]
+
+    result = await runner._evaluate_workflow_criteria(plan, {})
+    mock_evaluator.evaluate.assert_awaited_once()
+    assert result["overall"] == "full"
+
+
+@pytest.mark.asyncio
+async def test_evaluate_workflow_criteria_binary_fallback_when_no_structured():
+    runner = _make_runner()
+    runner._strategy_planner.check_success_criteria.return_value = True
+
+    plan = _plan()
+    plan.structured_criteria = []
+    result = await runner._evaluate_workflow_criteria(plan, {})
+    assert result["overall"] == "full"
+    assert result["score"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# fallback depth cap (#5058)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fallback_depth_capped_at_5():
+    runner = _make_runner()
+
+    with patch.object(runner, "_get_strategy_handler") as mock_handler_fn:
+        mock_handler = AsyncMock()
+        mock_handler.execute_by_strategy = AsyncMock(side_effect=RuntimeError("always fails"))
+        mock_handler_fn.return_value = mock_handler
+
+        with patch("enhanced_orchestration.workflow_runner._get_event_manager") as mock_em:
+            mock_em.return_value.publish = AsyncMock()
+
+            root_plan = _plan()
+            # Build a chain of 6 fallbacks (depth 0-5 = 6 levels total)
+            fallback = _plan()
+            fallback.fallback_plans = []
+            root_plan.fallback_plans = [fallback]
+
+            result = await runner.execute_workflow(root_plan, _depth=5)
+
+    assert result["success"] is False
+    assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# get_performance_report
+# ---------------------------------------------------------------------------
+
+
+def test_get_performance_report_shape():
+    runner = _make_runner()
+    runner._perf.report.return_value = {"agent_a": {"total": 1}}
+    runner._agent_router.calculate_capability_coverage.return_value = {"cap_x": 0.9}
+    runner.active_workflows["w1"] = MagicMock()
+
+    report = runner.get_performance_report()
+    assert "agent_performance" in report
+    assert report["active_workflows"] == 1
+    assert "capabilities_coverage" in report


### PR DESCRIPTION
## Summary
- **#6419**: Fix pubsub subscription leak in `coordinate_collaboration` — replaced `except CancelledError` cleanup with `try/finally` so `unsubscribe` fires unconditionally (Redis disconnect, unexpected exceptions, cancellation)
- **#6420**: Fix `execute_parallel` infinite loop on deadlocked dependencies — detect when pending tasks remain but none are ready and no tasks are running; fail them with `"Dependency deadlock"` error instead of spinning forever
- **#6421**: Add 22 unit tests across 3 new test files covering injectable deps, pubsub lifecycle (including the two bugs above), deadlock detection, `WorkflowDependencies` wiring, fallback depth cap, and `criteria_evaluator` injection
- **#6422**: Introduce `WorkflowDependencies` dataclass in `types.py`; collapse 6 positional `Callable` params in `ExecutionStrategyHandler.__init__` into a single `deps: WorkflowDependencies` argument

## Test Plan
- [x] 22 new tests all pass (`pytest enhanced_orchestration/*_test.py -v`)
- [x] `python3 -m py_compile` passes on all 4 modified source files
- [x] `test_coordinate_collaboration_unsubscribes_on_redis_error` directly validates #6419 fix
- [x] `test_parallel_deadlock_detection` directly validates #6420 fix
- [x] `test_workflow_dependencies_fields_wired_correctly` validates #6422 wiring

## Related Issues
Closes #6419
Closes #6420
Closes #6421
Closes #6422