### PR TITLE
feat(browser): region-marking + AI scraping templates MVP (#5136)

### DIFF
--- a/autobot-backend/api/playwright.py
+++ b/autobot-backend/api/playwright.py
@@ -15,6 +15,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
 from autobot_shared.ssot_config import config as _ssot_config
 from constants.network_constants import NetworkConstants
+from research_browser_manager import get_research_browser_manager
 from services.playwright_service import (
     get_playwright_service,
     playwright_service,
@@ -23,6 +24,8 @@ from services.playwright_service import (
     test_frontend_embedded,
 )
 from api.schemas_common import DataResponse
+import base64
+
 from api.schemas_code import (
     PlaywrightBrowserActionResponse,
     PlaywrightCapabilitiesResponse,
@@ -35,6 +38,7 @@ from api.schemas_code import (
     PlaywrightSearchRequest,
     PlaywrightStatusResponse,
     PlaywrightWorkerStatusResponse,
+    SnapshotWithRegionsResponse,
 )
 from api.schemas_system import PlaywrightEmbeddedResultResponse
 
@@ -49,6 +53,11 @@ class TestMessageRequest(BaseModel):
 
 class FrontendTestRequest(BaseModel):
     frontend_url: str = _ssot_config.frontend_url
+
+
+class SnapshotWithRegionsRequest(BaseModel):
+    session_id: str
+    goal: str = ""  # optional hint for filtering
 
 
 # Browser VM connection
@@ -749,3 +758,113 @@ async def get_capabilities():
             "description": "Docker container with native API integration",
         },
     }
+
+
+# JavaScript used by snapshot_with_regions to walk the DOM and collect regions.
+_JS_COLLECT_REGIONS = """
+() => {
+  const results = [];
+  const seen = new Set();
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
+  while (walker.nextNode()) {
+    const el = walker.currentNode;
+    const rect = el.getBoundingClientRect();
+    const area = rect.width * rect.height;
+    if (area < 20) continue;
+    const style = window.getComputedStyle(el);
+    if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') continue;
+    if (rect.width === 0 || rect.height === 0) continue;
+    const key = `${Math.round(rect.x)},${Math.round(rect.y)},${Math.round(rect.width)},${Math.round(rect.height)}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const role = el.getAttribute('role') || el.tagName.toLowerCase();
+    const textPreview = (el.textContent || '').trim().slice(0, 80);
+    if (!textPreview && !el.getAttribute('aria-label') && !el.getAttribute('alt')) continue;
+    let selector = el.tagName.toLowerCase();
+    if (el.id) selector = `#${el.id}`;
+    else if (el.className && typeof el.className === 'string') {
+      const cls = el.className.trim().split(/\\s+/)[0];
+      if (cls) selector = `.${cls}`;
+    }
+    let xpath = '';
+    let node = el;
+    while (node && node !== document.body) {
+      const tag = node.tagName.toLowerCase();
+      const idx = Array.from(node.parentElement?.children || []).filter(c => c.tagName === node.tagName).indexOf(node) + 1;
+      xpath = `/${tag}[${idx}]${xpath}`;
+      node = node.parentElement;
+    }
+    xpath = `/html/body${xpath}`;
+    results.push({
+      selector,
+      xpath,
+      rect: { x: rect.x, y: rect.y, w: rect.width, h: rect.height },
+      textPreview: textPreview || el.getAttribute('aria-label') || el.getAttribute('alt') || '',
+      role
+    });
+  }
+  return results.slice(0, 200);
+}
+"""
+
+
+@router.post(
+    "/snapshot-with-regions",
+    response_model=DataResponse[SnapshotWithRegionsResponse],
+)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="snapshot_with_regions",
+    error_code_prefix="PLAYWRIGHT",
+)
+async def snapshot_with_regions(request: SnapshotWithRegionsRequest):
+    """
+    Take a screenshot of a research browser session and return detected page regions.
+
+    Returns a base64 PNG screenshot together with a list of interactive DOM regions
+    (selector, xpath, bounding rect, text preview, ARIA role) so the frontend can
+    overlay clickable highlights for scraping-template creation. (#5136)
+    """
+    manager = get_research_browser_manager()
+    session = manager.get_session(request.session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    if session.page is None:
+        raise HTTPException(status_code=400, detail="Browser page not initialized")
+
+    logger.info(
+        "snapshot-with-regions: session=%s goal=%r", request.session_id, request.goal
+    )
+
+    screenshot_bytes: bytes = await session.page.screenshot(type="png")
+    screenshot_b64 = base64.b64encode(screenshot_bytes).decode("utf-8")
+
+    raw_regions: list = await session.page.evaluate(_JS_COLLECT_REGIONS)
+
+    viewport_size = session.page.viewport_size or {}
+
+    regions = [
+        {
+            "selector": r.get("selector", ""),
+            "xpath": r.get("xpath", ""),
+            "rect": r.get("rect", {"x": 0, "y": 0, "w": 0, "h": 0}),
+            "text_preview": r.get("textPreview", ""),
+            "role": r.get("role", ""),
+        }
+        for r in raw_regions
+    ]
+
+    logger.info(
+        "snapshot-with-regions: captured %d regions for session %s",
+        len(regions),
+        request.session_id,
+    )
+
+    return DataResponse(
+        data=SnapshotWithRegionsResponse(
+            screenshot=screenshot_b64,
+            regions=regions,
+            viewport=dict(viewport_size),
+        )
+    )

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -832,6 +832,33 @@ class PlaywrightCapabilitiesResponse(BaseModel):
     endpoints: List[str]
 
 
+class RegionRect(BaseModel):
+    """Bounding-box coordinates for a detected page region."""
+
+    x: float
+    y: float
+    w: float
+    h: float
+
+
+class PageRegion(BaseModel):
+    """A single interactive region detected on a browser page."""
+
+    selector: str
+    xpath: str
+    rect: RegionRect
+    text_preview: str
+    role: str
+
+
+class SnapshotWithRegionsResponse(BaseModel):
+    """Response for POST /playwright/snapshot-with-regions (#5136)."""
+
+    screenshot: str  # base64 PNG
+    regions: List[PageRegion]
+    viewport: Dict[str, Any]  # width, height, devicePixelRatio
+
+
 # ---------------------------------------------------------------------------
 # research_browser.py schemas  (Issue #5912)
 # ---------------------------------------------------------------------------

--- a/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
+++ b/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
@@ -14,8 +14,25 @@
 
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { createLogger } from '@/utils/logger'
 
 const { t } = useI18n()
+const logger = createLogger('InteractiveScreenshot')
+
+interface RegionRect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+interface PageRegion {
+  selector: string
+  xpath: string
+  rect: RegionRect
+  textPreview: string
+  role: string
+}
 
 interface Props {
   screenshot: string | null
@@ -23,6 +40,8 @@ interface Props {
   interactive?: boolean
   viewportWidth?: number
   viewportHeight?: number
+  regions?: PageRegion[]
+  markRegionsMode?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -30,15 +49,24 @@ const props = withDefaults(defineProps<Props>(), {
   interactive: true,
   viewportWidth: 1280,
   viewportHeight: 720,
+  regions: () => [],
+  markRegionsMode: false,
 })
 
 const emit = defineEmits<{
   interact: [payload: { action: string; params: Record<string, unknown> }]
+  regionsSelected: [regions: Array<{ selector: string; xpath: string; label: string }>]
 }>()
 
 const showTypeOverlay = ref(false)
 const typeText = ref('')
 const imgRef = ref<HTMLImageElement | null>(null)
+
+// Region-marking state (#5136)
+const hoveredRegion = ref<number | null>(null)
+const selectedRegions = ref<Array<{ selector: string; xpath: string; label: string }>>([])
+const popupRegionIndex = ref<number | null>(null)
+const popupLabel = ref('')
 
 const screenshotSrc = computed(() =>
   props.screenshot ? `data:image/png;base64,${props.screenshot}` : null
@@ -89,6 +117,56 @@ function submitType() {
   typeText.value = ''
   showTypeOverlay.value = false
 }
+
+// Region-marking helpers (#5136)
+function regionStyle(rect: RegionRect): Record<string, string> {
+  const img = imgRef.value
+  if (!img) return {}
+  const imgRect = img.getBoundingClientRect()
+  const scaleX = imgRect.width / props.viewportWidth
+  const scaleY = imgRect.height / props.viewportHeight
+  return {
+    position: 'absolute',
+    left: `${rect.x * scaleX}px`,
+    top: `${rect.y * scaleY}px`,
+    width: `${rect.w * scaleX}px`,
+    height: `${rect.h * scaleY}px`,
+    pointerEvents: 'all',
+    cursor: 'pointer',
+  }
+}
+
+function popupStyle(rect: RegionRect): Record<string, string> {
+  const img = imgRef.value
+  if (!img) return {}
+  const imgRect = img.getBoundingClientRect()
+  const scaleX = imgRect.width / props.viewportWidth
+  const scaleY = imgRect.height / props.viewportHeight
+  return {
+    position: 'absolute',
+    left: `${rect.x * scaleX}px`,
+    top: `${(rect.y + rect.h) * scaleY + 4}px`,
+    zIndex: '50',
+  }
+}
+
+function openPopup(index: number): void {
+  popupRegionIndex.value = index
+  popupLabel.value = ''
+}
+
+function saveRegion(index: number | null): void {
+  if (index === null || !props.regions) return
+  const region = props.regions[index]
+  selectedRegions.value.push({
+    selector: region.selector,
+    xpath: region.xpath,
+    label: popupLabel.value || region.textPreview.slice(0, 20),
+  })
+  logger.debug('Region saved', { selector: region.selector, label: popupLabel.value })
+  emit('regionsSelected', [...selectedRegions.value])
+  popupRegionIndex.value = null
+}
 </script>
 
 <template>
@@ -107,6 +185,35 @@ function submitType() {
       <div v-if="loading" class="loading-overlay">
         <div class="loading-spinner" />
       </div>
+
+      <!-- Region-marking overlay (#5136) -->
+      <template v-if="markRegionsMode && regions && regions.length > 0">
+        <div
+          v-for="(region, i) in regions"
+          :key="i"
+          class="region-overlay"
+          :class="{ 'region-hovered': hoveredRegion === i }"
+          :style="regionStyle(region.rect)"
+          @mouseenter="hoveredRegion = i"
+          @mouseleave="hoveredRegion = null"
+          @click.stop="openPopup(i)"
+        />
+        <div
+          v-if="popupRegionIndex !== null"
+          class="region-popup"
+          :style="popupStyle(regions[popupRegionIndex].rect)"
+          @click.stop
+        >
+          <div class="region-popup-selector">{{ regions[popupRegionIndex].selector }}</div>
+          <input
+            v-model="popupLabel"
+            placeholder="Label (e.g. title, price)"
+            class="region-popup-input"
+          />
+          <button class="region-popup-save" @click="saveRegion(popupRegionIndex)">Save</button>
+          <button class="region-popup-cancel" @click="popupRegionIndex = null">Cancel</button>
+        </div>
+      </template>
     </div>
 
     <!-- No screenshot placeholder -->
@@ -312,5 +419,69 @@ function submitType() {
   color: white;
   cursor: pointer;
   font-size: var(--text-xs);
+}
+
+/* Region-marking overlay (#5136) */
+.region-overlay {
+  position: absolute;
+  border: 2px solid transparent;
+  transition: border-color 0.1s;
+}
+
+.region-overlay.region-hovered {
+  border-color: rgba(59, 130, 246, 0.8);
+  background: rgba(59, 130, 246, 0.1);
+}
+
+.region-popup {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  padding: 8px;
+  min-width: 200px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.region-popup-selector {
+  font-size: 0.7rem;
+  color: #94a3b8;
+  margin-bottom: 6px;
+  font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.region-popup-input {
+  width: 100%;
+  background: #0f172a;
+  border: 1px solid #475569;
+  border-radius: 4px;
+  padding: 4px 6px;
+  color: #e2e8f0;
+  font-size: 0.8rem;
+  margin-bottom: 6px;
+  box-sizing: border-box;
+}
+
+.region-popup-save,
+.region-popup-cancel {
+  font-size: 0.75rem;
+  padding: 3px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.region-popup-save {
+  background: #3b82f6;
+  color: white;
+  border: none;
+  margin-right: 4px;
+}
+
+.region-popup-cancel {
+  background: transparent;
+  color: #94a3b8;
+  border: 1px solid #475569;
 }
 </style>


### PR DESCRIPTION
## Summary

- **Phase 1 — Backend** (`api/playwright.py` + `api/schemas_code.py`): New `POST /playwright/snapshot-with-regions` endpoint that walks the DOM via Playwright `page.evaluate()`, captures a base64 screenshot, and returns up to 200 interactive regions with `selector`, `xpath`, `rect`, `textPreview`, and `role`. Filters noise (area < 20px², hidden elements, empty text + no aria-label/alt).
- **Phase 2 — Frontend** (`components/browser/InteractiveScreenshot.vue`): New `markRegionsMode` prop + `regions` prop. When enabled, renders an invisible clickable overlay for each region. Hover outlines the region in blue. Click opens a floating popup with selector preview + label input + save button. Emits `@regionsSelected` with accumulated labeled regions. All existing click/scroll/type/hover interactions preserved.

## Test plan
- [ ] Navigate to a URL in the chat browser panel
- [ ] Call `POST /playwright/snapshot-with-regions` with the active session_id — verify response contains screenshot + regions array
- [ ] Toggle `markRegionsMode` on InteractiveScreenshot — verify overlay appears
- [ ] Hover a region — verify blue outline
- [ ] Click a region — verify popup with selector shown
- [ ] Enter label and Save — verify `@regionsSelected` emits with labeled region
- [ ] Verify all existing click/scroll/type interactions still work (no regression)
- [ ] Session not found → 404; uninitialized page → 400

Closes #5136 (phases 1+2 MVP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)