### PR TITLE
fix(execution_strategies): 4 bugs from discovery audit (#6428 #6429 #6430 #6431)

### DIFF
--- a/autobot-backend/enhanced_orchestration/execution_strategies.py
+++ b/autobot-backend/enhanced_orchestration/execution_strategies.py
@@ -179,8 +179,12 @@ class ExecutionStrategyHandler:
             result = await future
             results[task.task_id] = result
 
-        # Stop coordinator
+        # Stop coordinator and wait for its cleanup (finally/unsubscribe) to complete (#6431)
         coordinator_task.cancel()
+        try:
+            await coordinator_task
+        except asyncio.CancelledError:
+            pass
 
         return results
 
@@ -204,17 +208,14 @@ class ExecutionStrategyHandler:
         """Execute tasks in parallel batch."""
         batch_size = min(self.max_parallel_tasks, len(pending_tasks))
         batch_tasks = pending_tasks[:batch_size]
+        ready_tasks = [t for t in batch_tasks if self._dependencies_met(t, results)]
 
         batch_results = await asyncio.gather(
-            *[
-                self._execute_single_task(task, results)
-                for task in batch_tasks
-                if self._dependencies_met(task, results)
-            ]
+            *[self._execute_single_task(task, results) for task in ready_tasks]
         )
 
         completed, failed = 0, 0
-        for task, result in zip(batch_tasks, batch_results):
+        for task, result in zip(ready_tasks, batch_results):
             results[task.task_id] = result
             pending_tasks.remove(task)
             if result.get("status") == "completed":
@@ -261,6 +262,16 @@ class ExecutionStrategyHandler:
             else:
                 c, f = await self._execute_sequential_step(pending_tasks, results)
 
+            if c == 0 and f == 0 and pending_tasks:
+                # No progress made — dependency deadlock (#6429)
+                logger.error(
+                    "Dependency deadlock in adaptive: %d tasks unresolvable, failing them",
+                    len(pending_tasks),
+                )
+                for task in pending_tasks:
+                    results[task.task_id] = task.to_failed_result("Dependency deadlock")
+                break
+
             completed_tasks += c
             failed_tasks += f
 
@@ -269,6 +280,14 @@ class ExecutionStrategyHandler:
     async def _wait_for_dependencies(
         self, task: AgentTask, results: Dict[str, Any]
     ) -> None:
-        """Wait for task dependencies to complete."""
+        """Wait for task dependencies to complete, or raise if a dep is in a terminal failed state."""
         while not self._dependencies_met(task, results):
+            failed_deps = [
+                dep for dep in task.dependencies
+                if results.get(dep, {}).get("status") == "failed"
+            ]
+            if failed_deps:
+                raise RuntimeError(
+                    f"Task {task.task_id} cannot run: dependency {failed_deps[0]} failed"
+                )
             await asyncio.sleep(TimingConstants.SHORT_DELAY)

--- a/autobot-backend/enhanced_orchestration/execution_strategies_test.py
+++ b/autobot-backend/enhanced_orchestration/execution_strategies_test.py
@@ -59,8 +59,12 @@ def _deps_met(task: AgentTask, results: dict) -> bool:
     )
 
 
+async def _default_execute(task, ctx):
+    return _completed(task.task_id)
+
+
 def _make_handler(execute_fn=None, deps_met_fn=None, max_parallel=5):
-    execute_fn = execute_fn or (lambda task, ctx: asyncio.coroutine(lambda: _completed(task.task_id))())
+    execute_fn = execute_fn or _default_execute
     deps_met_fn = deps_met_fn or _deps_met
 
     async def _noop_coord(channel):
@@ -207,6 +211,84 @@ async def test_adaptive_switches_to_sequential_on_high_failure():
     handler = _make_handler(execute_fn=execute)
     results = await handler.execute_adaptive(_plan(tasks, ExecutionStrategy.ADAPTIVE))
     assert all(results[t.task_id]["status"] == "failed" for t in tasks)
+
+
+@pytest.mark.asyncio
+async def test_adaptive_deadlock_detection():
+    """execute_adaptive must not loop forever when dependencies can never be met (#6429)."""
+    t1 = _task("t1", deps=["t_missing"])
+
+    handler = _make_handler()
+    results = await handler.execute_adaptive(_plan([t1], ExecutionStrategy.ADAPTIVE))
+    assert results["t1"]["status"] == "failed"
+    assert "deadlock" in results["t1"]["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# _execute_parallel_batch zip/filter fix (#6430)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parallel_batch_skips_tasks_with_unmet_deps():
+    """Tasks with unmet deps must not be removed from pending or get wrong results (#6430)."""
+    t_ready = _task("t_ready")
+    t_blocked = _task("t_blocked", deps=["t_missing"])
+    executed = []
+
+    async def execute(task, ctx):
+        executed.append(task.task_id)
+        return _completed(task.task_id)
+
+    handler = _make_handler(execute_fn=execute)
+    pending = [t_ready, t_blocked]
+    results = {}
+    await handler._execute_parallel_batch(pending, results)
+
+    assert "t_ready" in executed
+    assert "t_blocked" not in executed
+    assert t_blocked in pending  # blocked task stays in pending
+    assert results.get("t_ready", {}).get("status") == "completed"
+    assert "t_blocked" not in results
+
+
+# ---------------------------------------------------------------------------
+# execute_collaborative coordinator cleanup (#6431)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collaborative_coordinator_awaited_on_cancel():
+    """coordinator_task must be awaited after cancel so finally/unsubscribe runs (#6431)."""
+    cleanup_ran = False
+
+    async def _coordinator(channel):
+        nonlocal cleanup_ran
+        try:
+            await asyncio.sleep(9999)
+        finally:
+            cleanup_ran = True
+
+    async def execute(task, ctx):
+        return _completed(task.task_id)
+
+    deps = WorkflowDependencies(
+        execute_single_task=execute,
+        topological_sort_tasks=lambda tasks, graph: tasks,
+        dependencies_met=lambda task, results: True,
+        group_pipeline_stages=lambda tasks, graph: [tasks],
+        enhance_task_for_collaboration=lambda task, channel: task,
+        coordinate_collaboration=_coordinator,
+    )
+    handler = ExecutionStrategyHandler(
+        max_parallel_tasks=5,
+        resource_semaphore=asyncio.Semaphore(5),
+        deps=deps,
+    )
+    from enhanced_orchestration.types import ExecutionStrategy, WorkflowPlan
+    plan = _plan([_task("t1")], ExecutionStrategy.COLLABORATIVE)
+    await handler.execute_collaborative(plan)
+    assert cleanup_ran, "coordinator finally block must run before execute_collaborative returns"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **#6428**: Replace `asyncio.coroutine` (removed in Python 3.12) with `async def _default_execute` in `_make_handler` test helper — tests now run correctly on Python 3.12
- **#6429**: Add deadlock guard to `execute_adaptive` — detect zero-progress iterations and fail remaining tasks; also make `_wait_for_dependencies` raise `RuntimeError` immediately when a dependency is in terminal failed state instead of polling forever
- **#6430**: Fix `_execute_parallel_batch` zip/filter mismatch — separate `ready_tasks` list aligns with `asyncio.gather` results; tasks with unmet deps remain in `pending_tasks` and receive no result entry
- **#6431**: Await `coordinator_task` after cancel in `execute_collaborative` so the `finally` block in `coordinate_collaboration` (`pubsub.unsubscribe`) completes before the method returns

## Test Plan
- [x] 11/11 tests pass (`pytest enhanced_orchestration/execution_strategies_test.py -v`)
- [x] `test_adaptive_deadlock_detection` — validates #6429
- [x] `test_parallel_batch_skips_tasks_with_unmet_deps` — validates #6430
- [x] `test_collaborative_coordinator_awaited_on_cancel` — validates #6431
- [x] `asyncio.coroutine` removed — validates #6428 (would fail on Python 3.12)

## Related Issues
Closes #6428
Closes #6429
Closes #6430
Closes #6431