### PR TITLE
feat(agents): per-agent diary with background append and runtime discovery (#5071)

### DIFF
--- a/autobot-backend/agents/base_agent.py
+++ b/autobot-backend/agents/base_agent.py
@@ -150,6 +150,11 @@ class BaseAgent(ABC):
         self._message_handlers = {}
         self._handlers_lock = threading.Lock()
 
+        # Per-agent diary (fire-and-forget; never blocks a turn)
+        from memory.agent_diary import AgentDiaryService
+
+        self._diary = AgentDiaryService()
+
         logger.info(
             "Initialized %s agent in %s mode", agent_type, deployment_mode.value
         )
@@ -296,6 +301,20 @@ class BaseAgent(ABC):
                 self.total_execution_time += execution_time
 
             response.execution_time = execution_time
+
+            # Fire-and-forget diary write — never blocks the caller (#5071)
+            _diary_entry = (
+                f"action={request.action} status={response.status} "
+                f"exec={execution_time:.2f}s"
+            )[:200]
+            asyncio.create_task(
+                self._diary.write(
+                    self.agent_type,
+                    request.request_id,
+                    _diary_entry,
+                    topic="turn",
+                )
+            )
 
             # Publish OBSERVATION event with any artifacts the agent collected (#4094)
             await self._publish_completion_observation(request, response, task_id)

--- a/autobot-backend/api/agent_diary.py
+++ b/autobot-backend/api/agent_diary.py
@@ -1,0 +1,105 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Agent Diary API — per-agent cross-session journal access.
+
+Endpoints:
+  GET /agent-diary/{agent_name}/entries?last_n=10   — recent entries for one agent
+  GET /agent-diary/{agent_name}/search?q=<query>    — semantic search within agent diary
+  GET /agent-diary/summary                          — recent entries for all known agents
+"""
+
+import logging
+from typing import List
+
+from fastapi import APIRouter, Depends, Query
+
+from auth_middleware import get_current_user
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from memory.agent_diary import AgentDiaryService, list_with_diaries
+from utils.response_helpers import create_success_response
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# Canonical list of agent names known to the system (mirrors AGENT_CAPABILITIES in api/agent.py)
+_KNOWN_AGENTS: List[str] = [
+    "chat",
+    "rag",
+    "research",
+    "web_research_assistant",
+    "knowledge_extraction",
+    "classification",
+    "npu_code_search",
+    "development_speedup",
+    "system_knowledge_manager",
+]
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_agent_diary_entries",
+    error_code_prefix="DIARY",
+)
+@router.get("/{agent_name}/entries")
+async def get_agent_diary_entries(
+    agent_name: str,
+    last_n: int = Query(10, ge=1, le=100, description="Number of recent entries"),
+    current_user: dict = Depends(get_current_user),
+):
+    """Return the most recent diary entries for a single agent."""
+    diary = AgentDiaryService()
+    entries = await diary.read(agent_name, last_n=last_n)
+    return create_success_response(
+        {
+            "agent_name": agent_name,
+            "entries": entries,
+            "count": len(entries),
+        }
+    )
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="search_agent_diary",
+    error_code_prefix="DIARY",
+)
+@router.get("/{agent_name}/search")
+async def search_agent_diary(
+    agent_name: str,
+    q: str = Query(..., min_length=1, description="Search query"),
+    n: int = Query(5, ge=1, le=50, description="Maximum results"),
+    current_user: dict = Depends(get_current_user),
+):
+    """Semantic search within one agent's diary."""
+    diary = AgentDiaryService()
+    results = await diary.search(agent_name, query=q, n=n)
+    return create_success_response(
+        {
+            "agent_name": agent_name,
+            "query": q,
+            "results": results,
+            "count": len(results),
+        }
+    )
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_agent_diary_summary",
+    error_code_prefix="DIARY",
+)
+@router.get("/summary")
+async def get_agent_diary_summary(
+    last_n: int = Query(3, ge=1, le=20, description="Entries per agent"),
+    current_user: dict = Depends(get_current_user),
+):
+    """Return recent diary entries for all known agents (parallel fetch)."""
+    summary = await list_with_diaries(_KNOWN_AGENTS, last_n=last_n)
+    return create_success_response(
+        {
+            "agents": summary,
+            "total_agents": len(summary),
+        }
+    )

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -473,6 +473,8 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
     ("api.marketplace", "/marketplace", ["marketplace", "plugins"], "marketplace"),
     # Issue #5070: verbatim conversational-memory lane
     ("api.verbatim_memory", "/verbatim-memory", ["memory"], "verbatim_memory"),
+    # Issue #5071: per-agent diary with background append and runtime discovery
+    ("api.agent_diary", "/agent-diary", ["agents"], "agent_diary"),
     # Partially wired or legacy feature routers
     ("api.chat_sessions", "", ["chat-sessions"], "chat_sessions"),
     # Issue #5061: First-run onboarding presets + doctor

--- a/autobot-backend/memory/agent_diary.py
+++ b/autobot-backend/memory/agent_diary.py
@@ -9,6 +9,7 @@ session_id, and topic so entries can be retrieved or searched per agent
 without touching any other KB content.
 """
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List
@@ -162,4 +163,32 @@ class AgentDiaryService:
             return []
 
 
-__all__ = ["AgentDiaryService"]
+async def list_with_diaries(
+    agent_names: List[str], last_n: int = 3
+) -> List[Dict[str, Any]]:
+    """Return recent diary entries for multiple agents in parallel.
+
+    Args:
+        agent_names: Agents to include in the summary.
+        last_n:      How many recent entries to fetch per agent.
+
+    Returns:
+        List of dicts ``{agent_name, recent_entries, entry_count}``,
+        one per agent.  Agents with no entries are still included with
+        ``recent_entries=[]`` and ``entry_count=0``.
+    """
+    diary = AgentDiaryService()
+
+    async def _fetch(name: str) -> Dict[str, Any]:
+        entries = await diary.read(name, last_n=last_n)
+        return {
+            "agent_name": name,
+            "recent_entries": entries,
+            "entry_count": len(entries),
+        }
+
+    results = await asyncio.gather(*[_fetch(name) for name in agent_names])
+    return list(results)
+
+
+__all__ = ["AgentDiaryService", "list_with_diaries"]

--- a/autobot-backend/memory/agent_diary_test.py
+++ b/autobot-backend/memory/agent_diary_test.py
@@ -1,0 +1,200 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for AgentDiaryService and list_with_diaries.
+
+Mocks ``memory.agent_diary._get_kb`` so no real KB connection is required.
+"""
+
+import asyncio
+import sys
+import os
+from unittest.mock import AsyncMock, patch
+
+# Add backend root and repo root (for autobot_shared) to path
+_backend_root = os.path.join(os.path.dirname(__file__), "..")
+_repo_root = os.path.join(_backend_root, "..")
+sys.path.insert(0, _backend_root)
+sys.path.insert(0, _repo_root)
+
+from memory.agent_diary import AgentDiaryService, list_with_diaries
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_kb_mock(
+    store_result: dict | None = None,
+    all_facts: list | None = None,
+    search_results: list | None = None,
+):
+    """Return an AsyncMock knowledge base with configurable responses."""
+    kb = AsyncMock()
+    kb.store_fact.return_value = store_result or {"fact_id": "fact-001", "status": "created"}
+    kb.get_all_facts.return_value = all_facts or []
+    kb.search.return_value = search_results or []
+    return kb
+
+
+def _make_diary_fact(
+    agent_name: str,
+    content: str = "did something",
+    timestamp: str = "2025-01-01T00:00:00+00:00",
+    topic: str = "turn",
+) -> dict:
+    return {
+        "content": content,
+        "metadata": {
+            "category": AgentDiaryService.CATEGORY,
+            "source": agent_name,
+            "agent_name": agent_name,
+            "session_id": "sess-1",
+            "topic": topic,
+            "diary_timestamp": timestamp,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+async def test_write_returns_fact_id():
+    """write() returns the fact_id from KB store_fact."""
+    kb = _make_kb_mock(store_result={"fact_id": "abc123", "status": "created"})
+    with patch("memory.agent_diary._get_kb", new=AsyncMock(return_value=kb)):
+        diary = AgentDiaryService()
+        fact_id = await diary.write("chat", "sess-1", "processed hello", topic="turn")
+    assert fact_id == "abc123", f"Expected 'abc123', got {fact_id!r}"
+    kb.store_fact.assert_awaited_once()
+    print("[PASS] test_write_returns_fact_id")
+
+
+async def test_write_swallows_errors():
+    """write() returns '' and does not raise on KB failure."""
+    kb = AsyncMock()
+    kb.store_fact.side_effect = RuntimeError("KB unavailable")
+    with patch("memory.agent_diary._get_kb", new=AsyncMock(return_value=kb)):
+        diary = AgentDiaryService()
+        result = await diary.write("chat", "sess-1", "entry", topic="turn")
+    assert result == "", f"Expected empty string, got {result!r}"
+    print("[PASS] test_write_swallows_errors")
+
+
+async def test_read_filters_by_agent_and_category():
+    """read() returns only facts matching agent_name and AGENT_DIARY category."""
+    facts = [
+        _make_diary_fact("chat", "entry A", "2025-01-02T10:00:00+00:00"),
+        _make_diary_fact("rag", "entry B", "2025-01-02T09:00:00+00:00"),
+        _make_diary_fact("chat", "entry C", "2025-01-02T11:00:00+00:00"),
+        {"content": "unrelated", "metadata": {"category": "OTHER", "source": "chat"}},
+    ]
+    kb = _make_kb_mock(all_facts=facts)
+    with patch("memory.agent_diary._get_kb", new=AsyncMock(return_value=kb)):
+        diary = AgentDiaryService()
+        entries = await diary.read("chat", last_n=10)
+
+    assert len(entries) == 2, f"Expected 2 entries for 'chat', got {len(entries)}"
+    # Newest first: entry C (11:00) before entry A (10:00)
+    assert entries[0]["content"] == "entry C"
+    assert entries[1]["content"] == "entry A"
+    print("[PASS] test_read_filters_by_agent_and_category")
+
+
+async def test_read_respects_last_n():
+    """read() caps results at last_n."""
+    facts = [
+        _make_diary_fact("rag", f"entry {i}", f"2025-01-01T{i:02d}:00:00+00:00")
+        for i in range(10)
+    ]
+    kb = _make_kb_mock(all_facts=facts)
+    with patch("memory.agent_diary._get_kb", new=AsyncMock(return_value=kb)):
+        diary = AgentDiaryService()
+        entries = await diary.read("rag", last_n=3)
+    assert len(entries) == 3, f"Expected 3, got {len(entries)}"
+    print("[PASS] test_read_respects_last_n")
+
+
+async def test_read_swallows_errors():
+    """read() returns [] and does not raise on KB failure."""
+    kb = AsyncMock()
+    kb.get_all_facts.side_effect = RuntimeError("KB down")
+    with patch("memory.agent_diary._get_kb", new=AsyncMock(return_value=kb)):
+        diary = AgentDiaryService()
+        result = await diary.read("chat")
+    assert result == []
+    print("[PASS] test_read_swallows_errors")
+
+
+async def test_search_delegates_to_kb():
+    """search() calls kb.search with correct filters and returns results."""
+    hits = [{"content": "found it", "score": 0.9}]
+    kb = _make_kb_mock(search_results=hits)
+    with patch("memory.agent_diary._get_kb", new=AsyncMock(return_value=kb)):
+        diary = AgentDiaryService()
+        results = await diary.search("research", "processed", n=3)
+    assert results == hits
+    kb.search.assert_awaited_once_with(
+        query="processed",
+        top_k=3,
+        filters={"source": "research", "category": AgentDiaryService.CATEGORY},
+    )
+    print("[PASS] test_search_delegates_to_kb")
+
+
+async def test_search_swallows_errors():
+    """search() returns [] and does not raise on KB failure."""
+    kb = AsyncMock()
+    kb.search.side_effect = RuntimeError("search failed")
+    with patch("memory.agent_diary._get_kb", new=AsyncMock(return_value=kb)):
+        diary = AgentDiaryService()
+        result = await diary.search("chat", "query")
+    assert result == []
+    print("[PASS] test_search_swallows_errors")
+
+
+async def test_list_with_diaries_parallel():
+    """list_with_diaries() returns one dict per agent with recent_entries."""
+    facts_chat = [_make_diary_fact("chat", "chat entry")]
+    facts_rag: list = []  # no entries
+
+    async def fake_kb_for_agent(*_args, **_kwargs):
+        return _make_kb_mock(all_facts=facts_chat + facts_rag)
+
+    # Use real read() but patch _get_kb so chat and rag use same fact pool;
+    # filtering separates them.
+    all_facts = [
+        _make_diary_fact("chat", "chat entry", "2025-01-01T12:00:00+00:00"),
+    ]
+    kb = _make_kb_mock(all_facts=all_facts)
+    with patch("memory.agent_diary._get_kb", new=AsyncMock(return_value=kb)):
+        result = await list_with_diaries(["chat", "rag"], last_n=3)
+
+    assert len(result) == 2
+    by_name = {r["agent_name"]: r for r in result}
+    assert by_name["chat"]["entry_count"] == 1
+    assert by_name["rag"]["entry_count"] == 0
+    assert by_name["rag"]["recent_entries"] == []
+    print("[PASS] test_list_with_diaries_parallel")
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+async def run_all():
+    await test_write_returns_fact_id()
+    await test_write_swallows_errors()
+    await test_read_filters_by_agent_and_category()
+    await test_read_respects_last_n()
+    await test_read_swallows_errors()
+    await test_search_delegates_to_kb()
+    await test_search_swallows_errors()
+    await test_list_with_diaries_parallel()
+    print("\n[ALL TESTS PASSED]")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_all())

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -614,6 +614,18 @@ const routes: RouteRecordRaw[] = [
       requiresAuth: true
     }
   },
+  // Issue #5071: per-agent diary with background append and runtime discovery
+  {
+    path: '/agents/activity',
+    name: 'agent-activity',
+    component: () => import('@/views/AgentActivity.vue'),
+    meta: {
+      title: 'Agent Activity',
+      icon: 'fas fa-journal-whills',
+      description: 'Per-agent diary — recent entries and cross-session journal',
+      requiresAuth: true
+    }
+  },
   // Issue #899: Code Intelligence — merged into /analytics/codebase
   {
     path: '/code-intelligence',

--- a/autobot-frontend/src/views/AgentActivity.vue
+++ b/autobot-frontend/src/views/AgentActivity.vue
@@ -1,0 +1,239 @@
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * AgentActivity — per-agent diary viewer (#5071)
+ *
+ * Fetches GET /api/agent-diary/summary and displays each agent's
+ * recent journal entries with timestamps and a "View all" link.
+ */
+
+import { ref, onMounted } from 'vue'
+import { useApi } from '@/composables/useApi'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('AgentActivity')
+
+interface DiaryEntry {
+  content?: string
+  metadata?: {
+    diary_timestamp?: string
+    topic?: string
+    session_id?: string
+  }
+}
+
+interface AgentSummary {
+  agent_name: string
+  recent_entries: DiaryEntry[]
+  entry_count: number
+}
+
+interface SummaryResponse {
+  data: {
+    agents: AgentSummary[]
+    total_agents: number
+  }
+}
+
+const api = useApi()
+
+const agents = ref<AgentSummary[]>([])
+const isLoading = ref(false)
+const error = ref<string | null>(null)
+const selectedAgent = ref<string | null>(null)
+const allEntries = ref<DiaryEntry[]>([])
+const isLoadingAll = ref(false)
+
+async function fetchSummary() {
+  isLoading.value = true
+  error.value = null
+  try {
+    const resp = await api.get<SummaryResponse>('/api/agent-diary/summary?last_n=3')
+    agents.value = (resp as SummaryResponse).data?.agents ?? []
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    logger.error('Failed to fetch agent diary summary:', msg)
+    error.value = msg
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function viewAll(agentName: string) {
+  selectedAgent.value = agentName
+  isLoadingAll.value = true
+  allEntries.value = []
+  try {
+    const resp = await api.get<{ data: { entries: DiaryEntry[] } }>(
+      `/api/agent-diary/${encodeURIComponent(agentName)}/entries?last_n=50`
+    )
+    allEntries.value = (resp as { data: { entries: DiaryEntry[] } }).data?.entries ?? []
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    logger.error('Failed to fetch entries for agent %s: %s', agentName, msg)
+  } finally {
+    isLoadingAll.value = false
+  }
+}
+
+function closeModal() {
+  selectedAgent.value = null
+  allEntries.value = []
+}
+
+function formatTimestamp(ts?: string): string {
+  if (!ts) return '—'
+  try {
+    return new Date(ts).toLocaleString()
+  } catch {
+    return ts
+  }
+}
+
+onMounted(fetchSummary)
+</script>
+
+<template>
+  <div class="p-6 max-w-5xl mx-auto">
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-2xl font-semibold text-autobot-text-primary">
+        Agent Activity
+      </h1>
+      <button
+        class="px-4 py-2 rounded bg-autobot-accent text-white text-sm hover:bg-autobot-accent/80 transition-colors"
+        :disabled="isLoading"
+        @click="fetchSummary"
+      >
+        {{ isLoading ? 'Refreshing…' : 'Refresh' }}
+      </button>
+    </div>
+
+    <!-- Error state -->
+    <div
+      v-if="error"
+      class="mb-4 p-4 rounded bg-red-50 border border-red-200 text-red-700 text-sm dark:bg-red-900/20 dark:border-red-800 dark:text-red-400"
+    >
+      {{ error }}
+    </div>
+
+    <!-- Loading skeleton -->
+    <div v-if="isLoading && !agents.length" class="space-y-4">
+      <div
+        v-for="i in 4"
+        :key="i"
+        class="h-28 rounded-lg bg-autobot-surface animate-pulse"
+      />
+    </div>
+
+    <!-- Agent cards -->
+    <div v-else class="space-y-4">
+      <div
+        v-for="agent in agents"
+        :key="agent.agent_name"
+        class="rounded-lg border border-autobot-border bg-autobot-surface p-4"
+      >
+        <!-- Card header -->
+        <div class="flex items-center justify-between mb-3">
+          <div class="flex items-center gap-2">
+            <span class="text-xs font-mono bg-autobot-accent/10 text-autobot-accent px-2 py-0.5 rounded">
+              {{ agent.agent_name }}
+            </span>
+            <span class="text-xs text-autobot-text-muted">
+              {{ agent.entry_count }} recent {{ agent.entry_count === 1 ? 'entry' : 'entries' }}
+            </span>
+          </div>
+          <button
+            class="text-xs text-autobot-accent hover:underline"
+            @click="viewAll(agent.agent_name)"
+          >
+            View all
+          </button>
+        </div>
+
+        <!-- Entries -->
+        <div v-if="agent.recent_entries.length" class="space-y-2">
+          <div
+            v-for="(entry, idx) in agent.recent_entries"
+            :key="idx"
+            class="text-sm border-l-2 border-autobot-accent/30 pl-3"
+          >
+            <p class="text-autobot-text-primary break-words">{{ entry.content ?? '—' }}</p>
+            <p class="text-xs text-autobot-text-muted mt-0.5">
+              {{ formatTimestamp(entry.metadata?.diary_timestamp) }}
+              <span v-if="entry.metadata?.topic" class="ml-2 italic">{{ entry.metadata.topic }}</span>
+            </p>
+          </div>
+        </div>
+        <p v-else class="text-sm text-autobot-text-muted italic">No entries yet.</p>
+      </div>
+
+      <p v-if="!isLoading && !agents.length" class="text-center text-autobot-text-muted py-12">
+        No agent diary data found.
+      </p>
+    </div>
+
+    <!-- "View all" modal overlay -->
+    <transition name="fade">
+      <div
+        v-if="selectedAgent"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        @click.self="closeModal"
+      >
+        <div class="bg-autobot-surface rounded-xl shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col mx-4">
+          <!-- Modal header -->
+          <div class="flex items-center justify-between px-6 py-4 border-b border-autobot-border">
+            <h2 class="font-semibold text-autobot-text-primary">
+              All entries — <span class="font-mono text-autobot-accent">{{ selectedAgent }}</span>
+            </h2>
+            <button
+              class="text-autobot-text-muted hover:text-autobot-text-primary"
+              @click="closeModal"
+            >
+              ✕
+            </button>
+          </div>
+
+          <!-- Modal body -->
+          <div class="overflow-y-auto flex-1 px-6 py-4 space-y-3">
+            <div v-if="isLoadingAll" class="flex justify-center py-8">
+              <span class="text-autobot-text-muted text-sm">Loading…</span>
+            </div>
+            <template v-else>
+              <div
+                v-for="(entry, idx) in allEntries"
+                :key="idx"
+                class="text-sm border-l-2 border-autobot-accent/30 pl-3"
+              >
+                <p class="text-autobot-text-primary break-words">{{ entry.content ?? '—' }}</p>
+                <p class="text-xs text-autobot-text-muted mt-0.5">
+                  {{ formatTimestamp(entry.metadata?.diary_timestamp) }}
+                  <span v-if="entry.metadata?.topic" class="ml-2 italic">{{ entry.metadata.topic }}</span>
+                  <span v-if="entry.metadata?.session_id" class="ml-2 text-autobot-text-muted/60">
+                    session {{ entry.metadata.session_id.slice(0, 8) }}
+                  </span>
+                </p>
+              </div>
+              <p v-if="!allEntries.length" class="text-autobot-text-muted italic text-center py-8">
+                No entries found.
+              </p>
+            </template>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.15s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>


### PR DESCRIPTION
## Summary
- `list_with_diaries()` added to `memory/agent_diary.py` — parallel asyncio.gather fetch for all agents
- `agents/base_agent.py` — `execute_with_tracking` fires `asyncio.create_task(self._diary.write(...))` after each turn; errors swallowed
- `api/agent_diary.py` — `GET /agent-diary/{name}/entries`, `/search`, `/summary` endpoints (auth-gated)
- `AgentActivity.vue` — lists agents with 3-entry preview + modal for full history at `/agents/activity`
- 8 unit tests (parallel fetch, error swallowing, filtering)

## Test plan
- [ ] `python3 -m pytest autobot-backend/memory/agent_diary_test.py -xvs`
- [ ] `GET /api/agent-diary/summary` returns list of agents with recent_entries
- [ ] Run a chat turn, check diary write is fire-and-forget (no latency impact)

Closes #5071

🤖 Generated with [Claude Code](https://claude.com/claude-code)