### PR TITLE
feat(security): wire audit_record into knowledge and API key mutation endpoints (#6386)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -46,8 +46,9 @@ from fastapi import (
 )
 from pydantic import BaseModel, Field, field_validator
 
-from auth_middleware import check_admin_permission, get_current_user
+from auth_middleware import check_admin_permission, get_auth_middleware, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from services.audit.audit_log import AuditAction, audit_record
 from constants.threshold_constants import CategoryDefaults, QueryDefaults
 from exceptions import InternalError
 from knowledge.query_sanitizer import sanitize_document as _sanitize_document
@@ -796,6 +797,17 @@ async def add_text_to_knowledge(
 
     fact_id = await _store_fact_in_kb(kb_to_use, text, metadata)
 
+    _user = get_auth_middleware().get_user_from_request(req)
+    audit_record(
+        user_id=str((_user or {}).get("user_id", "unknown")),
+        action=AuditAction.KNOWLEDGE_ADD,
+        resource_type="knowledge_doc",
+        resource_id=fact_id,
+        ip_address=req.client.host if req and req.client else "unknown",
+        session_id=None,
+        outcome="success",
+    )
+
     return AddTextResponse(
         status="success",
         message="Fact stored successfully",
@@ -1047,6 +1059,17 @@ async def add_facts_to_knowledge(
 
     fact_id = await _store_fact_in_kb(kb_to_use, request.content, metadata)
 
+    _user = get_auth_middleware().get_user_from_request(req)
+    audit_record(
+        user_id=str((_user or {}).get("user_id", "unknown")),
+        action=AuditAction.KNOWLEDGE_ADD,
+        resource_type="knowledge_doc",
+        resource_id=fact_id,
+        ip_address=req.client.host if req and req.client else "unknown",
+        session_id=None,
+        outcome="success",
+    )
+
     return AddFactResponse(
         success=True,
         document_id=fact_id,
@@ -1157,6 +1180,17 @@ async def add_url_to_knowledge(
         url_metadata["board_id"] = request.board_id
 
     fact_id = await _store_fact_in_kb(kb_to_use, content, url_metadata)
+
+    _user = get_auth_middleware().get_user_from_request(req)
+    audit_record(
+        user_id=str((_user or {}).get("user_id", "unknown")),
+        action=AuditAction.KNOWLEDGE_ADD,
+        resource_type="knowledge_doc",
+        resource_id=fact_id,
+        ip_address=req.client.host if req and req.client else "unknown",
+        session_id=None,
+        outcome="success",
+    )
 
     return AddUrlResponse(
         success=True,
@@ -1359,6 +1393,17 @@ async def upload_file_to_knowledge(
             "type": "file",
             "filename": filename,
         },
+    )
+
+    _user = get_auth_middleware().get_user_from_request(req)
+    audit_record(
+        user_id=str((_user or {}).get("user_id", "unknown")),
+        action=AuditAction.KNOWLEDGE_ADD,
+        resource_type="knowledge_doc",
+        resource_id=fact_id,
+        ip_address=req.client.host if req and req.client else "unknown",
+        session_id=None,
+        outcome="success",
     )
 
     word_count = len(content.split())
@@ -2284,6 +2329,17 @@ async def clear_all_knowledge(
             raise HTTPException(status_code=500, detail="Failed to clear")
 
     logger.warning("Knowledge base cleared. Removed %s entries.", items_removed)
+    _user = get_auth_middleware().get_user_from_request(req)
+    audit_record(
+        user_id=str((_user or {}).get("user_id", "unknown")),
+        action=AuditAction.KNOWLEDGE_REMOVE,
+        resource_type="knowledge_doc",
+        resource_id="all",
+        ip_address=req.client.host if req and req.client else "unknown",
+        session_id=None,
+        outcome="success",
+        metadata={"items_removed": items_removed},
+    )
     return {
         "status": "success",
         "items_removed": items_removed,

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -34,8 +34,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator
 
-from auth_middleware import check_admin_permission
+from auth_middleware import check_admin_permission, get_auth_middleware
 from autobot_memory_graph import AutoBotMemoryGraph
+from services.audit.audit_log import AuditAction, audit_record
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from middleware.proxy_utils import get_client_ip
 from type_defs.common import Metadata
@@ -718,6 +719,16 @@ async def create_secret(
             secret_data["expires_at"] = secret_data["expires_at"].isoformat()
 
         audit_log("CREATE", secret.id, http_request, details=f"name={request.name}")
+        _user = get_auth_middleware().get_user_from_request(http_request)
+        audit_record(
+            user_id=str((_user or {}).get("user_id", "unknown")),
+            action=AuditAction.API_KEY_CREATE,
+            resource_type="secret",
+            resource_id=secret.id,
+            ip_address=http_request.client.host if http_request.client else "unknown",
+            session_id=None,
+            outcome="success",
+        )
         return JSONResponse(
             status_code=201,
             content={
@@ -1074,6 +1085,16 @@ async def delete_secret(
             raise HTTPException(status_code=404, detail="Secret not found")
 
         audit_log("DELETE", secret_id, http_request)
+        _user = get_auth_middleware().get_user_from_request(http_request)
+        audit_record(
+            user_id=str((_user or {}).get("user_id", "unknown")),
+            action=AuditAction.API_KEY_REVOKE,
+            resource_type="secret",
+            resource_id=secret_id,
+            ip_address=http_request.client.host if http_request.client else "unknown",
+            session_id=None,
+            outcome="success",
+        )
         return JSONResponse(
             status_code=200,
             content={"status": "success", "message": "Secret deleted successfully"},


### PR DESCRIPTION
## Summary
- `api/knowledge.py`: adds `audit_record()` call after each mutating operation (5 endpoints: add text, add facts, add URL, upload file, clear all)
- `api/secrets.py`: adds `audit_record()` for secret create (`API_KEY_CREATE`) and delete (`API_KEY_REVOKE`)
- All calls are fire-and-forget (sync wrapper via `run_redis_write`) — no blocking added to request paths
- User ID extracted via `get_auth_middleware().get_user_from_request(request)` with `"unknown"` fallback

## Test plan
- [ ] Add knowledge entry → Redis `audit_log:*` sorted set contains `knowledge.add` event
- [ ] Create/delete secret → `api_key.create` / `api_key.revoke` events recorded
- [ ] Syntax: `python3 -m py_compile autobot-backend/api/knowledge.py autobot-backend/api/secrets.py`

Closes #6386

🤖 Generated with [Claude Code](https://claude.com/claude-code)