### PR TITLE
refactor(execution_strategies): _is_required_failure helper, gather exception safety, terminal dep detection, test helper cleanup (#6448 #6449 #6454 #6455)

### DIFF
--- a/autobot-backend/enhanced_orchestration/execution_strategies.py
+++ b/autobot-backend/enhanced_orchestration/execution_strategies.py
@@ -62,8 +62,9 @@ class ExecutionStrategyHandler:
             try:
                 await self._wait_for_dependencies(task, results)
             except RuntimeError as exc:
-                results[task.task_id] = task.to_failed_result(str(exc))
-                if not task.metadata.get("optional", False):
+                result = task.to_failed_result(str(exc))
+                results[task.task_id] = result
+                if self._is_required_failure(task, result):
                     logger.error("Required task %s blocked by failed dep, stopping", task.task_id)
                     break
                 continue
@@ -71,9 +72,7 @@ class ExecutionStrategyHandler:
             result = await self._execute_single_task(task, results)
             results[task.task_id] = result
 
-            if result.get("status") == "failed" and not task.metadata.get(
-                "optional", False
-            ):
+            if self._is_required_failure(task, result):
                 logger.error("Required task %s failed, stopping workflow", task.task_id)
                 break
 
@@ -139,20 +138,22 @@ class ExecutionStrategyHandler:
         for stage_num, stage_tasks in enumerate(stages):
             logger.info("Executing pipeline stage %d/%d", stage_num + 1, len(stages))
 
-            # Execute stage tasks in parallel
             stage_results = await asyncio.gather(
                 *[
                     self._execute_single_task(task, {**results, **pipeline_data})
                     for task in stage_tasks
-                ]
+                ],
+                return_exceptions=True,
             )
 
             stage_failed = False
             for task, result in zip(stage_tasks, stage_results):
+                if isinstance(result, BaseException):
+                    result = task.to_failed_result(repr(result))
                 results[task.task_id] = result
                 if result.get("status") == "completed" and "output" in result:
                     pipeline_data.update(result["output"])
-                if result.get("status") == "failed" and not task.metadata.get("optional", False):
+                if self._is_required_failure(task, result):
                     stage_failed = True
 
             if stage_failed:
@@ -210,6 +211,9 @@ class ExecutionStrategyHandler:
 
         return current
 
+    def _is_required_failure(self, task: AgentTask, result: dict) -> bool:
+        return result.get("status") == "failed" and not task.metadata.get("optional", False)
+
     async def _execute_parallel_batch(
         self, pending_tasks: list, results: Dict[str, Any]
     ) -> Tuple[int, int]:
@@ -219,11 +223,14 @@ class ExecutionStrategyHandler:
         ready_tasks = [t for t in batch_tasks if self._dependencies_met(t, results)]
 
         batch_results = await asyncio.gather(
-            *[self._execute_single_task(task, results) for task in ready_tasks]
+            *[self._execute_single_task(task, results) for task in ready_tasks],
+            return_exceptions=True,
         )
 
         completed, failed = 0, 0
         for task, result in zip(ready_tasks, batch_results):
+            if isinstance(result, BaseException):
+                result = task.to_failed_result(repr(result))
             results[task.task_id] = result
             pending_tasks.remove(task)
             if result.get("status") == "completed":
@@ -288,14 +295,16 @@ class ExecutionStrategyHandler:
     async def _wait_for_dependencies(
         self, task: AgentTask, results: Dict[str, Any]
     ) -> None:
-        """Wait for task dependencies to complete, or raise if a dep is in a terminal failed state."""
+        """Wait for task dependencies to complete, or raise if a dep is in any terminal non-completed state."""
         while not self._dependencies_met(task, results):
-            failed_deps = [
+            terminal_deps = [
                 dep for dep in task.dependencies
-                if results.get(dep, {}).get("status") == "failed"
+                if dep in results and results[dep].get("status") != "completed"
             ]
-            if failed_deps:
+            if terminal_deps:
+                status = results[terminal_deps[0]].get("status")
                 raise RuntimeError(
-                    f"Task {task.task_id} cannot run: dependency {failed_deps[0]} failed"
+                    f"Task {task.task_id} cannot run: dependency {terminal_deps[0]}"
+                    f" is terminal (status={status})"
                 )
             await asyncio.sleep(TimingConstants.SHORT_DELAY)

--- a/autobot-backend/enhanced_orchestration/execution_strategies_test.py
+++ b/autobot-backend/enhanced_orchestration/execution_strategies_test.py
@@ -61,9 +61,10 @@ async def _default_execute(task, ctx):
     return _completed(task.task_id)
 
 
-def _make_handler(execute_fn=None, deps_met_fn=None, max_parallel=5):
+def _make_handler(execute_fn=None, deps_met_fn=None, max_parallel=5, group_stages_fn=None):
     execute_fn = execute_fn or _default_execute
     deps_met_fn = deps_met_fn or _deps_met
+    group_stages_fn = group_stages_fn or (lambda tasks, graph: [tasks])
 
     async def _noop_coord(channel):
         pass
@@ -72,7 +73,7 @@ def _make_handler(execute_fn=None, deps_met_fn=None, max_parallel=5):
         execute_single_task=execute_fn,
         topological_sort_tasks=lambda tasks, graph: tasks,
         dependencies_met=deps_met_fn,
-        group_pipeline_stages=lambda tasks, graph: [tasks],
+        group_pipeline_stages=group_stages_fn,
         enhance_task_for_collaboration=lambda task, channel: task,
         coordinate_collaboration=_noop_coord,
     )
@@ -208,20 +209,9 @@ async def test_pipeline_stops_after_required_stage_failure():
             return _failed(task.task_id)
         return _completed(task.task_id)
 
-    deps = __import__("enhanced_orchestration.types", fromlist=["WorkflowDependencies"]).WorkflowDependencies(
-        execute_single_task=execute,
-        topological_sort_tasks=lambda tasks, graph: tasks,
-        dependencies_met=lambda task, results: True,
-        group_pipeline_stages=lambda tasks, graph: [stage1, stage2],
-        enhance_task_for_collaboration=lambda task, channel: task,
-        coordinate_collaboration=lambda channel: __import__("asyncio").sleep(0),
-    )
-    from enhanced_orchestration.execution_strategies import ExecutionStrategyHandler
-    import asyncio
-    handler = ExecutionStrategyHandler(
-        max_parallel_tasks=5,
-        resource_semaphore=asyncio.Semaphore(5),
-        deps=deps,
+    handler = _make_handler(
+        execute_fn=execute,
+        group_stages_fn=lambda tasks, graph: [stage1, stage2],
     )
     results = await handler.execute_pipeline(_plan([t1, t2]))
     assert results["t1"]["status"] == "failed"
@@ -243,24 +233,68 @@ async def test_pipeline_continues_when_failed_stage_task_is_optional():
             return _failed(task.task_id)
         return _completed(task.task_id)
 
-    deps = __import__("enhanced_orchestration.types", fromlist=["WorkflowDependencies"]).WorkflowDependencies(
-        execute_single_task=execute,
-        topological_sort_tasks=lambda tasks, graph: tasks,
-        dependencies_met=lambda task, results: True,
-        group_pipeline_stages=lambda tasks, graph: [stage1, stage2],
-        enhance_task_for_collaboration=lambda task, channel: task,
-        coordinate_collaboration=lambda channel: __import__("asyncio").sleep(0),
-    )
-    from enhanced_orchestration.execution_strategies import ExecutionStrategyHandler
-    import asyncio
-    handler = ExecutionStrategyHandler(
-        max_parallel_tasks=5,
-        resource_semaphore=asyncio.Semaphore(5),
-        deps=deps,
+    handler = _make_handler(
+        execute_fn=execute,
+        group_stages_fn=lambda tasks, graph: [stage1, stage2],
     )
     results = await handler.execute_pipeline(_plan([t1, t2]))
     assert "t2" in executed
     assert results["t2"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_records_failed_result_when_task_raises():
+    """execute_pipeline must record a failed result when _execute_single_task raises (#6449)."""
+    t1 = _task("t1")
+    t2 = _task("t2")
+    stage1, stage2 = [t1], [t2]
+    executed = []
+
+    async def execute(task, ctx):
+        executed.append(task.task_id)
+        if task.task_id == "t1":
+            raise ValueError("task exploded")
+        return _completed(task.task_id)
+
+    handler = _make_handler(
+        execute_fn=execute,
+        group_stages_fn=lambda tasks, graph: [stage1, stage2],
+    )
+    results = await handler.execute_pipeline(_plan([t1, t2]))
+    assert results["t1"]["status"] == "failed"
+    assert "t2" not in executed
+
+
+@pytest.mark.asyncio
+async def test_parallel_batch_records_failed_result_when_task_raises():
+    """_execute_parallel_batch must record a failed result when _execute_single_task raises (#6449)."""
+    t_ok = _task("t_ok")
+    t_bad = _task("t_bad")
+
+    async def execute(task, ctx):
+        if task.task_id == "t_bad":
+            raise RuntimeError("boom")
+        return _completed(task.task_id)
+
+    handler = _make_handler(execute_fn=execute)
+    pending = [t_ok, t_bad]
+    results = {}
+    c, f = await handler._execute_parallel_batch(pending, results)
+    assert results["t_ok"]["status"] == "completed"
+    assert results["t_bad"]["status"] == "failed"
+    assert c == 1 and f == 1
+    assert not pending
+
+
+@pytest.mark.asyncio
+async def test_wait_for_dependencies_raises_on_non_failed_terminal_status():
+    """_wait_for_dependencies must raise on any non-completed terminal status, not only 'failed' (#6454)."""
+    t1 = _task("t1", deps=["dep"])
+    results = {"dep": {"status": "cancelled"}}
+
+    handler = _make_handler()
+    with pytest.raises(RuntimeError, match="terminal"):
+        await handler._wait_for_dependencies(t1, results)
 
 
 # ---------------------------------------------------------------------------
@@ -408,7 +442,6 @@ async def test_collaborative_coordinator_awaited_on_cancel():
         resource_semaphore=asyncio.Semaphore(5),
         deps=deps,
     )
-    from enhanced_orchestration.types import ExecutionStrategy
     plan = _plan([_task("t1")], ExecutionStrategy.COLLABORATIVE)
     await handler.execute_collaborative(plan)
     assert cleanup_ran, "coordinator finally block must run before execute_collaborative returns"


### PR DESCRIPTION
## Summary
- Extract `_is_required_failure(task, result)` private method — replaces the 3 duplicate `result.get("status") == "failed" and not task.metadata.get("optional", False)` sites in `execute_sequential` and `execute_pipeline` (#6455)
- Add `return_exceptions=True` to `asyncio.gather` in `execute_pipeline` and `_execute_parallel_batch`; convert any `BaseException` item to `task.to_failed_result(repr(exc))` so an unhandled task exception never bypasses result recording or stage-failure logic (#6449)
- `_wait_for_dependencies` now detects any terminal non-completed dep status (`"cancelled"`, `"error"`, etc.), not only `"failed"` — prevents infinite sleep loop on non-standard statuses (#6454)
- Add `group_stages_fn` parameter to `_make_handler` test helper; remove `__import__` workarounds from both pipeline tests (#6448)
- 3 new regression tests; 18 total, all passing

## Test Plan
- [x] `test_pipeline_records_failed_result_when_task_raises` — gather exception converted to failed result, stage 2 skipped
- [x] `test_parallel_batch_records_failed_result_when_task_raises` — gather exception converted, c/f counts correct
- [x] `test_wait_for_dependencies_raises_on_non_failed_terminal_status` — "cancelled" status raises RuntimeError
- [x] All 18 tests passing

## Related Issues
Closes #6448
Closes #6449
Closes #6454
Closes #6455