### PR TITLE
refactor(schemas): Phase 10 — migrate 41 endpoint classes to domain schema files (#6042)

### DIFF
--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -8,11 +8,8 @@ Provides monitoring, desktop streaming, and takeover management endpoints
 
 import asyncio
 import logging
-from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
-from pydantic import BaseModel
-
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.error_constants import ERR_SESSION_NOT_FOUND
@@ -23,6 +20,14 @@ from takeover_manager import TakeoverTrigger, get_takeover_manager
 from task_execution_tracker import get_task_tracker
 from type_defs.common import Metadata
 from api.schemas_common import DataResponse
+from api.schemas_system import (
+    StreamingSessionRequest,
+    StreamingSessionResponse,
+    SystemMonitoringResponse,
+    TakeoverActionRequest,
+    TakeoverApprovalRequest,
+    TakeoverRequest,
+)
 from api.schemas_workflows import (
     AdvancedControlActiveTakeoversListResponse,
     AdvancedControlHealthResponse,
@@ -35,51 +40,6 @@ from api.schemas_workflows import (
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["advanced_control"])
-
-
-# Request/Response Models
-class StreamingSessionRequest(BaseModel):
-    user_id: str
-    resolution: str = "1024x768"
-    depth: int = 24
-
-
-class StreamingSessionResponse(BaseModel):
-    session_id: str
-    vnc_port: int
-    novnc_port: Optional[int]
-    display: str
-    vnc_url: str
-    web_url: Optional[str]
-    websocket_endpoint: str
-
-
-class TakeoverRequest(BaseModel):
-    trigger: str
-    reason: str
-    requesting_agent: Optional[str] = None
-    affected_tasks: Optional[List[str]] = None
-    priority: str = "HIGH"
-    timeout_minutes: Optional[int] = None
-    auto_approve: bool = False
-
-
-class TakeoverApprovalRequest(BaseModel):
-    human_operator: str
-    takeover_scope: Optional[Metadata] = None
-
-
-class TakeoverActionRequest(BaseModel):
-    action_type: str
-    action_data: Metadata
-
-
-class SystemMonitoringResponse(BaseModel):
-    system_status: Metadata
-    active_sessions: List[Metadata]
-    pending_takeovers: List[Metadata]
-    active_takeovers: List[Metadata]
-    resource_usage: Metadata
 
 
 # Desktop Streaming Endpoints

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -22,14 +22,19 @@ from uuid import uuid4
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel, Field
-
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.error_utils import safe_http_detail
 from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
-from constants.threshold_constants import CategoryDefaults, TimingConstants
+from constants.threshold_constants import TimingConstants
 
+from api.schemas_chat import (
+    ChatMessage,
+    ChatPreferences,
+    DetectLanguageRequest,
+    EnhancedChatMessage,
+    TranslateRequest,
+)
 from api.schemas_common import DataResponse
 
 # Import dependencies and utilities - Using available dependencies
@@ -313,108 +318,6 @@ logger = logging.getLogger(__name__)
 from api.chat_sessions import router as sessions_router
 
 router.include_router(sessions_router)
-
-# ====================================================================
-# Request/Response Models
-# ====================================================================
-
-
-class ChatMessage(BaseModel):
-    """Chat message model for requests"""
-
-    content: str = Field(
-        ..., min_length=1, max_length=50000, description="Message content"
-    )
-    role: str = Field(
-        default=CategoryDefaults.ROLE_USER,
-        pattern="^(user|assistant|system)$",
-        description="Message role",
-    )
-    session_id: Optional[str] = Field(None, description="Chat session ID")
-    message_type: Optional[str] = Field("text", description="Message type")
-    metadata: Optional[Metadata] = Field(
-        default_factory=dict, description="Additional metadata"
-    )
-    language: Optional[str] = Field(
-        None,
-        description="Preferred response language code (e.g. 'en', 'es', 'de'). "
-        "Overrides personality language when set.",
-    )
-
-
-class ChatResponse(BaseModel):
-    """Chat response model"""
-
-    content: str
-    role: str = CategoryDefaults.ROLE_ASSISTANT
-    session_id: str
-    message_id: str
-    timestamp: datetime
-    metadata: Metadata = Field(default_factory=dict)
-
-
-class MessageHistory(BaseModel):
-    """Message history response model"""
-
-    messages: List[Metadata]
-    session_id: str
-    total_count: int
-    page: int = 1
-    per_page: int = 50
-
-
-class EnhancedChatMessage(BaseModel):
-    """Enhanced chat message model with AI Stack integration (Issue #708 consolidation)."""
-
-    content: str = Field(
-        ..., min_length=1, max_length=50000, description="Message content"
-    )
-    role: str = Field(
-        default=CategoryDefaults.ROLE_USER,
-        pattern="^(user|assistant|system)$",
-        description="Message role",
-    )
-    session_id: Optional[str] = Field(None, description="Chat session ID")
-    message_type: Optional[str] = Field("text", description="Message type")
-    metadata: Optional[Metadata] = Field(
-        default_factory=dict, description="Additional metadata"
-    )
-
-    language: Optional[str] = Field(
-        None,
-        description="Preferred response language code (e.g. 'en', 'es', 'de'). "
-        "Overrides personality language when set.",
-    )
-
-    # AI Stack specific fields
-    use_ai_stack: bool = Field(
-        True, description="Whether to use AI Stack for enhanced responses"
-    )
-    use_knowledge_base: bool = Field(
-        True, description="Whether to include knowledge base context"
-    )
-    response_style: str = Field(
-        "conversational", description="Response style preference"
-    )
-    include_sources: bool = Field(
-        True, description="Whether to include source citations"
-    )
-
-
-class ChatPreferences(BaseModel):
-    """Chat preferences for customizing AI behavior (Issue #708 consolidation)."""
-
-    response_length: str = Field(
-        "medium", description="Preferred response length (short, medium, long)"
-    )
-    technical_level: str = Field("adaptive", description="Technical complexity level")
-    include_reasoning: bool = Field(
-        False, description="Include reasoning steps in responses"
-    )
-    fact_checking: bool = Field(
-        True, description="Enable fact checking against knowledge base"
-    )
-
 
 # ====================================================================
 # Configuration and State Management
@@ -2240,38 +2143,6 @@ async def get_enhanced_chat_capabilities(
 # ====================================================================
 # Issue #1328: Translation Shortcut Endpoint
 # ====================================================================
-
-
-class TranslateRequest(BaseModel):
-    """Request model for direct translation."""
-
-    text: str = Field(
-        ...,
-        min_length=1,
-        max_length=50000,
-        description="Text to translate",
-    )
-    target_language: str = Field(
-        ...,
-        min_length=1,
-        max_length=50,
-        description="Target language name",
-    )
-    source_language: Optional[str] = Field(
-        None,
-        description="Source language (auto-detect if omitted)",
-    )
-
-
-class DetectLanguageRequest(BaseModel):
-    """Request model for language detection."""
-
-    text: str = Field(
-        ...,
-        min_length=1,
-        max_length=50000,
-        description="Text to detect language of",
-    )
 
 
 @with_error_handling(

--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -22,17 +22,24 @@ from typing import Any, Dict, Optional, Tuple
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
-
 from api.schemas_code import (
     CachedSecurityScoreResponse,
     ClearStuckResponse,
+    CodeIntelAnalysisRequest,
     CodeIntelligenceTaskStatusResponse,
+    CodeIntelQuickScanRequest,
+    CodeIntelSuggestionsRequest,
     FindingsPlaceholderResponse,
+    PerformanceAnalysisRequest,
+    PerformanceFileScanRequest,
+    RedisAnalysisRequest,
+    RedisFileScanRequest,
+    SecurityAnalysisRequest,
+    SecurityFileScanRequest,
     StartTaskResponse,
     SuggestionsResponse,
 )
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.time_utils import parse_utc_iso
@@ -673,45 +680,6 @@ async def _generate_report_response(
     )
 
 
-class AnalysisRequest(BaseModel):
-    """Request model for code analysis (directory or inline code)."""
-
-    path: Optional[str] = Field(
-        default=None,
-        description="Directory path to analyze",
-    )
-    code: Optional[str] = Field(
-        default=None,
-        description="Inline code to analyze",
-    )
-    language: Optional[str] = Field(
-        default=None,
-        description="Language of the inline code",
-    )
-    filename: Optional[str] = Field(
-        default=None,
-        description="Virtual filename for inline code",
-    )
-    include_suggestions: Optional[bool] = Field(
-        default=None,
-        description="Whether to include improvement suggestions",
-    )
-    exclude_dirs: Optional[list] = Field(
-        default=None,
-        description="Directories to exclude from analysis",
-    )
-    min_severity: Optional[str] = Field(
-        default=None,
-        description="Minimum severity level to include",
-    )
-
-
-class QuickScanRequest(BaseModel):
-    """Request for quick single-file scan."""
-
-    file_path: str = Field(..., description="Path to Python file to analyze")
-
-
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_codebase",
@@ -724,7 +692,7 @@ class QuickScanRequest(BaseModel):
 )
 @router.post("/analyze", response_model=DataResponse)
 async def analyze_codebase(
-    request: AnalysisRequest,
+    request: CodeIntelAnalysisRequest,
     admin_check: bool = Depends(check_admin_permission),
 ):
     """
@@ -765,7 +733,7 @@ async def analyze_codebase(
         raise_internal_error("Analysis failed")
 
 
-def _analyze_inline_code(request: AnalysisRequest) -> JSONResponse:
+def _analyze_inline_code(request: CodeIntelAnalysisRequest) -> JSONResponse:
     """Analyze inline code snippet. Issue #1008."""
     code = request.code
     lines = code.split("\n")
@@ -829,15 +797,6 @@ def _analyze_inline_code(request: AnalysisRequest) -> JSONResponse:
     )
 
 
-class SuggestionsRequest(BaseModel):
-    """Request model for code suggestions. Issue #1006."""
-
-    code: str = Field(..., description="Code to get suggestions for")
-    language: Optional[str] = Field(
-        default="python", description="Programming language"
-    )
-
-
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_suggestions",
@@ -850,7 +809,7 @@ class SuggestionsRequest(BaseModel):
 )
 @router.post("/suggestions", response_model=SuggestionsResponse)
 async def get_code_suggestions(
-    request: SuggestionsRequest,
+    request: CodeIntelSuggestionsRequest,
     admin_check: bool = Depends(check_admin_permission),
 ):
     """Return code improvement suggestions. Issue #1006."""
@@ -884,7 +843,7 @@ async def get_code_suggestions(
 )
 @router.post("/scan-file", response_model=DataResponse)
 async def quick_scan_file(
-    request: QuickScanRequest,
+    request: CodeIntelQuickScanRequest,
     admin_check: bool = Depends(check_admin_permission),
 ):
     """
@@ -1020,29 +979,6 @@ async def get_supported_pattern_types(
 # =============================================================================
 # Redis Optimization Endpoints (Issue #220)
 # =============================================================================
-
-
-class RedisAnalysisRequest(BaseModel):
-    """Request model for Redis optimization analysis."""
-
-    path: str = Field(
-        ...,
-        description="Directory or file path to analyze for Redis optimizations",
-    )
-    exclude_patterns: Optional[list] = Field(
-        default=None,
-        description="Glob patterns to exclude from analysis",
-    )
-    min_severity: Optional[str] = Field(
-        default=None,
-        description="Minimum severity level to include (info, low, medium, high, critical)",
-    )
-
-
-class RedisFileScanRequest(BaseModel):
-    """Request for scanning a single file for Redis optimizations."""
-
-    file_path: str = Field(..., description="Path to Python file to analyze")
 
 
 @with_error_handling(
@@ -1281,29 +1217,6 @@ async def _run_redis_health_analysis(path: str) -> Dict[str, Any]:
 # ============================================================================
 # Security Analysis Endpoints (Issue #219)
 # ============================================================================
-
-
-class SecurityAnalysisRequest(BaseModel):
-    """Request model for security analysis."""
-
-    path: str = Field(
-        ...,
-        description="Directory path to analyze for security vulnerabilities",
-    )
-    exclude_patterns: Optional[list] = Field(
-        default=None,
-        description="Patterns to exclude from analysis (e.g., ['test_*', 'venv'])",
-    )
-    min_severity: Optional[str] = Field(
-        default=None,
-        description="Minimum severity level to include (info, low, medium, high, critical)",
-    )
-
-
-class SecurityFileScanRequest(BaseModel):
-    """Request for single file security scan."""
-
-    file_path: str = Field(..., description="Path to Python file to analyze")
 
 
 @with_error_handling(
@@ -1573,29 +1486,6 @@ async def get_security_report(
 # ============================================================================
 # Performance Analysis Endpoints (Issue #222)
 # ============================================================================
-
-
-class PerformanceAnalysisRequest(BaseModel):
-    """Request model for performance analysis."""
-
-    path: str = Field(
-        ...,
-        description="Directory path to analyze for performance issues",
-    )
-    exclude_patterns: Optional[list] = Field(
-        default=None,
-        description="Patterns to exclude from analysis",
-    )
-    min_severity: Optional[str] = Field(
-        default=None,
-        description="Minimum severity level to include",
-    )
-
-
-class PerformanceFileScanRequest(BaseModel):
-    """Request for single file performance scan."""
-
-    file_path: str = Field(..., description="Path to Python file to analyze")
 
 
 @with_error_handling(

--- a/autobot-backend/api/heartbeat.py
+++ b/autobot-backend/api/heartbeat.py
@@ -14,7 +14,6 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -30,8 +29,14 @@ from models.heartbeat import (
 )
 from services.heartbeat_scheduler import HeartbeatScheduler, _get_or_create_state
 from api.schemas_system import (
+    HeartbeatConfigRequest,
+    HeartbeatConfigResponse,
+    HeartbeatRunResponse,
     HeartbeatTriggerResponse,
     HeartbeatWakeupQueuedResponse,
+    RunEventResponse,
+    WakeupRequestCreate,
+    WakeupRequestResponse,
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
@@ -55,79 +60,6 @@ def _get_scheduler() -> HeartbeatScheduler:
             detail="Heartbeat scheduler not initialised",
         )
     return _scheduler
-
-
-class HeartbeatConfigRequest(BaseModel):
-    """Request body to configure heartbeat for an agent."""
-
-    heartbeat_enabled: bool = False
-    heartbeat_interval_seconds: int = Field(default=300, ge=10)
-    max_run_duration_seconds: int = Field(default=600, ge=10)
-
-
-class HeartbeatConfigResponse(BaseModel):
-    """Response for agent heartbeat config / runtime state."""
-
-    agent_id: str
-    heartbeat_enabled: bool
-    heartbeat_interval_seconds: int
-    max_run_duration_seconds: int
-    current_task_id: Optional[str]
-    last_heartbeat_at: Optional[str]
-    session_params: Optional[Dict[str, Any]]
-    extra: Optional[Dict[str, Any]]
-    created_at: Optional[str]
-    updated_at: Optional[str]
-
-
-class WakeupRequestCreate(BaseModel):
-    """Request body to queue a wakeup for an agent."""
-
-    priority: int = 0
-    context: Optional[Dict[str, Any]] = None
-    reason: Optional[str] = None
-
-
-class WakeupRequestResponse(BaseModel):
-    """Response for a queued wakeup request."""
-
-    id: str
-    agent_id: str
-    priority: int
-    context: Optional[Dict[str, Any]]
-    reason: Optional[str]
-    consumed: bool
-    consumed_at: Optional[str]
-    created_at: Optional[str]
-
-
-class RunEventResponse(BaseModel):
-    """Response for a single run event."""
-
-    id: str
-    event_type: str
-    message: Optional[str]
-    payload: Optional[Dict[str, Any]]
-    occurred_at: str
-
-
-class HeartbeatRunResponse(BaseModel):
-    """Response for a single heartbeat run."""
-
-    id: str
-    agent_id: str
-    status: str
-    trigger: str
-    wakeup_context: Optional[Dict[str, Any]]
-    started_at: Optional[str]
-    finished_at: Optional[str]
-    tokens_used: Optional[int]
-    cost_usd: Optional[float]
-    model: Optional[str]
-    provider: Optional[str]
-    error_message: Optional[str]
-    created_at: Optional[str]
-    events: List[RunEventResponse] = []
 
 
 @with_error_handling(

--- a/autobot-backend/api/personality.py
+++ b/autobot-backend/api/personality.py
@@ -14,114 +14,20 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, field_validator
-
 from auth_middleware import check_admin_permission
 from services.personality_service import SUPPORTED_LANGUAGES, get_personality_manager
-from api.schemas_common import DataResponse
+from api.schemas_agent import (
+    PersonalityProfileCreate,
+    PersonalityProfileDetail,
+    PersonalityProfileSummary,
+    PersonalityProfileUpdate,
+    PersonalityStatusResponse,
+    PersonalityToggleRequest,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["personality"])
-
-_VALID_TONES = {"direct", "professional", "casual", "technical"}
-
-
-# ---------------------------------------------------------------------------
-# Schemas
-# ---------------------------------------------------------------------------
-
-
-class ProfileSummary(BaseModel):
-    id: str
-    name: str
-    is_system: bool
-    active: bool
-
-
-class ProfileDetail(BaseModel):
-    id: str
-    name: str
-    tagline: str
-    tone: str
-    character_traits: List[str]
-    operating_style: List[str]
-    off_limits: List[str]
-    custom_notes: str
-    is_system: bool
-    created_by: str
-    created_at: str
-    updated_at: str
-    voice_id: str = ""
-    voice_ids: Dict[str, str] = {}
-    language_code: str = "en"
-
-
-class ProfileCreate(BaseModel):
-    name: str
-    tagline: str = ""
-    tone: str = "direct"
-    character_traits: List[str] = []
-    operating_style: List[str] = []
-    off_limits: List[str] = []
-    custom_notes: str = ""
-    voice_id: str = ""
-    voice_ids: Dict[str, str] = {}
-    language_code: str = "en"
-
-    @field_validator("tone")
-    @classmethod
-    def tone_must_be_valid(cls, v: str) -> str:
-        if v not in _VALID_TONES:
-            raise ValueError(f"tone must be one of {sorted(_VALID_TONES)}")
-        return v
-
-    @field_validator("language_code")
-    @classmethod
-    def language_code_must_be_valid(cls, v: str) -> str:
-        if v not in SUPPORTED_LANGUAGES:
-            raise ValueError(
-                f"language_code must be one of {sorted(SUPPORTED_LANGUAGES)}"
-            )
-        return v
-
-
-class ProfileUpdate(BaseModel):
-    name: Optional[str] = None
-    tagline: Optional[str] = None
-    tone: Optional[str] = None
-    character_traits: Optional[List[str]] = None
-    operating_style: Optional[List[str]] = None
-    off_limits: Optional[List[str]] = None
-    custom_notes: Optional[str] = None
-    voice_id: Optional[str] = None
-    voice_ids: Optional[Dict[str, str]] = None
-    language_code: Optional[str] = None
-
-    @field_validator("tone")
-    @classmethod
-    def tone_must_be_valid(cls, v: Optional[str]) -> Optional[str]:
-        if v is not None and v not in _VALID_TONES:
-            raise ValueError(f"tone must be one of {sorted(_VALID_TONES)}")
-        return v
-
-    @field_validator("language_code")
-    @classmethod
-    def language_code_must_be_valid(cls, v: Optional[str]) -> Optional[str]:
-        if v is not None and v not in SUPPORTED_LANGUAGES:
-            raise ValueError(
-                f"language_code must be one of {sorted(SUPPORTED_LANGUAGES)}"
-            )
-        return v
-
-
-class ToggleRequest(BaseModel):
-    enabled: bool
-
-
-class StatusResponse(BaseModel):
-    enabled: bool
-    active_id: Optional[str]
 
 
 # ---------------------------------------------------------------------------
@@ -129,8 +35,8 @@ class StatusResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _profile_to_detail(p) -> ProfileDetail:
-    return ProfileDetail(
+def _profile_to_detail(p) -> PersonalityProfileDetail:
+    return PersonalityProfileDetail(
         id=p.id,
         name=p.name,
         tagline=p.tagline,
@@ -166,7 +72,7 @@ def _not_found(pid: str) -> HTTPException:
     operation="list_profiles",
     error_code_prefix="PERSONALITY",
 )
-@router.get("/profiles", response_model=List[ProfileSummary])
+@router.get("/profiles", response_model=List[PersonalityProfileSummary])
 async def list_profiles() -> List[Dict[str, Any]]:
     """List all personality profiles."""
     return get_personality_manager().list_profiles()
@@ -177,8 +83,8 @@ async def list_profiles() -> List[Dict[str, Any]]:
     operation="get_active",
     error_code_prefix="PERSONALITY",
 )
-@router.get("/active", response_model=Optional[ProfileDetail])
-async def get_active() -> Optional[ProfileDetail]:
+@router.get("/active", response_model=Optional[PersonalityProfileDetail])
+async def get_active() -> Optional[PersonalityProfileDetail]:
     """Return the active profile, or null if personality is disabled."""
     mgr = get_personality_manager()
     profile = mgr.get_active_profile()
@@ -192,12 +98,12 @@ async def get_active() -> Optional[ProfileDetail]:
     operation="get_status",
     error_code_prefix="PERSONALITY",
 )
-@router.get("/status", response_model=StatusResponse)
-async def get_status() -> StatusResponse:
+@router.get("/status", response_model=PersonalityStatusResponse)
+async def get_status() -> PersonalityStatusResponse:
     """Return enabled flag and active profile id."""
     mgr = get_personality_manager()
     index = mgr._read_index()
-    return StatusResponse(
+    return PersonalityStatusResponse(
         enabled=index.get("enabled", True),
         active_id=index.get("active_id"),
     )
@@ -219,8 +125,8 @@ async def list_languages() -> Dict[str, str]:
     operation="get_profile",
     error_code_prefix="PERSONALITY",
 )
-@router.get("/profiles/{pid}", response_model=ProfileDetail)
-async def get_profile(pid: str) -> ProfileDetail:
+@router.get("/profiles/{pid}", response_model=PersonalityProfileDetail)
+async def get_profile(pid: str) -> PersonalityProfileDetail:
     """Fetch a single profile by id."""
     profile = get_personality_manager().get_profile(pid)
     if profile is None:
@@ -240,11 +146,11 @@ async def get_profile(pid: str) -> ProfileDetail:
 )
 @router.post(
     "/profiles",
-    response_model=ProfileDetail,
+    response_model=PersonalityProfileDetail,
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(check_admin_permission)],
 )
-async def create_profile(body: ProfileCreate) -> ProfileDetail:
+async def create_profile(body: PersonalityProfileCreate) -> PersonalityProfileDetail:
     """Create a new user personality profile."""
     profile = get_personality_manager().create_profile(**body.model_dump())
     return _profile_to_detail(profile)
@@ -257,10 +163,10 @@ async def create_profile(body: ProfileCreate) -> ProfileDetail:
 )
 @router.put(
     "/profiles/{pid}",
-    response_model=ProfileDetail,
+    response_model=PersonalityProfileDetail,
     dependencies=[Depends(check_admin_permission)],
 )
-async def update_profile(pid: str, body: ProfileUpdate) -> ProfileDetail:
+async def update_profile(pid: str, body: PersonalityProfileUpdate) -> PersonalityProfileDetail:
     """Update fields on an existing profile."""
     updates = {k: v for k, v in body.model_dump().items() if v is not None}
     try:
@@ -320,10 +226,10 @@ async def activate_profile(pid: str) -> None:
 )
 @router.post(
     "/profiles/{pid}/reset",
-    response_model=ProfileDetail,
+    response_model=PersonalityProfileDetail,
     dependencies=[Depends(check_admin_permission)],
 )
-async def reset_profile(pid: str) -> ProfileDetail:
+async def reset_profile(pid: str) -> PersonalityProfileDetail:
     """Reset a profile's content to match the default profile."""
     try:
         profile = get_personality_manager().reset_profile(pid)
@@ -339,15 +245,15 @@ async def reset_profile(pid: str) -> ProfileDetail:
 )
 @router.post(
     "/toggle",
-    response_model=StatusResponse,
+    response_model=PersonalityStatusResponse,
     dependencies=[Depends(check_admin_permission)],
 )
-async def toggle_personality(body: ToggleRequest) -> StatusResponse:
+async def toggle_personality(body: PersonalityToggleRequest) -> PersonalityStatusResponse:
     """Enable or disable the personality system globally."""
     mgr = get_personality_manager()
     mgr.set_enabled(body.enabled)
     index = mgr._read_index()
-    return StatusResponse(
+    return PersonalityStatusResponse(
         enabled=body.enabled,
         active_id=index.get("active_id"),
     )

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -11,8 +11,11 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field, field_validator
 
 from models.session_collaboration import PermissionLevel
+from services.personality_service import SUPPORTED_LANGUAGES
 from type_defs.common import Metadata
 from user_management.schemas import UserResponse as _UserResponse
+
+_PERSONALITY_VALID_TONES = {"direct", "professional", "casual", "technical"}
 
 
 # ---------------------------------------------------------------------------
@@ -1552,3 +1555,95 @@ class ResearchTaskRequest(BaseModel):
     include_web: bool = Field(True, description="Include web research")
     include_code_search: bool = Field(False, description="Include code search")
     sources: Optional[List[str]] = Field(None, description="Specific sources")
+
+
+class PersonalityProfileSummary(BaseModel):
+    id: str
+    name: str
+    is_system: bool
+    active: bool
+
+
+class PersonalityProfileDetail(BaseModel):
+    id: str
+    name: str
+    tagline: str
+    tone: str
+    character_traits: List[str]
+    operating_style: List[str]
+    off_limits: List[str]
+    custom_notes: str
+    is_system: bool
+    created_by: str
+    created_at: str
+    updated_at: str
+    voice_id: str = ""
+    voice_ids: Dict[str, str] = {}
+    language_code: str = "en"
+
+
+class PersonalityProfileCreate(BaseModel):
+    name: str
+    tagline: str = ""
+    tone: str = "direct"
+    character_traits: List[str] = []
+    operating_style: List[str] = []
+    off_limits: List[str] = []
+    custom_notes: str = ""
+    voice_id: str = ""
+    voice_ids: Dict[str, str] = {}
+    language_code: str = "en"
+
+    @field_validator("tone")
+    @classmethod
+    def tone_must_be_valid(cls, v: str) -> str:
+        if v not in _PERSONALITY_VALID_TONES:
+            raise ValueError(f"tone must be one of {sorted(_PERSONALITY_VALID_TONES)}")
+        return v
+
+    @field_validator("language_code")
+    @classmethod
+    def language_code_must_be_valid(cls, v: str) -> str:
+        if v not in SUPPORTED_LANGUAGES:
+            raise ValueError(
+                f"language_code must be one of {sorted(SUPPORTED_LANGUAGES)}"
+            )
+        return v
+
+
+class PersonalityProfileUpdate(BaseModel):
+    name: Optional[str] = None
+    tagline: Optional[str] = None
+    tone: Optional[str] = None
+    character_traits: Optional[List[str]] = None
+    operating_style: Optional[List[str]] = None
+    off_limits: Optional[List[str]] = None
+    custom_notes: Optional[str] = None
+    voice_id: Optional[str] = None
+    voice_ids: Optional[Dict[str, str]] = None
+    language_code: Optional[str] = None
+
+    @field_validator("tone")
+    @classmethod
+    def tone_must_be_valid(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in _PERSONALITY_VALID_TONES:
+            raise ValueError(f"tone must be one of {sorted(_PERSONALITY_VALID_TONES)}")
+        return v
+
+    @field_validator("language_code")
+    @classmethod
+    def language_code_must_be_valid(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in SUPPORTED_LANGUAGES:
+            raise ValueError(
+                f"language_code must be one of {sorted(SUPPORTED_LANGUAGES)}"
+            )
+        return v
+
+
+class PersonalityToggleRequest(BaseModel):
+    enabled: bool
+
+
+class PersonalityStatusResponse(BaseModel):
+    enabled: bool
+    active_id: Optional[str]

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -10,10 +10,12 @@ to give FastAPI enough type information to generate correct OpenAPI schemas.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from constants.threshold_constants import CategoryDefaults
 from type_defs.common import Metadata
 
 
@@ -228,3 +230,89 @@ class ChatResetRequest(BaseModel):
     session_id: Optional[str] = Field(None, description="Session ID to reset (optional)")
     clear_context: bool = Field(True, description="Clear conversation context")
     keep_system_prompt: bool = Field(True, description="Keep system prompt after reset")
+
+
+class ChatMessage(BaseModel):
+    """Chat message model for requests"""
+
+    content: str = Field(..., min_length=1, max_length=50000, description="Message content")
+    role: str = Field(
+        default=CategoryDefaults.ROLE_USER,
+        pattern="^(user|assistant|system)$",
+        description="Message role",
+    )
+    session_id: Optional[str] = Field(None, description="Chat session ID")
+    message_type: Optional[str] = Field("text", description="Message type")
+    metadata: Optional[Metadata] = Field(default_factory=dict, description="Additional metadata")
+    language: Optional[str] = Field(
+        None,
+        description="Preferred response language code (e.g. 'en', 'es', 'de'). "
+        "Overrides personality language when set.",
+    )
+
+
+class ChatResponse(BaseModel):
+    """Chat response model"""
+
+    content: str
+    role: str = CategoryDefaults.ROLE_ASSISTANT
+    session_id: str
+    message_id: str
+    timestamp: datetime
+    metadata: Metadata = Field(default_factory=dict)
+
+
+class MessageHistory(BaseModel):
+    """Message history response model"""
+
+    messages: List[Metadata]
+    session_id: str
+    total_count: int
+    page: int = 1
+    per_page: int = 50
+
+
+class EnhancedChatMessage(BaseModel):
+    """Enhanced chat message with AI Stack integration."""
+
+    content: str = Field(..., min_length=1, max_length=50000, description="Message content")
+    role: str = Field(
+        default=CategoryDefaults.ROLE_USER,
+        pattern="^(user|assistant|system)$",
+        description="Message role",
+    )
+    session_id: Optional[str] = Field(None, description="Chat session ID")
+    message_type: Optional[str] = Field("text", description="Message type")
+    metadata: Optional[Metadata] = Field(default_factory=dict, description="Additional metadata")
+    language: Optional[str] = Field(
+        None,
+        description="Preferred response language code (e.g. 'en', 'es', 'de'). "
+        "Overrides personality language when set.",
+    )
+    use_ai_stack: bool = Field(True, description="Whether to use AI Stack for enhanced responses")
+    use_knowledge_base: bool = Field(True, description="Whether to include knowledge base context")
+    response_style: str = Field("conversational", description="Response style preference")
+    include_sources: bool = Field(True, description="Whether to include source citations")
+
+
+class ChatPreferences(BaseModel):
+    """Chat preferences for customizing AI behavior."""
+
+    response_length: str = Field("medium", description="Preferred response length (short, medium, long)")
+    technical_level: str = Field("adaptive", description="Technical complexity level")
+    include_reasoning: bool = Field(False, description="Include reasoning steps in responses")
+    fact_checking: bool = Field(True, description="Enable fact checking against knowledge base")
+
+
+class TranslateRequest(BaseModel):
+    """Request model for direct translation."""
+
+    text: str = Field(..., min_length=1, max_length=50000, description="Text to translate")
+    target_language: str = Field(..., min_length=1, max_length=50, description="Target language name")
+    source_language: Optional[str] = Field(None, description="Source language (auto-detect if omitted)")
+
+
+class DetectLanguageRequest(BaseModel):
+    """Request model for language detection."""
+
+    text: str = Field(..., min_length=1, max_length=50000, description="Text to detect language of")

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -2008,3 +2008,70 @@ class ReusabilityReport(BaseModel):
     usage_patterns: List[str]
     refactor_suggestions: List[str]
     similar_declarations: List[str]
+
+
+class CodeIntelAnalysisRequest(BaseModel):
+    """Request model for code analysis (directory or inline code)."""
+
+    path: Optional[str] = Field(default=None, description="Directory path to analyze")
+    code: Optional[str] = Field(default=None, description="Inline code to analyze")
+    language: Optional[str] = Field(default=None, description="Language of the inline code")
+    filename: Optional[str] = Field(default=None, description="Virtual filename for inline code")
+    include_suggestions: Optional[bool] = Field(default=None, description="Whether to include improvement suggestions")
+    exclude_dirs: Optional[list] = Field(default=None, description="Directories to exclude from analysis")
+    min_severity: Optional[str] = Field(default=None, description="Minimum severity level to include")
+
+
+class CodeIntelQuickScanRequest(BaseModel):
+    """Request for quick single-file scan."""
+
+    file_path: str = Field(..., description="Path to Python file to analyze")
+
+
+class CodeIntelSuggestionsRequest(BaseModel):
+    """Request model for code suggestions."""
+
+    code: str = Field(..., description="Code to get suggestions for")
+    language: Optional[str] = Field(default="python", description="Programming language")
+
+
+class RedisAnalysisRequest(BaseModel):
+    """Request model for Redis optimization analysis."""
+
+    path: str = Field(..., description="Directory or file path to analyze for Redis optimizations")
+    exclude_patterns: Optional[list] = Field(default=None, description="Glob patterns to exclude from analysis")
+    min_severity: Optional[str] = Field(default=None, description="Minimum severity level to include (info, low, medium, high, critical)")
+
+
+class RedisFileScanRequest(BaseModel):
+    """Request for scanning a single file for Redis optimizations."""
+
+    file_path: str = Field(..., description="Path to Python file to analyze")
+
+
+class SecurityAnalysisRequest(BaseModel):
+    """Request model for security analysis."""
+
+    path: str = Field(..., description="Directory path to analyze for security vulnerabilities")
+    exclude_patterns: Optional[list] = Field(default=None, description="Patterns to exclude from analysis (e.g., ['test_*', 'venv'])")
+    min_severity: Optional[str] = Field(default=None, description="Minimum severity level to include (info, low, medium, high, critical)")
+
+
+class SecurityFileScanRequest(BaseModel):
+    """Request for single file security scan."""
+
+    file_path: str = Field(..., description="Path to Python file to analyze")
+
+
+class PerformanceAnalysisRequest(BaseModel):
+    """Request model for performance analysis."""
+
+    path: str = Field(..., description="Directory path to analyze for performance issues")
+    exclude_patterns: Optional[list] = Field(default=None, description="Patterns to exclude from analysis")
+    min_severity: Optional[str] = Field(default=None, description="Minimum severity level to include")
+
+
+class PerformanceFileScanRequest(BaseModel):
+    """Request for single file performance scan."""
+
+    file_path: str = Field(..., description="Path to Python file to analyze")

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -2419,3 +2419,193 @@ class TerminalHostSelectionResponse(BaseModel):
     selected_host_id: Optional[str] = Field(None, description="Selected host ID")
     selected_host_name: Optional[str] = Field(None, description="Selected host name")
     connection_info: Optional[Dict] = Field(None, description="Connection details (host, port, username)")
+
+
+class HeartbeatConfigRequest(BaseModel):
+    """Request body to configure heartbeat for an agent."""
+
+    heartbeat_enabled: bool = False
+    heartbeat_interval_seconds: int = Field(default=300, ge=10)
+    max_run_duration_seconds: int = Field(default=600, ge=10)
+
+
+class HeartbeatConfigResponse(BaseModel):
+    """Response for agent heartbeat config / runtime state."""
+
+    agent_id: str
+    heartbeat_enabled: bool
+    heartbeat_interval_seconds: int
+    max_run_duration_seconds: int
+    current_task_id: Optional[str]
+    last_heartbeat_at: Optional[str]
+    session_params: Optional[Dict[str, Any]]
+    extra: Optional[Dict[str, Any]]
+    created_at: Optional[str]
+    updated_at: Optional[str]
+
+
+class WakeupRequestCreate(BaseModel):
+    """Request body to queue a wakeup for an agent."""
+
+    priority: int = 0
+    context: Optional[Dict[str, Any]] = None
+    reason: Optional[str] = None
+
+
+class WakeupRequestResponse(BaseModel):
+    """Response for a queued wakeup request."""
+
+    id: str
+    agent_id: str
+    priority: int
+    context: Optional[Dict[str, Any]]
+    reason: Optional[str]
+    consumed: bool
+    consumed_at: Optional[str]
+    created_at: Optional[str]
+
+
+class RunEventResponse(BaseModel):
+    """Response for a single run event."""
+
+    id: str
+    event_type: str
+    message: Optional[str]
+    payload: Optional[Dict[str, Any]]
+    occurred_at: str
+
+
+class HeartbeatRunResponse(BaseModel):
+    """Response for a single heartbeat run."""
+
+    id: str
+    agent_id: str
+    status: str
+    trigger: str
+    wakeup_context: Optional[Dict[str, Any]]
+    started_at: Optional[str]
+    finished_at: Optional[str]
+    tokens_used: Optional[int]
+    cost_usd: Optional[float]
+    model: Optional[str]
+    provider: Optional[str]
+    error_message: Optional[str]
+    created_at: Optional[str]
+    events: List[RunEventResponse] = []
+
+
+class StreamingSessionRequest(BaseModel):
+    user_id: str
+    resolution: str = "1024x768"
+    depth: int = 24
+
+
+class StreamingSessionResponse(BaseModel):
+    session_id: str
+    vnc_port: int
+    novnc_port: Optional[int]
+    display: str
+    vnc_url: str
+    web_url: Optional[str]
+    websocket_endpoint: str
+
+
+class TakeoverRequest(BaseModel):
+    trigger: str
+    reason: str
+    requesting_agent: Optional[str] = None
+    affected_tasks: Optional[List[str]] = None
+    priority: str = "HIGH"
+    timeout_minutes: Optional[int] = None
+    auto_approve: bool = False
+
+
+class TakeoverApprovalRequest(BaseModel):
+    human_operator: str
+    takeover_scope: Optional[Metadata] = None
+
+
+class TakeoverActionRequest(BaseModel):
+    action_type: str
+    action_data: Metadata
+
+
+class SystemMonitoringResponse(BaseModel):
+    system_status: Metadata
+    active_sessions: List[Metadata]
+    pending_takeovers: List[Metadata]
+    active_takeovers: List[Metadata]
+    resource_usage: Metadata
+
+
+class ScreenAnalysisRequest(BaseModel):
+    """Request for screen analysis"""
+
+    session_id: Optional[str] = Field(None, description="Optional session ID for context")
+    include_multimodal: bool = Field(True, description="Include multi-modal analysis")
+
+
+class ElementDetectionRequest(BaseModel):
+    """Request for element detection"""
+
+    element_type: Optional[str] = Field(None, description="Filter by element type")
+    min_confidence: float = Field(0.5, ge=0.0, le=1.0, description="Minimum confidence threshold")
+    session_id: Optional[str] = None
+
+
+class OCRRequest(BaseModel):
+    """Request for OCR text extraction"""
+
+    region: Optional[Dict[str, int]] = Field(
+        None,
+        description=(
+            "Region to extract text from {x, y, width, height}. If None,"
+            "analyzes full screen."
+        ),
+    )
+    session_id: Optional[str] = None
+
+
+class ElementInteractionRequest(BaseModel):
+    """Request for element interaction validation"""
+
+    element_id: str = Field(..., description="ID of element to interact with")
+    interaction_type: str = Field(..., description="Type of interaction to perform")
+    parameters: Optional[Metadata] = Field(None, description="Additional interaction parameters")
+
+
+class UIElementResponse(BaseModel):
+    """Response model for UI element"""
+
+    element_id: str
+    element_type: str
+    bbox: Dict[str, int]
+    center_point: List[int]
+    confidence: float
+    text_content: str
+    attributes: Metadata
+    possible_interactions: List[str]
+
+
+class ScreenAnalysisResponse(BaseModel):
+    """Response model for screen analysis"""
+
+    timestamp: float
+    ui_elements: List[UIElementResponse]
+    text_regions: List[Metadata]
+    dominant_colors: List[Metadata]
+    layout_structure: Metadata
+    automation_opportunities: List[Metadata]
+    context_analysis: Metadata
+    confidence_score: float
+    multimodal_analysis: Optional[List[Metadata]] = None
+
+
+class VisionHealthResponse(BaseModel):
+    """Health check response"""
+
+    status: str
+    analyzer_ready: bool
+    capabilities: List[str]
+    element_types_supported: List[str]
+    interaction_types_supported: List[str]

--- a/autobot-backend/api/vision.py
+++ b/autobot-backend/api/vision.py
@@ -10,24 +10,26 @@ Author: mrveiss
 """
 
 import logging
-from typing import Dict, List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
-
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from computer_vision_system import ElementType, InteractionType, ScreenAnalyzer
-from type_defs.common import Metadata
 
 router = APIRouter(tags=["vision", "gui-automation"])
 logger = logging.getLogger(__name__)
 
 # Global screen analyzer instance (thread-safe)
 import threading
-from api.schemas_common import DataResponse
 from api.schemas_system import (
+    ElementDetectionRequest,
+    OCRRequest,
+    ScreenAnalysisRequest,
+    ScreenAnalysisResponse,
+    UIElementResponse,
     VisionDetectElementsResponse,
+    VisionHealthResponse,
     VisionOCRResponse,
     VisionAutomationOpportunitiesResponse,
     VisionElementTypesResponse,
@@ -50,86 +52,6 @@ def get_screen_analyzer() -> ScreenAnalyzer:
                 _screen_analyzer = ScreenAnalyzer()
                 logger.info("Screen analyzer initialized")
     return _screen_analyzer
-
-
-# Request/Response Models
-class ScreenAnalysisRequest(BaseModel):
-    """Request for screen analysis"""
-
-    session_id: Optional[str] = Field(
-        None, description="Optional session ID for context"
-    )
-    include_multimodal: bool = Field(True, description="Include multi-modal analysis")
-
-
-class ElementDetectionRequest(BaseModel):
-    """Request for element detection"""
-
-    element_type: Optional[str] = Field(None, description="Filter by element type")
-    min_confidence: float = Field(
-        0.5, ge=0.0, le=1.0, description="Minimum confidence threshold"
-    )
-    session_id: Optional[str] = None
-
-
-class OCRRequest(BaseModel):
-    """Request for OCR text extraction"""
-
-    region: Optional[Dict[str, int]] = Field(
-        None,
-        description=(
-            "Region to extract text from {x, y, width, height}. If None,"
-            "analyzes full screen."
-        ),
-    )
-    session_id: Optional[str] = None
-
-
-class ElementInteractionRequest(BaseModel):
-    """Request for element interaction validation"""
-
-    element_id: str = Field(..., description="ID of element to interact with")
-    interaction_type: str = Field(..., description="Type of interaction to perform")
-    parameters: Optional[Metadata] = Field(
-        None, description="Additional interaction parameters"
-    )
-
-
-class UIElementResponse(BaseModel):
-    """Response model for UI element"""
-
-    element_id: str
-    element_type: str
-    bbox: Dict[str, int]
-    center_point: List[int]
-    confidence: float
-    text_content: str
-    attributes: Metadata
-    possible_interactions: List[str]
-
-
-class ScreenAnalysisResponse(BaseModel):
-    """Response model for screen analysis"""
-
-    timestamp: float
-    ui_elements: List[UIElementResponse]
-    text_regions: List[Metadata]
-    dominant_colors: List[Metadata]
-    layout_structure: Metadata
-    automation_opportunities: List[Metadata]
-    context_analysis: Metadata
-    confidence_score: float
-    multimodal_analysis: Optional[List[Metadata]] = None
-
-
-class VisionHealthResponse(BaseModel):
-    """Health check response"""
-
-    status: str
-    analyzer_ready: bool
-    capabilities: List[str]
-    element_types_supported: List[str]
-    interaction_types_supported: List[str]
 
 
 # API Endpoints


### PR DESCRIPTION
## Summary

Phase 10 of issue #6042. Migrates 41 locally-defined \`BaseModel\` subclasses from 6 endpoint files into centralized domain schema files.

### Files migrated

| Endpoint file | Classes removed | Target schema file |
|---|---|---|
| \`heartbeat.py\` | 6 (HeartbeatConfigRequest/Response, WakeupRequestCreate/Response, RunEventResponse, HeartbeatRunResponse) | \`schemas_system.py\` |
| \`advanced_control.py\` | 6 (StreamingSessionRequest/Response, TakeoverRequest, TakeoverApprovalRequest, TakeoverActionRequest, SystemMonitoringResponse) | \`schemas_system.py\` |
| \`vision.py\` | 7 (ScreenAnalysisRequest/Response, ElementDetectionRequest, OCRRequest, ElementInteractionRequest, UIElementResponse, VisionHealthResponse) | \`schemas_system.py\` |
| \`personality.py\` | 6 (Profile{Summary,Detail,Create,Update}, ToggleRequest, StatusResponse → renamed Personality\* prefix) | \`schemas_agent.py\` |
| \`chat.py\` | 7 (ChatMessage, ChatResponse, MessageHistory, EnhancedChatMessage, ChatPreferences, TranslateRequest, DetectLanguageRequest) | \`schemas_chat.py\` |
| \`code_intelligence.py\` | 9 (3 generic renamed CodeIntel\* prefix; Redis/Security/Performance Analysis+FileScanRequest as-is) | \`schemas_code.py\` |

### Renames to avoid generic-name collisions

- \`ProfileSummary\` → \`PersonalityProfileSummary\` (and Detail/Create/Update)
- \`ToggleRequest\` → \`PersonalityToggleRequest\`, \`StatusResponse\` → \`PersonalityStatusResponse\`
- \`AnalysisRequest\` → \`CodeIntelAnalysisRequest\`
- \`QuickScanRequest\` → \`CodeIntelQuickScanRequest\`
- \`SuggestionsRequest\` → \`CodeIntelSuggestionsRequest\`

### Additional changes
- \`schemas_agent.py\`: imports \`SUPPORTED_LANGUAGES\` from \`services.personality_service\`; defines \`_PERSONALITY_VALID_TONES\` for v2 \`@field_validator\` constraints
- \`schemas_chat.py\`: adds \`datetime\` and \`CategoryDefaults\` imports for ChatResponse/ChatMessage role defaults

## Test Plan
- [x] \`py_compile\` clean on all 10 modified files
- [x] \`flake8 --select=F401,F811,F821\` — 0 errors
- [x] Rebased onto current Dev_new_gui (Phase 9 already merged via #6437)

Continues #6042

🤖 Generated with Claude Code