### PR TITLE
fix(chat_sessions): remove dead response_model on export endpoint (#6412)

### DIFF
--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -1394,7 +1394,7 @@ async def delete_session(
     operation="export_session",
     error_code_prefix="CHAT_SESSIONS",
 )
-@router.get("/chat/sessions/{session_id}/export", response_model=DataResponse)
+@router.get("/chat/sessions/{session_id}/export", response_model=None)
 async def export_session(session_id: str, request: Request, format: str = "json"):
     """
     Export a chat session in various formats.


### PR DESCRIPTION
## Summary
- Replace `response_model=DataResponse` with `response_model=None` on the chat session export endpoint, which returns a raw file `Response` (not JSON). The dead annotation was misleading OpenAPI into showing a JSON schema for a binary download.

## Test plan
- [ ] `python -m py_compile autobot-backend/api/chat_sessions.py`
- [ ] OpenAPI schema for `/chat/sessions/{id}/export` no longer shows DataResponse

Closes #6412

🤖 Generated with [Claude Code](https://claude.com/claude-code)