### PR TITLE
refactor(app): replace isChatPage path-check with meta.hideFooter (#6417 #6418)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -400,8 +400,8 @@
       </UnifiedLoadingView>
     </main>
 
-    <!-- Footer: About link (hidden on login page — /about requires auth) -->
-    <footer v-if="!isLoginPage && !isChatPage" class="flex-shrink-0 flex justify-center py-1 border-t border-autobot-border/30">
+    <!-- Footer: About link (hidden on login page and routes with hideFooter meta) -->
+    <footer v-if="!isLoginPage && !hideFooter" class="flex-shrink-0 flex justify-center py-1 border-t border-autobot-border/30">
       <router-link to="/about" class="text-xs text-autobot-text-muted hover:text-autobot-text-secondary transition-colors">
         {{ $t('nav.about') }}
       </router-link>
@@ -417,7 +417,7 @@
 
 <script lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted, defineAsyncComponent } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRouter, useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { useAppStore } from '@/stores/useAppStore'
 import { useUserStore } from '@/stores/useUserStore'
@@ -473,6 +473,7 @@ export default {
     const chatStore = useChatStore();
     const knowledgeStore = useKnowledgeStore();
     const router = useRouter();
+    const route = useRoute();
 
     // Initialize user preferences system (Issue #753)
     import('@/composables/usePreferences').then(({ usePreferences }) => {
@@ -542,11 +543,9 @@ export default {
     const isLoading = computed(() => appStore?.isLoading || false);
     const hasErrors = computed(() => false); // No errors property in store
     const isLoginPage = computed(() =>
-      router.currentRoute.value.path === '/login' || !userStore.isAuthenticated
+      route.path === '/login' || !userStore.isAuthenticated
     );
-    const isChatPage = computed(() =>
-      router.currentRoute.value.path.startsWith('/chat')
-    );
+    const hideFooter = computed(() => !!route.meta.hideFooter);
 
     // Methods
     const toggleMobileNav = () => {
@@ -876,7 +875,7 @@ export default {
       isLoading,
       hasErrors,
       isLoginPage,
-      isChatPage,
+      hideFooter,
       navItems,
       slmAdminUrl,
       displayUsername,

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -84,7 +84,8 @@ const routes: RouteRecordRaw[] = [
       title: 'AI Assistant',
       icon: 'fas fa-robot',
       description: 'Chat with AI assistant',
-      requiresAuth: true
+      requiresAuth: true,
+      hideFooter: true
     },
     children: [
       {
@@ -692,6 +693,7 @@ const routes: RouteRecordRaw[] = [
     meta: {
       title: 'Remote Desktop',
       requiresAuth: true,
+      hideFooter: true,
     },
   },
   // Issue #3502: Custom Dashboard renamed to /home (see home route above)


### PR DESCRIPTION
## Summary
- App.vue no longer hard-codes `/chat` paths to hide the footer — routes opt in via `meta: { hideFooter: true }`. Mirrors the existing `meta.chatTab` pattern.
- Adds `hideFooter: true` to the `/chat` parent route and to `/slm/tools/novnc` (fixes #6418 — the standalone noVNC view was still showing the footer).

## Test plan
- [ ] `vue-tsc --noEmit -p tsconfig.app.json` passes
- [ ] Visit `/chat`, `/chat/terminal`, `/chat/novnc`, `/chat/<sessionId>` → footer hidden
- [ ] Visit `/slm/tools/novnc` → footer hidden (was visible before, #6418)
- [ ] Visit other authenticated routes (`/dashboard`, `/agents`, etc.) → footer visible

Closes #6417
Closes #6418

🤖 Generated with [Claude Code](https://claude.com/claude-code)