### PR TITLE
fix(execution_strategies): _safe_execute wrapper — task exceptions can no longer bypass result recording in any strategy (#6459)

### DIFF
--- a/autobot-backend/enhanced_orchestration/execution_strategies.py
+++ b/autobot-backend/enhanced_orchestration/execution_strategies.py
@@ -69,7 +69,7 @@ class ExecutionStrategyHandler:
                     break
                 continue
 
-            result = await self._execute_single_task(task, results)
+            result = await self._safe_execute(task, results)
             results[task.task_id] = result
 
             if self._is_required_failure(task, result):
@@ -97,7 +97,7 @@ class ExecutionStrategyHandler:
                 if len(running_tasks) < self.max_parallel_tasks:
                     logger.info("Starting parallel task %s", task.task_id)
                     task_future = asyncio.create_task(
-                        self._execute_single_task(task, results)
+                        self._safe_execute(task, results)
                     )
                     running_tasks.append((task, task_future))
 
@@ -140,16 +140,13 @@ class ExecutionStrategyHandler:
 
             stage_results = await asyncio.gather(
                 *[
-                    self._execute_single_task(task, {**results, **pipeline_data})
+                    self._safe_execute(task, {**results, **pipeline_data})
                     for task in stage_tasks
-                ],
-                return_exceptions=True,
+                ]
             )
 
             stage_failed = False
             for task, result in zip(stage_tasks, stage_results):
-                if isinstance(result, BaseException):
-                    result = task.to_failed_result(repr(result))
                 results[task.task_id] = result
                 if result.get("status") == "completed" and "output" in result:
                     pipeline_data.update(result["output"])
@@ -179,7 +176,7 @@ class ExecutionStrategyHandler:
         for task in plan.tasks:
             enhanced_task = self._enhance_task_for_collaboration(task, collab_channel)
             future = asyncio.create_task(
-                self._execute_single_task(enhanced_task, results)
+                self._safe_execute(enhanced_task, results)
             )
             task_futures.append((task, future))
 
@@ -214,6 +211,19 @@ class ExecutionStrategyHandler:
     def _is_required_failure(self, task: AgentTask, result: dict) -> bool:
         return result.get("status") == "failed" and not task.metadata.get("optional", False)
 
+    async def _safe_execute(self, task: AgentTask, ctx: Dict[str, Any]) -> dict:
+        """Run _execute_single_task and convert any unhandled Exception to a failed result (#6459).
+
+        CancelledError is re-raised so cooperative cancellation still works.
+        """
+        try:
+            return await self._execute_single_task(task, ctx)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.exception("Task %s raised during execution", task.task_id)
+            return task.to_failed_result(repr(exc))
+
     async def _execute_parallel_batch(
         self, pending_tasks: list, results: Dict[str, Any]
     ) -> Tuple[int, int]:
@@ -223,14 +233,11 @@ class ExecutionStrategyHandler:
         ready_tasks = [t for t in batch_tasks if self._dependencies_met(t, results)]
 
         batch_results = await asyncio.gather(
-            *[self._execute_single_task(task, results) for task in ready_tasks],
-            return_exceptions=True,
+            *[self._safe_execute(task, results) for task in ready_tasks]
         )
 
         completed, failed = 0, 0
         for task, result in zip(ready_tasks, batch_results):
-            if isinstance(result, BaseException):
-                result = task.to_failed_result(repr(result))
             results[task.task_id] = result
             pending_tasks.remove(task)
             if result.get("status") == "completed":
@@ -248,7 +255,7 @@ class ExecutionStrategyHandler:
             if not self._dependencies_met(task, results):
                 continue
 
-            result = await self._execute_single_task(task, results)
+            result = await self._safe_execute(task, results)
             results[task.task_id] = result
             pending_tasks.remove(task)
 

--- a/autobot-backend/enhanced_orchestration/execution_strategies_test.py
+++ b/autobot-backend/enhanced_orchestration/execution_strategies_test.py
@@ -243,6 +243,102 @@ async def test_pipeline_continues_when_failed_stage_task_is_optional():
 
 
 @pytest.mark.asyncio
+async def test_sequential_records_failed_result_when_task_raises():
+    """execute_sequential must convert task exceptions to failed results, not propagate (#6459)."""
+    t1 = _task("t1")
+    t1.metadata["optional"] = True
+    t2 = _task("t2")
+
+    async def execute(task, ctx):
+        if task.task_id == "t1":
+            raise ValueError("boom")
+        return _completed(task.task_id)
+
+    handler = _make_handler(execute_fn=execute)
+    results = await handler.execute_sequential(_plan([t1, t2]))
+    assert results["t1"]["status"] == "failed"
+    assert "boom" in results["t1"]["error"]
+    assert results["t2"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_parallel_records_failed_result_when_task_raises():
+    """execute_parallel must convert task exceptions to failed results, not propagate (#6459)."""
+    t_ok = _task("t_ok")
+    t_bad = _task("t_bad")
+
+    async def execute(task, ctx):
+        if task.task_id == "t_bad":
+            raise RuntimeError("kaboom")
+        return _completed(task.task_id)
+
+    handler = _make_handler(execute_fn=execute)
+    results = await handler.execute_parallel(_plan([t_ok, t_bad], ExecutionStrategy.PARALLEL))
+    assert results["t_ok"]["status"] == "completed"
+    assert results["t_bad"]["status"] == "failed"
+    assert "kaboom" in results["t_bad"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_collaborative_records_failed_result_when_task_raises():
+    """execute_collaborative must convert task exceptions to failed results AND still clean up coordinator (#6459)."""
+    cleanup_ran = False
+
+    async def _coordinator(channel):
+        nonlocal cleanup_ran
+        try:
+            await asyncio.sleep(9999)
+        finally:
+            cleanup_ran = True
+
+    async def execute(task, ctx):
+        raise ValueError("collab boom")
+
+    deps = WorkflowDependencies(
+        execute_single_task=execute,
+        topological_sort_tasks=lambda tasks, graph: tasks,
+        dependencies_met=lambda task, results: True,
+        group_pipeline_stages=lambda tasks, graph: [tasks],
+        enhance_task_for_collaboration=lambda task, channel: task,
+        coordinate_collaboration=_coordinator,
+    )
+    handler = ExecutionStrategyHandler(
+        max_parallel_tasks=5,
+        resource_semaphore=asyncio.Semaphore(5),
+        deps=deps,
+    )
+    results = await handler.execute_collaborative(_plan([_task("t1")], ExecutionStrategy.COLLABORATIVE))
+    assert results["t1"]["status"] == "failed"
+    assert "collab boom" in results["t1"]["error"]
+    assert cleanup_ran
+
+
+@pytest.mark.asyncio
+async def test_adaptive_records_failed_result_when_sequential_step_raises():
+    """execute_adaptive (via _execute_sequential_step) must convert task exceptions to failed results (#6459)."""
+    t_bad = _task("t_bad")
+
+    async def execute(task, ctx):
+        raise RuntimeError("adaptive boom")
+
+    handler = _make_handler(execute_fn=execute)
+    results = await handler.execute_adaptive(_plan([t_bad], ExecutionStrategy.ADAPTIVE))
+    assert results["t_bad"]["status"] == "failed"
+    assert "adaptive boom" in results["t_bad"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_safe_execute_propagates_cancelled_error():
+    """_safe_execute must NOT swallow CancelledError — cooperative cancellation must still work (#6459)."""
+    async def execute(task, ctx):
+        raise asyncio.CancelledError()
+
+    handler = _make_handler(execute_fn=execute)
+    with pytest.raises(asyncio.CancelledError):
+        await handler._safe_execute(_task("t1"), {})
+
+
+@pytest.mark.asyncio
 async def test_pipeline_records_failed_result_when_task_raises():
     """execute_pipeline must record a failed result when _execute_single_task raises (#6449)."""
     t1 = _task("t1")


### PR DESCRIPTION
## Summary
- Add `_safe_execute(task, ctx)` private wrapper that calls `_execute_single_task` and converts any unhandled `Exception` to `task.to_failed_result(repr(exc))`. Re-raises `asyncio.CancelledError` so cooperative cancellation still works.
- Route **all 6** call sites through `_safe_execute`:
  - `execute_sequential` (was unprotected)
  - `execute_parallel` `asyncio.create_task(...)` (was unprotected)
  - `execute_pipeline` `asyncio.gather` (had `isinstance(BaseException)` guard)
  - `execute_collaborative` `asyncio.create_task(...)` (was unprotected)
  - `_execute_parallel_batch` `asyncio.gather` (had `isinstance(BaseException)` guard)
  - `_execute_sequential_step` (was unprotected, called from `execute_adaptive`)
- Drop `return_exceptions=True` and the `isinstance(BaseException)` guards from #6449 — `_safe_execute` already converts exceptions, so they're redundant.
- Add 5 regression tests + CancelledError contract test.

## Why
PR #6456 (closing #6449) only fixed `asyncio.gather` paths. The 4 other sites that called `_execute_single_task` directly (or via `await future`) still let task exceptions tear down the entire strategy handler. The composable wrapper fixes all 6 sites in one place.

## Test Plan
- [x] `test_sequential_records_failed_result_when_task_raises`
- [x] `test_parallel_records_failed_result_when_task_raises`
- [x] `test_collaborative_records_failed_result_when_task_raises` (also asserts coordinator cleanup ran)
- [x] `test_adaptive_records_failed_result_when_sequential_step_raises`
- [x] `test_safe_execute_propagates_cancelled_error` — CancelledError is NOT swallowed
- [x] All 23 tests passing

## Related Issues
Closes #6459