### PR TITLE
refactor(schemas): Phase 11 — migrate 10 classes (wake_word, skills) (#6042)

### DIFF
--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -1647,3 +1647,36 @@ class PersonalityToggleRequest(BaseModel):
 class PersonalityStatusResponse(BaseModel):
     enabled: bool
     active_id: Optional[str]
+
+
+class SkillConfigUpdate(BaseModel):
+    """Request body for updating a skill's configuration."""
+
+    config: Dict[str, Any] = Field(..., description="Configuration values")
+
+
+class SkillActionRequest(BaseModel):
+    """Request body for executing a skill action."""
+
+    action: str = Field(..., description="Tool/action name to execute")
+    params: Dict[str, Any] = Field(default_factory=dict, description="Action parameters")
+
+
+class UserSkillPreferences(BaseModel):
+    """Request body for updating user skill preferences."""
+
+    preferences: Dict[str, bool] = Field(..., description="Mapping of skill_name -> enabled")
+
+
+class SkillFeedbackRequest(BaseModel):
+    """Request body for submitting skill feedback."""
+
+    rating: int = Field(..., description="User rating (1-5)", ge=1, le=5)
+    feedback: Optional[str] = Field(None, description="Feedback text")
+
+
+class SkillInstallRequest(BaseModel):
+    """Request body for installing a skill from the catalog."""
+
+    catalog_url: str = Field(..., description="HTTP URL of the catalog endpoint")
+    repo_id: Optional[str] = Field(None, description="SkillRepo.id to link the package to")

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -2609,3 +2609,46 @@ class VisionHealthResponse(BaseModel):
     capabilities: List[str]
     element_types_supported: List[str]
     interaction_types_supported: List[str]
+
+
+class WakeWordCheckRequest(BaseModel):
+    """Request to check text for wake word"""
+
+    text: str = Field(..., description="Text to check for wake word")
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0, description="Recognition confidence")
+
+
+class WakeWordCheckResponse(BaseModel):
+    """Response for wake word check"""
+
+    detected: bool
+    wake_word: str = ""
+    confidence: float = 0.0
+    timestamp: float = 0.0
+    metadata: Metadata = {}
+
+
+class WakeWordConfigRequest(BaseModel):
+    """Request to update wake word configuration"""
+
+    enabled: bool = None
+    wake_words: List[str] = None
+    confidence_threshold: float = None
+    cooldown_seconds: float = None
+    adaptive_threshold: bool = None
+    max_false_positive_rate: float = None
+    max_cpu_percent: float = None
+
+
+class AddWakeWordRequest(BaseModel):
+    """Request to add a new wake word"""
+
+    wake_word: str = Field(..., min_length=2, max_length=50)
+
+
+class WakeWordReportFeedbackRequest(BaseModel):
+    """Request to report wake word detection feedback"""
+
+    is_correct: bool = Field(
+        ..., description="True if detection was correct, False if false positive"
+    )

--- a/autobot-backend/api/skills.py
+++ b/autobot-backend/api/skills.py
@@ -11,13 +11,18 @@ Includes metrics and health tracking (Issue #4339).
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel, Field
 
 from skills.manager import SkillManager
 from skills.registry import get_skill_registry
+from api.schemas_agent import (
+    SkillActionRequest,
+    SkillConfigUpdate,
+    SkillFeedbackRequest,
+    SkillInstallRequest,
+)
 from api.schemas_code import (
     SkillConfigUpdateResponse,
     SkillExecuteResponse,
@@ -56,46 +61,6 @@ def _get_manager() -> SkillManager:
     if _manager is None:
         _manager = SkillManager()
     return _manager
-
-
-# --- Request/Response Models ---
-
-
-class SkillConfigUpdate(BaseModel):
-    """Request body for updating a skill's configuration."""
-
-    config: Dict[str, Any] = Field(..., description="Configuration values")
-
-
-class SkillActionRequest(BaseModel):
-    """Request body for executing a skill action."""
-
-    action: str = Field(..., description="Tool/action name to execute")
-    params: Dict[str, Any] = Field(
-        default_factory=dict, description="Action parameters"
-    )
-
-
-class UserSkillPreferences(BaseModel):
-    """Request body for updating user skill preferences."""
-
-    preferences: Dict[str, bool] = Field(
-        ..., description="Mapping of skill_name -> enabled"
-    )
-
-
-class SkillFeedbackRequest(BaseModel):
-    """Request body for submitting skill feedback."""
-
-    rating: int = Field(..., description="User rating (1-5)", ge=1, le=5)
-    feedback: Optional[str] = Field(None, description="Feedback text")
-
-
-class SkillInstallRequest(BaseModel):
-    """Request body for installing a skill from the catalog."""
-
-    catalog_url: str = Field(..., description="HTTP URL of the catalog endpoint")
-    repo_id: Optional[str] = Field(None, description="SkillRepo.id to link the package to")
 
 
 # --- Endpoints ---

--- a/autobot-backend/api/wake_word.py
+++ b/autobot-backend/api/wake_word.py
@@ -7,69 +7,27 @@ Issue #54 - Advanced Wake Word Detection Optimization
 """
 
 import logging
-from typing import List
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.wake_word_service import WakeWordDetector, get_wake_word_detector
 from type_defs.common import Metadata
 from api.schemas_common import DataResponse
 from api.schemas_system import (
+    AddWakeWordRequest,
+    WakeWordCheckRequest,
+    WakeWordCheckResponse,
+    WakeWordConfigRequest,
     WakeWordGetConfigResponse,
     WakeWordGetWordsResponse,
     WakeWordListeningStatusResponse,
+    WakeWordReportFeedbackRequest,
     WakeWordStatsResponse,
 )
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["wake_word", "voice"])
-
-
-class WakeWordCheckRequest(BaseModel):
-    """Request to check text for wake word"""
-
-    text: str = Field(..., description="Text to check for wake word")
-    confidence: float = Field(
-        default=1.0, ge=0.0, le=1.0, description="Recognition confidence"
-    )
-
-
-class WakeWordCheckResponse(BaseModel):
-    """Response for wake word check"""
-
-    detected: bool
-    wake_word: str = ""
-    confidence: float = 0.0
-    timestamp: float = 0.0
-    metadata: Metadata = {}
-
-
-class WakeWordConfigRequest(BaseModel):
-    """Request to update wake word configuration"""
-
-    enabled: bool = None
-    wake_words: List[str] = None
-    confidence_threshold: float = None
-    cooldown_seconds: float = None
-    adaptive_threshold: bool = None
-    max_false_positive_rate: float = None
-    max_cpu_percent: float = None  # Issue #927: CPU cap for always-on detection
-
-
-class AddWakeWordRequest(BaseModel):
-    """Request to add a new wake word"""
-
-    wake_word: str = Field(..., min_length=2, max_length=50)
-
-
-class ReportFeedbackRequest(BaseModel):
-    """Request to report detection feedback"""
-
-    is_correct: bool = Field(
-        ..., description="True if detection was correct, False if false positive"
-    )
 
 
 @with_error_handling(
@@ -297,7 +255,7 @@ async def reset_wake_word_stats() -> Metadata:
     error_code_prefix="WAKE_WORD",
 )
 @router.post("/feedback", response_model=DataResponse)
-async def report_detection_feedback(request: ReportFeedbackRequest) -> Metadata:
+async def report_detection_feedback(request: WakeWordReportFeedbackRequest) -> Metadata:
     """
     Report feedback on the last wake word detection.
 


### PR DESCRIPTION
## Summary

Phase 11 of issue #6042. Migrates 10 \`BaseModel\` subclasses from 2 endpoint files into centralized domain schema files.

**Note:** Stacked on PR #6458 (Phase 10) — base branch is \`issue-6042\`. After Phase 10 merges, this will retarget to \`Dev_new_gui\` and rebase.

### Files migrated

| Endpoint file | Classes removed | Target schema file |
|---|---|---|
| \`wake_word.py\` | 5 (WakeWordCheckRequest/Response, WakeWordConfigRequest, AddWakeWordRequest, ReportFeedbackRequest → renamed WakeWordReportFeedbackRequest) | \`schemas_system.py\` |
| \`skills.py\` | 5 (SkillConfigUpdate, SkillActionRequest, UserSkillPreferences, SkillFeedbackRequest, SkillInstallRequest) | \`schemas_agent.py\` |

### Renames to avoid generic-name collisions
- \`ReportFeedbackRequest\` → \`WakeWordReportFeedbackRequest\`

### Cleanup
- Removed \`UserSkillPreferences\` import in \`skills.py\` — class was dead code (no callers); preserved in \`schemas_agent.py\` for future use

## Test Plan
- [x] \`py_compile\` clean on all 4 modified files
- [x] \`flake8 --select=F401,F811,F821\` — 0 errors

Continues #6042

🤖 Generated with Claude Code