### PR TITLE
feat(plugins): add ZIP upload + Git URL install for 3rd-party plugins (#6464)

### DIFF
--- a/autobot-backend/plugin_install.py
+++ b/autobot-backend/plugin_install.py
@@ -1,0 +1,249 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Plugin Install Service
+
+Issue #6464 - Install 3rd-party plugins from ZIP upload or Git URL.
+
+Note: Uses asyncio.create_subprocess_exec (no shell, args passed as a list)
+which is the safe equivalent of execFile — no shell injection possible.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import shutil
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+from fastapi import HTTPException, UploadFile, status
+from plugin_sdk.base import PluginManifest
+
+from autobot_shared.ssot_config import config
+
+logger = logging.getLogger(__name__)
+
+_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+_GIT_URL_SCHEMES = {"http", "https"}
+_GIT_REF_PATTERN = re.compile(r"^[A-Za-z0-9._/\-]{1,128}$")
+_MAX_ZIP_UNCOMPRESSED_BYTES = 256 * 1024 * 1024  # 256 MB
+_MAX_ZIP_ENTRIES = 5000
+_GIT_CLONE_TIMEOUT_SECONDS = 120
+
+
+@dataclass
+class InstallResult:
+    name: str
+    version: str
+    path: str
+    source: str  # "zip" | "git"
+
+
+def _community_plugins_dir() -> Path:
+    target = config.path.plugins_path / "community-plugins"
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def _sanitize_plugin_name(name: str) -> str:
+    if not _NAME_PATTERN.match(name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Invalid plugin name: must be lowercase alphanumeric with dashes/"
+                "underscores, start with letter or digit, max 63 chars."
+            ),
+        )
+    return name
+
+
+def _read_manifest(plugin_root: Path) -> PluginManifest:
+    manifest_path = plugin_root / "plugin.json"
+    if not manifest_path.is_file():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="plugin.json not found at plugin root",
+        )
+    try:
+        with manifest_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        return PluginManifest(**data)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"plugin.json is not valid JSON: {exc}",
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid plugin manifest: {exc}",
+        ) from exc
+
+
+def _ensure_install_target_free(name: str) -> Path:
+    target = _community_plugins_dir() / name
+    if target.exists():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Plugin '{name}' already installed. Unload and remove first.",
+        )
+    return target
+
+
+def _assert_safe_zip(zf: zipfile.ZipFile, extract_root: Path) -> None:
+    if len(zf.namelist()) > _MAX_ZIP_ENTRIES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Archive has too many entries (>{_MAX_ZIP_ENTRIES})",
+        )
+    total_size = 0
+    extract_root_resolved = extract_root.resolve()
+    for info in zf.infolist():
+        if info.is_dir():
+            continue
+        target = (extract_root / info.filename).resolve()
+        try:
+            target.relative_to(extract_root_resolved)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Archive entry escapes root: {info.filename}",
+            ) from exc
+        if info.external_attr >> 16 & 0xF000 == 0xA000:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Archive contains symlink: {info.filename}",
+            )
+        total_size += info.file_size
+        if total_size > _MAX_ZIP_UNCOMPRESSED_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Archive uncompressed size exceeds 256MB",
+            )
+
+
+def _find_plugin_root(extract_dir: Path) -> Path:
+    if (extract_dir / "plugin.json").is_file():
+        return extract_dir
+    children = [c for c in extract_dir.iterdir() if c.is_dir()]
+    if len(children) == 1 and (children[0] / "plugin.json").is_file():
+        return children[0]
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="plugin.json not found at archive root or single top-level folder",
+    )
+
+
+async def install_from_zip(upload: UploadFile) -> InstallResult:
+    if not upload.filename or not upload.filename.lower().endswith(".zip"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Upload must be a .zip file",
+        )
+    with tempfile.TemporaryDirectory(prefix="plugin-install-") as tmp:
+        tmp_path = Path(tmp)
+        zip_path = tmp_path / "upload.zip"
+        with zip_path.open("wb") as out:
+            while chunk := await upload.read(1024 * 1024):
+                out.write(chunk)
+        extract_dir = tmp_path / "extracted"
+        extract_dir.mkdir()
+        try:
+            with zipfile.ZipFile(zip_path) as zf:
+                _assert_safe_zip(zf, extract_dir)
+                zf.extractall(extract_dir)
+        except zipfile.BadZipFile as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Not a valid ZIP archive: {exc}",
+            ) from exc
+        plugin_root = _find_plugin_root(extract_dir)
+        manifest = _read_manifest(plugin_root)
+        name = _sanitize_plugin_name(manifest.name)
+        target = _ensure_install_target_free(name)
+        shutil.move(str(plugin_root), str(target))
+        logger.info("Installed plugin '%s' v%s from ZIP upload", name, manifest.version)
+        return InstallResult(
+            name=name, version=manifest.version, path=str(target), source="zip"
+        )
+
+
+def _validate_git_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in _GIT_URL_SCHEMES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only http(s) Git URLs are supported",
+        )
+    if not parsed.netloc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Git URL is missing host",
+        )
+
+
+def _validate_git_ref(ref: Optional[str]) -> Optional[str]:
+    if ref is None or ref == "":
+        return None
+    if not _GIT_REF_PATTERN.match(ref):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid git ref",
+        )
+    return ref
+
+
+async def _git_clone(url: str, ref: Optional[str], dest: Path) -> None:
+    cmd = ["git", "clone", "--depth=1", "--no-tags"]
+    if ref:
+        cmd += ["--branch", ref]
+    cmd += ["--", url, str(dest)]
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        _, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=_GIT_CLONE_TIMEOUT_SECONDS
+        )
+    except asyncio.TimeoutError as exc:
+        proc.kill()
+        await proc.wait()
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="git clone timed out",
+        ) from exc
+    if proc.returncode != 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"git clone failed: {stderr.decode(errors='replace')[:500]}",
+        )
+
+
+async def install_from_git(url: str, ref: Optional[str]) -> InstallResult:
+    _validate_git_url(url)
+    ref = _validate_git_ref(ref)
+    with tempfile.TemporaryDirectory(prefix="plugin-git-") as tmp:
+        clone_dir = Path(tmp) / "clone"
+        await _git_clone(url, ref, clone_dir)
+        manifest = _read_manifest(clone_dir)
+        name = _sanitize_plugin_name(manifest.name)
+        target = _ensure_install_target_free(name)
+        git_dir = clone_dir / ".git"
+        if git_dir.exists():
+            shutil.rmtree(git_dir, ignore_errors=True)
+        shutil.move(str(clone_dir), str(target))
+        logger.info(
+            "Installed plugin '%s' v%s from git %s", name, manifest.version, url
+        )
+        return InstallResult(
+            name=name, version=manifest.version, path=str(target), source="git"
+        )

--- a/autobot-backend/plugin_install.py
+++ b/autobot-backend/plugin_install.py
@@ -32,10 +32,27 @@ logger = logging.getLogger(__name__)
 
 _NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
 _GIT_URL_SCHEMES = {"http", "https"}
-_GIT_REF_PATTERN = re.compile(r"^[A-Za-z0-9._/\-]{1,128}$")
+# Disallow leading '-' (so '-foo' can't be mistaken for an option) and '..' segments.
+_GIT_REF_PATTERN = re.compile(r"^(?!-)(?!.*\.\.)[A-Za-z0-9._/\-]{1,128}$")
 _MAX_ZIP_UNCOMPRESSED_BYTES = 256 * 1024 * 1024  # 256 MB
 _MAX_ZIP_ENTRIES = 5000
+_MAX_UPLOAD_BYTES = 512 * 1024 * 1024  # 512 MB hard cap on the raw upload
+_MAX_COMPRESSION_RATIO = 100  # zip-bomb sentinel
 _GIT_CLONE_TIMEOUT_SECONDS = 120
+
+# Per-plugin install lock prevents two concurrent installs of the same name
+# from racing past the directory-existence check (TOCTOU).
+_install_locks: dict[str, asyncio.Lock] = {}
+_install_locks_guard = asyncio.Lock()
+
+
+async def _acquire_install_lock(name: str) -> asyncio.Lock:
+    async with _install_locks_guard:
+        lock = _install_locks.get(name)
+        if lock is None:
+            lock = asyncio.Lock()
+            _install_locks[name] = lock
+    return lock
 
 
 @dataclass
@@ -87,23 +104,35 @@ def _read_manifest(plugin_root: Path) -> PluginManifest:
         ) from exc
 
 
-def _ensure_install_target_free(name: str) -> Path:
+def _claim_install_target(name: str) -> Path:
+    """Atomically reserve `community-plugins/<name>/` by creating an empty
+    placeholder directory. Raises 409 if the name is already taken. The caller
+    is responsible for cleaning up the placeholder on any subsequent failure.
+    """
     target = _community_plugins_dir() / name
-    if target.exists():
+    try:
+        target.mkdir(parents=False, exist_ok=False)
+    except FileExistsError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"Plugin '{name}' already installed. Unload and remove first.",
-        )
+        ) from exc
     return target
 
 
-def _assert_safe_zip(zf: zipfile.ZipFile, extract_root: Path) -> None:
-    if len(zf.namelist()) > _MAX_ZIP_ENTRIES:
+def _is_zip_symlink(info: zipfile.ZipInfo) -> bool:
+    # External attr stores Unix mode in the high 16 bits; 0xA000 = symlink.
+    return ((info.external_attr >> 16) & 0xF000) == 0xA000
+
+
+def _validate_zip_metadata(zf: zipfile.ZipFile, extract_root: Path) -> None:
+    """Pre-flight checks on archive metadata. Cheap, runs before extraction."""
+    names = zf.namelist()
+    if len(names) > _MAX_ZIP_ENTRIES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Archive has too many entries (>{_MAX_ZIP_ENTRIES})",
         )
-    total_size = 0
     extract_root_resolved = extract_root.resolve()
     for info in zf.infolist():
         if info.is_dir():
@@ -116,29 +145,88 @@ def _assert_safe_zip(zf: zipfile.ZipFile, extract_root: Path) -> None:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Archive entry escapes root: {info.filename}",
             ) from exc
-        if info.external_attr >> 16 & 0xF000 == 0xA000:
+        if _is_zip_symlink(info):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Archive contains symlink: {info.filename}",
             )
-        total_size += info.file_size
-        if total_size > _MAX_ZIP_UNCOMPRESSED_BYTES:
+        # Sentinel against ZIP bombs whose header file_size is honest.
+        if (
+            info.compress_size > 0
+            and info.file_size // info.compress_size > _MAX_COMPRESSION_RATIO
+        ):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Archive uncompressed size exceeds 256MB",
+                detail=f"Archive entry has suspicious compression ratio: {info.filename}",
             )
+
+
+def _safe_extract(zf: zipfile.ZipFile, extract_root: Path) -> None:
+    """Stream-extract with byte cap. Tracks ACTUAL bytes written, so a
+    forged file_size in the central directory can't bypass the size cap."""
+    extract_root_resolved = extract_root.resolve()
+    bytes_written = 0
+    for info in zf.infolist():
+        if info.is_dir():
+            continue
+        # Skip macOS resource-fork dotfiles and __MACOSX/ noise.
+        if "__MACOSX/" in info.filename or Path(info.filename).name.startswith("._"):
+            continue
+        # Re-validate at extraction time (defense in depth).
+        target = (extract_root / info.filename).resolve()
+        target.relative_to(extract_root_resolved)
+        if _is_zip_symlink(info):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Archive contains symlink: {info.filename}",
+            )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with zf.open(info) as src, target.open("wb") as out:
+            while chunk := src.read(1024 * 1024):
+                bytes_written += len(chunk)
+                if bytes_written > _MAX_ZIP_UNCOMPRESSED_BYTES:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Archive uncompressed size exceeds 256MB",
+                    )
+                out.write(chunk)
 
 
 def _find_plugin_root(extract_dir: Path) -> Path:
     if (extract_dir / "plugin.json").is_file():
         return extract_dir
-    children = [c for c in extract_dir.iterdir() if c.is_dir()]
+    children = [
+        c
+        for c in extract_dir.iterdir()
+        if c.is_dir() and c.name != "__MACOSX" and not c.name.startswith(".")
+    ]
     if len(children) == 1 and (children[0] / "plugin.json").is_file():
         return children[0]
     raise HTTPException(
         status_code=status.HTTP_400_BAD_REQUEST,
         detail="plugin.json not found at archive root or single top-level folder",
     )
+
+
+def _move_into_target(source: Path, target: Path) -> None:
+    """Move source contents into a placeholder target dir, then remove the
+    now-empty source. Target must exist (created by _claim_install_target)."""
+    for child in source.iterdir():
+        shutil.move(str(child), str(target / child.name))
+    source.rmdir()
+
+
+async def _stream_upload_to(upload: UploadFile, dest: Path) -> None:
+    bytes_written = 0
+    with dest.open("wb") as out:
+        while chunk := await upload.read(1024 * 1024):
+            bytes_written += len(chunk)
+            if bytes_written > _MAX_UPLOAD_BYTES:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail=f"Upload exceeds {_MAX_UPLOAD_BYTES // (1024 * 1024)}MB",
+                )
+            out.write(chunk)
 
 
 async def install_from_zip(upload: UploadFile) -> InstallResult:
@@ -150,15 +238,12 @@ async def install_from_zip(upload: UploadFile) -> InstallResult:
     with tempfile.TemporaryDirectory(prefix="plugin-install-") as tmp:
         tmp_path = Path(tmp)
         zip_path = tmp_path / "upload.zip"
-        with zip_path.open("wb") as out:
-            while chunk := await upload.read(1024 * 1024):
-                out.write(chunk)
+        await _stream_upload_to(upload, zip_path)
         extract_dir = tmp_path / "extracted"
         extract_dir.mkdir()
         try:
-            with zipfile.ZipFile(zip_path) as zf:
-                _assert_safe_zip(zf, extract_dir)
-                zf.extractall(extract_dir)
+            # Open + extract are blocking I/O; offload from the event loop.
+            await asyncio.to_thread(_extract_archive, zip_path, extract_dir)
         except zipfile.BadZipFile as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -167,12 +252,25 @@ async def install_from_zip(upload: UploadFile) -> InstallResult:
         plugin_root = _find_plugin_root(extract_dir)
         manifest = _read_manifest(plugin_root)
         name = _sanitize_plugin_name(manifest.name)
-        target = _ensure_install_target_free(name)
-        shutil.move(str(plugin_root), str(target))
+        lock = await _acquire_install_lock(name)
+        async with lock:
+            target = _claim_install_target(name)
+            try:
+                await asyncio.to_thread(_move_into_target, plugin_root, target)
+            except Exception:
+                shutil.rmtree(target, ignore_errors=True)
+                raise
         logger.info("Installed plugin '%s' v%s from ZIP upload", name, manifest.version)
         return InstallResult(
             name=name, version=manifest.version, path=str(target), source="zip"
         )
+
+
+def _extract_archive(zip_path: Path, extract_dir: Path) -> None:
+    """Synchronous wrapper for offloading via asyncio.to_thread."""
+    with zipfile.ZipFile(zip_path) as zf:
+        _validate_zip_metadata(zf, extract_dir)
+        _safe_extract(zf, extract_dir)
 
 
 def _validate_git_url(url: str) -> None:
@@ -201,7 +299,15 @@ def _validate_git_ref(ref: Optional[str]) -> Optional[str]:
 
 
 async def _git_clone(url: str, ref: Optional[str], dest: Path) -> None:
-    cmd = ["git", "clone", "--depth=1", "--no-tags"]
+    cmd = [
+        "git",
+        "-c",
+        "protocol.file.allow=never",
+        "clone",
+        "--depth=1",
+        "--no-tags",
+        "--recurse-submodules=no",
+    ]
     if ref:
         cmd += ["--branch", ref]
     cmd += ["--", url, str(dest)]
@@ -222,9 +328,11 @@ async def _git_clone(url: str, ref: Optional[str], dest: Path) -> None:
             detail="git clone timed out",
         ) from exc
     if proc.returncode != 0:
+        stderr_text = stderr.decode(errors="replace")
+        logger.warning("git clone failed for %s: %s", url, stderr_text)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"git clone failed: {stderr.decode(errors='replace')[:500]}",
+            detail=f"git clone failed: {stderr_text[:500]}",
         )
 
 
@@ -236,11 +344,18 @@ async def install_from_git(url: str, ref: Optional[str]) -> InstallResult:
         await _git_clone(url, ref, clone_dir)
         manifest = _read_manifest(clone_dir)
         name = _sanitize_plugin_name(manifest.name)
-        target = _ensure_install_target_free(name)
+        # Strip .git so the installed plugin is a plain directory.
         git_dir = clone_dir / ".git"
         if git_dir.exists():
-            shutil.rmtree(git_dir, ignore_errors=True)
-        shutil.move(str(clone_dir), str(target))
+            await asyncio.to_thread(shutil.rmtree, git_dir, ignore_errors=True)
+        lock = await _acquire_install_lock(name)
+        async with lock:
+            target = _claim_install_target(name)
+            try:
+                await asyncio.to_thread(_move_into_target, clone_dir, target)
+            except Exception:
+                shutil.rmtree(target, ignore_errors=True)
+                raise
         logger.info(
             "Installed plugin '%s' v%s from git %s", name, manifest.version, url
         )

--- a/autobot-backend/plugin_manager.py
+++ b/autobot-backend/plugin_manager.py
@@ -90,7 +90,7 @@ class PluginInstallResponse(BaseModel):
 @with_error_handling(error_code_prefix="PLUGIN_INSTALL_UPLOAD")
 async def install_plugin_zip(
     file: UploadFile = File(..., description="Plugin ZIP archive"),
-    _admin: dict = Depends(check_admin_permission),
+    admin_check: bool = Depends(check_admin_permission),
 ) -> PluginInstallResponse:
     """Issue #6464: Install a 3rd-party plugin from a ZIP upload."""
     result = await install_from_zip(file)
@@ -111,7 +111,7 @@ async def install_plugin_zip(
 @with_error_handling(error_code_prefix="PLUGIN_INSTALL_GIT")
 async def install_plugin_git(
     request: PluginInstallGitRequest,
-    _admin: dict = Depends(check_admin_permission),
+    admin_check: bool = Depends(check_admin_permission),
 ) -> PluginInstallResponse:
     """Issue #6464: Install a 3rd-party plugin by cloning a Git repository."""
     result = await install_from_git(request.url, request.ref)

--- a/autobot-backend/plugin_manager.py
+++ b/autobot-backend/plugin_manager.py
@@ -14,13 +14,14 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import with_error_handling
 from autobot_shared.redis_client import get_async_redis_client, get_redis_client
 from autobot_shared.ssot_config import config
+from plugin_install import install_from_git, install_from_zip
 from plugin_sdk.base import PluginRegistry
 from plugin_sdk.loader import PluginLoader
 
@@ -60,6 +61,67 @@ class PluginListResponse(BaseModel):
 
     plugins: List[Dict] = Field(..., description="Plugin information list")
     total: int = Field(..., description="Total plugin count")
+
+
+class PluginInstallGitRequest(BaseModel):
+    """Install a plugin from a Git URL."""
+
+    url: str = Field(..., description="HTTP(S) Git repository URL")
+    ref: Optional[str] = Field(
+        default=None, description="Branch or tag to clone (default: HEAD)"
+    )
+
+
+class PluginInstallResponse(BaseModel):
+    """Result of a plugin install operation."""
+
+    name: str = Field(..., description="Installed plugin name")
+    version: str = Field(..., description="Plugin version from manifest")
+    path: str = Field(..., description="Filesystem path where the plugin was installed")
+    source: str = Field(..., description="Install source: 'zip' or 'git'")
+    message: str = Field(..., description="Human-readable status message")
+
+
+@router.post(
+    "/plugins/install/upload",
+    status_code=status.HTTP_201_CREATED,
+    response_model=PluginInstallResponse,
+)
+@with_error_handling(error_code_prefix="PLUGIN_INSTALL_UPLOAD")
+async def install_plugin_zip(
+    file: UploadFile = File(..., description="Plugin ZIP archive"),
+    _admin: dict = Depends(check_admin_permission),
+) -> PluginInstallResponse:
+    """Issue #6464: Install a 3rd-party plugin from a ZIP upload."""
+    result = await install_from_zip(file)
+    return PluginInstallResponse(
+        name=result.name,
+        version=result.version,
+        path=result.path,
+        source=result.source,
+        message=f"Plugin '{result.name}' v{result.version} installed. Use Discover → Load to activate.",
+    )
+
+
+@router.post(
+    "/plugins/install/git",
+    status_code=status.HTTP_201_CREATED,
+    response_model=PluginInstallResponse,
+)
+@with_error_handling(error_code_prefix="PLUGIN_INSTALL_GIT")
+async def install_plugin_git(
+    request: PluginInstallGitRequest,
+    _admin: dict = Depends(check_admin_permission),
+) -> PluginInstallResponse:
+    """Issue #6464: Install a 3rd-party plugin by cloning a Git repository."""
+    result = await install_from_git(request.url, request.ref)
+    return PluginInstallResponse(
+        name=result.name,
+        version=result.version,
+        path=result.path,
+        source=result.source,
+        message=f"Plugin '{result.name}' v{result.version} cloned from {request.url}.",
+    )
 
 
 @router.get("/plugins")

--- a/autobot-frontend/src/components/plugins/PluginInstallModal.vue
+++ b/autobot-frontend/src/components/plugins/PluginInstallModal.vue
@@ -1,0 +1,450 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal-fade">
+      <div
+        v-if="open"
+        class="modal-backdrop"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="$t('views.plugins.install.title')"
+        @click.self="onClose"
+      >
+        <div class="modal-card" @keydown.esc="onClose">
+          <header class="modal-header">
+            <h2 class="modal-title">{{ $t('views.plugins.install.title') }}</h2>
+            <button class="modal-close" :aria-label="$t('common.close')" @click="onClose">
+              <svg
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                class="close-icon"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </header>
+
+          <div class="modal-tabs" role="tablist">
+            <button
+              class="modal-tab"
+              :class="{ active: activeTab === 'zip' }"
+              role="tab"
+              :aria-selected="activeTab === 'zip'"
+              @click="activeTab = 'zip'"
+            >
+              {{ $t('views.plugins.install.zipTab') }}
+            </button>
+            <button
+              class="modal-tab"
+              :class="{ active: activeTab === 'git' }"
+              role="tab"
+              :aria-selected="activeTab === 'git'"
+              @click="activeTab = 'git'"
+            >
+              {{ $t('views.plugins.install.gitTab') }}
+            </button>
+          </div>
+
+          <div class="modal-body">
+            <!-- ZIP tab -->
+            <div v-if="activeTab === 'zip'" class="tab-pane">
+              <p class="hint">{{ $t('views.plugins.install.zipHint') }}</p>
+              <label class="file-drop" :class="{ 'has-file': zipFile }">
+                <input
+                  type="file"
+                  accept=".zip,application/zip"
+                  class="file-input"
+                  @change="onFileChange"
+                />
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  class="drop-icon"
+                  aria-hidden="true"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                    d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+                  />
+                </svg>
+                <span v-if="!zipFile" class="drop-label">
+                  {{ $t('views.plugins.install.zipPickFile') }}
+                </span>
+                <span v-else class="drop-label">
+                  {{ zipFile.name }}
+                </span>
+              </label>
+            </div>
+
+            <!-- Git tab -->
+            <div v-if="activeTab === 'git'" class="tab-pane">
+              <p class="hint">{{ $t('views.plugins.install.gitHint') }}</p>
+              <label class="form-field">
+                <span class="form-label">{{ $t('views.plugins.install.gitUrlLabel') }}</span>
+                <input
+                  v-model.trim="gitUrl"
+                  type="url"
+                  class="form-input"
+                  placeholder="https://github.com/owner/repo.git"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+              </label>
+              <label class="form-field">
+                <span class="form-label">
+                  {{ $t('views.plugins.install.gitRefLabel') }}
+                  <span class="form-label-optional">{{ $t('common.optional') }}</span>
+                </span>
+                <input
+                  v-model.trim="gitRef"
+                  type="text"
+                  class="form-input"
+                  placeholder="main"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+              </label>
+            </div>
+
+            <div v-if="error" class="error-banner" role="alert">
+              {{ error }}
+            </div>
+            <div v-if="successMessage" class="success-banner" role="status">
+              {{ successMessage }}
+            </div>
+          </div>
+
+          <footer class="modal-footer">
+            <button class="btn btn-ghost" :disabled="busy" @click="onClose">
+              {{ $t('common.cancel') }}
+            </button>
+            <button class="btn btn-primary" :disabled="!canSubmit || busy" @click="submit">
+              {{ busy ? $t('views.plugins.install.installing') : $t('views.plugins.install.install') }}
+            </button>
+          </footer>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { usePlugins } from '@/composables/usePlugins'
+
+const props = defineProps<{ open: boolean }>()
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'installed', payload: { name: string; version: string }): void
+}>()
+
+const { installFromZip, installFromGit } = usePlugins()
+
+const activeTab = ref<'zip' | 'git'>('zip')
+const zipFile = ref<File | null>(null)
+const gitUrl = ref('')
+const gitRef = ref('')
+const busy = ref(false)
+const error = ref<string | null>(null)
+const successMessage = ref<string | null>(null)
+
+const canSubmit = computed(() => {
+  if (activeTab.value === 'zip') return zipFile.value !== null
+  return gitUrl.value.length > 0
+})
+
+watch(
+  () => props.open,
+  (isOpen) => {
+    if (isOpen) {
+      activeTab.value = 'zip'
+      zipFile.value = null
+      gitUrl.value = ''
+      gitRef.value = ''
+      error.value = null
+      successMessage.value = null
+      busy.value = false
+    }
+  },
+)
+
+function onFileChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  zipFile.value = target.files?.[0] ?? null
+  error.value = null
+}
+
+function onClose() {
+  if (busy.value) return
+  emit('close')
+}
+
+async function submit() {
+  if (!canSubmit.value || busy.value) return
+  busy.value = true
+  error.value = null
+  successMessage.value = null
+  try {
+    const result =
+      activeTab.value === 'zip' && zipFile.value
+        ? await installFromZip(zipFile.value)
+        : await installFromGit(gitUrl.value, gitRef.value || undefined)
+    if (result) {
+      successMessage.value = `${result.name} v${result.version}`
+      emit('installed', result)
+      setTimeout(() => emit('close'), 800)
+    } else {
+      error.value = 'Install failed — check inputs and try again.'
+    }
+  } finally {
+    busy.value = false
+  }
+}
+</script>
+
+<style scoped>
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--spacing-md);
+}
+
+.modal-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow-xl);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.modal-title {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: var(--spacing-xs);
+  border-radius: var(--radius-sm);
+}
+
+.modal-close:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.close-icon {
+  width: 20px;
+  height: 20px;
+}
+
+.modal-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border-default);
+  padding: 0 var(--spacing-lg);
+}
+
+.modal-tab {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-secondary);
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: color var(--duration-150), border-color var(--duration-150);
+}
+
+.modal-tab.active {
+  color: var(--color-info);
+  border-bottom-color: var(--color-info);
+}
+
+.modal-body {
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.hint {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.file-drop {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  border: 1.5px dashed var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-xl);
+  cursor: pointer;
+  transition: border-color var(--duration-150), background var(--duration-150);
+}
+
+.file-drop:hover,
+.file-drop.has-file {
+  border-color: var(--color-info);
+  background: var(--bg-tertiary);
+}
+
+.file-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.drop-icon {
+  width: 32px;
+  height: 32px;
+  color: var(--text-tertiary);
+}
+
+.drop-label {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.form-label {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--text-primary);
+  display: flex;
+  gap: var(--spacing-xs);
+  align-items: baseline;
+}
+
+.form-label-optional {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  font-weight: 400;
+}
+
+.form-input {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: var(--color-info);
+}
+
+.error-banner {
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
+  color: var(--color-error);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+}
+
+.success-banner {
+  background: var(--color-success-bg);
+  border: 1px solid var(--color-success-border);
+  color: var(--color-success);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-top: 1px solid var(--border-default);
+}
+
+.btn {
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background var(--duration-150);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-ghost {
+  background: transparent;
+  border-color: var(--border-default);
+  color: var(--text-primary);
+}
+
+.btn-ghost:hover:not(:disabled) {
+  background: var(--bg-tertiary);
+}
+
+.btn-primary {
+  background: var(--color-info);
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 150ms ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/autobot-frontend/src/components/plugins/PluginInstallModal.vue
+++ b/autobot-frontend/src/components/plugins/PluginInstallModal.vue
@@ -137,7 +137,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { usePlugins } from '@/composables/usePlugins'
 
 const props = defineProps<{ open: boolean }>()
@@ -146,7 +147,9 @@ const emit = defineEmits<{
   (e: 'installed', payload: { name: string; version: string }): void
 }>()
 
-const { installFromZip, installFromGit } = usePlugins()
+const { t } = useI18n()
+const { installFromZip, installFromGit, error: composableError } = usePlugins()
+let closeTimer: ReturnType<typeof setTimeout> | null = null
 
 const activeTab = ref<'zip' | 'git'>('zip')
 const zipFile = ref<File | null>(null)
@@ -200,14 +203,21 @@ async function submit() {
     if (result) {
       successMessage.value = `${result.name} v${result.version}`
       emit('installed', result)
-      setTimeout(() => emit('close'), 800)
+      closeTimer = setTimeout(() => emit('close'), 800)
     } else {
-      error.value = 'Install failed — check inputs and try again.'
+      error.value = composableError.value || t('views.plugins.install.failed')
     }
   } finally {
     busy.value = false
   }
 }
+
+onUnmounted(() => {
+  if (closeTimer) {
+    clearTimeout(closeTimer)
+    closeTimer = null
+  }
+})
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/composables/usePlugins.ts
+++ b/autobot-frontend/src/composables/usePlugins.ts
@@ -182,6 +182,44 @@ export function usePlugins() {
     }
   }
 
+  // Issue #6464: install 3rd-party plugins from ZIP or Git URL
+  async function installFromZip(file: File): Promise<{ name: string; version: string } | null> {
+    error.value = null
+    const form = new FormData()
+    form.append('file', file)
+    try {
+      const data = await wrap(() =>
+        ApiClient.post(`${getApiBase()}/plugins/install/upload`, form),
+      ) as { name: string; version: string }
+      await discoverPlugins()
+      return { name: data.name, version: data.version }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to install plugin from ZIP'
+      error.value = msg
+      logger.error('installFromZip error: %s', msg)
+      return null
+    }
+  }
+
+  async function installFromGit(
+    url: string,
+    ref?: string,
+  ): Promise<{ name: string; version: string } | null> {
+    error.value = null
+    try {
+      const data = await wrap(() =>
+        ApiClient.post(`${getApiBase()}/plugins/install/git`, { url, ref: ref || null }),
+      ) as { name: string; version: string }
+      await discoverPlugins()
+      return { name: data.name, version: data.version }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to install plugin from Git'
+      error.value = msg
+      logger.error('installFromGit error: %s', msg)
+      return null
+    }
+  }
+
   return {
     plugins,
     discovered,
@@ -197,5 +235,7 @@ export function usePlugins() {
     getPluginInfo,
     getPluginConfig,
     updatePluginConfig,
+    installFromZip,
+    installFromGit,
   }
 }

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -5509,7 +5509,8 @@
         "gitUrlLabel": "عنوان المستودع",
         "gitRefLabel": "الفرع أو الوسم",
         "install": "تثبيت",
-        "installing": "جارٍ التثبيت…"
+        "installing": "جارٍ التثبيت…",
+        "failed": "فشل التثبيت — تحقق من الإدخالات وحاول مرة أخرى."
       },
       "pluginDetails": "Plugin details",
       "close": "إغلاق",

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -80,7 +80,8 @@
     "deselectAll": "إلغاء تحديد الكل",
     "page": "Page",
     "hasMore": "Load more",
-    "previous": "Previous"
+    "previous": "Previous",
+    "optional": "اختياري"
   },
   "chat": {
     "sendMessage": "أرسل رسالة...",
@@ -5497,7 +5498,19 @@
       "noNewPluginsHint": "All discovered plugins are already installed, or no plugin directories are configured.",
       "available": "available",
       "requires": "Requires",
-      "install": "Install",
+      "install": {
+        "button": "تثبيت",
+        "title": "تثبيت المكون الإضافي",
+        "zipTab": "رفع ZIP",
+        "gitTab": "من Git",
+        "zipHint": "ارفع ملف .zip يحتوي على plugin.json ورمز المكون.",
+        "zipPickFile": "اضغط لاختيار ملف .zip أو أفلته هنا",
+        "gitHint": "أدخل عنوان مستودع Git يحتوي على plugin.json في الجذر.",
+        "gitUrlLabel": "عنوان المستودع",
+        "gitRefLabel": "الفرع أو الوسم",
+        "install": "تثبيت",
+        "installing": "جارٍ التثبيت…"
+      },
       "pluginDetails": "Plugin details",
       "close": "إغلاق",
       "name": "الاسم",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -80,7 +80,8 @@
     },
     "page": "Page",
     "hasMore": "Load more",
-    "previous": "Previous"
+    "previous": "Previous",
+    "optional": "optional"
   },
   "chat": {
     "sendMessage": "Senden Sie eine Nachricht...",
@@ -5497,7 +5498,19 @@
       "noNewPluginsHint": "All discovered plugins are already installed, or no plugin directories are configured.",
       "available": "available",
       "requires": "Requires",
-      "install": "Install",
+      "install": {
+        "button": "Installieren",
+        "title": "Plugin installieren",
+        "zipTab": "ZIP hochladen",
+        "gitTab": "Aus Git",
+        "zipHint": "Lade eine .zip-Datei mit plugin.json und Plugin-Code hoch.",
+        "zipPickFile": "Klicke, um eine .zip-Datei auszuwählen, oder ziehe sie hierher",
+        "gitHint": "Gib die URL eines Git-Repositorys mit einer plugin.json im Root ein.",
+        "gitUrlLabel": "Repository-URL",
+        "gitRefLabel": "Branch oder Tag",
+        "install": "Installieren",
+        "installing": "Wird installiert…"
+      },
       "pluginDetails": "Plugin details",
       "close": "Close",
       "name": "Name",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -5509,7 +5509,8 @@
         "gitUrlLabel": "Repository-URL",
         "gitRefLabel": "Branch oder Tag",
         "install": "Installieren",
-        "installing": "Wird installiert…"
+        "installing": "Wird installiert…",
+        "failed": "Installation fehlgeschlagen — Eingaben prüfen und erneut versuchen."
       },
       "pluginDetails": "Plugin details",
       "close": "Close",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -80,7 +80,8 @@
     "deselectAll": "Deselect All",
     "hasMore": "Load more",
     "page": "Page",
-    "previous": "Previous"
+    "previous": "Previous",
+    "optional": "optional"
   },
   "chat": {
     "sendMessage": "Send a message...",
@@ -5540,7 +5541,19 @@
       "noNewPluginsHint": "All discovered plugins are already installed, or no plugin directories are configured.",
       "available": "available",
       "requires": "Requires",
-      "install": "Install",
+      "install": {
+        "button": "Install",
+        "title": "Install Plugin",
+        "zipTab": "Upload ZIP",
+        "gitTab": "From Git",
+        "zipHint": "Upload a .zip archive containing plugin.json and plugin code.",
+        "zipPickFile": "Click to choose a .zip file or drop it here",
+        "gitHint": "Enter the URL of a Git repository containing a plugin.json at its root.",
+        "gitUrlLabel": "Repository URL",
+        "gitRefLabel": "Branch or tag",
+        "install": "Install",
+        "installing": "Installing…"
+      },
       "pluginDetails": "Plugin details",
       "close": "Close",
       "name": "Name",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -5552,7 +5552,8 @@
         "gitUrlLabel": "Repository URL",
         "gitRefLabel": "Branch or tag",
         "install": "Install",
-        "installing": "Installing…"
+        "installing": "Installing…",
+        "failed": "Install failed — check inputs and try again."
       },
       "pluginDetails": "Plugin details",
       "close": "Close",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -80,7 +80,8 @@
     },
     "page": "Page",
     "hasMore": "Load more",
-    "previous": "Previous"
+    "previous": "Previous",
+    "optional": "opcional"
   },
   "chat": {
     "sendMessage": "Enviar un mensaje...",
@@ -5497,7 +5498,19 @@
       "noNewPluginsHint": "All discovered plugins are already installed, or no plugin directories are configured.",
       "available": "available",
       "requires": "Requires",
-      "install": "Install",
+      "install": {
+        "button": "Instalar",
+        "title": "Instalar plugin",
+        "zipTab": "Subir ZIP",
+        "gitTab": "Desde Git",
+        "zipHint": "Sube un archivo .zip que contenga plugin.json y el código del plugin.",
+        "zipPickFile": "Haz clic para elegir un archivo .zip o suéltalo aquí",
+        "gitHint": "Introduce la URL de un repositorio Git que contenga un plugin.json en la raíz.",
+        "gitUrlLabel": "URL del repositorio",
+        "gitRefLabel": "Rama o etiqueta",
+        "install": "Instalar",
+        "installing": "Instalando…"
+      },
       "pluginDetails": "Plugin details",
       "close": "Close",
       "name": "Name",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -5509,7 +5509,8 @@
         "gitUrlLabel": "URL del repositorio",
         "gitRefLabel": "Rama o etiqueta",
         "install": "Instalar",
-        "installing": "Instalando…"
+        "installing": "Instalando…",
+        "failed": "Instalación fallida — revisa los datos e inténtalo de nuevo."
       },
       "pluginDetails": "Plugin details",
       "close": "Close",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -80,7 +80,8 @@
     "deselectAll": "لغو انتخاب همه",
     "page": "Page",
     "hasMore": "Load more",
-    "previous": "Previous"
+    "previous": "Previous",
+    "optional": "اختیاری"
   },
   "nav": {
     "chat": "گفتگو",
@@ -5810,7 +5811,19 @@
       "invalidJson": "Invalid JSON — please fix before saving.",
       "author": "Author",
       "noPluginsLoaded": "No plugins loaded",
-      "install": "Install",
+      "install": {
+        "button": "نصب",
+        "title": "نصب افزونه",
+        "zipTab": "بارگذاری ZIP",
+        "gitTab": "از Git",
+        "zipHint": "یک فایل .zip شامل plugin.json و کد افزونه بارگذاری کنید.",
+        "zipPickFile": "برای انتخاب فایل .zip کلیک کنید یا آن را اینجا رها کنید",
+        "gitHint": "آدرس مخزن Git حاوی plugin.json در ریشه را وارد کنید.",
+        "gitUrlLabel": "آدرس مخزن",
+        "gitRefLabel": "شاخه یا برچسب",
+        "install": "نصب",
+        "installing": "در حال نصب…"
+      },
       "configJsonLabel": "Plugin configuration JSON",
       "unload": "Unload",
       "hooks": "Hooks",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -5822,7 +5822,8 @@
         "gitUrlLabel": "آدرس مخزن",
         "gitRefLabel": "شاخه یا برچسب",
         "install": "نصب",
-        "installing": "در حال نصب…"
+        "installing": "در حال نصب…",
+        "failed": "نصب ناموفق بود — ورودی‌ها را بررسی کنید و دوباره تلاش کنید."
       },
       "configJsonLabel": "Plugin configuration JSON",
       "unload": "Unload",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -5509,7 +5509,8 @@
         "gitUrlLabel": "URL du dépôt",
         "gitRefLabel": "Branche ou tag",
         "install": "Installer",
-        "installing": "Installation…"
+        "installing": "Installation…",
+        "failed": "Échec de l'installation — vérifiez les entrées et réessayez."
       },
       "pluginDetails": "Plugin details",
       "close": "Close",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -80,7 +80,8 @@
     },
     "page": "Page",
     "hasMore": "Load more",
-    "previous": "Previous"
+    "previous": "Previous",
+    "optional": "facultatif"
   },
   "chat": {
     "sendMessage": "Envoyer un message...",
@@ -5497,7 +5498,19 @@
       "noNewPluginsHint": "All discovered plugins are already installed, or no plugin directories are configured.",
       "available": "available",
       "requires": "Requires",
-      "install": "Install",
+      "install": {
+        "button": "Installer",
+        "title": "Installer le plugin",
+        "zipTab": "Téléverser ZIP",
+        "gitTab": "Depuis Git",
+        "zipHint": "Téléversez une archive .zip contenant plugin.json et le code du plugin.",
+        "zipPickFile": "Cliquez pour choisir un fichier .zip ou déposez-le ici",
+        "gitHint": "Saisissez l'URL d'un dépôt Git contenant un plugin.json à la racine.",
+        "gitUrlLabel": "URL du dépôt",
+        "gitRefLabel": "Branche ou tag",
+        "install": "Installer",
+        "installing": "Installation…"
+      },
       "pluginDetails": "Plugin details",
       "close": "Close",
       "name": "Name",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -80,7 +80,8 @@
     "deselectAll": "בטל בחירת הכל",
     "page": "Page",
     "hasMore": "Load more",
-    "previous": "Previous"
+    "previous": "Previous",
+    "optional": "אופציונלי"
   },
   "nav": {
     "chat": "צ'אט",
@@ -5810,7 +5811,19 @@
       "invalidJson": "Invalid JSON — please fix before saving.",
       "author": "Author",
       "noPluginsLoaded": "No plugins loaded",
-      "install": "Install",
+      "install": {
+        "button": "התקנה",
+        "title": "התקנת תוסף",
+        "zipTab": "העלאת ZIP",
+        "gitTab": "מ-Git",
+        "zipHint": "העלה קובץ .zip המכיל plugin.json וקוד התוסף.",
+        "zipPickFile": "לחץ כדי לבחור קובץ .zip או גרור אותו לכאן",
+        "gitHint": "הזן כתובת של מאגר Git המכיל plugin.json בשורש.",
+        "gitUrlLabel": "כתובת המאגר",
+        "gitRefLabel": "ענף או תגית",
+        "install": "התקנה",
+        "installing": "מתקין…"
+      },
       "configJsonLabel": "Plugin configuration JSON",
       "unload": "Unload",
       "hooks": "Hooks",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -5822,7 +5822,8 @@
         "gitUrlLabel": "כתובת המאגר",
         "gitRefLabel": "ענף או תגית",
         "install": "התקנה",
-        "installing": "מתקין…"
+        "installing": "מתקין…",
+        "failed": "ההתקנה נכשלה — בדוק את הקלט ונסה שוב."
       },
       "configJsonLabel": "Plugin configuration JSON",
       "unload": "Unload",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -80,7 +80,8 @@
     },
     "page": "Page",
     "hasMore": "Load more",
-    "previous": "Previous"
+    "previous": "Previous",
+    "optional": "pēc izvēles"
   },
   "chat": {
     "sendMessage": "Nosūtīt ziņu...",
@@ -5497,7 +5498,19 @@
       "noNewPluginsHint": "All discovered plugins are already installed, or no plugin directories are configured.",
       "available": "available",
       "requires": "Requires",
-      "install": "Install",
+      "install": {
+        "button": "Instalēt",
+        "title": "Instalēt spraudni",
+        "zipTab": "Augšupielādēt ZIP",
+        "gitTab": "No Git",
+        "zipHint": "Augšupielādējiet .zip arhīvu, kas satur plugin.json un spraudņa kodu.",
+        "zipPickFile": "Noklikšķiniet, lai izvēlētos .zip failu, vai nometiet to šeit",
+        "gitHint": "Ievadiet Git repozitorija URL, kas satur plugin.json saknē.",
+        "gitUrlLabel": "Repozitorija URL",
+        "gitRefLabel": "Zars vai tags",
+        "install": "Instalēt",
+        "installing": "Instalē…"
+      },
       "pluginDetails": "Plugin details",
       "close": "Close",
       "name": "Name",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -5509,7 +5509,8 @@
         "gitUrlLabel": "Repozitorija URL",
         "gitRefLabel": "Zars vai tags",
         "install": "Instalēt",
-        "installing": "Instalē…"
+        "installing": "Instalē…",
+        "failed": "Instalēšana neizdevās — pārbaudiet ievadi un mēģiniet vēlreiz."
       },
       "pluginDetails": "Plugin details",
       "close": "Close",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -5509,7 +5509,8 @@
         "gitUrlLabel": "URL repozytorium",
         "gitRefLabel": "Gałąź lub tag",
         "install": "Instaluj",
-        "installing": "Instalowanie…"
+        "installing": "Instalowanie…",
+        "failed": "Instalacja nie powiodła się — sprawdź dane i spróbuj ponownie."
       },
       "pluginDetails": "Plugin details",
       "close": "Close",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -80,7 +80,8 @@
     },
     "page": "Page",
     "hasMore": "Load more",
-    "previous": "Previous"
+    "previous": "Previous",
+    "optional": "opcjonalne"
   },
   "chat": {
     "sendMessage": "Wyślij wiadomość...",
@@ -5497,7 +5498,19 @@
       "noNewPluginsHint": "All discovered plugins are already installed, or no plugin directories are configured.",
       "available": "available",
       "requires": "Requires",
-      "install": "Install",
+      "install": {
+        "button": "Instaluj",
+        "title": "Instaluj wtyczkę",
+        "zipTab": "Prześlij ZIP",
+        "gitTab": "Z Git",
+        "zipHint": "Prześlij archiwum .zip zawierające plugin.json i kod wtyczki.",
+        "zipPickFile": "Kliknij, aby wybrać plik .zip lub upuść go tutaj",
+        "gitHint": "Wprowadź URL repozytorium Git zawierającego plugin.json w katalogu głównym.",
+        "gitUrlLabel": "URL repozytorium",
+        "gitRefLabel": "Gałąź lub tag",
+        "install": "Instaluj",
+        "installing": "Instalowanie…"
+      },
       "pluginDetails": "Plugin details",
       "close": "Close",
       "name": "Name",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -80,7 +80,8 @@
     },
     "page": "Page",
     "hasMore": "Load more",
-    "previous": "Previous"
+    "previous": "Previous",
+    "optional": "opcional"
   },
   "chat": {
     "sendMessage": "Envie uma mensagem...",
@@ -5497,7 +5498,19 @@
       "noNewPluginsHint": "All discovered plugins are already installed, or no plugin directories are configured.",
       "available": "available",
       "requires": "Requires",
-      "install": "Install",
+      "install": {
+        "button": "Instalar",
+        "title": "Instalar plugin",
+        "zipTab": "Enviar ZIP",
+        "gitTab": "Do Git",
+        "zipHint": "Envie um arquivo .zip contendo plugin.json e o código do plugin.",
+        "zipPickFile": "Clique para escolher um arquivo .zip ou solte-o aqui",
+        "gitHint": "Insira a URL de um repositório Git contendo plugin.json na raiz.",
+        "gitUrlLabel": "URL do repositório",
+        "gitRefLabel": "Branch ou tag",
+        "install": "Instalar",
+        "installing": "Instalando…"
+      },
       "pluginDetails": "Plugin details",
       "close": "Close",
       "name": "Name",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -5509,7 +5509,8 @@
         "gitUrlLabel": "URL do repositório",
         "gitRefLabel": "Branch ou tag",
         "install": "Instalar",
-        "installing": "Instalando…"
+        "installing": "Instalando…",
+        "failed": "Instalação falhou — verifique os dados e tente novamente."
       },
       "pluginDetails": "Plugin details",
       "close": "Close",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -80,7 +80,8 @@
     "deselectAll": "سب کی انتخاب ختم کریں",
     "page": "Page",
     "hasMore": "Load more",
-    "previous": "Previous"
+    "previous": "Previous",
+    "optional": "اختیاری"
   },
   "nav": {
     "chat": "چیٹ",
@@ -5810,7 +5811,19 @@
       "invalidJson": "Invalid JSON — please fix before saving.",
       "author": "Author",
       "noPluginsLoaded": "No plugins loaded",
-      "install": "Install",
+      "install": {
+        "button": "انسٹال",
+        "title": "پلگ ان انسٹال کریں",
+        "zipTab": "ZIP اپ لوڈ",
+        "gitTab": "Git سے",
+        "zipHint": "plugin.json اور پلگ ان کوڈ پر مشتمل .zip فائل اپ لوڈ کریں۔",
+        "zipPickFile": ".zip فائل منتخب کرنے کیلئے کلک کریں یا یہاں چھوڑ دیں",
+        "gitHint": "Git ریپوزٹری کا URL درج کریں جس میں روٹ پر plugin.json ہو۔",
+        "gitUrlLabel": "ریپوزٹری URL",
+        "gitRefLabel": "برانچ یا ٹیگ",
+        "install": "انسٹال",
+        "installing": "انسٹال ہو رہا ہے…"
+      },
       "configJsonLabel": "Plugin configuration JSON",
       "unload": "Unload",
       "hooks": "Hooks",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -5822,7 +5822,8 @@
         "gitUrlLabel": "ریپوزٹری URL",
         "gitRefLabel": "برانچ یا ٹیگ",
         "install": "انسٹال",
-        "installing": "انسٹال ہو رہا ہے…"
+        "installing": "انسٹال ہو رہا ہے…",
+        "failed": "انسٹالیشن ناکام — ان پٹس چیک کریں اور دوبارہ کوشش کریں۔"
       },
       "configJsonLabel": "Plugin configuration JSON",
       "unload": "Unload",

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -23,6 +23,28 @@
             />
           </svg>
         </button>
+        <!-- Issue #6464: Install plugin from ZIP/Git -->
+        <button
+          v-if="!isMarketplaceActive"
+          class="btn-install"
+          @click="installModalOpen = true"
+        >
+          <svg
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            class="install-icon"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 4v16m8-8H4"
+            />
+          </svg>
+          {{ $t('views.plugins.install.button') }}
+        </button>
       </div>
 
       <!-- Error Banner -->
@@ -368,6 +390,13 @@
         </div>
       </div>
     </div>
+
+    <!-- Install plugin modal — Issue #6464 -->
+    <PluginInstallModal
+      :open="installModalOpen"
+      @close="installModalOpen = false"
+      @installed="onPluginInstalled"
+    />
   </div>
 </template>
 
@@ -382,6 +411,7 @@ import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
 import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 import { usePlugins, type PluginInfo, type PluginManifest } from '@/composables/usePlugins'
+import PluginInstallModal from '@/components/plugins/PluginInstallModal.vue'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -404,6 +434,13 @@ const {
 } = usePlugins()
 
 const activeTab = ref<'installed' | 'discover'>('installed')
+const installModalOpen = ref(false)
+
+async function onPluginInstalled(): Promise<void> {
+  await listPlugins()
+  await discoverPlugins()
+  activeTab.value = 'discover'
+}
 const actionLoading = ref<Record<string, boolean>>({})
 
 // Modal state
@@ -601,6 +638,32 @@ onMounted(async () => {
 
 .refresh-icon.spinning {
   animation: spin 1s linear infinite;
+}
+
+/* ---- Install Button — Issue #6464 ---- */
+.btn-install {
+  background: var(--color-info);
+  border: 1px solid var(--color-info);
+  color: white;
+  border-radius: var(--radius-md);
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin-left: var(--spacing-sm);
+  transition: filter var(--duration-150) var(--ease-in-out);
+}
+
+.btn-install:hover {
+  filter: brightness(1.1);
+}
+
+.install-icon {
+  width: 16px;
+  height: 16px;
 }
 
 /* ---- Error Banner ---- */


### PR DESCRIPTION
## Summary
- Add `POST /api/plugins/install/upload` (multipart .zip) and `POST /api/plugins/install/git` (`{ url, ref? }`) endpoints
- Both validate `plugin.json` via existing `PluginManifest` Pydantic model, install to `community-plugins/<name>/`, refuse to overwrite existing plugins
- ZIP path rejects path traversal, symlinks, archives >256MB or >5000 entries
- Git path uses `asyncio.create_subprocess_exec` (no shell injection), 120s clone timeout, http(s) only, validates ref format
- Frontend: "Install" button in PluginsView header opens `PluginInstallModal` with two tabs (ZIP upload | Git URL + optional ref)
- After install, list refreshes and view switches to Discover tab so user can Load the new plugin
- i18n added across all 11 locales (no hardcoding)

## Test Plan
- [ ] Upload a valid plugin zip → Discover tab shows it after refresh
- [ ] Provide a public GitHub repo URL containing `plugin.json` → cloned and visible in Discover
- [ ] Upload a zip with `../etc/passwd` entry → 400, no extraction
- [ ] Re-install a plugin with the same name → 409 Conflict
- [ ] Invalid Git URL (e.g. `ssh://...`) → 400 with clear error
- [ ] Frontend type-check passes (`vue-tsc --noEmit -p tsconfig.app.json`)

## Related Issues
Closes #6464
Part of plugin marketplace work; PR 2 will add custom marketplace sources.