### PR TITLE
refactor(schemas): Phase 12 — migrate 18 classes + 11 enums (analytics files) (#6042)

### DIFF
--- a/autobot-backend/api/analytics_code_generation.py
+++ b/autobot-backend/api/analytics_code_generation.py
@@ -24,11 +24,9 @@ import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
 
 from api.analytics_shared import resolve_source_or_404 as _resolve_source_or_404
 from auth_middleware import check_admin_permission
@@ -37,10 +35,18 @@ from autobot_shared.redis_client import RedisDatabase, get_redis_client
 from api.schemas_common import DataResponse
 from api.schemas_analytics import (
     CodeGenerationHealthResponse,
+    CodeGenerationRefactoringTypesResponse,
+    CodeGenerationRequest,
+    CodeGenerationResponse,
+    CodeGenerationStatsResponse,
     CodeGenerationValidateResponse,
     CodeGenerationVersionsResponse,
-    CodeGenerationStatsResponse,
-    CodeGenerationRefactoringTypesResponse,
+    CodeGenRollbackRequest,
+    CodeGenValidationRequest,
+    CodeLanguage,
+    RefactoringRequest,
+    RefactoringResponse,
+    RefactoringType,
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
@@ -102,40 +108,6 @@ def _extract_language_stats(stats_data: dict) -> dict:
 # =============================================================================
 # Enums and Constants
 # =============================================================================
-
-
-class RefactoringType(str, Enum):
-    """Types of code refactoring operations"""
-
-    EXTRACT_FUNCTION = "extract_function"
-    RENAME_VARIABLE = "rename_variable"
-    SIMPLIFY_CONDITIONAL = "simplify_conditional"
-    REMOVE_DUPLICATION = "remove_duplication"
-    ADD_TYPE_HINTS = "add_type_hints"
-    IMPROVE_NAMING = "improve_naming"
-    OPTIMIZE_LOOPS = "optimize_loops"
-    ADD_DOCSTRINGS = "add_docstrings"
-    CLEAN_IMPORTS = "clean_imports"
-    GENERAL = "general"
-
-
-class CodeLanguage(str, Enum):
-    """Supported programming languages"""
-
-    PYTHON = "python"
-    TYPESCRIPT = "typescript"
-    JAVASCRIPT = "javascript"
-    VUE = "vue"
-
-
-class GenerationStatus(str, Enum):
-    """Status of code generation request"""
-
-    PENDING = "pending"
-    PROCESSING = "processing"
-    COMPLETED = "completed"
-    FAILED = "failed"
-    ROLLED_BACK = "rolled_back"
 
 
 # Prompt templates for different refactoring types
@@ -296,81 +268,6 @@ class RefactoringResult:
     validation: ValidationResult
     tokens_used: int = 0
     processing_time: float = 0.0
-
-
-# =============================================================================
-# Pydantic Models for API
-# =============================================================================
-
-
-class CodeGenerationRequest(BaseModel):
-    """Request model for code generation"""
-
-    description: str = Field(
-        ..., description="Natural language description of code to generate"
-    )
-    language: CodeLanguage = Field(
-        default=CodeLanguage.PYTHON, description="Target language"
-    )
-    context: Optional[str] = Field(
-        None, description="Additional context or requirements"
-    )
-    file_path: Optional[str] = Field(None, description="Target file path for context")
-    existing_code: Optional[str] = Field(
-        None, description="Existing code to integrate with"
-    )
-
-
-class RefactoringRequest(BaseModel):
-    """Request model for code refactoring"""
-
-    code: str = Field(..., description="Code to refactor")
-    refactoring_type: RefactoringType = Field(default=RefactoringType.GENERAL)
-    language: CodeLanguage = Field(default=CodeLanguage.PYTHON)
-    file_path: Optional[str] = Field(None, description="Source file path for context")
-    preserve_comments: bool = Field(default=True)
-    preserve_formatting: bool = Field(default=False)
-
-
-class ValidationRequest(BaseModel):
-    """Request model for code validation"""
-
-    code: str = Field(..., description="Code to validate")
-    language: CodeLanguage = Field(default=CodeLanguage.PYTHON)
-
-
-class RollbackRequest(BaseModel):
-    """Request model for code rollback"""
-
-    file_path: str = Field(..., description="File to rollback")
-    version_id: Optional[str] = Field(
-        None, description="Specific version to rollback to"
-    )
-
-
-class CodeGenerationResponse(BaseModel):
-    """Response model for code generation"""
-
-    success: bool
-    generated_code: Optional[str] = None
-    validation: Optional[Dict[str, Any]] = None
-    tokens_used: int = 0
-    processing_time: float = 0.0
-    error: Optional[str] = None
-
-
-class RefactoringResponse(BaseModel):
-    """Response model for refactoring"""
-
-    success: bool
-    original_code: str
-    refactored_code: Optional[str] = None
-    diff: Optional[str] = None
-    changes: List[str] = []
-    validation: Optional[Dict[str, Any]] = None
-    tokens_used: int = 0
-    processing_time: float = 0.0
-    error: Optional[str] = None
 
 
 # =============================================================================
@@ -1050,7 +947,7 @@ async def refactor_code(
 @router.post("/validate", response_model=CodeGenerationValidateResponse)
 async def validate_code(
     admin_check: bool = Depends(check_admin_permission),
-    request: ValidationRequest = None,
+    request: CodeGenValidationRequest = None,
 ):
     """
     Validate code syntax and structure.
@@ -1103,7 +1000,7 @@ async def get_versions(
 )
 @router.post("/rollback", response_model=DataResponse)
 async def rollback_code(
-    admin_check: bool = Depends(check_admin_permission), request: RollbackRequest = None
+    admin_check: bool = Depends(check_admin_permission), request: CodeGenRollbackRequest = None
 ):
     """
     Rollback code to a previous version.

--- a/autobot-backend/api/analytics_continuous_learning.py
+++ b/autobot-backend/api/analytics_continuous_learning.py
@@ -22,23 +22,31 @@ import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Query
-from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from api.schemas_analytics import (
+    ContinuousLearningFeedbackResponse,
+    ContinuousLearningGenerateInsightsResponse,
+    ContinuousLearningHealthResponse,
+    ContinuousLearningInsightsResponse,
+    ContinuousLearningMetrics,
+    ContinuousLearningRetrainResponse,
     ContinuousLearningStartStopResponse,
     ContinuousLearningStatusResponse,
-    ContinuousLearningFeedbackResponse,
-    ContinuousLearningRetrainResponse,
-    ContinuousLearningInsightsResponse,
-    ContinuousLearningGenerateInsightsResponse,
     ContinuousLearningUpdateConfigResponse,
-    ContinuousLearningHealthResponse,
+    InsightType,
+    LearningConfig,
+    LearningEvent,
+    LearningEventType,
+    LearningInsight,
+    LearningMonitoringStatus,
+    MonitoringState,
+    RetrainingReason,
+    RetrainingRequest,
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
@@ -50,50 +58,6 @@ router = APIRouter()
 # =============================================================================
 # Enums and Constants
 # =============================================================================
-
-
-class LearningEventType(str, Enum):
-    """Types of learning events."""
-
-    FILE_CHANGE = "file_change"
-    PATTERN_DETECTED = "pattern_detected"
-    FEEDBACK_RECEIVED = "feedback_received"
-    MODEL_UPDATED = "model_updated"
-    INSIGHT_GENERATED = "insight_generated"
-    THRESHOLD_CROSSED = "threshold_crossed"
-    ANOMALY_DETECTED = "anomaly_detected"
-
-
-class MonitoringState(str, Enum):
-    """States of the monitoring system."""
-
-    STOPPED = "stopped"
-    STARTING = "starting"
-    RUNNING = "running"
-    PAUSED = "paused"
-    STOPPING = "stopping"
-
-
-class InsightType(str, Enum):
-    """Types of generated insights."""
-
-    NEW_PATTERN = "new_pattern"
-    PATTERN_EVOLUTION = "pattern_evolution"
-    FALSE_POSITIVE_TREND = "false_positive_trend"
-    PERFORMANCE_IMPROVEMENT = "performance_improvement"
-    DEVELOPER_PREFERENCE = "developer_preference"
-    CODE_QUALITY_TREND = "code_quality_trend"
-    SECURITY_CONCERN = "security_concern"
-
-
-class RetrainingReason(str, Enum):
-    """Reasons for triggering model retraining."""
-
-    SCHEDULED = "scheduled"
-    FEEDBACK_THRESHOLD = "feedback_threshold"
-    ACCURACY_DROP = "accuracy_drop"
-    NEW_PATTERNS = "new_patterns"
-    MANUAL = "manual"
 
 
 # Thresholds for automated actions
@@ -109,80 +73,6 @@ THRESHOLDS = {
 # =============================================================================
 # Data Models
 # =============================================================================
-
-
-class LearningEvent(BaseModel):
-    """An event in the learning system."""
-
-    event_id: str
-    event_type: LearningEventType
-    timestamp: datetime
-    source: str
-    data: Dict[str, Any]
-    processed: bool = False
-
-
-class Insight(BaseModel):
-    """A generated insight."""
-
-    insight_id: str
-    insight_type: InsightType
-    title: str
-    description: str
-    confidence: float = Field(..., ge=0.0, le=1.0)
-    data: Dict[str, Any]
-    recommendations: List[str]
-    generated_at: datetime
-    expires_at: Optional[datetime] = None
-
-
-class LearningMetrics(BaseModel):
-    """Metrics for the learning system."""
-
-    total_events_processed: int
-    events_last_hour: int
-    events_last_day: int
-    patterns_learned: int
-    patterns_updated: int
-    false_positives_reduced: int
-    accuracy_improvement: float
-    last_retrain: Optional[datetime]
-    next_scheduled_retrain: Optional[datetime]
-    insights_generated: int
-    active_insights: int
-
-
-class MonitoringStatus(BaseModel):
-    """Status of the monitoring system."""
-
-    state: MonitoringState
-    started_at: Optional[datetime]
-    uptime_seconds: int
-    files_monitored: int
-    directories_watched: List[str]
-    events_queue_size: int
-    last_event_time: Optional[datetime]
-
-
-class RetrainingRequest(BaseModel):
-    """Request for model retraining."""
-
-    reason: RetrainingReason = RetrainingReason.MANUAL
-    force: bool = False
-    patterns_to_focus: Optional[List[str]] = None
-
-
-class LearningConfig(BaseModel):
-    """Configuration for the learning system."""
-
-    monitoring_enabled: bool = True
-    auto_retrain_enabled: bool = True
-    insight_generation_enabled: bool = True
-    monitored_paths: List[str] = Field(default_factory=lambda: ["backend/", "src/"])
-    scan_interval_seconds: int = 300
-    retrain_interval_hours: int = 24
-    feedback_threshold: int = 50
-    accuracy_threshold: float = 0.7
 
 
 # =============================================================================
@@ -228,7 +118,7 @@ class LearningPipeline:
         """Initialize learning pipeline with event tracking and statistics."""
         self.events: List[LearningEvent] = []
         self.pattern_stats: Dict[str, PatternStatistics] = {}
-        self.insights: List[Insight] = []
+        self.insights: List[LearningInsight] = []
         self.processed_count = 0
         self.last_retrain: Optional[datetime] = None
         self.accuracy_history: List[Tuple[datetime, float]] = []
@@ -258,7 +148,7 @@ class LearningPipeline:
         data: Dict[str, Any],
         recommendations: List[str],
         expires_days: int = 7,
-    ) -> Insight:
+    ) -> LearningInsight:
         """
         Create an Insight object with standardized ID generation and timestamps.
 
@@ -283,7 +173,7 @@ class LearningPipeline:
         hash_input = f"{id_prefix}_{pattern_id or ''}_{now.isoformat()}"
         insight_id = hashlib.sha256(hash_input.encode()).hexdigest()[:16]
 
-        return Insight(
+        return LearningInsight(
             insight_id=insight_id,
             insight_type=insight_type,
             title=title,
@@ -477,7 +367,7 @@ class LearningPipeline:
 
     def _generate_active_pattern_insight(
         self, recent_patterns: List["PatternStats"]  # noqa: F821
-    ) -> Optional[Insight]:
+    ) -> Optional[LearningInsight]:
         """Generate insight for most active pattern (Issue #398: extracted)."""
         if not recent_patterns:
             return None
@@ -506,7 +396,7 @@ class LearningPipeline:
 
     def _generate_false_positive_insight(
         self, pattern: "PatternStats"  # noqa: F821
-    ) -> Optional[Insight]:
+    ) -> Optional[LearningInsight]:
         """Generate insight for high false positive pattern (Issue #398: extracted)."""
         total = pattern.true_positives + pattern.false_positives
         fp_rate = pattern.false_positives / total if total > 0 else 0
@@ -534,7 +424,7 @@ class LearningPipeline:
             ],
         )
 
-    def _generate_accuracy_improvement_insight(self) -> Optional[Insight]:
+    def _generate_accuracy_improvement_insight(self) -> Optional[LearningInsight]:
         """Generate insight for accuracy improvement (Issue #398: extracted)."""
         if len(self.accuracy_history) < 2:
             return None
@@ -566,7 +456,7 @@ class LearningPipeline:
             expires_days=30,
         )
 
-    async def generate_insights(self) -> List[Insight]:
+    async def generate_insights(self) -> List[LearningInsight]:
         """
         Generate insights from learning data (Issue #398: refactored).
 
@@ -604,7 +494,7 @@ class LearningPipeline:
         self.insights.extend(new_insights)
         return new_insights
 
-    def get_metrics(self) -> LearningMetrics:
+    def get_metrics(self) -> ContinuousLearningMetrics:
         """Get current learning metrics."""
         now = datetime.now(tz=timezone.utc)
         hour_ago = now - timedelta(hours=1)
@@ -632,7 +522,7 @@ class LearningPipeline:
             1 for i in self.insights if i.expires_at is None or i.expires_at > now
         )
 
-        return LearningMetrics(
+        return ContinuousLearningMetrics(
             total_events_processed=self.processed_count,
             events_last_hour=events_last_hour,
             events_last_day=events_last_day,
@@ -829,7 +719,7 @@ class FileMonitor:
             )
             await self.event_queue.put(event)
 
-    def get_status(self) -> MonitoringStatus:
+    def get_status(self) -> LearningMonitoringStatus:
         """Get monitoring status."""
         uptime = 0
         if self.started_at and self.state == MonitoringState.RUNNING:
@@ -844,7 +734,7 @@ class FileMonitor:
             )
             last_event = last_modified
 
-        return MonitoringStatus(
+        return LearningMonitoringStatus(
             state=self.state,
             started_at=self.started_at,
             uptime_seconds=uptime,
@@ -1013,7 +903,7 @@ class ContinuousLearningEngine:
 
     async def get_insights(
         self, active_only: bool = True, limit: int = 20
-    ) -> List[Insight]:
+    ) -> List[LearningInsight]:
         """Get generated insights."""
         now = datetime.now(tz=timezone.utc)
         insights = self.pipeline.insights
@@ -1025,7 +915,7 @@ class ContinuousLearningEngine:
 
         return sorted(insights, key=lambda i: i.generated_at, reverse=True)[:limit]
 
-    def get_metrics(self) -> LearningMetrics:
+    def get_metrics(self) -> ContinuousLearningMetrics:
         """Get learning metrics."""
         return self.pipeline.get_metrics()
 
@@ -1126,10 +1016,10 @@ async def get_status(
     operation="get_metrics",
     error_code_prefix="ANALYTICS_CONTINUOUS_LEARNING",
 )
-@router.get("/metrics", summary="Get learning metrics", response_model=LearningMetrics)
+@router.get("/metrics", summary="Get learning metrics", response_model=ContinuousLearningMetrics)
 async def get_metrics(
     admin_check: bool = Depends(check_admin_permission),
-) -> LearningMetrics:
+) -> ContinuousLearningMetrics:
     """
     Get learning metrics.
 
@@ -1230,10 +1120,10 @@ async def generate_insights_now(
     operation="get_monitoring_status",
     error_code_prefix="ANALYTICS_CONTINUOUS_LEARNING",
 )
-@router.get("/monitoring", summary="Get monitoring status", response_model=MonitoringStatus)
+@router.get("/monitoring", summary="Get monitoring status", response_model=LearningMonitoringStatus)
 async def get_monitoring_status(
     admin_check: bool = Depends(check_admin_permission),
-) -> MonitoringStatus:
+) -> LearningMonitoringStatus:
     """
     Get file monitoring status.
 

--- a/autobot-backend/api/analytics_pattern_learning.py
+++ b/autobot-backend/api/analytics_pattern_learning.py
@@ -24,19 +24,26 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from autobot_shared.time_utils import parse_utc_iso
-from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel, Field
 from api.schemas_analytics import (
-    PatternLearningFeedbackResponse,
-    PatternLearningConfidenceResponse,
+    ActiveLearningQuery,
+    ConfidenceLevel,
+    ConfidenceScore,
+    FeedbackType,
+    LearningPhase,
+    PatternDefinition,
+    PatternFeedback,
     PatternLearningActiveLearningResponse,
-    PatternLearningRegisterResponse,
+    PatternLearningConfidenceResponse,
+    PatternLearningFeedbackResponse,
+    PatternLearningHealthResponse,
     PatternLearningHistoryResponse,
     PatternLearningLearnCycleResponse,
-    PatternLearningHealthResponse,
+    PatternLearningMetrics,
+    PatternLearningRegisterResponse,
+    PatternUpdate,
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
@@ -48,51 +55,6 @@ router = APIRouter()
 # =============================================================================
 # Enums and Constants
 # =============================================================================
-
-
-class FeedbackType(str, Enum):
-    """Types of feedback developers can provide."""
-
-    CORRECT = "correct"  # Pattern match is accurate
-    INCORRECT = "incorrect"  # False positive
-    MISSED = "missed"  # False negative - pattern should have matched
-    PARTIAL = "partial"  # Partially correct
-    IRRELEVANT = "irrelevant"  # Not useful pattern
-
-
-class PatternCategory(str, Enum):
-    """Categories of patterns for organization."""
-
-    SECURITY = "security"
-    PERFORMANCE = "performance"
-    CODE_QUALITY = "code_quality"
-    ARCHITECTURE = "architecture"
-    ERROR_HANDLING = "error_handling"
-    CONCURRENCY = "concurrency"
-    DATA_FLOW = "data_flow"
-    CONTROL_FLOW = "control_flow"
-    STYLE = "style"
-    DOCUMENTATION = "documentation"
-
-
-class LearningPhase(str, Enum):
-    """Phases of the active learning pipeline."""
-
-    COLLECTING = "collecting"  # Gathering feedback
-    ANALYZING = "analyzing"  # Analyzing patterns
-    TRAINING = "training"  # Updating models
-    VALIDATING = "validating"  # Validating changes
-    DEPLOYED = "deployed"  # Changes active
-
-
-class ConfidenceLevel(str, Enum):
-    """Human-readable confidence levels."""
-
-    VERY_LOW = "very_low"  # < 0.2
-    LOW = "low"  # 0.2 - 0.4
-    MEDIUM = "medium"  # 0.4 - 0.6
-    HIGH = "high"  # 0.6 - 0.8
-    VERY_HIGH = "very_high"  # > 0.8
 
 
 # Confidence thresholds
@@ -121,90 +83,6 @@ MIN_FEEDBACK_FOR_CONFIDENCE = 3  # Minimum feedback count for reliable scoring
 # =============================================================================
 # Data Models
 # =============================================================================
-
-
-class PatternFeedback(BaseModel):
-    """Feedback for a specific pattern match."""
-
-    pattern_id: str = Field(..., description="Unique identifier for the pattern")
-    feedback_type: FeedbackType = Field(..., description="Type of feedback")
-    file_path: str = Field(..., description="File where pattern was detected")
-    line_number: int = Field(..., description="Line number of pattern match")
-    code_snippet: Optional[str] = Field(None, description="Code snippet context")
-    developer_comment: Optional[str] = Field(None, description="Developer notes")
-    suggested_fix: Optional[str] = Field(None, description="Suggested improvement")
-    timestamp: Optional[datetime] = Field(None, description="Feedback timestamp")
-
-
-class PatternDefinition(BaseModel):
-    """Definition of a learnable pattern."""
-
-    pattern_id: str = Field(..., description="Unique pattern identifier")
-    name: str = Field(..., description="Human-readable pattern name")
-    description: str = Field(..., description="Pattern description")
-    category: PatternCategory = Field(..., description="Pattern category")
-    regex_patterns: List[str] = Field(
-        default_factory=list, description="Regex patterns"
-    )
-    ast_patterns: List[str] = Field(
-        default_factory=list, description="AST pattern descriptions"
-    )
-    examples: List[str] = Field(default_factory=list, description="Example matches")
-    counter_examples: List[str] = Field(
-        default_factory=list, description="Non-matching examples"
-    )
-    severity: str = Field(default="medium", description="Pattern severity")
-    enabled: bool = Field(default=True, description="Whether pattern is active")
-
-
-class ConfidenceScore(BaseModel):
-    """Confidence score for a pattern."""
-
-    pattern_id: str
-    score: float = Field(..., ge=0.0, le=1.0)
-    level: ConfidenceLevel
-    total_feedback: int
-    correct_count: int
-    incorrect_count: int
-    last_updated: datetime
-    trend: str  # "improving", "stable", "declining"
-
-
-class LearningMetrics(BaseModel):
-    """Metrics for the learning pipeline."""
-
-    total_patterns: int
-    total_feedback: int
-    average_confidence: float
-    high_confidence_patterns: int
-    low_confidence_patterns: int
-    patterns_improved: int
-    patterns_degraded: int
-    feedback_by_type: Dict[str, int]
-    feedback_by_category: Dict[str, int]
-    learning_rate: float
-    last_training_run: Optional[datetime]
-
-
-class ActiveLearningQuery(BaseModel):
-    """Query for active learning suggestions."""
-
-    pattern_id: str
-    code_snippet: str
-    predicted_match: bool
-    confidence: float
-    question: str  # Question to ask developer
-
-
-class PatternUpdate(BaseModel):
-    """Update to a pattern based on learning."""
-
-    pattern_id: str
-    update_type: str  # "regex_added", "regex_removed", "threshold_adjusted", etc.
-    old_value: Optional[Any]
-    new_value: Optional[Any]
-    reason: str
-    applied_at: datetime
 
 
 # =============================================================================
@@ -734,7 +612,7 @@ class PatternLearningEngine:
             return "declining"
         return "stable"
 
-    async def get_learning_metrics(self) -> LearningMetrics:
+    async def get_learning_metrics(self) -> PatternLearningMetrics:
         """Get comprehensive learning metrics."""
         await self.initialize()
 
@@ -770,7 +648,7 @@ class PatternLearningEngine:
                     cat = self.patterns[stats.pattern_id].category.value
                     feedback_by_category[cat] += 1
 
-        return LearningMetrics(
+        return PatternLearningMetrics(
             total_patterns=total_patterns,
             total_feedback=total_feedback,
             average_confidence=round(avg_confidence, 4),
@@ -1110,8 +988,8 @@ async def get_pattern_confidence(
     operation="get_learning_metrics",
     error_code_prefix="ANALYTICS_PATTERN_LEARNING",
 )
-@router.get("/metrics", response_model=LearningMetrics, summary="Get learning metrics")
-async def get_learning_metrics() -> LearningMetrics:
+@router.get("/metrics", response_model=PatternLearningMetrics, summary="Get learning metrics")
+async def get_learning_metrics() -> PatternLearningMetrics:
     """Get comprehensive metrics about the learning system."""
     engine = await get_learning_engine()
     return await engine.get_learning_metrics()

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -5,6 +5,7 @@
 Analytics, cost, budget, usage, and metrics schemas.
 """
 
+from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -1841,3 +1842,353 @@ class AgentCostResponse(BaseModel):
     input_tokens: int = 0
     output_tokens: int = 0
     call_count: int = 0
+
+
+# ---------------------------------------------------------------------------
+# analytics_code_generation.py enums + schemas
+# ---------------------------------------------------------------------------
+
+
+class RefactoringType(str, Enum):
+    """Types of code refactoring operations"""
+
+    EXTRACT_FUNCTION = "extract_function"
+    RENAME_VARIABLE = "rename_variable"
+    SIMPLIFY_CONDITIONAL = "simplify_conditional"
+    REMOVE_DUPLICATION = "remove_duplication"
+    ADD_TYPE_HINTS = "add_type_hints"
+    IMPROVE_NAMING = "improve_naming"
+    OPTIMIZE_LOOPS = "optimize_loops"
+    ADD_DOCSTRINGS = "add_docstrings"
+    CLEAN_IMPORTS = "clean_imports"
+    GENERAL = "general"
+
+
+class CodeLanguage(str, Enum):
+    """Supported programming languages"""
+
+    PYTHON = "python"
+    TYPESCRIPT = "typescript"
+    JAVASCRIPT = "javascript"
+    VUE = "vue"
+
+
+class GenerationStatus(str, Enum):
+    """Status of code generation request"""
+
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    ROLLED_BACK = "rolled_back"
+
+
+class CodeGenerationRequest(BaseModel):
+    """Request model for code generation"""
+
+    description: str = Field(..., description="Natural language description of code to generate")
+    language: CodeLanguage = Field(default=CodeLanguage.PYTHON, description="Target language")
+    context: Optional[str] = Field(None, description="Additional context or requirements")
+    file_path: Optional[str] = Field(None, description="Target file path for context")
+    existing_code: Optional[str] = Field(None, description="Existing code to integrate with")
+
+
+class RefactoringRequest(BaseModel):
+    """Request model for code refactoring"""
+
+    code: str = Field(..., description="Code to refactor")
+    refactoring_type: RefactoringType = Field(default=RefactoringType.GENERAL)
+    language: CodeLanguage = Field(default=CodeLanguage.PYTHON)
+    file_path: Optional[str] = Field(None, description="Source file path for context")
+    preserve_comments: bool = Field(default=True)
+    preserve_formatting: bool = Field(default=False)
+
+
+class CodeGenValidationRequest(BaseModel):
+    """Request model for code validation"""
+
+    code: str = Field(..., description="Code to validate")
+    language: CodeLanguage = Field(default=CodeLanguage.PYTHON)
+
+
+class CodeGenRollbackRequest(BaseModel):
+    """Request model for code rollback"""
+
+    file_path: str = Field(..., description="File to rollback")
+    version_id: Optional[str] = Field(None, description="Specific version to rollback to")
+
+
+class CodeGenerationResponse(BaseModel):
+    """Response model for code generation"""
+
+    success: bool
+    generated_code: Optional[str] = None
+    validation: Optional[Dict[str, Any]] = None
+    tokens_used: int = 0
+    processing_time: float = 0.0
+    error: Optional[str] = None
+
+
+class RefactoringResponse(BaseModel):
+    """Response model for refactoring"""
+
+    success: bool
+    original_code: str
+    refactored_code: Optional[str] = None
+    diff: Optional[str] = None
+    changes: List[str] = []
+    validation: Optional[Dict[str, Any]] = None
+    tokens_used: int = 0
+    processing_time: float = 0.0
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# analytics_pattern_learning.py enums + schemas
+# ---------------------------------------------------------------------------
+
+
+class FeedbackType(str, Enum):
+    """Types of feedback developers can provide."""
+
+    CORRECT = "correct"
+    INCORRECT = "incorrect"
+    MISSED = "missed"
+    PARTIAL = "partial"
+    IRRELEVANT = "irrelevant"
+
+
+class PatternCategory(str, Enum):
+    """Categories of patterns for organization."""
+
+    SECURITY = "security"
+    PERFORMANCE = "performance"
+    CODE_QUALITY = "code_quality"
+    ARCHITECTURE = "architecture"
+    ERROR_HANDLING = "error_handling"
+    CONCURRENCY = "concurrency"
+    DATA_FLOW = "data_flow"
+    CONTROL_FLOW = "control_flow"
+    STYLE = "style"
+    DOCUMENTATION = "documentation"
+
+
+class LearningPhase(str, Enum):
+    """Phases of the active learning pipeline."""
+
+    COLLECTING = "collecting"
+    ANALYZING = "analyzing"
+    TRAINING = "training"
+    VALIDATING = "validating"
+    DEPLOYED = "deployed"
+
+
+class ConfidenceLevel(str, Enum):
+    """Human-readable confidence levels."""
+
+    VERY_LOW = "very_low"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    VERY_HIGH = "very_high"
+
+
+class PatternFeedback(BaseModel):
+    """Feedback for a specific pattern match."""
+
+    pattern_id: str = Field(..., description="Unique identifier for the pattern")
+    feedback_type: FeedbackType = Field(..., description="Type of feedback")
+    file_path: str = Field(..., description="File where pattern was detected")
+    line_number: int = Field(..., description="Line number of pattern match")
+    code_snippet: Optional[str] = Field(None, description="Code snippet context")
+    developer_comment: Optional[str] = Field(None, description="Developer notes")
+    suggested_fix: Optional[str] = Field(None, description="Suggested improvement")
+    timestamp: Optional[datetime] = Field(None, description="Feedback timestamp")
+
+
+class PatternDefinition(BaseModel):
+    """Definition of a learnable pattern."""
+
+    pattern_id: str = Field(..., description="Unique pattern identifier")
+    name: str = Field(..., description="Human-readable pattern name")
+    description: str = Field(..., description="Pattern description")
+    category: PatternCategory = Field(..., description="Pattern category")
+    regex_patterns: List[str] = Field(default_factory=list, description="Regex patterns")
+    ast_patterns: List[str] = Field(default_factory=list, description="AST pattern descriptions")
+    examples: List[str] = Field(default_factory=list, description="Example matches")
+    counter_examples: List[str] = Field(default_factory=list, description="Non-matching examples")
+    severity: str = Field(default="medium", description="Pattern severity")
+    enabled: bool = Field(default=True, description="Whether pattern is active")
+
+
+class ConfidenceScore(BaseModel):
+    """Confidence score for a pattern."""
+
+    pattern_id: str
+    score: float = Field(..., ge=0.0, le=1.0)
+    level: ConfidenceLevel
+    total_feedback: int
+    correct_count: int
+    incorrect_count: int
+    last_updated: datetime
+    trend: str
+
+
+class PatternLearningMetrics(BaseModel):
+    """Metrics for the pattern learning pipeline."""
+
+    total_patterns: int
+    total_feedback: int
+    average_confidence: float
+    high_confidence_patterns: int
+    low_confidence_patterns: int
+    patterns_improved: int
+    patterns_degraded: int
+    feedback_by_type: Dict[str, int]
+    feedback_by_category: Dict[str, int]
+    learning_rate: float
+    last_training_run: Optional[datetime]
+
+
+class ActiveLearningQuery(BaseModel):
+    """Query for active learning suggestions."""
+
+    pattern_id: str
+    code_snippet: str
+    predicted_match: bool
+    confidence: float
+    question: str
+
+
+class PatternUpdate(BaseModel):
+    """Update to a pattern based on learning."""
+
+    pattern_id: str
+    update_type: str
+    old_value: Optional[Any]
+    new_value: Optional[Any]
+    reason: str
+    applied_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# analytics_continuous_learning.py enums + schemas
+# ---------------------------------------------------------------------------
+
+
+class LearningEventType(str, Enum):
+    """Types of learning events."""
+
+    FILE_CHANGE = "file_change"
+    PATTERN_DETECTED = "pattern_detected"
+    FEEDBACK_RECEIVED = "feedback_received"
+    MODEL_UPDATED = "model_updated"
+    INSIGHT_GENERATED = "insight_generated"
+    THRESHOLD_CROSSED = "threshold_crossed"
+    ANOMALY_DETECTED = "anomaly_detected"
+
+
+class MonitoringState(str, Enum):
+    """States of the monitoring system."""
+
+    STOPPED = "stopped"
+    STARTING = "starting"
+    RUNNING = "running"
+    PAUSED = "paused"
+    STOPPING = "stopping"
+
+
+class InsightType(str, Enum):
+    """Types of generated insights."""
+
+    NEW_PATTERN = "new_pattern"
+    PATTERN_EVOLUTION = "pattern_evolution"
+    FALSE_POSITIVE_TREND = "false_positive_trend"
+    PERFORMANCE_IMPROVEMENT = "performance_improvement"
+    DEVELOPER_PREFERENCE = "developer_preference"
+    CODE_QUALITY_TREND = "code_quality_trend"
+    SECURITY_CONCERN = "security_concern"
+
+
+class RetrainingReason(str, Enum):
+    """Reasons for triggering model retraining."""
+
+    SCHEDULED = "scheduled"
+    FEEDBACK_THRESHOLD = "feedback_threshold"
+    ACCURACY_DROP = "accuracy_drop"
+    NEW_PATTERNS = "new_patterns"
+    MANUAL = "manual"
+
+
+class LearningEvent(BaseModel):
+    """An event in the learning system."""
+
+    event_id: str
+    event_type: LearningEventType
+    timestamp: datetime
+    source: str
+    data: Dict[str, Any]
+    processed: bool = False
+
+
+class LearningInsight(BaseModel):
+    """A generated insight."""
+
+    insight_id: str
+    insight_type: InsightType
+    title: str
+    description: str
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    data: Dict[str, Any]
+    recommendations: List[str]
+    generated_at: datetime
+    expires_at: Optional[datetime] = None
+
+
+class ContinuousLearningMetrics(BaseModel):
+    """Metrics for the continuous learning system."""
+
+    total_events_processed: int
+    events_last_hour: int
+    events_last_day: int
+    patterns_learned: int
+    patterns_updated: int
+    false_positives_reduced: int
+    accuracy_improvement: float
+    last_retrain: Optional[datetime]
+    next_scheduled_retrain: Optional[datetime]
+    insights_generated: int
+    active_insights: int
+
+
+class LearningMonitoringStatus(BaseModel):
+    """Status of the monitoring system."""
+
+    state: MonitoringState
+    started_at: Optional[datetime]
+    uptime_seconds: int
+    files_monitored: int
+    directories_watched: List[str]
+    events_queue_size: int
+    last_event_time: Optional[datetime]
+
+
+class RetrainingRequest(BaseModel):
+    """Request for model retraining."""
+
+    reason: RetrainingReason = RetrainingReason.MANUAL
+    force: bool = False
+    patterns_to_focus: Optional[List[str]] = None
+
+
+class LearningConfig(BaseModel):
+    """Configuration for the learning system."""
+
+    monitoring_enabled: bool = True
+    auto_retrain_enabled: bool = True
+    insight_generation_enabled: bool = True
+    monitored_paths: List[str] = Field(default_factory=lambda: ["backend/", "src/"])
+    scan_interval_seconds: int = 300
+    retrain_interval_hours: int = 24
+    feedback_threshold: int = 50
+    accuracy_threshold: float = 0.7


### PR DESCRIPTION
## Summary

Phase 12 of issue #6042. Migrates 18 \`BaseModel\` subclasses and 11 \`Enum\` classes from 3 analytics endpoint files into \`schemas_analytics.py\`.

### Files migrated (all → \`schemas_analytics.py\`)

| Endpoint file | Enums | Classes |
|---|---|---|
| \`analytics_code_generation.py\` | RefactoringType, CodeLanguage, GenerationStatus | CodeGenerationRequest, RefactoringRequest, ValidationRequest→CodeGenValidationRequest, RollbackRequest→CodeGenRollbackRequest, CodeGenerationResponse, RefactoringResponse |
| \`analytics_pattern_learning.py\` | FeedbackType, PatternCategory, LearningPhase, ConfidenceLevel | PatternFeedback, PatternDefinition, ConfidenceScore, LearningMetrics→PatternLearningMetrics, ActiveLearningQuery, PatternUpdate |
| \`analytics_continuous_learning.py\` | LearningEventType, MonitoringState, InsightType, RetrainingReason | LearningEvent, Insight→LearningInsight, LearningMetrics→ContinuousLearningMetrics, MonitoringStatus→LearningMonitoringStatus, RetrainingRequest, LearningConfig |

### Renames to avoid cross-file collisions
- \`ValidationRequest\` → \`CodeGenValidationRequest\`
- \`RollbackRequest\` → \`CodeGenRollbackRequest\`
- \`LearningMetrics\` (in pattern_learning) → \`PatternLearningMetrics\`
- \`LearningMetrics\` (in continuous_learning) → \`ContinuousLearningMetrics\` (was a name collision)
- \`Insight\` → \`LearningInsight\`
- \`MonitoringStatus\` → \`LearningMonitoringStatus\`

### Notable
- This phase migrates **enums** alongside BaseModel classes. Enums were referenced by the BaseModel classes' field types, so co-locating them in schemas_analytics.py keeps the schema self-contained.
- \`schemas_analytics.py\`: added \`from datetime import datetime\` import for several classes that have datetime fields

## Test Plan
- [x] \`py_compile\` clean on all 4 modified files
- [x] \`flake8 --select=F401,F811,F821\` — 0 errors

Continues #6042

🤖 Generated with Claude Code