### PR TITLE
feat(nav): wire AgentActivity into App.vue navigation (#6451)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -819,6 +819,8 @@ export default {
       { to: '/analytics', labelKey: 'nav.analytics', iconPaths: ['M2 10a8 8 0 018-8v8h8a8 8 0 11-16 0z', 'M12 2.252A8.014 8.014 0 0117.748 8H12V2.252z'] },
       // Issue #4703: Agent Registry — backend + specialized agent dashboard
       { to: '/agents/registry', labelKey: 'nav.agentRegistry', icon: 'M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2V9M9 21H5a2 2 0 01-2-2V9m0 0h18', iconStroke: true },
+      // Issue #5071/#6451: Agent Activity — per-agent diary timeline
+      { to: '/agents/activity', labelKey: 'nav.agentActivity', icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z', iconStroke: true },
       // Issue #929: Plugin Manager — marketplace integrated within /plugins
       { to: '/plugins', labelKey: 'nav.plugins', icon: 'M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z', iconStroke: true },
       { to: '/secrets', labelKey: 'nav.secrets', icon: 'M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z', iconRule: 'evenodd' },

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -6958,6 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
+    "agentActivity": "Activity",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -6958,7 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
-    "agentActivity": "Activity",
+    "agentActivity": "نشاط الوكيل",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -6958,6 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
+    "agentActivity": "Activity",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -6958,7 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
-    "agentActivity": "Activity",
+    "agentActivity": "Agent-Aktivität",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7006,6 +7006,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
+    "agentActivity": "Activity",
     "experiments": "Experiments",
     "slmAdmin": "SLM Admin",
     "slmAdminTitle": "Open SLM Admin Panel",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7006,7 +7006,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
-    "agentActivity": "Activity",
+    "agentActivity": "Agent Activity",
     "experiments": "Experiments",
     "slmAdmin": "SLM Admin",
     "slmAdminTitle": "Open SLM Admin Panel",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -6958,6 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
+    "agentActivity": "Activity",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -6958,7 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
-    "agentActivity": "Activity",
+    "agentActivity": "Actividad del agente",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -110,7 +110,7 @@
     "devSpeedup": "Dev Tools",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
-    "agentActivity": "Activity",
+    "agentActivity": "فعالیت عامل",
     "mainNavigation": "Main navigation",
     "plugins": "Plugins",
     "switchLanguage": "Switch language",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -110,6 +110,7 @@
     "devSpeedup": "Dev Tools",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
+    "agentActivity": "Activity",
     "mainNavigation": "Main navigation",
     "plugins": "Plugins",
     "switchLanguage": "Switch language",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -6958,7 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
-    "agentActivity": "Activity",
+    "agentActivity": "Activité de l'agent",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -6958,6 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
+    "agentActivity": "Activity",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -110,6 +110,7 @@
     "devSpeedup": "Dev Tools",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
+    "agentActivity": "Activity",
     "mainNavigation": "Main navigation",
     "plugins": "Plugins",
     "switchLanguage": "Switch language",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -110,7 +110,7 @@
     "devSpeedup": "Dev Tools",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
-    "agentActivity": "Activity",
+    "agentActivity": "פעילות סוכן",
     "mainNavigation": "Main navigation",
     "plugins": "Plugins",
     "switchLanguage": "Switch language",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -6958,7 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
-    "agentActivity": "Activity",
+    "agentActivity": "Aģenta aktivitāte",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -6958,6 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
+    "agentActivity": "Activity",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -6958,7 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
-    "agentActivity": "Activity",
+    "agentActivity": "Aktywność agenta",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -6958,6 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
+    "agentActivity": "Activity",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -6958,7 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
-    "agentActivity": "Activity",
+    "agentActivity": "Atividade do agente",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -6958,6 +6958,7 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
+    "agentActivity": "Activity",
     "switchLanguage": "Switch language",
     "openMainMenu": "Open main menu",
     "skipToContent": "Skip to content",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -110,7 +110,7 @@
     "devSpeedup": "Dev Tools",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
-    "agentActivity": "Activity",
+    "agentActivity": "ایجنٹ کی سرگرمی",
     "mainNavigation": "Main navigation",
     "plugins": "Plugins",
     "switchLanguage": "Switch language",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -110,6 +110,7 @@
     "devSpeedup": "Dev Tools",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents",
+    "agentActivity": "Activity",
     "mainNavigation": "Main navigation",
     "plugins": "Plugins",
     "switchLanguage": "Switch language",


### PR DESCRIPTION
## Summary
- Adds a nav item entry for `/agents/activity` in `App.vue navItems` so the AgentActivity page (added in #5071) becomes reachable from the main nav. Placed right after Agent Registry.
- Adds matching `nav.agentActivity` translation key in 11 locales (default English text \"Activity\").

## Test plan
- [ ] `vue-tsc --noEmit -p tsconfig.app.json` passes
- [ ] Login → Agent Activity entry visible in main nav between Agents and Plugins
- [ ] Click → navigates to `/agents/activity`

Closes #6451

🤖 Generated with [Claude Code](https://claude.com/claude-code)