### PR TITLE
refactor(schemas): Phase 15 — migrate 22 classes (database_mcp, project_mgmt, knowledge_relations, nl_database, merge_conflict_resolution) (#6042)

### DIFF
--- a/autobot-backend/api/database_mcp.py
+++ b/autobot-backend/api/database_mcp.py
@@ -29,15 +29,14 @@ import re
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field, field_validator
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.time_utils import now_utc
-from type_defs.common import JSONObject, Metadata
+from type_defs.common import Metadata
 
 from .schemas_code import (
     DatabaseDescribeSchemaResponse,
@@ -45,8 +44,13 @@ from .schemas_code import (
     DatabaseListDatabasesResponse,
     DatabaseListTablesResponse,
     DatabaseMCPStatusResponse,
+    DatabaseMCPTool,
     DatabaseQueryResponse,
     DatabaseStatisticsResponse,
+    SQLExecuteRequest,
+    SQLQueryRequest,
+    SchemaRequest,
+    TableListRequest,
 )
 
 logger = logging.getLogger(__name__)
@@ -407,90 +411,16 @@ def _get_db_statistics_sync(db_path: Path) -> dict:
             conn.close()
 
 
-# Pydantic Models
-
-
-class MCPTool(BaseModel):
-    """Standard MCP tool definition"""
-
-    name: str
-    description: str
-    input_schema: JSONObject
-
-
-class SQLQueryRequest(BaseModel):
-    """SQL query request model"""
-
-    database: str = Field(..., description="Database name from whitelist")
-    query: str = Field(..., description="SQL SELECT query (parameterized)")
-    params: Optional[List[Any]] = (
-        Field(default=None, description="Query parameters for ? placeholders"),
-    )
-    limit: Optional[int] = Field(
-        default=100,
-        ge=1,
-        le=MAX_RESULT_ROWS,
-        description=f"Max rows to return (1-{MAX_RESULT_ROWS})",
-    )
-
-    @field_validator("query")
-    @classmethod
-    def validate_query_is_select(cls, v):
-        """Ensure query is SELECT only"""
-        normalized = v.strip().upper()
-        if not normalized.startswith("SELECT"):
-            raise ValueError(
-                "Only SELECT queries allowed. Use execute_sql for modifications."
-            )
-        return v
-
-
-class SQLExecuteRequest(BaseModel):
-    """SQL execute request model (for INSERT/UPDATE/DELETE)"""
-
-    database: str = Field(..., description="Database name from whitelist")
-    statement: str = Field(..., description="SQL statement (INSERT/UPDATE/DELETE)")
-    params: Optional[List[Any]] = Field(
-        default=None, description="Statement parameters for ? placeholders"
-    )
-
-    @field_validator("statement")
-    @classmethod
-    def validate_statement_type(cls, v):
-        """Ensure statement is DML operation (Issue #380: use module-level constant)"""
-        normalized = v.strip().upper()
-        if not any(normalized.startswith(op) for op in _ALLOWED_DML_OPERATIONS):
-            raise ValueError(
-                f"Only {', '.join(_ALLOWED_DML_OPERATIONS)} statements allowed"
-            )
-        return v
-
-
-class SchemaRequest(BaseModel):
-    """Database schema request model"""
-
-    database: str = Field(..., description="Database name from whitelist")
-    table: Optional[str] = Field(
-        default=None, description="Specific table to describe (optional)"
-    )
-
-
-class TableListRequest(BaseModel):
-    """List tables request model"""
-
-    database: str = Field(..., description="Database name from whitelist")
-
-
 # MCP Tool Definitions
 
 
-def _create_database_query_tool() -> MCPTool:
+def _create_database_query_tool() -> DatabaseMCPTool:
     """
     Create MCP tool definition for database SELECT queries.
 
     Issue #620.
     """
-    return MCPTool(
+    return DatabaseMCPTool(
         name="database_query",
         description=(
             "Execute SELECT query on SQLite database. Returns rows as JSON. Rate limited to 60"
@@ -532,13 +462,13 @@ def _create_database_query_tool() -> MCPTool:
     )
 
 
-def _create_database_execute_tool() -> MCPTool:
+def _create_database_execute_tool() -> DatabaseMCPTool:
     """
     Create MCP tool definition for database DML operations.
 
     Issue #620.
     """
-    return MCPTool(
+    return DatabaseMCPTool(
         name="database_execute",
         description=(
             "Execute INSERT/UPDATE/DELETE on SQLite database. Only works on non-read-only"
@@ -569,7 +499,7 @@ def _create_database_execute_tool() -> MCPTool:
     )
 
 
-def _get_database_query_tools() -> List[MCPTool]:
+def _get_database_query_tools() -> List[DatabaseMCPTool]:
     """
     Get MCP tools for database query and execute operations.
 
@@ -585,13 +515,13 @@ def _get_database_query_tools() -> List[MCPTool]:
     ]
 
 
-def _create_list_tables_tool() -> MCPTool:
+def _create_list_tables_tool() -> DatabaseMCPTool:
     """
     Create MCP tool definition for listing database tables.
 
     Issue #620.
     """
-    return MCPTool(
+    return DatabaseMCPTool(
         name="database_list_tables",
         description="List all tables in a SQLite database with row counts and basic info.",
         input_schema={
@@ -608,13 +538,13 @@ def _create_list_tables_tool() -> MCPTool:
     )
 
 
-def _create_describe_schema_tool() -> MCPTool:
+def _create_describe_schema_tool() -> DatabaseMCPTool:
     """
     Create MCP tool definition for describing database schema.
 
     Issue #620.
     """
-    return MCPTool(
+    return DatabaseMCPTool(
         name="database_describe_schema",
         description=(
             "Get schema information for database tables including columns, types,"
@@ -640,13 +570,13 @@ def _create_describe_schema_tool() -> MCPTool:
     )
 
 
-def _create_list_databases_tool() -> MCPTool:
+def _create_list_databases_tool() -> DatabaseMCPTool:
     """
     Create MCP tool definition for listing available databases.
 
     Issue #620.
     """
-    return MCPTool(
+    return DatabaseMCPTool(
         name="database_list_databases",
         description=(
             "List all available whitelisted databases with their access permissions and"
@@ -660,13 +590,13 @@ def _create_list_databases_tool() -> MCPTool:
     )
 
 
-def _create_statistics_tool() -> MCPTool:
+def _create_statistics_tool() -> DatabaseMCPTool:
     """
     Create MCP tool definition for getting database statistics.
 
     Issue #620.
     """
-    return MCPTool(
+    return DatabaseMCPTool(
         name="database_statistics",
         description=(
             "Get statistics for a database including size, table count,"
@@ -686,7 +616,7 @@ def _create_statistics_tool() -> MCPTool:
     )
 
 
-def _get_database_schema_tools() -> List[MCPTool]:
+def _get_database_schema_tools() -> List[DatabaseMCPTool]:
     """
     Get MCP tools for database schema and metadata operations.
 
@@ -714,8 +644,8 @@ def _get_database_schema_tools() -> List[MCPTool]:
     operation="get_database_mcp_tools",
     error_code_prefix="DATABASE_MCP",
 )
-@router.get("/mcp/tools", response_model=List[MCPTool])
-async def get_database_mcp_tools() -> List[MCPTool]:
+@router.get("/mcp/tools", response_model=List[DatabaseMCPTool])
+async def get_database_mcp_tools() -> List[DatabaseMCPTool]:
     """
     Return all available Database MCP tools
 

--- a/autobot-backend/api/integration_project_management.py
+++ b/autobot-backend/api/integration_project_management.py
@@ -17,9 +17,14 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
+from api.schemas_workflows import (
+    ConnectionTestRequest,
+    IssueCreateRequest,
+    IssueUpdateRequest,
+    ProviderInfo,
+)
 from integrations.base import IntegrationConfig, IntegrationHealth
 from integrations.project_management_integration import (
     AsanaIntegration,
@@ -46,60 +51,6 @@ router = APIRouter(
 # =============================================================================
 # Request/Response Models
 # =============================================================================
-
-
-class ConnectionTestRequest(BaseModel):
-    """Request to test project management connection."""
-
-    provider: str = Field(..., description="Provider: jira, trello, or asana")
-    base_url: Optional[str] = Field(None, description="Base URL for the service")
-    api_key: Optional[str] = Field(None, description="API key")
-    api_secret: Optional[str] = Field(None, description="API secret")
-    token: Optional[str] = Field(None, description="Auth token")
-    username: Optional[str] = Field(None, description="Username")
-    password: Optional[str] = Field(None, description="Password")
-
-
-class ProviderInfo(BaseModel):
-    """Information about a supported provider."""
-
-    provider: str
-    name: str
-    description: str
-    auth_type: str
-    base_url_required: bool
-    documentation_url: str
-
-
-class IssueCreateRequest(BaseModel):
-    """Request to create a new issue/card/task."""
-
-    title: str = Field(..., description="Issue title/name")
-    description: Optional[str] = Field(None, description="Description")
-    project_key: Optional[str] = Field(
-        None, description="Project key (Jira) or ID (Trello/Asana)"
-    )
-    issue_type: Optional[str] = Field("Task", description="Issue type (Jira)")
-    list_id: Optional[str] = Field(None, description="List ID (Trello)")
-    workspace_gid: Optional[str] = Field(None, description="Workspace GID (Asana)")
-
-
-class IssueUpdateRequest(BaseModel):
-    """Request to update an issue/card/task."""
-
-    title: Optional[str] = Field(None, description="New title")
-    description: Optional[str] = Field(None, description="New description")
-    status: Optional[str] = Field(None, description="New status")
-    transition_id: Optional[str] = Field(None, description="Transition ID (Jira)")
-    list_id: Optional[str] = Field(None, description="Target list ID (Trello)")
-    completed: Optional[bool] = Field(None, description="Completion status (Asana)")
-
-
-class SearchRequest(BaseModel):
-    """Request to search issues."""
-
-    query: str = Field(..., description="Search query or JQL")
-    max_results: Optional[int] = Field(50, description="Maximum results")
 
 
 # =============================================================================

--- a/autobot-backend/api/knowledge_relations.py
+++ b/autobot-backend/api/knowledge_relations.py
@@ -14,12 +14,18 @@ This eliminates the need for a separate AutoBotMemoryGraph system.
 """
 
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel, Field
 
-from api.schemas_knowledge import KnowledgeRelationResultResponse, KnowledgeRelationTypesResponse
+from api.schemas_knowledge import (
+    CreateRelationRequest,
+    DeleteRelationRequest,
+    HybridSearchRequest,
+    KnowledgeRelationResultResponse,
+    KnowledgeRelationTypesResponse,
+    TraverseRequest,
+)
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from knowledge_factory import get_or_create_knowledge_base
@@ -38,57 +44,6 @@ router = APIRouter(
 # ============================================================================
 # Pydantic Models
 # ============================================================================
-
-
-class CreateRelationRequest(BaseModel):
-    """Request model for creating a fact relation."""
-
-    source_fact_id: str = Field(..., description="ID of the source fact")
-    target_fact_id: str = Field(..., description="ID of the target fact")
-    relation_type: str = Field(
-        ...,
-        description="Type of relation (e.g., relates_to, depends_on, implements)",
-    )
-    metadata: Optional[dict] = Field(
-        None, description="Optional metadata for the relation"
-    )
-
-
-class DeleteRelationRequest(BaseModel):
-    """Request model for deleting a fact relation."""
-
-    source_fact_id: str = Field(..., description="ID of the source fact")
-    target_fact_id: str = Field(..., description="ID of the target fact")
-    relation_type: Optional[str] = Field(
-        None, description="Specific relation type to delete (None = all relations)"
-    )
-
-
-class TraverseRequest(BaseModel):
-    """Request model for graph traversal."""
-
-    start_fact_id: str = Field(..., description="Starting fact ID for traversal")
-    max_depth: int = Field(2, ge=1, le=5, description="Maximum traversal depth")
-    relation_types: Optional[List[str]] = Field(
-        None, description="Optional list of relation types to follow"
-    )
-    include_fact_details: bool = Field(
-        False, description="Include full fact content in results"
-    )
-
-
-class HybridSearchRequest(BaseModel):
-    """Request model for hybrid (vector + graph) search."""
-
-    query: str = Field(..., description="Search query text")
-    top_k: int = Field(10, ge=1, le=100, description="Number of vector matches")
-    expand_relations: bool = Field(
-        True, description="Expand results with graph relations"
-    )
-    relation_depth: int = Field(1, ge=1, le=3, description="Relation traversal depth")
-    relation_types: Optional[List[str]] = Field(
-        None, description="Filter by relation types"
-    )
 
 
 # ============================================================================

--- a/autobot-backend/api/merge_conflict_resolution.py
+++ b/autobot-backend/api/merge_conflict_resolution.py
@@ -22,7 +22,6 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -36,6 +35,12 @@ from code_intelligence.merge_conflict_resolver import (
     analyze_repository,
 )
 from api.schemas_common import DataResponse
+from api.schemas_code import (
+    ApplyResolutionRequest,
+    ConflictAnalysisRequest,
+    ConflictResolutionRequest,
+    RepositoryAnalysisRequest,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,59 +50,6 @@ router = APIRouter()
 # =============================================================================
 # Request/Response Models
 # =============================================================================
-
-
-class ConflictAnalysisRequest(BaseModel):
-    """Request model for conflict analysis."""
-
-    file_path: str = Field(
-        ...,
-        description="Path to file with merge conflicts",
-    )
-
-
-class ConflictResolutionRequest(BaseModel):
-    """Request model for conflict resolution."""
-
-    file_path: str = Field(
-        ...,
-        description="Path to file with merge conflicts",
-    )
-    strategy: Optional[str] = Field(
-        default=None,
-        description=(
-            "Resolution strategy: semantic_merge, accept_both, pattern_based, "
-            "accept_ours, accept_theirs, manual_review"
-        ),
-    )
-    safe_mode: bool = Field(
-        default=True,
-        description="Enable safe mode (require review for complex conflicts)",
-    )
-    validate: bool = Field(
-        default=True,
-        description="Validate resolved code for syntax errors",
-    )
-
-
-class RepositoryAnalysisRequest(BaseModel):
-    """Request model for repository-wide conflict analysis."""
-
-    repo_path: str = Field(
-        ...,
-        description="Path to git repository",
-    )
-
-
-class ApplyResolutionRequest(BaseModel):
-    """Request model for applying a resolution to file."""
-
-    file_path: str = Field(..., description="Path to file")
-    resolved_content: str = Field(..., description="Resolved file content")
-    create_backup: bool = Field(
-        default=True,
-        description="Create backup before applying",
-    )
 
 
 # =============================================================================

--- a/autobot-backend/api/nl_database.py
+++ b/autobot-backend/api/nl_database.py
@@ -18,12 +18,16 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from pydantic import BaseModel, Field
 
 from auth_middleware import get_current_user
 from services.nl_database_service import get_nl_database_service
-from api.schemas_common import DataResponse
 from api.schemas_agent import NLDatabaseSchemaResponse
+from api.schemas_knowledge import (
+    NLQueryRequest,
+    NLQueryResponse,
+    TrainRequest,
+    TrainResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
@@ -34,70 +38,6 @@ router = APIRouter()
 # ---------------------------------------------------------------------------
 # Request / Response models
 # ---------------------------------------------------------------------------
-
-
-class NLQueryRequest(BaseModel):
-    """Request body for a natural language database query."""
-
-    question: str = Field(
-        ...,
-        min_length=1,
-        max_length=2048,
-        description="Natural language question to translate into SQL",
-    )
-    db_id: str = Field(
-        default="local",
-        max_length=128,
-        description="Database identifier. Use 'local' for autobot_data.db",
-    )
-    db_secret_id: Optional[str] = Field(
-        default=None,
-        max_length=128,
-        description="Secret ID (from secrets manager) containing the database_url",
-    )
-
-
-class TrainRequest(BaseModel):
-    """Request body for training the NL service on an external database."""
-
-    db_id: str = Field(
-        ...,
-        min_length=1,
-        max_length=128,
-        description="Unique identifier for this database connection",
-    )
-    db_secret_id: str = Field(
-        ...,
-        max_length=128,
-        description="Secret ID containing the database_url in the secrets manager",
-    )
-    db_type: str = Field(
-        default="postgresql",
-        description="Database type: postgresql, mysql, or sqlite",
-    )
-
-
-class NLQueryResponse(BaseModel):
-    """Response for a natural language query execution."""
-
-    question: str
-    sql: Optional[str]
-    results: List[Dict[str, Any]]
-    columns: List[str]
-    row_count: int
-    db_id: str
-    elapsed_ms: int
-    error: Optional[str] = None
-
-
-class TrainResponse(BaseModel):
-    """Response for a database schema training operation."""
-
-    success: bool
-    db_id: str
-    schema_length: Optional[int] = None
-    table_count: Optional[int] = None
-    error: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -2075,3 +2075,114 @@ class PerformanceFileScanRequest(BaseModel):
     """Request for single file performance scan."""
 
     file_path: str = Field(..., description="Path to Python file to analyze")
+
+
+# ---------------------------------------------------------------------------
+# database_mcp.py schemas
+# ---------------------------------------------------------------------------
+
+_DB_MCP_MAX_RESULT_ROWS = 1000
+_DB_MCP_ALLOWED_DML_OPERATIONS = ("INSERT", "UPDATE", "DELETE")
+
+
+class DatabaseMCPTool(BaseModel):
+    """Standard MCP tool definition (database)"""
+
+    name: str
+    description: str
+    input_schema: JSONObject
+
+
+class SQLQueryRequest(BaseModel):
+    """SQL query request model."""
+
+    database: str = Field(..., description="Database name from whitelist")
+    query: str = Field(..., description="SQL SELECT query (parameterized)")
+    params: Optional[List[Any]] = Field(default=None, description="Query parameters for ? placeholders")
+    limit: Optional[int] = Field(
+        default=100,
+        ge=1,
+        le=_DB_MCP_MAX_RESULT_ROWS,
+        description=f"Max rows to return (1-{_DB_MCP_MAX_RESULT_ROWS})",
+    )
+
+    @field_validator("query")
+    @classmethod
+    def validate_query_is_select(cls, v):
+        normalized = v.strip().upper()
+        if not normalized.startswith("SELECT"):
+            raise ValueError(
+                "Only SELECT queries allowed. Use execute_sql for modifications."
+            )
+        return v
+
+
+class SQLExecuteRequest(BaseModel):
+    """SQL execute request model (for INSERT/UPDATE/DELETE)."""
+
+    database: str = Field(..., description="Database name from whitelist")
+    statement: str = Field(..., description="SQL statement (INSERT/UPDATE/DELETE)")
+    params: Optional[List[Any]] = Field(default=None, description="Statement parameters for ? placeholders")
+
+    @field_validator("statement")
+    @classmethod
+    def validate_statement_type(cls, v):
+        normalized = v.strip().upper()
+        if not any(normalized.startswith(op) for op in _DB_MCP_ALLOWED_DML_OPERATIONS):
+            raise ValueError(
+                f"Only {', '.join(_DB_MCP_ALLOWED_DML_OPERATIONS)} statements allowed"
+            )
+        return v
+
+
+class SchemaRequest(BaseModel):
+    """Database schema request model."""
+
+    database: str = Field(..., description="Database name from whitelist")
+    table: Optional[str] = Field(default=None, description="Specific table to describe (optional)")
+
+
+class TableListRequest(BaseModel):
+    """List tables request model."""
+
+    database: str = Field(..., description="Database name from whitelist")
+
+
+# ---------------------------------------------------------------------------
+# merge_conflict_resolution.py schemas
+# ---------------------------------------------------------------------------
+
+
+class ConflictAnalysisRequest(BaseModel):
+    """Request model for conflict analysis."""
+
+    file_path: str = Field(..., description="Path to file with merge conflicts")
+
+
+class ConflictResolutionRequest(BaseModel):
+    """Request model for conflict resolution."""
+
+    file_path: str = Field(..., description="Path to file with merge conflicts")
+    strategy: Optional[str] = Field(
+        default=None,
+        description=(
+            "Resolution strategy: semantic_merge, accept_both, pattern_based, "
+            "accept_ours, accept_theirs, manual_review"
+        ),
+    )
+    safe_mode: bool = Field(default=True, description="Enable safe mode (require review for complex conflicts)")
+    validate: bool = Field(default=True, description="Validate resolved code for syntax errors")
+
+
+class RepositoryAnalysisRequest(BaseModel):
+    """Request model for repository-wide conflict analysis."""
+
+    repo_path: str = Field(..., description="Path to git repository")
+
+
+class ApplyResolutionRequest(BaseModel):
+    """Request model for applying a resolution to file."""
+
+    file_path: str = Field(..., description="Path to file")
+    resolved_content: str = Field(..., description="Resolved file content")
+    create_backup: bool = Field(default=True, description="Create backup before applying")

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -4297,3 +4297,88 @@ class ConflictSchema(BaseModel):
     resolution: str
     chosen_fact: Optional[str] = None
     timestamp: float
+
+
+# ---------------------------------------------------------------------------
+# knowledge_relations.py schemas
+# ---------------------------------------------------------------------------
+
+
+class CreateRelationRequest(BaseModel):
+    """Request model for creating a fact relation."""
+
+    source_fact_id: str = Field(..., description="ID of the source fact")
+    target_fact_id: str = Field(..., description="ID of the target fact")
+    relation_type: str = Field(..., description="Type of relation (e.g., relates_to, depends_on, implements)")
+    metadata: Optional[dict] = Field(None, description="Optional metadata for the relation")
+
+
+class DeleteRelationRequest(BaseModel):
+    """Request model for deleting a fact relation."""
+
+    source_fact_id: str = Field(..., description="ID of the source fact")
+    target_fact_id: str = Field(..., description="ID of the target fact")
+    relation_type: Optional[str] = Field(None, description="Specific relation type to delete (None = all relations)")
+
+
+class TraverseRequest(BaseModel):
+    """Request model for graph traversal."""
+
+    start_fact_id: str = Field(..., description="Starting fact ID for traversal")
+    max_depth: int = Field(2, ge=1, le=5, description="Maximum traversal depth")
+    relation_types: Optional[List[str]] = Field(None, description="Optional list of relation types to follow")
+    include_fact_details: bool = Field(False, description="Include full fact content in results")
+
+
+class HybridSearchRequest(BaseModel):
+    """Request model for hybrid (vector + graph) search."""
+
+    query: str = Field(..., description="Search query text")
+    top_k: int = Field(10, ge=1, le=100, description="Number of vector matches")
+    expand_relations: bool = Field(True, description="Expand results with graph relations")
+    relation_depth: int = Field(1, ge=1, le=3, description="Relation traversal depth")
+    relation_types: Optional[List[str]] = Field(None, description="Filter by relation types")
+
+
+# ---------------------------------------------------------------------------
+# nl_database.py schemas
+# ---------------------------------------------------------------------------
+
+
+class NLQueryRequest(BaseModel):
+    """Request body for a natural language database query."""
+
+    question: str = Field(..., min_length=1, max_length=2048, description="Natural language question to translate into SQL")
+    db_id: str = Field(default="local", max_length=128, description="Database identifier. Use 'local' for autobot_data.db")
+    db_secret_id: Optional[str] = Field(default=None, max_length=128, description="Secret ID (from secrets manager) containing the database_url")
+
+
+class TrainRequest(BaseModel):
+    """Request body for training the NL service on an external database."""
+
+    db_id: str = Field(..., min_length=1, max_length=128, description="Unique identifier for this database connection")
+    db_secret_id: str = Field(..., max_length=128, description="Secret ID containing the database_url in the secrets manager")
+    db_type: str = Field(default="postgresql", description="Database type: postgresql, mysql, or sqlite")
+
+
+class NLQueryResponse(BaseModel):
+    """Response for a natural language query execution."""
+
+    question: str
+    sql: Optional[str]
+    results: List[Dict[str, Any]]
+    columns: List[str]
+    row_count: int
+    db_id: str
+    elapsed_ms: int
+    error: Optional[str] = None
+
+
+class TrainResponse(BaseModel):
+    """Response for a database schema training operation."""
+
+    success: bool
+    db_id: str
+    schema_length: Optional[int] = None
+    table_count: Optional[int] = None
+    error: Optional[str] = None

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -1601,3 +1601,60 @@ class ApprovalGateResponse(BaseModel):
     updated_at: Optional[str] = None
     comments: List[ApprovalCommentResponse] = Field(default_factory=list)
     task_links: List[TaskApprovalLinkResponse] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# integration_project_management.py schemas
+# ---------------------------------------------------------------------------
+
+
+class ConnectionTestRequest(BaseModel):
+    """Request to test project management connection."""
+
+    provider: str = Field(..., description="Provider: jira, trello, or asana")
+    base_url: Optional[str] = Field(None, description="Base URL for the service")
+    api_key: Optional[str] = Field(None, description="API key")
+    api_secret: Optional[str] = Field(None, description="API secret")
+    token: Optional[str] = Field(None, description="Auth token")
+    username: Optional[str] = Field(None, description="Username")
+    password: Optional[str] = Field(None, description="Password")
+
+
+class ProviderInfo(BaseModel):
+    """Information about a supported provider."""
+
+    provider: str
+    name: str
+    description: str
+    auth_type: str
+    base_url_required: bool
+    documentation_url: str
+
+
+class IssueCreateRequest(BaseModel):
+    """Request to create a new issue/card/task."""
+
+    title: str = Field(..., description="Issue title/name")
+    description: Optional[str] = Field(None, description="Description")
+    project_key: Optional[str] = Field(None, description="Project key (Jira) or ID (Trello/Asana)")
+    issue_type: Optional[str] = Field("Task", description="Issue type (Jira)")
+    list_id: Optional[str] = Field(None, description="List ID (Trello)")
+    workspace_gid: Optional[str] = Field(None, description="Workspace GID (Asana)")
+
+
+class IssueUpdateRequest(BaseModel):
+    """Request to update an issue/card/task."""
+
+    title: Optional[str] = Field(None, description="New title")
+    description: Optional[str] = Field(None, description="New description")
+    status: Optional[str] = Field(None, description="New status")
+    transition_id: Optional[str] = Field(None, description="Transition ID (Jira)")
+    list_id: Optional[str] = Field(None, description="Target list ID (Trello)")
+    completed: Optional[bool] = Field(None, description="Completion status (Asana)")
+
+
+class ProjectMgmtSearchRequest(BaseModel):
+    """Request to search issues."""
+
+    query: str = Field(..., description="Search query or JQL")
+    max_results: Optional[int] = Field(50, description="Maximum results")


### PR DESCRIPTION
## Summary

Phase 15 of issue #6042. Migrates 22 \`BaseModel\` subclasses from 5 endpoint files into centralized domain schema files.

### Files migrated

| Endpoint file | Classes removed | Target schema file |
|---|---|---|
| \`database_mcp.py\` | 5 (MCPTool→DatabaseMCPTool, SQLQueryRequest, SQLExecuteRequest, SchemaRequest, TableListRequest) | \`schemas_code.py\` |
| \`integration_project_management.py\` | 5 (ConnectionTestRequest, ProviderInfo, IssueCreateRequest, IssueUpdateRequest, SearchRequest→ProjectMgmtSearchRequest) | \`schemas_workflows.py\` |
| \`knowledge_relations.py\` | 4 (CreateRelationRequest, DeleteRelationRequest, TraverseRequest, HybridSearchRequest) | \`schemas_knowledge.py\` |
| \`nl_database.py\` | 4 (NLQueryRequest, TrainRequest, NLQueryResponse, TrainResponse) | \`schemas_knowledge.py\` |
| \`merge_conflict_resolution.py\` | 4 (ConflictAnalysisRequest, ConflictResolutionRequest, RepositoryAnalysisRequest, ApplyResolutionRequest) | \`schemas_code.py\` |

### Renames
- \`MCPTool\` → \`DatabaseMCPTool\` (avoids collision with prometheus MCPTool migrated in Phase 13)
- \`SearchRequest\` → \`ProjectMgmtSearchRequest\` (avoids collision with knowledge SearchRequest)

### Cleanup
- Removed dead-code \`SearchRequest\` import in \`integration_project_management.py\` — class was defined but \`search_issues\` endpoint uses Query parameters, not the model
- \`schemas_code.py\` gains \`_DB_MCP_MAX_RESULT_ROWS=1000\` and \`_DB_MCP_ALLOWED_DML_OPERATIONS\` constants for SQL request validators

### Validators preserved
- SQLQueryRequest.validate_query_is_select
- SQLExecuteRequest.validate_statement_type

## Test Plan
- [x] \`py_compile\` clean on all 8 modified files
- [x] \`flake8 --select=F401,F811,F821\` — 0 errors

Continues #6042

🤖 Generated with Claude Code