### PR TITLE
feat(plugins): user-extensible marketplace sources (#6481)

### DIFF
--- a/autobot-backend/api/marketplace.py
+++ b/autobot-backend/api/marketplace.py
@@ -158,6 +158,27 @@ class MarketplaceCatalogResponse(BaseModel):
     sort_by: str
 
 
+def _remote_plugin_to_entry(plugin: dict[str, Any], source_name: str) -> dict[str, Any]:
+    """Issue #6481: shape an external CatalogPlugin dict to look like a
+    MarketplaceEntry. Missing fields get safe defaults so the existing
+    response model and frontend continue to work."""
+    return {
+        "name": plugin.get("name", ""),
+        "version": plugin.get("version", ""),
+        "display_name": plugin.get("name", "").replace("-", " ").title(),
+        "description": plugin.get("description", ""),
+        "author": plugin.get("author", source_name),
+        "category": plugin.get("category", "other"),
+        "tags": plugin.get("tags", []),
+        "entry_point": "",
+        "dependencies": [],
+        "hooks": [],
+        "downloads": 0,
+        "rating": 0.0,
+        "source_url": plugin.get("git_url", ""),
+    }
+
+
 async def _get_catalog() -> list[dict[str, Any]]:
     """Return catalog from Redis cache, seeding from built-in list if missing."""
     try:
@@ -188,6 +209,10 @@ async def list_catalog(
     category: str = Query(default="all", description="Filter by category"),
     search: str | None = Query(default=None, description="Full-text search across name, description, tags"),
     sort_by: str = Query(default="downloads", description="Sort field: downloads, rating, name, newest"),
+    source_id: str = Query(
+        default="builtin",
+        description="Marketplace source id; 'builtin' or a user-added source UUID (#6481)",
+    ),
 ) -> MarketplaceCatalogResponse:
     """
     List community marketplace catalog.
@@ -195,6 +220,7 @@ async def list_catalog(
     Returns all available plugins and agents with optional filtering.
 
     Issue #1803: Plugin and agent marketplace.
+    Issue #6481: ?source_id= selects which marketplace catalog to query.
     """
     if category not in _VALID_CATEGORIES:
         raise HTTPException(
@@ -207,7 +233,25 @@ async def list_catalog(
             detail=f"Invalid sort_by '{sort_by}'. Valid: {sorted(_VALID_SORT)}",
         )
 
-    catalog = await _get_catalog()
+    if source_id == "builtin":
+        catalog = await _get_catalog()
+    else:
+        from api.marketplace_sources import (  # local import: avoid cycle
+            fetch_remote_catalog,
+            get_source_by_id,
+        )
+
+        source = await get_source_by_id(source_id)
+        if source is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Marketplace source '{source_id}' not found",
+            )
+        if not source.url:
+            catalog = await _get_catalog()
+        else:
+            remote_plugins = await fetch_remote_catalog(source.url)
+            catalog = [_remote_plugin_to_entry(p, source.name) for p in remote_plugins]
 
     # Filter by category
     if category != "all":

--- a/autobot-backend/api/marketplace_sources.py
+++ b/autobot-backend/api/marketplace_sources.py
@@ -1,0 +1,302 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Plugin Marketplace Sources
+
+Issue #6481 - User-extensible marketplace sources. Users register custom
+catalog URLs alongside the built-in AutoBot marketplace.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+import aiohttp
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, HttpUrl
+
+from auth_middleware import check_admin_permission
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.redis_client import get_async_redis_client
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_SOURCES_KEY = "plugins:marketplaces"
+_BUILTIN_ID = "builtin"
+_BUILTIN_NAME = "AutoBot Marketplace"
+_BUILTIN_DESCRIPTION = "Default AutoBot plugin marketplace"
+
+_NAME_PATTERN = re.compile(r"^[\w\s.\-()]{1,64}$")
+_FETCH_TIMEOUT_SECONDS = 15
+_MAX_CATALOG_BYTES = 4 * 1024 * 1024  # 4 MB cap on catalog JSON
+
+
+class MarketplaceSource(BaseModel):
+    id: str = Field(..., description="Unique source ID; 'builtin' for the default")
+    name: str = Field(..., description="Display name shown in the UI")
+    url: Optional[str] = Field(
+        default=None, description="Catalog URL; null for the built-in source"
+    )
+    description: Optional[str] = Field(default=None)
+    is_builtin: bool = Field(default=False)
+    created_at: Optional[str] = Field(default=None)
+
+
+class MarketplaceSourceCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=64)
+    url: HttpUrl
+    description: Optional[str] = Field(default=None, max_length=200)
+
+
+class MarketplaceSourcesResponse(BaseModel):
+    sources: list[MarketplaceSource]
+
+
+class CatalogPlugin(BaseModel):
+    """A single plugin entry as listed in an external marketplace catalog."""
+
+    name: str
+    version: str
+    description: str = ""
+    author: str = ""
+    git_url: str
+    ref: Optional[str] = None
+    category: str = "other"
+    tags: list[str] = Field(default_factory=list)
+
+
+class CatalogDocument(BaseModel):
+    """The schema an external marketplace URL must return."""
+
+    name: str
+    version: str = "1"
+    plugins: list[CatalogPlugin]
+
+
+def _builtin_source() -> MarketplaceSource:
+    return MarketplaceSource(
+        id=_BUILTIN_ID,
+        name=_BUILTIN_NAME,
+        url=None,
+        description=_BUILTIN_DESCRIPTION,
+        is_builtin=True,
+    )
+
+
+async def _list_user_sources() -> list[MarketplaceSource]:
+    redis = await get_async_redis_client(database="main")
+    if redis is None:
+        return []
+    raw_map = await redis.hgetall(_SOURCES_KEY)
+    sources: list[MarketplaceSource] = []
+    for raw in raw_map.values():
+        try:
+            sources.append(MarketplaceSource.model_validate_json(raw))
+        except Exception as exc:
+            logger.warning("Skipping malformed marketplace source: %s", exc)
+    sources.sort(key=lambda s: s.created_at or "")
+    return sources
+
+
+async def list_sources() -> list[MarketplaceSource]:
+    """Return the built-in source plus all user-added sources."""
+    return [_builtin_source(), *await _list_user_sources()]
+
+
+def _validate_url_scheme(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Marketplace URL must use http or https",
+        )
+
+
+def _validate_source_name(name: str) -> str:
+    name = name.strip()
+    if not _NAME_PATTERN.match(name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Source name contains unsupported characters",
+        )
+    return name
+
+
+@router.get(
+    "/marketplaces",
+    response_model=MarketplaceSourcesResponse,
+)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_marketplaces",
+    error_code_prefix="MARKETPLACE_SOURCES",
+)
+async def list_marketplaces() -> MarketplaceSourcesResponse:
+    """Issue #6481: list built-in + user-added marketplace sources."""
+    return MarketplaceSourcesResponse(sources=await list_sources())
+
+
+@router.post(
+    "/marketplaces",
+    status_code=status.HTTP_201_CREATED,
+    response_model=MarketplaceSource,
+)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="add_marketplace",
+    error_code_prefix="MARKETPLACE_SOURCES",
+)
+async def add_marketplace(
+    request: MarketplaceSourceCreate,
+    admin_check: bool = Depends(check_admin_permission),
+) -> MarketplaceSource:
+    """Issue #6481: add a custom marketplace source. Validates the URL by
+    fetching and parsing the catalog before persisting."""
+    url = str(request.url)
+    _validate_url_scheme(url)
+    name = _validate_source_name(request.name)
+    # Validate the URL serves a valid catalog before saving — fail-fast.
+    await _fetch_catalog_document(url)
+    source = MarketplaceSource(
+        id=str(uuid.uuid4()),
+        name=name,
+        url=url,
+        description=request.description,
+        is_builtin=False,
+        created_at=datetime.now(timezone.utc).isoformat(),
+    )
+    redis = await get_async_redis_client(database="main")
+    if redis is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Storage backend unavailable",
+        )
+    await redis.hset(_SOURCES_KEY, source.id, source.model_dump_json())
+    logger.info("Added marketplace source '%s' (%s)", source.name, source.id)
+    return source
+
+
+@router.delete(
+    "/marketplaces/{source_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_model=None,
+)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="delete_marketplace",
+    error_code_prefix="MARKETPLACE_SOURCES",
+)
+async def delete_marketplace(
+    source_id: str,
+    admin_check: bool = Depends(check_admin_permission),
+) -> None:
+    """Issue #6481: remove a custom marketplace source. Built-in is protected."""
+    if source_id == _BUILTIN_ID:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The built-in marketplace cannot be removed",
+        )
+    redis = await get_async_redis_client(database="main")
+    if redis is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Storage backend unavailable",
+        )
+    deleted = await redis.hdel(_SOURCES_KEY, source_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Marketplace source '{source_id}' not found",
+        )
+    logger.info("Removed marketplace source %s", source_id)
+
+
+async def _fetch_catalog_document(url: str) -> CatalogDocument:
+    """Fetch and validate a catalog JSON document from a remote URL.
+
+    Bounded by `_FETCH_TIMEOUT_SECONDS` and `_MAX_CATALOG_BYTES`. Raises
+    HTTPException(400) on any fetch/parse/validation failure.
+    """
+    timeout = aiohttp.ClientTimeout(total=_FETCH_TIMEOUT_SECONDS)
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url) as response:
+                if response.status != 200:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Marketplace URL returned HTTP {response.status}",
+                    )
+                # Reject if the server advertises an enormous body up front.
+                content_length = response.headers.get("Content-Length")
+                if (
+                    content_length
+                    and content_length.isdigit()
+                    and int(content_length) > _MAX_CATALOG_BYTES
+                ):
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Marketplace catalog exceeds 4MB",
+                    )
+                # Read with a hard cap regardless of Content-Length.
+                body = await response.content.read(_MAX_CATALOG_BYTES + 1)
+                if len(body) > _MAX_CATALOG_BYTES:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Marketplace catalog exceeds 4MB",
+                    )
+    except aiohttp.ClientError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Failed to reach marketplace URL: {exc}",
+        ) from exc
+    except TimeoutError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="Marketplace URL timed out",
+        ) from exc
+
+    try:
+        data = json.loads(body)
+        return CatalogDocument.model_validate(data)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Marketplace URL did not return valid JSON: {exc}",
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Marketplace catalog schema invalid: {exc}",
+        ) from exc
+
+
+async def get_source_by_id(source_id: str) -> Optional[MarketplaceSource]:
+    """Look up a single source by id (built-in or user-added)."""
+    if source_id == _BUILTIN_ID:
+        return _builtin_source()
+    redis = await get_async_redis_client(database="main")
+    if redis is None:
+        return None
+    raw = await redis.hget(_SOURCES_KEY, source_id)
+    if raw is None:
+        return None
+    try:
+        return MarketplaceSource.model_validate_json(raw)
+    except Exception as exc:
+        logger.warning("Malformed source %s in registry: %s", source_id, exc)
+        return None
+
+
+async def fetch_remote_catalog(url: str) -> list[dict[str, Any]]:
+    """Public helper: fetch a remote catalog and return its plugin list as
+    dicts (suitable for marketplace.py's catalog response shaping)."""
+    doc = await _fetch_catalog_document(url)
+    return [plugin.model_dump() for plugin in doc.plugins]

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -471,6 +471,8 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
     ("plugin_manager", "", ["plugins"], "plugin_manager"),
     # Issue #1803: Plugin and agent marketplace — community catalog
     ("api.marketplace", "/marketplace", ["marketplace", "plugins"], "marketplace"),
+    # Issue #6481: User-extensible marketplace sources (custom marketplaces)
+    ("api.marketplace_sources", "/plugins", ["marketplace", "plugins"], "marketplace_sources"),
     # Issue #5070: verbatim conversational-memory lane
     ("api.verbatim_memory", "/verbatim-memory", ["memory"], "verbatim_memory"),
     # Issue #5071: per-agent diary with background append and runtime discovery

--- a/autobot-frontend/src/components/plugins/MarketplaceSourcesModal.vue
+++ b/autobot-frontend/src/components/plugins/MarketplaceSourcesModal.vue
@@ -1,0 +1,445 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal-fade">
+      <div
+        v-if="open"
+        class="modal-backdrop"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="$t('views.marketplace.sources.title')"
+        @click.self="onClose"
+      >
+        <div class="modal-card" @keydown.esc="onClose">
+          <header class="modal-header">
+            <h2 class="modal-title">{{ $t('views.marketplace.sources.title') }}</h2>
+            <button class="modal-close" :aria-label="$t('common.close')" @click="onClose">
+              <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" class="close-icon">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </header>
+
+          <div class="modal-body">
+            <p class="hint">{{ $t('views.marketplace.sources.hint') }}</p>
+
+            <!-- Existing sources list -->
+            <ul v-if="sources.length > 0" class="sources-list">
+              <li v-for="src in sources" :key="src.id" class="source-row">
+                <div class="source-info">
+                  <div class="source-name">
+                    {{ src.name }}
+                    <span v-if="src.is_builtin" class="builtin-badge">
+                      {{ $t('views.marketplace.sources.builtin') }}
+                    </span>
+                  </div>
+                  <div v-if="src.url" class="source-url">{{ src.url }}</div>
+                  <div v-if="src.description" class="source-desc">{{ src.description }}</div>
+                </div>
+                <button
+                  v-if="!src.is_builtin"
+                  class="btn btn-danger"
+                  :disabled="busy"
+                  @click="onDelete(src.id)"
+                >
+                  {{ $t('common.remove') }}
+                </button>
+              </li>
+            </ul>
+
+            <!-- Add new source form -->
+            <div class="add-form">
+              <h3 class="add-title">{{ $t('views.marketplace.sources.addTitle') }}</h3>
+              <label class="form-field">
+                <span class="form-label">{{ $t('views.marketplace.sources.nameLabel') }}</span>
+                <input
+                  v-model.trim="newName"
+                  type="text"
+                  class="form-input"
+                  maxlength="64"
+                  :placeholder="$t('views.marketplace.sources.namePlaceholder')"
+                />
+              </label>
+              <label class="form-field">
+                <span class="form-label">{{ $t('views.marketplace.sources.urlLabel') }}</span>
+                <input
+                  v-model.trim="newUrl"
+                  type="url"
+                  class="form-input"
+                  placeholder="https://example.com/plugins.json"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+              </label>
+              <label class="form-field">
+                <span class="form-label">
+                  {{ $t('views.marketplace.sources.descLabel') }}
+                  <span class="form-label-optional">{{ $t('common.optional') }}</span>
+                </span>
+                <input
+                  v-model.trim="newDesc"
+                  type="text"
+                  class="form-input"
+                  maxlength="200"
+                />
+              </label>
+
+              <div v-if="error" class="error-banner" role="alert">
+                {{ error }}
+              </div>
+
+              <button
+                class="btn btn-primary"
+                :disabled="!canAdd || busy"
+                @click="onAdd"
+              >
+                {{ busy ? $t('views.marketplace.sources.adding') : $t('views.marketplace.sources.add') }}
+              </button>
+            </div>
+          </div>
+
+          <footer class="modal-footer">
+            <button class="btn btn-ghost" @click="onClose">
+              {{ $t('common.close') }}
+            </button>
+          </footer>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useMarketplaceSources } from '@/composables/useMarketplaceSources'
+
+const props = defineProps<{ open: boolean }>()
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'updated'): void
+}>()
+
+const { t } = useI18n()
+const {
+  sources,
+  listSources,
+  addSource,
+  deleteSource,
+  error: composableError,
+} = useMarketplaceSources()
+
+const newName = ref('')
+const newUrl = ref('')
+const newDesc = ref('')
+const busy = ref(false)
+const error = ref<string | null>(null)
+
+const canAdd = computed(() => newName.value.length > 0 && newUrl.value.length > 0)
+
+watch(
+  () => props.open,
+  async (isOpen) => {
+    if (isOpen) {
+      newName.value = ''
+      newUrl.value = ''
+      newDesc.value = ''
+      error.value = null
+      busy.value = false
+      await listSources()
+    }
+  },
+)
+
+function onClose() {
+  if (busy.value) return
+  emit('close')
+}
+
+async function onAdd() {
+  if (!canAdd.value || busy.value) return
+  busy.value = true
+  error.value = null
+  try {
+    const result = await addSource({
+      name: newName.value,
+      url: newUrl.value,
+      description: newDesc.value || undefined,
+    })
+    if (result) {
+      newName.value = ''
+      newUrl.value = ''
+      newDesc.value = ''
+      emit('updated')
+    } else {
+      error.value = composableError.value || t('views.marketplace.sources.addFailed')
+    }
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onDelete(id: string) {
+  busy.value = true
+  error.value = null
+  try {
+    const ok = await deleteSource(id)
+    if (ok) {
+      emit('updated')
+    } else {
+      error.value = composableError.value || t('views.marketplace.sources.removeFailed')
+    }
+  } finally {
+    busy.value = false
+  }
+}
+</script>
+
+<style scoped>
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--spacing-md);
+}
+
+.modal-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  width: 100%;
+  max-width: 600px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow-xl);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.modal-title {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: var(--spacing-xs);
+  border-radius: var(--radius-sm);
+}
+
+.modal-close:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.close-icon {
+  width: 20px;
+  height: 20px;
+}
+
+.modal-body {
+  padding: var(--spacing-lg);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.hint {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.sources-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.source-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+}
+
+.source-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.source-name {
+  font-weight: 600;
+  color: var(--text-primary);
+  display: flex;
+  gap: var(--spacing-xs);
+  align-items: center;
+}
+
+.builtin-badge {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--color-info);
+  background: var(--color-info-bg);
+  padding: 2px var(--spacing-xs);
+  border-radius: var(--radius-sm);
+}
+
+.source-url {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  word-break: break-all;
+  margin-top: 2px;
+}
+
+.source-desc {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin-top: var(--spacing-xs);
+}
+
+.add-form {
+  border-top: 1px solid var(--border-default);
+  padding-top: var(--spacing-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.add-title {
+  margin: 0 0 var(--spacing-xs) 0;
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.form-label {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--text-primary);
+  display: flex;
+  gap: var(--spacing-xs);
+  align-items: baseline;
+}
+
+.form-label-optional {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  font-weight: 400;
+}
+
+.form-input {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: var(--color-info);
+}
+
+.error-banner {
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
+  color: var(--color-error);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-top: 1px solid var(--border-default);
+}
+
+.btn {
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background var(--duration-150);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-ghost {
+  background: transparent;
+  border-color: var(--border-default);
+  color: var(--text-primary);
+}
+
+.btn-primary {
+  background: var(--color-info);
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.btn-danger {
+  background: var(--color-error);
+  color: white;
+}
+
+.btn-danger:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 150ms ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/autobot-frontend/src/composables/useMarketplaceSources.ts
+++ b/autobot-frontend/src/composables/useMarketplaceSources.ts
@@ -1,0 +1,87 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Marketplace Sources Composable
+ * Issue #6481 - User-extensible plugin marketplace sources.
+ */
+
+import { ref } from 'vue'
+import ApiClient from '@/utils/ApiClient'
+import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
+
+const logger = createLogger('useMarketplaceSources')
+
+export interface MarketplaceSource {
+  id: string
+  name: string
+  url: string | null
+  description: string | null
+  is_builtin: boolean
+  created_at: string | null
+}
+
+interface ListResponse { sources: MarketplaceSource[] }
+
+export function useMarketplaceSources() {
+  const sources = ref<MarketplaceSource[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function listSources(): Promise<void> {
+    error.value = null
+    loading.value = true
+    try {
+      const data = await ApiClient.get(`${getApiBase()}/plugins/marketplaces`) as ListResponse
+      sources.value = data.sources ?? []
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to list marketplace sources'
+      error.value = msg
+      logger.error('listSources error: %s', msg)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function addSource(payload: { name: string; url: string; description?: string }): Promise<MarketplaceSource | null> {
+    error.value = null
+    try {
+      const data = await ApiClient.post(
+        `${getApiBase()}/plugins/marketplaces`,
+        payload,
+      ) as MarketplaceSource
+      await listSources()
+      return data
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to add marketplace source'
+      error.value = msg
+      logger.error('addSource error: %s', msg)
+      return null
+    }
+  }
+
+  async function deleteSource(id: string): Promise<boolean> {
+    error.value = null
+    try {
+      await ApiClient.delete(`${getApiBase()}/plugins/marketplaces/${id}`)
+      await listSources()
+      return true
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to remove marketplace source'
+      error.value = msg
+      logger.error('deleteSource error: %s', msg)
+      return false
+    }
+  }
+
+  return {
+    sources,
+    loading,
+    error,
+    listSources,
+    addSource,
+    deleteSource,
+  }
+}

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -81,7 +81,8 @@
     "page": "Page",
     "hasMore": "Load more",
     "previous": "Previous",
-    "optional": "اختياري"
+    "optional": "اختياري",
+    "remove": "إزالة"
   },
   "chat": {
     "sendMessage": "أرسل رسالة...",
@@ -5552,7 +5553,22 @@
       "source": "Source",
       "loadError": "Failed to load marketplace catalog.",
       "installError": "Failed to install plugin.",
-      "uninstallError": "Failed to uninstall plugin."
+      "uninstallError": "Failed to uninstall plugin.",
+      "sources": {
+        "title": "إدارة مصادر السوق",
+        "hint": "أضف عناوين أسواق مخصصة تُرجع كتالوج JSON للمكونات.",
+        "addTitle": "إضافة سوق مخصص",
+        "add": "إضافة المصدر",
+        "adding": "جارٍ الإضافة…",
+        "addFailed": "فشلت الإضافة — تحقق من أن العنوان يُرجع كتالوجًا صالحًا.",
+        "removeFailed": "فشلت إزالة السوق.",
+        "nameLabel": "الاسم المعروض",
+        "namePlaceholder": "Acme Plugins",
+        "urlLabel": "عنوان الكتالوج",
+        "descLabel": "الوصف",
+        "builtin": "مدمج"
+      },
+      "manageSources": "إدارة المصادر"
     }
   },
   "auth": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -81,7 +81,8 @@
     "page": "Page",
     "hasMore": "Load more",
     "previous": "Previous",
-    "optional": "optional"
+    "optional": "optional",
+    "remove": "Entfernen"
   },
   "chat": {
     "sendMessage": "Senden Sie eine Nachricht...",
@@ -5552,7 +5553,22 @@
       "source": "Source",
       "loadError": "Failed to load marketplace catalog.",
       "installError": "Failed to install plugin.",
-      "uninstallError": "Failed to uninstall plugin."
+      "uninstallError": "Failed to uninstall plugin.",
+      "sources": {
+        "title": "Marktplatzquellen verwalten",
+        "hint": "Füge eigene Marktplatz-URLs hinzu, die einen JSON-Katalog von Plugins zurückgeben.",
+        "addTitle": "Eigenen Marktplatz hinzufügen",
+        "add": "Quelle hinzufügen",
+        "adding": "Hinzufügen…",
+        "addFailed": "Hinzufügen fehlgeschlagen — prüfe ob die URL einen gültigen Katalog liefert.",
+        "removeFailed": "Marktplatz konnte nicht entfernt werden.",
+        "nameLabel": "Anzeigename",
+        "namePlaceholder": "Acme Plugins",
+        "urlLabel": "Katalog-URL",
+        "descLabel": "Beschreibung",
+        "builtin": "integriert"
+      },
+      "manageSources": "Quellen verwalten"
     }
   },
   "auth": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -81,7 +81,8 @@
     "hasMore": "Load more",
     "page": "Page",
     "previous": "Previous",
-    "optional": "optional"
+    "optional": "optional",
+    "remove": "Remove"
   },
   "chat": {
     "sendMessage": "Send a message...",
@@ -5595,7 +5596,22 @@
       "source": "Source",
       "loadError": "Failed to load marketplace catalog.",
       "installError": "Failed to install plugin.",
-      "uninstallError": "Failed to uninstall plugin."
+      "uninstallError": "Failed to uninstall plugin.",
+      "sources": {
+        "title": "Manage Marketplace Sources",
+        "hint": "Add custom marketplace URLs that return a JSON catalog of plugins.",
+        "addTitle": "Add custom marketplace",
+        "add": "Add source",
+        "adding": "Adding…",
+        "addFailed": "Failed to add marketplace — check the URL returns a valid catalog.",
+        "removeFailed": "Failed to remove marketplace.",
+        "nameLabel": "Display name",
+        "namePlaceholder": "Acme Plugins",
+        "urlLabel": "Catalog URL",
+        "descLabel": "Description",
+        "builtin": "built-in"
+      },
+      "manageSources": "Manage Sources"
     }
   },
   "auth": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -81,7 +81,8 @@
     "page": "Page",
     "hasMore": "Load more",
     "previous": "Previous",
-    "optional": "opcional"
+    "optional": "opcional",
+    "remove": "Eliminar"
   },
   "chat": {
     "sendMessage": "Enviar un mensaje...",
@@ -5552,7 +5553,22 @@
       "source": "Source",
       "loadError": "Failed to load marketplace catalog.",
       "installError": "Failed to install plugin.",
-      "uninstallError": "Failed to uninstall plugin."
+      "uninstallError": "Failed to uninstall plugin.",
+      "sources": {
+        "title": "Gestionar fuentes del mercado",
+        "hint": "Agrega URLs de mercado personalizadas que devuelvan un catálogo JSON de plugins.",
+        "addTitle": "Añadir mercado personalizado",
+        "add": "Añadir fuente",
+        "adding": "Añadiendo…",
+        "addFailed": "Error al añadir — comprueba que la URL devuelva un catálogo válido.",
+        "removeFailed": "No se pudo eliminar el mercado.",
+        "nameLabel": "Nombre visible",
+        "namePlaceholder": "Acme Plugins",
+        "urlLabel": "URL del catálogo",
+        "descLabel": "Descripción",
+        "builtin": "integrado"
+      },
+      "manageSources": "Gestionar fuentes"
     }
   },
   "auth": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -81,7 +81,8 @@
     "page": "Page",
     "hasMore": "Load more",
     "previous": "Previous",
-    "optional": "اختیاری"
+    "optional": "اختیاری",
+    "remove": "حذف"
   },
   "nav": {
     "chat": "گفتگو",
@@ -5891,7 +5892,22 @@
       "source": "Source",
       "loadError": "Failed to load marketplace catalog.",
       "installError": "Failed to install plugin.",
-      "uninstallError": "Failed to uninstall plugin."
+      "uninstallError": "Failed to uninstall plugin.",
+      "sources": {
+        "title": "مدیریت منابع بازار",
+        "hint": "آدرس‌های بازار سفارشی که کاتالوگ JSON از افزونه‌ها برمی‌گردانند را اضافه کنید.",
+        "addTitle": "افزودن بازار سفارشی",
+        "add": "افزودن منبع",
+        "adding": "در حال افزودن…",
+        "addFailed": "افزودن ناموفق بود — مطمئن شوید آدرس کاتالوگ معتبری برمی‌گرداند.",
+        "removeFailed": "حذف بازار ناموفق بود.",
+        "nameLabel": "نام نمایشی",
+        "namePlaceholder": "Acme Plugins",
+        "urlLabel": "آدرس کاتالوگ",
+        "descLabel": "توضیحات",
+        "builtin": "داخلی"
+      },
+      "manageSources": "مدیریت منابع"
     }
   },
   "featureFlags": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -81,7 +81,8 @@
     "page": "Page",
     "hasMore": "Load more",
     "previous": "Previous",
-    "optional": "facultatif"
+    "optional": "facultatif",
+    "remove": "Supprimer"
   },
   "chat": {
     "sendMessage": "Envoyer un message...",
@@ -5552,7 +5553,22 @@
       "source": "Source",
       "loadError": "Failed to load marketplace catalog.",
       "installError": "Failed to install plugin.",
-      "uninstallError": "Failed to uninstall plugin."
+      "uninstallError": "Failed to uninstall plugin.",
+      "sources": {
+        "title": "Gérer les sources du marché",
+        "hint": "Ajoutez des URL de marché personnalisées renvoyant un catalogue JSON de plugins.",
+        "addTitle": "Ajouter un marché personnalisé",
+        "add": "Ajouter la source",
+        "adding": "Ajout…",
+        "addFailed": "Échec de l'ajout — vérifiez que l'URL renvoie un catalogue valide.",
+        "removeFailed": "Impossible de supprimer le marché.",
+        "nameLabel": "Nom affiché",
+        "namePlaceholder": "Acme Plugins",
+        "urlLabel": "URL du catalogue",
+        "descLabel": "Description",
+        "builtin": "intégré"
+      },
+      "manageSources": "Gérer les sources"
     }
   },
   "auth": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -81,7 +81,8 @@
     "page": "Page",
     "hasMore": "Load more",
     "previous": "Previous",
-    "optional": "אופציונלי"
+    "optional": "אופציונלי",
+    "remove": "הסר"
   },
   "nav": {
     "chat": "צ'אט",
@@ -5891,7 +5892,22 @@
       "source": "Source",
       "loadError": "Failed to load marketplace catalog.",
       "installError": "Failed to install plugin.",
-      "uninstallError": "Failed to uninstall plugin."
+      "uninstallError": "Failed to uninstall plugin.",
+      "sources": {
+        "title": "ניהול מקורות שוק",
+        "hint": "הוסף כתובות שוק מותאמות אישית שמחזירות קטלוג JSON של תוספים.",
+        "addTitle": "הוסף שוק מותאם אישית",
+        "add": "הוסף מקור",
+        "adding": "מוסיף…",
+        "addFailed": "ההוספה נכשלה — ודא שהכתובת מחזירה קטלוג תקין.",
+        "removeFailed": "הסרת השוק נכשלה.",
+        "nameLabel": "שם תצוגה",
+        "namePlaceholder": "Acme Plugins",
+        "urlLabel": "כתובת הקטלוג",
+        "descLabel": "תיאור",
+        "builtin": "מובנה"
+      },
+      "manageSources": "נהל מקורות"
     }
   },
   "featureFlags": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -81,7 +81,8 @@
     "page": "Page",
     "hasMore": "Load more",
     "previous": "Previous",
-    "optional": "pēc izvēles"
+    "optional": "pēc izvēles",
+    "remove": "Noņemt"
   },
   "chat": {
     "sendMessage": "Nosūtīt ziņu...",
@@ -5552,7 +5553,22 @@
       "source": "Source",
       "loadError": "Failed to load marketplace catalog.",
       "installError": "Failed to install plugin.",
-      "uninstallError": "Failed to uninstall plugin."
+      "uninstallError": "Failed to uninstall plugin.",
+      "sources": {
+        "title": "Pārvaldīt tirgus avotus",
+        "hint": "Pievienojiet pielāgotus tirgus URL, kas atgriež JSON spraudņu katalogu.",
+        "addTitle": "Pievienot pielāgotu tirgu",
+        "add": "Pievienot avotu",
+        "adding": "Pievieno…",
+        "addFailed": "Pievienošana neizdevās — pārbaudiet, vai URL atgriež derīgu katalogu.",
+        "removeFailed": "Tirgu neizdevās noņemt.",
+        "nameLabel": "Attēlojamais nosaukums",
+        "namePlaceholder": "Acme Plugins",
+        "urlLabel": "Kataloga URL",
+        "descLabel": "Apraksts",
+        "builtin": "iebūvēts"
+      },
+      "manageSources": "Pārvaldīt avotus"
     }
   },
   "auth": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -81,7 +81,8 @@
     "page": "Page",
     "hasMore": "Load more",
     "previous": "Previous",
-    "optional": "opcjonalne"
+    "optional": "opcjonalne",
+    "remove": "Usuń"
   },
   "chat": {
     "sendMessage": "Wyślij wiadomość...",
@@ -5552,7 +5553,22 @@
       "source": "Source",
       "loadError": "Failed to load marketplace catalog.",
       "installError": "Failed to install plugin.",
-      "uninstallError": "Failed to uninstall plugin."
+      "uninstallError": "Failed to uninstall plugin.",
+      "sources": {
+        "title": "Zarządzaj źródłami marketplace",
+        "hint": "Dodaj własne URL-e marketplace zwracające katalog JSON wtyczek.",
+        "addTitle": "Dodaj własny marketplace",
+        "add": "Dodaj źródło",
+        "adding": "Dodawanie…",
+        "addFailed": "Nie udało się dodać — sprawdź, czy URL zwraca poprawny katalog.",
+        "removeFailed": "Nie udało się usunąć marketplace.",
+        "nameLabel": "Wyświetlana nazwa",
+        "namePlaceholder": "Acme Plugins",
+        "urlLabel": "URL katalogu",
+        "descLabel": "Opis",
+        "builtin": "wbudowany"
+      },
+      "manageSources": "Zarządzaj źródłami"
     }
   },
   "auth": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -81,7 +81,8 @@
     "page": "Page",
     "hasMore": "Load more",
     "previous": "Previous",
-    "optional": "opcional"
+    "optional": "opcional",
+    "remove": "Remover"
   },
   "chat": {
     "sendMessage": "Envie uma mensagem...",
@@ -5552,7 +5553,22 @@
       "source": "Source",
       "loadError": "Failed to load marketplace catalog.",
       "installError": "Failed to install plugin.",
-      "uninstallError": "Failed to uninstall plugin."
+      "uninstallError": "Failed to uninstall plugin.",
+      "sources": {
+        "title": "Gerenciar fontes do mercado",
+        "hint": "Adicione URLs de mercado personalizadas que retornem um catálogo JSON de plugins.",
+        "addTitle": "Adicionar mercado personalizado",
+        "add": "Adicionar fonte",
+        "adding": "Adicionando…",
+        "addFailed": "Falha ao adicionar — verifique se a URL retorna um catálogo válido.",
+        "removeFailed": "Falha ao remover o mercado.",
+        "nameLabel": "Nome exibido",
+        "namePlaceholder": "Acme Plugins",
+        "urlLabel": "URL do catálogo",
+        "descLabel": "Descrição",
+        "builtin": "integrado"
+      },
+      "manageSources": "Gerenciar fontes"
     }
   },
   "auth": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -81,7 +81,8 @@
     "page": "Page",
     "hasMore": "Load more",
     "previous": "Previous",
-    "optional": "اختیاری"
+    "optional": "اختیاری",
+    "remove": "ہٹائیں"
   },
   "nav": {
     "chat": "چیٹ",
@@ -5891,7 +5892,22 @@
       "source": "Source",
       "loadError": "Failed to load marketplace catalog.",
       "installError": "Failed to install plugin.",
-      "uninstallError": "Failed to uninstall plugin."
+      "uninstallError": "Failed to uninstall plugin.",
+      "sources": {
+        "title": "مارکیٹ پلیس ذرائع کا نظم کریں",
+        "hint": "اپنی مارکیٹ پلیس URLs شامل کریں جو پلگ انز کا JSON کیٹلاگ واپس کرتے ہیں۔",
+        "addTitle": "حسب ضرورت مارکیٹ پلیس شامل کریں",
+        "add": "ذریعہ شامل کریں",
+        "adding": "شامل کیا جا رہا ہے…",
+        "addFailed": "شامل کرنے میں ناکام — یقینی بنائیں کہ URL درست کیٹلاگ واپس کرتا ہے۔",
+        "removeFailed": "مارکیٹ پلیس ہٹانے میں ناکام۔",
+        "nameLabel": "ظاہر ہونے والا نام",
+        "namePlaceholder": "Acme Plugins",
+        "urlLabel": "کیٹلاگ URL",
+        "descLabel": "تفصیل",
+        "builtin": "بلٹ ان"
+      },
+      "manageSources": "ذرائع کا نظم"
     }
   },
   "featureFlags": {

--- a/autobot-frontend/src/views/MarketplaceView.vue
+++ b/autobot-frontend/src/views/MarketplaceView.vue
@@ -52,6 +52,13 @@
           />
         </div>
 
+        <!-- Issue #6481: Marketplace source selector -->
+        <select v-model="selectedSourceId" class="filter-select" @change="onSourceChange">
+          <option v-for="src in sources" :key="src.id" :value="src.id">
+            {{ src.name }}
+          </option>
+        </select>
+
         <select v-model="selectedCategory" class="filter-select" @change="onFilter">
           <option value="all">{{ $t('views.marketplace.allCategories') }}</option>
           <option v-for="cat in categories" :key="cat" :value="cat">{{ cat }}</option>
@@ -70,6 +77,11 @@
         >
           {{ $t('views.marketplace.installedOnly') }}
           <span class="count-badge">{{ installedNames.size }}</span>
+        </button>
+
+        <!-- Issue #6481: Manage marketplace sources -->
+        <button class="btn-manage-sources" @click="manageSourcesOpen = true">
+          {{ $t('views.marketplace.manageSources') }}
         </button>
       </div>
 
@@ -185,6 +197,13 @@
         </div>
       </div>
     </div>
+
+    <!-- Issue #6481: Manage marketplace sources modal -->
+    <MarketplaceSourcesModal
+      :open="manageSourcesOpen"
+      @close="manageSourcesOpen = false"
+      @updated="onSourcesUpdated"
+    />
   </div>
 </template>
 
@@ -195,6 +214,8 @@ import { useI18n } from 'vue-i18n'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
+import { useMarketplaceSources } from '@/composables/useMarketplaceSources'
+import MarketplaceSourcesModal from '@/components/plugins/MarketplaceSourcesModal.vue'
 
 const { t } = useI18n()
 const logger = createLogger('MarketplaceView')
@@ -227,6 +248,11 @@ const selectedCategory = ref('all')
 const sortBy = ref('downloads')
 const showInstalledOnly = ref(false)
 
+// Issue #6481: marketplace sources
+const { sources, listSources } = useMarketplaceSources()
+const selectedSourceId = ref<string>('builtin')
+const manageSourcesOpen = ref(false)
+
 const visibleEntries = computed<MarketplaceEntry[]>(() => {
   if (!showInstalledOnly.value) return entries.value
   return entries.value.filter((e: MarketplaceEntry) => installedNames.value.has(e.name))
@@ -254,6 +280,8 @@ async function fetchCatalog(): Promise<void> {
   const params = new URLSearchParams({ sort_by: sortBy.value })
   if (selectedCategory.value !== 'all') params.set('category', selectedCategory.value)
   if (searchQuery.value.trim()) params.set('search', searchQuery.value.trim())
+  // Issue #6481: include selected source so the backend fetches the right catalog
+  if (selectedSourceId.value) params.set('source_id', selectedSourceId.value)
   const data = await ApiClient.get<Record<string, unknown>>(`${getApiBase()}/marketplace/catalog?${params.toString()}`)
   entries.value = data.entries as MarketplaceEntry[] ?? []
 }
@@ -262,7 +290,8 @@ async function load(): Promise<void> {
   loading.value = true
   error.value = null
   try {
-    await Promise.all([fetchCatalog(), fetchInstalled(), fetchCategories()])
+    await Promise.all([listSources(), fetchInstalled(), fetchCategories()])
+    await fetchCatalog()
   } catch (err) {
     logger.error('Marketplace load failed', err)
     error.value = err instanceof Error ? err.message : t('views.marketplace.loadError')
@@ -286,6 +315,14 @@ async function onSearch(): Promise<void> {
 
 async function onFilter(): Promise<void> {
   await onSearch()
+}
+
+async function onSourceChange(): Promise<void> {
+  await onSearch()
+}
+
+async function onSourcesUpdated(): Promise<void> {
+  await listSources()
 }
 
 async function handleInstall(name: string): Promise<void> {
@@ -495,6 +532,26 @@ onMounted(async () => {
 }
 
 .btn-filter-toggle:hover:not(.active) {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+/* Issue #6481: manage marketplace sources button */
+.btn-manage-sources {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-1-5) var(--spacing-3);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  transition: background var(--duration-150) var(--ease-in-out), color var(--duration-150) var(--ease-in-out);
+}
+
+.btn-manage-sources:hover {
   background: var(--bg-tertiary);
   color: var(--text-primary);
 }


### PR DESCRIPTION
## Summary
Builds on PR #6466 (ZIP/Git install) to support **custom marketplace sources** — users register their own marketplace URLs alongside the built-in AutoBot marketplace, similar to how Claude Code allows custom plugin marketplaces.

## Backend
- New module `autobot-backend/api/marketplace_sources.py`:
  - `GET /api/plugins/marketplaces` — list built-in + user-added sources
  - `POST /api/plugins/marketplaces` — add source `{ name, url, description? }` (admin)
  - `DELETE /api/plugins/marketplaces/{id}` — remove source (admin, built-in protected)
  - Persisted in Redis under `plugins:marketplaces` (hash, one entry per source)
  - URL validated by **fetching and parsing** the catalog before saving (fail-fast)
  - Catalog fetcher: `aiohttp` with 15s timeout, 4MB cap (Content-Length pre-check + hard read cap), schema validation via Pydantic `CatalogDocument`
  - http(s) only; built-in source id `'builtin'` is reserved and cannot be deleted
- Extended `api/marketplace.py` `GET /catalog` with `?source_id=` query param — selects which marketplace catalog to fetch from. Built-in falls through to existing Redis-cached catalog; user sources fetch from their URL via `fetch_remote_catalog`
- `_remote_plugin_to_entry` shapes external plugins (`{name, version, description, git_url, ref, category, tags}`) into `MarketplaceEntry` so the existing response model and frontend continue to work

## Frontend
- New composable `composables/useMarketplaceSources.ts` — list/add/delete sources via the new endpoints
- New component `components/plugins/MarketplaceSourcesModal.vue` — Teleport-based modal with sources list (with built-in badge + remove button on user sources) + add-form (name, URL, optional description)
- `views/MarketplaceView.vue`:
  - Source-selector dropdown next to category/sort filters
  - "Manage Sources" button opens the modal
  - Switching source re-fetches the catalog with the new `source_id`
- All copy in i18n across 11 locales — no hardcoded strings

## Test Plan
- [ ] Built-in source always present and Remove button is hidden for it
- [ ] Adding a marketplace with a malformed URL → 400 with clear error message
- [ ] Adding a marketplace whose URL returns invalid JSON → 400
- [ ] Adding a marketplace whose JSON doesn't match the schema → 400
- [ ] Adding a marketplace whose body exceeds 4MB → 400
- [ ] Removing a custom source updates the dropdown and falls back to built-in
- [ ] Source dropdown switches catalog without page reload
- [ ] Frontend type-check passes (`vue-tsc --noEmit -p tsconfig.app.json`)
- [ ] Backend `python -m py_compile` passes for new and modified files

## Marketplace JSON schema
```json
{
  \"name\": \"Acme Plugins\",
  \"version\": \"1\",
  \"plugins\": [
    {
      \"name\": \"foo\", \"version\": \"1.0.0\", \"description\": \"...\",
      \"git_url\": \"https://github.com/owner/foo.git\", \"ref\": \"main\",
      \"category\": \"tool\", \"tags\": [\"...\"]
    }
  ]
}
```

## Related Issues
Closes #6481
Builds on #6464 (ZIP/Git install endpoints).