### PR TITLE
refactor(schemas): Phase 16 — migrate 24 classes + 1 enum (triggers, services, project_state, research_browser, structured_thinking) (#6042)

### DIFF
--- a/autobot-backend/api/project_state.py
+++ b/autobot-backend/api/project_state.py
@@ -8,56 +8,24 @@ Exposes project development phase information and validation status
 """
 
 import logging
-from typing import Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from project_state_manager import DevelopmentPhase, get_project_state_manager
 from utils.advanced_cache_manager import smart_cache
 from api.schemas_common import DataResponse
-from api.schemas_system import ProjectStateHealthResponse
+from api.schemas_system import (
+    PhaseStatus,
+    PhaseValidationModel,
+    ProjectStateHealthResponse,
+    ProjectStatus,
+    ValidationResultModel,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/project", tags=["project_state"])
-
-
-# Pydantic models for API responses
-class PhaseStatus(BaseModel):
-    name: str
-    completion: float
-    is_active: bool
-    is_completed: bool
-    capabilities: int
-    implemented_capabilities: int
-
-
-class ProjectStatus(BaseModel):
-    current_phase: str
-    total_phases: int
-    completed_phases: int
-    active_phases: int
-    overall_completion: float
-    next_suggested_phase: Optional[str]
-    phases: Dict[str, PhaseStatus]
-
-
-class ValidationResultModel(BaseModel):
-    check_name: str
-    status: str
-    score: float
-    details: str
-    timestamp: str
-
-
-class PhaseValidationModel(BaseModel):
-    phase_name: str
-    completion_percentage: float
-    is_completed: bool
-    capabilities: List[str]
-    validation_results: List[ValidationResultModel]
 
 
 @with_error_handling(

--- a/autobot-backend/api/research_browser.py
+++ b/autobot-backend/api/research_browser.py
@@ -10,21 +10,24 @@ import asyncio
 import logging
 import os
 from datetime import datetime, timezone
-from typing import Optional
 
 import aiofiles
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.ssot_config import config as ssot_config
 from config.manager import get_config_manager
 from constants.error_constants import ERR_SESSION_NOT_FOUND
-from constants.network_constants import NetworkConstants
 from api.schemas_common import DataResponse
 from api.schemas_code import ResearchBrowserHealthResponse
+from api.schemas_workflows import (
+    BrowserResearchRequest,
+    CreateChatBrowserRequest,
+    NavigationRequest,
+    SessionAction,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,18 +46,6 @@ config = get_config_manager()
 router = APIRouter(
     dependencies=[Depends(check_admin_permission)],
 )
-
-
-class ResearchRequest(BaseModel):
-    conversation_id: str
-    url: str
-    extract_content: bool = True
-
-
-class SessionAction(BaseModel):
-    session_id: str
-    action: str  # "wait", "manual_intervention", "save_mhtml", "extract_content"
-    timeout_seconds: Optional[int] = 300
 
 
 def _require_browser():
@@ -87,7 +78,7 @@ async def health_check():
             "timestamp": datetime.now(tz=timezone.utc).isoformat(),
         }
 
-    status = "healthy" if research_browser_manager else "not_initialized"
+    status = "healthy" if get_research_browser_manager else "not_initialized"
 
     browser_service_url = ssot_config.browser_service_url
 
@@ -110,7 +101,7 @@ async def health_check():
     error_code_prefix="RESEARCH_BROWSER",
 )
 @router.post("/url", response_model=DataResponse)
-async def research_url(request: ResearchRequest):
+async def research_url(request: BrowserResearchRequest):
     """Research a URL with automatic fallbacks and interaction handling"""
     _require_browser()
     result = await get_research_browser_manager().research_url(
@@ -317,10 +308,6 @@ async def list_sessions():
     )
 
 
-class NavigationRequest(BaseModel):
-    url: str
-
-
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="navigate_session",
@@ -449,14 +436,6 @@ def _get_browser_actions() -> list:
 
 # Chat Browser Session Management (Issue #73)
 # These endpoints tie browser sessions to chat conversations like terminal
-
-
-class CreateChatBrowserRequest(BaseModel):
-    """Request to create/get browser session for chat"""
-
-    conversation_id: str
-    headless: bool = False
-    initial_url: Optional[str] = None
 
 
 @with_error_handling(

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -7,6 +7,7 @@ System health, cache, NPU worker, wake-word, and feature-flag schemas.
 
 import re
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
@@ -2691,3 +2692,213 @@ class ListMetricsRequest(BaseModel):
     """Request model for listing metrics"""
 
     filter: str = Field("", description="Optional filter pattern (e.g., 'autobot_', 'node_')")
+
+
+# ---------------------------------------------------------------------------
+# service_messages.py schemas
+# ---------------------------------------------------------------------------
+
+
+class ServiceMessageResponse(BaseModel):
+    """Single serialised ServiceMessage."""
+
+    msg_id: str
+    ts: str
+    sender: str
+    receiver: str
+    msg_type: str
+    content: str
+    correlation_id: str
+    meta: dict = Field(default_factory=dict)
+
+
+class LatestMessagesResponse(BaseModel):
+    """Response for GET /latest."""
+
+    success: bool
+    count: int
+    messages: List[ServiceMessageResponse]
+
+
+class SingleMessageResponse(BaseModel):
+    """Response for GET /{msg_id}."""
+
+    success: bool
+    message: Optional[ServiceMessageResponse] = None
+
+
+class CorrelationChainResponse(BaseModel):
+    """Response for GET /chain/{correlation_id}."""
+
+    success: bool
+    correlation_id: str
+    count: int
+    messages: List[ServiceMessageResponse]
+
+
+# ---------------------------------------------------------------------------
+# project_state.py schemas
+# ---------------------------------------------------------------------------
+
+
+class PhaseStatus(BaseModel):
+    name: str
+    completion: float
+    is_active: bool
+    is_completed: bool
+    capabilities: int
+    implemented_capabilities: int
+
+
+class ProjectStatus(BaseModel):
+    current_phase: str
+    total_phases: int
+    completed_phases: int
+    active_phases: int
+    overall_completion: float
+    next_suggested_phase: Optional[str]
+    phases: Dict[str, PhaseStatus]
+
+
+class ValidationResultModel(BaseModel):
+    check_name: str
+    status: str
+    score: float
+    details: str
+    timestamp: str
+
+
+class PhaseValidationModel(BaseModel):
+    phase_name: str
+    completion_percentage: float
+    is_completed: bool
+    capabilities: List[str]
+    validation_results: List[ValidationResultModel]
+
+
+# ---------------------------------------------------------------------------
+# services.py schemas
+# ---------------------------------------------------------------------------
+
+
+class ServiceStatus(BaseModel):
+    """Service status model."""
+
+    name: str
+    status: str = Field(..., description="Service status: healthy, warning, error")
+    message: str = Field(..., description="Status description")
+    last_check: Optional[datetime] = None
+    response_time_ms: Optional[float] = None
+
+
+class SystemInfo(BaseModel):
+    """System information model."""
+
+    version: str
+    build: str
+    environment: str
+    uptime: float
+    services_count: int
+
+
+class VMStatus(BaseModel):
+    """VM status model."""
+
+    name: str
+    ip: str
+    status: str = Field(..., description="VM status: online, offline, unknown")
+    services: List[str] = Field(default_factory=list)
+    last_check: Optional[datetime] = None
+
+
+class ServicesResponse(BaseModel):
+    """Services list response."""
+
+    services: List[ServiceStatus]
+    total_count: int
+    healthy_count: int
+    error_count: int
+    warning_count: int
+    last_updated: datetime
+
+
+# ---------------------------------------------------------------------------
+# structured_thinking_mcp.py schemas
+# ---------------------------------------------------------------------------
+
+
+class ThinkingStage(str, Enum):
+    """Five cognitive stages for structured thinking."""
+
+    PROBLEM_DEFINITION = "Problem Definition"
+    RESEARCH = "Research"
+    ANALYSIS = "Analysis"
+    SYNTHESIS = "Synthesis"
+    CONCLUSION = "Conclusion"
+
+
+class StructuredThinkingMCPTool(BaseModel):
+    """Standard MCP tool definition (structured thinking)."""
+
+    name: str
+    description: str
+    input_schema: Metadata
+
+
+class ProcessThoughtRequest(BaseModel):
+    """Request model for processing a thought in structured framework."""
+
+    thought: str = Field(..., description="The content of the thought")
+    thought_number: int = Field(..., ge=1, description="Position in the thinking sequence")
+    total_thoughts: int = Field(..., ge=1, description="Expected total number of thoughts")
+    next_thought_needed: bool = Field(..., description="Whether more thoughts will follow")
+    stage: ThinkingStage = Field(..., description="Cognitive stage for this thought")
+    tags: Optional[List[str]] = Field(None, description="Keywords or categories for this thought")
+    axioms_used: Optional[List[str]] = Field(None, description="Fundamental principles applied")
+    assumptions_challenged: Optional[List[str]] = Field(None, description="Assumptions being questioned")
+    session_id: Optional[str] = Field("default", description="Thinking session identifier")
+
+    def to_thought_record(self) -> Metadata:
+        """Convert request to thought record for storage."""
+        return {
+            "thought_number": self.thought_number,
+            "thought": self.thought,
+            "total_thoughts": self.total_thoughts,
+            "next_thought_needed": self.next_thought_needed,
+            "stage": self.stage.value,
+            "tags": self.tags or [],
+            "axioms_used": self.axioms_used or [],
+            "assumptions_challenged": self.assumptions_challenged or [],
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        }
+
+    def get_progress_percentage(self) -> float:
+        """Calculate progress percentage."""
+        return (self.thought_number / self.total_thoughts) * 100
+
+    def get_session_key(self) -> str:
+        """Get session key with fallback."""
+        return self.session_id or "default"
+
+    def is_thinking_complete(self) -> bool:
+        """Check if thinking process is complete."""
+        return not self.next_thought_needed
+
+    def get_progress_message(self) -> str:
+        """Get formatted progress message."""
+        return (
+            f"Processed thought {self.thought_number}/{self.total_thoughts} "
+            f"in {self.stage.value} stage"
+        )
+
+
+class GenerateSummaryRequest(BaseModel):
+    """Request model for generating thinking summary."""
+
+    session_id: Optional[str] = Field("default", description="Session to summarize")
+
+
+class ClearHistoryRequest(BaseModel):
+    """Request model for clearing thinking history."""
+
+    session_id: Optional[str] = Field("default", description="Session to clear")

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from api.schemas_common import SuccessMessageResponse
 from autobot_shared.models.service_message import ServiceMessage
+from services.trigger_service import TriggerType
 from autobot_shared.time_utils import now_utc
 from models.approval import ApprovalType
 from type_defs.common import Metadata
@@ -1658,3 +1659,74 @@ class ProjectMgmtSearchRequest(BaseModel):
 
     query: str = Field(..., description="Search query or JQL")
     max_results: Optional[int] = Field(50, description="Maximum results")
+
+
+# ---------------------------------------------------------------------------
+# triggers.py schemas
+# ---------------------------------------------------------------------------
+
+
+class TriggerCreateRequest(BaseModel):
+    """Request body for POST /api/triggers."""
+
+    trigger_type: TriggerType
+    workflow_id: str = Field(..., min_length=1)
+    config: Dict[str, Any] = Field(default_factory=dict)
+    conditions: List[Dict[str, Any]] = Field(default_factory=list)
+    enabled: bool = True
+
+    @field_validator("workflow_id")
+    @classmethod
+    def workflow_id_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("workflow_id must not be empty or whitespace")
+        return v
+
+
+class TriggerCreateResponse(BaseModel):
+    """Response body for POST /api/triggers."""
+
+    trigger_id: str
+    webhook_url: Optional[str] = None
+
+
+class TriggerListResponse(BaseModel):
+    """Response body for GET /api/triggers."""
+
+    triggers: List[Dict[str, Any]]
+    total: int
+
+
+class FireTriggerRequest(BaseModel):
+    """Optional request body for manually firing a trigger (internal/testing)."""
+
+    payload: Dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# research_browser.py schemas
+# ---------------------------------------------------------------------------
+
+
+class BrowserResearchRequest(BaseModel):
+    conversation_id: str
+    url: str
+    extract_content: bool = True
+
+
+class SessionAction(BaseModel):
+    session_id: str
+    action: str
+    timeout_seconds: Optional[int] = 300
+
+
+class NavigationRequest(BaseModel):
+    url: str
+
+
+class CreateChatBrowserRequest(BaseModel):
+    """Request to create/get browser session for chat."""
+
+    conversation_id: str
+    headless: bool = False
+    initial_url: Optional[str] = None

--- a/autobot-backend/api/service_messages.py
+++ b/autobot-backend/api/service_messages.py
@@ -13,13 +13,18 @@ Endpoints:
 """
 
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel, Field
 
 from auth_middleware import get_auth_middleware
 from autobot_shared.message_bus import get_message_bus
+from api.schemas_system import (
+    CorrelationChainResponse,
+    LatestMessagesResponse,
+    ServiceMessageResponse,
+    SingleMessageResponse,
+)
 from utils.catalog_http_exceptions import raise_auth_error, raise_server_error
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
@@ -31,43 +36,6 @@ router = APIRouter(prefix="/service-messages", tags=["service-messages"])
 # ------------------------------------------------------------------
 # Response models
 # ------------------------------------------------------------------
-
-
-class ServiceMessageResponse(BaseModel):
-    """Single serialised ServiceMessage."""
-
-    msg_id: str
-    ts: str
-    sender: str
-    receiver: str
-    msg_type: str
-    content: str
-    correlation_id: str
-    meta: dict = Field(default_factory=dict)
-
-
-class LatestMessagesResponse(BaseModel):
-    """Response for GET /latest."""
-
-    success: bool
-    count: int
-    messages: List[ServiceMessageResponse]
-
-
-class SingleMessageResponse(BaseModel):
-    """Response for GET /{msg_id}."""
-
-    success: bool
-    message: Optional[ServiceMessageResponse] = None
-
-
-class CorrelationChainResponse(BaseModel):
-    """Response for GET /chain/{correlation_id}."""
-
-    success: bool
-    correlation_id: str
-    count: int
-    messages: List[ServiceMessageResponse]
 
 
 # ------------------------------------------------------------------

--- a/autobot-backend/api/services.py
+++ b/autobot-backend/api/services.py
@@ -9,17 +9,19 @@ Provides service status, health checks, and system information endpoints.
 import logging
 import time
 from datetime import datetime, timezone
-from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from api.schemas_system import (
+    ServiceStatus,
     ServicesHealthAggregateResponse,
     ServicesHealthDeprecatedResponse,
+    ServicesResponse,
     ServicesVMsStatusResponse,
+    SystemInfo,
+    VMStatus,
 )
 
 # Import existing monitoring functionality
@@ -142,47 +144,6 @@ def _build_default_services(redis_status_obj) -> list:
             message="Automation services running",
         ),
     ]
-
-
-class ServiceStatus(BaseModel):
-    """Service status model"""
-
-    name: str
-    status: str = Field(..., description="Service status: healthy, warning, error")
-    message: str = Field(..., description="Status description")
-    last_check: Optional[datetime] = None
-    response_time_ms: Optional[float] = None
-
-
-class SystemInfo(BaseModel):
-    """System information model"""
-
-    version: str
-    build: str
-    environment: str
-    uptime: float
-    services_count: int
-
-
-class VMStatus(BaseModel):
-    """VM status model"""
-
-    name: str
-    ip: str
-    status: str = Field(..., description="VM status: online, offline, unknown")
-    services: List[str] = Field(default_factory=list)
-    last_check: Optional[datetime] = None
-
-
-class ServicesResponse(BaseModel):
-    """Services list response"""
-
-    services: List[ServiceStatus]
-    total_count: int
-    healthy_count: int
-    error_count: int
-    warning_count: int
-    last_updated: datetime
 
 
 @with_error_handling(

--- a/autobot-backend/api/structured_thinking_mcp.py
+++ b/autobot-backend/api/structured_thinking_mcp.py
@@ -23,14 +23,18 @@ Enables agents to:
 
 import asyncio
 import logging
-from datetime import datetime, timezone
-from enum import Enum
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
 
 from api.schemas_common import DataResponse
+from api.schemas_system import (
+    ClearHistoryRequest,
+    GenerateSummaryRequest,
+    ProcessThoughtRequest,
+    StructuredThinkingMCPTool,
+    ThinkingStage,
+)
 from api.schemas_workflows import (
     StructuredThinkingClearResponse,
     StructuredThinkingProcessThoughtResponse,
@@ -48,108 +52,11 @@ router = APIRouter(
 )
 
 
-class ThinkingStage(str, Enum):
-    """Five cognitive stages for structured thinking"""
-
-    PROBLEM_DEFINITION = "Problem Definition"
-    RESEARCH = "Research"
-    ANALYSIS = "Analysis"
-    SYNTHESIS = "Synthesis"
-    CONCLUSION = "Conclusion"
-
-
 # In-memory storage for structured thinking sessions
 structured_sessions: Dict[str, List[Metadata]] = {}
 
 # Lock for thread-safe access to structured_sessions
 _structured_sessions_lock = asyncio.Lock()
-
-
-class MCPTool(BaseModel):
-    """Standard MCP tool definition"""
-
-    name: str
-    description: str
-    input_schema: Metadata
-
-
-class ProcessThoughtRequest(BaseModel):
-    """Request model for processing a thought in structured framework"""
-
-    thought: str = Field(..., description="The content of the thought")
-    thought_number: int = Field(
-        ..., ge=1, description="Position in the thinking sequence"
-    )
-    total_thoughts: int = Field(
-        ..., ge=1, description="Expected total number of thoughts"
-    )
-    next_thought_needed: bool = Field(
-        ..., description="Whether more thoughts will follow"
-    )
-    stage: ThinkingStage = Field(..., description="Cognitive stage for this thought")
-
-    # Optional metadata
-    tags: Optional[List[str]] = Field(
-        None, description="Keywords or categories for this thought"
-    )
-    axioms_used: Optional[List[str]] = Field(
-        None, description="Fundamental principles applied"
-    )
-    assumptions_challenged: Optional[List[str]] = Field(
-        None, description="Assumptions being questioned"
-    )
-
-    # Session management
-    session_id: Optional[str] = Field(
-        "default", description="Thinking session identifier"
-    )
-
-    # === Issue #372: Feature Envy Reduction Methods ===
-
-    def to_thought_record(self) -> Metadata:
-        """Convert request to thought record for storage (Issue #372 - reduces feature envy)."""
-        return {
-            "thought_number": self.thought_number,
-            "thought": self.thought,
-            "total_thoughts": self.total_thoughts,
-            "next_thought_needed": self.next_thought_needed,
-            "stage": self.stage.value,
-            "tags": self.tags or [],
-            "axioms_used": self.axioms_used or [],
-            "assumptions_challenged": self.assumptions_challenged or [],
-            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-        }
-
-    def get_progress_percentage(self) -> float:
-        """Calculate progress percentage (Issue #372 - reduces feature envy)."""
-        return (self.thought_number / self.total_thoughts) * 100
-
-    def get_session_key(self) -> str:
-        """Get session key with fallback (Issue #372 - reduces feature envy)."""
-        return self.session_id or "default"
-
-    def is_thinking_complete(self) -> bool:
-        """Check if thinking process is complete (Issue #372 - reduces feature envy)."""
-        return not self.next_thought_needed
-
-    def get_progress_message(self) -> str:
-        """Get formatted progress message (Issue #372 - reduces feature envy)."""
-        return (
-            f"Processed thought {self.thought_number}/{self.total_thoughts} "
-            f"in {self.stage.value} stage"
-        )
-
-
-class GenerateSummaryRequest(BaseModel):
-    """Request model for generating thinking summary"""
-
-    session_id: Optional[str] = Field("default", description="Session to summarize")
-
-
-class ClearHistoryRequest(BaseModel):
-    """Request model for clearing thinking history"""
-
-    session_id: Optional[str] = Field("default", description="Session to clear")
 
 
 # =============================================================================
@@ -354,8 +261,8 @@ STRUCTURED_THINKING_MCP_TOOL_DEFINITIONS = (
     operation="get_structured_thinking_mcp_tools",
     error_code_prefix="STRUCTURED_THINKING_MCP",
 )
-@router.get("/mcp/tools", response_model=List[MCPTool])
-async def get_structured_thinking_mcp_tools() -> List[MCPTool]:
+@router.get("/mcp/tools", response_model=List[StructuredThinkingMCPTool])
+async def get_structured_thinking_mcp_tools() -> List[StructuredThinkingMCPTool]:
     """
     Get available MCP tools for structured thinking.
 
@@ -364,7 +271,7 @@ async def get_structured_thinking_mcp_tools() -> List[MCPTool]:
     """
     # Issue #281: Build MCPTool instances from module-level definitions
     return [
-        MCPTool(name=name, description=desc, input_schema=schema)
+        StructuredThinkingMCPTool(name=name, description=desc, input_schema=schema)
         for name, desc, schema in STRUCTURED_THINKING_MCP_TOOL_DEFINITIONS
     ]
 

--- a/autobot-backend/api/triggers.py
+++ b/autobot-backend/api/triggers.py
@@ -17,7 +17,6 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
-from pydantic import BaseModel, Field, field_validator
 
 from auth_middleware import get_current_user
 from services.trigger_service import (
@@ -27,6 +26,11 @@ from services.trigger_service import (
     TriggerType,
 )
 from api.schemas_agent import WebhookAcceptedResponse
+from api.schemas_workflows import (
+    TriggerCreateRequest,
+    TriggerCreateResponse,
+    TriggerListResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
@@ -51,44 +55,6 @@ def get_trigger_service() -> TriggerService:
 # ---------------------------------------------------------------------------
 # Pydantic request / response models
 # ---------------------------------------------------------------------------
-
-
-class TriggerCreateRequest(BaseModel):
-    """Request body for POST /api/triggers."""
-
-    trigger_type: TriggerType
-    workflow_id: str = Field(..., min_length=1)
-    config: Dict[str, Any] = Field(default_factory=dict)
-    conditions: List[Dict[str, Any]] = Field(default_factory=list)
-    enabled: bool = True
-
-    @field_validator("workflow_id")
-    @classmethod
-    def workflow_id_not_empty(cls, v: str) -> str:
-        """Ensure workflow_id is not blank after stripping whitespace."""
-        if not v.strip():
-            raise ValueError("workflow_id must not be empty or whitespace")
-        return v
-
-
-class TriggerCreateResponse(BaseModel):
-    """Response body for POST /api/triggers."""
-
-    trigger_id: str
-    webhook_url: Optional[str] = None
-
-
-class TriggerListResponse(BaseModel):
-    """Response body for GET /api/triggers."""
-
-    triggers: List[Dict[str, Any]]
-    total: int
-
-
-class FireTriggerRequest(BaseModel):
-    """Optional request body for manually firing a trigger (internal/testing)."""
-
-    payload: Dict[str, Any] = Field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 16 of issue #6042. Migrates 24 \`BaseModel\` subclasses + 1 \`Enum\` from 6 endpoint files into centralized domain schema files.

### Files migrated

| Endpoint file | Classes/enums | Target |
|---|---|---|
| \`triggers.py\` | 4 (TriggerCreateRequest, TriggerCreateResponse, TriggerListResponse, FireTriggerRequest) | \`schemas_workflows.py\` |
| \`service_messages.py\` | 4 (ServiceMessageResponse, LatestMessagesResponse, SingleMessageResponse, CorrelationChainResponse) | \`schemas_system.py\` |
| \`project_state.py\` | 4 (PhaseStatus, ProjectStatus, ValidationResultModel, PhaseValidationModel) | \`schemas_system.py\` |
| \`services.py\` | 4 (ServiceStatus, SystemInfo, VMStatus, ServicesResponse) | \`schemas_system.py\` |
| \`research_browser.py\` | 4 (ResearchRequest→BrowserResearchRequest, SessionAction, NavigationRequest, CreateChatBrowserRequest) | \`schemas_workflows.py\` |
| \`structured_thinking_mcp.py\` | 4 + 1 enum (MCPTool→StructuredThinkingMCPTool, ProcessThoughtRequest, GenerateSummaryRequest, ClearHistoryRequest, ThinkingStage) | \`schemas_system.py\` |

### Renames
- \`ResearchRequest\` → \`BrowserResearchRequest\` (collides with knowledge ResearchRequest)
- \`MCPTool\` → \`StructuredThinkingMCPTool\` (3rd MCPTool variant; previously DatabaseMCPTool, PrometheusMCPTool)

### Notable
- \`schemas_workflows.py\` adds \`from services.trigger_service import TriggerType\` for TriggerCreateRequest field type
- \`schemas_system.py\` gains \`Enum\` import for ThinkingStage
- ProcessThoughtRequest preserves helper methods (\`to_thought_record\`, \`get_progress_percentage\`, etc.)

### Bug Fix (out-of-scope but blocking)
- \`research_browser.py:81\` had pre-existing typo: \`research_browser_manager\` (undefined) instead of \`get_research_browser_manager\`. Fixed inline.

### Cleanup
- Removed dead-code imports: \`FireTriggerRequest\` in triggers.py, \`NetworkConstants\` and \`Optional\` in research_browser.py

## Test Plan
- [x] \`py_compile\` clean on all 8 modified files
- [x] \`flake8 --select=F401,F811,F821\` — 0 errors

Continues #6042

🤖 Generated with Claude Code