### PR TITLE
refactor(schemas): Phase 17 — migrate 20 classes (audit, anti_pattern, analytics_maintenance/log_patterns, long_running_operations) (#6042)

### DIFF
--- a/autobot-backend/api/analytics_log_patterns.py
+++ b/autobot-backend/api/analytics_log_patterns.py
@@ -16,15 +16,18 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import aiofiles
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from api.schemas_analytics import (
+    LogAnomaly,
+    LogPattern,
     LogPatternDetailResponse,
     LogPatternHotspotsResponse,
-    LogPatternStatsResponse,
     LogPatternRealtimeResponse,
+    LogPatternStatsResponse,
+    LogTrend,
+    PatternMiningResult,
 )
 
 logger = logging.getLogger(__name__)
@@ -42,58 +45,6 @@ LOG_LEVEL_PRIORITIES = ["CRITICAL", "ERROR", "WARNING", "WARN", "INFO", "DEBUG"]
 # ============================================================================
 # Pydantic Models
 # ============================================================================
-
-
-class LogPattern(BaseModel):
-    """Represents a discovered log pattern"""
-
-    pattern_id: str
-    pattern_template: str
-    occurrences: int
-    first_seen: str
-    last_seen: str
-    log_levels: List[str]
-    sources: List[str]
-    sample_messages: List[str] = Field(default_factory=list, max_length=5)
-    frequency_per_hour: float = 0.0
-    is_error_pattern: bool = False
-    is_anomaly: bool = False
-
-
-class LogAnomaly(BaseModel):
-    """Represents a detected anomaly in logs"""
-
-    anomaly_id: str
-    anomaly_type: str  # spike, gap, new_pattern, error_surge
-    severity: str  # critical, high, medium, low
-    description: str
-    timestamp: str
-    affected_sources: List[str]
-    metric_before: float
-    metric_after: float
-    confidence: float
-
-
-class LogTrend(BaseModel):
-    """Represents a trend in log data"""
-
-    trend_id: str
-    metric_name: str
-    direction: str  # increasing, decreasing, stable
-    change_percent: float
-    time_period: str
-    data_points: List[Dict[str, Any]]
-
-
-class PatternMiningResult(BaseModel):
-    """Result of pattern mining operation"""
-
-    patterns: List[LogPattern]
-    anomalies: List[LogAnomaly]
-    trends: List[LogTrend]
-    summary: Dict[str, Any]
-    analysis_time_ms: float
-    logs_analyzed: int
 
 
 # ============================================================================

--- a/autobot-backend/api/analytics_maintenance.py
+++ b/autobot-backend/api/analytics_maintenance.py
@@ -19,9 +19,14 @@ from datetime import timedelta
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
+from api.schemas_analytics import (
+    CustomReportRequest,
+    DashboardResponse,
+    MaintenanceRecommendationResponse,
+    ResourceOptimizationResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from services.analytics_service import (
@@ -51,64 +56,6 @@ router = APIRouter(tags=["analytics", "advanced"])
 # ============================================================================
 # PYDANTIC MODELS
 # ============================================================================
-
-
-class MaintenanceRecommendationResponse(BaseModel):
-    """Maintenance recommendation response model."""
-
-    id: str
-    title: str
-    description: str
-    priority: str
-    category: str
-    affected_component: str
-    predicted_issue: str
-    confidence: float
-    recommended_action: str
-    estimated_impact: str
-    detected_at: str
-    metadata: dict = Field(default_factory=dict)
-
-
-class ResourceOptimizationResponse(BaseModel):
-    """Resource optimization response model."""
-
-    id: str
-    resource_type: str
-    title: str
-    current_usage: dict
-    recommended_change: str
-    expected_savings: dict
-    implementation_effort: str
-    priority: str
-    details: str
-
-
-class DashboardResponse(BaseModel):
-    """Unified dashboard response model."""
-
-    generated_at: str
-    period_days: int
-    health: dict
-    cost: dict
-    agents: dict
-    engagement: dict
-    maintenance: dict
-    optimization: dict
-
-
-class CustomReportRequest(BaseModel):
-    """Custom report generation request."""
-
-    report_type: str = Field(
-        default="executive",
-        description="Report type: executive, technical, cost, performance",
-    )
-    days: int = Field(default=30, ge=1, le=365, description="Days to include")
-    include_sections: Optional[List[str]] = Field(
-        default=None,
-        description="Sections to include: cost, agents, behavior, maintenance, optimization",
-    )
 
 
 # ============================================================================

--- a/autobot-backend/api/anti_pattern.py
+++ b/autobot-backend/api/anti_pattern.py
@@ -16,9 +16,14 @@ from typing import List
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from api.schemas_code import (
+    AnalysisResponse,
+    AntiPatternAnalysisRequest,
+    AntiPatternSummary,
+    SeveritySummary,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -153,58 +158,6 @@ def _get_health_grade(score: float) -> tuple:
     return "F", "Critical"
 
 
-# ============ Request/Response Models ============
-
-
-class AnalysisRequest(BaseModel):
-    """Request model for anti-pattern analysis"""
-
-    root_path: str = Field(default=".", description="Root path to analyze")
-    patterns: List[str] = Field(
-        default=["**/*.py"], description="Glob patterns for files to include"
-    )
-    exclude_patterns: List[str] = Field(
-        default=[
-            "__pycache__",
-            ".git",
-            "node_modules",
-            ".venv",
-            "venv",
-            "test_",
-            "_test.py",
-        ],
-        description="Patterns to exclude from analysis",
-    )
-
-
-class SeveritySummary(BaseModel):
-    """Summary of issues by severity"""
-
-    critical: int = 0
-    high: int = 0
-    medium: int = 0
-    low: int = 0
-
-
-class AntiPatternSummary(BaseModel):
-    """Summary information about detected anti-patterns"""
-
-    total_issues: int
-    severity_counts: SeveritySummary
-    health_score: float
-    summary_by_type: dict
-    analysis_time_seconds: float
-
-
-class AnalysisResponse(BaseModel):
-    """Response model for anti-pattern analysis"""
-
-    success: bool
-    summary: AntiPatternSummary
-    anti_patterns: List[dict]
-    recommendations: List[str]
-
-
 # ============ API Endpoints ============
 
 
@@ -219,7 +172,7 @@ class AnalysisResponse(BaseModel):
     error_code_prefix="ANTI_PATTERN",
 )
 @router.post("/analyze", response_model=AnalysisResponse)
-async def analyze_anti_patterns(request: AnalysisRequest):
+async def analyze_anti_patterns(request: AntiPatternAnalysisRequest):
     """
     Analyze codebase for anti-patterns.
 
@@ -320,7 +273,7 @@ async def get_cached_analysis():
     error_code_prefix="ANTI_PATTERN",
 )
 @router.post("/god-classes", response_model=DataResponse)
-async def detect_god_classes(request: AnalysisRequest):
+async def detect_god_classes(request: AntiPatternAnalysisRequest):
     """
     Detect only God Class anti-patterns.
 
@@ -375,7 +328,7 @@ async def detect_god_classes(request: AnalysisRequest):
     error_code_prefix="ANTI_PATTERN",
 )
 @router.post("/circular-dependencies", response_model=DataResponse)
-async def detect_circular_dependencies(request: AnalysisRequest):
+async def detect_circular_dependencies(request: AntiPatternAnalysisRequest):
     """
     Detect circular dependencies in the codebase.
 
@@ -425,7 +378,7 @@ async def detect_circular_dependencies(request: AnalysisRequest):
     error_code_prefix="ANTI_PATTERN",
 )
 @router.post("/feature-envy", response_model=DataResponse)
-async def detect_feature_envy(request: AnalysisRequest):
+async def detect_feature_envy(request: AntiPatternAnalysisRequest):
     """
     Detect Feature Envy anti-pattern.
 
@@ -476,7 +429,7 @@ async def detect_feature_envy(request: AnalysisRequest):
     error_code_prefix="ANTI_PATTERN",
 )
 @router.post("/code-smells", response_model=DataResponse)
-async def detect_code_smells(request: AnalysisRequest):
+async def detect_code_smells(request: AntiPatternAnalysisRequest):
     """
     Detect general code smells.
 
@@ -538,7 +491,7 @@ async def detect_code_smells(request: AnalysisRequest):
     error_code_prefix="ANTI_PATTERN",
 )
 @router.post("/dead-code", response_model=DataResponse)
-async def detect_dead_code(request: AnalysisRequest):
+async def detect_dead_code(request: AntiPatternAnalysisRequest):
     """
     Detect potentially dead (unreferenced) code.
 
@@ -588,7 +541,7 @@ async def detect_dead_code(request: AnalysisRequest):
     error_code_prefix="ANTI_PATTERN",
 )
 @router.post("/health-score", response_model=DataResponse)
-async def get_health_score(request: AnalysisRequest):
+async def get_health_score(request: AntiPatternAnalysisRequest):
     """
     Get codebase health score based on anti-pattern analysis.
 

--- a/autobot-backend/api/audit.py
+++ b/autobot-backend/api/audit.py
@@ -22,7 +22,6 @@ from autobot_shared.time_utils import parse_utc_iso
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel, Field
 
 from auth_middleware import get_auth_middleware
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -34,48 +33,15 @@ from utils.catalog_http_exceptions import (
     raise_validation_error,
 )
 from api.schemas_common import DataResponse
+from api.schemas_system import (
+    AuditCleanupRequest,
+    AuditQueryRequest,
+    AuditQueryResponse,
+    AuditStatisticsResponse,
+)
 
 router = APIRouter(prefix="/audit", tags=["audit"])
 logger = logging.getLogger(__name__)
-
-
-class AuditQueryRequest(BaseModel):
-    """Audit log query parameters"""
-
-    start_time: Optional[datetime] = Field(None, description="Start of time range")
-    end_time: Optional[datetime] = Field(None, description="End of time range")
-    operation: Optional[str] = Field(None, description="Filter by operation type")
-    user_id: Optional[str] = Field(None, description="Filter by user")
-    session_id: Optional[str] = Field(None, description="Filter by session")
-    vm_name: Optional[str] = Field(None, description="Filter by VM source")
-    result: Optional[AuditResult] = Field(None, description="Filter by result")
-    limit: int = Field(100, ge=1, le=1000, description="Maximum entries to return")
-    offset: int = Field(0, ge=0, description="Pagination offset")
-
-
-class AuditQueryResponse(BaseModel):
-    """Audit log query response"""
-
-    success: bool
-    total_returned: int
-    has_more: bool
-    entries: List[dict]
-    query: dict
-
-
-class AuditStatisticsResponse(BaseModel):
-    """Audit statistics response"""
-
-    success: bool
-    statistics: dict
-    vm_info: dict
-
-
-class CleanupRequest(BaseModel):
-    """Audit log cleanup request"""
-
-    days_to_keep: int = Field(90, ge=7, le=365, description="Days of logs to retain")
-    confirm: bool = Field(False, description="Confirm cleanup operation")
 
 
 def check_admin_permission(request: Request) -> bool:
@@ -411,7 +377,7 @@ async def get_failed_operations(
 @router.post("/cleanup", response_model=DataResponse)
 async def cleanup_old_logs(
     request: Request,
-    cleanup_request: CleanupRequest,
+    cleanup_request: AuditCleanupRequest,
     admin_check: bool = Depends(check_admin_permission),
 ):
     """

--- a/autobot-backend/api/long_running_operations.py
+++ b/autobot-backend/api/long_running_operations.py
@@ -32,19 +32,21 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
-
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_path
 from constants.path_constants import PATH
 from constants.threshold_constants import TimingConstants
 from api.schemas_workflows import (
+    CodebaseIndexingRequest,
+    KnowledgeBaseRequest,
     LongRunningOperationCancelResponse,
     LongRunningOperationHealthResponse,
     LongRunningOperationListResponse,
     LongRunningOperationMigrateResponse,
     LongRunningOperationResumeResponse,
     LongRunningOperationStatusResponse,
+    SecurityScanRequest,
+    TestSuiteRequest,
 )
 
 # Add AutoBot paths
@@ -78,79 +80,6 @@ try:
     FAILED_OPERATION_STATUSES = {OperationStatus.FAILED, OperationStatus.TIMEOUT}
 except ImportError:
     FAILED_OPERATION_STATUSES = set()
-
-
-# Additional models specific to AutoBot integration
-class CodebaseIndexingRequest(BaseModel):
-    """Request model for codebase indexing operations"""
-
-    codebase_path: str = Field(
-        default=str(PATH.PROJECT_ROOT), description="Path to codebase to index"
-    )
-    file_patterns: List[str] = Field(
-        default=["*.py", "*.js", "*.vue", "*.ts", "*.jsx", "*.tsx"],
-        description="File patterns to include",
-    )
-    include_tests: bool = Field(default=True, description="Include test files")
-    include_docs: bool = Field(default=True, description="Include documentation files")
-    max_file_size: int = Field(
-        default=1024 * 1024, description="Maximum file size in bytes"
-    )
-    priority: str = Field(default="normal", description="Operation priority")
-
-
-class TestSuiteRequest(BaseModel):
-    """Request model for comprehensive test suite operations"""
-
-    test_path: str = Field(
-        default=str(PATH.TESTS_DIR), description="Path to test directory"
-    )
-    test_patterns: List[str] = Field(
-        default=["test_*.py", "*_test.py"], description="Test file patterns"
-    )
-    test_types: List[str] = Field(
-        default=["unit", "integration", "performance"],
-        description="Types of tests to run",
-    )
-    parallel_execution: bool = Field(default=True, description="Run tests in parallel")
-    timeout_per_test: int = Field(
-        default=300, description="Timeout per individual test in seconds"
-    )
-    priority: str = Field(default="high", description="Operation priority")
-
-
-class KnowledgeBaseRequest(BaseModel):
-    """Request model for knowledge base operations"""
-
-    source_paths: List[str] = Field(
-        default=[str(PATH.PROJECT_ROOT)], description="Paths to populate from"
-    )
-    document_types: List[str] = Field(
-        default=["code", "docs", "config"], description="Document types to include"
-    )
-    chunk_size: int = Field(default=1000, description="Chunk size for text processing")
-    overlap: int = Field(default=200, description="Overlap between chunks")
-    force_reindex: bool = Field(
-        default=False, description="Force reindexing of existing documents"
-    )
-    priority: str = Field(default="normal", description="Operation priority")
-
-
-class SecurityScanRequest(BaseModel):
-    """Request model for security scan operations"""
-
-    scan_paths: List[str] = Field(
-        default=[str(PATH.PROJECT_ROOT)], description="Paths to scan"
-    )
-    scan_types: List[str] = Field(
-        default=["vulnerability", "dependency", "secrets"],
-        description="Types of security scans",
-    )
-    severity_threshold: str = Field(
-        default="medium", description="Minimum severity to report"
-    )
-    include_dependencies: bool = Field(default=True, description="Scan dependencies")
-    priority: str = Field(default="high", description="Operation priority")
 
 
 async def get_operation_manager():

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -2319,3 +2319,120 @@ class ConversationAnalysisResult(BaseModel):
     hourly_distribution: Dict[str, int]
     analysis_period: str
     conversations_analyzed: int
+
+
+# ---------------------------------------------------------------------------
+# analytics_maintenance.py schemas
+# ---------------------------------------------------------------------------
+
+
+class MaintenanceRecommendationResponse(BaseModel):
+    """Maintenance recommendation response model."""
+
+    id: str
+    title: str
+    description: str
+    priority: str
+    category: str
+    affected_component: str
+    predicted_issue: str
+    confidence: float
+    recommended_action: str
+    estimated_impact: str
+    detected_at: str
+    metadata: dict = Field(default_factory=dict)
+
+
+class ResourceOptimizationResponse(BaseModel):
+    """Resource optimization response model."""
+
+    id: str
+    resource_type: str
+    title: str
+    current_usage: dict
+    recommended_change: str
+    expected_savings: dict
+    implementation_effort: str
+    priority: str
+    details: str
+
+
+class DashboardResponse(BaseModel):
+    """Unified dashboard response model."""
+
+    generated_at: str
+    period_days: int
+    health: dict
+    cost: dict
+    agents: dict
+    engagement: dict
+    maintenance: dict
+    optimization: dict
+
+
+class CustomReportRequest(BaseModel):
+    """Custom report generation request."""
+
+    report_type: str = Field(default="executive", description="Report type: executive, technical, cost, performance")
+    days: int = Field(default=30, ge=1, le=365, description="Days to include")
+    include_sections: Optional[List[str]] = Field(
+        default=None,
+        description="Sections to include: cost, agents, behavior, maintenance, optimization",
+    )
+
+
+# ---------------------------------------------------------------------------
+# analytics_log_patterns.py schemas
+# ---------------------------------------------------------------------------
+
+
+class LogPattern(BaseModel):
+    """Represents a discovered log pattern."""
+
+    pattern_id: str
+    pattern_template: str
+    occurrences: int
+    first_seen: str
+    last_seen: str
+    log_levels: List[str]
+    sources: List[str]
+    sample_messages: List[str] = Field(default_factory=list, max_length=5)
+    frequency_per_hour: float = 0.0
+    is_error_pattern: bool = False
+    is_anomaly: bool = False
+
+
+class LogAnomaly(BaseModel):
+    """Represents a detected anomaly in logs."""
+
+    anomaly_id: str
+    anomaly_type: str
+    severity: str
+    description: str
+    timestamp: str
+    affected_sources: List[str]
+    metric_before: float
+    metric_after: float
+    confidence: float
+
+
+class LogTrend(BaseModel):
+    """Represents a trend in log data."""
+
+    trend_id: str
+    metric_name: str
+    direction: str
+    change_percent: float
+    time_period: str
+    data_points: List[Dict[str, Any]]
+
+
+class PatternMiningResult(BaseModel):
+    """Result of pattern mining operation."""
+
+    patterns: List[LogPattern]
+    anomalies: List[LogAnomaly]
+    trends: List[LogTrend]
+    summary: Dict[str, Any]
+    analysis_time_ms: float
+    logs_analyzed: int

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -2186,3 +2186,55 @@ class ApplyResolutionRequest(BaseModel):
     file_path: str = Field(..., description="Path to file")
     resolved_content: str = Field(..., description="Resolved file content")
     create_backup: bool = Field(default=True, description="Create backup before applying")
+
+
+# ---------------------------------------------------------------------------
+# anti_pattern.py schemas
+# ---------------------------------------------------------------------------
+
+
+class AntiPatternAnalysisRequest(BaseModel):
+    """Request model for anti-pattern analysis."""
+
+    root_path: str = Field(default=".", description="Root path to analyze")
+    patterns: List[str] = Field(default=["**/*.py"], description="Glob patterns for files to include")
+    exclude_patterns: List[str] = Field(
+        default=[
+            "__pycache__",
+            ".git",
+            "node_modules",
+            ".venv",
+            "venv",
+            "test_",
+            "_test.py",
+        ],
+        description="Patterns to exclude from analysis",
+    )
+
+
+class SeveritySummary(BaseModel):
+    """Summary of issues by severity."""
+
+    critical: int = 0
+    high: int = 0
+    medium: int = 0
+    low: int = 0
+
+
+class AntiPatternSummary(BaseModel):
+    """Summary information about detected anti-patterns."""
+
+    total_issues: int
+    severity_counts: SeveritySummary
+    health_score: float
+    summary_by_type: dict
+    analysis_time_seconds: float
+
+
+class AnalysisResponse(BaseModel):
+    """Response model for anti-pattern analysis."""
+
+    success: bool
+    summary: AntiPatternSummary
+    anti_patterns: List[dict]
+    recommendations: List[str]

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field
 
 from api.schemas_common import SuccessDataResponse, SuccessMessageResponse
 from constants.threshold_constants import RetryConfig
+from services.audit_logger import AuditResult
 from type_defs.common import Metadata
 
 
@@ -2902,3 +2903,47 @@ class ClearHistoryRequest(BaseModel):
     """Request model for clearing thinking history."""
 
     session_id: Optional[str] = Field("default", description="Session to clear")
+
+
+# ---------------------------------------------------------------------------
+# audit.py schemas
+# ---------------------------------------------------------------------------
+
+
+class AuditQueryRequest(BaseModel):
+    """Audit log query parameters."""
+
+    start_time: Optional[datetime] = Field(None, description="Start of time range")
+    end_time: Optional[datetime] = Field(None, description="End of time range")
+    operation: Optional[str] = Field(None, description="Filter by operation type")
+    user_id: Optional[str] = Field(None, description="Filter by user")
+    session_id: Optional[str] = Field(None, description="Filter by session")
+    vm_name: Optional[str] = Field(None, description="Filter by VM source")
+    result: Optional[AuditResult] = Field(None, description="Filter by result")
+    limit: int = Field(100, ge=1, le=1000, description="Maximum entries to return")
+    offset: int = Field(0, ge=0, description="Pagination offset")
+
+
+class AuditQueryResponse(BaseModel):
+    """Audit log query response."""
+
+    success: bool
+    total_returned: int
+    has_more: bool
+    entries: List[dict]
+    query: dict
+
+
+class AuditStatisticsResponse(BaseModel):
+    """Audit statistics response."""
+
+    success: bool
+    statistics: dict
+    vm_info: dict
+
+
+class AuditCleanupRequest(BaseModel):
+    """Audit log cleanup request."""
+
+    days_to_keep: int = Field(90, ge=7, le=365, description="Days of logs to retain")
+    confirm: bool = Field(False, description="Confirm cleanup operation")

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from api.schemas_common import SuccessMessageResponse
 from autobot_shared.models.service_message import ServiceMessage
+from constants.path_constants import PATH
 from services.trigger_service import TriggerType
 from autobot_shared.time_utils import now_utc
 from models.approval import ApprovalType
@@ -1730,3 +1731,60 @@ class CreateChatBrowserRequest(BaseModel):
     conversation_id: str
     headless: bool = False
     initial_url: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# long_running_operations.py schemas
+# ---------------------------------------------------------------------------
+
+
+class CodebaseIndexingRequest(BaseModel):
+    """Request model for codebase indexing operations."""
+
+    codebase_path: str = Field(default=str(PATH.PROJECT_ROOT), description="Path to codebase to index")
+    file_patterns: List[str] = Field(
+        default=["*.py", "*.js", "*.vue", "*.ts", "*.jsx", "*.tsx"],
+        description="File patterns to include",
+    )
+    include_tests: bool = Field(default=True, description="Include test files")
+    include_docs: bool = Field(default=True, description="Include documentation files")
+    max_file_size: int = Field(default=1024 * 1024, description="Maximum file size in bytes")
+    priority: str = Field(default="normal", description="Operation priority")
+
+
+class TestSuiteRequest(BaseModel):
+    """Request model for comprehensive test suite operations."""
+
+    test_path: str = Field(default=str(PATH.TESTS_DIR), description="Path to test directory")
+    test_patterns: List[str] = Field(default=["test_*.py", "*_test.py"], description="Test file patterns")
+    test_types: List[str] = Field(
+        default=["unit", "integration", "performance"],
+        description="Types of tests to run",
+    )
+    parallel_execution: bool = Field(default=True, description="Run tests in parallel")
+    timeout_per_test: int = Field(default=300, description="Timeout per individual test in seconds")
+    priority: str = Field(default="high", description="Operation priority")
+
+
+class KnowledgeBaseRequest(BaseModel):
+    """Request model for knowledge base operations."""
+
+    source_paths: List[str] = Field(default=[str(PATH.PROJECT_ROOT)], description="Paths to populate from")
+    document_types: List[str] = Field(default=["code", "docs", "config"], description="Document types to include")
+    chunk_size: int = Field(default=1000, description="Chunk size for text processing")
+    overlap: int = Field(default=200, description="Overlap between chunks")
+    force_reindex: bool = Field(default=False, description="Force reindexing of existing documents")
+    priority: str = Field(default="normal", description="Operation priority")
+
+
+class SecurityScanRequest(BaseModel):
+    """Request model for security scan operations."""
+
+    scan_paths: List[str] = Field(default=[str(PATH.PROJECT_ROOT)], description="Paths to scan")
+    scan_types: List[str] = Field(
+        default=["vulnerability", "dependency", "secrets"],
+        description="Types of security scans",
+    )
+    severity_threshold: str = Field(default="medium", description="Minimum severity to report")
+    include_dependencies: bool = Field(default=True, description="Scan dependencies")
+    priority: str = Field(default="high", description="Operation priority")


### PR DESCRIPTION
## Summary

Phase 17 of issue #6042. Migrates 20 \`BaseModel\` subclasses from 5 endpoint files into centralized domain schema files.

### Files migrated

| Endpoint file | Classes | Target |
|---|---|---|
| \`audit.py\` | 4 (AuditQueryRequest, AuditQueryResponse, AuditStatisticsResponse, CleanupRequest→AuditCleanupRequest) | \`schemas_system.py\` |
| \`anti_pattern.py\` | 4 (AnalysisRequest→AntiPatternAnalysisRequest, SeveritySummary, AntiPatternSummary, AnalysisResponse) | \`schemas_code.py\` |
| \`analytics_maintenance.py\` | 4 (MaintenanceRecommendationResponse, ResourceOptimizationResponse, DashboardResponse, CustomReportRequest) | \`schemas_analytics.py\` |
| \`analytics_log_patterns.py\` | 4 (LogPattern, LogAnomaly, LogTrend, PatternMiningResult) | \`schemas_analytics.py\` |
| \`long_running_operations.py\` | 4 (CodebaseIndexingRequest, TestSuiteRequest, KnowledgeBaseRequest, SecurityScanRequest) | \`schemas_workflows.py\` |

### Renames
- \`CleanupRequest\` → \`AuditCleanupRequest\` (knowledge has its own CleanupRequest)
- \`AnalysisRequest\` → \`AntiPatternAnalysisRequest\` (code_intelligence has CodeIntelAnalysisRequest)

### Notable
- \`schemas_system.py\` adds \`from services.audit_logger import AuditResult\` for AuditQueryRequest field type
- \`schemas_workflows.py\` adds \`from constants.path_constants import PATH\` for default path values

## Test Plan
- [x] \`py_compile\` clean on all 9 modified files
- [x] \`flake8 --select=F401,F811,F821\` — 0 errors

Continues #6042

🤖 Generated with Claude Code