### PR TITLE
refactor(schemas): Phase 18 — migrate 16 classes (alertmanager, analytics_agents/behavior, integration_database) (#6042)

### DIFF
--- a/autobot-backend/api/alertmanager_webhook.py
+++ b/autobot-backend/api/alertmanager_webhook.py
@@ -9,13 +9,13 @@ Phase 3: Alert Migration (Issue #346)
 
 import logging
 from datetime import datetime, timezone
-from typing import Dict, List
 
 from fastapi import APIRouter, HTTPException, Request, status
-from pydantic import BaseModel
 
 from api.monitoring import ws_manager
 from api.schemas_system import (
+    AlertInstance,
+    AlertManagerWebhook,
     AlertManagerWebhookHealthResponse,
     AlertManagerWebhookReceiveResponse,
 )
@@ -24,51 +24,6 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/webhook", tags=["webhooks"])
-
-
-class AlertAnnotations(BaseModel):
-    """Alert annotations from AlertManager"""
-
-    summary: str
-    description: str
-    recommendation: str | None = None
-
-
-class AlertLabels(BaseModel):
-    """Alert labels from AlertManager"""
-
-    alertname: str
-    severity: str
-    component: str
-    resource: str | None = None
-    service: str | None = None
-
-
-class AlertInstance(BaseModel):
-    """Single alert instance from AlertManager"""
-
-    status: str  # "firing" or "resolved"
-    labels: Dict[str, str]
-    annotations: Dict[str, str]
-    startsAt: str
-    endsAt: str | None = None
-    generatorURL: str
-    fingerprint: str
-
-
-class AlertManagerWebhook(BaseModel):
-    """AlertManager webhook payload structure"""
-
-    version: str
-    groupKey: str
-    truncatedAlerts: int = 0
-    status: str  # "firing" or "resolved"
-    receiver: str
-    groupLabels: Dict[str, str]
-    commonLabels: Dict[str, str]
-    commonAnnotations: Dict[str, str]
-    externalURL: str
-    alerts: List[AlertInstance]
 
 
 @with_error_handling(

--- a/autobot-backend/api/analytics_agents.py
+++ b/autobot-backend/api/analytics_agents.py
@@ -17,20 +17,21 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.agent_analytics import AgentType, TaskStatus, get_agent_analytics
-from api.schemas_common import DataResponse
 from api.schemas_analytics import (
     AgentAllPerformanceResponse,
     AgentComparisonResponse,
     AgentHistoryResponse,
+    AgentMetricsResponse,
     AgentPerformanceTrendsResponse,
     AgentRecentTasksResponse,
     AgentRecommendationsResponse,
     AgentTaskCompleteResponse,
+    CompleteTaskRequest,
+    TrackTaskRequest,
     AgentTaskStartResponse,
     AgentTypesResponse,
 )
@@ -42,61 +43,6 @@ router = APIRouter(prefix="/agents", tags=["analytics", "agents"])
 # ============================================================================
 # PYDANTIC MODELS
 # ============================================================================
-
-
-class AgentMetricsResponse(BaseModel):
-    """Agent metrics response model"""
-
-    agent_id: str
-    agent_type: str
-    total_tasks: int
-    completed_tasks: int
-    failed_tasks: int
-    cancelled_tasks: int
-    timeout_tasks: int
-    avg_duration_ms: float
-    total_tokens_used: int
-    error_rate: float
-    success_rate: float
-    last_activity: Optional[str]
-
-
-class TaskRecordResponse(BaseModel):
-    """Task record response model"""
-
-    agent_id: str
-    agent_type: str
-    task_id: str
-    task_name: str
-    status: str
-    started_at: str
-    completed_at: Optional[str]
-    duration_ms: Optional[float]
-    tokens_used: Optional[int]
-    error_message: Optional[str]
-
-
-class TrackTaskRequest(BaseModel):
-    """Request to track a task start"""
-
-    agent_id: str = Field(..., description="Unique agent identifier")
-    agent_type: str = Field(..., description="Type of agent")
-    task_id: str = Field(..., description="Unique task identifier")
-    task_name: str = Field(..., description="Human-readable task name")
-    input_size: Optional[int] = Field(None, description="Size of input data")
-    metadata: Optional[dict] = Field(None, description="Additional metadata")
-
-
-class CompleteTaskRequest(BaseModel):
-    """Request to complete a task"""
-
-    task_id: str = Field(..., description="Task identifier")
-    status: str = Field(
-        ..., description="Final status (completed, failed, cancelled, timeout)"
-    )
-    output_size: Optional[int] = Field(None, description="Size of output data")
-    tokens_used: Optional[int] = Field(None, description="Tokens consumed")
-    error_message: Optional[str] = Field(None, description="Error message if failed")
 
 
 # ============================================================================

--- a/autobot-backend/api/analytics_behavior.py
+++ b/autobot-backend/api/analytics_behavior.py
@@ -17,17 +17,14 @@ Related Issues: #59 (Advanced Analytics & Business Intelligence)
 
 import asyncio
 import logging
-from datetime import datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from services.user_behavior_analytics import UserEvent, get_behavior_analytics
-from api.schemas_common import DataResponse
 from api.schemas_analytics import (
     BehaviorDailyStatsResponse,
     BehaviorEngagementResponse,
@@ -38,6 +35,8 @@ from api.schemas_analytics import (
     BehaviorRecentEventsResponse,
     BehaviorSummaryResponse,
     BehaviorTrackEventResponse,
+    TrackEventRequest,
+    UserJourneyResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -47,49 +46,6 @@ router = APIRouter(prefix="/behavior", tags=["analytics", "behavior"])
 # ============================================================================
 # PYDANTIC MODELS
 # ============================================================================
-
-
-class TrackEventRequest(BaseModel):
-    """Request model for tracking user events"""
-
-    event_type: str = Field(
-        ..., description="Type of event (page_view, click, search, etc.)"
-    )
-    feature: str = Field(..., description="Feature area (chat, knowledge, tools, etc.)")
-    user_id: Optional[str] = Field(None, description="User ID if authenticated")
-    session_id: Optional[str] = Field(None, description="Session ID")
-    duration_ms: Optional[int] = Field(
-        None, ge=0, description="Duration in milliseconds"
-    )
-    metadata: Optional[dict] = Field(
-        default_factory=dict, description="Additional metadata"
-    )
-
-
-class FeatureMetricsResponse(BaseModel):
-    """Response model for feature metrics"""
-
-    timestamp: str
-    features: dict
-    total_features: int
-
-
-class UserJourneyResponse(BaseModel):
-    """Response model for user journey"""
-
-    session_id: str
-    steps: list
-    total_steps: int
-    features_visited: list
-
-
-class EngagementMetricsResponse(BaseModel):
-    """Response model for engagement metrics"""
-
-    timestamp: str
-    metrics: dict
-    feature_popularity: list
-    most_popular_feature: Optional[str]
 
 
 # ============================================================================

--- a/autobot-backend/api/integration_database.py
+++ b/autobot-backend/api/integration_database.py
@@ -13,7 +13,6 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -31,6 +30,12 @@ from api.schemas_code import (
     IntegrationDatabaseListResponse,
     IntegrationTablesListResponse,
 )
+from api.schemas_workflows import (
+    DBIntegrationQueryRequest,
+    DatabaseConnectionRequest,
+    DatabaseListRequest,
+    MongoQueryRequest,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,55 +45,6 @@ router = APIRouter(
 )
 
 
-class DatabaseConnectionRequest(BaseModel):
-    """Request model for testing database connections."""
-
-    provider: str = Field(
-        ..., description="Database provider (postgresql/mysql/mongodb)"
-    )
-    host: str = Field("localhost", description="Database host")
-    port: Optional[int] = Field(
-        None, description="Database port (default: provider-specific)"
-    )
-    username: Optional[str] = Field(None, description="Database username")
-    password: Optional[str] = Field(None, description="Database password")
-    database: str = Field("", description="Database name")
-
-
-class QueryRequest(BaseModel):
-    """Request model for executing database queries."""
-
-    query: str = Field(..., description="SQL query to execute (read-only)")
-    database: str = Field("", description="Target database name")
-    host: str = Field("localhost", description="Database host")
-    port: Optional[int] = Field(None, description="Database port")
-    username: Optional[str] = Field(None, description="Database username")
-    password: Optional[str] = Field(None, description="Database password")
-
-
-class MongoQueryRequest(BaseModel):
-    """Request model for MongoDB collection queries."""
-
-    database: str = Field(..., description="Database name")
-    collection: str = Field(..., description="Collection name")
-    filter: Dict[str, Any] = Field(default_factory=dict, description="Query filter")
-    limit: int = Field(100, description="Maximum results to return")
-    host: str = Field("localhost", description="MongoDB host")
-    port: int = Field(27017, description="MongoDB port")
-    username: Optional[str] = Field(None, description="MongoDB username")
-    password: Optional[str] = Field(None, description="MongoDB password")
-
-
-class DatabaseListRequest(BaseModel):
-    """Request model for listing databases/tables."""
-
-    host: str = Field("localhost", description="Database host")
-    port: Optional[int] = Field(None, description="Database port")
-    username: Optional[str] = Field(None, description="Database username")
-    password: Optional[str] = Field(None, description="Database password")
-    database: Optional[str] = Field(
-        None, description="Database name (for table listing)"
-    )
 
 
 def _create_integration_config(
@@ -267,7 +223,7 @@ async def list_database_providers() -> Dict[str, List[Dict[str, Any]]]:
     error_code_prefix="INTEGRATION_DATABASE",
 )
 @router.post("/{provider}/query", response_model=IntegrationDatabaseQueryResponse)
-async def execute_database_query(provider: str, request: QueryRequest):
+async def execute_database_query(provider: str, request: DBIntegrationQueryRequest):
     """
     Execute a read-only query on a database.
 

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -2436,3 +2436,103 @@ class PatternMiningResult(BaseModel):
     summary: Dict[str, Any]
     analysis_time_ms: float
     logs_analyzed: int
+
+
+# ---------------------------------------------------------------------------
+# analytics_agents.py schemas
+# ---------------------------------------------------------------------------
+
+
+class AgentMetricsResponse(BaseModel):
+    """Agent metrics response model."""
+
+    agent_id: str
+    agent_type: str
+    total_tasks: int
+    completed_tasks: int
+    failed_tasks: int
+    cancelled_tasks: int
+    timeout_tasks: int
+    avg_duration_ms: float
+    total_tokens_used: int
+    error_rate: float
+    success_rate: float
+    last_activity: Optional[str]
+
+
+class TaskRecordResponse(BaseModel):
+    """Task record response model."""
+
+    agent_id: str
+    agent_type: str
+    task_id: str
+    task_name: str
+    status: str
+    started_at: str
+    completed_at: Optional[str]
+    duration_ms: Optional[float]
+    tokens_used: Optional[int]
+    error_message: Optional[str]
+
+
+class TrackTaskRequest(BaseModel):
+    """Request to track a task start."""
+
+    agent_id: str = Field(..., description="Unique agent identifier")
+    agent_type: str = Field(..., description="Type of agent")
+    task_id: str = Field(..., description="Unique task identifier")
+    task_name: str = Field(..., description="Human-readable task name")
+    input_size: Optional[int] = Field(None, description="Size of input data")
+    metadata: Optional[dict] = Field(None, description="Additional metadata")
+
+
+class CompleteTaskRequest(BaseModel):
+    """Request to complete a task."""
+
+    task_id: str = Field(..., description="Task identifier")
+    status: str = Field(..., description="Final status (completed, failed, cancelled, timeout)")
+    output_size: Optional[int] = Field(None, description="Size of output data")
+    tokens_used: Optional[int] = Field(None, description="Tokens consumed")
+    error_message: Optional[str] = Field(None, description="Error message if failed")
+
+
+# ---------------------------------------------------------------------------
+# analytics_behavior.py schemas
+# ---------------------------------------------------------------------------
+
+
+class TrackEventRequest(BaseModel):
+    """Request model for tracking user events."""
+
+    event_type: str = Field(..., description="Type of event (page_view, click, search, etc.)")
+    feature: str = Field(..., description="Feature area (chat, knowledge, tools, etc.)")
+    user_id: Optional[str] = Field(None, description="User ID if authenticated")
+    session_id: Optional[str] = Field(None, description="Session ID")
+    duration_ms: Optional[int] = Field(None, ge=0, description="Duration in milliseconds")
+    metadata: Optional[dict] = Field(default_factory=dict, description="Additional metadata")
+
+
+class FeatureMetricsResponse(BaseModel):
+    """Response model for feature metrics."""
+
+    timestamp: str
+    features: dict
+    total_features: int
+
+
+class UserJourneyResponse(BaseModel):
+    """Response model for user journey."""
+
+    session_id: str
+    steps: list
+    total_steps: int
+    features_visited: list
+
+
+class EngagementMetricsResponse(BaseModel):
+    """Response model for engagement metrics."""
+
+    timestamp: str
+    metrics: dict
+    feature_popularity: list
+    most_popular_feature: Optional[str]

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -2947,3 +2947,53 @@ class AuditCleanupRequest(BaseModel):
 
     days_to_keep: int = Field(90, ge=7, le=365, description="Days of logs to retain")
     confirm: bool = Field(False, description="Confirm cleanup operation")
+
+
+# ---------------------------------------------------------------------------
+# alertmanager_webhook.py schemas
+# ---------------------------------------------------------------------------
+
+
+class AlertAnnotations(BaseModel):
+    """Alert annotations from AlertManager."""
+
+    summary: str
+    description: str
+    recommendation: Optional[str] = None
+
+
+class AlertLabels(BaseModel):
+    """Alert labels from AlertManager."""
+
+    alertname: str
+    severity: str
+    component: str
+    resource: Optional[str] = None
+    service: Optional[str] = None
+
+
+class AlertInstance(BaseModel):
+    """Single alert instance from AlertManager."""
+
+    status: str
+    labels: Dict[str, str]
+    annotations: Dict[str, str]
+    startsAt: str
+    endsAt: Optional[str] = None
+    generatorURL: str
+    fingerprint: str
+
+
+class AlertManagerWebhook(BaseModel):
+    """AlertManager webhook payload structure."""
+
+    version: str
+    groupKey: str
+    truncatedAlerts: int = 0
+    status: str
+    receiver: str
+    groupLabels: Dict[str, str]
+    commonLabels: Dict[str, str]
+    commonAnnotations: Dict[str, str]
+    externalURL: str
+    alerts: List[AlertInstance]

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -1788,3 +1788,53 @@ class SecurityScanRequest(BaseModel):
     severity_threshold: str = Field(default="medium", description="Minimum severity to report")
     include_dependencies: bool = Field(default=True, description="Scan dependencies")
     priority: str = Field(default="high", description="Operation priority")
+
+
+# ---------------------------------------------------------------------------
+# integration_database.py schemas
+# ---------------------------------------------------------------------------
+
+
+class DatabaseConnectionRequest(BaseModel):
+    """Request model for testing database connections."""
+
+    provider: str = Field(..., description="Database provider (postgresql/mysql/mongodb)")
+    host: str = Field("localhost", description="Database host")
+    port: Optional[int] = Field(None, description="Database port (default: provider-specific)")
+    username: Optional[str] = Field(None, description="Database username")
+    password: Optional[str] = Field(None, description="Database password")
+    database: str = Field("", description="Database name")
+
+
+class DBIntegrationQueryRequest(BaseModel):
+    """Request model for executing database queries."""
+
+    query: str = Field(..., description="SQL query to execute (read-only)")
+    database: str = Field("", description="Target database name")
+    host: str = Field("localhost", description="Database host")
+    port: Optional[int] = Field(None, description="Database port")
+    username: Optional[str] = Field(None, description="Database username")
+    password: Optional[str] = Field(None, description="Database password")
+
+
+class MongoQueryRequest(BaseModel):
+    """Request model for MongoDB collection queries."""
+
+    database: str = Field(..., description="Database name")
+    collection: str = Field(..., description="Collection name")
+    filter: Dict[str, Any] = Field(default_factory=dict, description="Query filter")
+    limit: int = Field(100, description="Maximum results to return")
+    host: str = Field("localhost", description="MongoDB host")
+    port: int = Field(27017, description="MongoDB port")
+    username: Optional[str] = Field(None, description="MongoDB username")
+    password: Optional[str] = Field(None, description="MongoDB password")
+
+
+class DatabaseListRequest(BaseModel):
+    """Request model for listing databases/tables."""
+
+    host: str = Field("localhost", description="Database host")
+    port: Optional[int] = Field(None, description="Database port")
+    username: Optional[str] = Field(None, description="Database username")
+    password: Optional[str] = Field(None, description="Database password")
+    database: Optional[str] = Field(None, description="Database name (for table listing)")


### PR DESCRIPTION
## Summary

Phase 18 of issue #6042. Migrates 16 \`BaseModel\` subclasses from 4 endpoint files into centralized domain schema files.

### Files migrated

| Endpoint file | Classes | Target |
|---|---|---|
| \`alertmanager_webhook.py\` | 4 (AlertAnnotations, AlertLabels, AlertInstance, AlertManagerWebhook) | \`schemas_system.py\` |
| \`analytics_agents.py\` | 4 (AgentMetricsResponse, TaskRecordResponse, TrackTaskRequest, CompleteTaskRequest) | \`schemas_analytics.py\` |
| \`analytics_behavior.py\` | 4 (TrackEventRequest, FeatureMetricsResponse, UserJourneyResponse, EngagementMetricsResponse) | \`schemas_analytics.py\` |
| \`integration_database.py\` | 4 (DatabaseConnectionRequest, QueryRequest→DBIntegrationQueryRequest, MongoQueryRequest, DatabaseListRequest) | \`schemas_workflows.py\` |

### Renames
- \`QueryRequest\` → \`DBIntegrationQueryRequest\` (avoids generic name; schemas_code.py has DatabaseQuery* response types)

### Notable
- alertmanager_webhook classes used Python 3.10+ union syntax (\`str | None\`); converted to \`Optional[str]\` for Pydantic v2 compatibility
- Removed unused \`DataResponse\`, \`datetime\`, and unused alert imports at endpoints

## Test Plan
- [x] \`py_compile\` clean on all 7 modified files
- [x] \`flake8 --select=F401,F811,F821\` — 0 errors

Continues #6042

🤖 Generated with Claude Code