### PR TITLE
refactor(app): replace isLoginPage path-check with route meta.isPublic (#6508)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -1,14 +1,14 @@
 <template>
   <div id="app" class="h-screen bg-autobot-bg-primary flex flex-col overflow-hidden">
     <!-- Skip Navigation Links -->
-    <div v-if="!isLoginPage" class="skip-links">
+    <div v-if="showAuthChrome" class="skip-links">
       <a href="#main-content" class="skip-link sr-only-focusable">{{ $t('nav.skipToContent') }}</a>
       <a href="#navigation" class="skip-link sr-only-focusable">{{ $t('nav.skipToNavigation') }}</a>
     </div>
 
     <!-- Header - Issue #901: Professional solid color (no gradients) -->
     <!-- Hide navigation bar on login page -->
-    <header v-if="!isLoginPage" class="bg-autobot-bg-secondary border-b border-autobot-border relative z-30" style="min-height: 56px; height: auto;">
+    <header v-if="showAuthChrome" class="bg-autobot-bg-secondary border-b border-autobot-border relative z-30" style="min-height: 56px; height: auto;">
       <div class="max-w-full mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex items-center justify-between" style="min-height: 56px; height: auto;">
           <!-- Logo/Brand with System Status -->
@@ -400,8 +400,8 @@
       </UnifiedLoadingView>
     </main>
 
-    <!-- Footer: About link (hidden on login page and routes with hideFooter meta) -->
-    <footer v-if="!isLoginPage && !hideFooter" class="flex-shrink-0 flex justify-center py-1 border-t border-autobot-border/30">
+    <!-- Footer: About link (hidden on public routes and routes with hideFooter meta) -->
+    <footer v-if="showAuthChrome && !hideFooter" class="flex-shrink-0 flex justify-center py-1 border-t border-autobot-border/30">
       <router-link to="/about" class="text-xs text-autobot-text-muted hover:text-autobot-text-secondary transition-colors">
         {{ $t('nav.about') }}
       </router-link>
@@ -542,9 +542,8 @@ export default {
     // Computed properties
     const isLoading = computed(() => appStore?.isLoading || false);
     const hasErrors = computed(() => false); // No errors property in store
-    const isLoginPage = computed(() =>
-      route.path === '/login' || !userStore.isAuthenticated
-    );
+    const isPublicRoute = computed(() => !!route.meta.isPublic);
+    const showAuthChrome = computed(() => userStore.isAuthenticated && !isPublicRoute.value);
     const hideFooter = computed(() => !!route.meta.hideFooter);
 
     // Methods
@@ -876,7 +875,8 @@ export default {
       // Computed
       isLoading,
       hasErrors,
-      isLoginPage,
+      isPublicRoute,
+      showAuthChrome,
       hideFooter,
       navItems,
       slmAdminUrl,

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -57,7 +57,8 @@ const routes: RouteRecordRaw[] = [
     meta: {
       title: 'Login',
       hideInNav: true,
-      requiresAuth: false
+      requiresAuth: false,
+      isPublic: true
     }
   },
   {
@@ -819,7 +820,8 @@ const routes: RouteRecordRaw[] = [
     meta: {
       title: 'Permission Denied',
       hideInNav: true,
-      requiresAuth: false
+      requiresAuth: false,
+      isPublic: true
     }
   },
   {


### PR DESCRIPTION
## Summary
- App.vue no longer hard-codes `/login` to bypass auth chrome — public routes opt in via `meta: { isPublic: true }`. Mirrors the #6417 `meta.hideFooter` pattern.
- Tagged `/login` and `/permission-denied` with `meta.isPublic: true`.
- New `showAuthChrome` computed: `userStore.isAuthenticated && !route.meta.isPublic`. Three template `v-if` sites (skip-links, header, footer) updated.

## Test plan
- [ ] `vue-tsc --noEmit -p tsconfig.app.json` passes
- [ ] Visit `/login` while logged out → no header/footer/skip-links (unchanged behavior)
- [ ] Visit `/permission-denied` → no header/footer (was previously visible — now correctly hidden)
- [ ] Login → header/footer visible on dashboard, knowledge, etc.

Closes #6508

🤖 Generated with [Claude Code](https://claude.com/claude-code)