### PR TITLE
refactor(schemas): Phase 19 — migrate 16 classes (integration_communication, knowledge_collaboration, files, data_storage) (#6042)

### DIFF
--- a/autobot-backend/api/data_storage.py
+++ b/autobot-backend/api/data_storage.py
@@ -18,12 +18,17 @@ from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_relative_path
 from utils.catalog_http_exceptions import raise_server_error
+from api.schemas_system import (
+    CleanupResult,
+    StorageCategory,
+    StorageCleanupRequest,
+    StorageStats,
+)
 from api.schemas_workflows import (
     DataStorageCategoryDetailResponse,
     DataStorageConversationsSummaryResponse,
@@ -50,47 +55,6 @@ def _safe_data_path(user_segment: str) -> Path:
         raise HTTPException(status_code=400, detail="Invalid path")
 
 
-class StorageCategory(BaseModel):
-    """Storage category with size info."""
-
-    name: str
-    path: str
-    size_bytes: int
-    size_human: str
-    file_count: int
-    description: str
-    can_cleanup: bool = True
-    cleanup_type: str = "manual"
-
-
-class StorageStats(BaseModel):
-    """Overall storage statistics."""
-
-    total_size_bytes: int
-    total_size_human: str
-    total_files: int
-    total_directories: int
-    categories: list[StorageCategory]
-    last_cleanup: Optional[str] = None
-
-
-class CleanupRequest(BaseModel):
-    """Cleanup request model."""
-
-    category: str
-    older_than_days: int = 0
-    dry_run: bool = True
-
-
-class CleanupResult(BaseModel):
-    """Cleanup operation result."""
-
-    category: str
-    files_removed: int
-    bytes_freed: int
-    bytes_freed_human: str
-    dry_run: bool
-    errors: list[str] = []
 
 
 def format_size(size_bytes: int) -> str:
@@ -464,7 +428,7 @@ def _scan_and_remove_files(
 )
 @router.post("/cleanup", response_model=CleanupResult)
 async def cleanup_category(
-    request: CleanupRequest,
+    request: StorageCleanupRequest,
     _: None = Depends(check_admin_permission),
 ):
     """Clean up files in a storage category. Requires admin permission."""

--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -16,13 +16,12 @@ import mimetypes
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import aiofiles
 from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse
 from fastapi.security import HTTPBearer
-from pydantic import BaseModel, field_validator
 
 from auth_middleware import get_auth_middleware
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -37,17 +36,19 @@ from security_layer import SecurityLayer
 from utils.io_executor import run_in_file_executor
 from utils.path_validation import is_invalid_name
 from utils.paths_manager import ensure_data_directory, get_data_path
-from api.schemas_common import DataResponse
 from api.schemas_system import (
     AdminFileListResponse,
     AdminFileReadResponse,
     DirectoryCreateResponse,
+    DirectoryListing,
     DirectoryTreeResponse,
     FileDeleteResponse,
+    FileInfo,
     FilePreviewResponse,
     FileRenameResponse,
     FileStatsResponse,
     FileViewResponse,
+    FilesAPIUploadResponse,
 )
 
 router = APIRouter()
@@ -176,53 +177,6 @@ _DANGEROUS_EXTENSIONS = frozenset(
         ".msi",
     }
 )
-
-
-class FileInfo(BaseModel):
-    """File information model"""
-
-    name: str
-    path: str
-    is_directory: bool
-    size: Optional[int] = None
-    mime_type: Optional[str] = None
-    last_modified: datetime
-    permissions: str
-    extension: Optional[str] = None
-
-
-class DirectoryListing(BaseModel):
-    """Directory listing response model"""
-
-    current_path: str
-    parent_path: Optional[str] = None
-    files: List[FileInfo]
-    total_files: int
-    total_directories: int
-    total_size: int
-
-
-class FileUploadResponse(BaseModel):
-    """File upload response model"""
-
-    success: bool
-    message: str
-    file_info: Optional[FileInfo] = None
-    upload_id: Optional[str] = None
-
-
-class FileOperation(BaseModel):
-    """File operation request model"""
-
-    path: str
-
-    @field_validator("path")
-    @classmethod
-    def validate_path(cls, v):
-        """Validate path to prevent directory traversal attacks."""
-        if not v or ".." in v or v.startswith("/"):
-            raise ValueError("Invalid path")
-        return v
 
 
 def get_security_layer(request: Request) -> SecurityLayer:
@@ -695,7 +649,7 @@ async def _delete_directory_item(
     operation="upload_file",
     error_code_prefix="FILES",
 )
-@router.post("/upload", response_model=FileUploadResponse)
+@router.post("/upload", response_model=FilesAPIUploadResponse)
 async def upload_file(
     request: Request,
     file: UploadFile = File(...),
@@ -748,7 +702,7 @@ async def upload_file(
     # Audit logging (Issue #281: uses helper)
     _log_upload_audit(request, user_data, file, relative_path, len(content), overwrite)
 
-    return FileUploadResponse(
+    return FilesAPIUploadResponse(
         success=True,
         message=f"File '{file.filename}' uploaded successfully",
         file_info=file_info,

--- a/autobot-backend/api/integration_communication.py
+++ b/autobot-backend/api/integration_communication.py
@@ -13,9 +13,14 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
+from api.schemas_workflows import (
+    CommProviderInfo,
+    SendMessageRequest,
+    TestConnectionRequest,
+    WebhookMessageRequest,
+)
 from integrations.base import IntegrationConfig, IntegrationHealth
 from integrations.communication_integration import (
     DiscordIntegration,
@@ -30,42 +35,6 @@ router = APIRouter(
     tags=["integrations-communication"],
     dependencies=[Depends(check_admin_permission)],
 )
-
-
-class TestConnectionRequest(BaseModel):
-    """Request model for testing communication provider connections."""
-
-    provider: str = Field(..., description="Provider name: slack, teams, or discord")
-    token: Optional[str] = Field(None, description="Bot token or API token")
-    webhook_url: Optional[str] = Field(None, description="Webhook URL (for Teams)")
-    base_url: Optional[str] = Field(None, description="Custom base URL (optional)")
-
-
-class SendMessageRequest(BaseModel):
-    """Request model for sending messages."""
-
-    channel: Optional[str] = Field(None, description="Channel ID or name (Slack)")
-    channel_id: Optional[str] = Field(None, description="Channel ID (Discord)")
-    text: Optional[str] = Field(None, description="Message text")
-    content: Optional[str] = Field(None, description="Message content (Discord)")
-    title: Optional[str] = Field(None, description="Message title (Teams)")
-
-
-class ProviderInfo(BaseModel):
-    """Information about a supported communication provider."""
-
-    name: str
-    description: str
-    auth_type: str
-    required_fields: List[str]
-
-
-class WebhookMessageRequest(BaseModel):
-    """Request model for webhook messages."""
-
-    webhook_url: str = Field(..., description="Teams webhook URL")
-    text: str = Field(..., description="Message text")
-    title: Optional[str] = Field(None, description="Message title")
 
 
 @with_error_handling(
@@ -101,25 +70,25 @@ async def test_connection(request: TestConnectionRequest) -> IntegrationHealth:
 )
 @router.get(
     "/providers",
-    response_model=List[ProviderInfo],
+    response_model=List[CommProviderInfo],
     summary="List supported communication providers",
 )
-async def list_providers() -> List[ProviderInfo]:
+async def list_providers() -> List[CommProviderInfo]:
     """Return list of supported communication providers."""
     return [
-        ProviderInfo(
+        CommProviderInfo(
             name="slack",
             description="Slack workspace integration",
             auth_type="bot_token",
             required_fields=["token"],
         ),
-        ProviderInfo(
+        CommProviderInfo(
             name="teams",
             description="Microsoft Teams integration",
             auth_type="webhook_or_token",
             required_fields=["webhook_url or token"],
         ),
-        ProviderInfo(
+        CommProviderInfo(
             name="discord",
             description="Discord server integration",
             auth_type="bot_token",

--- a/autobot-backend/api/knowledge_collaboration.py
+++ b/autobot-backend/api/knowledge_collaboration.py
@@ -17,7 +17,6 @@ import logging
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel, Field
 
 from api.schemas_knowledge import (
     KnowledgeAccessInfoResponse,
@@ -25,6 +24,8 @@ from api.schemas_knowledge import (
     KnowledgeScopedFactsResponse,
     KnowledgeShareResponse,
     KnowledgeUnshareResponse,
+    ShareKnowledgeRequest,
+    UpdatePermissionsRequest,
 )
 from auth_middleware import get_current_user
 from autobot_shared.models.pagination import PaginationParams
@@ -41,57 +42,6 @@ router = APIRouter(prefix="/knowledge/collaboration", tags=["knowledge-collabora
 # =============================================================================
 # Pydantic Models
 # =============================================================================
-
-
-class KnowledgeScopeFilter(BaseModel):
-    """Filter for knowledge by scope."""
-
-    scope: Optional[VisibilityLevel] = Field(
-        default=None, description="Visibility level to filter by"
-    )
-    organization_id: Optional[str] = Field(
-        default=None, description="Organization ID filter"
-    )
-    group_ids: Optional[List[str]] = Field(
-        default=None, description="Group IDs to filter by"
-    )
-
-
-class ShareKnowledgeRequest(BaseModel):
-    """Request to share knowledge with users or groups."""
-
-    user_ids: Optional[List[str]] = Field(
-        default=None, description="User IDs to share with"
-    )
-    group_ids: Optional[List[str]] = Field(
-        default=None, description="Group IDs to share with"
-    )
-
-
-class UpdatePermissionsRequest(BaseModel):
-    """Request to update knowledge permissions."""
-
-    visibility: VisibilityLevel = Field(description="New visibility level")
-    organization_id: Optional[str] = Field(
-        default=None, description="Organization ID for org-level knowledge"
-    )
-    group_ids: Optional[List[str]] = Field(
-        default=None, description="Group IDs for group-level knowledge"
-    )
-
-
-class KnowledgeAccessResponse(BaseModel):
-    """Response with knowledge access details."""
-
-    fact_id: str
-    owner_id: str
-    visibility: VisibilityLevel
-    organization_id: Optional[str] = None
-    group_ids: List[str] = []
-    shared_with: List[str] = []
-    can_edit: bool
-    can_share: bool
-    can_delete: bool
 
 
 # =============================================================================

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel, Field, field_validator
 
 from constants.threshold_constants import CategoryDefaults, QueryDefaults
+from knowledge.ownership import VisibilityLevel
 from type_defs.common import Metadata
 from utils.path_validation import contains_path_traversal
 
@@ -4382,3 +4383,45 @@ class TrainResponse(BaseModel):
     schema_length: Optional[int] = None
     table_count: Optional[int] = None
     error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# knowledge_collaboration.py schemas
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeScopeFilter(BaseModel):
+    """Filter for knowledge by scope."""
+
+    scope: Optional[VisibilityLevel] = Field(default=None, description="Visibility level to filter by")
+    organization_id: Optional[str] = Field(default=None, description="Organization ID filter")
+    group_ids: Optional[List[str]] = Field(default=None, description="Group IDs to filter by")
+
+
+class ShareKnowledgeRequest(BaseModel):
+    """Request to share knowledge with users or groups."""
+
+    user_ids: Optional[List[str]] = Field(default=None, description="User IDs to share with")
+    group_ids: Optional[List[str]] = Field(default=None, description="Group IDs to share with")
+
+
+class UpdatePermissionsRequest(BaseModel):
+    """Request to update knowledge permissions."""
+
+    visibility: VisibilityLevel = Field(description="New visibility level")
+    organization_id: Optional[str] = Field(default=None, description="Organization ID for org-level knowledge")
+    group_ids: Optional[List[str]] = Field(default=None, description="Group IDs for group-level knowledge")
+
+
+class KnowledgeAccessResponse(BaseModel):
+    """Response with knowledge access details."""
+
+    fact_id: str
+    owner_id: str
+    visibility: VisibilityLevel
+    organization_id: Optional[str] = None
+    group_ids: List[str] = []
+    shared_with: List[str] = []
+    can_edit: bool
+    can_share: bool
+    can_delete: bool

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from api.schemas_common import SuccessDataResponse, SuccessMessageResponse
 from constants.threshold_constants import RetryConfig
@@ -2997,3 +2997,103 @@ class AlertManagerWebhook(BaseModel):
     commonAnnotations: Dict[str, str]
     externalURL: str
     alerts: List[AlertInstance]
+
+
+# ---------------------------------------------------------------------------
+# files.py schemas
+# ---------------------------------------------------------------------------
+
+
+class FileInfo(BaseModel):
+    """File information model."""
+
+    name: str
+    path: str
+    is_directory: bool
+    size: Optional[int] = None
+    mime_type: Optional[str] = None
+    last_modified: datetime
+    permissions: str
+    extension: Optional[str] = None
+
+
+class DirectoryListing(BaseModel):
+    """Directory listing response model."""
+
+    current_path: str
+    parent_path: Optional[str] = None
+    files: List[FileInfo]
+    total_files: int
+    total_directories: int
+    total_size: int
+
+
+class FilesAPIUploadResponse(BaseModel):
+    """File upload response model."""
+
+    success: bool
+    message: str
+    file_info: Optional[FileInfo] = None
+    upload_id: Optional[str] = None
+
+
+class FileOperation(BaseModel):
+    """File operation request model."""
+
+    path: str
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, v):
+        """Validate path to prevent directory traversal attacks."""
+        if not v or ".." in v or v.startswith("/"):
+            raise ValueError("Invalid path")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# data_storage.py schemas
+# ---------------------------------------------------------------------------
+
+
+class StorageCategory(BaseModel):
+    """Storage category with size info."""
+
+    name: str
+    path: str
+    size_bytes: int
+    size_human: str
+    file_count: int
+    description: str
+    can_cleanup: bool = True
+    cleanup_type: str = "manual"
+
+
+class StorageStats(BaseModel):
+    """Overall storage statistics."""
+
+    total_size_bytes: int
+    total_size_human: str
+    total_files: int
+    total_directories: int
+    categories: List[StorageCategory]
+    last_cleanup: Optional[str] = None
+
+
+class StorageCleanupRequest(BaseModel):
+    """Cleanup request model."""
+
+    category: str
+    older_than_days: int = 0
+    dry_run: bool = True
+
+
+class CleanupResult(BaseModel):
+    """Cleanup operation result."""
+
+    category: str
+    files_removed: int
+    bytes_freed: int
+    bytes_freed_human: str
+    dry_run: bool
+    errors: List[str] = []

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -1838,3 +1838,44 @@ class DatabaseListRequest(BaseModel):
     username: Optional[str] = Field(None, description="Database username")
     password: Optional[str] = Field(None, description="Database password")
     database: Optional[str] = Field(None, description="Database name (for table listing)")
+
+
+# ---------------------------------------------------------------------------
+# integration_communication.py schemas
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionRequest(BaseModel):
+    """Request model for testing communication provider connections."""
+
+    provider: str = Field(..., description="Provider name: slack, teams, or discord")
+    token: Optional[str] = Field(None, description="Bot token or API token")
+    webhook_url: Optional[str] = Field(None, description="Webhook URL (for Teams)")
+    base_url: Optional[str] = Field(None, description="Custom base URL (optional)")
+
+
+class SendMessageRequest(BaseModel):
+    """Request model for sending messages."""
+
+    channel: Optional[str] = Field(None, description="Channel ID or name (Slack)")
+    channel_id: Optional[str] = Field(None, description="Channel ID (Discord)")
+    text: Optional[str] = Field(None, description="Message text")
+    content: Optional[str] = Field(None, description="Message content (Discord)")
+    title: Optional[str] = Field(None, description="Message title (Teams)")
+
+
+class CommProviderInfo(BaseModel):
+    """Information about a supported communication provider."""
+
+    name: str
+    description: str
+    auth_type: str
+    required_fields: List[str]
+
+
+class WebhookMessageRequest(BaseModel):
+    """Request model for webhook messages."""
+
+    webhook_url: str = Field(..., description="Teams webhook URL")
+    text: str = Field(..., description="Message text")
+    title: Optional[str] = Field(None, description="Message title")


### PR DESCRIPTION
## Summary

Phase 19 of issue #6042. Migrates 16 \`BaseModel\` subclasses from 4 endpoint files into centralized domain schema files.

### Files migrated

| Endpoint file | Classes | Target |
|---|---|---|
| \`integration_communication.py\` | 4 (TestConnectionRequest, SendMessageRequest, ProviderInfo→CommProviderInfo, WebhookMessageRequest) | \`schemas_workflows.py\` |
| \`knowledge_collaboration.py\` | 4 (KnowledgeScopeFilter, ShareKnowledgeRequest, UpdatePermissionsRequest, KnowledgeAccessResponse) | \`schemas_knowledge.py\` |
| \`files.py\` | 4 (FileInfo, DirectoryListing, FileUploadResponse→FilesAPIUploadResponse, FileOperation) | \`schemas_system.py\` |
| \`data_storage.py\` | 4 (StorageCategory, StorageStats, CleanupRequest→StorageCleanupRequest, CleanupResult) | \`schemas_system.py\` |

### Renames
- \`ProviderInfo\` → \`CommProviderInfo\` (avoids collision with workflows ProviderInfo from project_management)
- \`FileUploadResponse\` → \`FilesAPIUploadResponse\` (avoids collision with knowledge FileUploadResponse)
- \`CleanupRequest\` → \`StorageCleanupRequest\` (knowledge has CleanupRequest, audit has AuditCleanupRequest)

### Notable
- \`schemas_knowledge.py\` adds \`from knowledge.ownership import VisibilityLevel\` for collaboration request fields
- \`schemas_system.py\` gains \`field_validator\` import for \`FileOperation.validate_path\` (preserves directory traversal protection)
- Preserves Python 3.9+ \`list[T]\` syntax conversion to \`List[T]\` for consistency

## Test Plan
- [x] \`py_compile\` clean on all 7 modified files
- [x] \`flake8 --select=F401,F811,F821\` — 0 errors

Continues #6042

🤖 Generated with Claude Code