### PR TITLE
fix(chat): align response_model with wire format + add get_statistics (#6490 #6497)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -851,7 +851,7 @@ async def stream_message(
     operation="chat_health_check",
     error_code_prefix="CHAT",
 )
-@router.get("/chat/health", response_model=DataResponse[ChatHealthData])
+@router.get("/chat/health", response_model=ChatHealthData)
 async def chat_health_check(
     current_user: dict = Depends(get_current_user),
     request: Request = None,
@@ -1909,7 +1909,7 @@ async def stream_enhanced_chat(
     operation="enhanced_chat_health_check",
     error_code_prefix="CHAT",
 )
-@router.get("/health-enhanced", response_model=DataResponse[EnhancedChatHealthData])
+@router.get("/health-enhanced", response_model=EnhancedChatHealthData)
 async def enhanced_chat_health_check(
     current_user: dict = Depends(get_current_user),
 ):
@@ -2025,7 +2025,7 @@ async def get_enhanced_chat_capabilities(
     operation="translate_text",
     error_code_prefix="CHAT",
 )
-@router.post("/translate", response_model=DataResponse[TranslateData])
+@router.post("/translate", response_model=TranslateData)
 async def translate_text(
     body: TranslateRequest,
     current_user: dict = Depends(get_current_user),
@@ -2059,7 +2059,7 @@ async def translate_text(
     operation="detect_language",
     error_code_prefix="CHAT",
 )
-@router.post("/detect-language", response_model=DataResponse[DetectLanguageData])
+@router.post("/detect-language", response_model=DetectLanguageData)
 async def detect_language(
     body: DetectLanguageRequest,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -204,11 +204,10 @@ class ChatHealthComponents(BaseModel):
 
 
 class ChatHealthData(BaseModel):
-    """data payload for GET /chat/health.
+    """Response shape for GET /chat/health (#6497).
 
-    Note: the /chat/health handler returns the health dict directly via
-    ``JSONResponse`` (without DataResponse wrapping). The response_model
-    annotation describes the conceptual ``data`` shape only.
+    Wire format is the model itself — no DataResponse envelope. The route
+    declares response_model=ChatHealthData directly.
     """
 
     status: str
@@ -217,10 +216,10 @@ class ChatHealthData(BaseModel):
 
 
 class ChatStatsData(BaseModel):
-    """data payload for GET /chat/stats.
+    """data payload for GET /chat/stats (#6490).
 
-    The handler proxies ``chat_history_manager.get_statistics()`` whose
-    keys vary by manager configuration; left untyped intentionally.
+    Wraps the dict returned by ChatHistoryManager.get_statistics() —
+    session_count, message_count, and a recent-sessions sample.
     """
 
     stats: Optional[Dict[str, Any]] = None
@@ -260,12 +259,11 @@ class EnhancedChatData(BaseModel):
 
 
 class EnhancedChatHealthData(BaseModel):
-    """data payload for GET /health-enhanced.
+    """Response shape for GET /health-enhanced (#6497).
 
-    The handler returns the health dict directly via JSONResponse;
-    response_model describes the conceptual ``data`` shape only.
-    The ``components`` map is heterogeneous (per-component status
-    strings keyed by component name) so it is typed as Dict[str, Any].
+    Wire format is the model itself — no DataResponse envelope. The
+    components map is heterogeneous (per-component status strings keyed
+    by component name) so it is typed as Dict[str, Any].
     """
 
     status: str
@@ -297,11 +295,10 @@ class EnhancedChatCapabilitiesData(BaseModel):
 
 
 class TranslateData(BaseModel):
-    """data payload for POST /translate.
+    """Response shape for POST /translate (#6497).
 
-    The handler returns the agent result dict directly via JSONResponse
-    (no DataResponse wrapping). Shape comes from
-    ``TranslationAgent.process_query``.
+    Wire format is the model itself — no DataResponse envelope. Shape
+    comes from TranslationAgent.process_query.
     """
 
     status: str
@@ -313,12 +310,12 @@ class TranslateData(BaseModel):
 
 
 class DetectLanguageData(BaseModel):
-    """data payload for POST /detect-language.
+    """Response shape for POST /detect-language (#6497).
 
-    Same envelope as ``TranslateData`` (both call
-    ``TranslationAgent.process_query``); the parsed
-    ``language``/``language_name``/``confidence`` JSON sits inside
-    ``response``/``response_text`` as a string.
+    Wire format is the model itself — no DataResponse envelope. Same
+    fields as TranslateData (both call TranslationAgent.process_query);
+    the parsed language/language_name/confidence JSON sits inside
+    response/response_text as a string.
     """
 
     status: str

--- a/autobot-backend/chat_history/__init__.py
+++ b/autobot-backend/chat_history/__init__.py
@@ -28,7 +28,7 @@ Usage:
     await manager.add_message("user", "Hello!")
 """
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from chat_history.analysis import AnalysisMixin
 from chat_history.base import ChatHistoryBase
@@ -124,6 +124,29 @@ class ChatHistoryManager(
             redis_host=redis_host,
             redis_port=redis_port,
         )
+
+    async def get_statistics(self) -> Dict[str, Any]:
+        """Aggregate basic counts for GET /chat/stats (#6490).
+
+        Sums message counts per session via the SessionListing + Messages
+        mixins. Cheap enough for an admin endpoint; not a hot path.
+        """
+        sessions = await self.list_sessions_fast()
+        session_count = len(sessions)
+        total_messages = 0
+        for session in sessions:
+            session_id = session.get("id") or session.get("session_id")
+            if not session_id:
+                continue
+            try:
+                total_messages += await self.get_session_message_count(session_id)
+            except Exception:
+                continue
+        return {
+            "session_count": session_count,
+            "message_count": total_messages,
+            "sessions": sessions[:10],
+        }
 
 
 # Convenience exports


### PR DESCRIPTION
## Summary

Two related fixes in chat.py:

**#6497** — 4 endpoints declared `response_model=DataResponse[T]` but their handlers return the raw `T` shape directly via `JSONResponse(content=...)`. The OpenAPI schema and the wire format disagreed; clients using the typed schema would fail to parse responses. Fix: switch declarations to bare `T` to match what handlers actually send.
- `/chat/health` → `response_model=ChatHealthData`
- `/health-enhanced` → `response_model=EnhancedChatHealthData`
- `/translate` → `response_model=TranslateData`
- `/detect-language` → `response_model=DetectLanguageData`

Updates schema docstrings in `schemas_chat.py` to reflect the correct wire format (no more "describes conceptual data shape only" disclaimers).

**#6490** — `GET /chat/stats` calls `chat_history_manager.get_statistics()` which didn't exist on `ChatHistoryManager` → runtime `AttributeError`. Added a real `get_statistics()` method that sums session counts and message counts via the existing `list_sessions_fast()` + `get_session_message_count()` mixin methods.

## Test plan
- [ ] `python -m py_compile autobot-backend/api/chat.py` (passed locally)
- [ ] `python -m py_compile autobot-backend/api/schemas_chat.py` (passed)
- [ ] `python -m py_compile autobot-backend/chat_history/__init__.py` (passed)
- [ ] `curl http://localhost:8001/chat/stats` returns `{session_count, message_count, sessions[]}` (no longer 500)
- [ ] `/chat/health`, `/health-enhanced`, `/translate`, `/detect-language` OpenAPI schemas now match the actual JSON wire format

Closes #6490
Closes #6497

🤖 Generated with [Claude Code](https://claude.com/claude-code)