### PR TITLE
fix(api): re-add pydantic imports removed by #6042 migration (#6536)

### DIFF
--- a/autobot-backend/api/cache_management.py
+++ b/autobot-backend/api/cache_management.py
@@ -13,6 +13,7 @@ import logging
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 
 from api.schemas_system import (
     CacheClearTypeResponse,

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
 from api.schemas_system import (
     ClipboardSyncRequest,
     ConnectionSettings,


### PR DESCRIPTION
## Summary

P0 hotfix — backend boot has been broken since commit `e43447c9a` (Apr 28). Workers crash-loop on import; port 8001 never binds; the Ansible `Wait for backend to be healthy (#3687)` task fails after 120 retries (~10 min) on every deploy attempt.

## Root cause

Migration commit `e43447c9a` ("phases 1–8 of #6042") removed `from pydantic import BaseModel, Field` from two endpoint files but left **12 orphan classes** still inheriting from `BaseModel` / using `Field(...)`:

- `autobot-backend/api/vnc_manager.py`: 6 classes at lines 1170, 1253, 1386, 1445, 1513, 1532
- `autobot-backend/api/cache_management.py`: 3 classes at lines 731, 793, 851

The migration commit message itself admits some classes were **deferred** ("TestMessageRequest/FrontendTestRequest deferred: depend on runtime ssot_config") — the import was just removed too aggressively. 11 of 12 are still **live** (referenced as route-handler param types). One (`OCRRequest`) is duplicated in `schemas_system.py:2558`.

## Why it only failed today

`/opt/autobot/autobot-backend/` was stale until today's playbook ran `Sync autobot-backend code from code_source` (`changed: true`). The previous backend kept running on pre-migration code.

## This PR

Smallest change that unblocks deploys — re-adds the imports the migration removed:

- `vnc_manager.py`: `from pydantic import BaseModel, Field`
- `cache_management.py`: `from pydantic import BaseModel`

Migrating the 12 orphan classes to `schemas_system.py` is a follow-up under #6042 (filed as discovery).

## Verification

```
$ sudo -u autobot bash -c 'cd /opt/autobot/autobot-backend && \
    venv/bin/python -c "from api import vnc_manager; from api import cache_management"'
BOTH IMPORT OK
```

(Done against the fixed files.)

## Test plan

- [ ] Re-run Ansible provisioning playbook
- [ ] `Wait for backend to be healthy (#3687)` task succeeds (was failing after 120 retries)
- [ ] `ss -tlnp | grep 8001` shows uvicorn bound to `10.255.255.254:8001`
- [ ] `curl https://<host>/health` returns 200
- [ ] No NameError in `/var/log/autobot/backend-error.log` after restart

Closes #6536