### PR TITLE
test(nav): navItems coverage test for requiresAuth routes (#6499)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -434,6 +434,7 @@ import { initializeNotificationBridge } from '@/utils/notificationBridge';
 import { smartMonitoringController, getAdaptiveInterval } from '@/config/OptimizedPerformance.js';
 import { clearAllSystemNotifications, resetHealthMonitor } from '@/utils/ClearNotifications.js';
 import { getSLMAdminUrl } from '@/config/ssot-config';
+import { navItems } from '@/config/navItems';
 import SystemStatusNotification from '@/components/ui/SystemStatusNotification.vue';
 import CaptchaNotification from '@/components/research/CaptchaNotification.vue';
 import ToastContainer from '@/components/ui/ToastContainer.vue';
@@ -800,41 +801,10 @@ export default {
     // SLM Admin URL from SSOT config (Issue #729)
     const slmAdminUrl = computed(() => getSLMAdminUrl());
 
-    // Data-driven navigation items: single source of truth for desktop + mobile nav
-    // iconRule is typed as a literal union to satisfy SVG fill-rule / clip-rule prop types (#4699)
-    type SvgFillRule = 'evenodd' | 'nonzero' | 'inherit';
-    const navItems: Array<{
-      to: string;
-      labelKey: string;
-      icon?: string;
-      iconPaths?: string[];
-      iconRule?: SvgFillRule;
-      iconStroke?: boolean;
-      adminOnly?: boolean;
-    }> = [
-      { to: '/home', labelKey: 'nav.home', icon: 'M10.707 2.293a1 1 0 00-1.414 0l-7 7v11a1 1 0 001 1h2a1 1 0 001-1v-5a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 001 1h2a1 1 0 001-1v-7l7-7a1 1 0 000-1.414z', iconRule: 'evenodd' },
-      { to: '/chat', labelKey: 'nav.chat', icon: 'M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z', iconRule: 'evenodd' },
-      { to: '/knowledge', labelKey: 'nav.knowledge', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' },
-      { to: '/automation', labelKey: 'nav.automation', icon: 'M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z', iconRule: 'evenodd' },
-      { to: '/analytics', labelKey: 'nav.analytics', iconPaths: ['M2 10a8 8 0 018-8v8h8a8 8 0 11-16 0z', 'M12 2.252A8.014 8.014 0 0117.748 8H12V2.252z'] },
-      // Issue #4703: Agent Registry — backend + specialized agent dashboard
-      { to: '/agents/registry', labelKey: 'nav.agentRegistry', icon: 'M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2V9M9 21H5a2 2 0 01-2-2V9m0 0h18', iconStroke: true },
-      // Issue #5071/#6451: Agent Activity — per-agent diary timeline
-      { to: '/agents/activity', labelKey: 'nav.agentActivity', icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z', iconStroke: true },
-      // Issue #929: Plugin Manager — marketplace integrated within /plugins
-      { to: '/plugins', labelKey: 'nav.plugins', icon: 'M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z', iconStroke: true },
-      { to: '/secrets', labelKey: 'nav.secrets', icon: 'M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z', iconRule: 'evenodd' },
-      // Issue #4270: Operations moved under /analytics/operations tab
-      // Code Intelligence removed from main nav — merged into /analytics/codebase
-      // Desktop nav removed — noVNC lives in the Chat tab. /desktop redirects to /chat.
-      // Issue #902: Dev Tools moved into /analytics/dev-tools tab
-      // Issue #4492: Custom Dashboard renamed to /home (removed separate nav entry)
-      { to: '/preferences', labelKey: 'nav.preferences', icon: 'M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z', iconRule: 'evenodd' },
-      // About moved to footer link
-      // Issue #4465: Usage moved under /analytics/usage tab
-      // Issue #1440: AutoResearch experiment dashboard (admin-only)
-      { to: '/experiments', labelKey: 'nav.experiments', adminOnly: true, icon: 'M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z' },
-    ];
+    // Data-driven navigation items: single source of truth for desktop + mobile nav.
+    // Lives in `@/config/navItems.ts` (#6499) so it can be unit-tested for
+    // coverage against the router. Adding a top-level `requiresAuth` route
+    // without a navItems entry will fail `nav-items-coverage.test.ts`.
 
     // Nav overflow: ref for container, filtered/visible/overflow computed slices
     const navContainerRef = ref<HTMLElement | null>(null)

--- a/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
+++ b/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
@@ -1,0 +1,123 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * navItems coverage test (#6499)
+ *
+ * Catches the recurring bug where a new top-level `requiresAuth: true` route
+ * is added to `router/index.ts` but the developer forgets to add a matching
+ * entry to `App.vue`'s `navItems`, leaving the new view unreachable from the
+ * main nav.
+ *
+ * Pattern recurred twice in past sessions:
+ *   - Remote Desktop (#4977 / SlmNoVnc) — added to router, forgotten in nav
+ *   - Agent Activity (#5071 / #6451) — same mistake
+ *
+ * Rule enforced:
+ *   For every top-level route with `meta.requiresAuth === true`, there must
+ *   be a matching `to:` entry in `navItems` UNLESS the route is in the
+ *   explicit `INTENTIONALLY_HIDDEN` allowlist below.
+ *
+ * Sub-routes (children) are intentionally excluded — only the parent appears
+ * in main nav. Redirects and dynamic-param routes (`:sessionId`, `:pathMatch`)
+ * are also excluded.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { RouteRecordRaw } from 'vue-router'
+import { routes } from '@/router'
+import { navItems } from '@/config/navItems'
+
+/**
+ * Routes that are intentionally NOT in main nav.
+ *
+ * Each entry MUST include a reason. If you add a new top-level `requiresAuth`
+ * route that should not appear in nav, add it here with justification.
+ *
+ * Prefer `hideInNav: true` on the route's `meta` instead of allowlisting —
+ * use this allowlist only for routes that have a different exposure path
+ * (footer link, accessed from another view, etc.) without an explicit flag.
+ */
+const INTENTIONALLY_HIDDEN: Record<string, string> = {
+  '/about': 'Reachable via footer "About" link, not main nav',
+  '/agents/heartbeat': 'Diagnostic panel — accessed from agent registry, not main nav',
+  '/documents': 'Opened from chat output ("Save as document"), not main nav',
+  '/admin/users': 'Admin-only — surfaced via separate admin entrypoint',
+  '/slm/tools/novnc': 'Accessed via Chat tab\'s noVNC sub-tab (#6414/#6415); standalone URL kept for bookmarks',
+}
+
+/** True if route is hidden from nav by an explicit meta flag. */
+function isHiddenByMeta(route: RouteRecordRaw): boolean {
+  return route.meta?.hideInNav === true
+}
+
+/** True if route requires auth (top-level only). */
+function requiresAuth(route: RouteRecordRaw): boolean {
+  return route.meta?.requiresAuth === true
+}
+
+/** True if route is a redirect (no real component) or dynamic catch-all. */
+function isRedirectOrCatchAll(route: RouteRecordRaw): boolean {
+  if (route.redirect !== undefined) return true
+  if (typeof route.path !== 'string') return false
+  // Dynamic param routes like ':sessionId' or ':pathMatch(.*)*' are not navigation targets
+  return route.path.includes(':') || route.path.includes('*')
+}
+
+/** Collect top-level routes (children are sub-routes, not main nav targets). */
+function topLevelRoutes(): RouteRecordRaw[] {
+  return routes.filter((r) => !isRedirectOrCatchAll(r))
+}
+
+describe('navItems coverage (#6499)', () => {
+  it('every top-level requiresAuth route has a navItems entry or is allowlisted', () => {
+    const navPaths = new Set(navItems.map((n) => n.to))
+    const missing: string[] = []
+
+    for (const route of topLevelRoutes()) {
+      if (!requiresAuth(route)) continue
+      if (isHiddenByMeta(route)) continue
+      if (route.path in INTENTIONALLY_HIDDEN) continue
+      if (navPaths.has(route.path)) continue
+      missing.push(route.path)
+    }
+
+    if (missing.length > 0) {
+      throw new Error(
+        `The following top-level requiresAuth routes have no navItems entry and are not in INTENTIONALLY_HIDDEN:\n` +
+          missing.map((p) => `  - ${p}`).join('\n') +
+          `\n\nFix: Either add an entry to src/config/navItems.ts, or set ` +
+          `meta.hideInNav: true on the route, or add the route to INTENTIONALLY_HIDDEN ` +
+          `in this test with a justification (sub-tab, footer link, admin entrypoint, etc.).`,
+      )
+    }
+
+    expect(missing).toEqual([])
+  })
+
+  it('every navItems entry corresponds to a real top-level route', () => {
+    const topLevelPaths = new Set(topLevelRoutes().map((r) => r.path))
+    const orphans = navItems.filter((n) => !topLevelPaths.has(n.to)).map((n) => n.to)
+
+    expect(orphans).toEqual([])
+  })
+
+  it('every allowlisted path corresponds to a real top-level route', () => {
+    const topLevelPaths = new Set(topLevelRoutes().map((r) => r.path))
+    const stale = Object.keys(INTENTIONALLY_HIDDEN).filter((p) => !topLevelPaths.has(p))
+
+    expect(stale).toEqual([])
+  })
+
+  it('allowlist size and route counts (regression sentinel)', () => {
+    const allowlistSize = Object.keys(INTENTIONALLY_HIDDEN).length
+    const checkedCount = topLevelRoutes().filter(
+      (r) => requiresAuth(r) && !isHiddenByMeta(r),
+    ).length
+
+    // Sanity: must be checking a meaningful number of routes
+    expect(checkedCount).toBeGreaterThan(5)
+    // Allowlist should stay small — if it grows, prefer hideInNav meta flag
+    expect(allowlistSize).toBeLessThan(15)
+  })
+})

--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -1,0 +1,51 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * Navigation Items — Single Source of Truth
+ *
+ * Extracted from App.vue (#6499) so it can be unit-tested for coverage
+ * against the router. Every top-level `requiresAuth: true` route in
+ * `router/index.ts` MUST appear here unless it is in the test allowlist.
+ *
+ * @see src/__tests__/nav-items-coverage.test.ts
+ */
+
+// iconRule is typed as a literal union to satisfy SVG fill-rule / clip-rule prop types (#4699)
+export type SvgFillRule = 'evenodd' | 'nonzero' | 'inherit';
+
+export interface NavItem {
+  to: string;
+  labelKey: string;
+  icon?: string;
+  iconPaths?: string[];
+  iconRule?: SvgFillRule;
+  iconStroke?: boolean;
+  adminOnly?: boolean;
+}
+
+// Data-driven navigation items: single source of truth for desktop + mobile nav
+export const navItems: NavItem[] = [
+  { to: '/home', labelKey: 'nav.home', icon: 'M10.707 2.293a1 1 0 00-1.414 0l-7 7v11a1 1 0 001 1h2a1 1 0 001-1v-5a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 001 1h2a1 1 0 001-1v-7l7-7a1 1 0 000-1.414z', iconRule: 'evenodd' },
+  { to: '/chat', labelKey: 'nav.chat', icon: 'M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z', iconRule: 'evenodd' },
+  { to: '/knowledge', labelKey: 'nav.knowledge', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' },
+  { to: '/automation', labelKey: 'nav.automation', icon: 'M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z', iconRule: 'evenodd' },
+  { to: '/analytics', labelKey: 'nav.analytics', iconPaths: ['M2 10a8 8 0 018-8v8h8a8 8 0 11-16 0z', 'M12 2.252A8.014 8.014 0 0117.748 8H12V2.252z'] },
+  // Issue #4703: Agent Registry — backend + specialized agent dashboard
+  { to: '/agents/registry', labelKey: 'nav.agentRegistry', icon: 'M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2V9M9 21H5a2 2 0 01-2-2V9m0 0h18', iconStroke: true },
+  // Issue #5071/#6451: Agent Activity — per-agent diary timeline
+  { to: '/agents/activity', labelKey: 'nav.agentActivity', icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z', iconStroke: true },
+  // Issue #929: Plugin Manager — marketplace integrated within /plugins
+  { to: '/plugins', labelKey: 'nav.plugins', icon: 'M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z', iconStroke: true },
+  { to: '/secrets', labelKey: 'nav.secrets', icon: 'M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z', iconRule: 'evenodd' },
+  // Issue #4270: Operations moved under /analytics/operations tab
+  // Code Intelligence removed from main nav — merged into /analytics/codebase
+  // Desktop nav removed — noVNC lives in the Chat tab. /desktop redirects to /chat.
+  // Issue #902: Dev Tools moved into /analytics/dev-tools tab
+  // Issue #4492: Custom Dashboard renamed to /home (removed separate nav entry)
+  { to: '/preferences', labelKey: 'nav.preferences', icon: 'M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z', iconRule: 'evenodd' },
+  // About moved to footer link
+  // Issue #4465: Usage moved under /analytics/usage tab
+  // Issue #1440: AutoResearch experiment dashboard (admin-only)
+  { to: '/experiments', labelKey: 'nav.experiments', adminOnly: true, icon: 'M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z' },
+];

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -45,7 +45,9 @@ import AboutView from '@/views/AboutView.vue'
 import OnboardingWizard from '@/views/OnboardingWizard.vue'
 
 // Route configuration - Issue #729: Business-only routes, infrastructure moved to slm-admin
-const routes: RouteRecordRaw[] = [
+// Exported (#6499) so `nav-items-coverage.test.ts` can verify every top-level
+// `requiresAuth: true` route has a matching entry in `@/config/navItems`.
+export const routes: RouteRecordRaw[] = [
   {
     path: '/',
     redirect: '/home'


### PR DESCRIPTION
## Summary
Catches the recurring regression where new full-screen views are added without a corresponding navItems entry (Remote Desktop, AgentActivity).

**Changes:**
- Extracted \`navItems\` array from App.vue into \`autobot-frontend/src/config/navItems.ts\` (with exported \`NavItem\` interface)
- Exported \`routes\` from \`router/index.ts\` so tests can import them
- New \`autobot-frontend/src/__tests__/nav-items-coverage.test.ts\` — 4 vitest cases
- App.vue now imports navItems instead of inline definition

**Allowlist (5 intentionally-hidden routes, each justified):**
- \`/about\` (footer link), \`/agents/heartbeat\` (diagnostic), \`/documents\` (chat output), \`/admin/users\` (admin entry), \`/slm/tools/novnc\` (chat sub-tab)

**Sentinel test** asserts \`checkedCount > 5\` and \`allowlistSize < 15\` to catch silent drift in either direction.

## Test plan
- [x] \`npx vitest run src/__tests__/nav-items-coverage.test.ts\` — 4 pass
- [x] Negative: temporary fake \`requiresAuth\` route makes test fail with clear message
- [x] vue-tsc --noEmit clean for App.vue + navItems.ts + router

Closes #6499