### PR TITLE
refactor(browser): extract region-marking state into useRegionMarking composable (#6447)

### DIFF
--- a/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
+++ b/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
@@ -12,27 +12,15 @@
  * Emits @interact({ action, params }) for the parent to proxy to the backend.
  */
 
-import { ref, computed } from 'vue'
+import { ref, computed, toRef, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { createLogger } from '@/utils/logger'
+import {
+  useRegionMarking,
+  type PageRegion,
+  type SelectedRegion,
+} from '@/composables/browser/useRegionMarking'
 
 const { t } = useI18n()
-const logger = createLogger('InteractiveScreenshot')
-
-interface RegionRect {
-  x: number
-  y: number
-  w: number
-  h: number
-}
-
-interface PageRegion {
-  selector: string
-  xpath: string
-  rect: RegionRect
-  textPreview: string
-  role: string
-}
 
 interface Props {
   screenshot: string | null
@@ -55,18 +43,22 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
   interact: [payload: { action: string; params: Record<string, unknown> }]
-  regionsSelected: [regions: Array<{ selector: string; xpath: string; label: string }>]
+  regionsSelected: [regions: SelectedRegion[]]
 }>()
 
 const showTypeOverlay = ref(false)
 const typeText = ref('')
 const imgRef = ref<HTMLImageElement | null>(null)
 
-// Region-marking state (#5136)
-const hoveredRegion = ref<number | null>(null)
-const selectedRegions = ref<Array<{ selector: string; xpath: string; label: string }>>([])
-const popupRegionIndex = ref<number | null>(null)
-const popupLabel = ref('')
+// Region-marking state (#5136) — extracted to composable (#6447)
+const { hoveredRegion, popupRegionIndex, popupLabel, regionStyle, popupStyle, openPopup, saveRegion } =
+  useRegionMarking({
+    regions: toRef(props, 'regions') as Ref<PageRegion[]>,
+    imgRef,
+    viewportWidth: toRef(props, 'viewportWidth') as Ref<number>,
+    viewportHeight: toRef(props, 'viewportHeight') as Ref<number>,
+    onRegionsSelected: (regions) => emit('regionsSelected', regions),
+  })
 
 const screenshotSrc = computed(() =>
   props.screenshot ? `data:image/png;base64,${props.screenshot}` : null
@@ -116,56 +108,6 @@ function submitType() {
   emit('interact', { action: 'type', params: { text: typeText.value } })
   typeText.value = ''
   showTypeOverlay.value = false
-}
-
-// Region-marking helpers (#5136)
-function regionStyle(rect: RegionRect): Record<string, string> {
-  const img = imgRef.value
-  if (!img) return {}
-  const imgRect = img.getBoundingClientRect()
-  const scaleX = imgRect.width / props.viewportWidth
-  const scaleY = imgRect.height / props.viewportHeight
-  return {
-    position: 'absolute',
-    left: `${rect.x * scaleX}px`,
-    top: `${rect.y * scaleY}px`,
-    width: `${rect.w * scaleX}px`,
-    height: `${rect.h * scaleY}px`,
-    pointerEvents: 'all',
-    cursor: 'pointer',
-  }
-}
-
-function popupStyle(rect: RegionRect): Record<string, string> {
-  const img = imgRef.value
-  if (!img) return {}
-  const imgRect = img.getBoundingClientRect()
-  const scaleX = imgRect.width / props.viewportWidth
-  const scaleY = imgRect.height / props.viewportHeight
-  return {
-    position: 'absolute',
-    left: `${rect.x * scaleX}px`,
-    top: `${(rect.y + rect.h) * scaleY + 4}px`,
-    zIndex: '50',
-  }
-}
-
-function openPopup(index: number): void {
-  popupRegionIndex.value = index
-  popupLabel.value = ''
-}
-
-function saveRegion(index: number | null): void {
-  if (index === null || !props.regions) return
-  const region = props.regions[index]
-  selectedRegions.value.push({
-    selector: region.selector,
-    xpath: region.xpath,
-    label: popupLabel.value || region.textPreview.slice(0, 20),
-  })
-  logger.debug('Region saved', { selector: region.selector, label: popupLabel.value })
-  emit('regionsSelected', [...selectedRegions.value])
-  popupRegionIndex.value = null
 }
 </script>
 

--- a/autobot-frontend/src/composables/browser/useRegionMarking.ts
+++ b/autobot-frontend/src/composables/browser/useRegionMarking.ts
@@ -1,0 +1,112 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import { ref, type Ref } from 'vue'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useRegionMarking')
+
+export interface RegionRect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export interface PageRegion {
+  selector: string
+  xpath: string
+  rect: RegionRect
+  textPreview: string
+  role: string
+}
+
+export interface SelectedRegion {
+  selector: string
+  xpath: string
+  label: string
+}
+
+export interface UseRegionMarkingOptions {
+  regions: Ref<PageRegion[]>
+  imgRef: Ref<HTMLImageElement | null>
+  viewportWidth: Ref<number>
+  viewportHeight: Ref<number>
+  onRegionsSelected?: (regions: SelectedRegion[]) => void
+}
+
+/**
+ * Region-marking state for InteractiveScreenshot (#5136).
+ *
+ * Encapsulates hover, popup, label-input, and selection state plus
+ * positioning helpers for region overlays drawn over a screenshot.
+ */
+export function useRegionMarking(options: UseRegionMarkingOptions) {
+  const { regions, imgRef, viewportWidth, viewportHeight, onRegionsSelected } = options
+
+  const hoveredRegion = ref<number | null>(null)
+  const selectedRegions = ref<SelectedRegion[]>([])
+  const popupRegionIndex = ref<number | null>(null)
+  const popupLabel = ref('')
+
+  function regionStyle(rect: RegionRect): Record<string, string> {
+    const img = imgRef.value
+    if (!img) return {}
+    const imgRect = img.getBoundingClientRect()
+    const scaleX = imgRect.width / viewportWidth.value
+    const scaleY = imgRect.height / viewportHeight.value
+    return {
+      position: 'absolute',
+      left: `${rect.x * scaleX}px`,
+      top: `${rect.y * scaleY}px`,
+      width: `${rect.w * scaleX}px`,
+      height: `${rect.h * scaleY}px`,
+      pointerEvents: 'all',
+      cursor: 'pointer',
+    }
+  }
+
+  function popupStyle(rect: RegionRect): Record<string, string> {
+    const img = imgRef.value
+    if (!img) return {}
+    const imgRect = img.getBoundingClientRect()
+    const scaleX = imgRect.width / viewportWidth.value
+    const scaleY = imgRect.height / viewportHeight.value
+    return {
+      position: 'absolute',
+      left: `${rect.x * scaleX}px`,
+      top: `${(rect.y + rect.h) * scaleY + 4}px`,
+      zIndex: '50',
+    }
+  }
+
+  function openPopup(index: number): void {
+    popupRegionIndex.value = index
+    popupLabel.value = ''
+  }
+
+  function saveRegion(index: number | null): void {
+    if (index === null || !regions.value) return
+    const region = regions.value[index]
+    selectedRegions.value.push({
+      selector: region.selector,
+      xpath: region.xpath,
+      label: popupLabel.value || region.textPreview.slice(0, 20),
+    })
+    logger.debug('Region saved', { selector: region.selector, label: popupLabel.value })
+    onRegionsSelected?.([...selectedRegions.value])
+    popupRegionIndex.value = null
+  }
+
+  return {
+    hoveredRegion,
+    selectedRegions,
+    popupRegionIndex,
+    popupLabel,
+    regionStyle,
+    popupStyle,
+    openPopup,
+    saveRegion,
+  }
+}


### PR DESCRIPTION
## Summary
Pure refactor — moves region-marking state out of \`InteractiveScreenshot.vue\` into a reusable composable. Zero behavior change.

**Changes:**
- New \`autobot-frontend/src/composables/browser/useRegionMarking.ts\` (109 lines)
  - State: \`hoveredRegion\`, \`selectedRegions\`, \`popupRegionIndex\`, \`popupLabel\`
  - Methods: \`openPopup()\`, \`saveRegion()\`, \`regionStyle()\`, \`popupStyle()\`
  - Exports types: \`PageRegion\`, \`RegionRect\`, \`SelectedRegion\`
- \`InteractiveScreenshot.vue\` shrinks by 58 lines net; emit (\`@regionsSelected\`) and props (\`markRegionsMode\`) interface unchanged
- Side fix: removed broken \`@/utils/logger\` import (canonical path is \`@/utils/debugUtils\`)

## Test plan
- [x] \`vue-tsc --noEmit -p tsconfig.app.json\` clean for both files
- [ ] Manual: VisualBrowserPanel + KnowledgeResearchPanel still mark regions correctly

Closes #6447