### PR TITLE
fix(plugins): swap @with_error_handling below @router on 8 marketplace routes (#6532)

### DIFF
--- a/autobot-backend/api/marketplace.py
+++ b/autobot-backend/api/marketplace.py
@@ -275,12 +275,12 @@ async def list_catalog(
     )
 
 
+@router.get("/catalog/{plugin_name}", response_model=MarketplaceEntry)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_catalog_entry",
     error_code_prefix="MARKETPLACE",
 )
-@router.get("/catalog/{plugin_name}", response_model=MarketplaceEntry)
 async def get_catalog_entry(plugin_name: str) -> MarketplaceEntry:
     """
     Get a single marketplace catalog entry by name.
@@ -299,12 +299,12 @@ async def get_catalog_entry(plugin_name: str) -> MarketplaceEntry:
     return MarketplaceEntry(**entry)
 
 
+@router.get("/categories", response_model=MarketplaceCategoriesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_categories",
     error_code_prefix="MARKETPLACE",
 )
-@router.get("/categories", response_model=MarketplaceCategoriesResponse)
 async def list_categories() -> dict[str, list[str]]:
     """
     List valid plugin categories and sort options.
@@ -335,12 +335,12 @@ async def _get_installed() -> set[str]:
         return set()
 
 
+@router.get("/installed", response_model=MarketplaceInstalledResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_installed",
     error_code_prefix="MARKETPLACE",
 )
-@router.get("/installed", response_model=MarketplaceInstalledResponse)
 async def list_installed() -> dict[str, list[str]]:
     """
     List names of installed marketplace plugins.
@@ -351,12 +351,12 @@ async def list_installed() -> dict[str, list[str]]:
     return {"installed": sorted(installed)}
 
 
+@router.post("/install", status_code=status.HTTP_201_CREATED, response_model=MarketplacePluginActionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="install_plugin",
     error_code_prefix="MARKETPLACE",
 )
-@router.post("/install", status_code=status.HTTP_201_CREATED, response_model=MarketplacePluginActionResponse)
 async def install_plugin(body: InstallRequest) -> dict[str, str]:
     """
     Mark a catalog plugin as installed.
@@ -396,12 +396,12 @@ async def install_plugin(body: InstallRequest) -> dict[str, str]:
     return {"status": "installed", "plugin": body.plugin_name}
 
 
+@router.delete("/install/{plugin_name}", response_model=MarketplacePluginActionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="uninstall_plugin",
     error_code_prefix="MARKETPLACE",
 )
-@router.delete("/install/{plugin_name}", response_model=MarketplacePluginActionResponse)
 async def uninstall_plugin(plugin_name: str) -> dict[str, str]:
     """
     Remove a marketplace plugin from the installed set.

--- a/autobot-backend/api/marketplace_sources.py
+++ b/autobot-backend/api/marketplace_sources.py
@@ -181,14 +181,14 @@ async def _resolve_safe_ip(host: str) -> str:
     return safe_ip
 
 
+@router.get(
+    "/marketplaces",
+    response_model=MarketplaceSourcesResponse,
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_marketplaces",
     error_code_prefix="MARKETPLACE_SOURCES",
-)
-@router.get(
-    "/marketplaces",
-    response_model=MarketplaceSourcesResponse,
 )
 async def list_marketplaces(
     user: dict = Depends(get_current_user),
@@ -199,15 +199,15 @@ async def list_marketplaces(
     return MarketplaceSourcesResponse(sources=await list_sources())
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_marketplace",
-    error_code_prefix="MARKETPLACE_SOURCES",
-)
 @router.post(
     "/marketplaces",
     status_code=status.HTTP_201_CREATED,
     response_model=MarketplaceSource,
+)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="add_marketplace",
+    error_code_prefix="MARKETPLACE_SOURCES",
 )
 async def add_marketplace(
     request: MarketplaceSourceCreate,
@@ -239,15 +239,15 @@ async def add_marketplace(
     return source
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_marketplace",
-    error_code_prefix="MARKETPLACE_SOURCES",
-)
 @router.delete(
     "/marketplaces/{source_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     response_model=None,
+)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="delete_marketplace",
+    error_code_prefix="MARKETPLACE_SOURCES",
 )
 async def delete_marketplace(
     source_id: str,


### PR DESCRIPTION
## Summary

PR #6510 fixed decorator order on `list_catalog` only. The other 8 routes in `api/marketplace.py` and `api/marketplace_sources.py` still had `@with_error_handling` above `@router.*`, which makes the error wrapper dead code: FastAPI registers the unwrapped handler at decoration time, then `with_error_handling` wraps a fresh return value FastAPI never sees.

## Routes fixed

**`autobot-backend/api/marketplace.py`** (5 routes)
- `get_catalog_entry`
- `list_categories`
- `list_installed`
- `install_plugin`
- `uninstall_plugin`

**`autobot-backend/api/marketplace_sources.py`** (3 routes)
- `list_marketplaces`
- `add_marketplace`
- `delete_marketplace`

## Verification

\`\`\`
$ grep -nE "^@(router|with_error)" autobot-backend/api/marketplace.py
180:@router.get("/catalog", response_model=MarketplaceCatalogResponse)
181:@with_error_handling(
278:@router.get("/catalog/{plugin_name}", response_model=MarketplaceEntry)
279:@with_error_handling(
302:@router.get("/categories", response_model=MarketplaceCategoriesResponse)
303:@with_error_handling(
338:@router.get("/installed", response_model=MarketplaceInstalledResponse)
339:@with_error_handling(
354:@router.post("/install", ...)
355:@with_error_handling(
399:@router.delete("/install/{plugin_name}", ...)
400:@with_error_handling(
\`\`\`

All 9 routes now have `@router.*` outermost (top), `@with_error_handling` below.

## Test plan

- [x] Syntax check both files (`ast.parse` OK)
- [ ] Verify on Dev_new_gui after merge: install endpoint returns `MARKETPLACE_*` structured error on bad input rather than raw 500.

## Refs

- Closes #6532
- Refs #6352 (codebase-wide tracking, closed prematurely)
- Refs #6481, PR #6500, PR #6510

🤖 Generated with [Claude Code](https://claude.com/claude-code)