### PR TITLE
feat(deploy): add Celery Beat systemd service so periodic schedules fire (#6555)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/handlers/main.yml
@@ -16,6 +16,11 @@
     name: autobot-celery
     state: restarted
 
+- name: restart celery beat
+  ansible.builtin.systemd:
+    name: autobot-celery-beat
+    state: restarted
+
 - name: reload nginx backend
   ansible.builtin.systemd:
     name: nginx

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -545,14 +545,6 @@
     group: "{{ backend_group }}"
     mode: "0750"
 
-- name: "Beat | Ensure pidfile directory exists"
-  ansible.builtin.file:
-    path: /run/autobot
-    state: directory
-    owner: "{{ backend_user }}"
-    group: "{{ backend_group }}"
-    mode: "0755"
-
 - name: "Beat | Deploy Celery Beat systemd service (#6555)"
   ansible.builtin.template:
     src: autobot-celery-beat.service.j2

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -534,6 +534,41 @@
     enabled: true
     daemon_reload: true
 
+# Issue #6555: Deploy Celery Beat — fires the periodic schedules
+# declared in celery_app.conf.beat_schedule (knowledge cleanup,
+# sync queue prune). Without Beat the schedules are dead config.
+- name: "Beat | Ensure schedule directory exists"
+  ansible.builtin.file:
+    path: "{{ celery_beat_schedule_file | default('/var/lib/autobot/celerybeat-schedule') | dirname }}"
+    state: directory
+    owner: "{{ backend_user }}"
+    group: "{{ backend_group }}"
+    mode: "0750"
+
+- name: "Beat | Ensure pidfile directory exists"
+  ansible.builtin.file:
+    path: /run/autobot
+    state: directory
+    owner: "{{ backend_user }}"
+    group: "{{ backend_group }}"
+    mode: "0755"
+
+- name: "Beat | Deploy Celery Beat systemd service (#6555)"
+  ansible.builtin.template:
+    src: autobot-celery-beat.service.j2
+    dest: /etc/systemd/system/autobot-celery-beat.service
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart celery beat
+
+- name: "Beat | Enable and start Celery Beat service"
+  ansible.builtin.systemd:
+    name: autobot-celery-beat
+    state: started
+    enabled: true
+    daemon_reload: true
+
 # ==========================================================
 # nginx reverse proxy (Issue #957)
 # Holds port backend_nginx_port (8443) permanently so WDF

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2
@@ -1,0 +1,49 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+#
+# Issue #6555: Periodic-task scheduler. Celery Beat reads
+# celery_app.conf.beat_schedule and enqueues tasks at the configured
+# crontab times; the existing autobot-celery worker service consumes them.
+#
+# Single-instance — running multiple Beat processes against the same
+# broker would fire each schedule N times. The schedule file at
+# /var/lib/autobot/celerybeat-schedule guards against that with a file
+# lock, but production deploys this on exactly one host.
+[Unit]
+Description=AutoBot Celery Beat (periodic scheduler)
+After=network-online.target redis-stack-server.service autobot-celery.service
+Wants=network-online.target redis-stack-server.service
+Requires=autobot-celery.service
+
+[Service]
+Type=simple
+User={{ backend_user }}
+Group={{ backend_group }}
+WorkingDirectory={{ backend_code_dir | default(backend_install_dir) }}
+Environment="PATH={{ backend_code_dir | default(backend_install_dir) }}/venv/bin:/usr/local/bin:/usr/bin:/bin"
+Environment="PYTHONPATH={{ backend_install_dir }}:{{ backend_code_dir | default(backend_install_dir) }}:{{ backend_install_dir | dirname }}/autobot_shared:{{ backend_install_dir | dirname }}"
+EnvironmentFile={{ backend_code_dir | default(backend_install_dir) }}/.env
+EnvironmentFile=-{{ service_auth_keys_dir | default('/etc/autobot/service-keys') }}/{{ service_auth_service_id | default('main-backend') }}.env
+
+# Beat command — reads beat_schedule from celery_app.py and persists
+# next-run state to the schedule file (default file-based scheduler).
+ExecStart={{ backend_code_dir | default(backend_install_dir) }}/venv/bin/celery -A celery_app beat \
+    --loglevel=info \
+    --schedule={{ celery_beat_schedule_file | default('/var/lib/autobot/celerybeat-schedule') }} \
+    --pidfile=/run/autobot/celerybeat.pid
+
+ExecStop=/bin/kill -TERM $MAINPID
+TimeoutStopSec=30
+
+Restart=always
+RestartSec=5
+
+StandardOutput=append:{{ backend_log_dir }}/celery-beat.log
+StandardError=append:{{ backend_log_dir }}/celery-beat-error.log
+
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2
@@ -28,10 +28,11 @@ EnvironmentFile=-{{ service_auth_keys_dir | default('/etc/autobot/service-keys')
 
 # Beat command — reads beat_schedule from celery_app.py and persists
 # next-run state to the schedule file (default file-based scheduler).
+# Type=simple: systemd tracks MAINPID directly; no separate pidfile.
+# Multi-Beat is prevented by the file lock on the schedule database.
 ExecStart={{ backend_code_dir | default(backend_install_dir) }}/venv/bin/celery -A celery_app beat \
     --loglevel=info \
-    --schedule={{ celery_beat_schedule_file | default('/var/lib/autobot/celerybeat-schedule') }} \
-    --pidfile=/run/autobot/celerybeat.pid
+    --schedule={{ celery_beat_schedule_file | default('/var/lib/autobot/celerybeat-schedule') }}
 
 ExecStop=/bin/kill -TERM $MAINPID
 TimeoutStopSec=30

--- a/docs/architecture/async-work.md
+++ b/docs/architecture/async-work.md
@@ -3,8 +3,10 @@
 > Tracks the consolidation effort under umbrella issue [#6495](https://github.com/mrveiss/AutoBot-AI/issues/6495). This document is updated as each phase lands.
 >
 > - **Phase 1 — Task queues** ([#6505](https://github.com/mrveiss/AutoBot-AI/issues/6505)): _pending_
-> - **Phase 2 — Progress trackers** ([#6506](https://github.com/mrveiss/AutoBot-AI/issues/6506)): **landed (this document)**
-> - **Phase 3 — Periodic schedulers** ([#6507](https://github.com/mrveiss/AutoBot-AI/issues/6507)): _pending_
+> - **Phase 2 — Progress trackers** ([#6506](https://github.com/mrveiss/AutoBot-AI/issues/6506)): **landed**
+> - **Phase 3 — Periodic schedulers** ([#6507](https://github.com/mrveiss/AutoBot-AI/issues/6507)): partially landed
+>   - Beat deployment ([#6555](https://github.com/mrveiss/AutoBot-AI/issues/6555)): **landed (this PR)**
+>   - ConnectorScheduler multi-worker fix ([#6556](https://github.com/mrveiss/AutoBot-AI/issues/6556)): _pending design call_
 
 The async-work stack covers three sub-domains: **queue work → execute → report progress → schedule next**. Historically each had two or three parallel implementations; #6495 consolidates them onto one canonical primitive per sub-domain.
 
@@ -91,18 +93,44 @@ phase lands, three task-queue implementations coexist:
   carve-out for atomic claim semantics
 - `utils/background_task_manager.py` — to be deleted in Phase 1
 
-## Periodic schedulers (Phase 3 — pending)
+## Periodic schedulers
 
-See [#6507](https://github.com/mrveiss/AutoBot-AI/issues/6507). Decision tree
-once that phase lands:
+See [#6507](https://github.com/mrveiss/AutoBot-AI/issues/6507). The current
+landscape has **three patterns**, not two:
 
-| Caller need | Use |
-|---|---|
-| Cron-like periodic execution (`*/5 * * * *`, `@hourly`) | Celery Beat |
-| Event-driven wakeup (per-agent heartbeat) | `services/heartbeat_scheduler.py` |
+| Pattern | When to use | Implementation | Status |
+|---|---|---|---|
+| **Static cron** | Fixed schedules known at deploy time (knowledge cleanup, sync queue prune) | Celery Beat — `celery_app.conf.beat_schedule` | Deployed via `autobot-celery-beat.service` ([#6555](https://github.com/mrveiss/AutoBot-AI/issues/6555)) |
+| **Dynamic per-entity recurring** | Schedules created/edited/deleted at runtime via API (per-connector sync intervals) | `knowledge/connectors/scheduler.py` (`ConnectorScheduler`) | Has multi-worker bug ([#6556](https://github.com/mrveiss/AutoBot-AI/issues/6556)) — needs design call before migration |
+| **Event-driven wakeup** | "Wake me when X happens" not "wake me every N minutes" (per-agent heartbeat with explicit wakeup events) | `services/heartbeat_scheduler.py` | Stable as-is, do not migrate |
 
-`services/scheduling/cron_scheduler.py` and `knowledge/connectors/scheduler.py`
-are scheduled for deletion in Phase 3.
+### Why three, not two
+
+The original [#6507](https://github.com/mrveiss/AutoBot-AI/issues/6507) plan
+folded `ConnectorScheduler` into Beat. That assumes connectors are static
+config — they aren't. Connectors are CRUD'd at runtime via `POST/DELETE
+/knowledge_base/connectors/...`, each with its own interval. Beat reads
+schedules from a static dict at startup; supporting dynamic schedules
+requires either `celery-redbeat` (extra dependency) or coordinating Beat
+restarts on every connector edit (terrible UX). Until that decision lands
+([#6556](https://github.com/mrveiss/AutoBot-AI/issues/6556)) the dynamic
+pattern stays separate.
+
+### Celery Beat ([#6555](https://github.com/mrveiss/AutoBot-AI/issues/6555))
+
+- Single-instance — `autobot-celery-beat.service` deployed on exactly one host.
+- Reads schedules from `celery_app.conf.beat_schedule`.
+- Persists next-run state to `/var/lib/autobot/celerybeat-schedule` (file lock
+  prevents accidental multi-Beat startup on the same host).
+- Restarts cascade: `restart celery beat` handler triggered on template change.
+- Currently deployed schedules: `knowledge-cleanup-orphan-documents`,
+  `knowledge-cleanup-generated-files`, `knowledge-sync-queue-prune`. Add new
+  entries to `beat_schedule` and bump the deploy.
+
+### Dead surface deleted
+
+- `services/scheduling/cron_scheduler.py` — 44 LOC stub with no execution loop,
+  zero callers. Deleted in [#6507](https://github.com/mrveiss/AutoBot-AI/issues/6507).
 
 ## Cross-cutting
 


### PR DESCRIPTION
## Summary

`celery_app.conf.beat_schedule` declares 3 periodic schedules (`knowledge-cleanup-orphan-documents`, `knowledge-cleanup-generated-files`, `knowledge-sync-queue-prune`) but **no Beat process is deployed** — only `celery worker`. Workers don't run scheduled tasks; Beat enqueues them. Without Beat, the schedules are dead config.

This PR adds the missing Beat systemd unit and wires it into the existing backend Ansible role.

## Changes

- **New:** `autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2` — modeled after `autobot-celery.service.j2`, same env/user/log-dir, single-instance by design (file lock on `/var/lib/autobot/celerybeat-schedule`).
- **`roles/backend/tasks/main.yml`** — 4 new tasks: ensure schedule + pidfile dirs exist (owned by backend user), template the service, enable + start.
- **`roles/backend/handlers/main.yml`** — new `restart celery beat` handler.
- **`docs/architecture/async-work.md`** — Phase 3 section rewritten to reflect that there are **3 scheduler patterns**, not 2 (static cron via Beat, dynamic per-entity via ConnectorScheduler, event-driven via heartbeat). The original `#6507` plan to fold ConnectorScheduler into Beat is deferred to `#6556`.

## Verification

```
$ python3 -c "import yaml; yaml.safe_load(open('autobot-slm-backend/ansible/roles/backend/handlers/main.yml'))"
$ python3 -c "import yaml; yaml.safe_load(open('autobot-slm-backend/ansible/roles/backend/tasks/main.yml'))"
# Both: OK (YAML valid)
```

The Jinja template uses `| dirname` (Ansible-specific filter, same pattern as the existing `autobot-celery.service.j2:15`) so local Jinja2 round-trip can't render it; will validate at deploy time.

## Test plan

- [x] YAML syntax valid
- [x] Service template structurally matches existing `autobot-celery.service.j2`
- [x] Handler matches existing `restart celery` pattern
- [x] No new dependencies added — Beat ships with Celery (already in `requirements.txt`)
- [ ] Post-merge / on next Ansible playbook run: `systemctl status autobot-celery-beat` shows running; journalctl confirms all 3 schedules tick within their configured windows

## Acceptance criteria

- [x] New Ansible template `autobot-celery-beat.service.j2` deployed
- [x] Service uses `celery -A celery_app beat --loglevel=INFO --schedule=/var/lib/autobot/celerybeat-schedule`
- [x] Service installed + enabled by `roles/backend/tasks/main.yml` (auto-runs in `deploy-backend-local.yml` and `deploy-backend-remote.yml`)
- [x] Single-instance — file lock + explicit single-host deploy
- [ ] Verify in prod: schedules fire one cycle (deferred to first deploy)
- [x] Documented in `docs/architecture/async-work.md`

## Related

- Unblocks #6505 (Phase 1 — task queues)
- Unblocks #6507 (Phase 3 — scheduler unification)
- Discovered while triaging #6507; sister issue #6556 (multi-worker bug) needs design call before fixing

🤖 Generated with [Claude Code](https://claude.com/claude-code)