### PR TITLE
feat(onboarding): first-login redirect when no preset applied (#6452)

### DIFF
--- a/autobot-backend/api/onboarding.py
+++ b/autobot-backend/api/onboarding.py
@@ -37,6 +37,13 @@ class ApplyPresetRequest(BaseModel):
     overrides: dict[str, Any] = {}
 
 
+class OnboardingStatus(BaseModel):
+    """Response model for GET /api/onboarding/status (#6452)."""
+
+    preset_applied: bool
+    preset_name: Optional[str] = None
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -93,6 +100,19 @@ async def apply_preset(body: ApplyPresetRequest) -> DataResponse:
         )
 
         logger.info("Onboarding preset '%s' applied successfully", body.preset_name)
+
+        # Persist preset_applied flag — used by frontend onboarding redirect (#6452)
+        try:
+            from autobot_shared.redis_client import get_async_redis_client
+
+            redis = await get_async_redis_client(database="main")
+            if redis:
+                await redis.set("onboarding:preset_applied", "1")
+                await redis.set("onboarding:preset_name", body.preset_name)
+        except Exception as flag_exc:
+            # Don't fail the apply if flag persistence has trouble — preset is already applied
+            logger.warning("Could not persist preset_applied flag: %s", flag_exc)
+
         return DataResponse(data={"preset": merged, "applied": applied})
 
     except Exception as exc:
@@ -102,6 +122,35 @@ async def apply_preset(body: ApplyPresetRequest) -> DataResponse:
             status_code=500,
             detail=f"Failed to apply preset '{body.preset_name}': {exc}",
         ) from exc
+
+
+@router.get("/status", response_model=OnboardingStatus)
+async def onboarding_status() -> OnboardingStatus:
+    """Return whether a preset has been applied (#6452).
+
+    Used by the frontend router guard to decide whether to redirect new
+    users to /onboarding on first login. No auth required — called before
+    the main app loads.
+
+    Fail-open: if Redis is unreachable or read fails, return
+    ``preset_applied=True`` so users are never trapped in onboarding by
+    infrastructure issues.
+    """
+    from autobot_shared.redis_client import get_async_redis_client
+
+    try:
+        redis = await get_async_redis_client(database="main")
+        if not redis:
+            return OnboardingStatus(preset_applied=True)
+        flag = await redis.get("onboarding:preset_applied")
+        applied = flag == "1" or flag == b"1"
+        name_value = await redis.get("onboarding:preset_name") if applied else None
+        if isinstance(name_value, (bytes, bytearray)):
+            name_value = name_value.decode("utf-8")
+        return OnboardingStatus(preset_applied=applied, preset_name=name_value)
+    except Exception as exc:
+        logger.warning("Could not read preset_applied flag: %s — failing open", exc)
+        return OnboardingStatus(preset_applied=True)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -27,7 +27,7 @@ import { useAppStore } from '@/stores/useAppStore'
 import { useUserStore } from '@/stores/useUserStore'
 import { setupAsyncComponentErrorHandler } from '@/utils/asyncComponentHelpers'
 import { createLogger } from '@/utils/debugUtils'
-import { getSLMAdminUrl } from '@/config/ssot-config'
+import { getBackendUrl, getSLMAdminUrl } from '@/config/ssot-config'
 
 const logger = createLogger('Router');
 
@@ -992,6 +992,45 @@ router.beforeEach(async (to, from) => {
     if (to.name === 'login' && userStore.isAuthenticated) {
       logger.debug('User already authenticated, redirecting to home')
       return { path: '/home' }
+    }
+
+    // Onboarding redirect (#6452) — first-login users with no preset applied get
+    // routed to /onboarding. Skip for: the onboarding route itself, public routes,
+    // and unauthenticated traffic (already handled above).
+    // sessionStorage cache avoids hitting /api/onboarding/status on every nav —
+    // one fetch per browser session is enough; OnboardingWizard clears it on
+    // successful preset apply so the next nav re-checks.
+    if (
+      userStore.isAuthenticated &&
+      requiresAuth &&
+      to.path !== '/onboarding' &&
+      !to.matched.some(record => record.meta.isPublic === true)
+    ) {
+      let presetApplied = sessionStorage.getItem('onboarding_preset_applied')
+      if (presetApplied === null) {
+        try {
+          const resp = await fetch(`${getBackendUrl()}/api/onboarding/status`, {
+            credentials: 'include',
+            headers: { Accept: 'application/json' },
+          })
+          if (resp.ok) {
+            const data = await resp.json()
+            presetApplied = data?.preset_applied ? '1' : '0'
+            sessionStorage.setItem('onboarding_preset_applied', presetApplied)
+          } else {
+            // Fail-open on non-2xx — don't trap users in onboarding.
+            presetApplied = '1'
+          }
+        } catch (statusErr) {
+          // Fail-open on network error — don't trap users in onboarding.
+          logger.debug('Onboarding status check failed, continuing:', statusErr)
+          presetApplied = '1'
+        }
+      }
+      if (presetApplied === '0') {
+        logger.debug('Onboarding not complete — redirecting to /onboarding')
+        return { path: '/onboarding' }
+      }
     }
 
     // Check for expired tokens

--- a/autobot-frontend/src/views/OnboardingWizard.vue
+++ b/autobot-frontend/src/views/OnboardingWizard.vue
@@ -142,6 +142,9 @@ async function applyPreset() {
     })
     applyResult.value = (response as { data: Record<string, unknown> }).data
     logger.info('Preset applied', applyResult.value)
+    // #6452: clear router-guard cache so next navigation re-checks status
+    // and sees preset_applied=true (then caches that).
+    sessionStorage.removeItem('onboarding_preset_applied')
   } catch (err) {
     logger.error('Apply preset failed', err)
     error.value = 'Failed to apply preset. Please try again.'


### PR DESCRIPTION
## Summary
Closes the #5061 acceptance gap: new users now auto-redirect to `/onboarding` until they apply a starter preset.

**Backend** (`autobot-backend/api/onboarding.py`):
- `apply_preset()` now sets `onboarding:preset_applied = "1"` and `onboarding:preset_name` in Redis after successful apply (wrapped in try/except so flag persistence trouble doesn't undo the apply).
- New `GET /api/onboarding/status` returns `OnboardingStatus(preset_applied: bool, preset_name: Optional[str])`. No auth — called before main app loads.

**Frontend** (`router/index.ts`, `OnboardingWizard.vue`):
- Extended existing `beforeEach` guard with onboarding redirect logic.
- Reads from `sessionStorage.getItem('onboarding_preset_applied')` first; on miss, fetches `/api/onboarding/status`, caches, and redirects to `/onboarding` when `applied=false`.
- `OnboardingWizard.vue` clears the cache on successful preset apply so the next nav re-checks and sees `applied=true`.

**Fail-open behavior** — if Redis or network fails, default to `preset_applied=true` so users are never trapped in onboarding by infrastructure issues.

## Test plan
- [ ] `python -m py_compile autobot-backend/api/onboarding.py` (passed locally)
- [ ] Manual: fresh Redis (no flag) → login → auto-redirect to `/onboarding`
- [ ] Apply preset → cache cleared → next nav shows `applied=true`, no redirect
- [ ] Redis down → endpoint returns `{preset_applied: true}` → no redirect (fail-open)
- [ ] Already-applied preset → login → goes to home, NOT onboarding

## Discoveries (not fixed inline)
- `/api/onboarding/{presets,doctor,apply,status}` all lack explicit auth — needs a security review of the entire onboarding router (not just `/status`).
- `/presets`, `/doctor`, `/apply` use `response_model=DataResponse`; `/status` returns the bare model (per spec). Same envelope-mismatch class as #6497.
- `apply_preset` rollback handling is per-key without a transaction — partial rollback could leave Redis half-state.

Closes #6452

🤖 Generated with [Claude Code](https://claude.com/claude-code)