### PR TITLE
fix(backend): P0 boot crash — restore 4 orphan annotation imports from #6042 (closes #6569 #6570 #6571 #6572)

### DIFF
--- a/autobot-backend/api/scheduler.py
+++ b/autobot-backend/api/scheduler.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.error_constants import ERR_TEMPLATE_NOT_FOUND, ERR_WORKFLOW_NOT_FOUND
+from type_defs.common import Metadata
 from workflow_scheduler import WorkflowPriority
 from workflow_scheduler import WorkflowScheduleRequest as InternalScheduleRequest
 from workflow_scheduler import WorkflowStatus, get_workflow_scheduler

--- a/autobot-backend/api/vnc_mcp.py
+++ b/autobot-backend/api/vnc_mcp.py
@@ -19,6 +19,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
 from constants.network_constants import NetworkConstants
+from type_defs.common import Metadata
 from api.schemas_system import (
     BrowserVncContextResponse,
     DesktopClickMcpResponse,

--- a/autobot-backend/api/workflow_permissions.py
+++ b/autobot-backend/api/workflow_permissions.py
@@ -21,8 +21,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.schemas_workflows import (
     GrantPermissionRequest,
-    WorkflowWorkflowAuditLogEntry,
-    WorkflowWorkflowPermissionResponse,
+    WorkflowAuditLogEntry,
+    WorkflowPermissionResponse,
 )
 from api.user_management.dependencies import get_db_session
 from auth_middleware import get_current_user
@@ -48,9 +48,9 @@ def _current_user_id(current_user: dict) -> str:
     return current_user.get("username") or current_user.get("user_id", "unknown")
 
 
-def _permission_to_response(perm) -> WorkflowWorkflowPermissionResponse:
+def _permission_to_response(perm) -> WorkflowPermissionResponse:
     """Convert a WorkflowPermission ORM row to its response schema."""
-    return WorkflowWorkflowPermissionResponse(
+    return WorkflowPermissionResponse(
         workflow_id=perm.workflow_id,
         user_id=perm.user_id,
         role=perm.role,
@@ -60,9 +60,9 @@ def _permission_to_response(perm) -> WorkflowWorkflowPermissionResponse:
     )
 
 
-def _audit_to_response(entry) -> WorkflowWorkflowAuditLogEntry:
+def _audit_to_response(entry) -> WorkflowAuditLogEntry:
     """Convert a WorkflowAuditLog ORM row to its response schema."""
-    return WorkflowWorkflowAuditLogEntry(
+    return WorkflowAuditLogEntry(
         id=str(entry.id),
         timestamp=entry.timestamp.isoformat() if entry.timestamp else "",
         user_id=entry.user_id,

--- a/autobot-backend/api/workflow_secrets.py
+++ b/autobot-backend/api/workflow_secrets.py
@@ -19,7 +19,7 @@ Issue #2153 — Secret management for workflow credentials.
 """
 
 import logging
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 


### PR DESCRIPTION
## Summary

- Restores 4 orphan annotation imports stripped during the #6042 Pydantic→domain schema migration. The first one (`Metadata` in `api/vnc_mcp.py`) was a **P0 boot crash** preventing every `/api/*` call — nginx was returning 502 for `/api/auth/login`, blocking user login on freshly provisioned hosts.
- Same regression class as #6536; would have been caught by #6540 (CI startup-import smoke test, not yet implemented).
- Bundled all 4 sites in one audit pass to keep the diff minimal and the migration debt closing as one logical change.

## Changes

| File | Issue | Severity | Fix |
|---|---|---|---|
| [api/vnc_mcp.py](autobot-backend/api/vnc_mcp.py) | #6569 | **P0** boot blocker | `+ from type_defs.common import Metadata` |
| [api/scheduler.py](autobot-backend/api/scheduler.py) | #6570 | P2 latent (test-imported only today) | `+ from type_defs.common import Metadata` |
| [api/workflow_permissions.py](autobot-backend/api/workflow_permissions.py) | #6571 | P2 latent | rename `WorkflowWorkflowAuditLogEntry` / `WorkflowWorkflowPermissionResponse` → canonical single-prefix names that exist in [api/schemas_workflows.py:1420,1431](autobot-backend/api/schemas_workflows.py#L1420) |
| [api/workflow_secrets.py](autobot-backend/api/workflow_secrets.py) | #6572 | P3 latent | `+ Optional` to existing `typing` import |

## Test plan

- [x] All 4 modules import cleanly via deployed venv:
  ```
  $ /opt/autobot/autobot-backend/venv/bin/python3.12 -c '...'
  OK   api.vnc_mcp
  OK   api.scheduler
  OK   api.workflow_permissions
  OK   api.workflow_secrets
  ```
- [x] Boot-path smoke test: `import initialization.router_registry.core_routers` exits 0 (this was crashing before).
- [ ] After Ansible deploy, `ss -tlnp | grep :8001` shows uvicorn bound; `curl -sSk https://localhost/api/health` returns 200; `https://localhost/login` POST flow works end-to-end.

## Why CI didn't catch it

There is no startup-import smoke test in CI yet (#6540). A 2-second `python -c 'from initialization.router_registry.core_routers import load_core_routers'` would catch every recurrence of this pattern.

## Related

- #6536 — first occurrence of the pattern (vnc_manager.py + cache_management.py)
- #6539 — broader migration audit (different files)
- #6540 — CI startup-import smoke test
- #6042 — parent schema-migration epic
- feedback memory `feedback_migration_imports_audit.md` — \"Schema-migration commits removing imports must grep for residual usages BEFORE merging\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)