### PR TITLE
refactor(schemas): migrate Phase 33 endpoint schemas — 6 files, 12 classes (#6042)

### DIFF
--- a/autobot-backend/api/agent_config.py
+++ b/autobot-backend/api/agent_config.py
@@ -18,7 +18,6 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.schemas_agent import (
@@ -26,6 +25,7 @@ from api.schemas_agent import (
     AgentConfigHealthResponse,
     AgentConfigOverviewResponse,
     AgentConfigUpdateModelResponse,
+    AgentModelUpdate,
 )
 from api.schemas_common import DataResponse
 
@@ -130,25 +130,6 @@ async def _get_available_providers() -> list:
     except Exception as e:
         logger.warning("Could not check provider availability: %s", e)
         return []
-
-
-class AgentConfig(BaseModel):
-    """Agent configuration model"""
-
-    agent_id: str
-    name: str
-    model: str
-    provider: str
-    enabled: bool
-    priority: Optional[int] = 1
-
-
-class AgentModelUpdate(BaseModel):
-    """Agent model update request"""
-
-    agent_id: str
-    model: str
-    provider: Optional[str] = "ollama"
 
 
 # Define agent types and their default configurations

--- a/autobot-backend/api/analytics_embedding_patterns.py
+++ b/autobot-backend/api/analytics_embedding_patterns.py
@@ -27,8 +27,8 @@ from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
 
+from api.schemas_analytics import EmbeddingUsageRequest
 from auth_middleware import check_admin_permission
 from autobot_shared.redis_client import RedisDatabase
 from autobot_shared.redis_mixin import AsyncRedisClientLockedMixin
@@ -129,71 +129,6 @@ class BatchOptimizationRecommendation:
 # =============================================================================
 # Pydantic Models
 # =============================================================================
-
-
-class EmbeddingUsageRequest(BaseModel):
-    """Request to record embedding usage"""
-
-    operation_type: str = Field(
-        default="document_vectorization", description="Type of embedding operation"
-    )
-    model: str = Field(..., description="Embedding model used")
-    provider: str = Field(default="ollama", description="Embedding provider")
-    token_count: int = Field(..., description="Total tokens processed")
-    document_count: int = Field(default=1, description="Number of documents processed")
-    batch_size: int = Field(default=1, description="Batch size used")
-    processing_time: float = Field(..., description="Processing time in seconds")
-    success: bool = Field(default=True, description="Whether operation succeeded")
-    source: Optional[str] = Field(None, description="Source of the operation")
-    metadata: Optional[Dict[str, Any]] = Field(None, description="Additional metadata")
-
-    # === Issue #372: Feature Envy Reduction Methods ===
-
-    def to_usage_record(self, operation_id: str, cost: float) -> Dict[str, Any]:
-        """Convert to usage record dict for storage (Issue #372)."""
-        return {
-            "operation_id": operation_id,
-            "operation_type": self.operation_type,
-            "model": self.model,
-            "provider": self.provider,
-            "token_count": self.token_count,
-            "document_count": self.document_count,
-            "batch_size": self.batch_size,
-            "processing_time": self.processing_time,
-            "success": self.success,
-            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            "cost": cost,
-            "source": self.source or "unknown",
-            "metadata": self.metadata or {},
-        }
-
-    def get_tokens_per_second(self) -> float:
-        """Calculate tokens per second (Issue #372)."""
-        if self.processing_time > 0:
-            return self.token_count / self.processing_time
-        return 0
-
-    def get_log_summary(self) -> str:
-        """Get formatted log summary (Issue #372)."""
-        return (
-            f"{self.document_count} docs, {self.token_count} tokens, "
-            f"{self.processing_time:.3f}s"
-        )
-
-
-class EmbeddingStatsResponse(BaseModel):
-    """Response model for embedding statistics"""
-
-    total_operations: int
-    total_tokens: int
-    total_documents: int
-    total_cost: float
-    avg_processing_time: float
-    success_rate: float
-    avg_batch_size: float
-    tokens_per_second: float
-    period: str
-    timestamp: str
 
 
 # =============================================================================

--- a/autobot-backend/api/branch_health.py
+++ b/autobot-backend/api/branch_health.py
@@ -12,8 +12,8 @@ import logging
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, Field
 
+from api.schemas_system import BranchDivergenceResponse, BranchHealthResponse
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.ssot_config import config
@@ -24,27 +24,6 @@ router = APIRouter(
     dependencies=[Depends(check_admin_permission)],
 )
 logger = logging.getLogger(__name__)
-
-
-class BranchDivergenceResponse(BaseModel):
-    """Branch divergence metrics response."""
-
-    branch: str
-    ahead: int
-    behind: int
-    total_commits_diverged: int
-    conflicting_files: List[str] = Field(default_factory=list)
-
-
-class BranchHealthResponse(BaseModel):
-    """Branch health metrics response."""
-
-    branch: str
-    divergence: BranchDivergenceResponse
-    days_since_activity: float
-    is_stale: bool
-    health_score: float
-    last_activity: str = Field(None, description="ISO format datetime or null")
 
 
 @router.get("/branch-health/all", response_model=List[BranchHealthResponse])

--- a/autobot-backend/api/captcha.py
+++ b/autobot-backend/api/captcha.py
@@ -22,8 +22,8 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Path
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 
+from api.schemas_workflows import CaptchaResolutionRequest, CaptchaResolutionResponse
 from autobot_shared.time_utils import utc_timestamp
 from services.captcha_human_loop import CaptchaResolutionStatus, get_captcha_human_loop
 from api.schemas_common import DataResponse
@@ -31,22 +31,6 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 router = APIRouter(prefix="/captcha", tags=["captcha"])
 logger = logging.getLogger(__name__)
-
-
-class CaptchaResolutionRequest(BaseModel):
-    """Request model for CAPTCHA resolution"""
-
-    notes: Optional[str] = None
-
-
-class CaptchaResolutionResponse(BaseModel):
-    """Response model for CAPTCHA resolution"""
-
-    success: bool
-    captcha_id: str
-    status: str
-    message: str
-    timestamp: Optional[str] = None
 
 
 @router.post("/{captcha_id}/resolve", response_model=CaptchaResolutionResponse)

--- a/autobot-backend/api/elevation.py
+++ b/autobot-backend/api/elevation.py
@@ -14,14 +14,15 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
 
 from api.schemas_common import SuccessResponse
 from api.schemas_workflows import (
+    ElevationAuthorization,
     ElevationAuthorizeResponse,
     ElevationExecuteResponse,
     ElevationHealthResponse,
     ElevationPendingResponse,
+    ElevationRequest,
     ElevationRequestResponse,
     ElevationStatusResponse,
 )
@@ -47,19 +48,6 @@ pending_requests: Dict[str, dict] = {}
 # Locks for thread-safe access
 _elevation_sessions_lock = asyncio.Lock()
 _pending_requests_lock = asyncio.Lock()
-
-
-class ElevationRequest(BaseModel):
-    operation: str
-    command: str
-    reason: str
-    risk_level: str = "MEDIUM"
-
-
-class ElevationAuthorization(BaseModel):
-    request_id: str
-    password: str
-    remember_session: bool = False
 
 
 @with_error_handling(

--- a/autobot-backend/api/hot_reload.py
+++ b/autobot-backend/api/hot_reload.py
@@ -9,13 +9,12 @@ Provides REST endpoints for hot reloading chat workflow modules during developme
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from type_defs.common import Metadata
 from api.schemas_common import DataResponse
-from api.schemas_system import HotReloadHealthResponse
+from api.schemas_system import HotReloadHealthResponse, ReloadRequest, ReloadResponse
 
 logger = logging.getLogger(__name__)
 
@@ -24,23 +23,6 @@ router = APIRouter(
     tags=["hot-reload", "development"],
     dependencies=[Depends(check_admin_permission)],
 )
-
-
-class ReloadRequest(BaseModel):
-    """Request model for module reload"""
-
-    module_name: str = None
-    force: bool = False
-
-
-class ReloadResponse(BaseModel):
-    """Response model for reload operations"""
-
-    success: bool
-    message: str
-    results: Metadata = {}
-    reloaded_modules: list = []
-    errors: list = []
 
 
 @with_error_handling(

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -1849,3 +1849,27 @@ class ResetLearningResponse(BaseModel):
 
     success: bool
     message: str
+
+
+# ---------------------------------------------------------------------------
+# agent_config.py schemas
+# ---------------------------------------------------------------------------
+
+
+class AgentConfig(BaseModel):
+    """Agent configuration model."""
+
+    agent_id: str
+    name: str
+    model: str
+    provider: str
+    enabled: bool
+    priority: Optional[int] = 1
+
+
+class AgentModelUpdate(BaseModel):
+    """Agent model update request."""
+
+    agent_id: str
+    model: str
+    provider: Optional[str] = "ollama"

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -3162,3 +3162,68 @@ class TaintSummary(BaseModel):
     vulnerabilities_by_type: Dict[str, int]
     vulnerabilities_by_severity: Dict[str, int]
     tainted_variables: List[str]
+
+
+# ---------------------------------------------------------------------------
+# analytics_embedding_patterns.py schemas
+# ---------------------------------------------------------------------------
+
+
+class EmbeddingUsageRequest(BaseModel):
+    """Request to record embedding usage."""
+
+    operation_type: str = Field(default="document_vectorization", description="Type of embedding operation")
+    model: str = Field(..., description="Embedding model used")
+    provider: str = Field(default="ollama", description="Embedding provider")
+    token_count: int = Field(..., description="Total tokens processed")
+    document_count: int = Field(default=1, description="Number of documents processed")
+    batch_size: int = Field(default=1, description="Batch size used")
+    processing_time: float = Field(..., description="Processing time in seconds")
+    success: bool = Field(default=True, description="Whether operation succeeded")
+    source: Optional[str] = Field(None, description="Source of the operation")
+    metadata: Optional[Dict[str, Any]] = Field(None, description="Additional metadata")
+
+    def to_usage_record(self, operation_id: str, cost: float) -> Dict[str, Any]:
+        """Convert to usage record dict for storage."""
+        from datetime import datetime, timezone
+        return {
+            "operation_id": operation_id,
+            "operation_type": self.operation_type,
+            "model": self.model,
+            "provider": self.provider,
+            "token_count": self.token_count,
+            "document_count": self.document_count,
+            "batch_size": self.batch_size,
+            "processing_time": self.processing_time,
+            "success": self.success,
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            "cost": cost,
+            "source": self.source or "unknown",
+            "metadata": self.metadata or {},
+        }
+
+    def get_tokens_per_second(self) -> float:
+        if self.processing_time > 0:
+            return self.token_count / self.processing_time
+        return 0
+
+    def get_log_summary(self) -> str:
+        return (
+            f"{self.document_count} docs, {self.token_count} tokens, "
+            f"{self.processing_time:.3f}s"
+        )
+
+
+class EmbeddingStatsResponse(BaseModel):
+    """Response model for embedding statistics."""
+
+    total_operations: int
+    total_tokens: int
+    total_documents: int
+    total_cost: float
+    avg_processing_time: float
+    success_rate: float
+    avg_batch_size: float
+    tokens_per_second: float
+    period: str
+    timestamp: str

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -3500,3 +3500,51 @@ class SessionActionLog(BaseModel):
     params: Dict = Field(default_factory=dict)
     timestamp: str = Field(default_factory=lambda: datetime.now(tz=timezone.utc).isoformat())
     result: str = Field(default="success", description="Action result: success/error")
+
+
+# ---------------------------------------------------------------------------
+# branch_health.py schemas
+# ---------------------------------------------------------------------------
+
+
+class BranchDivergenceResponse(BaseModel):
+    """Branch divergence metrics response."""
+
+    branch: str
+    ahead: int
+    behind: int
+    total_commits_diverged: int
+    conflicting_files: List[str] = Field(default_factory=list)
+
+
+class BranchHealthResponse(BaseModel):
+    """Branch health metrics response."""
+
+    branch: str
+    divergence: BranchDivergenceResponse
+    days_since_activity: float
+    is_stale: bool
+    health_score: float
+    last_activity: str = Field(None, description="ISO format datetime or null")
+
+
+# ---------------------------------------------------------------------------
+# hot_reload.py schemas
+# ---------------------------------------------------------------------------
+
+
+class ReloadRequest(BaseModel):
+    """Request model for module reload."""
+
+    module_name: str = None
+    force: bool = False
+
+
+class ReloadResponse(BaseModel):
+    """Response model for reload operations."""
+
+    success: bool
+    message: str
+    results: Metadata = {}
+    reloaded_modules: list = []
+    errors: list = []

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -2288,3 +2288,46 @@ class APIBatchResponse(BaseModel):
     responses: Dict
     errors: Dict[str, str]
     timing: Dict[str, float]
+
+
+# ---------------------------------------------------------------------------
+# captcha.py schemas
+# ---------------------------------------------------------------------------
+
+
+class CaptchaResolutionRequest(BaseModel):
+    """Request model for CAPTCHA resolution."""
+
+    notes: Optional[str] = None
+
+
+class CaptchaResolutionResponse(BaseModel):
+    """Response model for CAPTCHA resolution."""
+
+    success: bool
+    captcha_id: str
+    status: str
+    message: str
+    timestamp: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# elevation.py schemas
+# ---------------------------------------------------------------------------
+
+
+class ElevationRequest(BaseModel):
+    """Request to escalate privileges for a system operation."""
+
+    operation: str
+    command: str
+    reason: str
+    risk_level: str = "MEDIUM"
+
+
+class ElevationAuthorization(BaseModel):
+    """Authorization payload for an existing elevation request."""
+
+    request_id: str
+    password: str
+    remember_session: bool = False


### PR DESCRIPTION
## Summary
Migrates 12 Pydantic classes from 6 endpoint files into the matching domain schema modules under `autobot-backend/api/schemas_*`.

- agent_config.py: AgentConfig, AgentModelUpdate → schemas_agent.py
- branch_health.py: BranchDivergenceResponse, BranchHealthResponse → schemas_system.py
- captcha.py: CaptchaResolutionRequest, CaptchaResolutionResponse → schemas_workflows.py
- elevation.py: ElevationRequest, ElevationAuthorization → schemas_workflows.py
- hot_reload.py: ReloadRequest, ReloadResponse → schemas_system.py
- analytics_embedding_patterns.py: EmbeddingUsageRequest (helper methods preserved), EmbeddingStatsResponse → schemas_analytics.py

Endpoint files now import the moved classes from schemas modules; no behavior change.

## Test plan
- [x] py_compile clean on all 10 touched files
- [x] flake8 critical errors (E9, F63, F7, F82, F811) clean
- [x] EmbeddingUsageRequest helper methods (to_usage_record, get_tokens_per_second, get_log_summary) preserved

Closes part of #6042 (Phase 33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)