### PR TITLE
fix(frontend): correct misleading offline banner copy (closes #6565)

### DIFF
--- a/autobot-frontend/src/components/ui/OfflineBanner.vue
+++ b/autobot-frontend/src/components/ui/OfflineBanner.vue
@@ -31,8 +31,7 @@
           />
         </svg>
         <span>
-          Offline mode — local Ollama inference and knowledge base are available.
-          Web research and cloud LLMs are disabled.
+          Backend connection lost — retrying. Cached data still available.
           <span v-if="pendingCount > 0">
             {{ pendingCount }} action{{ pendingCount === 1 ? '' : 's' }} queued for retry.
           </span>


### PR DESCRIPTION
## Summary

- Banner previously claimed *\"Web research and cloud LLMs are disabled\"* but no production code actually disables those when `isOnline` is false.
- Verified: `grep -rn 'isOnline\|isFeatureAvailable\|requires-network' --include='*.vue' --include='*.ts' autobot-frontend/src` returns zero call-sites outside the composable, the banner, the action queue, and tests.
- New copy reflects what is actually observed: `/api/health` probe failed.
- The dead `'requires-network'` tier itself is tracked separately in #6566 (architectural decision required).

## Test plan

- [x] Diff is one Vue text block, no logic changes
- [ ] Visual check after merge + frontend build: banner displays new copy when backend is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)