### PR TITLE
fix(backend): use get_task_tracker() factory in desktop_streaming_manager (closes #6583)

### DIFF
--- a/autobot-backend/desktop_streaming_manager.py
+++ b/autobot-backend/desktop_streaming_manager.py
@@ -30,7 +30,7 @@ from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config
 from config import config_manager
 from constants.threshold_constants import TimingConstants
-from task_execution_tracker import TaskPriority, task_tracker
+from task_execution_tracker import TaskPriority, get_task_tracker
 
 # Type aliases for clarity
 SessionDict = dict[str, Any]
@@ -283,7 +283,7 @@ class VNCServerManager:
         Raises:
             RuntimeError: If VNC is not available or session creation fails.
         """
-        async with task_tracker.track_task(
+        async with get_task_tracker().track_task(
             "Create VNC Session",
             f"Creating desktop streaming session for user {user_id}",
             agent_type="desktop_streaming",


### PR DESCRIPTION
## Summary

- `desktop_streaming_manager.py:33` imported a non-existent symbol `task_tracker` from `task_execution_tracker`. That module exports `get_task_tracker = lazy_singleton(TaskExecutionTracker)` (factory pattern, line 570).
- Result: \`api.advanced_control\` router silently failed to load at boot (graceful-fallback feature-router pattern from #281 hides the failure as a log line).
- Fix: import the factory and call it at the use site, matching the `lazy_singleton` pattern enforced by #5622/#5626.

## Test plan

- [x] `python3 -c 'from api import advanced_control'` succeeds (was: `ImportError: cannot import name 'task_tracker'`)
- [x] `python3 -c 'import desktop_streaming_manager'` succeeds
- [ ] After merge + Ansible deploy, backend log shows `/advanced-control` in the loaded feature router count

🤖 Generated with [Claude Code](https://claude.com/claude-code)