### PR TITLE
fix(backend): replace deprecated FastAPI regex= with pattern= (closes #6584)

### DIFF
--- a/autobot-backend/api/knowledge_grounding.py
+++ b/autobot-backend/api/knowledge_grounding.py
@@ -235,12 +235,12 @@ async def verify_claim(
 async def list_conflicts(
     status: str = Query(
         "pending",
-        regex="^(pending|resolved|inconclusive)$",
+        pattern="^(pending|resolved|inconclusive)$",
         description="Filter by resolution status",
     ),
     severity: Optional[str] = Query(
         None,
-        regex="^(low|medium|high)$",
+        pattern="^(low|medium|high)$",
         description="Filter by severity",
     ),
     limit: int = Query(
@@ -446,7 +446,7 @@ async def resolve_conflict(
 async def get_stats(
     period: str = Query(
         "24h",
-        regex="^(1h|24h|7d|30d)$",
+        pattern="^(1h|24h|7d|30d)$",
         description="Time period for stats",
     ),
     current_user: str = Depends(check_admin_permission),

--- a/autobot-backend/routers/code_completion.py
+++ b/autobot-backend/routers/code_completion.py
@@ -180,7 +180,7 @@ async def list_patterns(
     category: Optional[str] = Query(None),
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
-    sort_by: str = Query("frequency", regex="^(frequency|acceptance_rate|created_at)$"),
+    sort_by: str = Query("frequency", pattern="^(frequency|acceptance_rate|created_at)$"),
 ):
     """
     List extracted patterns with filtering and pagination.


### PR DESCRIPTION
## Summary

- `Query(..., regex=...)` is deprecated by FastAPI in favor of `pattern=`. Found 4 sites across 2 files (one more than the issue listed):
  - [api/knowledge_grounding.py:238](autobot-backend/api/knowledge_grounding.py#L238), [:243](autobot-backend/api/knowledge_grounding.py#L243), [:449](autobot-backend/api/knowledge_grounding.py#L449)
  - [routers/code_completion.py:183](autobot-backend/routers/code_completion.py#L183)
- Pure rename, regex semantics unchanged.

## Test plan

- [x] `python3 -c 'from api import knowledge_grounding; from routers import code_completion'` succeeds
- [x] `grep -rn 'regex=' autobot-backend/api/ autobot-backend/routers/ --include='*.py'` shows no Query calls remaining
- [ ] After merge: boot path produces no `FastAPIDeprecationWarning` from these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)