### PR TITLE
refactor(schemas): migrate Phase 34 endpoint schemas — 8 files, 8 classes (#6042)

### DIFF
--- a/autobot-backend/api/bi_export_endpoints.py
+++ b/autobot-backend/api/bi_export_endpoints.py
@@ -17,25 +17,16 @@ Remaining endpoints:
   POST   /bi/reports/saved/{report_id}/run — execute a saved report
 """
 
-from typing import List
-
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.saved_reports_service import get_saved_reports_service
 from api.schemas_common import DataResponse
-from api.schemas_agent import SavedReportResponse, SavedReportsListResponse
+from api.schemas_agent import SavedReportRequest, SavedReportResponse, SavedReportsListResponse
 
 router = APIRouter(tags=["bi-reports"])
-
-
-class SavedReportRequest(BaseModel):
-    name: str
-    report_type: str = "executive"
-    sections: List[str] = ["cost", "agents"]
 
 
 # =========================================================================

--- a/autobot-backend/api/chat_compare.py
+++ b/autobot-backend/api/chat_compare.py
@@ -23,8 +23,8 @@ from typing import AsyncIterator, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
 
+from api.schemas_chat import CompareRequest
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
@@ -51,22 +51,6 @@ async def _get_compare_interface() -> object:
 
             _compare_interface = LLMInterface()
     return _compare_interface
-
-
-# ---------------------------------------------------------------------------
-# Request model
-# ---------------------------------------------------------------------------
-
-
-class CompareRequest(BaseModel):
-    prompt: str = Field(..., min_length=1, max_length=50000)
-    models: List[str] = Field(
-        ...,
-        min_length=1,
-        max_length=10,
-        description="List of 'provider/model' strings, e.g. ['ollama/llama3', 'openai/gpt-4o']",
-    )
-    context: Optional[str] = Field(None, max_length=50000)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/config_revisions.py
+++ b/autobot-backend/api/config_revisions.py
@@ -9,12 +9,12 @@ Endpoints for listing, inspecting, and rolling back configuration revisions.
 
 import logging
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.schemas_system import ConfigRevisionResponse
 from api.user_management.dependencies import get_db_session
 from auth_middleware import get_current_user
 from autobot_shared.models.pagination import PaginationParams
@@ -23,24 +23,6 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
-
-
-# -- Response schemas --------------------------------------------------
-
-
-class ConfigRevisionResponse(BaseModel):
-    """Response for a single config revision."""
-
-    id: str
-    entity_type: str
-    entity_id: str
-    before_config: Optional[Dict[str, Any]] = None
-    after_config: Dict[str, Any]
-    changed_keys: List[str] = Field(default_factory=list)
-    source: str
-    created_by: str
-    created_at: Optional[str] = None
-    updated_at: Optional[str] = None
 
 
 # -- Helpers -----------------------------------------------------------

--- a/autobot-backend/api/conversation_export.py
+++ b/autobot-backend/api/conversation_export.py
@@ -16,11 +16,9 @@ Endpoints:
 """
 
 import logging
-from typing import Optional
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import Response
-from pydantic import BaseModel, Field
 
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -33,7 +31,7 @@ from services.conversation_export import (
 from utils.chat_exceptions import get_exceptions_lazy
 from utils.chat_utils import get_chat_history_manager, validate_chat_session_id
 from api.schemas_common import DataResponse
-from api.schemas_agent import ConversationImportResponse
+from api.schemas_agent import ConversationImportRequest, ConversationImportResponse
 
 logger = logging.getLogger(__name__)
 
@@ -56,30 +54,6 @@ _FILE_EXTENSIONS = {
 
 # Valid on_conflict values
 _VALID_ON_CONFLICT = frozenset({"skip", "replace", "rename"})
-
-
-# ---------------------------------------------------------------------------
-# Request / Response models
-# ---------------------------------------------------------------------------
-
-
-class ConversationImportRequest(BaseModel):
-    """Request body for importing a conversation (#1808)."""
-
-    document: dict = Field(
-        ...,
-        description=(
-            "AutoBot conversation export document produced by the export endpoint "
-            "(format: autobot-conversation-v1)."
-        ),
-    )
-    on_conflict: str = Field(
-        default="skip",
-        description=(
-            "Conflict resolution strategy when session_id already exists. "
-            "One of: skip, replace, rename."
-        ),
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/development_speedup.py
+++ b/autobot-backend/api/development_speedup.py
@@ -12,7 +12,6 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 
 from agents.development_speedup_agent import (
     analyze_codebase,
@@ -21,6 +20,7 @@ from agents.development_speedup_agent import (
 )
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from api.schemas_code import DevelopmentSpeedupAnalysisRequest
 from api.schemas_common import DataResponse, SuccessResponse
 
 router = APIRouter()
@@ -86,14 +86,6 @@ ANALYSIS_TYPE_HANDLERS: Dict[str, AnalysisHandler] = {
 VALID_ANALYSIS_TYPES = ", ".join(ANALYSIS_TYPE_HANDLERS.keys())
 
 
-class AnalysisRequest(BaseModel):
-    """Request model for code analysis."""
-
-    root_path: str
-    # Options: comprehensive, duplicates, patterns, imports, dead_code, refactoring, quality
-    analysis_type: str = "comprehensive"
-
-
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_codebase_endpoint",
@@ -105,7 +97,7 @@ class AnalysisRequest(BaseModel):
     operation="analyze_codebase_endpoint",
     error_code_prefix="DEVELOPMENT_SPEEDUP",
 )
-async def analyze_codebase_endpoint(request: AnalysisRequest):
+async def analyze_codebase_endpoint(request: DevelopmentSpeedupAnalysisRequest):
     """
     Comprehensive codebase analysis for development speedup.
 
@@ -170,7 +162,7 @@ async def analyze_codebase_get(
     - path: Root directory path to analyze (required)
     - type: Analysis type (comprehensive, duplicates, patterns, imports, dead_code, refactoring, quality)
     """
-    request = AnalysisRequest(root_path=path, analysis_type=type)
+    request = DevelopmentSpeedupAnalysisRequest(root_path=path, analysis_type=type)
     return await analyze_codebase_endpoint(request)
 
 

--- a/autobot-backend/api/gpu_monitoring.py
+++ b/autobot-backend/api/gpu_monitoring.py
@@ -13,24 +13,17 @@ Issue #2315: Fix decorator order, router prefix, GPU guard, and tag case.
 
 import logging
 from dataclasses import asdict
-from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
 
+from api.schemas_common import DataResponse
+from api.schemas_system import GPUConfigUpdateRequest
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["gpu-monitoring"])
-
-
-class GPUConfigUpdateRequest(BaseModel):
-    """Request body for GPU optimization configuration updates."""
-
-    updates: Dict[str, Any]
 
 
 def _gpu_unavailable_error() -> HTTPException:

--- a/autobot-backend/api/knowledge_boards.py
+++ b/autobot-backend/api/knowledge_boards.py
@@ -21,15 +21,17 @@ Endpoints (all require admin auth):
 
 import json
 import logging
-import re
 import uuid
 from datetime import datetime, timezone
-from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, Field, field_validator
 
-from api.schemas_knowledge import KnowledgeBoardCreateResponse, KnowledgeBoardDeleteResponse, KnowledgeBoardsListResponse
+from api.schemas_knowledge import (
+    CreateBoardRequest,
+    KnowledgeBoardCreateResponse,
+    KnowledgeBoardDeleteResponse,
+    KnowledgeBoardsListResponse,
+)
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from knowledge_factory import get_or_create_knowledge_base
@@ -41,39 +43,8 @@ router = APIRouter()
 # Redis key that holds all known boards as a JSON-serialised hash-map
 _BOARDS_KEY = "kb:boards"
 
-# Allowed characters for board IDs: lowercase letters, digits, hyphen, underscore
-_BOARD_ID_RE = re.compile(r"^[a-z0-9_-]{1,100}$")
-
 # The implicit global board — never stored, always valid
 GLOBAL_BOARD_ID = "__global__"
-
-
-class CreateBoardRequest(BaseModel):
-    """Request model for creating a new knowledge board."""
-
-    board_id: Optional[str] = Field(
-        default=None,
-        max_length=100,
-        description=(
-            "Stable identifier for the board (lowercase letters, digits, "
-            "hyphen, underscore). Auto-generated when omitted."
-        ),
-    )
-    name: str = Field(..., min_length=1, max_length=200, description="Human-readable board name")
-    description: str = Field(default="", max_length=500, description="Optional description")
-
-    @field_validator("board_id", mode="before")
-    @classmethod
-    def validate_board_id(cls, v):
-        if v is None:
-            return v
-        if v == GLOBAL_BOARD_ID:
-            raise ValueError("'__global__' is reserved and cannot be created")
-        if not _BOARD_ID_RE.match(v):
-            raise ValueError(
-                "board_id must only contain lowercase letters, digits, hyphen, or underscore"
-            )
-        return v
 
 
 def _board_entry(board_id: str, name: str, description: str) -> dict:

--- a/autobot-backend/api/knowledge_cognition.py
+++ b/autobot-backend/api/knowledge_cognition.py
@@ -14,9 +14,12 @@ import logging
 import os
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException
-from pydantic import BaseModel
 
-from api.schemas_knowledge import KnowledgeCognitionSeedResponse, KnowledgeCognitionStatusResponse
+from api.schemas_knowledge import (
+    KnowledgeCognitionSeedResponse,
+    KnowledgeCognitionStatusResponse,
+    SeedRequest,
+)
 from auth_middleware import check_admin_permission
 from constants.path_constants import PATH
 from services.knowledge.cognition_seeder import get_cognition_seeder
@@ -28,12 +31,6 @@ router = APIRouter(tags=["knowledge-cognition"])
 
 # Default manifest path relative to project root
 _DEFAULT_MANIFEST = "cognition_seed.yaml"
-
-
-class SeedRequest(BaseModel):
-    """Optional body for the seed endpoint."""
-
-    manifest_path: str = _DEFAULT_MANIFEST
 
 
 @router.get("/cognition-store/status", response_model=KnowledgeCognitionStatusResponse)

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -1873,3 +1873,40 @@ class AgentModelUpdate(BaseModel):
     agent_id: str
     model: str
     provider: Optional[str] = "ollama"
+
+
+# ---------------------------------------------------------------------------
+# bi_export_endpoints.py schemas
+# ---------------------------------------------------------------------------
+
+
+class SavedReportRequest(BaseModel):
+    """Request to save a BI report configuration."""
+
+    name: str
+    report_type: str = "executive"
+    sections: List[str] = ["cost", "agents"]
+
+
+# ---------------------------------------------------------------------------
+# conversation_export.py schemas
+# ---------------------------------------------------------------------------
+
+
+class ConversationImportRequest(BaseModel):
+    """Request body for importing a conversation."""
+
+    document: dict = Field(
+        ...,
+        description=(
+            "AutoBot conversation export document produced by the export endpoint "
+            "(format: autobot-conversation-v1)."
+        ),
+    )
+    on_conflict: str = Field(
+        default="skip",
+        description=(
+            "Conflict resolution strategy when session_id already exists. "
+            "One of: skip, replace, rename."
+        ),
+    )

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -464,3 +464,21 @@ class DetectLanguageRequest(BaseModel):
     """Request model for language detection."""
 
     text: str = Field(..., min_length=1, max_length=50000, description="Text to detect language of")
+
+
+# ---------------------------------------------------------------------------
+# chat_compare.py schemas
+# ---------------------------------------------------------------------------
+
+
+class CompareRequest(BaseModel):
+    """Request body for /api/chat/compare multi-model comparison."""
+
+    prompt: str = Field(..., min_length=1, max_length=50000)
+    models: List[str] = Field(
+        ...,
+        min_length=1,
+        max_length=10,
+        description="List of 'provider/model' strings, e.g. ['ollama/llama3', 'openai/gpt-4o']",
+    )
+    context: Optional[str] = Field(None, max_length=50000)

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -2522,3 +2522,15 @@ class CompletionResponse(BaseModel):
     completion_time_ms: float
     source: str
     cached: bool = False
+
+
+# ---------------------------------------------------------------------------
+# development_speedup.py schemas
+# ---------------------------------------------------------------------------
+
+
+class DevelopmentSpeedupAnalysisRequest(BaseModel):
+    """Request model for development_speedup code analysis."""
+
+    root_path: str
+    analysis_type: str = "comprehensive"

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -4760,3 +4760,53 @@ class AIStackRAGQueryRequest(BaseModel):
     context: Optional[str] = Field(None, description="Additional context")
     max_results: int = Field(10, ge=1, le=30, description="Maximum results")
     include_reasoning: bool = Field(False, description="Include reasoning steps")
+
+
+# ---------------------------------------------------------------------------
+# knowledge_boards.py schemas
+# ---------------------------------------------------------------------------
+
+# The implicit global board — never stored, always valid
+KNOWLEDGE_BOARD_GLOBAL_ID = "__global__"
+
+# Allowed characters for board IDs: lowercase letters, digits, hyphen, underscore
+_BOARD_ID_RE = re.compile(r"^[a-z0-9_-]{1,100}$")
+
+
+class CreateBoardRequest(BaseModel):
+    """Request model for creating a new knowledge board."""
+
+    board_id: Optional[str] = Field(
+        default=None,
+        max_length=100,
+        description=(
+            "Stable identifier for the board (lowercase letters, digits, "
+            "hyphen, underscore). Auto-generated when omitted."
+        ),
+    )
+    name: str = Field(..., min_length=1, max_length=200, description="Human-readable board name")
+    description: str = Field(default="", max_length=500, description="Optional description")
+
+    @field_validator("board_id", mode="before")
+    @classmethod
+    def validate_board_id(cls, v):
+        if v is None:
+            return v
+        if v == KNOWLEDGE_BOARD_GLOBAL_ID:
+            raise ValueError("'__global__' is reserved and cannot be created")
+        if not _BOARD_ID_RE.match(v):
+            raise ValueError(
+                "board_id must only contain lowercase letters, digits, hyphen, or underscore"
+            )
+        return v
+
+
+# ---------------------------------------------------------------------------
+# knowledge_cognition.py schemas
+# ---------------------------------------------------------------------------
+
+
+class SeedRequest(BaseModel):
+    """Optional body for the cognition store seed endpoint."""
+
+    manifest_path: str = "cognition_seed.yaml"

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -3548,3 +3548,33 @@ class ReloadResponse(BaseModel):
     results: Metadata = {}
     reloaded_modules: list = []
     errors: list = []
+
+# ---------------------------------------------------------------------------
+# config_revisions.py schemas
+# ---------------------------------------------------------------------------
+
+
+class ConfigRevisionResponse(BaseModel):
+    """Response for a single config revision."""
+
+    id: str
+    entity_type: str
+    entity_id: str
+    before_config: Optional[Dict[str, Any]] = None
+    after_config: Dict[str, Any]
+    changed_keys: List[str] = Field(default_factory=list)
+    source: str
+    created_by: str
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# gpu_monitoring.py schemas
+# ---------------------------------------------------------------------------
+
+
+class GPUConfigUpdateRequest(BaseModel):
+    """Request body for GPU optimization configuration updates."""
+
+    updates: Dict[str, Any]


### PR DESCRIPTION
## Summary
Migrates 8 Pydantic classes from 8 endpoint files into matching domain schema modules.

- bi_export_endpoints.py: SavedReportRequest → schemas_agent.py
- chat_compare.py: CompareRequest → schemas_chat.py
- config_revisions.py: ConfigRevisionResponse → schemas_system.py
- conversation_export.py: ConversationImportRequest → schemas_agent.py
- development_speedup.py: AnalysisRequest → schemas_code.py as DevelopmentSpeedupAnalysisRequest (renamed for collision-safety)
- gpu_monitoring.py: GPUConfigUpdateRequest → schemas_system.py
- knowledge_boards.py: CreateBoardRequest (with field_validator) → schemas_knowledge.py
- knowledge_cognition.py: SeedRequest → schemas_knowledge.py

Endpoint files now import the moved classes from schemas modules; no behavior change. Unused typing imports removed where the local class was the only consumer.

## Test plan
- [x] py_compile clean on all 13 touched files
- [x] flake8 critical errors (E9, F63, F7, F82, F811, F821, F401) clean

Part of #6042 (Phase 34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)