### PR TITLE
docs(frontend): correct FeatureConnectivity tier docs (closes #6566)

### DIFF
--- a/autobot-frontend/src/composables/useNetworkStatus.ts
+++ b/autobot-frontend/src/composables/useNetworkStatus.ts
@@ -10,10 +10,20 @@
  * Uses Navigator.onLine as fast initial signal, then probes the backend health
  * endpoint for confirmation (handles captive portals and VPN splits).
  *
- * Features tagged as:
- *   - 'local-only'       — always available (Ollama inference, KB search)
- *   - 'requires-network' — disabled when offline (web research, cloud LLMs)
- *   - 'prefers-network'  — works offline with degraded output (analytics sync)
+ * "Online" means the browser can reach the backend. It says nothing about whether
+ * the backend itself can reach external services — server-side features like
+ * web research and cloud LLM calls run from the backend's outbound connectivity
+ * and are NOT gated by this composable.
+ *
+ * FeatureConnectivity tiers (#6566):
+ *   - 'local-only'       — works without browser→backend connectivity at all
+ *                          (purely client-rendered views; no API calls).
+ *   - 'requires-network' — needs the browser to reach the backend; disable
+ *                          submit/CTA buttons when offline. Reserve for features
+ *                          that genuinely cannot be queued (e.g., realtime
+ *                          streams). Do NOT use for backend-executed features
+ *                          like web research, RAG, or cloud LLMs.
+ *   - 'prefers-network'  — works offline via cache/queue; show staleness hints.
  */
 
 import { ref, readonly, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope } from 'vue'


### PR DESCRIPTION
## Summary

Resolves #6566 (\"\`requires-network\` / \`isFeatureAvailable\` is dead infrastructure — wire it in or simplify\") via documentation correction.

The right answer turned out to be neither A nor B: the API surface is fine, but its **JSDoc was misleading**. It claimed web research and cloud LLMs are `'requires-network'`, but those are *backend-executed* features that use the **backend's** outbound connectivity, not the browser→backend probe this composable performs. That false claim propagated into the offline banner copy (already fixed in #6565) and led the user to (correctly) flag that web research should not be disabled when the user's browser temporarily can't reach the backend.

## Why this resolves the issue

- **Per \"Never delete code — wire it in\"**: API kept intact for future legitimate use (realtime streams, browser-direct external calls).
- **Per user requirement**: web research/cloud LLMs explicitly documented as **NOT** gated by this composable.
- **Audit trail**: future contributors won't be tempted to wire `isFeatureAvailable('requires-network')` into web-research / RAG / cloud-LLM UIs — the tier definition now spells out which feature types it does and does not apply to.

## Test plan

- [x] Diff is JSDoc only (no API surface change, no behavior change)
- [x] Existing tests in [__tests__/useNetworkStatus.test.ts](autobot-frontend/src/composables/__tests__/useNetworkStatus.test.ts) still describe the API correctly (`isFeatureAvailable` semantics unchanged)

## Related

- #6565 — banner copy fix (already merged) — addressed the user-visible symptom
- #3275 — original offline-mode feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)