### PR TITLE
fix(install): out-of-the-box install now deploys autobot-backend (closes #6600)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -451,8 +451,12 @@ ansible_deployment() {
     local inventory="${ansible_dir}/inventory/localhost.yml"
 
     info "Generating localhost inventory..."
+    # Single-host install: SLM Manager host also runs autobot-backend so the
+    # /api/auth/login flow works out of the box (#6600). The plural node_roles
+    # is the variable consulted by provision-fleet-roles.yml's role gates;
+    # node_role (singular) is preserved for backward compat.
     cat > "${inventory}" << 'INVENTORY'
-# AutoBot localhost inventory for self-deploy (Issue #1294)
+# AutoBot localhost inventory for self-deploy (Issue #1294, #6600)
 all:
   hosts:
     00-SLM-Manager:
@@ -461,8 +465,17 @@ all:
       ansible_python_interpreter: /usr/bin/python3
       slm_node_id: "00-SLM-Manager"
       node_role: "slm-manager"
+      node_roles:
+        - autobot-backend
+        - vnc
   children:
     slm_server:
+      hosts:
+        00-SLM-Manager:
+    main:
+      hosts:
+        00-SLM-Manager:
+    backend:
       hosts:
         00-SLM-Manager:
 INVENTORY
@@ -543,7 +556,10 @@ EOF
     chown autobot:autobot /tmp/ansible_fact_cache /tmp/ansible-retry /tmp/.ansible-cp /tmp/ansible_local_tmp
 
     info "Running Ansible deployment (this may take several minutes)..."
-    log "  Playbook: deploy-slm-manager.yml --skip-tags seed,provision"
+    # #6600: keep `provision` so backend role applies to 00-SLM-Manager in
+    # single-host mode. Skip only `seed` — fleet seeding requires SLM DB
+    # rows that don't exist yet on a fresh install.
+    log "  Playbook: deploy-slm-manager.yml --skip-tags seed"
     info "  Live progress below — full output also in ${LOG_FILE}"
     echo
 
@@ -552,7 +568,7 @@ EOF
     ansible-playbook \
         -i "${inventory}" \
         playbooks/deploy-slm-manager.yml \
-        --skip-tags "seed,provision" \
+        --skip-tags "seed" \
         -e "slm_admin_password=${ADMIN_PASSWORD}" \
         -e "target_host=localhost" \
         2>&1 | tee -a "${LOG_FILE}" | \


### PR DESCRIPTION
## Summary

Fresh \`install.sh\` was leaving the autobot-backend service undeployed → \`/api/auth/login\` returned 502 forever. Two compounding root causes, both in \`install.sh\`:

1. **`--skip-tags \"seed,provision\"`** — the entire backend role apply in [provision-fleet-roles.yml](autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml#L299) is gated by the \`provision\` tag. Skipping it meant the backend role never ran, full stop.
2. **Generated localhost.yml had no \`node_roles\`** — even if provision had run, the gate at [provision-fleet-roles.yml:304-308](autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml#L304) checks plural `node_roles` (or membership in `main` / `backend` groups). The generated inventory only set singular `node_role: \"slm-manager\"`, which the gate ignores.

## Changes

- **`install.sh:454-481`** — generated localhost.yml now declares:
  - `node_roles: [autobot-backend, vnc]` on `00-SLM-Manager`
  - `00-SLM-Manager` added to `main` and `backend` groups
  - This is additive — the variable doesn't affect multi-host deployments because they use a different inventory file (\`slm-nodes.yml\`).

- **`install.sh:559`** — `--skip-tags \"seed,provision\"` → `--skip-tags \"seed\"`. \`seed\` correctly stays skipped on fresh install (no fleet DB rows exist yet); \`provision\` must run so the backend role actually deploys.

## Test plan

- [x] `bash -n install.sh` clean (syntax check)
- [x] Diff reviewed — additive only, no removed call paths
- [ ] Fresh install on a clean host: `./install.sh` → `ss -tlnp \| grep :8001` shows uvicorn bound → `curl -sSk https://localhost/api/health` returns 200 → `https://localhost/login` POST returns 401/200 (not 502)
- [ ] Existing multi-host install (using `inventory/slm-nodes.yml`) unaffected — that inventory is not regenerated by install.sh

## Related

- #6569 — boot-blocker that surfaced this install gap (same login-broken investigation)
- #1294 — single-host self-deploy (where `localhost.yml` was first introduced)
- #2961 — single-host deployment runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)