### PR TITLE
refactor(schemas): migrate Phase 36 endpoint schemas — 6 files, 12 classes (#6042)

### DIFF
--- a/autobot-backend/api/analytics_debt.py
+++ b/autobot-backend/api/analytics_debt.py
@@ -23,8 +23,8 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
 
+from api.schemas_analytics import DebtCalculationRequest
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_redis_client
@@ -115,29 +115,6 @@ class DebtItem:
             "recommendation": self.recommendation,
             "tags": self.tags,
         }
-
-
-class DebtCalculationRequest(BaseModel):
-    """Request for debt calculation"""
-
-    target_path: str = Field(default=".", description="Path to analyze")
-    hourly_rate: float = Field(default=75.0, description="Developer hourly rate in USD")
-    include_categories: List[str] = Field(
-        default=[], description="Categories to include (empty = all)"
-    )
-
-
-class DebtSummary(BaseModel):
-    """Summary of technical debt"""
-
-    total_items: int
-    total_hours: float
-    total_cost_usd: float
-    by_category: Dict[str, int]
-    by_severity: Dict[str, int]
-    top_files: List[Dict[str, Any]]
-    roi_ranking: List[Dict[str, Any]]
-    timestamp: str
 
 
 # Debt calculation weights

--- a/autobot-backend/api/integration_version_control.py
+++ b/autobot-backend/api/integration_version_control.py
@@ -8,19 +8,19 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
 
-from auth_middleware import check_admin_permission
-from integrations.base import IntegrationConfig, IntegrationHealth
-from integrations.version_control_integration import (
-    BitbucketIntegration,
-    GitLabIntegration,
-)
 from api.schemas_code import (
     VCSBranchesResponse,
     VCSCommitInfoResponse,
     VCSPullRequestsResponse,
     VCSRepositoriesResponse,
+)
+from api.schemas_workflows import ConnectionTestRequest, ProviderInfo
+from auth_middleware import check_admin_permission
+from integrations.base import IntegrationConfig, IntegrationHealth
+from integrations.version_control_integration import (
+    BitbucketIntegration,
+    GitLabIntegration,
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
@@ -29,30 +29,6 @@ router = APIRouter(
     tags=["integrations-version-control"],
     dependencies=[Depends(check_admin_permission)],
 )
-
-
-class ConnectionTestRequest(BaseModel):
-    """Request model for testing VCS connection."""
-
-    provider: str = Field(..., description="VCS provider (gitlab, bitbucket)")
-    api_key: str = Field(..., description="API key or access token")
-    settings: Dict[str, Any] = Field(
-        default_factory=dict, description="Provider-specific settings"
-    )
-
-
-class ProviderInfo(BaseModel):
-    """Information about a VCS provider."""
-
-    id: str = Field(..., description="Provider identifier")
-    name: str = Field(..., description="Provider display name")
-    description: str = Field(..., description="Provider description")
-    required_settings: List[str] = Field(
-        default_factory=list, description="Required configuration settings"
-    )
-    optional_settings: List[str] = Field(
-        default_factory=list, description="Optional configuration settings"
-    )
 
 
 SUPPORTED_PROVIDERS = {

--- a/autobot-backend/api/kb_librarian.py
+++ b/autobot-backend/api/kb_librarian.py
@@ -32,40 +32,22 @@ Overlap note (issue #3336):
 """
 
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
 
 from agents.kb_librarian_agent import get_kb_librarian
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from type_defs.common import Metadata
-from api.schemas_common import DataResponse
-from api.schemas_knowledge import KbLibrarianConfigureResponse, KbLibrarianStatusResponse
+from api.schemas_knowledge import (
+    KBQuery,
+    KBQueryResponse,
+    KbLibrarianConfigureResponse,
+    KbLibrarianStatusResponse,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-
-
-class KBQuery(BaseModel):
-    """Knowledge base query request model."""
-
-    query: str
-    max_results: Optional[int] = None
-    similarity_threshold: Optional[float] = None
-    auto_summarize: Optional[bool] = None
-
-
-class KBQueryResponse(BaseModel):
-    """Knowledge base query response model."""
-
-    enabled: bool
-    is_question: bool
-    query: str
-    documents_found: int
-    documents: List[Metadata]
-    summary: Optional[str] = None
 
 
 @with_error_handling(

--- a/autobot-backend/api/knowledge_audit.py
+++ b/autobot-backend/api/knowledge_audit.py
@@ -8,51 +8,28 @@ Issue #679: Audit logging and compliance reporting for knowledge access and modi
 """
 
 import logging
-from datetime import datetime, timedelta
-from autobot_shared.time_utils import now_utc
+from datetime import timedelta
 from typing import Dict, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel, Field
+from autobot_shared.time_utils import now_utc
 
-from api.schemas_knowledge import KnowledgeAuditEventsResponse, KnowledgeComplianceReportResponse, KnowledgePermissionChangesResponse
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from api.schemas_knowledge import (
+    ComplianceReportRequest,
+    KnowledgeAuditEventsResponse,
+    KnowledgeComplianceReportResponse,
+    KnowledgePermissionChangesResponse,
+)
 from auth_middleware import get_current_user
 from autobot_shared.models.pagination import PaginationParams
-from knowledge.audit_log import AuditEventType, KnowledgeAuditLog
+from knowledge.audit_log import KnowledgeAuditLog
 from knowledge_factory import get_or_create_knowledge_base
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/knowledge/audit", tags=["knowledge-audit"])
-
-
-# =============================================================================
-# Pydantic Models
-# =============================================================================
-
-
-class AuditEvent(BaseModel):
-    """Audit event model."""
-
-    id: str
-    type: AuditEventType
-    user_id: str
-    fact_id: Optional[str] = None
-    organization_id: Optional[str] = None
-    details: dict = Field(default_factory=dict)
-    ip_address: Optional[str] = None
-    timestamp: str
-
-
-class ComplianceReportRequest(BaseModel):
-    """Request for compliance report."""
-
-    start_date: datetime = Field(description="Report start date")
-    end_date: datetime = Field(description="Report end date")
-    organization_id: Optional[str] = Field(
-        default=None, description="Organization ID (defaults to user's org)"
-    )
 
 
 # =============================================================================

--- a/autobot-backend/api/onboarding.py
+++ b/autobot-backend/api/onboarding.py
@@ -13,35 +13,18 @@ Provides first-run UX endpoints:
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
 
 from api.schemas_common import DataResponse
+from api.schemas_system import ApplyPresetRequest, OnboardingStatus
 from onboarding.presets import get_all_presets, get_preset
 from onboarding.doctor import run_doctor
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["onboarding"])
-
-
-# ---------------------------------------------------------------------------
-# Request / Response models
-# ---------------------------------------------------------------------------
-
-
-class ApplyPresetRequest(BaseModel):
-    preset_name: str
-    overrides: dict[str, Any] = {}
-
-
-class OnboardingStatus(BaseModel):
-    """Response model for GET /api/onboarding/status (#6452)."""
-
-    preset_applied: bool
-    preset_name: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -8,12 +8,11 @@ Advanced multi-agent orchestration endpoints with improved coordination and stra
 """
 
 import logging
-from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 
+from api.schemas_workflows import AgentRecommendationRequest, WorkflowRequest
 from auth_middleware import check_admin_permission, get_current_user
 
 try:
@@ -37,18 +36,6 @@ from api.schemas_common import DataResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-
-
-class WorkflowRequest(BaseModel):
-    goal: str
-    strategy: Optional[str] = None  # Let system decide if not specified
-    context: Optional[dict] = None
-    max_parallel_tasks: Optional[int] = 5
-
-
-class AgentRecommendationRequest(BaseModel):
-    task_type: str
-    capabilities_needed: list[str]
 
 
 @with_error_handling(

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -3246,3 +3246,31 @@ class UsageRecordRequest(BaseModel):
     agent_id: Optional[str] = None
     latency_ms: Optional[float] = None
     success: bool = True
+
+
+# ---------------------------------------------------------------------------
+# analytics_debt.py schemas
+# ---------------------------------------------------------------------------
+
+
+class DebtCalculationRequest(BaseModel):
+    """Request for technical debt calculation."""
+
+    target_path: str = Field(default=".", description="Path to analyze")
+    hourly_rate: float = Field(default=75.0, description="Developer hourly rate in USD")
+    include_categories: List[str] = Field(
+        default_factory=list, description="Categories to include (empty = all)"
+    )
+
+
+class DebtSummary(BaseModel):
+    """Summary of technical debt."""
+
+    total_items: int
+    total_hours: float
+    total_cost_usd: float
+    by_category: Dict[str, int]
+    by_severity: Dict[str, int]
+    top_files: List[Dict[str, Any]]
+    roi_ranking: List[Dict[str, Any]]
+    timestamp: str

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -4851,3 +4851,59 @@ class ScopedSearchRequest(BaseModel):
     )
     enable_rag: bool = Field(default=False, description="Enable RAG enhancement")
     enable_reranking: bool = Field(default=False, description="Enable reranking")
+
+
+# ---------------------------------------------------------------------------
+# kb_librarian.py schemas
+# ---------------------------------------------------------------------------
+
+
+class KBQuery(BaseModel):
+    """Knowledge base query request model."""
+
+    query: str
+    max_results: Optional[int] = None
+    similarity_threshold: Optional[float] = None
+    auto_summarize: Optional[bool] = None
+
+
+class KBQueryResponse(BaseModel):
+    """Knowledge base query response model."""
+
+    enabled: bool
+    is_question: bool
+    query: str
+    documents_found: int
+    documents: List[Metadata]
+    summary: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# knowledge_audit.py schemas
+# ---------------------------------------------------------------------------
+
+from datetime import datetime as _datetime
+from knowledge.audit_log import AuditEventType as _AuditEventType
+
+
+class AuditEvent(BaseModel):
+    """Audit event model."""
+
+    id: str
+    type: _AuditEventType
+    user_id: str
+    fact_id: Optional[str] = None
+    organization_id: Optional[str] = None
+    details: dict = Field(default_factory=dict)
+    ip_address: Optional[str] = None
+    timestamp: str
+
+
+class ComplianceReportRequest(BaseModel):
+    """Request for compliance report."""
+
+    start_date: _datetime = Field(description="Report start date")
+    end_date: _datetime = Field(description="Report end date")
+    organization_id: Optional[str] = Field(
+        default=None, description="Organization ID (defaults to user's org)"
+    )

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -3622,3 +3622,22 @@ class VncProxyStatusResponse(BaseModel):
     accessible: bool
     status: Optional[int] = None
     error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# onboarding.py schemas
+# ---------------------------------------------------------------------------
+
+
+class ApplyPresetRequest(BaseModel):
+    """Request body for applying an onboarding preset."""
+
+    preset_name: str
+    overrides: Dict[str, Any] = Field(default_factory=dict)
+
+
+class OnboardingStatus(BaseModel):
+    """Response model for GET /api/onboarding/status."""
+
+    preset_applied: bool
+    preset_name: Optional[str] = None

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -2344,3 +2344,53 @@ class DashboardGenerateRequest(BaseModel):
     include_trends: bool = True
     include_recommendations: bool = True
     refresh_interval: int = 30  # seconds
+
+
+# ---------------------------------------------------------------------------
+# integration_version_control.py schemas
+# ---------------------------------------------------------------------------
+
+
+class ConnectionTestRequest(BaseModel):
+    """Request model for testing VCS connection."""
+
+    provider: str = Field(..., description="VCS provider (gitlab, bitbucket)")
+    api_key: str = Field(..., description="API key or access token")
+    settings: Dict[str, Any] = Field(
+        default_factory=dict, description="Provider-specific settings"
+    )
+
+
+class ProviderInfo(BaseModel):
+    """Information about a VCS provider."""
+
+    id: str = Field(..., description="Provider identifier")
+    name: str = Field(..., description="Provider display name")
+    description: str = Field(..., description="Provider description")
+    required_settings: List[str] = Field(
+        default_factory=list, description="Required configuration settings"
+    )
+    optional_settings: List[str] = Field(
+        default_factory=list, description="Optional configuration settings"
+    )
+
+
+# ---------------------------------------------------------------------------
+# orchestration.py schemas
+# ---------------------------------------------------------------------------
+
+
+class WorkflowRequest(BaseModel):
+    """Request body for orchestration workflow execution."""
+
+    goal: str
+    strategy: Optional[str] = None
+    context: Optional[dict] = None
+    max_parallel_tasks: Optional[int] = 5
+
+
+class AgentRecommendationRequest(BaseModel):
+    """Request body for agent recommendations from orchestrator."""
+
+    task_type: str
+    capabilities_needed: List[str]


### PR DESCRIPTION
## Summary
Migrates 12 Pydantic classes from 6 endpoint files into matching domain schema modules.

- integration_version_control.py: ConnectionTestRequest, ProviderInfo → schemas_workflows.py
- kb_librarian.py: KBQuery, KBQueryResponse → schemas_knowledge.py
- knowledge_audit.py: AuditEvent, ComplianceReportRequest → schemas_knowledge.py
- onboarding.py: ApplyPresetRequest, OnboardingStatus → schemas_system.py
- orchestration.py: WorkflowRequest, AgentRecommendationRequest → schemas_workflows.py
- analytics_debt.py: DebtCalculationRequest, DebtSummary → schemas_analytics.py

Endpoint files now import the moved classes from schemas modules; no behavior change.

## Test plan
- [x] py_compile clean on all 10 touched files
- [x] flake8 critical errors (E9, F63, F7, F82, F811, F821) clean

Part of #6042 (Phase 36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)