### PR TITLE
fix(backend): P0 boot crash — rename duplicate ProviderInfo/ConnectionTestRequest (closes #6604)

### DIFF
--- a/autobot-backend/api/integration_version_control.py
+++ b/autobot-backend/api/integration_version_control.py
@@ -15,7 +15,7 @@ from api.schemas_code import (
     VCSPullRequestsResponse,
     VCSRepositoriesResponse,
 )
-from api.schemas_workflows import ConnectionTestRequest, ProviderInfo
+from api.schemas_workflows import VCSConnectionTestRequest, VCSProviderInfo
 from auth_middleware import check_admin_permission
 from integrations.base import IntegrationConfig, IntegrationHealth
 from integrations.version_control_integration import (
@@ -98,7 +98,7 @@ def _create_integration(provider: str, config: IntegrationConfig) -> Any:
     operation="test_connection",
     error_code_prefix="INTEGRATION_VERSION_CONTROL",
 )
-async def test_connection(request: ConnectionTestRequest) -> IntegrationHealth:
+async def test_connection(request: VCSConnectionTestRequest) -> IntegrationHealth:
     """Test VCS provider connection.
 
     Args:
@@ -132,13 +132,13 @@ async def test_connection(request: ConnectionTestRequest) -> IntegrationHealth:
         raise HTTPException(status_code=500, detail="Connection test failed")
 
 
-@router.get("/providers", response_model=List[ProviderInfo])
+@router.get("/providers", response_model=List[VCSProviderInfo])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_providers",
     error_code_prefix="INTEGRATION_VERSION_CONTROL",
 )
-async def get_providers() -> List[ProviderInfo]:
+async def get_providers() -> List[VCSProviderInfo]:
     """Get list of supported VCS providers.
 
     Returns:
@@ -147,7 +147,7 @@ async def get_providers() -> List[ProviderInfo]:
     providers = []
     for provider_id, info in SUPPORTED_PROVIDERS.items():
         providers.append(
-            ProviderInfo(
+            VCSProviderInfo(
                 id=provider_id,
                 name=info["name"],
                 description=info["description"],

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -2351,8 +2351,13 @@ class DashboardGenerateRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class ConnectionTestRequest(BaseModel):
-    """Request model for testing VCS connection."""
+class VCSConnectionTestRequest(BaseModel):
+    """Request model for testing VCS connection (#6604).
+
+    Renamed from `ConnectionTestRequest` to disambiguate from the project-
+    management variant defined earlier in this module — same name, different
+    shape, last-definition-wins was masking the project-management caller.
+    """
 
     provider: str = Field(..., description="VCS provider (gitlab, bitbucket)")
     api_key: str = Field(..., description="API key or access token")
@@ -2361,8 +2366,13 @@ class ConnectionTestRequest(BaseModel):
     )
 
 
-class ProviderInfo(BaseModel):
-    """Information about a VCS provider."""
+class VCSProviderInfo(BaseModel):
+    """Information about a VCS provider (#6604).
+
+    Renamed from `ProviderInfo` to disambiguate from the project-management
+    `ProviderInfo` defined earlier in this module — same name, different shape,
+    last-definition-wins was masking the project-management caller.
+    """
 
     id: str = Field(..., description="Provider identifier")
     name: str = Field(..., description="Provider display name")


### PR DESCRIPTION
## Summary

Backend was crashing on import after PR #6575 cleared the prior \`Metadata\` orphan. New crash exposed by next provisioning run:

\`\`\`
File \"/opt/autobot/autobot-backend/api/integration_project_management.py\", line 61
    \"jira\": ProviderInfo(provider=\"jira\", name=\"Jira\", ...)
ValidationError: 1 validation error for ProviderInfo
id
  Field required
\`\`\`

**Root cause:** [\`api/schemas_workflows.py\`](autobot-backend/api/schemas_workflows.py) defines two classes with the same name but different field shapes:

| Line | Class | Shape | Used by |
|---:|---|---|---|
| 1626 | \`ProviderInfo\` | \`provider, name, description, auth_type, base_url_required, documentation_url\` | \`integration_project_management.py\` |
| 2364 | \`ProviderInfo\` | \`id, name, description, required_settings, optional_settings\` | \`integration_version_control.py\` |
| 1614 | \`ConnectionTestRequest\` | project-management auth fields | \`integration_project_management.py\` |
| 2354 | \`ConnectionTestRequest\` | VCS auth fields | \`integration_version_control.py\` |

Python's last-definition-wins meant the project-management caller silently got the VCS shape. Project-management crashed at import because it constructed instances using project-management fields against a model that required \`id\`.

## Fix

Rename the VCS variants only (one caller for each):

- \`schemas_workflows.py\`: \`ProviderInfo\` (line 2364) → \`VCSProviderInfo\`, \`ConnectionTestRequest\` (line 2354) → \`VCSConnectionTestRequest\`
- \`integration_version_control.py\`: 4 references updated (1 import + 3 use sites)

Both classes now coexist without name collision. Project-management variants kept as-is since they're the canonical shape used in their domain.

## Test plan

- [x] All affected modules import cleanly via deployed venv: \`api.integration_project_management\`, \`api.integration_version_control\`, \`api.schemas_workflows\`, \`initialization.router_registry.core_routers\`, \`main\`
- [x] No remaining duplicate-class collisions in \`schemas_workflows.py\` (verified via \`grep -n '^class' | sort | uniq -c\`)
- [ ] After merge + Ansible deploy: \`ss -tlnp | grep :8001\` shows uvicorn bound; \`https://localhost/api/auth/login\` POST returns 401/200 (not 502)

## Discovery noted

While auditing all schema files I also found \`UsageRecordRequest\` defined twice in [\`api/schemas_analytics.py\`](autobot-backend/api/schemas_analytics.py) (lines 2806 + 3237) with different shapes. **Not a boot blocker** — the two callers' import paths happen to resolve consistently — but a latent shape mismatch. Filed separately as a follow-up to keep this PR focused on the boot crash.

## Related

- #6569 — prior #6042 boot crash (Metadata orphan, fixed in PR #6575)
- #6536 — original schema-migration boot crash
- #6539 — broader migration audit (this is a recurring pattern)
- #6540 — CI startup-import smoke test (would have caught both #6604 and #6569 in <1s)
- feedback memory: \"Schema-migration commits removing imports must grep for residual usages BEFORE merging\" — applies equally to **duplicate class definitions** as to missing imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)