### PR TITLE
refactor(schemas): migrate Phase 37 endpoint schemas — 5 files, 10 classes (#6042)

### DIFF
--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -2551,3 +2551,23 @@ class AddRepoRequest(BaseModel):
     repo_type: _SkillsRepoType = Field(...)
     auto_sync: bool = Field(False)
     sync_interval: int = Field(60, description="Sync interval in minutes")
+
+
+# ---------------------------------------------------------------------------
+# templates.py schemas
+# ---------------------------------------------------------------------------
+
+
+class TemplateExecutionRequest(BaseModel):
+    """Request body for executing a workflow template."""
+
+    template_id: str
+    variables: Optional[Dict[str, str]] = None
+    auto_approve: bool = False
+
+
+class TemplateValidationRequest(BaseModel):
+    """Request body for validating template variables."""
+
+    template_id: str
+    variables: Dict[str, str]

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -2394,3 +2394,189 @@ class AgentRecommendationRequest(BaseModel):
 
     task_type: str
     capabilities_needed: List[str]
+
+
+# ---------------------------------------------------------------------------
+# sequential_thinking_mcp.py schemas
+# ---------------------------------------------------------------------------
+
+
+class SequentialThinkingMCPTool(BaseModel):
+    """Standard MCP tool definition for sequential thinking."""
+
+    name: str
+    description: str
+    input_schema: Metadata
+
+
+class SequentialThinkingRequest(BaseModel):
+    """Request model for sequential thinking tool."""
+
+    thought: str = Field(..., description="Current thinking step and analysis")
+    thought_number: int = Field(
+        ..., ge=1, description="Current thought number in sequence"
+    )
+    total_thoughts: int = Field(
+        ..., ge=1, description="Estimated total thoughts needed"
+    )
+    next_thought_needed: bool = Field(
+        ..., description="Whether another thought step is needed"
+    )
+
+    is_revision: Optional[bool] = Field(
+        False, description="Whether this revises previous thinking"
+    )
+    revises_thought: Optional[int] = Field(
+        None, ge=1, description="Which thought is being reconsidered"
+    )
+    branch_from_thought: Optional[int] = Field(
+        None, ge=1, description="Branching point thought number"
+    )
+    branch_id: Optional[str] = Field(None, description="Branch identifier")
+    needs_more_thoughts: Optional[bool] = Field(
+        False, description="If more thoughts are needed beyond initial estimate"
+    )
+
+    session_id: Optional[str] = Field(
+        "default", description="Thinking session identifier"
+    )
+
+    def to_thought_record(self) -> Metadata:
+        """Convert to thought record for storage."""
+        from datetime import datetime, timezone
+
+        return {
+            "thought_number": self.thought_number,
+            "thought": self.thought,
+            "total_thoughts": self.total_thoughts,
+            "next_thought_needed": self.next_thought_needed,
+            "is_revision": self.is_revision,
+            "revises_thought": self.revises_thought,
+            "branch_from_thought": self.branch_from_thought,
+            "branch_id": self.branch_id,
+            "needs_more_thoughts": self.needs_more_thoughts,
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        }
+
+    def get_progress_percentage(self) -> float:
+        """Calculate progress percentage."""
+        return (self.thought_number / self.total_thoughts) * 100
+
+    def get_session_key(self) -> str:
+        """Get session key with fallback."""
+        return self.session_id or "default"
+
+    def is_valid_thought_number(self) -> bool:
+        """Check if thought number is valid."""
+        return self.thought_number <= self.total_thoughts or self.needs_more_thoughts
+
+    def has_revision(self) -> bool:
+        """Check if this is a revision."""
+        return bool(self.is_revision)
+
+    def get_revision_info(self) -> Optional[Metadata]:
+        """Get revision info dict if this is a revision."""
+        if not self.is_revision:
+            return None
+        return {
+            "is_revision": True,
+            "revises_thought": self.revises_thought,
+        }
+
+    def has_branch(self) -> bool:
+        """Check if this is a branch."""
+        return bool(self.branch_from_thought)
+
+    def get_branch_info(self) -> Optional[Metadata]:
+        """Get branch info dict if this is a branch."""
+        if not self.branch_from_thought:
+            return None
+        return {
+            "branched": True,
+            "branch_from_thought": self.branch_from_thought,
+            "branch_id": self.branch_id,
+        }
+
+    def get_progress_message(self) -> str:
+        """Get progress message string."""
+        return f"Recorded thought {self.thought_number}/{self.total_thoughts}"
+
+
+# ---------------------------------------------------------------------------
+# state_tracking.py schemas
+# ---------------------------------------------------------------------------
+
+
+class StateChangeRequest(BaseModel):
+    """Request body for tracking a state change."""
+
+    change_type: str
+    description: str
+    after_state: Metadata
+    before_state: Optional[Metadata] = None
+    user_id: Optional[str] = "system"
+    metadata: Optional[Metadata] = None
+
+
+class StateTrackingExportRequest(BaseModel):
+    """Request body for state-tracking export."""
+
+    format: str = "json"  # json or markdown
+    include_history: bool = True
+    time_range_days: Optional[int] = None
+
+
+# ---------------------------------------------------------------------------
+# system_validation.py schemas
+# ---------------------------------------------------------------------------
+
+
+class SystemValidationRequestModel(BaseModel):
+    """Request model for system validation."""
+
+    validation_type: str = "comprehensive"
+    include_performance_tests: bool = True
+    include_stress_tests: bool = False
+    timeout_seconds: int = 300
+
+
+class SystemValidationResultModel(BaseModel):
+    """Response model for system validation results."""
+
+    validation_id: str
+    status: str
+    overall_score: float
+    component_scores: Dict[str, float]
+    recommendations: List[str]
+    test_results: Metadata
+    execution_time: float
+    timestamp: str
+
+
+# ---------------------------------------------------------------------------
+# web_research_settings.py schemas
+# ---------------------------------------------------------------------------
+
+
+class WebResearchSettings(BaseModel):
+    """Web research settings model."""
+
+    enabled: bool
+    require_user_confirmation: bool = True
+    preferred_method: str = "basic"
+    max_results: int = 5
+    timeout_seconds: int = 30
+    auto_research_threshold: float = 0.3
+    rate_limit_requests: int = 5
+    rate_limit_window: int = 60
+
+
+class ResearchPreferences(BaseModel):
+    """User research preferences."""
+
+    auto_research_enabled: bool = False
+    daily_limit: int = 50
+    quality_threshold: float = 0.5
+    store_results_in_kb: bool = True
+    filter_adult_content: bool = True
+    anonymize_requests: bool = True

--- a/autobot-backend/api/sequential_thinking_mcp.py
+++ b/autobot-backend/api/sequential_thinking_mcp.py
@@ -16,18 +16,18 @@ Enables agents to:
 
 import asyncio
 import logging
-from datetime import datetime, timezone
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from type_defs.common import Metadata
 from api.schemas_common import DataResponse
 from api.schemas_workflows import (
+    SequentialThinkingMCPTool,
     SequentialThinkingMCPToolsResponse,
+    SequentialThinkingRequest,
     SequentialThinkingResponse,
     SequentialThinkingSessionListResponse,
     SequentialThinkingSessionResponse,
@@ -116,111 +116,6 @@ SEQUENTIAL_THINKING_MCP_TOOL_DEFINITION = (
 )
 
 
-class MCPTool(BaseModel):
-    """Standard MCP tool definition"""
-
-    name: str
-    description: str
-    input_schema: Metadata
-
-
-class SequentialThinkingRequest(BaseModel):
-    """Request model for sequential thinking tool"""
-
-    thought: str = Field(..., description="Current thinking step and analysis")
-    thought_number: int = Field(
-        ..., ge=1, description="Current thought number in sequence"
-    )
-    total_thoughts: int = Field(
-        ..., ge=1, description="Estimated total thoughts needed"
-    )
-    next_thought_needed: bool = Field(
-        ..., description="Whether another thought step is needed"
-    )
-
-    # Optional revision/branching parameters
-    is_revision: Optional[bool] = Field(
-        False, description="Whether this revises previous thinking"
-    )
-    revises_thought: Optional[int] = Field(
-        None, ge=1, description="Which thought is being reconsidered"
-    )
-    branch_from_thought: Optional[int] = Field(
-        None, ge=1, description="Branching point thought number"
-    )
-    branch_id: Optional[str] = Field(None, description="Branch identifier")
-    needs_more_thoughts: Optional[bool] = Field(
-        False, description="If more thoughts are needed beyond initial estimate"
-    )
-
-    # Session management
-    session_id: Optional[str] = Field(
-        "default", description="Thinking session identifier"
-    )
-
-    def to_thought_record(self) -> Metadata:
-        """Convert to thought record for storage (Issue #372 - reduces feature envy).
-
-        Returns:
-            Dictionary containing thought record fields.
-        """
-        return {
-            "thought_number": self.thought_number,
-            "thought": self.thought,
-            "total_thoughts": self.total_thoughts,
-            "next_thought_needed": self.next_thought_needed,
-            "is_revision": self.is_revision,
-            "revises_thought": self.revises_thought,
-            "branch_from_thought": self.branch_from_thought,
-            "branch_id": self.branch_id,
-            "needs_more_thoughts": self.needs_more_thoughts,
-            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-        }
-
-    def get_progress_percentage(self) -> float:
-        """Calculate progress percentage (Issue #372 - reduces feature envy)."""
-        return (self.thought_number / self.total_thoughts) * 100
-
-    def get_session_key(self) -> str:
-        """Get session key with fallback (Issue #372 - reduces feature envy)."""
-        return self.session_id or "default"
-
-    def is_valid_thought_number(self) -> bool:
-        """Check if thought number is valid (Issue #372 - reduces feature envy)."""
-        return self.thought_number <= self.total_thoughts or self.needs_more_thoughts
-
-    def has_revision(self) -> bool:
-        """Check if this is a revision (Issue #372 - reduces feature envy)."""
-        return bool(self.is_revision)
-
-    def get_revision_info(self) -> Optional[Metadata]:
-        """Get revision info dict if this is a revision (Issue #372 - reduces feature envy)."""
-        if not self.is_revision:
-            return None
-        return {
-            "is_revision": True,
-            "revises_thought": self.revises_thought,
-        }
-
-    def has_branch(self) -> bool:
-        """Check if this is a branch (Issue #372 - reduces feature envy)."""
-        return bool(self.branch_from_thought)
-
-    def get_branch_info(self) -> Optional[Metadata]:
-        """Get branch info dict if this is a branch (Issue #372 - reduces feature envy)."""
-        if not self.branch_from_thought:
-            return None
-        return {
-            "branched": True,
-            "branch_from_thought": self.branch_from_thought,
-            "branch_id": self.branch_id,
-        }
-
-    def get_progress_message(self) -> str:
-        """Get progress message string (Issue #372 - reduces feature envy)."""
-        return f"Recorded thought {self.thought_number}/{self.total_thoughts}"
-
-
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_sequential_thinking_mcp_tools",
@@ -232,7 +127,7 @@ class SequentialThinkingRequest(BaseModel):
     operation="get_sequential_thinking_mcp_tools",
     error_code_prefix="SEQUENTIAL_THINKING_MCP",
 )
-async def get_sequential_thinking_mcp_tools() -> List[MCPTool]:
+async def get_sequential_thinking_mcp_tools() -> List[SequentialThinkingMCPTool]:
     """
     Get available MCP tools for sequential thinking.
 
@@ -240,7 +135,7 @@ async def get_sequential_thinking_mcp_tools() -> List[MCPTool]:
     Reduced from 84 lines to ~10 lines (88% reduction).
     """
     name, description, input_schema = SEQUENTIAL_THINKING_MCP_TOOL_DEFINITION
-    return [MCPTool(name=name, description=description, input_schema=input_schema)]
+    return [SequentialThinkingMCPTool(name=name, description=description, input_schema=input_schema)]
 
 
 def _enrich_thought_record(

--- a/autobot-backend/api/state_tracking.py
+++ b/autobot-backend/api/state_tracking.py
@@ -13,11 +13,12 @@ from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 
 from api.schemas_workflows import (
+    StateChangeRequest,
     StateTrackingChangeResponse,
     StateTrackingChangesResponse,
+    StateTrackingExportRequest,
     StateTrackingExportResponse,
     StateTrackingMetricsAllResponse,
     StateTrackingMilestonesResponse,
@@ -34,25 +35,9 @@ from enhanced_project_state_tracker import (
     TrackingMetric,
     get_state_tracker,
 )
-from type_defs.common import Metadata
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-
-
-class StateChangeRequest(BaseModel):
-    change_type: str
-    description: str
-    after_state: Metadata
-    before_state: Optional[Metadata] = None
-    user_id: Optional[str] = "system"
-    metadata: Optional[Metadata] = None
-
-
-class ExportRequest(BaseModel):
-    format: str = "json"  # json or markdown
-    include_history: bool = True
-    time_range_days: Optional[int] = None
 
 
 @with_error_handling(
@@ -427,7 +412,7 @@ async def generate_state_report():
     operation="export_state_data",
     error_code_prefix="STATE_TRACKING",
 )
-async def export_state_data(request: ExportRequest):
+async def export_state_data(request: StateTrackingExportRequest):
     """Export state tracking data"""
     try:
         tracker = get_state_tracker()

--- a/autobot-backend/api/system_validation.py
+++ b/autobot-backend/api/system_validation.py
@@ -7,13 +7,10 @@ System Validation API endpoints for AutoBot optimization suite
 """
 
 import logging
-from typing import Dict, List
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException
-from pydantic import BaseModel
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from type_defs.common import Metadata
 from utils.catalog_http_exceptions import raise_catalog_error_simple, raise_server_error
 from utils.system_validator import get_system_validator
 from api.schemas_workflows import (
@@ -22,6 +19,8 @@ from api.schemas_workflows import (
     SystemValidationHealthResponse,
     SystemValidationQuickResponse,
     SystemValidationRecommendationsResponse,
+    SystemValidationRequestModel,
+    SystemValidationResultModel,
     SystemValidationStatusResponse,
 )
 
@@ -29,28 +28,6 @@ logger = logging.getLogger(__name__)
 
 # Create router
 router = APIRouter()
-
-
-class ValidationRequest(BaseModel):
-    """Request model for system validation"""
-
-    validation_type: str = "comprehensive"
-    include_performance_tests: bool = True
-    include_stress_tests: bool = False
-    timeout_seconds: int = 300
-
-
-class ValidationResult(BaseModel):
-    """Response model for validation results"""
-
-    validation_id: str
-    status: str
-    overall_score: float
-    component_scores: Dict[str, float]
-    recommendations: List[str]
-    test_results: Metadata
-    execution_time: float
-    timestamp: str
 
 
 @with_error_handling(
@@ -84,14 +61,14 @@ async def validation_health():
     operation="run_comprehensive_validation",
     error_code_prefix="SYSTEM_VALIDATION",
 )
-@router.post("/validate/comprehensive", response_model=ValidationResult)
+@router.post("/validate/comprehensive", response_model=SystemValidationResultModel)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="run_comprehensive_validation",
     error_code_prefix="SYSTEM_VALIDATION",
 )
 async def run_comprehensive_validation(
-    request: ValidationRequest, background_tasks: BackgroundTasks
+    request: SystemValidationRequestModel, background_tasks: BackgroundTasks
 ):
     """Run comprehensive system validation"""
     try:
@@ -104,7 +81,7 @@ async def run_comprehensive_validation(
             raise_server_error("API_0003", "Validation failed")
 
         # Format response
-        validation_result = ValidationResult(
+        validation_result = SystemValidationResultModel(
             validation_id=result["validation_id"],
             status="completed",
             overall_score=result["overall_score"],

--- a/autobot-backend/api/templates.py
+++ b/autobot-backend/api/templates.py
@@ -15,18 +15,19 @@ import logging
 from typing import Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
 
 from api.schemas_code import (
     TemplateCategoriesResponse,
     TemplateCreateWorkflowResponse,
     TemplateDetailResponse,
     TemplateExecuteResponse,
+    TemplateExecutionRequest,
     TemplateListResponse,
     TemplatePreviewResponse,
     TemplateSearchResponse,
     TemplateSecretsUsageResponse,
     TemplateStatsResponse,
+    TemplateValidationRequest,
     TemplateValidationResponse,
     TemplatesRootResponse,
 )
@@ -42,17 +43,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     dependencies=[Depends(check_admin_permission)],
 )
-
-
-class TemplateExecutionRequest(BaseModel):
-    template_id: str
-    variables: Optional[Dict[str, str]] = None
-    auto_approve: bool = False
-
-
-class TemplateValidationRequest(BaseModel):
-    template_id: str
-    variables: Dict[str, str]
 
 
 def _generate_templates_cache_key(category, tags, complexity):

--- a/autobot-backend/api/web_research_settings.py
+++ b/autobot-backend/api/web_research_settings.py
@@ -12,38 +12,14 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 
+from api.schemas_workflows import WebResearchSettings
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from api.schemas_common import DataResponse, SuccessResponse
+from api.schemas_common import DataResponse
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/web-research", tags=["web-research"])
-
-
-class WebResearchSettings(BaseModel):
-    """Web research settings model"""
-
-    enabled: bool
-    require_user_confirmation: bool = True
-    preferred_method: str = "basic"  # basic, advanced, api_based
-    max_results: int = 5
-    timeout_seconds: int = 30
-    auto_research_threshold: float = 0.3
-    rate_limit_requests: int = 5
-    rate_limit_window: int = 60
-
-
-class ResearchPreferences(BaseModel):
-    """User research preferences"""
-
-    auto_research_enabled: bool = False
-    daily_limit: int = 50
-    quality_threshold: float = 0.5
-    store_results_in_kb: bool = True
-    filter_adult_content: bool = True
-    anonymize_requests: bool = True
 
 
 @with_error_handling(


### PR DESCRIPTION
## Summary
Migrates 10 Pydantic classes from 5 endpoint files into matching domain schema modules. Renames applied to avoid name collisions.

- sequential_thinking_mcp.py: MCPTool → SequentialThinkingMCPTool, SequentialThinkingRequest (9 helper methods preserved) → schemas_workflows.py
- state_tracking.py: StateChangeRequest, ExportRequest → StateTrackingExportRequest → schemas_workflows.py
- system_validation.py: ValidationRequest → SystemValidationRequestModel, ValidationResult → SystemValidationResultModel → schemas_workflows.py
- templates.py: TemplateExecutionRequest, TemplateValidationRequest → schemas_code.py
- web_research_settings.py: WebResearchSettings, ResearchPreferences → schemas_workflows.py

Endpoint files now import the moved classes from schemas modules; no behavior change.

## Test plan
- [x] py_compile clean on all 7 touched files
- [x] flake8 critical errors (E9, F63, F7, F82, F811, F821, F401) clean
- [x] SequentialThinkingRequest helper methods (to_thought_record, get_progress_percentage, get_session_key, is_valid_thought_number, has_revision, get_revision_info, has_branch, get_branch_info, get_progress_message) preserved

Part of #6042 (Phase 37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)