### PR TITLE
refactor(schemas): migrate Phase 38 endpoint schemas — analytics_bug_prediction (#6042)

### DIFF
--- a/autobot-backend/api/analytics_bug_prediction.py
+++ b/autobot-backend/api/analytics_bug_prediction.py
@@ -14,12 +14,10 @@ import hashlib
 import json
 import logging
 from datetime import datetime, timedelta, timezone
-from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.redis_client import get_redis_client
@@ -27,18 +25,20 @@ from constants.threshold_constants import TimingConstants
 from constants.ttl_constants import TTL_5_MINUTES
 from utils.background_task_manager import BackgroundTaskManager
 from api.schemas_analytics import (
-    BugPredictionAnalyzeResponse,
-    BugPredictionStatusResponse,
-    BugPredictionClearStuckResponse,
-    BugPredictionRiskFactorsResponse,
-    BugPredictionRecordBugResponse,
     BugPredictionAnalysisResponse,
+    BugPredictionAnalyzeResponse,
     BugPredictionCachedResponse,
-    BugPredictionHighRiskResponse,
+    BugPredictionClearStuckResponse,
     BugPredictionFileResponse,
     BugPredictionHeatmapResponse,
-    BugPredictionTrendsResponse,
+    BugPredictionHighRiskResponse,
+    BugPredictionRecordBugResponse,
+    BugPredictionRiskFactorsResponse,
+    BugPredictionStatusResponse,
     BugPredictionSummaryResponse,
+    BugPredictionTrendsResponse,
+    RiskFactor,
+    RiskLevel,
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
@@ -200,54 +200,6 @@ def _build_file_risk_dict(
 # ============================================================================
 # Models
 # ============================================================================
-
-
-class RiskLevel(str, Enum):
-    """Bug risk levels."""
-
-    CRITICAL = "critical"
-    HIGH = "high"
-    MEDIUM = "medium"
-    LOW = "low"
-    MINIMAL = "minimal"
-
-
-class RiskFactor(str, Enum):
-    """Factors contributing to bug risk."""
-
-    COMPLEXITY = "complexity"
-    CHANGE_FREQUENCY = "change_frequency"
-    CODE_AGE = "code_age"
-    TEST_COVERAGE = "test_coverage"
-    BUG_HISTORY = "bug_history"
-    AUTHOR_EXPERIENCE = "author_experience"
-    FILE_SIZE = "file_size"
-    DEPENDENCY_COUNT = "dependency_count"
-
-
-class FileRisk(BaseModel):
-    """Bug risk assessment for a file."""
-
-    file_path: str
-    risk_score: float = Field(..., ge=0, le=100)
-    risk_level: RiskLevel
-    factors: dict[str, float] = Field(default_factory=dict)
-    bug_count_history: int = 0
-    last_bug_date: Optional[str] = None
-    prevention_tips: list[str] = Field(default_factory=list)
-    suggested_tests: list[str] = Field(default_factory=list)
-
-
-class PredictionResult(BaseModel):
-    """Bug prediction result for the codebase."""
-
-    timestamp: datetime
-    total_files: int
-    high_risk_count: int
-    predicted_bugs: int
-    accuracy_score: float
-    risk_distribution: dict[str, int] = Field(default_factory=dict)
-    top_risk_files: list[FileRisk] = Field(default_factory=list)
 
 
 # ============================================================================

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -3274,3 +3274,59 @@ class DebtSummary(BaseModel):
     top_files: List[Dict[str, Any]]
     roi_ranking: List[Dict[str, Any]]
     timestamp: str
+
+
+# ---------------------------------------------------------------------------
+# analytics_bug_prediction.py schemas
+# ---------------------------------------------------------------------------
+
+from datetime import datetime as _dt_datetime
+from enum import Enum as _BugPredEnum
+
+
+class RiskLevel(str, _BugPredEnum):
+    """Bug risk levels."""
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    MINIMAL = "minimal"
+
+
+class RiskFactor(str, _BugPredEnum):
+    """Factors contributing to bug risk."""
+
+    COMPLEXITY = "complexity"
+    CHANGE_FREQUENCY = "change_frequency"
+    CODE_AGE = "code_age"
+    TEST_COVERAGE = "test_coverage"
+    BUG_HISTORY = "bug_history"
+    AUTHOR_EXPERIENCE = "author_experience"
+    FILE_SIZE = "file_size"
+    DEPENDENCY_COUNT = "dependency_count"
+
+
+class FileRisk(BaseModel):
+    """Bug risk assessment for a file."""
+
+    file_path: str
+    risk_score: float = Field(..., ge=0, le=100)
+    risk_level: RiskLevel
+    factors: Dict[str, float] = Field(default_factory=dict)
+    bug_count_history: int = 0
+    last_bug_date: Optional[str] = None
+    prevention_tips: List[str] = Field(default_factory=list)
+    suggested_tests: List[str] = Field(default_factory=list)
+
+
+class PredictionResult(BaseModel):
+    """Bug prediction result for the codebase."""
+
+    timestamp: _dt_datetime
+    total_files: int
+    high_risk_count: int
+    predicted_bugs: int
+    accuracy_score: float
+    risk_distribution: Dict[str, int] = Field(default_factory=dict)
+    top_risk_files: List[FileRisk] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
Migrates 4 items from analytics_bug_prediction.py to schemas_analytics.py:

- RiskLevel enum
- RiskFactor enum
- FileRisk BaseModel
- PredictionResult BaseModel

Endpoint file now imports RiskLevel/RiskFactor from schemas (still used by RISK_WEIGHTS and PREVENTION_TIPS dicts). FileRisk/PredictionResult were defined but never referenced in the endpoint file — left available in the schema module for future callers.

## Test plan
- [x] py_compile clean
- [x] flake8 critical errors (E9, F63, F7, F82, F811, F821, F401) clean

Part of #6042 (Phase 38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)