### PR TITLE
refactor(schemas): migrate Phase 39 endpoint schemas — http_client_mcp (#6042)

### DIFF
--- a/autobot-backend/api/http_client_mcp.py
+++ b/autobot-backend/api/http_client_mcp.py
@@ -27,14 +27,21 @@ Issue #49 - Additional MCP Bridges (Browser, HTTP, Database, Git)
 import asyncio
 import json
 import logging
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 import aiohttp
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field, field_validator
 
+from api.schemas_workflows import (
+    HTTPClientMCPTool,
+    HTTPDeleteRequest,
+    HTTPGetRequest,
+    HTTPHeadRequest,
+    HTTPPatchRequest,
+    HTTPPostRequest,
+    HTTPPutRequest,
+)
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
@@ -310,86 +317,12 @@ async def check_rate_limit() -> bool:
 # Pydantic Models
 
 
-class MCPTool(BaseModel):
-    """Standard MCP tool definition"""
-
-    name: str
-    description: str
-    input_schema: JSONObject
-
-
-class HTTPRequestBase(BaseModel):
-    """Base model for HTTP requests"""
-
-    url: str = Field(..., description="Target URL for the request")
-    headers: Optional[Dict[str, str]] = Field(
-        default=None, description="Optional HTTP headers"
-    )
-    timeout: Optional[int] = Field(
-        default=DEFAULT_TIMEOUT,
-        ge=1,
-        le=MAX_TIMEOUT,
-        description=f"Request timeout in seconds (1-{MAX_TIMEOUT})",
-    )
-
-    @field_validator("url")
-    @classmethod
-    def validate_url_format(cls, v):
-        """Ensure URL is properly formatted"""
-        if not v.startswith(_VALID_URL_SCHEMES):  # Issue #380
-            raise ValueError("URL must start with http:// or https://")
-        return v
-
-
-class HTTPGetRequest(HTTPRequestBase):
-    """GET request model"""
-
-    params: Optional[Dict[str, str]] = Field(
-        default=None, description="Query parameters"
-    )
-
-
-class HTTPPostRequest(HTTPRequestBase):
-    """POST request model"""
-
-    json_body: Optional[JSONObject] = Field(
-        default=None, description="JSON request body"
-    )
-    form_data: Optional[Dict[str, str]] = Field(
-        default=None, description="Form data (mutually exclusive with json_body)"
-    )
-
-
-class HTTPPutRequest(HTTPRequestBase):
-    """PUT request model"""
-
-    json_body: Optional[JSONObject] = Field(
-        default=None, description="JSON request body"
-    )
-
-
-class HTTPPatchRequest(HTTPRequestBase):
-    """PATCH request model"""
-
-    json_body: Optional[JSONObject] = Field(
-        default=None, description="JSON request body for partial update"
-    )
-
-
-class HTTPDeleteRequest(HTTPRequestBase):
-    """DELETE request model"""
-
-
-class HTTPHeadRequest(HTTPRequestBase):
-    """HEAD request model"""
-
-
 # MCP Tool Definitions
 
 
-def _get_http_get_tool() -> MCPTool:
+def _get_http_get_tool() -> HTTPClientMCPTool:
     """Helper for _get_http_read_tools. Build the http_get MCPTool. Ref: #1088."""
-    return MCPTool(
+    return HTTPClientMCPTool(
         name="http_get",
         description=(
             "Perform HTTP GET request to retrieve data from a URL. Supports query parameters and"
@@ -426,9 +359,9 @@ def _get_http_get_tool() -> MCPTool:
     )
 
 
-def _get_http_head_tool() -> MCPTool:
+def _get_http_head_tool() -> HTTPClientMCPTool:
     """Helper for _get_http_read_tools. Build the http_head MCPTool. Ref: #1088."""
-    return MCPTool(
+    return HTTPClientMCPTool(
         name="http_head",
         description=(
             "Perform HTTP HEAD request to retrieve headers only (no body). Useful for"
@@ -453,7 +386,7 @@ def _get_http_head_tool() -> MCPTool:
     )
 
 
-def _get_http_read_tools() -> List[MCPTool]:
+def _get_http_read_tools() -> List[HTTPClientMCPTool]:
     """Get MCP tools for HTTP read operations (GET, HEAD). Ref: #1088.
 
     Issue #281: Extracted from get_http_client_mcp_tools to reduce function length.
@@ -490,9 +423,9 @@ def _build_json_body_property(desc: str = "JSON request body") -> dict:
     return {"type": "object", "description": desc}
 
 
-def _get_http_post_tool() -> MCPTool:
+def _get_http_post_tool() -> HTTPClientMCPTool:
     """Build HTTP POST tool definition. Issue #484: Extracted from _get_http_write_tools."""
-    return MCPTool(
+    return HTTPClientMCPTool(
         name="http_post",
         description=(
             "Perform HTTP POST request to send data to a URL. "
@@ -516,9 +449,9 @@ def _get_http_post_tool() -> MCPTool:
     )
 
 
-def _get_http_put_tool() -> MCPTool:
+def _get_http_put_tool() -> HTTPClientMCPTool:
     """Build HTTP PUT tool definition. Issue #484: Extracted from _get_http_write_tools."""
-    return MCPTool(
+    return HTTPClientMCPTool(
         name="http_put",
         description=(
             "Perform HTTP PUT request to update/replace resource. "
@@ -539,9 +472,9 @@ def _get_http_put_tool() -> MCPTool:
     )
 
 
-def _get_http_patch_tool() -> MCPTool:
+def _get_http_patch_tool() -> HTTPClientMCPTool:
     """Build HTTP PATCH tool definition. Issue #484: Extracted from _get_http_write_tools."""
-    return MCPTool(
+    return HTTPClientMCPTool(
         name="http_patch",
         description=(
             "Perform HTTP PATCH request for partial resource update. "
@@ -562,9 +495,9 @@ def _get_http_patch_tool() -> MCPTool:
     )
 
 
-def _get_http_delete_tool() -> MCPTool:
+def _get_http_delete_tool() -> HTTPClientMCPTool:
     """Build HTTP DELETE tool definition. Issue #484: Extracted from _get_http_write_tools."""
-    return MCPTool(
+    return HTTPClientMCPTool(
         name="http_delete",
         description=(
             "Perform HTTP DELETE request to remove a resource. "
@@ -585,7 +518,7 @@ def _get_http_delete_tool() -> MCPTool:
     )
 
 
-def _get_http_write_tools() -> List[MCPTool]:
+def _get_http_write_tools() -> List[HTTPClientMCPTool]:
     """
     Get MCP tools for HTTP write operations (POST, PUT, PATCH, DELETE).
 
@@ -603,7 +536,7 @@ def _get_http_write_tools() -> List[MCPTool]:
     ]
 
 
-def _load_tools_from_yaml() -> List[MCPTool]:
+def _load_tools_from_yaml() -> List[HTTPClientMCPTool]:
     """
     Load MCP tools from YAML file with placeholder substitution.
 
@@ -618,7 +551,7 @@ def _load_tools_from_yaml() -> List[MCPTool]:
     }
 
     tool_dicts = load_mcp_tools("http_client_tools", config=config)
-    return [MCPTool(**tool) for tool in tool_dicts]
+    return [HTTPClientMCPTool(**tool) for tool in tool_dicts]
 
 
 @with_error_handling(
@@ -626,13 +559,13 @@ def _load_tools_from_yaml() -> List[MCPTool]:
     operation="get_http_client_mcp_tools",
     error_code_prefix="HTTP_MCP",
 )
-@router.get("/mcp/tools", response_model=List[MCPTool])
+@router.get("/mcp/tools", response_model=List[HTTPClientMCPTool])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_http_client_mcp_tools",
     error_code_prefix="HTTP_CLIENT_MCP",
 )
-async def get_http_client_mcp_tools() -> List[MCPTool]:
+async def get_http_client_mcp_tools() -> List[HTTPClientMCPTool]:
     """
     Return all available HTTP Client MCP tools
 

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -2590,3 +2590,90 @@ class ResearchPreferences(BaseModel):
     store_results_in_kb: bool = True
     filter_adult_content: bool = True
     anonymize_requests: bool = True
+
+
+# ---------------------------------------------------------------------------
+# http_client_mcp.py schemas
+# ---------------------------------------------------------------------------
+
+from pydantic import field_validator as _http_client_field_validator
+from type_defs.common import JSONObject as _HTTPClientJSONObject
+
+_HTTP_CLIENT_VALID_URL_SCHEMES = ("http://", "https://")
+_HTTP_CLIENT_DEFAULT_TIMEOUT = 30  # seconds
+_HTTP_CLIENT_MAX_TIMEOUT = 120  # seconds
+
+
+class HTTPClientMCPTool(BaseModel):
+    """Standard MCP tool definition for HTTP client (renamed to avoid collision
+    with SequentialThinkingMCPTool)."""
+
+    name: str
+    description: str
+    input_schema: _HTTPClientJSONObject
+
+
+class HTTPRequestBase(BaseModel):
+    """Base model for HTTP requests."""
+
+    url: str = Field(..., description="Target URL for the request")
+    headers: Optional[Dict[str, str]] = Field(
+        default=None, description="Optional HTTP headers"
+    )
+    timeout: Optional[int] = Field(
+        default=_HTTP_CLIENT_DEFAULT_TIMEOUT,
+        ge=1,
+        le=_HTTP_CLIENT_MAX_TIMEOUT,
+        description=f"Request timeout in seconds (1-{_HTTP_CLIENT_MAX_TIMEOUT})",
+    )
+
+    @_http_client_field_validator("url")
+    @classmethod
+    def validate_url_format(cls, v):
+        """Ensure URL is properly formatted."""
+        if not v.startswith(_HTTP_CLIENT_VALID_URL_SCHEMES):
+            raise ValueError("URL must start with http:// or https://")
+        return v
+
+
+class HTTPGetRequest(HTTPRequestBase):
+    """GET request model."""
+
+    params: Optional[Dict[str, str]] = Field(
+        default=None, description="Query parameters"
+    )
+
+
+class HTTPPostRequest(HTTPRequestBase):
+    """POST request model."""
+
+    json_body: Optional[_HTTPClientJSONObject] = Field(
+        default=None, description="JSON request body"
+    )
+    form_data: Optional[Dict[str, str]] = Field(
+        default=None, description="Form data (mutually exclusive with json_body)"
+    )
+
+
+class HTTPPutRequest(HTTPRequestBase):
+    """PUT request model."""
+
+    json_body: Optional[_HTTPClientJSONObject] = Field(
+        default=None, description="JSON request body"
+    )
+
+
+class HTTPPatchRequest(HTTPRequestBase):
+    """PATCH request model."""
+
+    json_body: Optional[_HTTPClientJSONObject] = Field(
+        default=None, description="JSON request body for partial update"
+    )
+
+
+class HTTPDeleteRequest(HTTPRequestBase):
+    """DELETE request model."""
+
+
+class HTTPHeadRequest(HTTPRequestBase):
+    """HEAD request model."""


### PR DESCRIPTION
## Summary
Migrates 8 Pydantic classes from http_client_mcp.py into schemas_workflows.py with collision-safe renaming.

- MCPTool → HTTPClientMCPTool (collision with SequentialThinkingMCPTool)
- HTTPRequestBase + 6 subclasses (GET, POST, PUT, PATCH, DELETE, HEAD)

Constants used in field defaults (DEFAULT_TIMEOUT, MAX_TIMEOUT, _VALID_URL_SCHEMES) are inlined as schema-private constants in schemas_workflows.py. Endpoint file keeps its own copies for non-schema usage.

## Test plan
- [x] py_compile clean
- [x] flake8 critical errors (E9, F63, F7, F82, F811, F821, F401) clean

Part of #6042 (Phase 39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)