### PR TITLE
fix(backend): default DataResponse.success=True — unblock onboarding wizard (closes #6609)

### DIFF
--- a/autobot-backend/api/schemas_common.py
+++ b/autobot-backend/api/schemas_common.py
@@ -66,7 +66,11 @@ class DataResponse(BaseModel, Generic[T]):
     bare DataResponse (equivalent to DataResponse[Any]) remains valid for opaque payloads.
     """
 
-    success: bool
+    # success defaults to True because every callsite of create_success_response
+    # writes a success envelope by definition. Without the default, bare
+    # DataResponse(data=...) callers (api/onboarding.py, api/playwright.py)
+    # crashed at request time — see #6609.
+    success: bool = True
     data: Optional[T] = None
     message: Optional[str] = None
     timestamp: Optional[str] = None


### PR DESCRIPTION
## Summary

After today's earlier P0s landed, the user got past login but is **trapped on \`/onboarding\` with no way out** because the wizard endpoints all return 500.

\`\`\`
File \"/opt/autobot/autobot-backend/api/onboarding.py\", line 50
    return DataResponse(data=report)
ValidationError: success / Field required
\`\`\`

[\`schemas_common.py:69\`](autobot-backend/api/schemas_common.py#L69) defines \`DataResponse.success: bool\` with no default. Four call sites omit it:
\`api/onboarding.py:39, 50, 99\` (the entire onboarding wizard) and \`api/playwright.py:852\`.

The schema docstring already documents \`success\` as effectively constant True for the success envelope. One-line default fixes all four callers.

## Test plan

- [x] \`DataResponse(data=...)\` constructs cleanly with all 4 broken patterns
- [x] \`DataResponse(success=False, data=...)\` explicit override still works (no regression)
- [ ] After merge + Ansible deploy: \`/api/onboarding/doctor\` returns 200, \`/api/onboarding/presets\` returns 200, user can apply preset and navigate out of \`/onboarding\`

## Fifth #6042 regression today

Pattern recap (all sourced from the schema migration epic):
- #6536 — orphan \`BaseModel, Field\` imports
- #6569 — orphan \`Metadata\` import
- #6604 — duplicate-class collisions
- (build/install) #6600 — install.sh skipping backend deploy
- #6609 — required-field added without supplying default

[#6540 (CI startup-import smoke test)](https://github.com/mrveiss/AutoBot-AI/issues/6540) wouldn't have caught this one — Pydantic only validates at constructor invocation, not at module import. Need a request-validation smoke test for the success envelope. Will file as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)