### PR TITLE
fix(backend): restore chat init paths — chat_history_manager kwarg, ensure_initialized, get_default_client kwarg (closes #6613)

### DIFF
--- a/autobot-backend/autobot_memory_graph/core.py
+++ b/autobot-backend/autobot_memory_graph/core.py
@@ -107,16 +107,36 @@ class AutoBotMemoryGraphCore:
     AutoBotMemoryGraph class which combines this core with all mixins.
     """
 
-    def __init__(self):
-        """Initialize the memory graph core."""
+    def __init__(self, chat_history_manager: Optional[Any] = None) -> None:
+        """Initialize the memory graph core.
+
+        Args:
+            chat_history_manager: Optional ChatHistoryManager instance to wire in
+                so memory graph mixins can read/write chat history. Restored in
+                #6613 — the kwarg was lost in a refactor but
+                ``chat_history/base.py`` still passes it.
+        """
         self.redis_client: Optional[Any] = None
-        self.chat_history_manager: Optional[Any] = None
+        self.chat_history_manager: Optional[Any] = chat_history_manager
         self.embedding_cache: Dict[str, List[float]] = {}
         self.embedding_model_name: str = config.embedding_model
         self.embedding_dimensions: int = config.embedding_dimensions
         self._initialized: bool = False
         self._lock: asyncio.Lock = asyncio.Lock()
         self.index_name: str = f"{config.index_prefix}:idx"
+
+    def ensure_initialized(self) -> None:
+        """Sync guard — raise if ``initialize()`` has not been awaited.
+
+        Mixin methods call this before performing operations that require the
+        Redis client and search index. Restored in #6613 — multiple call sites
+        in user_session.py / property_graph_mixin.py / queries.py / relations.py
+        rely on it but the method had been removed in a refactor.
+        """
+        if not self._initialized:
+            raise RuntimeError(
+                "AutoBotMemoryGraph not initialized — call await initialize() first"
+            )
 
     async def initialize(self) -> None:
         """

--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -675,8 +675,11 @@ class DocIndexerService:
             from knowledge.backends import get_default_client
 
             chromadb_path = self._root_dir / "data" / "chromadb"
+            # get_default_client takes only **kwargs (#6613) — pass db_path
+            # explicitly. Positional call raised TypeError at init, falling
+            # the indexer back to slow SCAN paths.
             self._client = await asyncio.to_thread(
-                get_default_client, str(chromadb_path)
+                get_default_client, db_path=str(chromadb_path)
             )
 
             self._collection = self._client.get_or_create_collection(


### PR DESCRIPTION
## Summary

User reports chat \"used to be instant; now 40-50s per message\". Backend log showed three cascading init failures during chat session creation, all from a recent refactor that dropped interfaces:

\`\`\`
Failed to initialize DocIndexerService: get_default_client() takes 0 positional arguments but 1 was given
⚠️ Failed to initialize Memory Graph: AutoBotMemoryGraphCore.__init__() got an unexpected keyword argument 'chat_history_manager'
Failed to create memory graph entities for session ...: 'AutoBotMemoryGraph' object has no attribute 'ensure_initialized'
\`\`\`

When init fails, fact retrieval and doc search fall back to slow SCAN paths → 40s of waiting per message.

## Three fixes in one commit (same regression family)

| File | Line | Fix |
|---|---|---|
| [\`autobot_memory_graph/core.py\`](autobot-backend/autobot_memory_graph/core.py) | \`__init__\` | accept \`chat_history_manager: Optional[Any] = None\` kwarg again — the \`self.chat_history_manager\` field was already there expecting a value |
| [\`autobot_memory_graph/core.py\`](autobot-backend/autobot_memory_graph/core.py) | new method | add \`ensure_initialized()\` sync guard — 5 mixin files (user_session, property_graph_mixin, queries, relations) call it as a precondition check; method had been removed in a refactor |
| [\`services/knowledge/doc_indexer.py:679\`](autobot-backend/services/knowledge/doc_indexer.py#L679) | \`asyncio.to_thread\` call | pass \`db_path\` as kwarg — \`get_default_client\` signature is \`**kwargs\`-only |

## Test plan

- [x] \`AutoBotMemoryGraph(chat_history_manager=...)\` constructs and stores the value
- [x] \`ensure_initialized()\` raises \`RuntimeError\` before \`await initialize()\`
- [x] \`get_default_client\` signature is \`(**kwargs)\` — \`db_path\` kwarg is what it expects
- [x] All touched modules + \`main\` import cleanly
- [ ] After Ansible deploy: backend log shows no \"Failed to initialize\" / \"no attribute 'ensure_initialized'\" errors; chat message latency drops to single-digit seconds

## Out of scope (file separately if persists)

The \`advanced_rag_optimizer\` itself logged 33s for ChromaDB queries. That may be cold-cache / embedding-model latency, separate from the init failures fixed here. If chat is still slow after this lands, will file a follow-up after measuring with init failures cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)