### PR TITLE
fix(chat): propagate h-full through ChatView keep-alive (closes #6615)

### DIFF
--- a/autobot-frontend/src/views/ChatView.vue
+++ b/autobot-frontend/src/views/ChatView.vue
@@ -1,10 +1,16 @@
 <template>
   <keep-alive>
-    <router-view />
+    <router-view class="h-full" />
   </keep-alive>
 </template>
 
 <script setup lang="ts">
 // Issue #4356: Wrap router-view in keep-alive to preserve ChatInterface state
-// and avoid full remount when navigating away and back to /chat
+// and avoid full remount when navigating away and back to /chat.
+//
+// Issue #6615: explicit class="h-full" on the inner router-view. The outer
+// route in App.vue declares `<router-view class="h-full">`, but classes do
+// not pass cleanly through `<keep-alive>` to the nested router-view, so the
+// rendered ChatInterface root would not get its viewport-height constraint —
+// breaking sidebar/input pinning and message-area scroll.
 </script>


### PR DESCRIPTION
One-line layout fix.

Adds \`class=\"h-full\"\` to the inner \`<router-view>\` inside [\`ChatView.vue\`](autobot-frontend/src/views/ChatView.vue) so ChatInterface gets its viewport-height constraint. Without it, the keep-alive wrapper swallows the class from the outer App.vue \`<router-view class=\"h-full\">\` and the chat layout collapses — sidebar/input drift away from the bottom edge, message area never scrolls.

Test plan after Ansible deploy:
- [ ] Sidebar reaches the viewport bottom
- [ ] ChatInput stays anchored at the bottom
- [ ] Message area scrolls when content overflows
- [ ] /chat/terminal, /chat/files, /chat/browser, /chat/novnc unaffected
- [ ] keep-alive state preservation still works (navigate away and back, ChatInterface state retained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)