### PR TITLE
feat(frontend): tabbed /agents shell — Registry/Activity/Heartbeat as sibling tabs (closes #6634)

### DIFF
--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -4032,6 +4032,12 @@
     "config": "Agent Configuration",
     "orchestrator": "Orchestrator",
     "translate": "Translate",
+    "nav": {
+      "label": "Agents navigation",
+      "registry": "Registry",
+      "activity": "Activity",
+      "heartbeat": "Heartbeat"
+    },
     "registry": {
       "title": "Agent Registry",
       "subtitle": "Browse and monitor all registered agents",

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -594,41 +594,55 @@ export const routes: RouteRecordRaw[] = [
   },
   // Issue #4270: Operations moved under /analytics/operations
   { path: '/operations', redirect: '/analytics/operations' },
-  // Issue #4703: Wire AgentRegistryView into router (#1794, #1822)
+  // Issue #6634: Tabbed /agents shell — Registry, Activity, Heartbeat as
+  // sibling tabs under a shared AgentsLayout. Each retains its own URL so
+  // existing nav-item links and bookmarks still work.
   {
-    path: '/agents/registry',
-    name: 'agent-registry',
-    component: () => import('@/views/AgentRegistryView.vue'),
+    path: '/agents',
+    component: () => import('@/views/AgentsLayout.vue'),
     meta: {
-      title: 'Agent Registry',
-      icon: 'fas fa-robot',
-      description: 'Browse backend and specialized agents, and manage agent settings',
-      requiresAuth: true
-    }
-  },
-  // Issue #1521: Agent Heartbeat Panel — real-time agent run status
-  {
-    path: '/agents/heartbeat',
-    name: 'agent-heartbeat',
-    component: () => import('@/components/agents/HeartbeatPanel.vue'),
-    meta: {
-      title: 'Agent Heartbeat',
-      icon: 'fas fa-heartbeat',
-      description: 'Monitor agent heartbeat and real-time run status',
-      requiresAuth: true
-    }
-  },
-  // Issue #5071: per-agent diary with background append and runtime discovery
-  {
-    path: '/agents/activity',
-    name: 'agent-activity',
-    component: () => import('@/views/AgentActivity.vue'),
-    meta: {
-      title: 'Agent Activity',
-      icon: 'fas fa-journal-whills',
-      description: 'Per-agent diary — recent entries and cross-session journal',
-      requiresAuth: true
-    }
+      title: 'Agents',
+      requiresAuth: true,
+    },
+    children: [
+      { path: '', redirect: '/agents/registry' },
+      // Issue #4703: Wire AgentRegistryView into router (#1794, #1822)
+      {
+        path: 'registry',
+        name: 'agent-registry',
+        component: () => import('@/views/AgentRegistryView.vue'),
+        meta: {
+          title: 'Agent Registry',
+          icon: 'fas fa-robot',
+          description: 'Browse backend and specialized agents, and manage agent settings',
+          requiresAuth: true,
+        },
+      },
+      // Issue #1521: Agent Heartbeat Panel — real-time agent run status
+      {
+        path: 'heartbeat',
+        name: 'agent-heartbeat',
+        component: () => import('@/components/agents/HeartbeatPanel.vue'),
+        meta: {
+          title: 'Agent Heartbeat',
+          icon: 'fas fa-heartbeat',
+          description: 'Monitor agent heartbeat and real-time run status',
+          requiresAuth: true,
+        },
+      },
+      // Issue #5071: per-agent diary with background append and runtime discovery
+      {
+        path: 'activity',
+        name: 'agent-activity',
+        component: () => import('@/views/AgentActivity.vue'),
+        meta: {
+          title: 'Agent Activity',
+          icon: 'fas fa-journal-whills',
+          description: 'Per-agent diary — recent entries and cross-session journal',
+          requiresAuth: true,
+        },
+      },
+    ],
   },
   // Issue #899: Code Intelligence — merged into /analytics/codebase
   {

--- a/autobot-frontend/src/views/AgentsLayout.vue
+++ b/autobot-frontend/src/views/AgentsLayout.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="agents-layout flex flex-col h-full bg-autobot-bg-primary">
+    <nav
+      class="flex shrink-0 border-b border-autobot-border bg-autobot-bg-secondary px-4"
+      :aria-label="$t('agent.nav.label')"
+      role="tablist"
+    >
+      <router-link
+        v-for="tab in tabs"
+        :key="tab.to"
+        :to="tab.to"
+        :class="[
+          'px-4 py-3 text-sm font-medium border-b-2 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-autobot-primary',
+          isActive(tab) ? activeClass : inactiveClass,
+        ]"
+        role="tab"
+        :aria-selected="isActive(tab)"
+      >
+        <i :class="['fas', tab.icon, 'mr-2']" aria-hidden="true"></i>
+        {{ $t(tab.labelKey) }}
+      </router-link>
+    </nav>
+
+    <div class="flex-1 min-h-0 overflow-hidden">
+      <router-view class="h-full" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * AgentsLayout — tabbed shell for /agents/* routes (#6634).
+ *
+ * Three tabs (Registry, Activity, Heartbeat). Each tab is a separate route
+ * so URLs stay bookmarkable and browser back/forward works. AgentRegistryView's
+ * own internal Backend/Specialized/Settings tabs live inside the Registry tab
+ * and are untouched.
+ */
+
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+
+const route = useRoute()
+const { t: _t } = useI18n() // ensure $t is available in template
+
+interface AgentTab {
+  to: string
+  labelKey: string
+  icon: string
+}
+
+const tabs: AgentTab[] = [
+  { to: '/agents/registry', labelKey: 'agent.nav.registry', icon: 'fa-robot' },
+  { to: '/agents/activity', labelKey: 'agent.nav.activity', icon: 'fa-journal-whills' },
+  { to: '/agents/heartbeat', labelKey: 'agent.nav.heartbeat', icon: 'fa-heartbeat' },
+]
+
+const activeClass =
+  'text-autobot-primary border-autobot-primary'
+const inactiveClass =
+  'text-autobot-text-secondary border-transparent hover:text-autobot-text-primary hover:border-autobot-border'
+
+const isActive = (tab: AgentTab) => computed(() => route.path === tab.to).value
+</script>


### PR DESCRIPTION
## Summary

Three agent pages were three separate top-level routes with no visual relationship. Now unified under a single \`/agents\` shell with a tab bar — each tab keeps its own URL so deep-linking, bookmarks, and browser back/forward still work.

## Changes

| File | Change |
|---|---|
| **NEW** [\`autobot-frontend/src/views/AgentsLayout.vue\`](autobot-frontend/src/views/AgentsLayout.vue) | small wrapper: tab bar (Registry / Activity / Heartbeat) + \`<router-view />\`. Uses \`router-link\` so each tab click changes the URL. |
| [\`router/index.ts\`](autobot-frontend/src/router/index.ts) | \`/agents\` becomes parent route (AgentsLayout). Existing 3 routes moved to children. Default \`/agents → /agents/registry\`. |
| [\`i18n/locales/en.json\`](autobot-frontend/src/i18n/locales/en.json) | added \`agent.nav.{label,registry,activity,heartbeat}\` |

**Untouched:**
- AgentRegistryView's internal Backend/Specialized/Settings tabs — still work inside the Registry tab
- \`navItems.ts\` — existing \`/agents/registry\` and \`/agents/activity\` sidebar links still resolve as deep links into the tabbed shell

## Test plan

- [x] \`python3 -c \"import json; json.load(...)\"\` validates en.json
- [ ] After Ansible deploy: \`/agents\` redirects to \`/agents/registry\` with Registry tab active
- [ ] \`/agents/activity\` and \`/agents/heartbeat\` highlight matching tabs
- [ ] Clicking tabs swaps URL + content without full page reload
- [ ] AgentRegistryView's internal tabs (Backend/Specialized/Settings) still work
- [ ] Sidebar links to \`/agents/registry\` and \`/agents/activity\` still navigate correctly

## Related

- #4703 / #1521 / #5071 — original three routes
- #6452 / #6615 / #6611 / #6614 / #6605 — same session's other UI / boot fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)