### PR TITLE
fix(schemas): wire AgentConfigDetailResponse to GET /agents/{id} (#6619)

### DIFF
--- a/autobot-backend/api/agent_config.py
+++ b/autobot-backend/api/agent_config.py
@@ -21,6 +21,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.schemas_agent import (
+    AgentConfigDetailResponse,
     AgentConfigEnableDisableResponse,
     AgentConfigHealthResponse,
     AgentConfigOverviewResponse,
@@ -937,7 +938,7 @@ async def get_agents_usage(
     operation="get_agent_config",
     error_code_prefix="AGENT_CONFIG",
 )
-@router.get("/agents/{agent_id}", response_model=DataResponse)
+@router.get("/agents/{agent_id}", response_model=AgentConfigDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_agent_config",

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -1857,7 +1857,7 @@ class ResetLearningResponse(BaseModel):
 
 
 class AgentConfig(BaseModel):
-    """Agent configuration model."""
+    """Agent configuration summary model — minimal shape for list views."""
 
     agent_id: str
     name: str
@@ -1865,6 +1865,42 @@ class AgentConfig(BaseModel):
     provider: str
     enabled: bool
     priority: Optional[int] = 1
+
+
+class AgentConfigDetailHealthCheck(BaseModel):
+    """Inline health-check block returned by GET /agents/{agent_id}."""
+
+    last_check: str = Field(..., description="ISO timestamp of last health check")
+    response_time: float = Field(default=0.0)
+    status: str = Field(..., description="healthy | disabled")
+
+
+class AgentConfigDetailOptions(BaseModel):
+    """Inline configuration_options block returned by GET /agents/{agent_id}."""
+
+    available_models: List[str] = Field(default_factory=list)
+    available_providers: List[str] = Field(default_factory=list)
+    configurable_settings: List[str] = Field(default_factory=list)
+
+
+class AgentConfigDetailResponse(BaseModel):
+    """Detailed response for GET /api/agents/{agent_id} — matches the actual
+    dict shape produced by api/agent_config.py:946."""
+
+    id: str
+    name: str
+    description: str
+    current_model: str
+    provider: str
+    enabled: bool
+    priority: int
+    tasks: List[str] = Field(default_factory=list)
+    mcp_tools: List[str] = Field(default_factory=list)
+    default_model: str
+    status: str = Field(..., description="connected | disconnected")
+    config_source: str = Field(..., description="slm | local")
+    configuration_options: AgentConfigDetailOptions
+    health_check: AgentConfigDetailHealthCheck
 
 
 class AgentModelUpdate(BaseModel):


### PR DESCRIPTION
## Summary

Partial fix for #6619 (Cluster C from the #6616 not-wired audit) — wires the highest-leverage piece (agent registry detail endpoint).

## Problem

`GET /api/agents/{agent_id}` (`api/agent_config.py:946`) returned `DataResponse` (untyped). The migrated `AgentConfig` DTO had only 6 fields and **did not match** the rich 14-field dict the endpoint actually returns:
- `id`, `name`, `description`, `current_model`, `provider`, `enabled`, `priority`, `tasks`, `mcp_tools`, `default_model`, `status`, `config_source`, `configuration_options` (nested), `health_check` (nested)

## Solution

Introduce `AgentConfigDetailResponse` + 2 nested models (`AgentConfigDetailHealthCheck`, `AgentConfigDetailOptions`) matching the actual endpoint shape. Wire as `response_model=AgentConfigDetailResponse`. `AgentConfig` is preserved as a list-summary DTO for future consumers.

## Frontend impact (post-merge)

After next openapi-typescript regen, `frontend-vue/src/types/api.gen.ts` will produce typed `AgentConfigDetailResponse` with all 14 fields including the nested `configuration_options` and `health_check` objects. Eliminates `as Type` casts in agent registry components.

## Remaining Cluster C work (deferred)

- `UserSkillPreferences` — needs a skill-preferences PUT endpoint that doesn't currently exist
- `LLMContextRequest` — has 3 fields (`level`, `include_history`, `include_progression_rules`) but the existing `GET /context` endpoint only honors `level` as Query — needs backend implementation of the additional flags before schema wiring is meaningful
- `TaskSendResponse` — needs match-up with the a2a/tasks send endpoint
- `AgentTaskData` and `AgentCapabilityInfo` — verified ACTIVE (used as parent class / field type), no work needed (audit false-positive cleanup)

These deferred items each have non-trivial backend work; they should be tracked as follow-up issues if not delivered alongside the schema wiring.

## Verification

- [x] `py_compile` clean
- [x] flake8 critical errors (E9, F63, F7, F82, F811, F821) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)