### PR TITLE
fix(schemas): wire EmbeddingStatsResponse to GET /stats (#6618)

### DIFF
--- a/autobot-backend/api/analytics_embedding_patterns.py
+++ b/autobot-backend/api/analytics_embedding_patterns.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 
-from api.schemas_analytics import EmbeddingUsageRequest
+from api.schemas_analytics import EmbeddingStatsResponse, EmbeddingUsageRequest
 from auth_middleware import check_admin_permission
 from autobot_shared.redis_client import RedisDatabase
 from autobot_shared.redis_mixin import AsyncRedisClientLockedMixin
@@ -499,7 +499,7 @@ async def record_embedding_usage(
     )
 
 
-@router.get("/stats", response_model=DataResponse)
+@router.get("/stats", response_model=EmbeddingStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_embedding_stats",

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -3253,8 +3253,8 @@ class EmbeddingUsageRequest(BaseModel):
         )
 
 
-class EmbeddingStatsResponse(BaseModel):
-    """Response model for embedding statistics."""
+class EmbeddingStatsBody(BaseModel):
+    """Inner stats body returned by EmbeddingPatternAnalyzer.get_stats()."""
 
     total_operations: int
     total_tokens: int
@@ -3264,8 +3264,21 @@ class EmbeddingStatsResponse(BaseModel):
     success_rate: float
     avg_batch_size: float
     tokens_per_second: float
-    period: str
-    timestamp: str
+    period_days: int
+
+
+class EmbeddingStatsResponse(BaseModel):
+    """Envelope response for GET /api/analytics/embedding-patterns/stats —
+    matches the dict shape returned by EmbeddingPatternAnalyzer.get_stats().
+    Also covers the error shape via extra="allow"."""
+
+    model_config = {"extra": "allow"}
+
+    status: str = Field(..., description="success | error")
+    stats: Optional[EmbeddingStatsBody] = None
+    timestamp: Optional[str] = None
+    # error shape
+    error: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #6618 (Cluster B from #6616 not-wired audit).

## Problem

`GET /api/analytics/embedding-patterns/stats` returned `DataResponse` (untyped). The migrated `EmbeddingStatsResponse` had 10 flat fields but the endpoint actually returns a 3-key envelope: `{status, stats: {...}, timestamp}`. Schema didn't match reality.

## Solution

Split into typed nested model:
- `EmbeddingStatsBody` — 9 inner stats fields (including `period_days` matching the actual `analyzer.get_stats()` output)
- `EmbeddingStatsResponse` envelope — `status`, `stats: EmbeddingStatsBody`, `timestamp`, `error`; `extra="allow"` for forward compat

Wired `GET /stats` to use `EmbeddingStatsResponse` as `response_model`.

## Frontend impact

OpenAPI codegen will produce typed `EmbeddingStatsResponse` with nested `EmbeddingStatsBody` instead of `Record<string, unknown>`.

## Out of scope

`/model-comparison` and `/optimization-recommendations` endpoints return different shapes (model lists, recommendation arrays). They need separate typed schemas — left as `DataResponse` to avoid scope creep. File a follow-up if needed.

## Verification

- [x] `py_compile` clean
- [x] flake8 critical errors clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)