### PR TITLE
fix(frontend): wss:// for LiveEventService when page is HTTPS (closes #6642)

### DIFF
--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -454,8 +454,20 @@ function buildConfig(): AutoBotConfig {
     },
 
     get websocketUrl(): string {
-      if (httpProtocol === 'https') {
-        return `wss://${vm.main}/api/ws`;
+      // #6642: detect protocol from window.location at runtime, not from
+      // build-time VITE_HTTP_PROTOCOL. The env var defaults to 'http' and
+      // produced ws:// URLs that browsers blocked as mixed-content when the
+      // page itself was served over HTTPS. Mirror the runtime detection that
+      // getBackendWsUrl() already uses so behaviour stays correct regardless
+      // of the build-time env.
+      const isHttps =
+        typeof window !== 'undefined'
+          ? window.location.protocol === 'https:'
+          : httpProtocol === 'https';
+      if (isHttps) {
+        const host =
+          typeof window !== 'undefined' ? window.location.host : vm.main;
+        return `wss://${host}/api/ws`;
       }
       return `ws://${vm.main}:${port.backend}/api/ws`;
     },


### PR DESCRIPTION
One-line root-cause fix.

[\`config/ssot-config.ts:456\`](autobot-frontend/src/config/ssot-config.ts#L456) now derives the WebSocket scheme from \`window.location.protocol\` at runtime instead of the build-time \`VITE_HTTP_PROTOCOL\` env (which defaulted to \`http\` and produced \`ws://\` URLs the browser blocked as mixed-content). Same pattern that \`getBackendWsUrl\` already uses correctly.

## Test plan

- [x] Diff scope is one getter, additive
- [ ] After Ansible deploy: console no longer shows \"Mixed Content / Connecting to a non-secure WebSocket\"
- [ ] LiveEventService connects, \`UnifiedLoadingView\` resolves under 15s
- [ ] Dev server (HTTP) still gets \`ws://{vm.main}:{port.backend}/api/ws\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)