### PR TITLE
fix(schemas): unshadow UsageRecordRequest LLM-analytics variant (#6636)

### DIFF
--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -3286,8 +3286,15 @@ class EmbeddingStatsResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class UsageRecordRequest(BaseModel):
-    """Request body for POST /api/usage/record."""
+class UsageRecordEndpointRequest(BaseModel):
+    """Request body for POST /api/usage/record.
+
+    Renamed from UsageRecordRequest in #6636 to disambiguate from the
+    LLM-analytics UsageRecordRequest at line 2845, which has a different
+    shape (prompt-based) and is used by analytics_llm_patterns.py and
+    llm_interface_pkg/interface.py. The previous shadowing caused silent
+    Pydantic validation failures in LLM usage tracking
+    (logged as non-critical and swallowed)."""
 
     provider: str
     model: str

--- a/autobot-backend/api/usage.py
+++ b/autobot-backend/api/usage.py
@@ -26,7 +26,7 @@ from api.schemas_common import UsageRecordResponse
 from api.schemas_analytics import (
     UsageByUserAllResponse,
     UsageMyUsageResponse,
-    UsageRecordRequest,
+    UsageRecordEndpointRequest,
     UsageByUserSingleResponse,
     UsageSummaryResponse,
 )
@@ -206,7 +206,7 @@ async def get_my_usage(
     error_code_prefix="USAGE",
 )
 async def record_usage_event(
-    body: UsageRecordRequest,
+    body: UsageRecordEndpointRequest,
     current_user: dict = Depends(get_current_user),
 ) -> dict[str, Any]:
     """


### PR DESCRIPTION
## Summary

Closes #6636. **Production bug fix** — LLM cost/usage tracking has been silently broken since Phase 35 (#6601).

## Root cause

Phase 35 added a second `UsageRecordRequest` to `schemas_analytics.py` for `POST /api/usage/record`, shadowing the existing LLM-analytics variant at line 2845. Last-definition-wins meant ALL callers got the wrong class:

- `api/analytics_llm_patterns.py:378` (`request.prompt`, `request.model`, etc.)
- `llm_interface_pkg/interface.py:1249` (instantiates with `prompt`, `response_time`)
- `llm_interface.py:65` (re-export)

The wrong class doesn't have `prompt`/`response_time` fields → Pydantic validation fails. Failure was wrapped in:

```python
except Exception as e:
    logger.debug("LLM usage tracking failed (non-critical): %s", e)
```

so the error was silently swallowed and **LLM cost tracking has been broken for all callers since #6601 merged**.

## Fix

Rename the Phase 35 variant to `UsageRecordEndpointRequest`, matching its `/api/usage/record` purpose. Update `usage.py` import + signature.

The original LLM-analytics `UsageRecordRequest` (with `prompt`, `model`, `input_tokens`, `output_tokens`, `response_time`, `success`, `session_id`, and `to_record_dict()` helper) is now unshadowed.

## Verification

- [x] `py_compile` clean on both touched files
- [x] flake8 F811 (redefinition) resolved
- [x] Single `UsageRecordRequest` class definition remaining (the LLM-analytics one)
- [x] usage.py uses renamed `UsageRecordEndpointRequest`

## Test plan

After deploy, monitor `var/log/autobot/backend.log` for absence of "LLM usage tracking failed (non-critical)" messages — they should disappear because the validation error no longer occurs. LLM cost dashboard should start showing data again.

🤖 Discovery from #6042 post-migration audit, escalated when usage tracing revealed real callers.