### PR TITLE
fix(chat): unblock chat from GUI — rename ChatAgent helper + repair AI Stack health probe (#6648, #6649)

### DIFF
--- a/autobot-backend/a2a/task_executor.py
+++ b/autobot-backend/a2a/task_executor.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 def _extract_response_text(result: Dict[str, Any]) -> str:
     """Pull the human-readable response from an orchestrator result dict.
 
-    Issue #4501: include "response_text" key used by ChatAgent._build_success_response.
+    Issue #4501: include "response_text" key used by ChatAgent._build_chat_payload.
     """
     for key in ("response", "response_text", "message", "text", "output"):
         value = result.get(key)

--- a/autobot-backend/agents/chat_agent.py
+++ b/autobot-backend/agents/chat_agent.py
@@ -87,11 +87,16 @@ class ChatAgent(StandardizedAgent):
         """Return list of capabilities this agent supports."""
         return self.capabilities.copy()
 
-    def _build_success_response(
+    def _build_chat_payload(
         self, response_text: str, response: Any
     ) -> Dict[str, Any]:
         """
-        Build success response dictionary for chat message processing.
+        Build the chat-specific payload dict.
+
+        Returned as the ``result`` field of the AgentResponse the base class
+        ``StandardizedAgent._build_success_response`` constructs (#6648). The
+        prior name shadowed the base method with an incompatible signature,
+        crashing every AI Stack chat request with a TypeError.
 
         Issue #620.
         Issue #4501: response is an LLMResponse object — use attribute access.
@@ -184,7 +189,7 @@ class ChatAgent(StandardizedAgent):
 
             # Extract response content and build response
             response_text = self._extract_response_content(response)
-            return self._build_success_response(response_text, response)
+            return self._build_chat_payload(response_text, response)
 
         except Exception as e:
             logger.error("Chat Agent error processing message: %s", e)

--- a/autobot-backend/services/ai_stack_client.py
+++ b/autobot-backend/services/ai_stack_client.py
@@ -325,8 +325,9 @@ class AIStackClient:
     async def health_check(self) -> Metadata:
         """Check AI Stack health status and update connection_status."""
         try:
-            # ChromaDB uses /api/v2 for heartbeat (not /health)
-            response = await self._make_request("GET", "/api/v2")
+            # AI Stack exposes /health (#6649) — /api/v2 is the ChromaDB heartbeat
+            # path and was wrongly applied here, producing a 404 every poll.
+            response = await self._make_request("GET", "/health")
             if self.connection_status != "connected":
                 logger.info("AI Stack connection restored at %s", self.base_url)
             self.connection_status = "connected"


### PR DESCRIPTION
## Summary

Fixes the GUI chat-send crash and the AI Stack health-check 404 spam — both surfaced when the user reported "can't start chat from GUI".

## Closes

- Closes #6648 — chat fails on every send, ChatAgent._build_success_response signature mismatch
- Closes #6649 — AI Stack health check probes /api/v2 (ChromaDB path), floods backend log

## Root cause

**#6648:** `ChatAgent._build_success_response(self, response_text, response)` overrode the base `StandardizedAgent._build_success_response(self, request, result, processing_time)`. The base class's `process_request` calls `self._build_success_response(request, result, processing_time)` (3 args). Python uses the override → TypeError on every chat call.

**#6649:** `AIStackClient.health_check()` probed `/api/v2` (a ChromaDB heartbeat path) against the AI Stack URL, getting 404 each poll and tripping the retry loop indefinitely.

## Changes

- `autobot-backend/agents/chat_agent.py` — rename override to `_build_chat_payload`; update the one internal caller. Base method now runs unmodified.
- `autobot-backend/services/ai_stack_client.py` — `/api/v2` → `/health`.
- `autobot-backend/a2a/task_executor.py` — docstring drift (referenced old method name).

## Verification

- `py_compile`: passes for all three files.
- AST signature check on the patched source:
  - `ChatAgent` no longer defines `_build_success_response` (override removed).
  - `_build_chat_payload(self, response_text, response)` exists.
  - `StandardizedAgent._build_success_response(self, request, result, processing_time)` unchanged.
- Live evidence (before fix) on the deployed AI Stack at `http://10.255.255.254:8080`:
  - `POST /agents/chat/process` → `"error":"Processing failed: ChatAgent._build_success_response() takes 3 positional arguments but 4 were given"`
  - `GET /api/v2` → 404 `{"detail":"Not Found"}` — the line spamming backend-error.log
  - `GET /health` → 200 with healthy agent registry

## Test plan

- [ ] After deploy, send a chat from GUI → response renders, no TypeError in `/var/log/autobot/backend-error.log`.
- [ ] After deploy, `tail -F /var/log/autobot/backend-error.log` no longer accumulates `AI Stack error 404` lines.
- [ ] AI Stack agent metrics: `chat.error_count` stays at 0 across several sends.

## Related discoveries (filed, not fixed in this PR)

- #6650 — same Liskov violation in `KnowledgeRetrievalAgent` and `EnhancedSystemCommandsAgent`.
- #6651 — `chat_agent_test.py` 4 tests fail on `Dev_new_gui` (pre-existing) — `standardized_agent.get_mcp_dispatcher` does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)