### PR TITLE
fix(agents): rename Liskov-violating _build_success_response overrides in KnowledgeRetrievalAgent + EnhancedSystemCommandsAgent (#6650)

### DIFF
--- a/autobot-backend/agents/enhanced_system_commands_agent.py
+++ b/autobot-backend/agents/enhanced_system_commands_agent.py
@@ -189,8 +189,15 @@ class EnhancedSystemCommandsAgent(StandardizedAgent):
         messages.append({"role": "user", "content": request})
         return messages
 
-    def _build_success_response(self, command_info: Dict[str, Any]) -> Dict[str, Any]:
-        """Build success response with metadata (Issue #398: extracted)."""
+    def _build_command_payload(self, command_info: Dict[str, Any]) -> Dict[str, Any]:
+        """Build the system-commands-specific payload dict.
+
+        Returned as the ``result`` field of the AgentResponse the base class
+        ``StandardizedAgent._build_success_response`` constructs (#6650). The
+        prior name shadowed the base method with an incompatible signature,
+        so any AI Stack ``/agents/system_commands/process`` request would
+        crash with a TypeError. (Issue #398: extracted.)
+        """
         return {
             "status": "success" if command_info.get("is_safe", False) else "warning",
             **command_info,
@@ -234,7 +241,7 @@ class EnhancedSystemCommandsAgent(StandardizedAgent):
                 command_info.get("command", "")
             )
             command_info.update(security_check)
-            return self._build_success_response(command_info)
+            return self._build_command_payload(command_info)
         except Exception as e:
             logger.error("System Commands Agent error: %s", e)
             return self._build_error_response(e)

--- a/autobot-backend/agents/knowledge_retrieval_agent.py
+++ b/autobot-backend/agents/knowledge_retrieval_agent.py
@@ -160,7 +160,7 @@ class KnowledgeRetrievalAgent(StandardizedAgent):
             "agent_type": "knowledge_retrieval",
         }
 
-    def _build_success_response(
+    def _build_query_payload(
         self,
         query: str,
         processed_results: Dict[str, Any],
@@ -169,7 +169,13 @@ class KnowledgeRetrievalAgent(StandardizedAgent):
         similarity_threshold: float,
     ) -> Dict[str, Any]:
         """
-        Build successful query response.
+        Build the knowledge-retrieval-specific payload dict.
+
+        Returned as the ``result`` field of the AgentResponse the base class
+        ``StandardizedAgent._build_success_response`` constructs (#6650). The
+        prior name shadowed the base method with an incompatible signature,
+        so any AI Stack ``/agents/knowledge_retrieval/process`` request would
+        crash with a TypeError.
 
         (Issue #398: extracted helper)
         """
@@ -249,7 +255,7 @@ class KnowledgeRetrievalAgent(StandardizedAgent):
                     query, processed_results["documents"][:3]
                 )
 
-            return self._build_success_response(
+            return self._build_query_payload(
                 query, processed_results, summary, processing_time, similarity_threshold
             )
 


### PR DESCRIPTION
## Summary

Same root cause as #6648, in two more agents: `KnowledgeRetrievalAgent._build_success_response` and `EnhancedSystemCommandsAgent._build_success_response` shadow the base method with incompatible signatures. Any AI Stack `/agents/knowledge_retrieval/process` or `/agents/system_commands/process` request crashes with TypeError.

## Closes

- Closes #6650

## Changes

- `autobot-backend/agents/knowledge_retrieval_agent.py`: rename `_build_success_response` → `_build_query_payload`, update internal caller.
- `autobot-backend/agents/enhanced_system_commands_agent.py`: rename `_build_success_response` → `_build_command_payload`, update internal caller.

## Verification

- `py_compile`: clean.
- Grep confirms no stale callers of the old name on either subclass.
- AST shows the override is gone — base `_build_success_response(self, request, result, processing_time)` is now used unmodified to wrap each helper's dict as `AgentResponse.result`.

## Test plan

- [ ] After deploy, `POST /agents/knowledge_retrieval/process` returns a non-error response for a valid query.
- [ ] After deploy, `POST /agents/system_commands/process` returns a non-error response (if registered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)