### PR TITLE
fix(slm-client): URL-aware permissive SSL — accept self-signed cert on loopback (#6654)

### DIFF
--- a/autobot-backend/services/slm_client.py
+++ b/autobot-backend/services/slm_client.py
@@ -137,17 +137,42 @@ class ServiceDiscoveryCache:
         logger.debug("Cleared service discovery cache")
 
 
-def _create_permissive_ssl_context():
-    """Create SSL context for internal SLM communication (#1048, #2852, #4664).
+_LOOPBACK_HOSTS: frozenset = frozenset({"127.0.0.1", "localhost", "::1", "ip6-localhost"})
+
+# Emit the loopback-permissive warning once per process to avoid log spam.
+_loopback_permissive_warned: bool = False
+
+
+def _is_loopback_target(target_url: Optional[str]) -> bool:
+    """Return True iff target_url's host resolves to a loopback address.
+
+    Loopback targets cannot be MITM'd (no off-host network path), so trusting
+    a self-signed cert here is safe even when no project CA is bundled.
+    """
+    if not target_url:
+        return False
+    try:
+        from urllib.parse import urlparse
+
+        host = (urlparse(target_url).hostname or "").lower()
+    except Exception:
+        return False
+    return host in _LOOPBACK_HOSTS
+
+
+def _create_permissive_ssl_context(target_url: Optional[str] = None):
+    """Create SSL context for internal SLM communication (#1048, #2852, #4664, #6654).
 
     Trust hierarchy (first match wins):
     1. AUTOBOT_TLS_CA_PATH env var → load that CA cert (production mTLS)
     2. AUTOBOT_SKIP_TLS_VERIFY=true → disable verification (dev/test only)
     3. AutoBot project CA fallback (certs/ca/ca-cert.pem) → load if present
-    4. System trust store → default Python SSL behaviour
+    4. Loopback target with no CA configured → CERT_NONE (single-host self-signed
+       installs, #6654: no MITM possible when SLM is on the same host)
+    5. System trust store → default Python SSL behaviour (strict)
 
     Set AUTOBOT_SKIP_TLS_VERIFY=true ONLY in dev/test environments — never in
-    production.
+    production. For non-loopback production deploys, configure AUTOBOT_TLS_CA_PATH.
     """
     ctx = ssl.create_default_context()
 
@@ -169,7 +194,25 @@ def _create_permissive_ssl_context():
     _fallback_ca = os.path.join(_project_root, _cert_dir, "ca", "ca-cert.pem")
     if os.path.isfile(_fallback_ca):
         ctx.load_verify_locations(_fallback_ca)
+        return ctx
 
+    # 4. Loopback target — accept self-signed certs. No MITM is possible because
+    #    the connection never leaves the host. Single-host installs typically have
+    #    no project CA bundled and would otherwise crash on every connect (#6654).
+    if _is_loopback_target(target_url):
+        global _loopback_permissive_warned
+        if not _loopback_permissive_warned:
+            logger.warning(
+                "TLS verification disabled for loopback target %s — no CA configured "
+                "(set AUTOBOT_TLS_CA_PATH for strict verification, #6654)",
+                target_url,
+            )
+            _loopback_permissive_warned = True
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+
+    # 5. Strict by default (system trust store).
     return ctx
 
 
@@ -320,8 +363,10 @@ class SLMClient:
             headers = {}
             if self.auth_token:
                 headers["Authorization"] = f"Bearer {self.auth_token}"
-            # Accept self-signed certs for internal HTTPS (#1048)
-            connector = aiohttp.TCPConnector(ssl=_create_permissive_ssl_context())
+            # Accept self-signed certs for internal HTTPS (#1048, #6654)
+            connector = aiohttp.TCPConnector(
+                ssl=_create_permissive_ssl_context(self.slm_url)
+            )
             self._http_session = aiohttp.ClientSession(headers=headers, connector=connector)
         return self._http_session
 
@@ -522,8 +567,12 @@ class SLMClient:
         logger.info("Connecting to WebSocket at %s", ws_url)
 
         try:
-            # Accept self-signed certs for wss:// connections (#1048)
-            ws_ssl = _create_permissive_ssl_context() if ws_url.startswith("wss://") else None
+            # Accept self-signed certs for wss:// connections (#1048, #6654)
+            ws_ssl = (
+                _create_permissive_ssl_context(ws_url)
+                if ws_url.startswith("wss://")
+                else None
+            )
             async with websockets.connect(
                 ws_url,
                 ssl=ws_ssl,

--- a/autobot-backend/services/slm_client_test.py
+++ b/autobot-backend/services/slm_client_test.py
@@ -102,6 +102,40 @@ class TestCreatePermissiveSslContext:
             ctx = _create_permissive_ssl_context()
         assert ctx.verify_mode == ssl.CERT_NONE
 
+    def test_loopback_target_uses_cert_none_when_no_ca_configured(self):
+        """Loopback target with no CA → CERT_NONE (#6654).
+
+        Same-host connections cannot be MITM'd, so trusting a self-signed cert
+        is safe. This unblocks single-host installs that don't ship a project CA.
+        """
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            for url in (
+                "https://127.0.0.1:8000",
+                "https://localhost:8000",
+                "wss://127.0.0.1:8000/api/ws/events",
+            ):
+                ctx = _create_permissive_ssl_context(url)
+                assert ctx.verify_mode == ssl.CERT_NONE, f"loopback URL {url} should disable verify"
+                assert ctx.check_hostname is False
+
+    def test_non_loopback_target_remains_strict_when_no_ca_configured(self):
+        """Non-loopback target with no CA → strict (no regression for production, #6654)."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            ctx = _create_permissive_ssl_context("https://10.0.0.5:8000")
+        assert ctx.verify_mode != ssl.CERT_NONE
+
+    def test_no_target_url_remains_strict(self):
+        """No URL passed → strict (preserves the original strict-by-default contract)."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            ctx = _create_permissive_ssl_context()
+        assert ctx.verify_mode != ssl.CERT_NONE
+
 
 class TestSLMClientReconnectBackoff:
     """Tests for exponential backoff in the WebSocket reconnect loop (#4664)."""


### PR DESCRIPTION
## Summary

`slm_client._ws_connect_and_listen` and the aiohttp connector flooded backend-error.log with `Unexpected WebSocket error: [SSL: CERTIFICATE_VERIFY_FAILED] self-signed certificate`. The "permissive" SSL context was only permissive in 3 narrow cases (env CA, env skip-flag, project CA fallback). On a single-host install where `AUTOBOT_TLS_CA_PATH` points at a path that wasn't materialized and no project CA is bundled, it silently falls through to system trust — which rejects self-signed certs.

## Closes

- Closes #6654

## Root cause (deployed-host evidence)

- `AUTOBOT_TLS_CA_PATH=/etc/autobot/certs/ca-cert.pem` is set
- `/etc/autobot/certs/` only contains `server-cert.pem` + `server-key.pem` — `ca-cert.pem` was never deployed
- Repo doesn't ship `autobot-backend/certs/ca/ca-cert.pem`
- → `os.path.isfile()` checks fail at every tier; tier-4 system trust rejects the SLM's self-signed cert; every WebSocket reconnect logs `CERTIFICATE_VERIFY_FAILED`

## Changes

- `autobot-backend/services/slm_client.py`: make `_create_permissive_ssl_context` URL-aware. Add tier 4: when `target_url` is loopback (127.0.0.1, localhost, ::1, ip6-localhost) AND no CA was loaded, use `CERT_NONE` with a one-time WARNING. Loopback = same host = no MITM possible. Strict-by-default behaviour preserved for non-loopback URLs.
- Update both call sites (aiohttp connector, websockets.connect) to pass the URL.
- `autobot-backend/services/slm_client_test.py`: 3 new tests covering the loopback path, non-loopback strict path, and no-URL strict path.

## Verification

- All 6 pre-existing `TestCreatePermissiveSslContext` tests still pass.
- 3 new tests pass: `test_loopback_target_uses_cert_none_when_no_ca_configured`, `test_non_loopback_target_remains_strict_when_no_ca_configured`, `test_no_target_url_remains_strict`.
- All 14 `slm_client_test.py` tests pass total.

## Test plan

- [x] Unit tests pass.
- [ ] After deploy, `tail -F /var/log/autobot/backend-error.log` no longer accumulates `Unexpected WebSocket error: [SSL: CERTIFICATE_VERIFY_FAILED]` lines.
- [ ] One-time WARNING `TLS verification disabled for loopback target ...` appears once on backend startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)