### PR TITLE
fix(schemas): wire knowledge-graph DTOs to memory.py endpoints (#6620)

### DIFF
--- a/autobot-backend/api/memory.py
+++ b/autobot-backend/api/memory.py
@@ -46,12 +46,14 @@ from api.schemas_knowledge import (
     InvalidateRelationRequest,
     MemoryDeleteEntityResponse,
     MemoryDeleteRelationResponse,
+    MemoryEntityDetailResponse,
     MemoryEntityInvalidateResponse,
     MemoryEntityListResponse,
     MemoryOrphanCleanupResponse,
     MemoryOrphanScanResponse,
     MemoryRelatedEntitiesResponse,
     MemoryRelationInvalidateResponse,
+    MemorySearchResponse,
     ObservationAddRequest,
     RelationCreateRequest,
 )
@@ -841,7 +843,7 @@ async def cleanup_orphaned_conversation_entities(
     operation="get_entity_by_id",
     error_code_prefix="MEMORY",
 )
-@router.get("/entities/{entity_id}", response_model=DataResponse)
+@router.get("/entities/{entity_id}", response_model=MemoryEntityDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_entity_by_id",
@@ -1310,7 +1312,7 @@ async def delete_relation(
     operation="search_entities",
     error_code_prefix="MEMORY",
 )
-@router.get("/search", response_model=DataResponse)
+@router.get("/search", response_model=MemorySearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="search_entities",

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -3873,6 +3873,23 @@ class SearchResponse(BaseModel):
     filters: Metadata
 
 
+class MemorySearchResponse(BaseModel):
+    """Envelope for GET /api/memory/search — wraps SearchResponse in the
+    standard {success, data, request_id} envelope used across memory.py."""
+
+    success: bool
+    data: SearchResponse
+    request_id: str
+
+
+class MemoryEntityDetailResponse(BaseModel):
+    """Envelope for GET /api/memory/entities/{entity_id} — wraps EntityResponse."""
+
+    success: bool
+    data: EntityResponse
+    request_id: str
+
+
 # ai_stack_integration.py schemas (#6042)
 
 


### PR DESCRIPTION
## Summary

Partial fix for #6620 (Cluster D from #6616 not-wired audit).

The 4 graph DTOs at `schemas_knowledge.py:3847-3873` (`EntityResponse`, `RelationResponse`, `GraphNodeResponse`, `SearchResponse`) were unwired — all matching memory.py endpoints used `response_model=DataResponse`.

## Wired

- Added **`MemorySearchResponse`** envelope `(success, data: SearchResponse, request_id)` → `GET /api/memory/search`
- Added **`MemoryEntityDetailResponse`** envelope `(success, data: EntityResponse, request_id)` → `GET /api/memory/entities/{entity_id}`

Verified the `{success, data, request_id}` envelope shape matches actual endpoint returns (`memory.py:890, 1362`).

## Deferred

- `GET /entities` (list endpoint) — different envelope shape (returns list, not single)
- `GET /graph` — needs `GraphNodeResponse`-shaped envelope; can use `MemoryGraphResponse` follow-up
- `RelationResponse` — used as composition field in `GraphNodeResponse`; will become wired when `/graph` is wired

## Verification

- [x] `py_compile` clean
- [x] flake8 critical errors clean (one pre-existing F821 false-positive on `Literal["..."]` strings unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)