### PR TITLE
fix(frontend): single Agents nav entry — drop redundant /agents/activity sidebar icon (#6634 follow-up)

### DIFF
--- a/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
+++ b/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
@@ -40,7 +40,9 @@ import { navItems } from '@/config/navItems'
  */
 const INTENTIONALLY_HIDDEN: Record<string, string> = {
   '/about': 'Reachable via footer "About" link, not main nav',
-  '/agents/heartbeat': 'Diagnostic panel — accessed from agent registry, not main nav',
+  '/agents': 'Parent shell — redirects to /agents/registry; nav uses the deep-link entry (#6634)',
+  '/agents/activity': 'Reached as a tab inside /agents shell (#6634); standalone URL kept for bookmarks',
+  '/agents/heartbeat': 'Reached as a tab inside /agents shell (#6634); standalone URL kept for bookmarks',
   '/documents': 'Opened from chat output ("Save as document"), not main nav',
   '/admin/users': 'Admin-only — surfaced via separate admin entrypoint',
   '/slm/tools/novnc': 'Accessed via Chat tab\'s noVNC sub-tab (#6414/#6415); standalone URL kept for bookmarks',

--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -31,10 +31,10 @@ export const navItems: NavItem[] = [
   { to: '/knowledge', labelKey: 'nav.knowledge', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' },
   { to: '/automation', labelKey: 'nav.automation', icon: 'M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z', iconRule: 'evenodd' },
   { to: '/analytics', labelKey: 'nav.analytics', iconPaths: ['M2 10a8 8 0 018-8v8h8a8 8 0 11-16 0z', 'M12 2.252A8.014 8.014 0 0117.748 8H12V2.252z'] },
-  // Issue #4703: Agent Registry — backend + specialized agent dashboard
+  // Issue #4703 / #6634: single Agents nav entry — Activity and Heartbeat
+  // are reached as tabs inside the AgentsLayout shell, not as separate
+  // sidebar items.
   { to: '/agents/registry', labelKey: 'nav.agentRegistry', icon: 'M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2V9M9 21H5a2 2 0 01-2-2V9m0 0h18', iconStroke: true },
-  // Issue #5071/#6451: Agent Activity — per-agent diary timeline
-  { to: '/agents/activity', labelKey: 'nav.agentActivity', icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z', iconStroke: true },
   // Issue #929: Plugin Manager — marketplace integrated within /plugins
   { to: '/plugins', labelKey: 'nav.plugins', icon: 'M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z', iconStroke: true },
   { to: '/secrets', labelKey: 'nav.secrets', icon: 'M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z', iconRule: 'evenodd' },


### PR DESCRIPTION
User feedback after #6634 landed:

> /agents/activity menu icon not needed in main menu since its already in agents menu

Fix:
- [\`navItems.ts\`](autobot-frontend/src/config/navItems.ts) — remove the \`/agents/activity\` entry. \"Agent Registry\" is the only sidebar Agents item; Activity is one click into the tab bar.
- [\`__tests__/nav-items-coverage.test.ts\`](autobot-frontend/src/__tests__/nav-items-coverage.test.ts) — add \`/agents\`, \`/agents/activity\`, \`/agents/heartbeat\` to the INTENTIONALLY_HIDDEN allowlist with reasons. The parent \`/agents\` was actually missing from the allowlist in #6634; this lands while we're here.

Bookmarked deep links to \`/agents/activity\` and \`/agents/heartbeat\` continue to resolve through the shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)