### PR TITLE
fix(backend): import MODERATE_RISK_PATTERNS from constants.terminal_constants (#6664)

### DIFF
--- a/autobot-backend/api/terminal_handlers.py
+++ b/autobot-backend/api/terminal_handlers.py
@@ -32,10 +32,12 @@ from fastapi import WebSocket
 
 # Import models from dedicated module (Issue #185)
 from api.schemas_terminal import (
-    MODERATE_RISK_PATTERNS,
-    RISKY_COMMAND_PATTERNS,
     CommandRiskLevel,
     SecurityLevel,
+)
+from constants.terminal_constants import (
+    MODERATE_RISK_PATTERNS,
+    RISKY_COMMAND_PATTERNS,
 )
 from chat_history import ChatHistoryManager
 from constants.path_constants import PATH

--- a/autobot-backend/tests/test_startup_imports.py
+++ b/autobot-backend/tests/test_startup_imports.py
@@ -69,9 +69,6 @@ def _schema_modules() -> list[str]:
 # keeps CI green while ensuring the test still catches NEW regressions of the
 # same shape. Remove an entry when its tracking issue is closed.
 KNOWN_BROKEN_AT_TEST_INTRODUCTION: dict[str, str] = {
-    # #6664 — MODERATE_RISK_PATTERNS missing from api.schemas_terminal
-    "api.terminal": "#6664",
-    "api.terminal_handlers": "#6664",
     # #6665 — Orchestrator.max_parallel_tasks attribute drift
     "api.orchestration": "#6665",
     "api.workflow_automation": "#6665",


### PR DESCRIPTION
## Summary

Closes #6664. **Production bug fix** — \`/api/terminal*\` endpoints have been silently absent since #6042 migration.

## Root cause

\`api/terminal_handlers.py\` imported \`MODERATE_RISK_PATTERNS\` and \`RISKY_COMMAND_PATTERNS\` from \`api.schemas_terminal\` during the schema migration, but those constants live in \`constants/terminal_constants.py\` and were never moved.

```
ImportError: cannot import name 'MODERATE_RISK_PATTERNS' from 'api.schemas_terminal'
```

The router loads via feature-router graceful-fallback (#281), which logs the error and continues boot — so the endpoints just aren't registered. Same pattern as #6536/#6569.

## Fix

Split the import in `terminal_handlers.py`:
- Keep `CommandRiskLevel` and `SecurityLevel` from `api.schemas_terminal` (where they live)
- Pull `MODERATE_RISK_PATTERNS` / `RISKY_COMMAND_PATTERNS` from `constants.terminal_constants`

The companion `api/terminal.py` already had this split correctly (line 147).

## Test coverage

The startup-import smoke test added by #6540 listed `api.terminal` and `api.terminal_handlers` as known-broken (xfail-marked under #6664). After this fix:
- Removed the xfail entries
- Test now positively asserts these modules import cleanly
- Any future regression of the same shape will fail CI immediately

## Verification

- [x] `py_compile` clean on `api/terminal_handlers.py`
- [x] Imports resolve correctly (`MODERATE_RISK_PATTERNS` defined at `constants/terminal_constants.py:27`)
- [x] Smoke test xfail entries removed

## Frontend impact

After deploy, all `/api/terminal*` endpoints come back online (terminal session list, command execution, signal handling, stats, system status, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)