### PR TITLE
fix(backend): correct Orchestrator.max_parallel_tasks attribute path (#6665)

### DIFF
--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -123,7 +123,7 @@ async def execute_workflow(
 
         # Update max parallel tasks if specified
         if request.max_parallel_tasks:
-            orchestrator.max_parallel_tasks = request.max_parallel_tasks
+            orchestrator.config.max_parallel_tasks = request.max_parallel_tasks
 
         # Create and execute workflow
         result = await create_and_execute_workflow(request.goal, request.context)
@@ -514,7 +514,7 @@ async def get_orchestration_status(
             content={
                 "status": "operational",
                 "active_workflows": performance_report.get("active_workflows", 0),
-                "max_parallel_tasks": orchestrator.max_parallel_tasks,
+                "max_parallel_tasks": orchestrator.config.max_parallel_tasks,
                 "total_agents": len(orchestrator.agent_capabilities),
                 "capabilities": {
                     "execution_strategies": [

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -271,7 +271,7 @@ class Orchestrator:
             active_workflows=self.active_workflows,
             collaboration=self._collab,
             agent_router=self._agent_router,
-            max_parallel_tasks=self.max_parallel_tasks,
+            max_parallel_tasks=self.config.max_parallel_tasks,
         )
 
     def __init__(self, config_mgr=None):

--- a/autobot-backend/tests/test_startup_imports.py
+++ b/autobot-backend/tests/test_startup_imports.py
@@ -69,9 +69,6 @@ def _schema_modules() -> list[str]:
 # keeps CI green while ensuring the test still catches NEW regressions of the
 # same shape. Remove an entry when its tracking issue is closed.
 KNOWN_BROKEN_AT_TEST_INTRODUCTION: dict[str, str] = {
-    # #6665 — Orchestrator.max_parallel_tasks attribute drift
-    "api.orchestration": "#6665",
-    "api.workflow_automation": "#6665",
     # #6666 — missing internal modules (tests.benchmarks, mcp.autobot_server, scripts.*)
     "api.api_benchmarks": "#6666",
     "api.autobot_mcp_router": "#6666",


### PR DESCRIPTION
## Summary

Closes #6665. Production bug — `/api/orchestration*` and `/api/workflow_automation*` endpoints have been silently absent since refactor that moved `max_parallel_tasks` onto `OrchestratorConfig`.

## Root cause

`Orchestrator.__init__` stores config in `self.config = OrchestratorConfig(...)`. `OrchestratorConfig` owns `max_parallel_tasks`. Three callsites used the wrong path:

- `orchestrator.py:274` — `max_parallel_tasks=self.max_parallel_tasks` inside `Orchestrator._init_runner`. Crashes at every `Orchestrator()` instantiation. Triggered at import time via `services/workflow_automation/manager.py:58 self.orchestrator = Orchestrator()`.
- `api/orchestration.py:126` — `orchestrator.max_parallel_tasks = request.max_parallel_tasks`
- `api/orchestration.py:517` — `orchestrator.max_parallel_tasks` in /system/status response

All three now route through `self.config.max_parallel_tasks` / `orchestrator.config.max_parallel_tasks`.

## Test coverage

Removed `#6665` xfail entries from `tests/test_startup_imports.py` — smoke test now positively asserts `api.orchestration` and `api.workflow_automation` import cleanly. Future regressions of the same shape will fail CI.

## Verification

- [x] `py_compile` clean on all 3 touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)