### PR TITLE
fix(quality): invalidate Redis cache on scan completion (#6669)

### DIFF
--- a/autobot-backend/api/codebase_analytics/progress_tracker.py
+++ b/autobot-backend/api/codebase_analytics/progress_tracker.py
@@ -362,6 +362,29 @@ def _update_task_stats(task_id: str, indexing_tasks: Dict, **kwargs) -> None:
             indexing_tasks[task_id]["stats"][key] = value
 
 
+async def _invalidate_quality_cache() -> None:
+    """Invalidate code_quality:latest* Redis keys after a scan changes ChromaDB.
+
+    Issue #6669: The Code Quality Dashboard caches calculated metrics in Redis
+    for 5 minutes (analytics_quality.py:130). Without invalidation, the
+    dashboard serves pre-scan results until that TTL elapses. We use a
+    pattern-delete so both the global ``code_quality:latest`` key and any
+    per-source ``code_quality:latest:{source_root}`` variants are cleared.
+    """
+    try:
+        redis = await get_async_redis_client(database="analytics")
+        if not redis:
+            return
+        keys = await redis.keys("code_quality:latest*")
+        if keys:
+            await redis.delete(*keys)
+            logger.info(
+                "Invalidated %d quality cache key(s) after scan", len(keys)
+            )
+    except Exception as exc:
+        logger.warning("Quality cache invalidation failed: %s", exc)
+
+
 def _mark_task_completed(
     task_id: str,
     analysis_results: Dict,
@@ -373,6 +396,8 @@ def _mark_task_completed(
     Mark indexing task as completed with results.
 
     Issue #398: Extracted from do_indexing_with_progress.
+    Issue #6669: Invalidate the Code Quality Dashboard's Redis cache so the
+    UI surfaces fresh scan output instead of serving 5-minute-stale results.
     """
     indexing_tasks[task_id]["status"] = "completed"
     total_files = analysis_results["stats"]["total_files"]
@@ -388,6 +413,13 @@ def _mark_task_completed(
         "timestamp": datetime.now(tz=timezone.utc).isoformat(),
     }
     indexing_tasks[task_id]["completed_at"] = datetime.now(tz=timezone.utc).isoformat()
+    # Fire-and-forget cache invalidation; safe in any running-loop context
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(_invalidate_quality_cache())
+    except RuntimeError:
+        # No running loop (called from a sync context); run a one-shot
+        asyncio.run(_invalidate_quality_cache())
 
 
 def _mark_task_failed(task_id: str, error: Exception, indexing_tasks: Dict) -> None:

--- a/autobot-backend/api/codebase_analytics/progress_tracker_test.py
+++ b/autobot-backend/api/codebase_analytics/progress_tracker_test.py
@@ -1,0 +1,103 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for progress_tracker._invalidate_quality_cache (Issue #6669).
+
+The Code Quality Dashboard caches calculated metrics under
+``code_quality:latest*`` for 5 minutes. After a scan completes,
+``_mark_task_completed`` must invalidate that cache so the dashboard
+returns fresh results instead of stale pre-scan values.
+"""
+
+import importlib.util
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _load_progress_tracker():
+    """Load progress_tracker.py without triggering the heavy analyzers import chain."""
+    spec = importlib.util.spec_from_file_location(
+        "progress_tracker_under_test",
+        "autobot-backend/api/codebase_analytics/progress_tracker.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestInvalidateQualityCache:
+    """Issue #6669: cache invalidation after scan completion."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_matching_keys(self):
+        """All keys matching code_quality:latest* must be passed to redis.delete()."""
+        pt = _load_progress_tracker()
+
+        fake_redis = MagicMock()
+        fake_redis.keys = AsyncMock(
+            return_value=[
+                "code_quality:latest",
+                "code_quality:latest:/repos/foo",
+                "code_quality:latest:/repos/bar",
+            ]
+        )
+        fake_redis.delete = AsyncMock(return_value=3)
+
+        async def fake_get_client(database=None):
+            assert database == "analytics"
+            return fake_redis
+
+        with patch.object(pt, "get_async_redis_client", new=fake_get_client):
+            await pt._invalidate_quality_cache()
+
+        fake_redis.keys.assert_awaited_once_with("code_quality:latest*")
+        fake_redis.delete.assert_awaited_once_with(
+            "code_quality:latest",
+            "code_quality:latest:/repos/foo",
+            "code_quality:latest:/repos/bar",
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_keys_no_delete(self):
+        """When no keys match, redis.delete() must not be called."""
+        pt = _load_progress_tracker()
+
+        fake_redis = MagicMock()
+        fake_redis.keys = AsyncMock(return_value=[])
+        fake_redis.delete = AsyncMock()
+
+        async def fake_get_client(database=None):
+            return fake_redis
+
+        with patch.object(pt, "get_async_redis_client", new=fake_get_client):
+            await pt._invalidate_quality_cache()
+
+        fake_redis.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_redis_unavailable_does_not_raise(self):
+        """If the analytics redis client is unavailable, the helper must not raise."""
+        pt = _load_progress_tracker()
+
+        async def fake_get_client(database=None):
+            return None
+
+        with patch.object(pt, "get_async_redis_client", new=fake_get_client):
+            # Must not raise — scan completion path can't fail because of cache cleanup.
+            await pt._invalidate_quality_cache()
+
+    @pytest.mark.asyncio
+    async def test_redis_exception_swallowed(self):
+        """Underlying Redis errors must be logged but not re-raised."""
+        pt = _load_progress_tracker()
+
+        fake_redis = MagicMock()
+        fake_redis.keys = AsyncMock(side_effect=RuntimeError("redis is down"))
+
+        async def fake_get_client(database=None):
+            return fake_redis
+
+        with patch.object(pt, "get_async_redis_client", new=fake_get_client):
+            await pt._invalidate_quality_cache()  # No exception should propagate


### PR DESCRIPTION
## Summary
- New `_invalidate_quality_cache()` helper pattern-deletes every `code_quality:latest*` key in the analytics Redis db.
- Wired into `_mark_task_completed` via fire-and-forget `loop.create_task()` so the sync caller signature stays the same and a slow Redis op can't block scan finalization.
- Without this fix the dashboard served pre-scan results for up to 5 minutes after every scan (TTL set in analytics_quality.py:130).

## Test plan
- [x] `pytest autobot-backend/api/codebase_analytics/progress_tracker_test.py` — 4 tests cover keys-deleted, no-keys, redis-unavailable, redis-raises
- [x] `_mark_task_completed` signature unchanged — verified via `inspect.signature`

Closes #6669

🤖 Generated with [Claude Code](https://claude.com/claude-code)