### PR TITLE
fix(quality): surface backend status:"no_data" instead of silent zeros (#6671)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -29,6 +29,22 @@
       </div>
     </div>
 
+    <!-- Issue #6671: surface backend status:"no_data" instead of silently rendering zeros -->
+    <EmptyState
+      v-if="noDataState.noData"
+      icon="chart-line"
+      :message="noDataState.message ?? $t('analytics.codeQuality.noScanData')"
+      variant="info"
+    >
+      <template #actions>
+        <button @click="refreshData" class="btn-link" :disabled="loading">
+          {{ $t('analytics.codeQuality.refresh') }}
+        </button>
+      </template>
+    </EmptyState>
+
+    <!-- Issue #6671: hide all data-driven sections when backend reports no_data -->
+    <template v-if="!noDataState.noData">
     <!-- Health Score Hero Card -->
     <div class="health-hero">
       <div class="health-score-circle">
@@ -364,6 +380,8 @@
       </div>
     </div>
 
+    </template>
+
     <!-- Drill-Down Modal -->
     <div v-if="drillDownCategory" class="modal-overlay" @click.self="drillDownCategory = null">
       <div class="modal-content drill-down-modal">
@@ -426,6 +444,7 @@ import { createLogger } from '@/utils/debugUtils';
 import { getCssVar } from '@/composables/useCssVars';
 import { useWebSocket } from '@/composables/useWebSocket';
 import { useCodeQualityData } from '@/composables/analytics/useCodeQualityData';
+import EmptyState from '@/components/ui/EmptyState.vue';
 
 const logger = createLogger('CodeQualityDashboard');
 
@@ -450,6 +469,7 @@ const {
   fetchSnapshot,
   fetchDrillDown,
   fetchExport,
+  noDataState,
 } = useCodeQualityData(withSourceId);
 
 // Helper to get CSS variable value for JavaScript usage (SVG, charts, etc.)

--- a/autobot-frontend/src/composables/analytics/useCodeQualityData.test.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeQualityData.test.ts
@@ -1,0 +1,99 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Unit tests for useCodeQualityData no-data state plumbing (Issue #6671).
+ *
+ * The backend's _no_data_response() returns { status: "no_data", ... } when
+ * no codebase scan has happened yet. The composable must surface that state
+ * via noDataState so the dashboard can render an empty-state banner instead
+ * of silently rendering Grade C / zeros.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Capture pickData callbacks the composable registers so we can drive them
+// directly without a fetch round-trip.
+type PickData = (raw: Record<string, unknown>) => unknown
+const registered: { path: string; pickData: PickData }[] = []
+
+vi.mock('@/composables/api/useFetchEndpoint', () => ({
+  useFetchEndpoint: (cfg: { path: string; pickData?: PickData }) => {
+    registered.push({ path: cfg.path, pickData: cfg.pickData ?? ((r) => r) })
+    return {
+      data: { value: null },
+      load: vi.fn().mockResolvedValue(undefined),
+    }
+  },
+}))
+
+import { useCodeQualityData } from './useCodeQualityData'
+
+describe('useCodeQualityData — no-data state (#6671)', () => {
+  beforeEach(() => {
+    registered.length = 0
+  })
+
+  it('starts with noDataState.noData === false', () => {
+    const data = useCodeQualityData((u) => u)
+    expect(data.noDataState.value.noData).toBe(false)
+    expect(data.noDataState.value.message).toBeNull()
+  })
+
+  it('flips noDataState.noData to true when health-score returns status:"no_data"', () => {
+    const data = useCodeQualityData((u) => u)
+    const ep = registered.find((r) => r.path === '/api/quality/health-score')
+    expect(ep).toBeDefined()
+    ep!.pickData({
+      status: 'no_data',
+      message: 'Run codebase indexing first.',
+    })
+    expect(data.noDataState.value.noData).toBe(true)
+    expect(data.noDataState.value.message).toBe('Run codebase indexing first.')
+  })
+
+  it('clears noDataState when a subsequent response has real data', () => {
+    const data = useCodeQualityData((u) => u)
+    const hs = registered.find((r) => r.path === '/api/quality/health-score')!
+    hs.pickData({ status: 'no_data', message: 'Run codebase indexing first.' })
+    expect(data.noDataState.value.noData).toBe(true)
+    hs.pickData({ status: 'ok', overall: 87, grade: 'B' })
+    expect(data.noDataState.value.noData).toBe(false)
+    expect(data.noDataState.value.message).toBeNull()
+  })
+
+  it('aggregates across endpoints — any endpoint reporting no_data wins', () => {
+    const data = useCodeQualityData((u) => u)
+    const hs = registered.find((r) => r.path === '/api/quality/health-score')!
+    const cx = registered.find((r) => r.path === '/api/quality/complexity')!
+    hs.pickData({ status: 'ok', overall: 90 })
+    expect(data.noDataState.value.noData).toBe(false)
+    cx.pickData({
+      status: 'no_data',
+      message: 'No complexity data',
+    })
+    expect(data.noDataState.value.noData).toBe(true)
+    expect(data.noDataState.value.message).toBe('No complexity data')
+  })
+
+  it('healthScore pickData still returns sensible defaults so the component does not crash', () => {
+    useCodeQualityData((u) => u)
+    const hs = registered.find((r) => r.path === '/api/quality/health-score')!
+    const result = hs.pickData({
+      status: 'no_data',
+      message: 'Run codebase indexing first.',
+    }) as { overall: number; grade: string; recommendations: string[] }
+    expect(result.overall).toBe(0)
+    expect(result.grade).toBe('C')
+    expect(result.recommendations).toEqual([])
+  })
+
+  it('metrics array path keeps existing semantics: a bare array means "ok, no rows"', () => {
+    const data = useCodeQualityData((u) => u)
+    const m = registered.find((r) => r.path === '/api/quality/metrics')!
+    const result = m.pickData([]) as unknown[]
+    expect(result).toEqual([])
+    expect(data.noDataState.value.noData).toBe(false)
+  })
+})

--- a/autobot-frontend/src/composables/analytics/useCodeQualityData.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeQualityData.ts
@@ -22,13 +22,20 @@
  *   GET  /quality/export?format=<format>
  */
 
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useCodeQualityData')
 
+// Issue #6671: Backend returns _no_data_response with status:"no_data" when no
+// scan has happened yet (analytics_quality.py:_no_data_response). The frontend
+// must treat that as a distinct empty state — not silently fall back to zeros.
+export type QualityStatus = 'ok' | 'no_data'
+
 export interface QualityHealthScore {
+  status: QualityStatus
+  message?: string
   overall: number
   grade: string
   trend: number
@@ -55,6 +62,8 @@ export interface QualityPattern {
 }
 
 export interface QualityComplexity {
+  status: QualityStatus
+  message?: string
   averages: { cyclomatic: number; cognitive: number }
   maximums: { cyclomatic: number; cognitive: number }
   hotspots: Array<{ file: string; complexity: number; lines: number }>
@@ -73,9 +82,52 @@ export interface QualityExportResult {
   [key: string]: unknown
 }
 
+export interface QualitySnapshot {
+  status: QualityStatus
+  message?: string
+  files: number
+  lines: number
+  issues: number
+}
+
+function readStatus(raw: Record<string, unknown>): QualityStatus {
+  return (raw.status as QualityStatus | undefined) === 'no_data' ? 'no_data' : 'ok'
+}
+
+function readMessage(raw: Record<string, unknown>): string | undefined {
+  const msg = raw.message
+  return typeof msg === 'string' ? msg : undefined
+}
+
 export function useCodeQualityData(withSourceId: (url: string) => string) {
   const isLoading = ref(false)
   const error = ref<string | null>(null)
+  // Issue #6671: track no-data state independently for each endpoint so the
+  // dashboard can render an empty-state banner instead of silent zeros.
+  const noDataMessage = ref<string | null>(null)
+  const noDataFlags = ref({
+    healthScore: false,
+    metrics: false,
+    patterns: false,
+    complexity: false,
+    trends: false,
+    snapshot: false,
+  })
+  const noDataState = computed(() => ({
+    noData: Object.values(noDataFlags.value).some(Boolean),
+    message: noDataMessage.value,
+  }))
+
+  function recordStatus(key: keyof typeof noDataFlags.value, raw: Record<string, unknown>) {
+    const status = readStatus(raw)
+    noDataFlags.value[key] = status === 'no_data'
+    if (status === 'no_data' && !noDataMessage.value) {
+      noDataMessage.value = readMessage(raw) ?? null
+    }
+    if (Object.values(noDataFlags.value).every((flag) => !flag)) {
+      noDataMessage.value = null
+    }
+  }
 
   // ---- Health Score --------------------------------------------------------
   // Issue #552: backend uses /api/quality/* not /api/analytics/quality/*
@@ -85,14 +137,19 @@ export function useCodeQualityData(withSourceId: (url: string) => string) {
     {
       path: '/api/quality/health-score',
       scopeToSource: true,
-      pickData: (raw) => ({
-        overall: (raw.overall as number) ?? 0,
-        grade: (raw.grade as string) || 'C',
-        trend: (raw.trend as number) ?? 0,
-        breakdown: (raw.breakdown as Record<string, number>) || {},
-        components: (raw.components as Record<string, number>) || { code_quality: 0, security: 0, performance: 0 },
-        recommendations: (raw.recommendations as string[]) || [],
-      }),
+      pickData: (raw) => {
+        recordStatus('healthScore', raw)
+        return {
+          status: readStatus(raw),
+          message: readMessage(raw),
+          overall: (raw.overall as number) ?? 0,
+          grade: (raw.grade as string) || 'C',
+          trend: (raw.trend as number) ?? 0,
+          breakdown: (raw.breakdown as Record<string, number>) || {},
+          components: (raw.components as Record<string, number>) || { code_quality: 0, security: 0, performance: 0 },
+          recommendations: (raw.recommendations as string[]) || [],
+        }
+      },
       onError: (message, err) => {
         logger.warn('Failed to load health score:', err)
         error.value = message
@@ -120,10 +177,15 @@ export function useCodeQualityData(withSourceId: (url: string) => string) {
       // Issue #552 / #3436
       path: '/api/quality/metrics',
       scopeToSource: true,
-      pickData: (raw) =>
-        Array.isArray(raw)
-          ? (raw as QualityMetric[])
-          : ((raw as Record<string, unknown>).metrics as QualityMetric[]) || [],
+      pickData: (raw) => {
+        if (Array.isArray(raw)) {
+          noDataFlags.value.metrics = false
+          return raw as QualityMetric[]
+        }
+        const obj = (raw as Record<string, unknown>) ?? {}
+        recordStatus('metrics', obj)
+        return (obj.metrics as QualityMetric[]) || []
+      },
       onError: (message, err) => {
         logger.warn('Failed to load metrics:', err)
         error.value = message
@@ -152,10 +214,15 @@ export function useCodeQualityData(withSourceId: (url: string) => string) {
       // Issue #552 / #3436
       path: '/api/quality/patterns',
       scopeToSource: true,
-      pickData: (raw) =>
-        Array.isArray(raw)
-          ? (raw as QualityPattern[])
-          : ((raw as Record<string, unknown>).patterns as QualityPattern[]) || [],
+      pickData: (raw) => {
+        if (Array.isArray(raw)) {
+          noDataFlags.value.patterns = false
+          return raw as QualityPattern[]
+        }
+        const obj = (raw as Record<string, unknown>) ?? {}
+        recordStatus('patterns', obj)
+        return (obj.patterns as QualityPattern[]) || []
+      },
       onError: (message, err) => {
         logger.warn('Failed to load patterns:', err)
         error.value = message
@@ -184,11 +251,16 @@ export function useCodeQualityData(withSourceId: (url: string) => string) {
       // Issue #552 / #3436
       path: '/api/quality/complexity',
       scopeToSource: true,
-      pickData: (raw) => ({
-        averages: (raw.averages as { cyclomatic: number; cognitive: number }) || { cyclomatic: 0, cognitive: 0 },
-        maximums: (raw.maximums as { cyclomatic: number; cognitive: number }) || { cyclomatic: 0, cognitive: 0 },
-        hotspots: (raw.hotspots as Array<{ file: string; complexity: number; lines: number }>) || [],
-      }),
+      pickData: (raw) => {
+        recordStatus('complexity', raw)
+        return {
+          status: readStatus(raw),
+          message: readMessage(raw),
+          averages: (raw.averages as { cyclomatic: number; cognitive: number }) || { cyclomatic: 0, cognitive: 0 },
+          maximums: (raw.maximums as { cyclomatic: number; cognitive: number }) || { cyclomatic: 0, cognitive: 0 },
+          hotspots: (raw.hotspots as Array<{ file: string; complexity: number; lines: number }>) || [],
+        }
+      },
       onError: (message, err) => {
         logger.warn('Failed to load complexity:', err)
         error.value = message
@@ -216,8 +288,10 @@ export function useCodeQualityData(withSourceId: (url: string) => string) {
       // Issue #552 / #3436
       path: '/api/quality/trends',
       scopeToSource: true,
-      pickData: (raw) =>
-        (raw.data_points as Array<{ date: string; score: number }>) || [],
+      pickData: (raw) => {
+        recordStatus('trends', raw)
+        return (raw.data_points as Array<{ date: string; score: number }>) || []
+      },
       onError: (message, err) => {
         logger.warn('Failed to load trends:', err)
         error.value = message
@@ -241,13 +315,25 @@ export function useCodeQualityData(withSourceId: (url: string) => string) {
 
   // ---- Snapshot -----------------------------------------------------------
 
-  const snapshotEndpoint = useFetchEndpoint<Record<string, unknown>, { files: number; lines: number; issues: number }>(
+  const snapshotEndpoint = useFetchEndpoint<Record<string, unknown>, QualitySnapshot>(
     {
       // Issue #552 / #3436
       path: '/api/quality/snapshot',
       scopeToSource: true,
-      pickData: (raw) =>
-        (raw.codebase_stats as { files: number; lines: number; issues: number }) || { files: 0, lines: 0, issues: 0 },
+      pickData: (raw) => {
+        recordStatus('snapshot', raw)
+        const stats =
+          (raw.codebase_stats as { files: number; lines: number; issues: number }) || {
+            files: 0,
+            lines: 0,
+            issues: 0,
+          }
+        return {
+          status: readStatus(raw),
+          message: readMessage(raw),
+          ...stats,
+        }
+      },
       onError: (message, err) => {
         logger.warn('Failed to load snapshot:', err)
         error.value = message
@@ -257,7 +343,7 @@ export function useCodeQualityData(withSourceId: (url: string) => string) {
     { withSourceId },
   )
 
-  async function fetchSnapshot(): Promise<{ files: number; lines: number; issues: number } | null> {
+  async function fetchSnapshot(): Promise<QualitySnapshot | null> {
     error.value = null
     isLoading.value = true
     try {
@@ -326,6 +412,7 @@ export function useCodeQualityData(withSourceId: (url: string) => string) {
   return {
     isLoading,
     error,
+    noDataState,
     fetchHealthScore,
     fetchMetrics,
     fetchPatterns,

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -1615,7 +1615,8 @@
       "file": "File",
       "score": "Score",
       "topIssue": "Top Issue",
-      "close": "Close"
+      "close": "Close",
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",


### PR DESCRIPTION
## Summary
- `useCodeQualityData` propagates `status` and `message` from the six `/api/quality/*` responses and aggregates them into a `noDataState` ref.
- `CodeQualityDashboard.vue` renders the existing `EmptyState` component with a refresh action and hides every data-driven section behind a `<template v-if>` when `noDataState.noData` is true — no more Grade C / zeros for unscanned codebases.
- Added `analytics.codeQuality.noScanData` translation key in `en.json`.

## Test plan
- [x] `npx vitest run src/composables/analytics/useCodeQualityData.test.ts` — 6 tests pass (initial state, single endpoint flip, recovery, cross-endpoint aggregation, default preservation, bare array path)
- [x] `npx vite build` succeeds; `vue-tsc` errors are pre-existing on Dev_new_gui (unrelated WebSocket onMessage typing + EmptyState.stories.ts missing storybook dep)

Closes #6671

## Sibling fixes
- #6669 — Redis cache invalidation on scan completion (PR #6682)
- #6670 — Per-source ChromaDB stats fallback (PR #6681)

The three together fully restore Code Quality Dashboard behaviour after a scan. This PR alone surfaces the empty state correctly; the other two are needed for real data to actually appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)