### PR TITLE
fix(backend): guard 5 missing-internal-module imports + add mcp __init__.py (#6666)

### DIFF
--- a/autobot-backend/api/api_benchmarks.py
+++ b/autobot-backend/api/api_benchmarks.py
@@ -21,7 +21,21 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from constants.api_constants import PATH_API_HEALTH
 from constants.network_constants import NetworkConstants
-from tests.benchmarks.benchmark_base import BenchmarkRunner, assert_performance
+
+try:
+    # benchmark_base lives in tests/benchmarks/ — only present when the test
+    # suite is on PYTHONPATH (#6666). This module functions both as a pytest
+    # benchmark suite and as an API router import target.
+    from tests.benchmarks.benchmark_base import BenchmarkRunner, assert_performance
+except ImportError as _benchmark_import_error:
+    from autobot_shared.missing_dep import MissingDep as _MissingDep
+
+    BenchmarkRunner = _MissingDep(  # type: ignore[assignment, misc]
+        "BenchmarkRunner", _benchmark_import_error
+    )
+    assert_performance = _MissingDep(  # type: ignore[assignment, misc]
+        "assert_performance", _benchmark_import_error
+    )
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/log_forwarding.py
+++ b/autobot-backend/api/log_forwarding.py
@@ -31,13 +31,34 @@ from constants.threshold_constants import TimingConstants
 # Add scripts path for log forwarder import
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from scripts.logging.log_forwarder import (
-    DestinationConfig,
-    DestinationScope,
-    DestinationType,
-    LogForwarder,
-    SyslogProtocol,
-)
+try:
+    # log_forwarder lives in autobot-infrastructure/shared/scripts/logging/ —
+    # only available when the infrastructure repo is on PYTHONPATH (#6666).
+    from scripts.logging.log_forwarder import (
+        DestinationConfig,
+        DestinationScope,
+        DestinationType,
+        LogForwarder,
+        SyslogProtocol,
+    )
+except ImportError as _log_forwarder_import_error:
+    from autobot_shared.missing_dep import MissingDep as _MissingDep
+
+    DestinationConfig = _MissingDep(  # type: ignore[assignment, misc]
+        "DestinationConfig", _log_forwarder_import_error
+    )
+    DestinationScope = _MissingDep(  # type: ignore[assignment, misc]
+        "DestinationScope", _log_forwarder_import_error
+    )
+    DestinationType = _MissingDep(  # type: ignore[assignment, misc]
+        "DestinationType", _log_forwarder_import_error
+    )
+    LogForwarder = _MissingDep(  # type: ignore[assignment, misc]
+        "LogForwarder", _log_forwarder_import_error
+    )
+    SyslogProtocol = _MissingDep(  # type: ignore[assignment, misc]
+        "SyslogProtocol", _log_forwarder_import_error
+    )
 from api.schemas_system import (
     LogForwardingDestinationItem,
     LogFwdAutoStartResponse,

--- a/autobot-backend/mcp/__init__.py
+++ b/autobot-backend/mcp/__init__.py
@@ -1,0 +1,2 @@
+# MCP package marker. Required so `from mcp.autobot_server import AutoBotMCPServer`
+# resolves at import time (#6666).

--- a/autobot-backend/phase_progression_manager.py
+++ b/autobot-backend/phase_progression_manager.py
@@ -19,7 +19,17 @@ import aiofiles
 
 from constants.path_constants import PATH
 from project_state_manager import ProjectStateManager
-from scripts.phase_validation_system import PhaseValidator
+
+try:
+    # PhaseValidator lives in autobot-infrastructure/shared/scripts/ — only
+    # available when the infrastructure repo is on PYTHONPATH (#6666).
+    from scripts.phase_validation_system import PhaseValidator
+except ImportError as _phase_validator_import_error:
+    from autobot_shared.missing_dep import MissingDep as _MissingDep
+
+    PhaseValidator = _MissingDep(  # type: ignore[assignment, misc]
+        "PhaseValidator", _phase_validator_import_error
+    )
 
 # Setup logging
 logger = logging.getLogger(__name__)

--- a/autobot-backend/project_state_tracking/tracker.py
+++ b/autobot-backend/project_state_tracking/tracker.py
@@ -21,7 +21,17 @@ from constants.path_constants import PATH
 from constants.threshold_constants import TimingConstants
 from phase_progression_manager import get_progression_manager
 from project_state_manager import ProjectStateManager
-from scripts.phase_validation_system import PhaseValidator
+
+try:
+    # PhaseValidator lives in autobot-infrastructure/shared/scripts/ — only
+    # available when the infrastructure repo is on PYTHONPATH (#6666).
+    from scripts.phase_validation_system import PhaseValidator
+except ImportError as _phase_validator_import_error:
+    from autobot_shared.missing_dep import MissingDep as _MissingDep
+
+    PhaseValidator = _MissingDep(  # type: ignore[assignment, misc]
+        "PhaseValidator", _phase_validator_import_error
+    )
 
 from .database import (
     init_database,

--- a/autobot-backend/tests/test_startup_imports.py
+++ b/autobot-backend/tests/test_startup_imports.py
@@ -69,13 +69,6 @@ def _schema_modules() -> list[str]:
 # keeps CI green while ensuring the test still catches NEW regressions of the
 # same shape. Remove an entry when its tracking issue is closed.
 KNOWN_BROKEN_AT_TEST_INTRODUCTION: dict[str, str] = {
-    # #6666 — missing internal modules (tests.benchmarks, mcp.autobot_server, scripts.*)
-    "api.api_benchmarks": "#6666",
-    "api.autobot_mcp_router": "#6666",
-    "api.llm_awareness": "#6666",
-    "api.log_forwarding": "#6666",
-    "api.state_tracking": "#6666",
-    "api.validation_dashboard": "#6666",
     # #6667 — optional deps not guarded (playwright, docker)
     "api.captcha": "#6667",
     "api.sandbox": "#6667",


### PR DESCRIPTION
## Summary

Closes #6666. **6 api/*.py modules** silently absent in production restored — orphan imports from #6042-era refactor.

## Fixes

| # | Module | Root cause | Fix |
|---|--------|------------|-----|
| 1 | `api.autobot_mcp_router` | `mcp/__init__.py` missing entirely | Added empty package marker |
| 2 | `api.llm_awareness` | Transitive `scripts.phase_validation_system` via `phase_progression_manager` | try/except + MissingDep guard |
| 3 | `api.state_tracking` | Transitive same import via `project_state_tracking/tracker.py` | try/except + MissingDep guard |
| 4 | `api.log_forwarding` | `scripts.logging.log_forwarder` (lives in autobot-infrastructure repo) | try/except + MissingDep guard for 5 symbols |
| 5 | `api.api_benchmarks` | `tests.benchmarks.benchmark_base` (only on PYTHONPATH during test runs) | try/except + MissingDep guard |
| 6 | `api.validation_dashboard` | Already guarded in production code | Just removed xfail entry |

## Pattern used

Same MissingDep stub pattern used by existing `validation_dashboard.py` guard. Affected endpoints will return 503 with a clear "<dependency> not available" error instead of silently being absent at boot.

## Test coverage

Removed all six `#6666` xfail entries from `tests/test_startup_imports.py`. Smoke test now positively asserts these modules import cleanly.

## Verification

- [x] `py_compile` clean on all 6 touched files
- [x] `mcp/autobot_server.py` exists; `class AutoBotMCPServer` at line 238

🤖 Generated with [Claude Code](https://claude.com/claude-code)