### PR TITLE
fix(backend): guard playwright + docker optional-dep imports (#6667)

### DIFF
--- a/autobot-backend/secure_sandbox_executor.py
+++ b/autobot-backend/secure_sandbox_executor.py
@@ -20,8 +20,25 @@ from services.tool_output_filter import _dedup_consecutive, _strip_ansi
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import docker
-from docker.errors import DockerException, ImageNotFound
+try:
+    # docker SDK is an optional runtime dep; required for the sandbox
+    # executor itself but the api/sandbox.py router and other importers
+    # need this module to load cleanly (#6667). When docker is missing,
+    # SecureSandboxExecutor raises an informative error on first use via
+    # the docker_client check at runtime.
+    import docker
+    from docker.errors import DockerException, ImageNotFound
+
+    DOCKER_SDK_AVAILABLE = True
+except ImportError as _docker_import_error:
+    DOCKER_SDK_AVAILABLE = False
+    docker = None  # type: ignore[assignment]
+
+    class DockerException(Exception):  # type: ignore[no-redef]
+        """Stub raised when docker SDK is not installed."""
+
+    class ImageNotFound(DockerException):  # type: ignore[no-redef]
+        """Stub raised when docker SDK is not installed."""
 
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.singleton_factory import lazy_optional_singleton
@@ -93,11 +110,17 @@ class SecureSandboxExecutor:
     - File system restrictions
     """
 
-    def __init__(self, docker_client: Optional[docker.DockerClient] = None):
+    def __init__(self, docker_client: "Optional[docker.DockerClient]" = None):
         """Initialize secure sandbox executor with Docker client and Redis monitoring."""
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 
-        # Docker client
+        # Docker client — fail informatively if SDK is missing (#6667)
+        if not DOCKER_SDK_AVAILABLE:
+            raise DockerException(
+                "docker SDK not installed; install with `pip install docker` to enable "
+                "the secure sandbox executor."
+            )
+
         try:
             self.docker_client = docker_client or docker.from_env()
             self.logger.info("Docker client initialized")

--- a/autobot-backend/services/captcha_human_loop.py
+++ b/autobot-backend/services/captcha_human_loop.py
@@ -46,7 +46,14 @@ from enum import Enum
 from typing import Any, Dict, Optional
 
 from autobot_shared.time_utils import utc_timestamp
-from playwright.async_api import Page
+
+try:
+    # playwright is an optional runtime dep; the captcha-resolution flow only
+    # runs when browser automation is enabled. `Page` is used purely as a type
+    # hint in this module (#6667).
+    from playwright.async_api import Page
+except ImportError:  # pragma: no cover
+    from typing import Any as Page  # type: ignore[assignment, misc]
 
 from constants.network_constants import NetworkConstants
 from constants.threshold_constants import TimingConstants

--- a/autobot-backend/tests/test_startup_imports.py
+++ b/autobot-backend/tests/test_startup_imports.py
@@ -68,11 +68,7 @@ def _schema_modules() -> list[str]:
 # affected /api/* endpoints are absent in production. xfail-marking them
 # keeps CI green while ensuring the test still catches NEW regressions of the
 # same shape. Remove an entry when its tracking issue is closed.
-KNOWN_BROKEN_AT_TEST_INTRODUCTION: dict[str, str] = {
-    # #6667 — optional deps not guarded (playwright, docker)
-    "api.captcha": "#6667",
-    "api.sandbox": "#6667",
-}
+KNOWN_BROKEN_AT_TEST_INTRODUCTION: dict[str, str] = {}
 
 
 @pytest.mark.parametrize("module_name", ALWAYS_IMPORT_AT_BOOT)


### PR DESCRIPTION
## Summary

Closes #6667. Last 2 modules in the smoke-test xfail list — fixed via try/except guards on optional deps. **`KNOWN_BROKEN_AT_TEST_INTRODUCTION` is now empty** — every router module imports cleanly at boot.

## Fixes

### `api/captcha.py` → `services/captcha_human_loop.py`
- `from playwright.async_api import Page` was unconditional
- Page is used purely as a type hint at module scope
- Wrapped in try/except with `from typing import Any as Page` fallback

### `api/sandbox.py` → `secure_sandbox_executor.py`
- `import docker` and `from docker.errors import DockerException, ImageNotFound` were unconditional
- Wrapped in try/except + `DOCKER_SDK_AVAILABLE` flag
- Stubbed `DockerException`/`ImageNotFound` as plain `Exception` subclasses when SDK missing
- Quoted the `docker.DockerClient` annotation on `__init__` so it's lazily resolved
- `SecureSandboxExecutor.__init__` now raises a clear "docker SDK not installed" error on construction (instead of crashing at module-load)

## Net result

After #6664, #6665, #6666, and now #6667 — the entire `tests/test_startup_imports.py` xfail dictionary is empty. Smoke test (#6540) positively asserts every boot-imported module loads cleanly. Any future regression of the same shape will fail CI.

## Verification

- [x] `py_compile` clean on all 3 touched files
- [x] xfail dict empty (no remaining known-broken modules from the initial #6042 audit set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)