### PR TITLE
fix(slm-backend): clean up 4 SSOT-CI hardcoded-value violations (#6678)

### DIFF
--- a/autobot-slm-backend/api/nodes_execution.py
+++ b/autobot-slm-backend/api/nodes_execution.py
@@ -489,7 +489,7 @@ async def _audit_execute_event(
 
 
 _SSH_KEY_PATH = os.environ.get("SLM_SSH_KEY", "/home/autobot/.ssh/autobot_key")  # noqa: ssot-path
-_SSH_KNOWN_HOSTS_PATH = os.environ.get("SLM_SSH_KNOWN_HOSTS", "/home/autobot/.ssh/known_hosts")
+_SSH_KNOWN_HOSTS_PATH = os.environ.get("SLM_SSH_KNOWN_HOSTS", "/home/autobot/.ssh/known_hosts")  # noqa: ssot-path
 # System-wide known_hosts populated by Ansible — used as fallback when the
 # per-user file is absent.  Defined at module level so tests can patch it.
 _SSH_SYSTEM_KNOWN_HOSTS_PATH = "/etc/ssh/ssh_known_hosts"
@@ -633,9 +633,10 @@ async def execute_on_node(
     Admin privileges are required (require_admin dependency).
 
     Local nodes (manager host) execute via subprocess with shell=False;
-    remote nodes execute via SSH using the SLM key (SLM_SSH_KEY env var,
-    default /home/autobot/.ssh/autobot_key) and known_hosts verification
-    (SLM_SSH_KNOWN_HOSTS env var, default /home/autobot/.ssh/known_hosts).
+    remote nodes execute via SSH using the SLM key (SLM_SSH_KEY env var)
+    and known_hosts verification (SLM_SSH_KNOWN_HOSTS env var). Default
+    paths are documented at the module-level constants ``_SSH_KEY_PATH``
+    and ``_SSH_KNOWN_HOSTS_PATH``.
 
     All executions are audit-logged including the full command and acting user.
     """

--- a/autobot-slm-backend/services/ansible_utils.py
+++ b/autobot-slm-backend/services/ansible_utils.py
@@ -10,7 +10,7 @@ def _extract_failure_summary(output: str) -> str:
     """Parse Ansible stdout and return a human-readable failure summary.
 
     Extracts failed hosts, the task that failed, and the error message so
-    users see e.g. '172.16.168.26 failed at "Common | Update apt cache":
+    users see e.g. '<host-ip> failed at "Common | Update apt cache":
     Failed to update apt cache: unknown reason' instead of 'exit code 2'.
     """
     lines = output.splitlines()


### PR DESCRIPTION
## Summary

`SSOT Configuration Compliance` CI was failing on `Dev_new_gui` HEAD with 4 violations in autobot-slm-backend. Every PR opened inherited the failing check (#6653 hit it during this session).

## Closes

- Closes #6678

## Changes

- `services/ansible_utils.py:13`: replace literal example IP `172.16.168.26` in docstring with `<host-ip>` placeholder. Pure documentation.
- `api/nodes_execution.py:493`: add `# noqa: ssot-path` matching the sibling `_SSH_KEY_PATH` line above which already has the marker.
- `api/nodes_execution.py:637-638`: rewrite docstring to reference env var names + module constants instead of literal default paths. Defaults remain documented at the constants.

## Verification

```
Before: Status: fail, Total violations: 4 (1 SSOT, 3 OTHER)
After:  Status: pass, Total violations: 0
```

`pipeline-scripts/detect-hardcoded-values.sh --report` returns `Status: pass`.
`py_compile` clean.

## Test plan

- [x] SSOT detector locally: `Status: pass, Total violations: 0`.
- [ ] After merge, fresh PR no longer inherits the SSOT failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)