### PR TITLE
fix(deploy): only set AUTOBOT_TLS_CA_PATH when SLM CA cert exists at deploy time (#6677)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -82,6 +82,16 @@
     group: root
   tags: ['backend', 'config']
 
+# Issue #6677: Stat the SLM CA cert before rendering the env file. The
+# template only sets AUTOBOT_TLS_CA_PATH when the cert actually exists, so
+# installs without TLS (or where distribute-tls-certs.yml has not yet run)
+# don't ship a dangling env var that points at a missing file.
+- name: "Backend | Stat SLM CA cert (#6677)"
+  ansible.builtin.stat:
+    path: /etc/autobot/certs/ca-cert.pem
+  register: backend_tls_ca_cert
+  tags: ['backend', 'config']
+
 - name: "Backend | Deploy /etc/autobot/autobot-backend.env"
   ansible.builtin.template:
     src: backend.env.j2

--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -41,9 +41,15 @@ SERVICE_AUTH_RATE_LIMIT_MAX_FAILURES={{ service_auth_rate_limit_max_failures | d
 
 # SLM connection (Issue #1048: route through nginx, not direct port)
 AUTOBOT_SLM_TLS_ENABLED=true
-# CA cert for SLM self-signed cert — deployed by enable-tls.yml. Code falls back
-# gracefully if the file is absent, so this is safe on installs without TLS.
+{% if backend_tls_ca_cert.stat.exists | default(false) %}
+# CA cert for SLM self-signed cert — deployed by enable-tls.yml / distribute-tls-certs.yml.
 AUTOBOT_TLS_CA_PATH=/etc/autobot/certs/ca-cert.pem
+{% else %}
+# AUTOBOT_TLS_CA_PATH intentionally unset (#6677): ca-cert.pem is not present
+# at deploy time. Run distribute-tls-certs.yml to provision and re-deploy this
+# role to pick it up. Loopback SLM keeps working via the slm_client.py
+# CERT_NONE fallback (#6654).
+{% endif %}
 
 # TTS Worker (#3431: port 8083; 8082 is WSL2/Hyper-V reserved for Windows NPU)
 AUTOBOT_TTS_WORKER_HOST={{ tts_host | default('127.0.0.1') }}


### PR DESCRIPTION
## Summary

The backend role's `backend.env.j2` hardcoded `AUTOBOT_TLS_CA_PATH=/etc/autobot/certs/ca-cert.pem` unconditionally. On hosts where `distribute-tls-certs.yml` had not run (or `ca-cert.pem` was otherwise absent), the env var pointed at a missing file. Code paths that consume it (`slm_client`, `celery_app`, `redis_management`) silently fell through to system trust which rejects self-signed certs — every WS reconnect logged `CERTIFICATE_VERIFY_FAILED`.

#6654 made `slm_client` tolerant on loopback. This PR fixes the deploy side so the env var is only emitted when the cert actually exists on the target host.

## Closes

- Closes #6677

## Live evidence

Deployed host had:
- `AUTOBOT_TLS_CA_PATH=/etc/autobot/certs/ca-cert.pem` set in env
- `/etc/autobot/certs/` containing only `server-cert.pem` + `server-key.pem` — no CA cert

## Changes

- `roles/backend/tasks/main.yml`: new task `Backend | Stat SLM CA cert (#6677)` registers `backend_tls_ca_cert` before rendering the env template.
- `roles/backend/templates/backend.env.j2`: wrap `AUTOBOT_TLS_CA_PATH` line in `{% if backend_tls_ca_cert.stat.exists | default(false) %}` with an explanatory else-branch comment pointing at the recovery playbook.

## Verification

- YAML parse: PASS.
- Jinja2 parse: PASS.
- Stub-rendered template both ways:
  - CA-present → emits `AUTOBOT_TLS_CA_PATH=/etc/autobot/certs/ca-cert.pem`
  - CA-missing → emits only the explanatory comment block, no env-var assignment.

## Test plan

- [x] Template renders correctly in both states.
- [ ] After deploy on a host without the CA cert: `grep AUTOBOT_TLS_CA_PATH /etc/autobot/autobot-backend.env` returns nothing.
- [ ] After deploy on a host with the CA cert (post `distribute-tls-certs.yml`): the env var is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)