### PR TITLE
fix(frontend): WS auth + chat history blanking — closes #6692, #6693, #6700

### DIFF
--- a/autobot-frontend/src/models/controllers/ChatController.ts
+++ b/autobot-frontend/src/models/controllers/ChatController.ts
@@ -88,7 +88,10 @@ export class ChatController {
   // Enhanced message operations with comprehensive error handling
   async sendMessage(content: string, options?: Record<string, unknown>): Promise<string> {
     try {
-      this.getAppStore()?.setLoading(true, 'Sending message...')
+      // #6693: don't toggle the global appStore.isLoading flag here. App.vue
+      // wraps the entire <router-view> in a UnifiedLoadingView bound to it,
+      // so flipping it on a per-message send blanks the chat history for the
+      // duration of the request. chatStore.setTyping is the per-message UX.
       this.chatStore.setTyping(true)
 
       // Validate message content
@@ -178,7 +181,6 @@ export class ChatController {
       throw error
     } finally {
       this.chatStore.setTyping(false)
-      this.getAppStore()?.setLoading(false)
     }
   }
 

--- a/autobot-frontend/src/services/GlobalWebSocketService.ts
+++ b/autobot-frontend/src/services/GlobalWebSocketService.ts
@@ -10,10 +10,11 @@
  * Author: mrveiss
  */
 
-import { ref, reactive, type Ref } from 'vue'
+import { ref, reactive, watch, type Ref } from 'vue'
 import { DEFAULT_CONFIG } from '@/config/defaults.js'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
+import { buildAuthenticatedWsUrl } from '@/utils/buildAuthenticatedWsUrl'
 import { useUserStore } from '@/stores/useUserStore'
 
 // ---------------------------------------------------------------------------
@@ -213,14 +214,15 @@ class GlobalWebSocketService {
       // Health check failed but continue with WebSocket attempt
     })
 
-    // Issue #2818: Append JWT token as query param so backend can authenticate
-    // before accepting the WebSocket handshake.
-    let wsUrl = this.state.url
-    const userStore = useUserStore()
-    const token = userStore.authState.token
-    if (token) {
-      const separator = wsUrl.includes('?') ? '&' : '?'
-      wsUrl = `${wsUrl}${separator}token=${encodeURIComponent(token)}`
+    // #2818/#6700: append JWT via shared helper. Defer when no token is
+    // available so we don't bombard the backend with guaranteed-403 handshakes.
+    const wsUrl = buildAuthenticatedWsUrl(this.state.url)
+    if (wsUrl === null) {
+      logger.debug(
+        'GlobalWebSocketService: no token, deferring connect until login',
+      )
+      this.connectionState.value = 'disconnected'
+      return
     }
 
     logger.debug(
@@ -739,7 +741,7 @@ if (typeof window !== 'undefined') {
   if (!win._autobotWebSocketInitialized) {
     win._autobotWebSocketInitialized = true
 
-    setTimeout(() => {
+    const tryConnect = () => {
       if (
         !globalWebSocketService.isConnected.value &&
         globalWebSocketService.connectionState.value !== 'connecting'
@@ -748,6 +750,24 @@ if (typeof window !== 'undefined') {
           logger.error('Initial WebSocket connection failed:', error)
         })
       }
+    }
+
+    setTimeout(() => {
+      const userStore = useUserStore()
+      tryConnect()
+      // #6692: react to login (token appears) and logout (token cleared) so a
+      // user who lands on the app pre-auth gets a connection the moment they
+      // sign in, without waiting for reconnect-backoff to fire.
+      watch(
+        () => userStore.authState.token,
+        (token, previous) => {
+          if (token && !previous) {
+            tryConnect()
+          } else if (!token && previous) {
+            globalWebSocketService.disconnect()
+          }
+        },
+      )
     }, 500)
   }
 }

--- a/autobot-frontend/src/services/LiveEventService.ts
+++ b/autobot-frontend/src/services/LiveEventService.ts
@@ -9,9 +9,11 @@
  * Author: mrveiss
  */
 
-import { ref, type Ref } from 'vue'
+import { ref, watch, type Ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 import config from '@/config/ssot-config'
+import { buildAuthenticatedWsUrl } from '@/utils/buildAuthenticatedWsUrl'
+import { useUserStore } from '@/stores/useUserStore'
 
 export type LiveEventConnectionState =
   | 'disconnected'
@@ -63,9 +65,16 @@ class LiveEventService {
   readonly isConnected: Ref<boolean> = ref(false)
   readonly connectionState: Ref<LiveEventConnectionState> = ref('disconnected')
 
-  private getUrl(token?: string): string {
+  // #6692/#6700: token resolved via shared helper unless caller supplies one
+  // explicitly (e.g., test override). Returns null when no token is available
+  // so connect() can defer instead of producing a guaranteed-403 handshake.
+  private getUrl(token?: string): string | null {
     const base = `${config.websocketUrl}/live`
-    return token ? `${base}?token=${encodeURIComponent(token)}` : base
+    if (token) {
+      const sep = base.includes('?') ? '&' : '?'
+      return `${base}${sep}token=${encodeURIComponent(token)}`
+    }
+    return buildAuthenticatedWsUrl(base)
   }
 
   async connect(token?: string): Promise<void> {
@@ -76,9 +85,15 @@ class LiveEventService {
     ) {
       return
     }
+    const url = this.getUrl(token)
+    if (url === null) {
+      // #6692: no token yet — defer until login (auto-connect watcher retries)
+      logger.debug('LiveEventService: no token, deferring connect until login')
+      this.connectionState.value = 'disconnected'
+      return
+    }
     this.connectionState.value = 'connecting'
     this._cleanup()
-    const url = this.getUrl(token)
     logger.debug('Connecting LiveEventService', { attempt: this.reconnectAttempts + 1 })
     return new Promise<void>((resolve, reject) => {
       try {
@@ -314,8 +329,10 @@ class LiveEventService {
 
 const liveEventService = new LiveEventService()
 
-// Auto-connect with delay to allow app initialization.
-// Only connect if this is the first import and not already connected.
+// Auto-connect after app initialization. #6692: connect only when a JWT is
+// available, and reactively reconnect/disconnect as the user logs in or out.
+// Pinia is only set up after main.ts mounts the app, so we defer the userStore
+// lookup into the setTimeout callback rather than reading it at module top.
 if (typeof window !== 'undefined') {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- one-time init flag on window with no type definition
   const win = window as any
@@ -323,27 +340,40 @@ if (typeof window !== 'undefined') {
   if (!win._autobotLiveEventInitialized) {
     win._autobotLiveEventInitialized = true
 
-    setTimeout(() => {
+    // Subscribe to the global channel up-front. Subscriptions queue until the
+    // socket opens, so this is safe before any connect() call.
+    liveEventService.subscribe('global', (event) => {
+      logger.debug('Global live event received:', {
+        event_type: event.event_type,
+        event_id: event.event_id,
+      })
+    })
+
+    const tryConnect = () => {
       if (
         !liveEventService.isConnected.value &&
         liveEventService.connectionState.value !== 'connecting'
       ) {
-        liveEventService
-          .connect()
-          .then(() => {
-            // Subscribe to the global channel by default so
-            // rag_retrieval and other broadcast events are received.
-            liveEventService.subscribe('global', (event) => {
-              logger.debug('Global live event received:', {
-                event_type: event.event_type,
-                event_id: event.event_id,
-              })
-            })
-          })
-          .catch((error: unknown) => {
-            logger.error('Initial LiveEventService connection failed:', error)
-          })
+        liveEventService.connect().catch((error: unknown) => {
+          logger.error('LiveEventService connection failed:', error)
+        })
       }
+    }
+
+    setTimeout(() => {
+      const userStore = useUserStore()
+      tryConnect()
+      // React to login (token appears) and logout (token cleared).
+      watch(
+        () => userStore.authState.token,
+        (token, previous) => {
+          if (token && !previous) {
+            tryConnect()
+          } else if (!token && previous) {
+            liveEventService.disconnect()
+          }
+        },
+      )
     }, 1000)
   }
 }

--- a/autobot-frontend/src/utils/__tests__/buildAuthenticatedWsUrl.test.ts
+++ b/autobot-frontend/src/utils/__tests__/buildAuthenticatedWsUrl.test.ts
@@ -1,0 +1,48 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { buildAuthenticatedWsUrl } from '@/utils/buildAuthenticatedWsUrl'
+import { useUserStore } from '@/stores/useUserStore'
+
+describe('buildAuthenticatedWsUrl', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('returns null when no token is present', () => {
+    expect(buildAuthenticatedWsUrl('ws://localhost/api/ws/live')).toBeNull()
+  })
+
+  it('appends ?token= when URL has no query string', () => {
+    const store = useUserStore()
+    store.authState.token = 'jwt-abc'
+    expect(buildAuthenticatedWsUrl('ws://localhost/api/ws/live')).toBe(
+      'ws://localhost/api/ws/live?token=jwt-abc'
+    )
+  })
+
+  it('appends &token= when URL already has a query string', () => {
+    const store = useUserStore()
+    store.authState.token = 'jwt-abc'
+    expect(buildAuthenticatedWsUrl('ws://localhost/api/ws/live?room=42')).toBe(
+      'ws://localhost/api/ws/live?room=42&token=jwt-abc'
+    )
+  })
+
+  it('URL-encodes tokens with reserved characters', () => {
+    const store = useUserStore()
+    store.authState.token = 'jwt+with/special=chars'
+    expect(buildAuthenticatedWsUrl('ws://localhost/api/ws/live')).toBe(
+      'ws://localhost/api/ws/live?token=jwt%2Bwith%2Fspecial%3Dchars'
+    )
+  })
+
+  it('returns null for empty-string token (treated as no auth)', () => {
+    const store = useUserStore()
+    store.authState.token = ''
+    expect(buildAuthenticatedWsUrl('ws://localhost/api/ws/live')).toBeNull()
+  })
+})

--- a/autobot-frontend/src/utils/buildAuthenticatedWsUrl.ts
+++ b/autobot-frontend/src/utils/buildAuthenticatedWsUrl.ts
@@ -1,0 +1,29 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * Authenticated WebSocket URL helper (#6700)
+ *
+ * The backend WebSocket endpoints (/api/ws/live, /api/ws/events, etc.) require
+ * a JWT in the `?token=...` query parameter. Each WS service used to construct
+ * this URL ad-hoc, and at least one (LiveEventService) silently omitted the
+ * token entirely — flooding the backend with 403s on every page load (#6692).
+ *
+ * This helper centralizes the pattern so:
+ *   - Token plumbing is identical across all WS services
+ *   - Missing-token state is explicit (returns null) instead of silently
+ *     producing an unauthenticated URL that the server will reject
+ *   - Future endpoints don't have to rediscover the convention
+ *
+ * Returns null when no token is available — callers must handle this and
+ * defer the connection until a token is present (e.g., post-login).
+ */
+
+import { useUserStore } from '@/stores/useUserStore'
+
+export function buildAuthenticatedWsUrl(baseUrl: string): string | null {
+  const token = useUserStore().authState.token
+  if (!token) return null
+  const separator = baseUrl.includes('?') ? '&' : '?'
+  return `${baseUrl}${separator}token=${encodeURIComponent(token)}`
+}


### PR DESCRIPTION
## Summary

Fixes 3 related frontend issues in one PR — all touch the WS auth + chat-send code paths and were filed together in [today's investigation](https://github.com/mrveiss/AutoBot-AI/issues/6692).

- **#6700** — extract `buildAuthenticatedWsUrl()` helper (new), centralizes JWT plumbing for all WS services, returns `null` when no token so callers can defer
- **#6692** — `LiveEventService` and `GlobalWebSocketService` now use the helper, defer connect when no token, and watch `userStore.authState.token` to react to login/logout. Stops the 403 spam in `backend-error.log`
- **#6693** — `ChatController.sendMessage` no longer flips `appStore.isLoading`. App.vue's `UnifiedLoadingView` was unmounting the entire `<router-view>` on every send, blanking chat history and triggering a Suspense skeleton flash on completion

## Why one PR

All three issues touch overlapping code in the WS auth and chat send paths. Splitting would force a second PR to use a helper that didn't yet exist or merge an LiveEventService that still hard-coded its URL. Three separate commits keep the history clean per-issue.

## Commits

1. `refactor(frontend/ws): extract buildAuthenticatedWsUrl helper (#6700)` — new file + 5 unit tests
2. `fix(frontend/ws): require JWT before opening /ws/live and /ws/events (#6692)` — both services use helper, defer + watch
3. `fix(frontend/chat): stop blanking chat history on send — drop appStore.setLoading from sendMessage (#6693)` — 2 lines removed

## Verification

- `npx vitest run src/utils/__tests__/buildAuthenticatedWsUrl.test.ts` → 5/5 passing
- `npm run type-check` → 206 pre-existing errors, **0 new errors** introduced (confirmed by stashing changes and re-running: same count both ways; touched files have zero errors)
- Pre-existing type errors are in `useChatStore`/`useAppStore`/`ApiRepository`/`KnowledgeRepository`/`Welcome.stories.ts` — none touched by this PR

## Test plan

- [ ] Pull branch, deploy via Ansible to MV-Stealth
- [ ] Tail `journalctl -u autobot-backend.service -f` while reloading frontend logged in → expect zero `WebSocket /api/ws/live 403` and zero `/ws/events 403` entries
- [ ] Reload frontend logged out → confirm WS connects within 2s of login, not after 60s backoff window
- [ ] Send a chat message in a session with existing history → chat history stays visible throughout the request
- [ ] Logout → WS closes cleanly (close code 1000), no reconnect storm
- [ ] Confirm CodeQL/security scans clean on the new helper file

## Out of scope

- Other 6 misuses of `appStore.setLoading()` in ChatController + KnowledgeController (KB reindex, session load, etc.) — all blank the app similarly. Tracked in #6694 audit umbrella for a codebase-wide cleanup.
- Full unification of three WS managers into a single event bus — see #6488. This PR is the precursor that lands the auth-plumbing piece cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)