### PR TITLE
fix(backend): forward-ref Optional[stub] annotations — finishes #6666

### DIFF
--- a/autobot-backend/api/log_forwarding.py
+++ b/autobot-backend/api/log_forwarding.py
@@ -78,12 +78,16 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["log-forwarding"])
 
-# Singleton forwarder instance
-_forwarder: Optional[LogForwarder] = None
+# Singleton forwarder instance.
+# #6666 follow-up: when scripts.logging is missing, LogForwarder is a
+# _MissingDep that raises ImportError on subscript — so Optional[LogForwarder]
+# crashes the module at load time. Use string forward-references so the type
+# expression is only resolved by callers that actually reach the runtime path.
+_forwarder: "Optional[LogForwarder]" = None
 _forwarder_lock = asyncio.Lock()
 
 
-async def _get_forwarder() -> LogForwarder:
+async def _get_forwarder() -> "LogForwarder":
     """Get or create the log forwarder singleton."""
     global _forwarder
     async with _forwarder_lock:

--- a/autobot-backend/api/validation_dashboard.py
+++ b/autobot-backend/api/validation_dashboard.py
@@ -77,7 +77,7 @@ _validation_judges_lock = threading.Lock()
 # Validation dashboard now returns proper error responses when generator unavailable.
 
 
-def _try_create_dashboard_generator() -> Optional[ValidationDashboardGenerator]:
+def _try_create_dashboard_generator() -> "Optional[ValidationDashboardGenerator]":  # #6666 follow-up: forward-ref for missing-dep stub
     """Try to create dashboard generator, return None on failure. (Issue #315 - extracted)"""
     try:
         generator = ValidationDashboardGenerator()
@@ -98,7 +98,7 @@ def _try_create_dashboard_generator() -> Optional[ValidationDashboardGenerator]:
     return None
 
 
-def get_dashboard_generator() -> Optional[ValidationDashboardGenerator]:
+def get_dashboard_generator() -> "Optional[ValidationDashboardGenerator]":  # #6666 follow-up: forward-ref for missing-dep stub
     """Get or create dashboard generator instance (thread-safe)"""
     global _dashboard_generator
 


### PR DESCRIPTION
PR #6685 made the optional-dep imports safe but missed three Optional[Stub] type annotations that still evaluated at module load. Fix is one-character per site (quote the type expression).

Smoke test 244 → 245 passed, 0 xfails left.