### PR TITLE
fix(agents): restore parent constructor signature on LLMFailsafe + DataAnalysis (#6660)

### DIFF
--- a/autobot-backend/agents/agent_constructor_signature_test.py
+++ b/autobot-backend/agents/agent_constructor_signature_test.py
@@ -1,0 +1,88 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Constructor compatibility tests for StandardizedAgent subclasses (Issue #6660).
+
+LLMFailsafeAgent and DataAnalysisAgent previously dropped the parent's
+required ``agent_type`` parameter, which broke factory call patterns like
+``cls(agent_type, deployment_mode)``. After #6660 both subclasses accept
+the parent signature with sensible defaults so:
+
+  * ``LLMFailsafeAgent()``                 still works (legacy singleton call)
+  * ``LLMFailsafeAgent("foo", mode)``      works (parent-shape factory call)
+  * ``DataAnalysisAgent()``                still works
+  * ``DataAnalysisAgent("foo", mode)``     works
+"""
+
+import inspect
+
+import pytest
+
+
+def _signature_or_skip(cls):
+    sig = inspect.signature(cls.__init__)
+    return list(sig.parameters.keys())
+
+
+class TestLLMFailsafeAgentSignature:
+    """Issue #6660: parent-compatible constructor."""
+
+    def test_signature_accepts_agent_type_and_deployment_mode(self):
+        try:
+            from agents.llm_failsafe_agent import LLMFailsafeAgent
+        except Exception as exc:  # pragma: no cover — env-dependent dep chain
+            pytest.skip(f"LLMFailsafeAgent dep chain unavailable: {exc}")
+
+        params = _signature_or_skip(LLMFailsafeAgent)
+        assert "agent_type" in params, (
+            "LLMFailsafeAgent.__init__ must accept agent_type for factory compatibility"
+        )
+        assert "deployment_mode" in params, (
+            "LLMFailsafeAgent.__init__ must accept deployment_mode for factory compatibility"
+        )
+
+    def test_default_agent_type_falls_back_to_AGENT_ID(self):
+        """Calling with no args must still produce the historical agent_type."""
+        try:
+            from agents.llm_failsafe_agent import LLMFailsafeAgent
+        except Exception as exc:  # pragma: no cover
+            pytest.skip(f"LLMFailsafeAgent dep chain unavailable: {exc}")
+
+        sig = inspect.signature(LLMFailsafeAgent.__init__)
+        # The agent_type parameter must default to None (so `or self.AGENT_ID`
+        # picks up the class constant); deployment_mode must default to LOCAL.
+        agent_type_param = sig.parameters["agent_type"]
+        assert agent_type_param.default is None
+        deployment_mode_param = sig.parameters["deployment_mode"]
+        assert deployment_mode_param.default is not inspect.Parameter.empty
+
+
+class TestDataAnalysisAgentSignature:
+    """Issue #6660: parent-compatible constructor."""
+
+    def test_signature_accepts_agent_type_and_deployment_mode(self):
+        try:
+            from agents.data_analysis_agent import DataAnalysisAgent
+        except Exception as exc:  # pragma: no cover
+            pytest.skip(f"DataAnalysisAgent dep chain unavailable: {exc}")
+
+        params = _signature_or_skip(DataAnalysisAgent)
+        assert "agent_type" in params, (
+            "DataAnalysisAgent.__init__ must accept agent_type for factory compatibility"
+        )
+        assert "deployment_mode" in params, (
+            "DataAnalysisAgent.__init__ must accept deployment_mode for factory compatibility"
+        )
+
+    def test_default_agent_type_falls_back_to_AGENT_ID(self):
+        try:
+            from agents.data_analysis_agent import DataAnalysisAgent
+        except Exception as exc:  # pragma: no cover
+            pytest.skip(f"DataAnalysisAgent dep chain unavailable: {exc}")
+
+        sig = inspect.signature(DataAnalysisAgent.__init__)
+        agent_type_param = sig.parameters["agent_type"]
+        assert agent_type_param.default is None
+        deployment_mode_param = sig.parameters["deployment_mode"]
+        assert deployment_mode_param.default is not inspect.Parameter.empty

--- a/autobot-backend/agents/data_analysis_agent.py
+++ b/autobot-backend/agents/data_analysis_agent.py
@@ -22,7 +22,7 @@ from autobot_shared.ssot_config import (
 from constants.threshold_constants import LLMDefaults
 from llm_interface import LLMInterface
 
-from .base_agent import AgentRequest
+from .base_agent import AgentRequest, DeploymentMode
 from .standardized_agent import ActionHandler, StandardizedAgent
 
 logger = logging.getLogger(__name__)
@@ -33,9 +33,19 @@ class DataAnalysisAgent(StandardizedAgent):
 
     AGENT_ID = "data_analysis"
 
-    def __init__(self):
-        """Initialize the Data Analysis Agent with LLM configuration."""
-        super().__init__("data_analysis")
+    def __init__(
+        self,
+        agent_type: Optional[str] = None,
+        deployment_mode: DeploymentMode = DeploymentMode.LOCAL,
+    ):
+        """Initialize the Data Analysis Agent with LLM configuration.
+
+        Issue #6660: Accepts the parent's full constructor signature so factory
+        callers (`cls(agent_type, deployment_mode)`) keep working. Defaults
+        match the historical no-arg call site so existing instantiations are
+        unaffected.
+        """
+        super().__init__(agent_type or self.AGENT_ID, deployment_mode)
         self.llm_interface = LLMInterface()
         self.llm_provider = get_agent_provider_explicit(self.AGENT_ID)
         self.llm_endpoint = get_agent_endpoint_explicit(self.AGENT_ID)

--- a/autobot-backend/agents/llm_failsafe_agent.py
+++ b/autobot-backend/agents/llm_failsafe_agent.py
@@ -63,9 +63,19 @@ class LLMFailsafeAgent(StandardizedAgent):
     # Agent identifier for SSOT config lookup
     AGENT_ID = "llm_failsafe"
 
-    def __init__(self):
-        """Initialize the failsafe LLM agent (#3387: migrated to StandardizedAgent)."""
-        super().__init__("llm_failsafe", DeploymentMode.LOCAL)
+    def __init__(
+        self,
+        agent_type: Optional[str] = None,
+        deployment_mode: DeploymentMode = DeploymentMode.LOCAL,
+    ):
+        """Initialize the failsafe LLM agent (#3387: migrated to StandardizedAgent).
+
+        Issue #6660: Accepts the parent's full constructor signature so factory
+        callers (`cls(agent_type, deployment_mode)`) keep working. Defaults
+        match the historical no-arg call site so existing instantiations are
+        unaffected.
+        """
+        super().__init__(agent_type or self.AGENT_ID, deployment_mode)
         # Override self.logger to preserve existing naming convention
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 


### PR DESCRIPTION
## Summary
- `LLMFailsafeAgent.__init__(self)` and `DataAnalysisAgent.__init__(self)` dropped the parent's required `agent_type` parameter, breaking factory call patterns like `cls(agent_type, mode)`.
- Both now accept the parent's full signature with sensible defaults: `agent_type=None` falls back to `AGENT_ID`, `deployment_mode=DeploymentMode.LOCAL` matches the historical singleton call.
- Existing no-arg singleton call sites (`LLMFailsafeAgent()`, `DataAnalysisAgent()`) remain unchanged.

## Test plan
- [x] `pytest autobot-backend/agents/agent_constructor_signature_test.py` — 4 tests pass (parameter names + defaults via `inspect.signature`)

Closes #6660

🤖 Generated with [Claude Code](https://claude.com/claude-code)