### PR TITLE
fix(integrations): execute_action returns error dict instead of raising (#6658)

### DIFF
--- a/autobot-backend/integrations/cicd_integration.py
+++ b/autobot-backend/integrations/cicd_integration.py
@@ -112,7 +112,7 @@ class JenkinsIntegration(BaseIntegration):
         }
         handler = action_map.get(action)
         if not handler:
-            raise ValueError(f"Unknown action: {action}")
+            return {"error": f"Unknown action: {action}"}
         return await handler(params)
 
     async def _list_jobs(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -253,7 +253,7 @@ class GitLabCIIntegration(BaseIntegration):
         }
         handler = action_map.get(action)
         if not handler:
-            raise ValueError(f"Unknown action: {action}")
+            return {"error": f"Unknown action: {action}"}
         return await handler(params)
 
     async def _list_pipelines(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -389,7 +389,7 @@ class CircleCIIntegration(BaseIntegration):
         }
         handler = action_map.get(action)
         if not handler:
-            raise ValueError(f"Unknown action: {action}")
+            return {"error": f"Unknown action: {action}"}
         return await handler(params)
 
     async def _list_pipelines(self, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/autobot-backend/integrations/cloud_integration.py
+++ b/autobot-backend/integrations/cloud_integration.py
@@ -112,8 +112,7 @@ class AWSIntegration(BaseIntegration):
 
         handler = action_map.get(action)
         if not handler:
-            raise ValueError(f"Unknown action: {action}")
-
+            return {"error": f"Unknown action: {action}"}
         return await handler(params)
 
     async def _list_ec2_instances(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -395,8 +394,7 @@ class AzureIntegration(BaseIntegration):
 
         handler = action_map.get(action)
         if not handler:
-            raise ValueError(f"Unknown action: {action}")
-
+            return {"error": f"Unknown action: {action}"}
         return await handler(params)
 
     async def _list_vms(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -580,8 +578,7 @@ class GCPIntegration(BaseIntegration):
 
         handler = action_map.get(action)
         if not handler:
-            raise ValueError(f"Unknown action: {action}")
-
+            return {"error": f"Unknown action: {action}"}
         return await handler(params)
 
     async def _list_instances(self, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/autobot-backend/integrations/communication_integration.py
+++ b/autobot-backend/integrations/communication_integration.py
@@ -117,7 +117,7 @@ class SlackIntegration(BaseIntegration):
         }
         handler = action_map.get(action)
         if not handler:
-            raise ValueError(f"Unknown action: {action}")
+            return {"error": f"Unknown action: {action}"}
         return await handler(params)
 
     async def _send_message(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -357,7 +357,7 @@ class TeamsIntegration(BaseIntegration):
         }
         handler = action_map.get(action)
         if not handler:
-            raise ValueError(f"Unknown action: {action}")
+            return {"error": f"Unknown action: {action}"}
         return await handler(params)
 
     async def _send_message(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -501,7 +501,7 @@ class DiscordIntegration(BaseIntegration):
         }
         handler = action_map.get(action)
         if not handler:
-            raise ValueError(f"Unknown action: {action}")
+            return {"error": f"Unknown action: {action}"}
         return await handler(params)
 
     async def _send_message(self, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/autobot-backend/integrations/database_integration.py
+++ b/autobot-backend/integrations/database_integration.py
@@ -150,8 +150,7 @@ class PostgreSQLIntegration(BaseIntegration):
             database = params.get("database", "postgres")
             return await self._execute_query(query, database)
         else:
-            raise ValueError(f"Unknown action: {action}")
-
+            return {"error": f"Unknown action: {action}"}
     async def _list_databases(self) -> Dict[str, Any]:
         """List all databases in PostgreSQL."""
         import asyncpg
@@ -315,8 +314,7 @@ class MySQLIntegration(BaseIntegration):
             database = params.get("database", "mysql")
             return await self._execute_query(query, database)
         else:
-            raise ValueError(f"Unknown action: {action}")
-
+            return {"error": f"Unknown action: {action}"}
     async def _list_databases(self) -> Dict[str, Any]:
         """List all databases in MySQL."""
         import aiomysql
@@ -493,8 +491,7 @@ class MongoDBIntegration(BaseIntegration):
                 database, collection, filter_dict, limit
             )
         else:
-            raise ValueError(f"Unknown action: {action}")
-
+            return {"error": f"Unknown action: {action}"}
     async def _list_databases(self) -> Dict[str, Any]:
         """List all databases in MongoDB."""
         from motor.motor_asyncio import AsyncIOMotorClient

--- a/autobot-backend/integrations/github_integration.py
+++ b/autobot-backend/integrations/github_integration.py
@@ -195,7 +195,7 @@ class GitHubIntegration(BaseIntegration):
         }
         handler = action_map.get(action)
         if not handler:
-            raise ValueError(f"Unknown action: {action}")
+            return {"error": f"Unknown action: {action}"}
         return await handler(params)
 
     # ------------------------------------------------------------------

--- a/autobot-backend/integrations/github_integration_test.py
+++ b/autobot-backend/integrations/github_integration_test.py
@@ -261,15 +261,19 @@ async def test_execute_action_get_repository():
 
 
 # ---------------------------------------------------------------------------
-# execute_action: unknown action raises ValueError
+# execute_action: unknown action returns error dict (#6658)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_execute_action_unknown_raises():
+async def test_execute_action_unknown_returns_error_dict():
+    """#6658: BaseIntegration.execute_action contract returns Dict[str, Any];
+    unknown actions must surface as {"error": ...} — not raise ValueError."""
     gh = GitHubIntegration(_make_config())
-    with pytest.raises(ValueError, match="Unknown action"):
-        await gh.execute_action("invalid_action", {})
+    result = await gh.execute_action("invalid_action", {})
+    assert isinstance(result, dict)
+    assert "error" in result
+    assert "Unknown action" in result["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/integrations/integration_unknown_action_contract_test.py
+++ b/autobot-backend/integrations/integration_unknown_action_contract_test.py
@@ -1,0 +1,95 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Contract test for BaseIntegration.execute_action's unknown-action behaviour
+(Issue #6658).
+
+The base contract (integrations/base.py:107-112) declares execute_action as
+``async def -> Dict[str, Any]`` with no documented Raises clause. Every
+concrete subclass must therefore return an error dict — not raise
+ValueError — when handed an action it doesn't know about. This test
+parametrically verifies the contract across the whole integration tree so
+the next person to add an integration can't silently re-introduce the
+violation.
+"""
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _discover_subclasses():
+    """Static-analysis discovery of BaseIntegration subclasses to avoid
+    importing the heavy dep chain. Returns (file_path, class_name) tuples.
+    """
+    pat = re.compile(r"^class (\w+)\(BaseIntegration\):", re.M)
+    root = Path("autobot-backend/integrations")
+    out = []
+    for py in sorted(root.glob("*.py")):
+        if py.name.endswith("_test.py"):
+            continue
+        for cls_name in pat.findall(py.read_text(encoding="utf-8")):
+            out.append((py, cls_name))
+    return out
+
+
+SUBCLASSES = _discover_subclasses()
+
+
+def test_at_least_one_subclass_discovered():
+    """Sanity: the discovery itself must work or every subsequent test
+    becomes vacuous."""
+    assert SUBCLASSES, "discovery returned zero BaseIntegration subclasses"
+
+
+@pytest.mark.parametrize(
+    "src_file,class_name",
+    SUBCLASSES,
+    ids=[f"{p.stem}::{n}" for p, n in SUBCLASSES],
+)
+def test_no_subclass_raises_value_error_on_unknown_action(src_file, class_name):
+    """Static check: no BaseIntegration subclass body contains a
+    ``raise ValueError(f"(Unknown|Unsupported) action: {action}")`` line.
+
+    This is the contract enforced by #6658 — the base type signature
+    promises Dict[str, Any], so unknown actions must surface as
+    {"error": ...} (matching JiraIntegration / TrelloIntegration /
+    AsanaIntegration / NotionIntegration which already did).
+    """
+    text = src_file.read_text(encoding="utf-8")
+    forbidden = re.compile(
+        r'raise ValueError\(f"(Unknown|Unsupported) action: \{action\}"\)'
+    )
+    matches = forbidden.findall(text)
+    assert not matches, (
+        f"{src_file.name} still raises ValueError on unknown action "
+        f"(violates BaseIntegration contract — see #6658)"
+    )
+
+
+# Live behavioural check for one canonical violator from the issue
+@pytest.mark.asyncio
+async def test_github_integration_returns_error_dict_for_unknown_action():
+    """Live test: GitHubIntegration was one of six canonical violators
+    in #6658. The fix must produce a dict {"error": ...} for unknown actions.
+    """
+    try:
+        from integrations.github_integration import GitHubIntegration
+        from integrations.base import IntegrationConfig
+    except Exception as exc:  # pragma: no cover — env-dependent
+        pytest.skip(f"GitHub dep chain unavailable: {exc}")
+
+    cfg = IntegrationConfig(
+        name="test-gh",
+        provider="github",
+        api_key="x",
+        base_url="https://api.github.com",
+    )
+    gh = GitHubIntegration(cfg)
+    result = await gh.execute_action("__never_a_real_action__", {})
+    assert isinstance(result, dict), "expected Dict per BaseIntegration contract"
+    assert "error" in result, f"expected error key, got {result!r}"
+    assert "Unknown action" in result["error"]

--- a/autobot-backend/integrations/monitoring_integration.py
+++ b/autobot-backend/integrations/monitoring_integration.py
@@ -168,8 +168,7 @@ class DatadogIntegration(BaseIntegration):
 
         handler = action_map.get(action)
         if not handler:
-            raise ValueError(f"Unsupported action: {action}")
-
+            return {"error": f"Unsupported action: {action}"}
         return await handler(params)
 
     async def _list_monitors(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -383,8 +382,7 @@ class NewRelicIntegration(BaseIntegration):
 
         handler = action_map.get(action)
         if not handler:
-            raise ValueError(f"Unsupported action: {action}")
-
+            return {"error": f"Unsupported action: {action}"}
         return await handler(params)
 
     async def _list_applications(self, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/autobot-backend/integrations/version_control_integration.py
+++ b/autobot-backend/integrations/version_control_integration.py
@@ -127,8 +127,7 @@ class GitLabIntegration(BaseIntegration):
         }
 
         if action not in action_map:
-            raise ValueError(f"Unknown action: {action}")
-
+            return {"error": f"Unknown action: {action}"}
         return await action_map[action](params)
 
     async def _list_projects(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -371,8 +370,7 @@ class BitbucketIntegration(BaseIntegration):
         }
 
         if action not in action_map:
-            raise ValueError(f"Unknown action: {action}")
-
+            return {"error": f"Unknown action: {action}"}
         return await action_map[action](params)
 
     async def _list_repositories(self, params: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- `BaseIntegration.execute_action`'s contract is `async def -> Dict[str, Any]` with no documented Raises, but **17 call sites** across 7 integration modules were raising `ValueError` on unknown action.
- Replaced every offending raise with `return {"error": f"... action: {action}"}` — matches the pattern Jira/Trello/Asana/Notion already implement correctly.
- Files touched: cicd, cloud, communication, database, github, monitoring, version_control integrations.

## Test plan
- [x] `pytest autobot-backend/integrations/integration_unknown_action_contract_test.py` — 23 tests pass (parametric static check across all 21 `BaseIntegration` subclasses + live `GitHubIntegration` behavioural test)
- [x] `github_integration_test.test_execute_action_unknown_returns_error_dict` — rewritten from `pytest.raises(ValueError)` assertion; PASS

The new contract test will fail loudly the next time a new integration is added that drops back into the raise pattern.

Closes #6658

🤖 Generated with [Claude Code](https://claude.com/claude-code)