### PR TITLE
feat(audit): add SESSION_EXPORT to AuditAction enum (#6639)

### DIFF
--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -1457,19 +1457,15 @@ async def export_session(session_id: str, request: Request, format: str = "json"
     )
 
     # Issue #6559: Audit session export
-    # TODO: AuditAction.SESSION_EXPORT does not exist in the enum yet — using
-    # ADMIN_ACTION with metadata.action="session.export" until the enum gains
-    # a dedicated value. See services/audit/audit_log.py.
     user_data = get_auth_middleware().get_user_from_request(request)
     audit_record(
         user_id=str((user_data or {}).get("user_id", "unknown")),
-        action=AuditAction.ADMIN_ACTION,
+        action=AuditAction.SESSION_EXPORT,
         resource_type="chat_session",
         resource_id=session_id,
         ip_address=request.client.host if request.client else "unknown",
         session_id=session_id,
         metadata={
-            "action": "session.export",
             "format": format,
             "request_id": request_id,
         },

--- a/autobot-backend/services/audit/audit_log.py
+++ b/autobot-backend/services/audit/audit_log.py
@@ -40,6 +40,7 @@ class AuditAction(str, Enum):
 
     SESSION_CREATE = "session.create"
     SESSION_DELETE = "session.delete"
+    SESSION_EXPORT = "session.export"
     KNOWLEDGE_ADD = "knowledge.add"
     KNOWLEDGE_REMOVE = "knowledge.remove"
     API_KEY_CREATE = "api_key.create"


### PR DESCRIPTION
## Summary
Adds \`SESSION_EXPORT = \"session.export\"\` to \`AuditAction\` enum and uses it in \`api/chat_sessions.py\` export_session, replacing the \`ADMIN_ACTION\` workaround from #6559.

## Changes
- \`services/audit/audit_log.py\`: +1 enum value (placed adjacent to SESSION_CREATE/SESSION_DELETE)
- \`api/chat_sessions.py\`: replaced \`AuditAction.ADMIN_ACTION\` → \`AuditAction.SESSION_EXPORT\`; removed TODO comment and \`metadata.action: \"session.export\"\` workaround key

Closes #6639