### PR TITLE
fix(api): remove 23 stacked-duplicate @with_error_handling decorators across 9 files (#6633)

### DIFF
--- a/autobot-backend/api/batch_jobs.py
+++ b/autobot-backend/api/batch_jobs.py
@@ -802,11 +802,6 @@ async def batch_load(batch_request: APIBatchRequest):
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="batch_chat_initialization",
-    error_code_prefix="BATCH",
-)
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="batch_chat_initialization",
     error_code_prefix="BATCH_JOBS",
 )
 @router.get("/chat-init", response_model=BatchChatInitResponse)

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -847,11 +847,6 @@ async def stream_message(
     operation="chat_health_check",
     error_code_prefix="CHAT",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="chat_health_check",
-    error_code_prefix="CHAT",
-)
 async def chat_health_check(
     current_user: dict = Depends(get_current_user),
     request: Request = None,
@@ -2021,11 +2016,6 @@ async def get_enhanced_chat_capabilities(
     operation="translate_text",
     error_code_prefix="TRANSLATE",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="translate_text",
-    error_code_prefix="CHAT",
-)
 async def translate_text(
     body: TranslateRequest,
     current_user: dict = Depends(get_current_user),
@@ -2054,11 +2044,6 @@ async def translate_text(
     category=ErrorCategory.SERVER_ERROR,
     operation="detect_language",
     error_code_prefix="TRANSLATE",
-)
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="detect_language",
-    error_code_prefix="CHAT",
 )
 async def detect_language(
     body: DetectLanguageRequest,

--- a/autobot-backend/api/llm.py
+++ b/autobot-backend/api/llm.py
@@ -138,11 +138,6 @@ async def test_llm_connection(
     operation="get_available_llm_models",
     error_code_prefix="LLM",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_available_llm_models",
-    error_code_prefix="LLM",
-)
 @router.get("/models", response_model=LLMModelsResponse)
 @cache_response(cache_key="llm_models", ttl=180)  # Cache for 3 minutes - RESTORED
 async def get_available_llm_models(
@@ -165,11 +160,6 @@ async def get_available_llm_models(
         raise HTTPException(status_code=500, detail="Error getting available models")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_current_llm",
-    error_code_prefix="LLM",
-)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_current_llm",
@@ -279,11 +269,6 @@ async def update_llm_provider(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_available_embedding_models",
-    error_code_prefix="LLM",
-)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_available_embedding_models",
@@ -505,11 +490,6 @@ def _build_active_provider_info(
     operation="get_comprehensive_llm_status",
     error_code_prefix="LLM",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_comprehensive_llm_status",
-    error_code_prefix="LLM",
-)
 @router.get("/status/comprehensive", response_model=DataResponse)
 @cache_response(cache_key="llm_status_comprehensive", ttl=30)  # Cache for 30 seconds
 async def get_comprehensive_llm_status(
@@ -635,11 +615,6 @@ def _get_model_from_cloud_config(unified_config: dict) -> str:
     operation="get_quick_llm_status",
     error_code_prefix="LLM",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_quick_llm_status",
-    error_code_prefix="LLM",
-)
 @router.get("/status/quick", response_model=DataResponse)
 @cache_response(cache_key="llm_status_quick", ttl=15)  # Cache for 15 seconds
 async def get_quick_llm_status(
@@ -710,11 +685,6 @@ def _build_providers_health_dict(results: dict) -> tuple:
     return providers_health, available_count
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_all_providers_health",
-    error_code_prefix="LLM",
-)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_all_providers_health",

--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -1168,11 +1168,6 @@ async def realtime_monitoring_websocket(websocket: WebSocket):
     operation="test_performance_monitoring",
     error_code_prefix="MONITORING",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_performance_monitoring",
-    error_code_prefix="MONITORING",
-)
 @router.post("/test/performance", response_model=TestPerformanceResponse)
 @monitor_performance("api_test")
 async def test_performance_monitoring(

--- a/autobot-backend/api/project_state.py
+++ b/autobot-backend/api/project_state.py
@@ -33,11 +33,6 @@ router = APIRouter(prefix="/project", tags=["project_state"])
     operation="get_project_status",
     error_code_prefix="PROJECT_STATE",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_project_status",
-    error_code_prefix="PROJECT_STATE",
-)
 @router.get("/status", response_model=ProjectStatus)
 @smart_cache(
     data_type="project_status",

--- a/autobot-backend/api/prompts.py
+++ b/autobot-backend/api/prompts.py
@@ -346,11 +346,6 @@ def _build_prompt_save_response(
     operation="save_prompt",
     error_code_prefix="PROMPTS",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="save_prompt",
-    error_code_prefix="PROMPTS",
-)
 @router.post("/{prompt_id}", response_model=PromptSaveResponse)
 @router.put("/{prompt_id}", response_model=PromptSaveResponse)  # Issue #570: Support PUT for frontend compatibility
 @with_error_handling(

--- a/autobot-backend/api/skills_repos.py
+++ b/autobot-backend/api/skills_repos.py
@@ -98,11 +98,6 @@ async def add_repo(
     operation="list_repos",
     error_code_prefix="SKILLS_REPOS",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_repos",
-    error_code_prefix="SKILLS_REPOS",
-)
 @router.get("", summary="List all registered skill repositories", response_model=List[SkillRepoItem])
 @router.get("/", include_in_schema=False, response_model=List[SkillRepoItem])
 @with_error_handling(

--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -168,11 +168,6 @@ def _build_frontend_meta_config() -> dict:
     operation="get_frontend_config",
     error_code_prefix="SYSTEM",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_frontend_config",
-    error_code_prefix="SYSTEM",
-)
 @router.get("/frontend-config", response_model=SystemFrontendConfigResponse)
 @cache_response(cache_key="frontend_config", ttl=60)  # Cache for 1 minute
 async def get_frontend_config(admin_check: bool = Depends(check_admin_permission)):
@@ -202,11 +197,6 @@ async def get_frontend_config(admin_check: bool = Depends(check_admin_permission
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_health",
-    error_code_prefix="SYSTEM",
-)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_system_health",
@@ -272,11 +262,6 @@ async def get_system_health(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_info",
-    error_code_prefix="SYSTEM",
-)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_system_info",
@@ -465,11 +450,6 @@ async def dynamic_import(
     operation="get_detailed_health",
     error_code_prefix="SYSTEM",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_detailed_health",
-    error_code_prefix="SYSTEM",
-)
 @router.get("/health/detailed", response_model=SystemHealthResponse)
 @cache_response(cache_key="system_health_detailed", ttl=30)  # Cache for 30 seconds
 async def get_detailed_health(
@@ -608,11 +588,6 @@ def _determine_overall_health_status(health_status: dict) -> None:
     operation="get_cache_stats",
     error_code_prefix="SYSTEM",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_cache_stats",
-    error_code_prefix="SYSTEM",
-)
 @router.get("/cache/stats", response_model=SystemCacheStatsResponse)
 @cache_response(cache_key="cache_stats", ttl=15)  # Cache for 15 seconds
 async def get_cache_stats(admin_check: bool = Depends(check_admin_permission)):
@@ -721,11 +696,6 @@ def _analyze_key_patterns(cache_keys: list, cache_prefix: str) -> dict:
     operation="get_cache_activity",
     error_code_prefix="SYSTEM",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_cache_activity",
-    error_code_prefix="SYSTEM",
-)
 @router.get("/cache/activity", response_model=SystemCacheActivityResponse)
 @cache_response(cache_key="cache_activity", ttl=10)  # Cache for 10 seconds
 async def get_cache_activity(admin_check: bool = Depends(check_admin_permission)):
@@ -783,11 +753,6 @@ async def get_cache_activity(admin_check: bool = Depends(check_admin_permission)
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_metrics",
-    error_code_prefix="SYSTEM",
-)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_system_metrics",

--- a/autobot-backend/api/templates.py
+++ b/autobot-backend/api/templates.py
@@ -87,11 +87,6 @@ async def get_templates_root():
     operation="list_workflow_templates",
     error_code_prefix="TEMPLATES",
 )
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_workflow_templates",
-    error_code_prefix="TEMPLATES",
-)
 @router.get("/templates", response_model=TemplateListResponse)
 @smart_cache(
     data_type="templates",
@@ -323,11 +318,6 @@ async def get_template_statistics():
 # --- Parameterized paths below (after all static paths) ---
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_template_details",
-    error_code_prefix="TEMPLATES",
-)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_template_details",


### PR DESCRIPTION
## Summary
After #6558 swapped decorator order, 23 stacked-duplicate \`@with_error_handling\` decorators remained — the OUTER one in each pair was dead code.

## Stats
- **9 files modified, 23 stacked pairs removed (~115 LOC)**
- 0 stacked pairs remain (verified by regex audit)
- All files pass \`python3 -m py_compile\`

## Files
| File | Pairs |
|---|---|
| api/system.py | 7 |
| api/llm.py | 6 |
| api/chat.py | 3 |
| api/templates.py | 2 |
| api/skills_repos.py, api/monitoring.py, api/project_state.py, api/batch_jobs.py, api/prompts.py | 1 each |

## Args differing between outer/inner (4 cases — kept the more specific one)
- \`chat.py:845\` chat_health_check — kept \`SERVICE_UNAVAILABLE\` (more specific for health endpoint)
- \`chat.py:2014\` translate_text — kept \`error_code_prefix=\"TRANSLATE\"\` (operation-specific)
- \`chat.py:2043\` detect_language — kept \`\"TRANSLATE\"\`
- \`batch_jobs.py:802\` batch_chat_initialization — kept \`\"BATCH_JOBS\"\` (matches router prefix)

Closes #6633