### PR TITLE
feat(ci): pre-commit lint hook for @with_error_handling/@router decorator order (#6638)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,6 +141,23 @@ repos:
         stages: [pre-commit]
         description: "Move BaseModel subclasses to domain schemas_*.py files (#6056)"
 
+  # AutoBot custom: regression-prevention for #6558 (decorator order) +
+  # #6633 (stacked-duplicate). In Python ``@A @B def f`` ≡ ``f = A(B(f))``;
+  # if ``@with_error_handling`` is placed above ``@router.*`` the FastAPI
+  # router registers the unwrapped function and the error wrapper becomes
+  # dead code. #6558 swapped 1801 endpoints across 188 files; this hook
+  # blocks the regression. Also catches two adjacent
+  # ``@with_error_handling`` decorators (#6633).
+  - repo: local
+    hooks:
+      - id: decorator-order
+        name: Check @with_error_handling/@router decorator order (#6638)
+        entry: tools/lint/check_decorator_order.py
+        language: python
+        files: ^autobot-backend/api/.*\.py$
+        stages: [pre-commit]
+        description: "Ensure @router.* is OUTERMOST and @with_error_handling is not stacked (#6558, #6633)"
+
   # Python-specific checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/tools/lint/check_decorator_order.py
+++ b/tools/lint/check_decorator_order.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Pre-commit hook: enforce @router.* / @with_error_handling decorator order.
+
+In Python ``@A @B def f`` is equivalent to ``f = A(B(f))``. With
+``@with_error_handling`` placed ABOVE ``@router.*``, FastAPI's router
+registers the raw, un-wrapped function — the error wrapper never runs.
+This was the codebase-wide dead-code pattern fixed in #6558 (1801 swaps
+across 188 files).
+
+A second variant (#6633) is two ``@with_error_handling`` decorators
+stacked on the same function — the outer one wraps the inner wrapper,
+producing a duplicate logging path and identical error envelope.
+
+This hook blocks both regressions:
+
+  * **Pattern A (decorator order)** — ``@with_error_handling(...)``
+    immediately above ``@router.*(...)``.
+  * **Pattern B (stacked duplicate)** — two adjacent
+    ``@with_error_handling(...)`` decorators on the same function.
+
+Scan target:
+  ``autobot-backend/api/**/*.py``
+
+Exit codes:
+  0 — clean
+  1 — violations found
+
+Background: #6558 (decorator order codebase-wide fix), #6633 (stacked
+duplicates), #6638 (this hook).
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _scan_helpers import iter_python_files  # noqa: E402
+
+HOOK_ID = "decorator-order"
+
+
+def _is_target_file(path: Path, repo_root: Path) -> bool:
+    """Return True if *path* should be scanned. Restricted to autobot-backend/api/**/*.py."""
+    try:
+        rel = path.resolve().relative_to(repo_root)
+    except ValueError:
+        return False
+    parts = rel.parts
+    if len(parts) < 3 or parts[0] != "autobot-backend" or parts[1] != "api":
+        return False
+    return path.suffix == ".py"
+
+
+def _decorator_name(deco: ast.expr) -> str:
+    """Best-effort fully-qualified name of a decorator node.
+
+    Handles:
+      @foo                          -> "foo"
+      @foo.bar                      -> "foo.bar"
+      @foo(...)                     -> "foo"
+      @foo.bar(...)                 -> "foo.bar"
+    """
+    target = deco.func if isinstance(deco, ast.Call) else deco
+    parts: List[str] = []
+    node: ast.expr | None = target
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return ".".join(reversed(parts))
+    return ""
+
+
+def _is_with_error_handling(deco: ast.expr) -> bool:
+    return _decorator_name(deco) == "with_error_handling"
+
+
+def _is_router_decorator(deco: ast.expr) -> bool:
+    name = _decorator_name(deco)
+    # Matches @router.get / @router.post / @router.api_route / etc., plus
+    # rarer @app.get / @app.post forms.
+    if name.startswith("router."):
+        return True
+    if name.startswith("app.") and name.split(".", 1)[1] in {
+        "get",
+        "post",
+        "put",
+        "delete",
+        "patch",
+        "head",
+        "options",
+        "api_route",
+        "websocket",
+    }:
+        return True
+    return False
+
+
+def _function_violations(node: ast.AST) -> List[Tuple[int, str, str]]:
+    """Return [(lineno, kind, message)] for each decorator-order issue on *node*.
+
+    *node* is expected to be a FunctionDef / AsyncFunctionDef.
+    """
+    decos = getattr(node, "decorator_list", None)
+    if not decos:
+        return []
+
+    hits: List[Tuple[int, str, str]] = []
+
+    # Pattern A: @with_error_handling immediately above @router.* (or app.*).
+    # In ``decorator_list`` index 0 is the OUTERMOST decorator (top-most
+    # ``@`` in source). For correct order, @router.* must be at a smaller
+    # index than @with_error_handling.
+    for i, deco in enumerate(decos):
+        if not _is_with_error_handling(deco):
+            continue
+        # Look for any @router.* later in the list (i.e. closer to the function).
+        for j in range(i + 1, len(decos)):
+            if _is_router_decorator(decos[j]):
+                func_name = getattr(node, "name", "<unknown>")
+                hits.append(
+                    (
+                        deco.lineno,
+                        "order",
+                        (
+                            f"@with_error_handling is above @{_decorator_name(decos[j])} "
+                            f"on '{func_name}'. Swap so @router.* is OUTERMOST "
+                            f"(above @with_error_handling) — see #6558."
+                        ),
+                    )
+                )
+                break
+
+    # Pattern B: two adjacent @with_error_handling decorators (stacked dup).
+    for i in range(len(decos) - 1):
+        if _is_with_error_handling(decos[i]) and _is_with_error_handling(decos[i + 1]):
+            func_name = getattr(node, "name", "<unknown>")
+            hits.append(
+                (
+                    decos[i].lineno,
+                    "stacked",
+                    (
+                        f"Two adjacent @with_error_handling decorators on '{func_name}'. "
+                        f"Remove the duplicate — see #6633."
+                    ),
+                )
+            )
+
+    return hits
+
+
+def _check_file(path: Path, repo_root: Path) -> List[Tuple[int, str, str]]:
+    if not _is_target_file(path, repo_root):
+        return []
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+    except (SyntaxError, UnicodeDecodeError, OSError):
+        return []
+
+    hits: List[Tuple[int, str, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            hits.extend(_function_violations(node))
+    return hits
+
+
+def main(argv: List[str]) -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    files = list(iter_python_files(argv[1:], repo_root))
+    total_order = 0
+    total_stacked = 0
+    for path in files:
+        hits = _check_file(path, repo_root)
+        if not hits:
+            continue
+        try:
+            rel = path.resolve().relative_to(repo_root)
+        except ValueError:
+            rel = path
+        for line_no, kind, message in hits:
+            print(f"[{HOOK_ID}] {rel}:{line_no}: {message}", file=sys.stderr)
+            if kind == "order":
+                total_order += 1
+            elif kind == "stacked":
+                total_stacked += 1
+    if total_order or total_stacked:
+        print(
+            f"\n[{HOOK_ID}] {total_order} decorator-order violation(s), "
+            f"{total_stacked} stacked-duplicate violation(s).\n"
+            f"  Fix: ensure @router.* is OUTERMOST (top-most), with "
+            f"@with_error_handling immediately below it. Remove any duplicate "
+            f"@with_error_handling stacks. See #6558 / #6633 for context.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/lint/check_decorator_order_test.py
+++ b/tools/lint/check_decorator_order_test.py
@@ -1,0 +1,207 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for tools/lint/check_decorator_order.py — see #6638.
+
+Covers detection of:
+  * Pattern A — @with_error_handling above @router.* (#6558)
+  * Pattern B — adjacent stacked @with_error_handling (#6633)
+
+Plus path filtering, exit codes, and the negative case (correct ordering
+is not flagged).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_HOOK_PATH = Path(__file__).parent / "check_decorator_order.py"
+_spec = importlib.util.spec_from_file_location("_hook_under_test", _HOOK_PATH)
+assert _spec is not None and _spec.loader is not None
+hook = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hook)
+
+
+def _write_api(tmp_path: Path, name: str, content: str) -> tuple[Path, Path]:
+    """Write a file under fake autobot-backend/api/, return (file_path, repo_root)."""
+    repo_root = tmp_path
+    api_dir = repo_root / "autobot-backend" / "api"
+    api_dir.mkdir(parents=True, exist_ok=True)
+    p = api_dir / name
+    p.write_text(content, encoding="utf-8")
+    return p, repo_root
+
+
+# ---------------------------------------------------------------------------
+# Pattern A — decorator order (@with_error_handling above @router.*)
+# ---------------------------------------------------------------------------
+
+
+def test_detects_with_error_handling_above_router_get(tmp_path: Path) -> None:
+    path, repo_root = _write_api(
+        tmp_path,
+        "bad_order.py",
+        """\
+@with_error_handling(category="x")
+@router.get("/foo")
+async def foo():
+    return {}
+""",
+    )
+    hits = hook._check_file(path, repo_root)
+    assert len(hits) == 1
+    line, kind, msg = hits[0]
+    assert kind == "order"
+    assert "@router.get" in msg
+
+
+def test_detects_with_error_handling_above_router_post_sync_def(tmp_path: Path) -> None:
+    path, repo_root = _write_api(
+        tmp_path,
+        "bad_sync.py",
+        """\
+@with_error_handling()
+@router.post("/foo")
+def foo():
+    return {}
+""",
+    )
+    hits = hook._check_file(path, repo_root)
+    assert len(hits) == 1
+    assert hits[0][1] == "order"
+
+
+def test_detects_app_decorators_too(tmp_path: Path) -> None:
+    """@app.get / @app.post are also FastAPI route registrations."""
+    path, repo_root = _write_api(
+        tmp_path,
+        "app_form.py",
+        """\
+@with_error_handling()
+@app.get("/foo")
+async def foo():
+    return {}
+""",
+    )
+    hits = hook._check_file(path, repo_root)
+    assert len(hits) == 1
+    assert hits[0][1] == "order"
+
+
+# ---------------------------------------------------------------------------
+# Pattern B — stacked duplicate @with_error_handling
+# ---------------------------------------------------------------------------
+
+
+def test_detects_stacked_duplicate_with_error_handling(tmp_path: Path) -> None:
+    path, repo_root = _write_api(
+        tmp_path,
+        "stacked.py",
+        """\
+@router.get("/foo")
+@with_error_handling(category="x")
+@with_error_handling(category="x")
+async def foo():
+    return {}
+""",
+    )
+    hits = hook._check_file(path, repo_root)
+    kinds = sorted(h[1] for h in hits)
+    assert "stacked" in kinds
+
+
+# ---------------------------------------------------------------------------
+# Negative — correct ordering (no violation)
+# ---------------------------------------------------------------------------
+
+
+def test_correct_order_no_violation(tmp_path: Path) -> None:
+    path, repo_root = _write_api(
+        tmp_path,
+        "ok.py",
+        """\
+@router.get("/foo")
+@with_error_handling(category="x")
+async def foo():
+    return {}
+""",
+    )
+    assert hook._check_file(path, repo_root) == []
+
+
+def test_no_decorators_no_violation(tmp_path: Path) -> None:
+    path, repo_root = _write_api(
+        tmp_path,
+        "plain.py",
+        """\
+async def foo():
+    return {}
+""",
+    )
+    assert hook._check_file(path, repo_root) == []
+
+
+def test_only_router_decorator_no_violation(tmp_path: Path) -> None:
+    path, repo_root = _write_api(
+        tmp_path,
+        "router_only.py",
+        """\
+@router.get("/foo")
+async def foo():
+    return {}
+""",
+    )
+    assert hook._check_file(path, repo_root) == []
+
+
+def test_only_with_error_handling_no_violation(tmp_path: Path) -> None:
+    """Non-route helper wrapped in @with_error_handling alone is fine."""
+    path, repo_root = _write_api(
+        tmp_path,
+        "helper.py",
+        """\
+@with_error_handling()
+async def helper():
+    return {}
+""",
+    )
+    assert hook._check_file(path, repo_root) == []
+
+
+# ---------------------------------------------------------------------------
+# Path filtering — only autobot-backend/api/**/*.py is scanned
+# ---------------------------------------------------------------------------
+
+
+def test_skips_files_outside_api_dir(tmp_path: Path) -> None:
+    """Files outside autobot-backend/api/ are not scanned even if they trigger pattern."""
+    other = tmp_path / "autobot-backend" / "services"
+    other.mkdir(parents=True)
+    p = other / "bad.py"
+    p.write_text(
+        "@with_error_handling()\n@router.get('/foo')\nasync def foo():\n    return {}\n",
+        encoding="utf-8",
+    )
+    assert hook._check_file(p, tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Module-level smoke checks — make sure HOOK_ID and helper names are exported.
+# ---------------------------------------------------------------------------
+
+
+def test_hook_id_constant() -> None:
+    assert hook.HOOK_ID == "decorator-order"
+
+
+def test_decorator_name_helpers() -> None:
+    """The internal helpers identify FastAPI route + with_error_handling decorators."""
+    import ast as _ast
+
+    tree = _ast.parse("@router.get('/x')\n@with_error_handling()\ndef f(): pass\n")
+    fn = tree.body[0]
+    decos = fn.decorator_list  # type: ignore[attr-defined]
+    assert hook._is_router_decorator(decos[0]) is True
+    assert hook._is_with_error_handling(decos[0]) is False
+    assert hook._is_router_decorator(decos[1]) is False
+    assert hook._is_with_error_handling(decos[1]) is True


### PR DESCRIPTION
## Summary
Adds an AST-based pre-commit hook that catches the decorator-order pattern (#6558) and stacked-duplicate pattern (#6633) at commit time. Without it, the regression will creep back in.

## Changes
- \`tools/lint/check_decorator_order.py\` — AST-based scanner (executable, +x). Detects two patterns:
  - **Pattern A**: \`@with_error_handling\` directly above \`@router.*\` (or \`@app.*\`) on a function — error wrapper is dead code
  - **Pattern B**: stacked \`@with_error_handling\` decorators (#6633)
- \`tools/lint/check_decorator_order_test.py\` — 11 unit tests
- \`.pre-commit-config.yaml\` — registers \`decorator-order\` hook with \`pass_filenames: true\` (matches existing \`no-utcnow-isoformat\` pattern — only blocks NEW violations on staged files)

## Why AST instead of regex
Multi-line decorator args like \`@with_error_handling(\n    category=...,\n)\` defeat naive regex \`\([^)]*\)\`. AST-based detection is robust.

## Verification
- 11/11 unit tests pass
- Negative test: injecting a violation → exit 1 with descriptive message
- Positive test: clean fixture → exit 0

## Discovery
Hook detected **1221 decorator-order + 23 stacked-duplicate residuals across 131 files** that survived #6558 / #6633 — multi-line arg regex used in #6558 missed cases the AST catches. Filed **#6706** for the follow-up sweep.

Hook uses \`pass_filenames: true\` so existing residuals are tolerated until those files are touched (matches \`no-utcnow-isoformat\` pattern).

Closes #6638