### PR TITLE
fix(ansible/nginx): unblock Phase 0 on flaky PPA — cache_valid_time (#6719)

### DIFF
--- a/autobot-slm-backend/ansible/roles/nginx/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/nginx/tasks/main.yml
@@ -12,6 +12,11 @@
     name: nginx
     state: present
     update_cache: true
+    # #6719: cache_valid_time avoids aborting Phase 0 when a third-party PPA
+    # (Launchpad ansible/deadsnakes) has a transient timeout. apt-get update
+    # would log a warning and proceed; Ansible's apt module treats the same
+    # warning as a hard failure. Skip refresh entirely when cache is fresh.
+    cache_valid_time: 3600
   become: true
   tags: ['deps', 'nginx']
 


### PR DESCRIPTION
## Summary

Unblocks `provision-fleet-roles.yml` Phase 0 when `ppa.launchpadcontent.net` (Launchpad PPAs for `ansible` + `deadsnakes`) has transient connectivity issues — exactly the failure observed in the most recent deploy run.

```
TASK [nginx : nginx | Install nginx]
fatal: [00-SLM-Manager]: FAILED!
msg: 'Failed to update apt cache: unknown reason'
```

## Why one-line fix works

`apt-get update` exits 0 with `W: Failed to fetch …` warnings when one repo is unreachable. Ansible's `apt:` module with `update_cache: true` treats those warnings as a hard failure. Adding `cache_valid_time: 3600` lets Ansible **skip** the refresh entirely when the cache is ≤1h old — sidestepping the strictness mismatch without changing CLI behavior.

The 4m50s hang the user saw was apt's TCP SYN retries (IPv6 → no default route → IPv4 timeout) before Ansible aborted.

## Why not remove the PPAs

- `ansible 10.7.0-1ppa~jammy` is installed FROM the Ansible PPA (Ubuntu universe ships `2.10.7`)
- `python3.12.13-1+jammy1` is installed FROM deadsnakes
Both are load-bearing.

## Scope

This PR fixes **only the nginx role** because that's the leaf that aborted today. The codebase-wide audit of the remaining ~40 `update_cache: true` callsites that need the same guard is tracked in **#6719** and will land as a separate, larger PR.

## Test plan

- [ ] Re-run `provision-fleet-roles.yml` on the SLM Manager host. Expect Phase 0 (`Install nginx`) to complete in <2s when local apt cache is fresh, even with the launchpad PPAs unreachable.
- [ ] Sanity: forcibly age the cache (`sudo touch -d '2h ago' /var/lib/apt/lists`) → expect Ansible to do a full update; if a PPA is still unreachable in that window the deploy will hit the original error. That's the audit's job (#6719) to address codebase-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)