### PR TITLE
fix(ansible/nodejs): add cache_valid_time so transient PPA timeouts don't abort Phase 0 (#6719)

### DIFF
--- a/autobot-slm-backend/ansible/roles/nodejs/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/nodejs/tasks/main.yml
@@ -48,6 +48,11 @@
     name: nodejs
     state: present
     update_cache: true
+    # #6719: cache_valid_time avoids aborting Phase 0 when a third-party PPA
+    # (Launchpad ansible/deadsnakes) has a transient timeout. apt-get update
+    # would log a warning and proceed; Ansible's apt module treats the same
+    # warning as a hard failure. Skip refresh entirely when cache is fresh.
+    cache_valid_time: 3600
   become: true
   tags: ['deps', 'nodejs']
 


### PR DESCRIPTION
## Summary

Same root cause and fix as #6720 for the nginx role, applied to nodejs.

The fleet provisioning playbook was aborting at Phase 0 on the local SLM Manager at `nodejs | Install Node.js` with `Failed to update apt cache: unknown reason` after a ~5-minute hang on the preceding `Check if NodeSource repo exists` task. Same Launchpad PPA flakiness as #6720 — apt-get update logs a warning and proceeds, but Ansible's apt module treats the same condition as a hard failure.

`cache_valid_time: 3600` makes the apt module skip the refresh entirely when the cache is fresh (≤1h), so a single flaky third-party repo no longer takes down the whole provisioning run.

## Why this matters now

Provisioning at the merged commit 621fcf93d couldn't deploy any of the 5 fixes from #6718 because Phase 0 failure short-circuits Phase 4a (Backend) and Phase 4b (Frontend) — backend service never restarts, frontend bundle never rebuilds. After this lands and the playbook is re-run, the 5 fixes from #6718 reach production.

## Test plan

- [x] Pattern verbatim matches the merged #6720 nginx fix
- [ ] Re-run `ansible-playbook provision-fleet-roles.yml` — Phase 0 completes for SLM-Manager
- [ ] Verify backend + frontend redeploy and the 5 #6718 fixes are live

Tracked under codebase-wide audit umbrella #6719 (~40 remaining `update_cache: true` callsites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)