### PR TITLE
fix(frontend/ws): revert double /ws/ prefix in LiveEventService URL

### DIFF
--- a/autobot-frontend/src/services/LiveEventService.ts
+++ b/autobot-frontend/src/services/LiveEventService.ts
@@ -68,8 +68,13 @@ class LiveEventService {
   // #6692/#6700: token resolved via shared helper unless caller supplies one
   // explicitly (e.g., test override). Returns null when no token is available
   // so connect() can defer instead of producing a guaranteed-403 handshake.
+  //
+  // Path is `/live` not `/ws/live` — `config.websocketUrl` already ends in
+  // `/api/ws` (see ssot-config.ts websocketUrl getter, baked in by #6271).
+  // Backend WS handler is `/api/ws/live`. Prepending `/ws/` here would build
+  // `wss://host/api/ws/ws/live` and 404 every connection.
   private getUrl(token?: string): string | null {
-    const base = `${config.websocketUrl}/ws/live`
+    const base = `${config.websocketUrl}/live`
     if (token) {
       const sep = base.includes('?') ? '&' : '?'
       return `${base}${sep}token=${encodeURIComponent(token)}`


### PR DESCRIPTION
## Summary

Reverts the `/live` → `/ws/live` change merged via #6718. That commit assumed `config.websocketUrl` returned a bare host (`wss://host`), but it actually returns `wss://host/api/ws` — see [ssot-config.ts:456-470](autobot-frontend/src/config/ssot-config.ts#L456-L470) and #6271 (\"unify WebSocket URL to /api/ws\"). Result on Dev_new_gui after #6718:

| code | URL built | matches backend `/api/ws/live`? |
|------|-----------|---|
| `\${websocketUrl}/ws/live` (current Dev_new_gui post-#6718) | `wss://host/api/ws/ws/live` | ❌ 404 every connection |
| `\${websocketUrl}/live` (this PR, restores pre-#6718 behavior) | `wss://host/api/ws/live` | ✅ matches |

Live-events WebSocket is currently broken on Dev_new_gui — chat replies, RAG retrieval events, and Workflow Builder dashboards all subscribe through it. Hotfix.

The Chrome 'WebSocket error: Event' that motivated #6718's URL change was the auth-token issue from #6692 (fixed by #6705 already on Dev_new_gui — JWT now correctly appended to `?token=`). The URL itself was always correct; only the missing JWT was the problem.

Comment added to `getUrl` to prevent the same mis-fix recurring.

## Test plan

- [ ] Deploy via Ansible
- [ ] Tail `journalctl -u autobot-backend.service -f` while logged in → expect zero `404 /api/ws/ws/live` and `connection_established` events on `/api/ws/live`
- [ ] Send a chat message → expect streaming reply (proves live-events WS is alive)
- [ ] Browser DevTools → Network → WS → expect single `wss://host/api/ws/live?token=...` connection in `connected` state, not `closed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)