### PR TITLE
fix(ansible/nginx): bounded shell apt-get update — survives stale-cache + flaky PPA (#6719)

### DIFF
--- a/autobot-slm-backend/ansible/roles/nginx/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/nginx/tasks/main.yml
@@ -7,16 +7,39 @@
 # Vhost configuration stays in service roles (slm_manager, backend, frontend).
 ---
 
+# #6719: refresh apt cache via shell-bounded apt-get update.
+# Why not `apt: update_cache=true cache_valid_time=3600`:
+#   - cache_valid_time only skips refresh when cache is fresh; once stale, the
+#     module still runs full apt-get update and aborts on any partial-fetch
+#     warning ("Failed to update apt cache: unknown reason"). A flaky third-
+#     party PPA (Launchpad ansible/deadsnakes, nvidia.github.io, etc.) takes
+#     down the whole deploy.
+#   - apt-get update via the CLI exits 0 with `W: Failed to fetch ...` for
+#     unreachable sources — the cache is updated for everything that did
+#     reach. That is the correct semantics for our use case.
+# Bounds:
+#   - timeout 60s : prevents the multi-minute TCP-retry hang we saw on flaky
+#     IPv6 routes to Launchpad.
+#   - Acquire::Retries=0 : disables apt's per-repo 3x backoff.
+#   - Acquire::http::Timeout=10 : per-request HTTP timeout.
+#   - failed_when: false : ignore the exit code; the next apt task will
+#     surface a real error if the cache is genuinely broken (e.g. nginx
+#     metadata missing entirely).
+- name: "nginx | Refresh apt cache (best-effort, bounded; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+  tags: ['deps', 'nginx']
+
 - name: "nginx | Install nginx"
   ansible.builtin.apt:
     name: nginx
     state: present
-    update_cache: true
-    # #6719: cache_valid_time avoids aborting Phase 0 when a third-party PPA
-    # (Launchpad ansible/deadsnakes) has a transient timeout. apt-get update
-    # would log a warning and proceed; Ansible's apt module treats the same
-    # warning as a hard failure. Skip refresh entirely when cache is fresh.
-    cache_valid_time: 3600
   become: true
   tags: ['deps', 'nginx']
 


### PR DESCRIPTION
## Why the earlier #6720 fix wasn't enough

`cache_valid_time: 3600` only **skips** the refresh when the cache is fresh. Once cache ages past 1 h, Ansible still runs full `apt-get update` and aborts on any partial-fetch warning — exactly what happened on the user's next deploy attempt:

```
TASK [nginx : nginx | Install nginx]
fatal: [00-SLM-Manager]: FAILED!
msg: 'Failed to update apt cache: unknown reason'
```

Same ~4 m hang on `ppa.launchpadcontent.net` SYN retries (IPv6 has no default route on this WSL2 host), same Ansible-module-strictness abort.

## Pattern

Shell out to `apt-get update` with explicit bounds and accept the CLI's tolerant exit semantics:

```yaml
- name: \"nginx | Refresh apt cache (best-effort, bounded; #6719)\"
  ansible.builtin.command:
    cmd: >-
      timeout 60 apt-get update -qq
      -o Acquire::Retries=0
      -o Acquire::http::Timeout=10
  become: true
  changed_when: false
  failed_when: false
```

Then a separate `apt: name=nginx state=present` task without `update_cache`. If the cache is genuinely broken (e.g. `nginx` metadata missing entirely), the install task surfaces the real error — we don't silently install stale software.

| knob | purpose |
|------|--------|
| `timeout 60` | bound TCP-retry hangs against unreachable PPAs |
| `Acquire::Retries=0` | disable apt's 3x per-repo backoff |
| `Acquire::http::Timeout=10` | per-request HTTP timeout |
| `failed_when: false` | accept CLI exit (apt-get exits 0 with `W: Failed to fetch …`) |

## Local smoke test

```
$ sudo timeout 60 apt-get update -qq -o Acquire::Retries=0 -o Acquire::http::Timeout=10
W: ... Failed to fetch ppa.launchpadcontent.net:443 (timed out)
W: ... Failed to fetch ppa.launchpadcontent.net:443 (Network unreachable)
W: Some index files failed to download. They have been ignored, or old ones used instead.
exit=0
```

~30 s wall time, exit 0 even with both Launchpad PPAs unreachable. Ansible's `command` + `failed_when: false` accepts this and proceeds.

## Scope

This PR fixes only the **nginx role** (the leaf that aborts Phase 0). The same pattern should propagate to the other ~40 `update_cache: true` callsites — tracked in **#6719**.

## Test plan

- [ ] Re-run `provision-fleet-roles.yml` on the SLM Manager host. Phase 0 (`Install nginx`) should complete in <90 s even when `ppa.launchpadcontent.net` is unreachable.
- [ ] Sanity: temporarily blackhole an Ubuntu archive mirror (`echo '127.0.0.2 archive.ubuntu.com' | sudo tee -a /etc/hosts`); confirm `apt: name=nginx state=present` fails with a CLEAR error like \"Unable to locate package nginx\" rather than a misleading apt-cache abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)