### PR TITLE
fix(ansible): bounded shell apt-get update across 5 SLM-Manager-bound roles (#6719)

### DIFF
--- a/autobot-slm-backend/ansible/roles/common/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/tasks/main.yml
@@ -2,15 +2,19 @@
 # Common role - Base system configuration for all AutoBot hosts
 # Applied to all VMs before service-specific roles
 
-- name: "Common | Update apt cache"
-  apt:
-    update_cache: yes
-    cache_valid_time: 3600
-  become: yes
-  retries: 3
-  delay: 5
-  register: _apt_update
-  until: _apt_update is success
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml for
+# rationale. Ansible's apt module aborts on any partial-fetch warning even
+# with retries:3 + cache_valid_time, because every retry sees the same
+# unreachable PPA and hits the same hard failure.
+- name: "Common | Refresh apt cache (best-effort, bounded; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
   tags: ['common', 'packages']
 
 - name: "Common | Install base packages"

--- a/autobot-slm-backend/ansible/roles/nodejs/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/nodejs/tasks/main.yml
@@ -43,16 +43,24 @@
     - not _nodesource_repo.stat.exists
   tags: ['deps', 'nodejs']
 
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml for
+# rationale. Ansible's apt module aborts on any partial-fetch warning, the
+# CLI does not. cache_valid_time alone isn't enough once cache ages past 1h.
+- name: "nodejs | Refresh apt cache (best-effort, bounded; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+  tags: ['deps', 'nodejs']
+
 - name: "nodejs | Install Node.js"
   ansible.builtin.apt:
     name: nodejs
     state: present
-    update_cache: true
-    # #6719: cache_valid_time avoids aborting Phase 0 when a third-party PPA
-    # (Launchpad ansible/deadsnakes) has a transient timeout. apt-get update
-    # would log a warning and proceed; Ansible's apt module treats the same
-    # warning as a hard failure. Skip refresh entirely when cache is fresh.
-    cache_valid_time: 3600
   become: true
   tags: ['deps', 'nodejs']
 

--- a/autobot-slm-backend/ansible/roles/python312/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/python312/tasks/main.yml
@@ -33,11 +33,26 @@
   when: _py312_check.rc != 0
   tags: ['deps', 'python312']
 
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+# Only fires when Python 3.12 is missing, but when it does it must tolerate
+# flaky PPAs (the deadsnakes PPA was just added; if it's unreachable, the
+# next deploy retry will still need to install Python 3.12).
+- name: "python312 | Refresh apt cache (best-effort, bounded; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+  when: _py312_check.rc != 0
+  tags: ['deps', 'python312']
+
 - name: "python312 | Install Python 3.12"
   ansible.builtin.apt:
     name: "{{ python312_packages }}"
     state: present
-    update_cache: true
   become: true
   when: _py312_check.rc != 0
   tags: ['deps', 'python312']

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/grafana.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/grafana.yml
@@ -24,11 +24,23 @@
   when: grafana_install | bool
   tags: ['grafana', 'packages']
 
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: "Grafana | Refresh apt cache after PPA add (best-effort; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+  when: grafana_install | bool
+  tags: ['grafana', 'packages']
+
 - name: "Grafana | Install Grafana"
   ansible.builtin.apt:
     name: grafana
     state: "{{ 'latest' if grafana_version == 'latest' else 'present' }}"
-    update_cache: true
   when: grafana_install | bool
   tags: ['grafana', 'packages']
 

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -16,6 +16,18 @@
 # ==========================================================
 # System packages (assume blank host)
 # ==========================================================
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: "SLM | Refresh apt cache (best-effort, bounded; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+  tags: ['slm', 'packages']
+
 - name: "SLM | Install prerequisites"
   ansible.builtin.apt:
     name:
@@ -29,7 +41,6 @@
       - software-properties-common
       - build-essential
     state: present
-    update_cache: true
   tags: ['slm', 'packages']
 
 # ==========================================================
@@ -39,7 +50,21 @@
   ansible.builtin.apt_repository:
     repo: ppa:ansible/ansible
     state: present
-    update_cache: true
+    # #6719: don't trigger Ansible-module apt-get update here — the bounded
+    # shell update below tolerates the same Launchpad timeouts that this
+    # PPA add would otherwise abort on.
+    update_cache: false
+  tags: ['slm', 'packages', 'ansible']
+
+- name: "SLM | Refresh apt cache after PPA add (best-effort; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
   tags: ['slm', 'packages', 'ansible']
 
 - name: "SLM | Install Ansible from PPA (2.17+)"


### PR DESCRIPTION
## Why

Phase 0 nginx unblocked by #6728. Next role (nodejs) hit the **same** Ansible-apt-module abort against the same Launchpad PPAs:

\`\`\`
TASK [nodejs : nodejs | Install Node.js]
fatal: [00-SLM-Manager]: FAILED!
msg: 'Failed to update apt cache: unknown reason'
\`\`\`

User confirmed locally:
\`\`\`
$ sudo apt update
Err:1 https://ppa.launchpadcontent.net/ansible/ansible/ubuntu jammy InRelease - Connection refused
Err:2 https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy InRelease - Unable to connect
Fetched 1477 B in 7s
Reading package lists... Done
$ echo \$?
0
\`\`\`

CLI exits 0 in 7 s with the same errors that abort Ansible's apt module. Pattern from #6728 mimics the CLI semantics; this PR replicates it across every role the SLM Manager actually hits in `provision-fleet-roles.yml`.

## Roles converted

| File | Phase | Notes |
|------|-------|-------|
| `roles/nodejs/tasks/main.yml` | 0 | Current blocker; removes ineffective `cache_valid_time: 3600` |
| `roles/common/tasks/main.yml` | 1 | Removes `retries: 3 + until: success` (every retry fails the same way) |
| `roles/python312/tasks/main.yml` | 0 | Only fires when Python 3.12 missing; adds bounded refresh after deadsnakes PPA add |
| `roles/slm_manager/tasks/main.yml` | 4 | 2 callsites: prerequisites install + Ansible PPA add (sets `update_cache: false` on the `apt_repository` and adds a separate bounded refresh after) |
| `roles/slm_manager/tasks/grafana.yml` | 4 | Bounded refresh after Grafana PPA add |

## Out of scope

The remaining ~30 `update_cache: true` callsites tracked in #6719 are NOT hit by SLM-Manager's traversal of this playbook (they're for backend, npu, ai-stack, redis, etc.). Will land in batches as other node types come online.

## Test plan

- [ ] Re-run `provision-fleet-roles.yml` on the SLM Manager host. All 5 phases reach `ok` for `00-SLM-Manager`.
- [ ] No `Failed to update apt cache: unknown reason` aborts in the run.
- [ ] Each \"Refresh apt cache\" task completes in <90 s even with both Launchpad PPAs unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)