### PR TITLE
fix(ansible): bounded shell apt-get update across remaining 14 role-level callsites (#6719)

### DIFF
--- a/autobot-slm-backend/ansible/roles/agent_config/tasks/nodejs.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/tasks/nodejs.yml
@@ -23,11 +23,21 @@
   command: bash /tmp/nodesource_setup.sh
   when: node_check.rc != 0
 
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: agent_config nodejs | Refresh apt cache after NodeSource add (best-effort, bounded; #6719)
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+
 - name: Install Node.js
   package:
     name: nodejs
     state: present
-    update_cache: yes
 
 - name: Verify Node.js installation
   command: node --version

--- a/autobot-slm-backend/ansible/roles/agent_config/tasks/openvino.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/tasks/openvino.yml
@@ -15,9 +15,16 @@
     state: present
     filename: intel-openvino
 
-- name: Update apt cache after adding OpenVINO repo
-  apt:
-    update_cache: yes
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: agent_config openvino | Refresh apt cache after OpenVINO repo add (best-effort, bounded; #6719)
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
 
 - name: Install OpenVINO Runtime
   package:

--- a/autobot-slm-backend/ansible/roles/agent_config/tasks/system_packages.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/tasks/system_packages.yml
@@ -4,10 +4,16 @@
 ---
 # Install system dependencies
 
-- name: Update apt cache
-  apt:
-    update_cache: yes
-    cache_valid_time: 3600
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: agent_config | Refresh apt cache (best-effort, bounded; #6719)
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
 
 - name: Install system packages
   package:

--- a/autobot-slm-backend/ansible/roles/ai-stack/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/tasks/main.yml
@@ -41,12 +41,23 @@
   tags: ['ai', 'config']
 
 # ============================================================
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: "AI Stack | Refresh apt cache (best-effort, bounded; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+  tags: ['ai-stack', 'packages']
+
 - name: "AI Stack | Install build dependencies"
   ansible.builtin.apt:
     name:
       - build-essential
     state: present
-    update_cache: true
   tags: ['ai-stack', 'packages']
 
 - name: Create AI stack directories

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -126,6 +126,18 @@
 # ============================================================
 # Backend-specific system dependencies (Python 3.12 now in shared Phase 0)
 # ============================================================
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: "Backend | Refresh apt cache (best-effort, bounded; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+  tags: ['backend', 'packages']
+
 - name: "Backend | Install backend-specific system dependencies"
   ansible.builtin.apt:
     name:
@@ -159,7 +171,6 @@
       # Matplotlib GUI backend
       - python3-tk
     state: present
-    update_cache: true
   tags: ['backend', 'packages']
 
 

--- a/autobot-slm-backend/ansible/roles/docker/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/docker/tasks/main.yml
@@ -17,6 +17,19 @@
 # ============================================================
 # Phase 2: Install Docker Engine (Debian/Ubuntu)
 # ============================================================
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: "Docker | Refresh apt cache (best-effort, bounded; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+  when: _docker_is_debian | bool
+  tags: ['docker', 'packages']
+
 - name: "Docker | Install prerequisite packages (Debian)"
   ansible.builtin.apt:
     name:
@@ -24,7 +37,6 @@
       - curl
       - gnupg
     state: present
-    update_cache: true
   when: _docker_is_debian | bool
   tags: ['docker', 'packages']
 
@@ -65,7 +77,21 @@
       {{ ansible_distribution_release }} {{ docker_apt_repo_channel }}
     state: present
     filename: docker
-    update_cache: true
+    # #6719: refresh handled by the bounded-shell task below; the apt module's
+    # update_cache aborts on flaky third-party PPAs.
+    update_cache: false
+  when: _docker_is_debian | bool
+  tags: ['docker', 'packages']
+
+- name: "Docker | Refresh apt cache after Docker repo add (best-effort, bounded; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
   when: _docker_is_debian | bool
   tags: ['docker', 'packages']
 

--- a/autobot-slm-backend/ansible/roles/llm/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/llm/tasks/main.yml
@@ -78,6 +78,18 @@
     path: /usr/local/bin/ollama
   register: _ollama_binary
 
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: "Install | Refresh apt cache (best-effort, bounded; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+  when: not _ollama_binary.stat.exists
+
 - name: "Install | Install LLM dependencies"
   ansible.builtin.apt:
     name:
@@ -85,7 +97,6 @@
       - ca-certificates
       - zstd
     state: present
-    update_cache: true
   when: not _ollama_binary.stat.exists
 
 - name: "Install | Download Ollama installer"

--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/grafana.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/grafana.yml
@@ -55,11 +55,24 @@
     - ansible_os_family == "Debian"
     - _grafana_installed.rc != 0
 
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: Grafana | Refresh apt cache after PPA add (best-effort, bounded; #6719)
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+  when:
+    - ansible_os_family == "Debian"
+    - _grafana_installed.rc != 0
+
 - name: Install Grafana
   ansible.builtin.apt:
     name: grafana
     state: present
-    update_cache: true
   when:
     - ansible_os_family == "Debian"
     - _grafana_installed.rc != 0

--- a/autobot-slm-backend/ansible/roles/npu-worker/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/npu-worker/tasks/main.yml
@@ -56,6 +56,17 @@
   tags: ['npu', 'config']
 
 # ============================================================
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: NPU worker | Refresh apt cache (best-effort, bounded; #6719)
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+
 - name: Install NPU worker dependencies
   ansible.builtin.apt:
     name:
@@ -67,7 +78,6 @@
       - libblas-dev
       - liblapack-dev
     state: present
-    update_cache: true
 
 - name: Create NPU worker directories
   ansible.builtin.file:

--- a/autobot-slm-backend/ansible/roles/postgresql/tasks/install.yml
+++ b/autobot-slm-backend/ansible/roles/postgresql/tasks/install.yml
@@ -55,11 +55,16 @@
   become: true
   when: _pg_installed.rc != 0
 
-- name: Update APT cache
-  ansible.builtin.apt:
-    update_cache: true
-    cache_valid_time: 3600
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: PostgreSQL | Refresh apt cache after PPA add (best-effort, bounded; #6719)
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
   become: true
+  changed_when: false
+  failed_when: false
   when: _pg_installed.rc != 0
 
 - name: Ensure en_US.UTF-8 locale is available

--- a/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
@@ -28,10 +28,16 @@
   when: _redis_installed.rc != 0
   tags: ['redis', 'packages']
 
-- name: "Redis | Update apt cache"
-  apt:
-    update_cache: yes
-  become: yes
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: "Redis | Refresh apt cache after PPA add (best-effort, bounded; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
   when: _redis_installed.rc != 0
   tags: ['redis', 'packages']
 

--- a/autobot-slm-backend/ansible/roles/time_sync/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/time_sync/tasks/main.yml
@@ -30,13 +30,24 @@
   when: current_timezone.stdout != time_sync.timezone
   tags: ['time_sync', 'timezone']
 
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: "Time Sync | Refresh apt cache (best-effort, bounded; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+  tags: ['time_sync', 'packages']
+
 - name: "Time Sync | Install NTP packages"
   apt:
     name:
       - systemd-timesyncd
       - cron
     state: present
-    update_cache: yes
     lock_timeout: 120
   tags: ['time_sync', 'packages']
 

--- a/autobot-slm-backend/ansible/roles/tts-worker/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/tts-worker/tasks/main.yml
@@ -51,6 +51,18 @@
 # ============================================================
 # System dependencies
 # ============================================================
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: "TTS Worker | Refresh apt cache (best-effort, bounded; #6719)"
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+  tags: ['tts', 'packages']
+
 - name: "TTS Worker | Install system dependencies"
   ansible.builtin.apt:
     name:
@@ -59,7 +71,6 @@
       - python3-venv
       - libsndfile1
     state: present
-    update_cache: true
   tags: ['tts', 'packages']
 
 # ============================================================

--- a/autobot-slm-backend/ansible/roles/vnc/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/vnc/tasks/main.yml
@@ -4,6 +4,17 @@
 #
 # VNC Role - Install and configure VNC server with noVNC web interface
 ---
+# #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
+- name: VNC | Refresh apt cache (best-effort, bounded; #6719)
+  ansible.builtin.command:
+    cmd: >-
+      timeout 60 apt-get update -qq
+      -o Acquire::Retries=0
+      -o Acquire::http::Timeout=10
+  become: true
+  changed_when: false
+  failed_when: false
+
 - name: Install VNC server packages
   ansible.builtin.apt:
     name:
@@ -17,7 +28,6 @@
       - xfce4-terminal
       - dbus-x11
     state: present
-    update_cache: true
   become: true
 
 - name: Create VNC user if not exists


### PR DESCRIPTION
## Why

Continues the rollout from #6728 (nginx) and #6729 (5 SLM-Manager roles). The user just deployed the 6729 PR and Phase 4a `backend` role tripped on the same Ansible-apt-module-strict-on-warning pattern:

\`\`\`
TASK [backend : Backend | Install backend-specific system dependencies]
fatal: [00-SLM-Manager]: FAILED!
msg: 'Failed to update apt cache: unknown reason'
\`\`\`

This PR converts every other role-level callsite so any node type the user provisions next won't repeat the loop.

## Roles converted (14)

| File | Notes |
|------|-------|
| `roles/backend/tasks/main.yml` | current blocker |
| `roles/ai-stack/tasks/main.yml` | |
| `roles/llm/tasks/main.yml` | preserves `when: not _ollama_binary.stat.exists` |
| `roles/tts-worker/tasks/main.yml` | |
| `roles/npu-worker/tasks/main.yml` | |
| `roles/vnc/tasks/main.yml` | |
| `roles/redis/tasks/main.yml` | preserves `when: _redis_installed.rc != 0` |
| `roles/postgresql/tasks/install.yml` | preserves `when: _pg_installed.rc != 0` |
| `roles/time_sync/tasks/main.yml` | preserves `lock_timeout: 120` on the install task |
| `roles/docker/tasks/main.yml` | 2 callsites: prerequisite install + apt_repository (switched to `update_cache: false` + dedicated bounded refresh after) |
| `roles/monitoring/tasks/grafana.yml` | preserves `when: ansible_os_family == \"Debian\" and _grafana_installed.rc != 0` |
| `roles/agent_config/tasks/nodejs.yml` | uses `package` module not `apt`, but same root cause |
| `roles/agent_config/tasks/openvino.yml` | refresh after Intel OpenVINO repo add |
| `roles/agent_config/tasks/system_packages.yml` | |

## Out of scope

- `roles/dependency_patching/tasks/update-system.yml` — intentionally strict (system-update path); per #6719 audit not converted.
- ~15 standalone playbook callsites (`playbooks/system-update.yml`, `apply-system-updates.yml`, `check-system-updates.yml`, `migrate-grafana-to-vm.yml`, etc.) — also intentionally strict or only run via dedicated maintenance flows, not `provision-fleet-roles.yml`.

After this PR merges, **only intentional strict-refresh paths still use the Ansible apt module's `update_cache: true`**.

## Verification

- All 14 YAML files parse cleanly via `yaml.safe_load`.
- Local smoke (same machine, same Launchpad failure as user's deploy):
  ```
  $ sudo timeout 60 apt-get update -qq -o Acquire::Retries=0 -o Acquire::http::Timeout=10
  W: ... ppa.launchpadcontent.net (Connection refused)
  W: Some index files failed to download. They have been ignored, or old ones used instead.
  $ echo $?
  0
  ```

## Test plan

- [ ] Re-run `provision-fleet-roles.yml` on the SLM Manager host. **All phases reach `ok` for `00-SLM-Manager`** — Phase 4a backend no longer aborts.
- [ ] No `Failed to update apt cache: unknown reason` aborts in the run.
- [ ] Each `Refresh apt cache` task completes in <90 s even with both Launchpad PPAs unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)