### PR TITLE
fix(agents): unblock backend boot — StandardizedAgent default is_available (#6659 follow-up)

### DIFF
--- a/autobot-backend/agents/standardized_agent.py
+++ b/autobot-backend/agents/standardized_agent.py
@@ -448,6 +448,22 @@ class StandardizedAgent(BaseAgent):
     def get_capabilities(self) -> List[str]:
         """Return list of capabilities - must be implemented by subclasses"""
 
+    async def is_available(self) -> bool:
+        """In-process default — override in subclasses with external dependencies.
+
+        #6659 promoted ``is_available`` to an abstract method on ``BaseAgent``
+        so container-deployed agents can do a network/health probe. The
+        contract for in-process StandardizedAgent subclasses is "always
+        available unless overridden". Without this default every
+        StandardizedAgent subclass crashes at instantiation
+        (``TypeError: Can't instantiate abstract class …``), which took down
+        the backend at module-load time of the JSONFormatterAgent
+        singleton — see backend-error.log on 2026-05-02.
+        Subclasses needing an LLM/network probe override this and return
+        the probe result.
+        """
+        return True
+
     # Convenience methods for common action patterns
 
     def register_simple_action(


### PR DESCRIPTION
## Symptom — backend won't start, all 4 uvicorn workers die at module load

Pulled from /var/log/autobot/backend-error.log on 00-SLM-Manager (post-deploy):

\`\`\`
File \"/opt/autobot/autobot-backend/agents/json_formatter_agent.py\", line 575, in <module>
    json_formatter = JSONFormatterAgent()
TypeError: Can't instantiate abstract class JSONFormatterAgent
           without an implementation for abstract method 'is_available'
INFO:     Child process [222357] died
INFO:     Child process [222358] died
INFO:     Child process [222361] died
\`\`\`

The Ansible playbook then waits 12 minutes (120 retries × 6s) at \`Backend | Wait for backend to be healthy (#3687)\` before aborting Phase 4a, and 172.16.168.26's VNC role can't reach the SLM backend either, so credential registration silently skips.

## Root cause

#6709 promoted \`is_available\` to an abstract method on \`BaseAgent\` so container-deployed agents could do a network/health probe. But the ~20 in-process \`StandardizedAgent\` subclasses don't have an external dependency — for them \"available\" means \"instance constructed without exception\", and the abstract requirement makes every subclass impossible to instantiate.

Three subclasses are instantiated as module-level singletons and so take down boot on import:

- [agents/json_formatter_agent.py:575](autobot-backend/agents/json_formatter_agent.py#L575)
- [agents/security_scanner_agent.py:689](autobot-backend/agents/security_scanner_agent.py#L689)
- [agents/network_discovery_agent.py:591](autobot-backend/agents/network_discovery_agent.py#L591)

JSONFormatterAgent imports first → that's the visible failure.

## Fix

Add a single in-process default to \`StandardizedAgent\`:

\`\`\`python
async def is_available(self) -> bool:
    \"\"\"In-process default — override in subclasses with external dependencies.\"\"\"
    return True
\`\`\`

This matches the contract documented on \`BaseAgent.is_available\` (\"in-process agents can simply return True synchronously inside the coroutine\"). Subclasses with a real probe (e.g. ContainerAgent siblings, LLM-backed agents) continue to override.

## Verified

\`\`\`
$ /opt/autobot/autobot-backend/venv/bin/python -c \"from agents.json_formatter_agent import json_formatter; \\
                                                   import asyncio; print(asyncio.run(json_formatter.is_available()))\"
True
\`\`\`

## Why the smoke test missed this

The startup-import smoke test added in #6540 imports modules but doesn't necessarily walk every import-time singleton — \`json_formatter\` is constructed at module load of \`agents.json_formatter_agent\`, and the test may not import that module along the same chain. Worth a follow-up to expand the smoke to cover module-level Agent instantiations specifically. Filing as a discovery once this lands.

## Test plan

- [ ] Pull branch, deploy via Ansible to MV-Stealth
- [ ] \`systemctl status autobot-backend\` shows running with \`ss -tlnp | grep 8001\` showing a listener (not just \"active\")
- [ ] \`curl -sk https://localhost/api/health\` returns 200
- [ ] Phase 4a \`Backend | Wait for backend to be healthy\` task completes within seconds, not 12 minutes
- [ ] 172.16.168.26 VNC credential registration succeeds (SLM backend reachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)