### PR TITLE
feat(code-analysis): add LSP-violation detector to AntiPatternDetector (#6661)

### DIFF
--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -91,6 +91,9 @@ class AntiPatternType(Enum):
     PRIMITIVE_OBSESSION = "primitive_obsession"
     LAZY_CLASS = "lazy_class"
     REFUSED_BEQUEST = "refused_bequest"
+    # Issue #6661: Liskov Substitution Principle violations
+    LSP_SIGNATURE_INCOMPATIBLE = "lsp_signature_incompatible"
+    LSP_EXCEPTION_CONTRACT_CHANGED = "lsp_exception_contract_changed"
 
 
 @dataclass
@@ -132,7 +135,7 @@ class ClassInfo:
     name: str
     file_path: str
     line_number: int
-    methods: List[ast.FunctionDef]
+    methods: List[ast.AST]  # ast.FunctionDef | ast.AsyncFunctionDef (#6661)
     attributes: Set[str]
     base_classes: List[str]
     method_calls: Dict[str, List[str]]  # method -> list of called methods/attrs
@@ -321,6 +324,8 @@ class AntiPatternDetector:
         anti_patterns.extend(await self._detect_lazy_classes())
         anti_patterns.extend(await self._detect_dead_code())
         anti_patterns.extend(await self._detect_data_clumps())
+        # Issue #6661: Liskov Substitution Principle violations
+        anti_patterns.extend(await self._detect_lsp_violations())
 
         # Phase 3: Generate report
         analysis_time = time.time() - start_time
@@ -437,7 +442,7 @@ class AntiPatternDetector:
 
     @staticmethod
     def _extract_method_call_data(
-        methods: List[ast.FunctionDef],
+        methods: List[ast.AST]  # ast.FunctionDef | ast.AsyncFunctionDef (#6661),
     ) -> Tuple[Dict[str, List[str]], Dict[str, int]]:
         """Extract method calls and external references from a list of AST methods.
 
@@ -466,8 +471,15 @@ class AntiPatternDetector:
     ) -> Optional[ClassInfo]:
         """Analyze a class definition"""
         try:
-            # Extract methods
-            methods = [n for n in node.body if isinstance(n, ast.FunctionDef)]
+            # Extract methods (#6661: include AsyncFunctionDef so the LSP
+            # detector can catch sync/async signature mismatches between
+            # parent and child overrides — previously async methods were
+            # silently skipped by every existing detector too).
+            methods = [
+                n
+                for n in node.body
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            ]
 
             # Extract attributes (from __init__ and class body)
             attributes = set()
@@ -1023,6 +1035,270 @@ class AntiPatternDetector:
                         related_entities=list(methods[:5]),
                     )
                 )
+
+        return issues
+
+    # ========== Liskov Substitution Principle Detection (Issue #6661) ==========
+
+    # Names that look like ABC/Protocol stubs in the parent — children adding
+    # behavior on top of these is the *purpose*, not an LSP violation.
+    _ABSTRACT_PARENT_NAMES = frozenset(
+        {"ABC", "ABCMeta", "Protocol", "RuntimeProtocol"}
+    )
+    _MIXIN_SUFFIXES = ("Mixin", "Protocol", "ABC")
+
+    def _is_async_method(self, method: ast.AST) -> bool:
+        """True when the method is declared `async def`."""
+        return isinstance(method, ast.AsyncFunctionDef)
+
+    def _required_positional_count(self, method: ast.AST) -> int:
+        """Count positional args without defaults (excluding ``self``/``cls``)."""
+        if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return 0
+        args = method.args.args
+        # Strip the bound argument (self/cls) if present
+        if args and args[0].arg in ("self", "cls"):
+            args = args[1:]
+        defaults = method.args.defaults or []
+        return max(0, len(args) - len(defaults))
+
+    def _is_abstract_or_stub(self, method: ast.AST) -> bool:
+        """Parent overrides should be skipped if the parent body is an
+        abstract / Protocol stub — children must add behavior."""
+        if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return True
+        # @abstractmethod / @abc.abstractmethod
+        for dec in method.decorator_list:
+            name = ""
+            if isinstance(dec, ast.Name):
+                name = dec.id
+            elif isinstance(dec, ast.Attribute):
+                name = dec.attr
+            if "abstract" in name.lower():
+                return True
+        body = method.body
+        if not body:
+            return True
+        if len(body) == 1:
+            stmt = body[0]
+            # `pass` / `...` / `raise NotImplementedError`
+            if isinstance(stmt, ast.Pass):
+                return True
+            if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant):
+                if stmt.value.value is Ellipsis or stmt.value.value is None:
+                    return True
+            if isinstance(stmt, ast.Raise):
+                exc = stmt.exc
+                if isinstance(exc, ast.Name) and exc.id == "NotImplementedError":
+                    return True
+                if isinstance(exc, ast.Call) and isinstance(exc.func, ast.Name):
+                    if exc.func.id == "NotImplementedError":
+                        return True
+        # Docstring-only body counts as a stub too
+        if (
+            len(body) == 1
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            return True
+        return False
+
+    def _is_skippable_class(self, cls_info: ClassInfo) -> bool:
+        """Mixins / Protocols / pure ABCs are not subject to LSP overrides."""
+        if any(cls_info.name.endswith(suf) for suf in self._MIXIN_SUFFIXES):
+            return True
+        if cls_info.has_base_class(*self._ABSTRACT_PARENT_NAMES):
+            return True
+        return False
+
+    def _exception_types_raised(self, method: ast.AST) -> Set[str]:
+        """Static set of exception type names ``raise``d directly in body."""
+        names: Set[str] = set()
+        if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return names
+        for node in ast.walk(method):
+            if isinstance(node, ast.Raise) and node.exc is not None:
+                exc = node.exc
+                if isinstance(exc, ast.Name):
+                    names.add(exc.id)
+                elif isinstance(exc, ast.Call) and isinstance(exc.func, ast.Name):
+                    names.add(exc.func.id)
+                elif isinstance(exc, ast.Call) and isinstance(exc.func, ast.Attribute):
+                    names.add(exc.func.attr)
+        return names
+
+    def _docstring_mentions_raises(self, method: ast.AST, exc_name: str) -> bool:
+        """Best-effort: parent's docstring documents the exception type."""
+        if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return False
+        doc = ast.get_docstring(method) or ""
+        return exc_name in doc
+
+    def _find_parent_method(
+        self, parent: ClassInfo, name: str
+    ) -> Optional[ast.AST]:
+        for m in parent.methods:
+            if (
+                isinstance(m, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and m.name == name
+            ):
+                return m
+        return None
+
+    def _resolve_parent(self, child: ClassInfo) -> Optional[ClassInfo]:
+        """Look up the FIRST in-codebase parent class. Returns None when
+        the parent is external (stdlib/library) — those are out of scope."""
+        for base_name in child.base_classes:
+            for full_name, info in self.classes.items():
+                if info.name == base_name:
+                    return info
+        return None
+
+    async def _detect_lsp_violations(self) -> List[AntiPatternInstance]:
+        """Detect Liskov Substitution Principle violations across class
+        hierarchies. Two high-confidence rules (Issue #6661):
+
+        * ``LSP_SIGNATURE_INCOMPATIBLE`` — sync/async mismatch between an
+          override and its parent, or required-param removal.
+        * ``LSP_EXCEPTION_CONTRACT_CHANGED`` — the override raises an
+          exception type that the parent neither raises nor mentions in
+          its docstring's Raises clause.
+
+        Excludes ABC/Protocol stubs, ``@abstractmethod`` parents, and
+        Mixin/Protocol classes — adding behavior to those is the *point*
+        of inheritance, not a contract break.
+        """
+        issues: List[AntiPatternInstance] = []
+
+        for full_name, child in self.classes.items():
+            if self._is_skippable_class(child):
+                continue
+            parent = self._resolve_parent(child)
+            if parent is None or self._is_skippable_class(parent):
+                continue
+
+            for child_method in child.methods:
+                if not isinstance(
+                    child_method, (ast.FunctionDef, ast.AsyncFunctionDef)
+                ):
+                    continue
+                parent_method = self._find_parent_method(parent, child_method.name)
+                if parent_method is None:
+                    continue
+                if self._is_abstract_or_stub(parent_method):
+                    continue
+
+                # --- Signature: sync/async mismatch ---
+                if self._is_async_method(child_method) != self._is_async_method(
+                    parent_method
+                ):
+                    issues.append(
+                        AntiPatternInstance(
+                            pattern_type=AntiPatternType.LSP_SIGNATURE_INCOMPATIBLE,
+                            severity=Severity.HIGH,
+                            file_path=child.file_path,
+                            line_number=child_method.lineno,
+                            entity_name=f"{child.name}.{child_method.name}",
+                            description=(
+                                f"Override of {parent.name}.{child_method.name} changes "
+                                f"sync/async: parent is "
+                                f"{'async' if self._is_async_method(parent_method) else 'sync'}, "
+                                f"child is "
+                                f"{'async' if self._is_async_method(child_method) else 'sync'}. "
+                                "Polymorphic callers will silently get an unawaited coroutine "
+                                "(or fail to await) depending on which subclass they hold."
+                            ),
+                            metrics={
+                                "parent_class": parent.name,
+                                "parent_file": parent.file_path,
+                                "parent_async": self._is_async_method(parent_method),
+                                "child_async": self._is_async_method(child_method),
+                            },
+                            suggestion=(
+                                "Unify the signature: if any subclass needs I/O, promote "
+                                "the parent contract to ``async def``; the in-process "
+                                "implementations can simply ``return value`` inside the "
+                                "coroutine. See #6659 for a worked example."
+                            ),
+                            refactoring_effort="low",
+                            related_entities=[parent.name, parent.file_path],
+                        )
+                    )
+
+                # --- Signature: required-param removal ---
+                child_required = self._required_positional_count(child_method)
+                parent_required = self._required_positional_count(parent_method)
+                if child_required < parent_required:
+                    issues.append(
+                        AntiPatternInstance(
+                            pattern_type=AntiPatternType.LSP_SIGNATURE_INCOMPATIBLE,
+                            severity=Severity.HIGH,
+                            file_path=child.file_path,
+                            line_number=child_method.lineno,
+                            entity_name=f"{child.name}.{child_method.name}",
+                            description=(
+                                f"Override of {parent.name}.{child_method.name} drops "
+                                f"required positional params: parent requires "
+                                f"{parent_required}, child requires {child_required}. "
+                                "A factory call like ``cls(arg1, arg2)`` against the parent "
+                                "will crash with TypeError on this subclass."
+                            ),
+                            metrics={
+                                "parent_class": parent.name,
+                                "parent_file": parent.file_path,
+                                "parent_required_args": parent_required,
+                                "child_required_args": child_required,
+                            },
+                            suggestion=(
+                                "Restore the parent's positional params with sensible "
+                                "defaults so factory callers keep working. See #6660 for "
+                                "a worked example with __init__."
+                            ),
+                            refactoring_effort="low",
+                            related_entities=[parent.name, parent.file_path],
+                        )
+                    )
+
+                # --- Exception contract: child raises type parent doesn't ---
+                child_excs = self._exception_types_raised(child_method)
+                parent_excs = self._exception_types_raised(parent_method)
+                new_excs = child_excs - parent_excs
+                # Filter out exceptions the parent's docstring documents
+                undocumented = {
+                    e
+                    for e in new_excs
+                    if not self._docstring_mentions_raises(parent_method, e)
+                }
+                if undocumented:
+                    issues.append(
+                        AntiPatternInstance(
+                            pattern_type=AntiPatternType.LSP_EXCEPTION_CONTRACT_CHANGED,
+                            severity=Severity.HIGH,
+                            file_path=child.file_path,
+                            line_number=child_method.lineno,
+                            entity_name=f"{child.name}.{child_method.name}",
+                            description=(
+                                f"Override of {parent.name}.{child_method.name} raises "
+                                f"{sorted(undocumented)} which the parent neither raises "
+                                "nor documents in its Raises clause. Polymorphic callers "
+                                "against the parent contract have no reason to catch these."
+                            ),
+                            metrics={
+                                "parent_class": parent.name,
+                                "parent_file": parent.file_path,
+                                "new_exceptions": sorted(undocumented),
+                            },
+                            suggestion=(
+                                "Either return an error value matching the parent's return "
+                                "contract, or promote the new exception into the parent's "
+                                "documented Raises clause and propagate it through every "
+                                "sibling subclass. See #6658 for a worked example."
+                            ),
+                            refactoring_effort="medium",
+                            related_entities=[parent.name, parent.file_path],
+                        )
+                    )
 
         return issues
 

--- a/autobot-backend/code_analysis/src/anti_pattern_detector_lsp_test.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector_lsp_test.py
@@ -1,0 +1,261 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for the Liskov Substitution Principle detector (Issue #6661).
+
+The new analyzer adds two AntiPatternType entries — LSP_SIGNATURE_INCOMPATIBLE
+and LSP_EXCEPTION_CONTRACT_CHANGED — that catch the same class of bug we
+just shipped manually as #6658, #6659 and #6660.
+
+Tests use temporary on-disk fixture files because the underlying class
+parser is file-path driven.
+"""
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+def _load_detector_module():
+    spec = importlib.util.spec_from_file_location(
+        "apd_under_test",
+        "autobot-backend/code_analysis/src/anti_pattern_detector.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:  # pragma: no cover — env-dependent
+        pytest.skip(f"AntiPatternDetector dep chain unavailable: {exc}")
+    # Pre-existing latent bug in this module: __init__ references the bare name
+    # ``config`` which is never imported (line 273). Production callers tolerate
+    # this because the import happens through a path where ``config`` is in
+    # globals; isolated-load tests must inject it. Filed as discovery.
+    if not hasattr(mod, "config"):
+        mod.config = None
+    return mod
+
+
+@pytest.fixture
+def fixture_root(tmp_path):
+    """A throwaway codebase fixture for AntiPatternDetector to scan."""
+    return tmp_path
+
+
+def _write_module(root: Path, name: str, body: str) -> Path:
+    p = root / f"{name}.py"
+    p.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+    return p
+
+
+@pytest.mark.asyncio
+async def test_lsp_signature_incompatible_async_sync_mismatch(fixture_root):
+    """Sync override of an async parent must be flagged (#6659 case)."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "agents",
+        """
+        class BaseAgent:
+            async def is_available(self) -> bool:
+                return True
+
+        class LocalAgent(BaseAgent):
+            def is_available(self) -> bool:  # sync override -> violation
+                return True
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],  # truthy non-default — see analyze() `or` idiom
+    )
+    sig_issues = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type.value == "lsp_signature_incompatible"
+    ]
+    assert sig_issues, "expected at least one LSP_SIGNATURE_INCOMPATIBLE finding"
+    msg = sig_issues[0].description
+    assert "sync" in msg and "async" in msg
+
+
+@pytest.mark.asyncio
+async def test_lsp_signature_incompatible_required_param_dropped(fixture_root):
+    """Constructor that drops a required parent param must be flagged (#6660 case)."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "ag",
+        """
+        class StandardizedAgent:
+            def __init__(self, agent_type, deployment_mode=None):
+                self.agent_type = agent_type
+
+        class LLMFailsafeAgent(StandardizedAgent):
+            def __init__(self):              # drops required agent_type -> violation
+                super().__init__("llm_failsafe")
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],  # truthy non-default — see analyze() `or` idiom
+    )
+    sig_issues = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type == apd.AntiPatternType.LSP_SIGNATURE_INCOMPATIBLE
+        and "drops required positional params" in ap.description
+    ]
+    assert sig_issues, "expected required-param-removal finding"
+
+
+@pytest.mark.asyncio
+async def test_lsp_exception_contract_changed(fixture_root):
+    """Child raising a type the parent doesn't must be flagged (#6658 case)."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "ints",
+        """
+        class BaseIntegration:
+            async def execute_action(self, action, params):
+                return {"ok": True}
+
+        class SlackIntegration(BaseIntegration):
+            async def execute_action(self, action, params):
+                if action == "x":
+                    raise ValueError("boom")  # not in parent's contract
+                return {}
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],  # truthy non-default — see analyze() `or` idiom
+    )
+    exc_issues = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type == apd.AntiPatternType.LSP_EXCEPTION_CONTRACT_CHANGED
+    ]
+    assert exc_issues
+    assert "ValueError" in exc_issues[0].description
+
+
+@pytest.mark.asyncio
+async def test_lsp_skips_abstract_parent(fixture_root):
+    """Subclass extending an @abstractmethod parent must NOT be flagged."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "abc_case",
+        """
+        from abc import abstractmethod
+
+        class Base:
+            @abstractmethod
+            def run(self):
+                ...
+
+        class Concrete(Base):
+            def run(self):
+                if True:
+                    raise ValueError("err")  # OK — parent is abstract stub
+                return None
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],  # truthy non-default — see analyze() `or` idiom
+    )
+    lsp = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type
+        in (
+            apd.AntiPatternType.LSP_SIGNATURE_INCOMPATIBLE,
+            apd.AntiPatternType.LSP_EXCEPTION_CONTRACT_CHANGED,
+        )
+    ]
+    assert not lsp, f"unexpected LSP findings against abstract parent: {lsp}"
+
+
+@pytest.mark.asyncio
+async def test_lsp_skips_mixin_classes(fixture_root):
+    """Mixin classes are not subject to LSP overrides."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "mixin_case",
+        """
+        class CacheMixin:
+            async def get(self, k):
+                return None
+
+        class FastCacheMixin(CacheMixin):
+            def get(self, k):  # would be a sync/async mismatch normally
+                return "fast"
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],  # truthy non-default — see analyze() `or` idiom
+    )
+    lsp = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type == apd.AntiPatternType.LSP_SIGNATURE_INCOMPATIBLE
+    ]
+    assert not lsp, f"Mixin override should be ignored, got: {lsp}"
+
+
+@pytest.mark.asyncio
+async def test_lsp_no_false_positives_on_clean_code(fixture_root):
+    """Identical signatures must not be flagged."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "clean",
+        """
+        class Base:
+            async def f(self, x: int) -> int:
+                return x
+
+        class Concrete(Base):
+            async def f(self, x: int) -> int:
+                return x * 2
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],  # truthy non-default — see analyze() `or` idiom
+    )
+    lsp = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type
+        in (
+            apd.AntiPatternType.LSP_SIGNATURE_INCOMPATIBLE,
+            apd.AntiPatternType.LSP_EXCEPTION_CONTRACT_CHANGED,
+        )
+    ]
+    assert not lsp, f"clean code should produce no LSP findings, got: {lsp}"


### PR DESCRIPTION
## Summary
- New \`_detect_lsp_violations()\` method on \`AntiPatternDetector\` adds 2 enum entries:
  - \`LSP_SIGNATURE_INCOMPATIBLE\` — sync/async mismatch between override and parent, or required-param removal
  - \`LSP_EXCEPTION_CONTRACT_CHANGED\` — child raises an exception type the parent neither raises nor documents
- Skips ABC/Protocol/Mixin classes, abstractmethod parents, and external (out-of-codebase) parents
- Side fix: \`_analyze_class\` now collects both \`ast.FunctionDef\` and \`ast.AsyncFunctionDef\` (every existing detector was silently skipping async methods too)

## Self-validation
The detector catches the same class of bug we just shipped manually as #6658, #6659, #6660:
- Async/sync override mismatch → caught (#6659 case)
- Required-param removal in __init__ → caught (#6660 case)
- Child raises ValueError parent doesn't → caught (#6658 case)

## Test plan
- [x] \`pytest autobot-backend/code_analysis/src/anti_pattern_detector_lsp_test.py\` — 6/6 PASS (3 positive + 3 false-positive guards: abstract parent, mixin, clean code)

## Discoveries filed
- #6733 — \`AntiPatternDetector.__init__\` references undefined \`config\` (line 273)
- #6734 — \`analyze() exclude_patterns=[]\` silently overridden by defaults via \`or\` idiom

## Scope note
Issue body references this exact module (\`code_analysis/src/anti_pattern_detector.py\`). Production wires through a parallel module (\`code_intelligence/anti_pattern_detector.py\`); porting the rules there to surface in \`/codebase/problems\` is left as a follow-up.

Closes #6661

🤖 Generated with [Claude Code](https://claude.com/claude-code)