### PR TITLE
feat(code-analysis): add enum/class consolidation detector to AntiPatternDetector (#6684)

### DIFF
--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -94,6 +94,9 @@ class AntiPatternType(Enum):
     # Issue #6661: Liskov Substitution Principle violations
     LSP_SIGNATURE_INCOMPATIBLE = "lsp_signature_incompatible"
     LSP_EXCEPTION_CONTRACT_CHANGED = "lsp_exception_contract_changed"
+    # Issue #6684: consolidation opportunities (missing-inheritance siblings to LSP)
+    DUPLICATE_ENUM = "duplicate_enum"
+    DUPLICATE_CLASS_SHAPE = "duplicate_class_shape"
 
 
 @dataclass
@@ -326,6 +329,9 @@ class AntiPatternDetector:
         anti_patterns.extend(await self._detect_data_clumps())
         # Issue #6661: Liskov Substitution Principle violations
         anti_patterns.extend(await self._detect_lsp_violations())
+        # Issue #6684: consolidation opportunities (missing-inheritance siblings to LSP)
+        anti_patterns.extend(await self._detect_duplicate_enums())
+        anti_patterns.extend(await self._detect_duplicate_class_shapes())
 
         # Phase 3: Generate report
         analysis_time = time.time() - start_time
@@ -1299,6 +1305,238 @@ class AntiPatternDetector:
                             related_entities=[parent.name, parent.file_path],
                         )
                     )
+
+        return issues
+
+    # ========== Consolidation Opportunity Detection (Issue #6684) ==========
+
+    _ENUM_BASE_NAMES = frozenset(
+        {"Enum", "IntEnum", "StrEnum", "Flag", "IntFlag", "ReprEnum"}
+    )
+    # Class-shape rule: skip patterns where shared method names is by design
+    _SHAPE_SKIP_BASE_NAMES = frozenset(
+        {
+            "BaseModel",      # Pydantic — sharing field names is fine
+            "Enum",
+            "IntEnum",
+            "StrEnum",
+            "Exception",
+            "BaseException",
+            "TypedDict",
+            "NamedTuple",
+        }
+    )
+    _SHAPE_MIN_METHODS = 5
+    _SHAPE_JACCARD_THRESHOLD = 0.7
+    _ENUM_JACCARD_THRESHOLD = 0.7
+    _ENUM_MIN_VALUES = 3
+
+    def _is_enum_class(self, cls_info: ClassInfo) -> bool:
+        """True when the class inherits from an Enum-family base."""
+        return any(b in self._ENUM_BASE_NAMES for b in cls_info.base_classes)
+
+    def _enum_value_set(self, cls_info: ClassInfo) -> Set[str]:
+        """Extract the set of enum *value* string literals from a class body.
+
+        Re-parses the source file (cheap; cached at the file level by the
+        OS/page cache).  Falls back to attribute names when values are not
+        string literals — that still gives a useful overlap signal.
+        """
+        try:
+            with open(cls_info.file_path, "r", encoding="utf-8") as f:
+                tree = ast.parse(f.read(), filename=cls_info.file_path)
+        except Exception:
+            return set()
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef) or node.name != cls_info.name:
+                continue
+            values: Set[str] = set()
+            for stmt in node.body:
+                target_name: Optional[str] = None
+                value_node: Optional[ast.AST] = None
+                if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
+                    tgt = stmt.targets[0]
+                    if isinstance(tgt, ast.Name):
+                        target_name = tgt.id
+                    value_node = stmt.value
+                elif isinstance(stmt, ast.AnnAssign) and isinstance(
+                    stmt.target, ast.Name
+                ):
+                    target_name = stmt.target.id
+                    value_node = stmt.value
+                if target_name is None or target_name.startswith("_"):
+                    continue
+                if (
+                    isinstance(value_node, ast.Constant)
+                    and isinstance(value_node.value, str)
+                ):
+                    values.add(value_node.value.lower())
+                else:
+                    # Fall back to the attribute name (lowered) — gives a
+                    # useful signal for `auto()` enums and ints alike.
+                    values.add(target_name.lower())
+            return values
+        return set()
+
+    @staticmethod
+    def _jaccard(a: Set[str], b: Set[str]) -> float:
+        union = a | b
+        if not union:
+            return 0.0
+        return len(a & b) / len(union)
+
+    def _shares_base_class(self, a: ClassInfo, b: ClassInfo) -> bool:
+        """True when a and b share at least one base class (already related)."""
+        if not a.base_classes or not b.base_classes:
+            return False
+        return bool(set(a.base_classes) & set(b.base_classes))
+
+    async def _detect_duplicate_enums(self) -> List[AntiPatternInstance]:
+        """Cluster enum classes whose value sets overlap above threshold.
+
+        Issue #6684: AutoBot's ``constants/status_enums.py`` is the canonical
+        home for status values, but many modules redeclare overlapping enums
+        (StepStatus, TaskStatus, PhasePromotionStatus, ...).  This detector
+        flags any pair of enum classes whose value sets have Jaccard
+        similarity >= 0.7 with at least 3 shared values.
+        """
+        issues: List[AntiPatternInstance] = []
+
+        enum_data: List[Tuple[str, ClassInfo, Set[str]]] = []
+        for full_name, cls_info in self.classes.items():
+            if not self._is_enum_class(cls_info):
+                continue
+            values = self._enum_value_set(cls_info)
+            if len(values) >= self._ENUM_MIN_VALUES:
+                enum_data.append((full_name, cls_info, values))
+
+        # O(n^2) over enums only — n is small in practice (~50 in this repo).
+        seen_pairs: Set[Tuple[str, str]] = set()
+        for i, (full_a, cls_a, vals_a) in enumerate(enum_data):
+            for full_b, cls_b, vals_b in enum_data[i + 1 :]:
+                # Skip if one inherits from the other (already canonical-vs-extension)
+                if cls_a.name in cls_b.base_classes or cls_b.name in cls_a.base_classes:
+                    continue
+                similarity = self._jaccard(vals_a, vals_b)
+                if similarity < self._ENUM_JACCARD_THRESHOLD:
+                    continue
+                shared = sorted(vals_a & vals_b)
+                pair_key = tuple(sorted([full_a, full_b]))
+                if pair_key in seen_pairs:
+                    continue
+                seen_pairs.add(pair_key)
+
+                issues.append(
+                    AntiPatternInstance(
+                        pattern_type=AntiPatternType.DUPLICATE_ENUM,
+                        severity=Severity.MEDIUM,
+                        file_path=cls_a.file_path,
+                        line_number=cls_a.line_number,
+                        entity_name=cls_a.name,
+                        description=(
+                            f"Enum '{cls_a.name}' overlaps {len(vals_a & vals_b)}/"
+                            f"{len(vals_a | vals_b)} values with '{cls_b.name}' in "
+                            f"{cls_b.file_path} (Jaccard={similarity:.2f}). "
+                            f"Shared values: {shared[:5]}"
+                            f"{' (truncated)' if len(shared) > 5 else ''}."
+                        ),
+                        metrics={
+                            "other_enum": cls_b.name,
+                            "other_file": cls_b.file_path,
+                            "jaccard_similarity": round(similarity, 3),
+                            "shared_value_count": len(vals_a & vals_b),
+                            "union_size": len(vals_a | vals_b),
+                            "shared_values": shared,
+                        },
+                        suggestion=(
+                            "Consolidate into a single canonical enum (see "
+                            "constants/status_enums.py for the existing pattern). "
+                            "Importing the canonical enum eliminates value drift "
+                            "and makes cross-module status comparisons type-safe."
+                        ),
+                        refactoring_effort="medium",
+                        related_entities=[cls_b.name, cls_b.file_path],
+                    )
+                )
+
+        return issues
+
+    async def _detect_duplicate_class_shapes(self) -> List[AntiPatternInstance]:
+        """Flag class pairs that share method-name sets above threshold but
+        DO NOT share a base class.  Indicates a missing extracted base /
+        Mixin / Protocol that should formalise the shared contract.
+
+        Excludes Pydantic models, exceptions, NamedTuples, TypedDicts —
+        these all naturally share method names by design.
+        """
+        issues: List[AntiPatternInstance] = []
+
+        candidates: List[Tuple[str, ClassInfo, Set[str]]] = []
+        for full_name, cls_info in self.classes.items():
+            # Skip enums and exception trees — different rules apply
+            if self._is_enum_class(cls_info):
+                continue
+            if cls_info.has_base_class(*self._SHAPE_SKIP_BASE_NAMES):
+                continue
+            method_names = {
+                m.name
+                for m in cls_info.methods
+                if isinstance(m, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and not m.name.startswith("_")
+            }
+            if len(method_names) < self._SHAPE_MIN_METHODS:
+                continue
+            candidates.append((full_name, cls_info, method_names))
+
+        seen_pairs: Set[Tuple[str, str]] = set()
+        for i, (full_a, cls_a, names_a) in enumerate(candidates):
+            for full_b, cls_b, names_b in candidates[i + 1 :]:
+                if self._shares_base_class(cls_a, cls_b):
+                    continue
+                similarity = self._jaccard(names_a, names_b)
+                if similarity < self._SHAPE_JACCARD_THRESHOLD:
+                    continue
+                shared = sorted(names_a & names_b)
+                pair_key = tuple(sorted([full_a, full_b]))
+                if pair_key in seen_pairs:
+                    continue
+                seen_pairs.add(pair_key)
+
+                issues.append(
+                    AntiPatternInstance(
+                        pattern_type=AntiPatternType.DUPLICATE_CLASS_SHAPE,
+                        severity=Severity.LOW,
+                        file_path=cls_a.file_path,
+                        line_number=cls_a.line_number,
+                        entity_name=cls_a.name,
+                        description=(
+                            f"Class '{cls_a.name}' shares {len(names_a & names_b)}/"
+                            f"{len(names_a | names_b)} public method names with "
+                            f"'{cls_b.name}' in {cls_b.file_path} "
+                            f"(Jaccard={similarity:.2f}) but they do NOT share a "
+                            f"base class.  Suggests a missing extracted base / "
+                            f"Mixin / Protocol.  Shared methods: {shared[:5]}"
+                            f"{' (truncated)' if len(shared) > 5 else ''}."
+                        ),
+                        metrics={
+                            "other_class": cls_b.name,
+                            "other_file": cls_b.file_path,
+                            "jaccard_similarity": round(similarity, 3),
+                            "shared_method_count": len(names_a & names_b),
+                            "union_size": len(names_a | names_b),
+                            "shared_methods": shared,
+                        },
+                        suggestion=(
+                            "Extract a shared base class (Template Method) or a "
+                            "Protocol describing the common interface.  See "
+                            "BaseIntegration → SlackIntegration / JiraIntegration "
+                            "for the canonical pattern in this repo."
+                        ),
+                        refactoring_effort="medium",
+                        related_entities=[cls_b.name, cls_b.file_path],
+                    )
+                )
 
         return issues
 

--- a/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
@@ -1,0 +1,376 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for the consolidation-opportunity detector (Issue #6684).
+
+The new analyzer adds two AntiPatternType entries — DUPLICATE_ENUM and
+DUPLICATE_CLASS_SHAPE — that catch *missing* inheritance: places where
+two declarations should share a parent (or extracted base/Mixin) but
+do not.  Sibling to #6661's *broken* inheritance detector.
+"""
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+def _load_detector_module():
+    spec = importlib.util.spec_from_file_location(
+        "apd_under_test",
+        "autobot-backend/code_analysis/src/anti_pattern_detector.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"AntiPatternDetector dep chain unavailable: {exc}")
+    # Pre-existing latent NameError on line 273 — see #6733.
+    if not hasattr(mod, "config"):
+        mod.config = None
+    return mod
+
+
+def _write_module(root: Path, name: str, body: str) -> Path:
+    p = root / f"{name}.py"
+    p.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def fixture_root(tmp_path):
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# DUPLICATE_ENUM
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duplicate_enum_string_values_overlap(fixture_root):
+    """Two enums with the same string values must be flagged."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "task_status",
+        """
+        from enum import Enum
+
+        class TaskStatus(Enum):
+            PENDING = "pending"
+            RUNNING = "running"
+            COMPLETED = "completed"
+            FAILED = "failed"
+        """,
+    )
+    _write_module(
+        fixture_root,
+        "step_status",
+        """
+        from enum import Enum
+
+        class StepStatus(Enum):
+            PENDING = "pending"
+            RUNNING = "running"
+            COMPLETED = "completed"
+            FAILED = "failed"
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+    dup_enum = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type.value == "duplicate_enum"
+    ]
+    assert dup_enum, "expected DUPLICATE_ENUM finding for fully-overlapping enums"
+    msg = dup_enum[0].description
+    assert "TaskStatus" in msg or "StepStatus" in msg
+
+
+@pytest.mark.asyncio
+async def test_duplicate_enum_ignores_non_enum_classes(fixture_root):
+    """Non-enum classes with similar attribute names must NOT be flagged."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "config",
+        """
+        class FirstConfig:
+            PENDING = "pending"
+            RUNNING = "running"
+            COMPLETED = "completed"
+
+        class SecondConfig:
+            PENDING = "pending"
+            RUNNING = "running"
+            COMPLETED = "completed"
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+    dup_enum = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type.value == "duplicate_enum"
+    ]
+    assert not dup_enum, "non-enum classes should not be flagged as DUPLICATE_ENUM"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_enum_skips_inheritance_relation(fixture_root):
+    """Enum that extends another enum must NOT be flagged against its parent."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "extended_status",
+        """
+        from enum import Enum
+
+        class CanonicalStatus(Enum):
+            PENDING = "pending"
+            RUNNING = "running"
+            COMPLETED = "completed"
+
+        class CanonicalStatusExtended(CanonicalStatus):
+            CANCELLED = "cancelled"
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+    dup_enum = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type.value == "duplicate_enum"
+    ]
+    # Note: Python actually disallows inheriting from a non-empty enum, but
+    # the AST stage doesn't care.  Detector must skip parent/child pairs.
+    assert not dup_enum, "parent/child enum pairs should be skipped"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_enum_below_threshold_not_flagged(fixture_root):
+    """Two enums with only one shared value (Jaccard < 0.7) must NOT be flagged."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "small_overlap",
+        """
+        from enum import Enum
+
+        class ColorEnum(Enum):
+            RED = "red"
+            GREEN = "green"
+            BLUE = "blue"
+            ACTIVE = "active"
+
+        class StateEnum(Enum):
+            ACTIVE = "active"
+            IDLE = "idle"
+            STOPPED = "stopped"
+            ERRORED = "errored"
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+    dup_enum = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type.value == "duplicate_enum"
+    ]
+    assert not dup_enum, "below-threshold overlap should not be flagged"
+
+
+# ---------------------------------------------------------------------------
+# DUPLICATE_CLASS_SHAPE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duplicate_class_shape_unrelated_classes_with_shared_methods(
+    fixture_root,
+):
+    """Two classes with overlapping public method sets and no shared base must be flagged."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "alpha",
+        """
+        class AlphaClient:
+            def connect(self): pass
+            def disconnect(self): pass
+            def send_message(self): pass
+            def receive_message(self): pass
+            def list_channels(self): pass
+            def get_channel(self): pass
+        """,
+    )
+    _write_module(
+        fixture_root,
+        "beta",
+        """
+        class BetaClient:
+            def connect(self): pass
+            def disconnect(self): pass
+            def send_message(self): pass
+            def receive_message(self): pass
+            def list_channels(self): pass
+            def get_channel(self): pass
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+    dup_shape = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type.value == "duplicate_class_shape"
+    ]
+    assert dup_shape, "expected DUPLICATE_CLASS_SHAPE for two unrelated similar classes"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_class_shape_skips_shared_base(fixture_root):
+    """Subclasses of the same base sharing methods must NOT be flagged."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "integrations",
+        """
+        class BaseClient:
+            pass
+
+        class AlphaClient(BaseClient):
+            def connect(self): pass
+            def disconnect(self): pass
+            def send_message(self): pass
+            def receive_message(self): pass
+            def list_channels(self): pass
+            def get_channel(self): pass
+
+        class BetaClient(BaseClient):
+            def connect(self): pass
+            def disconnect(self): pass
+            def send_message(self): pass
+            def receive_message(self): pass
+            def list_channels(self): pass
+            def get_channel(self): pass
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+    dup_shape = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type.value == "duplicate_class_shape"
+    ]
+    assert not dup_shape, "shared base class makes this expected, not anti-pattern"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_class_shape_skips_pydantic_models(fixture_root):
+    """Pydantic models naturally share field names — must NOT be flagged."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "models",
+        """
+        class BaseModel:
+            pass
+
+        class UserResponse(BaseModel):
+            id: int
+            name: str
+            email: str
+            created_at: str
+            updated_at: str
+            status: str
+
+        class AdminResponse(BaseModel):
+            id: int
+            name: str
+            email: str
+            created_at: str
+            updated_at: str
+            status: str
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+    dup_shape = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type.value == "duplicate_class_shape"
+    ]
+    # Pydantic models are excluded by base-class name; even though these
+    # don't have actual methods, they also don't trigger detection by design.
+    assert not dup_shape
+
+
+@pytest.mark.asyncio
+async def test_duplicate_class_shape_below_method_threshold_skipped(fixture_root):
+    """Classes with fewer than the method threshold must NOT be flagged."""
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "tiny",
+        """
+        class TinyA:
+            def f(self): pass
+            def g(self): pass
+
+        class TinyB:
+            def f(self): pass
+            def g(self): pass
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+    dup_shape = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type.value == "duplicate_class_shape"
+    ]
+    assert not dup_shape, "small classes (< _SHAPE_MIN_METHODS) should be skipped"


### PR DESCRIPTION
## Summary
Sibling to #6661 — catches *missing* inheritance opportunities. Adds 2 enum entries:

- **\`DUPLICATE_ENUM\`** — Jaccard similarity ≥0.7 across enum value sets, ≥3 shared values. Falls back to attribute-name overlap for \`auto()\` / int enums. Targets AutoBot's status-enum sprawl (StepStatus / TaskStatus / PhasePromotionStatus etc. redeclaring PENDING/RUNNING/COMPLETED/FAILED).
- **\`DUPLICATE_CLASS_SHAPE\`** — Two classes with ≥5 public methods sharing ≥70% of method names but no shared base. Suggests an extracted base / Mixin / Protocol.

## False-positive guards
- Pydantic \`BaseModel\` subclasses — sharing field names is by design
- Exception / NamedTuple / TypedDict trees
- Enum-family base classes
- Inheritance pairs (parent/child enum) — already related

## Test plan
- [x] \`pytest autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py\` — 8/8 PASS (string-overlap, non-enum skip, inheritance skip, below-threshold skip, unrelated-similar-classes positive, shared-base skip, Pydantic skip, small-class skip)

## Deferred
- \`COMPOSABLE_OPPORTUNITY\` (Vue \`<script setup>\` reactive boilerplate detection) — needs a JS/TS AST parser; left in the original issue body for a future iteration.
- Production wiring through \`code_intelligence/anti_pattern_detector.py\` — left as follow-up (same scope note as #6661).

Closes #6684

🤖 Generated with [Claude Code](https://claude.com/claude-code)