### PR TITLE
fix(api): delete 1183 dead @with_error_handling decorators above @router across 129 files (#6706)

### DIFF
--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -48,11 +48,6 @@ router = APIRouter(tags=["advanced_control"])
 
 
 # Desktop Streaming Endpoints
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_streaming_session",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.post("/streaming/create", response_model=StreamingSessionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -88,11 +83,6 @@ async def create_streaming_session(
         return response
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="terminate_streaming_session",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.delete("/streaming/{session_id}", response_model=AdvancedControlStreamingTerminateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -116,11 +106,6 @@ async def terminate_streaming_session(
         raise HTTPException(status_code=404, detail=ERR_SESSION_NOT_FOUND)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_streaming_sessions",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.get("/streaming/sessions", response_model=AdvancedControlStreamingSessionListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -139,11 +124,6 @@ async def list_streaming_sessions(
     return {"sessions": sessions, "count": len(sessions)}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_streaming_capabilities",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.get("/streaming/capabilities", response_model=AdvancedControlStreamingCapabilitiesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -163,11 +143,6 @@ async def get_streaming_capabilities(
 
 
 # Takeover Management Endpoints
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="request_takeover",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.post("/takeover/request", response_model=AdvancedControlTakeoverRequestResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -224,11 +199,6 @@ async def request_takeover(
     return {"success": True, "request_id": request_id}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="approve_takeover",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.post("/takeover/{request_id}/approve", response_model=AdvancedControlTakeoverApproveResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -261,11 +231,6 @@ async def approve_takeover(
         raise HTTPException(status_code=409, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="execute_takeover_action",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.post("/takeover/sessions/{session_id}/action", response_model=AdvancedControlTakeoverActionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -298,11 +263,6 @@ async def execute_takeover_action(
         raise HTTPException(status_code=404, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="pause_takeover_session",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.post("/takeover/sessions/{session_id}/pause", response_model=AdvancedControlTakeoverSessionStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -325,11 +285,6 @@ async def pause_takeover_session(
         raise HTTPException(status_code=404, detail="Session not found or not pausable")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="resume_takeover_session",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.post("/takeover/sessions/{session_id}/resume", response_model=AdvancedControlTakeoverSessionStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -354,11 +309,6 @@ async def resume_takeover_session(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="complete_takeover_session",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.post("/takeover/sessions/{session_id}/complete", response_model=AdvancedControlTakeoverSessionStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -387,11 +337,6 @@ async def complete_takeover_session(
         raise HTTPException(status_code=404, detail=ERR_SESSION_NOT_FOUND)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_pending_takeovers",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.get("/takeover/pending", response_model=AdvancedControlPendingTakeoversListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -410,11 +355,6 @@ async def get_pending_takeovers(
     return {"pending_requests": pending, "count": len(pending)}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_active_takeovers",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.get("/takeover/active", response_model=AdvancedControlActiveTakeoversListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -433,11 +373,6 @@ async def get_active_takeovers(
     return {"active_sessions": active, "count": len(active)}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_takeover_status",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.get("/takeover/status", response_model=AdvancedControlTakeoverSystemStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -457,11 +392,6 @@ async def get_takeover_status(
 
 
 # System Monitoring and Control
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_status",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.get("/system/status", response_model=SystemMonitoringResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -511,11 +441,6 @@ async def get_system_status(
     return response
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="emergency_system_stop",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.post("/system/emergency-stop", response_model=AdvancedControlEmergencyStopResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -547,11 +472,6 @@ async def emergency_system_stop(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_health",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.get("/system/health", response_model=AdvancedControlHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -587,11 +507,6 @@ async def get_system_health(
 
 
 # WebSocket endpoint for real-time monitoring
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="monitoring_websocket",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.websocket("/ws/monitoring")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -634,11 +549,6 @@ async def monitoring_websocket(websocket: WebSocket):
 
 
 # WebSocket handler for desktop streaming
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="desktop_streaming_websocket",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.websocket("/ws/desktop/{session_id}")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -658,11 +568,6 @@ async def desktop_streaming_websocket(websocket: WebSocket, session_id: str):
         logger.info("Desktop streaming WebSocket client disconnected: %s", session_id)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="advanced_control_info",
-    error_code_prefix="ADVANCED_CONTROL",
-)
 @router.get("/", response_model=AdvancedControlInfoResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -699,11 +699,6 @@ async def _execute_goal_with_error_handling(
     return {"message": str(orchestrator_result)}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="receive_goal",
-    error_code_prefix="AGENT",
-)
 @router.post("/goal", response_model=AgentMessageResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -771,11 +766,6 @@ async def receive_goal(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="pause_agent",
-    error_code_prefix="AGENT",
-)
 @router.post("/pause", response_model=AgentMessageResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -833,11 +823,6 @@ async def pause_agent_api(
     return {"message": "Agent paused successfully."}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="resume_agent",
-    error_code_prefix="AGENT",
-)
 @router.post("/resume", response_model=AgentMessageResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -895,11 +880,6 @@ async def resume_agent_api(
     return {"message": "Agent resumed successfully."}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="command_approval",
-    error_code_prefix="AGENT",
-)
 @router.post("/command_approval", response_model=AgentCommandApprovalResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -942,11 +922,6 @@ async def command_approval(
     return JSONResponse(status_code=500, content={"message": error_message})
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="execute_command",
-    error_code_prefix="AGENT",
-)
 @router.post("/execute_command", response_model=AgentCommandExecuteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1132,11 +1107,6 @@ def _determine_coordination_mode(payload, selected_agents: list) -> str:
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="execute_enhanced_goal",
-    error_code_prefix="AGENT",
-)
 @router.post("/goal/enhanced", response_model=DataResponse[EnhancedGoalData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1201,11 +1171,6 @@ async def execute_enhanced_goal(
         await handle_ai_stack_error(e, "Enhanced goal execution")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="coordinate_multi_agent_task",
-    error_code_prefix="AGENT",
-)
 @router.post("/multi-agent/coordinate", response_model=DataResponse[MultiAgentCoordinationData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1272,11 +1237,6 @@ async def coordinate_multi_agent_task(
         await handle_ai_stack_error(e, "Multi-agent coordination")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="comprehensive_research_task",
-    error_code_prefix="AGENT",
-)
 @router.post("/research/comprehensive", response_model=DataResponse[AgentResearchData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1342,11 +1302,6 @@ async def comprehensive_research_task(
         await handle_ai_stack_error(e, "Comprehensive research")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_development_task",
-    error_code_prefix="AGENT",
-)
 @router.post("/development/analyze", response_model=DataResponse[DevelopmentAnalysisData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1386,11 +1341,6 @@ async def analyze_development_task(
         await handle_ai_stack_error(e, "Development analysis")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_available_agents",
-    error_code_prefix="AGENT",
-)
 @router.get("/agents/available", response_model=DataResponse[AgentAvailableData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1439,11 +1389,6 @@ async def list_available_agents():
         await handle_ai_stack_error(e, "List available agents")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_agents_status",
-    error_code_prefix="AGENT",
-)
 @router.get("/agents/status", response_model=DataResponse[AgentStatusData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1485,11 +1430,6 @@ async def get_agents_status():
         await handle_ai_stack_error(e, "Agent status check")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_agent_health",
-    error_code_prefix="AGENT",
-)
 @router.get("/health/enhanced", response_model=AgentHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/agent_config.py
+++ b/autobot-backend/api/agent_config.py
@@ -562,11 +562,6 @@ async def _resolve_agent_effective_config(
     return current_model, current_provider, enabled, "local"
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_agents",
-    error_code_prefix="AGENT_CONFIG",
-)
 @router.get("/agents", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -687,11 +682,6 @@ async def _resolve_agent_entry(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_all_agents",
-    error_code_prefix="AGENT_CONFIG",
-)
 @router.get("/agents/all", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -738,11 +728,6 @@ async def get_all_agents(admin_check: bool = Depends(check_admin_permission)):
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_specialized_agents",
-    error_code_prefix="AGENT_CONFIG",
-)
 @router.get("/agents/specialized", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -776,11 +761,6 @@ async def list_specialized_agents(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_specialized_agent",
-    error_code_prefix="AGENT_CONFIG",
-)
 @router.get("/agents/specialized/{agent_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -811,11 +791,6 @@ async def get_specialized_agent(
     return JSONResponse(status_code=200, content=agent)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_agents_usage",
-    error_code_prefix="AGENT_CONFIG",
-)
 @router.get("/agents/usage", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -933,11 +908,6 @@ async def get_agents_usage(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_agent_config",
-    error_code_prefix="AGENT_CONFIG",
-)
 @router.get("/agents/{agent_id}", response_model=AgentConfigDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1065,11 +1035,6 @@ async def _apply_agent_model_update(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_agent_model",
-    error_code_prefix="AGENT_CONFIG",
-)
 @router.post("/agents/{agent_id}/model", response_model=AgentConfigUpdateModelResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1113,11 +1078,6 @@ async def update_agent_model(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="enable_agent",
-    error_code_prefix="AGENT_CONFIG",
-)
 @router.post("/agents/{agent_id}/enable", response_model=AgentConfigEnableDisableResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1169,11 +1129,6 @@ async def enable_agent(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="disable_agent",
-    error_code_prefix="AGENT_CONFIG",
-)
 @router.post("/agents/{agent_id}/disable", response_model=AgentConfigEnableDisableResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1262,11 +1217,6 @@ async def _check_provider_availability(agent_id: str) -> tuple:
     return provider_available, response_time
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="check_agent_health",
-    error_code_prefix="AGENT_CONFIG",
-)
 @router.get("/agents/{agent_id}/health", response_model=AgentConfigHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1313,11 +1263,6 @@ async def check_agent_health(
     return JSONResponse(status_code=200, content=health_status)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_agents_overview",
-    error_code_prefix="AGENT_CONFIG",
-)
 @router.get("/status/overview", response_model=AgentConfigOverviewResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/agent_terminal.py
+++ b/autobot-backend/api/agent_terminal.py
@@ -310,11 +310,6 @@ def get_agent_terminal_service(
 # API Endpoints
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_agent_terminal_session",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.post("/sessions", response_model=AgentTerminalSessionCreateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -370,11 +365,6 @@ async def create_agent_terminal_session(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_agent_terminal_sessions",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.get("/sessions", response_model=AgentTerminalSessionListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -424,11 +414,6 @@ async def list_agent_terminal_sessions(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_agent_terminal_session",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.get("/sessions/{session_id}", response_model=AgentTerminalSessionDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -456,11 +441,6 @@ async def get_agent_terminal_session(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_agent_terminal_session",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.delete("/sessions/{session_id}", response_model=AgentTerminalSessionDeleteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -488,11 +468,6 @@ async def delete_agent_terminal_session(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="execute_agent_command",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.post("/execute", response_model=AgentTerminalExecuteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -531,11 +506,6 @@ async def execute_agent_command(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="approve_agent_command",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.post("/sessions/{session_id}/approve", response_model=AgentTerminalApproveResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -577,11 +547,6 @@ async def approve_agent_command(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="submit_tool_approval",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.post("/tools/approve/{approval_id}", response_model=AgentTerminalToolApprovalResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -621,11 +586,6 @@ async def submit_tool_approval(
     return {"status": "ok", "approval_id": approval_id, "approved": request.approved}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="interrupt_agent_session",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.post("/sessions/{session_id}/interrupt", response_model=AgentTerminalInterruptResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -657,11 +617,6 @@ async def interrupt_agent_session(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="resume_agent_session",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.post("/sessions/{session_id}/resume", response_model=AgentTerminalResumeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -684,11 +639,6 @@ async def resume_agent_session(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_command_state",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.get("/commands/{command_id}", response_model=AgentTerminalCommandStateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -762,11 +712,6 @@ async def get_command_state(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="agent_terminal_info",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.get("/", response_model=AgentTerminalInfoResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -836,11 +781,6 @@ from datetime import datetime, timezone
 _pending_host_selections: Dict[str, Dict] = {}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="request_host_selection",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.post("/host-selection/request", response_model=AgentTerminalHostSelectionRequestResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -895,11 +835,6 @@ async def request_host_selection(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_host_selection",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.get("/host-selection/{request_id}", response_model=AgentTerminalHostSelectionGetResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -939,11 +874,6 @@ async def get_host_selection(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="submit_host_selection",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.post("/host-selection/{request_id}/select", response_model=AgentTerminalHostSelectionSubmitResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1014,11 +944,6 @@ async def submit_host_selection(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cancel_host_selection",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.post("/host-selection/{request_id}/cancel", response_model=AgentTerminalHostSelectionCancelResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1061,11 +986,6 @@ async def cancel_host_selection(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_pending_host_selections",
-    error_code_prefix="AGENT_TERMINAL",
-)
 @router.get("/host-selection", response_model=AgentTerminalPendingSelectionsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/ai_stack_integration.py
+++ b/autobot-backend/api/ai_stack_integration.py
@@ -64,11 +64,6 @@ router = APIRouter(tags=["ai-stack"])
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="ai_stack_health_check",
-    error_code_prefix="AI_STACK",
-)
 @router.get("/health", response_model=DataResponse[AIStackHealthData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -104,11 +99,6 @@ async def ai_stack_health_check(admin_check: bool = Depends(check_admin_permissi
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_ai_agents",
-    error_code_prefix="AI_STACK",
-)
 @router.get("/agents", response_model=DataResponse[AIStackAgentsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -132,11 +122,6 @@ async def list_ai_agents(admin_check: bool = Depends(check_admin_permission)):
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="rag_query",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/rag/query", response_model=DataResponse[AIStackAgentPayload])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -181,11 +166,6 @@ async def rag_query(
     return create_success_response(rag_result, "RAG query completed successfully")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reformulate_query",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/rag/reformulate", response_model=DataResponse[AIStackAgentPayload])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -208,11 +188,6 @@ async def reformulate_query(
     return create_success_response(result, "Query reformulated successfully")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_documents",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/rag/analyze-documents", response_model=DataResponse[AIStackAgentPayload])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -238,11 +213,6 @@ async def analyze_documents(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_chat",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/chat/enhanced", response_model=DataResponse[AIStackAgentPayload])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -295,11 +265,6 @@ async def enhanced_chat(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="extract_knowledge",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/knowledge/extract", response_model=DataResponse[AIStackAgentPayload])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -327,11 +292,6 @@ async def extract_knowledge(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_knowledge_search",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/knowledge/enhanced-search", response_model=DataResponse[EnhancedKnowledgeSearchData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -377,11 +337,6 @@ async def enhanced_knowledge_search(
     return create_success_response(results, "Enhanced knowledge search completed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_knowledge",
-    error_code_prefix="AI_STACK",
-)
 @router.get("/knowledge/system", response_model=DataResponse[AIStackAgentPayload])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -408,11 +363,6 @@ async def get_system_knowledge(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="comprehensive_research",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/research/comprehensive", response_model=DataResponse[ComprehensiveResearchData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -454,11 +404,6 @@ async def comprehensive_research(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="web_research",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/research/web", response_model=DataResponse[AIStackAgentPayload])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -489,11 +434,6 @@ async def web_research(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_code",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/development/search-code", response_model=DataResponse[AIStackAgentPayload])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -518,11 +458,6 @@ async def search_code(
     return create_success_response(result, "Code search completed successfully")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_development_speedup",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/development/analyze-speedup", response_model=DataResponse[AIStackAgentPayload])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -553,11 +488,6 @@ async def analyze_development_speedup(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="classify_content",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/classification/classify", response_model=DataResponse[AIStackAgentPayload])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -685,11 +615,6 @@ async def _execute_sequential_agents(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="multi_agent_query",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/orchestrate/multi-agent-query", response_model=DataResponse[MultiAgentQueryData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -736,11 +661,6 @@ async def multi_agent_query(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="legacy_rag_search",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/legacy/rag-search", response_model=DataResponse[AIStackAgentPayload])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -761,11 +681,6 @@ async def legacy_rag_search(
     return await rag_query(request)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="legacy_enhanced_chat",
-    error_code_prefix="AI_STACK",
-)
 @router.post("/legacy/enhanced-chat", response_model=DataResponse[AIStackAgentPayload])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/analytics.py
+++ b/autobot-backend/api/analytics.py
@@ -129,11 +129,6 @@ async def _get_code_analysis_status() -> Dict[str, Any]:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_dashboard_overview",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/dashboard/overview", response_model=AnalyticsOverview)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -235,11 +230,6 @@ def _check_resource_alerts(system_resources: Dict) -> List[Dict[str, Any]]:
     return alerts
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_detailed_system_health",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/system/health-detailed", response_model=AnalyticsDetailedHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -297,11 +287,6 @@ async def get_detailed_system_health(current_user: Dict = Depends(get_current_us
     return detailed_health
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_performance_metrics",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/performance/metrics", response_model=AnalyticsPerformanceMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -348,11 +333,6 @@ async def get_performance_metrics(current_user: Dict = Depends(get_current_user)
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_communication_patterns",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/communication/patterns", response_model=AnalyticsCommunicationPatternsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -406,11 +386,6 @@ async def get_communication_patterns(current_user: Dict = Depends(get_current_us
     return patterns
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_usage_statistics",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/usage/statistics", response_model=AnalyticsUsageStatisticsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -522,11 +497,6 @@ async def _collect_realtime_metrics_data() -> Dict[str, Any]:
     return realtime_data
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_realtime_metrics",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/realtime/metrics", response_model=AnalyticsRealtimeMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -538,11 +508,6 @@ async def get_realtime_metrics(current_user: Dict = Depends(get_current_user)):
     return await _collect_realtime_metrics_data()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="track_analytics_event",
-    error_code_prefix="ANALYTICS",
-)
 @router.post("/events/track", response_model=AnalyticsTrackEventResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -648,11 +613,6 @@ def _compute_hourly_stats(historical_calls: list) -> dict:
     return dict(hourly_stats)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_historical_trends",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/trends/historical", response_model=AnalyticsHistoricalTrendsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -745,11 +705,6 @@ async def _realtime_loop_iteration(websocket: WebSocket) -> tuple[bool, bool]:
         return send_ok, False
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="websocket_realtime_analytics",
-    error_code_prefix="ANALYTICS",
-)
 @router.websocket("/ws/realtime")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -791,11 +746,6 @@ async def websocket_realtime_analytics(websocket: WebSocket):
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_analytics_collection",
-    error_code_prefix="ANALYTICS",
-)
 @router.post("/collection/start", response_model=AnalyticsCollectionStartResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -822,11 +772,6 @@ async def start_analytics_collection(current_user: Dict = Depends(get_current_us
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="stop_analytics_collection",
-    error_code_prefix="ANALYTICS",
-)
 @router.post("/collection/stop", response_model=AnalyticsCollectionStopResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -887,11 +832,6 @@ async def _check_analytics_redis_connectivity() -> Dict[str, str]:
     return connectivity
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_analytics_status",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/status", response_model=AnalyticsStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1200,11 +1140,6 @@ async def _live_analytics_loop_iteration(
         return send_ok, last_performance_update, last_api_update, last_health_update
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="websocket_live_analytics",
-    error_code_prefix="ANALYTICS",
-)
 @router.websocket("/ws/analytics/live")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1288,11 +1223,6 @@ async def websocket_live_analytics(websocket: WebSocket):
 # ------------------------------------------------------------------
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_root_cause",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/root-cause/{task_id}", response_model=AnalyticsRootCauseResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,

--- a/autobot-backend/api/analytics_agents.py
+++ b/autobot-backend/api/analytics_agents.py
@@ -50,11 +50,6 @@ router = APIRouter(prefix="/agents", tags=["analytics", "agents"])
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_all_agents_performance",
-    error_code_prefix="AGENT",
-)
 @router.get("/performance", response_model=AgentAllPerformanceResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -90,11 +85,6 @@ async def get_all_agents_performance(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_agent_performance",
-    error_code_prefix="AGENT",
-)
 @router.get("/performance/{agent_id}", response_model=AgentMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -138,11 +128,6 @@ async def get_agent_performance(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_agent_history",
-    error_code_prefix="AGENT",
-)
 @router.get("/{agent_id}/history", response_model=AgentHistoryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -171,11 +156,6 @@ async def get_agent_history(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_recent_tasks",
-    error_code_prefix="AGENT",
-)
 @router.get("/tasks/recent", response_model=AgentRecentTasksResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -207,11 +187,6 @@ async def get_recent_tasks(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="compare_agents",
-    error_code_prefix="AGENT",
-)
 @router.get("/comparison", response_model=AgentComparisonResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -303,11 +278,6 @@ def _check_agent_metrics(metrics) -> list:
     return recommendations
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_agent_recommendations",
-    error_code_prefix="AGENT",
-)
 @router.get("/recommendations", response_model=AgentRecommendationsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -361,11 +331,6 @@ async def get_agent_recommendations(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_performance_trends",
-    error_code_prefix="AGENT",
-)
 @router.get("/trends", response_model=AgentPerformanceTrendsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -392,11 +357,6 @@ async def get_performance_trends(
     return trends
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_agent_types",
-    error_code_prefix="AGENT",
-)
 @router.get("/types", response_model=AgentTypesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -424,11 +384,6 @@ async def get_agent_types(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="track_task_start",
-    error_code_prefix="AGENT",
-)
 @router.post("/tasks/start", response_model=AgentTaskStartResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -462,11 +417,6 @@ async def track_task_start(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="track_task_complete",
-    error_code_prefix="AGENT",
-)
 @router.post("/tasks/complete", response_model=AgentTaskCompleteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/analytics_behavior.py
+++ b/autobot-backend/api/analytics_behavior.py
@@ -53,11 +53,6 @@ router = APIRouter(prefix="/behavior", tags=["analytics", "behavior"])
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="track_user_event",
-    error_code_prefix="BEHAVIOR",
-)
 @router.post("/track", response_model=BehaviorTrackEventResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -97,11 +92,6 @@ async def track_user_event(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_recent_events",
-    error_code_prefix="BEHAVIOR",
-)
 @router.get("/events/recent", response_model=BehaviorRecentEventsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -135,11 +125,6 @@ async def get_recent_events(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_feature_metrics",
-    error_code_prefix="BEHAVIOR",
-)
 @router.get("/features", response_model=BehaviorFeatureMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -165,11 +150,6 @@ async def get_feature_metrics(
     return metrics
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_feature_comparison",
-    error_code_prefix="BEHAVIOR",
-)
 @router.get("/features/comparison", response_model=BehaviorFeatureComparisonResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -222,11 +202,6 @@ async def get_feature_comparison(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_user_journey",
-    error_code_prefix="BEHAVIOR",
-)
 @router.get("/journey/{session_id}", response_model=UserJourneyResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -260,11 +235,6 @@ async def get_user_journey(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_engagement_metrics",
-    error_code_prefix="BEHAVIOR",
-)
 @router.get("/engagement", response_model=BehaviorEngagementResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -293,11 +263,6 @@ async def get_engagement_metrics(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_daily_stats",
-    error_code_prefix="BEHAVIOR",
-)
 @router.get("/stats/daily", response_model=BehaviorDailyStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -323,11 +288,6 @@ async def get_daily_stats(
     return stats
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_usage_heatmap",
-    error_code_prefix="BEHAVIOR",
-)
 @router.get("/stats/heatmap", response_model=BehaviorHeatmapResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -351,11 +311,6 @@ async def get_usage_heatmap(
     return heatmap
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_peak_usage",
-    error_code_prefix="BEHAVIOR",
-)
 @router.get("/stats/peak", response_model=BehaviorPeakUsageResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -411,11 +366,6 @@ async def get_peak_usage(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_behavior_summary",
-    error_code_prefix="BEHAVIOR",
-)
 @router.get("/summary", response_model=BehaviorSummaryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/analytics_cfg.py
+++ b/autobot-backend/api/analytics_cfg.py
@@ -1063,11 +1063,6 @@ def _calculate_cfg_summary(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_cfg",
-    error_code_prefix="CFG",
-)
 @router.post("/analyze", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1124,11 +1119,6 @@ async def analyze_control_flow(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_cfg_file",
-    error_code_prefix="CFG",
-)
 @router.post("/analyze-file", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1210,11 +1200,6 @@ def _convert_cfg_to_dot(graph: ControlFlowGraph) -> Dict[str, str]:
     return {"function_name": graph.function_name, "dot": "\n".join(dot_lines)}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_cfg_dot",
-    error_code_prefix="CFG",
-)
 @router.post("/export/dot", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1240,11 +1225,6 @@ async def export_cfg_dot(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_complexity_metrics",
-    error_code_prefix="CFG",
-)
 @router.post("/complexity", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1304,11 +1284,6 @@ async def get_complexity_metrics(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="detect_unreachable",
-    error_code_prefix="CFG",
-)
 @router.post("/unreachable", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1345,11 +1320,6 @@ async def detect_unreachable_code(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="detect_infinite_loops",
-    error_code_prefix="CFG",
-)
 @router.post("/infinite-loops", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1394,11 +1364,6 @@ async def detect_infinite_loops(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cfg_health",
-    error_code_prefix="CFG",
-)
 @router.get("/health", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/analytics_code.py
+++ b/autobot-backend/api/analytics_code.py
@@ -53,11 +53,6 @@ def set_analytics_dependencies(controller, state):
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="index_codebase",
-    error_code_prefix="ANALYTICS",
-)
 @router.post("/code/index", response_model=AnalyticsCodeIndexResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -93,11 +88,6 @@ async def index_codebase(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_code_analysis_status",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/code/status", response_model=AnalyticsCodeStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -154,11 +144,6 @@ async def get_code_analysis_status(
     return status
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_code_quality_assessment",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/quality/assessment", response_model=AnalyticsCodeQualityAssessmentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -228,11 +213,6 @@ async def get_code_quality_assessment(
     return quality_assessment
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_code_quality_metrics",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/code/quality-metrics", response_model=AnalyticsCodeQualityMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -343,11 +323,6 @@ def _build_chain_insights(static_endpoints: list, runtime_patterns: dict) -> lis
     return insights
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_communication_chains",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/code/communication-chains", response_model=AnalyticsCodeCommunicationChainsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -476,11 +451,6 @@ def _generate_communication_chain_insights(
     return insights
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_communication_chains_detailed",
-    error_code_prefix="ANALYTICS",
-)
 @router.post("/code/analyze/communication-chains", response_model=AnalyticsCodeCommunicationChainsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -625,11 +595,6 @@ def _score_to_grade(score: float) -> str:
     return "F"
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_code_quality_score",
-    error_code_prefix="ANALYTICS",
-)
 @router.get("/code/metrics/quality-score", response_model=AnalyticsCodeQualityScoreResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/analytics_conversation.py
+++ b/autobot-backend/api/analytics_conversation.py
@@ -734,11 +734,6 @@ async def load_chat_sessions(hours: int = 24) -> List[Dict[str, Any]]:
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_conversations",
-    error_code_prefix="CONVFLOW",
-)
 @router.get("/analyze", response_model=ConversationAnalysisResult)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -794,11 +789,6 @@ async def analyze_conversations(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_intent_stats",
-    error_code_prefix="CONVFLOW",
-)
 @router.get("/intents", response_model=ConversationIntentsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -862,11 +852,6 @@ async def get_intent_stats(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_flow_paths",
-    error_code_prefix="CONVFLOW",
-)
 @router.get("/flows", response_model=ConversationFlowsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -935,11 +920,6 @@ async def get_flow_paths(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_bottlenecks",
-    error_code_prefix="CONVFLOW",
-)
 @router.get("/bottlenecks", response_model=ConversationBottlenecksResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -979,11 +959,6 @@ async def get_bottlenecks(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_hourly_distribution",
-    error_code_prefix="CONVFLOW",
-)
 @router.get("/distribution", response_model=ConversationDistributionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1028,11 +1003,6 @@ async def get_hourly_distribution(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="detect_intent",
-    error_code_prefix="CONVFLOW",
-)
 @router.post("/detect-intent", response_model=ConversationDetectIntentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/analytics_cost.py
+++ b/autobot-backend/api/analytics_cost.py
@@ -53,11 +53,6 @@ router = APIRouter(prefix="/cost", tags=["analytics", "cost"])
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_cost_summary",
-    error_code_prefix="COST",
-)
 @router.get("/summary", response_model=CostSummaryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -92,11 +87,6 @@ async def get_cost_summary(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_cost_by_model",
-    error_code_prefix="COST",
-)
 @router.get("/by-model", response_model=CostByModelResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -144,11 +134,6 @@ async def get_cost_by_model(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_cost_by_session",
-    error_code_prefix="COST",
-)
 @router.get("/by-session/{session_id}", response_model=SessionCostResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -184,11 +169,6 @@ async def get_cost_by_session(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_cost_trends",
-    error_code_prefix="COST",
-)
 @router.get("/trends", response_model=CostTrendResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -222,11 +202,6 @@ async def get_cost_trends(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_cost_forecast",
-    error_code_prefix="COST",
-)
 @router.get("/forecast", response_model=CostForecastResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -290,11 +265,6 @@ async def get_cost_forecast(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_recent_usage",
-    error_code_prefix="COST",
-)
 @router.get("/usage/recent", response_model=UsageRecentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -328,11 +298,6 @@ async def get_recent_usage(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_model_pricing",
-    error_code_prefix="COST",
-)
 @router.get("/pricing", response_model=ModelPricingResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -385,11 +350,6 @@ async def get_model_pricing(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="calculate_cost_estimate",
-    error_code_prefix="COST",
-)
 @router.get("/estimate", response_model=CostEstimateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -426,11 +386,6 @@ async def calculate_cost_estimate(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="set_budget_alert",
-    error_code_prefix="COST",
-)
 @router.post("/budget-alert", response_model=BudgetAlertCreateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -468,11 +423,6 @@ async def set_budget_alert(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_budget_alerts",
-    error_code_prefix="COST",
-)
 @router.get("/budget-alerts", response_model=BudgetAlertsListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -567,11 +517,6 @@ async def _get_current_costs(tracker, today: datetime) -> dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_budget_status",
-    error_code_prefix="COST",
-)
 @router.get("/budget-status", response_model=BudgetStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -612,11 +557,6 @@ async def get_budget_status(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_cost_by_agent_all",
-    error_code_prefix="COST",
-)
 @router.get("/by-agent", response_model=AllAgentCostsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -662,11 +602,6 @@ async def get_cost_by_agent_all(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_cost_by_agent_single",
-    error_code_prefix="COST",
-)
 @router.get("/by-agent/{agent_id}", response_model=SingleAgentCostResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -692,11 +627,6 @@ async def get_cost_by_agent_single(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="set_agent_budget",
-    error_code_prefix="COST",
-)
 @router.put("/by-agent/{agent_id}/budget", response_model=AgentBudgetSetResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -718,11 +648,6 @@ async def set_agent_budget(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_agent_budget_status",
-    error_code_prefix="COST",
-)
 @router.get("/by-agent/{agent_id}/budget", response_model=AgentBudgetStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/analytics_debt.py
+++ b/autobot-backend/api/analytics_debt.py
@@ -493,11 +493,6 @@ def _get_latest_debt_data() -> Optional[Dict[str, Any]]:
         return None
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="calculate_debt",
-    error_code_prefix="DEBT",
-)
 @router.post("/calculate", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -547,11 +542,6 @@ async def calculate_technical_debt(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_debt_summary",
-    error_code_prefix="DEBT",
-)
 @router.get("/summary", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -584,11 +574,6 @@ async def get_debt_summary(admin_check: bool = Depends(check_admin_permission)):
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_debt_by_category",
-    error_code_prefix="DEBT",
-)
 @router.get("/by-category/{category}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -689,11 +674,6 @@ def _calculate_trend_change(trend_data: List[Dict[str, Any]]) -> tuple:
     return change, direction
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_debt_trends",
-    error_code_prefix="DEBT",
-)
 @router.get("/trends", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -726,11 +706,6 @@ async def get_debt_trends(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_roi_priorities",
-    error_code_prefix="DEBT",
-)
 @router.get("/roi-priorities", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -857,11 +832,6 @@ def _generate_markdown_report(debt_data: dict) -> str:
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_debt_report",
-    error_code_prefix="DEBT",
-)
 @router.get("/report", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/analytics_evolution.py
+++ b/autobot-backend/api/analytics_evolution.py
@@ -326,11 +326,6 @@ def _build_timeline_response(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_evolution_timeline",
-    error_code_prefix="EVOLUTION",
-)
 @router.get("/timeline", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -401,11 +396,6 @@ async def get_evolution_timeline(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_pattern_evolution",
-    error_code_prefix="EVOLUTION",
-)
 @router.get("/patterns", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -580,11 +570,6 @@ def _build_trends_success_response(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_quality_trends",
-    error_code_prefix="EVOLUTION",
-)
 @router.get("/trends", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -657,11 +642,6 @@ async def get_quality_trends(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="record_snapshot",
-    error_code_prefix="EVOLUTION",
-)
 @router.post("/snapshot", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -699,11 +679,6 @@ async def record_quality_snapshot(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="record_pattern_snapshot",
-    error_code_prefix="EVOLUTION",
-)
 @router.post("/pattern-snapshot", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -823,11 +798,6 @@ def _generate_json_export_response(timeline_data: list) -> JSONResponse:
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_evolution_data",
-    error_code_prefix="EVOLUTION",
-)
 @router.get("/export", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -889,11 +859,6 @@ async def export_evolution_data(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_evolution_summary",
-    error_code_prefix="EVOLUTION",
-)
 @router.get("/summary", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1229,11 +1194,6 @@ def _validate_evolution_repo_path(repo_path_str: str):
     return repo_path, None  # codeql[py/path-injection]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="trigger_evolution_analysis",
-    error_code_prefix="EVOLUTION",
-)
 @router.post("/analyze", response_model=EvolutionAnalysisResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/analytics_export.py
+++ b/autobot-backend/api/analytics_export.py
@@ -41,11 +41,6 @@ router = APIRouter(prefix="/export", tags=["analytics", "export"])
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_cost_csv",
-    error_code_prefix="EXPORT",
-)
 @router.get("/csv/costs", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -92,11 +87,6 @@ async def export_cost_csv(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_agent_csv",
-    error_code_prefix="EXPORT",
-)
 @router.get("/csv/agents", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -150,11 +140,6 @@ async def export_agent_csv(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_usage_csv",
-    error_code_prefix="EXPORT",
-)
 @router.get("/csv/usage", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -226,11 +211,6 @@ async def export_usage_csv(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_full_json",
-    error_code_prefix="EXPORT",
-)
 @router.get("/json/full", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -389,11 +369,6 @@ def _build_agent_metrics_lines(agent_metrics: list) -> list[str]:
     return lines
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_prometheus",
-    error_code_prefix="EXPORT",
-)
 @router.get("/prometheus", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -570,11 +545,6 @@ def _get_grafana_panels() -> list:
     return panels
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_grafana_dashboard",
-    error_code_prefix="EXPORT",
-)
 @router.get("/grafana-dashboard", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -631,11 +601,6 @@ async def export_grafana_dashboard(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_export_formats",
-    error_code_prefix="EXPORT",
-)
 @router.get("/formats", response_model=ExportFormatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/analytics_log_patterns.py
+++ b/autobot-backend/api/analytics_log_patterns.py
@@ -782,11 +782,6 @@ def _build_mining_summary(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="mine_log_patterns",
-    error_code_prefix="LOGPAT",
-)
 @router.get("/mine", response_model=PatternMiningResult)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -878,11 +873,6 @@ def _analyze_pattern_lines(
     return timestamps, levels, sources, hourly_dist
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_pattern_details",
-    error_code_prefix="LOGPAT",
-)
 @router.get("/pattern/{pattern_id}", response_model=LogPatternDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -932,11 +922,6 @@ async def get_pattern_details(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_error_hotspots",
-    error_code_prefix="LOGPAT",
-)
 @router.get("/hotspots", response_model=LogPatternHotspotsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1015,11 +1000,6 @@ def _aggregate_log_stats(
     return total, by_level, by_source, by_hour, timestamps
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_log_stats",
-    error_code_prefix="LOGPAT",
-)
 @router.get("/stats", response_model=LogPatternStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1064,11 +1044,6 @@ async def get_log_stats(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_realtime_summary",
-    error_code_prefix="LOGPAT",
-)
 @router.get("/realtime", response_model=LogPatternRealtimeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/analytics_maintenance.py
+++ b/autobot-backend/api/analytics_maintenance.py
@@ -63,11 +63,6 @@ router = APIRouter(tags=["analytics", "advanced"])
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_maintenance_recommendations",
-    error_code_prefix="MAINT",
-)
 @router.get("/maintenance", response_model=MaintenanceRecommendationsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -109,11 +104,6 @@ async def get_maintenance_recommendations(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_maintenance_by_category",
-    error_code_prefix="MAINT",
-)
 @router.get("/maintenance/category/{category}", response_model=MaintenanceByCategoryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -143,11 +133,6 @@ async def get_maintenance_by_category(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_maintenance_summary",
-    error_code_prefix="MAINT",
-)
 @router.get("/maintenance/summary", response_model=MaintenanceSummaryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -214,11 +199,6 @@ async def get_maintenance_summary(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_resource_optimizations",
-    error_code_prefix="OPT",
-)
 @router.get("/optimization", response_model=OptimizationRecommendationsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -261,11 +241,6 @@ async def get_resource_optimizations(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_optimization_by_type",
-    error_code_prefix="OPT",
-)
 @router.get("/optimization/type/{resource_type}", response_model=OptimizationByTypeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -295,11 +270,6 @@ async def get_optimization_by_type(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_quick_wins",
-    error_code_prefix="OPT",
-)
 @router.get("/optimization/quick-wins", response_model=OptimizationQuickWinsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -342,11 +312,6 @@ async def get_quick_wins(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_unified_dashboard",
-    error_code_prefix="DASH",
-)
 @router.get("/dashboard", response_model=MaintenanceDashboardResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -370,11 +335,6 @@ async def get_unified_dashboard(
     return dashboard
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_health_status",
-    error_code_prefix="HEALTH",
-)
 @router.get("/health", response_model=MaintenanceHealthStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -413,11 +373,6 @@ async def get_health_status(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="generate_custom_report",
-    error_code_prefix="REPORT",
-)
 @router.post("/report", response_model=MaintenanceCustomReportResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -454,11 +409,6 @@ async def generate_custom_report(
     return report
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_executive_summary",
-    error_code_prefix="REPORT",
-)
 @router.get("/report/executive", response_model=MaintenanceCustomReportResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -496,11 +446,6 @@ async def get_executive_summary(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_insights",
-    error_code_prefix="INSIGHT",
-)
 @router.get("/insights", response_model=MaintenanceInsightsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -569,11 +514,6 @@ async def get_insights(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_trends_analysis",
-    error_code_prefix="TREND",
-)
 @router.get("/trends", response_model=MaintenanceTrendsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/analytics_reporting.py
+++ b/autobot-backend/api/analytics_reporting.py
@@ -287,10 +287,6 @@ def _build_unified_report_response(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.API,
-    error_code_prefix="UNIFIED",
-)
 @router.get("/report", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -331,10 +327,6 @@ async def get_unified_report():
     return JSONResponse(content=response)
 
 
-@with_error_handling(
-    category=ErrorCategory.API,
-    error_code_prefix="UNIFIED",
-)
 @router.get("/summary", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -372,10 +364,6 @@ async def get_quick_summary():
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.API,
-    error_code_prefix="UNIFIED",
-)
 @router.get("/trends", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/anti_pattern.py
+++ b/autobot-backend/api/anti_pattern.py
@@ -161,11 +161,6 @@ def _get_health_grade(score: float) -> tuple:
 # ============ API Endpoints ============
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_anti_patterns",
-    error_code_prefix="ANTI_PATTERN",
-)
 @router.post("/analyze", response_model=AnalysisResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -223,11 +218,6 @@ async def analyze_anti_patterns(request: AntiPatternAnalysisRequest):
         raise HTTPException(status_code=500, detail="Analysis failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_cached_analysis",
-    error_code_prefix="ANTI_PATTERN",
-)
 @router.get("/cached", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -262,11 +252,6 @@ async def get_cached_analysis():
         raise HTTPException(status_code=500, detail="Failed to retrieve cache")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_god_classes",
-    error_code_prefix="ANTI_PATTERN",
-)
 @router.post("/god-classes", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -317,11 +302,6 @@ async def detect_god_classes(request: AntiPatternAnalysisRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_circular_dependencies",
-    error_code_prefix="ANTI_PATTERN",
-)
 @router.post("/circular-dependencies", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -367,11 +347,6 @@ async def detect_circular_dependencies(request: AntiPatternAnalysisRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_feature_envy",
-    error_code_prefix="ANTI_PATTERN",
-)
 @router.post("/feature-envy", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -418,11 +393,6 @@ async def detect_feature_envy(request: AntiPatternAnalysisRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_code_smells",
-    error_code_prefix="ANTI_PATTERN",
-)
 @router.post("/code-smells", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -480,11 +450,6 @@ async def detect_code_smells(request: AntiPatternAnalysisRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_dead_code",
-    error_code_prefix="ANTI_PATTERN",
-)
 @router.post("/dead-code", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -530,11 +495,6 @@ async def detect_dead_code(request: AntiPatternAnalysisRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_health_score",
-    error_code_prefix="ANTI_PATTERN",
-)
 @router.post("/health-score", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/audit.py
+++ b/autobot-backend/api/audit.py
@@ -102,11 +102,6 @@ def _build_query_dict(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="query_audit_logs",
-    error_code_prefix="AUDIT",
-)
 @router.get("/logs", response_model=AuditQueryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -175,11 +170,6 @@ async def query_audit_logs(
         raise_server_error("API_0003", "Audit log query error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_audit_statistics",
-    error_code_prefix="AUDIT",
-)
 @router.get("/statistics", response_model=AuditStatisticsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -212,11 +202,6 @@ async def get_audit_statistics(
         raise_server_error("API_0003", "Statistics error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_session_audit_trail",
-    error_code_prefix="AUDIT",
-)
 @router.get("/session/{session_id}", response_model=AuditQueryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -261,11 +246,6 @@ async def get_session_audit_trail(
         raise_server_error("API_0003", "Session audit query error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_user_audit_trail",
-    error_code_prefix="AUDIT",
-)
 @router.get("/user/{user_id}", response_model=AuditQueryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -310,11 +290,6 @@ async def get_user_audit_trail(
         raise_server_error("API_0003", "User audit query error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_failed_operations",
-    error_code_prefix="AUDIT",
-)
 @router.get("/failures", response_model=AuditQueryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -364,11 +339,6 @@ async def get_failed_operations(
         raise_server_error("API_0003", "Failed operations query error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cleanup_old_logs",
-    error_code_prefix="AUDIT",
-)
 @router.post("/cleanup", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -414,11 +384,6 @@ async def cleanup_old_logs(
         raise_server_error("API_0003", "Cleanup error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_operation_types",
-    error_code_prefix="AUDIT",
-)
 @router.get("/operations", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -138,11 +138,6 @@ async def _authenticate_and_build_user_data(
     return user_data
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="login",
-    error_code_prefix="AUTH",
-)
 @router.post("/login", response_model=LoginResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -224,11 +219,6 @@ async def login(request: Request, login_data: LoginRequest):
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="logout",
-    error_code_prefix="AUTH",
-)
 @router.post("/logout", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -260,11 +250,6 @@ async def logout(request: Request, logout_data: LogoutRequest):
         return {"success": True, "message": "Logged out successfully"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_current_user_info",
-    error_code_prefix="AUTH",
-)
 @router.get("/me", response_model=AuthUserInfoResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -314,11 +299,6 @@ async def get_current_user_info(request: Request):
         raise HTTPException(status_code=500, detail="Error retrieving user information")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="check_authentication",
-    error_code_prefix="AUTH",
-)
 @router.get("/check", response_model=AuthCheckResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -363,11 +343,6 @@ async def check_authentication(request: Request):
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="check_permission",
-    error_code_prefix="AUTH",
-)
 @router.get("/permissions/{operation}", response_model=AuthPermissionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -456,11 +431,6 @@ def _persist_password_change(username: str, new_password_hash: str) -> None:
     config_manager.save_settings()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="change_password",
-    error_code_prefix="AUTH",
-)
 @router.post("/change-password", response_model=ChangePasswordResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -522,11 +492,6 @@ async def change_password(request: Request, password_data: ChangePasswordRequest
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="signup",
-    error_code_prefix="AUTH",
-)
 @router.post("/signup", response_model=SignupResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -603,11 +568,6 @@ def _decode_refresh_token(token: str) -> Dict:
     return payload
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="refresh_token",
-    error_code_prefix="AUTH",
-)
 @router.post("/refresh", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/batch_jobs.py
+++ b/autobot-backend/api/batch_jobs.py
@@ -95,11 +95,6 @@ def _deserialize_job(data: str) -> BatchJob:
 # =============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_batch_job",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.post("", response_model=BatchJob)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -147,11 +142,6 @@ async def create_batch_job(
     return job
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_batch_jobs",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.get("", response_model=BatchJobList)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -211,11 +201,6 @@ async def list_batch_jobs(
     return BatchJobList(jobs=jobs, total_count=total_count, status_counts=status_counts)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_batch_job",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.get("/{job_id}", response_model=BatchJob)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -250,11 +235,6 @@ async def get_batch_job(
     return _deserialize_job(job_data.decode("utf-8"))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_batch_job",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.delete("/{job_id}", response_model=BatchJobDeleteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -303,11 +283,6 @@ async def delete_batch_job(
     return {"status": "success", "job_id": job_id, "message": "Job deleted"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_job_logs",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.get("/{job_id}/logs", response_model=List[BatchLogEntry])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -353,11 +328,6 @@ async def get_job_logs(
 # =============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_batch_templates",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.get("/templates/", response_model=List[BatchTemplate])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -391,11 +361,6 @@ async def list_batch_templates(
     return templates
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_batch_template",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.post("/templates/", response_model=BatchTemplate)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -434,11 +399,6 @@ async def create_batch_template(
     return template
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_batch_template",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.get("/templates/{template_id}", response_model=BatchTemplate)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -468,11 +428,6 @@ async def get_batch_template(
     return BatchTemplate(**template_dict)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_batch_template",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.delete("/templates/{template_id}", response_model=BatchTemplateDeleteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -508,11 +463,6 @@ async def delete_batch_template(
 # =============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_batch_schedules",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.get("/schedules/", response_model=List[BatchSchedule])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -546,11 +496,6 @@ async def list_batch_schedules(
     return schedules
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_batch_schedule",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.post("/schedules/", response_model=BatchSchedule)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -593,11 +538,6 @@ async def create_batch_schedule(
     return schedule
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_batch_schedule",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.delete("/schedules/{schedule_id}", response_model=BatchScheduleDeleteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -633,11 +573,6 @@ async def delete_batch_schedule(
 # =============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_batch_jobs_health",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.get("/health", response_model=BatchJobsHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -717,11 +652,6 @@ def _process_session_file(filename: str, chats_directory: str):
         return None
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_batch_status",
-    error_code_prefix="BATCH",
-)
 @router.get("/status", response_model=BatchStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -740,11 +670,6 @@ async def get_batch_status():
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="batch_load",
-    error_code_prefix="BATCH",
-)
 @router.post("/load", response_model=BatchLoadResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -799,11 +724,6 @@ async def batch_load(batch_request: APIBatchRequest):
     return APIBatchResponse(responses=responses, errors=errors, timing=timing)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="batch_chat_initialization",
-    error_code_prefix="BATCH_JOBS",
-)
 @router.get("/chat-init", response_model=BatchChatInitResponse)
 @router.post("/chat-init", response_model=BatchChatInitResponse)
 @with_error_handling(

--- a/autobot-backend/api/bi_export_endpoints.py
+++ b/autobot-backend/api/bi_export_endpoints.py
@@ -34,11 +34,6 @@ router = APIRouter(tags=["bi-reports"])
 # =========================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="save_report",
-    error_code_prefix="BI_EXPORT_ENDPOINTS",
-)
 @router.post("/reports/save", response_model=SavedReportResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -64,11 +59,6 @@ async def save_report(
 # =========================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_saved_reports",
-    error_code_prefix="BI_EXPORT_ENDPOINTS",
-)
 @router.get("/reports/saved", response_model=SavedReportsListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -89,11 +79,6 @@ async def list_saved_reports(
 # =========================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_saved_report",
-    error_code_prefix="BI_EXPORT_ENDPOINTS",
-)
 @router.get("/reports/saved/{report_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -120,11 +105,6 @@ async def get_saved_report(
 # =========================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_saved_report",
-    error_code_prefix="BI_EXPORT_ENDPOINTS",
-)
 @router.put("/reports/saved/{report_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -157,11 +137,6 @@ async def update_saved_report(
 # =========================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_saved_report",
-    error_code_prefix="BI_EXPORT_ENDPOINTS",
-)
 @router.delete("/reports/saved/{report_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -188,11 +163,6 @@ async def delete_saved_report(
 # =========================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="run_saved_report",
-    error_code_prefix="BI_EXPORT_ENDPOINTS",
-)
 @router.post("/reports/saved/{report_id}/run", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/browser_mcp.py
+++ b/autobot-backend/api/browser_mcp.py
@@ -464,11 +464,6 @@ def _get_browser_extraction_tools() -> List[MCPTool]:
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_browser_mcp_tools",
-    error_code_prefix="BROWSER_MCP",
-)
 @router.get("/mcp/tools", response_model=List[MCPTool])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -531,11 +526,6 @@ async def send_to_browser_vm(action: str, params: Metadata) -> Metadata:
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="navigate_mcp",
-    error_code_prefix="BROWSER_MCP",
-)
 @router.post("/mcp/navigate", response_model=BrowserNavigateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -573,11 +563,6 @@ async def navigate_mcp(request: BrowserNavigateRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="click_mcp",
-    error_code_prefix="BROWSER_MCP",
-)
 @router.post("/mcp/click", response_model=BrowserClickResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -605,11 +590,6 @@ async def click_mcp(request: BrowserClickRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="fill_mcp",
-    error_code_prefix="BROWSER_MCP",
-)
 @router.post("/mcp/fill", response_model=BrowserFillResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -642,11 +622,6 @@ async def fill_mcp(request: BrowserFillRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="screenshot_mcp",
-    error_code_prefix="BROWSER_MCP",
-)
 @router.post("/mcp/screenshot", response_model=BrowserScreenshotResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -678,11 +653,6 @@ async def screenshot_mcp(request: BrowserScreenshotRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="evaluate_mcp",
-    error_code_prefix="BROWSER_MCP",
-)
 @router.post("/mcp/evaluate", response_model=BrowserEvaluateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -713,11 +683,6 @@ async def evaluate_mcp(request: BrowserEvaluateRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="wait_for_selector_mcp",
-    error_code_prefix="BROWSER_MCP",
-)
 @router.post("/mcp/wait_for_selector", response_model=BrowserWaitForSelectorResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -750,11 +715,6 @@ async def wait_for_selector_mcp(request: BrowserWaitForSelectorRequest) -> Metad
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_text_mcp",
-    error_code_prefix="BROWSER_MCP",
-)
 @router.post("/mcp/get_text", response_model=BrowserGetTextResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -779,11 +739,6 @@ async def get_text_mcp(request: BrowserGetTextRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_attribute_mcp",
-    error_code_prefix="BROWSER_MCP",
-)
 @router.post("/mcp/get_attribute", response_model=BrowserGetAttributeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -812,11 +767,6 @@ async def get_attribute_mcp(request: BrowserGetAttributeRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="select_mcp",
-    error_code_prefix="BROWSER_MCP",
-)
 @router.post("/mcp/select", response_model=BrowserSelectResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -845,11 +795,6 @@ async def select_mcp(request: BrowserSelectRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="hover_mcp",
-    error_code_prefix="BROWSER_MCP",
-)
 @router.post("/mcp/hover", response_model=BrowserHoverResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -874,11 +819,6 @@ async def hover_mcp(request: BrowserHoverRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_browser_mcp_status",
-    error_code_prefix="BROWSER_MCP",
-)
 @router.get("/mcp/status", response_model=BrowserMcpStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/cache_management.py
+++ b/autobot-backend/api/cache_management.py
@@ -125,11 +125,6 @@ def _process_data_type_stats_results(
 # ── Redis-level endpoints (consolidated from cache.py, Issue #1286) ──
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_cache_stats",
-    error_code_prefix="CACHE",
-)
 @router.get("/stats", response_model=RedisStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -179,11 +174,6 @@ async def get_cache_stats():
     return {"status": "success", "stats": stats}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_redis_cache",
-    error_code_prefix="CACHE",
-)
 @router.post("/redis/clear/{database}", response_model=RedisClearResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -230,11 +220,6 @@ async def clear_redis_cache(database: str):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_cache_type",
-    error_code_prefix="CACHE",
-)
 @router.post("/clear/{cache_type}", response_model=CacheClearTypeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -264,11 +249,6 @@ async def clear_cache_type(cache_type: str):
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="save_cache_config",
-    error_code_prefix="CACHE",
-)
 @router.post("/config", response_model=CacheConfigResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -303,11 +283,6 @@ async def save_cache_config(config_data: Metadata):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_cache_config",
-    error_code_prefix="CACHE",
-)
 @router.get("/config", response_model=CacheConfigResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -337,11 +312,6 @@ async def get_cache_config():
     return {"status": "success", "config": default_config, "source": "default"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="warmup_caches",
-    error_code_prefix="CACHE",
-)
 @router.post("/warmup", response_model=CacheWarmupResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -368,11 +338,6 @@ async def warmup_caches():
 # ── Advanced cache management endpoints ──
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_advanced_cache_stats",
-    error_code_prefix="CACHE_MANAGEMENT",
-)
 @router.get("/advanced-stats", response_model=CacheStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -416,11 +381,6 @@ async def get_advanced_cache_stats(
         raise HTTPException(status_code=500, detail="Error getting cache stats")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="warm_cache",
-    error_code_prefix="CACHE_MANAGEMENT",
-)
 @router.post("/warm", response_model=WarmCacheResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -465,11 +425,6 @@ async def warm_cache(
         raise HTTPException(status_code=500, detail="Error warming cache")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="invalidate_cache",
-    error_code_prefix="CACHE_MANAGEMENT",
-)
 @router.delete("/invalidate/{data_type}", response_model=InvalidateCacheResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -502,11 +457,6 @@ async def invalidate_cache(
         raise HTTPException(status_code=500, detail="Error invalidating cache")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_all_cache",
-    error_code_prefix="CACHE_MANAGEMENT",
-)
 @router.post("/clear-all", response_model=ClearAllResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -653,11 +603,6 @@ async def _warm_data_type(data_type: str, force_refresh: bool = False) -> bool:
         return False
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cache_health_check",
-    error_code_prefix="CACHE_MANAGEMENT",
-)
 @router.get("/health", response_model=CacheHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -689,11 +634,6 @@ async def cache_health_check():
 # =========================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="semantic_cache_stats",
-    error_code_prefix="CACHE_MANAGEMENT",
-)
 @router.get("/semantic-cache/stats", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -710,11 +650,6 @@ async def semantic_cache_stats(
     return cache.get_stats()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="semantic_cache_clear",
-    error_code_prefix="CACHE_MANAGEMENT",
-)
 @router.delete("/semantic-cache/clear", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -732,11 +667,6 @@ async def semantic_cache_clear(
     return {"status": "cleared", **result}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="semantic_cache_config",
-    error_code_prefix="CACHE_MANAGEMENT",
-)
 @router.put("/semantic-cache/config", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -764,11 +694,6 @@ async def semantic_cache_update_config(
 # =========================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="context_sufficiency_stats",
-    error_code_prefix="CACHE_MANAGEMENT",
-)
 @router.get("/context-sufficiency/stats", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -785,11 +710,6 @@ async def context_sufficiency_stats(
     return evaluator.get_stats()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="context_sufficiency_config",
-    error_code_prefix="CACHE_MANAGEMENT",
-)
 @router.put("/context-sufficiency/config", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -813,11 +733,6 @@ async def context_sufficiency_update_config(
 # ---------------------------------------------------------------------------
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="topic_cache_stats",
-    error_code_prefix="CACHE_MANAGEMENT",
-)
 @router.get("/topic-cache/stats", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -834,11 +749,6 @@ async def topic_cache_stats(
     return cache.get_stats()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="topic_cache_config",
-    error_code_prefix="CACHE_MANAGEMENT",
-)
 @router.put("/topic-cache/config", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/chat_knowledge.py
+++ b/autobot-backend/api/chat_knowledge.py
@@ -527,11 +527,6 @@ chat_knowledge_manager = None
 # API Endpoints
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_chat_context",
-    error_code_prefix="CHAT_KNOWLEDGE",
-)
 @router.post("/context/create", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -566,11 +561,6 @@ async def create_chat_context(request_data: CreateContextRequest, request: Reque
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="associate_file_with_chat",
-    error_code_prefix="CHAT_KNOWLEDGE",
-)
 @router.post("/files/associate", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -605,11 +595,6 @@ async def associate_file_with_chat(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="upload_file_to_chat",
-    error_code_prefix="CHAT_KNOWLEDGE",
-)
 @router.post("/files/upload/{chat_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -657,11 +642,6 @@ async def upload_file_to_chat(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_temporary_knowledge",
-    error_code_prefix="CHAT_KNOWLEDGE",
-)
 @router.post("/knowledge/add_temporary", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -682,11 +662,6 @@ async def add_temporary_knowledge(request: AddKnowledgeRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_pending_knowledge_decisions",
-    error_code_prefix="CHAT_KNOWLEDGE",
-)
 @router.get("/knowledge/pending/{chat_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -709,11 +684,6 @@ async def get_pending_knowledge_decisions(chat_id: str):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="apply_knowledge_decision",
-    error_code_prefix="CHAT_KNOWLEDGE",
-)
 @router.post("/knowledge/decide", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -739,11 +709,6 @@ async def apply_knowledge_decision(request: KnowledgeDecisionRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="compile_chat_to_knowledge",
-    error_code_prefix="CHAT_KNOWLEDGE",
-)
 @router.post("/compile", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -767,11 +732,6 @@ async def compile_chat_to_knowledge(request_data: CompileChatRequest, request: R
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_chat_knowledge",
-    error_code_prefix="CHAT_KNOWLEDGE",
-)
 @router.post("/search", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -794,11 +754,6 @@ async def search_chat_knowledge(request: ChatKnowledgeSearchRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_chat_context",
-    error_code_prefix="CHAT_KNOWLEDGE",
-)
 @router.get("/context/{chat_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -843,11 +798,6 @@ async def get_chat_context(chat_id: str):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="health_check",
-    error_code_prefix="CHAT_KNOWLEDGE",
-)
 @router.get("/health", response_model=ChatKnowledgeHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -873,11 +823,6 @@ async def health_check():
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_session_facts",
-    error_code_prefix="CHAT_KNOWLEDGE",
-)
 @router.get("/chat/sessions/{session_id}/facts", response_model=SessionFactsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1003,11 +948,6 @@ def _count_preserve_results(results: list, session_id: str) -> tuple[int, int, l
     return updated_count, failed_count, errors
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="preserve_session_facts",
-    error_code_prefix="CHAT_KNOWLEDGE",
-)
 @router.post("/chat/sessions/{session_id}/facts/preserve", response_model=PreserveSessionFactsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -326,11 +326,6 @@ _EXPORT_CONTENT_TYPES = {
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_session_messages",
-    error_code_prefix="CHAT",
-)
 @router.get("/chat/sessions/{session_id}", response_model=DataResponse[SessionMessagesData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -378,11 +373,6 @@ async def get_session_messages(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_sessions",
-    error_code_prefix="CHAT",
-)
 @router.get("/chat/sessions", response_model=DataResponse[SessionListData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -739,11 +729,6 @@ async def _track_session_in_memory_graph(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_session",
-    error_code_prefix="CHAT",
-)
 @router.post("/chat/sessions", response_model=DataResponse[SessionCreateData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -831,11 +816,6 @@ async def create_session(session_data: SessionCreate, request: Request):
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_session",
-    error_code_prefix="CHAT",
-)
 @router.put("/chat/sessions/{session_id}", response_model=DataResponse[SessionUpdateData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1337,11 +1317,6 @@ def _build_delete_session_response(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_session",
-    error_code_prefix="CHAT",
-)
 @router.delete("/chat/sessions/{session_id}", response_model=DataResponse[SessionDeleteData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1422,11 +1397,6 @@ async def delete_session(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_session",
-    error_code_prefix="CHAT",
-)
 @router.get("/chat/sessions/{session_id}/export", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1518,11 +1488,6 @@ def _clear_and_restore_session(
     return len(messages_to_restore)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reset_chat",
-    error_code_prefix="CHAT",
-)
 @router.post("/chat/reset", response_model=DataResponse[ChatResetData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1696,11 +1661,6 @@ async def _process_activity_batch(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_session_activity",
-    error_code_prefix="CHAT",
-)
 @router.post("/chat/sessions/{session_id}/activities", response_model=DataResponse[ActivityAddData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1765,11 +1725,6 @@ async def add_session_activity(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_session_activities_batch",
-    error_code_prefix="CHAT",
-)
 @router.post("/chat/sessions/{session_id}/activities/batch", response_model=DataResponse[ActivityBatchData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1873,11 +1828,6 @@ async def _fetch_activities_from_graph(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_session_activities",
-    error_code_prefix="CHAT",
-)
 @router.get("/chat/sessions/{session_id}/activities", response_model=DataResponse[SessionActivitiesData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1960,11 +1910,6 @@ async def _share_session_facts(
     return await kb_manager.share_facts(fact_ids, share_with, shared_by)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="share_session",
-    error_code_prefix="CHAT",
-)
 @router.post("/chat/sessions/{session_id}/share", response_model=DataResponse[SessionShareData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2017,11 +1962,6 @@ async def share_session(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_session_share_preview",
-    error_code_prefix="CHAT",
-)
 @router.get("/chat/sessions/{session_id}/share/preview", response_model=DataResponse[SessionSharePreviewData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -680,11 +680,6 @@ async def _generate_report_response(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_codebase",
-    error_code_prefix="CODE_INTEL",
-)
 @router.post("/analyze", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -797,11 +792,6 @@ def _analyze_inline_code(request: CodeIntelAnalysisRequest) -> JSONResponse:
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_suggestions",
-    error_code_prefix="CODE_INTEL",
-)
 @router.post("/suggestions", response_model=SuggestionsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -831,11 +821,6 @@ async def get_code_suggestions(
     return {"suggestions": suggestions}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="quick_scan",
-    error_code_prefix="CODE_INTEL",
-)
 @router.post("/scan-file", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -885,11 +870,6 @@ async def quick_scan_file(
         raise_internal_error("Scan failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_health_score",
-    error_code_prefix="CODE_INTEL",
-)
 @router.get("/health-score", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -941,11 +921,6 @@ async def get_codebase_health_score(
         raise_internal_error("Health check failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_pattern_types",
-    error_code_prefix="CODE_INTEL",
-)
 @router.get("/pattern-types", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -981,11 +956,6 @@ async def get_supported_pattern_types(
 # =============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_redis_usage",
-    error_code_prefix="CODE_INTEL",
-)
 @router.post("/redis/analyze", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1032,11 +1002,6 @@ async def analyze_redis_usage_endpoint(
         raise_internal_error("Redis analysis failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="scan_redis_file",
-    error_code_prefix="CODE_INTEL",
-)
 @router.post("/redis/scan-file", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1086,11 +1051,6 @@ async def scan_redis_file(
         raise_internal_error("Scan failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_redis_optimization_types",
-    error_code_prefix="CODE_INTEL",
-)
 @router.get("/redis/optimization-types", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1127,11 +1087,6 @@ _REDIS_HEALTH_CACHE_TTL = TTL_5_MINUTES
 _REDIS_HEALTH_TIMEOUT = 30.0  # seconds
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_redis_health",
-    error_code_prefix="CODE_INTEL",
-)
 @router.get("/redis/health-score", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1219,11 +1174,6 @@ async def _run_redis_health_analysis(path: str) -> Dict[str, Any]:
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="security_analyze",
-    error_code_prefix="SECURITY",
-)
 @router.post("/security/analyze", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1277,11 +1227,6 @@ async def security_analyze(
         raise_internal_error("Security analysis failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="security_scan_file",
-    error_code_prefix="SECURITY",
-)
 @router.post("/security/scan-file", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1339,11 +1284,6 @@ async def security_scan_file(
         raise_internal_error("File scan failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_vulnerability_types",
-    error_code_prefix="SECURITY",
-)
 @router.get("/security/vulnerability-types", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1383,11 +1323,6 @@ async def list_vulnerability_types(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="security_score",
-    error_code_prefix="SECURITY",
-)
 @router.get("/security/score", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1445,11 +1380,6 @@ async def get_security_score(
         raise_internal_error("Security score calculation failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="security_report",
-    error_code_prefix="SECURITY",
-)
 @router.get("/security/report", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1488,11 +1418,6 @@ async def get_security_report(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="performance_analyze",
-    error_code_prefix="PERFORMANCE",
-)
 @router.post("/performance/analyze", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1545,11 +1470,6 @@ async def performance_analyze(
         raise_internal_error("Performance analysis failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="performance_scan_file",
-    error_code_prefix="PERFORMANCE",
-)
 @router.post("/performance/scan-file", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1607,11 +1527,6 @@ async def performance_scan_file(
         raise_internal_error("File scan failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_performance_issue_types",
-    error_code_prefix="PERFORMANCE",
-)
 @router.get("/performance/issue-types", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1651,11 +1566,6 @@ async def list_performance_issue_types(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="performance_score",
-    error_code_prefix="PERFORMANCE",
-)
 @router.get("/performance/score", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1722,11 +1632,6 @@ async def get_performance_score(
         raise_internal_error("Performance score calculation failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="performance_report",
-    error_code_prefix="PERFORMANCE",
-)
 @router.get("/performance/report", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1765,11 +1670,6 @@ async def get_performance_report(
 from code_intelligence.code_evolution_miner import CodeEvolutionMiner
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_evolution",
-    error_code_prefix="EVOLUTION",
-)
 @router.post("/evolution/analyze", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1826,11 +1726,6 @@ async def analyze_code_evolution(
         raise_internal_error("Evolution analysis failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_pattern_evolution",
-    error_code_prefix="EVOLUTION",
-)
 @router.get("/evolution/patterns", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1887,11 +1782,6 @@ async def get_pattern_evolution(
         raise_internal_error("Pattern evolution failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="detect_refactorings",
-    error_code_prefix="EVOLUTION",
-)
 @router.get("/evolution/refactorings", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1948,11 +1838,6 @@ async def detect_refactorings(
         raise_internal_error("Refactoring detection failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_timeline",
-    error_code_prefix="EVOLUTION",
-)
 @router.get("/evolution/timeline", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2021,11 +1906,6 @@ def _build_evolution_summary(evolution_report: dict) -> dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_evolution_report",
-    error_code_prefix="EVOLUTION",
-)
 @router.get("/evolution/report", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2225,11 +2105,6 @@ async def clear_stuck_sec_tasks(
 # These GET stubs prevent 404s and return a consistent "not yet implemented" response.
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_security_findings",
-    error_code_prefix="CODE_INTEL",
-)
 @router.get("/security/findings", response_model=FindingsPlaceholderResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2253,11 +2128,6 @@ async def get_security_findings(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_performance_findings",
-    error_code_prefix="CODE_INTEL",
-)
 @router.get("/performance/findings", response_model=FindingsPlaceholderResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2281,11 +2151,6 @@ async def get_performance_findings(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_redis_findings",
-    error_code_prefix="CODE_INTEL",
-)
 @router.get("/redis/findings", response_model=FindingsPlaceholderResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/code_search.py
+++ b/autobot-backend/api/code_search.py
@@ -141,11 +141,6 @@ SEARCH_EXAMPLES_DATA = {
 _get_code_search_agent = lazy_singleton(get_npu_code_search)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="index_codebase",
-    error_code_prefix="CODE_SEARCH",
-)
 @router.post("/index", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -198,11 +193,6 @@ async def index_codebase(request: CodeSearchIndexRequest):
         raise HTTPException(status_code=500, detail="Indexing failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_code",
-    error_code_prefix="CODE_SEARCH",
-)
 @router.post("/search", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -275,11 +265,6 @@ async def search_code(request: CodeSearchRequest):
         raise HTTPException(status_code=500, detail="Search failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_code_get",
-    error_code_prefix="CODE_SEARCH",
-)
 @router.get("/search", response_model=CodeSearchGetResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -305,11 +290,6 @@ async def search_code_get(
     return await search_code(request)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_search_status",
-    error_code_prefix="CODE_SEARCH",
-)
 @router.get("/status", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -367,11 +347,6 @@ async def get_search_status():
         raise HTTPException(status_code=500, detail="Status check failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_search_cache",
-    error_code_prefix="CODE_SEARCH",
-)
 @router.delete("/cache", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -410,11 +385,6 @@ async def clear_search_cache():
         raise HTTPException(status_code=500, detail="Cache clear failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_search_examples",
-    error_code_prefix="CODE_SEARCH",
-)
 @router.get("/examples", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -771,11 +741,6 @@ async def _analyze_all_pattern_types() -> dict:
     return analysis_results
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_declarations",
-    error_code_prefix="CODE_SEARCH",
-)
 @router.post("/analytics/declarations", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -809,11 +774,6 @@ async def analyze_declarations(request: CodeAnalyticsRequest):
         raise HTTPException(status_code=500, detail="Analysis failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="find_code_duplicates",
-    error_code_prefix="CODE_SEARCH",
-)
 @router.post("/analytics/duplicates", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -861,11 +821,6 @@ async def find_code_duplicates(request: CodeAnalyticsRequest):
         raise HTTPException(status_code=500, detail="Duplicate detection failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_codebase_statistics",
-    error_code_prefix="CODE_SEARCH",
-)
 @router.get("/analytics/stats", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -958,11 +913,6 @@ def _build_refactor_response(root_path: str, suggestions: list) -> dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_refactor_suggestions",
-    error_code_prefix="CODE_SEARCH",
-)
 @router.post("/analytics/refactor-suggestions", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/conversation_export.py
+++ b/autobot-backend/api/conversation_export.py
@@ -130,11 +130,6 @@ def _build_export_response(
 # ---------------------------------------------------------------------------
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_conversation",
-    error_code_prefix="CONVEXPORT",
-)
 @router.get("/conversations/{session_id}/export", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -168,11 +163,6 @@ async def export_conversation(
     return _build_export_response(content, session_id, format)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_all_conversations",
-    error_code_prefix="CONVEXPORT",
-)
 @router.get("/conversations/export-all", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -208,11 +198,6 @@ async def export_all_conversations(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="import_conversation",
-    error_code_prefix="CONVEXPORT",
-)
 @router.post("/conversations/import", response_model=ConversationImportResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/conversation_files.py
+++ b/autobot-backend/api/conversation_files.py
@@ -353,11 +353,6 @@ async def _validate_and_read_upload_file(
     return content
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="upload_conversation_file",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.post("/conversation/{session_id}/upload", response_model=FileUploadResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -443,11 +438,6 @@ def _build_file_list_response(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_conversation_files",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.get(
     "/conversation/{session_id}/list", response_model=ConversationFileListResponse
 )
@@ -540,11 +530,6 @@ def _build_download_response(file_info_dict: Dict, file_path: Path) -> FileRespo
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="download_conversation_file",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.get("/conversation/{session_id}/download/{file_id}", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -634,11 +619,6 @@ async def _generate_file_preview(
     return preview_content, preview_type, preview_available
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="preview_conversation_file",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.get(
     "/conversation/{session_id}/preview/{file_id}", response_model=FilePreviewResponse
 )
@@ -736,11 +716,6 @@ def _build_delete_response(session_id: str, file_id: str) -> JSONResponse:
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_conversation_file",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.delete("/conversation/{session_id}/files/{file_id}", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -785,11 +760,6 @@ async def delete_conversation_file(request: Request, session_id: str, file_id: s
         raise_internal_error("Error deleting file")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="transfer_conversation_files",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.post("/conversation/{session_id}/transfer", response_model=FileTransferResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -849,11 +819,6 @@ async def transfer_conversation_files(
 # ============================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_conversation_file",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.post("/conversation/{session_id}/files/create", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -897,11 +862,6 @@ async def create_conversation_file(
         raise_internal_error("Error creating file")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="rename_conversation_file",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.put("/conversation/{session_id}/files/{file_id}/rename", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -942,11 +902,6 @@ async def rename_conversation_file(
         raise_internal_error("Error renaming file")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_file_content",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.get("/conversation/{session_id}/files/{file_id}/content", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -976,11 +931,6 @@ async def get_file_content(request: Request, session_id: str, file_id: str):
         raise_internal_error("Error reading file")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_file_content",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.put("/conversation/{session_id}/files/{file_id}/content", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1020,11 +970,6 @@ async def update_file_content(
         raise_internal_error("Error updating file")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="copy_conversation_file",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.post("/conversation/{session_id}/files/{file_id}/copy", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1065,11 +1010,6 @@ async def copy_conversation_file(
         raise_internal_error("Error copying file")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_conversation_files",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.get("/conversation/{session_id}/files/search", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1095,11 +1035,6 @@ async def search_conversation_files(request: Request, session_id: str, q: str = 
         raise_internal_error("Error searching files")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="agent_generate_file",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.post("/conversation/{session_id}/generate", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1218,11 +1153,6 @@ SESSION_MCP_TOOLS = [
 ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="session_mcp_tools",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.get("/conversation/{session_id}/mcp/tools", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1287,11 +1217,6 @@ async def _dispatch_mcp_tool(
     raise_invalid_input("tool_name", f"unknown tool: {tool_name}")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="session_mcp_call_tool",
-    error_code_prefix="CONVERSATION_FILES",
-)
 @router.post("/conversation/{session_id}/mcp/call", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/data_storage.py
+++ b/autobot-backend/api/data_storage.py
@@ -256,11 +256,6 @@ def get_database_files() -> list[dict]:
     return sorted(db_files, key=lambda x: x["size_bytes"], reverse=True)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_storage_stats",
-    error_code_prefix="STORAGE",
-)
 @router.get("/stats", response_model=StorageStats)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -297,11 +292,6 @@ async def get_storage_stats():
         raise_server_error("STORAGE_0001", "Error getting storage stats")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_database_files",
-    error_code_prefix="STORAGE",
-)
 @router.get("/databases", response_model=DataStorageDatabasesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -326,11 +316,6 @@ async def get_database_files_endpoint():
         raise_server_error("STORAGE_0002", "Error getting database files")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_category_details",
-    error_code_prefix="STORAGE",
-)
 @router.get("/category/{category_path}", response_model=DataStorageCategoryDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -416,11 +401,6 @@ def _scan_and_remove_files(
     return files_removed, bytes_freed, errors
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cleanup_category",
-    error_code_prefix="STORAGE",
-)
 @router.post("/cleanup", response_model=CleanupResult)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -483,11 +463,6 @@ async def cleanup_category(
         raise_server_error("STORAGE_0004", "Error during cleanup")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cleanup_old_backups",
-    error_code_prefix="STORAGE",
-)
 @router.post("/cleanup/old-backups", response_model=DataStorageOldBackupsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -539,11 +514,6 @@ async def cleanup_old_backups(
         raise_server_error("STORAGE_0005", "Error cleaning up old backups")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_conversation",
-    error_code_prefix="STORAGE",
-)
 @router.delete("/conversations/{conversation_id}", response_model=DataStorageDeleteConversationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -603,11 +573,6 @@ async def delete_conversation(
         raise_server_error("STORAGE_0006", "Error deleting conversation")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_conversations_summary",
-    error_code_prefix="STORAGE",
-)
 @router.get("/conversations/summary", response_model=DataStorageConversationsSummaryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/database_mcp.py
+++ b/autobot-backend/api/database_mcp.py
@@ -634,11 +634,6 @@ def _get_database_schema_tools() -> List[DatabaseMCPTool]:
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_database_mcp_tools",
-    error_code_prefix="DB_MCP",
-)
 @router.get("/mcp/tools", response_model=List[DatabaseMCPTool])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -661,11 +656,6 @@ async def get_database_mcp_tools() -> List[DatabaseMCPTool]:
 # Tool Implementations
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="database_query_mcp",
-    error_code_prefix="DATABASE_MCP",
-)
 @router.post("/mcp/query", response_model=DatabaseQueryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -737,11 +727,6 @@ async def database_query_mcp(request: SQLQueryRequest) -> Metadata:
         raise HTTPException(status_code=500, detail="Database query error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="database_execute_mcp",
-    error_code_prefix="DATABASE_MCP",
-)
 @router.post("/mcp/execute", response_model=DatabaseExecuteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -808,11 +793,6 @@ async def database_execute_mcp(request: SQLExecuteRequest) -> Metadata:
         raise HTTPException(status_code=500, detail="Database execute error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="database_list_tables_mcp",
-    error_code_prefix="DATABASE_MCP",
-)
 @router.post("/mcp/list_tables", response_model=DatabaseListTablesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -866,11 +846,6 @@ async def database_list_tables_mcp(request: TableListRequest) -> Metadata:
         raise HTTPException(status_code=500, detail="Error listing tables")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="database_describe_schema_mcp",
-    error_code_prefix="DATABASE_MCP",
-)
 @router.post("/mcp/describe_schema", response_model=DatabaseDescribeSchemaResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -928,11 +903,6 @@ async def database_describe_schema_mcp(request: SchemaRequest) -> Metadata:
         raise HTTPException(status_code=500, detail="Error describing schema")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="database_list_databases_mcp",
-    error_code_prefix="DATABASE_MCP",
-)
 @router.get("/mcp/list_databases", response_model=DatabaseListDatabasesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -979,11 +949,6 @@ async def database_list_databases_mcp() -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="database_statistics_mcp",
-    error_code_prefix="DATABASE_MCP",
-)
 @router.post("/mcp/statistics", response_model=DatabaseStatisticsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1039,11 +1004,6 @@ async def database_statistics_mcp(request: TableListRequest) -> Metadata:
         raise HTTPException(status_code=500, detail="Error getting statistics")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_database_mcp_status",
-    error_code_prefix="DB_MCP",
-)
 @router.get("/mcp/status", response_model=DatabaseMCPStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/developer.py
+++ b/autobot-backend/api/developer.py
@@ -93,11 +93,6 @@ class APIRegistry:
 api_registry = APIRegistry()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_api_endpoints",
-    error_code_prefix="DEVELOPER",
-)
 @router.get("/endpoints", response_model=DeveloperEndpointsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -114,11 +109,6 @@ async def get_api_endpoints():
     return api_registry.get_all_endpoints()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_developer_config",
-    error_code_prefix="DEVELOPER",
-)
 @router.get("/config", response_model=DeveloperConfigResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -136,11 +126,6 @@ async def get_developer_config():
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_developer_config",
-    error_code_prefix="DEVELOPER",
-)
 @router.post("/config", response_model=DeveloperConfigUpdateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -162,11 +147,6 @@ async def update_developer_config(config: dict):
     return {"status": "success", "config": current_config}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_info",
-    error_code_prefix="DEVELOPER",
-)
 @router.get("/system-info", response_model=DeveloperSystemInfoResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/development_speedup.py
+++ b/autobot-backend/api/development_speedup.py
@@ -86,11 +86,6 @@ ANALYSIS_TYPE_HANDLERS: Dict[str, AnalysisHandler] = {
 VALID_ANALYSIS_TYPES = ", ".join(ANALYSIS_TYPE_HANDLERS.keys())
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_codebase_endpoint",
-    error_code_prefix="DEVELOPMENT_SPEEDUP",
-)
 @router.post("/analyze", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -140,11 +135,6 @@ async def analyze_codebase_endpoint(request: DevelopmentSpeedupAnalysisRequest):
         raise HTTPException(status_code=500, detail="Analysis failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_codebase_get",
-    error_code_prefix="DEVELOPMENT_SPEEDUP",
-)
 @router.get("/analyze", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -166,11 +156,6 @@ async def analyze_codebase_get(
     return await analyze_codebase_endpoint(request)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="find_duplicates_endpoint",
-    error_code_prefix="DEVELOPMENT_SPEEDUP",
-)
 @router.get("/duplicates", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -219,11 +204,6 @@ async def find_duplicates_endpoint(
         raise HTTPException(status_code=500, detail="Duplicate detection failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_patterns_endpoint",
-    error_code_prefix="DEVELOPMENT_SPEEDUP",
-)
 @router.get("/patterns", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -272,11 +252,6 @@ async def analyze_patterns_endpoint(
         raise HTTPException(status_code=500, detail="Pattern analysis failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_imports_endpoint",
-    error_code_prefix="DEVELOPMENT_SPEEDUP",
-)
 @router.get("/imports", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -317,11 +292,6 @@ async def analyze_imports_endpoint(
         raise HTTPException(status_code=500, detail="Import analysis failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="detect_dead_code_endpoint",
-    error_code_prefix="DEVELOPMENT_SPEEDUP",
-)
 @router.get("/dead-code", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -356,11 +326,6 @@ async def detect_dead_code_endpoint(
         raise HTTPException(status_code=500, detail="Dead code detection failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="find_refactoring_opportunities_endpoint",
-    error_code_prefix="DEVELOPMENT_SPEEDUP",
-)
 @router.get("/refactoring", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -410,11 +375,6 @@ async def find_refactoring_opportunities_endpoint(
         raise HTTPException(status_code=500, detail="Refactoring analysis failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_quality_endpoint",
-    error_code_prefix="DEVELOPMENT_SPEEDUP",
-)
 @router.get("/quality", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -504,11 +464,6 @@ def _calculate_health_score(result: dict, metrics: dict) -> int:
     return max(0, 100 - (total_issues * 2))  # Simple scoring
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_recommendations_endpoint",
-    error_code_prefix="DEVELOPMENT_SPEEDUP",
-)
 @router.get("/recommendations", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -551,11 +506,6 @@ async def get_recommendations_endpoint(
         raise HTTPException(status_code=500, detail="Recommendations failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_development_speedup_status",
-    error_code_prefix="DEVELOPMENT_SPEEDUP",
-)
 @router.get("/status", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -623,11 +573,6 @@ async def get_development_speedup_status():
         raise HTTPException(status_code=500, detail="Status check failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_analysis_examples",
-    error_code_prefix="DEVELOPMENT_SPEEDUP",
-)
 @router.get("/examples", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/documents.py
+++ b/autobot-backend/api/documents.py
@@ -102,11 +102,6 @@ async def _assert_ownership(doc: AIDocument, user_id: str) -> None:
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_document",
-    error_code_prefix="DOCUMENTS",
-)
 @router.post("/documents", status_code=201, response_model=AIDocumentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -138,11 +133,6 @@ async def create_document(
     return doc.model_dump()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_documents",
-    error_code_prefix="DOCUMENTS",
-)
 @router.get("/documents", response_model=AIDocumentListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -184,11 +174,6 @@ async def list_documents(
     return {"documents": [d.model_dump() for d in page], "total": total}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_document",
-    error_code_prefix="DOCUMENTS",
-)
 @router.get("/documents/{doc_id}", response_model=AIDocumentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -209,11 +194,6 @@ async def get_document(
     return doc.model_dump()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_document",
-    error_code_prefix="DOCUMENTS",
-)
 @router.put("/documents/{doc_id}", response_model=AIDocumentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -250,11 +230,6 @@ async def update_document(
     return doc.model_dump()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_document",
-    error_code_prefix="DOCUMENTS",
-)
 @router.delete("/documents/{doc_id}", status_code=204, response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -280,11 +255,6 @@ async def delete_document(
     logger.info("Deleted AI document %s for user %s", doc_id, uid)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="refine_document",
-    error_code_prefix="DOCUMENTS",
-)
 @router.post("/documents/{doc_id}/refine", response_model=AIDocumentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/elevation.py
+++ b/autobot-backend/api/elevation.py
@@ -50,11 +50,6 @@ _elevation_sessions_lock = asyncio.Lock()
 _pending_requests_lock = asyncio.Lock()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="request_elevation",
-    error_code_prefix="ELEVATION",
-)
 @router.post("/request", response_model=ElevationRequestResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -85,11 +80,6 @@ async def request_elevation(request: ElevationRequest):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="authorize_elevation",
-    error_code_prefix="ELEVATION",
-)
 @router.post("/authorize", response_model=ElevationAuthorizeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -155,11 +145,6 @@ async def authorize_elevation(auth: ElevationAuthorization):
         raise HTTPException(status_code=500, detail="Authorization failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_elevation_status",
-    error_code_prefix="ELEVATION",
-)
 @router.get("/status/{request_id}", response_model=ElevationStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -183,11 +168,6 @@ async def get_elevation_status(request_id: str):
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="execute_elevated_command",
-    error_code_prefix="ELEVATION",
-)
 @router.post("/execute/{session_token}", response_model=ElevationExecuteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -234,11 +214,6 @@ async def execute_elevated_command(session_token: str, command: str):
         raise HTTPException(status_code=500, detail="Command execution failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_pending_requests",
-    error_code_prefix="ELEVATION",
-)
 @router.get("/pending", response_model=ElevationPendingResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -330,11 +305,6 @@ async def run_elevated_command(command: str) -> dict:
         return {"stdout": "", "stderr": "An internal error occurred", "return_code": 1}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="revoke_elevation_session",
-    error_code_prefix="ELEVATION",
-)
 @router.delete("/session/{session_token}", response_model=SuccessResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -350,11 +320,6 @@ async def revoke_elevation_session(session_token: str):
     return {"success": True, "message": "Session revoked"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="elevation_health_check",
-    error_code_prefix="ELEVATION",
-)
 @router.get("/health", response_model=ElevationHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/embeddings.py
+++ b/autobot-backend/api/embeddings.py
@@ -27,11 +27,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["embeddings"])
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_embedding_settings",
-    error_code_prefix="EMBEDDINGS",
-)
 @router.get("/settings", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -80,11 +75,6 @@ async def get_embedding_settings(
         raise HTTPException(status_code=500, detail="Failed to get embedding settings")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_embedding_settings",
-    error_code_prefix="EMBEDDINGS",
-)
 @router.put("/settings", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -144,11 +134,6 @@ async def update_embedding_settings(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_available_embedding_models",
-    error_code_prefix="EMBEDDINGS",
-)
 @router.get("/models", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -197,11 +182,6 @@ async def get_available_embedding_models(
         raise HTTPException(status_code=500, detail="Failed to get embedding models")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="refresh_embedding_models",
-    error_code_prefix="EMBEDDINGS",
-)
 @router.post("/providers/{provider_name}/refresh-models", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -263,11 +243,6 @@ async def refresh_embedding_models(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_embedding_status",
-    error_code_prefix="EMBEDDINGS",
-)
 @router.get("/status", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/enhanced_memory.py
+++ b/autobot-backend/api/enhanced_memory.py
@@ -113,11 +113,6 @@ async def get_memory_manager() -> (
 # Use /api/system/health?detailed=true for comprehensive status
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_memory_statistics",
-    error_code_prefix="MEMORY",
-)
 @router.get("/statistics", response_model=MemoryStatisticsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -153,11 +148,6 @@ async def get_memory_statistics(days_back: int = Query(30, ge=1, le=365)):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_task_history",
-    error_code_prefix="MEMORY",
-)
 @router.get("/tasks/history", response_model=MemoryTaskHistoryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -202,11 +192,6 @@ async def get_task_history(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_task",
-    error_code_prefix="MEMORY",
-)
 @router.post("/tasks", response_model=MemoryTaskCreateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -263,11 +248,6 @@ async def create_task(request: TaskCreateRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_task",
-    error_code_prefix="MEMORY",
-)
 @router.put("/tasks/{task_id}", response_model=MemoryTaskUpdateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -319,11 +299,6 @@ async def update_task(task_id: str, request: TaskUpdateRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_markdown_reference",
-    error_code_prefix="MEMORY",
-)
 @router.post("/tasks/{task_id}/markdown-reference", response_model=MemoryMarkdownReferenceResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -370,11 +345,6 @@ async def add_markdown_reference(task_id: str, request: MarkdownReferenceRequest
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="scan_markdown_system",
-    error_code_prefix="MEMORY",
-)
 @router.get("/markdown/scan", response_model=MemoryMarkdownScanResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -399,11 +369,6 @@ async def scan_markdown_system():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_markdown",
-    error_code_prefix="MEMORY",
-)
 @router.get("/markdown/search", response_model=MemoryMarkdownSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -438,11 +403,6 @@ async def search_markdown(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_document_references",
-    error_code_prefix="MEMORY",
-)
 @router.get("/markdown/{file_path:path}/references", response_model=MemoryDocumentReferencesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -471,11 +431,6 @@ async def get_document_references(file_path: str):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_embedding_cache_stats",
-    error_code_prefix="MEMORY",
-)
 @router.get("/embeddings/cache-stats", response_model=MemoryEmbeddingCacheStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -505,11 +460,6 @@ async def get_embedding_cache_stats():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cleanup_old_data",
-    error_code_prefix="MEMORY",
-)
 @router.delete("/cleanup", response_model=MemoryCleanupResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -537,11 +487,6 @@ async def cleanup_old_data(days_to_keep: int = Query(90, ge=30, le=365)):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_active_tasks",
-    error_code_prefix="MEMORY",
-)
 @router.get("/active-tasks", response_model=MemoryActiveTasksResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/enhanced_search.py
+++ b/autobot-backend/api/enhanced_search.py
@@ -96,11 +96,6 @@ def _convert_metrics_to_api_format(metrics) -> dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_semantic_search",
-    error_code_prefix="ENHANCED_SEARCH",
-)
 @router.post("/semantic", response_model=NPUSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -161,11 +156,6 @@ async def enhanced_semantic_search(request: NPUSearchRequest):
         raise HTTPException(status_code=500, detail="Search failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_hardware_status",
-    error_code_prefix="ENHANCED_SEARCH",
-)
 @router.get("/hardware/status", response_model=EnhancedSearchHardwareStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -195,11 +185,6 @@ async def get_hardware_status():
         raise HTTPException(status_code=500, detail="Failed to get hardware status")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="benchmark_search_performance",
-    error_code_prefix="ENHANCED_SEARCH",
-)
 @router.post("/benchmark", response_model=EnhancedSearchBenchmarkResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -231,11 +216,6 @@ async def benchmark_search_performance(request: BenchmarkRequest):
         raise HTTPException(status_code=500, detail="Benchmark failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="optimize_search_engine",
-    error_code_prefix="ENHANCED_SEARCH",
-)
 @router.post("/optimize", response_model=EnhancedSearchOptimizeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -268,11 +248,6 @@ async def optimize_search_engine(request: NPUOptimizationRequest):
         raise HTTPException(status_code=500, detail="Optimization failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_performance_analytics",
-    error_code_prefix="ENHANCED_SEARCH",
-)
 @router.get("/performance/analytics", response_model=EnhancedSearchPerformanceAnalyticsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -321,11 +296,6 @@ async def get_performance_analytics():
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_npu_connectivity",
-    error_code_prefix="ENHANCED_SEARCH",
-)
 @router.get("/test/connectivity", response_model=EnhancedSearchConnectivityResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -521,11 +491,6 @@ def _generate_system_recommendations(
 
 
 # Health check endpoint
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="health_check",
-    error_code_prefix="ENHANCED_SEARCH",
-)
 @router.get("/health", response_model=EnhancedSearchHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/enterprise_features.py
+++ b/autobot-backend/api/enterprise_features.py
@@ -268,11 +268,6 @@ def _build_service_distribution(vm_topology: dict) -> dict:
     return service_distribution
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_enterprise_status",
-    error_code_prefix="ENTERPRISE_FEATURES",
-)
 @router.get("/status", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -307,11 +302,6 @@ async def get_enterprise_status():
         raise HTTPException(status_code=500, detail="Failed to get enterprise status")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="enable_enterprise_feature",
-    error_code_prefix="ENTERPRISE_FEATURES",
-)
 @router.post("/features/enable", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -369,11 +359,6 @@ async def enable_enterprise_feature(request: FeatureEnableRequest):
         raise HTTPException(status_code=500, detail="Failed to enable feature")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="enable_all_enterprise_features",
-    error_code_prefix="ENTERPRISE_FEATURES",
-)
 @router.post("/features/enable-all", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -410,11 +395,6 @@ async def enable_all_enterprise_features():
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_enterprise_features",
-    error_code_prefix="ENTERPRISE_FEATURES",
-)
 @router.get("/features", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -473,11 +453,6 @@ async def list_enterprise_features(
         raise HTTPException(status_code=500, detail="Failed to list features")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="bulk_enable_features",
-    error_code_prefix="ENTERPRISE_FEATURES",
-)
 @router.post("/features/bulk-enable", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -539,11 +514,6 @@ async def bulk_enable_features(request: BulkFeatureRequest):
         raise HTTPException(status_code=500, detail="Bulk enablement failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_enterprise_health",
-    error_code_prefix="ENTERPRISE_FEATURES",
-)
 @router.get("/health", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -599,11 +569,6 @@ async def get_enterprise_health():
         raise HTTPException(status_code=500, detail="Failed to get health status")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="optimize_system_performance",
-    error_code_prefix="ENTERPRISE_FEATURES",
-)
 @router.post("/performance/optimize", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -645,11 +610,6 @@ async def optimize_system_performance(request: PerformanceOptimizationRequest):
         raise HTTPException(status_code=500, detail="Performance optimization failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_infrastructure_status",
-    error_code_prefix="ENTERPRISE_FEATURES",
-)
 @router.get("/infrastructure", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -699,11 +659,6 @@ async def get_infrastructure_status():
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="deploy_zero_downtime",
-    error_code_prefix="ENTERPRISE_FEATURES",
-)
 @router.post("/deployment/zero-downtime", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -752,11 +707,6 @@ async def deploy_zero_downtime():
         raise HTTPException(status_code=500, detail="Zero-downtime deployment failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="validate_phase4_completion",
-    error_code_prefix="ENTERPRISE_FEATURES",
-)
 @router.get("/phase4/validation", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/entity_extraction.py
+++ b/autobot-backend/api/entity_extraction.py
@@ -157,11 +157,6 @@ def _build_extraction_response(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="entity_extraction",
-    error_code_prefix="ENTITY_EXTRACT",
-)
 @router.post("/extract", response_model=EntityExtractionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -298,11 +293,6 @@ def _process_extraction_results(
     return successful_results, failed_results
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="batch_entity_extraction",
-    error_code_prefix="ENTITY_EXTRACT",
-)
 @router.post("/extract-batch", response_model=BatchExtractionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -373,11 +363,6 @@ async def extract_entities_batch(
         raise HTTPException(status_code=500, detail="Batch extraction failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="entity_extraction_health",
-    error_code_prefix="ENTITY_EXTRACT",
-)
 @router.get("/extract/health", response_model=EntityExtractionHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/error_monitoring.py
+++ b/autobot-backend/api/error_monitoring.py
@@ -53,11 +53,6 @@ router = APIRouter(tags=["Error Monitoring"])
 
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_error_statistics",
-    error_code_prefix="ERROR_MONITORING",
-)
 @router.get("/statistics", response_model=ErrorMonitoringDataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -77,11 +72,6 @@ async def get_system_error_statistics():
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_recent_errors",
-    error_code_prefix="ERROR_MONITORING",
-)
 @router.get("/recent", response_model=ErrorMonitoringDataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -137,11 +127,6 @@ async def get_recent_errors(limit: int = 20):
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_error_categories",
-    error_code_prefix="ERROR_MONITORING",
-)
 @router.get("/categories", response_model=ErrorMonitoringDataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -177,11 +162,6 @@ async def get_error_categories():
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_error_by_component",
-    error_code_prefix="ERROR_MONITORING",
-)
 @router.get("/components", response_model=ErrorMonitoringDataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -229,11 +209,6 @@ def _calculate_health_status(
     return "excellent", 100
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_error_system_health",
-    error_code_prefix="ERROR_MONITORING",
-)
 @router.get("/health", response_model=ErrorMonitoringDataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -274,11 +249,6 @@ async def get_error_system_health():
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_error_history",
-    error_code_prefix="ERROR_MONITORING",
-)
 @router.post("/clear", response_model=ErrorMonitoringClearResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -323,11 +293,6 @@ async def clear_error_history(authorization: Optional[str] = Header(None)):
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_error_system",
-    error_code_prefix="ERROR_MONITORING",
-)
 @router.post("/test-error", response_model=ErrorMonitoringTestErrorResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -425,11 +390,6 @@ def _get_health_recommendations(health_status: str, stats: Metadata) -> list:
 # =============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_metrics_summary",
-    error_code_prefix="ERROR_MONITORING",
-)
 @router.get("/metrics/summary", response_model=ErrorMonitoringDataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -456,11 +416,6 @@ async def get_metrics_summary():
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_error_timeline",
-    error_code_prefix="ERROR_MONITORING",
-)
 @router.get("/metrics/timeline", response_model=ErrorMonitoringDataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -500,11 +455,6 @@ async def get_error_timeline_endpoint(hours: int = 24, component: Optional[str] 
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_top_errors",
-    error_code_prefix="ERROR_MONITORING",
-)
 @router.get("/metrics/top-errors", response_model=ErrorMonitoringDataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -536,11 +486,6 @@ async def get_top_errors_endpoint(limit: int = 10):
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="mark_error_resolved",
-    error_code_prefix="ERROR_MONITORING",
-)
 @router.post("/metrics/resolve/{trace_id}", response_model=ErrorMonitoringResolveResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -576,11 +521,6 @@ async def mark_error_resolved_endpoint(trace_id: str):
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="set_alert_threshold",
-    error_code_prefix="ERROR_MONITORING",
-)
 @router.post("/metrics/alert-threshold", response_model=ErrorMonitoringAlertThresholdResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -618,11 +558,6 @@ async def set_alert_threshold_endpoint(request: AlertThresholdRequest):
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cleanup_metrics",
-    error_code_prefix="ERROR_MONITORING",
-)
 @router.post("/metrics/cleanup", response_model=ErrorMonitoringCleanupResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/feature_flags.py
+++ b/autobot-backend/api/feature_flags.py
@@ -81,11 +81,6 @@ async def require_admin(
     return current_user
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_feature_flags_status",
-    error_code_prefix="FEATURE_FLAGS",
-)
 @router.get("/feature-flags/status", response_model=FeatureFlagStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -111,11 +106,6 @@ async def get_feature_flags_status(
         raise HTTPException(status_code=500, detail="Failed to get status")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_enforcement_mode",
-    error_code_prefix="FEATURE_FLAGS",
-)
 @router.put("/feature-flags/enforcement-mode", response_model=FeatureFlagEnforcementModeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -184,11 +174,6 @@ async def update_enforcement_mode(
         raise HTTPException(status_code=500, detail="Failed to update mode")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="set_endpoint_enforcement",
-    error_code_prefix="FEATURE_FLAGS",
-)
 @router.put("/feature-flags/endpoint/{endpoint:path}", response_model=FeatureFlagEndpointSetResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -243,11 +228,6 @@ async def set_endpoint_enforcement(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="remove_endpoint_enforcement",
-    error_code_prefix="FEATURE_FLAGS",
-)
 @router.delete("/feature-flags/endpoint/{endpoint:path}", response_model=FeatureFlagEndpointRemoveResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -291,11 +271,6 @@ async def remove_endpoint_enforcement(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_access_control_metrics",
-    error_code_prefix="FEATURE_FLAGS",
-)
 @router.get("/access-control/metrics", response_model=AccessControlMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -342,11 +317,6 @@ async def get_access_control_metrics(
         raise HTTPException(status_code=500, detail="Failed to get metrics")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_endpoint_metrics",
-    error_code_prefix="FEATURE_FLAGS",
-)
 @router.get("/access-control/endpoint/{endpoint:path}", response_model=AccessControlEndpointMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -379,11 +349,6 @@ async def get_endpoint_metrics(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_user_metrics",
-    error_code_prefix="FEATURE_FLAGS",
-)
 @router.get("/access-control/user/{username}", response_model=AccessControlUserMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -416,11 +381,6 @@ async def get_user_metrics(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cleanup_old_metrics",
-    error_code_prefix="FEATURE_FLAGS",
-)
 @router.post("/access-control/cleanup", response_model=AccessControlCleanupResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -367,11 +367,6 @@ def _list_directory_contents(target_path: Path) -> tuple:
     return files, total_size, total_files, total_directories
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_files",
-    error_code_prefix="FILES",
-)
 @router.get("/list", response_model=DirectoryListing)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -639,11 +634,6 @@ async def _delete_directory_item(
     return {"message": f"Directory '{target_path.name}' deleted successfully"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="upload_file",
-    error_code_prefix="FILES",
-)
 @router.post("/upload", response_model=FilesAPIUploadResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -710,11 +700,6 @@ async def upload_file(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="download_file",
-    error_code_prefix="FILES",
-)
 @router.get("/download/{path:path}", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -774,11 +759,6 @@ async def download_file(request: Request, path: str):
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="view_file",
-    error_code_prefix="FILES",
-)
 @router.get("/view/{path:path}", response_model=FileViewResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -903,11 +883,6 @@ async def _validate_rename_paths(source_path: Path, new_name: str) -> Path:
     return target_path
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="rename_file_or_directory",
-    error_code_prefix="FILES",
-)
 @router.post("/rename", response_model=FileRenameResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -998,11 +973,6 @@ async def _read_text_content(target_file: Path) -> tuple:
         return None, "binary"
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="preview_file",
-    error_code_prefix="FILES",
-)
 @router.get("/preview", response_model=FilePreviewResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1051,11 +1021,6 @@ async def preview_file(request: Request, path: str):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_file",
-    error_code_prefix="FILES",
-)
 @router.delete("/delete", response_model=FileDeleteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1131,11 +1096,6 @@ def _log_directory_create_audit(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_directory",
-    error_code_prefix="FILES",
-)
 @router.post("/create_directory", response_model=DirectoryCreateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1180,11 +1140,6 @@ async def create_directory(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_directory_tree",
-    error_code_prefix="FILES",
-)
 @router.get("/tree", response_model=DirectoryTreeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1253,11 +1208,6 @@ async def get_directory_tree(request: Request, path: str = ""):
     return {"path": path, "tree": tree_data}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_file_stats",
-    error_code_prefix="FILES",
-)
 @router.get("/stats", response_model=FileStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/filesystem_mcp.py
+++ b/autobot-backend/api/filesystem_mcp.py
@@ -567,11 +567,6 @@ def _get_discovery_analysis_tools() -> List[MCPTool]:
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_filesystem_mcp_tools",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.get("/mcp/tools", response_model=List[MCPTool])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -598,11 +593,6 @@ async def get_filesystem_mcp_tools(
 # Tool Implementations
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="read_text_file_mcp",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.post("/mcp/read_text_file", response_model=FilesystemReadTextResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -661,11 +651,6 @@ async def read_text_file_mcp(
         raise_internal_error("Failed to read file")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="read_media_file_mcp",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.post("/mcp/read_media_file", response_model=FilesystemReadMediaResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -791,11 +776,6 @@ def _separate_batch_read_results(all_results: list) -> tuple:
     return results, errors
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="read_multiple_files_mcp",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.post("/mcp/read_multiple_files", response_model=FilesystemReadMultipleResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -830,11 +810,6 @@ async def read_multiple_files_mcp(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="write_file_mcp",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.post("/mcp/write_file", response_model=FilesystemWriteFileResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -935,11 +910,6 @@ def _apply_edits_to_content(content: str, edits: list) -> tuple:
     return content, edits_applied
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="edit_file_mcp",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.post("/mcp/edit_file", response_model=FilesystemEditFileResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -990,11 +960,6 @@ async def edit_file_mcp(
         raise_internal_error("Error editing file")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_directory_mcp",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.post("/mcp/create_directory", response_model=FilesystemCreateDirectoryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1024,11 +989,6 @@ async def create_directory_mcp(
         raise_internal_error("Error creating directory")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_directory_mcp",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.post("/mcp/list_directory", response_model=FilesystemListDirectoryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1155,11 +1115,6 @@ async def _build_directory_entries_with_sizes(path: str) -> list:
     return entries
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_directory_with_sizes_mcp",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.post("/mcp/list_directory_with_sizes", response_model=FilesystemListDirectoryWithSizesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1202,11 +1157,6 @@ async def list_directory_with_sizes_mcp(
         raise_internal_error("Error listing directory")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="move_file_mcp",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.post("/mcp/move_file", response_model=FilesystemMoveFileResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1248,11 +1198,6 @@ async def move_file_mcp(
         raise_internal_error("Error moving file")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_files_mcp",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.post("/mcp/search_files", response_model=FilesystemSearchFilesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1305,11 +1250,6 @@ async def search_files_mcp(
         raise_internal_error("Error searching files")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="directory_tree_mcp",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.post("/mcp/directory_tree", response_model=FilesystemDirectoryTreeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1366,11 +1306,6 @@ async def directory_tree_mcp(
         raise_internal_error("Error building directory tree")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_file_info_mcp",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.post("/mcp/get_file_info", response_model=FilesystemFileInfoResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1418,11 +1353,6 @@ async def get_file_info_mcp(
         raise_internal_error("Error getting file info")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_allowed_directories_mcp",
-    error_code_prefix="FILESYSTEM_MCP",
-)
 @router.get("/mcp/list_allowed_directories", response_model=FilesystemListAllowedResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/frontend_config.py
+++ b/autobot-backend/api/frontend_config.py
@@ -156,11 +156,6 @@ def _build_fallback_config() -> Dict[str, Any]:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_frontend_config",
-    error_code_prefix="FRONTEND_CONFIG",
-)
 @router.get("/frontend-config", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/git_mcp.py
+++ b/autobot-backend/api/git_mcp.py
@@ -550,11 +550,6 @@ def _get_git_change_tools() -> List[MCPTool]:
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_git_mcp_tools",
-    error_code_prefix="GIT_MCP",
-)
 @router.get("/mcp/tools", response_model=List[MCPTool])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -578,11 +573,6 @@ async def get_git_mcp_tools() -> List[MCPTool]:
 # Tool Implementations
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="git_status_mcp",
-    error_code_prefix="GIT_MCP",
-)
 @router.post("/mcp/status", response_model=GitMCPOperationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -622,11 +612,6 @@ async def git_status_mcp(request: GitStatusRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="git_log_mcp",
-    error_code_prefix="GIT_MCP",
-)
 @router.post("/mcp/log", response_model=GitMCPOperationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -674,11 +659,6 @@ async def git_log_mcp(request: GitLogRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="git_diff_mcp",
-    error_code_prefix="GIT_MCP",
-)
 @router.post("/mcp/diff", response_model=GitMCPOperationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -730,11 +710,6 @@ async def git_diff_mcp(request: GitDiffRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="git_branch_mcp",
-    error_code_prefix="GIT_MCP",
-)
 @router.post("/mcp/branch", response_model=GitMCPOperationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -788,11 +763,6 @@ async def git_branch_mcp(request: GitBranchRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="git_blame_mcp",
-    error_code_prefix="GIT_MCP",
-)
 @router.post("/mcp/blame", response_model=GitMCPOperationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -837,11 +807,6 @@ async def git_blame_mcp(request: GitBlameRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="git_show_mcp",
-    error_code_prefix="GIT_MCP",
-)
 @router.post("/mcp/show", response_model=GitMCPOperationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -943,11 +908,6 @@ async def get_git_repo_info() -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_git_mcp_status",
-    error_code_prefix="GIT_MCP",
-)
 @router.get("/mcp/service_status", response_model=GitMCPServiceStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/gpu_monitoring.py
+++ b/autobot-backend/api/gpu_monitoring.py
@@ -37,11 +37,6 @@ def _gpu_unavailable_error() -> HTTPException:
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_gpu_efficiency",
-    error_code_prefix="GPU_MONITORING",
-)
 @router.get("/efficiency", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -68,11 +63,6 @@ async def get_gpu_efficiency(
     return {"success": True, "efficiency": result}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_gpu_capabilities",
-    error_code_prefix="GPU_MONITORING",
-)
 @router.get("/capabilities", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -96,11 +86,6 @@ async def get_gpu_capabilities(
     return {"success": True, "capabilities": caps}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="run_gpu_benchmark",
-    error_code_prefix="GPU_MONITORING",
-)
 @router.post("/benchmark", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -124,11 +109,6 @@ async def run_gpu_benchmark(
     return {"success": True, "benchmark": result}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="optimize_gpu_multimodal",
-    error_code_prefix="GPU_MONITORING",
-)
 @router.post("/optimize", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -156,11 +136,6 @@ async def optimize_gpu_multimodal(
     return {"success": True, "optimization": asdict(result)}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_gpu_config",
-    error_code_prefix="GPU_MONITORING",
-)
 @router.patch("/config", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/graph_rag.py
+++ b/autobot-backend/api/graph_rag.py
@@ -139,11 +139,6 @@ def _determine_overall_status(components: Dict[str, str]) -> str:
     return "unhealthy"
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="graph_rag_search",
-    error_code_prefix="GRAPH_RAG",
-)
 @router.post("/search", response_model=GraphRAGSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -206,11 +201,6 @@ async def graph_rag_search(
         raise HTTPException(status_code=500, detail="Graph-RAG search failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="graph_rag_health",
-    error_code_prefix="GRAPH_RAG",
-)
 @router.get("/health", response_model=GraphRAGHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -276,11 +266,6 @@ async def graph_rag_health(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="graph_rag_metrics",
-    error_code_prefix="GRAPH_RAG",
-)
 @router.get("/metrics", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/hot_reload.py
+++ b/autobot-backend/api/hot_reload.py
@@ -25,11 +25,6 @@ router = APIRouter(
 )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reload_chat_workflow",
-    error_code_prefix="HOT_RELOAD",
-)
 @router.post("/chat-workflow", response_model=ReloadResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -76,11 +71,6 @@ async def reload_chat_workflow():
         raise HTTPException(status_code=500, detail="Failed to reload chat workflow")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reload_module",
-    error_code_prefix="HOT_RELOAD",
-)
 @router.post("/module", response_model=ReloadResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -126,11 +116,6 @@ async def reload_module(request: ReloadRequest):
         raise HTTPException(status_code=500, detail="Failed to reload module")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_reload_status",
-    error_code_prefix="HOT_RELOAD",
-)
 @router.get("/status", response_model=Metadata)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -152,11 +137,6 @@ async def get_reload_status():
         raise HTTPException(status_code=500, detail="Failed to get status")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_hot_reload",
-    error_code_prefix="HOT_RELOAD",
-)
 @router.post("/start", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -187,11 +167,6 @@ async def start_hot_reload():
         raise HTTPException(status_code=500, detail="Failed to start hot reload")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="stop_hot_reload",
-    error_code_prefix="HOT_RELOAD",
-)
 @router.post("/stop", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -214,11 +189,6 @@ async def stop_hot_reload():
         raise HTTPException(status_code=500, detail="Failed to stop hot reload")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="hot_reload_health",
-    error_code_prefix="HOT_RELOAD",
-)
 @router.get("/health", response_model=HotReloadHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/http_client_mcp.py
+++ b/autobot-backend/api/http_client_mcp.py
@@ -554,11 +554,6 @@ def _load_tools_from_yaml() -> List[HTTPClientMCPTool]:
     return [HTTPClientMCPTool(**tool) for tool in tool_dicts]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_http_client_mcp_tools",
-    error_code_prefix="HTTP_MCP",
-)
 @router.get("/mcp/tools", response_model=List[HTTPClientMCPTool])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -652,11 +647,6 @@ async def execute_http_request(
         raise HTTPException(status_code=502, detail="HTTP request failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="http_get_mcp",
-    error_code_prefix="HTTP_CLIENT_MCP",
-)
 @router.post("/mcp/get", response_model=HTTPRequestResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -700,11 +690,6 @@ async def http_get_mcp(request: HTTPGetRequest) -> JSONObject:
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="http_post_mcp",
-    error_code_prefix="HTTP_CLIENT_MCP",
-)
 @router.post("/mcp/post", response_model=HTTPRequestResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -765,11 +750,6 @@ async def http_post_mcp(request: HTTPPostRequest) -> JSONObject:
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="http_put_mcp",
-    error_code_prefix="HTTP_CLIENT_MCP",
-)
 @router.post("/mcp/put", response_model=HTTPRequestResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -822,11 +802,6 @@ async def http_put_mcp(request: HTTPPutRequest) -> JSONObject:
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="http_patch_mcp",
-    error_code_prefix="HTTP_CLIENT_MCP",
-)
 @router.post("/mcp/patch", response_model=HTTPRequestResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -879,11 +854,6 @@ async def http_patch_mcp(request: HTTPPatchRequest) -> JSONObject:
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="http_delete_mcp",
-    error_code_prefix="HTTP_CLIENT_MCP",
-)
 @router.post("/mcp/delete", response_model=HTTPRequestResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -926,11 +896,6 @@ async def http_delete_mcp(request: HTTPDeleteRequest) -> JSONObject:
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="http_head_mcp",
-    error_code_prefix="HTTP_CLIENT_MCP",
-)
 @router.post("/mcp/head", response_model=HTTPRequestResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -972,11 +937,6 @@ async def http_head_mcp(request: HTTPHeadRequest) -> JSONObject:
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_http_client_mcp_status",
-    error_code_prefix="HTTP_MCP",
-)
 @router.get("/mcp/status", response_model=HTTPClientMCPStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/integration_cloud.py
+++ b/autobot-backend/api/integration_cloud.py
@@ -40,11 +40,6 @@ router = APIRouter(
 logger = logging.getLogger(__name__)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_providers",
-    error_code_prefix="INTEGRATION_CLOUD",
-)
 @router.get("/providers", response_model=List[CloudProviderInfo])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -79,11 +74,6 @@ async def list_providers():
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_connection",
-    error_code_prefix="INTEGRATION_CLOUD",
-)
 @router.post("/test-connection", response_model=CloudConnectionTestResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -118,11 +108,6 @@ async def test_connection(request: CloudConnectionTestRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_resources",
-    error_code_prefix="INTEGRATION_CLOUD",
-)
 @router.get("/{provider}/resources", response_model=CloudResourcesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -167,11 +152,6 @@ async def list_resources(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_storage",
-    error_code_prefix="INTEGRATION_CLOUD",
-)
 @router.get("/{provider}/storage", response_model=CloudStorageResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -215,11 +195,6 @@ async def list_storage(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_account_info",
-    error_code_prefix="INTEGRATION_CLOUD",
-)
 @router.get("/{provider}/account", response_model=CloudAccountInfoResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/integration_database.py
+++ b/autobot-backend/api/integration_database.py
@@ -125,11 +125,6 @@ def _get_integration_class(provider: str):
     return integration_class
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_database_connection",
-    error_code_prefix="INTEGRATION_DATABASE",
-)
 @router.post("/test-connection", response_model=IntegrationDatabaseConnectionTestResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -170,11 +165,6 @@ async def test_database_connection(request: DatabaseConnectionRequest):
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_database_providers",
-    error_code_prefix="INTEGRATION_DATABASE",
-)
 @router.get("/providers", response_model=IntegrationDatabaseProvidersResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -212,11 +202,6 @@ async def list_database_providers() -> Dict[str, List[Dict[str, Any]]]:
     return {"providers": providers, "count": len(providers)}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="execute_database_query",
-    error_code_prefix="INTEGRATION_DATABASE",
-)
 @router.post("/{provider}/query", response_model=IntegrationDatabaseQueryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -270,11 +255,6 @@ async def execute_database_query(provider: str, request: DBIntegrationQueryReque
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="query_mongodb_collection",
-    error_code_prefix="INTEGRATION_DATABASE",
-)
 @router.post("/mongodb/query-collection", response_model=IntegrationMongoQueryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -323,11 +303,6 @@ async def query_mongodb_collection(request: MongoQueryRequest):
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_databases",
-    error_code_prefix="INTEGRATION_DATABASE",
-)
 @router.post("/{provider}/databases", response_model=IntegrationDatabaseListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -369,11 +344,6 @@ async def list_databases(provider: str, request: DatabaseListRequest):
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_tables",
-    error_code_prefix="INTEGRATION_DATABASE",
-)
 @router.post("/{provider}/tables", response_model=IntegrationTablesListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/intelligent_agent.py
+++ b/autobot-backend/api/intelligent_agent.py
@@ -109,11 +109,6 @@ async def get_agent() -> "IntelligentAgent":
 router = APIRouter(tags=["intelligent-agent"])
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="process_natural_language_goal",
-    error_code_prefix="INTELLIGENT_AGENT",
-)
 @router.post("/process", response_model=GoalResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -172,11 +167,6 @@ async def process_natural_language_goal(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_info",
-    error_code_prefix="INTELLIGENT_AGENT",
-)
 @router.get("/system-info", response_model=AgentSystemCapabilitiesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -217,11 +207,6 @@ async def get_system_info(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="health_check",
-    error_code_prefix="INTELLIGENT_AGENT",
-)
 @router.get("/health", response_model=HealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -261,11 +246,6 @@ async def health_check(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reload_agent",
-    error_code_prefix="INTELLIGENT_AGENT",
-)
 @router.post("/reload", response_model=AgentReloadResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -289,11 +269,6 @@ async def reload_agent(
     return {"status": "reloaded", "message": "Agent reloaded successfully"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="websocket_stream",
-    error_code_prefix="INTELLIGENT_AGENT",
-)
 @router.websocket("/stream")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/kb_librarian.py
+++ b/autobot-backend/api/kb_librarian.py
@@ -50,11 +50,6 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="query_knowledge_base",
-    error_code_prefix="KB_LIBRARIAN",
-)
 @router.post("/query", response_model=KBQueryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -112,11 +107,6 @@ async def query_knowledge_base(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_kb_librarian_status",
-    error_code_prefix="KB_LIBRARIAN",
-)
 @router.get("/status", response_model=KbLibrarianStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -148,11 +138,6 @@ async def get_kb_librarian_status(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="configure_kb_librarian",
-    error_code_prefix="KB_LIBRARIAN",
-)
 @router.put("/configure", response_model=KbLibrarianConfigureResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -241,11 +241,6 @@ from api.knowledge_population import (
 # ===== ENDPOINTS =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_knowledge_stats",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/stats", response_model=KnowledgeStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -302,11 +297,6 @@ async def get_knowledge_stats(
     return KnowledgeStatsResponse(**stats)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_main_categories",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/test_categories_main", response_model=TestCategoriesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -327,11 +317,6 @@ async def test_main_categories(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_knowledge_stats_basic",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/stats/basic", response_model=KnowledgeStatsBasic)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -428,11 +413,6 @@ def _build_main_categories(CATEGORY_METADATA, category_counts: dict) -> list:
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_main_categories",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/categories/main", response_model=KnowledgeMainCategoriesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -505,11 +485,6 @@ async def get_main_categories(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_knowledge_categories",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/categories", response_model=KnowledgeCategoriesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -685,11 +660,6 @@ def _build_ownership_metadata(
     return metadata
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_text_to_knowledge",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/add_text", response_model=AddTextResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -958,11 +928,6 @@ def _validate_file_upload(filename: str, file_size: int) -> None:
         raise HTTPException(status_code=400, detail="Invalid filename")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_facts_to_knowledge",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/facts", response_model=AddFactResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1067,11 +1032,6 @@ async def _fetch_and_extract_url(
         raise HTTPException(status_code=400, detail="Failed to fetch URL")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_url_to_knowledge",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/url", response_model=AddUrlResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1270,11 +1230,6 @@ def _parse_upload_tags(tags_str) -> list:
         return []
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="upload_file_to_knowledge",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/upload", response_model=UploadFileResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1448,11 +1403,6 @@ async def _ingest_audio_source(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="ingest_audio_url",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/audio", response_model=AudioIngestResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1500,11 +1450,6 @@ async def ingest_audio_url(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="upload_audio_file",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/audio/upload", response_model=AudioIngestResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1605,11 +1550,6 @@ async def upload_audio_file(
 # Includes: /search, /enhanced_search, /rag_search, /similarity_search
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVICE_UNAVAILABLE,
-    operation="get_knowledge_health",
-    error_code_prefix="KB",
-)
 @router.get("/health", response_model=KnowledgeHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1813,11 +1753,6 @@ def _compute_size_metrics(fact_sizes: list) -> dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_detailed_stats",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/detailed_stats", response_model=DetailedKnowledgeStats)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1866,11 +1801,6 @@ async def get_detailed_stats(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_machine_profile",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/machine_profile", response_model=MachineProfileResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1923,11 +1853,6 @@ async def get_machine_profile(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_man_pages_summary",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/man_pages/summary", response_model=ManPagesSummaryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2008,11 +1933,6 @@ async def get_man_pages_summary(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="initialize_machine_knowledge",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/machine_knowledge/initialize", response_model=MachineKnowledgeInitResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2065,11 +1985,6 @@ async def initialize_machine_knowledge(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="integrate_man_pages",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/man_pages/integrate", response_model=ManPagesIntegrateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2114,11 +2029,6 @@ async def integrate_man_pages(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_man_pages",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/man_pages/search", response_model=ManPageSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2189,11 +2099,6 @@ async def _clear_kb_via_redis(kb) -> int:
     return len(keys) if keys else 0
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_all_knowledge",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/clear_all", response_model=ClearAllResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2264,11 +2169,6 @@ async def clear_all_knowledge(
 
 
 # Legacy endpoints for backward compatibility
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_document_to_knowledge",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/add_document", response_model=AddTextResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2287,11 +2187,6 @@ async def add_document_to_knowledge(
     return await add_text_to_knowledge(request, req)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="query_knowledge",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/query", response_model=QueryKnowledgeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2464,11 +2359,6 @@ def _build_categories_dict(all_fact_keys: list, fact_results: list) -> dict:
     return categories_dict
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_facts_by_category",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/facts/by_category", response_model=FactsByCategoryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2695,11 +2585,6 @@ def _extract_fact_created_at(fact_data: dict) -> str:
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_fact_by_key",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/fact/{fact_key}", response_model=FactByKeyResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2743,11 +2628,6 @@ async def get_fact_by_key(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_import_status",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/import/status", response_model=ImportStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2772,11 +2652,6 @@ async def get_import_status(
     return {"status": "success", "imports": results, "total": len(results)}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_import_statistics",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/import/statistics", response_model=ImportStatisticsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2893,11 +2768,6 @@ def _paginate_docs(docs: list, page: int, page_size: int) -> tuple:
     return docs[start:end], total, total_pages
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="browse_documentation",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/docs/browse", response_model=DocsBrowseResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -2959,11 +2829,6 @@ async def browse_documentation(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_doc_categories",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/docs/categories", response_model=DocsCategoriesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -3035,11 +2900,6 @@ async def get_documentation_categories(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_doc_stats",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/docs/stats", response_model=DocsStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -3096,11 +2956,6 @@ async def get_documentation_stats(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_doc_watcher_status",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/docs/watcher/status", response_model=DocsWatcherStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -3137,11 +2992,6 @@ async def get_documentation_watcher_status(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="control_doc_watcher",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/docs/watcher/control", response_model=DocsWatcherControlResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_ai_stack.py
+++ b/autobot-backend/api/knowledge_ai_stack.py
@@ -259,11 +259,6 @@ async def _run_all_search_sources(
     return results
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_search",
-    error_code_prefix="KNOWLEDGE_ENHANCED",
-)
 @router.post("/search/enhanced", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -315,11 +310,6 @@ async def enhanced_search(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="rag_search",
-    error_code_prefix="KNOWLEDGE_ENHANCED",
-)
 @router.post("/search/rag", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -453,11 +443,6 @@ async def _store_extracted_facts(
     return stored_facts
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="extract_knowledge",
-    error_code_prefix="KNOWLEDGE_ENHANCED",
-)
 @router.post("/extract", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -510,11 +495,6 @@ async def extract_knowledge(
         await handle_ai_stack_error(e, "Knowledge extraction")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_documents",
-    error_code_prefix="KNOWLEDGE_ENHANCED",
-)
 @router.post("/analyze/documents", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -560,11 +540,6 @@ async def analyze_documents(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reformulate_query",
-    error_code_prefix="KNOWLEDGE_ENHANCED",
-)
 @router.post("/query/reformulate", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -608,11 +583,6 @@ async def reformulate_query(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_knowledge_insights",
-    error_code_prefix="KNOWLEDGE_ENHANCED",
-)
 @router.get("/system/insights", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -651,11 +621,6 @@ async def get_system_knowledge_insights(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_enhanced_stats",
-    error_code_prefix="KNOWLEDGE_ENHANCED",
-)
 @router.get("/stats/enhanced", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -710,11 +675,6 @@ async def get_enhanced_stats(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_knowledge_health",
-    error_code_prefix="KNOWLEDGE_ENHANCED",
-)
 @router.get("/health/enhanced", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_boards.py
+++ b/autobot-backend/api/knowledge_boards.py
@@ -57,11 +57,6 @@ def _board_entry(board_id: str, name: str, description: str) -> dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_boards",
-    error_code_prefix="KB_BOARDS",
-)
 @router.get("/boards", response_model=KnowledgeBoardsListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -104,11 +99,6 @@ async def list_boards(
     return {"boards": boards, "total": len(boards)}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_board",
-    error_code_prefix="KB_BOARDS",
-)
 @router.post("/boards", status_code=201, response_model=KnowledgeBoardCreateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -146,11 +136,6 @@ async def create_board(
     return {"board_id": board_id, "name": request.name, "created": True}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_board",
-    error_code_prefix="KB_BOARDS",
-)
 @router.delete("/boards/{board_id}", response_model=KnowledgeBoardDeleteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_categories.py
+++ b/autobot-backend/api/knowledge_categories.py
@@ -77,11 +77,6 @@ def _raise_kb_error(error_message: str, default_code: int = 500) -> None:
 # ===== CATEGORY CRUD OPERATIONS (Issue #411) =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_category",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/categories", response_model=KnowledgeCategoryCreateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -139,11 +134,6 @@ async def create_category(
             raise HTTPException(status_code=400, detail=error_message)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_category_tree",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/categories/tree", response_model=KnowledgeCategoryTreeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -205,11 +195,6 @@ async def get_category_tree(
         _raise_kb_error(result.get("message", "Unknown error"))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_category",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/categories/{category_id}", response_model=KnowledgeCategoryDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -253,11 +238,6 @@ async def get_category(
         _raise_kb_error(result.get("message", "Unknown error"))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_category_by_path",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/categories/path/{path:path}", response_model=KnowledgeCategoryDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -296,11 +276,6 @@ async def get_category_by_path(
         _raise_kb_error(result.get("message", "Unknown error"))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_category",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.put("/categories/{category_id}", response_model=KnowledgeCategoryUpdateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -366,11 +341,6 @@ async def update_category(
             raise HTTPException(status_code=400, detail=error_message)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_category",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.delete("/categories/{category_id}", response_model=KnowledgeCategoryDeleteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -453,11 +423,6 @@ def _raise_delete_category_error(result: dict) -> None:
 # ===== CATEGORY HIERARCHY OPERATIONS (Issue #411) =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_category_children",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/categories/{category_id}/children", response_model=KnowledgeCategoryChildrenResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -504,11 +469,6 @@ async def get_category_children(
         _raise_kb_error(result.get("message", "Unknown error"))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_category_ancestors",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/categories/{category_id}/ancestors", response_model=KnowledgeCategoryAncestorsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -558,11 +518,6 @@ async def get_category_ancestors(
 # ===== CATEGORY-FACT OPERATIONS (Issue #411) =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_facts_in_category",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/categories/{category_id}/facts", response_model=KnowledgeCategoryFactsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -628,11 +583,6 @@ async def get_facts_in_category(
         _raise_kb_error(result.get("message", "Unknown error"))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="assign_fact_to_category",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/facts/{fact_id}/category", response_model=KnowledgeFactAssignCategoryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -688,11 +638,6 @@ async def assign_fact_to_category(
         _raise_kb_error(result.get("message", "Unknown error"), 400)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_categories_by_path",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/categories/search", response_model=KnowledgeCategorySearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_collections.py
+++ b/autobot-backend/api/knowledge_collections.py
@@ -74,11 +74,6 @@ def _raise_kb_error(error_message: str, default_code: int = 500) -> None:
 # ===== COLLECTION CRUD OPERATIONS (Issue #412) =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_collection",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/collections", response_model=KnowledgeCollectionCreateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -134,11 +129,6 @@ async def create_collection(
         raise HTTPException(status_code=400, detail=error_message)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_collections",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/collections", response_model=KnowledgeCollectionListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -193,11 +183,6 @@ async def list_collections(
         raise HTTPException(status_code=500, detail=error_message)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_collection",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/collections/{collection_id}", response_model=KnowledgeCollectionDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -247,11 +232,6 @@ async def get_collection(
         _raise_kb_error(result.get("message", "Unknown error"))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_collection",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.put("/collections/{collection_id}", response_model=KnowledgeCollectionUpdateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -317,11 +297,6 @@ async def update_collection(
         _raise_kb_error(result.get("message", "Unknown error"), 400)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_collection",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.delete("/collections/{collection_id}", response_model=KnowledgeCollectionDeleteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -387,11 +362,6 @@ async def delete_collection(
 # ===== COLLECTION MEMBERSHIP OPERATIONS (Issue #412) =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_facts_to_collection",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/collections/{collection_id}/facts", response_model=KnowledgeCollectionAddFactsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -457,11 +427,6 @@ async def add_facts_to_collection(
         _raise_kb_error(result.get("message", "Unknown error"), 400)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="remove_facts_from_collection",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.delete("/collections/{collection_id}/facts", response_model=KnowledgeCollectionRemoveFactsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -525,11 +490,6 @@ async def remove_facts_from_collection(
         _raise_kb_error(result.get("message", "Unknown error"), 400)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_facts_in_collection",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/collections/{collection_id}/facts", response_model=KnowledgeCollectionFactsListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -596,11 +556,6 @@ async def get_facts_in_collection(
         _raise_kb_error(result.get("message", "Unknown error"))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_fact_collections",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/facts/{fact_id}/collections", response_model=KnowledgeFactCollectionsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -656,11 +611,6 @@ async def get_fact_collections(
 # ===== COLLECTION BULK OPERATIONS (Issue #412) =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_collection",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/collections/{collection_id}/export", response_model=KnowledgeCollectionExportResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -725,11 +675,6 @@ async def export_collection(
         _raise_kb_error(result.get("message", "Unknown error"))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="bulk_delete_collection_facts",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/collections/{collection_id}/bulk-delete", response_model=KnowledgeCollectionBulkDeleteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_debug.py
+++ b/autobot-backend/api/knowledge_debug.py
@@ -23,11 +23,6 @@ router = APIRouter(
 logger = logging.getLogger(__name__)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_fresh_knowledge_stats",
-    error_code_prefix="KNOWLEDGE_FRESH",
-)
 @router.get("/fresh_stats", response_model=KnowledgeFreshStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -99,11 +94,6 @@ async def get_fresh_knowledge_stats(request: Request = None):
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="debug_redis_connection",
-    error_code_prefix="KNOWLEDGE_FRESH",
-)
 @router.get("/debug_redis", response_model=KnowledgeDebugRedisResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -175,11 +165,6 @@ async def debug_redis_connection():
         return {"redis_connection": "failed", "error": "Internal server error"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="rebuild_search_index",
-    error_code_prefix="KNOWLEDGE_FRESH",
-)
 @router.post("/rebuild_index", response_model=KnowledgeRebuildIndexResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_grounding.py
+++ b/autobot-backend/api/knowledge_grounding.py
@@ -59,11 +59,6 @@ router = APIRouter(
 # ===== ENDPOINTS =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="ground_response",
-    error_code_prefix="KNOWLEDGE_GROUNDING",
-)
 @router.post("/ground-response", response_model=KnowledgeGroundResponseResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -143,11 +138,6 @@ async def ground_response(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="verify_claim",
-    error_code_prefix="KNOWLEDGE_GROUNDING",
-)
 @router.post("/verify-claim", response_model=KnowledgeVerifyClaimResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -221,11 +211,6 @@ async def verify_claim(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_conflicts",
-    error_code_prefix="KNOWLEDGE_GROUNDING",
-)
 @router.get("/kb-conflicts", response_model=KnowledgeConflictsListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -362,11 +347,6 @@ async def list_conflicts(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="resolve_conflict",
-    error_code_prefix="KNOWLEDGE_GROUNDING",
-)
 @router.post("/kb-conflicts/{conflict_id}/resolve", response_model=KnowledgeResolveConflictResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -432,11 +412,6 @@ async def resolve_conflict(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_stats",
-    error_code_prefix="KNOWLEDGE_GROUNDING",
-)
 @router.get("/kb-stats", response_model=KnowledgeGroundingStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_maintenance.py
+++ b/autobot-backend/api/knowledge_maintenance.py
@@ -209,11 +209,6 @@ async def _delete_facts_in_batches(
     return deleted_count
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="deduplicate_facts",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/deduplicate", response_model=DeduplicateFactsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -271,11 +266,6 @@ async def deduplicate_facts(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="find_duplicates",
-    error_code_prefix="KB",
-)
 @router.post("/deduplicate/advanced", response_model=FindDuplicatesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -334,11 +324,6 @@ async def find_duplicates(
 # ===== DATA QUALITY METRICS (Issue #418) =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_data_quality_metrics",
-    error_code_prefix="KB",
-)
 @router.get("/quality", response_model=DataQualityMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -450,11 +435,6 @@ def _build_quality_summary(quality: dict) -> dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_health_dashboard",
-    error_code_prefix="KB",
-)
 @router.get("/health/dashboard", response_model=HealthDashboardResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -686,11 +666,6 @@ def _perform_fast_scan(
     return scanner, result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="scan_host_changes",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/scan_host_changes", response_model=ScanHostChangesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -866,11 +841,6 @@ def _build_orphan_response(total_checked: int, orphaned_facts: list) -> dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="find_orphaned_facts",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/orphans", response_model=FindOrphanedFactsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -909,11 +879,6 @@ async def find_orphaned_facts(
     return _build_orphan_response(total_checked, orphaned_facts)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cleanup_orphaned_facts",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.delete("/orphans", response_model=CleanupOrphanedFactsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1080,11 +1045,6 @@ def _scan_redis_for_session_orphans(redis_client, existing_session_ids: set) -> 
     return total_checked, total_with_session, orphaned_facts, session_stats
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="find_session_orphans",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/session-orphans", response_model=FindSessionOrphansResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1191,11 +1151,6 @@ async def _delete_orphan_facts(
     return deleted_count, preserved_count, preserved_facts
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cleanup_session_orphans",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.delete("/session-orphans", response_model=CleanupSessionOrphansResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1266,11 +1221,6 @@ async def cleanup_session_orphan_facts(
 # ===== IMPORT/EXPORT OPERATIONS =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="scan_for_unimported_files",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/import/scan", response_model=ScanUnimportedFilesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1320,11 +1270,6 @@ async def scan_for_unimported_files(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_knowledge",
-    error_code_prefix="KB",
-)
 @router.post("/export", response_model=ExportKnowledgeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1390,11 +1335,6 @@ async def export_knowledge(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="import_knowledge",
-    error_code_prefix="KB",
-)
 @router.post("/import", response_model=ImportKnowledgeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1539,11 +1479,6 @@ def _handle_update_fact_result(result: dict, fact_id: str) -> dict:
     raise HTTPException(status_code=500, detail=error_message)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_fact",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.put("/fact/{fact_id}", response_model=UpdateFactResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1590,11 +1525,6 @@ async def update_fact(
     return _handle_update_fact_result(result, fact_id)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_fact",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.delete("/fact/{fact_id}", response_model=DeleteFactResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1663,11 +1593,6 @@ async def delete_fact(
 # ===== BULK OPERATION ENDPOINTS =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="bulk_delete",
-    error_code_prefix="KB",
-)
 @router.delete("/bulk", response_model=BulkDeleteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1716,11 +1641,6 @@ async def bulk_delete_facts(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="bulk_update_category",
-    error_code_prefix="KB",
-)
 @router.post("/bulk/category", response_model=BulkCategoryUpdateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1767,11 +1687,6 @@ async def bulk_update_category(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cleanup_knowledge_base",
-    error_code_prefix="KB",
-)
 @router.post("/cleanup", response_model=CleanupKnowledgeBaseResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1827,11 +1742,6 @@ async def cleanup_knowledge_base(
 # ===== BACKUP AND RESTORE ENDPOINTS (Issue #419) =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_backup",
-    error_code_prefix="KB",
-)
 @router.post("/backup", response_model=CreateBackupResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1885,11 +1795,6 @@ async def create_backup(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="restore_backup",
-    error_code_prefix="KB",
-)
 @router.post("/restore", response_model=RestoreBackupResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1948,11 +1853,6 @@ async def restore_backup(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_backups",
-    error_code_prefix="KB",
-)
 @router.get("/backups", response_model=ListBackupsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1998,11 +1898,6 @@ async def list_backups(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_backup",
-    error_code_prefix="KB",
-)
 @router.delete("/backup", response_model=DeleteBackupResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_mcp.py
+++ b/autobot-backend/api/knowledge_mcp.py
@@ -296,11 +296,6 @@ def _get_knowledge_management_tools() -> List[McpToolsResponse]:
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_mcp_tools",
-    error_code_prefix="KNOWLEDGE_MCP",
-)
 @router.get("/mcp/tools", response_model=List[McpToolsResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -321,11 +316,6 @@ async def get_mcp_tools(
     return tools
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="mcp_search_knowledge_base",
-    error_code_prefix="KNOWLEDGE_MCP",
-)
 @router.post("/mcp/search_knowledge_base", response_model=McpSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -372,11 +362,6 @@ async def mcp_search_knowledge_base(
         return {"success": False, "error": "Internal server error", "results": []}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="mcp_add_to_knowledge_base",
-    error_code_prefix="KNOWLEDGE_MCP",
-)
 @router.post("/mcp/add_to_knowledge_base", response_model=McpAddDocumentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -412,11 +397,6 @@ async def mcp_add_to_knowledge_base(
         return {"success": False, "error": "Internal server error"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="mcp_get_knowledge_stats",
-    error_code_prefix="KNOWLEDGE_MCP",
-)
 @router.post("/mcp/get_knowledge_stats", response_model=McpKnowledgeStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -460,11 +440,6 @@ async def mcp_get_knowledge_stats(
         return {"success": False, "error": "Internal server error", "stats": {}}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="mcp_summarize_knowledge_topic",
-    error_code_prefix="KNOWLEDGE_MCP",
-)
 @router.post("/mcp/summarize_knowledge_topic", response_model=McpSummarizeTopicResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -529,11 +504,6 @@ async def mcp_summarize_knowledge_topic(
         return {"success": False, "error": "Internal server error", "summary": ""}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="mcp_vector_similarity_search",
-    error_code_prefix="KNOWLEDGE_MCP",
-)
 @router.post("/mcp/vector_similarity_search", response_model=McpVectorSimilarityResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -583,11 +553,6 @@ async def mcp_vector_similarity_search(
         return {"success": False, "error": "Internal server error", "results": []}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="mcp_langchain_qa_chain",
-    error_code_prefix="KNOWLEDGE_MCP",
-)
 @router.post("/mcp/langchain_qa_chain", response_model=McpQaChainResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -714,11 +679,6 @@ _VECTOR_OPERATIONS = {
 }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="mcp_redis_vector_operations",
-    error_code_prefix="KNOWLEDGE_MCP",
-)
 @router.post("/mcp/redis_vector_operations", response_model=McpRedisVectorOpsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -752,11 +712,6 @@ async def mcp_redis_vector_operations(
         return {"success": False, "error": "Internal server error"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_mcp_schema",
-    error_code_prefix="KNOWLEDGE_MCP",
-)
 @router.get("/mcp/schema", response_model=McpSchemaResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -786,11 +741,6 @@ async def get_mcp_schema(
 
 
 # Health check for MCP bridge
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="mcp_health",
-    error_code_prefix="KNOWLEDGE_MCP",
-)
 @router.get("/mcp/health", response_model=McpHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_ownership.py
+++ b/autobot-backend/api/knowledge_ownership.py
@@ -82,11 +82,6 @@ async def _get_fact_with_ownership(kb, fact_id: str, user_id: str):
     return fact
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="share_fact",
-    error_code_prefix="KNOWLEDGE_OWNERSHIP",
-)
 @router.post("/api/knowledge/facts/{fact_id}/share", response_model=KnowledgeShareFactResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -150,11 +145,6 @@ async def share_fact(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="unshare_fact",
-    error_code_prefix="KNOWLEDGE_OWNERSHIP",
-)
 @router.delete("/api/knowledge/facts/{fact_id}/share/{user_id_to_remove}", response_model=KnowledgeUnshareFactResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -218,11 +208,6 @@ async def unshare_fact(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_fact_visibility",
-    error_code_prefix="KNOWLEDGE_OWNERSHIP",
-)
 @router.put("/api/knowledge/facts/{fact_id}/visibility", response_model=KnowledgeUpdateVisibilityResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -315,11 +300,6 @@ async def _fetch_fact_details(
     return facts
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_my_facts",
-    error_code_prefix="KNOWLEDGE_OWNERSHIP",
-)
 @router.get("/api/knowledge/facts/mine", response_model=KnowledgeMyFactsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -382,11 +362,6 @@ async def get_my_facts(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_shared_facts",
-    error_code_prefix="KNOWLEDGE_OWNERSHIP",
-)
 @router.get("/api/knowledge/facts/shared-with-me", response_model=KnowledgeSharedWithMeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_population.py
+++ b/autobot-backend/api/knowledge_population.py
@@ -414,11 +414,6 @@ async def _store_autobot_config_info(kb_to_use) -> bool:
 # ===== POPULATION ENDPOINTS =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="populate_system_commands",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/populate_system_commands", response_model=PopulateSystemCommandsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -631,11 +626,6 @@ async def _populate_man_pages_background(kb_to_use):
         return 0
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="populate_man_pages",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/populate_man_pages", response_model=PopulateManPagesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -667,11 +657,6 @@ async def populate_man_pages(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="refresh_system_knowledge",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/refresh_system_knowledge", response_model=RefreshSystemKnowledgeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -713,11 +698,6 @@ async def refresh_system_knowledge(request: dict, req: Request):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_job_status",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/job_status/{task_id}", response_model=JobStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1030,11 +1010,6 @@ async def _process_all_doc_files(
     return items_added, items_skipped, items_failed
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="populate_autobot_docs",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/populate_autobot_docs", response_model=TaskQueuedResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1255,10 +1230,6 @@ async def _index_code_background(task_id: str, root_dir: str, force: bool) -> No
         )
 
 
-@with_error_handling(
-    operation="index_code",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/index/code", response_model=TaskQueuedResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1541,11 +1512,6 @@ def _parse_scan_request(request: dict | None) -> tuple[int | None, list | None, 
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="scan_man_pages",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/scan_man_pages", response_model=ScanManPagesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1613,11 +1579,6 @@ async def _store_parsed_man_pages(kb_to_use, parsed_content: list) -> int:
     return items_added
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="scan_man_pages_changes",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/scan_man_pages_changes", response_model=ScanManPagesChangesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_rag.py
+++ b/autobot-backend/api/knowledge_rag.py
@@ -120,11 +120,6 @@ def _build_search_metrics(metrics) -> dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="advanced_rag_search",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/advanced_search", response_model=AdvancedSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -188,11 +183,6 @@ async def advanced_search(
     return response
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="rerank_results",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/rerank_results", response_model=RerankResultsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -238,11 +228,6 @@ async def rerank_results(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_rag_config",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/config/rag", response_model=RagConfigResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -270,11 +255,6 @@ async def get_rag_configuration(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_rag_config",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.put("/config/rag", response_model=UpdateRagConfigResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -321,11 +301,6 @@ async def update_rag_configuration(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_loop_status",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/loop/status", response_model=LoopStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -368,11 +343,6 @@ async def get_loop_status(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="approve_loop_variant",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/loop/approve", response_model=LoopApproveResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -407,11 +377,6 @@ async def approve_loop_variant(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reject_loop_variant",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/loop/reject", response_model=LoopRejectResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -443,11 +408,6 @@ async def reject_loop_variant(
     return {"message": "Pending variant rejected and cleared"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_rag_stats",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/stats/rag", response_model=RagStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -477,11 +437,6 @@ async def get_rag_stats(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="run_rag_benchmark",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/benchmark/run", response_model=BenchmarkRunResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -615,11 +570,6 @@ async def run_rag_benchmark(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_entity_history",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/entity/{entity_id}/history", response_model=EntityHistoryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_rag_feedback.py
+++ b/autobot-backend/api/knowledge_rag_feedback.py
@@ -35,11 +35,6 @@ router = APIRouter(tags=["knowledge-rag-feedback"])
 _STREAM_TTL_SECONDS = TTL_30_DAYS
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="record_rag_feedback",
-    error_code_prefix="KNOWLEDGE_RAG_FEEDBACK",
-)
 @router.post("/rag-feedback", response_model=RagFeedbackResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_relations.py
+++ b/autobot-backend/api/knowledge_relations.py
@@ -51,11 +51,6 @@ router = APIRouter(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_fact_relation",
-    error_code_prefix="KNOWLEDGE_RELATIONS",
-)
 @router.post("/create", response_model=KnowledgeRelationResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -103,11 +98,6 @@ async def create_fact_relation(req: Request, body: CreateRelationRequest):
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_fact_relation",
-    error_code_prefix="KNOWLEDGE_RELATIONS",
-)
 @router.delete("/delete", response_model=KnowledgeRelationResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -140,11 +130,6 @@ async def delete_fact_relation(req: Request, body: DeleteRelationRequest):
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_fact_relations",
-    error_code_prefix="KNOWLEDGE_RELATIONS",
-)
 @router.get("/fact/{fact_id}", response_model=KnowledgeRelationResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -194,11 +179,6 @@ async def get_fact_relations(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="traverse_relations",
-    error_code_prefix="KNOWLEDGE_RELATIONS",
-)
 @router.post("/traverse", response_model=KnowledgeRelationResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -233,11 +213,6 @@ async def traverse_relations(req: Request, body: TraverseRequest):
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="hybrid_search",
-    error_code_prefix="KNOWLEDGE_RELATIONS",
-)
 @router.post("/hybrid-search", response_model=KnowledgeRelationResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -276,11 +251,6 @@ async def hybrid_search(req: Request, body: HybridSearchRequest):
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_relation_stats",
-    error_code_prefix="KNOWLEDGE_RELATIONS",
-)
 @router.get("/stats", response_model=KnowledgeRelationResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -309,11 +279,6 @@ async def get_relation_stats(req: Request):
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_available_relation_types",
-    error_code_prefix="KNOWLEDGE_RELATIONS",
-)
 @router.get("/types", response_model=KnowledgeRelationTypesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_search.py
+++ b/autobot-backend/api/knowledge_search.py
@@ -563,11 +563,6 @@ async def _execute_basic_search_with_reranking(
 # ===== SEARCH ENDPOINTS =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="consolidated_search",
-    error_code_prefix="KB",
-)
 @router.post("/search", response_model=KnowledgeSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -772,11 +767,6 @@ def _enhanced_search_not_initialized_response() -> dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_search",
-    error_code_prefix="KB",
-)
 @router.post("/enhanced_search", deprecated=True, response_model=EnhancedSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -847,11 +837,6 @@ async def enhanced_search(request: EnhancedSearchRequest, req: Request):
     return await kb_to_use.enhanced_search(**request.to_search_params())
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="rag_enhanced_search",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/rag_search", deprecated=True, response_model=RagSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -915,11 +900,6 @@ async def rag_enhanced_search(request: dict, req: Request):
     return _build_no_results_response(query, reformulated_queries)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="similarity_search",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/similarity_search", deprecated=True, response_model=SimilaritySearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1073,11 +1053,6 @@ async def _fallback_to_enhanced_search(kb_to_use, params: dict):
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_search_v2",
-    error_code_prefix="KB",
-)
 @router.post("/enhanced_search_v2", deprecated=True, response_model=EnhancedSearchV2Response)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1136,11 +1111,6 @@ async def enhanced_search_v2(request: dict, req: Request):
     return await kb_to_use.enhanced_search_v2(**params)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_search_analytics",
-    error_code_prefix="KB",
-)
 @router.get("/search_analytics", response_model=SearchAnalyticsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1179,11 +1149,6 @@ async def get_search_analytics():
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="record_search_click",
-    error_code_prefix="KB",
-)
 @router.post("/record_click", response_model=RecordClickResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1223,11 +1188,6 @@ async def record_search_click(request: dict):
         return {"success": False, "message": "Search analytics not available"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="expand_query",
-    error_code_prefix="KB",
-)
 @router.post("/expand_query", response_model=ExpandQueryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_search_aggregator.py
+++ b/autobot-backend/api/knowledge_search_aggregator.py
@@ -336,11 +336,6 @@ def _search_documentation(
         logger.warning("Documentation search failed: %s", e)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="unified_search",
-    error_code_prefix="KNOWLEDGE_UNIFIED",
-)
 @router.post("/search", response_model=KnowledgeUnifiedSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -390,11 +385,6 @@ async def unified_search(req: Request, body: UnifiedSearchRequest):
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="unified_stats",
-    error_code_prefix="KNOWLEDGE_UNIFIED",
-)
 @router.get("/stats", response_model=KnowledgeUnifiedStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -463,11 +453,6 @@ async def unified_stats(req: Request):
     return stats
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_llm_context",
-    error_code_prefix="KNOWLEDGE_UNIFIED",
-)
 @router.post("/context", response_model=KnowledgeUnifiedContextResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -539,11 +524,6 @@ async def get_llm_context(req: Request, body: ContextRequest):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_documentation",
-    error_code_prefix="KNOWLEDGE_UNIFIED",
-)
 @router.get("/documentation/search", response_model=KnowledgeDocumentationSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -597,11 +577,6 @@ async def search_documentation(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="documentation_stats",
-    error_code_prefix="KNOWLEDGE_UNIFIED",
-)
 @router.get("/documentation/stats", response_model=KnowledgeDocumentationStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -932,11 +907,6 @@ def _update_category_fact_counts(
             node["metadata"]["fact_count"] = count
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_unified_graph",
-    error_code_prefix="KNOWLEDGE_UNIFIED",
-)
 @router.post("/graph", response_model=KnowledgeUnifiedGraphResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1007,11 +977,6 @@ async def get_unified_graph(req: Request, body: GraphRequest):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_unified_graph_simple",
-    error_code_prefix="KNOWLEDGE_UNIFIED",
-)
 @router.get("/graph", response_model=KnowledgeUnifiedGraphResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_tags.py
+++ b/autobot-backend/api/knowledge_tags.py
@@ -81,11 +81,6 @@ def _raise_kb_error(error_message: str, default_code: int = 500) -> None:
 # ===== TAG MANAGEMENT ENDPOINTS (Issue #77) =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_tags_to_fact",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/fact/{fact_id}/tags", response_model=KnowledgeTagFactTagsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -141,11 +136,6 @@ async def add_tags_to_fact(
         _raise_kb_error(result.get("message", "Unknown error"))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="remove_tags_from_fact",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.delete("/fact/{fact_id}/tags", response_model=KnowledgeTagFactTagsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -201,11 +191,6 @@ async def remove_tags_from_fact(
         _raise_kb_error(result.get("message", "Unknown error"))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_fact_tags",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/fact/{fact_id}/tags", response_model=KnowledgeTagGetFactTagsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -252,11 +237,6 @@ async def get_fact_tags(
         _raise_kb_error(result.get("message", "Unknown error"))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_facts_by_tags",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/tags/search", response_model=KnowledgeTagSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -316,11 +296,6 @@ async def search_facts_by_tags(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_all_tags",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/tags", response_model=KnowledgeTagListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -372,11 +347,6 @@ async def list_all_tags(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="bulk_tag_facts",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/tags/bulk", response_model=KnowledgeTagBulkResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -435,11 +405,6 @@ async def bulk_tag_facts(
 # ===== TAG CRUD OPERATIONS (Issue #409) =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="rename_tag",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.put("/tags/{tag_name}", response_model=KnowledgeTagRenameResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -500,11 +465,6 @@ async def rename_tag(
         _raise_kb_error(result.get("message", "Unknown error"), 400)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_tag_globally",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.delete("/tags/{tag_name}", response_model=KnowledgeTagDeleteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -561,11 +521,6 @@ async def delete_tag_globally(
         _raise_kb_error(result.get("message", "Unknown error"))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="merge_tags",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/tags/merge", response_model=KnowledgeTagMergeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -624,11 +579,6 @@ async def merge_tags(
         raise HTTPException(status_code=400, detail=error_message)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_facts_by_tag",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/tags/{tag_name}/facts", response_model=KnowledgeTagFactsByTagResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -701,11 +651,6 @@ async def get_facts_by_tag(
         raise HTTPException(status_code=500, detail=error_message)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_tag_info",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/tags/{tag_name}/info", response_model=KnowledgeTagInfoResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -762,11 +707,6 @@ async def get_tag_info(
 # ===== TAG STYLING OPERATIONS (Issue #410) =====
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_tag_style",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.patch("/tags/{tag_name}/style", response_model=KnowledgeTagStyleResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -837,11 +777,6 @@ async def update_tag_style(
         _raise_kb_error(result.get("message", "Unknown error"), 400)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_tag_style",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/tags/{tag_name}/style", response_model=KnowledgeTagStyleResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -903,11 +838,6 @@ async def get_tag_style(
         raise HTTPException(status_code=500, detail=error_message)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_tag_style",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.delete("/tags/{tag_name}/style", response_model=KnowledgeTagDeleteStyleResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_test.py
+++ b/autobot-backend/api/knowledge_test.py
@@ -19,11 +19,6 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_fresh_kb_stats",
-    error_code_prefix="KNOWLEDGE_TEST",
-)
 @router.get("/test/fresh_stats", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -60,11 +55,6 @@ async def get_fresh_kb_stats():
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_rebuild_search_index",
-    error_code_prefix="KNOWLEDGE_TEST",
-)
 @router.post("/test/rebuild_index", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_vectorization.py
+++ b/autobot-backend/api/knowledge_vectorization.py
@@ -329,11 +329,6 @@ async def _perform_uncached_batch_check(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="check_vectorization_status_batch",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/vectorization_status", response_model=VectorizationStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -611,11 +606,6 @@ def _build_vectorization_response(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vectorize_existing_facts",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/vectorize_facts", response_model=VectorizeFactsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1077,11 +1067,6 @@ async def _vectorize_fact_background(
         await _update_job_status(kb_instance, job_id, job_data)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vectorize_individual_fact",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/vectorize_fact/{fact_id}", response_model=VectorizeFactJobResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1156,11 +1141,6 @@ async def _vectorize_single_document(kb, document_id: str) -> dict:
         return {"id": document_id, "status": "error", "error": "Vectorization failed"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="batch_vectorize_documents",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/vectorize_documents", response_model=VectorizeDocumentsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1220,11 +1200,6 @@ async def batch_vectorize_documents(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_vectorization_job_status",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/vectorize_job/{job_id}", response_model=VectorizeJobStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1288,11 +1263,6 @@ def _collect_failed_keys(keys: list, results: list) -> List[str]:
     return failed_keys
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_failed_vectorization_jobs",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/vectorize_jobs/failed", response_model=FailedJobsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1350,11 +1320,6 @@ async def get_failed_vectorization_jobs(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="retry_vectorization_job",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/vectorize_jobs/{job_id}/retry", response_model=RetryJobResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1407,11 +1372,6 @@ async def retry_vectorization_job(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_vectorization_job",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.delete("/vectorize_jobs/{job_id}", response_model=DeleteJobResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1453,11 +1413,6 @@ async def delete_vectorization_job(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_failed_vectorization_jobs",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.delete("/vectorize_jobs/failed/clear", response_model=ClearFailedJobsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1521,11 +1476,6 @@ async def clear_failed_vectorization_jobs(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_background_vectorization",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post("/vectorize_facts/background", response_model=BackgroundVectorizationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1558,11 +1508,6 @@ async def start_background_vectorization(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_vectorization_status",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/vectorize_facts/status", response_model=VectorizationStatusPollResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1778,11 +1723,6 @@ async def _run_reindex(collection_name: str, batch_size: int) -> None:
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reindex_with_context",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.post(
     "/reindex_with_context",
     response_model=ReindexWithContextResponse,
@@ -1835,11 +1775,6 @@ async def reindex_with_context(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_reindex_with_context_status",
-    error_code_prefix="KNOWLEDGE",
-)
 @router.get("/reindex_with_context/status", response_model=ReindexWithContextStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/knowledge_verification.py
+++ b/autobot-backend/api/knowledge_verification.py
@@ -79,11 +79,6 @@ def _build_pending_response(fact: dict) -> PendingSourceResponse:
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_pending_verification",
-    error_code_prefix="KNOWLEDGE_VERIFICATION",
-)
 @router.get("/verification/pending", response_model=KnowledgeVerificationPendingResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -143,11 +138,6 @@ async def list_pending_verification(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="approve_fact",
-    error_code_prefix="KNOWLEDGE_VERIFICATION",
-)
 @router.post("/verification/{fact_id}/approve", response_model=KnowledgeVerificationApproveResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -201,11 +191,6 @@ async def approve_fact(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reject_fact",
-    error_code_prefix="KNOWLEDGE_VERIFICATION",
-)
 @router.post("/verification/{fact_id}/reject", response_model=KnowledgeVerificationRejectResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/llm.py
+++ b/autobot-backend/api/llm.py
@@ -47,11 +47,6 @@ def _get_llm_interface():
     return LLMInterface()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_llm_config",
-    error_code_prefix="LLM",
-)
 @router.get("/config", response_model=LLMConfigResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -104,11 +99,6 @@ async def update_llm_config(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_llm_connection",
-    error_code_prefix="LLM",
-)
 @router.post("/test_connection", response_model=LLMConnectionTestResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -133,13 +123,13 @@ async def test_llm_connection(
         }
 
 
+@router.get("/models", response_model=LLMModelsResponse)
+@cache_response(cache_key="llm_models", ttl=180)  # Cache for 3 minutes - RESTORED
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_available_llm_models",
     error_code_prefix="LLM",
 )
-@router.get("/models", response_model=LLMModelsResponse)
-@cache_response(cache_key="llm_models", ttl=180)  # Cache for 3 minutes - RESTORED
 async def get_available_llm_models(
     current_user: dict = Depends(get_current_user),
 ):
@@ -160,13 +150,13 @@ async def get_available_llm_models(
         raise HTTPException(status_code=500, detail="Error getting available models")
 
 
+@router.get("/current", response_model=LLMCurrentResponse)
+@cache_response(cache_key="current_llm", ttl=60)  # Cache for 1 minute
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_current_llm",
     error_code_prefix="LLM",
 )
-@router.get("/current", response_model=LLMCurrentResponse)
-@cache_response(cache_key="current_llm", ttl=60)  # Cache for 1 minute
 async def get_current_llm(
     current_user: dict = Depends(get_current_user),
 ):
@@ -269,13 +259,13 @@ async def update_llm_provider(
     )
 
 
+@router.get("/embedding/models", response_model=LLMEmbeddingModelsResponse)
+@cache_response(cache_key="embedding_models", ttl=300)  # Cache for 5 minutes
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_available_embedding_models",
     error_code_prefix="LLM",
 )
-@router.get("/embedding/models", response_model=LLMEmbeddingModelsResponse)
-@cache_response(cache_key="embedding_models", ttl=300)  # Cache for 5 minutes
 async def get_available_embedding_models(
     current_user: dict = Depends(get_current_user),
 ):
@@ -485,13 +475,13 @@ def _build_active_provider_info(
     }
 
 
+@router.get("/status/comprehensive", response_model=DataResponse)
+@cache_response(cache_key="llm_status_comprehensive", ttl=30)  # Cache for 30 seconds
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_comprehensive_llm_status",
     error_code_prefix="LLM",
 )
-@router.get("/status/comprehensive", response_model=DataResponse)
-@cache_response(cache_key="llm_status_comprehensive", ttl=30)  # Cache for 30 seconds
 async def get_comprehensive_llm_status(
     current_user: dict = Depends(get_current_user),
 ):
@@ -537,11 +527,6 @@ async def get_comprehensive_llm_status(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_llm_status",
-    error_code_prefix="LLM",
-)
 @router.get("/status", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -610,13 +595,13 @@ def _get_model_from_cloud_config(unified_config: dict) -> str:
     return model if (api_key and model) else ""
 
 
+@router.get("/status/quick", response_model=DataResponse)
+@cache_response(cache_key="llm_status_quick", ttl=15)  # Cache for 15 seconds
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_quick_llm_status",
     error_code_prefix="LLM",
 )
-@router.get("/status/quick", response_model=DataResponse)
-@cache_response(cache_key="llm_status_quick", ttl=15)  # Cache for 15 seconds
 async def get_quick_llm_status(
     current_user: dict = Depends(get_current_user),
 ):
@@ -685,13 +670,13 @@ def _build_providers_health_dict(results: dict) -> tuple:
     return providers_health, available_count
 
 
+@router.get("/health/providers", response_model=DataResponse)
+@cache_response(cache_key="llm_providers_health", ttl=30)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_all_providers_health",
     error_code_prefix="LLM",
 )
-@router.get("/health/providers", response_model=DataResponse)
-@cache_response(cache_key="llm_providers_health", ttl=30)
 async def get_all_providers_health():
     """
     Get health status of all configured LLM providers.
@@ -746,11 +731,6 @@ async def get_all_providers_health():
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_provider_health",
-    error_code_prefix="LLM",
-)
 @router.get("/health/providers/{provider_name}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -812,11 +792,6 @@ async def get_provider_health(provider_name: str, use_cache: bool = True):
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_provider_health_cache",
-    error_code_prefix="LLM",
-)
 @router.post("/health/providers/clear-cache", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -869,11 +844,6 @@ async def clear_provider_health_cache(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_tiered_routing_metrics",
-    error_code_prefix="LLM",
-)
 @router.get("/tiered-routing/metrics", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -929,11 +899,6 @@ async def get_tiered_routing_metrics(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_tiered_routing_config",
-    error_code_prefix="LLM",
-)
 @router.get("/tiered-routing/config", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1060,11 +1025,6 @@ def _build_tiered_routing_response(tier_router) -> dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_tiered_routing_config",
-    error_code_prefix="LLM",
-)
 @router.post("/tiered-routing/config", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1112,11 +1072,6 @@ async def update_tiered_routing_config(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reset_tiered_routing_metrics",
-    error_code_prefix="LLM",
-)
 @router.post("/tiered-routing/metrics/reset", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/llm_awareness.py
+++ b/autobot-backend/api/llm_awareness.py
@@ -37,11 +37,6 @@ VALID_CONTEXT_LEVELS = {"basic", "detailed", "full"}
 DETAILED_CONTEXT_LEVELS = {"detailed", "full"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_awareness_status",
-    error_code_prefix="LLM_AWARENESS",
-)
 @router.get("/status", response_model=LLMAwarenessStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -67,11 +62,6 @@ async def get_awareness_status():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_context",
-    error_code_prefix="LLM_AWARENESS",
-)
 @router.get("/context", response_model=LLMSystemContextResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -142,11 +132,6 @@ async def get_system_context(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_capabilities_summary",
-    error_code_prefix="LLM_AWARENESS",
-)
 @router.get("/capabilities", response_model=LLMCapabilitiesSummaryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -187,11 +172,6 @@ async def get_capabilities_summary():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="inject_awareness_context",
-    error_code_prefix="LLM_AWARENESS",
-)
 @router.post("/inject-context", response_model=LLMInjectContextResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -231,11 +211,6 @@ async def inject_awareness_context(request: PromptInjectionRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_query_with_awareness",
-    error_code_prefix="LLM_AWARENESS",
-)
 @router.post("/analyze-query", response_model=LLMAnalyzeQueryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -260,11 +235,6 @@ async def analyze_query_with_awareness(request: QueryAnalysisRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_capability_summary_text",
-    error_code_prefix="LLM_AWARENESS",
-)
 @router.get("/summary/text", response_model=LLMCapabilitySummaryTextResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -288,11 +258,6 @@ async def get_capability_summary_text():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_phase_information",
-    error_code_prefix="LLM_AWARENESS",
-)
 @router.get("/phase-info", response_model=LLMPhaseInfoResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -324,11 +289,6 @@ async def get_phase_information():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_awareness_metrics",
-    error_code_prefix="LLM_AWARENESS",
-)
 @router.get("/metrics", response_model=LLMAwarenessMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -369,11 +329,6 @@ async def get_awareness_metrics():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_awareness_data",
-    error_code_prefix="LLM_AWARENESS",
-)
 @router.post("/export", response_model=LLMExportAwarenessResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -403,11 +358,6 @@ async def export_awareness_data(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="llm_awareness_health",
-    error_code_prefix="LLM_AWARENESS",
-)
 @router.get("/health", response_model=LLMAwarenessHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/llm_optimization.py
+++ b/autobot-backend/api/llm_optimization.py
@@ -43,11 +43,6 @@ logger = logging.getLogger(__name__)
 config = get_config_manager()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_optimization_health",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.get("/health", response_model=LLMOptimizationHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -82,11 +77,6 @@ async def get_optimization_health(admin_check: bool = Depends(check_admin_permis
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_available_models",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.get("/models/available", response_model=LLMAvailableModelsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -118,11 +108,6 @@ async def get_available_models(admin_check: bool = Depends(check_admin_permissio
         raise HTTPException(status_code=500, detail="Failed to get available models")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="select_optimal_model",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.post("/models/select", response_model=LLMSelectModelResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -186,11 +171,6 @@ async def select_optimal_model(
         raise HTTPException(status_code=500, detail="Failed to select optimal model")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="track_model_performance",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.post("/models/performance/track", response_model=LLMTrackPerformanceResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -230,11 +210,6 @@ async def track_model_performance(
         raise HTTPException(status_code=500, detail="Failed to track performance")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_model_performance_history",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.get("/models/performance/history/{model_name}", response_model=LLMModelPerformanceHistoryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -270,11 +245,6 @@ async def get_model_performance_history(
         raise HTTPException(status_code=500, detail="Failed to get performance history")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_optimization_suggestions",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.get("/optimization/suggestions", response_model=LLMOptimizationSuggestionsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -304,11 +274,6 @@ async def get_optimization_suggestions(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="compare_models",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.get("/models/comparison", response_model=LLMModelsComparisonResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -366,11 +331,6 @@ async def compare_models(admin_check: bool = Depends(check_admin_permission)):
         raise HTTPException(status_code=500, detail="Failed to compare models")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="benchmark_model",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.post("/models/benchmark/{model_name}", response_model=LLMBenchmarkResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -436,11 +396,6 @@ async def benchmark_model(
         raise HTTPException(status_code=500, detail="Failed to benchmark model")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_resources",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.get("/system/resources", response_model=LLMSystemResourcesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -501,11 +456,6 @@ async def get_system_resources(admin_check: bool = Depends(check_admin_permissio
         raise HTTPException(status_code=500, detail="Failed to get system resources")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_optimization_config",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.get("/config", response_model=LLMOptimizationConfigResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -616,11 +566,6 @@ def _get_local_settings(opt_config: dict) -> dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_inference_optimization_settings",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.get("/inference/settings", response_model=LLMInferenceSettingsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -666,11 +611,6 @@ async def get_inference_optimization_settings(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_inference_optimization_settings",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.post("/inference/settings", response_model=LLMInferenceSettingsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -743,11 +683,6 @@ async def update_inference_optimization_settings(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_inference_metrics",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.get("/inference/metrics", response_model=LLMInferenceMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -783,11 +718,6 @@ async def get_inference_metrics(admin_check: bool = Depends(check_admin_permissi
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_provider_optimization_summary",
-    error_code_prefix="LLM_OPTIMIZATION",
-)
 @router.get("/inference/provider/{provider_type}/optimizations", response_model=LLMProviderOptimizationSummaryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/llm_providers.py
+++ b/autobot-backend/api/llm_providers.py
@@ -58,13 +58,13 @@ async def switch_llm_provider(
     return JSONResponse(status_code=200, content=result)
 
 
+@router.get("/providers", response_model=DataResponse)
+@cache_response(cache_key="llm_providers_list", ttl=30)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_llm_providers",
     error_code_prefix="LLM_PROVIDERS",
 )
-@router.get("/providers", response_model=DataResponse)
-@cache_response(cache_key="llm_providers_list", ttl=30)
 async def list_llm_providers(
     current_user: dict = Depends(get_current_user),
 ):

--- a/autobot-backend/api/log_forwarding.py
+++ b/autobot-backend/api/log_forwarding.py
@@ -202,11 +202,6 @@ def _destination_to_response(dest) -> LogFwdDestinationResponse:
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_destinations",
-    error_code_prefix="LOGFWD",
-)
 @router.get("/destinations", response_model=List[LogForwardingDestinationItem])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -239,11 +234,6 @@ async def list_destinations(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_destination",
-    error_code_prefix="LOGFWD",
-)
 @router.get("/destinations/{name}", response_model=LogForwardingDestinationItem)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -280,11 +270,6 @@ async def get_destination(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_destination",
-    error_code_prefix="LOGFWD",
-)
 @router.post("/destinations", response_model=LogFwdCreateUpdateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -332,11 +317,6 @@ async def create_destination_endpoint(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_destination",
-    error_code_prefix="LOGFWD",
-)
 @router.put("/destinations/{name}", response_model=LogFwdCreateUpdateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -388,11 +368,6 @@ async def update_destination(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_destination",
-    error_code_prefix="LOGFWD",
-)
 @router.delete("/destinations/{name}", response_model=LogFwdMessageResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -427,11 +402,6 @@ async def delete_destination(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_destination",
-    error_code_prefix="LOGFWD",
-)
 @router.post("/destinations/{name}/test", response_model=LogFwdTestResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -476,11 +446,6 @@ async def test_destination(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_all_destinations",
-    error_code_prefix="LOGFWD",
-)
 @router.post("/test-all", response_model=LogFwdTestAllResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -509,11 +474,6 @@ async def test_all_destinations(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_status",
-    error_code_prefix="LOGFWD",
-)
 @router.get("/status", response_model=LogFwdStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -570,11 +530,6 @@ async def get_status(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_forwarding",
-    error_code_prefix="LOGFWD",
-)
 @router.post("/start", response_model=LogFwdMessageResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -609,11 +564,6 @@ async def start_forwarding(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="stop_forwarding",
-    error_code_prefix="LOGFWD",
-)
 @router.post("/stop", response_model=LogFwdMessageResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -715,11 +665,6 @@ def _get_syslog_protocol_list() -> list:
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_destination_types",
-    error_code_prefix="LOGFWD",
-)
 @router.get("/destination-types", response_model=LogFwdDestinationTypesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -750,11 +695,6 @@ async def get_destination_types(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_known_hosts",
-    error_code_prefix="LOGFWD",
-)
 @router.get("/known-hosts", response_model=LogFwdKnownHostsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -807,11 +747,6 @@ async def get_known_hosts(
 
 
 # Issue #553: Auto-start configuration
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_auto_start",
-    error_code_prefix="LOGFWD",
-)
 @router.get("/auto-start", response_model=LogFwdAutoStartResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -836,11 +771,6 @@ async def get_auto_start(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="set_auto_start",
-    error_code_prefix="LOGFWD",
-)
 @router.put("/auto-start", response_model=LogFwdAutoStartResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/logs.py
+++ b/autobot-backend/api/logs.py
@@ -404,12 +404,6 @@ async def _get_container_log_sources() -> List[Metadata]:
     return container_logs
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_log_sources",
-    error_code_prefix="LOGS",
-)
-# Issue #552: Fixed duplicate /logs prefix - router already mounted at /api/logs
 @router.get("/sources", response_model=LogSourcesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -477,11 +471,6 @@ async def _read_recent_log_lines(log_path: str, limit: int) -> List[str]:
         return []
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_recent_logs",
-    error_code_prefix="LOGS",
-)
 @router.get("/recent", response_model=LogRecentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -521,11 +510,6 @@ async def get_recent_logs(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_logs",
-    error_code_prefix="LOGS",
-)
 @router.get("/list", response_model=List[LogFileMetadata])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -547,11 +531,6 @@ async def list_logs(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="read_log",
-    error_code_prefix="LOGS",
-)
 @router.get("/read/{filename}", response_model=LogReadResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -673,11 +652,6 @@ def _parse_and_limit_container_output(
     return log_lines
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="read_container_logs",
-    error_code_prefix="LOGS",
-)
 @router.get("/container/{service}", response_model=LogContainerResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -783,11 +757,6 @@ def parse_docker_log_line(line: str, service: str) -> Metadata:
     return parsed
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_unified_logs",
-    error_code_prefix="LOGS",
-)
 @router.get("/unified", response_model=LogUnifiedResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -869,11 +838,6 @@ def parse_file_log_line(line: str, source: str) -> Metadata:
     return parsed
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="stream_log",
-    error_code_prefix="LOGS",
-)
 @router.get("/stream/{filename}", response_model=None)  # StreamingResponse — no Pydantic schema
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1002,11 +966,6 @@ async def _search_single_log_file(
     return results
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_logs",
-    error_code_prefix="LOGS",
-)
 @router.get("/search", response_model=LogSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1064,11 +1023,6 @@ async def search_logs(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_log",
-    error_code_prefix="LOGS",
-)
 @router.delete("/clear/{filename}", response_model=AgentMessageResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/long_running_operations.py
+++ b/autobot-backend/api/long_running_operations.py
@@ -92,11 +92,6 @@ async def get_operation_manager():
 
 
 # Enhanced API endpoints with AutoBot-specific operations
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_codebase_indexing",
-    error_code_prefix="LONG_RUNNING_OPERATIONS",
-)
 @router.post("/codebase/index", response_model=Dict[str, str])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -175,11 +170,6 @@ async def start_codebase_indexing(
         raise HTTPException(status_code=500, detail="Failed to start operation")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_comprehensive_testing",
-    error_code_prefix="LONG_RUNNING_OPERATIONS",
-)
 @router.post("/testing/comprehensive", response_model=Dict[str, str])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -256,11 +246,6 @@ async def start_comprehensive_testing(
         raise HTTPException(status_code=500, detail="Failed to start operation")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_knowledge_base_population",
-    error_code_prefix="LONG_RUNNING_OPERATIONS",
-)
 @router.post("/knowledge-base/populate", response_model=Dict[str, str])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -316,11 +301,6 @@ async def start_knowledge_base_population(
         raise HTTPException(status_code=500, detail="Failed to start operation")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_security_scan",
-    error_code_prefix="LONG_RUNNING_OPERATIONS",
-)
 @router.post("/security/scan", response_model=Dict[str, str])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -374,11 +354,6 @@ async def start_security_scan(
 
 
 # Legacy operation migration endpoints
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="migrate_existing_operation",
-    error_code_prefix="LONG_RUNNING_OPERATIONS",
-)
 @router.post("/migrate/existing", response_model=LongRunningOperationMigrateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -424,11 +399,6 @@ async def migrate_existing_operation(
 
 
 # Operation status and control endpoints (proxy to integration manager)
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_operation_status",
-    error_code_prefix="LONG_RUNNING_OPERATIONS",
-)
 @router.get("/{operation_id}", response_model=LongRunningOperationStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -450,11 +420,6 @@ async def get_operation_status(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_operations",
-    error_code_prefix="LONG_RUNNING_OPERATIONS",
-)
 @router.get("/", response_model=LongRunningOperationListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -509,11 +474,6 @@ async def list_operations(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cancel_operation",
-    error_code_prefix="LONG_RUNNING_OPERATIONS",
-)
 @router.post("/{operation_id}/cancel", response_model=LongRunningOperationCancelResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -536,11 +496,6 @@ async def cancel_operation(operation_id: str, manager=Depends(get_operation_mana
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="resume_operation",
-    error_code_prefix="LONG_RUNNING_OPERATIONS",
-)
 @router.post("/{operation_id}/resume", response_model=LongRunningOperationResumeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -636,11 +591,6 @@ async def websocket_progress_updates(websocket: WebSocket, operation_id: str):
 
 
 # Health check endpoint
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="operations_health",
-    error_code_prefix="LONG_RUNNING_OPERATIONS",
-)
 @router.get("/health", response_model=LongRunningOperationHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/manual_mcp.py
+++ b/autobot-backend/api/manual_mcp.py
@@ -291,11 +291,6 @@ def _doc_index_tool_schema() -> dict:
 # ---------------------------------------------------------------------------
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="manual_mcp_tools",
-    error_code_prefix="MANUAL_MCP",
-)
 @router.get("/mcp/tools", response_model=List[ManualMCPToolItem])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -316,11 +311,6 @@ async def get_manual_mcp_tools(
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="manual_mcp_lookup",
-    error_code_prefix="MANUAL_MCP",
-)
 @router.post("/mcp/lookup_man_page", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -361,11 +351,6 @@ async def mcp_lookup_man_page(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="manual_mcp_search",
-    error_code_prefix="MANUAL_MCP",
-)
 @router.post("/mcp/search_man_pages", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -402,11 +387,6 @@ async def mcp_search_man_pages(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="manual_mcp_doc_index",
-    error_code_prefix="MANUAL_MCP",
-)
 @router.post("/mcp/get_doc_index", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/mcp_registry.py
+++ b/autobot-backend/api/mcp_registry.py
@@ -449,11 +449,6 @@ async def _fetch_bridges_info() -> Metadata:
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_all_mcp_tools",
-    error_code_prefix="MCP_REGISTRY",
-)
 @router.get("/tools", response_model=MCPRegistryToolsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -502,11 +497,6 @@ async def list_all_mcp_tools() -> Metadata:
     return tools_data
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_mcp_bridges",
-    error_code_prefix="MCP_REGISTRY",
-)
 @router.get("/bridges", response_model=MCPRegistryBridgesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -551,11 +541,6 @@ async def get_mcp_bridges() -> Metadata:
     return bridges_data
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="invalidate_mcp_cache",
-    error_code_prefix="MCP_REGISTRY",
-)
 @router.post("/cache/invalidate", response_model=MCPRegistryCacheInvalidateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -584,11 +569,6 @@ async def invalidate_mcp_cache() -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_mcp_cache_stats",
-    error_code_prefix="MCP_REGISTRY",
-)
 @router.get("/cache/stats", response_model=MCPRegistryCacheStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -696,11 +676,6 @@ def _find_tool_in_list(tools: list, tool_name: str, bridge_name: str) -> dict:
     return tool
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_mcp_tool_details",
-    error_code_prefix="MCP_REGISTRY",
-)
 @router.get("/tools/{bridge_name}/{tool_name}", response_model=MCPRegistryToolDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -755,11 +730,6 @@ async def get_mcp_tool_details(bridge_name: str, tool_name: str) -> Metadata:
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_mcp_registry_health",
-    error_code_prefix="MCP_REGISTRY",
-)
 @router.get("/health", response_model=MCPRegistryHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -826,11 +796,6 @@ async def get_mcp_registry_health() -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_mcp_registry_stats",
-    error_code_prefix="MCP_REGISTRY",
-)
 @router.get("/stats", response_model=MCPRegistryStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -879,11 +844,6 @@ async def get_mcp_registry_stats() -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_mcp_registry_info",
-    error_code_prefix="MCP_REGISTRY",
-)
 @router.get("/", response_model=MCPRegistryInfoResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/memory.py
+++ b/autobot-backend/api/memory.py
@@ -342,11 +342,6 @@ def _build_list_entities_response(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_entity",
-    error_code_prefix="MEMORY",
-)
 @router.post("/entities", status_code=201, response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -411,11 +406,6 @@ async def create_entity(
         raise HTTPException(status_code=500, detail="Failed to create entity")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_all_entities",
-    error_code_prefix="MEMORY",
-)
 @router.get("/entities/all", response_model=MemoryEntityListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -461,11 +451,6 @@ async def list_all_entities(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="find_orphaned_conversation_entities",
-    error_code_prefix="MEMORY",
-)
 @router.get("/entities/orphans", response_model=MemoryOrphanScanResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -783,11 +768,6 @@ async def _detect_orphaned_entities(
     return _find_orphaned_entities(all_entities, existing_session_ids)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cleanup_orphaned_conversation_entities",
-    error_code_prefix="MEMORY",
-)
 @router.delete("/entities/orphans", response_model=MemoryOrphanCleanupResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -838,11 +818,6 @@ async def cleanup_orphaned_conversation_entities(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_entity_by_id",
-    error_code_prefix="MEMORY",
-)
 @router.get("/entities/{entity_id}", response_model=MemoryEntityDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -901,11 +876,6 @@ async def get_entity_by_id(
         raise HTTPException(status_code=500, detail="Failed to retrieve entity")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_entity_by_name",
-    error_code_prefix="MEMORY",
-)
 @router.get("/entities", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -962,11 +932,6 @@ async def get_entity_by_name(
         raise HTTPException(status_code=500, detail="Failed to search entity")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_observations",
-    error_code_prefix="MEMORY",
-)
 @router.patch("/entities/{entity_id}/observations", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1030,11 +995,6 @@ async def add_observations(
         raise HTTPException(status_code=500, detail="Failed to add observations")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_entity",
-    error_code_prefix="MEMORY",
-)
 @router.delete("/entities/{entity_id}", response_model=MemoryDeleteEntityResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1098,11 +1058,6 @@ async def delete_entity(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_relation",
-    error_code_prefix="MEMORY",
-)
 @router.post("/relations", status_code=201, response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1172,11 +1127,6 @@ async def create_relation(
         raise HTTPException(status_code=500, detail="Failed to create relation")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_related_entities",
-    error_code_prefix="MEMORY",
-)
 @router.get("/entities/{entity_id}/relations", response_model=MemoryRelatedEntitiesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1232,11 +1182,6 @@ async def get_related_entities(
         raise HTTPException(status_code=500, detail="Failed to get related entities")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_relation",
-    error_code_prefix="MEMORY",
-)
 @router.delete("/relations", response_model=MemoryDeleteRelationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1307,11 +1252,6 @@ async def delete_relation(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_entities",
-    error_code_prefix="MEMORY",
-)
 @router.get("/search", response_model=MemorySearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1385,11 +1325,6 @@ async def search_entities(
         raise HTTPException(status_code=500, detail="Search failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_entity_graph",
-    error_code_prefix="MEMORY",
-)
 @router.get("/graph", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1453,11 +1388,6 @@ async def get_entity_graph(
 # ====================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="memory_health_check",
-    error_code_prefix="MEMORY",
-)
 @router.get("/health", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1591,11 +1521,6 @@ def _build_invalidate_relation_response(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="invalidate_entity",
-    error_code_prefix="MEMORY",
-)
 @router.patch("/entities/{entity_id}/invalidate", response_model=MemoryEntityInvalidateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1660,11 +1585,6 @@ async def invalidate_entity(
         raise HTTPException(status_code=500, detail="Failed to invalidate entity")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="invalidate_relation",
-    error_code_prefix="MEMORY",
-)
 @router.patch("/relations/invalidate", response_model=MemoryRelationInvalidateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/merge_conflict_resolution.py
+++ b/autobot-backend/api/merge_conflict_resolution.py
@@ -199,11 +199,6 @@ def _build_no_conflicts_response(file_path: str) -> JSONResponse:
 # =============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_conflicts",
-    error_code_prefix="MERGE_CONFLICT",
-)
 @router.post("/analyze", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -259,11 +254,6 @@ async def analyze_conflicts(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="resolve_conflicts",
-    error_code_prefix="MERGE_CONFLICT",
-)
 @router.post("/resolve", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -332,11 +322,6 @@ async def resolve_conflicts(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_repository",
-    error_code_prefix="MERGE_CONFLICT",
-)
 @router.post("/analyze-repository", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -399,11 +384,6 @@ async def analyze_repository_conflicts(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="apply_resolution",
-    error_code_prefix="MERGE_CONFLICT",
-)
 @router.post("/apply", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -472,11 +452,6 @@ async def apply_resolution(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_resolution_strategies",
-    error_code_prefix="MERGE_CONFLICT",
-)
 @router.get("/strategies", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -544,11 +519,6 @@ async def get_resolution_strategies(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="check_file_conflicts",
-    error_code_prefix="MERGE_CONFLICT",
-)
 @router.get("/check", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/metrics.py
+++ b/autobot-backend/api/metrics.py
@@ -34,11 +34,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_workflow_metrics",
-    error_code_prefix="METRICS",
-)
 @router.get("/workflow/{workflow_id}", response_model=MetricsWorkflowResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -58,11 +53,6 @@ async def get_workflow_metrics(workflow_id: str):
         raise HTTPException(status_code=500, detail="Failed to get workflow metrics")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_performance_summary",
-    error_code_prefix="METRICS",
-)
 @router.get("/performance/summary", response_model=MetricsPerformanceSummaryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -84,11 +74,6 @@ async def get_performance_summary(
         raise HTTPException(status_code=500, detail="Failed to get performance summary")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_current_system_metrics",
-    error_code_prefix="METRICS",
-)
 @router.get("/system/current", response_model=MetricsSystemCurrentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -117,11 +102,6 @@ _HISTORY_DURATION_MAP = {
 }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_metrics_history",
-    error_code_prefix="METRICS",
-)
 @router.get("/system/history", response_model=MetricsSystemHistoryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -159,11 +139,6 @@ async def get_system_metrics_history(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_summary",
-    error_code_prefix="METRICS",
-)
 @router.get("/system/summary", response_model=MetricsSystemSummaryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -190,11 +165,6 @@ async def get_system_summary(
 # Use /api/system/health?detailed=true for comprehensive status
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_workflow_metrics",
-    error_code_prefix="METRICS",
-)
 @router.get("/export/workflow", response_model=MetricsExportResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -214,11 +184,6 @@ async def export_workflow_metrics(
         raise HTTPException(status_code=500, detail="Failed to export metrics")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_system_metrics",
-    error_code_prefix="METRICS",
-)
 @router.get("/export/system", response_model=MetricsExportResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -238,11 +203,6 @@ async def export_system_metrics(
         raise HTTPException(status_code=500, detail="Failed to export system data")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_system_monitoring",
-    error_code_prefix="METRICS",
-)
 @router.post("/system/monitoring/start", response_model=MetricsMonitoringStartResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -264,11 +224,6 @@ async def start_system_monitoring():
         raise HTTPException(status_code=500, detail="Failed to start monitoring")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="stop_system_monitoring",
-    error_code_prefix="METRICS",
-)
 @router.post("/system/monitoring/stop", response_model=MetricsMonitoringStopResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -286,11 +241,6 @@ async def stop_system_monitoring():
         raise HTTPException(status_code=500, detail="Failed to stop monitoring")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_metrics_dashboard",
-    error_code_prefix="METRICS",
-)
 @router.get("/dashboard", response_model=MetricsDashboardResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/models.py
+++ b/autobot-backend/api/models.py
@@ -23,11 +23,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_available_models",
-    error_code_prefix="MODELS",
-)
 @router.get("/available", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -478,11 +478,6 @@ def _compute_overall_status(svc_list: list) -> dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_services_health",
-    error_code_prefix="MONITORING",
-)
 @router.get("/services/health", response_model=ServicesSummaryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -514,11 +509,6 @@ async def get_services_health():
     return summary
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_monitoring_status",
-    error_code_prefix="MONITORING",
-)
 @router.get("/status", response_model=MonitoringStatus)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -556,11 +546,6 @@ async def get_monitoring_status(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_monitoring",
-    error_code_prefix="MONITORING",
-)
 @router.post("/start", response_model=MonitoringActionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -601,11 +586,6 @@ async def start_monitoring_endpoint(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="stop_monitoring",
-    error_code_prefix="MONITORING",
-)
 @router.post("/stop", response_model=MonitoringActionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -630,11 +610,6 @@ async def stop_monitoring_endpoint(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_performance_dashboard",
-    error_code_prefix="MONITORING",
-)
 @router.get("/dashboard", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -658,11 +633,6 @@ async def get_dashboard_endpoint(
     return dashboard
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_dashboard_overview",
-    error_code_prefix="MONITORING",
-)
 @router.get("/dashboard/overview", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -686,11 +656,6 @@ async def get_dashboard_overview(
     return dashboard
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_current_metrics",
-    error_code_prefix="MONITORING",
-)
 @router.get("/metrics/current", response_model=CurrentMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -709,11 +674,6 @@ async def get_current_metrics(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="query_metrics",
-    error_code_prefix="MONITORING",
-)
 @router.post("/metrics/query", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -787,11 +747,6 @@ async def query_metrics(
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_optimization_recommendations",
-    error_code_prefix="MONITORING",
-)
 @router.get(
     "/optimization/recommendations", response_model=List[OptimizationRecommendation]
 )
@@ -818,11 +773,6 @@ async def get_optimization_recommendations_endpoint(
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_performance_alerts",
-    error_code_prefix="MONITORING",
-)
 @router.get("/alerts", response_model=List[PerformanceAlert])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -861,11 +811,6 @@ async def get_performance_alerts(
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="check_alerts",
-    error_code_prefix="MONITORING",
-)
 @router.get("/alerts/check", response_model=AlertCheckResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -906,11 +851,6 @@ async def check_alerts(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_alertmanager_alerts",
-    error_code_prefix="MONITORING",
-)
 @router.get("/alerts/alertmanager", response_model=AlertManagerResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -953,11 +893,6 @@ async def get_alertmanager_alerts(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_performance_threshold",
-    error_code_prefix="MONITORING",
-)
 @router.post("/thresholds/update", response_model=ThresholdUpdateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -992,11 +927,6 @@ async def update_performance_threshold(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_metrics",
-    error_code_prefix="MONITORING",
-)
 @router.get("/export/metrics", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1126,11 +1056,6 @@ _MONITORING_WS_HANDLERS = {
 }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="realtime_monitoring_websocket",
-    error_code_prefix="MONITORING",
-)
 @router.websocket("/realtime")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1163,13 +1088,13 @@ async def realtime_monitoring_websocket(websocket: WebSocket):
 
 # Helper functions
 # Performance monitoring decorator endpoint
+@router.post("/test/performance", response_model=TestPerformanceResponse)
+@monitor_performance("api_test")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="test_performance_monitoring",
     error_code_prefix="MONITORING",
 )
-@router.post("/test/performance", response_model=TestPerformanceResponse)
-@monitor_performance("api_test")
 async def test_performance_monitoring(
     admin_check: bool = Depends(check_admin_permission),
 ):
@@ -1193,11 +1118,6 @@ async def test_performance_monitoring(
 
 
 # Issue #1190: Hardware stub endpoints for analytics dashboard
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_hardware_npu",
-    error_code_prefix="MONITORING",
-)
 @router.get("/hardware/npu", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1211,11 +1131,6 @@ async def get_hardware_npu_status(
     return await hardware_monitor.get_npu_status()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_hardware_gpu",
-    error_code_prefix="MONITORING",
-)
 @router.get("/hardware/gpu", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1229,11 +1144,6 @@ async def get_hardware_gpu_status(
     return await hardware_monitor.get_gpu_status()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_hardware_system",
-    error_code_prefix="MONITORING",
-)
 @router.get("/hardware/system", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1250,11 +1160,6 @@ async def get_hardware_system_status(
 # External API status endpoints — extracted from monitoring_compat.py (Issue #1283)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_claude_api_status",
-    error_code_prefix="MONITORING",
-)
 @router.get("/claude-api/status", response_model=ClaudeApiStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1294,11 +1199,6 @@ async def get_claude_api_status():
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_github_status",
-    error_code_prefix="MONITORING",
-)
 @router.get("/github/status", response_model=GitHubStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/multimodal.py
+++ b/autobot-backend/api/multimodal.py
@@ -88,11 +88,6 @@ def _build_image_modal_input(
 # API Endpoints
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="process_image",
-    error_code_prefix="MULTIMODAL",
-)
 @router.post("/process/image", response_model=MultiModalResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -156,11 +151,6 @@ async def process_image(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="process_audio",
-    error_code_prefix="MULTIMODAL",
-)
 @router.post("/process/audio", response_model=MultiModalResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -233,11 +223,6 @@ async def process_audio(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="process_text",
-    error_code_prefix="MULTIMODAL",
-)
 @router.post("/process/text", response_model=MultiModalResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -297,11 +282,6 @@ async def process_text(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="generate_embedding",
-    error_code_prefix="MULTIMODAL",
-)
 @router.post("/embeddings/generate", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -358,11 +338,6 @@ async def generate_embedding(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cross_modal_search",
-    error_code_prefix="MULTIMODAL",
-)
 @router.post("/search/cross-modal", response_model=CrossModalSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -436,11 +411,6 @@ async def cross_modal_search(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_multimodal_stats",
-    error_code_prefix="MULTIMODAL",
-)
 @router.get("/stats", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -610,11 +580,6 @@ def _create_combined_input(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="combine_multimodal_inputs",
-    error_code_prefix="MULTIMODAL",
-)
 @router.post("/fusion/combine", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -684,11 +649,6 @@ async def combine_multimodal_inputs(
 
 
 # Performance monitoring endpoints
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_performance_stats",
-    error_code_prefix="MULTIMODAL",
-)
 @router.get("/performance/stats", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -735,11 +695,6 @@ async def get_performance_stats(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="optimize_performance",
-    error_code_prefix="MULTIMODAL",
-)
 @router.post("/performance/optimize", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -775,11 +730,6 @@ async def optimize_performance(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_performance_summary",
-    error_code_prefix="MULTIMODAL",
-)
 @router.get("/performance/summary", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -808,11 +758,6 @@ async def get_performance_summary(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_batch_size",
-    error_code_prefix="MULTIMODAL",
-)
 @router.post("/performance/batch-size", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -864,11 +809,6 @@ async def update_batch_size(
 
 
 # Health check endpoint
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="health_check",
-    error_code_prefix="MULTIMODAL",
-)
 @router.get("/health", response_model=MultimodalHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/npu_workers.py
+++ b/autobot-backend/api/npu_workers.py
@@ -75,11 +75,6 @@ router = APIRouter()
 # ==============================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_workers",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.get("/npu/workers", response_model=List[NPUWorkerDetails])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -105,11 +100,6 @@ async def list_workers(admin_check: bool = Depends(check_admin_permission)):
         raise_internal_error("Failed to retrieve workers")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_worker",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.post(
     "/npu/workers", response_model=NPUWorkerDetails, status_code=status.HTTP_201_CREATED
 )
@@ -154,11 +144,6 @@ async def add_worker(
         raise_internal_error("Failed to register worker")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_worker",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.get("/npu/workers/{worker_id}", response_model=NPUWorkerDetails)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -200,11 +185,6 @@ async def get_worker(
         raise_internal_error("Failed to retrieve worker")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_worker",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.put("/npu/workers/{worker_id}", response_model=NPUWorkerDetails)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -256,11 +236,6 @@ async def update_worker(
         raise_internal_error("Failed to update worker")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="remove_worker",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.delete("/npu/workers/{worker_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -298,11 +273,6 @@ async def remove_worker(
         raise_internal_error("Failed to remove worker")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_worker",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.post("/npu/workers/{worker_id}/test", response_model=WorkerTestResult)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -350,11 +320,6 @@ async def test_worker(
         raise_internal_error("Failed to test worker")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_worker_metrics",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.get(
     "/npu/workers/{worker_id}/metrics", response_model=Optional[NPUWorkerMetrics]
 )
@@ -404,11 +369,6 @@ async def get_worker_metrics(
 # ==============================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_worker_log_level",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.get("/npu/workers/{worker_id}/logging", response_model=Dict[str, Any])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -474,11 +434,6 @@ async def _send_log_level_to_worker(
         return response.json()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="set_worker_log_level",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.put("/npu/workers/{worker_id}/logging", response_model=Dict[str, Any])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -535,11 +490,6 @@ async def set_worker_log_level(
 # ==============================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_load_balancing_config",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.get("/npu/load-balancing", response_model=LoadBalancingConfig)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -567,11 +517,6 @@ async def get_load_balancing_config(
         raise_internal_error("Failed to retrieve load balancing configuration")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_load_balancing_config",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.put("/npu/load-balancing", response_model=LoadBalancingConfig)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -617,11 +562,6 @@ async def update_load_balancing_config(
 # ==============================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_npu_status",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.get("/npu/status", response_model=NPUStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -672,11 +612,6 @@ async def get_npu_status(admin_check: bool = Depends(check_admin_permission)):
 # ==============================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="proxy_npu_health",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.get("/npu/health", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -720,11 +655,6 @@ async def proxy_npu_health():
 # ==============================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="unpair_worker",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.post("/npu/workers/{worker_id}/unpair", response_model=NPUWorkerUnpairResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -863,11 +793,6 @@ async def _resolve_repair_worker_info(
     return worker_url, platform, new_worker_id
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="repair_worker",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.post("/npu/workers/{worker_id}/repair", response_model=NPUWorkerRepairResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1144,11 +1069,6 @@ async def _execute_worker_pairing(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="pair_worker",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.post("/npu/workers/pair", response_model=NPUWorkerPairResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1427,11 +1347,6 @@ def _build_bootstrap_response(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="worker_bootstrap",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.post("/npu/workers/bootstrap", response_model=Dict[str, Any])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1481,11 +1396,6 @@ async def worker_bootstrap(request: dict):
 # ==============================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_pool_stats",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.get("/npu/pool/stats", response_model=Dict[str, Any])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1519,11 +1429,6 @@ async def get_pool_stats(admin_check: bool = Depends(check_admin_permission)):
         raise_internal_error("Failed to retrieve pool stats")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_pool_workers",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.get("/npu/pool/workers", response_model=NPUPoolWorkersResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1576,11 +1481,6 @@ async def get_pool_workers(admin_check: bool = Depends(check_admin_permission)):
         raise_internal_error("Failed to retrieve pool workers")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reload_pool_config",
-    error_code_prefix="NPU_WORKERS",
-)
 @router.post("/npu/pool/reload", response_model=NPUPoolReloadResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -141,11 +141,6 @@ async def execute_workflow(
         raise HTTPException(status_code=500, detail="Workflow execution failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_workflow_plan",
-    error_code_prefix="ORCHESTRATION",
-)
 @router.post("/workflow/plan", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -211,11 +206,6 @@ async def create_workflow_plan(
         raise HTTPException(status_code=500, detail="Plan creation failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_agent_performance",
-    error_code_prefix="ORCHESTRATION",
-)
 @router.get("/agents/performance", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -249,11 +239,6 @@ async def get_agent_performance(
         raise HTTPException(status_code=500, detail="Failed to get performance report")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="recommend_agents",
-    error_code_prefix="ORCHESTRATION",
-)
 @router.post("/agents/recommend", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -308,11 +293,6 @@ async def recommend_agents(
         raise HTTPException(status_code=500, detail="Failed to get recommendations")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_active_workflows",
-    error_code_prefix="ORCHESTRATION",
-)
 @router.get("/workflow/active", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -364,11 +344,6 @@ async def get_active_workflows(
         raise HTTPException(status_code=500, detail="Failed to get active workflows")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_execution_strategies",
-    error_code_prefix="ORCHESTRATION",
-)
 @router.get("/strategies", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -416,11 +391,6 @@ async def get_execution_strategies(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_agent_capabilities",
-    error_code_prefix="ORCHESTRATION",
-)
 @router.get("/capabilities", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -491,11 +461,6 @@ async def get_agent_capabilities(
         raise HTTPException(status_code=500, detail="Failed to get capabilities")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_orchestration_status",
-    error_code_prefix="ORCHESTRATION",
-)
 @router.get("/status", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -551,11 +516,6 @@ async def get_orchestration_status(
         raise HTTPException(status_code=500, detail="Failed to get status")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_orchestration_examples",
-    error_code_prefix="ORCHESTRATION",
-)
 @router.get("/examples", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/playwright.py
+++ b/autobot-backend/api/playwright.py
@@ -54,11 +54,6 @@ BROWSER_VM_URL = (
 )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_playwright_status",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.get("/status", response_model=PlaywrightStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -82,11 +77,6 @@ async def get_playwright_status():
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="health_check",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.get("/health", response_model=PlaywrightHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -114,11 +104,6 @@ async def health_check():
         raise HTTPException(status_code=503, detail="Playwright service unavailable")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="web_search",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.post("/search", response_model=PlaywrightEmbeddedResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -160,11 +145,6 @@ async def web_search(request: PlaywrightSearchRequest):
         raise HTTPException(status_code=500, detail="Web search failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_frontend",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.post("/test-frontend", response_model=PlaywrightEmbeddedResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -199,11 +179,6 @@ async def test_frontend(request: FrontendTestRequest):
         raise HTTPException(status_code=500, detail="Frontend test failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="send_test_message",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.post("/send-test-message", response_model=PlaywrightEmbeddedResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -242,11 +217,6 @@ async def send_test_message(request: TestMessageRequest):
         raise HTTPException(status_code=500, detail="Test message failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="capture_screenshot",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.post("/screenshot", response_model=PlaywrightEmbeddedResultResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -286,11 +256,6 @@ async def capture_screenshot(request: PlaywrightScreenshotRequest):
         raise HTTPException(status_code=500, detail="Screenshot failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="quick_automation_test",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.post("/automation/quick-test", response_model=PlaywrightQuickTestResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -354,11 +319,6 @@ async def quick_automation_test(background_tasks: BackgroundTasks):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="navigate",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.post("/navigate", response_model=PlaywrightBrowserActionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -404,11 +364,6 @@ async def navigate_to_url(request: PlaywrightNavigateRequest):
         raise HTTPException(status_code=500, detail="Navigation failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reload",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.post("/reload", response_model=PlaywrightBrowserActionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -450,11 +405,6 @@ async def reload_page(request: PlaywrightReloadRequest):
         raise HTTPException(status_code=500, detail="Reload failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="go_back",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.post("/back", response_model=PlaywrightBrowserActionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -497,11 +447,6 @@ async def go_back():
         raise HTTPException(status_code=500, detail="Back navigation failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="go_forward",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.post("/forward", response_model=PlaywrightBrowserActionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -546,11 +491,6 @@ async def go_forward():
         raise HTTPException(status_code=500, detail="Forward navigation failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="worker_status",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.get("/worker-status", response_model=PlaywrightWorkerStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -592,11 +532,6 @@ async def get_worker_status():
         return {"status": "error", "browser_connected": False, "page_open": False}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="worker_screenshot",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.post("/worker-screenshot", response_model=PlaywrightBrowserActionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -635,11 +570,6 @@ async def take_worker_screenshot():
         raise HTTPException(status_code=500, detail="Screenshot failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="interact",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.post("/interact", response_model=PlaywrightBrowserActionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -691,11 +621,6 @@ async def interact_with_page(request: PlaywrightInteractRequest):
         raise HTTPException(status_code=500, detail="Interaction failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_capabilities",
-    error_code_prefix="PLAYWRIGHT",
-)
 @router.get("/capabilities", response_model=PlaywrightCapabilitiesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/project_state.py
+++ b/autobot-backend/api/project_state.py
@@ -28,15 +28,15 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/project", tags=["project_state"])
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_project_status",
-    error_code_prefix="PROJECT_STATE",
-)
 @router.get("/status", response_model=ProjectStatus)
 @smart_cache(
     data_type="project_status",
     key_func=lambda detailed=False: f"status:{'detailed' if detailed else 'fast'}",
+)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_project_status",
+    error_code_prefix="PROJECT_STATE",
 )
 async def get_project_status(detailed: bool = False):
     """Get overall project development status
@@ -78,11 +78,6 @@ async def get_project_status(detailed: bool = False):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="run_validation",
-    error_code_prefix="PROJECT_STATE",
-)
 @router.post("/validate", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -124,11 +119,6 @@ async def run_validation():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_validation_report",
-    error_code_prefix="PROJECT_STATE",
-)
 @router.get("/report", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -156,11 +146,6 @@ async def get_validation_report():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_all_phases",
-    error_code_prefix="PROJECT_STATE",
-)
 @router.get("/phases", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -217,11 +202,6 @@ async def get_all_phases():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="activate_phase",
-    error_code_prefix="PROJECT_STATE",
-)
 @router.post("/phase/{phase_id}/activate", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -263,11 +243,6 @@ async def activate_phase(phase_id: str):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="auto_progress_phases",
-    error_code_prefix="PROJECT_STATE",
-)
 @router.post("/auto-progress", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -291,11 +266,6 @@ async def auto_progress_phases():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="health_check",
-    error_code_prefix="PROJECT_STATE",
-)
 @router.get("/health", response_model=ProjectStateHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/prometheus_mcp.py
+++ b/autobot-backend/api/prometheus_mcp.py
@@ -115,11 +115,6 @@ PROMETHEUS_MCP_TOOL_DEFINITIONS = (
 )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_prometheus_mcp_tools",
-    error_code_prefix="PROMETHEUS_MCP",
-)
 @router.get("/mcp/tools", response_model=List[PrometheusMCPTool])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -380,11 +375,6 @@ TOOL_HANDLERS = {
 }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="execute_prometheus_tool",
-    error_code_prefix="PROMETHEUS_MCP",
-)
 @router.post("/mcp/{tool_name}", response_model=PrometheusMCPExecuteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/prompts.py
+++ b/autobot-backend/api/prompts.py
@@ -227,11 +227,6 @@ async def _collect_prompt_files(
         return []
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_prompts",
-    error_code_prefix="PROMPTS",
-)
 @router.get("/", response_model=PromptsListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -294,11 +289,6 @@ async def get_prompts(admin_check: bool = Depends(check_admin_permission)):
         raise HTTPException(status_code=500, detail="Error getting prompts")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_prompts_cache",
-    error_code_prefix="PROMPTS",
-)
 @router.post("/cache/clear", response_model=PromptsCacheClearResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -341,11 +331,6 @@ def _build_prompt_save_response(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="save_prompt",
-    error_code_prefix="PROMPTS",
-)
 @router.post("/{prompt_id}", response_model=PromptSaveResponse)
 @router.put("/{prompt_id}", response_model=PromptSaveResponse)  # Issue #570: Support PUT for frontend compatibility
 @with_error_handling(
@@ -453,11 +438,6 @@ async def _write_prompt_from_default(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="revert_prompt",
-    error_code_prefix="PROMPTS",
-)
 @router.post("/{prompt_id}/revert", response_model=PromptRevertResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/redis.py
+++ b/autobot-backend/api/redis.py
@@ -19,11 +19,6 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_redis_config",
-    error_code_prefix="REDIS",
-)
 @router.get("/config", response_model=RedisConfigResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -39,11 +34,6 @@ async def get_redis_config():
         raise HTTPException(status_code=500, detail="Error getting Redis config")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_redis_config",
-    error_code_prefix="REDIS",
-)
 @router.post("/config", response_model=RedisConfigResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -60,11 +50,6 @@ async def update_redis_config(config_data: dict):
         raise HTTPException(status_code=500, detail="Error updating Redis config")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_redis_status",
-    error_code_prefix="REDIS",
-)
 @router.get("/status", response_model=RedisConnectionStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -84,11 +69,6 @@ async def get_redis_status():
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_redis_connection",
-    error_code_prefix="REDIS",
-)
 @router.post("/test_connection", response_model=RedisConnectionStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -108,11 +88,6 @@ async def test_redis_connection():
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_redis_health",
-    error_code_prefix="REDIS",
-)
 @router.get("/health", response_model=RedisHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/redis_service.py
+++ b/autobot-backend/api/redis_service.py
@@ -121,11 +121,6 @@ def check_operator_permission(request: Request) -> str:
 
 
 # API Endpoints
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_redis_service",
-    error_code_prefix="REDIS_SERVICE",
-)
 @router.post("/start", response_model=ServiceOperationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -169,11 +164,6 @@ async def start_redis_service(
         raise HTTPException(status_code=500, detail="Service start failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="stop_redis_service",
-    error_code_prefix="REDIS_SERVICE",
-)
 @router.post("/stop", response_model=ServiceOperationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -219,11 +209,6 @@ async def stop_redis_service(
         raise HTTPException(status_code=500, detail="Service stop failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="restart_redis_service",
-    error_code_prefix="REDIS_SERVICE",
-)
 @router.post("/restart", response_model=ServiceOperationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -267,11 +252,6 @@ async def restart_redis_service(
         raise HTTPException(status_code=500, detail="Service restart failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_redis_status",
-    error_code_prefix="REDIS_SERVICE",
-)
 @router.get("/status", response_model=ServiceStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -300,11 +280,6 @@ async def get_redis_status(manager: RedisServiceManager = Depends(get_service_ma
         raise HTTPException(status_code=500, detail="Failed to get status")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_redis_health",
-    error_code_prefix="REDIS_SERVICE",
-)
 @router.get("/health", response_model=HealthStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/registry.py
+++ b/autobot-backend/api/registry.py
@@ -485,11 +485,6 @@ def get_endpoint_documentation() -> List[Dict]:
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_endpoints",
-    error_code_prefix="REGISTRY",
-)
 @router.get("/endpoints", response_model=RegistryEndpointsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -504,11 +499,6 @@ async def list_endpoints():
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_routers",
-    error_code_prefix="REGISTRY",
-)
 @router.get("/routers", response_model=RegistryRoutersResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -533,11 +523,6 @@ async def list_routers():
     return routers_data
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_router_details",
-    error_code_prefix="REGISTRY",
-)
 @router.get("/router/{router_name}", response_model=RegistryRouterDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -563,11 +548,6 @@ async def get_router_details(router_name: str):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_tags",
-    error_code_prefix="REGISTRY",
-)
 @router.get("/tags", response_model=RegistryTagsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -582,11 +562,6 @@ async def list_tags():
     return {"tags": sorted(list(all_tags))}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_routers_by_tag",
-    error_code_prefix="REGISTRY",
-)
 @router.get("/tags/{tag}", response_model=RegistryTagRoutersResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -603,11 +578,6 @@ async def get_routers_by_tag(tag: str):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="validate_dependencies",
-    error_code_prefix="REGISTRY",
-)
 @router.get("/validate", response_model=RegistryValidateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -620,11 +590,6 @@ async def validate_dependencies():
     return {"valid": len(errors) == 0, "errors": errors}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="registry_health",
-    error_code_prefix="REGISTRY",
-)
 @router.get("/health", response_model=RegistryHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/research_browser.py
+++ b/autobot-backend/api/research_browser.py
@@ -57,11 +57,6 @@ def _require_browser():
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="health_check",
-    error_code_prefix="RESEARCH_BROWSER",
-)
 @router.get("/health", response_model=ResearchBrowserHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -90,11 +85,6 @@ async def health_check():
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="research_url",
-    error_code_prefix="RESEARCH_BROWSER",
-)
 @router.post("/url", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -111,11 +101,6 @@ async def research_url(request: BrowserResearchRequest):
     return JSONResponse(status_code=200, content=result)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="handle_session_action",
-    error_code_prefix="RESEARCH_BROWSER",
-)
 @router.post("/session/action", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -166,11 +151,6 @@ async def handle_session_action(request: SessionAction):
     return JSONResponse(status_code=200, content=result)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_session_status",
-    error_code_prefix="RESEARCH_BROWSER",
-)
 @router.get("/session/{session_id}/status", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -200,11 +180,6 @@ async def get_session_status(session_id: str):
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="download_mhtml",
-    error_code_prefix="RESEARCH_BROWSER",
-)
 @router.get("/session/{session_id}/mhtml/{filename}", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -251,11 +226,6 @@ async def download_mhtml(session_id: str, filename: str):
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cleanup_session",
-    error_code_prefix="RESEARCH_BROWSER",
-)
 @router.delete("/session/{session_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -273,11 +243,6 @@ async def cleanup_session(session_id: str):
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_sessions",
-    error_code_prefix="RESEARCH_BROWSER",
-)
 @router.get("/sessions", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -308,11 +273,6 @@ async def list_sessions():
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="navigate_session",
-    error_code_prefix="RESEARCH_BROWSER",
-)
 @router.post("/session/{session_id}/navigate", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -332,11 +292,6 @@ async def navigate_session(session_id: str, request: NavigationRequest):
 
 
 # Browser integration endpoints for frontend
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_browser_info",
-    error_code_prefix="RESEARCH_BROWSER",
-)
 @router.get("/browser/{session_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -438,11 +393,6 @@ def _get_browser_actions() -> list:
 # These endpoints tie browser sessions to chat conversations like terminal
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_or_create_chat_browser_session",
-    error_code_prefix="RESEARCH_BROWSER",
-)
 @router.post("/chat-session", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -511,11 +461,6 @@ async def get_or_create_chat_browser_session(request: CreateChatBrowserRequest):
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_chat_browser_session",
-    error_code_prefix="RESEARCH_BROWSER",
-)
 @router.get("/chat-session/{conversation_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -567,11 +512,6 @@ async def get_chat_browser_session(conversation_id: str):
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_chat_browser_session",
-    error_code_prefix="RESEARCH_BROWSER",
-)
 @router.delete("/chat-session/{conversation_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/rum.py
+++ b/autobot-backend/api/rum.py
@@ -179,11 +179,6 @@ def setup_rum_logger():
 rum_logger = setup_rum_logger()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="configure_rum",
-    error_code_prefix="RUM",
-)
 @router.post("/config", response_model=RUMConfigResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -221,11 +216,6 @@ async def configure_rum(config: RumConfig):
         raise HTTPException(status_code=500, detail="Error configuring RUM")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="log_rum_event",
-    error_code_prefix="RUM",
-)
 @router.post("/event", response_model=RUMEventResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -285,11 +275,6 @@ async def log_rum_event(event: RumEvent):
         return {"status": "error", "message": "Failed to log RUM event"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="disable_rum",
-    error_code_prefix="RUM",
-)
 @router.post("/disable", response_model=RUMDisableResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -312,11 +297,6 @@ async def disable_rum():
         raise HTTPException(status_code=500, detail="Error disabling RUM")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_rum_data",
-    error_code_prefix="RUM",
-)
 @router.post("/clear", response_model=RUMClearResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -350,11 +330,6 @@ async def clear_rum_data():
         raise HTTPException(status_code=500, detail="Error clearing RUM data")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_rum_data",
-    error_code_prefix="RUM",
-)
 @router.get("/export", response_model=RUMExportResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -400,11 +375,6 @@ async def export_rum_data():
         raise HTTPException(status_code=500, detail="Error exporting RUM data")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_rum_status",
-    error_code_prefix="RUM",
-)
 @router.get("/status", response_model=RUMStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -610,11 +580,6 @@ def _dispatch_and_tally_rum_metrics(metrics_manager, metrics: RumMetrics) -> int
     return recorded_count
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="receive_rum_metrics",
-    error_code_prefix="RUM",
-)
 @router.post("/metrics", response_model=RUMMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/sandbox.py
+++ b/autobot-backend/api/sandbox.py
@@ -42,11 +42,6 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="execute_command",
-    error_code_prefix="SANDBOX",
-)
 @router.post("/execute", response_model=SandboxExecutionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -108,11 +103,6 @@ async def execute_command(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="execute_script",
-    error_code_prefix="SANDBOX",
-)
 @router.post("/execute/script", response_model=SandboxExecutionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -174,11 +164,6 @@ async def execute_script(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="execute_batch",
-    error_code_prefix="SANDBOX",
-)
 @router.post("/execute/batch", response_model=SandboxExecutionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -309,11 +294,6 @@ def _build_batch_result_data(commands: List[str], result: Any) -> Dict[str, Any]
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_sandbox_stats",
-    error_code_prefix="SANDBOX",
-)
 @router.get("/stats", response_model=SandboxStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -369,11 +349,6 @@ async def get_sandbox_stats(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_security_levels",
-    error_code_prefix="SANDBOX",
-)
 @router.get("/security-levels", response_model=SandboxSecurityLevelsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -443,11 +418,6 @@ async def get_security_levels(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_sandbox_examples",
-    error_code_prefix="SANDBOX",
-)
 @router.get("/examples", response_model=SandboxExamplesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/scheduler.py
+++ b/autobot-backend/api/scheduler.py
@@ -43,11 +43,6 @@ router = APIRouter(dependencies=[Depends(check_admin_permission)])
 
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="schedule_workflow",
-    error_code_prefix="SCHEDULER",
-)
 @router.post("/schedule", response_model=SchedulerWorkflowCreateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -92,11 +87,6 @@ async def schedule_workflow(request: ScheduleWorkflowRequest):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_scheduled_workflows",
-    error_code_prefix="SCHEDULER",
-)
 @router.get("/workflows", response_model=SchedulerWorkflowListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -136,11 +126,6 @@ async def list_scheduled_workflows(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_workflow_details",
-    error_code_prefix="SCHEDULER",
-)
 @router.get("/workflows/{workflow_id}", response_model=SchedulerWorkflowDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -160,11 +145,6 @@ async def get_workflow_details(workflow_id: str):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reschedule_workflow",
-    error_code_prefix="SCHEDULER",
-)
 @router.put("/workflows/{workflow_id}/reschedule", response_model=SchedulerRescheduleResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -208,11 +188,6 @@ async def reschedule_workflow(workflow_id: str, request: RescheduleRequest):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="cancel_workflow",
-    error_code_prefix="SCHEDULER",
-)
 @router.delete("/workflows/{workflow_id}", response_model=SchedulerCancelResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -235,11 +210,6 @@ async def cancel_workflow(workflow_id: str):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_scheduler_status",
-    error_code_prefix="SCHEDULER",
-)
 @router.get("/status", response_model=SchedulerStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -253,11 +223,6 @@ async def get_scheduler_status():
     return {"success": True, "scheduler_status": status}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_queue_status",
-    error_code_prefix="SCHEDULER",
-)
 @router.get("/queue", response_model=SchedulerQueueResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -303,11 +268,6 @@ async def get_queue_status():
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="control_queue",
-    error_code_prefix="SCHEDULER",
-)
 @router.post("/queue/control", response_model=SchedulerQueueControlResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -340,11 +300,6 @@ async def control_queue(request: QueueControlRequest):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_scheduler",
-    error_code_prefix="SCHEDULER",
-)
 @router.post("/start", response_model=SchedulerStartResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -362,11 +317,6 @@ async def start_scheduler():
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="stop_scheduler",
-    error_code_prefix="SCHEDULER",
-)
 @router.post("/stop", response_model=SchedulerStopResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -450,11 +400,6 @@ def _build_template_schedule_request(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="schedule_template_workflow",
-    error_code_prefix="SCHEDULER",
-)
 @router.get("/templates/schedule/{template_id}", response_model=SchedulerTemplateScheduleResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -515,11 +460,6 @@ async def schedule_template_workflow(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_scheduler_statistics",
-    error_code_prefix="SCHEDULER",
-)
 @router.get("/stats", response_model=SchedulerStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -575,11 +515,6 @@ async def get_scheduler_statistics():
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="batch_schedule_workflows",
-    error_code_prefix="SCHEDULER",
-)
 @router.post("/batch-schedule", response_model=SchedulerBatchScheduleResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -560,11 +560,6 @@ def audit_log(
 # API Endpoints
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_secret",
-    error_code_prefix="SECRETS",
-)
 @router.post("/", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -620,11 +615,6 @@ async def create_secret(
         raise HTTPException(status_code=500, detail="Failed to create secret")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_secrets",
-    error_code_prefix="SECRETS",
-)
 @router.get("/", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -658,11 +648,6 @@ async def list_secrets(
         raise HTTPException(status_code=500, detail="Failed to list secrets")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_secret_types",
-    error_code_prefix="SECRETS",
-)
 @router.get("/types", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -687,11 +672,6 @@ async def get_secret_types(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_secrets_status",
-    error_code_prefix="SECRETS",
-)
 @router.get("/status", response_model=SecretsStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -724,11 +704,6 @@ async def get_secrets_status(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_secrets_stats",
-    error_code_prefix="SECRETS",
-)
 @router.get("/stats", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -778,11 +753,6 @@ async def get_secrets_stats(
         raise HTTPException(status_code=500, detail="Failed to get stats")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_secret",
-    error_code_prefix="SECRETS",
-)
 @router.get("/{secret_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -858,11 +828,6 @@ async def get_secret(
         raise HTTPException(status_code=500, detail="Failed to get secret")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_secret",
-    error_code_prefix="SECRETS",
-)
 @router.put("/{secret_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -926,11 +891,6 @@ async def update_secret(
         raise HTTPException(status_code=500, detail="Failed to update secret")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_secret",
-    error_code_prefix="SECRETS",
-)
 @router.delete("/{secret_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -990,11 +950,6 @@ async def delete_secret(
         raise HTTPException(status_code=500, detail="Failed to delete secret")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="transfer_secrets",
-    error_code_prefix="SECRETS",
-)
 @router.post("/transfer", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1037,11 +992,6 @@ async def transfer_secrets(
         raise HTTPException(status_code=500, detail="Failed to transfer secrets")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_chat_cleanup_info",
-    error_code_prefix="SECRETS",
-)
 @router.get("/chat/{chat_id}/cleanup", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1062,11 +1012,6 @@ async def get_chat_cleanup_info(
         raise HTTPException(status_code=500, detail="Failed to get cleanup info")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_chat_secrets",
-    error_code_prefix="SECRETS",
-)
 @router.delete("/chat/{chat_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/security.py
+++ b/autobot-backend/api/security.py
@@ -38,11 +38,6 @@ router = APIRouter(dependencies=[Depends(check_admin_permission)])
 
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_security_status",
-    error_code_prefix="SECURITY",
-)
 @router.get("/status", response_model=SecurityStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -89,11 +84,6 @@ async def get_security_status(request: Request):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="approve_command",
-    error_code_prefix="SECURITY",
-)
 @router.post("/approve-command", response_model=CommandApprovalResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -123,11 +113,6 @@ async def approve_command(request: Request, approval: CommandApprovalRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_pending_approvals",
-    error_code_prefix="SECURITY",
-)
 @router.get("/pending-approvals", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -150,11 +135,6 @@ async def get_pending_approvals(request: Request):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_command_history",
-    error_code_prefix="SECURITY",
-)
 @router.get("/command-history", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -204,11 +184,6 @@ async def _read_audit_log_file(log_file: str, limit: int) -> list:
         return []
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_audit_log",
-    error_code_prefix="SECURITY",
-)
 @router.get("/audit-log", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -242,11 +217,6 @@ async def get_audit_log(request: Request, limit: int = 100):
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_threat_intel_status",
-    error_code_prefix="SECURITY",
-)
 @router.get("/threat-intel/status", response_model=ThreatIntelStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -275,11 +245,6 @@ async def get_threat_intel_status(request: Request):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="check_url_reputation",
-    error_code_prefix="SECURITY",
-)
 @router.post("/threat-intel/check-url", response_model=URLCheckResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -326,11 +291,6 @@ async def check_url_reputation(request: Request, url_request: URLCheckRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_domain_security_stats",
-    error_code_prefix="SECURITY",
-)
 @router.get("/domain-security/stats", response_model=DomainSecurityStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/security_assessment.py
+++ b/autobot-backend/api/security_assessment.py
@@ -55,11 +55,6 @@ async def get_workflow_manager() -> SecurityWorkflowManager:
 # API Endpoints
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_assessment",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.post("/assessments", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -109,11 +104,6 @@ async def create_assessment(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_assessments",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.get("/assessments", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -159,11 +149,6 @@ async def list_assessments(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_assessment",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.get("/assessments/{assessment_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
@@ -204,11 +189,6 @@ async def get_assessment(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_assessment_summary",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.get("/assessments/{assessment_id}/summary", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
@@ -249,11 +229,6 @@ async def get_assessment_summary(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_assessment",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.delete("/assessments/{assessment_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
@@ -294,11 +269,6 @@ async def delete_assessment(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_current_phase",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.get("/assessments/{assessment_id}/phase", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
@@ -349,11 +319,6 @@ async def get_current_phase(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="advance_phase",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.post("/assessments/{assessment_id}/phase", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.VALIDATION,
@@ -404,11 +369,6 @@ async def advance_phase(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_host",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.post("/assessments/{assessment_id}/hosts", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
@@ -458,11 +418,6 @@ async def add_host(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_port",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.post("/assessments/{assessment_id}/ports", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
@@ -514,11 +469,6 @@ async def add_port(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_vulnerability",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.post("/assessments/{assessment_id}/vulnerabilities", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
@@ -572,11 +522,6 @@ async def add_vulnerability(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_finding",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.post("/assessments/{assessment_id}/findings", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
@@ -629,11 +574,6 @@ async def add_finding(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_findings",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.get("/assessments/{assessment_id}/findings", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
@@ -782,11 +722,6 @@ async def _store_parsed_vulnerabilities(manager, assessment_id: str, parsed) -> 
     return vulns_added
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="parse_and_store_tool_output",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.post("/assessments/{assessment_id}/parse", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.VALIDATION,
@@ -855,11 +790,6 @@ async def parse_and_store_tool_output(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="set_error_state",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.post("/assessments/{assessment_id}/error", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
@@ -902,11 +832,6 @@ async def set_error_state(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="recover_from_error",
-    error_code_prefix="SECURITY_ASSESSMENT",
-)
 @router.post("/assessments/{assessment_id}/recover", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.VALIDATION,

--- a/autobot-backend/api/self_capabilities.py
+++ b/autobot-backend/api/self_capabilities.py
@@ -208,11 +208,6 @@ async def discover_endpoints(app: Any) -> Dict[str, Any]:
 # API endpoint
 # ---------------------------------------------------------------------------
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_capabilities",
-    error_code_prefix="SELF_CAPABILITIES",
-)
 @router.get(
     "/capabilities",
     summary="Dynamic endpoint capability discovery",

--- a/autobot-backend/api/sequential_thinking_mcp.py
+++ b/autobot-backend/api/sequential_thinking_mcp.py
@@ -116,11 +116,6 @@ SEQUENTIAL_THINKING_MCP_TOOL_DEFINITION = (
 )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_sequential_thinking_mcp_tools",
-    error_code_prefix="SEQUENTIAL_THINKING_MCP",
-)
 @router.get("/mcp/tools", response_model=SequentialThinkingMCPToolsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -172,11 +167,6 @@ def _calculate_session_summary(session_thoughts: list, thought_number: int) -> d
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="sequential_thinking_mcp",
-    error_code_prefix="SEQUENTIAL_THINKING_MCP",
-)
 @router.post("/mcp/sequential_thinking", response_model=SequentialThinkingResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -239,11 +229,6 @@ async def sequential_thinking_mcp(request: SequentialThinkingRequest) -> Metadat
     return response
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_thinking_session",
-    error_code_prefix="SEQUENTIAL_THINKING_MCP",
-)
 @router.get("/sessions/{session_id}", response_model=SequentialThinkingSessionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -274,11 +259,6 @@ async def get_thinking_session(session_id: str) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_thinking_session",
-    error_code_prefix="SEQUENTIAL_THINKING_MCP",
-)
 @router.delete("/sessions/{session_id}", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -304,11 +284,6 @@ async def clear_thinking_session(session_id: str) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_thinking_sessions",
-    error_code_prefix="SEQUENTIAL_THINKING_MCP",
-)
 @router.get("/sessions", response_model=SequentialThinkingSessionListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/services.py
+++ b/autobot-backend/api/services.py
@@ -146,11 +146,6 @@ def _build_default_services(redis_status_obj) -> list:
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_services",
-    error_code_prefix="SERVICES",
-)
 @router.get("/services", response_model=ServicesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -193,11 +188,6 @@ async def get_services(admin_check: bool = Depends(check_admin_permission)):
         raise HTTPException(status_code=500, detail="Failed to get services")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_health",
-    error_code_prefix="SERVICES",
-)
 @router.get("/health", response_model=ServicesHealthDeprecatedResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -224,11 +214,6 @@ async def get_health(admin_check: bool = Depends(check_admin_permission)):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_services_health",
-    error_code_prefix="SERVICES",
-)
 @router.get("/services/health", response_model=ServicesHealthAggregateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -325,11 +310,6 @@ def _build_vm_status_list(vm_definitions: list) -> list:
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_vms_status",
-    error_code_prefix="SERVICES",
-)
 @router.get("/vms/status", response_model=ServicesVMsStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -364,11 +344,6 @@ async def get_vms_status(admin_check: bool = Depends(check_admin_permission)):
         raise HTTPException(status_code=500, detail="Failed to get VM status")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_version",
-    error_code_prefix="SERVICES",
-)
 @router.get("/version", response_model=SystemInfo)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -53,11 +53,6 @@ RBAC_MARKER_PATH = Path("/etc/autobot/rbac-initialized")
 
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_settings",
-    error_code_prefix="SETTINGS",
-)
 @router.get("/", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -73,11 +68,6 @@ async def get_settings():
         raise_server_error("API_0003", "Error getting settings")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_settings_explicit",
-    error_code_prefix="SETTINGS",
-)
 @router.get("/settings", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -102,11 +92,6 @@ async def get_settings_explicit():
         raise_server_error("API_0003", "Error getting settings")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="save_settings",
-    error_code_prefix="SETTINGS",
-)
 @router.post("/", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -141,11 +126,6 @@ async def save_settings(
         raise_server_error("API_0003", "Error saving settings")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="save_settings_explicit",
-    error_code_prefix="SETTINGS",
-)
 @router.post("/settings", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -188,11 +168,6 @@ async def save_settings_explicit(
         raise_server_error("API_0003", "Error saving settings")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_backend_settings",
-    error_code_prefix="SETTINGS",
-)
 @router.get("/backend", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -208,11 +183,6 @@ async def get_backend_settings():
         raise_server_error("API_0003", "Error getting backend settings")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="save_backend_settings",
-    error_code_prefix="SETTINGS",
-)
 @router.post("/backend", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -242,11 +212,6 @@ async def save_backend_settings(
         raise_server_error("API_0003", "Error saving backend settings")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_full_config",
-    error_code_prefix="SETTINGS",
-)
 @router.get("/config", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -262,11 +227,6 @@ async def get_full_config():
         raise_server_error("API_0003", "Error getting full config")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="save_full_config",
-    error_code_prefix="SETTINGS",
-)
 @router.post("/config", response_model=dict)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -296,11 +256,6 @@ async def save_full_config(
         raise_server_error("API_0003", "Error saving full config")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_cache",
-    error_code_prefix="SETTINGS",
-)
 @router.post("/clear-cache", response_model=ClearCacheResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -334,11 +289,6 @@ async def clear_cache():
 # ==================== RBAC Management Endpoints (Issue #687) ====================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="initialize_rbac",
-    error_code_prefix="RBAC",
-)
 @router.post("/rbac/initialize", response_model=SettingsTaskQueuedResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -388,11 +338,6 @@ async def initialize_rbac_endpoint(
         raise_server_error("RBAC_0001", "Error queuing RBAC initialization")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_rbac_task_status",
-    error_code_prefix="RBAC",
-)
 @router.get("/rbac/status/{task_id}", response_model=SettingsTaskStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -440,11 +385,6 @@ async def get_rbac_task_status(
         raise_server_error("RBAC_0002", "Error getting task status")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_rbac_status",
-    error_code_prefix="RBAC",
-)
 @router.get("/rbac/status", response_model=RBACStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -488,11 +428,6 @@ UPDATES_MARKER_PATH = Path("/etc/autobot/last-update")
 
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="run_system_update",
-    error_code_prefix="UPDATES",
-)
 @router.post("/updates/run", response_model=SettingsTaskQueuedResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -561,11 +496,6 @@ async def run_system_update_endpoint(
         raise_server_error("UPDATES_0001", "Error queuing system update")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_update_task_status",
-    error_code_prefix="UPDATES",
-)
 @router.get("/updates/status/{task_id}", response_model=SettingsTaskStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -655,11 +585,6 @@ def _check_celery_worker_available() -> tuple[bool, str]:
         return False, "Cannot verify worker status"
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="check_celery_health",
-    error_code_prefix="UPDATES",
-)
 @router.get("/updates/worker-status", response_model=WorkerStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -683,11 +608,6 @@ async def check_celery_worker_status(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="check_available_updates",
-    error_code_prefix="UPDATES",
-)
 @router.post("/updates/check", response_model=SettingsTaskQueuedResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -740,11 +660,6 @@ async def check_updates_endpoint(
         raise_server_error("UPDATES_0003", "Error queuing update check")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_update_status",
-    error_code_prefix="UPDATES",
-)
 @router.get("/updates/status", response_model=UpdateStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -883,11 +798,6 @@ def _count_unchanged_keys(incoming: dict, changed: dict) -> int:
     return max(0, all_incoming_leaf_count - len(changed))
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="sync_config",
-    error_code_prefix="SETTINGS",
-)
 @router.post("/sync", response_model=ConfigSyncResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -986,11 +896,6 @@ async def sync_config(
 # ==================== Hardware Priority Endpoint (Issue #3288) ====================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_hardware_priority",
-    error_code_prefix="SETTINGS",
-)
 @router.patch("/hardware-priority", response_model=HardwarePriorityResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/skills_repos.py
+++ b/autobot-backend/api/skills_repos.py
@@ -54,11 +54,6 @@ async def _get_repo_by_id(session: AsyncSession, repo_id: str) -> SkillRepo:
     return repo
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_repo",
-    error_code_prefix="SKILLS_REPOS",
-)
 @router.post("/", summary="Register a new skill repository", response_model=SkillRepoAddResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -93,11 +88,6 @@ async def add_repo(
     return {"id": repo.id, "name": repo.name, "status": "registered"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_repos",
-    error_code_prefix="SKILLS_REPOS",
-)
 @router.get("", summary="List all registered skill repositories", response_model=List[SkillRepoItem])
 @router.get("/", include_in_schema=False, response_model=List[SkillRepoItem])
 @with_error_handling(
@@ -127,11 +117,6 @@ async def list_repos() -> List[Dict[str, Any]]:
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="sync_repo",
-    error_code_prefix="SKILLS_REPOS",
-)
 @router.post("/{repo_id}/sync", summary="Sync packages from a repository", response_model=SkillRepoSyncResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -161,11 +146,6 @@ async def sync_repo(
     return {"synced": len(packages), "repo": repo.name}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="browse_repo",
-    error_code_prefix="SKILLS_REPOS",
-)
 @router.get("/{repo_id}/browse", summary="Browse packages in a repository", response_model=SkillRepoBrowseResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/startup.py
+++ b/autobot-backend/api/startup.py
@@ -99,11 +99,6 @@ async def broadcast_startup_message(message: StartupMessage):
             startup_state["websocket_clients"].discard(ws)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_startup_status",
-    error_code_prefix="STARTUP",
-)
 @router.get("/status", response_model=StartupStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -168,11 +163,6 @@ async def startup_websocket(websocket: WebSocket):
             startup_state["websocket_clients"].discard(websocket)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_startup_phase",
-    error_code_prefix="STARTUP",
-)
 @router.post("/phase", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/state_tracking.py
+++ b/autobot-backend/api/state_tracking.py
@@ -40,11 +40,6 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_state_tracking_status",
-    error_code_prefix="STATE",
-)
 @router.get("/status", response_model=StateTrackingStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -82,11 +77,6 @@ async def get_state_tracking_status():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_state_summary",
-    error_code_prefix="STATE",
-)
 @router.get("/summary", response_model=StateTrackingSummaryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -112,11 +102,6 @@ async def get_state_summary():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="capture_state_snapshot",
-    error_code_prefix="STATE",
-)
 @router.post("/snapshot", response_model=StateTrackingSnapshotResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -149,11 +134,6 @@ async def capture_state_snapshot(background_tasks: BackgroundTasks):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="record_state_change",
-    error_code_prefix="STATE",
-)
 @router.post("/change", response_model=StateTrackingChangeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -205,11 +185,6 @@ async def record_state_change(request: StateChangeRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_milestones",
-    error_code_prefix="STATE",
-)
 @router.get("/milestones", response_model=StateTrackingMilestonesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -239,11 +214,6 @@ async def get_milestones():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_metric_trends",
-    error_code_prefix="STATE",
-)
 @router.get("/trends/{metric}", response_model=StateTrackingTrendsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -303,11 +273,6 @@ async def get_metric_trends(metric: str, days: int = Query(7, ge=1, le=90)):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_recent_changes",
-    error_code_prefix="STATE",
-)
 @router.get("/changes", response_model=StateTrackingChangesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -365,11 +330,6 @@ async def get_recent_changes(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="generate_state_report",
-    error_code_prefix="STATE",
-)
 @router.get("/report", response_model=StateTrackingReportResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -401,11 +361,6 @@ async def generate_state_report():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_state_data",
-    error_code_prefix="STATE",
-)
 @router.post("/export", response_model=StateTrackingExportResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -461,11 +416,6 @@ async def export_state_data(request: StateTrackingExportRequest):
 # Use /api/system/health?detailed=true for comprehensive status
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_all_metrics",
-    error_code_prefix="STATE",
-)
 @router.get("/metrics/all", response_model=StateTrackingMetricsAllResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -494,11 +444,6 @@ async def get_all_metrics():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_phase_history",
-    error_code_prefix="STATE",
-)
 @router.get("/phase-history/{phase_name}", response_model=StateTrackingPhaseHistoryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/structured_thinking_mcp.py
+++ b/autobot-backend/api/structured_thinking_mcp.py
@@ -251,11 +251,6 @@ STRUCTURED_THINKING_MCP_TOOL_DEFINITIONS = (
 )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_structured_thinking_mcp_tools",
-    error_code_prefix="STRUCTURED_THINKING_MCP",
-)
 @router.get("/mcp/tools", response_model=List[StructuredThinkingMCPTool])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -276,11 +271,6 @@ async def get_structured_thinking_mcp_tools() -> List[StructuredThinkingMCPTool]
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="process_thought_mcp",
-    error_code_prefix="STRUCTURED_THINKING_MCP",
-)
 @router.post("/mcp/process_thought", response_model=StructuredThinkingProcessThoughtResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -352,11 +342,6 @@ async def process_thought_mcp(request: ProcessThoughtRequest) -> Metadata:
     return response
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="generate_summary_mcp",
-    error_code_prefix="STRUCTURED_THINKING_MCP",
-)
 @router.post("/mcp/generate_summary", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -424,11 +409,6 @@ async def generate_summary_mcp(request: GenerateSummaryRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_history_mcp",
-    error_code_prefix="STRUCTURED_THINKING_MCP",
-)
 @router.post("/mcp/clear_history", response_model=StructuredThinkingClearResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -456,11 +436,6 @@ async def clear_history_mcp(request: ClearHistoryRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_structured_session",
-    error_code_prefix="STRUCTURED_THINKING_MCP",
-)
 @router.get("/sessions/{session_id}", response_model=StructuredThinkingSessionDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -500,11 +475,6 @@ async def get_structured_session(session_id: str) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_structured_sessions",
-    error_code_prefix="STRUCTURED_THINKING_MCP",
-)
 @router.get("/sessions", response_model=StructuredThinkingSessionsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -163,13 +163,13 @@ def _build_frontend_meta_config() -> dict:
     }
 
 
+@router.get("/frontend-config", response_model=SystemFrontendConfigResponse)
+@cache_response(cache_key="frontend_config", ttl=60)  # Cache for 1 minute
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_frontend_config",
     error_code_prefix="SYSTEM",
 )
-@router.get("/frontend-config", response_model=SystemFrontendConfigResponse)
-@cache_response(cache_key="frontend_config", ttl=60)  # Cache for 1 minute
 async def get_frontend_config(admin_check: bool = Depends(check_admin_permission)):
     """Get configuration values needed by the frontend.
 
@@ -197,19 +197,14 @@ async def get_frontend_config(admin_check: bool = Depends(check_admin_permission
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_health",
-    error_code_prefix="SYSTEM",
-)
 @router.get("/health", response_model=SystemHealthResponse)
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_health",
-    error_code_prefix="SYSTEM",
-)
 @router.get("/system/health", response_model=SystemHealthResponse)  # Frontend compatibility alias
 @cache_response(cache_key="system_health", ttl=30)  # Cache for 30 seconds
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_system_health",
+    error_code_prefix="SYSTEM",
+)
 async def get_system_health(
     request: Request = None,
 ):
@@ -262,13 +257,13 @@ async def get_system_health(
         }
 
 
+@router.get("/info", response_model=SystemInfoResponse)
+@cache_response(cache_key="system_info", ttl=300)  # Cache for 5 minutes
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_system_info",
     error_code_prefix="SYSTEM",
 )
-@router.get("/info", response_model=SystemInfoResponse)
-@cache_response(cache_key="system_info", ttl=300)  # Cache for 5 minutes
 async def get_system_info(admin_check: bool = Depends(check_admin_permission)):
     """Get system information
 
@@ -295,11 +290,6 @@ async def get_system_info(admin_check: bool = Depends(check_admin_permission)):
     return system_info
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reload_system_config",
-    error_code_prefix="SYSTEM",
-)
 @router.post("/reload_config", response_model=SystemReloadConfigResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -334,11 +324,6 @@ async def reload_system_config(admin_check: bool = Depends(check_admin_permissio
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reload_prompts",
-    error_code_prefix="SYSTEM",
-)
 @router.get("/prompt_reload", response_model=SystemPromptReloadResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -371,11 +356,6 @@ async def reload_prompts(admin_check: bool = Depends(check_admin_permission)):
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="admin_check",
-    error_code_prefix="SYSTEM",
-)
 @router.get("/admin_check", response_model=SystemAdminCheckResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -398,11 +378,6 @@ async def admin_check(admin_check: bool = Depends(check_admin_permission)):
     return admin_status
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="dynamic_import",
-    error_code_prefix="SYSTEM",
-)
 @router.post("/dynamic_import", response_model=SystemDynamicImportResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -445,13 +420,13 @@ async def dynamic_import(
     }
 
 
+@router.get("/health/detailed", response_model=SystemHealthResponse)
+@cache_response(cache_key="system_health_detailed", ttl=30)  # Cache for 30 seconds
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_detailed_health",
     error_code_prefix="SYSTEM",
 )
-@router.get("/health/detailed", response_model=SystemHealthResponse)
-@cache_response(cache_key="system_health_detailed", ttl=30)  # Cache for 30 seconds
 async def get_detailed_health(
     request: Request, admin_check: bool = Depends(check_admin_permission)
 ):
@@ -583,13 +558,13 @@ def _determine_overall_health_status(health_status: dict) -> None:
         health_status["errors"] = error_components
 
 
+@router.get("/cache/stats", response_model=SystemCacheStatsResponse)
+@cache_response(cache_key="cache_stats", ttl=15)  # Cache for 15 seconds
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_cache_stats",
     error_code_prefix="SYSTEM",
 )
-@router.get("/cache/stats", response_model=SystemCacheStatsResponse)
-@cache_response(cache_key="cache_stats", ttl=15)  # Cache for 15 seconds
 async def get_cache_stats(admin_check: bool = Depends(check_admin_permission)):
     """Get cache statistics and performance metrics
 
@@ -691,13 +666,13 @@ def _analyze_key_patterns(cache_keys: list, cache_prefix: str) -> dict:
     return key_patterns
 
 
+@router.get("/cache/activity", response_model=SystemCacheActivityResponse)
+@cache_response(cache_key="cache_activity", ttl=10)  # Cache for 10 seconds
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_cache_activity",
     error_code_prefix="SYSTEM",
 )
-@router.get("/cache/activity", response_model=SystemCacheActivityResponse)
-@cache_response(cache_key="cache_activity", ttl=10)  # Cache for 10 seconds
 async def get_cache_activity(admin_check: bool = Depends(check_admin_permission)):
     """Get recent cache activity and key information.
 
@@ -753,13 +728,13 @@ async def get_cache_activity(admin_check: bool = Depends(check_admin_permission)
         }
 
 
+@router.get("/metrics", response_model=SystemMetricsResponse)
+@cache_response(cache_key="system_metrics", ttl=15)  # Cache for 15 seconds
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_system_metrics",
     error_code_prefix="SYSTEM",
 )
-@router.get("/metrics", response_model=SystemMetricsResponse)
-@cache_response(cache_key="system_metrics", ttl=15)  # Cache for 15 seconds
 async def get_system_metrics(admin_check: bool = Depends(check_admin_permission)):
     """Get system performance metrics
 
@@ -822,11 +797,6 @@ async def get_system_metrics(admin_check: bool = Depends(check_admin_permission)
 
 
 # Issue #743: Cache coordinator endpoints for memory optimization (Phase 3.2)
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_cache_coordinator_stats",
-    error_code_prefix="SYSTEM",
-)
 @router.get("/api/cache/stats", response_model=SystemCacheCoordinatorStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -859,11 +829,6 @@ async def get_cache_coordinator_stats(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="trigger_cache_eviction",
-    error_code_prefix="SYSTEM",
-)
 @router.post("/api/cache/evict", response_model=SystemCacheEvictResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -894,11 +859,6 @@ async def trigger_cache_eviction(admin_check: bool = Depends(check_admin_permiss
         raise HTTPException(status_code=500, detail="Error triggering cache eviction")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_cache",
-    error_code_prefix="SYSTEM",
-)
 @router.post("/api/cache/clear/{cache_name}", response_model=SystemCacheClearResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/system_validation.py
+++ b/autobot-backend/api/system_validation.py
@@ -30,11 +30,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="validation_health",
-    error_code_prefix="SYSTEM_VALIDATION",
-)
 @router.get("/health", response_model=SystemValidationHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -56,11 +51,6 @@ async def validation_health():
         raise_server_error("API_0003", "Health check failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="run_comprehensive_validation",
-    error_code_prefix="SYSTEM_VALIDATION",
-)
 @router.post("/validate/comprehensive", response_model=SystemValidationResultModel)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -99,11 +89,6 @@ async def run_comprehensive_validation(
         raise_server_error("API_0003", "Validation error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="run_quick_validation",
-    error_code_prefix="SYSTEM_VALIDATION",
-)
 @router.get("/validate/quick", response_model=SystemValidationQuickResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -171,11 +156,6 @@ async def run_quick_validation():
         raise_server_error("API_0003", "Quick validation error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="validate_component",
-    error_code_prefix="SYSTEM_VALIDATION",
-)
 @router.get("/validate/component/{component_name}", response_model=SystemValidationComponentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -224,11 +204,6 @@ async def validate_component(component_name: str):
         raise_server_error("API_0003", "Component validation error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_optimization_recommendations",
-    error_code_prefix="SYSTEM_VALIDATION",
-)
 @router.get("/validate/recommendations", response_model=SystemValidationRecommendationsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -294,11 +269,6 @@ async def get_optimization_recommendations():
         raise_server_error("API_0003", "Recommendations error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_validation_status",
-    error_code_prefix="SYSTEM_VALIDATION",
-)
 @router.get("/validate/status", response_model=SystemValidationStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -331,11 +301,6 @@ async def get_validation_status():
         raise_server_error("API_0003", "Status error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="run_performance_benchmark",
-    error_code_prefix="SYSTEM_VALIDATION",
-)
 @router.post("/validate/benchmark", response_model=SystemValidationBenchmarkResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/templates.py
+++ b/autobot-backend/api/templates.py
@@ -57,11 +57,6 @@ def _generate_templates_cache_key(category, tags, complexity):
     return "list:" + (":".join(key_parts) if key_parts else "all")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_templates_root",
-    error_code_prefix="TEMPLATES",
-)
 @router.get("/", response_model=TemplatesRootResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -82,17 +77,17 @@ async def get_templates_root():
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_workflow_templates",
-    error_code_prefix="TEMPLATES",
-)
 @router.get("/templates", response_model=TemplateListResponse)
 @smart_cache(
     data_type="templates",
     key_func=lambda category=None, tags=None, complexity=None: _generate_templates_cache_key(
         category, tags, complexity
     ),
+)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_workflow_templates",
+    error_code_prefix="TEMPLATES",
 )
 async def list_workflow_templates(
     category: Optional[str] = Query(None, description="Filter by template category"),
@@ -152,11 +147,6 @@ async def list_workflow_templates(
 # --- Static paths MUST be registered before /templates/{template_id} ---
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_secrets_usage",
-    error_code_prefix="TEMPLATES",
-)
 @router.get("/templates/secrets-usage", response_model=TemplateSecretsUsageResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -188,11 +178,6 @@ async def get_secrets_usage():
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="search_templates",
-    error_code_prefix="TEMPLATES",
-)
 @router.get("/templates/search", response_model=TemplateSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -222,11 +207,6 @@ async def search_templates(
         raise HTTPException(status_code=500, detail="Failed to search templates")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_template_categories",
-    error_code_prefix="TEMPLATES",
-)
 @router.get("/templates/categories", response_model=TemplateCategoriesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -256,11 +236,6 @@ async def list_template_categories():
         raise HTTPException(status_code=500, detail="Failed to list categories")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_template_statistics",
-    error_code_prefix="TEMPLATES",
-)
 @router.get("/templates/stats", response_model=TemplateStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -318,14 +293,14 @@ async def get_template_statistics():
 # --- Parameterized paths below (after all static paths) ---
 
 
+@router.get("/templates/{template_id}", response_model=TemplateDetailResponse)
+@smart_cache(
+    data_type="templates", key_func=lambda template_id: f"detail:{template_id}"
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_template_details",
     error_code_prefix="TEMPLATES",
-)
-@router.get("/templates/{template_id}", response_model=TemplateDetailResponse)
-@smart_cache(
-    data_type="templates", key_func=lambda template_id: f"detail:{template_id}"
 )
 async def get_template_details(template_id: str):
     """Get detailed information about a specific template (Issue #372 - uses model methods)"""
@@ -346,11 +321,6 @@ async def get_template_details(template_id: str):
         raise HTTPException(status_code=500, detail="Failed to get template")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="preview_template_workflow",
-    error_code_prefix="TEMPLATES",
-)
 @router.get("/templates/{template_id}/preview", response_model=TemplatePreviewResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -415,11 +385,6 @@ async def preview_template_workflow(
         raise HTTPException(status_code=500, detail="Failed to preview template")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="validate_template_variables",
-    error_code_prefix="TEMPLATES",
-)
 @router.post("/templates/{template_id}/validate", response_model=TemplateValidationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -448,11 +413,6 @@ async def validate_template_variables(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_workflow_from_template",
-    error_code_prefix="TEMPLATES",
-)
 @router.post("/templates/{template_id}/create-workflow", response_model=TemplateCreateWorkflowResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -507,11 +467,6 @@ async def create_workflow_from_template(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="execute_template_workflow",
-    error_code_prefix="TEMPLATES",
-)
 @router.post("/templates/{template_id}/execute", response_model=TemplateExecuteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/terminal.py
+++ b/autobot-backend/api/terminal.py
@@ -319,11 +319,6 @@ router.include_router(tools_router, prefix="/terminal")
 # REST API Endpoints
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="create_terminal_session",
-    error_code_prefix="TERMINAL",
-)
 @router.post("/sessions", response_model=TerminalSessionCreateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -395,11 +390,6 @@ async def create_terminal_session(
     return response
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_terminal_sessions",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/sessions", response_model=TerminalSessionListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -432,11 +422,6 @@ async def list_terminal_sessions(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_terminal_session",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/sessions/{session_id}", response_model=TerminalSessionDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -469,11 +454,6 @@ async def get_terminal_session(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_terminal_session",
-    error_code_prefix="TERMINAL",
-)
 @router.delete("/sessions/{session_id}", response_model=TerminalSessionDeleteResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -515,11 +495,6 @@ async def delete_terminal_session(
 # SSH Key Management Endpoints (Issue #211)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="setup_ssh_keys",
-    error_code_prefix="TERMINAL",
-)
 @router.post("/sessions/{session_id}/ssh-keys", response_model=SSHKeyListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -563,11 +538,6 @@ async def setup_ssh_keys(
         raise HTTPException(status_code=500, detail="SSH key setup failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_session_ssh_keys",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/sessions/{session_id}/ssh-keys", response_model=SSHKeyListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -598,11 +568,6 @@ async def list_session_ssh_keys(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_key_to_agent",
-    error_code_prefix="TERMINAL",
-)
 @router.post("/sessions/{session_id}/ssh-keys/{key_name}/agent", response_model=SSHKeyAgentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -645,11 +610,6 @@ async def add_key_to_ssh_agent(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_key_path",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/sessions/{session_id}/ssh-keys/{key_name}/path", response_model=SSHKeyPathResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -685,11 +645,6 @@ async def get_ssh_key_path(
         raise HTTPException(status_code=404, detail=f"Key '{key_name}' not found")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="execute_single_command",
-    error_code_prefix="TERMINAL",
-)
 @router.post("/command", response_model=CommandAssessResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -734,11 +689,6 @@ async def execute_single_command(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="send_terminal_input",
-    error_code_prefix="TERMINAL",
-)
 @router.post("/sessions/{session_id}/input", response_model=TerminalInputResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -770,11 +720,6 @@ async def send_terminal_input(
         raise HTTPException(status_code=500, detail="Failed to send input")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="send_terminal_signal",
-    error_code_prefix="TERMINAL",
-)
 @router.post("/sessions/{session_id}/signal/{signal_name}", response_model=TerminalSignalResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -812,11 +757,6 @@ async def send_terminal_signal(
         raise HTTPException(status_code=500, detail="Failed to send signal")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_terminal_command_history",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/sessions/{session_id}/history", response_model=TerminalCommandHistoryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -856,11 +796,6 @@ async def get_terminal_command_history(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_session_audit_log",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/audit/{session_id}", response_model=TerminalAuditLogResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -972,11 +907,6 @@ async def _run_terminal_message_loop(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="consolidated_terminal_websocket",
-    error_code_prefix="TERMINAL",
-)
 @router.websocket("/ws/{session_id}")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1095,11 +1025,6 @@ async def _run_ssh_message_loop(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="ssh_terminal_websocket",
-    error_code_prefix="TERMINAL",
-)
 @router.websocket("/ws/ssh/{host_id}")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1159,11 +1084,6 @@ async def ssh_terminal_websocket(
 # Information endpoints
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="terminal_info",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/", response_model=TerminalInfoResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1203,11 +1123,6 @@ async def terminal_info(
 # Health and Status endpoints
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="terminal_health_check",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/health", response_model=TerminalHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1254,11 +1169,6 @@ async def terminal_health_check(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_terminal_system_status",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/status", response_model=TerminalSystemStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1303,11 +1213,6 @@ async def get_terminal_system_status(
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_terminal_capabilities",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/capabilities", response_model=TerminalCapabilitiesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1364,11 +1269,6 @@ async def get_terminal_capabilities(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_security_policies",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/security", response_model=TerminalSecurityPoliciesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1411,11 +1311,6 @@ async def get_security_policies(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_terminal_features",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/features", response_model=TerminalFeaturesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1475,11 +1370,6 @@ async def get_terminal_features(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_terminal_statistics",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/stats", response_model=TerminalStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/terminal_tools.py
+++ b/autobot-backend/api/terminal_tools.py
@@ -35,11 +35,6 @@ router = APIRouter(tags=["terminal-tools"])
 # Tool Management endpoints
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="install_tool",
-    error_code_prefix="TERMINAL",
-)
 @router.post("/install-tool", response_model=Dict[str, Any])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -65,11 +60,6 @@ async def install_tool(request: ToolInstallRequest):
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="check_tool_installed",
-    error_code_prefix="TERMINAL",
-)
 @router.post("/check-tool", response_model=Dict[str, Any])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -85,11 +75,6 @@ async def check_tool_installed(tool_name: str):
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="validate_command",
-    error_code_prefix="TERMINAL",
-)
 @router.post("/validate-command", response_model=Dict[str, Any])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -105,11 +90,6 @@ async def validate_command(command: str):
     return result
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_package_managers",
-    error_code_prefix="TERMINAL",
-)
 @router.get("/package-managers", response_model=PackageManagersResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/usage.py
+++ b/autobot-backend/api/usage.py
@@ -45,11 +45,6 @@ router = APIRouter(prefix="/usage", tags=["usage", "analytics"])
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_usage_summary",
-    error_code_prefix="USAGE",
-)
 @router.get("/summary", response_model=UsageSummaryResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -98,11 +93,6 @@ async def get_usage_summary(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_usage_by_user_all",
-    error_code_prefix="USAGE",
-)
 @router.get("/by-user", response_model=UsageByUserAllResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -127,11 +117,6 @@ async def get_usage_by_user_all(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_usage_by_user_single",
-    error_code_prefix="USAGE",
-)
 @router.get("/by-user/{user_id}", response_model=UsageByUserSingleResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -151,11 +136,6 @@ async def get_usage_by_user_single(
     return await tracker.get_cost_by_user(user_id)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_my_usage",
-    error_code_prefix="USAGE",
-)
 @router.get("/me", response_model=UsageMyUsageResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -194,11 +174,6 @@ async def get_my_usage(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="record_usage_event",
-    error_code_prefix="USAGE",
-)
 @router.post("/record", response_model=UsageRecordResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -243,11 +218,6 @@ async def record_usage_event(
 # ============================================================================
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="export_usage_csv",
-    error_code_prefix="USAGE",
-)
 @router.get("/export/csv", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/validation_dashboard.py
+++ b/autobot-backend/api/validation_dashboard.py
@@ -152,11 +152,6 @@ def get_validation_judges() -> Optional[Metadata]:
     return _validation_judges
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_dashboard_status",
-    error_code_prefix="VALIDATION_DASHBOARD",
-)
 @router.get("/status", response_model=ValidationDashboardStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -192,11 +187,6 @@ async def get_dashboard_status():
         raise_service_unavailable("API_0005", "Dashboard generator not available")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_validation_report",
-    error_code_prefix="VALIDATION_DASHBOARD",
-)
 @router.get("/report", response_model=ValidationDashboardReportResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -250,11 +240,6 @@ async def get_validation_report():
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_dashboard_html",
-    error_code_prefix="VALIDATION_DASHBOARD",
-)
 @router.get("/dashboard", response_class=HTMLResponse, response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -313,11 +298,6 @@ async def get_dashboard_html():
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_dashboard_file",
-    error_code_prefix="VALIDATION_DASHBOARD",
-)
 @router.get("/dashboard/file", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -351,11 +331,6 @@ async def get_dashboard_file():
         raise_server_error("API_0003", "File system error")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="generate_dashboard",
-    error_code_prefix="VALIDATION_DASHBOARD",
-)
 @router.post("/generate", response_model=ValidationDashboardGenerateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -418,11 +393,6 @@ async def generate_dashboard(
         raise_service_unavailable("API_0005", "Dashboard generator not available")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_dashboard_metrics",
-    error_code_prefix="VALIDATION_DASHBOARD",
-)
 @router.get("/metrics", response_model=ValidationDashboardMetricsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -484,11 +454,6 @@ async def get_dashboard_metrics():
         raise_service_unavailable("API_0005", "Dashboard generator not available")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_trend_data",
-    error_code_prefix="VALIDATION_DASHBOARD",
-)
 @router.get("/trends", response_model=ValidationDashboardTrendsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -519,11 +484,6 @@ async def get_trend_data():
         raise_service_unavailable("API_0005", "Dashboard generator not available")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_alerts",
-    error_code_prefix="VALIDATION_DASHBOARD",
-)
 @router.get("/alerts", response_model=ValidationDashboardAlertsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -563,11 +523,6 @@ async def get_system_alerts():
         raise_service_unavailable("API_0005", "Dashboard generator not available")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_system_recommendations",
-    error_code_prefix="VALIDATION_DASHBOARD",
-)
 @router.get("/recommendations", response_model=ValidationDashboardRecommendationsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -616,11 +571,6 @@ async def get_system_recommendations():
 # Use /api/system/health?detailed=true for comprehensive status
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="judge_workflow_step",
-    error_code_prefix="VALIDATION_DASHBOARD",
-)
 @router.post("/judge_workflow_step", response_model=ValidationJudgmentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -678,11 +628,6 @@ async def judge_workflow_step(request: dict):
         raise_validation_error("API_0001", "Invalid workflow step data")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="judge_agent_response",
-    error_code_prefix="VALIDATION_DASHBOARD",
-)
 @router.post("/judge_agent_response", response_model=ValidationJudgmentResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -743,11 +688,6 @@ async def judge_agent_response(request: dict):
         raise_validation_error("API_0001", "Invalid agent response data")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_judge_status",
-    error_code_prefix="VALIDATION_DASHBOARD",
-)
 @router.get("/judge_status", response_model=ValidationJudgeStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/vision.py
+++ b/autobot-backend/api/vision.py
@@ -55,11 +55,6 @@ def get_screen_analyzer() -> ScreenAnalyzer:
 
 
 # API Endpoints
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vision_health_check",
-    error_code_prefix="VISION",
-)
 @router.get("/health", response_model=VisionHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -103,11 +98,6 @@ async def vision_health_check(
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="analyze_screen",
-    error_code_prefix="VISION",
-)
 @router.post("/analyze", response_model=ScreenAnalysisResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -168,11 +158,6 @@ async def analyze_screen(
         raise HTTPException(status_code=500, detail="Screen analysis failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="detect_elements",
-    error_code_prefix="VISION",
-)
 @router.post("/elements", response_model=VisionDetectElementsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -235,11 +220,6 @@ async def detect_elements(
         raise HTTPException(status_code=500, detail="Element detection failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="extract_text_ocr",
-    error_code_prefix="VISION",
-)
 @router.post("/ocr", response_model=VisionOCRResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -296,11 +276,6 @@ async def extract_text_ocr(
         raise HTTPException(status_code=500, detail="OCR extraction failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_automation_opportunities",
-    error_code_prefix="VISION",
-)
 @router.get("/automation-opportunities", response_model=VisionAutomationOpportunitiesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -333,11 +308,6 @@ async def get_automation_opportunities(
         raise HTTPException(status_code=500, detail="Failed to identify opportunities")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_element_types",
-    error_code_prefix="VISION",
-)
 @router.get("/element-types", response_model=VisionElementTypesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -365,11 +335,6 @@ async def get_element_types(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_interaction_types",
-    error_code_prefix="VISION",
-)
 @router.get("/interaction-types", response_model=VisionInteractionTypesResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -397,11 +362,6 @@ async def get_interaction_types(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_layout_analysis",
-    error_code_prefix="VISION",
-)
 @router.get("/layout", response_model=VisionLayoutResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -433,11 +393,6 @@ async def get_layout_analysis(
         raise HTTPException(status_code=500, detail="Layout analysis failed")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vision_service_status",
-    error_code_prefix="VISION",
-)
 @router.get("/status", response_model=VisionStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -166,11 +166,6 @@ def start_vnc_server() -> Dict[str, str]:
         return {"status": "error", "message": "Operation failed"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_vnc_status",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.get("/status", response_model=VncRunningResponse)
 @with_error_handling(error_code_prefix="VNC_STATUS")
 async def get_vnc_status(
@@ -187,11 +182,6 @@ async def get_vnc_status(
     return {"running": running}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="ensure_vnc_running",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/ensure-running", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_ENSURE")
 async def ensure_vnc_running(
@@ -211,11 +201,6 @@ async def ensure_vnc_running(
     return start_vnc_server()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="restart_vnc_server",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/restart", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_RESTART")
 async def restart_vnc_server(
@@ -345,11 +330,6 @@ def _run_xdotool_cmd(args: list[str], timeout: int = 5) -> Dict[str, str]:
         return {"status": "error", "message": "Internal server error"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vnc_mouse_click",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/click", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_CLICK")
 async def vnc_mouse_click(
@@ -381,11 +361,6 @@ async def vnc_mouse_click(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vnc_keyboard_type",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/type", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_TYPE")
 async def vnc_keyboard_type(
@@ -433,11 +408,6 @@ async def vnc_keyboard_type(
         return _run_xdotool_cmd(["type", "--delay", str(delay_ms), "--", request.text])
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vnc_special_key",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/key", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_KEY")
 async def vnc_special_key(
@@ -457,11 +427,6 @@ async def vnc_special_key(
     return _run_xdotool_cmd(["key", request.key])
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vnc_mouse_scroll",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/scroll", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_SCROLL")
 async def vnc_mouse_scroll(
@@ -489,11 +454,6 @@ async def vnc_mouse_scroll(
     return _run_xdotool_cmd(args)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vnc_mouse_drag",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/drag", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_DRAG")
 async def vnc_mouse_drag(
@@ -534,11 +494,6 @@ async def vnc_mouse_drag(
     return _run_xdotool_cmd(["mouseup", "1"])
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vnc_screenshot",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.get("/screenshot", response_model=VncScreenshotResponse)
 @with_error_handling(error_code_prefix="VNC_SCREENSHOT")
 async def vnc_screenshot(
@@ -603,11 +558,6 @@ async def vnc_screenshot(
         return {"status": "error", "message": "Operation failed", "image_data": ""}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vnc_clipboard_sync",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/clipboard", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_CLIPBOARD")
 async def vnc_clipboard_sync(
@@ -654,11 +604,6 @@ async def vnc_clipboard_sync(
 # Connection Settings Management (Issue #74 - Area 4)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_connection_settings",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.get("/connection/settings", response_model=ConnectionSettings)
 @with_error_handling(error_code_prefix="VNC_CONN_GET")
 async def get_connection_settings(
@@ -681,11 +626,6 @@ async def get_connection_settings(
         return _connection_settings[session_id]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_connection_settings",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/connection/settings", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_CONN_SET")
 async def update_connection_settings(
@@ -717,11 +657,6 @@ async def update_connection_settings(
     return {"status": "success", "message": "Connection settings updated"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_connection_quality_metrics",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.get("/connection/quality-metrics", response_model=VncQualityMetricsResponse)
 @with_error_handling(error_code_prefix="VNC_QUALITY")
 async def get_connection_quality_metrics(
@@ -942,11 +877,6 @@ def _get_process_list() -> List[Dict[str, str]]:
     return processes
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_desktop_context",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.get("/desktop/context", response_model=VncDesktopContextResponse)
 @with_error_handling(error_code_prefix="VNC_CONTEXT")
 async def get_desktop_context(
@@ -981,11 +911,6 @@ _recording_session: Dict[str, MacroRecording] = {}
 _macros_lock = asyncio.Lock()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_macro_recording",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/macro/record/start", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_MACRO_START")
 async def start_macro_recording(
@@ -1011,11 +936,6 @@ async def start_macro_recording(
     return {"status": "success", "message": f"Started recording macro '{name}'"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="stop_macro_recording",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/macro/record/stop", response_model=MacroStopResponse)
 @with_error_handling(error_code_prefix="VNC_MACRO_STOP")
 async def stop_macro_recording(
@@ -1048,11 +968,6 @@ async def stop_macro_recording(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_macros",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.get("/macros", response_model=MacroListResponse)
 @with_error_handling(error_code_prefix="VNC_MACROS_LIST")
 async def list_macros(
@@ -1078,11 +993,6 @@ async def list_macros(
     return {"macros": macro_list}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="playback_macro",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/macro/playback", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_MACRO_PLAY")
 async def playback_macro(
@@ -1141,11 +1051,6 @@ async def playback_macro(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="delete_macro",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.delete("/macro/{name}", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_MACRO_DELETE")
 async def delete_macro(
@@ -1174,11 +1079,6 @@ async def delete_macro(
 # Area 5: Automation Features - OCR Text Recognition
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vnc_ocr_text",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/ocr", response_model=VncOcrResponse)
 @with_error_handling(error_code_prefix="VNC_OCR")
 async def vnc_ocr_text(
@@ -1310,11 +1210,6 @@ def _build_match_result(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vnc_find_image",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/find-image", response_model=VncFindImageResponse)
 @with_error_handling(error_code_prefix="VNC_FIND_IMAGE")
 async def vnc_find_image(
@@ -1372,11 +1267,6 @@ async def vnc_find_image(
 # Area 5: Automation Features - Wait Conditions
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vnc_wait_for_text",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/wait-for-text", response_model=WaitForTextResponse)
 @with_error_handling(error_code_prefix="VNC_WAIT_TEXT")
 async def vnc_wait_for_text(
@@ -1419,11 +1309,6 @@ async def vnc_wait_for_text(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="vnc_wait_for_image",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/wait-for-image", response_model=WaitForImageResponse)
 @with_error_handling(error_code_prefix="VNC_WAIT_IMAGE")
 async def vnc_wait_for_image(
@@ -1484,11 +1369,6 @@ _session_states: Dict[str, DesktopSessionState] = {}
 _session_lock = asyncio.Lock()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="save_session_desktop_state",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/session/save-state", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_SAVE")
 async def save_session_desktop_state(
@@ -1536,11 +1416,6 @@ async def save_session_desktop_state(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="restore_session_desktop_state",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.get("/session/restore-state", response_model=RestoreStateResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_RESTORE")
 async def restore_session_desktop_state(
@@ -1577,11 +1452,6 @@ async def restore_session_desktop_state(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="log_session_action",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/session/log-action", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_LOG")
 async def log_session_action(
@@ -1612,11 +1482,6 @@ async def log_session_action(
     return {"status": "success", "message": "Action logged to session"}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_session_action_log",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.get("/session/action-log", response_model=SessionActionLogResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_LOG_GET")
 async def get_session_action_log(
@@ -1655,11 +1520,6 @@ async def get_session_action_log(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="save_session_screenshot",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.post("/session/save-screenshot", response_model=SessionScreenshotSaveResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_SCREENSHOT")
 async def save_session_screenshot(
@@ -1722,11 +1582,6 @@ async def save_session_screenshot(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_session_screenshots",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.get("/session/screenshots", response_model=SessionScreenshotsResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_SCREENSHOTS")
 async def get_session_screenshots(
@@ -1765,11 +1620,6 @@ async def get_session_screenshots(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_session_state",
-    error_code_prefix="VNC_MANAGER",
-)
 @router.delete("/session/clear-state", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_SESSION_CLEAR")
 async def clear_session_state(

--- a/autobot-backend/api/vnc_mcp.py
+++ b/autobot-backend/api/vnc_mcp.py
@@ -215,11 +215,6 @@ VNC_MCP_TOOL_DEFINITIONS = (
 )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_vnc_mcp_tools",
-    error_code_prefix="VNC_MCP",
-)
 @router.get("/mcp/tools", response_model=List[VncMCPTool])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -244,11 +239,6 @@ async def get_vnc_mcp_tools() -> List[VncMCPTool]:
     ]
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="check_vnc_status_mcp",
-    error_code_prefix="VNC_MCP",
-)
 @router.post("/mcp/check_vnc_status", response_model=VncStatusMcpResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -304,11 +294,6 @@ async def check_vnc_status_mcp(request: VNCStatusRequest) -> Metadata:
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="observe_vnc_activity_mcp",
-    error_code_prefix="VNC_MCP",
-)
 @router.post("/mcp/observe_vnc_activity", response_model=VncObservationMcpResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -356,11 +341,6 @@ async def observe_vnc_activity_mcp(request: VNCObservationRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_browser_vnc_context_mcp",
-    error_code_prefix="VNC_MCP",
-)
 @router.post("/mcp/get_browser_vnc_context", response_model=BrowserVncContextResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -431,11 +411,6 @@ async def get_browser_vnc_context_mcp() -> Metadata:
 
 
 # Observation recording endpoint (called by VNC proxy)
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="record_vnc_observation",
-    error_code_prefix="VNC_MCP",
-)
 @router.post("/observations/{vnc_type}", response_model=VncRecordObservationResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -475,11 +450,6 @@ async def record_vnc_observation(vnc_type: str, observation: Metadata):
 # These endpoints allow AI agents to interact with the desktop via MCP tools
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="desktop_mouse_click_mcp",
-    error_code_prefix="VNC_MCP",
-)
 @router.post("/mcp/desktop_mouse_click", response_model=DesktopClickMcpResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -509,11 +479,6 @@ async def desktop_mouse_click_mcp(request: DesktopMouseClickRequest) -> Metadata
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="desktop_keyboard_type_mcp",
-    error_code_prefix="VNC_MCP",
-)
 @router.post("/mcp/desktop_keyboard_type", response_model=DesktopKeyboardTypeMcpResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -537,11 +502,6 @@ async def desktop_keyboard_type_mcp(request: DesktopKeyboardTypeRequest) -> Meta
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="desktop_special_key_mcp",
-    error_code_prefix="VNC_MCP",
-)
 @router.post("/mcp/desktop_special_key", response_model=DesktopSpecialKeyMcpResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -565,11 +525,6 @@ async def desktop_special_key_mcp(request: DesktopSpecialKeyRequest) -> Metadata
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="desktop_screenshot_mcp",
-    error_code_prefix="VNC_MCP",
-)
 @router.post("/mcp/desktop_screenshot", response_model=DesktopScreenshotMcpResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -640,11 +595,6 @@ async def desktop_screenshot_mcp() -> Metadata:
         }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="desktop_observe_state_mcp",
-    error_code_prefix="VNC_MCP",
-)
 @router.post("/mcp/desktop_observe_state", response_model=DesktopObserveStateMcpResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/vnc_proxy.py
+++ b/autobot-backend/api/vnc_proxy.py
@@ -141,11 +141,6 @@ async def record_observation(vnc_type: str, observation_type: str, data: Metadat
         logger.debug("Failed to record observation for %s: %s", vnc_type, e)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_vnc_client",
-    error_code_prefix="VNC_PROXY",
-)
 @router.get("/{vnc_type}/vnc.html", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -190,11 +185,6 @@ async def get_vnc_client(vnc_type: str, current_user: dict = Depends(get_current
         raise HTTPException(status_code=503, detail="VNC server unavailable")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="proxy_vnc_assets",
-    error_code_prefix="VNC_PROXY",
-)
 @router.get("/{vnc_type}/{path:path}", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -300,11 +290,6 @@ async def websocket_proxy(websocket: WebSocket, vnc_type: str):
         await record_observation(vnc_type, "disconnection", {"status": "closed"})
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_vnc_status",
-    error_code_prefix="VNC_PROXY",
-)
 @router.get("/{vnc_type}/status", response_model=VncProxyStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/wake_word.py
+++ b/autobot-backend/api/wake_word.py
@@ -35,11 +35,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["wake_word", "voice"])
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="check_wake_word",
-    error_code_prefix="WAKE_WORD",
-)
 @router.post("/check", response_model=WakeWordCheckResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -68,11 +63,6 @@ async def check_wake_word(request: WakeWordCheckRequest) -> WakeWordCheckRespons
     return WakeWordCheckResponse(detected=False)
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_wake_words",
-    error_code_prefix="WAKE_WORD",
-)
 @router.get("/words", response_model=WakeWordGetWordsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -88,11 +78,6 @@ async def get_wake_words() -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="add_wake_word",
-    error_code_prefix="WAKE_WORD",
-)
 @router.post("/words", response_model=WakeWordMutateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -118,11 +103,6 @@ async def add_wake_word(request: AddWakeWordRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="remove_wake_word",
-    error_code_prefix="WAKE_WORD",
-)
 @router.delete("/words/{wake_word}", response_model=WakeWordMutateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -152,11 +132,6 @@ async def remove_wake_word(wake_word: str) -> Metadata:
     raise HTTPException(status_code=404, detail=f"Wake word '{wake_word}' not found")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_wake_word_config",
-    error_code_prefix="WAKE_WORD",
-)
 @router.get("/config", response_model=WakeWordGetConfigResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -169,11 +144,6 @@ async def get_wake_word_config() -> Metadata:
     return detector.get_config()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_wake_word_config",
-    error_code_prefix="WAKE_WORD",
-)
 @router.put("/config", response_model=WakeWordConfigUpdateResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -210,11 +180,6 @@ async def update_wake_word_config(request: WakeWordConfigRequest) -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_wake_word_stats",
-    error_code_prefix="WAKE_WORD",
-)
 @router.get("/stats", response_model=WakeWordStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -227,11 +192,6 @@ async def get_wake_word_stats() -> Metadata:
     return detector.get_stats()
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reset_wake_word_stats",
-    error_code_prefix="WAKE_WORD",
-)
 @router.post("/stats/reset", response_model=WakeWordStatsResetResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -249,11 +209,6 @@ async def reset_wake_word_stats() -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="report_detection_feedback",
-    error_code_prefix="WAKE_WORD",
-)
 @router.post("/feedback", response_model=WakeWordFeedbackResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -280,11 +235,6 @@ async def report_detection_feedback(request: WakeWordReportFeedbackRequest) -> M
     return {"success": True, "message": message, "stats": detector.get_stats()}
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="enable_wake_word",
-    error_code_prefix="WAKE_WORD",
-)
 @router.post("/enable", response_model=WakeWordToggleResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -302,11 +252,6 @@ async def enable_wake_word() -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="disable_wake_word",
-    error_code_prefix="WAKE_WORD",
-)
 @router.post("/disable", response_model=WakeWordToggleResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -329,11 +274,6 @@ async def disable_wake_word() -> Metadata:
 # -------------------------------------------------------------------------
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="start_listening",
-    error_code_prefix="WAKE_WORD",
-)
 @router.post("/listening/start", response_model=WakeWordListeningToggleResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -356,11 +296,6 @@ async def start_listening() -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="stop_listening",
-    error_code_prefix="WAKE_WORD",
-)
 @router.post("/listening/stop", response_model=WakeWordListeningToggleResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -378,11 +313,6 @@ async def stop_listening() -> Metadata:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_listening_status",
-    error_code_prefix="WAKE_WORD",
-)
 @router.get("/listening/status", response_model=WakeWordListeningStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/web_research_settings.py
+++ b/autobot-backend/api/web_research_settings.py
@@ -22,11 +22,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/web-research", tags=["web-research"])
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_research_status",
-    error_code_prefix="WEB_RESEARCH_SETTINGS",
-)
 @router.get("/status", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -76,11 +71,6 @@ async def get_research_status():
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="enable_web_research",
-    error_code_prefix="WEB_RESEARCH_SETTINGS",
-)
 @router.post("/enable", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -133,11 +123,6 @@ async def enable_web_research():
         raise HTTPException(status_code=500, detail="Failed to enable web research")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="disable_web_research",
-    error_code_prefix="WEB_RESEARCH_SETTINGS",
-)
 @router.post("/disable", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -190,11 +175,6 @@ async def disable_web_research():
         raise HTTPException(status_code=500, detail="Failed to disable web research")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_research_settings",
-    error_code_prefix="WEB_RESEARCH_SETTINGS",
-)
 @router.get("/settings", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -247,11 +227,6 @@ async def get_research_settings():
         raise HTTPException(status_code=500, detail="Failed to get research settings")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_research_settings",
-    error_code_prefix="WEB_RESEARCH_SETTINGS",
-)
 @router.put("/settings", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -314,11 +289,6 @@ async def update_research_settings(settings: WebResearchSettings):
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="test_web_research",
-    error_code_prefix="WEB_RESEARCH_SETTINGS",
-)
 @router.post("/test", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -362,11 +332,6 @@ async def test_web_research(query: str = "test query"):
         )
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="clear_research_cache",
-    error_code_prefix="WEB_RESEARCH_SETTINGS",
-)
 @router.post("/clear-cache", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -399,11 +364,6 @@ async def clear_research_cache():
         raise HTTPException(status_code=500, detail="Failed to clear research cache")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="reset_circuit_breakers",
-    error_code_prefix="WEB_RESEARCH_SETTINGS",
-)
 @router.post("/reset-circuit-breakers", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -436,11 +396,6 @@ async def reset_circuit_breakers():
         raise HTTPException(status_code=500, detail="Failed to reset circuit breakers")
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="get_usage_stats",
-    error_code_prefix="WEB_RESEARCH_SETTINGS",
-)
 @router.get("/usage-stats", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,

--- a/autobot-backend/api/workflow.py
+++ b/autobot-backend/api/workflow.py
@@ -406,11 +406,6 @@ def _legacy_workflow_to_summary(workflow_id: str, workflow_data: Dict) -> Dict:
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="list_active_workflows",
-    error_code_prefix="WORKFLOW",
-)
 @router.get("/workflows", response_model=WorkflowListResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -451,11 +446,6 @@ async def list_active_workflows(admin_check: bool = Depends(check_admin_permissi
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.NOT_FOUND,
-    operation="get_workflow_details",
-    error_code_prefix="WORKFLOW",
-)
 @router.get("/workflow/{workflow_id}", response_model=WorkflowDetailResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -478,11 +468,6 @@ async def get_workflow_details(
     return {"success": True, "workflow": workflow}
 
 
-@with_error_handling(
-    category=ErrorCategory.NOT_FOUND,
-    operation="get_workflow_status",
-    error_code_prefix="WORKFLOW",
-)
 @router.get("/workflow/{workflow_id}/status", response_model=WorkflowStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -570,11 +555,6 @@ async def _update_step_status_and_metrics(
     )
 
 
-@with_error_handling(
-    category=ErrorCategory.NOT_FOUND,
-    operation="approve_workflow_step",
-    error_code_prefix="WORKFLOW",
-)
 @router.post("/workflow/{workflow_id}/approve", response_model=WorkflowApproveResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -621,11 +601,6 @@ async def approve_workflow_step(
     }
 
 
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="execute_workflow",
-    error_code_prefix="WORKFLOW",
-)
 @router.post("/execute", response_model=WorkflowExecutionResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1040,11 +1015,6 @@ async def execute_single_step(workflow_id: str, step: Metadata, orchestrator):
             )
 
 
-@with_error_handling(
-    category=ErrorCategory.NOT_FOUND,
-    operation="cancel_workflow",
-    error_code_prefix="WORKFLOW",
-)
 @router.delete("/workflow/{workflow_id}", response_model=WorkflowCancelResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1082,11 +1052,6 @@ async def cancel_workflow(
     return {"success": True, "message": "Workflow cancelled successfully"}
 
 
-@with_error_handling(
-    category=ErrorCategory.NOT_FOUND,
-    operation="get_pending_approvals",
-    error_code_prefix="WORKFLOW",
-)
 @router.get(
     "/workflow/{workflow_id}/pending_approvals",
     response_model=WorkflowPendingApprovalsResponse,


### PR DESCRIPTION
## Summary
Cleans up the 1221 residual decorator-order violations the AST hook (#6638) caught after #6558/#6633 landed. Most are the pattern:

\`\`\`python
@with_error_handling(...)   # ← OUTER (dead — above @router)
@router.get(...)
@cache_response(...)        # ← optional middle decorators
@with_error_handling(...)   # ← INNER (correctly placed)
async def f(): ...
\`\`\`

The OUTER block is dead because Python \`@A @B def f\` ≡ \`f = A(B(f))\` — once \`@router.*\` sees the wrapped function it registers it; the outer \`@with_error_handling\` never runs.

## Stats
- **129 files modified**
- **1183 outer-deletes + 18 swaps**
- **~5912 LOC removed**
- **0 residual violations** (verified by AST hook)
- All 129 files pass \`python3 -m py_compile\`

## Why #6558 missed these
The regex in #6558 expected \`@with_error_handling\` immediately followed by \`@router.*\` then \`def\`. It didn't handle:
- Multi-line decorator args (\`(...\\n...\\n)\`)
- \`@cache_response\`, \`@router.get\` (multiple), or other decorators between
- Already-correct \`@with_error_handling\` BELOW \`@router\` — meaning the one above is dead, not just misordered

## Mechanism
Line-based parser (line-by-line). Three cases:
1. **SWAP**: \`@with_error_handling\` immediately above \`@router\` → swap so router is outermost
2. **DELETE_OUTER**: \`@with_error_handling\` above \`@router\`(s) and another \`@with_error_handling\` below them → delete the outer (dead) one
3. **STACKED**: two \`@with_error_handling\` adjacent → delete outer

Required two passes: first deletes outer-dead decorators, second handles cases revealed when nested patterns get unmasked.

## Test plan
- [x] All 129 files compile (\`python3 -m py_compile\`)
- [x] AST hook exit 0 (\`tools/lint/check_decorator_order.py\`)
- [ ] CI test suite

Closes #6706