### PR TITLE
fix(p2-batch): debug-session batch 2 — redis_exporter IP, ApexCharts race, Agent Registry tabs

### DIFF
--- a/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
+++ b/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
@@ -42,14 +42,22 @@
     </div>
 
     <div v-else class="heatmap-container">
-      <!-- ApexCharts Heatmap -->
+      <!-- ApexCharts Heatmap — only mount once chartSeries has data; mounting
+           against an empty series triggers the vue3-apexcharts "Element not
+           found" race (chart instance is created before the parent has any
+           rows to lay out, and the SVG target it looks for never exists). -->
       <apexchart
+        v-if="chartSeries.length > 0"
         ref="chartRef"
         type="heatmap"
         :height="height"
         :options="chartOptions"
         :series="chartSeries"
       />
+      <div v-else class="no-data-state">
+        <i class="fas fa-chart-bar"></i>
+        <span>{{ t('visualizations.resourceHeatmap.noData') }}</span>
+      </div>
 
       <!-- Legend -->
       <div class="heatmap-legend">
@@ -384,7 +392,8 @@ defineExpose({
 }
 
 .loading-state,
-.error-state {
+.error-state,
+.no-data-state {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -6351,6 +6351,7 @@
       "last24Hours": "Last 24 Hours",
       "last7Days": "Last 7 Days",
       "loadingData": "Loading heatmap data...",
+      "noData": "No metrics available yet",
       "retry": "Retry",
       "legendLow": "Low",
       "legendHigh": "High",

--- a/autobot-frontend/src/views/AgentRegistryView.vue
+++ b/autobot-frontend/src/views/AgentRegistryView.vue
@@ -140,7 +140,7 @@ onMounted(async () => {
 
     <!-- Tabs -->
     <div class="border-b border-default">
-      <nav class="-mb-px flex space-x-8">
+      <nav class="-mb-px flex gap-8">
         <button
           @click="activeTab = 'backend'"
           :class="[

--- a/autobot-slm-backend/ansible/roles/redis/templates/redis_exporter.service.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/redis_exporter.service.j2
@@ -14,7 +14,7 @@ Type=simple
 User=redis_exporter
 Group=redis_exporter
 ExecStart=/opt/redis_exporter/redis_exporter \
-  --redis.addr=redis://{{ ansible_default_ipv4.address }}:{{ redis_port }} \
+  --redis.addr=redis://127.0.0.1:{{ redis_port }} \
   --web.listen-address=:{{ redis_exporter_port }} \
   --web.telemetry-path=/metrics
 {% if redis_password is defined and redis_password %}


### PR DESCRIPTION
## Summary

Three independent fixes from the same /superpowers:systematic-debugging session as PR #6718.

### 1. redis_exporter target 127.0.0.1 (my finding B)

`ansible_default_ipv4.address` resolved to `192.168.168.21` on the SLM Manager — an IP that exists on no interface here (eth1=192.168.1.101, eth2=172.16.168.20). Result: redis_exporter floods journald every ~14 s with `Couldn't connect to redis instance` (20+ errors per 5 min observed), Prometheus loses Redis metrics. Fixed: redis_exporter and redis-stack-server are co-located by the same role, so `127.0.0.1` is bullet-proof and removes the brittle fact dependency.

### 2. ApexCharts "Element not found" race on /home (item #6)

`useResourceMetrics` initialises `heatmapData = ref<HeatmapSeries[]>([])`. ResourceHeatmap's existing v-if/v-else gate hands an empty series to `<apexchart>` on first paint after the loading flag flips. vue3-apexcharts then creates an instance whose `onMounted` looks for an SVG row that an empty series never produces → `Element not found` toast. Fixed by adding `v-if="chartSeries.length > 0"` to the chart and a no-data placeholder in the same dashed-frame style. Added i18n key `visualizations.resourceHeatmap.noData`.

### 3. Agent Registry tab spacing (item #19)

User report: header showed `Backend Agents (29)Specialized Agents (0)Settings` with no gap between the three tabs. The `<nav>` used Tailwind `space-x-8` which sets `margin-left` on adjacent siblings. After PR #6718 imported `base.css` (`* { margin: 0 }` global reset), the spacing became fragile in nested contexts. Swapped to `gap-8` on the flex container — a parent layout property immune to descendant margin resets.

## Test plan

- [x] redis_exporter template diff is one line; `127.0.0.1` is correct because exporter and Redis are colocated by the role
- [x] ResourceHeatmap diff guards the chart and adds a placeholder
- [x] AgentRegistryView diff is one utility class swap
- [ ] After deploy: `journalctl -u redis_exporter -f` shows zero connection errors
- [ ] After deploy: /home loads without "Element not found" toast on first visit
- [ ] After deploy: Agent Registry tabs are visually separated

## Discoveries (filed as separate issues in follow-up sweep)

- ~38 other `space-x-*` callsites across views/components — same potential brittleness pattern; sweep to prefer `gap-*` for new code
- ~20 other `ansible_default_ipv4.address` callsites in templates (frontend.env.j2, redis-backup.sh.j2, etc.) — broader audit umbrella; some may need different replacements depending on local-vs-remote semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)