### PR TITLE
fix(backend/chat): replace hard-coded 1h TTL with configurable 24h default (#6743)

### DIFF
--- a/autobot-backend/chat_history/cache.py
+++ b/autobot-backend/chat_history/cache.py
@@ -12,11 +12,52 @@ Provides caching functionality for chat sessions:
 
 import json
 import logging
+import os
 from typing import Any, Dict
 
 from chat_history.file_io import run_in_chat_io_executor
+from constants.ttl_constants import TTL_24_HOURS
 
 logger = logging.getLogger(__name__)
+
+
+# #6743: chat:session:* cache TTL.
+#
+# Previously hard-coded to 3600 (1h) which silently dropped active conversations
+# from Redis after an hour. Combined with the disk-fallback bug (#6744), that
+# meant message data was permanently lost when the user left a tab open across
+# lunch.
+#
+# Default raised to 24h to match the sibling chat:conversation:* TTL
+# (chat_workflow/conversation.py uses self.conversation_history_ttl, also 24h
+# by default). Override via env var when tuning memory pressure.
+def _resolve_chat_session_cache_ttl() -> int:
+    """Return TTL seconds for chat:session:* Redis keys."""
+    raw = os.getenv("AUTOBOT_CHAT_SESSION_CACHE_TTL")
+    if raw is None:
+        return TTL_24_HOURS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "AUTOBOT_CHAT_SESSION_CACHE_TTL=%r is not an integer; "
+            "falling back to %ds (24h)",
+            raw,
+            TTL_24_HOURS,
+        )
+        return TTL_24_HOURS
+    if value <= 0:
+        logger.warning(
+            "AUTOBOT_CHAT_SESSION_CACHE_TTL=%d must be positive; "
+            "falling back to %ds (24h)",
+            value,
+            TTL_24_HOURS,
+        )
+        return TTL_24_HOURS
+    return value
+
+
+_CHAT_SESSION_CACHE_TTL = _resolve_chat_session_cache_ttl()
 
 
 class CacheMixin:
@@ -38,10 +79,11 @@ class CacheMixin:
         try:
             # Issue #361 - avoid blocking
             # Issue #718 - Use dedicated executor to avoid blocking on saturated pool
+            # #6743 - TTL configurable via AUTOBOT_CHAT_SESSION_CACHE_TTL
             await run_in_chat_io_executor(
                 self.redis_client.setex,
                 cache_key,
-                3600,  # 1 hour TTL
+                _CHAT_SESSION_CACHE_TTL,
                 json.dumps(chat_data, ensure_ascii=False),
             )
         except Exception as e:


### PR DESCRIPTION
## Summary

Closes #6743. \`chat:session:*\` Redis cache TTL was a hard-coded \`3600\` literal — silently dropping active conversations every hour. Combined with the broken disk-fallback (#6744), this manifested as the user's \"chat messages disappear from sessions\" symptom.

## Diff

```diff
+ from constants.ttl_constants import TTL_24_HOURS
+
+ def _resolve_chat_session_cache_ttl() -> int:
+     raw = os.getenv(\"AUTOBOT_CHAT_SESSION_CACHE_TTL\")
+     if raw is None:
+         return TTL_24_HOURS
+     try:
+         value = int(raw)
+     except ValueError:
+         logger.warning(...)
+         return TTL_24_HOURS
+     if value <= 0:
+         logger.warning(...)
+         return TTL_24_HOURS
+     return value
+
+ _CHAT_SESSION_CACHE_TTL = _resolve_chat_session_cache_ttl()
...
- 3600,  # 1 hour TTL
+ _CHAT_SESSION_CACHE_TTL,
```

24 h default matches the sibling `chat:conversation:*` TTL (set by `self.conversation_history_ttl` in `chat_workflow/conversation.py`).

## Verified

```
default          → 86400s (24h)
override 604800  → 604800s (7d)
'bogus'          → warning + 86400s fallback
'-1'             → warning + 86400s fallback
```

## Test plan

- [ ] Deploy via Ansible. Send a chat message.
- [ ] `redis-cli TTL chat:session:<id>` returns ≥86399 (was ≤3599 before).
- [ ] `AUTOBOT_CHAT_SESSION_CACHE_TTL=604800` in `/etc/autobot/autobot-backend.env` → next deploy applies 7d TTL.
- [ ] Set `AUTOBOT_CHAT_SESSION_CACHE_TTL=bogus` → backend log shows warning, behavior falls back to 86400.

## Out of scope (still tracked separately)

- #6744 — `add_message` signature mismatch. The disk-fallback path is broken so messages can still be lost on Redis miss after this PR. Bug B is the next fix in this iteration.
- #6745 — session_id churns across 4+ IDs per send (frontend race condition).
- #6746 — architectural unification of chat state model.
- #6694 — codebase-wide `setLoading()` audit (covers the screen-flicker UX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)