### PR TITLE
fix(security+frontend): debug-session batch 3 — CSP wss tighten, ssot https detection

### DIFF
--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -438,11 +438,25 @@ function buildConfig(): AutoBotConfig {
 
     // Computed URLs as getters
     get backendUrl(): string {
-      return `${httpProtocol}://${vm.main}:${port.backend}`;
+      // #6642 pattern: detect protocol from window.location at runtime, not
+      // from build-time VITE_HTTP_PROTOCOL. The env var defaults to 'http'
+      // and produced http:// URLs that browsers blocked as mixed-content
+      // when the page itself was served over HTTPS. Mirror the runtime
+      // detection that getBackendWsUrl() and websocketUrl already use so
+      // behaviour stays correct regardless of the build-time env.
+      const proto =
+        typeof window !== 'undefined'
+          ? (window.location.protocol === 'https:' ? 'https' : 'http')
+          : httpProtocol;
+      return `${proto}://${vm.main}:${port.backend}`;
     },
 
     get frontendUrl(): string {
-      return `${httpProtocol}://${vm.frontend}:${port.frontend}`;
+      const proto =
+        typeof window !== 'undefined'
+          ? (window.location.protocol === 'https:' ? 'https' : 'http')
+          : httpProtocol;
+      return `${proto}://${vm.frontend}:${port.frontend}`;
     },
 
     get redisUrl(): string {

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2
@@ -41,7 +41,7 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     # Issue #1015: Content Security Policy
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' wss://$host; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
 
     # Issue #1090: Allow SLM agent event sync payloads (typically 1.5-2MB)
     client_max_body_size 10m;
@@ -266,7 +266,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' wss:; frame-ancestors 'self'; base-uri 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' wss://$host; frame-ancestors 'self'; base-uri 'self';" always;
     }
 
     # Grafana reverse proxy (monitoring dashboards)
@@ -285,7 +285,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' wss:; frame-ancestors 'self'; base-uri 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' wss://$host; frame-ancestors 'self'; base-uri 'self';" always;
 {% if grafana_enable_cors | default(false) %}
 
         # CORS headers for external Grafana iframe embedding


### PR DESCRIPTION
## Summary

Two independent fixes from the same /superpowers:systematic-debugging session as PRs #6718 and #6749. Two other items from the Chrome-plugin debug TODO were verified already-fixed against the live deployment and are documented below for traceability.

### 1. CSP `connect-src` tightened (item #26)

Previous CSP `connect-src 'self' wss:` allowed WebSocket connections to ANY `wss://` host. The SPA only opens WebSockets to the same origin that served the page, so we can scope to `wss://$host` (nginx interpolates the request's Host header at runtime — stays correct under any deployment IP/hostname). Three CSP `add_header` sites updated in `autobot-slm.conf.j2`. `'self'` is kept because some Chromium versions don't treat 'self' as authoritative for ws/wss; both guards are cheap.

### 2. ssot-config: runtime https detection for backendUrl + frontendUrl (item #14)

`backendUrl` and `frontendUrl` getters at `ssot-config.ts:440-446` returned `http://...` (from build-time `VITE_HTTP_PROTOCOL` defaulting to 'http'), causing the browser to block requests like `http://172.16.168.20/api/secrets/` as mixed-content on HTTPS pages — exactly the symptom user reported in DevTools (status 'pending'). PR #6642 already fixed this for `websocketUrl`; same pattern applied here. In browser context derive protocol from `window.location.protocol`; in SSR fall back to build-time. Most production code paths take the `getBackendUrl()` proxy-mode branch (returns '' → relative URLs), but any composable that hits `getConfig().backendUrl` directly was broken.

## Verified already-fixed against live deployment

### Item #10 — HEAD /api/health
`curl -X HEAD https://172.16.168.20/api/health` returns 200 (was 503). Source: `initialization/endpoints.py:145` registers `@app.head("/api/health")` explicitly. Already done.

### Item #9 — /api/secrets trailing slash
`curl /api/secrets` now returns 307 (FastAPI `redirect_slashes=True` working) instead of the previously-reported 503. The 307 redirects to `/api/secrets/` which returns 200 with data. Browsers follow 307 with method+headers preserved, so the frontend works correctly. Acceptance criterion 'both /api/secrets and /api/secrets/ return 200' is partially met (307→200 vs direct 200) — the practical outcome is identical for the SPA.

## Test plan

- [x] Three CSP sites in autobot-slm.conf.j2 updated
- [x] backendUrl + frontendUrl getters mirror websocketUrl runtime-detect pattern
- [x] HEAD /api/health verified 200 against live
- [x] /api/secrets verified 307→200 against live
- [ ] After deploy: `https://172.16.168.20/` loads with no CSP violations in console
- [ ] After deploy + frontend rebuild: no http:// URLs in DevTools Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)