### PR TITLE
feat(code-analysis): wire LSP + consolidation rules through scanner finalize step (#6747, #6733, #6734)

### DIFF
--- a/autobot-backend/api/codebase_analytics/cross_file_analysis.py
+++ b/autobot-backend/api/codebase_analytics/cross_file_analysis.py
@@ -1,0 +1,164 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Cross-file anti-pattern analysis hook for the codebase indexing pipeline (#6747).
+
+The production per-file analyzer at
+``code_intelligence.anti_pattern_detector.AntiPatternDetector.analyze_file()``
+cannot detect rules that need a whole-codebase class index — LSP violations
+(parent class lookup) and consolidation opportunities (pairwise enum / class
+shape comparison).  Those rules live in
+``code_analysis.src.anti_pattern_detector.AntiPatternDetector`` and need a
+directory-level pass.
+
+This module bridges the gap: a single ``run_cross_file_analysis()`` call at
+indexing finalization runs only the cross-file rules and persists every
+finding to ChromaDB with ``type="problem"`` so they surface in
+``/codebase/problems`` alongside the per-file results.
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional  # noqa: F401  (List used in pub API)
+
+logger = logging.getLogger(__name__)
+
+
+def _antipattern_to_problem(ap: Any, file_category: str = "code") -> Dict[str, Any]:
+    """Map an ``AntiPatternInstance`` to the dict shape persisted by
+    ``_store_problems_batch_to_chromadb`` in chromadb_storage.py:251-287.
+
+    The persistence layer reads the keys ``type``, ``severity``, ``file_path``,
+    ``line``, ``description``, ``suggestion`` — others are ignored.  We prefix
+    the type with ``code_smell_`` to match the convention from
+    ``analyzers.py::_run_anti_pattern_analysis`` so the dashboard's existing
+    grouping picks the new findings up automatically.
+    """
+    pattern_type = ap.pattern_type.value if hasattr(ap, "pattern_type") else "unknown"
+    severity = ap.severity.value if hasattr(ap, "severity") else "medium"
+    return {
+        "type": f"code_smell_{pattern_type}",
+        "severity": severity,
+        "file_path": getattr(ap, "file_path", ""),
+        "file_category": file_category,
+        "line": getattr(ap, "line_number", 0),
+        "description": getattr(ap, "description", ""),
+        "suggestion": getattr(ap, "suggestion", ""),
+    }
+
+
+async def _persist_to_chromadb(
+    problems: List[Dict[str, Any]],
+    source_id: Optional[str],
+) -> int:
+    """Append cross-file findings to the existing problems collection.
+
+    Returns the number persisted.  Reuses the same batch helper as the
+    per-file path so dashboard grouping/filtering is unchanged.
+    """
+    if not problems:
+        return 0
+    try:
+        from api.codebase_analytics.chromadb_storage import (
+            _store_problems_batch_to_chromadb,
+        )
+        from api.codebase_analytics.storage import get_code_collection_async
+
+        collection = await get_code_collection_async()
+        if collection is None:
+            logger.warning(
+                "[#6747] Cross-file findings ready but ChromaDB unavailable; skipping persistence"
+            )
+            return 0
+
+        # The batch helper expects a starting index; we use a high offset to
+        # avoid colliding with per-file problem IDs.  A timestamp-derived
+        # base would also work; the dashboard just needs unique doc_ids.
+        import time as _time
+
+        start_idx = int(_time.time() * 1000) & 0x7FFFFFFF
+        await _store_problems_batch_to_chromadb(
+            collection, problems, start_idx, source_id=source_id
+        )
+        return len(problems)
+    except Exception as exc:
+        logger.warning("[#6747] Failed to persist cross-file findings: %s", exc)
+        return 0
+
+
+async def run_cross_file_analysis(
+    root_path: str,
+    source_id: Optional[str] = None,
+    exclude_patterns: Optional[List[str]] = None,
+) -> int:
+    """Run the four cross-file rules over ``root_path`` and persist findings.
+
+    Issue #6747: Hooks into the scanner finalize step so LSP and consolidation
+    findings appear in ``/codebase/problems`` after every index run.
+
+    Args:
+        root_path: Directory the scan ran over.
+        source_id: Optional source scope tag for per-source filtering.
+        exclude_patterns: Optional override for the analyzer's exclude list.
+            Pass ``None`` (default) to use the analyzer's production defaults
+            (skips ``test_``, ``__pycache__``, ``node_modules``, ...).  Tests
+            can pass ``["__pycache__"]`` to keep fixtures discoverable when
+            they live under pytest's ``tmp_path``-rooted ``test_*`` dirs.
+
+    Returns:
+        Number of findings persisted to ChromaDB.
+    """
+    try:
+        from code_analysis.src.anti_pattern_detector import AntiPatternDetector
+    except Exception as exc:  # pragma: no cover — env-dependent import chain
+        logger.warning("[#6747] AntiPatternDetector not importable: %s", exc)
+        return 0
+
+    if not Path(root_path).exists():
+        logger.warning("[#6747] root_path %s does not exist; skipping", root_path)
+        return 0
+
+    detector = AntiPatternDetector()
+    try:
+        findings = await detector.analyze_cross_file_only(
+            root_path=root_path, exclude_patterns=exclude_patterns
+        )
+    except Exception as exc:
+        logger.warning("[#6747] Cross-file analysis failed: %s", exc)
+        return 0
+
+    if not findings:
+        logger.info("[#6747] Cross-file analysis: 0 findings")
+        return 0
+
+    problems = [_antipattern_to_problem(ap) for ap in findings]
+    persisted = await _persist_to_chromadb(problems, source_id=source_id)
+    logger.info(
+        "[#6747] Cross-file analysis: %d findings, %d persisted to ChromaDB",
+        len(findings),
+        persisted,
+    )
+    return persisted
+
+
+def schedule_cross_file_analysis(
+    root_path: str,
+    source_id: Optional[str] = None,
+) -> None:
+    """Fire-and-forget launcher for the cross-file pass.
+
+    Mirrors the pattern used by ``progress_tracker._invalidate_quality_cache``:
+    detect a running event loop and spawn a task on it; fall back to
+    ``asyncio.run`` in sync contexts.  Never raises into the caller — scan
+    finalization must not fail because the cross-file pass had a hiccup.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(run_cross_file_analysis(root_path, source_id))
+    except RuntimeError:
+        try:
+            asyncio.run(run_cross_file_analysis(root_path, source_id))
+        except Exception as exc:  # pragma: no cover
+            logger.warning("[#6747] Cross-file analysis scheduling failed: %s", exc)

--- a/autobot-backend/api/codebase_analytics/cross_file_analysis_test.py
+++ b/autobot-backend/api/codebase_analytics/cross_file_analysis_test.py
@@ -1,0 +1,203 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+End-to-end tests for the cross-file analysis hook (#6747).
+
+Verifies that:
+  1. The four cross-file rules from #6661 + #6684 fire when the analyzer
+     is run over a fixture codebase.
+  2. The findings get translated to the same dict shape ChromaDB persistence
+     expects (so they surface in /codebase/problems with code_smell_*
+     prefix matching the existing dashboard convention).
+  3. The fire-and-forget scheduler swallows errors instead of breaking
+     scan finalization.
+"""
+
+import importlib.util
+import textwrap
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _load_cross_file_module():
+    spec = importlib.util.spec_from_file_location(
+        "xfa_under_test",
+        "autobot-backend/api/codebase_analytics/cross_file_analysis.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"cross_file_analysis dep chain unavailable: {exc}")
+    return mod
+
+
+def _write(root: Path, name: str, body: str) -> Path:
+    p = root / f"{name}.py"
+    p.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+    return p
+
+
+@pytest.mark.asyncio
+async def test_cross_file_analysis_finds_lsp_violation(tmp_path):
+    """A fixture with a sync override of an async parent must produce
+    a ``code_smell_lsp_signature_incompatible`` finding via the bridge."""
+    xfa = _load_cross_file_module()
+
+    _write(
+        tmp_path,
+        "agents",
+        """
+        class BaseAgent:
+            async def is_available(self) -> bool:
+                return True
+
+        class LocalAgent(BaseAgent):
+            def is_available(self) -> bool:
+                return True
+        """,
+    )
+
+    persisted: list = []
+
+    async def fake_persist(problems, source_id=None):
+        persisted.extend(problems)
+        return len(problems)
+
+    with patch.object(xfa, "_persist_to_chromadb", new=fake_persist):
+        count = await xfa.run_cross_file_analysis(
+            str(tmp_path), source_id=None, exclude_patterns=["__pycache__"]
+        )
+
+    assert count >= 1, f"expected at least one finding persisted, got {count}"
+    types = {p.get("type") for p in persisted}
+    assert "code_smell_lsp_signature_incompatible" in types, (
+        f"expected LSP signature finding, got types={types}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cross_file_analysis_finds_duplicate_enum(tmp_path):
+    """Two overlapping enums must produce a ``code_smell_duplicate_enum`` finding."""
+    xfa = _load_cross_file_module()
+
+    _write(
+        tmp_path,
+        "task_status",
+        """
+        from enum import Enum
+
+        class TaskStatus(Enum):
+            PENDING = "pending"
+            RUNNING = "running"
+            COMPLETED = "completed"
+            FAILED = "failed"
+        """,
+    )
+    _write(
+        tmp_path,
+        "step_status",
+        """
+        from enum import Enum
+
+        class StepStatus(Enum):
+            PENDING = "pending"
+            RUNNING = "running"
+            COMPLETED = "completed"
+            FAILED = "failed"
+        """,
+    )
+
+    persisted: list = []
+
+    async def fake_persist(problems, source_id=None):
+        persisted.extend(problems)
+        return len(problems)
+
+    with patch.object(xfa, "_persist_to_chromadb", new=fake_persist):
+        count = await xfa.run_cross_file_analysis(
+            str(tmp_path), source_id=None, exclude_patterns=["__pycache__"]
+        )
+
+    assert count >= 1
+    types = {p.get("type") for p in persisted}
+    assert "code_smell_duplicate_enum" in types
+
+
+@pytest.mark.asyncio
+async def test_problem_dict_shape_matches_chromadb_persistence(tmp_path):
+    """The dict shape produced by the bridge must include exactly the keys
+    chromadb_storage._prepare_problem_document expects to read."""
+    xfa = _load_cross_file_module()
+
+    _write(
+        tmp_path,
+        "agents",
+        """
+        class BaseAgent:
+            async def is_available(self) -> bool:
+                return True
+
+        class LocalAgent(BaseAgent):
+            def is_available(self) -> bool:
+                return True
+        """,
+    )
+
+    persisted: list = []
+
+    async def fake_persist(problems, source_id=None):
+        persisted.extend(problems)
+        return len(problems)
+
+    with patch.object(xfa, "_persist_to_chromadb", new=fake_persist):
+        await xfa.run_cross_file_analysis(
+            str(tmp_path), source_id=None, exclude_patterns=["__pycache__"]
+        )
+
+    assert persisted, "fixture must produce at least one finding"
+    p = persisted[0]
+    # Required keys read by chromadb_storage._prepare_problem_document:
+    for key in ("type", "severity", "file_path", "line", "description", "suggestion"):
+        assert key in p, f"problem dict missing required key {key!r}: {p}"
+    # The type prefix matches the existing analyzers.py::_run_anti_pattern_analysis
+    # convention so the dashboard groups findings consistently.
+    assert p["type"].startswith("code_smell_"), p["type"]
+
+
+@pytest.mark.asyncio
+async def test_run_swallows_missing_root(tmp_path):
+    """Non-existent root_path returns 0 — must NOT raise into scan finalization."""
+    xfa = _load_cross_file_module()
+    bogus = tmp_path / "does_not_exist"
+    count = await xfa.run_cross_file_analysis(str(bogus), source_id=None)
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_run_swallows_detector_failure(tmp_path):
+    """If the detector raises, the bridge must log + return 0 — never propagate."""
+    xfa = _load_cross_file_module()
+    _write(tmp_path, "noop", "x = 1\n")
+
+    class _Boom:
+        async def analyze_cross_file_only(self, **_kwargs):
+            raise RuntimeError("simulated failure")
+
+    fake_module = type(
+        "fake_apd",
+        (),
+        {"AntiPatternDetector": lambda *args, **kwargs: _Boom()},
+    )
+    import sys as _sys
+
+    with patch.dict(
+        _sys.modules, {"code_analysis.src.anti_pattern_detector": fake_module}
+    ):
+        count = await xfa.run_cross_file_analysis(
+            str(tmp_path), source_id=None, exclude_patterns=["__pycache__"]
+        )
+    assert count == 0

--- a/autobot-backend/api/codebase_analytics/scanner.py
+++ b/autobot-backend/api/codebase_analytics/scanner.py
@@ -422,6 +422,19 @@ async def do_indexing_with_progress(
 
         await _verify_chromadb_storage(task_id, analysis_results)
 
+        # #6747: Run cross-file rules (LSP + consolidation) over the scanned
+        # root and persist findings to ChromaDB so they surface in
+        # /codebase/problems alongside the per-file results.  Imported lazily
+        # so a missing dep doesn't break the existing per-file pipeline.
+        try:
+            from api.codebase_analytics.cross_file_analysis import (
+                run_cross_file_analysis,
+            )
+
+            await run_cross_file_analysis(root_path, source_id=source_id)
+        except Exception as exc:
+            logger.warning("[Task %s] Cross-file analysis skipped: %s", task_id, exc)
+
         _mark_task_completed_bound(
             task_id, analysis_results, hardcodes_stored, "chromadb"
         )

--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -273,7 +273,9 @@ class AntiPatternDetector:
 
     def __init__(self, redis_client=None):
         self.redis_client = redis_client
-        self.config = config
+        # #6733: removed `self.config = config` — referenced an undefined name
+        # and was never read elsewhere in the module. Direct AntiPatternDetector()
+        # instantiation now works in any context.
 
         # Cache keys
         self.CACHE_KEY = "anti_pattern_analysis"
@@ -305,9 +307,14 @@ class AntiPatternDetector:
         """
         start_time = time.time()
 
-        patterns = patterns or ["**/*.py"]
-        # Issue #1183: Use module-level constant
-        exclude_patterns = exclude_patterns or _DEFAULT_EXCLUDE_PATTERNS
+        # #6734: use `is None` sentinel instead of `or` idiom — explicit
+        # `exclude_patterns=[]` should disable exclusion, not silently
+        # apply the defaults (the `or` form treated empty list as falsy).
+        if patterns is None:
+            patterns = ["**/*.py"]
+        if exclude_patterns is None:
+            # Issue #1183: Use module-level constant
+            exclude_patterns = _DEFAULT_EXCLUDE_PATTERNS
 
         logger.info(f"Starting anti-pattern analysis in {root_path}")
 
@@ -345,8 +352,41 @@ class AntiPatternDetector:
             f"Anti-pattern analysis complete: {report.total_issues} issues found "
             f"in {analysis_time:.2f}s (health score: {report.health_score:.1f}/100)"
         )
-
         return report
+
+    async def analyze_cross_file_only(
+        self,
+        root_path: str = ".",
+        patterns: List[str] = None,
+        exclude_patterns: List[str] = None,
+    ) -> List[AntiPatternInstance]:
+        """Run only the cross-file rules (#6747).
+
+        The four rules added by #6661 (LSP) and #6684 (consolidation) need
+        a whole-codebase class index, but the production per-file
+        ``AntiPatternDetector.analyze_file()`` in
+        ``code_intelligence/anti_pattern_detector.py`` doesn't build one.
+        This method does the parse pass once and runs ONLY the cross-file
+        rules — letting the scanner finalize step surface them through
+        ``/codebase/problems`` without re-running the per-file rules
+        already covered by the production analyzer.
+
+        Returns:
+            List of AntiPatternInstance for ChromaDB persistence.
+        """
+        # Default-arg handling: same `is None` discipline as analyze() (#6734)
+        if patterns is None:
+            patterns = ["**/*.py"]
+        if exclude_patterns is None:
+            exclude_patterns = _DEFAULT_EXCLUDE_PATTERNS
+
+        await self._parse_codebase(root_path, patterns, exclude_patterns)
+
+        results: List[AntiPatternInstance] = []
+        results.extend(await self._detect_lsp_violations())
+        results.extend(await self._detect_duplicate_enums())
+        results.extend(await self._detect_duplicate_class_shapes())
+        return results
 
     async def _parse_codebase(
         self, root_path: str, patterns: List[str], exclude_patterns: List[str]


### PR DESCRIPTION
## Summary
Closes the wiring gap from #6661/#6684: the four cross-file rules (LSP signature, LSP exception contract, duplicate enum, duplicate class shape) now surface in \`/codebase/problems\` after every index run.

## Architectural decision (Option 1 from the issue thread)
Production analyzer is per-file (\`analyze_file()\`) — can't host rules that need a whole-codebase class index. This PR runs a **directory-level cross-file pass at scan finalization**, persisting findings to ChromaDB with the same \`code_smell_*\` type prefix the per-file path uses, so dashboard grouping picks them up automatically.

## Changes
- **\`AntiPatternDetector.analyze_cross_file_only()\`** — new entrypoint that runs ONLY the 4 new rules. Skips per-file rules production already covers.
- **\`api/codebase_analytics/cross_file_analysis.py\`** — bridge module that translates \`AntiPatternInstance\` → \`{type, severity, file_path, line, description, suggestion}\` dict matching the ChromaDB persistence contract.
- **Scanner finalize hook** — \`run_cross_file_analysis()\` invoked between \`_verify_chromadb_storage\` and \`_mark_task_completed_bound\`. Runs AFTER per-file findings land, BEFORE the #6669 quality-cache invalidation, so the freshly-refreshed dashboard sees both finding sources.
- **Fail-safe**: missing root, import failure, or detector exception returns 0 and logs — never propagates into scan finalization.

## Side fixes
- \`self.config = config\` (undefined name, dead code) removed — closes #6733
- \`exclude_patterns or _DEFAULT_EXCLUDE_PATTERNS\` → \`is None\` sentinel — closes #6734

## Test plan
- [x] \`pytest cross_file_analysis_test.py\` — 5/5 PASS:
  - LSP fixture surfaces \`code_smell_lsp_signature_incompatible\`
  - Duplicate-enum fixture surfaces \`code_smell_duplicate_enum\`
  - Problem dict shape matches \`chromadb_storage._prepare_problem_document\` keys
  - Missing root_path returns 0 (no exception into scan)
  - Detector exception returns 0 (no exception into scan)
- [x] Pre-existing #6661 + #6684 suites still green — 14/14 PASS

## What this enables
After Ansible deploy, every \`POST /codebase/index\` will populate ChromaDB with cross-file findings. \`GET /codebase/problems\` will return them with types \`code_smell_lsp_signature_incompatible\`, \`code_smell_lsp_exception_contract_changed\`, \`code_smell_duplicate_enum\`, \`code_smell_duplicate_class_shape\`. The Real-time Codebase Analytics dashboard groups them with existing \`code_smell_*\` findings — no UI changes needed.

## Out of scope (filed separately)
- #6748 — \`COMPOSABLE_OPPORTUNITY\` Vue detector (still deferred; needs JS/TS AST tooling)

Closes #6747
Closes #6733
Closes #6734

🤖 Generated with [Claude Code](https://claude.com/claude-code)