### PR TITLE
fix(nginx): route /openapi.json /docs /redoc to backend (item #27)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2
@@ -185,6 +185,39 @@ server {
         proxy_read_timeout 300s;
     }
 
+    # FastAPI OpenAPI docs (#6749 follow-up — without these, the SPA fallback
+    # serves index.html for /openapi.json /docs /redoc instead of the spec).
+    # Use `=` for /openapi.json (exact match) so it can't shadow real routes;
+    # `^~` for /docs and /redoc so prefix match takes priority over the SPA
+    # catch-all.
+    location = /openapi.json {
+        proxy_pass {{ frontend_backend_protocol }}://autobot_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+{% if frontend_backend_protocol == 'https' %}
+        proxy_ssl_verify off;
+{% endif %}
+    }
+    location ^~ /docs {
+        proxy_pass {{ frontend_backend_protocol }}://autobot_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+{% if frontend_backend_protocol == 'https' %}
+        proxy_ssl_verify off;
+{% endif %}
+    }
+    location ^~ /redoc {
+        proxy_pass {{ frontend_backend_protocol }}://autobot_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+{% if frontend_backend_protocol == 'https' %}
+        proxy_ssl_verify off;
+{% endif %}
+    }
+
 {% else %}
     # ── Standalone mode ───────────────────────────────────────
     # SLM API at both /api/ and /slm/api/ (#3268: agents always use /slm/api/)


### PR DESCRIPTION
## Summary

Hitting `/openapi.json`, `/docs`, or `/redoc` returned 200 with `text/html` (the SPA index) instead of the FastAPI OpenAPI spec / Swagger UI / ReDoc UI. nginx had no location block matching those paths, so they fell through to `location /` which serves the SPA's index.html.

Added three explicit location blocks in the co-located (Frontend + SLM) server section:
- `location = /openapi.json` — exact match, can't be shadowed by future regex rules
- `location ^~ /docs` — `^~` makes prefix match take priority over the SPA catch-all; covers /docs/oauth2-redirect too
- `location ^~ /redoc` — same; ReDoc emits scripts under /redoc/

All three proxy to the same upstream as /api/ with matching Host/proto headers.

## Test plan

- [x] curl /openapi.json now returns text/html (will return application/json after deploy)
- [ ] After deploy: `curl -ksI https://172.16.168.20/openapi.json` returns `content-type: application/json`
- [ ] After deploy: /docs serves Swagger UI
- [ ] After deploy: /redoc serves ReDoc UI

## Discovery

Standalone-mode nginx block (lower in the template, currently unused) wasn't updated. If that path becomes active later it'll need the same three blocks. Tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)