### PR TITLE
fix(api/health): rename misleading agent_count → ai_stack_agent_count (#8)

### DIFF
--- a/autobot-backend/initialization/endpoints.py
+++ b/autobot-backend/initialization/endpoints.py
@@ -131,7 +131,11 @@ def register_root_endpoints(app: FastAPI) -> None:
             "service": "autobot-backend",
             "services": services,
             "ai_enhanced": ai_stack_ready,
-            "agent_count": _get_agent_count(state),
+            # `_get_agent_count` only counts AI Stack agents, not the local
+            # backend agent registry. Renamed to make the semantic explicit so
+            # consumers don't conflate this with the (much larger) total in
+            # /api/agents/registry. (#6749 follow-up — Chrome-plugin TODO #8.)
+            "ai_stack_agent_count": _get_agent_count(state),
             "capabilities": _build_capabilities(ai_stack_ready, ai_agents_ready),
             "circuit_breakers": _get_circuit_breaker_states(),
         }


### PR DESCRIPTION
## Summary

The /api/health response field 'agent_count' is computed by `_get_agent_count(state)` ([endpoints.py:73-78](autobot-backend/initialization/endpoints.py#L73-L78)) which only counts agents registered with the AI Stack. When AI Stack is unavailable (current production state), the value is 0 — even though the backend agent registry at `/api/agents/registry → summary.total` has 29 agents.

User-reported (Chrome-plugin debug TODO #8):
> Mismatch: /api/health says agent_count: 0, ai_stack_agents: 'unavailable', multi_agent_coordination: false. UI /agents/registry shows 29 connected agents.

Renamed the response field to `ai_stack_agent_count` so consumers can no longer mistake an unavailable-AI-Stack response for an empty backend registry. Anyone wanting the local-registry total uses `/api/agents/registry`.

## Test plan

- [x] grep confirms no other backend or frontend code reads literal 'agent_count' from /api/health (3 matches found, all unrelated — orchestration recommendations, workflow metrics counter, test fixture)
- [ ] After deploy: `curl /api/health | jq .ai_stack_agent_count` returns 0 (was previously 'agent_count: 0')

🤖 Generated with [Claude Code](https://claude.com/claude-code)