### PR TITLE
fix(code-analysis): treat docstring + raise NotImplementedError as stub in LSP detector (#6755)

### DIFF
--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -1108,9 +1108,44 @@ class AntiPatternDetector:
         defaults = method.args.defaults or []
         return max(0, len(args) - len(defaults))
 
+    @staticmethod
+    def _is_docstring_stmt(stmt: ast.stmt) -> bool:
+        """True when the statement is a bare string literal (function docstring)."""
+        return (
+            isinstance(stmt, ast.Expr)
+            and isinstance(stmt.value, ast.Constant)
+            and isinstance(stmt.value.value, str)
+        )
+
+    @staticmethod
+    def _is_stub_statement(stmt: ast.stmt) -> bool:
+        """True when the statement is a stub form: ``pass`` / ``...`` /
+        ``raise NotImplementedError``."""
+        if isinstance(stmt, ast.Pass):
+            return True
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant):
+            if stmt.value.value is Ellipsis or stmt.value.value is None:
+                return True
+        if isinstance(stmt, ast.Raise):
+            exc = stmt.exc
+            if isinstance(exc, ast.Name) and exc.id == "NotImplementedError":
+                return True
+            if isinstance(exc, ast.Call) and isinstance(exc.func, ast.Name):
+                if exc.func.id == "NotImplementedError":
+                    return True
+        return False
+
     def _is_abstract_or_stub(self, method: ast.AST) -> bool:
         """Parent overrides should be skipped if the parent body is an
-        abstract / Protocol stub — children must add behavior."""
+        abstract / Protocol stub — children must add behavior.
+
+        Recognized stub bodies (a leading docstring is allowed and ignored):
+          * ``pass``
+          * ``...``  (Ellipsis as expression statement)
+          * ``raise NotImplementedError`` / ``raise NotImplementedError(...)``
+          * docstring-only body
+          * docstring + any of the above
+        """
         if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
             return True
         # @abstractmethod / @abc.abstractmethod
@@ -1125,28 +1160,15 @@ class AntiPatternDetector:
         body = method.body
         if not body:
             return True
-        if len(body) == 1:
-            stmt = body[0]
-            # `pass` / `...` / `raise NotImplementedError`
-            if isinstance(stmt, ast.Pass):
-                return True
-            if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant):
-                if stmt.value.value is Ellipsis or stmt.value.value is None:
-                    return True
-            if isinstance(stmt, ast.Raise):
-                exc = stmt.exc
-                if isinstance(exc, ast.Name) and exc.id == "NotImplementedError":
-                    return True
-                if isinstance(exc, ast.Call) and isinstance(exc.func, ast.Name):
-                    if exc.func.id == "NotImplementedError":
-                        return True
-        # Docstring-only body counts as a stub too
-        if (
-            len(body) == 1
-            and isinstance(body[0], ast.Expr)
-            and isinstance(body[0].value, ast.Constant)
-            and isinstance(body[0].value.value, str)
-        ):
+
+        # Strip an optional leading docstring; the remaining body must be
+        # either empty (docstring-only) or a single stub statement.
+        non_doc_body = (
+            body[1:] if self._is_docstring_stmt(body[0]) else list(body)
+        )
+        if not non_doc_body:
+            return True  # docstring-only stub
+        if len(non_doc_body) == 1 and self._is_stub_statement(non_doc_body[0]):
             return True
         return False
 

--- a/autobot-backend/code_analysis/src/anti_pattern_detector_lsp_test.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector_lsp_test.py
@@ -194,6 +194,55 @@ async def test_lsp_skips_abstract_parent(fixture_root):
 
 
 @pytest.mark.asyncio
+async def test_lsp_skips_docstring_plus_raise_notimplemented_stub(fixture_root):
+    """Parent body of ``\"docstring\"; raise NotImplementedError`` is a stub —
+    children adding behaviour must NOT be flagged.
+
+    Regression: dogfood pass over autobot-backend produced 2 false-positive
+    LSP_EXCEPTION_CONTRACT_CHANGED findings against ``BaseModalProcessor.process``
+    because the original detector only matched length-1 bodies and missed the
+    very common ``\"\"\"docstring\"\"\"`` + ``raise NotImplementedError`` form.
+    """
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "modal_case",
+        '''
+        class BaseModalProcessor:
+            async def process(self, input_data):
+                """Process input and return result"""
+                raise NotImplementedError
+
+        class VisionProcessor(BaseModalProcessor):
+            async def process(self, input_data):
+                if input_data is None:
+                    raise ValueError("missing input")  # OK — parent is stub
+                return "vision-result"
+        ''',
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+    lsp = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type
+        in (
+            apd.AntiPatternType.LSP_SIGNATURE_INCOMPATIBLE,
+            apd.AntiPatternType.LSP_EXCEPTION_CONTRACT_CHANGED,
+        )
+    ]
+    assert not lsp, (
+        f"docstring + raise NotImplementedError parent must be treated as a "
+        f"stub; unexpected findings: {[(ap.pattern_type.value, ap.entity_name) for ap in lsp]}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_lsp_skips_mixin_classes(fixture_root):
     """Mixin classes are not subject to LSP overrides."""
     apd = _load_detector_module()


### PR DESCRIPTION
## Summary
Fixes a detector false-positive: \`_is_abstract_or_stub()\` only matched length-1 function bodies, so the very common \`\"\"\"docstring\"\"\"\` + \`raise NotImplementedError\` pattern (length 2 body) was misclassified as a non-stub.

## Detected when
Dogfood run for #6747 produced 2 \`lsp_exception_contract_changed\` findings against \`BaseModalProcessor.process\` from \`VisionProcessor\` and \`VoiceProcessor\` — the parent IS a stub, the detector just didn't recognize the docstring + raise form.

## Refactor
Split stub detection into two helpers — \`_is_docstring_stmt()\` and \`_is_stub_statement()\` — and updated \`_is_abstract_or_stub()\` to strip an optional leading docstring before checking. Now recognizes:
- \`pass\`
- \`...\`
- \`raise NotImplementedError\` (with or without \`()\`)
- docstring-only body
- **docstring + any of the above** (the originally-missed case)

## Dogfood impact (autobot-backend codebase)
- \`lsp_exception_contract_changed\`: 2 → 0
- \`lsp_signature_incompatible\`: 38 → 37
- \`duplicate_enum\`: 432 → 407
- \`duplicate_class_shape\`: 61 → 60

## Test plan
- [x] \`pytest anti_pattern_detector_lsp_test.py::test_lsp_skips_docstring_plus_raise_notimplemented_stub\` — new regression case PASSES
- [x] All 19 pre-existing analyzer tests still PASS — total **20/20**

Part of #6755 (the 2 LSP exception findings turn out to be detector bugs, not application bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)