### PR TITLE
fix(media): restore parent constructor signature on 5 BasePipeline subclasses (#6755)

### DIFF
--- a/autobot-backend/media/audio/pipeline.py
+++ b/autobot-backend/media/audio/pipeline.py
@@ -13,7 +13,7 @@ import base64
 import logging
 import os
 import tempfile
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from media.core.pipeline import BasePipeline
 from media.core.types import MediaInput, MediaType, ProcessingResult
@@ -54,11 +54,24 @@ def _get_whisper_pipeline() -> Optional[Any]:
 class AudioPipeline(BasePipeline):
     """Pipeline for processing audio content (voice, music, sound)."""
 
-    def __init__(self):
-        """Initialize audio processing pipeline."""
+    def __init__(
+        self,
+        pipeline_name: str = "audio",
+        supported_types: List[MediaType] = None,
+    ):
+        """Initialize audio processing pipeline.
+
+        Issue #6755: accepts the parent's full signature with sensible
+        defaults so factory callers (`cls(name, supported_types)`) keep
+        working. The historical no-arg call site is unaffected.
+        """
         super().__init__(
-            pipeline_name="audio",
-            supported_types=[MediaType.AUDIO],
+            pipeline_name=pipeline_name,
+            supported_types=(
+                supported_types
+                if supported_types is not None
+                else [MediaType.AUDIO]
+            ),
         )
 
     async def _process_impl(self, media_input: MediaInput) -> ProcessingResult:

--- a/autobot-backend/media/document/pipeline.py
+++ b/autobot-backend/media/document/pipeline.py
@@ -38,11 +38,24 @@ logger = logging.getLogger(__name__)
 class DocumentPipeline(BasePipeline):
     """Pipeline for processing document content (PDF, DOCX, TXT, etc.)."""
 
-    def __init__(self):
-        """Initialize document processing pipeline."""
+    def __init__(
+        self,
+        pipeline_name: str = "document",
+        supported_types: List[MediaType] = None,
+    ):
+        """Initialize document processing pipeline.
+
+        Issue #6755: accepts the parent's full signature with sensible
+        defaults so factory callers (`cls(name, supported_types)`) keep
+        working. The historical no-arg call site is unaffected.
+        """
         super().__init__(
-            pipeline_name="document",
-            supported_types=[MediaType.DOCUMENT, MediaType.TEXT],
+            pipeline_name=pipeline_name,
+            supported_types=(
+                supported_types
+                if supported_types is not None
+                else [MediaType.DOCUMENT, MediaType.TEXT]
+            ),
         )
 
     async def _process_impl(self, media_input: MediaInput) -> ProcessingResult:

--- a/autobot-backend/media/image/pipeline.py
+++ b/autobot-backend/media/image/pipeline.py
@@ -12,7 +12,7 @@ import asyncio
 import base64
 import io
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from media.core.pipeline import BasePipeline
 from media.core.types import MediaInput, MediaType, ProcessingResult
@@ -56,11 +56,24 @@ def _get_vision_processor() -> Optional[Any]:
 class ImagePipeline(BasePipeline):
     """Pipeline for processing image content."""
 
-    def __init__(self):
-        """Initialize image processing pipeline."""
+    def __init__(
+        self,
+        pipeline_name: str = "image",
+        supported_types: List[MediaType] = None,
+    ):
+        """Initialize image processing pipeline.
+
+        Issue #6755: accepts the parent's full signature with sensible
+        defaults so factory callers (`cls(name, supported_types)`) keep
+        working. The historical no-arg call site is unaffected.
+        """
         super().__init__(
-            pipeline_name="image",
-            supported_types=[MediaType.IMAGE],
+            pipeline_name=pipeline_name,
+            supported_types=(
+                supported_types
+                if supported_types is not None
+                else [MediaType.IMAGE]
+            ),
         )
 
     async def _process_impl(self, media_input: MediaInput) -> ProcessingResult:

--- a/autobot-backend/media/link/pipeline.py
+++ b/autobot-backend/media/link/pipeline.py
@@ -72,11 +72,24 @@ _jina_session_lock: Optional[asyncio.Lock] = None
 class LinkPipeline(BasePipeline):
     """Pipeline for processing web links and URLs."""
 
-    def __init__(self):
-        """Initialize link processing pipeline."""
+    def __init__(
+        self,
+        pipeline_name: str = "link",
+        supported_types: List[MediaType] = None,
+    ):
+        """Initialize link processing pipeline.
+
+        Issue #6755: accepts the parent's full signature with sensible
+        defaults so factory callers (`cls(name, supported_types)`) keep
+        working. The historical no-arg call site is unaffected.
+        """
         super().__init__(
-            pipeline_name="link",
-            supported_types=[MediaType.LINK],
+            pipeline_name=pipeline_name,
+            supported_types=(
+                supported_types
+                if supported_types is not None
+                else [MediaType.LINK]
+            ),
         )
 
     async def _process_impl(self, media_input: MediaInput) -> ProcessingResult:

--- a/autobot-backend/media/pipeline_constructor_compat_test.py
+++ b/autobot-backend/media/pipeline_constructor_compat_test.py
@@ -1,0 +1,79 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Constructor-compatibility regression test for media pipeline classes (#6755).
+
+Catches the same class of bug as #6660 (StandardizedAgent subclasses): every
+``BasePipeline`` subclass must accept the parent's full ``(pipeline_name,
+supported_types)`` signature so factory callers like ``cls(name, types)``
+keep working.  Pre-#6755 the five pipeline subclasses had ``def __init__(self):``
+and crashed on factory-style instantiation.
+"""
+
+import importlib
+import inspect
+
+import pytest
+
+
+PIPELINE_MODULES = [
+    ("media.document.pipeline", "DocumentPipeline"),
+    ("media.link.pipeline", "LinkPipeline"),
+    ("media.audio.pipeline", "AudioPipeline"),
+    ("media.video.pipeline", "VideoPipeline"),
+    ("media.image.pipeline", "ImagePipeline"),
+]
+
+
+@pytest.mark.parametrize("module_path,class_name", PIPELINE_MODULES)
+def test_pipeline_constructor_accepts_parent_signature(module_path, class_name):
+    """Every BasePipeline subclass must accept (pipeline_name, supported_types).
+
+    Regression: pre-#6755 these were `def __init__(self):` with hardcoded
+    super() args, breaking `cls(name, types)` factory patterns.
+    """
+    try:
+        mod = importlib.import_module(module_path)
+    except Exception as exc:  # pragma: no cover — env-dependent dep chain
+        pytest.skip(f"{module_path} dep chain unavailable: {exc}")
+
+    cls = getattr(mod, class_name)
+    params = inspect.signature(cls.__init__).parameters
+    assert "pipeline_name" in params, (
+        f"{class_name}.__init__ must accept 'pipeline_name' for factory compat"
+    )
+    assert "supported_types" in params, (
+        f"{class_name}.__init__ must accept 'supported_types' for factory compat"
+    )
+    # Both parameters must have defaults so the historical no-arg call site
+    # (e.g. `DocumentPipeline()` in production) keeps working.
+    assert (
+        params["pipeline_name"].default is not inspect.Parameter.empty
+    ), f"{class_name}.pipeline_name must have a default"
+    assert (
+        params["supported_types"].default is not inspect.Parameter.empty
+    ), f"{class_name}.supported_types must have a default"
+
+
+@pytest.mark.parametrize("module_path,class_name", PIPELINE_MODULES)
+def test_pipeline_no_arg_instantiation_still_works(module_path, class_name):
+    """The historical `Pipeline()` call (no args) must keep producing a
+    well-formed instance with the original hardcoded defaults."""
+    try:
+        mod = importlib.import_module(module_path)
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"{module_path} dep chain unavailable: {exc}")
+
+    cls = getattr(mod, class_name)
+    try:
+        inst = cls()
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"{class_name}() requires extra deps: {exc}")
+    # Pipeline name should match the historical hardcoded value
+    expected = class_name.replace("Pipeline", "").lower()
+    assert inst.pipeline_name == expected, (
+        f"no-arg {class_name}() should produce pipeline_name='{expected}', "
+        f"got {inst.pipeline_name!r}"
+    )
+    assert inst.supported_types, f"{class_name}() should have non-empty supported_types"

--- a/autobot-backend/media/video/pipeline.py
+++ b/autobot-backend/media/video/pipeline.py
@@ -72,11 +72,24 @@ _MAX_FRAMES = 5
 class VideoPipeline(BasePipeline):
     """Pipeline for processing video content."""
 
-    def __init__(self):
-        """Initialize video processing pipeline."""
+    def __init__(
+        self,
+        pipeline_name: str = "video",
+        supported_types: List[MediaType] = None,
+    ):
+        """Initialize video processing pipeline.
+
+        Issue #6755: accepts the parent's full signature with sensible
+        defaults so factory callers (`cls(name, supported_types)`) keep
+        working. The historical no-arg call site is unaffected.
+        """
         super().__init__(
-            pipeline_name="video",
-            supported_types=[MediaType.VIDEO],
+            pipeline_name=pipeline_name,
+            supported_types=(
+                supported_types
+                if supported_types is not None
+                else [MediaType.VIDEO]
+            ),
         )
 
     async def _process_impl(self, media_input: MediaInput) -> ProcessingResult:


### PR DESCRIPTION
## Summary
Same class of bug as #6660. Five \`BasePipeline\` subclasses had \`def __init__(self):\` with hardcoded \`super().__init__(...)\` args — broke factory call patterns like \`cls(name, supported_types)\`.

Detected by the new \`LSP_SIGNATURE_INCOMPATIBLE\` rule (#6661) during the dogfood pass for #6747.

## Files changed
- \`media/document/pipeline.py:41\` — \`DocumentPipeline.__init__\`
- \`media/link/pipeline.py:75\` — \`LinkPipeline.__init__\`
- \`media/audio/pipeline.py:57\` — \`AudioPipeline.__init__\`
- \`media/video/pipeline.py:75\` — \`VideoPipeline.__init__\`
- \`media/image/pipeline.py:59\` — \`ImagePipeline.__init__\`

All five now accept the parent's full signature with sensible defaults matching the historical hardcoded values:
- \`DocumentPipeline()\` (existing call sites) still works
- \`DocumentPipeline(name, types)\` (factory pattern) now works

## Test plan
- [x] \`pytest pipeline_constructor_compat_test.py\` — **10/10 PASS** (5 signature checks + 5 no-arg backward-compat checks)

Part of #6755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)