### PR TITLE
fix(code-analysis): LSP positional-arity rule was inverted (#6755)

### DIFF
--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -1108,6 +1108,18 @@ class AntiPatternDetector:
         defaults = method.args.defaults or []
         return max(0, len(args) - len(defaults))
 
+    def _total_positional_count(self, method: ast.AST) -> int:
+        """Count total positional slots — required + with-default — excluding
+        ``self``/``cls``. A child can WIDEN preconditions by adding defaults,
+        which is correct LSP; the comparison that matters is whether the child
+        accepts as many positional slots as the parent requires (#6755)."""
+        if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return 0
+        args = method.args.args
+        if args and args[0].arg in ("self", "cls"):
+            args = args[1:]
+        return len(args)
+
     @staticmethod
     def _is_docstring_stmt(stmt: ast.stmt) -> bool:
         """True when the statement is a bare string literal (function docstring)."""
@@ -1294,10 +1306,20 @@ class AntiPatternDetector:
                         )
                     )
 
-                # --- Signature: required-param removal ---
-                child_required = self._required_positional_count(child_method)
+                # --- Signature: child rejects positional args parent accepts ---
+                # LSP correctness: a child override can WIDEN preconditions
+                # (accept more inputs via defaults) but must NOT NARROW them.
+                # The original bug class (#6660) was a child with `def __init__(self):`
+                # under a parent with `def __init__(self, agent_type, ...):` —
+                # `cls(agent_type)` crashes on the child because it has no slot
+                # for that positional. The check is: count the child's TOTAL
+                # positional slots (required + optional with defaults), and
+                # compare against the parent's REQUIRED count. If the child
+                # has fewer slots than the parent requires, factory calls
+                # against the parent's required-positional surface will fail.
+                child_total_positional = self._total_positional_count(child_method)
                 parent_required = self._required_positional_count(parent_method)
-                if child_required < parent_required:
+                if child_total_positional < parent_required:
                     issues.append(
                         AntiPatternInstance(
                             pattern_type=AntiPatternType.LSP_SIGNATURE_INCOMPATIBLE,
@@ -1306,17 +1328,17 @@ class AntiPatternDetector:
                             line_number=child_method.lineno,
                             entity_name=f"{child.name}.{child_method.name}",
                             description=(
-                                f"Override of {parent.name}.{child_method.name} drops "
-                                f"required positional params: parent requires "
-                                f"{parent_required}, child requires {child_required}. "
-                                "A factory call like ``cls(arg1, arg2)`` against the parent "
-                                "will crash with TypeError on this subclass."
+                                f"Override of {parent.name}.{child_method.name} accepts "
+                                f"{child_total_positional} positional args but the parent "
+                                f"requires {parent_required}. A factory call like "
+                                "``cls(arg1, arg2)`` against the parent contract will "
+                                "crash with TypeError on this subclass."
                             ),
                             metrics={
                                 "parent_class": parent.name,
                                 "parent_file": parent.file_path,
                                 "parent_required_args": parent_required,
-                                "child_required_args": child_required,
+                                "child_total_positional_args": child_total_positional,
                             },
                             suggestion=(
                                 "Restore the parent's positional params with sensible "

--- a/autobot-backend/code_analysis/src/anti_pattern_detector_lsp_test.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector_lsp_test.py
@@ -194,6 +194,64 @@ async def test_lsp_skips_abstract_parent(fixture_root):
 
 
 @pytest.mark.asyncio
+async def test_lsp_skips_child_with_widened_preconditions(fixture_root):
+    """Child override that widens the parent's signature (adds defaults)
+    must NOT be flagged.
+
+    Regression: #6755 dogfood pass produced 5 false-positive
+    LSP_SIGNATURE_INCOMPATIBLE findings against ``BasePipeline`` subclasses
+    AFTER they were correctly fixed to accept the parent's args with
+    defaults. The original rule (``child_required < parent_required``)
+    flagged this — but a child widening preconditions is correct LSP.
+    The corrected rule compares child's TOTAL positional slots against
+    parent's REQUIRED count.
+    """
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "widening",
+        """
+        from typing import List
+
+        class BasePipeline:
+            def __init__(self, pipeline_name: str, supported_types: List[str]):
+                self.pipeline_name = pipeline_name
+                self.supported_types = supported_types
+
+        class DocumentPipeline(BasePipeline):
+            # Widens preconditions — accepts both as kwargs OR positional, with
+            # defaults matching the historical hardcoded values. Factory call
+            # `cls("doc", [])` still works against the parent contract.
+            def __init__(
+                self,
+                pipeline_name: str = "document",
+                supported_types: List[str] = None,
+            ):
+                super().__init__(
+                    pipeline_name=pipeline_name,
+                    supported_types=supported_types if supported_types is not None else ["DOCUMENT"],
+                )
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+    sig_issues = [
+        ap
+        for ap in report.anti_patterns
+        if ap.pattern_type == apd.AntiPatternType.LSP_SIGNATURE_INCOMPATIBLE
+    ]
+    assert not sig_issues, (
+        f"child widening preconditions should NOT be flagged; got: "
+        f"{[(ap.entity_name, ap.description[:80]) for ap in sig_issues]}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_lsp_skips_docstring_plus_raise_notimplemented_stub(fixture_root):
     """Parent body of ``\"docstring\"; raise NotImplementedError`` is a stub —
     children adding behaviour must NOT be flagged.


### PR DESCRIPTION
## Summary
Discovered while verifying #6777 (Pipeline constructor fixes): the analyzer kept flagging the **correctly-fixed** Pipeline subclasses as LSP violations.

Root cause: the rule fired when \`child_required < parent_required\`, but a child that adds DEFAULTS to parent params is **widening preconditions** (accepts more inputs) — that's correct LSP per Liskov's contravariance of arguments.

## The corrected rule
Compare child's TOTAL positional slots (required + with-default) against parent's REQUIRED count. Flag only if the child has fewer slots than the parent requires.

| Case | child_required | child_total | parent_required | Flag? |
|---|---|---|---|---|
| #6660 (broken) | 0 | 0 | 1 | ✅ flagged |
| #6777 (fixed Pipeline) | 0 | 2 | 2 | ❌ NOT flagged (correct LSP widening) |

## Dogfood impact
\`lsp_signature_incompatible\`: **37 → 20** (-17 FPs cleared, all 5 Pipeline findings gone)

## Test plan
- [x] New \`test_lsp_skips_child_with_widened_preconditions\` regression case PASSES
- [x] Existing #6660-style detection (\`test_lsp_signature_incompatible_required_param_dropped\`) still PASSES
- [x] All 19 pre-existing analyzer tests still PASS — total **20/20**

Part of #6755 (this was a detector bug, not application code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)