### PR TITLE
fix(chat): single-source-of-truth session_id — closes 4-IDs-per-send churn (#6745)

### DIFF
--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -745,7 +745,14 @@ async def create_session(session_data: SessionCreate, request: Request):
     log_request_context(request, "create_session", request_id)
 
     chat_history_manager = get_chat_history_manager(request)
-    session_id = generate_chat_session_id()
+    # #6746: accept client-supplied session_id when provided and well-formed,
+    # so the frontend's locally-minted UUID survives the round-trip and
+    # frontend/backend stay aligned. Falls back to server-mint when absent
+    # (legacy callers, CLI, tests).
+    if session_data.id and validate_chat_session_id(session_data.id):
+        session_id = session_data.id
+    else:
+        session_id = generate_chat_session_id()
     session_title = session_data.title or DEFAULT_SESSION_TITLE
 
     # SECURITY: Extract authenticated user and add to metadata as owner

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -334,6 +334,16 @@ class DetectLanguageData(BaseModel):
 class SessionCreate(BaseModel):
     """Session creation model"""
 
+    # #6746: accept client-supplied session_id so frontend and backend stay
+    # aligned on a single UUID. Backend validates and uses it as-is; if absent
+    # or invalid, backend mints a new one. Eliminates the two-phase create
+    # that produced divergent IDs and "blank session" sidebar entries (#6745).
+    id: Optional[str] = Field(
+        None,
+        max_length=64,
+        description="Optional client-supplied session UUID. Validated server-side; "
+        "backend mints a new ID when absent or malformed.",
+    )
     title: Optional[str] = Field(None, max_length=200, description="Session title")
     team_id: Optional[str] = Field(None, description="Team ID for team-scoped sessions (#684)")
     metadata: Optional[Metadata] = Field(default_factory=dict, description="Session metadata")

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -899,19 +899,14 @@ const heartbeatPoller = usePollingJob(
   { intervalMs: 60_000, maxAttempts: Number.MAX_SAFE_INTEGER }
 )
 
-// Auto-save current session every 2 minutes
-const autoSavePoller = usePollingJob(
-  async () => {
-    if (store.settings.autoSave && store.currentSessionId) {
-      await controller.saveChatSession().catch((error: any) => logger.warn('Auto-save failed:', error))
-    }
-    return null
-  },
-  { intervalMs: 2 * 60 * 1000, maxAttempts: Number.MAX_SAFE_INTEGER }
-)
+// #6746: autosave poller deleted. Backend now persists every chat message
+// via add_messages_batch in the request handler (#6744 fix), so frontend-
+// driven autosave is redundant — and was a session_id churn source: it ran
+// every 2 min against `store.currentSessionId`, which could be racing with
+// pushLocalOnlySessions, syncSessionsWithBackend, or message-poller
+// state churn. Backend writes are now the sole authoritative path.
 
 const startHeartbeat = () => heartbeatPoller.start('')
-const enableAutoSave = () => autoSavePoller.start('')
 
 // Message polling with exponential backoff + circuit breaker (#1100)
 // Prevents 499 cascade: skips in-flight polls, backs off on failure, opens circuit
@@ -1060,7 +1055,7 @@ onMounted(async () => {
   // Start connection monitoring
   checkConnection()
   startHeartbeat()
-  enableAutoSave()
+  // #6746: autosave removed; backend persists messages directly
 
   // Start message polling to fetch new messages
   startMessagePolling()
@@ -1082,7 +1077,6 @@ onUnmounted(() => {
 
   // Clean up intervals
   heartbeatPoller.stop()
-  autoSavePoller.stop()
 
   _stopCountdown()
   messagePoller.stop()
@@ -1100,7 +1094,7 @@ onActivated(() => {
   checkConnection()
 
   // Resume auto-save
-  enableAutoSave()
+  // #6746: autosave removed; backend persists messages directly
 
   // Resume message polling
   startMessagePolling()
@@ -1119,7 +1113,6 @@ onDeactivated(() => {
 
   // Pause intervals while cached
   heartbeatPoller.stop()
-  autoSavePoller.stop()
 
   // Clean up keyboard shortcuts while cached
   document.removeEventListener('keydown', handleKeyboardShortcuts)

--- a/autobot-frontend/src/models/controllers/ChatController.ts
+++ b/autobot-frontend/src/models/controllers/ChatController.ts
@@ -100,16 +100,20 @@ export class ChatController {
         throw new Error(validation.error)
       }
 
-      // Add user message to store with sending status
+      // #6746: ensure session exists BEFORE addMessage. addMessage no longer
+      // creates a session as a side effect (that was a major churn source —
+      // see #6745). Order: session-first, then attach message.
+      if (!this.chatStore.currentSessionId) {
+        await this.createNewSession()
+      }
+
       const userMessageId = this.chatStore.addMessage({
         content,
         sender: 'user',
         status: 'sending'
       })
-
-      // Ensure we have a current session
-      if (!this.chatStore.currentSessionId) {
-        await this.createNewSession()
+      if (!userMessageId) {
+        throw new Error('Failed to add user message — no current session')
       }
 
       let lastError: Error | null = null
@@ -605,25 +609,21 @@ export class ChatController {
   // Enhanced session operations with error handling
   async createNewSession(title?: string): Promise<string> {
     try {
-
-      // Create session in store first for immediate UI feedback
+      // #6746: single-path create — local UUID is registered with the backend
+      // in one round-trip. No two-phase create with diverging IDs.
       const sessionId = this.chatStore.createNewSession(title)
-
-      // Sync with backend with retry logic
       try {
-        await chatRepository.createNewChat(title)
+        await chatRepository.createNewChat(title, undefined, sessionId)
         logger.debug('New chat session synced with backend:', sessionId)
       } catch (error) {
+        // Backend create failed but local session is usable — autosave / send-
+        // message paths will retry. Surface the warning and continue.
         logger.warn('Failed to sync new chat with backend, continuing with local session:', error)
-        // Don't throw error here, allow local session to work
       }
-
       return sessionId
-
     } catch (error: unknown) {
       this.getAppStore()?.setGlobalError(`Failed to create chat: ${extractErrorMessage(error, 'Unknown error')}`)
       throw error
-    } finally {
     }
   }
 

--- a/autobot-frontend/src/models/repositories/ChatRepository.ts
+++ b/autobot-frontend/src/models/repositories/ChatRepository.ts
@@ -327,9 +327,19 @@ export class ChatRepository {
   }
 
   // Create new chat session
-  async createNewChat(title?: string, metadata?: Record<string, unknown>): Promise<ChatSession> {
+  async createNewChat(
+    title?: string,
+    metadata?: Record<string, unknown>,
+    id?: string,
+  ): Promise<ChatSession> {
     try {
+      // #6746: pass the client-minted UUID so backend's create_session uses
+      // it as-is instead of minting a new one. Without this, frontend creates
+      // local UUID-A but backend creates UUID-B, and any subsequent
+      // /api/chats/{id}/message calls land in different sessions — that's the
+      // root of #6745 "answer arrived in different session".
       const response = await this.post(`${getApiBase()}/chat/sessions`, {
+        id,
         title: title || 'New Chat',
         metadata: metadata || {}
       })

--- a/autobot-frontend/src/stores/useChatStore.ts
+++ b/autobot-frontend/src/stores/useChatStore.ts
@@ -151,9 +151,20 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  function addMessage(message: Omit<ChatMessage, 'id' | 'timestamp'>) {
+  function addMessage(message: Omit<ChatMessage, 'id' | 'timestamp'>): string | null {
+    // #6746: don't auto-create a session as a side effect of addMessage.
+    // The previous fallback was a major source of session_id churn (#6745):
+    // any state path that nulled currentSession (page mount, sync, race)
+    // caused subsequent stream chunks to spawn a new session, scattering
+    // assistant replies across blank "Chat N" sidebar entries. Now callers
+    // must own session lifecycle explicitly.
     if (!currentSession.value) {
-      createNewSession()
+      logger.error(
+        'addMessage called with no current session — message dropped. ' +
+          'Caller must invoke createNewSession() first.',
+        message,
+      )
+      return null
     }
 
     const newMessage: ChatMessage = {
@@ -162,8 +173,8 @@ export const useChatStore = defineStore('chat', () => {
       ...message
     }
 
-    currentSession.value!.messages.push(newMessage)
-    currentSession.value!.updatedAt = new Date()
+    currentSession.value.messages.push(newMessage)
+    currentSession.value.updatedAt = new Date()
 
     return newMessage.id
   }


### PR DESCRIPTION
## Summary

Closes #6745 (session_id churn) and lands the first concrete piece of #6746 (architectural unification of chat state).

User reported \"I started in session A, but the answer came in session B, and multiple blank sessions get generated.\" Backend logs confirmed **4+ different session IDs per single user-typed message**.

Root cause was a two-phase create with diverging IDs:
1. Frontend mints UUID-A locally for instant UI feedback
2. Frontend POSTs `/api/chat/sessions` with no ID in body
3. Backend mints UUID-B (chat_sessions.py:748) and returns it
4. Frontend ignores UUID-B, keeps UUID-A as currentSessionId
5. `POST /api/chats/UUID-A/message` lands on disk under UUID-A
6. Autosave + message-poller race the half-aligned state
7. Messages scatter across multiple session files

## Changes (6 files, +66/-35 lines)

### Backend — accept client-supplied session_id

| File | Change |
|------|--------|
| `api/schemas_chat.py` | `SessionCreate` model gains `id: Optional[str]` (max 64 chars) |
| `api/chat_sessions.py` | `create_session` validates client id via existing `validate_chat_session_id` (rejects `../`, null bytes, spaces, etc.) and uses it; falls back to mint on miss |

### Frontend — single-path create

| File | Change |
|------|--------|
| `models/repositories/ChatRepository.ts` | `createNewChat(title, metadata, id?)` — passes id in POST body |
| `models/controllers/ChatController.ts` | `createNewSession` is now one path: local mint → POST with that ID → backend returns same ID → no divergence. `sendMessage` reorders so session exists BEFORE addMessage |
| `stores/useChatStore.ts` | `addMessage` no longer creates a session as side effect; returns null + logs error if no current session. The previous fallback was a major churn source |
| `components/chat/ChatInterface.vue` | Autosave poller deleted (after #6744, backend persists every message; frontend autosave was redundant AND race-prone) |

## Verified

- `validate_chat_session_id` correctly rejects path-traversal / null-bytes / spaces / capitals — safe to accept client IDs
- TS parse clean on all 4 frontend files (typescript createSourceFile, 0 errors)
- Backend `py_compile` clean
- Brace balance preserved in `ChatInterface.vue` (278/278)

## Test plan

- [ ] Deploy. Click \"New Chat\" → exactly **one** \`POST /api/chat/sessions\` in backend log; subsequent \`POST /api/chats/<same-id>/message\` uses the same ID.
- [ ] Send a message → backend log shows ONE session_id used end-to-end (was 4+).
- [ ] Disk: \`data/chats/<id>_chat.json\` contains BOTH user message AND assistant reply (after #6744).
- [ ] Sidebar: no \"blank Chat N\" entries appearing on each send.
- [ ] Reload page → previously-seen sessions reappear with their messages intact.

## Still out of scope

- 30-s message poller (separate path that can overwrite local state) — replace with WebSocket push using #6705 \`/ws/live\` as a follow-up
- \`useAppStore.sessions\` duplicate store (no external users; harmless dead code; cleanup deferred)
- \`syncSessionsWithBackend\` mount-time path

🤖 Generated with [Claude Code](https://claude.com/claude-code)