### PR TITLE
feat(observability): RAG per-stage timing + iconMappings non-string telemetry (closes #6791 #6796)

### DIFF
--- a/autobot-backend/advanced_rag_optimizer.py
+++ b/autobot-backend/advanced_rag_optimizer.py
@@ -814,12 +814,27 @@ class AdvancedRAGOptimizer:
         return optimized_results
 
     def _log_search_completion(self, metrics: RAGMetrics, context: Any) -> None:
-        """Log search completion metrics (Issue #665: extracted helper)."""
-        logger.info("Advanced search completed:")
-        logger.info("  - Total time: %.3fs", metrics.total_time)
-        logger.info("  - Documents considered: %s", metrics.documents_considered)
-        logger.info("  - Final results: %s", metrics.final_results_count)
-        logger.info("  - Query type: %s", context.query_type)
+        """Log search completion metrics (Issue #665: extracted helper).
+
+        #6791: when total_time exceeds the perceptual budget, escalate to
+        WARNING and emit per-stage timing breakdown so operators can identify
+        the slow stage (query processing vs retrieval vs reranking) without
+        re-running with debug logging. The fields already exist on RAGMetrics
+        — they just weren't being surfaced.
+        """
+        slow_threshold_s = 5.0  # perceptual UX budget for chat replies
+        is_slow = metrics.total_time >= slow_threshold_s
+        log_fn = logger.warning if is_slow else logger.info
+        log_fn("Advanced search completed%s:", " (SLOW)" if is_slow else "")
+        log_fn("  - Total time: %.3fs", metrics.total_time)
+        log_fn("  - Query processing: %.3fs", metrics.query_processing_time)
+        log_fn("  - Retrieval (ChromaDB + embedding): %.3fs", metrics.retrieval_time)
+        log_fn("  - Reranking: %.3fs", metrics.reranking_time)
+        log_fn("  - Documents considered: %s", metrics.documents_considered)
+        log_fn("  - Final results: %s", metrics.final_results_count)
+        log_fn("  - Query type: %s", context.query_type)
+        log_fn("  - GPU acceleration: %s", metrics.gpu_acceleration_used)
+        log_fn("  - Hybrid search: %s", metrics.hybrid_search_enabled)
 
     def _build_context_parts(
         self,

--- a/autobot-frontend/src/utils/iconMappings.ts
+++ b/autobot-frontend/src/utils/iconMappings.ts
@@ -133,6 +133,23 @@ export const platformIcons = {
 // HELPER FUNCTIONS
 // ============================================================================
 
+// #6796: telemetry — log (with stack trace) the first time getFileIcon
+// receives a non-string `filename`, so the upstream serialization bug can
+// be found from a real session. We only warn once per page load to avoid
+// drowning the console.
+let _nonStringFilenameWarned = false
+function _warnNonStringFilenameOnce(value: unknown): void {
+  if (_nonStringFilenameWarned) return
+  _nonStringFilenameWarned = true
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[iconMappings #6796] getFileIcon received non-string filename — ' +
+      'upstream payload (likely TreeNode.name) is not a string. ' +
+      `typeof=${typeof value} value=${String(value).slice(0, 80)}`,
+    new Error('iconMappings non-string trace'),
+  )
+}
+
 /**
  * Get icon for file based on extension
  */
@@ -142,6 +159,7 @@ export function getFileIcon(filename: string, isFolder: boolean = false): string
   // boundary, and TreeNode.name occasionally arrives as null/number/undefined,
   // which crashed KnowledgeBrowser with "t.split is not a function".
   if (typeof filename !== 'string' || filename.length === 0) {
+    if (typeof filename !== 'string') _warnNonStringFilenameOnce(filename)
     return fileTypeIcons.file
   }
 


### PR DESCRIPTION
Two instrumentation additions for the runtime-evidence-required investigations:

- **#6791** — `advanced_rag_optimizer._log_search_completion` now logs query_processing_time / retrieval_time / reranking_time alongside total_time. Escalates to WARNING with "(SLOW)" tag when total_time >= 5s.
- **#6796** — `getFileIcon` warns-once with stack trace when receiving non-string filename, capturing typeof + value preview so the upstream serialization issue can be traced from a real session.

Smoke test 246 passed.