### PR TITLE
refactor(voice): unify duplicate /api/voice/stream WS — single owner (#6788)

### DIFF
--- a/autobot-frontend/src/composables/useVoiceConversation.ts
+++ b/autobot-frontend/src/composables/useVoiceConversation.ts
@@ -16,7 +16,7 @@ import { useVoiceProfiles } from '@/composables/useVoiceProfiles'
 import { useChatController } from '@/models/controllers'
 import { useChatStore } from '@/stores/useChatStore'
 import { usePreferences } from '@/composables/usePreferences'
-import { getBackendWsUrl, getApiBase } from '@/config/ssot-config'
+import { getApiBase } from '@/config/ssot-config'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -43,7 +43,6 @@ const currentTranscript = ref('')
 const bubbles = ref<VoiceBubble[]>([])
 const isActive = ref(false)
 const errorMessage = ref('')
-const wsConnected = ref(false)
 
 // Secure context check — getUserMedia requires HTTPS with a trusted cert (#1059)
 const micAccessAvailable = ref(
@@ -58,7 +57,7 @@ const audioLevel = ref(0)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let _recognition: any = null
-let _ws: WebSocket | null = null
+let _voiceUnsubscribe: (() => void) | null = null
 let _vadAudioCtx: AudioContext | null = null
 let _vadNode: AudioWorkletNode | null = null
 let _micStream: MediaStream | null = null
@@ -123,73 +122,35 @@ function _sanitizeForSpeech(text: string): string {
   return lastBreak > 50 ? truncated.slice(0, lastBreak + 1) : truncated
 }
 
-// ─── WebSocket helpers ───────────────────────────────────
+// ─── Voice WS (#6788: shared with useVoiceOutput, single owner) ──────────
 
-function _connectWs(): void {
-  if (_ws && _ws.readyState <= WebSocket.OPEN) return
-
-  const base = getBackendWsUrl()
-  const url = `${base}/api/voice/stream`
-  logger.debug('Connecting voice WS:', url)
-
-  _ws = new WebSocket(url)
-
-  _ws.onopen = () => {
-    wsConnected.value = true
-    logger.debug('Voice WS connected')
-  }
-
-  _ws.onmessage = (event) => {
-    try {
-      const msg = JSON.parse(event.data)
-      _handleWsMessage(msg)
-    } catch (e) {
-      logger.error('Voice WS parse error:', e)
-    }
-  }
-
-  _ws.onclose = () => {
-    wsConnected.value = false
-    logger.debug('Voice WS disconnected')
-    if (mode.value === 'full-duplex' && isActive.value) {
-      logger.warn('WS dropped — falling back to walkie-talkie')
-      mode.value = 'walkie-talkie'
-      errorMessage.value = 'Connection lost. Switched to walkie-talkie.'
-    }
-  }
-
-  _ws.onerror = (e) => {
-    logger.error('Voice WS error:', e)
-  }
+function _subscribeVoice(): void {
+  if (_voiceUnsubscribe) return
+  const { subscribeVoiceMessages } = useVoiceOutput()
+  _voiceUnsubscribe = subscribeVoiceMessages(_handleWsMessage)
 }
 
-function _disconnectWs(): void {
-  if (_ws) {
-    try { _ws.close() } catch { /* ignore */ }
-    _ws = null
+function _unsubscribeVoice(): void {
+  if (_voiceUnsubscribe) {
+    _voiceUnsubscribe()
+    _voiceUnsubscribe = null
   }
-  wsConnected.value = false
 }
 
 function _sendWs(data: Record<string, unknown>): void {
-  if (_ws && _ws.readyState === WebSocket.OPEN) {
-    _ws.send(JSON.stringify(data))
-  }
+  // Fire-and-forget; sendVoiceFrame logs on failure.
+  void useVoiceOutput().sendVoiceFrame(data)
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _handleWsMessage(msg: any): void {
-  const { playAudioChunk } = useVoiceOutput()
-
+  // tts_audio playback is owned by useVoiceOutput; we only react to state.
   switch (msg.type) {
     case 'state':
       logger.debug('Server state:', msg.state)
       break
     case 'tts_start':
       state.value = 'speaking'
-      break
-    case 'tts_audio':
-      playAudioChunk(msg.data)
       break
     case 'tts_end':
       // Handled by isSpeaking watcher when audio queue drains
@@ -566,7 +527,8 @@ function _dispatchTranscript(text: string): void {
       return
     }
 
-    if (mode.value === 'full-duplex' && wsConnected.value) {
+    const { wsConnected: voiceWsConnected } = useVoiceOutput()
+    if (mode.value === 'full-duplex' && voiceWsConnected.value) {
       const { effectiveVoiceId } = useVoiceProfiles()
       _sendWs({ type: 'speak', text: speechText, voice_id: effectiveVoiceId.value })
     } else {
@@ -738,7 +700,7 @@ function _handleVadSpeechEnd(audio: Float32Array): void {
 // ─── Main composable ────────────────────────────────────
 
 export function useVoiceConversation() {
-  const { isSpeaking, unlockAudio, stopSpeaking } = useVoiceOutput()
+  const { isSpeaking, unlockAudio, stopSpeaking, wsConnected } = useVoiceOutput()
 
   const isListening = computed(() => state.value === 'listening')
   const isProcessing = computed(() => state.value === 'processing')
@@ -766,8 +728,8 @@ export function useVoiceConversation() {
     currentLanguage.value = _getShortLanguage()
     unlockAudio()
 
+    _subscribeVoice()
     if (mode.value === 'full-duplex') {
-      _connectWs()
       await _initVad()
       _startListeningInternal()
     } else if (mode.value === 'hands-free') {
@@ -779,7 +741,7 @@ export function useVoiceConversation() {
   function deactivate(): void {
     _stopRecognition()
     _stopHandsFree()
-    _disconnectWs()
+    _unsubscribeVoice()
     _teardownVad()
     stopSpeaking()
     if (_ttsCooldownTimer) { clearTimeout(_ttsCooldownTimer); _ttsCooldownTimer = null }
@@ -836,7 +798,6 @@ export function useVoiceConversation() {
     if (wasActive) {
       _stopRecognition()
       _stopHandsFree()
-      _disconnectWs()
       _teardownVad()
       stopSpeaking()
       if (_ttsCooldownTimer) { clearTimeout(_ttsCooldownTimer); _ttsCooldownTimer = null }
@@ -847,7 +808,7 @@ export function useVoiceConversation() {
     mode.value = newMode
 
     if (wasActive && newMode === 'full-duplex') {
-      _connectWs()
+      _subscribeVoice()
       _initVad().then(() => _startListeningInternal())
     } else if (wasActive && newMode === 'hands-free') {
       _startHandsFree()

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -36,11 +36,21 @@ let _scheduledSources: AudioBufferSourceNode[] = []
 let _nextStartTime = 0
 let _activeChunkCount = 0
 
-// Streaming TTS WebSocket connection (#1319)
+// Single shared WebSocket to /api/voice/stream (#6788).
+// Was: useVoiceOutput + useVoiceConversation each opened their own socket to the
+// same endpoint, causing diverging backend state machines and dropped TTS on the
+// second turn. This composable is now the sole owner; consumers subscribe via
+// subscribeVoiceMessages() and send via sendVoiceFrame().
 let _ttsWs: WebSocket | null = null
 let _ttsWsConnecting: Promise<WebSocket> | null = null
 let _ttsWsIdleTimer: ReturnType<typeof setTimeout> | null = null
 const _TTS_WS_IDLE_TIMEOUT = 30_000
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type VoiceMessage = Record<string, any>
+type VoiceMessageHandler = (msg: VoiceMessage) => void
+const _voiceSubscribers = new Set<VoiceMessageHandler>()
+const wsConnected = ref<boolean>(false)
 
 // AbortController for the current in-flight speak() HTTP request.
 // Module-level so a new speak() call can abort the previous one.
@@ -198,34 +208,42 @@ function _connectTtsWs(): Promise<WebSocket> {
     ws.onopen = () => {
       _ttsWs = ws
       _ttsWsConnecting = null
+      wsConnected.value = true
       _resetTtsWsIdleTimer()
-      logger.debug('TTS WS connected')
+      logger.debug('Voice WS connected')
       resolve(ws)
     }
     ws.onerror = (e) => {
-      logger.warn('TTS WS error:', e)
+      logger.warn('Voice WS error:', e)
       _ttsWs = null
       _ttsWsConnecting = null
+      wsConnected.value = false
       reject(e)
     }
     ws.onclose = () => {
-      logger.debug('TTS WS closed')
+      logger.debug('Voice WS closed')
       _ttsWs = null
       _ttsWsConnecting = null
+      wsConnected.value = false
     }
     ws.onmessage = (event) => {
       _resetTtsWsIdleTimer()
+      let msg: VoiceMessage
       try {
-        const msg = JSON.parse(event.data)
-        if (msg.type === 'tts_audio' && msg.data) {
-          _playAudioChunkFromBase64(msg.data)
-        } else if (msg.type === 'tts_end') {
-          // Sentence stream complete — isSpeaking cleared by drain
-        } else if (msg.type === 'error') {
-          logger.warn('TTS WS server error:', msg.message)
-        }
+        msg = JSON.parse(event.data)
       } catch (e) {
-        logger.warn('TTS WS message parse error:', e)
+        logger.warn('Voice WS message parse error:', e)
+        return
+      }
+      // Internal: audio playback owned here.
+      if (msg.type === 'tts_audio' && msg.data) {
+        _playAudioChunkFromBase64(msg.data)
+      } else if (msg.type === 'error') {
+        logger.warn('Voice WS server error:', msg.message)
+      }
+      // Fan-out to external subscribers (state machine, transcripts, etc.)
+      for (const handler of _voiceSubscribers) {
+        try { handler(msg) } catch (e) { logger.warn('voice subscriber error:', e) }
       }
     }
   })
@@ -326,9 +344,31 @@ export function useVoiceOutput() {
     }
   }
 
+  /**
+   * Subscribe to inbound voice WS messages (#6788). Returns an unsubscribe fn.
+   * The subscription drives lazy connection: first subscribe opens the socket;
+   * audio playback (`tts_audio`) is still handled internally by this composable.
+   */
+  function subscribeVoiceMessages(handler: VoiceMessageHandler): () => void {
+    _voiceSubscribers.add(handler)
+    _connectTtsWs().catch(() => { /* logged inside */ })
+    return () => { _voiceSubscribers.delete(handler) }
+  }
+
+  /** Send a frame on the shared voice WS, lazy-connecting if needed (#6788). */
+  async function sendVoiceFrame(payload: VoiceMessage): Promise<void> {
+    try {
+      const ws = await _connectTtsWs()
+      ws.send(JSON.stringify(payload))
+    } catch {
+      logger.warn('sendVoiceFrame: WS unavailable')
+    }
+  }
+
   return {
     voiceOutputEnabled,
     isSpeaking,
+    wsConnected,
     toggleVoiceOutput,
     speak,
     speakStreaming,
@@ -336,5 +376,7 @@ export function useVoiceOutput() {
     unlockAudio,
     playAudioChunk,
     stopSpeaking,
+    subscribeVoiceMessages,
+    sendVoiceFrame,
   }
 }


### PR DESCRIPTION
## Summary

Two composables opened independent WebSockets to the SAME `/api/voice/stream` endpoint, causing diverging backend state machines and dropped TTS on the second turn (root cause of user-reported _"tts works only first time - trying to keep up conversation speech not transferred"_).

This PR makes `useVoiceOutput` the **single owner** of the socket; `useVoiceConversation` subscribes to it instead of opening its own.

## Changes

**`useVoiceOutput.ts`** — sole owner of `/api/voice/stream`
- `subscribeVoiceMessages(handler) → unsubscribe` — fan-out to consumers (lazy-connects)
- `sendVoiceFrame(payload)` — outbound, lazy-connects
- Audio playback (`tts_audio`) still handled internally; other types fan out
- Exposes `wsConnected: Ref<boolean>` for UI state indicators

**`useVoiceConversation.ts`** — no longer owns a socket
- Removed `_ws`, `_connectWs`, `_disconnectWs`
- `activate()` calls `_subscribeVoice()`; `deactivate()` calls `_unsubscribeVoice()`
- `_sendWs` delegates to `sendVoiceFrame`
- `_handleWsMessage` no longer routes `tts_audio` (single audio owner)
- Re-exports `wsConnected` from `useVoiceOutput` so `VoiceConversationOverlay.vue` keeps its current binding

## Verification

```bash
$ grep -rn "new WebSocket" .../composables/useVoice{Output,Conversation}.ts
useVoiceOutput.ts:206:    const ws = new WebSocket(url)
```

Only one socket constructor remains. ✅

`vue-tsc -p tsconfig.app.json` shows zero new TS errors in modified files (208 pre-existing baseline errors in unrelated files).

`eslint` clean on both files.

## Test plan

- [ ] Walkie-talkie mode: tap mic → speak → response speaks → tap again → response speaks again (TTS works on subsequent turns)
- [ ] Hands-free mode: speak → wait → response speaks → speak again → response speaks again
- [ ] Full-duplex mode: continuous conversation; barge-in still cancels TTS
- [ ] DevTools Network: only one WS connection to `/api/voice/stream` per session
- [ ] `VoiceConversationOverlay.vue` "connection" indicator still reflects WS state

## Closes

Closes #6788