### PR TITLE
perf(voice): make _TTS_PIPELINE_DEPTH env-configurable; default 2 (#6811)

### DIFF
--- a/autobot-backend/api/voice_stream.py
+++ b/autobot-backend/api/voice_stream.py
@@ -30,6 +30,7 @@ Protocol (JSON messages):
 import asyncio
 import base64
 import logging
+import os
 from collections import deque
 from typing import Optional
 
@@ -92,12 +93,23 @@ async def _cancel_pending_task(task: "asyncio.Task | None") -> None:
         task.cancel()
 
 
-# Pipelining depth for TTS streaming (#6752). With depth=1 (the previous
-# behaviour), any TTS-worker latency spike that exceeds the playback duration
-# of the current chunk produced an audible gap on the client (the frontend's
-# gapless scheduler falls back to "now"). Buffering N chunks ahead absorbs
-# jitter up to N * chunk_duration.
-_TTS_PIPELINE_DEPTH = 3
+# Pipelining depth for TTS streaming (#6752, tuned in #6811).
+# Pocket TTS calls run via run_in_executor and serialize on the GIL/model lock,
+# so depth>2 only adds queue contention without true parallelism. depth=2 lets
+# chunk N+1 synthesize while the client plays chunk N — enough to absorb
+# typical jitter without piling backlog. Override with AUTOBOT_TTS_PIPELINE_DEPTH
+# (clamped to 1..8 to prevent ops typos OOMing the worker).
+def _resolve_tts_pipeline_depth() -> int:
+    raw = os.getenv("AUTOBOT_TTS_PIPELINE_DEPTH", "2")
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Invalid AUTOBOT_TTS_PIPELINE_DEPTH=%r; using 2", raw)
+        return 2
+    return max(1, min(8, value))
+
+
+_TTS_PIPELINE_DEPTH = _resolve_tts_pipeline_depth()
 
 
 async def _send_one_chunk(


### PR DESCRIPTION
## Summary

`_TTS_PIPELINE_DEPTH` was hardcoded to 3 (#6752). Pocket TTS calls run via `loop.run_in_executor(None, _run_synthesis, ...)` and serialize on the GIL/model lock — depth>2 only adds queue contention without true parallelism.

This PR:
- Lowers default to 2 (one chunk synthesizes ahead while the client plays the current one — the actual jitter-absorption goal of #6752)
- Adds `AUTOBOT_TTS_PIPELINE_DEPTH` env var override
- Clamps to 1..8 to prevent ops typos OOMing the worker
- Logs a warning + falls back to 2 on invalid values

## Verification

```python
$ python3 -c '... resolver tests ...'
Invalid AUTOBOT_TTS_PIPELINE_DEPTH='banana'; using 2
All resolver cases pass
```

Edge cases tested:
- default → 2
- '1' → 1 (min)
- '8' → 8 (max)
- '99' → 8 (upper clamp)
- '0' → 1 (lower clamp)
- '-5' → 1
- 'banana' → 2 + warning

`python -m py_compile` passes.

## Test plan

- [ ] Deploy with default — voice latency improves vs current `depth=3`
- [ ] Set `AUTOBOT_TTS_PIPELINE_DEPTH=1` (sequential) and `=4` (over-saturated) in dev to compare
- [ ] Verify backend log line `Invalid AUTOBOT_TTS_PIPELINE_DEPTH=...` on bad value
- [ ] No regression in #6752 jitter absorption (playback still gapless on multi-sentence responses)

## Closes

Closes #6811

Related: #6810 (single-WS unification), #6752 (original jitter-absorption introducing depth=3)