### PR TITLE
refactor(chat): delete duplicate useAppStore.sessions store (#6813)

### DIFF
--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -787,7 +787,7 @@ import { ref, reactive, computed, onMounted, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 // @ts-ignore - JavaScript API client without type declarations
 import { secretsApiClient } from '@/utils/SecretsApiClient';
-import { useAppStore } from '@/stores/useAppStore';
+import { useChatStore } from '@/stores/useChatStore';
 import { createLogger } from '@/utils/debugUtils';
 import { formatDateTime } from '@/utils/formatHelpers';
 import { useDebounce } from '@/composables/useDebounce';
@@ -1347,14 +1347,14 @@ const saveSecret = async () => {
 
   saving.value = true;
   try {
-    const appStore = useAppStore();
+    const chatStore = useChatStore();
 
     // Build base secret data
     const secretData: any = {
       name: secretForm.name,
       type: secretForm.type,
       scope: secretForm.scope,
-      chat_id: secretForm.scope === 'chat' ? (secretForm.chat_id || appStore.currentSessionId) : null,
+      chat_id: secretForm.scope === 'chat' ? (secretForm.chat_id || chatStore.currentSessionId) : null,
       description: secretForm.description,
       expires_at: secretForm.expires_at ? new Date(secretForm.expires_at).toISOString() : null,
       tags: secretForm.tags,

--- a/autobot-frontend/src/stores/useAppStore.ts
+++ b/autobot-frontend/src/stores/useAppStore.ts
@@ -1,24 +1,11 @@
 import { ref, computed } from 'vue'
 import type { Router } from 'vue-router'
 import { defineStore } from 'pinia'
-import { generateChatId } from '@/utils/ChatIdGenerator.js'
 
 // Issue #156 Fix: Changed 'desktop' to 'infrastructure' to match router routes
 // Issue #545: Added 'analytics' for consolidated analytics section
 // Issue #591: Added 'operations' for long-running operations tracker
 export type TabType = 'chat' | 'infrastructure' | 'knowledge' | 'tools' | 'monitoring' | 'operations' | 'analytics' | 'secrets' | 'settings' | 'automation'
-
-/** Shape of a message stored in the app store sessions */
-export interface AppSessionMessage {
-  id: string
-  content: string
-  sender: 'user' | 'assistant' | 'system'
-  timestamp: Date
-  status?: 'sending' | 'sent' | 'error'
-  type?: 'message' | 'command' | 'response' | 'error' | 'system' | 'file' | 'image' | 'code'
-  attachments?: { name: string; size: number; type: string; url?: string; data?: string }[]
-  metadata?: { model?: string; tokens?: number; processingTime?: number; reasoning?: string }
-}
 
 export interface BackendStatus {
   text: string
@@ -117,38 +104,8 @@ export const useAppStore = defineStore('app', () => {
   const isLoading = ref(false)
   const loadingMessage = ref('')
 
-  // Chat State
-  const sessions = ref<{
-    id: string
-    title: string
-    messages: {
-      id: string
-      content: string
-      sender: 'user' | 'assistant' | 'system'
-      timestamp: Date
-      status?: 'sending' | 'sent' | 'error'
-      type?: 'message' | 'command' | 'response' | 'error' | 'system' | 'file' | 'image' | 'code'
-      attachments?: {
-        name: string
-        size: number
-        type: string
-        url?: string
-        data?: string
-      }[]
-      metadata?: {
-        model?: string
-        tokens?: number
-        processingTime?: number
-        reasoning?: string
-      }
-    }[]
-    status: 'active' | 'archived'
-    lastActivity: Date
-    summary?: string
-    tags?: string[]
-  }[]>([])
-
-  const currentSessionId = ref<string | null>(null)
+  // Chat session state moved to useChatStore (#6781). useAppStore is no longer
+  // a session SSOT — consumers use useChatStore.{sessions,currentSessionId,...}.
 
   // System status for status indicator
   const systemStatusIndicator = computed(() => {
@@ -175,22 +132,6 @@ export const useAppStore = defineStore('app', () => {
       return { status: 'success', text: backendStatus.value.text, pulse: false }  // Use actual backend status text instead of generic message
     }
     return { status: 'warning', text: backendStatus.value.text, pulse: true }
-  })
-
-  // Getters
-  const currentSession = computed(() => {
-    if (!currentSessionId.value) return null
-    return sessions.value.find(s => s.id === currentSessionId.value) || null
-  })
-
-  const activeSessions = computed(() => {
-    return sessions.value.filter(s => s.status === 'active')
-  })
-
-  const recentSessions = computed(() => {
-    return [...sessions.value]
-      .sort((a, b) => b.lastActivity.getTime() - a.lastActivity.getTime())
-      .slice(0, 10)
   })
 
   // Actions
@@ -243,94 +184,6 @@ export const useAppStore = defineStore('app', () => {
   const setLoading = (loading: boolean, message: string = '') => {
     isLoading.value = loading
     loadingMessage.value = message
-  }
-
-  // Chat Session Management
-  const createNewSession = (title?: string) => {
-    const sessionId = generateChatId()
-    const newSession = {
-      id: sessionId,
-      title: title || `Chat ${sessions.value.length + 1}`,
-      messages: [],
-      status: 'active' as const,
-      lastActivity: new Date(),
-      tags: []
-    }
-
-    sessions.value.push(newSession)
-    currentSessionId.value = sessionId
-    return sessionId
-  }
-
-  const switchToSession = (sessionId: string) => {
-    const session = sessions.value.find(s => s.id === sessionId)
-    if (session) {
-      currentSessionId.value = sessionId
-      session.lastActivity = new Date()
-    }
-  }
-
-  const updateSessionTitle = (sessionId: string, title: string) => {
-    const session = sessions.value.find(s => s.id === sessionId)
-    if (session) {
-      session.title = title
-    }
-  }
-
-  const archiveSession = (sessionId: string) => {
-    const session = sessions.value.find(s => s.id === sessionId)
-    if (session) {
-      session.status = 'archived'
-      if (currentSessionId.value === sessionId) {
-        // Switch to most recent active session or create new one
-        const activeSession = activeSessions.value[0]
-        if (activeSession) {
-          currentSessionId.value = activeSession.id
-        } else {
-          createNewSession()
-        }
-      }
-    }
-  }
-
-  const deleteSession = (sessionId: string) => {
-    const index = sessions.value.findIndex(s => s.id === sessionId)
-    if (index !== -1) {
-      sessions.value.splice(index, 1)
-      if (currentSessionId.value === sessionId) {
-        // Switch to most recent session or create new one
-        const remainingSession = sessions.value.find(s => s.status === 'active')
-        if (remainingSession) {
-          currentSessionId.value = remainingSession.id
-        } else {
-          createNewSession()
-        }
-      }
-    }
-  }
-
-  const addMessageToSession = (sessionId: string, message: Omit<AppSessionMessage, 'id'> & { id?: string }) => {
-    const session = sessions.value.find(s => s.id === sessionId)
-    if (session) {
-      session.messages.push({
-        ...message,
-        timestamp: message.timestamp || new Date()
-      })
-      session.lastActivity = new Date()
-    }
-  }
-
-  const updateMessageInSession = (sessionId: string, messageId: string, updates: Partial<AppSessionMessage>) => {
-    const session = sessions.value.find(s => s.id === sessionId)
-    if (session) {
-      const messageIndex = session.messages.findIndex(m => m.id === messageId)
-      if (messageIndex !== -1) {
-        session.messages[messageIndex] = {
-          ...session.messages[messageIndex],
-          ...updates
-        }
-      }
-    }
   }
 
   // System Notifications
@@ -427,11 +280,6 @@ export const useAppStore = defineStore('app', () => {
     })
   }
 
-  // Initialize with a default session if none exists
-  if (sessions.value.length === 0) {
-    createNewSession('Welcome Chat')
-  }
-
   return {
     // State
     activeTab,
@@ -446,15 +294,8 @@ export const useAppStore = defineStore('app', () => {
     isLoading,
     loadingMessage,
 
-    // Chat State
-    sessions,
-    currentSessionId,
-
     // Computed
     systemStatusIndicator,
-    currentSession,
-    activeSessions,
-    recentSessions,
 
     // Actions
     setActiveTab,
@@ -464,15 +305,6 @@ export const useAppStore = defineStore('app', () => {
     setConnectedUsers,
     setLoading,
     setGlobalError,
-
-    // Chat Actions
-    createNewSession,
-    switchToSession,
-    updateSessionTitle,
-    archiveSession,
-    deleteSession,
-    addMessageToSession,
-    updateMessageInSession,
 
     // Notification Actions
     addSystemNotification,
@@ -487,8 +319,6 @@ export const useAppStore = defineStore('app', () => {
     key: 'autobot-app',
     storage: localStorage,
     pick: [
-      'sessions',
-      'currentSessionId',
       'notificationSettings',
       'activeTab'
     ]


### PR DESCRIPTION
## Summary

#6781 made `useChatStore` the single source of truth for chat session state, but the duplicate copy in `useAppStore` lingered as dead code persisted under the `autobot-app` localStorage key.

This PR removes:
- `AppSessionMessage` interface
- `sessions` ref + `currentSessionId` ref
- `currentSession` / `activeSessions` / `recentSessions` computeds
- 7 session actions (`createNewSession`, `switchToSession`, `updateSessionTitle`, `archiveSession`, `deleteSession`, `addMessageToSession`, `updateMessageInSession`)
- The "Welcome Chat" bootstrap that initialized a default session on first load
- `sessions` and `currentSessionId` from `persist.pick`
- The `Chat State` and `Chat Actions` sections in the return object
- Dead `import { generateChatId }`

And migrates the one remaining external consumer:
- `SecretsManager.vue:1357` — `appStore.currentSessionId` → `chatStore.currentSessionId`

## Verification

```
$ git diff --stat
.../SecretsManager.vue     |   6 +-
.../stores/useAppStore.ts  | 174 +--------------------
2 files changed, 5 insertions(+), 175 deletions(-)
```

```
$ grep -rn "appStore\.\(sessions\|currentSessionId\|...\)\|AppSessionMessage" src
(no results — zero orphan consumers)
```

`vue-tsc -p tsconfig.app.json`: 207 errors (baseline 208 — one fewer). Lint: 0 errors, 25 pre-existing warnings.

## Test plan

- [ ] Open app fresh — no "Welcome Chat" auto-created in localStorage `autobot-app` key
- [ ] Create a new chat in the sidebar — works (uses `useChatStore`, unchanged)
- [ ] Open SecretsManager → "Add Secret" → set scope to "chat" without picking a chat_id → it falls back to current session ID from `useChatStore`
- [ ] No console errors related to undefined session methods on the app store

## Closes

Closes #6813

Related: #6781 (chat-state SSOT), #6746 (umbrella)