### PR TITLE
fix(frontend/theme): apply dark theme via data-theme attribute, not class (#6772)

### DIFF
--- a/autobot-frontend/src/stores/useUserStore.ts
+++ b/autobot-frontend/src/stores/useUserStore.ts
@@ -213,15 +213,18 @@ export const useUserStore = defineStore('user', () => {
   }
 
   // Theme and accessibility helpers
+  // Theme is applied via the `data-theme` attribute to match the SSOT
+  // selector convention in src/assets/tailwind.css (`@variant dark
+  // (&:where([data-theme="dark"], [data-theme="dark"] *))`). Setting a
+  // `dark` class instead leaves Tailwind's `dark:` utilities and the
+  // design-token CSS unmatched, which is why /preferences could show
+  // "Dark" while pages still rendered in light mode (#6772).
   function applyTheme() {
     const currentTheme = theme.value
     const root = document.documentElement
 
-    if (currentTheme === 'dark') {
-      root.classList.add('dark')
-    } else {
-      root.classList.remove('dark')
-    }
+    root.setAttribute('data-theme', currentTheme)
+    root.style.colorScheme = currentTheme
 
     // Update meta theme-color for mobile browsers
     const metaThemeColor = document.querySelector('meta[name="theme-color"]')


### PR DESCRIPTION
## Summary
\`useUserStore.applyTheme()\` was setting \`class=\"dark\"\` on \`<html>\` while \`tailwind.css\` wires \`@variant dark\` to \`[data-theme=\"dark\"]\`. \`useTheme.ts\` correctly set the attribute, but \`useUserStore.applyTheme()\` (called from \`initializeFromStorage\` and \`updateTheme\`) silently un-darkened the DOM right after.

## Changes
- \`stores/useUserStore.ts:216\` — \`applyTheme()\` now sets \`document.documentElement.setAttribute('data-theme', ...)\` and \`document.documentElement.style.colorScheme\` instead of toggling a \`dark\` class
- The \`theme\` computed already resolves \`auto\` → \`light|dark\`, so single \`setAttribute\` covers both code paths

## Test plan
- [x] Theme: Dark in /preferences now actually renders dark
- [x] No \`classList.*('dark'...)\` calls remain in \`src/\`
- [x] vue-tsc clean (no new errors introduced)

Closes #6772