### PR TITLE
refactor(media): consolidate 5 Pipeline __init__ blocks via class-level constants (#6779)

### DIFF
--- a/autobot-backend/media/audio/pipeline.py
+++ b/autobot-backend/media/audio/pipeline.py
@@ -13,7 +13,7 @@ import base64
 import logging
 import os
 import tempfile
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from media.core.pipeline import BasePipeline
 from media.core.types import MediaInput, MediaType, ProcessingResult
@@ -54,25 +54,8 @@ def _get_whisper_pipeline() -> Optional[Any]:
 class AudioPipeline(BasePipeline):
     """Pipeline for processing audio content (voice, music, sound)."""
 
-    def __init__(
-        self,
-        pipeline_name: str = "audio",
-        supported_types: List[MediaType] = None,
-    ):
-        """Initialize audio processing pipeline.
-
-        Issue #6755: accepts the parent's full signature with sensible
-        defaults so factory callers (`cls(name, supported_types)`) keep
-        working. The historical no-arg call site is unaffected.
-        """
-        super().__init__(
-            pipeline_name=pipeline_name,
-            supported_types=(
-                supported_types
-                if supported_types is not None
-                else [MediaType.AUDIO]
-            ),
-        )
+    PIPELINE_NAME = "audio"
+    SUPPORTED_TYPES = [MediaType.AUDIO]
 
     async def _process_impl(self, media_input: MediaInput) -> ProcessingResult:
         """Process audio content."""

--- a/autobot-backend/media/core/pipeline.py
+++ b/autobot-backend/media/core/pipeline.py
@@ -10,7 +10,7 @@
 import logging
 import time
 from abc import ABC, abstractmethod
-from typing import List
+from typing import ClassVar, List, Optional
 
 from media.core.types import MediaInput, MediaType, PipelineMetrics, ProcessingResult
 
@@ -112,18 +112,53 @@ class BasePipeline(MediaPipeline):
     Base implementation of MediaPipeline with common functionality.
 
     Subclasses can override specific methods while inheriting shared logic.
+
+    Subclasses declare two class-level constants — ``PIPELINE_NAME`` and
+    ``SUPPORTED_TYPES`` — which serve as defaults when the constructor is
+    called with no arguments (the historical ``Pipeline()`` factory call).
+    Factory callers (``cls(name, supported_types)``) keep working because
+    explicit args still override the class-level defaults. This eliminated
+    five identical ``__init__`` blocks across the document/link/audio/video/
+    image subclasses (#6779, follow-up to #6755 / #6660).
     """
 
-    def __init__(self, pipeline_name: str, supported_types: List[MediaType]):
+    # Subclasses override these. ``None`` here means "no default" — passing
+    # ``None`` to ``__init__`` then raises so we never silently construct
+    # a misconfigured pipeline.
+    PIPELINE_NAME: ClassVar[Optional[str]] = None
+    SUPPORTED_TYPES: ClassVar[Optional[List[MediaType]]] = None
+
+    def __init__(
+        self,
+        pipeline_name: Optional[str] = None,
+        supported_types: Optional[List[MediaType]] = None,
+    ):
         """
         Initialize base pipeline.
 
         Args:
-            pipeline_name: Name identifier for this pipeline
-            supported_types: List of media types this pipeline supports
+            pipeline_name: Name identifier for this pipeline.  Falls back to
+                the subclass's ``PIPELINE_NAME`` class attribute when omitted.
+            supported_types: Media types this pipeline supports.  Falls back
+                to the subclass's ``SUPPORTED_TYPES`` class attribute when
+                omitted.
         """
-        super().__init__(pipeline_name)
-        self.supported_types = supported_types
+        resolved_name = pipeline_name if pipeline_name is not None else self.PIPELINE_NAME
+        if resolved_name is None:
+            raise TypeError(
+                f"{type(self).__name__} requires 'pipeline_name' argument or "
+                "PIPELINE_NAME class attribute"
+            )
+        resolved_types = (
+            supported_types if supported_types is not None else self.SUPPORTED_TYPES
+        )
+        if resolved_types is None:
+            raise TypeError(
+                f"{type(self).__name__} requires 'supported_types' argument or "
+                "SUPPORTED_TYPES class attribute"
+            )
+        super().__init__(resolved_name)
+        self.supported_types = resolved_types
 
     def supports(self, media_type: MediaType) -> bool:
         """Check if media type is in supported types list."""

--- a/autobot-backend/media/document/pipeline.py
+++ b/autobot-backend/media/document/pipeline.py
@@ -38,25 +38,8 @@ logger = logging.getLogger(__name__)
 class DocumentPipeline(BasePipeline):
     """Pipeline for processing document content (PDF, DOCX, TXT, etc.)."""
 
-    def __init__(
-        self,
-        pipeline_name: str = "document",
-        supported_types: List[MediaType] = None,
-    ):
-        """Initialize document processing pipeline.
-
-        Issue #6755: accepts the parent's full signature with sensible
-        defaults so factory callers (`cls(name, supported_types)`) keep
-        working. The historical no-arg call site is unaffected.
-        """
-        super().__init__(
-            pipeline_name=pipeline_name,
-            supported_types=(
-                supported_types
-                if supported_types is not None
-                else [MediaType.DOCUMENT, MediaType.TEXT]
-            ),
-        )
+    PIPELINE_NAME = "document"
+    SUPPORTED_TYPES = [MediaType.DOCUMENT, MediaType.TEXT]
 
     async def _process_impl(self, media_input: MediaInput) -> ProcessingResult:
         """Process document content."""

--- a/autobot-backend/media/image/pipeline.py
+++ b/autobot-backend/media/image/pipeline.py
@@ -12,7 +12,7 @@ import asyncio
 import base64
 import io
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from media.core.pipeline import BasePipeline
 from media.core.types import MediaInput, MediaType, ProcessingResult
@@ -56,25 +56,8 @@ def _get_vision_processor() -> Optional[Any]:
 class ImagePipeline(BasePipeline):
     """Pipeline for processing image content."""
 
-    def __init__(
-        self,
-        pipeline_name: str = "image",
-        supported_types: List[MediaType] = None,
-    ):
-        """Initialize image processing pipeline.
-
-        Issue #6755: accepts the parent's full signature with sensible
-        defaults so factory callers (`cls(name, supported_types)`) keep
-        working. The historical no-arg call site is unaffected.
-        """
-        super().__init__(
-            pipeline_name=pipeline_name,
-            supported_types=(
-                supported_types
-                if supported_types is not None
-                else [MediaType.IMAGE]
-            ),
-        )
+    PIPELINE_NAME = "image"
+    SUPPORTED_TYPES = [MediaType.IMAGE]
 
     async def _process_impl(self, media_input: MediaInput) -> ProcessingResult:
         """Process image content."""

--- a/autobot-backend/media/link/pipeline.py
+++ b/autobot-backend/media/link/pipeline.py
@@ -72,25 +72,8 @@ _jina_session_lock: Optional[asyncio.Lock] = None
 class LinkPipeline(BasePipeline):
     """Pipeline for processing web links and URLs."""
 
-    def __init__(
-        self,
-        pipeline_name: str = "link",
-        supported_types: List[MediaType] = None,
-    ):
-        """Initialize link processing pipeline.
-
-        Issue #6755: accepts the parent's full signature with sensible
-        defaults so factory callers (`cls(name, supported_types)`) keep
-        working. The historical no-arg call site is unaffected.
-        """
-        super().__init__(
-            pipeline_name=pipeline_name,
-            supported_types=(
-                supported_types
-                if supported_types is not None
-                else [MediaType.LINK]
-            ),
-        )
+    PIPELINE_NAME = "link"
+    SUPPORTED_TYPES = [MediaType.LINK]
 
     async def _process_impl(self, media_input: MediaInput) -> ProcessingResult:
         """Process link content."""

--- a/autobot-backend/media/video/pipeline.py
+++ b/autobot-backend/media/video/pipeline.py
@@ -72,25 +72,8 @@ _MAX_FRAMES = 5
 class VideoPipeline(BasePipeline):
     """Pipeline for processing video content."""
 
-    def __init__(
-        self,
-        pipeline_name: str = "video",
-        supported_types: List[MediaType] = None,
-    ):
-        """Initialize video processing pipeline.
-
-        Issue #6755: accepts the parent's full signature with sensible
-        defaults so factory callers (`cls(name, supported_types)`) keep
-        working. The historical no-arg call site is unaffected.
-        """
-        super().__init__(
-            pipeline_name=pipeline_name,
-            supported_types=(
-                supported_types
-                if supported_types is not None
-                else [MediaType.VIDEO]
-            ),
-        )
+    PIPELINE_NAME = "video"
+    SUPPORTED_TYPES = [MediaType.VIDEO]
 
     async def _process_impl(self, media_input: MediaInput) -> ProcessingResult:
         """Process video content."""


### PR DESCRIPTION
## Summary
PR #6777 added 5 nearly-identical \`__init__\` blocks across Document/Link/Audio/Video/Image pipelines, differing only in 2 literals each. Replaced with class-level constants + parent fallback.

## Approach
**Hybrid Option A** (class-level constants) + minimal parent change:
- \`BasePipeline.__init__\` now accepts \`Optional[str]\` / \`Optional[List[MediaType]]\` and falls back to class-level \`PIPELINE_NAME\` / \`SUPPORTED_TYPES\` when omitted
- Each subclass declares just \`PIPELINE_NAME = \"document\"\` + \`SUPPORTED_TYPES = [MediaType.DOCUMENT, MediaType.TEXT]\` instead of a 19-line \`__init__\` block

Pure Option B (delete \`__init__\`, hardcode args) was rejected because \`pipeline_constructor_compat_test.py\` (added in #6755) requires \`inspect.signature(cls.__init__)\` to expose \`pipeline_name\` + \`supported_types\` with defaults — pure Option B fails that contract.

## Stats
- 6 files changed: 1 parent + 5 subclasses
- **−50 LOC** net (103 deletions, 53 insertions)
- Each subclass: −16 to −19 lines of identical boilerplate

## Test plan
- [x] \`media/pipeline_constructor_compat_test.py\` — **10/10 PASS**
- [x] Manual smoke: \`cls()\` no-arg + \`cls('custom', [...])\` factory-style validated for all 5
- [x] Broader \`media/\` suite: identical pass/fail counts pre/post (8 pre-existing optional-dep failures unrelated)

Closes #6779