### PR TITLE
feat(system-health): post-#3333 follow-ups — boilerplate cleanup, KB metric, cache removal, breaker visibility, feature-routers probe (#6903 #6905 #6906 #6907 #6908)

### DIFF
--- a/autobot-backend/api/analytics_architecture.py
+++ b/autobot-backend/api/analytics_architecture.py
@@ -31,7 +31,6 @@ import aiofiles
 from fastapi import APIRouter, Depends, Query, Request
 
 from auth_middleware import check_admin_permission
-from api.system_health import ComponentHealth, register_health_probe
 from api.schemas_analytics import (
     AnalyticsArchitectureConsistencyResponse,
     AnalyticsArchitectureDiagramResponse,
@@ -1335,27 +1334,6 @@ async def check_consistency(
     }
 
 
-@register_health_probe("analytics_architecture")
-async def probe_analytics_architecture(
-    request: Optional[Request] = None,
-) -> ComponentHealth:
-    """Issue #3333: probe registration for the architecture analytics module."""
-    try:
-        return ComponentHealth(
-            name="analytics_architecture",
-            status="ok",
-            detail="module loaded",
-            data={
-                "available_patterns": len(PatternType),
-                "templates_loaded": len(PATTERN_TEMPLATES),
-            },
-        )
-    except Exception as exc:  # noqa: BLE001 - defensive, never re-raise
-        return ComponentHealth(
-            name="analytics_architecture",
-            status="down",
-            detail=f"probe error: {type(exc).__name__}",
-        )
 
 
 @router.get("/health", response_model=AnalyticsArchitectureHealthResponse, summary="Health check")

--- a/autobot-backend/api/analytics_cfg.py
+++ b/autobot-backend/api/analytics_cfg.py
@@ -27,7 +27,6 @@ from fastapi.responses import JSONResponse
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_path
-from api.system_health import ComponentHealth, register_health_probe
 from api.schemas_analytics import (
     CFGAnalyzeFileRequest,
     CFGAnalyzeRequest,
@@ -1365,23 +1364,6 @@ async def detect_infinite_loops(
     )
 
 
-@register_health_probe("analytics_cfg")
-async def probe_analytics_cfg(
-    request: Optional[Request] = None,
-) -> ComponentHealth:
-    """Issue #3333: probe registration for the CFG analytics module."""
-    try:
-        return ComponentHealth(
-            name="analytics_cfg",
-            status="ok",
-            detail="module loaded",
-        )
-    except Exception as exc:  # noqa: BLE001 - defensive, never re-raise
-        return ComponentHealth(
-            name="analytics_cfg",
-            status="down",
-            detail=f"probe error: {type(exc).__name__}",
-        )
 
 
 @router.get("/health", response_model=DataResponse)

--- a/autobot-backend/api/analytics_code_generation.py
+++ b/autobot-backend/api/analytics_code_generation.py
@@ -33,7 +33,6 @@ from auth_middleware import check_admin_permission
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
 from api.schemas_common import DataResponse
-from api.system_health import ComponentHealth, register_health_probe
 from api.schemas_analytics import (
     CodeGenerationHealthResponse,
     CodeGenerationRefactoringTypesResponse,
@@ -862,23 +861,6 @@ get_code_generation_engine = lazy_singleton(CodeGenerationEngine)
 # =============================================================================
 
 
-@register_health_probe("analytics_code_generation")
-async def probe_analytics_code_generation(
-    request: Optional[Request] = None,
-) -> ComponentHealth:
-    """Issue #3333: probe registration for the code-generation analytics module."""
-    try:
-        return ComponentHealth(
-            name="analytics_code_generation",
-            status="ok",
-            detail="module loaded",
-        )
-    except Exception as exc:  # noqa: BLE001 - defensive, never re-raise
-        return ComponentHealth(
-            name="analytics_code_generation",
-            status="down",
-            detail=f"probe error: {type(exc).__name__}",
-        )
 
 
 @router.get("/health", response_model=CodeGenerationHealthResponse)

--- a/autobot-backend/api/analytics_dfa.py
+++ b/autobot-backend/api/analytics_dfa.py
@@ -26,7 +26,6 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from auth_middleware import check_admin_permission
 from autobot_shared.security.path_validator import validate_path
-from api.system_health import ComponentHealth, register_health_probe
 from api.schemas_analytics import (
     DFAAnalysisResponse,
     DFAAnalyzeFileRequest,
@@ -1257,23 +1256,6 @@ async def list_sanitizers(admin_check: bool = Depends(check_admin_permission)):
     return {"sanitizers": sorted(SANITIZERS)}
 
 
-@register_health_probe("analytics_dfa")
-async def probe_analytics_dfa(
-    request: Optional[Request] = None,
-) -> ComponentHealth:
-    """Issue #3333: probe registration for the DFA analytics module."""
-    try:
-        return ComponentHealth(
-            name="analytics_dfa",
-            status="ok",
-            detail="module loaded",
-        )
-    except Exception as exc:  # noqa: BLE001 - defensive, never re-raise
-        return ComponentHealth(
-            name="analytics_dfa",
-            status="down",
-            detail=f"probe error: {type(exc).__name__}",
-        )
 
 
 @router.get("/health", response_model=DfaHealthResponse)

--- a/autobot-backend/api/analytics_llm_patterns.py
+++ b/autobot-backend/api/analytics_llm_patterns.py
@@ -27,7 +27,6 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Query, Request
 
-from api.system_health import ComponentHealth, register_health_probe
 from api.schemas_agent import (
     LLMPatternsAnalyzeResponse,
     LLMPatternsCacheOpportunitiesResponse,
@@ -940,23 +939,6 @@ def get_pattern_analyzer() -> LLMPatternAnalyzer:
 # =============================================================================
 
 
-@register_health_probe("analytics_llm_patterns")
-async def probe_analytics_llm_patterns(
-    request: Optional[Request] = None,
-) -> ComponentHealth:
-    """Issue #3333: probe registration for the LLM-patterns analytics module."""
-    try:
-        return ComponentHealth(
-            name="analytics_llm_patterns",
-            status="ok",
-            detail="module loaded",
-        )
-    except Exception as exc:  # noqa: BLE001 - defensive, never re-raise
-        return ComponentHealth(
-            name="analytics_llm_patterns",
-            status="down",
-            detail=f"probe error: {type(exc).__name__}",
-        )
 
 
 @router.get("/health", response_model=LLMPatternsHealthResponse)

--- a/autobot-backend/api/error_resilience.py
+++ b/autobot-backend/api/error_resilience.py
@@ -37,12 +37,48 @@ router = APIRouter(prefix="/api/resilience", tags=["resilience"])
 async def probe_error_resilience(
     request: Optional[Request] = None,
 ) -> ComponentHealth:
-    """Issue #3333: probe registration for error-resilience subsystem."""
+    """Issue #3333 / #6907: probe reflects actual breaker + budget state.
+
+    Singleton resolution alone hid the failure mode the file was designed
+    to surface (Issue #4342). Reports ``degraded`` when any circuit
+    breaker is open or any error budget is exhausted, and passes the
+    affected names through ``data`` for diagnostic dashboards.
+    """
     try:
-        get_circuit_breaker_manager()
-        get_error_budget_tracker()
-        get_fallback_manager()
-        return ComponentHealth(name="error_resilience", status="ok")
+        cb_status = get_circuit_breaker_manager().get_status()
+        budget_status = get_error_budget_tracker().get_status()
+        get_fallback_manager()  # liveness only — no rich state to inspect
+        open_breakers = [
+            name for name, cb in cb_status.items() if cb.get("state") == "open"
+        ]
+        exhausted_budgets = [
+            name
+            for name, budget in budget_status.items()
+            if budget.get("has_budget") is False
+        ]
+        if open_breakers or exhausted_budgets:
+            return ComponentHealth(
+                name="error_resilience",
+                status="degraded",
+                detail=(
+                    f"{len(open_breakers)} breaker(s) open, "
+                    f"{len(exhausted_budgets)} budget(s) exhausted"
+                ),
+                data={
+                    "open_breakers": open_breakers,
+                    "exhausted_budgets": exhausted_budgets,
+                    "total_breakers": len(cb_status),
+                    "total_budgets": len(budget_status),
+                },
+            )
+        return ComponentHealth(
+            name="error_resilience",
+            status="ok",
+            data={
+                "total_breakers": len(cb_status),
+                "total_budgets": len(budget_status),
+            },
+        )
     except Exception as exc:
         return ComponentHealth(
             name="error_resilience",

--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -1555,8 +1555,19 @@ async def upload_audio_file(
 async def probe_knowledge(
     request: Optional[Request] = None,
 ) -> ComponentHealth:
-    """Issue #3333: probe registration for the knowledge base."""
+    """Issue #3333: probe registration for the knowledge base.
+
+    Issue #6905: increments ``autobot_kb_degradation_total`` on every
+    degraded/down outcome with ``endpoint="probe"`` so the SLO dashboard
+    keeps the kb_uninit signal once the legacy /health route is sunset
+    by #6902.
+    """
+    from knowledge.metrics import autobot_kb_degradation_total
+
     if request is None or not hasattr(request.app.state, "knowledge_base"):
+        autobot_kb_degradation_total.labels(
+            endpoint="probe", reason="kb_uninit"
+        ).inc()
         return ComponentHealth(
             name="knowledge",
             status="degraded",
@@ -1565,11 +1576,17 @@ async def probe_knowledge(
     try:
         kb = await get_or_create_knowledge_base(request.app, force_refresh=False)
         if kb is None:
+            autobot_kb_degradation_total.labels(
+                endpoint="probe", reason="kb_uninit"
+            ).inc()
             return ComponentHealth(
                 name="knowledge", status="down", detail="kb instance is None"
             )
         return ComponentHealth(name="knowledge", status="ok")
     except Exception as exc:
+        autobot_kb_degradation_total.labels(
+            endpoint="probe", reason="probe_error"
+        ).inc()
         return ComponentHealth(
             name="knowledge",
             status="down",

--- a/autobot-backend/api/services.py
+++ b/autobot-backend/api/services.py
@@ -13,7 +13,6 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from api.system_health import ComponentHealth, register_health_probe
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from api.schemas_system import (
@@ -190,27 +189,6 @@ async def get_services(admin_check: bool = Depends(check_admin_permission)):
         raise HTTPException(status_code=500, detail="Failed to get services")
 
 
-@register_health_probe("services")
-async def probe_services(
-    request: Optional[Request] = None,
-) -> ComponentHealth:
-    """Issue #3333: probe registration for services module.
-
-    The legacy ``/health`` route is deprecated boilerplate (PR #3353), so this
-    probe is a static load check — if the module imported, it is ok.
-    """
-    try:
-        return ComponentHealth(
-            name="services",
-            status="ok",
-            detail="module loaded",
-        )
-    except Exception as exc:
-        return ComponentHealth(
-            name="services",
-            status="down",
-            detail=f"probe error: {type(exc).__name__}",
-        )
 
 
 @router.get("/health", response_model=ServicesHealthDeprecatedResponse)

--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -50,6 +50,65 @@ _ALLOWED_IMPORT_MODULES = (
 )
 
 
+# Issue #6908: surface feature-router partial-boot through the canonical
+# /api/system/health aggregator so oncall scrapers see the partial state
+# without scraping the dedicated /api/health/feature-routers endpoint.
+# Registers at import time alongside the rest of the system module.
+from api.system_health import (  # noqa: E402 — registration must happen at import
+    ComponentHealth,
+    register_health_probe,
+)
+
+
+@register_health_probe("feature_routers")
+async def _probe_feature_routers(request=None) -> ComponentHealth:
+    """Reflect ``_LOAD_RESULTS`` from #6797 into the canonical aggregator.
+
+    Per #6808, ``_LOAD_RESULTS`` is per-uvicorn-worker — each worker reports
+    its own snapshot. Cross-worker aggregation is tracked separately; this
+    probe is the per-worker view, which is sufficient for the canonical
+    surface to flag any partial boot.
+    """
+    try:
+        from initialization.router_registry.feature_routers import (
+            get_feature_router_load_results,
+        )
+
+        results = get_feature_router_load_results()
+        total = len(results)
+        if total == 0:
+            return ComponentHealth(
+                name="feature_routers",
+                status="degraded",
+                detail="load results empty — feature routers may not have been loaded yet",
+            )
+        loaded = [r for r in results if r.get("loaded")]
+        failed = [r for r in results if not r.get("loaded")]
+        if not failed:
+            return ComponentHealth(
+                name="feature_routers",
+                status="ok",
+                detail=f"{len(loaded)}/{total} routers loaded",
+                data={"loaded": len(loaded), "total": total},
+            )
+        return ComponentHealth(
+            name="feature_routers",
+            status="degraded",
+            detail=f"only {len(loaded)}/{total} routers loaded",
+            data={
+                "loaded": len(loaded),
+                "total": total,
+                "failed": [r.get("name") for r in failed],
+            },
+        )
+    except Exception as exc:
+        return ComponentHealth(
+            name="feature_routers",
+            status="down",
+            detail=f"probe error: {type(exc).__name__}",
+        )
+
+
 async def _check_conversation_files_db(request: Request, health_status: dict) -> None:
     """Check conversation files database health (Issue #315 - extracted)."""
     if not hasattr(request.app.state, "conversation_file_manager"):
@@ -199,7 +258,6 @@ async def get_frontend_config(admin_check: bool = Depends(check_admin_permission
 
 @router.get("/health", response_model=SystemHealthResponse)
 @router.get("/system/health", response_model=SystemHealthResponse)  # Frontend compatibility alias
-@cache_response(cache_key="system_health", ttl=30)  # Cache for 30 seconds
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_system_health",
@@ -218,6 +276,11 @@ async def get_system_health(
     string-valued statuses are merged into ``components`` to preserve the
     frontend ``HealthCheckResponse`` shape. Per-component diagnostic detail
     (latency, error reason, structured data) lives under ``probes``.
+
+    Issue #6906: ``@cache_response`` was removed because the embedded probe
+    results flip status second-by-second; a 30s TTL hid real failures.
+    Probe execution is bounded at ~2s by the registry's per-probe timeout,
+    so the uncached aggregator is acceptable on its own.
     """
     try:
         # Import app_state to get initialization status


### PR DESCRIPTION
## Summary

Five tightly-scoped follow-ups to #3333 (PR #6870). All discovered during the post-implementation gap audit; all five corresponding GitHub issues stay open until this PR merges.

| Commit | Issue | Change |
|---|---|---|
| `60c8396c3` | #6903 | Drop 6 always-`ok` probes that resurrected PR #3353-deprecated boilerplate (`analytics_architecture`, `analytics_cfg`, `analytics_code_generation`, `analytics_dfa`, `analytics_llm_patterns`, `services`). Probe count: 44 → 38. |
| `d0a2f4f46` | #6905 | `probe_knowledge` now increments `autobot_kb_degradation_total{endpoint=probe, reason=...}` on every degraded/down outcome — preserves the #5407 SLO signal once Phase 4 (#6902) sunsets the legacy route. |
| `a602b2b45` | #6907 | `probe_error_resilience` calls `cb_manager.get_status()` + `budget_tracker.get_status()`, reports `degraded` with affected names in `data` when any breaker is open or any budget exhausted. Was reporting `ok` regardless. |
| `5297129d9` | #6906 + #6908 | Drop `@cache_response(ttl=30)` from `/api/system/health` (was hiding flips for up to 30 s) AND register a `feature_routers` probe that reads `get_feature_router_load_results()` (#6797 helper) so partial-boot surfaces on the canonical aggregator. |

## Out of scope (still tracked)

- **#6904** — composable probe helpers (`probe_singleton`, `probe_redis_db`, `probe_app_state`). Larger refactor; deserves its own PR.
- **#6909** — vocabulary unification (probe `ok/degraded/down` vs legacy `healthy/unhealthy`). Blocked on #6902 deleting the 44 grace-period routes that hard-code legacy strings.
- **#6902** — Phase 4 sunset (route deletion, frontend caller migration).

## Test Plan

- [x] `pytest tests/test_system_health_registry.py` — 9/9 pass on the new branch
- [x] `python3 -m py_compile` for all 9 modified files — clean
- [x] Probe count: `grep -rln "@register_health_probe" autobot-backend/api/ | wc -l` = 38 + `system.py` registers `feature_routers` = 39 total
- [x] System.py docstring updated to document the cache removal
- [ ] Reviewer: smoke `curl /api/system/health` against a dev backend; confirm:
  - No `analytics_*` / `services` probe entries (deleted)
  - `feature_routers` entry present
  - `error_resilience.data` includes `total_breakers` / `total_budgets`
  - Two consecutive calls within 1s show distinct `timestamp` (cache disabled)

Closes #6903, #6905, #6906, #6907, #6908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)