### PR TITLE
refactor(orchestration): rename enhanced WorkflowPlanner → StrategyPlanner (#6817)

### DIFF
--- a/autobot-backend/enhanced_orchestration/__init__.py
+++ b/autobot-backend/enhanced_orchestration/__init__.py
@@ -36,7 +36,7 @@ from .types import (
     ExecutionStrategy,
     WorkflowPlan,
 )
-from .workflow_planning import WorkflowPlanner
+from .workflow_planning import StrategyPlanner
 from .workflow_runner import WorkflowRunner
 
 # Backward compatibility alias
@@ -53,7 +53,7 @@ __all__ = [
     # Strategy handler
     "ExecutionStrategyHandler",
     # Workflow planner
-    "WorkflowPlanner",
+    "StrategyPlanner",
     # Issue #3293: success criteria
     "SuccessCriteriaType",
     "SuccessCriteria",

--- a/autobot-backend/enhanced_orchestration/workflow_planning.py
+++ b/autobot-backend/enhanced_orchestration/workflow_planning.py
@@ -6,6 +6,13 @@ Workflow Planning Module
 
 Issue #381: Extracted from enhanced_multi_agent_orchestrator.py god class refactoring.
 Contains workflow planning, building, and utility functions.
+
+Note: The class in this module is named ``StrategyPlanner`` — not ``WorkflowPlanner`` —
+to distinguish it from the canonical (but currently unwired) ``orchestration.WorkflowPlanner``
+in ``autobot-backend/orchestration/workflow_planner.py``.  Both classes were historically
+called ``WorkflowPlanner`` and every import site aliased this one ``as StrategyPlanner``;
+the rename removes that aliasing smell (#6817).  The orphan status of the canonical class
+is tracked separately in #6820.
 """
 
 import logging
@@ -18,7 +25,7 @@ from .types import AgentCapability, AgentTask, ExecutionStrategy, WorkflowPlan
 logger = logging.getLogger(__name__)
 
 
-class WorkflowPlanner:
+class StrategyPlanner:
     """Handles workflow plan creation and task management."""
 
     def __init__(self, agent_capabilities: Dict[str, Set[AgentCapability]]):

--- a/autobot-backend/enhanced_orchestration/workflow_runner.py
+++ b/autobot-backend/enhanced_orchestration/workflow_runner.py
@@ -17,7 +17,7 @@ from enhanced_orchestration.collaboration_coordinator import CollaborationCoordi
 from enhanced_orchestration.execution_strategies import ExecutionStrategyHandler
 from enhanced_orchestration.success_criteria import SuccessCriteriaEvaluator
 from enhanced_orchestration.types import AgentTask, WorkflowDependencies, WorkflowPlan
-from enhanced_orchestration.workflow_planning import WorkflowPlanner as StrategyPlanner
+from enhanced_orchestration.workflow_planning import StrategyPlanner
 from event_manager import get_event_manager as _get_event_manager
 from orchestration.performance_tracker import PerformanceTracker
 

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -60,9 +60,7 @@ from enhanced_orchestration.types import (
 )
 from enhanced_orchestration.agent_router import AgentRouter
 from enhanced_orchestration.collaboration_coordinator import CollaborationCoordinator
-from enhanced_orchestration.workflow_planning import (
-    WorkflowPlanner as StrategyPlanner,
-)
+from enhanced_orchestration.workflow_planning import StrategyPlanner
 from enhanced_orchestration.workflow_runner import WorkflowRunner
 
 logger = get_logger("orchestrator")


### PR DESCRIPTION
## Summary

Closes #6817. Resolves the dual `WorkflowPlanner` name collision surfaced during the #4048 closure audit.

The class in [`enhanced_orchestration/workflow_planning.py`](autobot-backend/enhanced_orchestration/workflow_planning.py) was always imported `as StrategyPlanner` at every call site — the `as` alias was a code smell admitting the class was misnamed. This rename makes intent explicit and drops the alias.

The canonical `orchestration.workflow_planner.WorkflowPlanner` is unchanged (its orphan status is tracked separately in #6820).

## Changes

- `enhanced_orchestration/workflow_planning.py` — `class WorkflowPlanner` → `class StrategyPlanner`, docstring updated to explain the distinction
- `enhanced_orchestration/__init__.py` — export `StrategyPlanner` (was `WorkflowPlanner`)
- `orchestrator.py` — drop `as StrategyPlanner` alias
- `enhanced_orchestration/workflow_runner.py` — drop `as StrategyPlanner` alias

## Test plan

- [x] `grep -rn "enhanced_orchestration.*WorkflowPlanner" autobot-backend/ --include="*.py"` returns zero hits
- [x] `python3 -m pytest enhanced_orchestration/workflow_runner_test.py` — 6/6 pass
- [ ] Smoke-test `Orchestrator` boot in dev environment

## Acceptance criteria — implementation

- [x] Tests passing
- [x] No `as StrategyPlanner` aliasing in production code
- [x] One canonical `WorkflowPlanner` class remains in `orchestration/`

## Acceptance criteria — integration (#6836 gate)

This is a rename refactor — no new modules added. Integration check N/A; existing production callers continue to use the class via the new name.

Closes #6817

🤖 Generated with [Claude Code](https://claude.com/claude-code)