### PR TITLE
refactor(agents): rename AgentCapability dataclass → AgentCapabilityDescriptor (#6818)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/__init__.py
+++ b/autobot-backend/agents/agent_orchestration/__init__.py
@@ -35,7 +35,7 @@ from .types import (
     SUMMARIZATION_PATTERNS,
     SYSTEM_COMMAND_PATTERNS,
     TRANSLATION_PATTERNS,
-    AgentCapability,
+    AgentCapabilityDescriptor,
     AgentType,
     DistributedAgentInfo,
 )
@@ -43,7 +43,7 @@ from .types import (
 __all__ = [
     # Types and enums
     "AgentType",
-    "AgentCapability",
+    "AgentCapabilityDescriptor",
     "DistributedAgentInfo",
     "DEFAULT_AGENT_CAPABILITIES",
     # Pattern constants

--- a/autobot-backend/agents/agent_orchestration/routing.py
+++ b/autobot-backend/agents/agent_orchestration/routing.py
@@ -28,7 +28,7 @@ from .types import (
     SUMMARIZATION_PATTERNS,
     SYSTEM_COMMAND_PATTERNS,
     TRANSLATION_PATTERNS,
-    AgentCapability,
+    AgentCapabilityDescriptor,
     AgentType,
 )
 
@@ -40,7 +40,7 @@ class AgentRouter:
 
     def __init__(
         self,
-        agent_capabilities: Dict[AgentType, AgentCapability],
+        agent_capabilities: Dict[AgentType, AgentCapabilityDescriptor],
         llm_interface: Any,
     ):
         """

--- a/autobot-backend/agents/agent_orchestration/types.py
+++ b/autobot-backend/agents/agent_orchestration/types.py
@@ -144,7 +144,7 @@ class AgentType(Enum):
 
 
 @dataclass
-class AgentCapability:
+class AgentCapabilityDescriptor:
     """Describes an agent's capabilities and constraints."""
 
     agent_type: AgentType
@@ -182,7 +182,7 @@ class DistributedAgentInfo:
 
 # Default agent capabilities configuration
 DEFAULT_AGENT_CAPABILITIES = {
-    AgentType.CHAT: AgentCapability(
+    AgentType.CHAT: AgentCapabilityDescriptor(
         agent_type=AgentType.CHAT,
         model_size="1B",
         specialization="Conversational interactions",
@@ -199,7 +199,7 @@ DEFAULT_AGENT_CAPABILITIES = {
         ],
         resource_usage="Low",
     ),
-    AgentType.SYSTEM_COMMANDS: AgentCapability(
+    AgentType.SYSTEM_COMMANDS: AgentCapabilityDescriptor(
         agent_type=AgentType.SYSTEM_COMMANDS,
         model_size="1B",
         specialization="System command generation",
@@ -212,7 +212,7 @@ DEFAULT_AGENT_CAPABILITIES = {
         limitations=["Complex system analysis", "Multi-server orchestration"],
         resource_usage="Low",
     ),
-    AgentType.RAG: AgentCapability(
+    AgentType.RAG: AgentCapabilityDescriptor(
         agent_type=AgentType.RAG,
         model_size="3B",
         specialization="Document synthesis",
@@ -225,7 +225,7 @@ DEFAULT_AGENT_CAPABILITIES = {
         limitations=["Real-time data", "Interactive tasks"],
         resource_usage="Medium-High",
     ),
-    AgentType.KNOWLEDGE_RETRIEVAL: AgentCapability(
+    AgentType.KNOWLEDGE_RETRIEVAL: AgentCapabilityDescriptor(
         agent_type=AgentType.KNOWLEDGE_RETRIEVAL,
         model_size="1B",
         specialization="Fast fact lookup",
@@ -238,7 +238,7 @@ DEFAULT_AGENT_CAPABILITIES = {
         limitations=["Complex synthesis", "Cross-document analysis"],
         resource_usage="Low",
     ),
-    AgentType.RESEARCH: AgentCapability(
+    AgentType.RESEARCH: AgentCapabilityDescriptor(
         agent_type=AgentType.RESEARCH,
         model_size="3B + Playwright",
         specialization="Web research coordination",
@@ -252,7 +252,7 @@ DEFAULT_AGENT_CAPABILITIES = {
         resource_usage="High",
     ),
     # Issue #60: Specialized agent capabilities
-    AgentType.DATA_ANALYSIS: AgentCapability(
+    AgentType.DATA_ANALYSIS: AgentCapabilityDescriptor(
         agent_type=AgentType.DATA_ANALYSIS,
         model_size="3B",
         specialization="Data analysis and pattern detection",
@@ -260,7 +260,7 @@ DEFAULT_AGENT_CAPABILITIES = {
         limitations=["Large dataset processing", "Real-time streaming data"],
         resource_usage="Medium",
     ),
-    AgentType.CODE_GENERATION: AgentCapability(
+    AgentType.CODE_GENERATION: AgentCapabilityDescriptor(
         agent_type=AgentType.CODE_GENERATION,
         model_size="3B",
         specialization="Programming assistance and code generation",
@@ -268,7 +268,7 @@ DEFAULT_AGENT_CAPABILITIES = {
         limitations=["Complex system architecture", "Runtime debugging"],
         resource_usage="Medium",
     ),
-    AgentType.TRANSLATION: AgentCapability(
+    AgentType.TRANSLATION: AgentCapabilityDescriptor(
         agent_type=AgentType.TRANSLATION,
         model_size="1B",
         specialization="Multi-language translation",
@@ -280,7 +280,7 @@ DEFAULT_AGENT_CAPABILITIES = {
         limitations=["Rare languages", "Highly specialized jargon"],
         resource_usage="Low",
     ),
-    AgentType.SUMMARIZATION: AgentCapability(
+    AgentType.SUMMARIZATION: AgentCapabilityDescriptor(
         agent_type=AgentType.SUMMARIZATION,
         model_size="3B",
         specialization="Text and document summarization",
@@ -292,7 +292,7 @@ DEFAULT_AGENT_CAPABILITIES = {
         limitations=["Very long documents", "Technical precision"],
         resource_usage="Medium",
     ),
-    AgentType.SENTIMENT_ANALYSIS: AgentCapability(
+    AgentType.SENTIMENT_ANALYSIS: AgentCapabilityDescriptor(
         agent_type=AgentType.SENTIMENT_ANALYSIS,
         model_size="1B",
         specialization="Sentiment and emotion classification",
@@ -300,7 +300,7 @@ DEFAULT_AGENT_CAPABILITIES = {
         limitations=["Sarcasm detection", "Cultural nuance"],
         resource_usage="Low",
     ),
-    AgentType.IMAGE_ANALYSIS: AgentCapability(
+    AgentType.IMAGE_ANALYSIS: AgentCapabilityDescriptor(
         agent_type=AgentType.IMAGE_ANALYSIS,
         model_size="3B",
         specialization="Image analysis and vision tasks",
@@ -308,7 +308,7 @@ DEFAULT_AGENT_CAPABILITIES = {
         limitations=["Video processing", "3D reconstruction"],
         resource_usage="Medium-High",
     ),
-    AgentType.AUDIO_PROCESSING: AgentCapability(
+    AgentType.AUDIO_PROCESSING: AgentCapabilityDescriptor(
         agent_type=AgentType.AUDIO_PROCESSING,
         model_size="3B",
         specialization="Audio transcription and analysis",


### PR DESCRIPTION
## Summary

Closes #6818. Resolves the dual `AgentCapability` definition collision surfaced during the #4048 closure audit.

Two completely different classes shared the name `AgentCapability`:

1. `orchestration.types.AgentCapability` — `Enum` with 7 capability tags (RESEARCH, ANALYSIS, …). Canonical, widely imported. **Unchanged.**
2. `agents.agent_orchestration.types.AgentCapability` — `dataclass` with 5 fields (model_size, specialization, strengths, limitations, …). This is an *agent profile descriptor*, not a capability tag.

This PR renames the **dataclass** to `AgentCapabilityDescriptor` so its semantic role matches its name. The Enum is untouched.

## Changes

- `agents/agent_orchestration/types.py` — `class AgentCapability` (line 147) → `class AgentCapabilityDescriptor`; 12 instantiations in `DEFAULT_AGENT_CAPABILITIES` updated
- `agents/agent_orchestration/__init__.py` — import + `__all__` updated
- `agents/agent_orchestration/routing.py` — type hint `Dict[AgentType, AgentCapabilityDescriptor]` updated

Total: 14 caller references updated across 3 files.

## Test plan

- [x] `grep -rn "^class AgentCapability\b" autobot-backend --include="*.py"` returns one hit (the Enum) — collision resolved
- [x] `python3 -m pytest agents/agent_orchestration/` — 76 passed (1 pre-existing failure in `rl_router` confirmed present on the unmodified branch, unrelated)
- [x] Syntax check on modified files

## Acceptance criteria — implementation

- [x] Single class named `AgentCapability` in the codebase (the Enum)
- [x] All call sites updated
- [x] Tests passing (no new failures)

## Acceptance criteria — integration (#6836 gate)

Rename refactor — no new modules. Integration N/A.

Closes #6818

🤖 Generated with [Claude Code](https://claude.com/claude-code)