### PR TITLE
i18n(frontend/ui): wire OfflineBanner through vue-i18n (#6878)

### DIFF
--- a/autobot-frontend/src/components/ui/OfflineBanner.vue
+++ b/autobot-frontend/src/components/ui/OfflineBanner.vue
@@ -31,9 +31,9 @@
           />
         </svg>
         <span>
-          Backend connection lost — retrying. Cached data still available.
+          {{ t('ui.offlineBanner.backendLost') }}
           <span v-if="pendingCount > 0">
-            {{ pendingCount }} action{{ pendingCount === 1 ? '' : 's' }} queued for retry.
+            {{ t('ui.offlineBanner.queuedForRetry', { count: pendingCount }, pendingCount) }}
           </span>
         </span>
       </div>
@@ -42,7 +42,7 @@
         @click="retryNow"
         :disabled="isChecking"
       >
-        {{ isChecking ? 'Checking…' : 'Retry' }}
+        {{ isChecking ? t('ui.offlineBanner.checking') : t('ui.offlineBanner.retry') }}
       </button>
     </div>
   </Transition>
@@ -50,9 +50,11 @@
 
 <script lang="ts" setup>
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useNetworkStatus } from '@/composables/useNetworkStatus'
 import { useActionQueue } from '@/composables/useActionQueue'
 
+const { t } = useI18n()
 const { isOnline, isChecking } = useNetworkStatus()
 const { queue } = useActionQueue()
 

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -5179,6 +5179,12 @@
     "progressBar": {
       "timeRemaining": "{time} remaining"
     },
+    "offlineBanner": {
+      "backendLost": "Backend connection lost — retrying. Cached data still available.",
+      "queuedForRetry": "{count} action queued for retry. | {count} actions queued for retry.",
+      "checking": "Checking…",
+      "retry": "Retry"
+    },
     "systemStatus": {
       "dismissNotification": "Dismiss notification",
       "close": "Close",


### PR DESCRIPTION
## Summary

Replaces 4 hardcoded English strings in `OfflineBanner.vue` with `t()` calls, following the `BaseAlert.vue` / `DataTable.vue` / `MessageStatus.vue` pattern.

## Strings localized

| Original | Key |
|---|---|
| "Backend connection lost — retrying. Cached data still available." | `ui.offlineBanner.backendLost` |
| "{N} action{s} queued for retry." | `ui.offlineBanner.queuedForRetry` (vue-i18n plural form) |
| "Checking…" | `ui.offlineBanner.checking` |
| "Retry" | `ui.offlineBanner.retry` |

`queuedForRetry` uses vue-i18n 11's explicit plural syntax (`{count} X | {count} Xs`) and is invoked with `pendingCount` as the 3rd positional arg, matching existing `AuditLogTable` / `SecretsManager` usage.

## Test plan

- [x] en.json parses as valid JSON
- [x] Pattern matches existing useI18n/t() callers in `src/components/ui/`
- [ ] Visual smoke test: kill backend, verify banner shows localized copy
- [ ] CI type-check

Closes #6878