### PR TITLE
feat(ci): generalize hook→CI wrapper to no-direct-redis + no-print-console (closes #6785)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -113,6 +113,12 @@ jobs:
     - name: Block hardcoded-IP fallback regressions (#6783)
       run: bash pipeline-scripts/check-hardcoded-ip-fallbacks-pr.sh
 
+    - name: Block direct redis client regressions (#1086, #6785)
+      run: bash pipeline-scripts/check-pre-commit-hook-pr.sh pre-commit-no-direct-redis
+
+    - name: Block print/console regressions (#1082, #6785)
+      run: bash pipeline-scripts/check-pre-commit-hook-pr.sh pre-commit-no-print-console
+
     - name: Check for unused imports with autoflake
       run: |
         source .venv/bin/activate

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-direct-redis
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-direct-redis
@@ -32,9 +32,16 @@ NC='\033[0m'
 
 VIOLATIONS=0
 
-# Get staged Python files (production code only)
+# Get Python files to scan (production code only).
+# Issue #6785: when called with file paths as positional args (CI on a PR),
+# use those instead of the staged-files lookup. Lets the same hook run as
+# both a local pre-commit AND a CI gate. Allowlist applies to either source.
 get_staged_python_files() {
-    git diff --cached --name-only --diff-filter=ACM 2>/dev/null | \
+    if [ "$#" -gt 0 ]; then
+        printf '%s\n' "$@"
+    else
+        git diff --cached --name-only --diff-filter=ACM 2>/dev/null
+    fi | \
         grep -E '\.py$' | \
         grep -v -E '(__pycache__|node_modules|\.venv|venv|archive|temp)' | \
         grep -v -E '(_test\.py$|\.e2e_test\.py$|\.integration_test\.py$|\.performance_test\.py$)' | \
@@ -150,7 +157,7 @@ main() {
     echo ""
 
     local py_files
-    py_files=$(get_staged_python_files)
+    py_files=$(get_staged_python_files "$@")
 
     if [[ -z "$py_files" ]]; then
         echo -e "${GREEN}No production Python files staged for commit.${NC}"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console
@@ -32,9 +32,15 @@ NC='\033[0m'
 
 VIOLATIONS=0
 
-# Get staged Python files (production code only)
+# Get Python files to scan (production code only).
+# Issue #6785: positional args override the staged-files lookup (CI argv mode).
+# Same allowlist applies regardless of source.
 get_staged_python_files() {
-    git diff --cached --name-only --diff-filter=ACM 2>/dev/null | \
+    if [ "$#" -gt 0 ]; then
+        printf '%s\n' "$@"
+    else
+        git diff --cached --name-only --diff-filter=ACM 2>/dev/null
+    fi | \
         grep -E '\.py$' | \
         grep -v -E '(__pycache__|node_modules|\.venv|venv|archive|temp)' | \
         grep -v -E '(_test\.py$|\.e2e_test\.py$|\.integration_test\.py$|\.performance_test\.py$)' | \
@@ -44,9 +50,14 @@ get_staged_python_files() {
         grep -v -E '(ansible/)' || true  # code_analysis: CLI output; ansible: deployed copies with doctest examples
 }
 
-# Get staged TypeScript/Vue files (production code only)
+# Get TypeScript/Vue files to scan (production code only).
+# Issue #6785: positional args override the staged-files lookup (CI argv mode).
 get_staged_ts_files() {
-    git diff --cached --name-only --diff-filter=ACM 2>/dev/null | \
+    if [ "$#" -gt 0 ]; then
+        printf '%s\n' "$@"
+    else
+        git diff --cached --name-only --diff-filter=ACM 2>/dev/null
+    fi | \
         grep -E '\.(ts|vue|js)$' | \
         grep -v -E '(node_modules|\.venv|venv|archive|temp|dist)' | \
         grep -v -E '(\.spec\.(ts|js)$|\.test\.(ts|js)$|\.e2e\.(ts|js)$|-test\.(ts|js)$)' | \
@@ -119,8 +130,8 @@ main() {
     echo ""
 
     local py_files ts_files
-    py_files=$(get_staged_python_files)
-    ts_files=$(get_staged_ts_files)
+    py_files=$(get_staged_python_files "$@")
+    ts_files=$(get_staged_ts_files "$@")
 
     if [[ -z "$py_files" ]] && [[ -z "$ts_files" ]]; then
         echo -e "${GREEN}No production files staged for commit.${NC}"

--- a/docs/developer/HARDCODING_PREVENTION.md
+++ b/docs/developer/HARDCODING_PREVENTION.md
@@ -95,6 +95,26 @@ Doesn't trigger on:
 
 Test fixtures live in `autobot-frontend/eslint-tests/` (excluded from production lint by design — see `eslint-tests/README.md`).
 
+### Generic CI wrapper for any pre-commit hook (Issue #6785)
+
+`pipeline-scripts/check-pre-commit-hook-pr.sh <hook-name>` runs any pre-commit hook in argv mode against the PR's changed files. Hooks that support argv mode today:
+
+- `pre-commit-hardcoded-values` (#6725) — wrapped by `check-hardcoded-values-pr.sh`
+- `pre-commit-no-direct-redis` (#1086, argv mode added in #6785)
+- `pre-commit-no-print-console` (#1082, argv mode added in #6785)
+
+To add a new hook to CI:
+
+1. Add argv mode to the hook (positional args = files to scan, no args = `git diff --cached`).
+2. Add a step in `.github/workflows/code-quality.yml`:
+
+   ```yaml
+   - name: Block <thing> regressions (#issue)
+     run: bash pipeline-scripts/check-pre-commit-hook-pr.sh <hook-name>
+   ```
+
+3. Optionally add a test class in `pipeline-scripts/check-pre-commit-hook-pr_test.py` for end-to-end coverage.
+
 ### Manual Scan
 
 Run the detection script manually to audit the entire codebase:

--- a/pipeline-scripts/check-pre-commit-hook-pr.sh
+++ b/pipeline-scripts/check-pre-commit-hook-pr.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Generic CI wrapper for any pre-commit hook that supports argv mode.
+# Issue #6785 (follow-up to #6725 / #6783): closes the bypass gap for
+# pre-commit hooks across the board, not just hardcoded-values.
+#
+# Each hook gets an argv mode (positional args = files to scan, no args =
+# fall back to git diff --cached). This wrapper computes the changed-file
+# set for the PR/push context and invokes the hook in argv mode.
+#
+# Usage:
+#   bash pipeline-scripts/check-pre-commit-hook-pr.sh <hook-name>
+#
+# Example (in a GitHub Actions step):
+#   - run: bash pipeline-scripts/check-pre-commit-hook-pr.sh pre-commit-no-print-console
+#
+# Inputs (env, all optional — defaults derived from git/GH Actions):
+#   BASE_SHA          explicit PR base SHA
+#   HEAD_SHA          explicit head SHA (default: HEAD or GITHUB_SHA)
+#   GITHUB_BASE_REF   PR target branch (set by GH Actions)
+#   GITHUB_SHA        commit SHA (set by GH Actions)
+#
+# The hook script must:
+#   1. Live at autobot-infrastructure/shared/scripts/hooks/<hook-name>
+#   2. Accept positional args as a file list (override git diff --cached)
+#   3. Exit 1 on violations, 0 on clean
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <hook-name>" >&2
+    echo "Example: $0 pre-commit-no-print-console" >&2
+    exit 2
+fi
+
+HOOK_NAME="$1"
+HOOK_PATH="$(dirname "$0")/../autobot-infrastructure/shared/scripts/hooks/${HOOK_NAME}"
+
+if [ ! -f "$HOOK_PATH" ]; then
+    echo "Hook script not found: $HOOK_PATH" >&2
+    exit 2
+fi
+
+BASE_SHA="${BASE_SHA:-}"
+HEAD_SHA="${HEAD_SHA:-${GITHUB_SHA:-HEAD}}"
+
+if [ -z "$BASE_SHA" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+    BASE_SHA=$(git rev-parse "origin/${GITHUB_BASE_REF}" 2>/dev/null || true)
+fi
+
+if [ -n "$BASE_SHA" ]; then
+    base="$BASE_SHA"
+else
+    base="${HEAD_SHA}^"
+fi
+
+# Cast a wide net (all relevant source extensions); the hook itself
+# applies its category-specific allowlist.
+files=$(git diff --name-only "$base" "$HEAD_SHA" -- '*.py' '*.ts' '*.tsx' '*.vue' '*.js' '*.mjs' \
+    | while read -r f; do [ -f "$f" ] && printf '%s\n' "$f"; done \
+    || true)
+
+if [ -z "$files" ]; then
+    echo "No changed source files — skipping ${HOOK_NAME}."
+    exit 0
+fi
+
+count=$(echo "$files" | wc -l)
+echo "Running ${HOOK_NAME} against $count changed file(s)..."
+# shellcheck disable=SC2086
+bash "$HOOK_PATH" $files

--- a/pipeline-scripts/check-pre-commit-hook-pr_test.py
+++ b/pipeline-scripts/check-pre-commit-hook-pr_test.py
@@ -1,0 +1,142 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for pipeline-scripts/check-pre-commit-hook-pr.sh (#6785).
+
+Confirms the generic CI wrapper:
+
+1. Routes the right hook based on argv[1].
+2. Skips cleanly when no source files changed.
+3. Forwards an explicit file list to the hook in argv mode (so the hook's
+   allowlist is the only filter that matters).
+4. Surfaces hook exit codes (1 = violation, 0 = clean).
+
+Each test creates a tmp git repo, sets up a synthetic PR commit, and runs
+the wrapper with BASE_SHA/HEAD_SHA pointing at it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = REPO_ROOT / "pipeline-scripts" / "check-pre-commit-hook-pr.sh"
+
+
+def _make_pr(tmp_path: Path, files: dict[str, str]) -> tuple[str, str]:
+    """Create a tmp git repo with one base commit + one 'PR' commit.
+
+    Returns (base_sha, head_sha) suitable for BASE_SHA/HEAD_SHA env.
+    """
+    subprocess.run(["git", "init", "--quiet"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    # Empty base commit so we have something to diff against.
+    (tmp_path / ".gitkeep").write_text("", encoding="utf-8")
+    subprocess.run(["git", "add", ".gitkeep"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "base"],
+        cwd=tmp_path,
+        check=True,
+    )
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    # Add the PR's files in a second commit.
+    for rel, content in files.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        subprocess.run(["git", "add", rel], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "pr"],
+        cwd=tmp_path,
+        check=True,
+    )
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    # Hooks live at <REPO_ROOT>/autobot-infrastructure/...; tmp_path doesn't
+    # have those, so we run the wrapper from the real REPO_ROOT and pass
+    # the diff endpoints via env. The wrapper does `git diff` on cwd's repo;
+    # to make that match tmp_path's diff, we cd to tmp_path AND point GIT_DIR.
+    return base, head
+
+
+def _run_wrapper(
+    tmp_path: Path, hook_name: str, base: str, head: str
+) -> subprocess.CompletedProcess:
+    """Run the wrapper inside ``tmp_path`` so its `git diff` finds the test repo."""
+    return subprocess.run(
+        ["bash", str(WRAPPER), hook_name],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env={"BASE_SHA": base, "HEAD_SHA": head, "PATH": "/usr/bin:/bin"},
+    )
+
+
+@pytest.mark.skipif(not WRAPPER.exists(), reason="wrapper script not found")
+class TestArgvDispatch:
+    """The wrapper's first arg picks which hook to run."""
+
+    def test_unknown_hook_name_exits_2(self, tmp_path: Path) -> None:
+        base, head = _make_pr(tmp_path, {"a.py": "x = 1\n"})
+        result = subprocess.run(
+            ["bash", str(WRAPPER), "pre-commit-does-not-exist"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env={"BASE_SHA": base, "HEAD_SHA": head, "PATH": "/usr/bin:/bin"},
+        )
+        assert result.returncode == 2
+        assert "not found" in result.stderr.lower()
+
+    def test_missing_arg_exits_2(self, tmp_path: Path) -> None:
+        result = subprocess.run(
+            ["bash", str(WRAPPER)],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+        assert "Usage" in result.stderr
+
+
+@pytest.mark.skipif(not WRAPPER.exists(), reason="wrapper script not found")
+class TestNoChangedFiles:
+    """Skip cleanly when the diff has no source files."""
+
+    def test_no_relevant_files_exits_0(self, tmp_path: Path) -> None:
+        base, head = _make_pr(tmp_path, {"docs/notes.md": "# unrelated\n"})
+        result = _run_wrapper(tmp_path, "pre-commit-no-print-console", base, head)
+        assert result.returncode == 0
+        assert "No changed source files" in result.stdout
+
+
+@pytest.mark.skipif(not WRAPPER.exists(), reason="wrapper script not found")
+class TestForwardsArgvToHooks:
+    """End-to-end: wrapper passes argv to hooks correctly."""
+
+    def test_no_print_console_blocks_print(self, tmp_path: Path) -> None:
+        # Production .py with a print() call must trip the no-print hook
+        base, head = _make_pr(tmp_path, {"src/worker.py": 'print("hi")\n'})
+        result = _run_wrapper(tmp_path, "pre-commit-no-print-console", base, head)
+        assert result.returncode != 0
+
+    def test_no_print_console_allows_test_files(self, tmp_path: Path) -> None:
+        # Test files are allowlisted by the hook's filter
+        base, head = _make_pr(tmp_path, {"src/foo_test.py": 'print("hi")\n'})
+        result = _run_wrapper(tmp_path, "pre-commit-no-print-console", base, head)
+        assert result.returncode == 0
+
+    def test_no_direct_redis_blocks_bare_redis(self, tmp_path: Path) -> None:
+        # `redis.Redis()` direct instantiation in production code
+        base, head = _make_pr(
+            tmp_path, {"src/r.py": "import redis\nclient = redis.Redis()\n"}
+        )
+        result = _run_wrapper(tmp_path, "pre-commit-no-direct-redis", base, head)
+        assert result.returncode != 0


### PR DESCRIPTION
Closes #6785. Final follow-up in the recommended sequence after #6715.

## Summary

Generalizes the hook→CI wrapper pattern from #6725 / #6783 (which had per-hook wrappers for hardcoded-values + IP fallbacks) into one shared script + adds 2 more pre-commit hooks to the CI gate.

## Diff

| File | Change |
|------|--------|
| ``pipeline-scripts/check-pre-commit-hook-pr.sh`` | new — generic CI wrapper, takes ``<hook-name>`` argv |
| ``pipeline-scripts/check-pre-commit-hook-pr_test.py`` | new — 6 end-to-end tests |
| ``pre-commit-no-direct-redis`` | argv mode added (#1086) |
| ``pre-commit-no-print-console`` | argv mode added (#1082) |
| ``code-quality.yml`` | +2 steps invoking the generic wrapper |
| ``HARDCODING_PREVENTION.md`` | new section: 'Generic CI wrapper for any pre-commit hook' |

## Test coverage

6 tests in ``check-pre-commit-hook-pr_test.py``, all passing:

- ``test_unknown_hook_name_exits_2`` — argv dispatch error
- ``test_missing_arg_exits_2`` — usage error
- ``test_no_relevant_files_exits_0`` — clean skip when diff has no source files
- ``test_no_print_console_blocks_print`` — end-to-end: ``print(\"hi\")`` in production code blocked
- ``test_no_print_console_allows_test_files`` — allowlist still works (test files exempt)
- ``test_no_direct_redis_blocks_bare_redis`` — end-to-end: ``redis.Redis()`` in production code blocked

## Out of scope (deliberate)

- **``pre-commit-detect-mass-deletions``** — semantically a diff-counter, not a file-list scanner. ``git diff --cached --diff-filter=D | wc -l > 50`` doesn't fit the argv pattern. Separate issue worth filing if CI gating becomes desirable, but the local-only behavior is also defensible (mass-deletions is about a clumsy ``rm -rf`` mid-commit, not something that lands in PRs deliberately).
- **``pre-commit-branch-guard``**, **``pre-commit-target-branch-guard``**, **``pre-commit-warn-untracked``**, **``pre-commit-worktree-branch-guard``** — all operate on git state (which branch you're on, what's in the index, etc.), not file content. Commit-time-only by nature. Not CI-relevant.

## Sequence complete

| Step | What | Status |
|------|------|--------|
| 1 | #6723 — required ``smoke-test`` gating | ✅ live |
| 2 | #6782 + #6783 — temp filter + AST validator | ✅ #6882 merged |
| 3 | #6786 — 8 untested hook category tests | 🟡 #6945 in CI |
| 4 | #6784 — ESLint rule | 🟡 #6949 in CI |
| 5 | #6785 — generalize hook→CI wrapper | 🟡 this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)