### PR TITLE
chore(frontend/ui): remove dead useAppStore import in SystemStatusNotification (#6879)

### DIFF
--- a/autobot-frontend/src/components/ui/SystemStatusNotification.vue
+++ b/autobot-frontend/src/components/ui/SystemStatusNotification.vue
@@ -182,7 +182,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useAppStore } from '@/stores/useAppStore'
 
 // Now using wrapper div to avoid fragment root issues
 
@@ -228,7 +227,6 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const appStore = useAppStore()
 
 // Computed properties for notification data
 const notificationData = computed(() => {


### PR DESCRIPTION
## Summary

Removes a dead `useAppStore` import + instantiation from `SystemStatusNotification.vue`. The component imports the store, calls `useAppStore()`, then never reads anything from the resulting object — verified by reading the entire post-instantiation script body.

## Why this is dead, not unwired

The component reads all its data from props (`visible`, `severity`, `title`, `message`, `statusDetails`, etc.). There's no documented plan that it should consume app-state. This is leftover from a refactor, not infrastructure-by-design. If a future change decides otherwise, re-adding the import is trivial.

## Test plan

- [x] All `appStore` references removed
- [x] No other behavior touched
- [ ] Type-check
- [ ] Visual smoke (notification still renders correctly)

Closes #6879