### PR TITLE
feat(workflow): Phase 1b — canonical WorkflowTask + WorkflowPlan (#6951)

### DIFF
--- a/autobot_shared/workflow/__init__.py
+++ b/autobot_shared/workflow/__init__.py
@@ -1,0 +1,31 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Canonical workflow types for cross-service consolidation (#6951).
+
+This module is the single source of truth for `WorkflowTask`, `WorkflowPlan`,
+`PromptSpec`, and `ExecutionStrategy`. Phase 2 of #6951 migrates the existing
+8 step shapes / 4 task shapes / 2 template shapes onto these canonical types,
+completing the consolidation that #381 did not finish.
+
+Usage:
+    from autobot_shared.workflow import WorkflowTask, WorkflowPlan, PromptSpec
+
+The shapes intentionally treat ``prompt`` and ``tools_allowed`` / ``tools_denied``
+as first-class fields. Existing duplicate shapes smuggle prompts inside
+``action: str`` strings and have no per-step tool gates.
+"""
+
+from autobot_shared.workflow.types import (
+    ExecutionStrategy,
+    PromptSpec,
+    WorkflowPlan,
+    WorkflowTask,
+)
+
+__all__ = [
+    "ExecutionStrategy",
+    "PromptSpec",
+    "WorkflowPlan",
+    "WorkflowTask",
+]

--- a/autobot_shared/workflow/types.py
+++ b/autobot_shared/workflow/types.py
@@ -1,0 +1,141 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Canonical workflow data shapes (#6951).
+
+This module defines the single canonical ``WorkflowTask`` and ``WorkflowPlan``
+that replace the eight step shapes and four task shapes that grew out of the
+incomplete #381 god-class refactor (closed 2025-12-19, work was extracted
+into 3 separate type modules instead of consolidating into one).
+
+Design choices
+
+* **First-class prompt** — ``WorkflowTask.prompt`` is a structured
+  ``PromptSpec`` with system/user split + template variables + version, instead
+  of being smuggled into the ``action: str`` field as the existing shapes do.
+  This enables prompt versioning for cache-key purposes and explicit template
+  substitution contracts.
+* **First-class tool gates** — ``tools_allowed`` and ``tools_denied`` let a
+  step constrain its toolset independently of the agent's capabilities. The
+  existing shapes have no per-step tool gate, so a step can only restrict
+  tools by switching agents. ``None`` for ``tools_allowed`` means "inherit
+  from agent" (current behaviour).
+* **Plain string status** — the field type stays ``str`` (matching every
+  existing shape) so callers can use ``constants.status_enums.TaskStatus``
+  values without ``autobot_shared`` taking a dependency on ``autobot-backend``.
+* **Plain string capabilities** — same layering reason; callers can pass
+  ``AgentCapability.value`` strings.
+* **Both ``action`` and ``command``** — ``action`` is the agent-dispatched
+  verb (``summarize_report``, ``run_audit``); ``command`` is the optional
+  shell command (``echo 'hello'``). The existing shapes split this concern
+  across ``action`` (orchestration/enhanced/templates) and ``command``
+  (services/workflow_automation, overseer); the union accommodates both.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class ExecutionStrategy(Enum):
+    """Plan-level execution strategy.
+
+    Promoted from ``enhanced_orchestration.types.ExecutionStrategy`` (#381 work
+    that should have landed here in the first place).
+    """
+
+    SEQUENTIAL = "sequential"
+    PARALLEL = "parallel"
+    PIPELINE = "pipeline"
+    COLLABORATIVE = "collaborative"
+    ADAPTIVE = "adaptive"
+
+
+@dataclass
+class PromptSpec:
+    """Structured prompt for a workflow task.
+
+    Replaces the pattern of smuggling prompt content inside ``action: str`` or
+    burying it in ``inputs["prompt"]``. The ``version`` field enables prompt
+    cache-key versioning (compatible with #3185 LLMService cache layer).
+    """
+
+    user_prompt: str
+    system_prompt: Optional[str] = None
+    template_vars: Dict[str, Any] = field(default_factory=dict)
+    version: str = "1"
+
+
+@dataclass
+class WorkflowTask:
+    """Canonical task shape — single source of truth for #6951 Phase 2.
+
+    Field union absorbs every field from the four existing task shapes:
+    ``orchestration.types.WorkflowStep``, ``enhanced_orchestration.types.AgentTask``,
+    ``workflow_templates.types.WorkflowStep``, ``services/workflow_automation.WorkflowStep``,
+    and ``agents/overseer/types.AgentTask``. ``orchestration.sub_workflow.SubWorkflowStep``
+    is intentionally NOT absorbed — it represents a distinct concern (sub-workflow
+    invocation, #2143) and stays separate.
+    """
+
+    task_id: str
+    description: str
+
+    agent_type: Optional[str] = None
+    action: Optional[str] = None
+    command: Optional[str] = None
+
+    prompt: Optional[PromptSpec] = None
+    tools_allowed: Optional[List[str]] = None
+    tools_denied: List[str] = field(default_factory=list)
+
+    inputs: Dict[str, Any] = field(default_factory=dict)
+    expected_outputs: Optional[Dict[str, str]] = None
+    outputs: Optional[Dict[str, Any]] = None
+
+    dependencies: List[str] = field(default_factory=list)
+    requires_approval: bool = False
+    priority: int = 5
+    timeout_seconds: float = 300.0
+    max_retries: int = 3
+    retry_count: int = 0
+
+    capabilities_required: List[str] = field(default_factory=list)
+    estimated_duration_seconds: float = 0.0
+
+    status: str = "pending"
+    error: Optional[str] = None
+    start_time: Optional[float] = None
+    end_time: Optional[float] = None
+
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class WorkflowPlan:
+    """Canonical plan shape — single source of truth for #6951 Phase 2.
+
+    Field union absorbs every field from the two existing plan shapes:
+    ``orchestration.types.WorkflowPlan`` (workflow_id, approval_required, approved)
+    and ``enhanced_orchestration.types.WorkflowPlan`` (plan_id, goal, strategy,
+    dependencies_graph, success_criteria, fallback_plans).
+    """
+
+    plan_id: str
+    goal: str
+    tasks: List[WorkflowTask]
+
+    description: str = ""
+    strategy: ExecutionStrategy = ExecutionStrategy.SEQUENTIAL
+    dependencies_graph: Dict[str, List[str]] = field(default_factory=dict)
+    estimated_total_duration_seconds: float = 0.0
+    resource_requirements: Dict[str, Any] = field(default_factory=dict)
+    success_criteria: List[str] = field(default_factory=list)
+    fallback_plans: List["WorkflowPlan"] = field(default_factory=list)
+
+    approval_required: bool = True
+    approved: bool = False
+    status: str = "pending"
+
+    created_at_epoch: Optional[float] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)

--- a/autobot_shared/workflow/types_test.py
+++ b/autobot_shared/workflow/types_test.py
@@ -1,0 +1,140 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for autobot_shared.workflow.types (#6951)."""
+
+from autobot_shared.workflow import (
+    ExecutionStrategy,
+    PromptSpec,
+    WorkflowPlan,
+    WorkflowTask,
+)
+
+
+def test_workflow_task_minimal_construction():
+    """Only task_id and description are required."""
+    t = WorkflowTask(task_id="t1", description="do the thing")
+    assert t.task_id == "t1"
+    assert t.description == "do the thing"
+    assert t.status == "pending"
+    assert t.prompt is None
+    assert t.tools_allowed is None
+    assert t.tools_denied == []
+    assert t.inputs == {}
+    assert t.dependencies == []
+    assert t.metadata == {}
+
+
+def test_workflow_task_first_class_prompt():
+    """PromptSpec attaches to the task and preserves all fields."""
+    spec = PromptSpec(
+        user_prompt="summarize {report}",
+        system_prompt="you are a helpful summarizer",
+        template_vars={"report": "Q3 sales"},
+        version="2",
+    )
+    t = WorkflowTask(task_id="t1", description="summarize", prompt=spec)
+    assert t.prompt is spec
+    assert t.prompt.user_prompt == "summarize {report}"
+    assert t.prompt.system_prompt == "you are a helpful summarizer"
+    assert t.prompt.template_vars == {"report": "Q3 sales"}
+    assert t.prompt.version == "2"
+
+
+def test_workflow_task_first_class_tool_gates():
+    """tools_allowed=None means inherit; explicit list locks the toolset."""
+    inherit = WorkflowTask(task_id="t1", description="d")
+    assert inherit.tools_allowed is None
+
+    locked = WorkflowTask(
+        task_id="t2",
+        description="d",
+        tools_allowed=["read_file", "grep"],
+        tools_denied=["shell_exec"],
+    )
+    assert locked.tools_allowed == ["read_file", "grep"]
+    assert locked.tools_denied == ["shell_exec"]
+
+
+def test_workflow_task_action_and_command_coexist():
+    """``action`` (agent verb) and ``command`` (shell exec) are independent fields."""
+    t = WorkflowTask(
+        task_id="t1",
+        description="d",
+        action="run_audit",
+        command="bash audit.sh",
+    )
+    assert t.action == "run_audit"
+    assert t.command == "bash audit.sh"
+
+
+def test_workflow_task_default_factory_isolation():
+    """Mutating one task's mutable defaults must not affect another's."""
+    t1 = WorkflowTask(task_id="t1", description="d")
+    t2 = WorkflowTask(task_id="t2", description="d")
+    t1.dependencies.append("d1")
+    t1.tools_denied.append("shell")
+    t1.inputs["k"] = "v"
+    assert t2.dependencies == []
+    assert t2.tools_denied == []
+    assert t2.inputs == {}
+
+
+def test_prompt_spec_minimal_construction():
+    """Only user_prompt is required; other fields default sensibly."""
+    spec = PromptSpec(user_prompt="hello")
+    assert spec.user_prompt == "hello"
+    assert spec.system_prompt is None
+    assert spec.template_vars == {}
+    assert spec.version == "1"
+
+
+def test_workflow_plan_minimal_construction():
+    """plan_id, goal, and tasks are required; strategy defaults to SEQUENTIAL."""
+    p = WorkflowPlan(plan_id="p1", goal="do work", tasks=[])
+    assert p.plan_id == "p1"
+    assert p.goal == "do work"
+    assert p.tasks == []
+    assert p.strategy is ExecutionStrategy.SEQUENTIAL
+    assert p.approval_required is True
+    assert p.approved is False
+    assert p.status == "pending"
+
+
+def test_workflow_plan_holds_tasks():
+    """Plan composes WorkflowTasks and dependency graph stays separate."""
+    t1 = WorkflowTask(task_id="t1", description="first")
+    t2 = WorkflowTask(task_id="t2", description="second", dependencies=["t1"])
+    p = WorkflowPlan(
+        plan_id="p1",
+        goal="g",
+        tasks=[t1, t2],
+        dependencies_graph={"t2": ["t1"]},
+        strategy=ExecutionStrategy.PIPELINE,
+    )
+    assert len(p.tasks) == 2
+    assert p.tasks[1].dependencies == ["t1"]
+    assert p.dependencies_graph == {"t2": ["t1"]}
+    assert p.strategy is ExecutionStrategy.PIPELINE
+
+
+def test_execution_strategy_values_match_legacy():
+    """Enum string values stay compatible with the enhanced_orchestration version
+    so Phase 2 callers can swap imports without value changes."""
+    assert ExecutionStrategy.SEQUENTIAL.value == "sequential"
+    assert ExecutionStrategy.PARALLEL.value == "parallel"
+    assert ExecutionStrategy.PIPELINE.value == "pipeline"
+    assert ExecutionStrategy.COLLABORATIVE.value == "collaborative"
+    assert ExecutionStrategy.ADAPTIVE.value == "adaptive"
+
+
+def test_workflow_plan_supports_nested_fallback_plans():
+    """fallback_plans takes other WorkflowPlan instances (forward ref)."""
+    fallback = WorkflowPlan(plan_id="p1-fb", goal="fallback", tasks=[])
+    primary = WorkflowPlan(
+        plan_id="p1",
+        goal="g",
+        tasks=[],
+        fallback_plans=[fallback],
+    )
+    assert primary.fallback_plans[0].plan_id == "p1-fb"


### PR DESCRIPTION
## Summary

Phase 1b of #6951 — adds the single canonical `WorkflowTask`, `WorkflowPlan`, `PromptSpec`, and `ExecutionStrategy` under `autobot_shared/workflow/`. **Additive only** — no existing types modified, no callers migrated yet.

These shapes consolidate the eight step shapes / four task shapes / two template shapes that grew out of the incomplete #381 god-class refactor (closed 2025-12-19, work was extracted into 3 separate type modules instead of consolidating into one — see [Phase 0 audit comment on #6951](https://github.com/mrveiss/AutoBot-AI/issues/6951#issuecomment-4377948567)).

## What's new

- **First-class `prompt` field** — `PromptSpec(user_prompt, system_prompt, template_vars, version)` instead of smuggling prompts inside `action: str` or `inputs["prompt"]`. The `version` field is compatible with the #3185 LLMService cache key layer.
- **First-class tool gates** — `tools_allowed` (None = inherit from agent) + `tools_denied` for per-step tool restriction. Existing shapes have no per-step tool gate.
- **`action` + `command` coexist** — `action` is the agent-dispatched verb (`run_audit`, `summarize_report`); `command` is the optional shell exec (`bash audit.sh`). The existing shapes split this concern across `action` (orchestration/enhanced/templates) and `command` (services/workflow_automation, overseer); the union accommodates both.
- **Layering-clean** — `autobot_shared/workflow/` takes no dependency on `autobot-backend/`. Status uses `str` (not `TaskStatus` enum) so callers can use `constants.status_enums.TaskStatus.X.value` without forcing autobot_shared to depend on backend constants.
- **`SubWorkflowStep` intentionally NOT absorbed** — it represents a distinct concern (sub-workflow invocation, #2143 closed correctly) and stays separate per Phase 0 audit recommendation.

## Why ship Phase 1b alone

This PR is the architectural commitment that Phase 2 callers depend on. Splitting it out:

1. Lets the canonical shape get review without 40+ caller migrations buried in the same diff
2. Avoids the #4969 risk pattern (uncommitted edits silently discarded when subagent commits)
3. Provides a clean revert point if the canonical shape needs revision before migrations begin

## Wire-in plan (Phase 2, separate PR)

Per the absolute "wire it in, never delete" rule, Phase 2 PRs migrate callers onto the canonical types in dependency order:

1. Phase 2A — `workflow_templates/` (8 callers) — also touches frontend `TemplateStep` codegen
2. Phase 2B — `enhanced_orchestration/` (3 callers, heavy logic in `workflow_runner.py` + `dag_executor.py`)
3. Phase 2C — `services/workflow_automation/` (manager + takeover_manager test)
4. Phase 2D — `agents/overseer/` (state lifecycle for step sequencing)
5. Phase 2E — `services/advanced_workflow/` (template-only)
6. Phase 2F — frontend `TemplateStep` regeneration

Phase 3 (consolidation cleanup) replaces the old shapes with imports from `autobot_shared.workflow` — **not deletion of dead code**. The old shapes vanish only as a consequence of the migration, the same way the #3185 LLMInterface retirement collapsed three abstractions into one.

## Test plan

- [x] `pytest autobot_shared/workflow/types_test.py -v` → **10 passed in 0.07s**
- [x] `python3 -m py_compile` on all 3 files → clean
- [x] Direct import smoke test → `from autobot_shared.workflow import WorkflowTask, WorkflowPlan, PromptSpec, ExecutionStrategy` → OK
- [x] `python3 -m black --check autobot_shared/workflow/` → clean

## Integration check (#6836 gate)

The new module currently has **zero production callers by design** — Phase 2 PRs provide wire-in. Per the deliberate-deferral override in CLAUDE.md's Issue Closure Verification Gate, this is acceptable because Phase 2 is a pre-filed follow-up under the same parent #6951.

## Files

- `autobot_shared/workflow/__init__.py` (31 lines) — re-exports
- `autobot_shared/workflow/types.py` (141 lines) — `WorkflowTask`, `WorkflowPlan`, `PromptSpec`, `ExecutionStrategy`
- `autobot_shared/workflow/types_test.py` (140 lines) — 10 unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)