### PR TITLE
fix(ci): make pip install failures in startup-import-smoke surface (closes #6947)

### DIFF
--- a/.github/workflows/startup-import-smoke.yml
+++ b/.github/workflows/startup-import-smoke.yml
@@ -47,11 +47,17 @@ jobs:
           echo "$VIRTUAL_ENV/bin" >> "$GITHUB_PATH"
 
       - name: Install backend dependencies
+        # #6947: self-hosted-runner default shell is `bash -e` (no pipefail),
+        # so prior `pip install ... | tail -5` silently swallowed install failures.
+        # Force pipefail explicitly + don't truncate pip output so dependency
+        # conflicts surface immediately.
+        shell: bash
         run: |
+          set -euo pipefail
           source .venv/bin/activate
           python -m pip install --upgrade pip >/dev/null
           python -m pip install pytest >/dev/null
-          python -m pip install -r autobot-backend/requirements.txt 2>&1 | tail -5
+          python -m pip install -r autobot-backend/requirements.txt
 
       - name: Run startup-import smoke test
         run: |


### PR DESCRIPTION
Closes #6947.

## Root cause

Self-hosted-runner default shell is ``bash -e {0}`` (no ``pipefail``), unlike github-hosted runners which use ``bash --noprofile --norc -eo pipefail``. The Install backend dependencies step ended with:

```yaml
python -m pip install -r autobot-backend/requirements.txt 2>&1 | tail -5
```

Without ``pipefail``, the pipeline's exit code is ``tail``'s (always 0), so the step succeeded even when pip failed mid-resolve. Pytest then ran in a venv missing pydantic and other backend deps, producing the misleading ``ModuleNotFoundError: No module named 'pydantic'`` with no sign that pip install had failed.

## Fix

- Add ``shell: bash`` + ``set -euo pipefail`` explicitly — works on both runner types and future-proofs against shell-default changes
- Drop the ``| tail -5`` truncation so dependency conflicts and resolution failures show their full output in CI logs

Either change alone would fix the silent-failure; both combined make the fix robust against future log-truncation tweaks AND provide full diagnostic output when pip does fail.

## Why this is small

The issue title says "CI venv missing backend deps" — that's the symptom. The actual bug is the swallowed failure. Once this lands, the next run will show the real underlying pip failure (which may be a dependency conflict — file separately if so).

## Verification gap

I can't reproduce the failure locally without access to the self-hosted runner. The PR's own CI run will be the validation — if pip install was failing for a real reason, the next run shows the real error message instead of silently passing and failing at pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)