### PR TITLE
refactor(schemas): retire duplicate ModelPricingInfo (#6668)

### DIFF
--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -1863,13 +1863,6 @@ class BudgetAlertRequest(BaseModel):
     enabled: bool = Field(default=True)
 
 
-class ModelPricingInfo(BaseModel):
-    model: str
-    input_price_per_1m: float
-    output_price_per_1m: float
-    provider: str
-
-
 class AgentBudgetRequest(BaseModel):
     budget_monthly_usd: float = Field(..., gt=0, description="Monthly budget in USD")
 


### PR DESCRIPTION
## Summary

Retires `ModelPricingInfo` (line 1866) — a near-duplicate of `ModelPricingEntry` (line 244) with zero non-self callers.

## Caller verification

```
$ grep -rn 'ModelPricingInfo' autobot-backend/ --include='*.py' | grep -v 'schemas_analytics.py'
(no output)
```

`ModelPricingEntry` (the wired one) is a strict superset — it has `is_free` while `ModelPricingInfo` does not. Any future caller that needs the old shape is already covered.

Closes #6668