### PR TITLE
fix(knowledge): tag regex `*` → `+` rejects empty/whitespace tags (#6672)

### DIFF
--- a/autobot-backend/api/knowledge_tags.py
+++ b/autobot-backend/api/knowledge_tags.py
@@ -63,8 +63,13 @@ from knowledge_factory import get_or_create_knowledge_base
 logger = logging.getLogger(__name__)
 
 
-# Issue #380: Pre-compiled regex for tag prefix validation
-_TAG_PREFIX_RE = re.compile(r"^[a-z0-9_-]*$")
+# Issue #380: Pre-compiled regex for tag-name + prefix validation.
+# #6672: was r"^[a-z0-9_-]*$" — the `*` quantifier accepted empty/whitespace
+# input (after .strip()) as a "valid" tag name across 7 endpoints, letting
+# blank tags slip past the create/update/delete/get/relations callsites.
+# The `+` quantifier matches schemas_knowledge.py:_LOWERCASE_TAG_RE which is
+# the canonical tag validator (used by TagValidator + 9 other field validators).
+_TAG_PREFIX_RE = re.compile(r"^[a-z0-9_-]+$")
 
 # Create router for tag management endpoints
 router = APIRouter(tags=["knowledge-tags"])


### PR DESCRIPTION
## Summary

`knowledge_tags.py:67` had `_TAG_PREFIX_RE = re.compile(r'^[a-z0-9_-]*$')` — the `*` quantifier silently accepted empty input across 7 endpoints that do `tag_name.lower().strip()`. Whitespace-only payloads stripped to `''` and passed validation, creating blank tags.

## Repro

```bash
$ curl -X POST /api/knowledge/tags -d '{"tag_name": "   "}'
# passed validation pre-fix
```

## Fix

Single-character change: `*` → `+`. Now matches `schemas_knowledge.py:_LOWERCASE_TAG_RE` — the canonical regex used by `TagValidator` and 9 other field validators.

Also tightens the prefix-search endpoint at line 335 — a whitespace-only prefix passed `if prefix:` then stripped to `''` which the old regex accepted; now correctly returns HTTP 400.

Closes #6672