### PR TITLE
ci: migrate 4 lint/security workflows to ubuntu-latest (partial #6721)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   code-quality:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze Python
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     strategy:

--- a/.github/workflows/ssot-coverage.yml
+++ b/.github/workflows/ssot-coverage.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   ssot-coverage:
     name: SSOT Configuration Compliance
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code

--- a/.github/workflows/startup-import-smoke.yml
+++ b/.github/workflows/startup-import-smoke.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   startup-import-smoke:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
Partial fix for #6721 (single self-hosted runner SPOF). Migrates the 4 highest-confidence workflows. Tracks the rest in a follow-up issue.

## Migrated

| Workflow | Why safe |
|----------|----------|
| ``codeql.yml`` | GitHub-managed CodeQL action, designed for github-hosted runners |
| ``ssot-coverage.yml`` | Pure shell script + JSON parsing, no infra deps |
| ``code-quality.yml`` | Black/isort/flake8/autoflake/bandit — pure Python lint |
| ``startup-import-smoke.yml`` | Python import smoke test, installs requirements.txt only |

## Diff

| File | Change |
|------|--------|
| 4 workflow files | ``runs-on: self-hosted`` → ``runs-on: ubuntu-latest`` (1 line each) |

Python 3.12 is pre-installed on ``ubuntu-latest``, so the existing ``sudo add-apt-repository deadsnakes`` install lines remain harmless (conditional skips the install). Cleaning those up later is a separate non-functional refactor.

## Effect on bus-factor-1 risk

- **Before:** when ``MV-Stealth-VM`` desyncs (original #6721 failure mode), 17 workflows all queued indefinitely
- **After this PR:** 4 of the most-frequently-run PR-time gates run on github-hosted. SPOF surface still 13 workflows, but CodeQL/code-quality/SSOT/startup-import keep working during runner outages

## Out of scope (deferred to follow-up tracker)

13 remaining self-hosted workflows split into 2 buckets:

**Genuinely need self-hosted (or substantial refactor)**: ``ci``, ``frontend-test``, ``phase_validation``, ``security``, ``visual-regression`` — backend deps, browser, large RAM/disk.

**Could migrate but each needs its own analysis**: ``auto-close-issues``, ``branch-cleanup``, ``branch-health-report``, ``dependabot-auto-merge``, ``release``, ``stale-branches-warning``, ``sync-main-to-dev``, ``unwired-tracker-audit`` — pure git/gh API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)