### PR TITLE
ci: migrate Bucket A workflows to ubuntu-latest (8 files, #6982 follow-up)

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   notify-issues:
     if: github.event.pull_request.merged == true
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       issues: write
 

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: read

--- a/.github/workflows/branch-health-report.yml
+++ b/.github/workflows/branch-health-report.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   generate-report:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   auto-merge:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/stale-branches-warning.yml
+++ b/.github/workflows/stale-branches-warning.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   detect-stale:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   sync:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/unwired-tracker-audit.yml
+++ b/.github/workflows/unwired-tracker-audit.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   audit:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout


### PR DESCRIPTION
Bucket A from #6982 (follow-up to #6721). Migrates 8 more workflows that have zero infra dependencies — pure git/gh API operations.

## Migrated

| Workflow | What it does | Why migration is safe |
|----------|--------------|----------------------|
| ``auto-close-issues.yml`` | gh issue/PR notify on merge | gh CLI only |
| ``branch-cleanup.yml`` | gh API + git remote ops | gh + git |
| ``branch-health-report.yml`` | gh API + report generation | gh + script |
| ``dependabot-auto-merge.yml`` | gh pr review/merge | gh CLI |
| ``release.yml`` | jq + gh release | jq is pre-installed on ubuntu-latest |
| ``stale-branches-warning.yml`` | gh API | gh CLI |
| ``sync-main-to-dev.yml`` | git operations | pure git |
| ``unwired-tracker-audit.yml`` | gh issue API + audit script | gh + Python |

## Diff

8 files × 1 line change = 8-line diff.

## Bus-factor-1 risk reduction

| State | Self-hosted job slots |
|-------|----------------------|
| Before #6981 | 17 workflows / 27 slots |
| After #6981 | 13 workflows / 23 slots |
| **After this PR** | 5 workflows / 15 slots |

Remaining 5 are Bucket B in #6982 — genuinely-need-self-hosted analysis territory:

- ``ci.yml`` (4 slots) — backend tests; Redis/Ollama deps
- ``frontend-test.yml`` (4 slots) — Vue/Vite + Storybook
- ``phase_validation.yml`` (2 slots) — migration validation
- ``security.yml`` (4 slots) — some scans need local infra
- ``visual-regression.yml`` (1 slot) — Playwright visual diffing

Each Bucket B workflow warrants its own per-workflow review before migrating. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)