### PR TITLE
feat(workflow): Phase 2A — migrate workflow_templates onto canonical WorkflowTask (#6951)

### DIFF
--- a/autobot-backend/workflow_templates/analysis.py
+++ b/autobot-backend/workflow_templates/analysis.py
@@ -24,27 +24,27 @@ def _build_data_preparation_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="data_exploration",
+            task_id="data_exploration",
             agent_type="system_commands",
             action="Explore and profile the dataset",
             description="System_Commands: Data Exploration",
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
         WorkflowStep(
-            id="analysis_research",
+            task_id="analysis_research",
             agent_type="research",
             action="Research appropriate analysis techniques and tools",
             description="Research: Analysis Techniques",
             dependencies=["data_exploration"],
-            expected_duration_ms=25000,
+            estimated_duration_seconds=25.0,
         ),
         WorkflowStep(
-            id="data_cleaning",
+            task_id="data_cleaning",
             agent_type="system_commands",
             action="Clean and prepare data for analysis",
             description="System_Commands: Data Preparation",
             dependencies=["analysis_research"],
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
     ]
 
@@ -58,36 +58,36 @@ def _build_data_processing_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="statistical_analysis",
+            task_id="statistical_analysis",
             agent_type="system_commands",
             action="Perform statistical analysis on the data",
             description="System_Commands: Statistical Analysis",
             dependencies=["data_cleaning"],
-            expected_duration_ms=35000,
+            estimated_duration_seconds=35.0,
         ),
         WorkflowStep(
-            id="generate_insights",
+            task_id="generate_insights",
             agent_type="orchestrator",
             action="Generate insights and recommendations from analysis",
             description="Orchestrator: Insights Generation",
             dependencies=["statistical_analysis"],
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
         WorkflowStep(
-            id="create_visualizations",
+            task_id="create_visualizations",
             agent_type="system_commands",
             action="Create visualizations and charts for findings",
             description="System_Commands: Data Visualization",
             dependencies=["generate_insights"],
-            expected_duration_ms=25000,
+            estimated_duration_seconds=25.0,
         ),
         WorkflowStep(
-            id="store_analysis",
+            task_id="store_analysis",
             agent_type="knowledge_manager",
             action="Store analysis results and methodology",
             description="Knowledge_Manager: Store Analysis Results",
             dependencies=["create_visualizations"],
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
     ]
 
@@ -136,19 +136,19 @@ def _build_log_collection_steps() -> List[WorkflowStep]:
     """Build initial log collection and parsing steps. Issue #620."""
     return [
         WorkflowStep(
-            id="collect_logs",
+            task_id="collect_logs",
             agent_type="system_commands",
             action="Collect and aggregate log files from specified sources",
             description="System_Commands: Log Collection",
-            expected_duration_ms=15000,
+            estimated_duration_seconds=15.0,
         ),
         WorkflowStep(
-            id="parse_logs",
+            task_id="parse_logs",
             agent_type="system_commands",
             action="Parse and normalize log entries",
             description="System_Commands: Log Parsing",
             dependencies=["collect_logs"],
-            expected_duration_ms=25000,
+            estimated_duration_seconds=25.0,
         ),
     ]
 
@@ -157,21 +157,21 @@ def _build_log_analysis_steps() -> List[WorkflowStep]:
     """Build security analysis and pattern detection steps. Issue #620."""
     return [
         WorkflowStep(
-            id="security_analysis",
+            task_id="security_analysis",
             agent_type="security_scanner",
             action="Analyze logs for security events and threats",
             description="Security_Scanner: Security Log Analysis",
             dependencies=["parse_logs"],
             inputs={"scan_type": "log_analysis"},
-            expected_duration_ms=35000,
+            estimated_duration_seconds=35.0,
         ),
         WorkflowStep(
-            id="pattern_detection",
+            task_id="pattern_detection",
             agent_type="system_commands",
             action="Detect patterns and anomalies in log data",
             description="System_Commands: Pattern Detection",
             dependencies=["parse_logs"],
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
     ]
 
@@ -180,29 +180,29 @@ def _build_log_reporting_steps() -> List[WorkflowStep]:
     """Build report generation and storage steps. Issue #620."""
     return [
         WorkflowStep(
-            id="generate_report",
+            task_id="generate_report",
             agent_type="orchestrator",
             action="Generate comprehensive log analysis report",
             description="Orchestrator: Analysis Report",
             dependencies=["security_analysis", "pattern_detection"],
-            expected_duration_ms=15000,
+            estimated_duration_seconds=15.0,
         ),
         WorkflowStep(
-            id="create_alerts",
+            task_id="create_alerts",
             agent_type="orchestrator",
             action="Create alerts and monitoring rules based on findings",
             description="Orchestrator: Create Alert Rules (requires your approval)",
             requires_approval=True,
             dependencies=["generate_report"],
-            expected_duration_ms=10000,
+            estimated_duration_seconds=10.0,
         ),
         WorkflowStep(
-            id="store_findings",
+            task_id="store_findings",
             agent_type="knowledge_manager",
             action="Store log analysis findings and alert rules",
             description="Knowledge_Manager: Store Log Analysis",
             dependencies=["create_alerts"],
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
     ]
 

--- a/autobot-backend/workflow_templates/community.py
+++ b/autobot-backend/workflow_templates/community.py
@@ -20,7 +20,7 @@ def _build_reddit_monitor_gather_steps() -> List[WorkflowStep]:
     """Build search and draft steps for Reddit Monitor & Reply. Issue #1161."""
     return [
         WorkflowStep(
-            id="reddit_search",
+            task_id="reddit_search",
             agent_type="community_growth",
             action="reddit_search",
             description=(
@@ -34,10 +34,10 @@ def _build_reddit_monitor_gather_steps() -> List[WorkflowStep]:
                 "limit": 25,
                 "min_score": 5,
             },
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
         WorkflowStep(
-            id="draft_replies",
+            task_id="draft_replies",
             agent_type="community_growth",
             action="llm_draft_content",
             description=(
@@ -53,7 +53,7 @@ def _build_reddit_monitor_gather_steps() -> List[WorkflowStep]:
                     "Mention AutoBot at {autobot_url} where relevant."
                 ),
             },
-            expected_duration_ms=45000,
+            estimated_duration_seconds=45.0,
         ),
     ]
 
@@ -62,7 +62,7 @@ def _build_reddit_monitor_post_steps() -> List[WorkflowStep]:
     """Build approval and post steps for Reddit Monitor & Reply. Issue #1161."""
     return [
         WorkflowStep(
-            id="review_drafts",
+            task_id="review_drafts",
             agent_type="orchestrator",
             action="human_review",
             description=(
@@ -72,10 +72,10 @@ def _build_reddit_monitor_post_steps() -> List[WorkflowStep]:
             ),
             requires_approval=True,
             dependencies=["draft_replies"],
-            expected_duration_ms=0,
+            estimated_duration_seconds=0.0,
         ),
         WorkflowStep(
-            id="reddit_reply",
+            task_id="reddit_reply",
             agent_type="community_growth",
             action="reddit_reply",
             description=(
@@ -86,7 +86,7 @@ def _build_reddit_monitor_post_steps() -> List[WorkflowStep]:
             ),
             dependencies=["review_drafts"],
             inputs={"dry_run": False},
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
     ]
 
@@ -145,7 +145,7 @@ def _build_blast_fetch_draft_steps() -> List[WorkflowStep]:
     """Build fetch and draft steps for Release Announcement Blast. Issue #1161."""
     return [
         WorkflowStep(
-            id="fetch_release",
+            task_id="fetch_release",
             agent_type="community_growth",
             action="github_get_releases",
             description=(
@@ -155,10 +155,10 @@ def _build_blast_fetch_draft_steps() -> List[WorkflowStep]:
                 "repos require a GITHUB_TOKEN)."
             ),
             inputs={"repo": "{repo}", "limit": 1},
-            expected_duration_ms=10000,
+            estimated_duration_seconds=10.0,
         ),
         WorkflowStep(
-            id="draft_content",
+            task_id="draft_content",
             agent_type="community_growth",
             action="llm_draft_content",
             description=(
@@ -175,7 +175,7 @@ def _build_blast_fetch_draft_steps() -> List[WorkflowStep]:
                     "Include the release tag, key highlights, and a link."
                 ),
             },
-            expected_duration_ms=60000,
+            estimated_duration_seconds=60.0,
         ),
     ]
 
@@ -184,7 +184,7 @@ def _build_blast_review_step() -> List[WorkflowStep]:
     """Build human review step for Release Announcement Blast. Issue #1161."""
     return [
         WorkflowStep(
-            id="review_content",
+            task_id="review_content",
             agent_type="orchestrator",
             action="human_review",
             description=(
@@ -195,7 +195,7 @@ def _build_blast_review_step() -> List[WorkflowStep]:
             ),
             requires_approval=True,
             dependencies=["draft_content"],
-            expected_duration_ms=0,
+            estimated_duration_seconds=0.0,
         ),
     ]
 
@@ -204,7 +204,7 @@ def _build_blast_posting_steps() -> List[WorkflowStep]:
     """Build parallel posting steps for Release Announcement Blast. Issue #1161."""
     return [
         WorkflowStep(
-            id="reddit_post",
+            task_id="reddit_post",
             agent_type="community_growth",
             action="reddit_post",
             description=(
@@ -214,10 +214,10 @@ def _build_blast_posting_steps() -> List[WorkflowStep]:
             ),
             dependencies=["review_content"],
             inputs={"subreddit": "{target_subreddits}", "dry_run": False},
-            expected_duration_ms=15000,
+            estimated_duration_seconds=15.0,
         ),
         WorkflowStep(
-            id="twitter_post",
+            task_id="twitter_post",
             agent_type="community_growth",
             action="twitter_post",
             description=(
@@ -225,10 +225,10 @@ def _build_blast_posting_steps() -> List[WorkflowStep]:
             ),
             dependencies=["review_content"],
             inputs={"dry_run": False},
-            expected_duration_ms=10000,
+            estimated_duration_seconds=10.0,
         ),
         WorkflowStep(
-            id="discord_notify",
+            task_id="discord_notify",
             agent_type="community_growth",
             action="discord_notify",
             description=(
@@ -238,7 +238,7 @@ def _build_blast_posting_steps() -> List[WorkflowStep]:
             ),
             dependencies=["review_content"],
             inputs={"dry_run": False},
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
     ]
 
@@ -313,7 +313,7 @@ def _build_digest_gather_steps() -> List[WorkflowStep]:
     """Build parallel gather steps for Community Digest Post. Issue #1161."""
     return [
         WorkflowStep(
-            id="fetch_releases",
+            task_id="fetch_releases",
             agent_type="community_growth",
             action="github_get_releases",
             description=(
@@ -322,10 +322,10 @@ def _build_digest_gather_steps() -> List[WorkflowStep]:
                 "step. Public repos need no token."
             ),
             inputs={"repo": "{repo}", "limit": 5},
-            expected_duration_ms=10000,
+            estimated_duration_seconds=10.0,
         ),
         WorkflowStep(
-            id="search_mentions",
+            task_id="search_mentions",
             agent_type="community_growth",
             action="reddit_search",
             description=(
@@ -339,7 +339,7 @@ def _build_digest_gather_steps() -> List[WorkflowStep]:
                 "limit": 10,
                 "min_score": 1,
             },
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
     ]
 
@@ -348,7 +348,7 @@ def _build_digest_draft_review_post_steps() -> List[WorkflowStep]:
     """Build draft, review, and post steps for Community Digest Post. Issue #1161."""
     return [
         WorkflowStep(
-            id="draft_digest",
+            task_id="draft_digest",
             agent_type="community_growth",
             action="llm_draft_content",
             description=(
@@ -365,10 +365,10 @@ def _build_digest_draft_review_post_steps() -> List[WorkflowStep]:
                     "and notable Reddit mentions from the past {lookback_days} days."
                 ),
             },
-            expected_duration_ms=60000,
+            estimated_duration_seconds=60.0,
         ),
         WorkflowStep(
-            id="review_digest",
+            task_id="review_digest",
             agent_type="orchestrator",
             action="human_review",
             description=(
@@ -378,10 +378,10 @@ def _build_digest_draft_review_post_steps() -> List[WorkflowStep]:
             ),
             requires_approval=True,
             dependencies=["draft_digest"],
-            expected_duration_ms=0,
+            estimated_duration_seconds=0.0,
         ),
         WorkflowStep(
-            id="post_digest",
+            task_id="post_digest",
             agent_type="community_growth",
             action="reddit_post",
             description=(
@@ -391,7 +391,7 @@ def _build_digest_draft_review_post_steps() -> List[WorkflowStep]:
             ),
             dependencies=["review_digest"],
             inputs={"subreddit": "{target_subreddits}", "dry_run": False},
-            expected_duration_ms=15000,
+            estimated_duration_seconds=15.0,
         ),
     ]
 

--- a/autobot-backend/workflow_templates/development.py
+++ b/autobot-backend/workflow_templates/development.py
@@ -23,28 +23,28 @@ def _create_deployment_setup_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="pipeline_research",
+            task_id="pipeline_research",
             agent_type="research",
             action="Research deployment pipeline best practices",
             description="Research: Pipeline Best Practices",
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
         WorkflowStep(
-            id="environment_setup",
+            task_id="environment_setup",
             agent_type="system_commands",
             action="Setup and configure deployment environment",
             description="System_Commands: Environment Setup (requires your approval)",
             requires_approval=True,
             dependencies=["pipeline_research"],
-            expected_duration_ms=40000,
+            estimated_duration_seconds=40.0,
         ),
         WorkflowStep(
-            id="pipeline_config",
+            task_id="pipeline_config",
             agent_type="orchestrator",
             action="Configure deployment pipeline and stages",
             description="Orchestrator: Pipeline Configuration",
             dependencies=["environment_setup"],
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
     ]
 
@@ -57,29 +57,29 @@ def _create_deployment_execution_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="deploy_application",
+            task_id="deploy_application",
             agent_type="system_commands",
             action="Execute deployment pipeline",
             description="System_Commands: Application Deployment (requires your approval)",
             requires_approval=True,
             dependencies=["pipeline_config"],
-            expected_duration_ms=35000,
+            estimated_duration_seconds=35.0,
         ),
         WorkflowStep(
-            id="verify_deployment",
+            task_id="verify_deployment",
             agent_type="system_commands",
             action="Verify deployment success and perform health checks",
             description="System_Commands: Deployment Verification",
             dependencies=["deploy_application"],
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
         WorkflowStep(
-            id="document_pipeline",
+            task_id="document_pipeline",
             agent_type="knowledge_manager",
             action="Document deployment pipeline and procedures",
             description="Knowledge_Manager: Document Pipeline",
             dependencies=["verify_deployment"],
-            expected_duration_ms=8000,
+            estimated_duration_seconds=8.0,
         ),
     ]
 
@@ -101,28 +101,28 @@ def _create_analysis_and_scan_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="code_analysis",
+            task_id="code_analysis",
             agent_type="system_commands",
             action="Perform static code analysis and metrics collection",
             description="System_Commands: Static Code Analysis",
-            expected_duration_ms=25000,
+            estimated_duration_seconds=25.0,
         ),
         WorkflowStep(
-            id="security_scan",
+            task_id="security_scan",
             agent_type="security_scanner",
             action="Scan code for security vulnerabilities",
             description="Security_Scanner: Code Security Scan",
             dependencies=["code_analysis"],
             inputs={"scan_type": "code_security"},
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
         WorkflowStep(
-            id="best_practices_research",
+            task_id="best_practices_research",
             agent_type="research",
             action="Research current coding best practices and standards",
             description="Research: Coding Best Practices",
             dependencies=["code_analysis"],
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
     ]
 
@@ -135,28 +135,28 @@ def _create_assessment_and_report_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="quality_assessment",
+            task_id="quality_assessment",
             agent_type="orchestrator",
             action="Assess code quality against industry standards",
             description="Orchestrator: Quality Assessment",
             dependencies=["security_scan", "best_practices_research"],
-            expected_duration_ms=15000,
+            estimated_duration_seconds=15.0,
         ),
         WorkflowStep(
-            id="review_report",
+            task_id="review_report",
             agent_type="orchestrator",
             action="Generate comprehensive code review report",
             description="Orchestrator: Code Review Report",
             dependencies=["quality_assessment"],
-            expected_duration_ms=12000,
+            estimated_duration_seconds=12.0,
         ),
         WorkflowStep(
-            id="store_review",
+            task_id="store_review",
             agent_type="knowledge_manager",
             action="Store code review findings and recommendations",
             description="Knowledge_Manager: Store Review Results",
             dependencies=["review_report"],
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
     ]
 
@@ -231,28 +231,28 @@ def _create_testing_research_and_setup_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="testing_research",
+            task_id="testing_research",
             agent_type="research",
             action="Research testing frameworks and methodologies",
             description="Research: Testing Methodologies",
-            expected_duration_ms=25000,
+            estimated_duration_seconds=25.0,
         ),
         WorkflowStep(
-            id="test_strategy",
+            task_id="test_strategy",
             agent_type="orchestrator",
             action="Design comprehensive testing strategy",
             description="Orchestrator: Testing Strategy",
             dependencies=["testing_research"],
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
         WorkflowStep(
-            id="setup_frameworks",
+            task_id="setup_frameworks",
             agent_type="system_commands",
             action="Setup testing frameworks and tools",
             description="System_Commands: Framework Setup (requires your approval)",
             requires_approval=True,
             dependencies=["test_strategy"],
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
     ]
 
@@ -265,28 +265,28 @@ def _create_testing_execution_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="create_tests",
+            task_id="create_tests",
             agent_type="system_commands",
             action="Create initial test suites and examples",
             description="System_Commands: Create Test Suites",
             dependencies=["setup_frameworks"],
-            expected_duration_ms=40000,
+            estimated_duration_seconds=40.0,
         ),
         WorkflowStep(
-            id="run_tests",
+            task_id="run_tests",
             agent_type="system_commands",
             action="Execute test suites and generate reports",
             description="System_Commands: Execute Tests",
             dependencies=["create_tests"],
-            expected_duration_ms=25000,
+            estimated_duration_seconds=25.0,
         ),
         WorkflowStep(
-            id="document_testing",
+            task_id="document_testing",
             agent_type="knowledge_manager",
             action="Document testing strategy and procedures",
             description="Knowledge_Manager: Document Testing Strategy",
             dependencies=["run_tests"],
-            expected_duration_ms=8000,
+            estimated_duration_seconds=8.0,
         ),
     ]
 

--- a/autobot-backend/workflow_templates/research.py
+++ b/autobot-backend/workflow_templates/research.py
@@ -24,43 +24,43 @@ def _create_comprehensive_research_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="kb_search",
+            task_id="kb_search",
             agent_type="librarian",
             action="Search existing knowledge base for relevant information",
             description="Librarian: Knowledge Base Search",
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
         WorkflowStep(
-            id="web_research",
+            task_id="web_research",
             agent_type="research",
             action="Conduct comprehensive web research on the topic",
             description="Research: Web Research",
             dependencies=["kb_search"],
-            expected_duration_ms=60000,
+            estimated_duration_seconds=60.0,
         ),
         WorkflowStep(
-            id="source_verification",
+            task_id="source_verification",
             agent_type="research",
             action="Verify and cross-reference research sources",
             description="Research: Source Verification",
             dependencies=["web_research"],
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
         WorkflowStep(
-            id="synthesis",
+            task_id="synthesis",
             agent_type="orchestrator",
             action="Synthesize research findings into comprehensive report",
             description="Orchestrator: Research Synthesis",
             dependencies=["source_verification"],
-            expected_duration_ms=15000,
+            estimated_duration_seconds=15.0,
         ),
         WorkflowStep(
-            id="store_research",
+            task_id="store_research",
             agent_type="knowledge_manager",
             action="Store research findings and sources in knowledge base",
             description="Knowledge_Manager: Store Research",
             dependencies=["synthesis"],
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
     ]
 
@@ -92,27 +92,27 @@ def _create_competitive_research_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="market_research",
+            task_id="market_research",
             agent_type="research",
             action="Research market landscape and key players",
             description="Research: Market Analysis",
-            expected_duration_ms=45000,
+            estimated_duration_seconds=45.0,
         ),
         WorkflowStep(
-            id="competitor_identification",
+            task_id="competitor_identification",
             agent_type="research",
             action="Identify direct and indirect competitors",
             description="Research: Competitor Identification",
             dependencies=["market_research"],
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
         WorkflowStep(
-            id="feature_analysis",
+            task_id="feature_analysis",
             agent_type="research",
             action="Analyze competitor features and positioning",
             description="Research: Feature Comparison",
             dependencies=["competitor_identification"],
-            expected_duration_ms=40000,
+            estimated_duration_seconds=40.0,
         ),
     ]
 
@@ -125,29 +125,29 @@ def _create_competitive_analysis_final_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="swot_analysis",
+            task_id="swot_analysis",
             agent_type="orchestrator",
             action="Perform SWOT analysis of competitive landscape",
             description="Orchestrator: SWOT Analysis",
             dependencies=["feature_analysis"],
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
         WorkflowStep(
-            id="strategic_recommendations",
+            task_id="strategic_recommendations",
             agent_type="orchestrator",
             action="Generate strategic recommendations based on analysis",
             description="Orchestrator: Strategic Recommendations (requires your approval)",
             requires_approval=True,
             dependencies=["swot_analysis"],
-            expected_duration_ms=15000,
+            estimated_duration_seconds=15.0,
         ),
         WorkflowStep(
-            id="store_analysis",
+            task_id="store_analysis",
             agent_type="knowledge_manager",
             action="Store competitive analysis and recommendations",
             description="Knowledge_Manager: Store Analysis",
             dependencies=["strategic_recommendations"],
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
     ]
 
@@ -193,19 +193,19 @@ def _create_tech_research_initial_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="existing_knowledge",
+            task_id="existing_knowledge",
             agent_type="librarian",
             action="Search knowledge base for existing technology information",
             description="Librarian: Technology Knowledge Search",
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
         WorkflowStep(
-            id="technology_overview",
+            task_id="technology_overview",
             agent_type="research",
             action="Research technology overview and capabilities",
             description="Research: Technology Overview",
             dependencies=["existing_knowledge"],
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
     ]
 
@@ -218,20 +218,20 @@ def _create_tech_research_analysis_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="alternatives_research",
+            task_id="alternatives_research",
             agent_type="research",
             action="Research alternative technologies and solutions",
             description="Research: Alternative Solutions",
             dependencies=["technology_overview"],
-            expected_duration_ms=35000,
+            estimated_duration_seconds=35.0,
         ),
         WorkflowStep(
-            id="pros_cons_analysis",
+            task_id="pros_cons_analysis",
             agent_type="orchestrator",
             action="Analyze pros, cons, and trade-offs of each option",
             description="Orchestrator: Pros/Cons Analysis",
             dependencies=["alternatives_research"],
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
     ]
 
@@ -244,21 +244,21 @@ def _create_tech_research_final_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="recommendation",
+            task_id="recommendation",
             agent_type="orchestrator",
             action="Provide technology recommendation with rationale",
             description="Orchestrator: Technology Recommendation (requires your approval)",
             requires_approval=True,
             dependencies=["pros_cons_analysis"],
-            expected_duration_ms=10000,
+            estimated_duration_seconds=10.0,
         ),
         WorkflowStep(
-            id="store_research",
+            task_id="store_research",
             agent_type="knowledge_manager",
             action="Store technology research and recommendations",
             description="Knowledge_Manager: Store Technology Research",
             dependencies=["recommendation"],
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
     ]
 
@@ -306,52 +306,52 @@ def _create_autoresearch_loop_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="web_search",
+            task_id="web_search",
             agent_type="research",
             action="Search arxiv and GitHub for recent techniques related to the research direction",
             description="Research: Web Search for Hypotheses",
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
         WorkflowStep(
-            id="generate_hypothesis",
+            task_id="generate_hypothesis",
             agent_type="orchestrator",
             action="Generate a concrete, testable hypothesis for improving val_bpb from search results",
             description="Orchestrator: Hypothesis Generation",
             dependencies=["web_search"],
-            expected_duration_ms=10000,
+            estimated_duration_seconds=10.0,
         ),
         WorkflowStep(
-            id="run_experiment",
+            task_id="run_experiment",
             agent_type="orchestrator",
             action="Execute 5-minute training run with the proposed hyperparameter changes",
             description="Orchestrator: Run Experiment",
             dependencies=["generate_hypothesis"],
-            expected_duration_ms=360000,
+            estimated_duration_seconds=360.0,
         ),
         WorkflowStep(
-            id="evaluate_result",
+            task_id="evaluate_result",
             agent_type="orchestrator",
             action="Compare val_bpb against baseline and decide keep or discard",
             description="Orchestrator: Evaluate Result",
             dependencies=["run_experiment"],
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
         WorkflowStep(
-            id="approval_gate",
+            task_id="approval_gate",
             agent_type="orchestrator",
             action="Request human approval before applying a significant improvement (>1% val_bpb)",
             description="Orchestrator: Approval Gate (requires your approval)",
             requires_approval=True,
             dependencies=["evaluate_result"],
-            expected_duration_ms=0,
+            estimated_duration_seconds=0.0,
         ),
         WorkflowStep(
-            id="index_findings",
+            task_id="index_findings",
             agent_type="knowledge_manager",
             action="Index successful experiment findings in ChromaDB for future RAG retrieval",
             description="Knowledge_Manager: Index Experiment Findings",
             dependencies=["approval_gate"],
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
     ]
 

--- a/autobot-backend/workflow_templates/security.py
+++ b/autobot-backend/workflow_templates/security.py
@@ -23,37 +23,37 @@ def _get_network_scan_discovery_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="kb_search",
+            task_id="kb_search",
             agent_type="librarian",
             action="Search Knowledge Base for network scanning tools and techniques",
             description="Librarian: Search Knowledge Base",
-            expected_duration_ms=3000,
+            estimated_duration_seconds=3.0,
         ),
         WorkflowStep(
-            id="research_tools",
+            task_id="research_tools",
             agent_type="research",
             action="Research latest network security scanning tools and methodologies",
             description="Research: Research Tools",
             dependencies=["kb_search"],
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
         WorkflowStep(
-            id="present_options",
+            task_id="present_options",
             agent_type="orchestrator",
             action="Present scanning tool options and scan types",
             description="Orchestrator: Present Tool Options (requires your approval)",
             requires_approval=True,
             dependencies=["research_tools"],
-            expected_duration_ms=2000,
+            estimated_duration_seconds=2.0,
         ),
         WorkflowStep(
-            id="network_discovery",
+            task_id="network_discovery",
             agent_type="network_discovery",
             action="Perform network discovery and host enumeration",
             description="Network_Discovery: Host Discovery",
             dependencies=["present_options"],
             inputs={"task_type": "network_scan"},
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
     ]
 
@@ -66,39 +66,39 @@ def _get_network_scan_assessment_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="security_scan",
+            task_id="security_scan",
             agent_type="security_scanner",
             action="Execute comprehensive security scan on discovered hosts",
             description="Security_Scanner: Port and Service Scan",
             dependencies=["network_discovery"],
             inputs={"scan_type": "comprehensive"},
-            expected_duration_ms=45000,
+            estimated_duration_seconds=45.0,
         ),
         WorkflowStep(
-            id="vulnerability_check",
+            task_id="vulnerability_check",
             agent_type="security_scanner",
             action="Perform vulnerability assessment on identified services",
             description="Security_Scanner: Vulnerability Assessment",
             dependencies=["security_scan"],
             inputs={"scan_type": "vulnerability_scan"},
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
         WorkflowStep(
-            id="generate_report",
+            task_id="generate_report",
             agent_type="orchestrator",
             action="Generate comprehensive security assessment report",
             description="Orchestrator: Generate Security Report (requires your approval)",
             requires_approval=True,
             dependencies=["vulnerability_check"],
-            expected_duration_ms=10000,
+            estimated_duration_seconds=10.0,
         ),
         WorkflowStep(
-            id="store_results",
+            task_id="store_results",
             agent_type="knowledge_manager",
             action="Store security scan results and recommendations in knowledge base",
             description="Knowledge_Manager: Store Results",
             dependencies=["generate_report"],
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
     ]
 
@@ -145,20 +145,20 @@ def _create_vuln_scan_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="research_vulnerabilities",
+            task_id="research_vulnerabilities",
             agent_type="research",
             action="Research current vulnerability databases and threat intelligence",
             description="Research: CVE and Threat Research",
-            expected_duration_ms=25000,
+            estimated_duration_seconds=25.0,
         ),
         WorkflowStep(
-            id="vulnerability_scan",
+            task_id="vulnerability_scan",
             agent_type="security_scanner",
             action="Execute comprehensive vulnerability scan",
             description="Security_Scanner: Vulnerability Scan",
             dependencies=["research_vulnerabilities"],
             inputs={"scan_type": "vulnerability_scan"},
-            expected_duration_ms=60000,
+            estimated_duration_seconds=60.0,
         ),
     ]
 
@@ -172,29 +172,29 @@ def _create_vuln_analysis_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="analyze_results",
+            task_id="analyze_results",
             agent_type="security_scanner",
             action="Analyze vulnerability scan results and prioritize findings",
             description="Security_Scanner: Results Analysis",
             dependencies=["vulnerability_scan"],
-            expected_duration_ms=15000,
+            estimated_duration_seconds=15.0,
         ),
         WorkflowStep(
-            id="remediation_plan",
+            task_id="remediation_plan",
             agent_type="orchestrator",
             action="Create remediation plan with prioritized recommendations",
             description="Orchestrator: Create Remediation Plan (requires your approval)",
             requires_approval=True,
             dependencies=["analyze_results"],
-            expected_duration_ms=10000,
+            estimated_duration_seconds=10.0,
         ),
         WorkflowStep(
-            id="store_assessment",
+            task_id="store_assessment",
             agent_type="knowledge_manager",
             action="Store vulnerability assessment and remediation plan",
             description="Knowledge_Manager: Store Assessment",
             dependencies=["remediation_plan"],
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
     ]
 
@@ -236,29 +236,29 @@ def _create_audit_planning_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="audit_planning",
+            task_id="audit_planning",
             agent_type="orchestrator",
             action="Plan security audit scope and methodology",
             description="Orchestrator: Audit Planning (requires your approval)",
             requires_approval=True,
-            expected_duration_ms=10000,
+            estimated_duration_seconds=10.0,
         ),
         WorkflowStep(
-            id="compliance_research",
+            task_id="compliance_research",
             agent_type="research",
             action="Research compliance requirements and security standards",
             description="Research: Compliance Standards",
             dependencies=["audit_planning"],
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
         WorkflowStep(
-            id="asset_discovery",
+            task_id="asset_discovery",
             agent_type="network_discovery",
             action="Discover and inventory all network assets",
             description="Network_Discovery: Asset Inventory",
             dependencies=["audit_planning"],
             inputs={"task_type": "asset_inventory"},
-            expected_duration_ms=25000,
+            estimated_duration_seconds=25.0,
         ),
     ]
 
@@ -271,38 +271,38 @@ def _create_audit_execution_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="security_scanning",
+            task_id="security_scanning",
             agent_type="security_scanner",
             action="Perform comprehensive security scanning of all assets",
             description="Security_Scanner: Comprehensive Scan",
             dependencies=["asset_discovery"],
             inputs={"scan_type": "comprehensive"},
-            expected_duration_ms=90000,
+            estimated_duration_seconds=90.0,
         ),
         WorkflowStep(
-            id="compliance_check",
+            task_id="compliance_check",
             agent_type="security_scanner",
             action="Verify compliance with security standards",
             description="Security_Scanner: Compliance Verification",
             dependencies=["compliance_research", "security_scanning"],
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
         WorkflowStep(
-            id="audit_report",
+            task_id="audit_report",
             agent_type="orchestrator",
             action="Generate comprehensive security audit report",
             description="Orchestrator: Generate Audit Report (requires your approval)",
             requires_approval=True,
             dependencies=["compliance_check"],
-            expected_duration_ms=15000,
+            estimated_duration_seconds=15.0,
         ),
         WorkflowStep(
-            id="store_audit",
+            task_id="store_audit",
             agent_type="knowledge_manager",
             action="Store audit findings and recommendations",
             description="Knowledge_Manager: Store Audit Results",
             dependencies=["audit_report"],
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
     ]
 

--- a/autobot-backend/workflow_templates/sysadmin.py
+++ b/autobot-backend/workflow_templates/sysadmin.py
@@ -24,35 +24,35 @@ def _create_health_check_collection_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="system_overview",
+            task_id="system_overview",
             agent_type="system_commands",
             action="Collect basic system information and status",
             description="System_Commands: System Overview",
-            expected_duration_ms=10000,
+            estimated_duration_seconds=10.0,
         ),
         WorkflowStep(
-            id="resource_check",
+            task_id="resource_check",
             agent_type="system_commands",
             action="Check CPU, memory, disk, and network utilization",
             description="System_Commands: Resource Utilization",
             dependencies=["system_overview"],
-            expected_duration_ms=15000,
+            estimated_duration_seconds=15.0,
         ),
         WorkflowStep(
-            id="service_status",
+            task_id="service_status",
             agent_type="system_commands",
             action="Check status of critical services and processes",
             description="System_Commands: Service Status Check",
             dependencies=["resource_check"],
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
         WorkflowStep(
-            id="security_status",
+            task_id="security_status",
             agent_type="system_commands",
             action="Check system security status and updates",
             description="System_Commands: Security Status",
             dependencies=["service_status"],
-            expected_duration_ms=25000,
+            estimated_duration_seconds=25.0,
         ),
     ]
 
@@ -66,29 +66,29 @@ def _create_health_check_reporting_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="health_report",
+            task_id="health_report",
             agent_type="orchestrator",
             action="Generate comprehensive system health report",
             description="Orchestrator: Generate Health Report",
             dependencies=["security_status"],
-            expected_duration_ms=10000,
+            estimated_duration_seconds=10.0,
         ),
         WorkflowStep(
-            id="recommendations",
+            task_id="recommendations",
             agent_type="orchestrator",
             action="Provide system optimization recommendations",
             description="Orchestrator: Optimization Recommendations (requires your approval)",
             requires_approval=True,
             dependencies=["health_report"],
-            expected_duration_ms=8000,
+            estimated_duration_seconds=8.0,
         ),
         WorkflowStep(
-            id="store_results",
+            task_id="store_results",
             agent_type="knowledge_manager",
             action="Store health check results and recommendations",
             description="Knowledge_Manager: Store Health Check",
             dependencies=["recommendations"],
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
     ]
 
@@ -130,27 +130,27 @@ def _create_perf_analysis_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="baseline_metrics",
+            task_id="baseline_metrics",
             agent_type="system_commands",
             action="Collect baseline performance metrics",
             description="System_Commands: Baseline Metrics Collection",
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
         WorkflowStep(
-            id="bottleneck_analysis",
+            task_id="bottleneck_analysis",
             agent_type="system_commands",
             action="Analyze system for performance bottlenecks",
             description="System_Commands: Bottleneck Analysis",
             dependencies=["baseline_metrics"],
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
         WorkflowStep(
-            id="optimization_research",
+            task_id="optimization_research",
             agent_type="research",
             action="Research performance optimization techniques",
             description="Research: Optimization Techniques",
             dependencies=["bottleneck_analysis"],
-            expected_duration_ms=35000,
+            estimated_duration_seconds=35.0,
         ),
     ]
 
@@ -164,38 +164,38 @@ def _create_perf_implementation_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="optimization_plan",
+            task_id="optimization_plan",
             agent_type="orchestrator",
             action="Create detailed optimization implementation plan",
             description="Orchestrator: Optimization Plan (requires your approval)",
             requires_approval=True,
             dependencies=["optimization_research"],
-            expected_duration_ms=15000,
+            estimated_duration_seconds=15.0,
         ),
         WorkflowStep(
-            id="implement_optimizations",
+            task_id="implement_optimizations",
             agent_type="system_commands",
             action="Implement approved performance optimizations",
             description="System_Commands: Apply Optimizations (requires your approval)",
             requires_approval=True,
             dependencies=["optimization_plan"],
-            expected_duration_ms=45000,
+            estimated_duration_seconds=45.0,
         ),
         WorkflowStep(
-            id="verify_improvements",
+            task_id="verify_improvements",
             agent_type="system_commands",
             action="Verify performance improvements and measure impact",
             description="System_Commands: Performance Verification",
             dependencies=["implement_optimizations"],
-            expected_duration_ms=20000,
+            estimated_duration_seconds=20.0,
         ),
         WorkflowStep(
-            id="store_optimization",
+            task_id="store_optimization",
             agent_type="knowledge_manager",
             action="Store optimization results and procedures",
             description="Knowledge_Manager: Store Optimization Results",
             dependencies=["verify_improvements"],
-            expected_duration_ms=5000,
+            estimated_duration_seconds=5.0,
         ),
     ]
 
@@ -243,28 +243,28 @@ def _create_backup_planning_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="assess_data",
+            task_id="assess_data",
             agent_type="system_commands",
             action="Assess critical data and system components",
             description="System_Commands: Data Assessment",
-            expected_duration_ms=15000,
+            estimated_duration_seconds=15.0,
         ),
         WorkflowStep(
-            id="backup_research",
+            task_id="backup_research",
             agent_type="research",
             action="Research backup solutions and best practices",
             description="Research: Backup Solutions",
             dependencies=["assess_data"],
-            expected_duration_ms=25000,
+            estimated_duration_seconds=25.0,
         ),
         WorkflowStep(
-            id="backup_strategy",
+            task_id="backup_strategy",
             agent_type="orchestrator",
             action="Design comprehensive backup strategy",
             description="Orchestrator: Backup Strategy (requires your approval)",
             requires_approval=True,
             dependencies=["backup_research"],
-            expected_duration_ms=15000,
+            estimated_duration_seconds=15.0,
         ),
     ]
 
@@ -278,29 +278,29 @@ def _create_backup_implementation_steps() -> List[WorkflowStep]:
     """
     return [
         WorkflowStep(
-            id="implement_backup",
+            task_id="implement_backup",
             agent_type="system_commands",
             action="Implement backup solution and schedule",
             description="System_Commands: Backup Implementation (requires your approval)",
             requires_approval=True,
             dependencies=["backup_strategy"],
-            expected_duration_ms=40000,
+            estimated_duration_seconds=40.0,
         ),
         WorkflowStep(
-            id="test_recovery",
+            task_id="test_recovery",
             agent_type="system_commands",
             action="Test backup and recovery procedures",
             description="System_Commands: Recovery Testing",
             dependencies=["implement_backup"],
-            expected_duration_ms=30000,
+            estimated_duration_seconds=30.0,
         ),
         WorkflowStep(
-            id="document_procedures",
+            task_id="document_procedures",
             agent_type="knowledge_manager",
             action="Document backup and recovery procedures",
             description="Knowledge_Manager: Document Procedures",
             dependencies=["test_recovery"],
-            expected_duration_ms=10000,
+            estimated_duration_seconds=10.0,
         ),
     ]
 

--- a/autobot-backend/workflow_templates/types.py
+++ b/autobot-backend/workflow_templates/types.py
@@ -5,6 +5,12 @@
 Workflow Template Types and Data Classes
 
 Issue #381: Extracted from workflow_templates.py god class refactoring.
+Issue #6951: Phase 2A — local WorkflowStep dataclass replaced by an alias to
+the canonical autobot_shared.workflow.WorkflowTask. The legacy ``to_dict()``
+method is preserved as a free function so the public API contract returned
+by ``WorkflowTemplate.to_detail_dict()`` does not change for the frontend
+``TemplateStep`` interface (frontend codegen migrates in Phase 2F).
+
 Contains core data structures for workflow template definitions.
 """
 
@@ -12,7 +18,13 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List
 
+from autobot_shared.workflow import WorkflowTask
 from autobot_types import TaskComplexity
+
+# Transitional alias — Phase 3 removes this and updates callers to use
+# ``WorkflowTask`` directly. Until then, every ``WorkflowStep(task_id=..., ...)``
+# call site (#6951 Phase 2A) constructs a real ``WorkflowTask``.
+WorkflowStep = WorkflowTask
 
 
 class TemplateCategory(Enum):
@@ -26,50 +38,44 @@ class TemplateCategory(Enum):
     COMMUNITY = "community"
 
 
-@dataclass
-class WorkflowStep:
-    """Individual step in a workflow template."""
+def _legacy_step_dict(step: WorkflowTask) -> Dict[str, Any]:
+    """Emit the historical TemplateStep dict shape for the public API.
 
-    id: str
-    agent_type: str
-    action: str
-    description: str
-    requires_approval: bool = False
-    dependencies: List[str] = None
-    inputs: Dict[str, Any] = None
-    expected_duration_ms: int = 5000
-
-    def __post_init__(self):
-        """Initialize default values for dependencies and inputs fields."""
-        if self.dependencies is None:
-            self.dependencies = []
-        if self.inputs is None:
-            self.inputs = {}
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert step to dictionary for caching/serialization."""
-        return {
-            "id": self.id,
-            "agent_type": self.agent_type,
-            "action": self.action,
-            "description": self.description,
-            "requires_approval": self.requires_approval,
-            "dependencies": self.dependencies,
-            "inputs": self.inputs,
-            "expected_duration_ms": self.expected_duration_ms,
-        }
+    Phase 2F migrates the frontend ``TemplateStep`` interface to consume the
+    canonical ``WorkflowTask`` shape directly; until then this helper preserves
+    the wire format. The ``expected_duration_ms`` round-trip is exact because
+    the migration script set ``estimated_duration_seconds = ms / 1000.0``.
+    """
+    return {
+        "id": step.task_id,
+        "agent_type": step.agent_type or "",
+        "action": step.action or "",
+        "description": step.description,
+        "requires_approval": step.requires_approval,
+        "dependencies": step.dependencies,
+        "inputs": step.inputs,
+        "expected_duration_ms": int(step.estimated_duration_seconds * 1000),
+    }
 
 
 @dataclass
 class WorkflowTemplate:
-    """Complete workflow template definition."""
+    """Complete workflow template definition.
+
+    Note: a ``WorkflowTemplate`` is a static blueprint (category, complexity,
+    variable slots, secret requirements). It produces ``WorkflowTask`` lists
+    at runtime and is *not* a duplicate of ``WorkflowPlan`` — the plan is the
+    runtime execution shape. Phase 2E may relocate this class to
+    ``autobot_shared.workflow`` after the advanced_workflow template module
+    consolidates onto the same shape.
+    """
 
     id: str
     name: str
     description: str
     category: TemplateCategory
     complexity: TaskComplexity
-    steps: List[WorkflowStep]
+    steps: List[WorkflowTask]
     estimated_duration_minutes: int
     agents_involved: List[str]
     tags: List[str]
@@ -113,5 +119,5 @@ class WorkflowTemplate:
             "tags": self.tags,
             "variables": self.variables,
             "required_secrets": self.required_secrets,
-            "steps": [step.to_dict() for step in self.steps],
+            "steps": [_legacy_step_dict(step) for step in self.steps],
         }


### PR DESCRIPTION
## Summary

Phase 2A of #6951 — migrates the `workflow_templates/` package onto the canonical `WorkflowTask` shape that landed in #6965 (Phase 1b, merged as `d06450887`). This is the first of six caller-migration phases.

**No API contract change.** The historical `TemplateStep` wire format is preserved via a new `_legacy_step_dict()` helper in `workflow_templates/types.py` so the frontend `TemplateStep` interface keeps working unchanged. Phase 2F regenerates frontend types from the canonical shape.

## What changed

- `workflow_templates.types.WorkflowStep` is now an alias to `autobot_shared.workflow.WorkflowTask` (the local dataclass is gone).
- All 6 template files (analysis / community / research / sysadmin / security / development) had their `WorkflowStep(...)` kwargs rewritten:
  - `id="..."` → `task_id="..."`
  - `expected_duration_ms=N` → `estimated_duration_seconds=N/1000.0`
- 220 kwarg rewrites done via AST-aware migration script (per the [bulk-Python-edits use AST](https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/.claude/projects/feedback_bulk_python_edits_use_ast.md) feedback). `WorkflowTemplate.id` is NOT renamed — only `WorkflowStep` callees are touched. The script is in `/tmp/migrate_workflow_step_phase2a.py` (one-shot, not committed).
- `WorkflowTemplate.to_detail_dict()` now uses `_legacy_step_dict(step)` instead of `step.to_dict()`. Round-trip is exact because `/1000.0` was lossless.

## Verification

- [x] All 6 template factories instantiate cleanly: `network_security_scan` (8 steps), `comprehensive_research` (5), `system_health_check` (7), `data_analysis` (7), `code_review` (6), `reddit_monitor_reply` (4)
- [x] `WorkflowStep is WorkflowTask` → True (alias check)
- [x] Legacy step dict shape preserved in `to_detail_dict()` output (id + expected_duration_ms still emitted, ms→s round-trip exact)
- [x] 10 canonical `autobot_shared/workflow/types_test.py` tests still pass
- [x] `python3 -m py_compile` clean on all 7 modified files
- [x] Consumer modules (`api.cache_management`, `api.scheduler`, `api.templates`) still import cleanly
- [x] `workflow_templates.py` top-level facade still re-exports correctly (for #381 backward-compat shim)

## Discovery filed

**[#6983](https://github.com/mrveiss/AutoBot-AI/issues/6983)** — `orchestrator.py:33` has `from llm_interface import LLMInterface` plus 6 more references at lines 187, 352, 380, 400, 505, 516. All broken since #3185 retired `LLMInterface`. Reproducible on `origin/Dev_new_gui` HEAD, unrelated to this PR. The MEMORY.md entry for #3185 documents `"2 missed-by-grep + 5 misc"` — `orchestrator.py` was apparently in the missed cohort.

## Wire-in plan

Phase 2A wires the canonical `WorkflowTask` into 6 production caller files. Per the #6836 integration check: every new module added by #6951 (the `autobot_shared/workflow/` package) now has ≥1 production caller. ✅

Remaining migration phases:

- **Phase 2B** — `enhanced_orchestration/` (3 callers, heavy logic in `workflow_runner.py` + `dag_executor.py`)
- **Phase 2C** — `services/workflow_automation/` (manager + takeover_manager test)
- **Phase 2D** — `agents/overseer/` (state lifecycle for step sequencing)
- **Phase 2E** — `services/advanced_workflow/` (template-only)
- **Phase 2F** — frontend `TemplateStep` regeneration (this is when `_legacy_step_dict()` goes away)

## Test plan

- [x] All 6 template factories instantiate via direct import
- [x] Legacy dict shape preserved (id + expected_duration_ms keys present, ms round-trip exact)
- [x] Canonical `autobot_shared/workflow/types_test.py` still 10/10 passing
- [x] Consumer module imports clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)