### PR TITLE
ci: migrate Bucket B (final 5 workflows) to ubuntu-latest — eliminates self-hosted SPOF (#6982)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   security-tests:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v6
@@ -164,7 +164,7 @@ jobs:
         rm -rf .venv || true
 
   frontend-tests:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
 
@@ -210,7 +210,7 @@ jobs:
         rm -rf autobot-frontend/node_modules autobot-frontend/dist || true
 
   deployment-check:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [security-tests, frontend-tests]
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/Dev_new_gui'
 
@@ -331,7 +331,7 @@ jobs:
         rm -rf .venv || true
 
   notify:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [security-tests, frontend-tests, deployment-check]
     if: always()
 

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -30,7 +30,7 @@ jobs:
   # Job 1: Unit and Integration Tests
   unit-tests:
     name: Unit & Integration Tests
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -117,7 +117,7 @@ jobs:
   # Job 2: Security Scanning
   security-scan:
     name: Security Scan
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -159,7 +159,7 @@ jobs:
   # Job 3: Build Test
   build-test:
     name: Build Test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: unit-tests
 
     steps:
@@ -193,7 +193,7 @@ jobs:
   # Job 4: Test Summary and Reporting
   test-summary:
     name: Test Summary
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [unit-tests, security-scan, build-test]
     if: always()
 

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   phase-validation:
     name: AutoBot Phase Validation
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
@@ -199,7 +199,7 @@ jobs:
 
   integration-validation:
     name: Integration Phase Validation
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: phase-validation
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/Dev_new_gui'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   dependency-security:
     name: Dependency Security Scan
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
@@ -112,7 +112,7 @@ jobs:
 
   static-analysis:
     name: Static Application Security Testing (SAST)
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
@@ -217,7 +217,7 @@ jobs:
 
   compliance-check:
     name: Security Compliance Check
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
@@ -265,7 +265,7 @@ jobs:
 
   security-summary:
     name: Security Summary Report
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [dependency-security, static-analysis, compliance-check]
     if: always()
 

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -44,7 +44,7 @@ permissions:
 jobs:
   visual-regression:
     name: Storybook visual regression
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:


### PR DESCRIPTION
Closes Bucket B from #6982. Migrates the **final** 5 self-hosted workflows. Combined with Bucket A (PR #6984) and the 4-workflow first slice (#6981), this fully eliminates the self-hosted-runner SPOF that started this whole thread (#6721).

## Migrated

| Workflow | Job slots | Why migration was safe (originally flagged risky) |
|----------|-----------|---------------------------------------------------|
| ``ci.yml`` | 4 | ``ollama:`` / ``redis:`` matches were heredoc config, NOT service containers |
| ``frontend-test.yml`` | 4 | Pure Node/npm — type-check, lint, i18n, unit tests |
| ``phase_validation.yml`` | 2 | Same heredoc-config pattern as ``ci.yml`` |
| ``security.yml`` | 4 | Header comment said "self-hosted to avoid quota limits" — cost choice, not infra need |
| ``visual-regression.yml`` | 1 | No committed Playwright baselines yet → first run on ubuntu-latest just generates them |

## Bus-factor-1 timeline

| State | Self-hosted workflows / slots |
|-------|------------------------------|
| Original | 17 / 27 |
| After #6981 (lint partial) | 13 / 23 |
| After #6984 (Bucket A merge) | 5 / 15 |
| **After this PR** | **0 / 0** ✅ |

## Operational follow-up

Once this and #6984 merge:

1. The ``MV-Stealth-VM`` self-hosted runner can be retired or repurposed
2. #6721 closes
3. Required-status-checks (#6723) can safely expand from just ``smoke-test`` to also include ``code-quality``, ``CodeQL Analysis``, ``SSOT Coverage``, etc. — they all run on github-hosted now and won't get stuck

## Verification gap

I haven't dry-run each workflow on ubuntu-latest — that'll happen on the PR's own CI run. If any workflow has a hidden self-hosted assumption (e.g., a path like ``/home/martins/`` or ``172.16.168.X``), CI will surface it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)