### PR TITLE
feat(workflow): Phase 2B — migrate enhanced_orchestration onto canonical WorkflowTask (#6951)

### DIFF
--- a/autobot-backend/enhanced_orchestration/execution_strategies_test.py
+++ b/autobot-backend/enhanced_orchestration/execution_strategies_test.py
@@ -37,7 +37,7 @@ def _plan(tasks, strategy=ExecutionStrategy.SEQUENTIAL, deps_graph=None) -> Work
         strategy=strategy,
         tasks=tasks,
         dependencies_graph=deps_graph or {},
-        estimated_duration=1.0,
+        estimated_total_duration_seconds=1.0,
         resource_requirements={},
         success_criteria=[],
     )

--- a/autobot-backend/enhanced_orchestration/subagent_dispatcher.py
+++ b/autobot-backend/enhanced_orchestration/subagent_dispatcher.py
@@ -98,7 +98,7 @@ class SubagentDispatcher:
             try:
                 coro = asyncio.wait_for(
                     self._execute_task(task),
-                    timeout=task.timeout,
+                    timeout=task.timeout_seconds,
                 )
                 pending.append((task.task_id, coro))
             except Exception as exc:

--- a/autobot-backend/enhanced_orchestration/types.py
+++ b/autobot-backend/enhanced_orchestration/types.py
@@ -5,88 +5,72 @@
 Enhanced Orchestration Types Module
 
 Issue #381: Extracted from enhanced_multi_agent_orchestrator.py god class refactoring.
-Contains enums and dataclasses for the enhanced orchestration system.
+Issue #6951 Phase 2B: ``AgentTask`` and ``WorkflowPlan`` are now thin subclasses
+of the canonical ``autobot_shared.workflow.WorkflowTask`` / ``WorkflowPlan``.
+The local definitions only add behaviour the canonical shapes intentionally
+omit (task lifecycle methods + structured success criteria), keeping fields
+in one place.
 """
 
 import time
 from dataclasses import dataclass, field
-from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Dict, FrozenSet, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Callable, Dict, FrozenSet, List
 
 if TYPE_CHECKING:
     from .success_criteria import SuccessCriteria
 
+from autobot_shared.workflow import ExecutionStrategy as ExecutionStrategy
+from autobot_shared.workflow import WorkflowPlan as _SharedWorkflowPlan
+from autobot_shared.workflow import WorkflowTask
 from constants.status_enums import TaskStatus
-from constants.threshold_constants import RetryConfig, TimingConstants
 from orchestration.types import AgentCapability  # single canonical definition (#6192)
 
 # Module-level frozenset for fallback tier checks
 FALLBACK_TIERS: FrozenSet[str] = frozenset({"basic", "emergency"})
 
 
-class ExecutionStrategy(Enum):
-    """Task execution strategies"""
+class AgentTask(WorkflowTask):
+    """Workflow task with execution lifecycle methods.
 
-    SEQUENTIAL = "sequential"  # One after another
-    PARALLEL = "parallel"  # All at once
-    PIPELINE = "pipeline"  # Output feeds next input
-    COLLABORATIVE = "collaborative"  # Agents work together
-    ADAPTIVE = "adaptive"  # Strategy changes based on progress
-
-
-@dataclass
-class AgentTask:
-    """Enhanced task definition for agents"""
-
-    task_id: str
-    agent_type: str
-    action: str
-    inputs: Dict[str, Any]
-    dependencies: List[str] = field(default_factory=list)
-    priority: int = 5  # 1-10, higher is more important
-    timeout: float = float(TimingConstants.STANDARD_TIMEOUT)
-    retry_count: int = 0
-    max_retries: int = RetryConfig.DEFAULT_RETRIES
-    capabilities_required: Set[AgentCapability] = field(default_factory=set)
-    outputs: Optional[Dict[str, Any]] = None
-    status: str = TaskStatus.PENDING.value  # Issue #670: Use centralized enum
-    error: Optional[str] = None
-    start_time: Optional[float] = None
-    end_time: Optional[float] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    Inherits every field from ``autobot_shared.workflow.WorkflowTask`` (#6951
+    Phase 1b). The methods below were extracted under Issue #372 to reduce
+    feature envy in the runner; they live in this subclass — not on the
+    canonical type — because they encode an execution-runtime concern that
+    the shared shape intentionally avoids.
+    """
 
     def start_execution(self) -> None:
-        """Mark task as started (Issue #372 - reduces feature envy)."""
+        """Mark task as started (Issue #372)."""
         self.start_time = time.time()
         self.status = TaskStatus.RUNNING.value
 
     def complete_execution(self, result: Dict[str, Any]) -> None:
-        """Mark task as completed with result (Issue #372 - reduces feature envy)."""
+        """Mark task as completed with result (Issue #372)."""
         self.end_time = time.time()
         self.status = TaskStatus.COMPLETED.value
         self.outputs = result
 
     def fail_execution(self, error_msg: str) -> None:
-        """Mark task as failed with error (Issue #372 - reduces feature envy)."""
+        """Mark task as failed with error (Issue #372)."""
         self.status = TaskStatus.FAILED.value
         self.error = error_msg
 
     def get_execution_time(self) -> float:
-        """Get execution time in seconds (Issue #372 - reduces feature envy)."""
+        """Get execution time in seconds (Issue #372)."""
         if self.start_time and self.end_time:
             return self.end_time - self.start_time
         return 0.0
 
     def can_retry(self) -> bool:
-        """Check if task can be retried (Issue #372 - reduces feature envy)."""
+        """Check if task can be retried (Issue #372)."""
         return self.retry_count < self.max_retries
 
     def increment_retry(self) -> None:
-        """Increment retry counter (Issue #372 - reduces feature envy)."""
+        """Increment retry counter (Issue #372)."""
         self.retry_count += 1
 
     def get_enhanced_inputs(self, context: Dict[str, Any]) -> Dict[str, Any]:
-        """Get inputs enhanced with context (Issue #372 - reduces feature envy)."""
+        """Get inputs enhanced with context (Issue #372)."""
         return {
             **self.inputs,
             "context": context,
@@ -95,7 +79,7 @@ class AgentTask:
         }
 
     def to_completed_result(self, result: Dict[str, Any]) -> Dict[str, Any]:
-        """Build completed result dict (Issue #372 - reduces feature envy)."""
+        """Build completed result dict (Issue #372)."""
         return {
             "status": "completed",
             "output": result,
@@ -104,7 +88,7 @@ class AgentTask:
         }
 
     def to_failed_result(self, error_msg: str) -> Dict[str, Any]:
-        """Build failed result dict (Issue #372 - reduces feature envy)."""
+        """Build failed result dict (Issue #372)."""
         return {
             "status": "failed",
             "error": error_msg,
@@ -113,21 +97,16 @@ class AgentTask:
 
 
 @dataclass
-class WorkflowPlan:
-    """Enhanced workflow execution plan"""
+class WorkflowPlan(_SharedWorkflowPlan):
+    """Enhanced workflow plan with structured success criteria.
 
-    plan_id: str
-    goal: str
-    strategy: ExecutionStrategy
-    tasks: List[AgentTask]
-    dependencies_graph: Dict[str, List[str]]  # task_id -> [dependency_ids]
-    estimated_duration: float
-    resource_requirements: Dict[str, Any]
-    success_criteria: List[str]
-    # Issue #3293: structured success criteria for partial/full/failed evaluation
+    Inherits every field from ``autobot_shared.workflow.WorkflowPlan`` (#6951
+    Phase 1b). ``structured_criteria`` (#3293) lives here, not on the canonical
+    shape, because it depends on backend-only ``SuccessCriteria`` semantics for
+    partial/full/failed evaluation.
+    """
+
     structured_criteria: List["SuccessCriteria"] = field(default_factory=list)
-    fallback_plans: List["WorkflowPlan"] = field(default_factory=list)
-    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/autobot-backend/enhanced_orchestration/workflow_planning.py
+++ b/autobot-backend/enhanced_orchestration/workflow_planning.py
@@ -82,7 +82,7 @@ class StrategyPlanner:
             strategy=strategy,
             tasks=tasks,
             dependencies_graph=dependencies_graph,
-            estimated_duration=plan_data.get("estimated_duration", 60.0),
+            estimated_total_duration_seconds=plan_data.get("estimated_duration", 60.0),
             resource_requirements=plan_data.get("resource_requirements", {}),
             success_criteria=plan_data.get("success_criteria", ["All tasks completed"]),
         )
@@ -130,7 +130,7 @@ class StrategyPlanner:
                 )
             ],
             dependencies_graph={},
-            estimated_duration=30.0,
+            estimated_total_duration_seconds=30.0,
             resource_requirements={},
             success_criteria=["Task completed"],
         )

--- a/autobot-backend/enhanced_orchestration/workflow_runner.py
+++ b/autobot-backend/enhanced_orchestration/workflow_runner.py
@@ -189,7 +189,7 @@ class WorkflowRunner:
                 enhanced_inputs = task.get_enhanced_inputs(context)
                 result = await asyncio.wait_for(
                     agent.process_request({"action": task.action, "payload": enhanced_inputs}),
-                    timeout=task.timeout,
+                    timeout=task.timeout_seconds,
                 )
                 task.complete_execution(result)
                 self._perf.update(task.agent_type, True, task.get_execution_time())

--- a/autobot-backend/enhanced_orchestration/workflow_runner_test.py
+++ b/autobot-backend/enhanced_orchestration/workflow_runner_test.py
@@ -38,7 +38,7 @@ def _plan(tasks=None, strategy=ExecutionStrategy.SEQUENTIAL) -> WorkflowPlan:
         strategy=strategy,
         tasks=tasks,
         dependencies_graph={},
-        estimated_duration=1.0,
+        estimated_total_duration_seconds=1.0,
         resource_requirements={},
         success_criteria=[],
     )

--- a/autobot_shared/workflow/types.py
+++ b/autobot_shared/workflow/types.py
@@ -79,7 +79,7 @@ class WorkflowTask:
     """
 
     task_id: str
-    description: str
+    description: str = ""
 
     agent_type: Optional[str] = None
     action: Optional[str] = None

--- a/autobot_shared/workflow/types_test.py
+++ b/autobot_shared/workflow/types_test.py
@@ -12,7 +12,7 @@ from autobot_shared.workflow import (
 
 
 def test_workflow_task_minimal_construction():
-    """Only task_id and description are required."""
+    """Only task_id is required; description defaults to empty string."""
     t = WorkflowTask(task_id="t1", description="do the thing")
     assert t.task_id == "t1"
     assert t.description == "do the thing"
@@ -23,6 +23,16 @@ def test_workflow_task_minimal_construction():
     assert t.inputs == {}
     assert t.dependencies == []
     assert t.metadata == {}
+
+
+def test_workflow_task_task_id_only_construction():
+    """Phase 2B (#6951) — legacy enhanced_orchestration.AgentTask had no
+    description field. Subclassing the canonical type required dropping the
+    `description` requirement so subclass call sites that do not pass
+    description still work."""
+    t = WorkflowTask(task_id="legacy-style")
+    assert t.task_id == "legacy-style"
+    assert t.description == ""
 
 
 def test_workflow_task_first_class_prompt():


### PR DESCRIPTION
## Summary

Phase 2B of #6951 — migrates `enhanced_orchestration/` onto the canonical `WorkflowTask` shape from Phase 1b (#6965, merged as `d06450887`). This is the **heaviest** caller cohort because of the 9 lifecycle methods (`start_execution`, `complete_execution`, `fail_execution`, `get_execution_time`, `can_retry`, `increment_retry`, `get_enhanced_inputs`, `to_completed_result`, `to_failed_result`) that the runner depends on.

**Independent of Phase 2A (#6985)** — these touch different caller files and can be reviewed/merged in either order.

## Subclass strategy (wire-in, not delete)

Per the absolute "wire it in, never delete" rule, the local `enhanced_orchestration.types` definitions become thin subclasses that absorb only the backend-specific concerns:

- **`AgentTask(WorkflowTask)`** — adds the 9 lifecycle methods that were extracted under #372 to reduce feature envy. Fields stay in canonical; methods stay in backend subclass because they encode runtime concerns the canonical shape intentionally avoids.
- **`WorkflowPlan(_SharedWorkflowPlan)`** — adds `structured_criteria: List[SuccessCriteria]` (#3293) which depends on backend-only `SuccessCriteria` semantics for partial/full/failed evaluation. Stays in subclass for the same layering reason.
- **`ExecutionStrategy`** — re-exported from `autobot_shared.workflow` (was duplicated locally with identical enum values).
- **`WorkflowDependencies`, `AgentPerformance`, `FALLBACK_TIERS`** — kept unchanged (not duplicates, distinct concerns).

## Canonical adjustment

`WorkflowTask.description: str = ""` (was required). Legacy `enhanced_orchestration.AgentTask` had no `description` field, so the default lets subclass call sites work unchanged. Test added: `test_workflow_task_task_id_only_construction`.

## Caller kwarg renames (5 sites)

| File:line | Before | After |
|---|---|---|
| `workflow_planning.py:85` | `estimated_duration=` | `estimated_total_duration_seconds=` |
| `workflow_planning.py:133` | `estimated_duration=` | `estimated_total_duration_seconds=` |
| `workflow_runner_test.py:41` | `estimated_duration=` | `estimated_total_duration_seconds=` |
| `execution_strategies_test.py:40` | `estimated_duration=` | `estimated_total_duration_seconds=` |
| `workflow_runner.py:192` | `task.timeout` (read) | `task.timeout_seconds` |
| `subagent_dispatcher.py:101` | `task.timeout` (read) | `task.timeout_seconds` |

## Verification

- [x] **57/57 enhanced_orchestration tests pass** (collaboration + execution_strategies + success_criteria + workflow_runner)
- [x] **11/11 canonical autobot_shared/workflow tests pass** (10 from Phase 1b + 1 new)
- [x] `issubclass(AgentTask, WorkflowTask)` → True
- [x] All 9 lifecycle methods on `AgentTask` work end-to-end (instantiate → start → complete → check execution_time)
- [x] `WorkflowPlan` carries `structured_criteria` field with default factory
- [x] `ExecutionStrategy is autobot_shared.workflow.ExecutionStrategy` → True
- [x] `orchestration.performance_tracker` imports cleanly (still uses `WorkflowPlan` as type ref)
- [x] `python3 -m py_compile` clean on all 8 modified files
- [x] `python3 -m black --check` clean

## Net diff

-64 / +53 lines across 8 files. Negative because the local `AgentTask` (16 fields), `WorkflowPlan` (10 fields), and `ExecutionStrategy` enum bodies are gone — replaced by subclasses that only add behaviour.

## What this enables

After 2B lands, the canonical type is wired into the **highest-traffic** workflow execution path in the platform. Phases 2C-2F (services/workflow_automation, agents/overseer, services/advanced_workflow, frontend codegen) become much smaller deltas because the shared shape is now battle-tested in the runtime.

## Test plan

- [x] `pytest autobot_shared/workflow/types_test.py` → 11 passed
- [x] `pytest autobot-backend/enhanced_orchestration/` → 57 passed
- [x] AgentTask lifecycle smoke test (start → complete with result → query execution time)
- [x] WorkflowPlan with structured_criteria default factory
- [x] ExecutionStrategy identity check (canonical re-export)
- [x] orchestration.performance_tracker import smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)