### PR TITLE
feat(tools/lint): block dict-style access on LLMResponse (#6940)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,22 @@ repos:
         stages: [pre-commit]
         description: "Use autobot_shared.time_utils.utc_timestamp() instead of datetime.utcnow().isoformat()"
 
+  # AutoBot custom: regression-prevention for #6940. PR #6881 found 7 files
+  # calling response.get("content") on LLMResponse (a Pydantic BaseModel)
+  # — masked by MockLLMInterface in tests but raised AttributeError in prod.
+  # AST-aware: only flags `.get(...)` / `[...]` access on variables assigned
+  # from llm_service.chat() / chat_optimized() / etc. in files that import
+  # LLMResponse. Allowlists judges/__init__.py (intentional triple-fallback).
+  - repo: local
+    hooks:
+      - id: no-llm-response-dict-access
+        name: Block dict-style access on LLMResponse (#6940)
+        entry: tools/lint/check_no_llm_response_dict_access.py
+        language: python
+        files: \.py$
+        stages: [pre-commit]
+        description: "Use response.content (attribute), not response.get('content') — LLMResponse is a Pydantic BaseModel"
+
   # AutoBot custom: regression-prevention for #5225 KB redis accessor migration.
   # Blocks any reference to the old public ``aioredis_client`` attribute
   # (renamed to ``_aioredis_client`` in #5225) and any reference to the new

--- a/tools/lint/check_no_llm_response_dict_access.py
+++ b/tools/lint/check_no_llm_response_dict_access.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Regression-prevention check for the #6940 LLMResponse dict-style access pattern.
+
+Background
+----------
+PR #6881 (#3185 LLMInterface retirement) found 7 production files calling
+``response.get("content")`` / ``response_data.get("response")`` /
+``response["content"]`` on objects whose runtime type is ``LLMResponse`` —
+a Pydantic ``BaseModel``. Dict-style access on a model instance raises
+``AttributeError`` at runtime, but tests were masking it via ``MockLLMInterface``
+which accepted both shapes.
+
+This hook prevents the regression by AST-scanning files that import
+``LLMResponse`` for variable assignments like::
+
+    response = await llm_service.chat(...)
+
+…then flagging subsequent ``response.get(...)`` or ``response[key]`` access on
+the assigned name. Files that don't import ``LLMResponse`` are exempt — the
+``.get(...)`` access there is on a real dict.
+
+Allowlist
+---------
+``autobot-backend/judges/__init__.py`` is exempt: it has an *intentional*
+triple-fallback (``hasattr(.., 'content') -> .content``,
+``isinstance(str)``, else legacy-dict ``.get('content', '')``) that supports
+all three return shapes documented in #3185 Phase 2D. The else-branch dict
+access is gated by the ``hasattr`` check above it, so the runtime path is
+safe.
+
+Exit code
+---------
+  0 — clean
+  1 — banned patterns found
+  2 — usage error
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+# tools/lint/ is not a Python package; ensure sibling module is importable
+# regardless of invocation mode (script / importlib from tests).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _scan_helpers import iter_python_files  # noqa: E402
+
+# LLM-service method names whose return value is LLMResponse. Variables
+# assigned from these calls are tracked.
+LLM_CHAT_METHODS = frozenset(
+    {
+        "chat",
+        "chat_optimized",
+        "achat_completion",
+        "chat_completion",
+        "generate",
+        "complete",
+    }
+)
+
+# Subscript/attr keys that signify the dict-shape access bug. ``.get("content")``
+# on an LLMResponse hits AttributeError; on a dict it works.
+DICT_ACCESS_KEYS = frozenset({"content", "response", "text", "message"})
+
+# Files exempt from the check — see module docstring for rationale.
+ALLOWLIST = frozenset(
+    {
+        # Intentional triple-fallback for LLMResponse | str | legacy-dict.
+        "autobot-backend/judges/__init__.py",
+        # The hook itself + tests reference the patterns as strings.
+        "tools/lint/check_no_llm_response_dict_access.py",
+        "tools/lint/check_no_llm_response_dict_access_test.py",
+    }
+)
+
+
+def _imports_llm_response(tree: ast.AST) -> bool:
+    """Return True if file imports ``LLMResponse`` from any module."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == "LLMResponse":
+                    return True
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.endswith(".LLMResponse"):
+                    return True
+    return False
+
+
+def _is_llm_call(node: ast.AST) -> bool:
+    """Return True if node is a call like ``svc.chat(...)``,
+    ``await svc.chat_optimized(...)``, etc.
+    """
+    if isinstance(node, ast.Await):
+        node = node.value
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr in LLM_CHAT_METHODS
+    return False
+
+
+def _scan_file(path: Path, source: str) -> list[tuple[int, str]]:
+    """Return [(line_no, message), …] for any banned access pattern."""
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []  # let other linters handle
+
+    if not _imports_llm_response(tree):
+        return []
+
+    # Track variables assigned from an LLM chat call. Whole-file scope is fine
+    # for our purposes — the pattern lives in single function bodies, and a
+    # rebind in another function will still match if it's a real bug.
+    tracked: dict[str, int] = {}  # var name → assignment lineno
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            if _is_llm_call(node.value):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        tracked[target.id] = node.lineno
+        elif isinstance(node, ast.AnnAssign):
+            # Explicit annotation: ``response: LLMResponse = ...``
+            if (
+                isinstance(node.annotation, ast.Name)
+                and node.annotation.id == "LLMResponse"
+                and isinstance(node.target, ast.Name)
+            ):
+                tracked[node.target.id] = node.lineno
+
+    if not tracked:
+        return []
+
+    findings: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        # `<var>.get("content")` style
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if (
+                node.func.attr == "get"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id in tracked
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and node.args[0].value in DICT_ACCESS_KEYS
+            ):
+                findings.append(
+                    (
+                        node.lineno,
+                        f"{node.func.value.id}.get({node.args[0].value!r}) — "
+                        f"LLMResponse is a Pydantic model; use .content / .{node.args[0].value} attribute access",
+                    )
+                )
+        # `<var>["content"]` style
+        elif isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+            if node.value.id in tracked:
+                # Pull literal subscript key
+                key_node = (
+                    node.slice
+                    if isinstance(node.slice, ast.Constant)
+                    else None
+                )
+                if key_node and key_node.value in DICT_ACCESS_KEYS:
+                    findings.append(
+                        (
+                            node.lineno,
+                            f"{node.value.id}[{key_node.value!r}] — "
+                            f"LLMResponse is a Pydantic model; use .{key_node.value} attribute access",
+                        )
+                    )
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    files = iter_python_files(args, repo_root)
+
+    total_violations = 0
+    for f in files:
+        try:
+            rel = f.relative_to(repo_root)
+        except ValueError:
+            rel = f
+        rel_str = str(rel).replace("\\", "/")
+        if rel_str in ALLOWLIST:
+            continue
+        try:
+            source = f.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        findings = _scan_file(f, source)
+        for lineno, msg in findings:
+            print(f"{rel_str}:{lineno}: {msg}", file=sys.stderr)
+            total_violations += 1
+
+    if total_violations:
+        print(
+            f"\n{total_violations} LLMResponse dict-access violation(s) found.\n"
+            f"LLMResponse is a Pydantic BaseModel — use attribute access (.content, .response):\n"
+            f"  ❌ response.get('content', '')\n"
+            f"  ❌ response['content']\n"
+            f"  ✅ response.content\n"
+            f"  ✅ getattr(response, 'content', '')\n",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lint/check_no_llm_response_dict_access_test.py
+++ b/tools/lint/check_no_llm_response_dict_access_test.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for tools/lint/check_no_llm_response_dict_access.py (#6940)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent / "check_no_llm_response_dict_access.py"
+_SPEC = importlib.util.spec_from_file_location("check_llm_response", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+hook = importlib.util.module_from_spec(_SPEC)
+sys.modules["check_llm_response"] = hook
+_SPEC.loader.exec_module(hook)
+
+
+def _scan(source: str, name: str = "fake.py") -> list[tuple[int, str]]:
+    return hook._scan_file(Path(name), source)
+
+
+# ---------------------------------------------------------------------------
+# Files without LLMResponse import are exempt
+# ---------------------------------------------------------------------------
+
+
+def test_skips_files_not_importing_llm_response() -> None:
+    """Files that don't import LLMResponse are exempt — `.get()` access there
+    is on a real dict, never on a Pydantic LLMResponse."""
+    src = """
+import json
+
+def handle_response(data):
+    return data.get("content", "")
+"""
+    assert _scan(src) == []
+
+
+# ---------------------------------------------------------------------------
+# Banned patterns: assigned-from-chat-call + dict access
+# ---------------------------------------------------------------------------
+
+
+def test_flags_get_after_chat_assignment() -> None:
+    src = """
+from llm_interface_pkg.models import LLMResponse
+
+async def parse():
+    response = await llm_service.chat(prompt)
+    return response.get("content", "")
+"""
+    findings = _scan(src)
+    assert len(findings) == 1
+    assert findings[0][1].startswith("response.get('content')")
+
+
+def test_flags_get_after_chat_optimized_assignment() -> None:
+    src = """
+from llm_interface_pkg.models import LLMResponse
+
+async def parse():
+    result = await llm.chat_optimized(prompt)
+    return result.get("response", "")
+"""
+    findings = _scan(src)
+    assert len(findings) == 1
+    assert "result.get('response')" in findings[0][1]
+
+
+def test_flags_subscript_access() -> None:
+    src = """
+from llm_interface_pkg.models import LLMResponse
+
+async def parse():
+    r = await svc.chat(prompt)
+    return r["content"]
+"""
+    findings = _scan(src)
+    assert len(findings) == 1
+    assert "r['content']" in findings[0][1]
+
+
+def test_flags_explicit_annotation() -> None:
+    """``response: LLMResponse = …`` should also be tracked."""
+    src = """
+from llm_interface_pkg.models import LLMResponse
+
+def parse():
+    response: LLMResponse = call()
+    return response.get("content")
+"""
+    findings = _scan(src)
+    assert len(findings) == 1
+
+
+def test_flags_multiple_violations() -> None:
+    src = """
+from llm_interface_pkg.models import LLMResponse
+
+async def f():
+    a = await svc.chat(p)
+    b = await svc.complete(p)
+    return a.get("content"), b["response"]
+"""
+    findings = _scan(src)
+    assert len(findings) == 2
+
+
+# ---------------------------------------------------------------------------
+# Correct usage is allowed
+# ---------------------------------------------------------------------------
+
+
+def test_allows_attribute_access() -> None:
+    src = """
+from llm_interface_pkg.models import LLMResponse
+
+async def f():
+    response = await llm.chat(p)
+    return response.content
+"""
+    assert _scan(src) == []
+
+
+def test_allows_getattr_fallback() -> None:
+    src = """
+from llm_interface_pkg.models import LLMResponse
+
+async def f():
+    response = await llm.chat(p)
+    return getattr(response, "content", "")
+"""
+    assert _scan(src) == []
+
+
+def test_ignores_get_on_unrelated_variable() -> None:
+    """A `.get()` call on a variable that isn't tracked must not be flagged.
+    e.g. dict lookups on arguments unrelated to the chat call."""
+    src = """
+from llm_interface_pkg.models import LLMResponse
+
+async def f(metadata: dict):
+    response = await llm.chat(p)
+    text = response.content
+    tag = metadata.get("tag", "")  # unrelated dict — must not trigger
+    return text, tag
+"""
+    assert _scan(src) == []
+
+
+def test_ignores_get_with_non_content_key() -> None:
+    """A `.get('user_id')` on a tracked LLMResponse var is suspicious but
+    not the specific bug pattern — only flag the documented dict-shape keys."""
+    src = """
+from llm_interface_pkg.models import LLMResponse
+
+async def f():
+    response = await llm.chat(p)
+    return response.get("user_id")  # unusual but not the documented bug
+"""
+    assert _scan(src) == []
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_handles_syntax_error_gracefully() -> None:
+    src = "this is not valid python ===="
+    assert _scan(src) == []
+
+
+def test_handles_no_chat_assignments() -> None:
+    """File imports LLMResponse but never assigns from a chat call —
+    nothing to track, nothing to flag."""
+    src = """
+from llm_interface_pkg.models import LLMResponse
+
+def parse(payload):
+    return payload.get("content")
+"""
+    assert _scan(src) == []


### PR DESCRIPTION
## Summary

PR #6881 (#3185) found 7 production files calling \`response.get(\"content\")\` / \`response[\"content\"]\` on \`LLMResponse\` instances — a Pydantic BaseModel that doesn't expose dict-shape access. Bug raised \`AttributeError\` in production but was masked by \`MockLLMInterface\` returning dict-like objects in tests.

## Hook design (AST-aware)

1. Skip files that don't import \`LLMResponse\` (their \`.get()\` calls are on real dicts).
2. In LLMResponse-importing files, track variables assigned from LLM-service methods (\`chat\`, \`chat_optimized\`, \`achat_completion\`, \`chat_completion\`, \`generate\`, \`complete\`) plus explicit \`var: LLMResponse = …\` annotations.
3. Flag \`<tracked>.get(\"content\"|\"response\"|\"text\"|\"message\")\` and \`<tracked>[\"content\"|...]\` access.

## Allowlist

\`autobot-backend/judges/__init__.py\` exempt — has an intentional \`hasattr(., 'content') / isinstance(str) / .get('content', '')\` triple-fallback for backward-compat with the legacy dict shape (#3185 Phase 2D), and the dict access is gated by the hasattr check above it.

## Verification

\`\`\`
$ python3 tools/lint/check_no_llm_response_dict_access.py    # full-codebase scan
$ echo \$?
0

$ python3 -m pytest tools/lint/check_no_llm_response_dict_access_test.py -xvs
============================== 12 passed in 0.13s ==============================
\`\`\`

Registered in \`.pre-commit-config.yaml\` next to \`no-utcnow-isoformat\`.

Closes #6940