### PR TITLE
feat(autobot_shared): add optional_import() helper to MissingDep (#6691)

### DIFF
--- a/autobot_shared/missing_dep.py
+++ b/autobot_shared/missing_dep.py
@@ -12,16 +12,26 @@ Issue #6297: Add __bool__ and __eq__ so the sentinel is falsy and compares
 equal to None, allowing `if not dep:` and `dep is None` guards to work
 correctly without per-file workaround flags.
 
+Issue #6691: Add ``optional_import(module, names)`` helper to collapse the
+verbose ``try: from X import a, b, c; except ImportError: ...`` block —
+3-7 lines of repetition per call site — into a single call.
+
 Usage::
 
+    # Single-symbol shape (still supported, sometimes preferable for type
+    # hints since the local name retains its original module's type):
     from autobot_shared.missing_dep import MissingDep as _MissingDep
-
     try:
         import some_optional_lib
     except ImportError as e:
         some_optional_lib = _MissingDep("some_optional_lib", e)
+
+    # Multi-symbol shape (#6691) — expanded into module globals:
+    from autobot_shared.missing_dep import optional_import
+    globals().update(optional_import("log_forwarder", ["start", "stop", "Forwarder"]))
 """
 
+import importlib
 from typing import NoReturn
 
 
@@ -84,3 +94,41 @@ class MissingDep:
         failure stays at runtime call / non-dunder attribute access.
         """
         return self
+
+
+def optional_import(module_name: str, names: list[str]) -> dict[str, object]:
+    """Resolve ``names`` from ``module_name``; return ``MissingDep`` stubs on ImportError.
+
+    Collapses the 5-line ``try: from X import a, b; except: a = MissingDep(...);
+    b = MissingDep(...)`` boilerplate into a single call. Every name is wired
+    consistently so a partial-import failure (e.g. one name missing from a
+    real module) doesn't leave callers with inconsistent ``MissingDep``-vs-real
+    mixing — when ImportError fires for the *module*, **all** names become
+    sentinels.
+
+    Args:
+        module_name: dotted import path, e.g. ``"autobot_backend.log_forwarder"``.
+        names: symbol names to pull from the module.
+
+    Returns:
+        ``{name: real_attribute}`` on success, ``{name: MissingDep(name, err)}``
+        on ImportError. Use with ``globals().update(...)`` at module top-level
+        to expand into local namespace.
+
+    Example:
+        >>> # Equivalent to a 6-line try/except block:
+        >>> globals().update(optional_import(
+        ...     "autobot_backend.log_forwarder",
+        ...     ["start_forwarder", "stop_forwarder", "ForwarderStatus"],
+        ... ))
+
+    Raises:
+        AttributeError: if the module imports successfully but is missing one
+            of ``names``. This is **not** caught — a missing symbol after a
+            successful module import is a real bug, not an optional-dep gap.
+    """
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as e:
+        return {name: MissingDep(name, e) for name in names}
+    return {name: getattr(module, name) for name in names}

--- a/autobot_shared/tests/test_missing_dep.py
+++ b/autobot_shared/tests/test_missing_dep.py
@@ -111,3 +111,71 @@ def test_hashable() -> None:
     """
     s = {_stub(), _stub()}
     assert len(s) == 2  # identity-based hashing is preserved
+
+
+# ---------------------------------------------------------------------------
+# optional_import helper (#6691)
+# ---------------------------------------------------------------------------
+
+
+def test_optional_import_resolves_real_module() -> None:
+    """A real module yields actual symbols, not stubs."""
+    from autobot_shared.missing_dep import optional_import
+
+    result = optional_import("os.path", ["join", "exists"])
+    import os.path
+    assert result["join"] is os.path.join
+    assert result["exists"] is os.path.exists
+
+
+def test_optional_import_returns_stubs_on_missing_module() -> None:
+    """ImportError on the module substitutes MissingDep for every name."""
+    from autobot_shared.missing_dep import MissingDep, optional_import
+
+    result = optional_import(
+        "nonexistent_module_xyz_definitely_not_installed_12345",
+        ["foo", "bar", "baz"],
+    )
+    assert set(result.keys()) == {"foo", "bar", "baz"}
+    for name, value in result.items():
+        assert isinstance(value, MissingDep)
+        # Each stub keeps the symbol's own name for diagnostics
+        assert repr(value) == f"MissingDep({name!r})"
+
+
+def test_optional_import_calling_stub_raises_importerror() -> None:
+    """Calling a returned stub raises ImportError citing the symbol name."""
+    from autobot_shared.missing_dep import optional_import
+
+    result = optional_import("nonexistent_xyz_pkg", ["entry_point"])
+    with pytest.raises(ImportError, match="entry_point is not available"):
+        result["entry_point"]()
+
+
+def test_optional_import_globals_update_pattern() -> None:
+    """Documented pattern: ``globals().update(optional_import(...))`` —
+    verify the dict shape is suitable for that usage.
+    """
+    from autobot_shared.missing_dep import optional_import
+
+    fake_globals: dict[str, object] = {}
+    fake_globals.update(optional_import("os.path", ["sep"]))
+    import os.path
+    assert fake_globals["sep"] == os.path.sep
+
+
+def test_optional_import_attribute_error_propagates_for_real_modules() -> None:
+    """If the module imports successfully but is missing a name, AttributeError
+    propagates (it's a real bug, not an optional-dep gap)."""
+    from autobot_shared.missing_dep import optional_import
+
+    with pytest.raises(AttributeError):
+        optional_import("os.path", ["this_attr_does_not_exist_on_os_path"])
+
+
+def test_optional_import_empty_names_list() -> None:
+    """Empty names list returns empty dict (degenerate but valid)."""
+    from autobot_shared.missing_dep import optional_import
+
+    assert optional_import("os.path", []) == {}
+    assert optional_import("nonexistent_xyz", []) == {}


### PR DESCRIPTION
## Summary

Collapses the verbose 5-line `try: from X import a, b, c; except ImportError: a = MissingDep('a', e); ...` boilerplate into a single function call.

```python
from autobot_shared.missing_dep import optional_import
globals().update(optional_import("log_forwarder", ["start", "stop", "Forwarder"]))
```

## Design notes

- **Atomic stub-or-real** — when the *module* fails to import, every requested name becomes a MissingDep stub. No partial-import path that mixes real symbols with sentinels.
- **AttributeError propagates** — module-imports-but-name-missing is a real bug, not an optional-dep gap. Surface loudly to the caller.
- **Stub names match symbol names** — `MissingDep('start', err)` not `MissingDep('log_forwarder', err)` so error messages identify which name failed.

## Test plan

```
$ python3 -m pytest autobot_shared/tests/test_missing_dep.py -xvs
============================== 17 passed in 0.05s ==============================
```

(11 existing + 6 new tests for optional_import)

## Migration

Doesn't touch the 7 known existing MissingDep call sites — they can migrate incrementally. Issue #6691 lists them.

Closes #6691