### PR TITLE
ci: broaden path filters added in #6998 to cover all workflow inputs (#6992)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,25 +9,31 @@ on:
     branches: [ main, Dev_new_gui, develop ]
     paths:
       - '**/*.py'
-      - 'autobot-backend/requirements*.txt'
-      - 'autobot-slm-backend/requirements*.txt'
+      - '**/requirements*.txt'
       - 'pyproject.toml'
       - '.flake8'
+      - '.bandit'
       - '.pre-commit-config.yaml'
-      - 'pipeline-scripts/check-hardcoded-*.sh'
-      - 'tools/lint/check_no_*.py'
+      - 'pipeline-scripts/**'
+      - 'tools/lint/**'
+      - 'autobot-infrastructure/shared/scripts/hooks/**'
+      - 'autobot-infrastructure/ansible/roles/slm_agent/files/**'
+      - 'docs/developer/**'
       - '.github/workflows/code-quality.yml'
   pull_request:
     branches: [ main, Dev_new_gui, develop ]
     paths:
       - '**/*.py'
-      - 'autobot-backend/requirements*.txt'
-      - 'autobot-slm-backend/requirements*.txt'
+      - '**/requirements*.txt'
       - 'pyproject.toml'
       - '.flake8'
+      - '.bandit'
       - '.pre-commit-config.yaml'
-      - 'pipeline-scripts/check-hardcoded-*.sh'
-      - 'tools/lint/check_no_*.py'
+      - 'pipeline-scripts/**'
+      - 'tools/lint/**'
+      - 'autobot-infrastructure/shared/scripts/hooks/**'
+      - 'autobot-infrastructure/ansible/roles/slm_agent/files/**'
+      - 'docs/developer/**'
       - '.github/workflows/code-quality.yml'
 
 concurrency:

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -8,15 +8,21 @@ on:
     branches: [ main, Dev_new_gui ]
     paths:
       - 'autobot-backend/**/*.py'
+      - 'autobot-slm-backend/**/*.py'
       - 'autobot_shared/**/*.py'
+      - '**/requirements*.txt'
       - 'pipeline-scripts/**'
+      - 'tools/lint/**'
       - '.github/workflows/phase_validation.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'autobot-backend/**/*.py'
+      - 'autobot-slm-backend/**/*.py'
       - 'autobot_shared/**/*.py'
+      - '**/requirements*.txt'
       - 'pipeline-scripts/**'
+      - 'tools/lint/**'
       - '.github/workflows/phase_validation.yml'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/startup-import-smoke.yml
+++ b/.github/workflows/startup-import-smoke.yml
@@ -16,14 +16,16 @@ on:
     paths:
       - 'autobot-backend/**/*.py'
       - 'autobot_shared/**/*.py'
-      - 'autobot-backend/requirements*.txt'
+      - 'autobot-slm-backend/**/*.py'
+      - '**/requirements*.txt'
       - '.github/workflows/startup-import-smoke.yml'
   pull_request:
     branches: [main, Dev_new_gui, develop]
     paths:
       - 'autobot-backend/**/*.py'
       - 'autobot_shared/**/*.py'
-      - 'autobot-backend/requirements*.txt'
+      - 'autobot-slm-backend/**/*.py'
+      - '**/requirements*.txt'
       - '.github/workflows/startup-import-smoke.yml'
 
 concurrency:


### PR DESCRIPTION
Follow-up to merged #6998. The initial filters were narrower than the inputs the workflows actually depend on; self-review caught the gap post-merge.

## Why a follow-up?

Race: PR #6998 was merged before my second commit (broadening) was pushed. Rather than reverting/re-pushing, this PR lands the broadening as a separate, reviewable delta on top of the merged narrower set.

## Inputs the merged version was missing

**`code-quality.yml`:**
- `.bandit` (used by bandit-check step)
- broader `pipeline-scripts/**` (was just `check-hardcoded-*.sh`) — other CI scripts get edited there too
- broader `tools/lint/**` (was just `check_no_*.py`) — the validator family keeps growing (#6940 LLMResponse static check)
- `autobot-infrastructure/shared/scripts/hooks/**` — where the pre-commit hook scripts live (edited frequently for #6782/#6786)
- `autobot-infrastructure/ansible/roles/slm_agent/files/**` — Ansible-deployed scripts are linted alongside repo code
- `docs/developer/**` — used by check-doc-references.sh
- generalized `autobot-backend/requirements*.txt` + `autobot-slm-backend/requirements*.txt` → `**/requirements*.txt`

**`startup-import-smoke.yml`:**
- `autobot-slm-backend/**/*.py` — slm backend failures should also block this gate
- generalized `autobot-backend/requirements*.txt` → `**/requirements*.txt`

**`phase_validation.yml`:**
- `autobot-slm-backend/**/*.py` (was missing)
- `**/requirements*.txt` — dependency change can affect Phase-2 workflow validation
- `tools/lint/**` — validators run as part of phase checks

## Trade-off

Broader filter = slightly more triggers, but every new path is something the workflow actually reads. False positives matter less than missed validations.

## Verification

- All 3 YAML files parse (`yaml.safe_load`)
- Net diff: +24/-10 across 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)