### PR TITLE
feat(system-health): expose GET /api/system/health/probes (phase 1 of #6917)

### DIFF
--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -354,6 +354,29 @@ async def get_system_health(
         }
 
 
+@router.get("/system/health/probes", response_model=list[str])
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_system_health_probes",
+    error_code_prefix="SYSTEM",
+)
+async def get_system_health_probes() -> list[str]:
+    """List names of every currently-registered health probe (#6917).
+
+    Returns the canonical set of probe names so frontend callers can
+    validate at startup that an expected probe exists before reading
+    ``probes[name=…]`` from ``GET /api/system/health``. A typo on either
+    side surfaces here as a missing-name mismatch instead of silently
+    returning ``undefined``/'unavailable' to the user.
+
+    Public endpoint — no auth required (matches /api/system/health).
+    Cheap call: returns sorted list of strings, no probe execution.
+    """
+    from api.system_health import list_registered_probes
+
+    return list_registered_probes()
+
+
 @router.get("/info", response_model=SystemInfoResponse)
 @cache_response(cache_key="system_info", ttl=300)  # Cache for 5 minutes
 @with_error_handling(


### PR DESCRIPTION
## Summary

Adds `GET /api/system/health/probes` returning the canonical sorted list of registered probe names. Lets frontend callers validate at startup that an expected probe exists before reading `probes[name=…]` from `/api/system/health`.

## Why

#6917 documented that probe names are hardcoded twice (backend `@register_health_probe('batch_jobs')` + frontend `probes.find(p => p.name === 'batch_jobs')`). Typo on either side breaks silently — frontend gets undefined, falls back to 'unavailable'.

This is **phase 1**: enables runtime validation. Phase 2 (codegen/enum-based SSOT) tracked separately as #6917 stays open.

## Implementation

`list_registered_probes()` already existed at `api/system_health.py:137`. This PR is a single new `@router.get` endpoint in `api/system.py` that wraps it. Public, cheap, auth-matches `/api/system/health`.

## Test plan

- [x] Syntax check — `python3 -m py_compile autobot-backend/api/system.py`
- [ ] Manual hit: `curl /api/system/health/probes` returns `["batch_jobs", "knowledge", ...]`
- [ ] OpenAPI surface: `/docs` shows the new endpoint

Phase 1 of #6917