### PR TITLE
refactor(observability): probe_long_running uses public accessor (#6921)

### DIFF
--- a/autobot-backend/api/long_running_operations.py
+++ b/autobot-backend/api/long_running_operations.py
@@ -622,8 +622,7 @@ async def probe_long_running(
             operation_integration_manager.redis_client is not None
         )
         background_processor_running = (
-            operation_integration_manager.operation_manager._background_processor_task
-            is not None
+            operation_integration_manager.is_background_processor_running()
         )
         return ComponentHealth(
             name="long_running",
@@ -674,8 +673,7 @@ async def operations_health():
             "total_operations": len(all_operations),
             "redis_connected": operation_integration_manager.redis_client is not None,
             "background_processor_running": (
-                operation_integration_manager.operation_manager._background_processor_task
-                is not None
+                operation_integration_manager.is_background_processor_running()
             ),
         }
 

--- a/autobot-backend/utils/long_running_operations/operation_manager.py
+++ b/autobot-backend/utils/long_running_operations/operation_manager.py
@@ -129,6 +129,18 @@ class LongRunningOperationManager:
                 logger.debug("Background processor cancelled")
             self._background_processor_task = None
 
+    def is_background_processor_running(self) -> bool:
+        """Public accessor for the background processor state (#6921).
+
+        Health probes and monitoring callers used to read the private
+        ``_background_processor_task`` attribute directly. That coupled the
+        probe to internal storage — a refactor renaming/removing the
+        attribute would have made the probe AttributeError silently and the
+        registry would have reported the otherwise-healthy module as
+        ``status="down"``.
+        """
+        return self._background_processor_task is not None
+
     async def _background_processor(self) -> None:
         """Process background operations with concurrency control."""
         while True:

--- a/autobot-backend/utils/operation_timeout_integration.py
+++ b/autobot-backend/utils/operation_timeout_integration.py
@@ -191,6 +191,18 @@ class OperationIntegrationManager:
             return list(self.operation_manager.operations.values())
         return []
 
+    def is_background_processor_running(self) -> bool:
+        """Public accessor for the underlying background-processor state (#6921).
+
+        Replaces direct reads of ``self.operation_manager._background_processor_task``
+        from health probes / monitoring routes — the private attribute is owned
+        by ``LongRunningOperationManager`` and shouldn't be coupled to other
+        callers.
+        """
+        if self.operation_manager is None:
+            return False
+        return self.operation_manager.is_background_processor_running()
+
     async def list_operation_checkpoints(self, operation_id: str) -> List:
         """List checkpoints for operation, reducing checkpoint_manager.list_checkpoints chain."""
         if self.operation_manager and self.operation_manager.checkpoint_manager:


### PR DESCRIPTION
## Summary

Replaces direct `_background_processor_task` private-attribute reads in the long_running health probe with a new public `is_background_processor_running()` method on `LongRunningOperationManager` (and a delegating wrapper on `OperationIntegrationManager`).

## Why

PR #6913 enriched `probe_long_running` to expose `background_processor_running`. The implementation reached into a private attribute on a class the probe didn't own — if `_background_processor_task` is ever renamed/dropped, the probe AttributeErrors silently and the registry reports `status=down`, masking what was previously healthy.

After #6902 deletes the legacy `/api/long-running/health` route, the probe becomes the single point of access. Time to decouple from internal storage.

## Test plan

- [x] `grep _background_processor_task` confirms no production reads outside the owning module
- [x] `py_compile` clean for 3 modified files
- [ ] CI

Closes #6921