### PR TITLE
feat(workflow): Phase 3 — alias orchestration.types WorkflowStep/Plan to canonical (#6951)

### DIFF
--- a/autobot-backend/orchestration/types.py
+++ b/autobot-backend/orchestration/types.py
@@ -5,6 +5,13 @@
 Orchestration Types and Data Classes
 
 Issue #381: Extracted from enhanced_orchestrator.py god class refactoring.
+Issue #6951 Phase 3: ``WorkflowStep`` and ``WorkflowPlan`` are now aliases
+to the canonical ``autobot_shared.workflow`` shapes — completing the
+consolidation that #381 should have produced. Both shapes had zero
+production callers (only re-exports through ``__init__.py``); the alias
+preserves the import path so any future caller of ``orchestration.types``
+gets the canonical type, per the wire-in-not-delete rule.
+
 Contains enums and dataclasses for agent orchestration.
 """
 
@@ -13,7 +20,16 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Set
 
+from autobot_shared.workflow import WorkflowPlan as _SharedWorkflowPlan
+from autobot_shared.workflow import WorkflowTask as _WorkflowTask
 from constants.status_enums import TaskStatus
+
+# Transitional aliases — Phase 3 of #6951 consolidates the two #381-derivative
+# shapes here onto canonical types. ``orchestration.types`` had zero importers
+# of these names by the time this landed (verified on Dev_new_gui), so the
+# alias is risk-free and preserves the import path for any future caller.
+WorkflowStep = _WorkflowTask
+WorkflowPlan = _SharedWorkflowPlan
 
 
 class AgentCapability(Enum):
@@ -93,31 +109,5 @@ class AgentInteraction:
     outcome: str = TaskStatus.PENDING.value
 
 
-@dataclass
-class WorkflowStep:
-    """Represents a single step in a workflow plan."""
-
-    step_id: str
-    action: str
-    description: str
-    agent_id: str
-    required_capabilities: Set[AgentCapability]
-    estimated_duration: float
-    dependencies: List[str] = field(default_factory=list)
-    status: str = TaskStatus.PENDING.value
-    result: Dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass
-class WorkflowPlan:
-    """Complete workflow execution plan."""
-
-    workflow_id: str
-    title: str
-    description: str
-    steps: List[WorkflowStep]
-    created_at: datetime
-    estimated_total_duration: float
-    status: str = TaskStatus.PENDING.value
-    approval_required: bool = True
-    approved: bool = False
+# NOTE: ``WorkflowStep`` and ``WorkflowPlan`` aliases are declared at module
+# top alongside the imports they depend on. See the docstring for context.


### PR DESCRIPTION
## Summary

Phase 3 of #6951 — replaces the two zero-caller dataclasses in `orchestration/types.py` with aliases to the canonical `autobot_shared.workflow` shapes. **Independent of Phase 2A (#6985) and 2B (#6993)** — these shapes had no production callers, so the alias is risk-free.

This completes the consolidation that Issue #381 should have produced when it extracted the god class. Per the [Distinguish "unwired" from "orphan"](https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/.claude/projects/feedback_unwired_not_orphan.md) feedback, this is the same pattern as #6836: parent tracker closed prematurely with the integration step skipped — the right action is "complete the integration", not "delete dead code".

## What changed

```python
# Before — two #381-derivative duplicate dataclasses
@dataclass
class WorkflowStep:
    step_id: str
    action: str
    description: str
    agent_id: str
    required_capabilities: Set[AgentCapability]
    estimated_duration: float
    dependencies: List[str] = field(default_factory=list)
    status: str = TaskStatus.PENDING.value
    result: Dict[str, Any] = field(default_factory=dict)

@dataclass
class WorkflowPlan:
    workflow_id: str
    title: str
    description: str
    steps: List[WorkflowStep]
    created_at: datetime
    estimated_total_duration: float
    status: str = TaskStatus.PENDING.value
    approval_required: bool = True
    approved: bool = False

# After — wire-in to canonical
from autobot_shared.workflow import WorkflowPlan as _SharedWorkflowPlan
from autobot_shared.workflow import WorkflowTask as _WorkflowTask

WorkflowStep = _WorkflowTask
WorkflowPlan = _SharedWorkflowPlan
```

## Why aliases, not deletion

Per CLAUDE.md's absolute "wire it in, never delete" rule, even zero-caller code with a tracker reference gets aliased rather than removed. The `orchestration.types.WorkflowStep` import path persists; any caller (current zero or future N) resolves to the canonical shape — exactly the design intent #381 was supposed to deliver.

## Verification

- [x] `python3 -m py_compile` clean
- [x] `from orchestration.types import WorkflowStep, WorkflowPlan` resolves to canonical (`is` identity check passes)
- [x] `from orchestration import WorkflowStep, WorkflowPlan` (package re-export via `__init__.py`) also resolves to canonical
- [x] `AgentCapability`, `AgentProfile`, `DocumentationType`, `WorkflowDocumentation`, `AgentInteraction` — all unaffected (still local dataclasses)
- [x] Pre-existing zero-caller verified on `origin/Dev_new_gui` HEAD — no migration risk

## Discoveries filed during this work

- **[#7010](https://github.com/mrveiss/AutoBot-AI/issues/7010)** — 15 pre-existing orchestration test failures across 5 clusters (DAG branching, CHECKPOINT_TTL, dry-run/debug-mode, causal executor, workflow memory injection). All reproducible on `origin/Dev_new_gui` unmodified.
- [#6983](https://github.com/mrveiss/AutoBot-AI/issues/6983) (earlier) — `orchestrator.py` 7 stale `llm_interface` imports, blocks 4 e2e test files from collecting.

## Net diff

-28 / +18 lines (one file changed). Two dataclass bodies removed, two aliases added, plus the docstring + imports.

## Test plan

- [x] Compile check
- [x] Identity check (`WorkflowStep is canonical_WorkflowTask`)
- [x] Package re-export still works through `orchestration/__init__.py`
- [x] Other types in the file (`AgentCapability`, `AgentProfile`, etc) still importable

🤖 Generated with [Claude Code](https://claude.com/claude-code)