### PR TITLE
fix(ci): startup-import-smoke install step must run from autobot-backend/ (closes #7001)

### DIFF
--- a/.github/workflows/startup-import-smoke.yml
+++ b/.github/workflows/startup-import-smoke.yml
@@ -53,12 +53,15 @@ jobs:
         # so prior `pip install ... | tail -5` silently swallowed install failures.
         # Force pipefail explicitly + don't truncate pip output so dependency
         # conflicts surface immediately.
+        # #7001: working-directory: autobot-backend so `-e ../autobot_shared`
+        # in requirements.txt resolves correctly (pip resolves -e relative to CWD).
         shell: bash
+        working-directory: autobot-backend
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip >/dev/null
           python -m pip install pytest >/dev/null
-          python -m pip install -r autobot-backend/requirements.txt
+          python -m pip install -r requirements.txt
 
       - name: Run startup-import smoke test
         run: |


### PR DESCRIPTION
Fixes #7001.

## Root cause

\`autobot-backend/requirements.txt\` line 1 has \`-e ../autobot_shared\`. pip resolves \`-e <path>\` relative to the **current working directory**, not the requirements.txt location.

The workflow ran:

\`\`\`yaml
run: |
  python -m pip install -r autobot-backend/requirements.txt
\`\`\`

…from repo root. So \`../autobot_shared\` resolved to \`/home/runner/work/AutoBot-AI/autobot_shared\` (one level above the repo, doesn't exist) instead of \`/home/runner/work/AutoBot-AI/AutoBot-AI/autobot_shared\`.

## Why now

Failed silently for years because the step had \`pip install ... | tail -5\` on a \`bash -e\` (no pipefail) shell — \`tail\` always exited 0, masking pip's failure. #6947 fixed both: \`set -euo pipefail\` + dropped \`| tail -5\`. Every Dev_new_gui push since has failed the smoke workflow.

## Fix

Add \`working-directory: autobot-backend\` to the install step. Now pip's CWD is \`<repo>/autobot-backend/\` so \`-e ../autobot_shared\` resolves to \`<repo>/autobot_shared\` correctly.

## Verification

Simulated locally:

\`\`\`
cd autobot-backend
'-e ../autobot_shared'
resolves to: /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-7001/autobot_shared
exists: True
\`\`\`

Plus the actual smoke-test on this PR will be the live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)