### PR TITLE
ci: add `set -euo pipefail` to all piped run blocks (closes #7015)

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -63,7 +63,9 @@ jobs:
         id: merged
         env:
           DRY_RUN: ${{ steps.env.outputs.dry_run }}
+        shell: bash
         run: |
+          set -euo pipefail
           BASE_BRANCH="Dev_new_gui"
           DAYS_OLD=7
           CUTOFF_DATE=$(date -d "$DAYS_OLD days ago" +%s)
@@ -112,7 +114,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ steps.env.outputs.dry_run }}
+        shell: bash
         run: |
+          set -euo pipefail
           deleted_count=0
           skipped_count=0
           errors=0

--- a/.github/workflows/branch-health-report.yml
+++ b/.github/workflows/branch-health-report.yml
@@ -38,7 +38,9 @@ jobs:
 
       - name: Collect metrics
         id: metrics
+        shell: bash
         run: |
+          set -euo pipefail
           # Count branches
           total_local=$(git branch | wc -l)
           total_remote=$(git branch -r | wc -l)

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -69,7 +69,9 @@ jobs:
           exit 1
 
       - name: Verify services are running
+        shell: bash
         run: |
+          set -euo pipefail
           echo "Verifying services..."
           docker compose --env-file docker/.env.docker ps
 

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -181,7 +181,9 @@ jobs:
 
       - name: Analyze bundle size
         working-directory: autobot-frontend
+        shell: bash
         run: |
+          set -euo pipefail
           du -sh dist/
           find dist/ -name "*.js" -exec du -h {} \; | sort -hr
 

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -184,7 +184,9 @@ jobs:
 
     - name: Phase Validation Summary
       if: always()
+      shell: bash
       run: |
+        set -euo pipefail
         echo "Phase Validation Summary"
         echo "=========================="
         if [ -f "phase_validation_results.json" ]; then

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -135,7 +135,9 @@ jobs:
         cat flake8-report.txt || true
 
     - name: Secret Detection
+      shell: bash
       run: |
+        set -euo pipefail
         echo "## Secret Detection" >> $GITHUB_STEP_SUMMARY
         # Check for common secret patterns (without Docker)
         echo "Scanning for potential secrets..."
@@ -218,7 +220,9 @@ jobs:
         fi
 
     - name: Security Best Practices Check
+      shell: bash
       run: |
+        set -euo pipefail
         echo "## Security Best Practices" >> $GITHUB_STEP_SUMMARY
 
         # Check for security-related imports

--- a/.github/workflows/ssot-coverage.yml
+++ b/.github/workflows/ssot-coverage.yml
@@ -37,7 +37,9 @@ jobs:
 
     - name: Run SSOT-aware hardcoded value detection
       id: ssot_check
+      shell: bash
       run: |
+        set -euo pipefail
         chmod +x ./pipeline-scripts/detect-hardcoded-values.sh
         # Run with JSON output for parsing
         set +e  # Don't exit on error

--- a/.github/workflows/stale-branches-warning.yml
+++ b/.github/workflows/stale-branches-warning.yml
@@ -37,7 +37,9 @@ jobs:
 
       - name: Find stale branches
         id: stale
+        shell: bash
         run: |
+          set -euo pipefail
           DAYS_STALE=30
           CUTOFF_DATE=$(date -d "$DAYS_STALE days ago" +%s)
           stale_branches=""


### PR DESCRIPTION
Closes #7015. Sister of #6947 / #7001 — eliminates the same silent-failure class across all workflows.

## Why

GitHub Actions default shell is \`bash --noprofile --norc -e {0}\` — \`-e\` (errexit) but **no pipefail**. When a command is piped through tail/head/grep/wc/awk/sed/cut/jq/tr/sort/uniq/xargs, \`bash\` sees only the filter's exit code (usually 0). The actual command's failure is silently swallowed.

Cascade evidence:
- #6947 (March 2026): \`pip install ... | tail -5\` masked pip failures in startup-import-smoke
- #7001 / #7013 (today): \`-e ../autobot_shared\` editable-install failure was hidden by the same pattern
- #7018 (today): torch/vllm resolver conflict hidden by the previous two

Each layer hid the next. This PR removes the masking everywhere it still exists.

## What changed

8 workflows / 10 \`run:\` blocks now declare \`shell: bash\` + \`set -euo pipefail\`:

| Workflow | Affected step(s) |
|----------|------------------|
| \`branch-cleanup.yml\` | Find merged branches; Delete branches |
| \`branch-health-report.yml\` | Generate report |
| \`docker-smoke-test.yml\` | Verify services |
| \`frontend-test.yml\` | Analyze bundle size |
| \`phase_validation.yml\` | Phase validation step |
| \`security.yml\` | Secret Detection; Security Best Practices |
| \`ssot-coverage.yml\` | Coverage scan step |
| \`stale-branches-warning.yml\` | Find stale branches |

## Detector

Iterates over every \`run: |\` block and checks if it contains a pipe to a known-masking filter. False-positive caught during self-review: original regex matched \`cmd || true\` because \`tr\` is a prefix of \`true\`. Added \`\b\` word boundary to alternation.

Final verification: 0 piped-without-pipefail blocks remaining across all .github/workflows/ files.

## Verification

- All 8 modified YAML files parse (\`yaml.safe_load\`)
- Self-review caught and fixed one false-positive before commit
- Net diff: +20 lines across 8 files (just the \`shell: bash\` + \`set -euo pipefail\` pairs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)