### PR TITLE
ci: workflow polish — stale comments, action version drift, missing concurrency (#7017 A-C)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 # AutoBot CI/CD Pipeline
-# Uses self-hosted runner to avoid GitHub Actions quota limits
 
 name: AutoBot CI/CD Pipeline
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,6 +1,5 @@
 # GitHub Actions workflow for code quality enforcement
 # Runs on every push and pull request
-# Uses self-hosted runner to avoid GitHub Actions quota limits
 
 name: Code Quality
 

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: '0 10 * * 0'  # Every Sunday at 10 AM UTC
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   smoke-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -1,5 +1,4 @@
 # Phase Validation Integration workflow
-# Uses self-hosted runner to avoid GitHub Actions quota limits
 
 name: Phase Validation Integration
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,4 @@
 # Security Scanning workflow
-# Uses self-hosted runner to avoid GitHub Actions quota limits
 #
 # Security checks are blocking — failures prevent merge (Issue #2874).
 

--- a/.github/workflows/unwired-tracker-audit.yml
+++ b/.github/workflows/unwired-tracker-audit.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,5 +1,5 @@
 # CI requirements — role-based split for isolated dependency management (#1655)
-# Python version: 3.12 (installed via deadsnakes PPA on self-hosted runner)
+# Python version: 3.12 (installed via actions/setup-python@v5 on ubuntu-latest)
 #
 # Each file groups tightly-coupled packages so version conflicts
 # stay contained within their ecosystem. To debug a conflict,


### PR DESCRIPTION
Closes #7017 items A, B, C. Item D (YAML anchors) deferred to a separate PR.

## What changed

### A. Stale \`self-hosted runner\` header comments (5 files)

Removed lines claiming self-hosted post-#6982 / #6997 migration:

\`\`\`
.github/workflows/code-quality.yml
.github/workflows/security.yml
.github/workflows/ci.yml
.github/workflows/phase_validation.yml
requirements-ci.txt (also rewrote: 'deadsnakes PPA on self-hosted' → 'actions/setup-python@v5 on ubuntu-latest')
\`\`\`

### B. \`unwired-tracker-audit.yml\`: checkout@v4 → @v6

Lone straggler. Every other workflow uses \`@v6\`.

### C. \`docker-smoke-test.yml\`: added \`concurrency:\` block

The only push/PR-triggered workflow without \`cancel-in-progress\`. Each ~12-15min docker build was running to completion even when superseded by a newer push.

\`\`\`yaml
concurrency:
  group: \${{ github.workflow }}-\${{ github.ref }}
  cancel-in-progress: true
\`\`\`

### D. YAML anchors — DEFERRED

Path-filter duplication consolidation needs isolated verification because GH Actions' YAML parser may interact unexpectedly with anchors. Tracked in #7017 for separate PR.

## Verification

- All 6 modified YAML files parse (\`yaml.safe_load\`)
- Net diff: +6/-6 across 7 files
- No functional changes for items A and B; item C eliminates duplicate runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)