### PR TITLE
fix(ci): startup-import-smoke uses requirements-ci.txt to dodge torch/vllm conflict (closes #7018)

### DIFF
--- a/.github/workflows/startup-import-smoke.yml
+++ b/.github/workflows/startup-import-smoke.yml
@@ -49,19 +49,19 @@ jobs:
           cache: 'pip'
 
       - name: Install backend dependencies
-        # #6947: self-hosted-runner default shell is `bash -e` (no pipefail),
-        # so prior `pip install ... | tail -5` silently swallowed install failures.
-        # Force pipefail explicitly + don't truncate pip output so dependency
-        # conflicts surface immediately.
-        # #7001: working-directory: autobot-backend so `-e ../autobot_shared`
-        # in requirements.txt resolves correctly (pip resolves -e relative to CWD).
+        # #6947: pipefail required so pip install failures surface (was masked by `| tail -5`).
+        # #7018: switched from `autobot-backend/requirements.txt` to `requirements-ci.txt`
+        # because the former pulls torch>=2.11.0 + transitive vllm 0.19.x (requires torch==2.10.0),
+        # an unsatisfiable resolver state. `requirements-ci.txt` is purpose-built to exclude
+        # vllm and other GPU-dependent packages — see `security.yml` which has used it for years.
+        # autobot_shared is installed separately (editable, from repo root, no CWD trickery).
         shell: bash
-        working-directory: autobot-backend
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip >/dev/null
           python -m pip install pytest >/dev/null
-          python -m pip install -r requirements.txt
+          python -m pip install -r requirements-ci.txt --prefer-binary
+          python -m pip install -e autobot_shared
 
       - name: Run startup-import smoke test
         run: |


### PR DESCRIPTION
Closes #7018. Fixes the third layer of the silent-failure cascade started by #6947.

## The cascade

Each fix unmasks the next:

| Layer | Fix | What it unmasked |
|-------|-----|------------------|
| #6947 | pipefail in startup-import-smoke | pip install was failing — \`tail -5\` masked it |
| #7001 / #7013 | working-directory: autobot-backend | \`-e ../autobot_shared\` resolution failure |
| **#7018 / this PR** | switch to requirements-ci.txt | torch>=2.11.0 vs vllm 0.19.x torch==2.10.0 conflict |

## Root cause of #7018

\`autobot-backend/requirements.txt\` line 26: \`torch>=2.11.0\` (#904)

Some transitive dep pulls in \`vllm\`. Latest \`vllm 0.19.x\` requires \`torch==2.10.0\`. Pip resolver gives up — \`ResolutionImpossible\`.

## Fix

\`requirements-ci.txt\` (root level) was created in #1655 specifically to exclude vllm and other GPU-dependent packages. It's been used by \`security.yml\` for years without conflict. The smoke test only needs imports — not the full ML stack — so requirements-ci.txt is the right scope.

## Side benefits

- **Drops the \`working-directory: autobot-backend\` workaround from #7013.** pip now installs from repo root; \`autobot_shared\` is installed separately as an editable package by absolute-from-cwd path.
- **Faster:** \`--prefer-binary\` skips source builds.
- **Aligns with security.yml's pattern**, reducing per-workflow drift.

## Verification

- YAML parses
- Will be live-verified once smoke-test runs on this PR — the startup-import-smoke check should now succeed for the first time since #6947 was added

🤖 Generated with [Claude Code](https://claude.com/claude-code)