### PR TITLE
fix(ansible/grafana): apt_repository update_cache:false — survives flaky PPA (#6719)

### DIFF
--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/grafana.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/grafana.yml
@@ -51,6 +51,9 @@
     repo: "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com stable main"
     state: present
     filename: grafana
+    # #6719: refresh handled by the bounded-shell task below; the apt module's
+    # update_cache aborts on flaky third-party PPAs.
+    update_cache: false
   when:
     - ansible_os_family == "Debian"
     - _grafana_installed.rc != 0

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/grafana.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/grafana.yml
@@ -21,6 +21,9 @@
     repo: deb https://apt.grafana.com stable main
     state: present
     filename: grafana
+    # #6719: refresh handled by the bounded-shell task below; the apt module's
+    # update_cache aborts on flaky third-party PPAs.
+    update_cache: false
   when: grafana_install | bool
   tags: ['grafana', 'packages']
 


### PR DESCRIPTION
## Summary

- Both Grafana roles' `apt_repository:` task ran with implicit `update_cache: true`, which aborted install with `Failed to update apt cache: unknown reason` when `ppa.launchpadcontent.net` was momentarily unreachable (Ansible PPA + deadsnakes PPA).
- Fix mirrors the existing pattern in `roles/docker/tasks/main.yml:80-82` (`update_cache: false` with the same `#6719` rationale comment). The bounded `apt-get update -qq` task that follows in both files still does the refresh.
- Two files: `roles/slm_manager/tasks/grafana.yml` (blocked install on the SLM-Manager host today) and `roles/monitoring/tasks/grafana.yml` (same bug, would bite next monitoring run).

## Why this is part of #6719

#6719's Symptom section quotes the exact error message I hit (`'Failed to update apt cache: unknown reason'`), just from `nginx`'s install task instead of `grafana`'s `apt_repository`. Same root cause: Ansible's apt module treats any repo fetch warning as fatal. #6719's audit table lists `roles/slm_manager/tasks/grafana.yml:31` and `roles/monitoring/tasks/grafana.yml:62` — those line numbers point at the bounded refresh tasks, **not** the `apt_repository:` tasks that actually trigger the implicit refresh. This PR fixes the `apt_repository:` blind spot.

## Test plan

- [x] `sudo apt-get update` exits 0 with PPA failures degraded to warnings (CLI behaviour); confirms the failure is Ansible-module-specific
- [x] After fix: `ansible-playbook deploy-slm-manager.yml --skip-tags seed,provision` ran to `ok=121, failed=0`
- [x] `./install.sh --validate` passes; nginx, postgres, grafana all listening
- [x] `curl -sI https://apt.grafana.com` → 200 OK (Grafana endpoint itself fine, never the issue)
- [ ] Reviewer to confirm `roles/docker/` precedent is the right pattern to mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)