### PR TITLE
ci: per-job path filters for ci.yml + security.yml (closes #7006)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,32 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python:
+              - '**/*.py'
+              - '**/requirements*.txt'
+              - 'pyproject.toml'
+              - 'autobot_shared/pyproject.toml'
+              - '.github/workflows/ci.yml'
+            frontend:
+              - 'autobot-frontend/**'
+              - '!autobot-frontend/node_modules/**'
+              - '.github/workflows/ci.yml'
+
   security-tests:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -147,6 +172,8 @@ jobs:
         rm -rf .venv || true
 
   frontend-tests:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -194,8 +221,11 @@ jobs:
 
   deployment-check:
     runs-on: ubuntu-latest
-    needs: [security-tests, frontend-tests]
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/Dev_new_gui'
+    needs: [changes, security-tests, frontend-tests]
+    if: |
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/Dev_new_gui') &&
+      (needs.security-tests.result == 'success' || needs.security-tests.result == 'skipped') &&
+      (needs.frontend-tests.result == 'success' || needs.frontend-tests.result == 'skipped')
 
     steps:
     - uses: actions/checkout@v6
@@ -302,7 +332,7 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
-    needs: [security-tests, frontend-tests, deployment-check]
+    needs: [changes, security-tests, frontend-tests, deployment-check]
     if: always()
 
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,8 +26,35 @@ permissions:
   security-events: write
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      deps: ${{ steps.filter.outputs.deps }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'autobot-backend/**/*.py'
+              - 'autobot-slm-backend/**/*.py'
+              - 'autobot_shared/**/*.py'
+              - '.github/workflows/security.yml'
+            deps:
+              - '**/requirements*.txt'
+              - 'pyproject.toml'
+              - 'autobot_shared/pyproject.toml'
+              - 'autobot-frontend/package*.json'
+              - '.github/workflows/security.yml'
+
   dependency-security:
     name: Dependency Security Scan
+    needs: changes
+    # Always run on schedule (daily security scan); gate on `deps` for push/PR.
+    if: github.event_name == 'schedule' || needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -97,6 +124,9 @@ jobs:
 
   static-analysis:
     name: Static Application Security Testing (SAST)
+    needs: changes
+    # Always run on schedule (daily SAST scan); gate on `python` for push/PR.
+    if: github.event_name == 'schedule' || needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -239,7 +269,7 @@ jobs:
   security-summary:
     name: Security Summary Report
     runs-on: ubuntu-latest
-    needs: [dependency-security, static-analysis, compliance-check]
+    needs: [changes, dependency-security, static-analysis, compliance-check]
     if: always()
 
     steps:


### PR DESCRIPTION
Closes #7006. Follow-up to #6992 / #6998 / #7002.

## Why a separate PR

Workflow-level \`paths:\` filters (used by #6998 / #7002 in code-quality.yml, phase_validation.yml, startup-import-smoke.yml) don't fit ci.yml and security.yml because each runs multiple jobs with **different** file-scope dependencies. Per-job filtering needs \`dorny/paths-filter@v3\` + downstream \`if:\` conditions.

## ci.yml gating

| Job | Gate |
|-----|------|
| \`security-tests\` (Python tests + bandit) | \`needs.changes.outputs.python\` |
| \`frontend-tests\` (Node lint/build/test) | \`needs.changes.outputs.frontend\` |
| \`deployment-check\` | success-or-skipped from both above (still gated by \`main\` / \`Dev_new_gui\` branch) |
| \`notify\` (rollup) | always (existing behavior, now also depends on \`changes\`) |

## security.yml gating

| Job | Gate |
|-----|------|
| \`dependency-security\` | \`schedule\` || \`deps\` (deps-file changes) |
| \`static-analysis\` | \`schedule\` || \`python\` (Python-file changes) |
| \`compliance-check\` | always (cheap: file existence + grep) |
| \`security-summary\` (rollup) | always |

**Schedule branch preserved:** the nightly cron runs all jobs unconditionally regardless of file changes — security scanning of a static repo state is still useful for catching newly-disclosed CVEs.

## Estimated savings

- Frontend-only PRs (~30%): skip \`security-tests\` (~10-12 min) + \`static-analysis\` (~5 min)
- Backend-only PRs (~50%): skip \`frontend-tests\` (~5-8 min) + \`dependency-security\` Node portion
- Doc-only PRs: skip everything except \`compliance-check\` (~30s)

## Edge cases handled

**deployment-check needs both upstream jobs.** When one is skipped, the original \`if: github.ref == ...\` would still try to run, but \`needs:\` would block on a missing predecessor. Updated condition:

\`\`\`yaml
if: |
  (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/Dev_new_gui') &&
  (needs.security-tests.result == 'success' || needs.security-tests.result == 'skipped') &&
  (needs.frontend-tests.result == 'success' || needs.frontend-tests.result == 'skipped')
\`\`\`

This treats \`skipped\` as not-failed for the purposes of running deployment-check.

**notify uses \`if: always()\`** and string-compares results in its existing logic — \`skipped\` status reads cleanly as not-\`success\` in its existing branches.

## Verification

- Both YAML files parse (\`yaml.safe_load\`)
- Net diff: +64/-4 across 2 files
- All previous workflow-level path filters (#6998 / #7002) preserved as-is on other workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)