### PR TITLE
fix(ssot): replace 3 hardcoded 172.16.168.20 references — restore green SSOT gate (#7028)

### DIFF
--- a/autobot-backend/prompt_manager.py
+++ b/autobot-backend/prompt_manager.py
@@ -352,7 +352,7 @@ def _get_ssot_template_vars() -> Dict[str, str]:
     Build a dict of SSOT-derived Jinja variables available to every prompt template.
 
     Issue #6724: lets prompts reference deployment IPs/ports as ``{{ vm_main }}``
-    instead of hardcoding ``172.16.168.20``. Caller kwargs to ``get()`` still win
+    instead of hardcoding the literal IP. Caller kwargs to ``get()`` still win
     over these defaults. Returns an empty dict if SSOT config can't be loaded so
     legacy templates with literal text continue to render.
     """

--- a/autobot-frontend/src/components/ui/HostSelector.stories.ts
+++ b/autobot-frontend/src/components/ui/HostSelector.stories.ts
@@ -57,7 +57,7 @@ export const Preselected: Story = {
     modelValue: {
       id: 'host-1',
       name: 'Backend VM',
-      host: '172.16.168.20',
+      host: '192.0.2.20',
       ssh_port: 22,
       capabilities: ['ssh'],
       os: 'Ubuntu 24.04',

--- a/autobot-frontend/src/components/ui/SystemStatusNotification.stories.ts
+++ b/autobot-frontend/src/components/ui/SystemStatusNotification.stories.ts
@@ -97,7 +97,7 @@ export const CriticalOverlay: Story = {
       status: 'offline',
       lastCheck: Date.now(),
       consecutiveFailures: 8,
-      error: 'ECONNREFUSED 172.16.168.20:8001',
+      error: 'ECONNREFUSED 192.0.2.20:8001',
     },
   },
 };


### PR DESCRIPTION
## Summary
- 3 hardcoded \`172.16.168.20\` references on \`Dev_new_gui\` were tripping the \`SSOT Configuration Compliance\` CI gate on every PR (verified inherited the failure on PR #7023).
- Replaced each with non-routable RFC 5737 TEST-NET-1 (\`192.0.2.20\`) for stories, and dropped the literal IP from a docstring that was literally explaining why not to hardcode IPs.
- After: \`bash pipeline-scripts/detect-hardcoded-values.sh --report\` → \`Status: pass, Total violations: 0\`.

## Test plan
- [x] \`bash pipeline-scripts/detect-hardcoded-values.sh --report\` returns \`pass / 0 violations\` locally
- [x] Storybook fixtures still render (no schema/type changes — pure string replace)
- [ ] CI \`SSOT Configuration Compliance\` check goes green on this PR

## Closes
Closes #7028

🤖 Generated with [Claude Code](https://claude.com/claude-code)