### PR TITLE
fix(slm-admin-ui): pin self-signed cert via --cacert; drop misplaced OnFailure (#7024)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/slm-admin-ui.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/slm-admin-ui.service.j2
@@ -10,14 +10,12 @@ Type=oneshot
 User=root
 Group=root
 
-# Health check: verify SLM frontend is built and nginx can serve it
-ExecStart=/bin/sh -c 'test -f /opt/autobot/autobot-slm-frontend/dist/index.html && curl -sf https://127.0.0.1/slm/ > /dev/null'
+# Health check: verify SLM frontend is built and nginx can serve it.
+# --cacert pins the self-signed cert installed at TLS bootstrap (#7024).
+ExecStart=/bin/sh -c 'test -f /opt/autobot/autobot-slm-frontend/dist/index.html && curl -sf --cacert /etc/autobot/certs/server-cert.pem https://127.0.0.1/slm/ > /dev/null'
 
 # Mark service as successful if health check passes
 RemainAfterExit=yes
-
-# Restart on failure
-OnFailure=
 
 # Logging
 StandardOutput=journal


### PR DESCRIPTION
## Summary
- The \`slm-admin-ui.service\` health check ran \`curl -sf https://127.0.0.1/slm/\` against a self-signed cert with no trust anchor → exit 60 (TLS verify) on every fresh install. Added \`--cacert /etc/autobot/certs/server-cert.pem\` so curl pins the install's own cert as its CA bundle.
- Dropped the empty \`OnFailure=\` directive that was misplaced in \`[Service]\` (belongs in \`[Unit]\`); systemd warned \"Unknown key name 'OnFailure'\" on every start.

## Verification
\`\`\`bash
$ sudo curl -v --cacert /etc/autobot/certs/server-cert.pem https://127.0.0.1/slm/
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4): { [249 bytes data]
< HTTP/2 ...    # TLS handshake succeeds (no exit 60)
\`\`\`

systemd unit runs as \`User=root\` which can read the 0600 cert file owned by \`autobot:autobot\`.

## Test plan
- [x] TLS verification succeeds with \`--cacert\` against the install's self-signed cert (verified live)
- [ ] After deploy: \`systemctl status slm-admin-ui\` reports \`active (exited)\`
- [ ] No \`Unknown key name 'OnFailure'\` warnings in journal
- [ ] \`test -f dist/index.html && curl -sf --cacert ...\` still detects a missing dist (negative test, AC #3 in #7024)

## Closes
Closes #7024

🤖 Generated with [Claude Code](https://claude.com/claude-code)