### PR TITLE
fix(ansible/cleanup): SLM Manager owns autobot-slm-* dirs — guard 7 wipe tasks (#7031)

### DIFF
--- a/autobot-slm-backend/ansible/roles/ai-stack/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/tasks/clean.yml
@@ -46,6 +46,7 @@
   when:
     - node_roles is defined
     - "'slm-backend' not in node_roles"
+    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
   tags: ['clean']
 
 - name: "AI Stack | Clean: legacy npu-worker dir"

--- a/autobot-slm-backend/ansible/roles/backend/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/clean.yml
@@ -17,6 +17,12 @@
 # autobot-slm-backend) ONLY run when node_roles is defined (dynamic inventory).
 # When undefined (localhost self-deploy via install.sh), skip ALL cross-role
 # deletions to prevent wiping co-located services on single-host (#2836).
+#
+# #7031: Co-located SLM Manager hosts have node_roles like
+# ['slm-manager', 'backend', ...] — 'slm-frontend'/'slm-backend' are NEVER
+# in that list (they're slm_manager-role-internal subdirs, not standalone
+# fleet roles). The 'slm-manager not in node_roles' guard prevents the
+# backend cleanup from wiping the SLM stack the slm_manager role just built.
 
 - name: "Backend | Clean: legacy npu-worker dir"
   ansible.builtin.file:
@@ -50,6 +56,7 @@
   when:
     - node_roles is defined
     - "'slm-frontend' not in node_roles"
+    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
   tags: ['clean']
 
 - name: "Backend | Clean: wrong-node autobot-slm-backend dir"
@@ -59,4 +66,5 @@
   when:
     - node_roles is defined
     - "'slm-backend' not in node_roles"
+    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
   tags: ['clean']

--- a/autobot-slm-backend/ansible/roles/browser/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/clean.yml
@@ -46,6 +46,7 @@
   when:
     - node_roles is defined
     - "'slm-backend' not in node_roles"
+    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
   tags: ['clean']
 
 - name: "Browser | Clean: legacy npu-worker dir"

--- a/autobot-slm-backend/ansible/roles/frontend/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/tasks/clean.yml
@@ -28,6 +28,7 @@
   when:
     - node_roles is defined
     - "'slm-backend' not in node_roles"
+    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
   tags: ['clean']
 
 - name: "Frontend | Clean: wrong-node autobot-slm-backend dir"
@@ -37,6 +38,7 @@
   when:
     - node_roles is defined
     - "'slm-backend' not in node_roles"
+    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
   tags: ['clean']
 
 - name: "Frontend | Clean: wrong-node autobot-backend dir"

--- a/autobot-slm-backend/ansible/roles/npu-worker/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/npu-worker/tasks/clean.yml
@@ -46,6 +46,7 @@
   when:
     - node_roles is defined
     - "'slm-backend' not in node_roles"
+    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
   tags: ['clean']
 
 - name: "NPU Worker | Clean: legacy browser-service dir"


### PR DESCRIPTION
## Root cause

\`./install.sh --reinstall\` was failing at the post-install validation step with:
\`\`\`
[ERROR]   autobot-slm-backend: MISSING at /opt/autobot/autobot-slm-backend
[ERROR]   autobot-slm-frontend: MISSING at /opt/autobot/autobot-slm-frontend
\`\`\`

Traced the cause from the full Ansible playbook output: the \`slm_manager\` role correctly **deploys** to \`/opt/autobot/autobot-slm-{backend,frontend}/\` on the SLM-Manager host (00-SLM-Manager), but later in the same run, the \`backend\` role's \`Clean: wrong-node autobot-slm-frontend dir\` and \`Clean: wrong-node autobot-slm-backend dir\` tasks fire and delete what was just deployed.

The cleanup tasks gate on \`'slm-frontend' not in node_roles\`. The SLM-Manager's \`node_roles\` contains \`'slm-manager'\` but never \`'slm-frontend'\` or \`'slm-backend'\` (those aren't standalone fleet roles — they're slm_manager-internal subdirs). So the guard always lets the deletion through on the SLM Manager.

Same anti-pattern in 5 role clean.yml files (7 tasks total). Added \`'slm-manager' not in node_roles\` guard to each, mirroring the existing \`'slm-frontend' not in node_roles\` guard.

## Diff
| File | Tasks fixed |
|---|---|
| roles/backend/tasks/clean.yml | 2 (slm-frontend, slm-backend) |
| roles/frontend/tasks/clean.yml | 2 (slm-frontend, slm-backend) |
| roles/ai-stack/tasks/clean.yml | 1 (slm-backend) |
| roles/browser/tasks/clean.yml | 1 (slm-backend) |
| roles/npu-worker/tasks/clean.yml | 1 (slm-backend) |

## Test plan
- [x] Locally synced fix into \`/opt/autobot/code_source\` and re-ran the playbook (pre-push) — cleanup tasks now show \`changed=false\` (skipped) instead of \`changed: [00-SLM-Manager]\` (deleted)
- [ ] After merge: \`./install.sh --reinstall\` followed by \`./install.sh --validate\` passes
- [ ] \`/opt/autobot/autobot-slm-frontend/dist/index.html\` exists post-install
- [ ] \`curl -sk https://127.0.0.1/slm/\` returns 200 OK

## Closes
Closes #7031

🤖 Generated with [Claude Code](https://claude.com/claude-code)