### PR TITLE
fix(backend): complete #3185 migration — 3 missed callers + broken constructor (#6983)

### DIFF
--- a/autobot-backend/dependencies.py
+++ b/autobot-backend/dependencies.py
@@ -62,46 +62,44 @@ def get_knowledge_base(config: ConfigManager = Depends(get_config)):
 
 def get_llm_interface(config: ConfigManager = Depends(get_config)):
     """
-    Dependency injection provider for LLM interface.
+    Dependency injection provider for the LLM service.
+
+    The function name is retained for back-compat with any FastAPI route that
+    references ``LLMInterfaceDep`` below; the returned instance is now an
+    ``LLMService`` (the canonical post-#3185 successor to LLMInterface).
 
     Args:
         config: Configuration manager instance
 
     Returns:
-        LLMInterface: LLM interface instance configured with the provided config
+        LLMService: shared singleton instance.
     """
-    from llm_interface import LLMInterface
+    # #6983: migrated from LLMInterface() to LLMService singleton (#3185 missed this caller)
+    from services.llm_service import get_llm_service
 
-    return LLMInterface()
+    return get_llm_service()
 
 
 def get_orchestrator(
     config: ConfigManager = Depends(get_config),
-    llm_interface=Depends(get_llm_interface),
-    knowledge_base=Depends(get_knowledge_base),
-    diagnostics=Depends(get_diagnostics),
 ):
     """
     Lazy loading dependency injection provider for orchestrator.
 
     Args:
         config: Configuration manager instance
-        llm_interface: LLM interface instance
-        knowledge_base: Knowledge base instance
-        diagnostics: Diagnostics instance
 
     Returns:
-        Orchestrator: instance configured with all dependencies
+        Orchestrator: instance configured with the provided config manager.
     """
     # Lazy import to reduce startup time
     from orchestrator import Orchestrator
 
-    return Orchestrator(
-        config_manager=config,
-        llm_interface=llm_interface,
-        knowledge_base=knowledge_base,
-        diagnostics=diagnostics,
-    )
+    # #6983: Orchestrator.__init__ takes only ``config_mgr``; the previous
+    # call passed three extra args (llm_interface, knowledge_base, diagnostics)
+    # that have no matching parameter — would TypeError at first invocation.
+    # Orchestrator self-instantiates its sub-components from the config.
+    return Orchestrator(config_mgr=config)
 
 
 def get_security_layer(config: ConfigManager = Depends(get_config)):

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -30,7 +30,7 @@ from typing import Any, Dict, List, Optional, Set
 from autobot_shared.logging_manager import get_logger
 from config.manager import get_config_manager as _get_config_manager
 from constants.threshold_constants import LLMDefaults, TimingConstants
-from llm_interface import LLMInterface
+from services.llm_service import get_llm_service
 from memory import LongTermMemoryManager
 
 # Issue #381: shared orchestration types
@@ -184,7 +184,8 @@ class Orchestrator:
     def _init_core_components(self, config_mgr) -> None:
         self.config_manager = config_mgr or _get_config_manager()
         self.config = OrchestratorConfig(self.config_manager)
-        self.llm_interface = LLMInterface()
+        # #6983: migrated from LLMInterface to LLMService (#3185 missed this caller)
+        self.llm_service = get_llm_service()
         self.memory_manager = LongTermMemoryManager()
         self.agent_manager = AgentManager()
 
@@ -349,10 +350,13 @@ class Orchestrator:
 
     async def _validate_llm_model(self, model_name: str) -> bool:
         try:
-            test_response = await self.llm_interface.generate_response(
-                "Test connection", model=model_name, max_tokens=LLMDefaults.MINIMAL_MAX_TOKENS
+            # #6983: migrated to LLMService.chat() — returns LLMResponse with .content/.error attrs
+            response = await self.llm_service.chat(
+                [{"role": "user", "content": "Test connection"}],
+                model_name=model_name,
+                max_tokens=LLMDefaults.MINIMAL_MAX_TOKENS,
             )
-            return bool(test_response)
+            return not response.error and bool(response.content)
         except Exception as e:
             logger.debug("Model test failed for %s: %s", model_name, e)
             return False
@@ -377,7 +381,8 @@ class Orchestrator:
                 self.memory_manager.initialize(),
                 self.agent_manager.initialize(),
             )
-            ollama_connected = await self.llm_interface.check_ollama_connection()
+            # #6983: migrated from llm_interface.check_ollama_connection() to LLMService.is_provider_healthy()
+            ollama_connected = await self.llm_service.is_provider_healthy(provider_name="ollama")
             if not ollama_connected:
                 raise Exception("Failed to connect to Ollama or configured models not found.")
             logger.info("✅ Ollama connection established")
@@ -396,8 +401,8 @@ class Orchestrator:
             logger.info("Waiting for %d active tasks to complete...", len(self.active_tasks))
             await asyncio.sleep(TimingConstants.STANDARD_DELAY)
         try:
+            # #6983: LLMService has no cleanup() (provider lifecycle managed elsewhere); drop the call
             await asyncio.gather(
-                self.llm_interface.cleanup(),
                 self.memory_manager.cleanup(),
                 self.agent_manager.cleanup(),
                 return_exceptions=True,
@@ -502,18 +507,27 @@ class Orchestrator:
     async def _process_simple_request(
         self, user_message: str, task_id: str, model: str, context: Optional[Dict]
     ) -> Dict[str, Any]:
-        response = await self.llm_interface.generate_response(
-            user_message, model=model, max_tokens=LLMDefaults.ENRICHED_MAX_TOKENS, context=context
+        # #6983: migrated to LLMService.chat() — context is forwarded as additional kwargs
+        # since LLMService.chat() has no positional `context` parameter (was specific to LLMInterface)
+        response = await self.llm_service.chat(
+            [{"role": "user", "content": user_message}],
+            model_name=model,
+            max_tokens=LLMDefaults.ENRICHED_MAX_TOKENS,
+            context=context,
         )
-        return {"type": "simple_response", "content": response, "sources": [{"type": "llm", "model": model}]}
+        return {"type": "simple_response", "content": response.content, "sources": [{"type": "llm", "model": model}]}
 
     # ------------------------------------------------- execute_enhanced_workflow
 
     def _get_enhanced_documenter(self) -> WorkflowDocumenter:
         if not hasattr(self, "_enh_documenter") or self._enh_documenter is None:
+            # #6983: WorkflowDocumenter still names its dep `llm_interface` (legacy slot,
+            # typed Optional[Any]). Pass the LLMService instance — the rename is tracked
+            # separately. WorkflowDocumenter's internal call to .chat_completion() is
+            # broken-on-LLMService (different method name) — see follow-up tracker.
             self._enh_documenter = WorkflowDocumenter(
                 knowledge_base=self.knowledge_base,
-                llm_interface=self.llm_interface,
+                llm_interface=self.llm_service,
             )
         return self._enh_documenter
 

--- a/autobot-backend/worker_node.py
+++ b/autobot-backend/worker_node.py
@@ -36,7 +36,7 @@ from autobot_shared.redis_client import get_redis_client
 from config import config as global_config_manager
 from event_manager import get_event_manager
 from knowledge_base import KnowledgeBase
-from llm_interface import LLMInterface
+from services.llm_service import get_llm_service
 from security_layer import SecurityLayer
 from system_integration import SystemIntegration
 from task_handlers import TaskExecutor
@@ -76,7 +76,8 @@ class WorkerNode:
             logger.info("Worker node configured for local task transport. " "No Redis connection.")
 
         # Initialize modules that worker might need for task execution
-        self.llm_interface = LLMInterface()
+        # #6983: migrated from LLMInterface to LLMService (#3185 missed this caller)
+        self.llm_service = get_llm_service()
         self.knowledge_base = KnowledgeBase()
         self.gui_controller = GUIController()
         self.system_integration = SystemIntegration()
@@ -232,7 +233,9 @@ class WorkerNode:
         """Detect available LLM backends."""
         backends = ["ollama"]
 
-        if self.llm_interface.openai_api_key:
+        # #6983: post-LLMService migration, openai_api_key is no longer exposed on the
+        # service surface. Read from config directly — same effective check.
+        if global_config_manager.get_nested("llm_config.openai.api_key"):
             backends.append("openai")
         if global_config_manager.get_nested("llm_config.transformers.model_path"):
             backends.append("transformers")


### PR DESCRIPTION
## Summary

P1 boot bug fix. #3185 retired \`LLMInterface\` and deleted the \`llm_interface\` module on 2026-05-04, but missed 3 production callers (the closure note flagged \"2 missed-by-grep + 5 misc\" as a known undercount). All 3 fail with \`ModuleNotFoundError: No module named 'llm_interface'\` at import time.

## Files fixed

| File | Refs | Notes |
|---|---|---|
| \`autobot-backend/orchestrator.py\` | 7 | Boot-blocking — \`get_orchestrator_sync()\` callers fail |
| \`autobot-backend/worker_node.py\` | 3 | Used by \`code_embedding_generator.py\` |
| \`autobot-backend/dependencies.py\` | 1 + bogus 3-arg constructor call | \`get_orchestrator\` passed \`llm_interface\` / \`knowledge_base\` / \`diagnostics\` to a constructor that only takes \`config_mgr\` |

A 4th file (\`performance_benchmarks.performance_test.py\`) has the same stale import but isn't pytest-collected (non-standard filename); follow-up tracker filed.

## Verification

\`\`\`
$ grep -rn 'from llm_interface import\\|import llm_interface\\b' \\
    autobot-backend --include='*.py' | grep -v __pycache__ | grep -v performance_test
(empty)

$ PYTHONPATH=autobot-backend:. python3 -c 'import orchestrator'
orchestrator OK
\`\`\`

## Discovery filed inline (runtime bug, separate scope)

\`workflow_documentation.py:175\` calls \`self.llm_interface.chat_completion(...)\` — a method that doesn't exist on LLMService. Boot succeeds (LLMService instance is passed in fine), runtime fails when the documenter actually executes. Tracked separately.

## Test plan

- [x] All 3 modules \`py_compile\` clean
- [x] \`import orchestrator\` succeeds with \`PYTHONPATH=autobot-backend:.\`
- [x] \`grep llm_interface\` shows zero stale imports in production code
- [ ] CI smoke test on Dev_new_gui

Closes #6983