### PR TITLE
feat(hooks): no-new-workflow-step pre-commit guard (closes #7014, #6951 Phase 4)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -281,6 +281,18 @@ repos:
         stages: [pre-commit]
         description: "Blocks new @router.get('/health') definitions; modules must call api.system_health.register_health_probe instead"
 
+  # No new top-level WorkflowStep/AgentTask/WorkflowPlan outside canonical (Issue #6951)
+  - repo: local
+    hooks:
+      - id: no-new-workflow-step
+        name: No New WorkflowStep/AgentTask/WorkflowPlan Outside Canonical (Issue #6951)
+        entry: autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-workflow-step
+        language: script
+        types: [python]
+        pass_filenames: false
+        stages: [pre-commit]
+        description: "Blocks new top-level dataclass declarations of WorkflowStep/AgentTask/WorkflowPlan outside autobot_shared/workflow/types.py; subclasses and aliases are allowed"
+
   # No print()/console.* in production code (Issue #1082)
   - repo: local
     hooks:

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-workflow-step
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-workflow-step
@@ -1,0 +1,148 @@
+#!/bin/bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Pre-commit Hook: No New WorkflowStep / AgentTask / WorkflowPlan Outside Canonical Location
+# ==========================================================================================
+#
+# Issue #6951 — consolidates duplicate workflow shapes onto the canonical
+# autobot_shared.workflow.{WorkflowTask, WorkflowPlan} types. New modules MUST
+# either:
+#   1. Import the canonical type:
+#        from autobot_shared.workflow import WorkflowTask, WorkflowPlan
+#   2. Subclass for domain-specific behaviour (lifecycle methods, extra fields):
+#        class MyTask(WorkflowTask):
+#            def my_method(self) -> None: ...
+#   3. Alias for transitional compat:
+#        WorkflowStep = WorkflowTask
+#
+# This hook blocks commits that add NEW top-level dataclass declarations of
+# `class WorkflowStep:` / `class AgentTask:` / `class WorkflowPlan:` (no base
+# class) outside the exempt locations.
+#
+# Allowed patterns (NOT blocked):
+#   - `class WorkflowStep(WorkflowTask):`         — subclass (parens before colon)
+#   - `WorkflowStep = WorkflowTask`               — alias (no `class` keyword)
+#   - Lines under EXEMPT_PATHS below
+#
+# Exempt locations (canonical + 3 documented domain shapes per #6951 audit):
+#   - autobot_shared/workflow/types.py                            (canonical)
+#   - autobot-backend/services/workflow_automation/models.py      (shell+vision execution)
+#   - autobot-backend/agents/overseer/types.py                    (multi-step decomposition)
+#
+# Suppression: append `# noqa: workflow-shape` to the offending line (last resort).
+#
+# Install: pre-commit install (uses .pre-commit-config.yaml)
+
+set -uo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+EXEMPT_PATHS=(
+    "autobot_shared/workflow/types.py"
+    "autobot-backend/services/workflow_automation/models.py"
+    "autobot-backend/agents/overseer/types.py"
+)
+
+is_exempt() {
+    local path="$1"
+    for exempt in "${EXEMPT_PATHS[@]}"; do
+        if [[ "$path" == "$exempt" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Pull every "+ class WorkflowStep:" / "+ class AgentTask:" / "+ class WorkflowPlan:"
+# line that is not a removal, not a hunk header, not a subclass declaration
+# (no parens before the colon), and not a noqa-suppressed line.
+collect_violations() {
+    git diff --cached --no-color -U0 -- '*.py' 2>/dev/null | \
+    awk '
+        /^diff --git/ {
+            file = ""
+            next
+        }
+        /^\+\+\+ b\// {
+            file = substr($0, 7)
+            next
+        }
+        /^@@ / {
+            match($0, /\+[0-9]+/)
+            new_lineno = substr($0, RSTART + 1, RLENGTH - 1) + 0
+            next
+        }
+        /^\+/ && !/^\+\+\+/ {
+            line = substr($0, 2)
+            # Match "class WorkflowStep:" (top-level, no base class — parens absent)
+            # Reject if line contains parens before the colon (= subclass).
+            if (match(line, /^class[[:space:]]+(WorkflowStep|AgentTask|WorkflowPlan)[[:space:]]*:/)) {
+                if (line !~ /#[[:space:]]*noqa:.*workflow-shape/) {
+                    printf "%s\t%d\t%s\n", file, new_lineno, line
+                }
+            }
+            new_lineno++
+            next
+        }
+    '
+}
+
+main() {
+    echo -e "${BOLD}${CYAN}Pre-commit: No New WorkflowStep/AgentTask/WorkflowPlan Outside Canonical Location${NC}"
+    echo "Issue #6951 — Workflow Type Consolidation"
+    echo "================================================"
+    echo ""
+
+    local violations
+    violations=$(collect_violations)
+
+    if [[ -z "$violations" ]]; then
+        echo -e "${GREEN}No new top-level workflow-shape declarations detected.${NC}"
+        exit 0
+    fi
+
+    local count=0
+    while IFS=$'\t' read -r path lineno text; do
+        if is_exempt "$path"; then
+            continue
+        fi
+        echo -e "  ${RED}VIOLATION${NC} ${path}:${lineno}"
+        echo "    ${text}"
+        ((count++))
+    done <<< "$violations"
+
+    echo ""
+    echo "================================================"
+
+    if (( count > 0 )); then
+        echo -e "${RED}COMMIT BLOCKED: $count new top-level workflow-shape declaration(s) found${NC}"
+        echo ""
+        echo "Quick fix — import the canonical type instead of redeclaring it:"
+        echo ""
+        echo "  from autobot_shared.workflow import WorkflowTask, WorkflowPlan"
+        echo ""
+        echo "  # Option 1: alias for transitional compat"
+        echo "  WorkflowStep = WorkflowTask"
+        echo ""
+        echo "  # Option 2: subclass for domain-specific behaviour"
+        echo "  class MyTask(WorkflowTask):"
+        echo "      def my_lifecycle_method(self) -> None: ..."
+        echo ""
+        echo "Suppression (last resort): append '# noqa: workflow-shape' to the class line."
+        echo ""
+        echo "See #6951 for the consolidation context and #7014 for this hook."
+        echo ""
+        exit 1
+    fi
+
+    echo -e "${GREEN}All new workflow-shape declarations are in exempt files.${NC}"
+    exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Closes [#7014](https://github.com/mrveiss/AutoBot-AI/issues/7014). Phase 4 of [#6951](https://github.com/mrveiss/AutoBot-AI/issues/6951) — adds a pre-commit hook that durably prevents reintroduction of duplicate `WorkflowStep` / `AgentTask` / `WorkflowPlan` classes after the consolidation Phases 1b/2A/2B/3 just landed.

Mirrors the proven `no-new-health-route` pattern from #3333 (PR [#6870](https://github.com/mrveiss/AutoBot-AI/pull/6870)).

## What it blocks

```python
# BLOCKED — top-level dataclass declaration outside canonical location:
@dataclass
class WorkflowStep:        # ← rejected
    step_id: str

@dataclass
class AgentTask:           # ← rejected
    task_id: str

@dataclass
class WorkflowPlan:        # ← rejected
    plan_id: str
```

## What it allows

```python
# ALLOWED — subclasses (parens before colon):
class CustomTask(WorkflowTask):
    def my_lifecycle_method(self) -> None: ...

# ALLOWED — aliases (no class keyword):
WorkflowStep = WorkflowTask

# ALLOWED — files in EXEMPT_PATHS (canonical + 2 domain shapes):
# - autobot_shared/workflow/types.py  (canonical)
# - autobot-backend/services/workflow_automation/models.py  (shell+vision)
# - autobot-backend/agents/overseer/types.py  (multi-step decomposition)

# ALLOWED — noqa-suppressed (last resort):
@dataclass
class AgentTask:  # noqa: workflow-shape
    ...
```

## Why these specific exempt paths

Per the [#6951 audit comment](https://github.com/mrveiss/AutoBot-AI/issues/6951#issuecomment-4377948567), three top-level declarations are legitimately separate domain shapes (not duplicates):

- `autobot_shared/workflow/types.py:class WorkflowPlan:` — the canonical itself
- `autobot-backend/services/workflow_automation/models.py:class WorkflowStep:` — shell + vision execution + approval flow (#2397, #2159, #390)
- `autobot-backend/agents/overseer/types.py:class AgentTask:` — multi-step task decomposition with its own `StepStatus` enum

Two more exist but don't need exemption:
- `services/advanced_workflow/models.py:SmartWorkflowStep(WorkflowStep)` — subclass, allowed by default
- `orchestration/sub_workflow.py:SubWorkflowStep` — different class name, regex doesn't match

## Test coverage

8 test cases run against an isolated temp git repo with the hook script:

| # | Scenario | Expected | Result |
|---|---|---|---|
| 1 | Clean tree (no staged changes) | exit 0 | ✅ PASS |
| 2 | New `class WorkflowStep:` in `autobot-backend/services/test_module/` | exit 1 with file:line | ✅ PASS |
| 3 | New `class CustomTask(WorkflowTask):` (subclass) | exit 0 | ✅ PASS |
| 4 | New `WorkflowStep = WorkflowTask` alias | exit 0 | ✅ PASS |
| 5 | New `class AgentTask:  # noqa: workflow-shape` | exit 0 | ✅ PASS |
| 6 | New `class WorkflowPlan:` in `autobot_shared/workflow/types.py` (canonical) | exit 0 | ✅ PASS |
| 7 | New `class AgentTask:` in `autobot-backend/agents/overseer/types.py` (domain exempt) | exit 0 | ✅ PASS |
| 8 | New `class MyCustomStep:` (different name, regex doesn't match) | exit 0 | ✅ PASS |

## Files

- `autobot-infrastructure/shared/scripts/hooks/pre-commit-no-new-workflow-step` (148 lines, +x)
- `.pre-commit-config.yaml` — registered the hook entry (12 lines added)

## Test plan

- [x] All 8 hook test cases pass
- [x] Hook runs successfully against clean Dev_new_gui state (no false positives)
- [x] Hook script is executable (`chmod +x`)
- [x] `.pre-commit-config.yaml` entry mirrors the `no-new-health-route` template

## Related

- #6951 — workflow type consolidation (parent)
- #7014 — this issue
- #3333 — `no-new-health-route` (template hook)
- #4113 — branching discipline pre-commit hook (related precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)