### PR TITLE
ci: dedupe path-filter lists via YAML anchors (closes #7038)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,7 +6,7 @@ name: Code Quality
 on:
   push:
     branches: [ main, Dev_new_gui, develop ]
-    paths:
+    paths: &cq_paths
       - '**/*.py'
       - '**/requirements*.txt'
       - 'pyproject.toml'
@@ -21,19 +21,7 @@ on:
       - '.github/workflows/code-quality.yml'
   pull_request:
     branches: [ main, Dev_new_gui, develop ]
-    paths:
-      - '**/*.py'
-      - '**/requirements*.txt'
-      - 'pyproject.toml'
-      - '.flake8'
-      - '.bandit'
-      - '.pre-commit-config.yaml'
-      - 'pipeline-scripts/**'
-      - 'tools/lint/**'
-      - 'autobot-infrastructure/shared/scripts/hooks/**'
-      - 'autobot-infrastructure/ansible/roles/slm_agent/files/**'
-      - 'docs/developer/**'
-      - '.github/workflows/code-quality.yml'
+    paths: *cq_paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -5,7 +5,7 @@ name: Phase Validation Integration
 on:
   push:
     branches: [ main, Dev_new_gui ]
-    paths:
+    paths: &phase_paths
       - 'autobot-backend/**/*.py'
       - 'autobot-slm-backend/**/*.py'
       - 'autobot_shared/**/*.py'
@@ -15,14 +15,7 @@ on:
       - '.github/workflows/phase_validation.yml'
   pull_request:
     branches: [ main ]
-    paths:
-      - 'autobot-backend/**/*.py'
-      - 'autobot-slm-backend/**/*.py'
-      - 'autobot_shared/**/*.py'
-      - '**/requirements*.txt'
-      - 'pipeline-scripts/**'
-      - 'tools/lint/**'
-      - '.github/workflows/phase_validation.yml'
+    paths: *phase_paths
   workflow_dispatch:
     inputs:
       phase_filter:

--- a/.github/workflows/startup-import-smoke.yml
+++ b/.github/workflows/startup-import-smoke.yml
@@ -13,7 +13,7 @@ name: Backend Startup Import Smoke
 on:
   push:
     branches: [main, Dev_new_gui, develop]
-    paths:
+    paths: &smoke_paths
       - 'autobot-backend/**/*.py'
       - 'autobot_shared/**/*.py'
       - 'autobot-slm-backend/**/*.py'
@@ -21,12 +21,7 @@ on:
       - '.github/workflows/startup-import-smoke.yml'
   pull_request:
     branches: [main, Dev_new_gui, develop]
-    paths:
-      - 'autobot-backend/**/*.py'
-      - 'autobot_shared/**/*.py'
-      - 'autobot-slm-backend/**/*.py'
-      - '**/requirements*.txt'
-      - '.github/workflows/startup-import-smoke.yml'
+    paths: *smoke_paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Closes #7038. Last item from the #6992 cost-monitoring epic.

## What

Three workflows had identical \`paths:\` lists under \`push:\` and \`pull_request:\` (verified with md5sum during #7017 self-review). Now anchored once, aliased under pull_request:

\`\`\`yaml
push:
  paths: &smoke_paths
    - 'autobot-backend/**/*.py'
    - ...
pull_request:
  paths: *smoke_paths
\`\`\`

## Why paths-only anchor (not whole event block)

\`phase_validation.yml\` has **divergent branches** per event:

| Event | Branches |
|-------|----------|
| push  | \`[main, Dev_new_gui]\` |
| pull_request | \`[main]\` |

Whole-block anchor would force the same branches list on both — wrong. Paths-only anchor preserves the branch divergence cleanly.

## Files

| File | Lines deduped | Path list size |
|------|---------------|----------------|
| \`startup-import-smoke.yml\` | 10 | 5 entries |
| \`code-quality.yml\` | 24 | 12 entries |
| \`phase_validation.yml\` | 14 | 7 entries |

Net diff: **+6 / -30** across 3 files.

## Verification

Local pyyaml round-trip confirms:
- All 3 files parse cleanly
- Alias resolution: \`push.paths == pull_request.paths\` AND they're the same Python object (\`is\` comparison) — alias preserved through parse, not just structurally equal
- \`phase_validation.yml\` branches stay independent: push has Dev_new_gui, pr only has main

GH Actions natively parses standard YAML aliases. **Live verification will be the smoke-test on this PR** — this very file change matches the path filter, so if the workflow runs at all, parsing works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)