### PR TITLE
fix(ansible/cleanup): correct SLM Manager guard — use inventory_hostname (#7031 follow-up to #7035)

### DIFF
--- a/autobot-slm-backend/ansible/roles/ai-stack/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/tasks/clean.yml
@@ -46,7 +46,7 @@
   when:
     - node_roles is defined
     - "'slm-backend' not in node_roles"
-    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
+    - inventory_hostname != '00-SLM-Manager'  # #7031: SLM Manager owns SLM dirs
   tags: ['clean']
 
 - name: "AI Stack | Clean: legacy npu-worker dir"

--- a/autobot-slm-backend/ansible/roles/backend/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/clean.yml
@@ -18,11 +18,14 @@
 # When undefined (localhost self-deploy via install.sh), skip ALL cross-role
 # deletions to prevent wiping co-located services on single-host (#2836).
 #
-# #7031: Co-located SLM Manager hosts have node_roles like
-# ['slm-manager', 'backend', ...] — 'slm-frontend'/'slm-backend' are NEVER
-# in that list (they're slm_manager-role-internal subdirs, not standalone
-# fleet roles). The 'slm-manager not in node_roles' guard prevents the
-# backend cleanup from wiping the SLM stack the slm_manager role just built.
+# #7031: Co-located SLM Manager (00-SLM-Manager) hosts the SLM stack
+# (autobot-slm-backend, autobot-slm-frontend) AS WELL AS regular fleet
+# roles (autobot-slm-database, autobot-monitoring). Its node_roles never
+# contains 'slm-frontend' or 'slm-backend' (those are slm_manager-internal
+# subdirs, not standalone fleet roles), so the 'not in node_roles' guard
+# alone lets the wipe proceed. The inventory_hostname check pins the
+# canonical SLM Manager hostname (set in seed-fleet-nodes.yml) and prevents
+# the backend cleanup from wiping the SLM stack the slm_manager role built.
 
 - name: "Backend | Clean: legacy npu-worker dir"
   ansible.builtin.file:
@@ -56,7 +59,7 @@
   when:
     - node_roles is defined
     - "'slm-frontend' not in node_roles"
-    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
+    - inventory_hostname != '00-SLM-Manager'  # #7031: SLM Manager owns SLM dirs
   tags: ['clean']
 
 - name: "Backend | Clean: wrong-node autobot-slm-backend dir"
@@ -66,5 +69,5 @@
   when:
     - node_roles is defined
     - "'slm-backend' not in node_roles"
-    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
+    - inventory_hostname != '00-SLM-Manager'  # #7031: SLM Manager owns SLM dirs
   tags: ['clean']

--- a/autobot-slm-backend/ansible/roles/browser/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/clean.yml
@@ -46,7 +46,7 @@
   when:
     - node_roles is defined
     - "'slm-backend' not in node_roles"
-    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
+    - inventory_hostname != '00-SLM-Manager'  # #7031: SLM Manager owns SLM dirs
   tags: ['clean']
 
 - name: "Browser | Clean: legacy npu-worker dir"

--- a/autobot-slm-backend/ansible/roles/frontend/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/tasks/clean.yml
@@ -28,7 +28,7 @@
   when:
     - node_roles is defined
     - "'slm-backend' not in node_roles"
-    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
+    - inventory_hostname != '00-SLM-Manager'  # #7031: SLM Manager owns SLM dirs
   tags: ['clean']
 
 - name: "Frontend | Clean: wrong-node autobot-slm-backend dir"
@@ -38,7 +38,7 @@
   when:
     - node_roles is defined
     - "'slm-backend' not in node_roles"
-    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
+    - inventory_hostname != '00-SLM-Manager'  # #7031: SLM Manager owns SLM dirs
   tags: ['clean']
 
 - name: "Frontend | Clean: wrong-node autobot-backend dir"

--- a/autobot-slm-backend/ansible/roles/npu-worker/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/npu-worker/tasks/clean.yml
@@ -46,7 +46,7 @@
   when:
     - node_roles is defined
     - "'slm-backend' not in node_roles"
-    - "'slm-manager' not in node_roles"  # #7031: SLM Manager owns this dir
+    - inventory_hostname != '00-SLM-Manager'  # #7031: SLM Manager owns SLM dirs
   tags: ['clean']
 
 - name: "NPU Worker | Clean: legacy browser-service dir"


### PR DESCRIPTION
## Why this exists

#7035 added \`'slm-manager' not in node_roles\` as a guard to 7 cleanup tasks, intending to prevent the backend role from wiping the SLM stack on the SLM-Manager host (00-SLM-Manager).

**That guard was wrong.** Verified end-to-end after merge: the actual \`node_roles\` for \`00-SLM-Manager\` (set in [\`seed-fleet-nodes.yml:42-46\`](https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/autobot-slm-backend/ansible/playbooks/seed-fleet-nodes.yml#L42-L46) \`node_role_map\`) is:

\`\`\`yaml
00-SLM-Manager:
  - autobot-slm-agent
  - autobot-slm-database
  - autobot-monitoring
\`\`\`

There is **no \`slm-manager\` role** in that list — the string never appears. So \`'slm-manager' not in node_roles\` was always TRUE, and the cleanup still fired:

\`\`\`
TASK [backend : Backend | Clean: wrong-node autobot-slm-frontend dir]
changed: [00-SLM-Manager]   ← STILL DELETED after #7035
\`\`\`

This was caught by re-running \`./install.sh --reinstall\` after #7035 merged: the install pulled \`f041f6493\` into code_source (verified: \`git log\` shows the right commit; \`grep\` confirmed the guard string was present), the playbook ran, and \`./install.sh --validate\` STILL failed:

\`\`\`
[ERROR]   autobot-slm-backend: MISSING at /opt/autobot/autobot-slm-backend
[ERROR]   autobot-slm-frontend: MISSING at /opt/autobot/autobot-slm-frontend
\`\`\`

## The corrected guard

\`inventory_hostname != '00-SLM-Manager'\` — pins the canonical SLM Manager hostname directly. This is the same hardcoded string used in [\`seed-fleet-nodes.yml\`](https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/autobot-slm-backend/ansible/playbooks/seed-fleet-nodes.yml), [\`update-all-nodes.yml\`](https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml), [\`sync-code-source.yml\`](https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/autobot-slm-backend/ansible/playbooks/sync-code-source.yml), and [\`deploy-slm-manager.yml\`](https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/autobot-slm-backend/ansible/playbooks/deploy-slm-manager.yml) itself, AND [\`roles/common/tasks/main.yml:187,199\`](https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/autobot-slm-backend/ansible/roles/common/tasks/main.yml#L187-L199) which already uses \`inventory_hostname != '00-SLM-Manager'\` for the same kind of \"don't apply this to the SLM Manager\" gate.

In single-host self-deploy mode (localhost inventory), \`inventory_hostname\` is \`'localhost'\` not \`'00-SLM-Manager'\`, so the guard correctly stays True — but the upstream \`node_roles is defined\` check (#2836) already short-circuits in that mode anyway.

## Files (same 5 as #7035, swap one when-clause line in each)

| File | Tasks fixed |
|---|---|
| roles/backend/tasks/clean.yml | 2 + docstring update |
| roles/frontend/tasks/clean.yml | 2 |
| roles/ai-stack/tasks/clean.yml | 1 |
| roles/browser/tasks/clean.yml | 1 |
| roles/npu-worker/tasks/clean.yml | 1 |

## Test plan

- [x] Locally synced corrected fix into code_source and inspected — guard pattern matches existing \`roles/common/tasks/main.yml\` precedent
- [ ] After merge: \`./install.sh --reinstall\` followed by \`./install.sh --validate\` passes
- [ ] \`/opt/autobot/autobot-slm-frontend/dist/index.html\` exists post-install
- [ ] Backend cleanup tasks now show \`skipping: [00-SLM-Manager]\` (not \`changed: [00-SLM-Manager]\`)

## Closes
Closes #7031 (re-opened after #7035 verification failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)