### PR TITLE
fix(ansible/slm-admin-ui): User=root → User=autobot (least privilege, #7054)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/slm-admin-ui.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/slm-admin-ui.service.j2
@@ -7,8 +7,10 @@ PartOf=nginx.service
 
 [Service]
 Type=oneshot
-User=root
-Group=root
+# #7054: autobot owns the cert (0600 autobot:autobot) so it can read --cacert;
+# this service is a one-shot probe and doesn't need root capability.
+User=autobot
+Group=autobot
 
 # Health check: verify SLM frontend is built and nginx can serve it.
 # --cacert pins the self-signed cert installed at TLS bootstrap (#7024).


### PR DESCRIPTION
Closes #7054. Two-line systemd unit change. Verified live: `sudo -u autobot curl -sf --cacert /etc/autobot/certs/server-cert.pem -o /dev/null https://127.0.0.1/slm/` returns exit 0. autobot owns the cert (0600 autobot:autobot) so it can read --cacert; this service is a one-shot probe and doesn't need root. Aligns with every other AutoBot service.