### PR TITLE
fix(ansible/venv): health-check + auto-recreate broken venv (#7052)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -358,6 +358,27 @@
     state: absent
   when: venv_check.stat.exists and venv_check.stat.islnk
 
+# #7052: Detect partially-corrupted venv from a prior failed install.
+# A venv with a working python3.12 binary but stale .pth files (e.g. from
+# an editable install whose finder module was removed during venv rebuild)
+# breaks pip on first import. The `Create venv` task below skips when
+# bin/activate exists, so without this check the corruption survives reinstall.
+- name: "Backend | Check venv health (pip importable, #7052)"
+  ansible.builtin.command:
+    cmd: "{{ backend_code_dir }}/venv/bin/python3.12 -c 'import pip'"
+  register: _venv_health
+  changed_when: false
+  failed_when: false
+  when: venv_check.stat.exists and venv_check.stat.isdir
+
+- name: "Backend | Remove broken venv when health check failed (#7052)"
+  ansible.builtin.file:
+    path: "{{ backend_code_dir }}/venv"
+    state: absent
+  when:
+    - venv_check.stat.exists and venv_check.stat.isdir
+    - (_venv_health.rc | default(0)) != 0
+
 - name: Create Python 3.12 virtual environment via deadsnakes
   ansible.builtin.command:
     cmd: "python3.12 -m venv {{ backend_code_dir }}/venv"

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -209,6 +209,29 @@
     - _venv_py_version.rc != 0 or _venv_py_version.stdout != '3.12'
   tags: ['slm', 'backend']
 
+# #7052: also detect partially-corrupted venv (correct python version but
+# broken pip — e.g. stale .pth referencing a removed editable-install finder).
+- name: "SLM | Check venv health (pip importable, #7052)"
+  ansible.builtin.command:
+    cmd: "{{ slm_backend_dir }}/venv/bin/python3 -c 'import pip'"
+  register: _slm_venv_health
+  changed_when: false
+  failed_when: false
+  when:
+    - slm_requirements_stat.stat.exists
+    - _venv_py_version.rc == 0
+    - _venv_py_version.stdout == '3.12'
+  tags: ['slm', 'backend']
+
+- name: "SLM | Remove broken venv when health check failed (#7052)"
+  ansible.builtin.file:
+    path: "{{ slm_backend_dir }}/venv"
+    state: absent
+  when:
+    - slm_requirements_stat.stat.exists
+    - (_slm_venv_health.rc | default(0)) != 0
+  tags: ['slm', 'backend']
+
 - name: "SLM | Create Python 3.12 virtual environment"
   ansible.builtin.command:
     cmd: python3.12 -m venv {{ slm_backend_dir }}/venv


### PR DESCRIPTION
Closes #7052.

Adds a `python3.12 -c 'import pip'` health check before the existing `Create Python 3.12 virtual environment` task. If the check fails (rc != 0), the venv directory is removed so Create rebuilds it cleanly.

Same pattern as the existing `Check venv Python version` / `Remove stale venv if not Python 3.12` guard in slm_manager — this just extends it to also catch the corrupted-site-packages case (e.g. stale `.pth` referencing a removed editable-install finder module).

Hit the original bug twice in my session today. After this fix lands, `./install.sh --reinstall` will recover from interrupted prior runs without manual `rm -rf venv/` workaround.

Files:
- `roles/backend/tasks/main.yml` — 2 new tasks
- `roles/slm_manager/tasks/main.yml` — 2 new tasks alongside existing version check

YAML validated. Idempotent: healthy venv = check passes, remove skips, create no-ops.