### PR TITLE
fix(deps): bump langchain-core floor 1.2.28 → 1.2.31 (closes #7049)

### DIFF
--- a/requirements-ci/langchain.txt
+++ b/requirements-ci/langchain.txt
@@ -2,6 +2,6 @@
 langchain==1.2.13                # Issue #2808: bumped to match canonical minimum (was 1.2.12)
 langchain-classic==1.0.2
 langchain-community==0.4.1
-langchain-core==1.2.28
+langchain-core>=1.2.31,<2.0.0    # #7049: floor bumped from ==1.2.28 — langchain-text-splitters 1.1.2 requires >=1.2.31
 langchain-text-splitters==1.1.2
 langsmith==0.7.31


### PR DESCRIPTION
Closes #7049. Fourth layer of the silent-failure cascade started by #6947.

## Conflict

From Dev_new_gui run [25396312960](https://github.com/mrveiss/AutoBot-AI/actions/runs/25396312960) (push event, no PR involvement):

\`\`\`
The user requested langchain-core==1.2.28
langchain 1.2.13 depends on langchain-core>=1.2.10           ✓
langchain-classic 1.0.2 depends on langchain-core>=1.2.17    ✓
langchain-text-splitters 1.1.2 depends on langchain-core>=1.2.31  ✗
\`\`\`

The exact pin was 3 patch versions below what \`langchain-text-splitters 1.1.2\` requires.

## Fix

\`\`\`diff
-langchain-core==1.2.28
+langchain-core>=1.2.31,<2.0.0
\`\`\`

Loosened to a range — matches the shape used in \`autobot-backend/requirements.txt:55\` (\`langchain-core>=1.2.22,<2.0.0\`). Upper bound preserved per security tradition.

## Cascade closure

| Layer | Fix |
|-------|-----|
| #6947 pipefail | merged |
| #7001 / #7013 editable install | merged |
| #7018 / #7021 torch/vllm | merged |
| **#7049 / this PR** langchain-core floor | this PR |

After this lands, \`startup-import-smoke\` should pass on Dev_new_gui for the first time since #6947 added pipefail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)