### PR TITLE
fix(ci): docker-smoke-test informational curls tolerate SIGPIPE under pipefail (closes #7066)

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -79,17 +79,21 @@ jobs:
           echo "Verifying services..."
           docker compose --env-file docker/.env.docker ps
 
+          # #7066: || true to swallow SIGPIPE from curl when head exits early.
+          # These pipelines are informational only — the actual smoke gate is
+          # the docker-compose healthchecks above. With set -o pipefail (added
+          # by #7019), curl receives SIGPIPE → exit 23 → step fails.
           echo ""
           echo "=== Frontend Health Check ==="
-          curl -v http://localhost 2>&1 | head -20
+          curl -v http://localhost 2>&1 | head -20 || true
 
           echo ""
           echo "=== Backend Health Check ==="
-          curl -v http://localhost/api/system/health 2>&1 | head -20
+          curl -v http://localhost/api/system/health 2>&1 | head -20 || true
 
           echo ""
           echo "=== SLM Health Check ==="
-          curl -v http://localhost/slm/api/health 2>&1 | head -20
+          curl -v http://localhost/slm/api/health 2>&1 | head -20 || true
 
       - name: Collect logs on failure
         if: failure()


### PR DESCRIPTION
Closes #7066. Regression I introduced in #7019.

## Root cause

\`docker-smoke-test.yml\` "Verify services are running" step has 3 informational pipelines:

\`\`\`yaml
curl -v http://localhost 2>&1 | head -20
\`\`\`

\`head -20\` exits after reading 20 lines → sends SIGPIPE to curl → curl exits 23. With \`set -o pipefail\` (added by #7019), the rightmost non-zero exit code propagates → the step fails despite HTTP 200 from the service.

## Fix

Append \`|| true\` to each of the 3 informational pipelines. They're for human inspection only — the actual smoke gate is the docker-compose healthchecks above this step.

\`\`\`diff
-curl -v http://localhost 2>&1 | head -20
+curl -v http://localhost 2>&1 | head -20 || true
\`\`\`

## Evidence

Same exit-23 failure on:
- Dev_new_gui run 25420396625 (push, 06:39 UTC)
- PR #7065 run 25420356091
- PR #7039 run 25420338858

## Lesson

#7019 verified pipefail addition with static analysis only — YAML parse + regex match. **Did not run the actual workflows** to confirm pipefail wouldn't break the pipelines it was supposedly protecting. Memory captured for future audits.

## Verification

- YAML parses
- Live test will be the smoke-test on this PR — if it passes, the fix is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)