### PR TITLE
test(ci): regression guard for shared role_*_active facts (#7056)

### DIFF
--- a/.github/workflows/ansible-role-facts-test.yml
+++ b/.github/workflows/ansible-role-facts-test.yml
@@ -1,0 +1,60 @@
+# #7056: regression guard for the shared role_*_active facts.
+#
+# Runs the test playbook (autobot-slm-backend/ansible/tests/playbooks/
+# test_role_active_facts.yml) against synthetic inventories that exercise
+# every code path in inventory/group_vars/all.yml.
+#
+# Catches:
+#   - Forgotten `autobot-X` variant when adding a new role
+#   - Forgotten group-membership check
+#   - Drift between provision-fleet-roles.yml gates and group_vars facts
+#   - Cleanup-gate regressions of the #7031 class
+#
+# Security note: this workflow does NOT interpolate any untrusted GitHub
+# event data (no issue titles, PR bodies, commit messages, head_ref, etc.)
+# into run: commands. All inputs are static file paths under the repo.
+---
+name: ansible-role-facts-test
+
+on:
+  pull_request:
+    paths:
+      - 'autobot-slm-backend/ansible/inventory/group_vars/**'
+      - 'autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml'
+      - 'autobot-slm-backend/ansible/roles/*/tasks/clean.yml'
+      - 'autobot-slm-backend/ansible/tests/**'
+      - '.github/workflows/ansible-role-facts-test.yml'
+  push:
+    branches:
+      - Dev_new_gui
+      - main
+    paths:
+      - 'autobot-slm-backend/ansible/inventory/group_vars/**'
+      - 'autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml'
+      - 'autobot-slm-backend/ansible/roles/*/tasks/clean.yml'
+      - 'autobot-slm-backend/ansible/tests/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Ansible (system Python is fine for this test)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y ansible-core
+
+      - name: Run role_*_active facts test playbook
+        working-directory: autobot-slm-backend/ansible
+        run: |
+          ansible-playbook \
+            -i tests/inventory/test_role_facts.yml \
+            tests/playbooks/test_role_active_facts.yml
+
+      - name: Lint test playbook + inventory YAML
+        working-directory: autobot-slm-backend/ansible
+        run: |
+          python3 -c "import yaml; yaml.safe_load(open('tests/playbooks/test_role_active_facts.yml'))"
+          python3 -c "import yaml; yaml.safe_load(open('tests/inventory/test_role_facts.yml'))"

--- a/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
@@ -1,0 +1,1 @@
+../../../inventory/group_vars/all.yml

--- a/autobot-slm-backend/ansible/tests/inventory/test_role_facts.yml
+++ b/autobot-slm-backend/ansible/tests/inventory/test_role_facts.yml
@@ -1,0 +1,148 @@
+# AutoBot - Test inventory for role_*_active facts (#7056)
+#
+# Synthetic hosts covering every code path in the shared facts
+# (group_vars/all.yml). Each host defines the (node_roles, group membership)
+# inputs and the EXPECTED role_*_active output. The test playbook asserts
+# input → output matches the fact definition.
+#
+# This catches:
+#   - Forgotten autobot-X variant when adding a new role
+#   - Forgotten group-membership check
+#   - Drift between provision-fleet-roles.yml gates and group_vars facts
+---
+all:
+  hosts:
+    # 1. Single-host install layout written by install.sh (#6600):
+    #    SLM Manager hosts the SLM stack AND co-hosts backend + vnc.
+    #    Was the failure mode of #7031 — cleanup wiped autobot-backend
+    #    because 'backend' was not in node_roles (only 'autobot-backend').
+    test-single-host-slm-and-backend:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - autobot-backend
+        - vnc
+      expected_role_backend_active: true
+      expected_role_vnc_active: true
+      expected_role_frontend_active: false
+      expected_role_slm_active: true
+      expected_role_redis_active: false
+      expected_role_ai_stack_active: false
+      expected_role_npu_worker_active: false
+      expected_role_browser_active: false
+      expected_role_llm_active: false
+      expected_role_tts_worker_active: false
+
+    # 2. Dedicated SLM Manager (multi-host fleet — seed-fleet-nodes.yml).
+    #    No backend, no frontend.
+    test-dedicated-slm-manager:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - autobot-slm-agent
+        - autobot-slm-database
+        - autobot-monitoring
+      expected_role_backend_active: false
+      expected_role_vnc_active: false
+      expected_role_frontend_active: false
+      expected_role_slm_active: true
+      expected_role_redis_active: false
+      expected_role_ai_stack_active: false
+      expected_role_npu_worker_active: false
+      expected_role_browser_active: false
+      expected_role_llm_active: false
+      expected_role_tts_worker_active: false
+
+    # 3. Backend host using SHORT role name (no prefix). Provision gates and
+    #    cleanup gates must both treat this as "backend is active".
+    test-backend-short-name:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - backend
+      expected_role_backend_active: true
+      expected_role_vnc_active: false
+      expected_role_slm_active: false
+
+    # 4. Frontend host with autobot-prefixed name.
+    test-frontend-prefixed:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - autobot-frontend
+      expected_role_backend_active: false
+      expected_role_frontend_active: true
+      expected_role_slm_active: false
+
+    # 5. AI Stack + LLM (co-located).
+    test-ai-stack-and-llm:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - ai-stack
+        - llm
+      expected_role_ai_stack_active: true
+      expected_role_llm_active: true
+      expected_role_backend_active: false
+      expected_role_slm_active: false
+
+    # 6. NPU + TTS worker (co-located convention).
+    test-npu-and-tts:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - autobot-npu-worker
+        - tts-worker
+      expected_role_npu_worker_active: true
+      expected_role_tts_worker_active: true
+      expected_role_backend_active: false
+      expected_role_slm_active: false
+
+    # 7. Browser worker — variant naming (browser-service legacy).
+    test-browser-legacy-name:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - browser-service
+      expected_role_browser_active: true
+      expected_role_backend_active: false
+      expected_role_slm_active: false
+
+    # 8. Empty node_roles + group membership (legacy multi-host inventory).
+    #    Backend role should still gate-on via groups['main'] membership.
+    test-empty-roles-via-group:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles: []
+      expected_role_backend_active: true   # via groups['main']
+      expected_role_vnc_active: true       # via groups['main']
+      expected_role_frontend_active: false
+      expected_role_slm_active: false
+
+    # 9. No node_roles defined at all (truly empty host).
+    #    All facts should evaluate to false.
+    test-no-roles-defined:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      expected_role_backend_active: false
+      expected_role_vnc_active: false
+      expected_role_frontend_active: false
+      expected_role_slm_active: false
+      expected_role_redis_active: false
+      expected_role_ai_stack_active: false
+      expected_role_npu_worker_active: false
+      expected_role_browser_active: false
+      expected_role_llm_active: false
+      expected_role_tts_worker_active: false
+
+  children:
+    # Group-membership-only test for #8 (test-empty-roles-via-group).
+    main:
+      hosts:
+        test-empty-roles-via-group: {}
+    # SLM Manager hosts must be in slm_server group (matches install.sh
+    # localhost.yml + seed-fleet-nodes.yml inventory layout).
+    slm_server:
+      hosts:
+        test-single-host-slm-and-backend: {}
+        test-dedicated-slm-manager: {}

--- a/autobot-slm-backend/ansible/tests/playbooks/test_role_active_facts.yml
+++ b/autobot-slm-backend/ansible/tests/playbooks/test_role_active_facts.yml
@@ -1,0 +1,110 @@
+# AutoBot - Test playbook: assert role_*_active facts (#7056)
+#
+# For each synthetic test host (defined in tests/inventory/test_role_facts.yml),
+# evaluate every role_*_active fact and assert it matches the expected value.
+#
+# Catches regressions like #7031 where cleanup gates and provision gates
+# diverged because the role-name match was incomplete.
+#
+# Usage:
+#   cd autobot-slm-backend/ansible
+#   ansible-playbook -i tests/inventory/test_role_facts.yml \
+#                    tests/playbooks/test_role_active_facts.yml
+#
+# Exit non-zero on the first assertion failure.
+---
+- name: "Test: shared role_*_active facts (#7056)"
+  hosts: all
+  gather_facts: false
+  any_errors_fatal: true
+
+  tasks:
+    - name: "role_backend_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_backend_active | bool) == (expected_role_backend_active | bool)
+        fail_msg: >-
+          {{ inventory_hostname }}: role_backend_active={{ role_backend_active }},
+          expected={{ expected_role_backend_active }} (node_roles={{ node_roles | default([]) }})
+      when: expected_role_backend_active is defined
+
+    - name: "role_frontend_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_frontend_active | bool) == (expected_role_frontend_active | bool)
+        fail_msg: >-
+          {{ inventory_hostname }}: role_frontend_active={{ role_frontend_active }},
+          expected={{ expected_role_frontend_active }} (node_roles={{ node_roles | default([]) }})
+      when: expected_role_frontend_active is defined
+
+    - name: "role_slm_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_slm_active | bool) == (expected_role_slm_active | bool)
+        fail_msg: >-
+          {{ inventory_hostname }}: role_slm_active={{ role_slm_active }},
+          expected={{ expected_role_slm_active }} (node_roles={{ node_roles | default([]) }})
+      when: expected_role_slm_active is defined
+
+    - name: "role_ai_stack_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_ai_stack_active | bool) == (expected_role_ai_stack_active | bool)
+        fail_msg: >-
+          {{ inventory_hostname }}: role_ai_stack_active={{ role_ai_stack_active }},
+          expected={{ expected_role_ai_stack_active }} (node_roles={{ node_roles | default([]) }})
+      when: expected_role_ai_stack_active is defined
+
+    - name: "role_npu_worker_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_npu_worker_active | bool) == (expected_role_npu_worker_active | bool)
+        fail_msg: >-
+          {{ inventory_hostname }}: role_npu_worker_active={{ role_npu_worker_active }},
+          expected={{ expected_role_npu_worker_active }} (node_roles={{ node_roles | default([]) }})
+      when: expected_role_npu_worker_active is defined
+
+    - name: "role_browser_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_browser_active | bool) == (expected_role_browser_active | bool)
+        fail_msg: >-
+          {{ inventory_hostname }}: role_browser_active={{ role_browser_active }},
+          expected={{ expected_role_browser_active }} (node_roles={{ node_roles | default([]) }})
+      when: expected_role_browser_active is defined
+
+    - name: "role_redis_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_redis_active | bool) == (expected_role_redis_active | bool)
+        fail_msg: >-
+          {{ inventory_hostname }}: role_redis_active={{ role_redis_active }},
+          expected={{ expected_role_redis_active }} (node_roles={{ node_roles | default([]) }})
+      when: expected_role_redis_active is defined
+
+    - name: "role_vnc_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_vnc_active | bool) == (expected_role_vnc_active | bool)
+        fail_msg: >-
+          {{ inventory_hostname }}: role_vnc_active={{ role_vnc_active }},
+          expected={{ expected_role_vnc_active }} (node_roles={{ node_roles | default([]) }})
+      when: expected_role_vnc_active is defined
+
+    - name: "role_llm_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_llm_active | bool) == (expected_role_llm_active | bool)
+        fail_msg: >-
+          {{ inventory_hostname }}: role_llm_active={{ role_llm_active }},
+          expected={{ expected_role_llm_active }} (node_roles={{ node_roles | default([]) }})
+      when: expected_role_llm_active is defined
+
+    - name: "role_tts_worker_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_tts_worker_active | bool) == (expected_role_tts_worker_active | bool)
+        fail_msg: >-
+          {{ inventory_hostname }}: role_tts_worker_active={{ role_tts_worker_active }},
+          expected={{ expected_role_tts_worker_active }} (node_roles={{ node_roles | default([]) }})
+      when: expected_role_tts_worker_active is defined


### PR DESCRIPTION
Closes #7056. Adds 9-host synthetic inventory + assertion playbook + GH Actions workflow. Catches the #7031-class drift between provision gates and cleanup gates.

Verified locally: 51 assertions across 9 hosts, 0 failures. Caught one test-design bug during authoring (test SLM Manager hosts must be in slm_server group) — exactly the kind of slip the gate prevents in production.