### PR TITLE
feat(frontend/settings): wire 'Test backend connection' button (#6964, resolves #6845)

### DIFF
--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -664,7 +664,18 @@
     },
     "connection": {
       "title": "Connection",
-      "desc": "Configure backend connection settings"
+      "desc": "Configure backend connection settings",
+      "backendCheck": {
+        "title": "Backend reachability",
+        "description": "Run a one-shot ping to verify that the AutoBot backend is reachable from this browser. No periodic polling — manual only.",
+        "button": "Test backend connection",
+        "checking": "Checking…",
+        "reachable": "Reachable",
+        "unreachable": "Unreachable",
+        "latency": "Latency",
+        "lastTested": "Last tested",
+        "neverTested": "Not yet tested"
+      }
     }
   },
   "voice": {

--- a/autobot-frontend/src/views/SettingsView.vue
+++ b/autobot-frontend/src/views/SettingsView.vue
@@ -155,6 +155,56 @@ Issue #753: User preference management interface
             <p class="section-description">{{ $t('settings.connection.desc') }}</p>
           </div>
           <div class="section-content">
+            <!-- Backend reachability check (#6964 wire-in for apiClient.validateConnection, resolves #6845) -->
+            <div class="backend-check-panel">
+              <div class="backend-check-header">
+                <h3 class="backend-check-title">
+                  {{ $t('settings.connection.backendCheck.title') }}
+                </h3>
+                <p class="backend-check-description">
+                  {{ $t('settings.connection.backendCheck.description') }}
+                </p>
+              </div>
+              <div class="backend-check-actions">
+                <button
+                  type="button"
+                  class="backend-check-button"
+                  :disabled="isChecking"
+                  @click="testBackendConnection"
+                  data-testid="test-backend-connection"
+                >
+                  <Icon :name="isChecking ? 'sync-alt' : 'plug'" :spin="isChecking" />
+                  <span>
+                    {{
+                      isChecking
+                        ? $t('settings.connection.backendCheck.checking')
+                        : $t('settings.connection.backendCheck.button')
+                    }}
+                  </span>
+                </button>
+                <div
+                  v-if="lastResult !== null"
+                  :class="['backend-check-status', lastResult ? 'status-ok' : 'status-fail']"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <Icon :name="lastResult ? 'check-circle' : 'times-circle'" />
+                  <span class="status-label">
+                    {{
+                      lastResult
+                        ? $t('settings.connection.backendCheck.reachable')
+                        : $t('settings.connection.backendCheck.unreachable')
+                    }}
+                  </span>
+                  <span v-if="lastLatencyMs !== null" class="status-latency">
+                    · {{ $t('settings.connection.backendCheck.latency') }}: {{ lastLatencyMs }}ms
+                  </span>
+                </div>
+                <p v-if="lastTestedAt" class="backend-check-meta">
+                  {{ $t('settings.connection.backendCheck.lastTested') }}: {{ lastTestedAt }}
+                </p>
+              </div>
+            </div>
             <ConnectionSettingsPanel />
           </div>
         </section>
@@ -188,15 +238,53 @@ import ConnectionSettingsPanel from '@/components/desktop/ConnectionSettingsPane
 import FeatureFlagsSettingsPanel from '@/components/settings/FeatureFlagsSettingsPanel.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
+import { useToast } from '@/composables/useToast'
+import apiClient from '@/utils/ApiClient'
 
 const logger = createLogger('SettingsView')
+const { t } = useI18n()
+const { showToast } = useToast()
 
 logger.debug('Settings view initialized')
 
 type PreferenceTab = 'appearance' | 'language' | 'voice' | 'webresearch' | 'apikeys' | 'connection' | 'featureflags'
 const activeTab = ref<PreferenceTab>('appearance')
 const showApiKeyWizard = ref(false)
+
+// Backend reachability check (#6964 wire-in for apiClient.validateConnection, resolves #6845)
+const isChecking = ref(false)
+const lastResult = ref<boolean | null>(null)
+const lastLatencyMs = ref<number | null>(null)
+const lastTestedAt = ref<string | null>(null)
+
+async function testBackendConnection(): Promise<void> {
+  if (isChecking.value) return
+  isChecking.value = true
+  const t0 = performance.now()
+  try {
+    const reachable = await apiClient.validateConnection()
+    lastLatencyMs.value = Math.round(performance.now() - t0)
+    lastResult.value = reachable
+    lastTestedAt.value = new Date().toLocaleTimeString()
+    showToast(
+      reachable
+        ? `${t('settings.connection.backendCheck.reachable')} (${lastLatencyMs.value}ms)`
+        : t('settings.connection.backendCheck.unreachable'),
+      reachable ? 'success' : 'error'
+    )
+    logger.info('Backend reachability test', { reachable, latencyMs: lastLatencyMs.value })
+  } catch (error) {
+    lastLatencyMs.value = Math.round(performance.now() - t0)
+    lastResult.value = false
+    lastTestedAt.value = new Date().toLocaleTimeString()
+    showToast(t('settings.connection.backendCheck.unreachable'), 'error')
+    logger.error('Backend reachability test failed', error)
+  } finally {
+    isChecking.value = false
+  }
+}
 
 function onApiKeysSaved(): void {
   logger.info('API keys saved successfully')
@@ -409,5 +497,97 @@ function onApiKeysSaved(): void {
 
 .open-wizard-btn:hover {
   opacity: 0.9;
+}
+
+/* ============================================
+ * BACKEND REACHABILITY CHECK (#6964)
+ * ============================================ */
+
+.backend-check-panel {
+  padding: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+  background: var(--surface-secondary, var(--bg-secondary));
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md, 8px);
+}
+
+.backend-check-header {
+  margin-bottom: var(--spacing-md);
+}
+
+.backend-check-title {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-xs) 0;
+}
+
+.backend-check-description {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.backend-check-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.backend-check-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  align-self: flex-start;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md, 8px);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: opacity var(--duration-150);
+}
+
+.backend-check-button:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.backend-check-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.backend-check-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-sm, 4px);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  align-self: flex-start;
+}
+
+.backend-check-status.status-ok {
+  color: var(--color-success, #16a34a);
+  background: var(--color-success-bg, rgba(22, 163, 74, 0.1));
+}
+
+.backend-check-status.status-fail {
+  color: var(--color-danger, #dc2626);
+  background: var(--color-danger-bg, rgba(220, 38, 38, 0.1));
+}
+
+.status-latency {
+  font-weight: var(--font-normal);
+  opacity: 0.85;
+}
+
+.backend-check-meta {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin: 0;
 }
 </style>


### PR DESCRIPTION
## Summary

`apiClient.validateConnection()` lost its only caller in #6773 (heartbeat removal). #6845 flagged the chain as dead; #6964 is the wire-in tracker. Per project policy (never delete — wire it in), surfacing it as a user-triggered diagnostic in the existing Settings → Connection tab.

- New "Backend reachability" panel above `<ConnectionSettingsPanel />` in `SettingsView.vue`'s connection tab. Single button + inline status + last-tested timestamp.
- `testBackendConnection()` calls `apiClient.validateConnection()`, reports reachable/unreachable + measured latency via toast (`useToast`) and inline status. Disabled in-flight via `isChecking` ref. **One-shot only** — no periodic polling (the periodic caller was deliberately removed in #6773).
- New i18n keys under `settings.connection.backendCheck.*` in `en.json`. Other locales fall back to `en` (i18n `fallbackLocale: 'en'`).
- Uses `createLogger('SettingsView')` for diagnostics — no `console.*` calls.

## Behavioral grep audit

```
$ grep -rnE "apiClient\.validateConnection|client\.validateConnection" autobot-frontend/src \
    --include="*.ts" --include="*.vue" --include="*.js" | grep -v "__tests__\|test\."
```

| | callers |
|---|---|
| Before this PR | 0 |
| After this PR  | 1 (`testBackendConnection` in `SettingsView.vue`) |

## Test plan

- [x] `npx vue-tsc --noEmit -p tsconfig.app.json` — 0 errors in `SettingsView.vue`
- [x] `npx eslint src/views/SettingsView.vue` — clean
- [x] `node scripts/check-i18n-keys.mjs` — exits 0 (no new missing keys; the 4 missing keys reported are pre-existing in `FunctionCallGraph.vue` / `KnowledgeGraph.vue`, unrelated to this PR)
- [ ] Manual UI verification — open Settings → Connection tab, click "Test backend connection", verify toast + inline status + latency display

Closes #6964
Closes #6845

🤖 Generated with [Claude Code](https://claude.com/claude-code)