### PR TITLE
fix(orchestrator): unpack is_provider_healthy tuple — guard now actually fires (#7069)

### DIFF
--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -381,10 +381,17 @@ class Orchestrator:
                 self.memory_manager.initialize(),
                 self.agent_manager.initialize(),
             )
-            # #6983: migrated from llm_interface.check_ollama_connection() to LLMService.is_provider_healthy()
-            ollama_connected = await self.llm_service.is_provider_healthy(provider_name="ollama")
+            # is_provider_healthy returns (is_healthy, error_message_or_None);
+            # tuple is always truthy, so the prior `if not <tuple>:` guard
+            # never fired and ollama-down failures fell through to the
+            # less-specific model validation step.
+            ollama_connected, ollama_error = await self.llm_service.is_provider_healthy(
+                provider_name="ollama"
+            )
             if not ollama_connected:
-                raise Exception("Failed to connect to Ollama or configured models not found.")
+                raise Exception(
+                    f"Failed to connect to Ollama: {ollama_error or 'unknown error'}"
+                )
             logger.info("✅ Ollama connection established")
             await self._ensure_working_llm_model()
             self.is_running = True


### PR DESCRIPTION
## Self-reported regression

PR #7036 (#6983) migrated \`check_ollama_connection()\` (returned bool) to \`LLMService.is_provider_healthy()\` (returns \`tuple[bool, Optional[str]]\`). I treated the tuple return as a bool — non-empty tuples are always truthy in Python, so \`not (False, \"...\")\` is \`False\` and the guard never fired.

## Effect on Dev_new_gui (current state)

Ollama-unreachable failures fell through \`Orchestrator.initialize()\` to a later \`_ensure_working_llm_model()\` step, producing a less-specific error trace. Boot didn't crash, but the failure-fast guard was effectively unreachable.

## Fix

\`\`\`python
ollama_connected, ollama_error = await self.llm_service.is_provider_healthy(...)
if not ollama_connected:
    raise Exception(f\"Failed to connect to Ollama: {ollama_error or 'unknown error'}\")
\`\`\`

Tuple unpacking + improved error message that surfaces the underlying reason.

## Verification

\`\`\`
>>> ollama_connected, ollama_error = (True, None);   ollama_connected → True
>>> ollama_connected, ollama_error = (False, 'ollama unavailable')
>>> raises: 'Failed to connect to Ollama: ollama unavailable'
\`\`\`

\`py_compile\` clean.

## Process gap

PR #7036 verified \`py_compile\` and \`import\` success but didn't exercise runtime behavior of the migrated calls. Method-replacement migrations need return-shape verification, not just import-time checks. Lesson is already in MEMORY (#5142, feedback_migration_initial_grep) but didn't fire here because I focused on \"does the import succeed\" rather than \"does the new behavior match the old\".

Closes #7069