### PR TITLE
fix(ansible/provision): regression from #7051 — load role_*_active facts via vars_files for SLM-triggered provision

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
@@ -185,6 +185,12 @@
   become: true
   gather_facts: true
 
+  # #7050/#7051 shared role-active facts — see vars/role_active_facts.yml
+  # for why this is needed (SLM-triggered provision uses temp inventory
+  # without sibling group_vars/, so this loads the facts directly).
+  vars_files:
+    - vars/role_active_facts.yml
+
   tasks:
     - name: "Deps | Install nginx"
       ansible.builtin.include_role:
@@ -277,6 +283,12 @@
   become: true
   gather_facts: true
 
+  # #7050/#7051 shared role-active facts — see vars/role_active_facts.yml
+  # for why this is needed (SLM-triggered provision uses temp inventory
+  # without sibling group_vars/, so this loads the facts directly).
+  vars_files:
+    - vars/role_active_facts.yml
+
   tasks:
     - name: "Data | Deploy Redis role"
       ansible.builtin.import_role:
@@ -292,6 +304,12 @@
   hosts: all
   become: true
   gather_facts: true
+
+  # #7050/#7051 shared role-active facts — see vars/role_active_facts.yml
+  # for why this is needed (SLM-triggered provision uses temp inventory
+  # without sibling group_vars/, so this loads the facts directly).
+  vars_files:
+    - vars/role_active_facts.yml
 
   tasks:
     - name: "App | Deploy backend role"
@@ -319,6 +337,12 @@
   hosts: all
   become: true
   gather_facts: true
+
+  # #7050/#7051 shared role-active facts — see vars/role_active_facts.yml
+  # for why this is needed (SLM-triggered provision uses temp inventory
+  # without sibling group_vars/, so this loads the facts directly).
+  vars_files:
+    - vars/role_active_facts.yml
 
   tasks:
     - name: "App | Deploy frontend role"
@@ -457,6 +481,12 @@
   become: true
   gather_facts: true
 
+  # #7050/#7051 shared role-active facts — see vars/role_active_facts.yml
+  # for why this is needed (SLM-triggered provision uses temp inventory
+  # without sibling group_vars/, so this loads the facts directly).
+  vars_files:
+    - vars/role_active_facts.yml
+
   tasks:
     - name: "AI | Deploy AI stack role"
       ansible.builtin.include_role:
@@ -484,6 +514,12 @@
   become: true
   gather_facts: true
 
+  # #7050/#7051 shared role-active facts — see vars/role_active_facts.yml
+  # for why this is needed (SLM-triggered provision uses temp inventory
+  # without sibling group_vars/, so this loads the facts directly).
+  vars_files:
+    - vars/role_active_facts.yml
+
   tasks:
     - name: "AI | Deploy NPU worker role"
       ansible.builtin.include_role:
@@ -501,6 +537,12 @@
   hosts: all
   become: true
   gather_facts: true
+
+  # #7050/#7051 shared role-active facts — see vars/role_active_facts.yml
+  # for why this is needed (SLM-triggered provision uses temp inventory
+  # without sibling group_vars/, so this loads the facts directly).
+  vars_files:
+    - vars/role_active_facts.yml
 
   tasks:
     - name: "AI | Deploy TTS worker role"
@@ -520,6 +562,12 @@
   become: true
   gather_facts: true
 
+  # #7050/#7051 shared role-active facts — see vars/role_active_facts.yml
+  # for why this is needed (SLM-triggered provision uses temp inventory
+  # without sibling group_vars/, so this loads the facts directly).
+  vars_files:
+    - vars/role_active_facts.yml
+
   tasks:
     - name: "LLM | Deploy LLM role (GPU auto-detected)"
       ansible.builtin.include_role:
@@ -537,6 +585,12 @@
   hosts: all
   become: true
   gather_facts: true
+
+  # #7050/#7051 shared role-active facts — see vars/role_active_facts.yml
+  # for why this is needed (SLM-triggered provision uses temp inventory
+  # without sibling group_vars/, so this loads the facts directly).
+  vars_files:
+    - vars/role_active_facts.yml
 
   tasks:
     - name: "Auto | Deploy browser role"

--- a/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
+++ b/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
@@ -1,0 +1,74 @@
+# #7050/#7051 shared role-active facts — DUPLICATE of inventory/group_vars/all.yml.
+#
+# WHY DUPLICATED:
+# When SLM triggers provision-fleet-roles.yml from a node-add or wizard flow,
+# it generates a TEMP inventory file in /tmp/ (no sibling group_vars/ dir).
+# Ansible only loads group_vars from directories adjacent to the inventory
+# file, so the facts in inventory/group_vars/all.yml are NOT available to
+# playbooks invoked with the temp inventory. Result: every conditional
+# `when: role_X_active` evaluates as undefined → fatal.
+#
+# Fix: load these facts via `vars_files: [vars/role_active_facts.yml]` in
+# every playbook that uses them, regardless of inventory layout. Static
+# inventories (localhost.yml, slm-nodes.yml) still get them via group_vars
+# for direct invocations; dynamic inventories get them via this file.
+#
+# DRY trade-off: kept identical to group_vars/all.yml definitions. If they
+# diverge, the CI test playbook (#7068) won't catch it — that test loads
+# group_vars directly. TODO follow-up: single source of truth via include.
+---
+role_backend_active: >-
+  {{ ('backend' in (node_roles | default([]))) or
+     ('autobot-backend' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('main', []) | default([]))) or
+     (inventory_hostname in (groups.get('backend', []) | default([]))) }}
+
+role_frontend_active: >-
+  {{ ('frontend' in (node_roles | default([]))) or
+     ('autobot-frontend' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('frontend', []) | default([]))) }}
+
+role_ai_stack_active: >-
+  {{ ('ai-stack' in (node_roles | default([]))) or
+     ('autobot-ai-stack' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('ai_stack', []) | default([]))) or
+     (inventory_hostname in (groups.get('aiml', []) | default([]))) }}
+
+role_npu_worker_active: >-
+  {{ ('npu-worker' in (node_roles | default([]))) or
+     ('autobot-npu-worker' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('npu_worker', []) | default([]))) or
+     (inventory_hostname in (groups.get('npu_workers', []) | default([]))) or
+     (inventory_hostname in (groups.get('npu', []) | default([]))) }}
+
+role_browser_active: >-
+  {{ ('browser' in (node_roles | default([]))) or
+     ('autobot-browser-worker' in (node_roles | default([]))) or
+     ('browser-service' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('browser', []) | default([]))) or
+     (inventory_hostname in (groups.get('browser_worker', []) | default([]))) }}
+
+role_slm_active: >-
+  {{ (inventory_hostname == '00-SLM-Manager') or
+     (inventory_hostname in (groups.get('slm_server', []) | default([]))) or
+     (inventory_hostname in (groups.get('slm', []) | default([]))) }}
+
+role_redis_active: >-
+  {{ ('redis' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('redis', []) | default([]))) or
+     (inventory_hostname in (groups.get('database', []) | default([]))) }}
+
+role_vnc_active: >-
+  {{ ('vnc' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('main', []) | default([]))) or
+     (inventory_hostname in (groups.get('backend', []) | default([]))) or
+     (inventory_hostname in (groups.get('vnc_nodes', []) | default([]))) }}
+
+role_llm_active: >-
+  {{ ('llm' in (node_roles | default([]))) or
+     (inventory_hostname in (groups.get('ai_stack', []) | default([]))) or
+     (inventory_hostname in (groups.get('llm_nodes', []) | default([]))) }}
+
+role_tts_worker_active: >-
+  {{ ('tts-worker' in (node_roles | default([]))) or
+     ('autobot-tts-worker' in (node_roles | default([]))) }}


### PR DESCRIPTION
Regression caused by #7051. SLM triggers provision-fleet-roles.yml with a temp inventory file (no sibling group_vars/), so role_*_active facts in inventory/group_vars/all.yml are not loaded → every gate fatal-undefined.

Fix: duplicate facts to playbooks/vars/role_active_facts.yml, load via vars_files in every play. Static-inventory playbooks unchanged (still use group_vars). Verified syntax-check passes; ready to deploy on the user's blocked install.