### PR TITLE
fix(slm-frontend): provision state survives navigation + WS disconnect (#7096)

### DIFF
--- a/autobot-slm-frontend/src/stores/provision.ts
+++ b/autobot-slm-frontend/src/stores/provision.ts
@@ -1,0 +1,349 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Provision Store (#7096)
+ *
+ * Pinia store for fleet provisioning state. Lifts state out of
+ * SetupWizardView so it survives:
+ *   - Component unmount (user navigates to another page)
+ *   - Browser tab refresh (state recovers from backend GET)
+ *   - WebSocket disconnect (auto-falls back to polling)
+ *
+ * Architecture:
+ *   - WS for live updates while open (low-latency)
+ *   - Polling as fallback (handles tab background, network blips)
+ *   - GET /provision-status on mount (resync after reload/navigation)
+ *
+ * Backend state lives in SLM API (api/setup_wizard.py:_provision_state)
+ * which is currently in-memory only. Backend restart loses tracking
+ * (filed as #7096 follow-up — Redis persistence).
+ */
+
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { useSlmApi } from '@/composables/useSlmApi'
+import { getConfig } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('ProvisionStore')
+
+export type ProvisionStatus = 'idle' | 'running' | 'completed' | 'failed'
+
+export interface ProvisionLogEntry {
+  type: 'info' | 'task' | 'success' | 'error' | 'warning' | 'phase'
+  message: string
+}
+
+const POLL_INTERVAL_MS = 3000
+const HEARTBEAT_STALE_MS = 30000  // Clear stuck "Still running..." after 30s without WS update
+
+export const useProvisionStore = defineStore('provision', () => {
+  const api = useSlmApi()
+
+  // ── State ───────────────────────────────────────────────────────────────
+  const status = ref<ProvisionStatus>('idle')
+  const stage = ref('')
+  const elapsedSeconds = ref(0)
+  const currentTask = ref('')
+  const currentPhase = ref('')
+  const completedPhases = ref<Set<string>>(new Set())
+  const logs = ref<ProvisionLogEntry[]>([])
+  const error = ref<string | null>(null)
+  const startedAt = ref<number | null>(null)
+  const finishedAt = ref<number | null>(null)
+  const wsConnected = ref(false)
+
+  // ── Computed ────────────────────────────────────────────────────────────
+  const isRunning = computed(() => status.value === 'running')
+  const isComplete = computed(() => status.value === 'completed')
+  const isFailed = computed(() => status.value === 'failed')
+  const isActive = computed(() => isRunning.value || isComplete.value || isFailed.value)
+  const elapsedFormatted = computed(() => formatElapsed(elapsedSeconds.value))
+
+  function formatElapsed(seconds: number): string {
+    if (seconds < 60) return `${seconds}s`
+    const mins = Math.floor(seconds / 60)
+    const secs = Math.floor(seconds % 60)
+    return `${mins}m ${secs}s`
+  }
+
+  // ── Internal: WebSocket lifecycle ───────────────────────────────────────
+  let ws: WebSocket | null = null
+  let pollTimer: number | null = null
+  let linesSeen = 0
+  let lastWsMessageAt = 0
+  let staleTaskTimer: number | null = null
+
+  function connectWs(): void {
+    if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) {
+      return
+    }
+    const cfg = getConfig()
+    const apiPrefix = cfg.apiBaseUrl.startsWith('/') ? cfg.apiBaseUrl : ''
+    const url = `${cfg.wsBaseUrl}${apiPrefix}/api/ws/provision`
+
+    try {
+      ws = new WebSocket(url)
+    } catch (e) {
+      logger.error('Failed to open provision WebSocket', e)
+      // Fall back to polling immediately
+      startPolling()
+      return
+    }
+
+    ws.onopen = () => {
+      logger.info('Provision WebSocket connected')
+      wsConnected.value = true
+      lastWsMessageAt = Date.now()
+      stopPolling()
+      startStaleTaskWatcher()
+    }
+    ws.onmessage = handleWsMessage
+    ws.onclose = () => {
+      logger.debug('Provision WebSocket closed')
+      ws = null
+      wsConnected.value = false
+      stopStaleTaskWatcher()
+      // Fall back to polling if provision is still running
+      if (isRunning.value) {
+        startPolling()
+      }
+    }
+    ws.onerror = (err) => {
+      logger.error('Provision WebSocket error', err)
+    }
+  }
+
+  function disconnectWs(): void {
+    if (ws) {
+      ws.onclose = null  // Suppress fallback trigger
+      ws.close()
+      ws = null
+    }
+    wsConnected.value = false
+    stopPolling()
+    stopStaleTaskWatcher()
+  }
+
+  function handleWsMessage(event: MessageEvent): void {
+    lastWsMessageAt = Date.now()
+    try {
+      const msg = JSON.parse(event.data)
+      if (msg.type === 'log') {
+        if (msg.log_type === 'heartbeat') {
+          currentTask.value = msg.message
+        } else if (msg.log_type === 'phase') {
+          const m = msg.message.match(/Provision Phase\s+(\S+):/)
+          if (m) {
+            if (currentPhase.value) completedPhases.value.add(currentPhase.value)
+            currentPhase.value = m[1]
+          }
+          currentTask.value = ''
+          logs.value.push({ type: 'phase', message: msg.message })
+        } else {
+          if (msg.log_type === 'task') currentTask.value = ''
+          logs.value.push({
+            type: msg.log_type || 'info',
+            message: msg.message,
+          })
+        }
+        linesSeen = logs.value.length
+      } else if (msg.type === 'status') {
+        stage.value = msg.stage || ''
+        elapsedSeconds.value = Math.round(msg.elapsed_seconds || 0)
+
+        if (msg.status === 'completed') {
+          if (currentPhase.value) completedPhases.value.add(currentPhase.value)
+          currentTask.value = ''
+          status.value = 'completed'
+          finishedAt.value = Date.now()
+          disconnectWs()
+        } else if (msg.status === 'failed') {
+          logs.value.push({
+            type: 'error',
+            message: msg.error || 'Provisioning failed',
+          })
+          status.value = 'failed'
+          error.value = msg.error || 'Provisioning failed'
+          finishedAt.value = Date.now()
+          disconnectWs()
+        } else if (msg.status === 'running' && status.value === 'idle') {
+          // Provision started elsewhere (e.g. from another tab) — pick up state
+          status.value = 'running'
+          startedAt.value = Date.now()
+        }
+      } else if (msg.type === 'ping') {
+        ws?.send('pong')
+      }
+    } catch {
+      // Ignore non-JSON messages
+    }
+  }
+
+  // ── Internal: polling fallback ──────────────────────────────────────────
+  function startPolling(): void {
+    if (pollTimer !== null) return
+    logger.info('Starting provision polling fallback')
+    pollTimer = window.setInterval(async () => {
+      try {
+        const result = await api.getProvisionStatus(linesSeen)
+        if (result.lines.length > 0) {
+          for (const line of result.lines) {
+            logs.value.push({ type: 'info', message: line })
+          }
+          linesSeen = result.total_lines
+        }
+        if (result.elapsed_seconds !== undefined) {
+          elapsedSeconds.value = Math.round(result.elapsed_seconds)
+        }
+        if (result.status === 'completed') {
+          status.value = 'completed'
+          finishedAt.value = Date.now()
+          stopPolling()
+          // Try reconnecting WS for any final messages
+          connectWs()
+        } else if (result.status === 'failed') {
+          status.value = 'failed'
+          error.value = result.error || 'Provisioning failed'
+          finishedAt.value = Date.now()
+          stopPolling()
+        }
+      } catch (err) {
+        logger.error('Provision polling error', err)
+      }
+    }, POLL_INTERVAL_MS) as unknown as number
+  }
+
+  function stopPolling(): void {
+    if (pollTimer !== null) {
+      clearInterval(pollTimer)
+      pollTimer = null
+    }
+  }
+
+  // ── Internal: stale-heartbeat watcher ───────────────────────────────────
+  // If the WebSocket goes silent (browser tab backgrounded, network blip)
+  // for longer than HEARTBEAT_STALE_MS, clear the stuck `currentTask` so
+  // the UI doesn't display an outdated "Still running... [task]" line.
+  function startStaleTaskWatcher(): void {
+    if (staleTaskTimer !== null) return
+    staleTaskTimer = window.setInterval(() => {
+      if (currentTask.value && Date.now() - lastWsMessageAt > HEARTBEAT_STALE_MS) {
+        logger.debug('Clearing stale heartbeat — no WS message for', Date.now() - lastWsMessageAt, 'ms')
+        currentTask.value = ''
+      }
+    }, 5000) as unknown as number
+  }
+
+  function stopStaleTaskWatcher(): void {
+    if (staleTaskTimer !== null) {
+      clearInterval(staleTaskTimer)
+      staleTaskTimer = null
+    }
+  }
+
+  // ── Public actions ──────────────────────────────────────────────────────
+
+  /**
+   * Start a fresh provisioning run. Resets state and connects WS.
+   * Caller is responsible for invoking the actual API to start the
+   * backend playbook (this only sets up live tracking).
+   */
+  function start(): void {
+    reset()
+    status.value = 'running'
+    startedAt.value = Date.now()
+    connectWs()
+  }
+
+  /**
+   * Resync provision state from the backend. Call from any view's
+   * onMounted (or app-level setup) to recover state after navigation,
+   * tab refresh, or backend restart.
+   */
+  async function restoreFromBackend(): Promise<void> {
+    try {
+      const result = await api.getProvisionStatus(0)
+      // Backend returns 'idle' if no provision has ever run on this server,
+      // OR if a previous run was reset. Either way, leave store at idle.
+      if (!result.status || result.status === 'idle') {
+        return
+      }
+
+      // Replay buffered log lines
+      logs.value = result.lines.map((line) => ({
+        type: 'info' as const,
+        message: line,
+      }))
+      linesSeen = result.total_lines
+      if (result.elapsed_seconds !== undefined) {
+        elapsedSeconds.value = Math.round(result.elapsed_seconds)
+      }
+
+      if (result.status === 'running') {
+        status.value = 'running'
+        startedAt.value = startedAt.value ?? Date.now()
+        // Reconnect WS for live updates
+        connectWs()
+      } else if (result.status === 'completed') {
+        status.value = 'completed'
+        finishedAt.value = Date.now()
+      } else if (result.status === 'failed') {
+        status.value = 'failed'
+        error.value = result.error || 'Provisioning failed'
+        finishedAt.value = Date.now()
+      }
+    } catch (err) {
+      logger.error('Failed to restore provision state from backend', err)
+    }
+  }
+
+  /**
+   * Reset store to idle. Disconnects WS/polling. Use after the user
+   * acknowledges a completed/failed run and is ready for a new one.
+   */
+  function reset(): void {
+    disconnectWs()
+    status.value = 'idle'
+    stage.value = ''
+    elapsedSeconds.value = 0
+    currentTask.value = ''
+    currentPhase.value = ''
+    completedPhases.value = new Set()
+    logs.value = []
+    error.value = null
+    startedAt.value = null
+    finishedAt.value = null
+    linesSeen = 0
+    lastWsMessageAt = 0
+  }
+
+  return {
+    // State
+    status,
+    stage,
+    elapsedSeconds,
+    currentTask,
+    currentPhase,
+    completedPhases,
+    logs,
+    error,
+    startedAt,
+    finishedAt,
+    wsConnected,
+    // Computed
+    isRunning,
+    isComplete,
+    isFailed,
+    isActive,
+    elapsedFormatted,
+    // Actions
+    start,
+    restoreFromBackend,
+    reset,
+    connectWs,
+    disconnectWs,
+  }
+})

--- a/autobot-slm-frontend/src/views/SetupWizardView.vue
+++ b/autobot-slm-frontend/src/views/SetupWizardView.vue
@@ -466,11 +466,11 @@
 // Copyright (c) 2025 mrveiss
 // Author: mrveiss
 
-import { ref, computed, nextTick, onMounted, onUnmounted } from 'vue'
+import { ref, computed, nextTick, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useSlmApi } from '@/composables/useSlmApi'
+import { useProvisionStore } from '@/stores/provision'
 import type { NodeRole } from '@/types/slm'
-import { getConfig } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('SetupWizard')
@@ -489,9 +489,13 @@ const {
   completeWizardStep,
   skipWizardSetup,
   provisionWizardFleet,
-  getProvisionStatus,
   validateWizardFleet,
 } = useSlmApi()
+
+// #7096: provision state lives in a Pinia store so it survives component
+// unmount (user navigates to another page during provisioning), browser
+// refresh (state recovers via getProvisionStatus), and WS disconnect.
+const provisionStore = useProvisionStore()
 
 // ── Wizard state ──────────────────────────────────────────────────────────
 
@@ -714,22 +718,18 @@ async function saveSecrets() {
 
 // ── Provisioning ──────────────────────────────────────────────────────────
 
-const provisioning = ref(false)
-const provisionComplete = ref(false)
-
-interface ProvisionLogEntry {
-  type: 'info' | 'task' | 'success' | 'error' | 'warning' | 'phase'
-  message: string
-}
-
-const provisionLogs = ref<ProvisionLogEntry[]>([])
-const provisionStage = ref('')
-const provisionElapsed = ref(0)
-const currentTask = ref('')
-const currentPhase = ref('')
-const completedPhases = ref<Set<string>>(new Set())
+// #7096: provision state proxied from store (survives component unmount).
+// Names preserved to minimize template churn; the underlying refs live in
+// useProvisionStore() and persist across navigation.
+const provisioning = computed(() => provisionStore.isRunning)
+const provisionComplete = computed(() => provisionStore.isComplete)
+const provisionLogs = computed(() => provisionStore.logs)
+const provisionStage = computed(() => formatStage(provisionStore.stage))
+const provisionElapsed = computed(() => provisionStore.elapsedSeconds)
+const currentTask = computed(() => provisionStore.currentTask)
+const currentPhase = computed(() => provisionStore.currentPhase)
+const completedPhases = computed(() => provisionStore.completedPhases)
 const logContainerRef = ref<HTMLElement | null>(null)
-let provisionWs: WebSocket | null = null
 
 const knownPhases = [
   { id: '0', label: 'Shared Deps' },
@@ -951,142 +951,9 @@ async function saveAndContinueRoles() {
   await completeStep('assign_roles')
 }
 
-let provisionPollTimer: ReturnType<typeof setInterval> | null = null
-
-function connectProvisionWs() {
-  // Use SSOT config for WS URL (Issue #2489: Docker prefix support)
-  const cfg = getConfig()
-  const apiPrefix = cfg.apiBaseUrl.startsWith('/') ? cfg.apiBaseUrl : ''
-  const url = `${cfg.wsBaseUrl}${apiPrefix}/api/ws/provision`
-
-  provisionWs = new WebSocket(url)
-
-  provisionWs.onopen = () => {
-    logger.info('Provision WebSocket connected')
-  }
-
-  provisionWs.onmessage = (event) => {
-    try {
-      const msg = JSON.parse(event.data)
-
-      if (msg.type === 'log') {
-        if (msg.log_type === 'heartbeat') {
-          // Update in-place — never flood the log with repeated heartbeat lines
-          currentTask.value = msg.message
-        } else if (msg.log_type === 'phase') {
-          // Track phase progress
-          const m = msg.message.match(/Provision Phase\s+(\S+):/)
-          if (m) {
-            if (currentPhase.value) completedPhases.value.add(currentPhase.value)
-            currentPhase.value = m[1]
-          }
-          currentTask.value = ''
-          provisionLogs.value.push({ type: 'phase', message: msg.message })
-          scrollProvisionLog()
-        } else {
-          // A new real task arrived — clear the heartbeat indicator
-          if (msg.log_type === 'task') currentTask.value = ''
-          provisionLogs.value.push({
-            type: msg.log_type || 'info',
-            message: msg.message,
-          })
-          scrollProvisionLog()
-        }
-      } else if (msg.type === 'status') {
-        provisionStage.value = formatStage(msg.stage || '')
-        provisionElapsed.value = Math.round(msg.elapsed_seconds || 0)
-
-        if (msg.status === 'completed') {
-          if (currentPhase.value) completedPhases.value.add(currentPhase.value)
-          currentTask.value = ''
-          provisionComplete.value = true
-          provisioning.value = false
-          disconnectProvisionWs()
-        } else if (msg.status === 'failed') {
-          provisionLogs.value.push({
-            type: 'error',
-            message: msg.error || 'Provisioning failed',
-          })
-          provisioning.value = false
-          scrollProvisionLog()
-          disconnectProvisionWs()
-        }
-      } else if (msg.type === 'ping') {
-        provisionWs?.send('pong')
-      }
-    } catch {
-      // Ignore non-JSON messages (pong, etc.)
-    }
-  }
-
-  provisionWs.onclose = () => {
-    logger.debug('Provision WebSocket closed')
-    // If still provisioning, fall back to polling
-    if (provisioning.value) {
-      logger.info('WebSocket closed during provisioning, falling back to polling')
-      startProvisionPolling()
-    }
-  }
-
-  provisionWs.onerror = (err) => {
-    logger.error('Provision WebSocket error:', err)
-  }
-}
-
-function disconnectProvisionWs() {
-  if (provisionWs) {
-    provisionWs.onclose = null // Prevent fallback trigger
-    provisionWs.close()
-    provisionWs = null
-  }
-  stopProvisionPolling()
-}
-
-function startProvisionPolling() {
-  let linesSeen = provisionLogs.value.length
-  provisionPollTimer = setInterval(async () => {
-    try {
-      const status = await getProvisionStatus(linesSeen)
-      if (status.lines.length > 0) {
-        for (const line of status.lines) {
-          provisionLogs.value.push({ type: 'info', message: line })
-        }
-        linesSeen = status.total_lines
-        scrollProvisionLog()
-      }
-      if (status.elapsed_seconds) {
-        provisionElapsed.value = Math.round(status.elapsed_seconds)
-      }
-      if (status.status === 'completed') {
-        stopProvisionPolling()
-        provisionLogs.value.push({
-          type: 'success',
-          message: 'Provisioning completed successfully.',
-        })
-        provisionComplete.value = true
-        provisioning.value = false
-        scrollProvisionLog()
-      } else if (status.status === 'failed') {
-        stopProvisionPolling()
-        provisionLogs.value.push({
-          type: 'error',
-          message: status.error || 'Provisioning failed',
-        })
-        provisioning.value = false
-        scrollProvisionLog()
-      }
-    } catch {
-      // Poll failure is transient - keep trying
-    }
-  }, 2000)
-}
-
-function stopProvisionPolling() {
-  if (provisionPollTimer) {
-    clearInterval(provisionPollTimer)
-    provisionPollTimer = null
-  }
-}
+// #7096: WebSocket + polling moved to useProvisionStore() so connection
+// survives component unmount (user navigates away mid-provision). The view
+// only consumes the store's reactive state via the computed proxies above.
 
 function formatElapsed(seconds: number): string {
   if (seconds < 60) return `${seconds}s`
@@ -1124,19 +991,13 @@ function scrollProvisionLog() {
   })
 }
 
+// #7096: log appends now happen in the store; watch + auto-scroll here
+watch(() => provisionStore.logs.length, () => scrollProvisionLog())
+
 async function provisionFleet() {
-  provisioning.value = true
-  provisionLogs.value = []
-  provisionStage.value = 'Starting...'
-  provisionElapsed.value = 0
-  currentTask.value = ''
-  currentPhase.value = ''
-  completedPhases.value = new Set()
-
-  provisionLogs.value.push({ type: 'info', message: 'Starting fleet provisioning...' })
-
-  // Connect WebSocket first
-  connectProvisionWs()
+  // #7096: store handles state reset, WS connection, and survives unmount
+  provisionStore.start()
+  provisionStore.logs.push({ type: 'info', message: 'Starting fleet provisioning...' })
 
   try {
     await provisionWizardFleet(nodes.value.map(n => n.node_id))
@@ -1144,15 +1005,14 @@ async function provisionFleet() {
     const detail =
       (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail ||
       'Unknown error'
-    provisionLogs.value.push({ type: 'error', message: `ERROR: ${detail}` })
-    provisioning.value = false
-    disconnectProvisionWs()
+    provisionStore.logs.push({ type: 'error', message: `ERROR: ${detail}` })
+    provisionStore.disconnectWs()
   }
 }
 
-onUnmounted(() => {
-  disconnectProvisionWs()
-})
+// #7096: NO disconnectProvisionWs() on unmount — store keeps the WebSocket
+// alive across navigation so users can leave the wizard and return without
+// losing provision visibility.
 
 async function checkFleetHealth() {
   checkingHealth.value = true
@@ -1180,6 +1040,9 @@ onMounted(async () => {
   await loadNodes()
   await loadRoles()
   await loadExistingSecrets()
+  // #7096: pick up any in-flight or recently-finished provision state
+  // so the user sees live progress even after navigating away and back.
+  await provisionStore.restoreFromBackend()
 })
 </script>
 


### PR DESCRIPTION
Closes #7096.

New Pinia store at `stores/provision.ts` owns provision state + WS lifecycle. SetupWizardView refactored to consume the store via computed proxies. `onMounted` calls `restoreFromBackend()` to seed state from backend; `onUnmounted` no longer disconnects WS. Stale-heartbeat watcher clears stuck `currentTask` after 30s WS silence.

Diff: -172 / +35 in view, +346 (new store). Net: +209 LOC, mostly the new store with full WS/polling/restore/reset logic. View becomes a thin reactive consumer.

Verified: vue-tsc clean for changed files; vite build succeeds.