### PR TITLE
ux(slm-frontend/code-sync): move 'Pull from Source' button to page header next to 'Refresh'

### DIFF
--- a/autobot-slm-frontend/src/views/CodeSyncView.vue
+++ b/autobot-slm-frontend/src/views/CodeSyncView.vue
@@ -407,26 +407,48 @@ onUnmounted(() => {
           Manage agent code versions across the fleet
         </p>
       </div>
-      <button
-        @click="handleRefresh"
-        :disabled="codeSync.loading.value"
-        class="btn btn-secondary flex items-center gap-2"
-      >
-        <svg
-          :class="['w-4 h-4', codeSync.loading.value ? 'animate-spin' : '']"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
+      <div class="flex items-center gap-2">
+        <button
+          @click="handlePullFromSource"
+          :disabled="isPulling"
+          class="btn btn-secondary flex items-center gap-2"
         >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-          />
-        </svg>
-        {{ codeSync.loading.value ? 'Refreshing...' : 'Refresh' }}
-      </button>
+          <svg
+            :class="['w-4 h-4', isPulling ? 'animate-spin' : '']"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+            />
+          </svg>
+          {{ isPulling ? 'Pulling...' : 'Pull from Source' }}
+        </button>
+        <button
+          @click="handleRefresh"
+          :disabled="codeSync.loading.value"
+          class="btn btn-secondary flex items-center gap-2"
+        >
+          <svg
+            :class="['w-4 h-4', codeSync.loading.value ? 'animate-spin' : '']"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+          {{ codeSync.loading.value ? 'Refreshing...' : 'Refresh' }}
+        </button>
+      </div>
     </div>
 
     <!-- Status Banner -->
@@ -903,13 +925,7 @@ onUnmounted(() => {
     <div class="card p-5 mt-6">
       <div class="flex items-center justify-between mb-4">
         <h2 class="text-lg font-semibold text-gray-900">Role-Based Sync</h2>
-        <button
-          @click="handlePullFromSource"
-          :disabled="isPulling"
-          class="btn btn-secondary text-sm"
-        >
-          {{ isPulling ? 'Pulling...' : 'Pull from Source' }}
-        </button>
+        <!-- Pull from Source button moved to page header next to Refresh -->
       </div>
 
       <div v-if="codeSync.roles.value.length === 0" class="text-gray-500">


### PR DESCRIPTION
User feedback: "Pull from Source" was buried in the Role-Based Sync card header at the bottom of the page; "Refresh" was in the page header. Both are global actions and belong together. Pure template move, same handlers.