### PR TITLE
ci: add `requirements-ci/**` to path filters (closes #7089)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
             python:
               - '**/*.py'
               - '**/requirements*.txt'
+              - 'requirements-ci/**'
               - 'pyproject.toml'
               - 'autobot_shared/pyproject.toml'
               - '.github/workflows/ci.yml'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,6 +9,7 @@ on:
     paths: &cq_paths
       - '**/*.py'
       - '**/requirements*.txt'
+      - 'requirements-ci/**'
       - 'pyproject.toml'
       - '.flake8'
       - '.bandit'

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -10,6 +10,7 @@ on:
       - 'autobot-slm-backend/**/*.py'
       - 'autobot_shared/**/*.py'
       - '**/requirements*.txt'
+      - 'requirements-ci/**'
       - 'pipeline-scripts/**'
       - 'tools/lint/**'
       - '.github/workflows/phase_validation.yml'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,6 +45,7 @@ jobs:
               - '.github/workflows/security.yml'
             deps:
               - '**/requirements*.txt'
+              - 'requirements-ci/**'
               - 'pyproject.toml'
               - 'autobot_shared/pyproject.toml'
               - 'autobot-frontend/package*.json'

--- a/.github/workflows/startup-import-smoke.yml
+++ b/.github/workflows/startup-import-smoke.yml
@@ -18,6 +18,7 @@ on:
       - 'autobot_shared/**/*.py'
       - 'autobot-slm-backend/**/*.py'
       - '**/requirements*.txt'
+      - 'requirements-ci/**'
       - '.github/workflows/startup-import-smoke.yml'
   pull_request:
     branches: [main, Dev_new_gui, develop]


### PR DESCRIPTION
Closes #7089. Closes the per-domain requirements-ci file blind spot.

## Problem

\`**/requirements*.txt\` only matches basenames starting with "requirements". The split per-domain files in \`requirements-ci/\` (\`langchain.txt\`, \`framework.txt\`, etc.) don't match — so dep changes there don't trigger the workflows that install them.

Empirical verification:

| File | Matched by \`**/requirements*.txt\`? |
|------|-------------------------------------|
| \`requirements-ci/langchain.txt\` | NO ❌ |
| \`requirements-ci/llama-index.txt\` | NO ❌ |
| \`autobot-backend/requirements.txt\` | YES ✓ |

PR #7065 demonstrated the miss — only \`smoke-test\` ran (matched on workflow file change), not \`startup-import-smoke\` despite that being the workflow most directly affected by a langchain-core bump.

## Fix

Add \`requirements-ci/**\` to 5 path-filter blocks across 4 workflows:

| Workflow | Filter location |
|----------|-----------------|
| \`startup-import-smoke.yml\` | paths anchor (covers push+pr via #7038's YAML alias) |
| \`code-quality.yml\` | same anchor pattern |
| \`phase_validation.yml\` | same anchor pattern |
| \`ci.yml\` | \`python\` filter in \`changes\` job (from #7027) |
| \`security.yml\` | \`deps\` filter in \`changes\` job (from #7027) |

Net diff: +5 lines.

## Verification

- All 5 YAML files parse
- A future change to \`requirements-ci/<domain>.txt\` will now trigger the relevant workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)