### PR TITLE
fix(slm-agent): version.json commit always empty — Jinja default() doesn't fall back on empty string

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
@@ -270,7 +270,7 @@
       - "Heartbeat Interval: {{ slm_heartbeat_interval }}s"
       - "Agent Directory: {{ slm_agent_dir }}"
       - "Data Directory: {{ slm_agent_data_dir }}"
-      - "Version: {{ slm_agent_version | default(git_commit) }}"
+      - "Version: {{ slm_agent_version | default(git_commit, true) | default('unknown', true) }}"
       - "Services Monitored: {{ slm_services_to_monitor | join(', ') | default('None') }}"
       - "Service Status: {{ slm_agent_status.status.ActiveState }}"
   tags: ['slm_agent', 'report']

--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/role.json.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/role.json.j2
@@ -2,7 +2,7 @@
   "role": "autobot-slm-agent",
   "required": true,
   "degraded_without": [],
-  "version": "{{ slm_agent_version | default(git_commit) | default('unknown') }}",
+  "version": "{{ slm_agent_version | default(git_commit, true) | default('unknown', true) }}",
   "deploy_path": "{{ slm_agent_dir }}",
   "pythonpath": "{{ slm_agent_dir }}",
   "service": "slm-agent",

--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/version.json.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/version.json.j2
@@ -3,7 +3,10 @@
 {# Author: mrveiss #}
 {# Issue #741: Version tracking for SLM agents #}
 {
-  "commit": "{{ slm_agent_version | default(git_commit) }}",
+  {# default(value, true) falls back when value is "" too — slm_agent_version
+     is defined as "" in defaults/main.yml so plain default(...) returned
+     empty string and broke code-drift detection in the GUI. #}
+  "commit": "{{ slm_agent_version | default(git_commit, true) | default('unknown', true) }}",
   "built_at": "{{ ansible_date_time.iso8601 }}",
   "deployed_at": "{{ ansible_date_time.iso8601 }}",
   "deployed_by": "ansible",


### PR DESCRIPTION
Closes the bug where SLM Code Sync UI shows 'All nodes are up to date' regardless of actual drift, because every node reports code_version='' (empty string).

Root cause: roles/slm_agent/defaults/main.yml has slm_agent_version: "" (empty string default). Templates use {{ slm_agent_version | default(git_commit) }} but Jinja's default() doesn't fall back on empty string — only on undefined/None. So version.json is always written with commit="".

Fix: switch to default(value, true) which falls back on falsy values including "". 3-file change, no behavior change for the override case.

Verified live: cat /var/lib/slm-agent/version.json shows {"commit": ""}; nodes table has code_version=NULL.