### PR TITLE
fix(api/chat): wire chat endpoint through LLMService.chat() — closes silent canned-response regression (#7047)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -103,7 +103,7 @@ def get_memory_interface(request: Request) -> Optional[Any]:
 
 def get_llm_service(request: Request) -> Any:
     """Get LLM service from app state, with lazy initialization"""
-    from llm_service import LLMService
+    from services.llm_service import LLMService
 
     from utils.lazy_singleton import lazy_init_singleton
 
@@ -540,15 +540,21 @@ async def _generate_ai_response(llm_service, llm_context: List[Dict], session_id
         AI response dict with content and role
     """
     try:
-        if hasattr(llm_service, "generate_response"):
-            return await llm_service.generate_response(
-                messages=llm_context, session_id=session_id, request_id=request_id
-            )
-        else:
+        # LLMService.chat() accepts OpenAI-format messages and uses
+        # conversation_id for per-conversation provider/model overrides.
+        # request_id flows through via **kwargs for tracing.
+        response = await llm_service.chat(
+            messages=llm_context,
+            conversation_id=session_id,
+            request_id=request_id,
+        )
+        if response.error:
+            logger.warning("LLM returned error for request %s: %s", request_id, response.error)
             return {
-                "content": "I'm currently unable to generate a response. Please try again.",
+                "content": "I encountered an error processing your message. Please try again.",
                 "role": "assistant",
             }
+        return {"content": response.content, "role": "assistant"}
     except Exception as e:
         logger.error("LLM generation failed: %s", e)
         return {

--- a/autobot-backend/api/chat_generate_ai_response_test.py
+++ b/autobot-backend/api/chat_generate_ai_response_test.py
@@ -1,0 +1,147 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Contract tests for ``api.chat._generate_ai_response`` (#7047).
+
+Two regressions shipped silently in the same helper after the #3185
+LLMInterface retirement:
+
+  1. ``api/chat.py:106`` imported from a non-existent ``llm_service`` module
+     (canonical path is ``services.llm_service``); function-scoped, so it
+     fired only on first call.
+
+  2. ``api/chat.py:543`` had ``hasattr(llm_service, "generate_response")``
+     guarding a method that LLMService never exposed. The else-branch ran
+     for every chat request — users got a canned "I'm currently unable
+     to generate a response" string instead of the model's reply.
+
+These tests pin the migrated shape so the same class of drift can't
+recur silently.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture
+def make_llm_response():
+    """Return a factory that builds a stub ``LLMResponse``-shaped object."""
+
+    class _StubResponse:
+        def __init__(self, *, content: str = "", error: str | None = None):
+            self.content = content
+            self.error = error
+
+    return _StubResponse
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_response_returns_model_content_on_success(make_llm_response: Any) -> None:
+    """Happy path: LLMResponse.content surfaces in the result dict."""
+    from api.chat import _generate_ai_response
+
+    llm_service = AsyncMock()
+    llm_service.chat = AsyncMock(return_value=make_llm_response(content="Hello, world!", error=None))
+
+    result = await _generate_ai_response(
+        llm_service=llm_service,
+        llm_context=[{"role": "user", "content": "hi"}],
+        session_id="s-123",
+        request_id="r-abc",
+    )
+
+    assert result == {"content": "Hello, world!", "role": "assistant"}
+    # Pin the call shape — confirms migrated args reach LLMService.chat correctly.
+    llm_service.chat.assert_awaited_once_with(
+        messages=[{"role": "user", "content": "hi"}],
+        conversation_id="s-123",
+        request_id="r-abc",
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_response_falls_back_when_llm_returns_error(make_llm_response: Any) -> None:
+    """LLMResponse.error truthy → user-friendly fallback message."""
+    from api.chat import _generate_ai_response
+
+    llm_service = AsyncMock()
+    llm_service.chat = AsyncMock(return_value=make_llm_response(content="", error="rate limit exceeded"))
+
+    result = await _generate_ai_response(
+        llm_service=llm_service,
+        llm_context=[{"role": "user", "content": "hi"}],
+        session_id="s-1",
+        request_id="r-1",
+    )
+
+    assert result["role"] == "assistant"
+    # Must NOT leak the underlying error message to the user — fallback string only.
+    assert "I encountered an error" in result["content"]
+    assert "rate limit" not in result["content"]
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_response_falls_back_when_chat_raises(make_llm_response: Any) -> None:
+    """Network/runtime exception in chat() → user-friendly fallback."""
+    from api.chat import _generate_ai_response
+
+    llm_service = AsyncMock()
+    llm_service.chat = AsyncMock(side_effect=RuntimeError("boom"))
+
+    result = await _generate_ai_response(
+        llm_service=llm_service,
+        llm_context=[{"role": "user", "content": "hi"}],
+        session_id="s-1",
+        request_id="r-1",
+    )
+
+    assert result["role"] == "assistant"
+    assert "I encountered an error" in result["content"]
+    # Underlying exception detail must not surface in user-facing string.
+    assert "boom" not in result["content"]
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_response_does_not_call_legacy_generate_response(make_llm_response: Any) -> None:
+    """Regression pin: post-#3185 the helper must call .chat(), never
+    .generate_response() (which was the deleted LLMInterface method).
+    Catches the original #7047 silent-fallback bug if reintroduced.
+    """
+    from api.chat import _generate_ai_response
+
+    llm_service = AsyncMock()
+    llm_service.chat = AsyncMock(return_value=make_llm_response(content="ok", error=None))
+    # If a future caller hits this attribute, the test fails — locks the migration.
+    llm_service.generate_response = AsyncMock(side_effect=AssertionError("legacy method"))
+
+    result = await _generate_ai_response(
+        llm_service=llm_service,
+        llm_context=[{"role": "user", "content": "hi"}],
+        session_id="s-1",
+        request_id="r-1",
+    )
+
+    assert result["content"] == "ok"
+    llm_service.generate_response.assert_not_awaited()
+    llm_service.chat.assert_awaited_once()
+
+
+def test_get_llm_service_imports_canonical_module_path() -> None:
+    """Regression pin: the lazy import inside ``get_llm_service`` must
+    resolve to ``services.llm_service.LLMService`` (the canonical post-#3185
+    location), not a non-existent top-level ``llm_service`` module.
+    """
+    import inspect
+
+    from api import chat
+
+    src = inspect.getsource(chat.get_llm_service)
+    assert "from services.llm_service import LLMService" in src, (
+        "get_llm_service must import from services.llm_service "
+        "(canonical post-#3185 path); the older 'from llm_service import' "
+        "raises ModuleNotFoundError at first call."
+    )


### PR DESCRIPTION
## Summary

P1 user-facing regression. Since #3185 (LLMInterface retirement on 2026-05-04), the chat endpoint has been silently returning a canned **\"I'm currently unable to generate a response. Please try again.\"** string for **every user request**. Two bugs in one helper:

### Bug 1 — broken module path

\`\`\`python
# api/chat.py:106 (before)
from llm_service import LLMService              # ← module doesn't exist
\`\`\`

Canonical path is \`services.llm_service\`. Import was inside \`get_llm_service()\`, so it deferred to first call — would have raised \`ModuleNotFoundError\` on the first chat request had bug 2 not masked it.

### Bug 2 — hasattr guard around a deleted method

\`\`\`python
# api/chat.py:543 (before)
if hasattr(llm_service, \"generate_response\"):       # always False post-#3185
    return await llm_service.generate_response(...)
else:
    return {\"content\": \"I'm currently unable to...\"}
\`\`\`

\`LLMService\` doesn't expose \`generate_response\`. Every call took the else branch.

## Fix

- Lazy-import path corrected.
- Body migrated to \`llm_service.chat(messages=..., conversation_id=session_id, request_id=...)\` returning \`LLMResponse\`. Response shape verified: \`.content: str\`, \`.error: Optional[str]\`.
- User-facing fallback strings unchanged on error — internal reasons logged but never leaked.

## Regression pins (5 tests added)

- Happy path: \`response.content\` surfaces as result content
- Args verified: \`messages\` / \`conversation_id\` / \`request_id\` passed through
- LLM error: fallback message, internal error NOT leaked
- Exception in \`chat()\`: fallback message, exception detail NOT leaked
- **Bug 1 pin**: source string match on \`from services.llm_service import LLMService\` — fails if anyone reintroduces the broken import path
- **Bug 2 pin**: \`generate_response\` mock with \`AssertionError\` side-effect — test fails if a future change reintroduces the legacy method call

\`\`\`
$ python3 -m pytest autobot-backend/api/chat_generate_ai_response_test.py -xvs
============================== 5 passed in 2.80s ===============================
\`\`\`

## Out of scope (deferred per PR-discipline / different contexts)

The other sites flagged in #7047 (async_chat_workflow.py:344, modern_ai_integration.py:673, nl_database_service.py:549) need per-site verification — return-shape and call-context differ enough that batching them risks the [verify-return-shape lesson](https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/.claude/projects/feedback_verify_return_shape_in_method_migration.md) again. #7047 stays open until those land.

Closes parts 1 + 2 of #7047