### PR TITLE
ci(security): pin all 3rd-party actions to commit SHAs (closes #7091)

### DIFF
--- a/.github/workflows/autoresearch-image.yml
+++ b/.github/workflows/autoresearch-image.yml
@@ -21,14 +21,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7
         with:
           context: autobot-backend/services/autoresearch
           file: autobot-backend/services/autoresearch/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
         id: filter
         with:
           filters: |
@@ -160,7 +160,7 @@ jobs:
         fi
 
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6
       with:
         files: ./coverage.xml
         flags: unittests

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
 
       - name: Create .env from .env.example
         run: cp .env.example .env

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -91,7 +91,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6
         with:
           files: ./autobot-frontend/coverage/lcov.info
           directory: ./autobot-frontend/coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Determine next version
         id: version
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5  # v4
         with:
           config: cliff.toml
           args: --bumped-version
@@ -59,7 +59,7 @@ jobs:
       - name: Generate release notes (git-cliff)
         if: steps.check.outputs.release_needed == 'true'
         id: cliff_notes
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5  # v4
         with:
           config: cliff.toml
           args: --latest --strip header
@@ -79,7 +79,7 @@ jobs:
 
       - name: Update CHANGELOG.md (full history index)
         if: steps.check.outputs.release_needed == 'true'
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5  # v4
         with:
           config: cliff.toml
           args: --verbose
@@ -101,7 +101,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check.outputs.release_needed == 'true'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3
         with:
           tag_name: ${{ steps.check.outputs.version }}
           name: ${{ steps.check.outputs.version }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ jobs:
       deps: ${{ steps.filter.outputs.deps }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
         id: filter
         with:
           filters: |


### PR DESCRIPTION
Closes #7091. Supply-chain hardening per GitHub's [security hardening guide for actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## Why

Tags are mutable. A compromised maintainer could force-push \`v3\` → a malicious commit that lands silently in CI on next run. SHA pinning makes the action immutable.

## Scope

7 third-party actions, 11 occurrences across 6 workflows. SHAs resolved 2026-05-06 via \`git ls-remote\`:

| Action | Tag | SHA |
|--------|-----|-----|
| \`codecov/codecov-action\` | v6 | \`57e3a136...\` |
| \`docker/build-push-action\` | v7 | \`bcafcacb...\` |
| \`docker/login-action\` | v4 | \`4907a6dd...\` |
| \`docker/setup-buildx-action\` | v4 | \`4d04d5d9...\` |
| \`dorny/paths-filter\` | v3 | \`d1c1ffe0...\` |
| \`orhun/git-cliff-action\` | v4 | \`f50e1156...\` |
| \`softprops/action-gh-release\` | v3 | \`b4309332...\` |

Trailing \`# vX\` comment preserves human-readable version intent.

\`actions/*\` (first-party, GitHub-maintained) left tag-pinned per common practice — the supply-chain risk surface is much smaller for those.

## Dependabot

\`.github/dependabot.yml\` already covers \`github-actions\` ecosystem — Dependabot will auto-PR SHA updates as new versions release.

## Verification

\`\`\`bash
$ grep -rE 'uses: [a-z-]+/[a-z-]+@v[0-9]+(\s|$)' .github/workflows/ | grep -v 'actions/'
# (no remaining 3rd-party tag-pins)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)