### PR TITLE
security(P1): remove committed Fernet encryption key from repo (#7088)

### DIFF
--- a/data/secrets.key
+++ b/data/secrets.key
@@ -1,1 +1,0 @@
-rz_O8SJQc1ZyxM7_HCSEmiDN_dSegiPGoZ2MEaiwPjs=


### PR DESCRIPTION
Closes #7088. `git rm --cached data/secrets.key` — file content unchanged in working trees, removed from index. Backend has bootstrap-on-first-start at autobot-backend/api/secrets.py:148-160 so fresh deploys auto-generate. Existing deployments using the leaked key still need manual rotation (operator runbook in #7088).