### PR TITLE
test(ci): cover vars_files codepath + diff-guard fact-file dup (#7094 + #7095)

### DIFF
--- a/.github/workflows/ansible-role-facts-test.yml
+++ b/.github/workflows/ansible-role-facts-test.yml
@@ -46,15 +46,28 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y ansible-core
 
-      - name: Run role_*_active facts test playbook
+      - name: Run role_*_active facts test (group_vars codepath)
         working-directory: autobot-slm-backend/ansible
         run: |
-          ansible-playbook \
-            -i tests/inventory/test_role_facts.yml \
-            tests/playbooks/test_role_active_facts.yml
+          ansible-playbook -i tests/inventory/test_role_facts.yml tests/playbooks/test_role_active_facts.yml
+
+      - name: Run role_*_active facts test (vars_files codepath, #7094)
+        working-directory: autobot-slm-backend/ansible
+        # #7094: tests/inventory_dynamic/ is a copy of tests/inventory/ WITHOUT
+        # the group_vars/all.yml symlink. Mimics the SLM-triggered provision
+        # path where the temp inventory in /tmp/ has no sibling group_vars/.
+        # The playbook MUST succeed loading facts via vars_files alone.
+        run: |
+          ansible-playbook -i tests/inventory_dynamic/test_role_facts.yml tests/playbooks/test_role_active_facts_no_group_vars.yml
+
+      - name: "Diff guard: ensure both fact-file copies stay byte-equal (#7095)"
+        working-directory: autobot-slm-backend/ansible
+        run: |
+          python3 tests/check_role_facts_synced.py
 
       - name: Lint test playbook + inventory YAML
         working-directory: autobot-slm-backend/ansible
         run: |
           python3 -c "import yaml; yaml.safe_load(open('tests/playbooks/test_role_active_facts.yml'))"
+          python3 -c "import yaml; yaml.safe_load(open('tests/playbooks/test_role_active_facts_no_group_vars.yml'))"
           python3 -c "import yaml; yaml.safe_load(open('tests/inventory/test_role_facts.yml'))"

--- a/autobot-slm-backend/ansible/tests/check_role_facts_synced.py
+++ b/autobot-slm-backend/ansible/tests/check_role_facts_synced.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Diff guard: role_*_active facts must stay byte-equal across the two
+copies until #7095 (single source of truth) lands.
+
+Two consumers exist:
+- inventory/group_vars/all.yml   (loaded by static-inventory playbooks)
+- playbooks/vars/role_active_facts.yml  (loaded by playbooks via vars_files
+                                          when invoked with dynamic temp
+                                          inventories that lack a sibling
+                                          group_vars/, e.g. the SLM wizard)
+
+If the two files drift, behavior diverges silently. This script extracts
+the role_*_active definitions from each and compares them; exits non-zero
+on any divergence so CI fails the PR.
+"""
+import re
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[3]
+GROUP_VARS = REPO / "autobot-slm-backend/ansible/inventory/group_vars/all.yml"
+PLAYBOOK_VARS = REPO / "autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml"
+
+
+def extract_facts(path: Path) -> dict:
+    """Extract role_X_active blocks (key + multiline `>-` value) from a file.
+
+    Returns dict mapping fact name → normalized whitespace value.
+    """
+    text = path.read_text()
+    pattern = re.compile(r"(role_\w+_active:\s*>-(?:\n[ \t]+.*)*)")
+    blocks = pattern.findall(text)
+    return {
+        re.match(r"(role_\w+_active)", b).group(1): re.sub(r"\s+", " ", b).strip()
+        for b in blocks
+    }
+
+
+def main() -> int:
+    a = extract_facts(GROUP_VARS)
+    b = extract_facts(PLAYBOOK_VARS)
+    if set(a) != set(b):
+        print(f"FACT KEYS DIVERGED:")
+        print(f"  in group_vars only:    {sorted(set(a) - set(b))}")
+        print(f"  in playbooks/vars only: {sorted(set(b) - set(a))}")
+        return 1
+    for k in sorted(a):
+        if a[k] != b[k]:
+            print(f"FACT {k!r} DIVERGED:")
+            print(f"  group_vars: {a[k]}")
+            print(f"  playbooks:  {b[k]}")
+            return 1
+    print(f"OK — {len(a)} role_*_active facts identical across both files")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/autobot-slm-backend/ansible/tests/inventory_dynamic/test_role_facts.yml
+++ b/autobot-slm-backend/ansible/tests/inventory_dynamic/test_role_facts.yml
@@ -1,0 +1,148 @@
+# AutoBot - Test inventory for role_*_active facts (#7056)
+#
+# Synthetic hosts covering every code path in the shared facts
+# (group_vars/all.yml). Each host defines the (node_roles, group membership)
+# inputs and the EXPECTED role_*_active output. The test playbook asserts
+# input → output matches the fact definition.
+#
+# This catches:
+#   - Forgotten autobot-X variant when adding a new role
+#   - Forgotten group-membership check
+#   - Drift between provision-fleet-roles.yml gates and group_vars facts
+---
+all:
+  hosts:
+    # 1. Single-host install layout written by install.sh (#6600):
+    #    SLM Manager hosts the SLM stack AND co-hosts backend + vnc.
+    #    Was the failure mode of #7031 — cleanup wiped autobot-backend
+    #    because 'backend' was not in node_roles (only 'autobot-backend').
+    test-single-host-slm-and-backend:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - autobot-backend
+        - vnc
+      expected_role_backend_active: true
+      expected_role_vnc_active: true
+      expected_role_frontend_active: false
+      expected_role_slm_active: true
+      expected_role_redis_active: false
+      expected_role_ai_stack_active: false
+      expected_role_npu_worker_active: false
+      expected_role_browser_active: false
+      expected_role_llm_active: false
+      expected_role_tts_worker_active: false
+
+    # 2. Dedicated SLM Manager (multi-host fleet — seed-fleet-nodes.yml).
+    #    No backend, no frontend.
+    test-dedicated-slm-manager:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - autobot-slm-agent
+        - autobot-slm-database
+        - autobot-monitoring
+      expected_role_backend_active: false
+      expected_role_vnc_active: false
+      expected_role_frontend_active: false
+      expected_role_slm_active: true
+      expected_role_redis_active: false
+      expected_role_ai_stack_active: false
+      expected_role_npu_worker_active: false
+      expected_role_browser_active: false
+      expected_role_llm_active: false
+      expected_role_tts_worker_active: false
+
+    # 3. Backend host using SHORT role name (no prefix). Provision gates and
+    #    cleanup gates must both treat this as "backend is active".
+    test-backend-short-name:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - backend
+      expected_role_backend_active: true
+      expected_role_vnc_active: false
+      expected_role_slm_active: false
+
+    # 4. Frontend host with autobot-prefixed name.
+    test-frontend-prefixed:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - autobot-frontend
+      expected_role_backend_active: false
+      expected_role_frontend_active: true
+      expected_role_slm_active: false
+
+    # 5. AI Stack + LLM (co-located).
+    test-ai-stack-and-llm:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - ai-stack
+        - llm
+      expected_role_ai_stack_active: true
+      expected_role_llm_active: true
+      expected_role_backend_active: false
+      expected_role_slm_active: false
+
+    # 6. NPU + TTS worker (co-located convention).
+    test-npu-and-tts:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - autobot-npu-worker
+        - tts-worker
+      expected_role_npu_worker_active: true
+      expected_role_tts_worker_active: true
+      expected_role_backend_active: false
+      expected_role_slm_active: false
+
+    # 7. Browser worker — variant naming (browser-service legacy).
+    test-browser-legacy-name:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - browser-service
+      expected_role_browser_active: true
+      expected_role_backend_active: false
+      expected_role_slm_active: false
+
+    # 8. Empty node_roles + group membership (legacy multi-host inventory).
+    #    Backend role should still gate-on via groups['main'] membership.
+    test-empty-roles-via-group:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles: []
+      expected_role_backend_active: true   # via groups['main']
+      expected_role_vnc_active: true       # via groups['main']
+      expected_role_frontend_active: false
+      expected_role_slm_active: false
+
+    # 9. No node_roles defined at all (truly empty host).
+    #    All facts should evaluate to false.
+    test-no-roles-defined:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      expected_role_backend_active: false
+      expected_role_vnc_active: false
+      expected_role_frontend_active: false
+      expected_role_slm_active: false
+      expected_role_redis_active: false
+      expected_role_ai_stack_active: false
+      expected_role_npu_worker_active: false
+      expected_role_browser_active: false
+      expected_role_llm_active: false
+      expected_role_tts_worker_active: false
+
+  children:
+    # Group-membership-only test for #8 (test-empty-roles-via-group).
+    main:
+      hosts:
+        test-empty-roles-via-group: {}
+    # SLM Manager hosts must be in slm_server group (matches install.sh
+    # localhost.yml + seed-fleet-nodes.yml inventory layout).
+    slm_server:
+      hosts:
+        test-single-host-slm-and-backend: {}
+        test-dedicated-slm-manager: {}

--- a/autobot-slm-backend/ansible/tests/playbooks/test_role_active_facts_no_group_vars.yml
+++ b/autobot-slm-backend/ansible/tests/playbooks/test_role_active_facts_no_group_vars.yml
@@ -1,0 +1,100 @@
+# AutoBot - Test playbook: role_*_active facts via vars_files (#7094)
+#
+# Mirrors test_role_active_facts.yml but loads the facts via vars_files
+# instead of group_vars. Mimics the SLM-triggered provision codepath
+# where the temp inventory has NO sibling group_vars/ directory.
+#
+# Without this test, drift between inventory/group_vars/all.yml and
+# playbooks/vars/role_active_facts.yml goes undetected (the regression
+# that #7093 had to fix retroactively).
+#
+# Usage:
+#   cd autobot-slm-backend/ansible
+#   ansible-playbook -i tests/inventory/test_role_facts.yml \
+#                    tests/playbooks/test_role_active_facts_no_group_vars.yml
+---
+- name: "Test: role_*_active facts via vars_files (#7094 dynamic-inventory codepath)"
+  hosts: all
+  gather_facts: false
+  any_errors_fatal: true
+
+  # Critical: load via vars_files (NOT group_vars symlink).
+  # Path is relative to this playbook file:
+  #   tests/playbooks/test_role_active_facts_no_group_vars.yml
+  #     ../../playbooks/vars/role_active_facts.yml
+  vars_files:
+    - ../../playbooks/vars/role_active_facts.yml
+
+  tasks:
+    - name: "role_backend_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_backend_active | bool) == (expected_role_backend_active | bool)
+        fail_msg: >-
+          {{ inventory_hostname }} (vars_files path):
+          role_backend_active={{ role_backend_active }},
+          expected={{ expected_role_backend_active }}
+      when: expected_role_backend_active is defined
+
+    - name: "role_frontend_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_frontend_active | bool) == (expected_role_frontend_active | bool)
+        fail_msg: "{{ inventory_hostname }}: role_frontend_active mismatch (vars_files path)"
+      when: expected_role_frontend_active is defined
+
+    - name: "role_slm_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_slm_active | bool) == (expected_role_slm_active | bool)
+        fail_msg: "{{ inventory_hostname }}: role_slm_active mismatch (vars_files path)"
+      when: expected_role_slm_active is defined
+
+    - name: "role_ai_stack_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_ai_stack_active | bool) == (expected_role_ai_stack_active | bool)
+        fail_msg: "{{ inventory_hostname }}: role_ai_stack_active mismatch (vars_files path)"
+      when: expected_role_ai_stack_active is defined
+
+    - name: "role_npu_worker_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_npu_worker_active | bool) == (expected_role_npu_worker_active | bool)
+        fail_msg: "{{ inventory_hostname }}: role_npu_worker_active mismatch (vars_files path)"
+      when: expected_role_npu_worker_active is defined
+
+    - name: "role_browser_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_browser_active | bool) == (expected_role_browser_active | bool)
+        fail_msg: "{{ inventory_hostname }}: role_browser_active mismatch (vars_files path)"
+      when: expected_role_browser_active is defined
+
+    - name: "role_redis_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_redis_active | bool) == (expected_role_redis_active | bool)
+        fail_msg: "{{ inventory_hostname }}: role_redis_active mismatch (vars_files path)"
+      when: expected_role_redis_active is defined
+
+    - name: "role_vnc_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_vnc_active | bool) == (expected_role_vnc_active | bool)
+        fail_msg: "{{ inventory_hostname }}: role_vnc_active mismatch (vars_files path)"
+      when: expected_role_vnc_active is defined
+
+    - name: "role_llm_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_llm_active | bool) == (expected_role_llm_active | bool)
+        fail_msg: "{{ inventory_hostname }}: role_llm_active mismatch (vars_files path)"
+      when: expected_role_llm_active is defined
+
+    - name: "role_tts_worker_active matches expected"
+      ansible.builtin.assert:
+        that:
+          - (role_tts_worker_active | bool) == (expected_role_tts_worker_active | bool)
+        fail_msg: "{{ inventory_hostname }}: role_tts_worker_active mismatch (vars_files path)"
+      when: expected_role_tts_worker_active is defined


### PR DESCRIPTION
Closes #7094. Partial #7095 (diff guard ships now; single-source design tracked separately).

- New tests/inventory_dynamic/ (no group_vars symlink) + test_role_active_facts_no_group_vars.yml — exercises the vars_files codepath that #7093 had to fix retroactively.
- New tests/check_role_facts_synced.py — extracts role_*_active blocks from both files and asserts identical (normalized whitespace). Exits non-zero on drift.
- Workflow gains 2 steps: vars_files test + diff guard.

Both verified locally: 9 hosts × 10 facts pass via vars_files; 10 facts identical between files.