### PR TITLE
fix(backend/codebase-analytics): await AsyncChromaDBCollection.get/.delete directly (#6695)

### DIFF
--- a/autobot-backend/api/codebase_analytics/chromadb_storage.py
+++ b/autobot-backend/api/codebase_analytics/chromadb_storage.py
@@ -397,8 +397,10 @@ async def _delete_source_documents(collection, task_id: str, source_id: str):
     Deletes in batches to avoid SQLite C-extension limits.
     """
     try:
-        existing = await asyncio.to_thread(
-            collection.get,
+        # #6695: collection is an AsyncChromaDBCollection — its .get/.delete are
+        # async def and must be awaited directly. Wrapping in asyncio.to_thread
+        # produced an unawaited coroutine, silently masking source-doc deletion.
+        existing = await collection.get(
             where={"source_id": source_id},
             include=[],
         )
@@ -407,7 +409,7 @@ async def _delete_source_documents(collection, task_id: str, source_id: str):
             batch_size = 5000
             for i in range(0, len(ids_to_delete), batch_size):
                 batch = ids_to_delete[i : i + batch_size]
-                await asyncio.to_thread(collection.delete, ids=batch)
+                await collection.delete(ids=batch)
             logger.info(
                 "[Task %s] Deleted %d documents for source %s",
                 task_id,

--- a/autobot-backend/api/codebase_analytics/chromadb_storage_test.py
+++ b/autobot-backend/api/codebase_analytics/chromadb_storage_test.py
@@ -1,0 +1,81 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for chromadb_storage._delete_source_documents (Issue #6695).
+
+Background: the helper passed AsyncChromaDBCollection.get/.delete (both
+``async def``) to ``asyncio.to_thread``, which calls but does not await them.
+The result was a coroutine object, not a dict — ``existing.get("ids")`` then
+raised AttributeError silently swallowed by the broad except. Source
+documents were never deleted; re-indexing accumulated duplicates.
+
+These tests fail against the pre-#6695 code (``existing`` is a coroutine →
+``existing.get("ids")`` raises ``AttributeError: 'coroutine' object has no
+attribute 'get'`` and the bug branch logs a warning instead of deleting).
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api.codebase_analytics.chromadb_storage import _delete_source_documents
+
+
+class TestDeleteSourceDocuments:
+    """Issue #6695: async-in-to_thread bug for AsyncChromaDBCollection."""
+
+    @pytest.mark.asyncio
+    async def test_awaits_get_directly_and_deletes_returned_ids(self):
+        """``collection.get`` and ``.delete`` must be awaited (not to_thread'd)."""
+        collection = AsyncMock()
+        collection.get = AsyncMock(return_value={"ids": ["a", "b", "c"]})
+        collection.delete = AsyncMock(return_value=None)
+
+        await _delete_source_documents(collection, "task-1", "source-X")
+
+        collection.get.assert_awaited_once_with(
+            where={"source_id": "source-X"}, include=[]
+        )
+        collection.delete.assert_awaited_once_with(ids=["a", "b", "c"])
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_no_existing_documents(self):
+        """Empty result must not call delete."""
+        collection = AsyncMock()
+        collection.get = AsyncMock(return_value={"ids": []})
+        collection.delete = AsyncMock(return_value=None)
+
+        await _delete_source_documents(collection, "task-2", "source-Y")
+
+        collection.get.assert_awaited_once()
+        collection.delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_batches_delete_for_large_id_sets(self):
+        """``delete`` must be called once per 5000-id batch."""
+        ids = [f"id-{i}" for i in range(12_345)]  # 3 batches: 5000 + 5000 + 2345
+        collection = AsyncMock()
+        collection.get = AsyncMock(return_value={"ids": ids})
+        collection.delete = AsyncMock(return_value=None)
+
+        await _delete_source_documents(collection, "task-3", "source-Z")
+
+        assert collection.delete.await_count == 3
+        called_batches = [c.kwargs["ids"] for c in collection.delete.await_args_list]
+        assert len(called_batches[0]) == 5000
+        assert len(called_batches[1]) == 5000
+        assert len(called_batches[2]) == 2345
+
+    @pytest.mark.asyncio
+    async def test_swallows_exceptions_with_warning(self, caplog):
+        """Errors must not propagate but must be logged."""
+        import logging
+
+        collection = AsyncMock()
+        collection.get = AsyncMock(side_effect=RuntimeError("chroma down"))
+
+        with caplog.at_level(logging.WARNING):
+            await _delete_source_documents(collection, "task-4", "source-W")
+
+        assert any("Could not delete source" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- Replace `asyncio.to_thread(collection.get/.delete)` with `await collection.get/.delete` in `_delete_source_documents` — the wrapped methods are `async def`, so to_thread produced an unawaited coroutine, silently masking source-document deletion.
- Re-indexing now actually removes stale documents (no more duplicate accumulation).
- Add 4 unit tests in `chromadb_storage_test.py` covering happy path, no-op-on-empty, 12345-id batching across 5000-id chunks, and exception swallowing with logged warning.

## Behavioral grep audit

```bash
$ grep -rnE "asyncio\.to_thread\(\s*\w+\.(get|add|delete|query|peek|count|update|upsert)\b" autobot-backend --include="*.py"
```

Found 5 suspect chromadb-collection callsites in `gpu_vector_search.py`, `knowledge/index.py`, `knowledge/search.py`, `knowledge/base.py` — verified all wrap a SYNC `chromadb.Collection` (`BaseCollection` or `vector_store._collection`). Only `chromadb_storage._delete_source_documents` passed an `AsyncChromaDBCollection`.

## Test plan

- [x] `pytest autobot-backend/api/codebase_analytics/chromadb_storage_test.py -xvs` → 4/4 pass
- [x] `python3 -m py_compile autobot-backend/api/codebase_analytics/chromadb_storage.py` → OK
- [ ] Live verify post-deploy: tail backend logs during a re-index — no more "coroutine 'AsyncChromaDBCollection.get' was never awaited" RuntimeWarning
- [ ] Live verify: ChromaDB doc count drops correctly when re-indexing a single source

Closes #6695