### PR TITLE
fix(backend/cache): RedisCache.set_json default= covers dataclasses + Pydantic (#6696)

### DIFF
--- a/autobot_shared/redis_management/cache_wrapper.py
+++ b/autobot_shared/redis_management/cache_wrapper.py
@@ -23,11 +23,34 @@ Usage::
     await cache.delete("my:key")
 """
 
+import dataclasses
 import json
 import logging
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _json_default(obj: Any) -> Any:
+    """Fallback serializer for ``json.dumps`` covering common AutoBot types.
+
+    #6696: A bare ``json.dumps`` raised TypeError on dataclasses (e.g.
+    ``SystemMetric``) and Pydantic models, silently failing every cache
+    write. Handle them centrally so callers don't repeat the conversion.
+    """
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
+    # Pydantic v2 BaseModel exposes model_dump(); v1 exposes dict(). Detect
+    # via duck-typing to avoid importing pydantic in the shared layer.
+    model_dump = getattr(obj, "model_dump", None)
+    if callable(model_dump):
+        return model_dump()
+    pydantic_v1_dict = getattr(obj, "dict", None)
+    if callable(pydantic_v1_dict) and getattr(obj, "__fields__", None) is not None:
+        return pydantic_v1_dict()
+    raise TypeError(
+        f"Object of type {type(obj).__name__} is not JSON serializable"
+    )
 
 
 class RedisCache:
@@ -83,7 +106,7 @@ class RedisCache:
         """
         try:
             ex = ttl if ttl is not None else self._default_ttl
-            payload = json.dumps(data, ensure_ascii=False)
+            payload = json.dumps(data, ensure_ascii=False, default=_json_default)
             if ex:
                 await self._client.set(key, payload, ex=ex)
             else:

--- a/autobot_shared/redis_management/cache_wrapper_test.py
+++ b/autobot_shared/redis_management/cache_wrapper_test.py
@@ -1,0 +1,170 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for RedisCache.set_json/.get_json default serializer (Issue #6696).
+
+Background: ``json.dumps`` raised TypeError on dataclass instances (e.g.
+``SystemMetric`` in autobot-backend/utils/system_metrics.py) — every Redis
+cache write of dash_task analytics results silently failed. The fix is a
+``default=`` fallback in cache_wrapper.set_json that handles dataclasses
+and Pydantic models centrally.
+"""
+
+import dataclasses
+from typing import Any, Dict
+from unittest.mock import AsyncMock
+
+import pytest
+
+from autobot_shared.redis_management.cache_wrapper import RedisCache, _json_default
+
+
+# ---------------------------------------------------------------------------
+# Sample types
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class _Metric:
+    timestamp: float
+    name: str
+    value: float
+    metadata: Dict[str, Any] = None
+
+
+class _PydanticV2Like:
+    """Stand-in for a Pydantic v2 BaseModel — has model_dump()."""
+
+    def __init__(self, name: str, value: int) -> None:
+        self.name = name
+        self.value = value
+
+    def model_dump(self) -> Dict[str, Any]:
+        return {"name": self.name, "value": self.value}
+
+
+class _PydanticV1Like:
+    """Stand-in for a Pydantic v1 BaseModel — has dict() + __fields__."""
+
+    __fields__ = {"name": ..., "value": ...}
+
+    def __init__(self, name: str, value: int) -> None:
+        self.name = name
+        self.value = value
+
+    def dict(self) -> Dict[str, Any]:
+        return {"name": self.name, "value": self.value}
+
+
+# ---------------------------------------------------------------------------
+# _json_default unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestJsonDefault:
+    """Issue #6696: the json.dumps default= fallback."""
+
+    def test_serializes_dataclass(self):
+        m = _Metric(timestamp=1.0, name="cpu", value=42.0, metadata={"host": "vm1"})
+        assert _json_default(m) == {
+            "timestamp": 1.0,
+            "name": "cpu",
+            "value": 42.0,
+            "metadata": {"host": "vm1"},
+        }
+
+    def test_serializes_pydantic_v2_model(self):
+        assert _json_default(_PydanticV2Like("k", 7)) == {"name": "k", "value": 7}
+
+    def test_serializes_pydantic_v1_model(self):
+        assert _json_default(_PydanticV1Like("k", 7)) == {"name": "k", "value": 7}
+
+    def test_raises_typeerror_for_unknown_type(self):
+        class Custom:
+            pass
+
+        with pytest.raises(TypeError, match="Custom"):
+            _json_default(Custom())
+
+    def test_does_not_treat_dataclass_class_itself_as_instance(self):
+        # is_dataclass returns True for both the class and its instances —
+        # we only want to serialise instances.
+        with pytest.raises(TypeError):
+            _json_default(_Metric)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRedisCacheRoundTrip:
+    """Issue #6696: end-to-end set_json / get_json with non-JSON-native types."""
+
+    @pytest.mark.asyncio
+    async def test_dataclass_round_trip_via_set_json(self):
+        """SystemMetric-shaped dataclass must serialise without raising."""
+        store = {}
+
+        async def fake_set(key, payload, ex=None):
+            store[key] = payload
+            return True
+
+        async def fake_get(key):
+            return store.get(key)
+
+        client = AsyncMock()
+        client.set = fake_set
+        client.get = fake_get
+
+        cache = RedisCache(client)
+        m = _Metric(timestamp=1.0, name="cpu", value=42.0)
+
+        ok = await cache.set_json("m:1", {"latest": m})
+        assert ok is True
+        assert "m:1" in store
+
+        got = await cache.get_json("m:1")
+        assert got == {
+            "latest": {"timestamp": 1.0, "name": "cpu", "value": 42.0, "metadata": None}
+        }
+
+    @pytest.mark.asyncio
+    async def test_pydantic_round_trip(self):
+        store = {}
+
+        async def fake_set(key, payload, ex=None):
+            store[key] = payload
+            return True
+
+        async def fake_get(key):
+            return store.get(key)
+
+        client = AsyncMock()
+        client.set = fake_set
+        client.get = fake_get
+
+        cache = RedisCache(client)
+        ok = await cache.set_json("p:1", _PydanticV2Like("ratio", 99))
+        assert ok is True
+        assert (await cache.get_json("p:1")) == {"name": "ratio", "value": 99}
+
+    @pytest.mark.asyncio
+    async def test_unknown_type_still_logs_and_returns_false(self):
+        """Custom unknown classes must surface the failure as before."""
+
+        async def failing_set(*args, **kwargs):
+            raise AssertionError("set() should never be called with bad payload")
+
+        client = AsyncMock()
+        client.set = failing_set
+
+        cache = RedisCache(client)
+
+        class Custom:
+            pass
+
+        ok = await cache.set_json("k", Custom())
+        # set_json wraps json.dumps in try/except → False on failure, no raise
+        assert ok is False


### PR DESCRIPTION
## Summary

- Add `_json_default` fallback to `RedisCache.set_json` that handles dataclasses (via `dataclasses.asdict`) and Pydantic v1/v2 models (via `dict()` / `model_dump()`).
- Eliminates the silent `TypeError: Object of type SystemMetric is not JSON serializable` failure on every `dash_task:*` cache write — previously the cache layer was effectively dead for analytics dashboard tasks.
- One-function change in `autobot_shared` with codebase-wide benefit: 348 `@dataclass`-defining files + 69 `BaseModel`-using files in `autobot-backend/` may have been silently failing through this path.

## Test plan

- [x] `pytest autobot_shared/redis_management/cache_wrapper_test.py -xvs` → 8/8 pass
  - `_json_default` unit tests: dataclass, Pydantic v2 (model_dump), Pydantic v1 (dict + __fields__), unknown-type TypeError, dataclass-class-itself rejection
  - Round-trip integration via fake AsyncMock client (set_json + get_json structural equality)
  - Unknown-type cache write returns False (no regression on truly-broken payloads)
- [x] `python3 -m py_compile autobot_shared/redis_management/cache_wrapper.py` → OK
- [ ] Live verify post-deploy: no "Cache set failed for dash_task" warnings during analytics task runs
- [ ] Live verify: `redis-cli GET dash_task:latest_result` returns valid JSON containing `SystemMetric` data

Closes #6696