### PR TITLE
docs(deps): point Backend Common section to pyproject.toml (post-#7113)

### DIFF
--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -326,7 +326,7 @@ python3 -m playwright install webkit
 
 ### Backend Common (autobot_shared)
 ```python
-# See autobot_shared/requirements.txt
+# See autobot_shared/pyproject.toml (canonical since #7022 / #7113)
 redis>=5.0.0
 pydantic>=2.5.0
 PyJWT[crypto]>=2.8.0


### PR DESCRIPTION
Single-line stale-reference fix discovered during #7113 self-review.

`autobot_shared/requirements.txt` was deleted in #7113 (pyproject.toml is now canonical). Updates the inline doc reference to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)