### PR TITLE
fix(packaging): pyproject.toml — drop unused `requests`, add 5 missing deps (closes #7119)

### DIFF
--- a/autobot_shared/pyproject.toml
+++ b/autobot_shared/pyproject.toml
@@ -18,10 +18,14 @@ dependencies = [
     "redis>=7.4.0",
     "pyyaml>=6.0.3",
     "pydantic>=2.13.3",
+    "pydantic-settings>=2.0.0",   # ssot_config.py
     "python-dotenv>=1.2.2",
-    "requests>=2.31.0",
     "aiohttp>=3.9.0",
     "prometheus-client>=0.20.0",
+    "fastapi>=0.100.0",            # models/pagination.py (Query, Depends)
+    "starlette>=0.27.0",           # proxy_utils.py (starlette.requests.Request)
+    "PyJWT[crypto]>=2.8.0",        # auth/jwt_core.py
+    "bcrypt>=4.0.0",               # auth/jwt_core.py
     # OpenTelemetry distributed tracing (Issue #697)
     "opentelemetry-api>=1.41.1",
     "opentelemetry-sdk>=1.40.0",


### PR DESCRIPTION
Closes #7119. Self-review follow-up from #7113.

## Dep utilization audit

| Issue | Package | Detail |
|-------|---------|--------|
| **Unused** (declared but no \`import\`) | \`requests\` | Inherited from legacy setup.py via #7022; never imported in \`autobot_shared/\` |
| **Missing** (used in production code) | \`bcrypt\` | \`auth/jwt_core.py\` |
| | \`fastapi\` | \`models/pagination.py\` — Query, Depends |
| | \`PyJWT[crypto]\` | \`auth/jwt_core.py\` (\`import jwt\`) |
| | \`pydantic-settings\` | \`ssot_config.py\` |
| | \`starlette\` | \`proxy_utils.py\` — starlette.requests.Request |

These currently work in deployed builds because \`autobot-backend\` installs them transitively. But \`pip install autobot_shared\` standalone (now possible after #7022) gets ImportError. Real packaging gap — the package is not self-contained.

## Version floors

| Package | Floor | Rationale |
|---------|-------|-----------|
| \`bcrypt\` | \`>=4.0.0\` | Modern bcrypt API |
| \`fastapi\` | \`>=0.100.0\` | Modern Query API; autobot-backend pins tighter (\`>=0.136.1\`) for security but autobot_shared as a library should use loose floor |
| \`PyJWT[crypto]\` | \`>=2.8.0\` | Per docs/DEPENDENCIES.md |
| \`pydantic-settings\` | \`>=2.0.0\` | Pydantic v2 era |
| \`starlette\` | \`>=0.27.0\` | Modern \`starlette.requests\` |

## Verification

\`\`\`bash
$ python3 -c "import tomllib; tomllib.load(open('autobot_shared/pyproject.toml','rb'))"
# (parses cleanly)
\`\`\`

Total deps: 13 → 17 (-1 unused, +5 missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)