### PR TITLE
fix(ansible): replace removed community.general.yaml callback (closes #7137)

### DIFF
--- a/autobot-slm-backend/ansible/ansible.cfg
+++ b/autobot-slm-backend/ansible/ansible.cfg
@@ -16,8 +16,13 @@ forks = 5
 local_tmp = /tmp/ansible_local_tmp
 
 # Output and Logging
-stdout_callback = yaml
-stderr_callback = yaml
+# #7137: `stdout_callback = yaml` was the legacy short alias for
+# `community.general.yaml`, removed in community.general v12. Use the
+# ansible-core default callback with `result_format = yaml` per ansible-core
+# 2.13+ guidance — same YAML rendering, no community.general dependency.
+stdout_callback = ansible.builtin.default
+stderr_callback = ansible.builtin.default
+result_format = yaml
 log_path = /var/log/autobot/ansible.log
 display_skipped_hosts = False
 display_ok_hosts = True


### PR DESCRIPTION
## Summary

Closes #7137 — `stdout_callback = yaml` (legacy alias for `community.general.yaml`, removed in v12) replaced with the ansible-core canonical `ansible.builtin.default` + `result_format = yaml`.

## Why

`ansible-role-facts-test` workflow has been failing on `Dev_new_gui` since 2026-05-06T19:39Z because ubuntu-latest runners now ship community.general >= 12, which dropped the YAML callback. This shadowed real regressions in #7050 / #7058.

## Test plan

- [x] Same YAML output rendering (verified locally — warning gone)
- [x] CI `ansible-role-facts-test` workflow turns green
- [x] No new collection dependency added

🤖 Generated with [Claude Code](https://claude.com/claude-code)