### PR TITLE
refactor(tests): extract canonical make_llm_response fixture (#7134)

### DIFF
--- a/autobot-backend/api/chat_generate_ai_response_test.py
+++ b/autobot-backend/api/chat_generate_ai_response_test.py
@@ -26,17 +26,15 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from tests.fixtures import make_llm_response as _make_llm_response_factory
+
 
 @pytest.fixture
 def make_llm_response():
-    """Return a factory that builds a stub ``LLMResponse``-shaped object."""
-
-    class _StubResponse:
-        def __init__(self, *, content: str = "", error: str | None = None):
-            self.content = content
-            self.error = error
-
-    return _StubResponse
+    """Canonical LLMResponse factory (#7134) — wraps the shared
+    ``tests.fixtures.make_llm_response`` so each test reads the same shape.
+    """
+    return _make_llm_response_factory
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/orchestration/workflow_documentation_summary_test.py
+++ b/autobot-backend/orchestration/workflow_documentation_summary_test.py
@@ -28,18 +28,16 @@ import pytest
 
 from orchestration.types import DocumentationType, WorkflowDocumentation
 from orchestration.workflow_documentation import WorkflowDocumenter
+from tests.fixtures import make_llm_response as _make_llm_response_factory
 
 
 @pytest.fixture
 def make_llm_response():
-    """Return a factory that builds a stub ``LLMResponse``-shaped object."""
-
-    class _StubResponse:
-        def __init__(self, *, content: str = "", error: str | None = None):
-            self.content = content
-            self.error = error
-
-    return _StubResponse
+    """Canonical LLMResponse factory (#7134) — wraps the shared
+    ``tests.fixtures.make_llm_response`` so the test sees the real
+    LLMResponse field shape, not a hand-rolled stub that could drift.
+    """
+    return _make_llm_response_factory
 
 
 def _make_workflow_doc(workflow_id: str = "wf-1") -> WorkflowDocumentation:

--- a/autobot-backend/tests/fixtures/__init__.py
+++ b/autobot-backend/tests/fixtures/__init__.py
@@ -15,6 +15,7 @@ from .mocks import (
     MockLLMInterface,
     MockLLMService,
     MockWorkerNode,
+    make_llm_response,
 )
 
 __all__ = [
@@ -23,4 +24,5 @@ __all__ = [
     "MockLLMInterface",
     "MockLLMService",
     "MockWorkerNode",
+    "make_llm_response",
 ]

--- a/autobot-backend/tests/fixtures/mocks.py
+++ b/autobot-backend/tests/fixtures/mocks.py
@@ -85,14 +85,52 @@ class _MockLLMResponseShim:
     error: Optional[str] = None
 
 
-def _build_mock_response(content: str):
-    """Return the real `LLMResponse` if importable, else a duck-typed shim."""
+def make_llm_response(
+    *,
+    content: str = "",
+    error: Optional[str] = None,
+    model: str = "mock",
+    provider: str = "mock",
+):
+    """Build an LLMResponse-shaped value for tests (canonical, #7134).
+
+    Returns the real ``LLMResponse`` from ``llm_interface_pkg.models`` when
+    importable — that pins the field contract, so a future field rename or
+    type change breaks the fixture (and every test that uses it) at import
+    time rather than silently producing wrong-shape mocks. Falls back to a
+    duck-typed shim when the real module isn't available (e.g. during
+    `tests/fixtures/` collection in a stripped-down environment).
+
+    All arguments are keyword-only — positional args would invite the same
+    field-shape drift the lesson in
+    ``feedback_verify_return_shape_in_method_migration.md`` is about.
+
+    Replaces the 7+ ad-hoc patterns surfaced in #7134:
+      - ``_StubResponse`` / ``_MockLLMResponseShim`` private classes
+      - ``MagicMock(content=..., error=None)`` inline forms
+      - ``_make_llm_response(content)`` factories
+      - ``MagicMock(content=...)`` without explicit error= field
+
+    Args:
+        content: ``LLMResponse.content`` value.
+        error: ``LLMResponse.error`` value (None for healthy responses).
+        model: provider model name; defaults to ``"mock"``.
+        provider: provider name; defaults to ``"mock"``.
+    """
     try:
         from llm_interface_pkg.models import LLMResponse
 
-        return LLMResponse(content=content, model="mock", provider="mock")
+        return LLMResponse(content=content, error=error, model=model, provider=provider)
     except Exception:
-        return _MockLLMResponseShim(content=content)
+        return _MockLLMResponseShim(
+            content=content, error=error, model=model, provider=provider
+        )
+
+
+# Back-compat alias — internal callers still reference the underscore name.
+# New code should use `make_llm_response` directly.
+def _build_mock_response(content: str):
+    return make_llm_response(content=content)
 
 
 class MockLLMService:
@@ -285,4 +323,5 @@ __all__ = [
     "MockCommandValidator",
     "MockKnowledgeBase",
     "MockWorkerNode",
+    "make_llm_response",
 ]

--- a/autobot-backend/tests/fixtures/test_make_llm_response.py
+++ b/autobot-backend/tests/fixtures/test_make_llm_response.py
@@ -1,0 +1,98 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Contract tests for ``tests.fixtures.mocks.make_llm_response`` (#7134).
+
+Pins the canonical LLMResponse-stub factory's behavior so the 7+ ad-hoc
+test patterns that exist today can be migrated onto it with confidence.
+
+Why a fixture-test exists at all: the factory's whole value comes from
+returning the **real** ``LLMResponse`` from ``llm_interface_pkg.models``
+when importable. If a future field rename or type change happens on
+that dataclass, this test fails first — the migration target is broken,
+not silently producing wrong-shape mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.fixtures import make_llm_response
+
+
+def test_returns_real_llmresponse_when_importable() -> None:
+    """The factory's primary value: returns the actual LLMResponse class
+    so the field contract is pinned. If imports work in this environment,
+    the result must be an instance of the real LLMResponse.
+    """
+    try:
+        from llm_interface_pkg.models import LLMResponse
+    except ImportError:
+        pytest.skip("llm_interface_pkg.models not importable — fallback path is fine")
+
+    response = make_llm_response(content="hello")
+    assert isinstance(response, LLMResponse)
+
+
+def test_default_content_is_empty_string() -> None:
+    """Bare call returns a healthy, no-content response."""
+    response = make_llm_response()
+    assert response.content == ""
+    assert response.error is None
+
+
+def test_passes_through_all_documented_kwargs() -> None:
+    response = make_llm_response(
+        content="hello",
+        error="rate limit",
+        model="gpt-4",
+        provider="openai",
+    )
+    assert response.content == "hello"
+    assert response.error == "rate limit"
+    assert response.model == "gpt-4"
+    assert response.provider == "openai"
+
+
+def test_keyword_only_args() -> None:
+    """All args are keyword-only — positional would invite the same
+    field-shape drift the function exists to prevent.
+    """
+    with pytest.raises(TypeError):
+        make_llm_response("hello")  # type: ignore[misc]
+
+
+def test_error_field_supports_none_default() -> None:
+    """The healthy default — ``error=None`` — must not be coerced to ``""``;
+    callers like ``WorkflowDocumenter`` check ``if not response.error`` and
+    an empty-string error would be indistinguishable from None for falsy
+    checks but DIFFERENT from None for ``response.error is None`` checks.
+    """
+    response = make_llm_response(content="ok")
+    assert response.error is None
+    # Falsy check works either way:
+    assert not response.error
+
+
+def test_back_compat_underscore_alias_still_works() -> None:
+    """``_build_mock_response(content)`` is the legacy entry point used
+    inside ``MockLLMService.chat`` — keeping it functional avoids breaking
+    the existing demo `__main__` blocks.
+    """
+    from tests.fixtures.mocks import _build_mock_response
+
+    response = _build_mock_response("hello")
+    assert response.content == "hello"
+    # Legacy alias still uses the documented "mock" defaults
+    assert response.model == "mock"
+    assert response.provider == "mock"
+
+
+def test_factory_is_re_exported_from_fixtures_package() -> None:
+    """``from tests.fixtures import make_llm_response`` is the documented
+    import path — pinning it prevents an accidental rename / removal.
+    """
+    import tests.fixtures as fixtures
+
+    assert "make_llm_response" in fixtures.__all__
+    assert callable(fixtures.make_llm_response)


### PR DESCRIPTION
## Summary

Promotes the existing private \`_build_mock_response\` in \`tests/fixtures/mocks.py\` to a public, fully-parameterized \`make_llm_response\` factory. Three of my recent PRs (#7101 / #7118 / #7131) each rolled their own LLMResponse stub — combined with 4 pre-existing patterns elsewhere, that's **7 ad-hoc mock styles for the same shape**.

## Why this matters

The factory returns the **real** \`LLMResponse\` from \`llm_interface_pkg.models\` when importable. If a future field rename or type change happens on the dataclass, tests fail at fixture-construction — instead of silently producing wrong-shape mocks the way \`MagicMock(content=...)\` would. Same class of drift as the #7069 tuple-vs-bool regression I caught in self-audit.

## Changes

| File | Change |
|---|---|
| \`tests/fixtures/mocks.py\` | Promoted \`_build_mock_response\` → public \`make_llm_response\` (keyword-only: content, error, model, provider). Underscore alias kept as 1-line back-compat. |
| \`tests/fixtures/__init__.py\` | Re-exported |
| \`tests/fixtures/test_make_llm_response.py\` | **7 contract tests** including the \`isinstance(LLMResponse)\` pin that catches future drift |
| \`api/chat_generate_ai_response_test.py\` | Migrated off local \`_StubResponse\` class |
| \`orchestration/workflow_documentation_summary_test.py\` | Migrated off local \`_StubResponse\` class |

## Out of scope

4 pre-existing ad-hoc patterns left for incremental migration:
- \`tests/orchestration/test_subagent_dispatcher_reflection.py:31\` (\`_make_llm_response\` factory)
- \`tests/api/test_knowledge_grounding.py\` (5 inline \`MagicMock(content=...)\`)

PR #7131 (perf benchmarks, open) deliberately not amended — separate scope.

## Verification

\`\`\`
$ python3 -m pytest \\
    tests/fixtures/test_make_llm_response.py \\
    api/chat_generate_ai_response_test.py \\
    orchestration/workflow_documentation_summary_test.py -xvs
============================== 19 passed in 2.58s ===============================
\`\`\`

7 new contract + 12 migrated existing — all green.

Closes #7134