### PR TITLE
fix(ansible/slm_manager): cleanup stale Ansible PPA source files before adding (#7140)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -46,6 +46,22 @@
 # ==========================================================
 # Ansible PPA (for latest Ansible 2.17+)
 # ==========================================================
+- name: "SLM | Remove stale Ansible PPA source files (#7140)"
+  # On re-install, prior runs can leave both `*.list` (legacy) and
+  # `*.sources` (deb822) describing the same PPA with mismatched
+  # Signed-By values, causing APT to abort with:
+  #   E:Conflicting values set for option Signed-By regarding source
+  # Sweep them before re-adding so apt_repository can write a single
+  # consistent file.
+  ansible.builtin.shell:
+    cmd: |
+      set -e
+      rm -f /etc/apt/sources.list.d/ansible-ubuntu-ansible-*.list
+      rm -f /etc/apt/sources.list.d/ansible-ubuntu-ansible-*.sources
+  become: true
+  changed_when: false
+  tags: ['slm', 'packages', 'ansible']
+
 - name: "SLM | Add Ansible PPA repository"
   ansible.builtin.apt_repository:
     repo: ppa:ansible/ansible


### PR DESCRIPTION
## Summary
On re-install on Ubuntu 24 (noble), `apt-get update` aborts with:

```
E:Conflicting values set for option Signed-By regarding source
https://ppa.launchpadcontent.net/ansible/ansible/ubuntu/ noble
```

Cause: prior install leaves both `*.list` (legacy) and `*.sources` (deb822) source files describing the same PPA with mismatched `Signed-By` values. APT refuses to merge them.

Fix: remove any stale `ansible-ubuntu-ansible-*.list` and `*.sources` files immediately before invoking `apt_repository`, so the module writes a single consistent source file from a clean slate.

First-time install behavior unchanged (`rm -f` is a no-op when files don't exist). Same mitigation pattern as #7023 for Grafana PPA.

## Test plan
- [x] YAML lint passes (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] Re-install on a machine with stale PPA files — playbook now succeeds
- [ ] First-install on a clean machine — unchanged behavior

## User-facing workaround
Users hitting this NOW can manually run:
```bash
sudo rm -f /etc/apt/sources.list.d/ansible-ubuntu-ansible-*.list \
           /etc/apt/sources.list.d/ansible-ubuntu-ansible-*.sources
sudo apt-get update
```

Closes #7140