### PR TITLE
ci(security): add pre-commit-no-tag-pinned-action hook (closes #7120)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,12 +43,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7  # v4
         with:
           languages: ${{ matrix.language }}
           config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7  # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -293,6 +293,18 @@ repos:
         stages: [pre-commit]
         description: "Blocks new top-level dataclass declarations of WorkflowStep/AgentTask/WorkflowPlan outside autobot_shared/workflow/types.py; subclasses and aliases are allowed"
 
+  # No tag-pinned 3rd-party GitHub Actions (Issue #7120, preventive for #7091)
+  - repo: local
+    hooks:
+      - id: no-tag-pinned-action
+        name: No Tag-Pinned 3rd-Party GitHub Actions (Issue #7120)
+        entry: autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tag-pinned-action
+        language: script
+        files: ^\.github/(workflows|actions)/.*\.ya?ml$
+        pass_filenames: true
+        stages: [pre-commit]
+        description: "Blocks tag-pinned `uses: <org>/<repo>@vN` for non-actions/* orgs in workflows/composite actions; SHA pins required for supply-chain immutability"
+
   # No print()/console.* in production code (Issue #1082)
   - repo: local
     hooks:

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tag-pinned-action
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tag-pinned-action
@@ -1,0 +1,117 @@
+#!/bin/bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Pre-commit Hook: No Tag-Pinned 3rd-Party GitHub Actions
+# ========================================================
+#
+# Blocks commits that introduce `uses: <org>/<repo>@vN` for non-actions/*
+# orgs in .github/workflows/ or .github/actions/.
+#
+# Tags are mutable. A compromised maintainer could force-push v3 → a
+# malicious commit that lands silently in CI on next run. SHA pinning
+# makes the action immutable until we explicitly update.
+#
+# Allowed forms:
+#   - actions/checkout@v6                            (first-party)
+#   - dorny/paths-filter@d1c1ffe0...  # v3           (40-char SHA + comment)
+#
+# Rejected forms:
+#   - dorny/paths-filter@v3                          (3rd-party tag-pin)
+#   - dorny/paths-filter@main                        (3rd-party branch-pin)
+#
+# Issue: #7120 (preventive enforcement for #7091)
+# Reference: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+#
+# Install: pre-commit install (uses .pre-commit-config.yaml)
+
+set -uo pipefail
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+VIOLATIONS=0
+
+# Get staged workflow files. Issue #6785: positional args override the
+# staged lookup (CI argv mode).
+get_staged_workflow_files() {
+    if [ "$#" -gt 0 ]; then
+        printf '%s\n' "$@"
+        return
+    fi
+    git diff --cached --name-only --diff-filter=ACMRT \
+        | grep -E '^\.github/(workflows|actions)/.*\.ya?ml$' \
+        || true
+}
+
+check_file() {
+    local file="$1"
+    [ -f "$file" ] || return 0
+
+    # Match `uses: <action>@<ref>` and inspect <ref>.
+    # Allowed:
+    #   - actions/* (first-party — GitHub-maintained)
+    #   - 40-char hex SHA
+    # Rejected:
+    #   - vN, vN.N, vN.N.N tags for non-actions/* orgs
+    #   - branch names (main, master, latest, ...) for non-actions/* orgs
+
+    local line_num=0
+    local hits=0
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+        # Look for `uses: <something>@<ref>` (skip comments)
+        if [[ "$line" =~ ^[[:space:]]*#  ]]; then continue; fi
+        if ! [[ "$line" =~ uses:[[:space:]]+([^@[:space:]]+)@([^[:space:]]+) ]]; then
+            continue
+        fi
+        local action="${BASH_REMATCH[1]}"
+        local ref="${BASH_REMATCH[2]}"
+
+        # Allow actions/* (first-party)
+        if [[ "$action" =~ ^actions/ ]]; then continue; fi
+
+        # Allow 40-char SHA (with or without trailing comment)
+        if [[ "$ref" =~ ^[0-9a-f]{40}$ ]]; then continue; fi
+
+        # Anything else is rejected
+        if [ $hits -eq 0 ]; then
+            printf "%b%s%b\n" "$RED" "✗ $file" "$NC"
+            hits=1
+        fi
+        printf "  %bline %d:%b %s\n" "$YELLOW" "$line_num" "$NC" "$line"
+        printf "    %baction:%b %s @%s\n" "$CYAN" "$NC" "$action" "$ref"
+        VIOLATIONS=$((VIOLATIONS + 1))
+    done < "$file"
+}
+
+main() {
+    local files
+    files="$(get_staged_workflow_files "$@")"
+    [ -z "$files" ] && exit 0
+
+    while IFS= read -r f; do
+        [ -z "$f" ] || check_file "$f"
+    done <<< "$files"
+
+    if [ "$VIOLATIONS" -gt 0 ]; then
+        printf "\n%b%bRejected: %d tag-pinned 3rd-party action(s)%b\n\n" "$RED" "$BOLD" "$VIOLATIONS" "$NC"
+        printf "Tags are mutable. Pin to a 40-char commit SHA instead:\n\n"
+        printf "  %b# Resolve tag → SHA:%b\n" "$CYAN" "$NC"
+        printf "  git ls-remote https://github.com/<org>/<repo>.git 'refs/tags/v3^{}'\n\n"
+        printf "  %b# Then update workflow line to:%b\n" "$CYAN" "$NC"
+        printf "  uses: <org>/<repo>@<40-char-sha>  # v3\n\n"
+        printf "actions/* (first-party) are exempt — all other orgs (including github/*) need SHA pinning.\n"
+        printf "Issue: https://github.com/mrveiss/AutoBot-AI/issues/7091\n"
+        exit 1
+    fi
+    printf "%b%b✓ All 3rd-party actions are SHA-pinned%b\n" "$GREEN" "$BOLD" "$NC"
+    exit 0
+}
+
+main "$@"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tag-pinned-action_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tag-pinned-action_test.py
@@ -1,0 +1,157 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for pre-commit-no-tag-pinned-action hook.
+
+Issue #7120: lock down hook behavior so future tightening (or relaxation)
+of the allowed-action policy can be done safely.
+
+Each test invokes the hook in argv mode (positional file args), reads
+exit code + stdout/stderr, and asserts on the rejection messages.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOK_PATH = (
+    Path(__file__).resolve().parent / "pre-commit-no-tag-pinned-action"
+)
+
+
+def _run(tmp_path: Path, content: str, rel: str = ".github/workflows/test.yml") -> subprocess.CompletedProcess:
+    """Write a workflow file and invoke the hook via argv mode."""
+    f = tmp_path / rel
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(content, encoding="utf-8")
+    return subprocess.run(
+        [str(HOOK_PATH), str(f)],
+        capture_output=True,
+        text=True,
+    )
+
+
+# === Allowed forms ===
+
+def test_allow_first_party_actions_tag_pinned(tmp_path):
+    """actions/* (first-party, GitHub-maintained) are allowed with tag pins."""
+    result = _run(tmp_path, "jobs:\n  test:\n    steps:\n    - uses: actions/checkout@v6\n")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_allow_third_party_sha_pinned(tmp_path):
+    """3rd-party actions with 40-char SHA are allowed."""
+    sha = "d1c1ffe0248fe513906c8e24db8ea791d46f8590"
+    result = _run(
+        tmp_path,
+        f"jobs:\n  test:\n    steps:\n    - uses: dorny/paths-filter@{sha}  # v3\n",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_allow_actions_with_subpath_tag_pinned(tmp_path):
+    """actions/cache/save@v4 etc. — subpath under actions/* still allowed."""
+    result = _run(tmp_path, "jobs:\n  test:\n    steps:\n    - uses: actions/cache/save@v4\n")
+    assert result.returncode == 0
+
+
+# === Rejected forms ===
+
+def test_reject_third_party_tag_pinned_v3(tmp_path):
+    """Common 3rd-party tag pin must be rejected."""
+    result = _run(tmp_path, "jobs:\n  test:\n    steps:\n    - uses: dorny/paths-filter@v3\n")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "dorny/paths-filter" in result.stdout
+    assert "v3" in result.stdout
+
+
+def test_reject_third_party_branch_pinned(tmp_path):
+    """Branch pins (e.g., @main, @master) must be rejected."""
+    result = _run(tmp_path, "jobs:\n  test:\n    steps:\n    - uses: dorny/paths-filter@main\n")
+    assert result.returncode == 1
+
+
+def test_reject_github_namespace_tag_pinned(tmp_path):
+    """github/* (GitHub-org but not actions/*) is treated as 3rd-party."""
+    result = _run(tmp_path, "jobs:\n  test:\n    steps:\n    - uses: github/codeql-action/init@v4\n")
+    assert result.returncode == 1
+    assert "github/codeql-action" in result.stdout
+
+
+def test_reject_short_sha(tmp_path):
+    """Short SHAs (less than 40 chars) must be rejected — only full SHA pins are immutable."""
+    result = _run(
+        tmp_path,
+        "jobs:\n  test:\n    steps:\n    - uses: dorny/paths-filter@d1c1ffe\n",
+    )
+    assert result.returncode == 1
+
+
+def test_reject_semver_patch_tag(tmp_path):
+    """Even precise semver tags (v3.0.2) are mutable in principle — reject."""
+    result = _run(
+        tmp_path,
+        "jobs:\n  test:\n    steps:\n    - uses: dorny/paths-filter@v3.0.2\n",
+    )
+    assert result.returncode == 1
+
+
+# === Mixed / multi-line ===
+
+def test_multiple_uses_only_violators_reported(tmp_path):
+    """File with mixed allowed + rejected — should fail and report only violators."""
+    content = (
+        "jobs:\n"
+        "  test:\n"
+        "    steps:\n"
+        "    - uses: actions/checkout@v6\n"
+        "    - uses: dorny/paths-filter@v3\n"
+        "    - uses: actions/setup-python@v5\n"
+        "    - uses: codecov/codecov-action@v6\n"
+    )
+    result = _run(tmp_path, content)
+    assert result.returncode == 1
+    assert "dorny/paths-filter" in result.stdout
+    assert "codecov/codecov-action" in result.stdout
+    assert "actions/checkout" not in result.stdout  # not flagged
+    assert "actions/setup-python" not in result.stdout  # not flagged
+
+
+def test_comment_lines_ignored(tmp_path):
+    """Commented-out tag pins should not trigger the hook."""
+    result = _run(
+        tmp_path,
+        "jobs:\n  test:\n    steps:\n    # - uses: dorny/paths-filter@v3\n    - uses: actions/checkout@v6\n",
+    )
+    assert result.returncode == 0
+
+
+def test_empty_file(tmp_path):
+    """No staged workflow files — hook exits cleanly."""
+    result = subprocess.run([str(HOOK_PATH)], capture_output=True, text=True)
+    assert result.returncode == 0
+
+
+def test_actions_path_allowed(tmp_path):
+    """Composite actions under .github/actions/ also scanned."""
+    # Composite action with allowed first-party uses
+    result = _run(
+        tmp_path,
+        "name: composite\nruns:\n  using: composite\n  steps:\n    - uses: actions/checkout@v6\n",
+        rel=".github/actions/setup/action.yml",
+    )
+    assert result.returncode == 0
+
+
+def test_actions_path_rejects_third_party_tag(tmp_path):
+    """Composite action with 3rd-party tag pin is rejected."""
+    result = _run(
+        tmp_path,
+        "name: composite\nruns:\n  using: composite\n  steps:\n    - uses: dorny/paths-filter@v3\n",
+        rel=".github/actions/setup/action.yml",
+    )
+    assert result.returncode == 1


### PR DESCRIPTION
Closes #7120. Preventive enforcement for #7091 — without this hook, the SHA-pinning landed in PR #7102 silently regresses on the next copy-paste from stale docs.

## Hook policy

| Form | Decision |
|------|----------|
| \`actions/checkout@v6\` | ✅ first-party (GitHub-maintained) |
| \`actions/cache/save@v4\` | ✅ subpath under actions/* |
| \`dorny/paths-filter@d1c1ffe0...  # v3\` | ✅ 40-char SHA + comment |
| \`dorny/paths-filter@v3\` | ❌ 3rd-party tag-pin |
| \`dorny/paths-filter@main\` | ❌ branch-pin |
| \`dorny/paths-filter@v3.0.2\` | ❌ semver patch tag (still mutable) |
| \`dorny/paths-filter@d1c1ffe\` | ❌ short SHA (only 40-char is immutable) |
| \`github/codeql-action/init@v4\` | ❌ github/* is **not** actions/* |

## Found during smoke test (also fixed in this PR)

Running the hook against current Dev_new_gui surfaced 2 violations my #7091 audit missed:

\`\`\`
github/codeql-action/init@v4
github/codeql-action/analyze@v4
\`\`\`

\`github/*\` is GitHub-the-org but **not** under the blessed \`actions/*\` namespace. Same supply-chain risk surface as any 3rd-party. Pinned both to \`e46ed2cbd01164d986452f91f178727624ae40d7\` in this PR.

## Tests (13/13 pass)

\`autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tag-pinned-action_test.py\`:
- 3 allowed forms
- 5 rejected forms
- 5 mixed/edge cases (multiple uses on one file, comments, empty, .github/actions/, subpath)

## Wired into .pre-commit-config.yaml

\`\`\`yaml
files: ^\.github/(workflows|actions)/.*\.ya?ml$
pass_filenames: true   # per #6785 generic-wrapper convention
stages: [pre-commit]
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)