### PR TITLE
fix(frontend/i18n): add 4 missing en.json keys for graph loading + retry (#7079)

### DIFF
--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -2849,7 +2849,9 @@
         "sourcesCount": "{count} sources"
       },
       "noEntities3D": "No entities to display",
-      "loading3dVisualization": "Loading3d visualization"
+      "loading3dVisualization": "Loading3d visualization",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "connectors": {
       "title": "Source Connectors",
@@ -4502,7 +4504,9 @@
         "showingOf": "Showing {showing} of {total} functions (scroll for more)",
         "noMatch": "No orphaned functions match your filter",
         "allConnected": "No orphaned functions detected - all functions are connected!"
-      }
+      },
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "importTree": {
       "title": "File Import Tree",


### PR DESCRIPTION
## Summary

\`check-i18n-keys.mjs\` flagged 4 keys used by \`FunctionCallGraph.vue\` and \`KnowledgeGraph.vue\` as absent from \`en.json\`. The Vue calls pass fallback strings to \`\$t()\` so the runtime UI was fine, but the missing entries broke the keys-coverage signal.

Adds the 4 keys:

- \`charts.callGraph.loadingVisualization\`
- \`charts.callGraph.retry\`
- \`knowledge.graph.loadingVisualization\`
- \`knowledge.graph.retry\`

## Verification

\`\`\`bash
$ node scripts/check-i18n-keys.mjs
All translation keys found in en.json.
\`\`\`

Closes #7079

🤖 Generated with [Claude Code](https://claude.com/claude-code)