### PR TITLE
fix(ansible): pre-flight git commands fail with dubious ownership (closes #7150)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/pre-flight-code-sync.yml
+++ b/autobot-slm-backend/ansible/playbooks/pre-flight-code-sync.yml
@@ -43,7 +43,7 @@
 
     - name: "[PRE-FLIGHT] Get code_source commit before sync"
       ansible.builtin.command:
-        cmd: git -C {{ git_repo_root }} log -1 --format='%h %s'
+        cmd: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} log -1 --format='%h %s'
       register: pre_sync_commit
       changed_when: false
       tags: [always]
@@ -83,7 +83,7 @@
 
     - name: "[PRE-FLIGHT] Show code_source age when sync skipped"
       ansible.builtin.command:
-        cmd: "git -C {{ git_repo_root }} log -1 --format='Last commit: %h %s (%cr)'"
+        cmd: "git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} log -1 --format='Last commit: %h %s (%cr)'"
       register: code_source_age
       changed_when: false
       when: github_sync is failed
@@ -97,14 +97,14 @@
 
     - name: "[PRE-FLIGHT] Get current deploy commit"
       ansible.builtin.command:
-        cmd: git -C {{ git_repo_root }} log -1 --format='%h %s'
+        cmd: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} log -1 --format='%h %s'
       register: deploy_info
       changed_when: false
       tags: [always]
 
     - name: "[PRE-FLIGHT] Count commits advanced during sync"
       ansible.builtin.command:
-        cmd: git -C {{ git_repo_root }} rev-list --count {{ pre_sync_commit.stdout.split()[0] }}..HEAD
+        cmd: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} rev-list --count {{ pre_sync_commit.stdout.split()[0] }}..HEAD
       register: sync_commit_count
       changed_when: false
       when: github_sync is not failed

--- a/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
@@ -55,7 +55,7 @@
 
     - name: "[PRE-FLIGHT] Get code_source commit before sync"
       ansible.builtin.command:
-        cmd: git -C {{ git_repo_root }} log -1 --format='%h %s'
+        cmd: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} log -1 --format='%h %s'
       register: pre_sync_commit
       changed_when: false
       tags: [always]
@@ -123,7 +123,7 @@
 
     - name: "[PRE-FLIGHT] Show code_source age when sync skipped"
       ansible.builtin.command:
-        cmd: "git -C {{ git_repo_root }} log -1 --format='Last commit: %h %s (%cr)'"
+        cmd: "git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} log -1 --format='Last commit: %h %s (%cr)'"
       register: code_source_age
       changed_when: false
       when: github_sync is failed
@@ -137,14 +137,14 @@
 
     - name: "[PRE-FLIGHT] Get current deploy commit"
       ansible.builtin.command:
-        cmd: git -C {{ git_repo_root }} log -1 --format='%h %s'
+        cmd: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} log -1 --format='%h %s'
       register: deploy_info
       changed_when: false
       tags: [always]
 
     - name: "[PRE-FLIGHT] Count commits advanced during sync"
       ansible.builtin.command:
-        cmd: git -C {{ git_repo_root }} rev-list --count {{ pre_sync_commit.stdout.split()[0] }}..HEAD
+        cmd: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} rev-list --count {{ pre_sync_commit.stdout.split()[0] }}..HEAD
       register: sync_commit_count
       changed_when: false
       when: github_sync is not failed

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -59,19 +59,19 @@
         depth: 1
 
     - name: "[PRE-FLIGHT] Get current git branch"
-      command: git -C {{ git_repo_root }} branch --show-current
+      command: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} branch --show-current
       register: git_branch
       changed_when: false
 
     - name: "[PRE-FLIGHT] Resolve deploy ref to commit"
       command: >-
-        git -C {{ git_repo_root }}
+        git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }}
         log -1 --format='%h %s' {{ deploy_ref }}
       register: deploy_info
       changed_when: false
 
     - name: "[PRE-FLIGHT] Check for uncommitted changes"
-      command: git -C {{ git_repo_root }} status --porcelain
+      command: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} status --porcelain
       register: git_dirty
       changed_when: false
 
@@ -106,7 +106,7 @@
 
     - name: "[PRE-FLIGHT] Create component archives"
       shell: >-
-        git -C {{ git_repo_root }} archive {{ deploy_ref }}
+        git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} archive {{ deploy_ref }}
         -- {{ item.path }} | gzip > {{ deploy_tmp }}/{{ item.name }}.tar.gz
       loop:
         - { name: slm-backend, path: autobot-slm-backend/ }
@@ -127,14 +127,14 @@
     # --- Dependency change detection (#1603) ---
     - name: "[PRE-FLIGHT] Get previous commit (before pull)"
       command: >-
-        git -C {{ git_repo_root }} rev-parse HEAD~1
+        git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} rev-parse HEAD~1
       register: prev_commit
       changed_when: false
       failed_when: false
 
     - name: "[PRE-FLIGHT] Check if Python deps changed"
       shell: >-
-        git -C {{ git_repo_root }} diff --name-only
+        git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} diff --name-only
         {{ prev_commit.stdout | default('HEAD') }} HEAD
         -- '*/requirements.txt' 'autobot_shared/pyproject.toml'
       register: python_deps_diff
@@ -143,7 +143,7 @@
 
     - name: "[PRE-FLIGHT] Check if Node.js deps changed"
       shell: >-
-        git -C {{ git_repo_root }} diff --name-only
+        git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} diff --name-only
         {{ prev_commit.stdout | default('HEAD') }} HEAD
         -- '*/package.json' '*/package-lock.json'
       register: node_deps_diff
@@ -163,12 +163,12 @@
           - "  Changed files: {{ (python_deps_diff.stdout_lines | default([])) + (node_deps_diff.stdout_lines | default([])) }}"
 
     - name: "[PRE-FLIGHT] Get full commit hash"
-      command: git -C {{ git_repo_root }} log -1 --format='%H'
+      command: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} log -1 --format='%H'
       register: deploy_commit_full
       changed_when: false
 
     - name: "[PRE-FLIGHT] Get commit subject"
-      command: git -C {{ git_repo_root }} log -1 --format='%s'
+      command: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} log -1 --format='%s'
       register: deploy_commit_subject
       changed_when: false
 


### PR DESCRIPTION
## Summary

Closes #7150. \`./install.sh\` fails on DGX Spark and any host where \`code_source/\` is owned by a different user than the one Ansible runs as. Git 2.35+ refuses all operations with \"dubious ownership\" rc=128.

## Why

\`code_source/\` is cloned by \`install.sh\` as the \`autobot\` user; Ansible runs as root via sudo. Pre-flight tasks like \`git -C /opt/autobot/code_source log -1 --format='%h %s'\` (which is **read-only** — the task name \"Get code_source commit\" refers to a SHA, not making a commit) fail before deployment can proceed.

## Fix

Pass \`-c safe.directory={{ git_repo_root }}\` per-command to all 17 git invocations across 3 playbooks:
- \`pre-flight-code-sync.yml\` (4 sites)
- \`provision-fleet-roles.yml\` (4 sites)
- \`update-all-nodes.yml\` (9 sites)

Per-command \`-c\` is scoped — no global \`git config\` mutation.

## Test plan

- [x] All 3 playbooks YAML-parse-verified
- [ ] DGX Spark install retries past previous failure point — user to verify after PR lands

## Reproduced on

- 192.168.88.96 (DGX Spark, Ubuntu 24.04 ARM64) — May 7 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)