### PR TITLE
fix(frontend/ui): EmptyState stories use correct prop name 'message' (#6874)

### DIFF
--- a/autobot-frontend/src/components/ui/EmptyState.stories.ts
+++ b/autobot-frontend/src/components/ui/EmptyState.stories.ts
@@ -1,6 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
 import EmptyState from './EmptyState.vue';
 
+// #6874: stories used `description` but the actual prop on EmptyState.vue is `message`.
+// DataTable.vue + every other production caller already uses `:message`, so the bug
+// was in this stories file (mismatched prop name made stories render blank body text
+// in Storybook). Realigning to `message`.
 const meta = {
   title: 'Components/UI/EmptyState',
   component: EmptyState,
@@ -14,9 +18,13 @@ const meta = {
       control: 'text',
       description: 'Empty state title',
     },
-    description: {
+    message: {
       control: 'text',
-      description: 'Empty state description',
+      description: 'Empty state message text (rendered below the title)',
+    },
+    compact: {
+      control: 'boolean',
+      description: 'Compact mode (smaller spacing)',
     },
   },
 } satisfies Meta<typeof EmptyState>;
@@ -27,7 +35,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     title: 'No data available',
-    description: 'There is no data to display at this time',
+    message: 'There is no data to display at this time',
   },
 };
 
@@ -35,7 +43,7 @@ export const NoResults: Story = {
   args: {
     icon: 'fas fa-search',
     title: 'No search results',
-    description: 'Try adjusting your search criteria',
+    message: 'Try adjusting your search criteria',
   },
 };
 
@@ -43,7 +51,7 @@ export const NoItems: Story = {
   args: {
     icon: 'fas fa-inbox',
     title: 'Inbox is empty',
-    description: 'You have no items in your inbox',
+    message: 'You have no items in your inbox',
   },
 };
 
@@ -51,7 +59,7 @@ export const WithIcon: Story = {
   args: {
     icon: 'fas fa-folder-open',
     title: 'No files',
-    description: 'This directory is empty',
+    message: 'This directory is empty',
   },
 };
 
@@ -59,7 +67,7 @@ export const CreateNew: Story = {
   args: {
     icon: 'fas fa-plus-circle',
     title: 'No projects yet',
-    description: 'Create your first project to get started',
+    message: 'Create your first project to get started',
   },
 };
 
@@ -70,7 +78,7 @@ export const WithSlot: Story = {
       <EmptyState
         icon="fas fa-chart-bar"
         title="No analytics data"
-        description="Analytics will appear here once data is available"
+        message="Analytics will appear here once data is available"
       >
         <button class="mt-4 px-4 py-2 bg-blue-500 text-white rounded">
           Refresh Data

--- a/autobot-frontend/src/components/ui/__tests__/DataTable.test.ts
+++ b/autobot-frontend/src/components/ui/__tests__/DataTable.test.ts
@@ -1,0 +1,92 @@
+/**
+ * DataTable empty-state prop tests (#6874)
+ *
+ * The empty-state slot in DataTable.vue passes `:message` to <EmptyState>.
+ * The previous claim in #6874 was that EmptyState expects `:description` —
+ * but the source of truth (EmptyState.vue defineProps) shows `message`.
+ * The actual mismatch was in EmptyState.stories.ts (which used `description`
+ * as an argType + arg name, making Storybook stories render blank body text).
+ *
+ * These tests pin the contract: DataTable empty-state passes the
+ * caller-provided text through to EmptyState.message and that prop renders.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import DataTable from '../DataTable.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      ui: {
+        dataTable: {
+          loading: 'Loading…',
+          noDataAvailable: 'No data available',
+          noItemsToDisplay: 'No items to display',
+          dataTable: 'Data table',
+          actions: 'Actions',
+          sortBy: 'Sort by {column}',
+        },
+      },
+    },
+  },
+})
+
+const mountDataTable = (props: Record<string, unknown> = {}) =>
+  mount(DataTable, {
+    props: {
+      data: [],
+      columns: [{ key: 'name', label: 'Name' }],
+      loading: false,
+      ...props,
+    },
+    global: {
+      plugins: [i18n],
+      stubs: { Icon: true, LoadingSpinner: true },
+    },
+  })
+
+describe('DataTable empty state (#6874)', () => {
+  it('renders the default empty message when no rows are passed', () => {
+    const wrapper = mountDataTable({ data: [] })
+
+    const emptyState = wrapper.findComponent({ name: 'EmptyState' })
+    expect(emptyState.exists()).toBe(true)
+    // The default falls through to t('ui.dataTable.noItemsToDisplay').
+    expect(emptyState.props('message')).toBe('No items to display')
+  })
+
+  it('passes a custom emptyMessage prop to EmptyState.message', () => {
+    const wrapper = mountDataTable({
+      data: [],
+      emptyMessage: 'Nothing to show here yet',
+    })
+
+    const emptyState = wrapper.findComponent({ name: 'EmptyState' })
+    expect(emptyState.props('message')).toBe('Nothing to show here yet')
+  })
+
+  it('renders the message text in the DOM (not blank)', () => {
+    const wrapper = mountDataTable({
+      data: [],
+      emptyMessage: 'Concrete empty body text',
+    })
+
+    // EmptyState.vue renders <p class="empty-message">{{ message }}</p>.
+    // If the prop name were wrong (the original #6874 premise), this DOM
+    // assertion would fail.
+    expect(wrapper.text()).toContain('Concrete empty body text')
+  })
+
+  it('does not render the empty state when rows are present', () => {
+    const wrapper = mountDataTable({
+      data: [{ name: 'Alice' }, { name: 'Bob' }],
+    })
+
+    const emptyState = wrapper.findComponent({ name: 'EmptyState' })
+    expect(emptyState.exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Issue #6874 premise was inverted: it claimed `DataTable.vue` passed `:message` while `EmptyState` expected `:description`. Source-of-truth check shows `EmptyState.vue defineProps<Props>()` declares `message?: string` — DataTable + every other production caller correctly use `:message`.
- The actual mismatch was in **`EmptyState.stories.ts`** which used `description` as both the argType and arg name in 6 stories. Storybook would render the body text as blank because EmptyState has no `description` prop.
- Realigns stories file to use `message`. Adds Vitest `DataTable.test.ts` per the issue's AC pinning the prop contract.

## Test plan

- [x] `npx vitest run src/components/ui/__tests__/DataTable.test.ts` → 4/4 pass
  - default emptyMessage falls through to `t('ui.dataTable.noItemsToDisplay')`
  - custom `emptyMessage` flows to `EmptyState.message`
  - message text appears in DOM (would fail if prop name were wrong)
  - empty state hidden when rows present
- [ ] Storybook visual check post-deploy — verify EmptyState stories now render body text

Closes #6874