### PR TITLE
fix(test/worker): unbreak src.* mock path in worker_node_test (#6987 part 2/N)

### DIFF
--- a/autobot-backend/worker_node_test.py
+++ b/autobot-backend/worker_node_test.py
@@ -22,7 +22,7 @@ class TestWorkerNodeRefactored:
     @pytest.fixture
     def worker_node(self):
         """Create a WorkerNode instance for testing"""
-        with patch("src.worker_node.get_redis_client", return_value=None):
+        with patch("worker_node.get_redis_client", return_value=None):
             worker = WorkerNode()
             # Mock the modules to avoid dependencies
             worker.llm_interface = MagicMock()


### PR DESCRIPTION
## Summary

Single-line fix: drop the bogus \`src.\` prefix from the \`get_redis_client\` mock path in \`worker_node_test.py\`.

## Before/after

\`\`\`
# Before
$ pytest worker_node_test.py
ModuleNotFoundError: No module named 'src'

# After
$ pytest worker_node_test.py
8 passed, 2 failed   (the 2 are pre-existing — see below)
\`\`\`

## Pre-existing failures surfaced (NOT introduced)

With the Redis mock now actually firing, 2 tests fail because the worker_node return shape was refactored to wrap responses in a \`{'status', 'message', 'data': {...}}\` envelope — but the tests still assert on the unwrapped shape:

\`\`\`
FAILED test_llm_chat_completion_success: 'response' in {data: {response: ...}}
FAILED test_kb_search_success: 'results' in {data: {results: [...]}}
\`\`\`

Different bug class from #6987 — filing separate tracker.

Closes part 2/N of #6987 (4 of 48 sites cleaned across PRs)