### PR TITLE
fix(frontend/i18n): pass count as 3rd arg to t() for 3 plural callsites (#6976)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -187,7 +187,7 @@
           <div v-if="message.attachments && message.attachments.length > 0" class="message-attachments">
             <div class="attachment-header">
               <i class="fas fa-paperclip" aria-hidden="true"></i>
-              <span>{{ $t('chat.messages.attachments', { count: message.attachments.length }) }}</span>
+              <span>{{ $t('chat.messages.attachments', { count: message.attachments.length }, message.attachments.length) }}</span>
             </div>
             <div class="attachment-list">
               <div

--- a/autobot-frontend/src/components/chat/MessageAttachments.vue
+++ b/autobot-frontend/src/components/chat/MessageAttachments.vue
@@ -2,7 +2,7 @@
   <div v-if="attachments && attachments.length > 0" class="message-attachments">
     <div class="attachment-header">
       <i class="fas fa-paperclip" aria-hidden="true"></i>
-      <span>{{ $t('chat.messages.attachments', { count: attachments.length }) }}</span>
+      <span>{{ $t('chat.messages.attachments', { count: attachments.length }, attachments.length) }}</span>
     </div>
     <div class="attachment-list">
       <div

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -104,7 +104,7 @@
       <header class="content-header">
         <div class="header-left">
           <h2>{{ currentCategoryLabel }}</h2>
-          <span class="subtitle">{{ t('security.secretsManager.credentialCount', { count: filteredSecrets.length }) }}</span>
+          <span class="subtitle">{{ t('security.secretsManager.credentialCount', { count: filteredSecrets.length }, filteredSecrets.length) }}</span>
         </div>
         <div class="header-actions">
           <button @click="loadSecrets" class="btn-icon" :disabled="loading" :title="t('security.secretsManager.refresh')">


### PR DESCRIPTION
## Summary

- 3 production callsites in autobot-frontend invoked vue-i18n keys with plural-form values (\`{count} X | {count} Xs\`) using the 2-arg form \`t(key, { count: N })\` — vue-i18n 9+ requires the count as 3rd positional arg for the \`|\` plural branch to be selected. Output for count=2 was "2 attachment" (singular with interpolated value) instead of "2 attachments".
- Fixed all 3 sites by passing the count as 3rd positional arg, matching the canonical pattern from \`AuditLogTable.vue\` and \`OfflineBanner.vue\`.

## Behavioral grep audit

Plural keys in \`en.json\`: 4 (\`attachments\`, \`queuedForRetry\`, \`credentialCount\`, \`entriesCount\`)

Production callers post-fix:

\`\`\`bash
$ grep -rnE "t\([^,)]+\.(attachments|count|Count)[^,)]*,\s*\{\s*count:[^}]+\}\s*\)" autobot-frontend/src --include="*.vue" --include="*.ts"
# 0 hits — all 5 callers now use the 3rd-arg form
\`\`\`

## Test plan

- [x] All 3 fixed sites use 3rd-positional-arg form (verified by grep)
- [x] Audit confirmed: 5/5 production plural-key callers now correct
- [ ] Live verify post-deploy: render attachment count of 2 → message reads "2 attachments" (plural)

## Out of scope (deferred)

- ESLint custom rule to prevent regression — tracked in #7155

Closes #6976