### PR TITLE
fix(packaging): add [project.optional-dependencies] test group (closes #7156 partial)

### DIFF
--- a/autobot_shared/pyproject.toml
+++ b/autobot_shared/pyproject.toml
@@ -35,6 +35,14 @@ dependencies = [
     "opentelemetry-instrumentation-aiohttp-client>=0.62b1",
 ]
 
+[project.optional-dependencies]
+# Test deps (pytest, pytest-asyncio) used by autobot_shared/**/*_test.py.
+# Install with: pip install autobot_shared[test]
+test = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+]
+
 [tool.setuptools.packages.find]
 where = ["."]
 exclude = ["tests*", "*_test*"]


### PR DESCRIPTION
Partial fix for #7156 — closes the immediate gap (test deps missing).

## Why

15 files in \`autobot_shared/\` import \`pytest\`, 1 imports \`pytest_asyncio\`, but pyproject.toml declared neither. \`pip install autobot_shared && pytest autobot_shared/\` on a clean venv currently fails with ImportError.

Currently works in CI because \`autobot-backend\` installs pytest separately, masking the gap.

## Fix

Adds minimal PEP-621 \`[project.optional-dependencies]\`:

\`\`\`toml
[project.optional-dependencies]
test = [
    "pytest>=8.0",
    "pytest-asyncio>=0.24",
]
\`\`\`

Install with: \`pip install autobot_shared[test]\`

## Scope (and what's deferred)

This PR closes only the **test-deps** part of #7156. The broader runtime-dep grouping proposed in the issue (\`[auth]\` / \`[http]\` / \`[observability]\`) is **intentionally not in this PR** — that refactor changes the contract for every caller (\`autobot-backend\` would need \`autobot_shared[auth,http,observability]\` instead of bare \`autobot_shared\`) and warrants its own verification of all callsites + Dockerfile updates.

#7156 stays open with the runtime-grouping work captured for follow-up.

## Verification

\`\`\`bash
$ python3 -c "import tomllib; data=tomllib.load(open('autobot_shared/pyproject.toml','rb')); print(data['project']['optional-dependencies']['test'])"
['pytest>=8.0', 'pytest-asyncio>=0.24']
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)