### PR TITLE
fix(test/security): unbreak 3 src.* mock paths in enhanced_security_layer_test (#6987 part 3/N)

### DIFF
--- a/autobot-backend/enhanced_security_layer_test.py
+++ b/autobot-backend/enhanced_security_layer_test.py
@@ -26,7 +26,7 @@ class TestEnhancedSecurityLayer:
         self.temp_audit_file.close()
 
         # Mock config to use temporary file
-        with patch("src.enhanced_security_layer.global_config_manager") as mock_config:
+        with patch("enhanced_security_layer.global_config_manager") as mock_config:
             mock_config.get.return_value = {
                 "enable_auth": False,
                 "enable_command_security": True,
@@ -63,7 +63,7 @@ class TestEnhancedSecurityLayer:
     def test_create_security_policy(self):
         """Test security policy creation from configuration"""
         # Test with custom policies in config
-        with patch("src.enhanced_security_layer.global_config_manager") as mock_config:
+        with patch("enhanced_security_layer.global_config_manager") as mock_config:
             mock_config.get.return_value = {
                 "enable_command_security": True,
                 "command_policies": {
@@ -454,7 +454,7 @@ class TestEnhancedSecurityLayerIntegration:
 
     def setup_method(self):
         """Set up test fixtures"""
-        with patch("src.enhanced_security_layer.global_config_manager") as mock_config:
+        with patch("enhanced_security_layer.global_config_manager") as mock_config:
             mock_config.get.return_value = {
                 "enable_auth": False,
                 "enable_command_security": True,


### PR DESCRIPTION
## Summary

3 mechanical \`src.\` prefix removals in \`enhanced_security_layer_test.py\`. Result: 23 passed, **4 SECURITY tests now failing — pre-existing rot surfaced, P1 follow-up filed**.

## Failures surfaced (NOT introduced)

These tests were silently passing on stale-mock-luck for the entire duration the \`src.*\` bug existed (potentially since #3185 / #6987 timeframe):

| Test | Failure |
|---|---|
| \`test_create_security_policy\` | \`frozenset has no attribute 'update'\` |
| \`test_check_permission_god_mode\` | \`check_permission('god', 'allow_shell_execute')\` → False (expected True) |
| \`test_check_permission_shell_execute\` | \`check_permission('admin', 'allow_shell_execute')\` → False |
| \`test_get_default_role_permissions\` | guest role permissions are \`[]\` instead of \`{'files.view', ...}\` |

These are SECURITY-CRITICAL invariants. Three possibilities for each:
1. Test rot (implementation correct, assertions stale)
2. Security regression (implementation lost permissions)
3. Test setup wrong (mock not establishing right state)

**All three need security-domain triage.** Filing as P1 discovery.

## Approach

Per #6987's documented expectation: *"if any tests fail (after the fix), those are real regressions to address"* — these qualify. Separate triage scope from the mechanical \`src.\` fix.

Closes part 3/N of #6987 (7 of 48 sites cleaned across PRs)