### PR TITLE
ci(security): enable Dependabot for docker ecosystem (closes #7157)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,3 +79,41 @@ updates:
     labels:
       - "dependencies"
       - "devops"
+
+  # Docker base images (Issue #7157 — supply-chain hardening, sister of #7091/#7120)
+  # Dependabot auto-PRs digest updates when new versions publish.
+  - package-ecosystem: "docker"
+    directory: "/docker/backend"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "devops"
+      - "security"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/slm"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "devops"
+      - "security"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/frontend"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "devops"
+      - "security"


### PR DESCRIPTION
Closes #7157. Sister of #7091 / #7120 — supply-chain hardening for Dockerfile FROM directives.

## Why

Mutable Docker tags allow upstream maintainers to silently re-push different content under the same tag (e.g., \`python:3.12-slim-bookworm\`). Same risk surface as GitHub Actions tag-pinning — addressed in #7091 / #7120.

## Fix

Adds 3 \`docker\` ecosystem entries to \`.github/dependabot.yml\`:

| Directory | FROM directives |
|-----------|-----------------|
| \`/docker/backend\` | \`python:3.12-slim-bookworm\` (deps + production stages) |
| \`/docker/slm\` | \`python:3.12-slim-bookworm\` |
| \`/docker/frontend\` | \`node:20-bookworm-slim\`, \`ubuntu:22.04\` |

Weekly cadence matches existing \`github-actions\` / \`pip\` / \`npm\` schedules. Dependabot auto-PRs digest updates when new versions publish.

## Why Option B (Dependabot) over Option A (manual digest pin)

| Approach | Pro | Con |
|----------|-----|-----|
| **A. Manual \`@sha256:...\` digest** | Immediate immutability | Zero auto-update — patches require manual digest hunting |
| **B. Dependabot-managed mutable tag** | Ongoing auto-updates, matches existing workflow | 1-week tag-mutation window between runs |

For a small repo with weekly Dependabot cadence, Option B trades a 1-week tag-mutation window for ongoing maintenance. Production builds freeze a digest in the resulting image anyway. Escalate to digest pinning if a real incident demonstrates the window is unacceptable.

## Verification

\`\`\`bash
$ python3 -c "import yaml; print(len(yaml.safe_load(open('.github/dependabot.yml'))['updates']))"
9   # was 6 (pip×3, npm×2, github-actions) → now 9 (+ docker×3)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)