### PR TITLE
fix(install.sh): generate localhost.yml with network_subnet/gateway/slm_host (closes #7162)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -522,8 +522,15 @@ ansible_deployment() {
     # is the variable consulted by provision-fleet-roles.yml's role gates;
     # node_role (singular) is preserved for backward compat.
     cat > "${inventory}" << 'INVENTORY'
-# AutoBot localhost inventory for self-deploy (Issue #1294, #6600)
+# AutoBot localhost inventory for self-deploy (Issue #1294, #6600, #7162)
 all:
+  vars:
+    # #7162: network_subnet/network_gateway/slm_host MUST be defined here so
+    # firewall rules in group_vars/slm.yml resolve. Match slm-nodes.yml's
+    # lookup-with-fallback pattern: env first, then secrets file, then default.
+    slm_host: "{{ lookup('env', 'SLM_HOST') | default(lookup('pipe', 'grep -oP \"SLM_HOST=\\K.*\" /etc/autobot/slm-secrets.env 2>/dev/null || echo 127.0.0.1'), true) }}"
+    network_subnet: "{{ lookup('env', 'NETWORK_SUBNET') or lookup('pipe', 'grep -oP \"NETWORK_SUBNET=\\K.*\" /etc/autobot/slm-secrets.env 2>/dev/null') or '0.0.0.0/0' }}"
+    network_gateway: "{{ lookup('env', 'NETWORK_GATEWAY') or lookup('pipe', 'grep -oP \"NETWORK_GATEWAY=\\K.*\" /etc/autobot/slm-secrets.env 2>/dev/null') or '0.0.0.0' }}"
   hosts:
     00-SLM-Manager:
       ansible_connection: local


### PR DESCRIPTION
## Summary

Closes #7162. After #7150 unblocked pre-flight git, install hit \`'network_subnet' is undefined\` on the firewall-rules merge. The dynamically-generated \`inventory/localhost.yml\` was missing the \`network_subnet\`/\`network_gateway\`/\`slm_host\` vars that \`group_vars/slm.yml\` firewall rules reference.

## Fix

Add \`vars:\` block to the generated \`localhost.yml\` mirroring \`inventory/slm-nodes.yml\`'s lookup-with-fallback pattern (env → \`/etc/autobot/slm-secrets.env\` → safe default).

\`install.sh\` already writes those values to the secrets file on lines 565-571 — they just weren't being read by the inventory.

## Test plan

- [x] \`bash -n install.sh\` syntax check
- [ ] Re-run on DGX Spark 192.168.88.96 reaches end of common-firewall task — to verify after merge

## Reproduced on

- 192.168.88.96 (DGX Spark, Ubuntu 24.04 ARM64) — 2026-05-07T13:25Z

🤖 Generated with [Claude Code](https://claude.com/claude-code)