### PR TITLE
fix(audit-script): filter test_*.py + detect router_registry callers (#7128, #7109)

### DIFF
--- a/pipeline-scripts/audit-unwired-trackers.py
+++ b/pipeline-scripts/audit-unwired-trackers.py
@@ -78,6 +78,21 @@ SKIP_PATH_FRAGMENTS = (
     "/migrations/",
 )
 TEST_PATH_FRAGMENTS = ("_test.", ".test.", "/tests/", "/__tests__/")
+# #7128: pytest TEST_*.PY prefix style is checked separately on the basename.
+# We don't add "/test_" to TEST_PATH_FRAGMENTS because pytest's own tmp_path
+# directories embed `test_<name>/` and would short-circuit the audit's walker.
+
+# Router-registry directories — modules registered here are wired at runtime
+# via dotted-path string lookup (e.g. ("api.captcha", ...) in feature_routers.py),
+# which the import-grep below cannot detect. We parse these files at script
+# startup and treat any file whose dotted module path appears in a registry
+# tuple as already wired (#7109).
+ROUTER_REGISTRY_DIR = (
+    Path(__file__).resolve().parent.parent / "autobot-backend" / "initialization" / "router_registry"
+)
+REGISTRY_TUPLE_RE = re.compile(
+    r'\(\s*"([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)+)"'
+)
 
 DOCSTRING_HEAD_LINES = 40  # how many lines from top of file to scan for tracker refs
 # Match common docstring tracker-reference shapes (#6928 widened the set).
@@ -111,12 +126,58 @@ class Finding:
 
 def is_test_path(path: Path) -> bool:
     s = str(path)
-    return any(frag in s for frag in TEST_PATH_FRAGMENTS)
+    if any(frag in s for frag in TEST_PATH_FRAGMENTS):
+        return True
+    # #7128: catch pytest's `test_<name>.py` prefix-style modules. We check
+    # the basename rather than the full path to avoid false-positives from
+    # directories upstream (e.g. pytest tmp_path lives under `test_<id>/`).
+    return path.name.startswith("test_") and path.suffix == ".py"
 
 
 def should_skip_path(path: Path) -> bool:
     s = str(path)
     return any(frag in s for frag in SKIP_PATH_FRAGMENTS)
+
+
+def load_router_registry_modules() -> set[str]:
+    """Return dotted module paths registered in any router_registry/*.py file.
+
+    Registry tuples look like ``("api.captcha", "", ["captcha"], "captcha")`` —
+    the first element is the dotted import path. Modules registered this way
+    are wired at runtime, so the import-grep heuristic falsely reports them as
+    having zero callers (#7109). Parsing the registry once at script startup
+    lets us treat them as wired.
+    """
+    modules: set[str] = set()
+    if not ROUTER_REGISTRY_DIR.exists():
+        return modules
+    for f in ROUTER_REGISTRY_DIR.glob("*.py"):
+        if f.name == "__init__.py":
+            continue
+        try:
+            content = f.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for m in REGISTRY_TUPLE_RE.finditer(content):
+            modules.add(m.group(1))
+    return modules
+
+
+def derive_module_path(file_path: Path) -> Optional[str]:
+    """Convert ``autobot-backend/api/captcha.py`` to ``api.captcha``.
+
+    Strips the top-level scan-directory and the file extension. Returns None
+    for files that don't fit the expected layout (top-level scripts, etc.).
+    """
+    try:
+        rel = file_path.relative_to(REPO_ROOT)
+    except ValueError:
+        return None
+    parts = rel.parts
+    if len(parts) < 2 or not parts[-1].endswith(".py"):
+        return None
+    inner = parts[1:-1] + (parts[-1][:-3],)
+    return ".".join(inner)
 
 
 def extract_tracker_refs(file_path: Path) -> list[int]:
@@ -240,6 +301,7 @@ def existing_audit_issues_by_tracker() -> set[int]:
 
 def scan() -> list[Finding]:
     closed_set = fetch_closed_tracker_set()
+    registry_modules = load_router_registry_modules()
     findings: list[Finding] = []
     for sd in SCAN_DIRS:
         base = REPO_ROOT / sd
@@ -248,6 +310,12 @@ def scan() -> list[Finding]:
         for pattern in SOURCE_GLOBS:
             for f in base.rglob(pattern):
                 if should_skip_path(f) or is_test_path(f):
+                    continue
+                # #7109: skip files registered via router_registry tuples;
+                # they're wired at runtime via dotted-path lookup which the
+                # import-grep below cannot detect.
+                module_path = derive_module_path(f)
+                if module_path and module_path in registry_modules:
                     continue
                 refs = extract_tracker_refs(f)
                 if not refs:

--- a/pipeline-scripts/test_audit_unwired_trackers.py
+++ b/pipeline-scripts/test_audit_unwired_trackers.py
@@ -16,6 +16,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -86,9 +87,17 @@ def test_extract_tracker_refs_unreadable_file(tmp_path: Path) -> None:
         (Path("autobot-backend/foo.test.ts"), True),
         (Path("autobot-backend/tests/test_foo.py"), True),
         (Path("autobot-frontend/src/__tests__/Foo.spec.ts"), True),
+        # #7128: pytest test_*.py PREFIX style — these are pytest modules in
+        # production directories, not unwired production code. Previously
+        # leaked into the audit's findings (7 of 252 in the 2026-05-06 run).
+        (Path("autobot-backend/agent_loop/test_loop_repetition.py"), True),
+        (Path("autobot-backend/knowledge/test_rag_benchmarks.py"), True),
+        (Path("autobot-backend/knowledge/backends/test_async_base.py"), True),
         (Path("autobot-backend/foo.py"), False),
         # Edge: 'test' in a non-test segment shouldn't match
         (Path("autobot-backend/contestant.py"), False),
+        # Edge: 'testfile.py' without underscore shouldn't match
+        (Path("autobot-backend/testfile.py"), False),
     ],
 )
 def test_is_test_path(path: Path, is_test: bool) -> None:
@@ -262,3 +271,108 @@ def test_render_json_round_trips() -> None:
     ]
     parsed = json.loads(audit.render_json(findings))
     assert parsed == [{"file": "x.py", "tracker": 1, "tracker_state": "CLOSED", "production_callers": 0}]
+
+
+# ---------------------------------------------------------------------------
+# derive_module_path / load_router_registry_modules — #7109 registry detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rel,expected",
+    [
+        ("autobot-backend/api/captcha.py", "api.captcha"),
+        ("autobot-backend/intelligence/streaming_executor.py", "intelligence.streaming_executor"),
+        ("autobot-frontend/src/composables/useApi.ts", None),  # not .py
+        ("README.md", None),  # not .py and no scan-dir layout
+        ("autobot-backend/conftest.py", "conftest"),  # ends up empty inner
+    ],
+)
+def test_derive_module_path(rel: str, expected: Optional[str]) -> None:
+    p = audit.REPO_ROOT / rel
+    assert audit.derive_module_path(p) == expected
+
+
+def test_load_router_registry_modules_extracts_dotted_paths(tmp_path: Path) -> None:
+    """Parses ('module.path', ...) tuples from any router_registry/*.py."""
+    fake_registry = tmp_path / "router_registry"
+    fake_registry.mkdir()
+    (fake_registry / "feature_routers.py").write_text(
+        '''FEATURE_ROUTERS = [
+    ("api.captcha", "", ["captcha"], "captcha"),
+    ("api.vision", "/vision", ["vision"], "vision"),
+]
+''',
+        encoding="utf-8",
+    )
+    (fake_registry / "core_routers.py").write_text(
+        '''CORE_ROUTERS = [
+    ("api.health", "/health", ["health"], "health"),
+]
+''',
+        encoding="utf-8",
+    )
+    (fake_registry / "__init__.py").write_text("# excluded by name", encoding="utf-8")
+
+    with patch.object(audit, "ROUTER_REGISTRY_DIR", fake_registry):
+        modules = audit.load_router_registry_modules()
+    assert modules == {"api.captcha", "api.vision", "api.health"}
+
+
+def test_load_router_registry_modules_missing_dir() -> None:
+    """No registry dir → empty set, no crash."""
+    with patch.object(audit, "ROUTER_REGISTRY_DIR", Path("/nonexistent/path")):
+        assert audit.load_router_registry_modules() == set()
+
+
+def test_scan_skips_router_registry_modules(tmp_path: Path) -> None:
+    """End-to-end: a file registered in router_registry must not be flagged.
+
+    Reproduces the #7109 false-positive: api/captcha.py looks unwired to
+    the import-grep heuristic but is actually a live router.
+    """
+    fake_root = tmp_path
+    backend = fake_root / "autobot-backend"
+    api = backend / "api"
+    api.mkdir(parents=True)
+    (api / "captcha.py").write_text('"""Issue #206 — captcha API."""\n', encoding="utf-8")
+
+    registry_dir = backend / "initialization" / "router_registry"
+    registry_dir.mkdir(parents=True)
+    (registry_dir / "feature_routers.py").write_text(
+        'X = [("api.captcha", "", ["captcha"], "captcha")]\n',
+        encoding="utf-8",
+    )
+
+    with patch.object(audit, "REPO_ROOT", fake_root), \
+         patch.object(audit, "ROUTER_REGISTRY_DIR", registry_dir), \
+         patch.object(audit, "fetch_closed_tracker_set", return_value={206}), \
+         patch.object(audit, "grep_count_production_callers", return_value=0):
+        findings = audit.scan()
+
+    assert findings == [], f"api/captcha.py should be filtered as registry-wired, got {findings}"
+
+
+def test_scan_still_flags_truly_orphaned_module(tmp_path: Path) -> None:
+    """Sanity check: real orphans (not in registry, 0 callers) still get flagged."""
+    fake_root = tmp_path
+    backend = fake_root / "autobot-backend"
+    orphan_dir = backend / "orchestration"
+    orphan_dir.mkdir(parents=True)
+    (orphan_dir / "ghost_module.py").write_text(
+        '"""Issue #4242 — never wired anywhere."""\n',
+        encoding="utf-8",
+    )
+    registry_dir = backend / "initialization" / "router_registry"
+    registry_dir.mkdir(parents=True)
+    (registry_dir / "feature_routers.py").write_text("X = []\n", encoding="utf-8")
+
+    with patch.object(audit, "REPO_ROOT", fake_root), \
+         patch.object(audit, "ROUTER_REGISTRY_DIR", registry_dir), \
+         patch.object(audit, "fetch_closed_tracker_set", return_value={4242}), \
+         patch.object(audit, "grep_count_production_callers", return_value=0):
+        findings = audit.scan()
+
+    assert len(findings) == 1
+    assert findings[0].tracker == 4242
+    assert findings[0].file.endswith("ghost_module.py")


### PR DESCRIPTION
## Summary

The 2026-05-06 \`audit-unwired-trackers.py\` run on the live codebase produced **252 findings** (filed as evidence on #6872). Two heuristic gaps made them all false positives:

1. **Pytest \`test_*.py\` prefix-style modules** weren't filtered (#7128). The existing \`TEST_PATH_FRAGMENTS\` only matched \`_test.py\` suffix, \`.test.ts\`, \`/tests/\`, \`/__tests__/\`. Files like \`agent_loop/test_loop_repetition.py\` leaked through.
2. **Router-registry-wired modules** were reported as orphan (#7109). Modules registered via \`autobot-backend/initialization/router_registry/*.py\` tuples (e.g. \`("api.captcha", "", [...], "captcha")\`) look caller-less to the import-grep heuristic but are live FastAPI routers.

This PR closes both gaps in one place since they share the same file.

## Changes

- **\`is_test_path()\`** now also returns True when \`path.name.startswith("test_")\` and the file is \`.py\`. We use a basename check (not substring) because pytest's own \`tmp_path\` fixture lives under \`test_<id>/\` directories and would otherwise cause the audit walker to skip its own test setup.
- **\`load_router_registry_modules()\`** parses every \`router_registry/*.py\` for \`("module.path", ...)\` tuples and returns the set of registered dotted paths. Found **144 modules** registered this way in the current codebase.
- **\`derive_module_path()\`** converts a file path like \`autobot-backend/api/captcha.py\` to the dotted name \`api.captcha\`.
- **\`scan()\`** skips files whose derived module path is in the registry set.

## Result

Re-running the audit on Dev_new_gui:

\`\`\`bash
$ python3 pipeline-scripts/audit-unwired-trackers.py
✅ No unwired-tracker findings.
\`\`\`

252 → 0. All prior findings were either pytest test files or registry-wired routers.

## Test plan

- [x] **51/51** audit-script unit tests pass (added 11 new cases):
  - 4 new \`is_test_path\` cases (prefix-style + edge cases)
  - 5 \`derive_module_path\` parametrized cases
  - \`load_router_registry_modules\`: extracts paths + handles missing dir
  - \`scan\`: end-to-end registry-skip + sanity check for true orphans
- [x] Audit dry-run on full codebase: 0 findings (down from 252)
- [x] Spot check: \`api.captcha\` (was flagged FP, now correctly identified as registered) — \`load_router_registry_modules()\` returns set containing \`api.captcha\`

Closes #7128
Closes #7109

🤖 Generated with [Claude Code](https://claude.com/claude-code)