### PR TITLE
fix(orchestration): CHECKPOINT_TTL = 30 days + add refresh_ttl() (#7010 cluster 2)

### DIFF
--- a/autobot-backend/orchestration/error_handler.py
+++ b/autobot-backend/orchestration/error_handler.py
@@ -32,7 +32,7 @@ from typing import Any, Dict, Optional
 
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.time_utils import now_utc
-from constants.ttl_constants import TTL_7_DAYS
+from constants.ttl_constants import TTL_30_DAYS
 from retry_mechanism import BackoffStrategy, RetryConfig, RetryMechanism
 
 logger = logging.getLogger(__name__)
@@ -42,7 +42,12 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 CHECKPOINT_KEY_PREFIX = "autobot:workflow:checkpoint:"
-CHECKPOINT_TTL = TTL_7_DAYS
+# #3231 / #7010 cluster 2: paused workflows awaiting human approval must
+# survive ≥30 days. Aligns with autobot_shared/ssot_config.py's
+# `checkpoint_ttl_minutes` default of 43200 (30 days) for LangGraph
+# checkpoint keys. Earlier TTL_7_DAYS was a stale carryover from when this
+# value was used for short-term retry retention only.
+CHECKPOINT_TTL = TTL_30_DAYS
 
 
 # ---------------------------------------------------------------------------
@@ -218,6 +223,28 @@ class WorkflowCheckpointManager:
                 "Failed to save checkpoint for workflow=%s step=%s: %s",
                 workflow_id,
                 checkpoint.step_id,
+                exc,
+            )
+
+    def refresh_ttl(self, workflow_id: str) -> None:
+        """Refresh the TTL on a workflow's checkpoint hash key.
+
+        Per #3231: an active session that resumes work on a paused workflow
+        must reset the 30-day window so the checkpoint survives further idle
+        time. Callers invoke this on every read/resume of a checkpoint.
+
+        Redis errors are logged at warning level but never raised — a TTL
+        refresh failure must not break the calling resume flow. Worst case
+        the key expires earlier than intended; the next save() resets it.
+        """
+        redis = self._get_redis()
+        key = self._checkpoint_key(workflow_id)
+        try:
+            redis.expire(key, CHECKPOINT_TTL)
+        except Exception as exc:
+            logger.warning(
+                "Failed to refresh checkpoint TTL for workflow=%s: %s",
+                workflow_id,
                 exc,
             )
 


### PR DESCRIPTION
## Summary

Fixes 3 of the 15 pre-existing test failures in [#7010](https://github.com/mrveiss/AutoBot-AI/issues/7010) — specifically **cluster 2** (Workflow Checkpoint TTL).

## Two related fixes

### 1. CHECKPOINT_TTL: TTL_7_DAYS → TTL_30_DAYS

Per [#3231](https://github.com/mrveiss/AutoBot-AI/issues/3231), paused workflows awaiting human approval must survive at least 30 days. The 7-day setting was a stale carryover from when this constant was used for short-term retry retention.

Aligns with [autobot_shared/ssot_config.py:checkpoint_ttl_minutes](autobot_shared/ssot_config.py) default of \`43200\` (30 days) for LangGraph checkpoint keys.

### 2. Added \`WorkflowCheckpointManager.refresh_ttl(workflow_id)\`

The 2 cluster-2 tests \`test_refresh_ttl_resets_expiry\` and \`test_refresh_ttl_redis_error_does_not_raise\` referenced this method but it didn't exist on \`WorkflowCheckpointManager\`. Added per #3231 design intent: "active sessions that resume work on a paused workflow must reset the 30-day window so the checkpoint survives further idle time."

Behavior:
- Calls \`redis.expire(key, CHECKPOINT_TTL)\` on the checkpoint hash key
- Redis errors logged at warning level — **never raised** (a TTL refresh failure must not break the calling resume flow)

## Verification

\`\`\`bash
$ pytest autobot-backend/orchestration/error_handler_test.py
28 passed in 0.46s

# Specifically the cluster-2 trio:
$ pytest autobot-backend/orchestration/error_handler_test.py::TestWorkflowCheckpointManager -v
...
::test_checkpoint_ttl_is_30_days PASSED                # was failing
::test_save_sets_ttl PASSED
::test_refresh_ttl_resets_expiry PASSED                # was failing
::test_refresh_ttl_redis_error_does_not_raise PASSED   # was failing
============================== 11 passed in 0.52s ==============================
\`\`\`

(Was 8/11 passing on \`Dev_new_gui\` HEAD, now 11/11.)

## Wire-in note

\`refresh_ttl()\` is currently called only by the test. Production callers in the resume flow (chat_workflow, workflow_executor on resume from paused) are the next step. Tracked separately if not already under #3231.

## Closes

- #7010 cluster 2 (3 of 15 failures)
- #3231 partial — design intent (30-day TTL + refresh hook) now matches code

🤖 Generated with [Claude Code](https://claude.com/claude-code)