### PR TITLE
ci(security): add 2 missed Dockerfiles + semver-major ignore rules to docker Dependabot (#7157 self-review)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,6 +82,10 @@ updates:
 
   # Docker base images (Issue #7157 — supply-chain hardening, sister of #7091/#7120)
   # Dependabot auto-PRs digest updates when new versions publish.
+  #
+  # Major version bumps are explicitly ignored — `python:3.12` should NOT auto-PR
+  # to `python:3.13` until autobot_shared/pyproject.toml's `requires-python` is
+  # bumped first. Same logic for node-major and ubuntu-major.
   - package-ecosystem: "docker"
     directory: "/docker/backend"
     target-branch: "Dev_new_gui"
@@ -93,6 +97,9 @@ updates:
       - "dependencies"
       - "devops"
       - "security"
+    ignore:
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "docker"
     directory: "/docker/slm"
@@ -105,6 +112,9 @@ updates:
       - "dependencies"
       - "devops"
       - "security"
+    ignore:
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "docker"
     directory: "/docker/frontend"
@@ -117,3 +127,39 @@ updates:
       - "dependencies"
       - "devops"
       - "security"
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "ubuntu"
+        update-types: ["version-update:semver-major"]
+
+  # Self-review during #7157 implementation surfaced 2 missed Dockerfiles:
+  - package-ecosystem: "docker"
+    directory: "/autobot-backend/services/autoresearch"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "devops"
+      - "security"
+    ignore:
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "docker"
+    directory: "/autobot-infrastructure/shared/mcp/tools/context7"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "devops"
+      - "security"
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Self-review follow-up to #7163 — caught 2 gaps post-merge.

## Two real improvements

### 1. Missed Dockerfiles outside \`/docker/<service>/\`

\`\`\`
autobot-backend/services/autoresearch/Dockerfile      (FROM python:3.12-slim)
autobot-infrastructure/shared/mcp/tools/context7/Dockerfile  (FROM node:lts-alpine)
\`\`\`

#7163 only covered the 3 main service Dockerfiles. Adding both as their own Dependabot entries.

### 2. \`ignore\` rules for semver-major bumps

Without these, Dependabot could auto-PR \`python:3.12\` → \`python:3.13\` (or \`node:20\` → \`node:22\`), which would silently bypass \`autobot_shared/pyproject.toml\`'s \`requires-python = \">=3.12\"\` floor and break compat for downstream consumers until major-version migration is coordinated.

\`\`\`yaml
ignore:
  - dependency-name: \"python\"
    update-types: [\"version-update:semver-major\"]
\`\`\`

Mirrors the existing \`pip\` ecosystem pattern (numpy / pydantic / sqlalchemy semver-major already ignored).

## Net effect

| Metric | Before #7163 | After #7163 (merged) | After this PR |
|--------|-------------|---------------------|---------------|
| Docker Dependabot entries | 0 | 3 | **5** |
| Semver-major ignore coverage | n/a | none | **all 5 entries** |

## Why follow-up PR

Self-review caught these 2 gaps after #7163 was merged. Captured in \`feedback_review_before_merge_race.md\` — when iterating on a PR, push the amend BEFORE the merge fires, otherwise it lands as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)