### PR TITLE
fix(orchestration): DAG branch pruning preserves diamond join nodes (#7010 cluster 1)

### DIFF
--- a/autobot-backend/orchestration/dag_executor.py
+++ b/autobot-backend/orchestration/dag_executor.py
@@ -178,6 +178,16 @@ class WorkflowDAG:
         """Outgoing edges from *node_id*."""
         return self._successors.get(node_id, [])
 
+    def predecessors(self, node_id: str) -> List[str]:
+        """IDs of nodes with edges into *node_id* (#7010 cluster 1).
+
+        Public read-only accessor for the predecessor map; needed by branch
+        pruning to detect diamond joins where one branch is taken and the
+        other is pruned — the join node itself must remain executable from
+        the live branch.
+        """
+        return list(self._predecessors.get(node_id, []))
+
     def has_condition_nodes(self) -> bool:
         """True when at least one node is a CONDITION node."""
         return any(n.node_type == NodeType.CONDITION for n in self._nodes.values())
@@ -546,12 +556,28 @@ class DAGExecutor:
         dag: WorkflowDAG,
         ctx: DAGExecutionContext,
     ) -> None:
-        """BFS-mark all descendants of *node_ids* as skipped."""
+        """BFS-mark descendants as skipped, respecting diamond joins (#7010 cluster 1).
+
+        The initial *node_ids* (immediate not-taken-branch targets) are
+        always marked. Their descendants are marked **only if all their
+        predecessors are also skipped** — otherwise the descendant is a
+        join node where another live path will reach it (e.g. the diamond
+        ``cond → (true|false) → end``: ``end`` must execute via
+        ``true_branch`` even when ``false_branch`` is pruned).
+        """
+        initial = set(node_ids)
         queue = list(node_ids)
         while queue:
             nid = queue.pop(0)
             if nid in ctx.skipped_nodes:
                 continue
+            if nid not in initial:
+                # Join check: skip the descendant only if every incoming edge
+                # comes from a node that's also skipped. A live predecessor
+                # means the descendant will be reached via that path.
+                preds = dag.predecessors(nid)
+                if not all(p in ctx.skipped_nodes for p in preds):
+                    continue
             ctx.skipped_nodes.add(nid)
             for edge in dag.successors(nid):
                 queue.append(edge.target)


### PR DESCRIPTION
## Summary

Fixes 1 of the 15 pre-existing test failures in [#7010](https://github.com/mrveiss/AutoBot-AI/issues/7010) — **cluster 1** (DAG branching).

## The bug

\`_mark_descendants_skipped()\` was BFS-marking ALL descendants of the not-taken branch as skipped — including join nodes that other live branches still reach. For the canonical diamond pattern:

\`\`\`
start → cond → (true_branch | false_branch) → end
\`\`\`

When \`cond\` evaluates True, \`false_branch\` should be pruned. The old code marked \`end\` as skipped too (because it's a descendant of \`false_branch\`), then when \`true_branch\` finished and the executor tried to visit \`end\`, \`_visit_single\` saw it in \`skipped_nodes\` and bypassed it.

## The fix

Add a predecessor check: a descendant is skipped **only if every predecessor is also skipped**. The initial nodes (immediate not-taken-branch targets) are still unconditionally skipped, but BFS-discovered descendants must clear the predecessor check first.

\`\`\`python
# Before
def _mark_descendants_skipped(self, node_ids, dag, ctx):
    queue = list(node_ids)
    while queue:
        nid = queue.pop(0)
        if nid in ctx.skipped_nodes:
            continue
        ctx.skipped_nodes.add(nid)        # BFS-skips everything
        for edge in dag.successors(nid):
            queue.append(edge.target)

# After
def _mark_descendants_skipped(self, node_ids, dag, ctx):
    initial = set(node_ids)
    queue = list(node_ids)
    while queue:
        nid = queue.pop(0)
        if nid in ctx.skipped_nodes:
            continue
        if nid not in initial:
            # Join check: skip only if all preds are skipped
            preds = dag.predecessors(nid)
            if not all(p in ctx.skipped_nodes for p in preds):
                continue
        ctx.skipped_nodes.add(nid)
        for edge in dag.successors(nid):
            queue.append(edge.target)
\`\`\`

Trace for the diamond after fix:

\`\`\`
initial = {false_branch}
BFS:
  pop false_branch (in initial) → skip; queue [end]
  pop end → not in initial; preds={true_branch, false_branch};
            true_branch NOT skipped → don't skip end
\`\`\`

## Also added

\`WorkflowDAG.predecessors(node_id)\` public accessor — previously only \`_predecessors\` private dict existed. Needed by the join check.

## Verification

\`\`\`bash
$ pytest autobot-backend/orchestration/dag_executor_test.py
32 passed in 1.17s

# Specifically cluster 1:
$ pytest autobot-backend/orchestration/dag_executor_test.py::TestDAGExecutorBranching -v
::test_true_branch_taken PASSED      # was failing on Dev_new_gui
::test_false_branch_taken PASSED
::test_skipped_nodes_recorded PASSED
::test_condition_result_in_step_results PASSED
============================== 4 passed in 0.60s ===============================
\`\`\`

## Closes

- #7010 cluster 1 (1 of 15 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)