### PR TITLE
ci(security): add npm ecosystem for context7 MCP tool (#7170 self-review)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -163,3 +163,17 @@ updates:
     ignore:
       - dependency-name: "node"
         update-types: ["version-update:semver-major"]
+
+  # context7 MCP tool has its own npm deps — Dockerfile FROM is tracked above
+  # but the package.json runtime deps need their own ecosystem.
+  # (#7170 self-review found this — surfaced after #7163 + #7170 merged)
+  - package-ecosystem: "npm"
+    directory: "/autobot-infrastructure/shared/mcp/tools/context7"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "devops"


### PR DESCRIPTION
Self-review of PR #7170 — caught a gap post-merge.

## What's missing

After #7170 added Docker Dependabot tracking for \`/autobot-infrastructure/shared/mcp/tools/context7/Dockerfile\`, I checked whether that dir has OTHER ecosystem files needing coverage:

\`\`\`bash
$ ls autobot-infrastructure/shared/mcp/tools/context7/{requirements*.txt,package*.json,pyproject.toml}
autobot-infrastructure/shared/mcp/tools/context7/package.json
\`\`\`

A \`package.json\` exists with runtime deps (\`@upstash/context7-mcp\`, typescript, eslint, etc.) that go unmanaged without a corresponding npm Dependabot entry.

## Fix

Adds 12th Dependabot ecosystem:

\`\`\`yaml
- package-ecosystem: "npm"
  directory: "/autobot-infrastructure/shared/mcp/tools/context7"
\`\`\`

Final breakdown: pip × 3, npm × 3 (+1 for context7), github-actions × 1, docker × 5.

## Why follow-up PR

Should have been part of #7170 if I'd done the directory audit before pushing. Captured for the n-th time in \`feedback_review_before_merge_race.md\` — exhaustive directory audit BEFORE pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)