### PR TITLE
docs(autobot_shared): document local pytest invocation pattern (closes #7175)

### DIFF
--- a/autobot_shared/README.md
+++ b/autobot_shared/README.md
@@ -26,3 +26,34 @@ from autobot_shared.ssot_config import config
 | `logging_manager.py` | Centralized logging |
 | `error_boundaries.py` | Error handling |
 | `ssot_config.py` | SSOT configuration |
+
+## Local Testing
+
+`autobot_shared` uses the canonical pytest layout but the `from autobot_shared.X import Y`
+imports inside test files require `autobot_shared` to be importable as a package — which
+needs the **repo root** on `sys.path`.
+
+### Recommended (matches CI):
+
+```bash
+# From repo root — autobot_shared resolves as a package via cwd
+cd <repo-root>
+python3 -m pytest autobot_shared/
+```
+
+### Editable install (run from anywhere):
+
+```bash
+pip install -e ./autobot_shared[test]
+pytest autobot_shared/
+```
+
+### Common error and fix:
+
+```
+ImportError: cannot import name 'get_async_redis_client' from 'autobot_shared.redis_client'
+```
+
+This means pytest was invoked from inside `autobot_shared/` — pytest's rootdir doesn't put the
+parent on `sys.path`, so `autobot_shared` is not importable as a package. Re-run from repo
+root, or use the editable install above. (Tracked in #7175.)


### PR DESCRIPTION
Closes #7175. Doc-only fix for the local-dev pytest gap surfaced during #7171 verification.

## What

Adds a \"Local Testing\" section to \`autobot_shared/README.md\`:

\`\`\`bash
# Canonical (matches CI):
cd <repo-root>
python3 -m pytest autobot_shared/

# Or editable install (works from any CWD):
pip install -e ./autobot_shared[test]
pytest autobot_shared/
\`\`\`

Plus the exact ImportError contributors hit when invoking pytest wrong, with the fix.

## Why doc-only (Option A)

Two alternatives considered and rejected:

- **Option B**: \`conftest.py\` that prepends \`..\` to sys.path — adds magic to support a non-canonical invocation
- **Option C**: Force editable install in setup docs — heavier than necessary; the canonical \`cd <repo-root>\` works without setup

Doc-only teaches the canonical pattern that already matches how CI invokes pytest (\`.github/workflows/ci.yml\` runs from repo root with \`--cov=autobot_shared\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)