### PR TITLE
fix(ansible/redis): pin Redis Stack repo to jammy on noble (closes #7178)

### DIFF
--- a/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
@@ -19,9 +19,22 @@
   when: _redis_installed.rc != 0
   tags: ['redis', 'packages']
 
+# #7178: Redis only publishes redis-stack-server for jammy/bullseye/focal.
+# Noble (Ubuntu 24.04) has no redis-stack-server package — repo dist exists
+# but ships only redis-server/redis-sentinel. Pin to jammy when the host
+# distribution release isn't one of the supported suites; jammy packages
+# work fine on noble (same glibc family, statically-linked redis modules).
+- name: "Redis | Determine Redis Stack repo suite (#7178: noble fallback)"
+  ansible.builtin.set_fact:
+    redis_stack_suite: >-
+      {{ ansible_distribution_release
+         if ansible_distribution_release in ['jammy', 'bullseye', 'focal']
+         else 'jammy' }}
+  tags: ['redis', 'packages']
+
 - name: "Redis | Add Redis Stack repository"
   apt_repository:
-    repo: "deb https://packages.redis.io/deb {{ ansible_distribution_release }} main"
+    repo: "deb https://packages.redis.io/deb {{ redis_stack_suite }} main"
     state: present
     filename: redis
   become: yes


### PR DESCRIPTION
## Summary

Closes #7178. Provision Phase 3 fails on every Ubuntu 24.04 host (DGX Spark + any noble VM) with:
\`No package matching 'redis-stack-server' is available\`.

## Cause

Redis publishes \`redis-stack-server\` only for \`jammy\`/\`bullseye\`/\`focal\`. Noble has the apt-dist tree but ships only \`redis-server\` + \`redis-sentinel\`. The role used \`{{ ansible_distribution_release }}\` blindly.

## Fix

Add \`redis_stack_suite\` fact: use host's release if supported, else fall back to \`jammy\`. Jammy packages work on noble (same glibc family, statically-linked redis modules).

## Test plan

- [x] YAML parse
- [ ] Re-run on DGX Spark — Provision Phase 3 \"Install Redis Stack\" succeeds (to verify after merge)
- [x] No regression for jammy hosts — fact resolves to \`jammy\` directly

## Reproduced on

- 192.168.88.96 (DGX Spark, Ubuntu 24.04 noble, ARM64) — 2026-05-07T~14Z
- Same root cause for any x86_64 Ubuntu 24.04 install

🤖 Generated with [Claude Code](https://claude.com/claude-code)