### PR TITLE
fix(orchestration): dry-run report shape + NotificationConfig double-kwarg (#7010 cluster 3 partial)

### DIFF
--- a/autobot-backend/orchestration/workflow_executor.py
+++ b/autobot-backend/orchestration/workflow_executor.py
@@ -217,7 +217,12 @@ class WorkflowExecutor:
         if isinstance(raw, NotificationConfig):
             return raw
         if isinstance(raw, dict):
-            return NotificationConfig(workflow_id=workflow_id, **raw)
+            # #7010 cluster 3: caller-provided dict may itself contain a
+            # `workflow_id` key (e.g., chat_workflow snapshots the config
+            # before passing it down). Drop it before spreading so we don't
+            # raise "got multiple values for keyword argument 'workflow_id'".
+            kwargs = {k: v for k, v in raw.items() if k != "workflow_id"}
+            return NotificationConfig(workflow_id=workflow_id, **kwargs)
         return None
 
     async def _send_workflow_notification(
@@ -652,13 +657,17 @@ class WorkflowExecutor:
             Execution context with results.
         """
         # Issue #2148: dry-run returns a validation report without executing.
+        # #7010 cluster 3: tests expect report fields (valid / issues /
+        # warnings / execution_plan) at the top level alongside workflow_id
+        # and mode — flatten the report dict so result["valid"] etc. work.
         if mode == ExecutionMode.DRY_RUN:
             validator = DryRunValidator()
             report = validator.validate(workflow_id, steps, edges)
             return {
                 "status": "dry_run_complete",
                 "mode": "dry_run",
-                "dry_run_report": report.to_dict(),
+                "workflow_id": workflow_id,
+                **report.to_dict(),
             }
 
         effective_edges = edges or []


### PR DESCRIPTION
## Summary

Fixes 3 of the 6 cluster-3 failures in [#7010](https://github.com/mrveiss/AutoBot-AI/issues/7010). Three remaining failures filed as follow-up — each requires its own investigation.

## What's fixed

### 1. Dry-run result dict flattened (2 tests)

\`\`\`python
# Before — nested under "dry_run_report"
return {
    "status": "dry_run_complete",
    "mode": "dry_run",
    "dry_run_report": report.to_dict(),
}

# After — flattened, with workflow_id
return {
    "status": "dry_run_complete",
    "mode": "dry_run",
    "workflow_id": workflow_id,
    **report.to_dict(),  # adds valid / issues / warnings / execution_plan
}
\`\`\`

Fixes \`test_dry_run_returns_report_dict\` (KeyError 'workflow_id') and \`test_dry_run_detects_broken_dependency\` (asserts \`result["valid"]\` and \`result["issues"]\`).

### 2. NotificationConfig double-kwarg (1 test)

\`_resolve_notification_config()\` built \`NotificationConfig(workflow_id=workflow_id, **raw)\`. When the caller's \`raw\` dict already contained a \`workflow_id\` (e.g., the test's \`cfg = {"workflow_id": "wf_nc", ...}\`), Python raised \`TypeError: got multiple values for keyword argument 'workflow_id'\`.

\`\`\`python
# Filter workflow_id out of raw before spreading
kwargs = {k: v for k, v in raw.items() if k != "workflow_id"}
return NotificationConfig(workflow_id=workflow_id, **kwargs)
\`\`\`

Fixes \`test_notification_config_injected_into_execution_context\`.

## Verification

\`\`\`bash
$ pytest autobot-backend/orchestration/execution_modes_test.py::TestWorkflowExecutorDryRun \
         autobot-backend/orchestration/execution_modes_test.py::TestWorkflowExecutorDebugMode --no-header
6 passed, 3 failed in 2.11s
\`\`\`

(Was 3 passed, 6 failed on Dev_new_gui.)

## Remaining 3 failures (separate follow-up)

| Test | Error | Likely fix |
|---|---|---|
| \`test_debug_mode_skip_marks_step_skipped\` | KeyError 'skipped' in step result dict | Debug-mode step result must include \`skipped: bool\` key |
| \`test_debug_mode_without_controller_falls_back_to_normal\` | assert False | Debug mode without controller should fall back to NORMAL — branching logic bug |
| \`test_dag_path_fires_send_workflow_notification\` | KeyError 'source' in dag_executor.py:153 | DAG executor receives edges in non-dict form |

Each is a distinct bug needing investigation. Will file as follow-up sub-issues if not already tracked.

## Closes

Partial — #7010 cluster 3 (3 of 6 failures resolved here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)