### PR TITLE
ci(security): expand Dependabot to cover production worker dirs + root manifests (closes #7182 P1+P2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -177,3 +177,89 @@ updates:
     labels:
       - "dependencies"
       - "devops"
+
+  # === #7182 P1: Production worker dirs ===
+  # Comprehensive audit of all manifest files vs Dependabot coverage caught
+  # 8+ uncovered dirs. Workers below all deploy via autobot-infrastructure
+  # (per autobot-infrastructure/README.md): browser→.25, npu→.22, ai-stack→.24.
+  - package-ecosystem: "pip"
+    directory: "/autobot-browser-worker"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "backend"
+
+  - package-ecosystem: "npm"
+    directory: "/autobot-browser-worker"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  - package-ecosystem: "pip"
+    directory: "/autobot-npu-worker"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "backend"
+
+  - package-ecosystem: "pip"
+    directory: "/autobot-tts-worker"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "backend"
+
+  - package-ecosystem: "pip"
+    directory: "/autobot-infrastructure/shared/docker/ai-stack"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "backend"
+
+  - package-ecosystem: "pip"
+    directory: "/autobot-infrastructure/autobot-npu-worker/docker"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "backend"
+
+  # === #7182 P2: Root-level manifests ===
+  # Catches root-level requirements*.txt (requirements.txt, requirements-ci.txt,
+  # requirements-dev.txt) AND root pyproject.toml — used by ci.yml + security.yml.
+  # Risk of stale CI tooling without this entry.
+  - package-ecosystem: "pip"
+    directory: "/"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+      - "devops"


### PR DESCRIPTION
Closes #7182 P1+P2. Comprehensive coverage of all production manifest dirs.

## What changed

Total Dependabot ecosystems: **12 → 19** (+7 entries).

### P1 — production worker dirs

| Entry | Reason |
|-------|--------|
| \`pip /autobot-browser-worker\` | Deploys to .25 |
| \`npm /autobot-browser-worker\` | Separate package.json |
| \`pip /autobot-npu-worker\` | Deploys to .22 |
| \`pip /autobot-tts-worker\` | Deployment uncertain — added defensively (if dead, generates 0 PRs) |
| \`pip /autobot-infrastructure/shared/docker/ai-stack\` | AI Stack VM, deploys to .24 |
| \`pip /autobot-infrastructure/autobot-npu-worker/docker\` | NPU Docker variant |

### P2 — root-level manifests

| Entry | Coverage |
|-------|----------|
| \`pip /\` | Root \`requirements.txt\`, \`requirements-ci.txt\`, \`requirements-dev.txt\`, root \`pyproject.toml\` — used by ci.yml + security.yml |

## Deferred to follow-up (#7182 stays open for P3-P5)

- **4 MCP tools** (mcp-structured-thinking, mcp-autobot-tracker, mcp-task-manager-server, knowledge-base-mcp) — needs active-MCP-config audit to determine which are in production
- **vscode-autobot IDE extension** — dev-only, doesn't ship to production
- **Windows NPU worker** (\`autobot-npu-worker/resources/windows-npu-worker/\`) — Windows-only deps, needs Linux-runner-resolvability check

## Verification

\`\`\`bash
$ python3 -c "import yaml; print(len(yaml.safe_load(open('.github/dependabot.yml'))['updates']))"
19
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)