### PR TITLE
ci(hooks): extract lib/_common.sh — DRY proof-of-concept (#7185)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ venvs/
 bin/
 lib/
 !scripts/lib/
+!autobot-infrastructure/shared/scripts/hooks/lib/
 lib64/
 include/
 share/

--- a/autobot-infrastructure/shared/scripts/hooks/lib/_common.sh
+++ b/autobot-infrastructure/shared/scripts/hooks/lib/_common.sh
@@ -1,0 +1,51 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Common shell library for pre-commit hooks (Issue #7185).
+#
+# Sourced via:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/lib/_common.sh"
+#
+# Provides:
+# - ANSI color codes (RED, YELLOW, GREEN, CYAN, BOLD, NC)
+# - get_staged_files <pattern> [argv...]: returns staged files matching regex,
+#   with positional-args override per #6785 generic-wrapper convention.
+
+# Exit early if already sourced (idempotent — multiple hooks in pre-commit may share env)
+if [ -n "${_AUTOBOT_HOOK_COMMON_LOADED:-}" ]; then
+    return 0
+fi
+_AUTOBOT_HOOK_COMMON_LOADED=1
+
+# ANSI color codes (matching existing hooks pattern).
+# Use printf '%b' to interpret these — `echo` won't.
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# Get staged files matching a regex pattern, with argv override.
+#
+# Issue #6785: positional args override the staged-files lookup so that the
+# same hook script can be invoked by:
+#   - pre-commit (no args, reads `git diff --cached`)
+#   - CI wrappers (passes file list explicitly via argv)
+#
+# Usage:
+#   get_staged_files '\.py$' "$@"
+#   get_staged_files '^\.github/(workflows|actions)/.*\.ya?ml$' "$@"
+get_staged_files() {
+    local pattern="$1"
+    shift
+    if [ "$#" -gt 0 ]; then
+        printf '%s\n' "$@"
+        return
+    fi
+    git diff --cached --name-only --diff-filter=ACMRT \
+        | grep -E "$pattern" \
+        || true
+}

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tag-pinned-action
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tag-pinned-action
@@ -28,26 +28,12 @@
 
 set -uo pipefail
 
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-GREEN='\033[0;32m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
+# Source shared library (#7185 — colors + get_staged_files)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/_common.sh
+source "$SCRIPT_DIR/lib/_common.sh"
 
 VIOLATIONS=0
-
-# Get staged workflow files. Issue #6785: positional args override the
-# staged lookup (CI argv mode).
-get_staged_workflow_files() {
-    if [ "$#" -gt 0 ]; then
-        printf '%s\n' "$@"
-        return
-    fi
-    git diff --cached --name-only --diff-filter=ACMRT \
-        | grep -E '^\.github/(workflows|actions)/.*\.ya?ml$' \
-        || true
-}
 
 check_file() {
     local file="$1"
@@ -92,7 +78,7 @@ check_file() {
 
 main() {
     local files
-    files="$(get_staged_workflow_files "$@")"
+    files="$(get_staged_files '^\.github/(workflows|actions)/.*\.ya?ml$' "$@")"
     [ -z "$files" ] && exit 0
 
     while IFS= read -r f; do


### PR DESCRIPTION
PoC for #7185. Extracts shared library + converts one hook as proof; remaining 12 hooks deferred to followup batches.

## Why PoC instead of all 13

Each hook conversion is mechanical (replace color block + replace per-hook get_staged_*_files with the new \`get_staged_files <pattern>\`). But verifying 13 hooks × their tests in one PR is high blast radius if anything subtle goes wrong with bash sourcing under pre-commit framework. PoC validates the approach end-to-end on the most-recently-authored hook (\`no-tag-pinned-action\`); 12 followup conversions can each be a 1-file PR with tests.

## Files

| File | Change |
|------|--------|
| \`autobot-infrastructure/shared/scripts/hooks/lib/_common.sh\` | NEW — color codes + \`get_staged_files <pattern>\` |
| \`pre-commit-no-tag-pinned-action\` | -19 LOC (replaces inline color + staged-files func with \`source\`) |
| \`.gitignore\` | +1 line — \`!autobot-infrastructure/shared/scripts/hooks/lib/\` exception (root \`lib/\` rule was hiding the new dir) |

## Verification

\`\`\`bash
$ python3 -m pytest autobot-infrastructure/shared/scripts/hooks/pre-commit-no-tag-pinned-action_test.py -v
============== 13 passed in 0.19s ==============
\`\`\`

All existing 13 tests pass after refactor — zero behavior change.

## Discovery (caught during PoC)

\`.gitignore:7\` has \`lib/\` (broad rule from venv setup) which silently masked the new \`hooks/lib/\` directory. \`git status\` showed only the modified hook, not the new file, until I ran \`git check-ignore -v\` to find the rule. Existing \`!scripts/lib/\` exception didn't match because the actual path is \`autobot-infrastructure/shared/scripts/hooks/lib/\`. **Filed as inline observation in this commit.**

## Estimated savings (when followup batches land)

- 13 hooks × ~8 lines color block = 104 LOC eliminated
- 7 hooks × ~6 lines staged-files = 42 LOC eliminated
- Net: ~146 LOC of duplication → 1 sourced file (~50 LOC)

## Sourcing pattern verified

\`source "\$SCRIPT_DIR/lib/_common.sh\"\` works under both:
- \`pre-commit\` invocation (file given to pre-commit framework as \`language: script\`)
- CI argv-mode invocation (per #6785 generic-wrapper convention)

#7185 stays open for the 12-hook followup batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)