### PR TITLE
feat(code-sync): add 'Resync from Source' button to drift report (closes #7149)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -34,6 +34,8 @@ from models.schemas import (
     CodeSyncStatusResponse,
     CodeVersionNotification,
     CodeVersionNotificationResponse,
+    DriftResolveRequest,
+    DriftResolveResponse,
     FileDriftReport,
     FleetSyncJobStatus,
     FleetSyncNodeStatus,
@@ -426,6 +428,74 @@ async def get_file_drift(
     )
 
     return FileDriftReport(**report)
+
+
+@router.post("/drift/resolve", response_model=DriftResolveResponse)
+async def resolve_drift(
+    request: DriftResolveRequest,
+    _: Annotated[dict, Depends(get_current_user)],
+) -> DriftResolveResponse:
+    """
+    Resync a single component from code_source/ to /opt/autobot/<component>/ (#7149).
+
+    Drives the same `_rsync_component_local()` used by SLM self-sync — pulls
+    files from the local code_source checkout and overwrites the deployed copy.
+    Used by the CodeSyncView "Resync from Source" button to clear drift in one
+    click (instead of forcing the user to find the SLM self-node and trigger a
+    full /nodes/{id}/sync).
+
+    Body:
+        component: Sub-directory under /opt/autobot/. Must be in ALLOWED_COMPONENTS.
+
+    Returns DriftResolveResponse with success flag + rsync output snippet.
+    """
+    if request.component not in ALLOWED_COMPONENTS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid component '{request.component}'. Must be one of: {sorted(ALLOWED_COMPONENTS)}",
+        )
+
+    try:
+        source_dir = get_default_source_dir(request.component)
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail="Failed to determine source path") from exc
+    deployed_dir = get_default_deployed_dir(request.component)
+
+    # source_dir = /opt/autobot/code_source/<component>; _rsync_component_local
+    # constructs `{source_path}/{component}/` so pass the parent.
+    source_root = str(Path(source_dir).parent)
+
+    excludes_map = {comp: excl for comp, excl in _SLM_COMPONENTS}
+    excludes = excludes_map.get(
+        request.component,
+        ["__pycache__", "*.pyc", ".git", "node_modules", "dist", "venv", "*.log"],
+    )
+
+    logger.info(
+        "drift resolve: rsync source=%s/%s deployed=%s",
+        source_root,
+        request.component,
+        deployed_dir,
+    )
+
+    ok, msg = await _rsync_component_local(source_root, request.component, excludes)
+
+    if not ok:
+        return DriftResolveResponse(
+            success=False,
+            component=request.component,
+            message=msg or "rsync failed",
+            source_dir=source_dir,
+            deployed_dir=deployed_dir,
+        )
+
+    return DriftResolveResponse(
+        success=True,
+        component=request.component,
+        message=f"Resynced {request.component} from code_source",
+        source_dir=source_dir,
+        deployed_dir=deployed_dir,
+    )
 
 
 @router.post("/refresh", response_model=CodeSyncRefreshResponse)

--- a/autobot-slm-backend/models/schemas.py
+++ b/autobot-slm-backend/models/schemas.py
@@ -1538,6 +1538,22 @@ class FileDriftReport(BaseModel):
     checked_at: str
 
 
+class DriftResolveRequest(BaseModel):
+    """Resync a component from code_source to /opt/autobot/<component>/ (#7149)."""
+
+    component: str
+
+
+class DriftResolveResponse(BaseModel):
+    """Result of a local rsync to resolve drift for a component (#7149)."""
+
+    success: bool
+    component: str
+    message: str
+    source_dir: str
+    deployed_dir: str
+
+
 class PendingNodeResponse(BaseModel):
     """Node that needs code update."""
 

--- a/autobot-slm-frontend/src/composables/useCodeSync.ts
+++ b/autobot-slm-frontend/src/composables/useCodeSync.ts
@@ -164,6 +164,15 @@ export interface FileDriftReport {
   checked_at: string
 }
 
+// Issue #7149: Drift resolution types
+export interface DriftResolveResponse {
+  success: boolean
+  component: string
+  message: string
+  source_dir: string
+  deployed_dir: string
+}
+
 // Re-export role types for consumers (Issue #779)
 export type { Role, SyncResult }
 
@@ -649,6 +658,38 @@ export function useCodeSync() {
     }
   }
 
+  /**
+   * Resync a component from code_source/ to /opt/autobot/<component>/ (#7149).
+   *
+   * Drives the same local rsync used by SLM self-sync. Used by CodeSyncView's
+   * "Resync from Source" button on the drift card so users can clear drift in
+   * one click instead of finding the SLM self-node and triggering a full sync.
+   *
+   * @param component - Sub-directory under /opt/autobot/. Must be in ALLOWED_COMPONENTS.
+   */
+  async function resolveDrift(component: string): Promise<DriftResolveResponse | null> {
+    loading.value = true
+    error.value = null
+
+    try {
+      const response = await client.post<DriftResolveResponse>('/code-sync/drift/resolve', {
+        component,
+      })
+      if (!response.data.success) {
+        error.value = response.data.message
+      }
+      return response.data
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to resolve drift'
+      if (axios.isAxiosError(e) && e.response?.data?.detail) {
+        error.value = e.response.data.detail
+      }
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
   // =============================================================================
   // Return Public API
   // =============================================================================
@@ -700,7 +741,8 @@ export function useCodeSync() {
     syncRole: rolesComposable.syncRole,
     pullFromSource: rolesComposable.pullFromSource,
 
-    // Drift detection (Issue #2834)
+    // Drift detection (Issue #2834) + resolution (#7149)
     fetchDrift,
+    resolveDrift,
   }
 }

--- a/autobot-slm-frontend/src/views/CodeSyncView.vue
+++ b/autobot-slm-frontend/src/views/CodeSyncView.vue
@@ -65,6 +65,7 @@ const showCodeSourceModal = ref(false)
 // Drift detection state (Issue #2834)
 const driftReport = ref<FileDriftReport | null>(null)
 const isDriftLoading = ref(false)
+const isResolvingDrift = ref(false) // #7149: separate from drift-check spinner
 const showDriftDetails = ref(false)
 const selectedDriftComponent = ref('autobot-slm-backend')
 
@@ -377,6 +378,23 @@ async function handleCheckDrift(): Promise<void> {
   }
 }
 
+// #7149: Resync the selected component from code_source/, then re-check drift.
+async function handleResolveDrift(): Promise<void> {
+  if (!driftReport.value?.drift_detected) return
+  isResolvingDrift.value = true
+  try {
+    const result = await codeSync.resolveDrift(selectedDriftComponent.value)
+    if (result?.success) {
+      successMessage.value = `Resynced ${result.component} from code_source`
+      // Re-run drift check to confirm resolution
+      await handleCheckDrift()
+    }
+    // Errors are surfaced via codeSync.error already
+  } finally {
+    isResolvingDrift.value = false
+  }
+}
+
 // =============================================================================
 // Lifecycle
 // =============================================================================
@@ -670,14 +688,36 @@ onUnmounted(() => {
           Deployed: <code class="font-mono">{{ driftReport.deployed_dir }}</code>
         </div>
 
-        <!-- Toggle details button -->
-        <button
-          v-if="driftReport.drift_detected"
-          @click="showDriftDetails = !showDriftDetails"
-          class="text-sm text-primary-600 hover:text-primary-800 font-medium mb-3"
-        >
-          {{ showDriftDetails ? 'Hide details' : 'Show details' }}
-        </button>
+        <!-- Action row: Resync (#7149) + Toggle details -->
+        <div v-if="driftReport.drift_detected" class="flex items-center gap-3 mb-3">
+          <button
+            @click="handleResolveDrift"
+            :disabled="isResolvingDrift || isDriftLoading"
+            class="btn btn-primary flex items-center gap-2 text-sm"
+            :title="`Run rsync from ${driftReport.source_dir} to ${driftReport.deployed_dir}`"
+          >
+            <svg
+              :class="['w-4 h-4', isResolvingDrift ? 'animate-spin' : '']"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
+            </svg>
+            {{ isResolvingDrift ? 'Resyncing...' : 'Resync from Source' }}
+          </button>
+          <button
+            @click="showDriftDetails = !showDriftDetails"
+            class="text-sm text-primary-600 hover:text-primary-800 font-medium"
+          >
+            {{ showDriftDetails ? 'Hide details' : 'Show details' }}
+          </button>
+        </div>
 
         <!-- Drifted files table -->
         <div v-if="showDriftDetails && driftReport.drifted_files.length > 0" class="overflow-x-auto">


### PR DESCRIPTION
## Summary

Closes #7149. Drift detection identified stale deployed files but had no in-UI way to resolve them — users had to find the SLM self-node in Pending Nodes and trigger a full \`/nodes/{id}/sync\`.

## Changes

**Backend** (\`autobot-slm-backend/api/code_sync.py\`):
- New \`POST /api/code-sync/drift/resolve\` endpoint takes \`{component}\`, runs \`_rsync_component_local()\` (same function used by SLM self-sync), validates against \`ALLOWED_COMPONENTS\`
- New schemas: \`DriftResolveRequest\`, \`DriftResolveResponse\` in \`models/schemas.py\`

**Frontend** (\`autobot-slm-frontend/src/views/CodeSyncView.vue\` + composable):
- \"Resync from Source\" button on drift card, only visible when \`drift_detected\`
- Click → \`resolveDrift(component)\` → on success, auto re-runs drift check so user sees cleared count
- New composable method: \`codeSync.resolveDrift(component)\`
- New TS interface: \`DriftResolveResponse\`

## Test plan

- [x] \`bash -n\` + \`py_compile\` clean
- [x] \`vue-tsc --noEmit\` reports only pre-existing baseUrl deprecation
- [x] Schemas import cleanly
- [ ] End-to-end: SLM UI → Drift section → Check Drift → Resync from Source → drift count drops to 0 (to verify after merge)

## Acceptance criteria
- [x] One-click drift resolution
- [x] Button disabled when no drift
- [x] Loading state during rsync
- [x] No new SSH dependency — local rsync only

🤖 Generated with [Claude Code](https://claude.com/claude-code)