### PR TITLE
fix(orchestration): causal executor — validation gate, summary case, trace wording (#7010 cluster 4)

### DIFF
--- a/autobot-backend/orchestration/causal_executor.py
+++ b/autobot-backend/orchestration/causal_executor.py
@@ -96,7 +96,12 @@ class CausalExecutor:
         self.effect_trace = EffectTrace(workflow_id=workflow_id)
 
         # Pre-execution validation
-        if validate_causal and self.metadata_map:
+        # #7010 cluster 4: validation runs whenever validate_causal=True,
+        # regardless of whether metadata_map is populated. An empty
+        # metadata_map yields a trivially-valid result (no causal
+        # relationships declared = nothing to invalidate); the test
+        # `test_validation_before_execution` documents this contract.
+        if validate_causal:
             validator = CausalValidator()
             self.validation_result = validator.validate_workflow(dag, self.metadata_map)
             logger.info("Causal validation: %s", self.validation_result.summary())
@@ -337,8 +342,11 @@ class CausalExecutor:
 
     def trace_effect_chain(self, state_key: str) -> str:
         """Generate a human-readable trace of how a state key was set."""
+        # #7010 cluster 4: callers (incl. UI) match on the substring
+        # "not available" / "not modified" to detect the no-data case;
+        # phrase both arms with those tokens explicitly.
         if not self.effect_trace:
-            return f"No trace available for key '{state_key}'"
+            return f"Effect trace not available for key '{state_key}' (no execution data)"
 
         chain = self.effect_trace.trace_effect(state_key)
         if not chain:
@@ -355,11 +363,14 @@ class CausalExecutor:
         if not self.effect_trace:
             return "No execution data available"
 
+        # #7010 cluster 4: UI/test consumers grep these labels case-sensitively
+        # for tokens "steps executed" and "mutated" — keep the lowercase
+        # form so substring searches succeed.
         lines = [
             f"Workflow: {self.effect_trace.workflow_id}",
-            f"Steps executed: {len(self.effect_trace.execution_frames)}",
-            f"State keys mutated: {len(self.effect_trace.mutation_map)}",
-            f"Total mutations: {sum(len(m) for m in self.effect_trace.mutation_map.values())}",
+            f"steps executed: {len(self.effect_trace.execution_frames)}",
+            f"state keys mutated: {len(self.effect_trace.mutation_map)}",
+            f"total mutations: {sum(len(m) for m in self.effect_trace.mutation_map.values())}",
         ]
 
         if self.validation_result:


### PR DESCRIPTION
## Summary

Fixes 3 of 3 cluster-4 failures in [#7010](https://github.com/mrveiss/AutoBot-AI/issues/7010). All test/code contract mismatches.

## Three fixes

### 1. \`validate_causal=True\` without metadata still runs validation

\`\`\`python
# Before — short-circuited when metadata_map empty
if validate_causal and self.metadata_map:
    self.validation_result = validator.validate_workflow(dag, self.metadata_map)

# After — drop the metadata gate; empty map = trivially-valid result
if validate_causal:
    self.validation_result = validator.validate_workflow(dag, self.metadata_map)
\`\`\`

\`test_validation_before_execution\` constructs an executor with no metadata, calls \`execute(dag, validate_causal=True)\`, and expects \`validation_result is not None\`. The empty-metadata case is a valid contract — nothing to invalidate.

### 2. \`summary()\` field labels lowercase

Tests assert \`"steps executed" in summary\` (substring, case-sensitive). Code emitted \`"Steps executed: 3"\` — capital S. Fixed by lowercasing the field labels in summary lines.

### 3. \`trace_effect_chain()\` no-data wording

Test asserts \`"not available" in trace.lower() or "not modified" in trace.lower()\`. Code emitted \`"No trace available"\` — \`"not"\` (with the second t) is not in \`"no"\`. Reworded to include \`"not available"\` explicitly.

## Verification

\`\`\`bash
$ pytest autobot-backend/orchestration/test_causal_executor.py
18 passed in 0.47s
\`\`\`

(Was 15 passed, 3 failed on \`Dev_new_gui\`.)

## Closes

- #7010 cluster 4 (3 of 15 failures resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)