### PR TITLE
refactor(infra/shared): re-export mocks from canonical autobot-backend SSOT (#7125)

### DIFF
--- a/autobot-infrastructure/shared/tests/fixtures/__init__.py
+++ b/autobot-infrastructure/shared/tests/fixtures/__init__.py
@@ -4,18 +4,22 @@
 """
 Test fixtures package for AutoBot.
 
-Provides reusable mock components and test utilities.
+Provides reusable mock components and test utilities. As of #7125, the
+mocks themselves live canonically at `autobot-backend/tests/fixtures/mocks.py`;
+this package re-exports them for infrastructure-side tests.
 """
 
 from .mocks import (
     MockCommandValidator,
     MockKnowledgeBase,
     MockLLMInterface,
+    MockLLMService,
     MockWorkerNode,
 )
 
 __all__ = [
     "MockLLMInterface",
+    "MockLLMService",
     "MockCommandValidator",
     "MockKnowledgeBase",
     "MockWorkerNode",

--- a/autobot-infrastructure/shared/tests/fixtures/mocks.py
+++ b/autobot-infrastructure/shared/tests/fixtures/mocks.py
@@ -1,289 +1,42 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
+"""Re-export of canonical mock fixtures (#7125 wire-in).
+
+The 289-LOC original at this path duplicated `MockLLMInterface`,
+`MockCommandValidator`, `MockKnowledgeBase`, and `MockWorkerNode` verbatim
+with `autobot-backend/tests/fixtures/mocks.py`. After #6994 made
+`autobot-backend/tests/fixtures/mocks.py` the canonical location and added
+`MockLLMService`, this shared copy had 0 production callers and would have
+silently drifted from the SSOT (e.g. `MockLLMService` only existed in the
+canonical file).
+
+This module is now a thin re-export pointing at the SSOT. Importing names
+from `autobot_infrastructure.shared.tests.fixtures.mocks` continues to work
+for infrastructure-side tests, and any new mock added to the canonical file
+is automatically reachable here.
 """
-Mock fixtures for AutoBot testing.
 
-Provides mock implementations of core components for testing:
-- MockLLMInterface - Mock LLM for testing agent workflows
-- MockCommandValidator - Mock validator for command safety testing
-- MockKnowledgeBase - Mock KB for knowledge management testing
-- MockWorkerNode - Mock worker for distributed testing
+import sys
+from pathlib import Path
 
-Moved from production code as part of Issue #458.
-"""
+# autobot-infrastructure/shared/tests/fixtures/mocks.py → repo root is 5 levels up
+_BACKEND = Path(__file__).resolve().parents[4] / "autobot-backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
 
-from typing import Any, Dict, Optional
-
-
-class MockLLMInterface:
-    """Mock LLM interface for testing agent workflows.
-
-    Provides deterministic responses based on prompt keywords
-    to enable predictable testing of agent behavior.
-    """
-
-    def __init__(self, responses: Optional[Dict[str, str]] = None):
-        """Initialize mock LLM with optional custom responses.
-
-        Args:
-            responses: Dict mapping keywords to responses.
-        """
-        self._custom_responses = responses or {}
-        self._call_count = 0
-        self._call_history: list = []
-
-    async def generate_response(self, prompt: str, **kwargs) -> str:
-        """Generate mock LLM response based on prompt keywords.
-
-        Args:
-            prompt: Input prompt text.
-            **kwargs: Additional parameters (ignored in mock).
-
-        Returns:
-            Mock response string.
-        """
-        self._call_count += 1
-        self._call_history.append({"prompt": prompt, "kwargs": kwargs})
-
-        # Check custom responses first
-        for keyword, response in self._custom_responses.items():
-            if keyword.lower() in prompt.lower():
-                return response
-
-        # Default responses based on prompt content
-        prompt_lower = prompt.lower()
-        if "progress" in prompt_lower:
-            return "Processing data..."
-        elif "completion" in prompt_lower:
-            return "Task completed successfully!"
-        elif "command" in prompt_lower:
-            return "COMMAND: echo 'This is a test response'\n" "EXPLANATION: Testing the system"
-        else:
-            return "Command executing..."
-
-    @property
-    def call_count(self) -> int:
-        """Get number of times generate_response was called."""
-        return self._call_count
-
-    @property
-    def call_history(self) -> list:
-        """Get history of all calls to generate_response."""
-        return self._call_history
-
-    def reset(self) -> None:
-        """Reset call count and history."""
-        self._call_count = 0
-        self._call_history = []
-
-
-class MockCommandValidator:
-    """Mock command validator for testing command safety.
-
-    Provides configurable validation behavior for testing
-    both safe and unsafe command scenarios.
-    """
-
-    def __init__(
-        self,
-        default_safe: bool = True,
-        dangerous_patterns: Optional[list] = None,
-    ):
-        """Initialize mock validator.
-
-        Args:
-            default_safe: Default safety for unmatched commands.
-            dangerous_patterns: List of patterns to mark as unsafe.
-        """
-        self._default_safe = default_safe
-        self._dangerous_patterns = dangerous_patterns or [
-            "rm -r",
-            "format",
-            "del /s",
-            "mkfs",
-            "dd if=",
-        ]
-        self._validation_history: list = []
-
-    def is_command_safe(self, command: str) -> bool:
-        """Check if command is safe by filtering dangerous patterns.
-
-        Args:
-            command: Command string to validate.
-
-        Returns:
-            True if command is considered safe.
-        """
-        self._validation_history.append(command)
-
-        # Check against dangerous patterns
-        command_lower = command.lower()
-        for pattern in self._dangerous_patterns:
-            if pattern.lower() in command_lower:
-                return False
-
-        return self._default_safe
-
-    @property
-    def validation_history(self) -> list:
-        """Get history of validated commands."""
-        return self._validation_history
-
-    def reset(self) -> None:
-        """Reset validation history."""
-        self._validation_history = []
-
-
-class MockKnowledgeBase:
-    """Mock knowledge base for testing knowledge management.
-
-    Provides in-memory storage for testing fact storage
-    and retrieval without requiring actual database connections.
-    """
-
-    def __init__(self):
-        """Initialize mock knowledge base."""
-        self._facts: list = []
-        self._queries: list = []
-
-    async def store_fact(
-        self,
-        content: str,
-        metadata: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
-        """Store a fact in the mock knowledge base.
-
-        Args:
-            content: Fact content to store.
-            metadata: Optional metadata for the fact.
-
-        Returns:
-            Dict with storage confirmation.
-        """
-        fact = {
-            "id": len(self._facts) + 1,
-            "content": content,
-            "metadata": metadata or {},
-        }
-        self._facts.append(fact)
-        return {"status": "stored", "id": fact["id"]}
-
-    async def query(
-        self,
-        query: str,
-        limit: int = 10,
-    ) -> list:
-        """Query the mock knowledge base.
-
-        Args:
-            query: Search query.
-            limit: Maximum results to return.
-
-        Returns:
-            List of matching facts.
-        """
-        self._queries.append(query)
-        query_lower = query.lower()
-
-        # Simple keyword matching
-        matches = [fact for fact in self._facts if query_lower in fact["content"].lower()]
-        return matches[:limit]
-
-    @property
-    def facts(self) -> list:
-        """Get all stored facts."""
-        return self._facts
-
-    @property
-    def query_history(self) -> list:
-        """Get history of all queries."""
-        return self._queries
-
-    def reset(self) -> None:
-        """Reset knowledge base state."""
-        self._facts = []
-        self._queries = []
-
-
-class MockWorkerNode:
-    """Mock worker node for testing distributed processing.
-
-    Provides simulation of NPU/worker node behavior for
-    testing distributed workflows without actual hardware.
-    """
-
-    def __init__(
-        self,
-        node_id: str = "mock-worker-1",
-        capabilities: Optional[list] = None,
-    ):
-        """Initialize mock worker node.
-
-        Args:
-            node_id: Identifier for this worker.
-            capabilities: List of supported capabilities.
-        """
-        self.node_id = node_id
-        self.capabilities = capabilities or ["text", "vision", "audio"]
-        self._tasks_processed: list = []
-        self._is_healthy = True
-
-    async def process_task(
-        self,
-        task: Dict[str, Any],
-    ) -> Dict[str, Any]:
-        """Process a task on the mock worker.
-
-        Args:
-            task: Task to process.
-
-        Returns:
-            Processing result.
-        """
-        self._tasks_processed.append(task)
-        return {
-            "status": "completed",
-            "node_id": self.node_id,
-            "task_id": task.get("id", "unknown"),
-            "result": f"Mock processed: {task.get('type', 'unknown')}",
-        }
-
-    async def health_check(self) -> Dict[str, Any]:
-        """Check worker health status.
-
-        Returns:
-            Health status dict.
-        """
-        return {
-            "healthy": self._is_healthy,
-            "node_id": self.node_id,
-            "capabilities": self.capabilities,
-            "tasks_processed": len(self._tasks_processed),
-        }
-
-    def set_healthy(self, healthy: bool) -> None:
-        """Set worker health status for testing.
-
-        Args:
-            healthy: Health status to set.
-        """
-        self._is_healthy = healthy
-
-    @property
-    def tasks_processed(self) -> list:
-        """Get list of processed tasks."""
-        return self._tasks_processed
-
-    def reset(self) -> None:
-        """Reset worker state."""
-        self._tasks_processed = []
-        self._is_healthy = True
-
+from tests.fixtures.mocks import (  # noqa: E402  (sys.path bootstrap above)
+    MockCommandValidator,
+    MockKnowledgeBase,
+    MockLLMInterface,
+    MockLLMService,
+    MockWorkerNode,
+)
 
 __all__ = [
-    "MockLLMInterface",
     "MockCommandValidator",
     "MockKnowledgeBase",
+    "MockLLMInterface",
+    "MockLLMService",
     "MockWorkerNode",
 ]


### PR DESCRIPTION
## Summary

#6994 made \`autobot-backend/tests/fixtures/mocks.py\` the canonical home for test mocks (and added \`MockLLMService\` which lived only there). The older \`autobot-infrastructure/shared/tests/fixtures/mocks.py\` kept duplicating \`MockLLMInterface\`, \`MockCommandValidator\`, \`MockKnowledgeBase\`, \`MockWorkerNode\` verbatim — and was already at zero production callers post-#6994. Drift between the two copies was a question of when, not if.

Per #7125 Option 3 (re-export, the recommended path over wire-in or domain-owner-retire), this PR replaces the 289-LOC duplicate with a 42-LOC re-export shim that:

- Bootstraps sys.path to include \`autobot-backend/\` at module-import time
- Re-exports the five canonical classes via \`from tests.fixtures.mocks import …\`
- Updates the package \`__init__.py\` to also export \`MockLLMService\`

## Result

- **0 functional content duplicated** — same class objects on both sides (\`mocks.MockLLMService is canonical_MockLLMService\` → \`True\`)
- Any new mock added to the canonical file is automatically reachable through the shared package
- File shrinks from 289 → 42 lines (**-247 LOC duplication eliminated**)
- The shim itself is now wired (imports the canonical module), satisfying the "never delete code — wire it in" policy

## Test plan

- [x] py_compile clean
- [x] Smoke-tested re-export — same class identity verified:
  \`\`\`bash
  $ python3 -c "
  import sys
  sys.path.insert(0, 'autobot-infrastructure/shared/tests/fixtures')
  import mocks
  sys.path.insert(0, 'autobot-backend')
  from tests.fixtures.mocks import MockLLMService as Canonical
  assert mocks.MockLLMService is Canonical
  print('OK')
  "
  OK
  \`\`\`
- [x] Both \`MockLLMService\` (the new class) and \`MockLLMInterface\` (the legacy class kept per policy) reachable through the shim
- [x] Audit script (#7168 sibling fix) won't flag the shim — \`mocks\` stem has callers (\`from .mocks import …\` in the package \`__init__.py\`)

## Acceptance criteria (from issue)

- [x] **Re-export approach chosen** — domain-owner explicit retire-or-wire decision deferred to favor the lowest-risk path (no production callers means re-export costs nothing)
- [x] **The shim is wired** — at least 1 caller (the package \`__init__.py\` imports from it), and any future infrastructure-side test that needs the mocks gets the canonical surface for free

Closes #7125

🤖 Generated with [Claude Code](https://claude.com/claude-code)