### PR TITLE
ci(deps): add semver-major ignore rules to worker pip ecosystems (closes #7192)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -214,6 +214,11 @@ updates:
     labels:
       - "dependencies"
       - "backend"
+    ignore:
+      - dependency-name: "torch"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "numpy"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/autobot-tts-worker"
@@ -225,6 +230,11 @@ updates:
     labels:
       - "dependencies"
       - "backend"
+    ignore:
+      - dependency-name: "torch"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "numpy"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/autobot-infrastructure/shared/docker/ai-stack"
@@ -236,6 +246,15 @@ updates:
     labels:
       - "dependencies"
       - "backend"
+    ignore:
+      - dependency-name: "torch"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "numpy"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "pydantic"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "sqlalchemy"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/autobot-infrastructure/autobot-npu-worker/docker"
@@ -247,6 +266,11 @@ updates:
     labels:
       - "dependencies"
       - "backend"
+    ignore:
+      - dependency-name: "numpy"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "pydantic"
+        update-types: ["version-update:semver-major"]
 
   # === #7182 P2: Root-level manifests ===
   # Catches root-level requirements*.txt (requirements.txt, requirements-ci.txt,


### PR DESCRIPTION
Closes #7192. Self-review follow-up to PR #7187.

## Audit results

| Entry | Risky deps | Action |
|-------|-----------|--------|
| \`/autobot-browser-worker\` | none (Selenium-based) | skip |
| \`/autobot-npu-worker\` | torch, numpy | + ignores |
| \`/autobot-tts-worker\` | torch, numpy | + ignores |
| \`/autobot-infrastructure/shared/docker/ai-stack\` | torch, numpy, pydantic, sqlalchemy | + ignores |
| \`/autobot-infrastructure/autobot-npu-worker/docker\` | numpy, pydantic | + ignores |
| \`/\` (root) | none in root requirements | skip |

## Pattern

Mirrors existing \`pip /autobot-backend\` ignore block:

\`\`\`yaml
ignore:
  - dependency-name: "torch"
    update-types: ["version-update:semver-major"]
  - dependency-name: "numpy"
    update-types: ["version-update:semver-major"]
\`\`\`

## Why these specific deps

The #7018 / #7049 cascade was triggered by `torch>=2.11.0` colliding with vllm 0.19.x's `torch==2.10.0` constraint — exactly the pattern an unguarded auto-PR could have introduced. Adding the same ignore wall the autobot-backend entry has prevents repeats.

## Net diff

+24 lines across 4 dependabot.yml entries (one ignore block each, 4-6 lines per entry).

## Verification

\`\`\`bash
$ python3 -c "import yaml; data=yaml.safe_load(open('.github/dependabot.yml')); print(sum(1 for u in data['updates'] if u.get('ignore')))"
11   # was 7 → now 11 (+4 worker entries with semver-major ignores)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)