### PR TITLE
fix(orchestration+retry): NotImplementedError propagates through executor + retry (#7010 cluster 5)

### DIFF
--- a/autobot-backend/orchestration/workflow_executor.py
+++ b/autobot-backend/orchestration/workflow_executor.py
@@ -1088,6 +1088,14 @@ class WorkflowExecutor:
                 interaction.message["result"] = result
             return self._build_step_success_result(result, agent_id, step_id)
 
+        except NotImplementedError:
+            # #7010 cluster 5: NotImplementedError marks a stub / unwired
+            # codepath (e.g., #2869 agent dispatcher not implemented yet).
+            # Propagate to the caller so the workflow halts loudly instead
+            # of silently treating the unwired step as "failed". Test
+            # fixtures rely on this propagation to verify intermediate
+            # state was updated before the unimplemented call ran.
+            raise
         except Exception as e:
             logger.error("Step %s execution failed: %s", step_id, e)
             if interaction:

--- a/autobot-backend/retry_mechanism.py
+++ b/autobot-backend/retry_mechanism.py
@@ -81,6 +81,11 @@ class RetryConfig:
         SyntaxError,
         TypeError,
         ValueError,  # Usually indicates bad input, not transient failure
+        # #7010 cluster 5: NotImplementedError marks a code stub or unwired
+        # path (e.g., #2869 agent dispatcher). Retrying just delays the
+        # inevitable — and obscures intermediate state for tests that use
+        # NotImplementedError as a halt-after-side-effects marker.
+        NotImplementedError,
     )
 
 


### PR DESCRIPTION
## Summary

Fixes 2 of 2 cluster-5 failures in [#7010](https://github.com/mrveiss/AutoBot-AI/issues/7010). NotImplementedError is a stub-marker exception that two layers were silently swallowing.

## The bug — two layers of swallowing

### Layer 1: \`workflow_executor._execute_coordinated_step\`

Broad \`except Exception\` converted any error into \`_build_step_failure_result()\` — losing the distinction between transient failures and "this code path isn't wired yet".

### Layer 2: \`retry_mechanism.@retry_async\`

Decorator configured with \`max_attempts=2\` + catch-all \`Exception\` in \`retryable_exceptions\` re-tried the unwired call before wrapping the final NotImplementedError in \`RetryExhaustedError\`. Net effect: one stub raise → "Retry exhausted after 2 attempts".

## The fix

Two surgical changes:

\`\`\`python
# 1. workflow_executor.py:1091 — explicit propagation arm
try:
    result = await self._simulate_step_execution(step, context)
    ...
except NotImplementedError:
    raise  # halt loudly; tests rely on this for intermediate-state assertions
except Exception as e:
    logger.error("Step %s execution failed: %s", step_id, e)
    ...

# 2. retry_mechanism.py — add NotImplementedError to non_retryable_exceptions
non_retryable_exceptions: tuple = (
    KeyboardInterrupt,
    SystemExit,
    MemoryError,
    SyntaxError,
    TypeError,
    ValueError,
    NotImplementedError,  # NEW (#7010 cluster 5)
)
\`\`\`

## Verification

\`\`\`bash
$ pytest autobot-backend/orchestration/workflow_memory_test.py
34 passed in 0.58s

$ pytest autobot-backend/retry_mechanism_test.py
27 passed in 3.77s

$ pytest autobot-backend/orchestration/error_handler_test.py autobot-backend/orchestration/dag_executor_test.py
60 passed in 0.53s
\`\`\`

Cluster 5 specifically:

- \`test_prior_findings_injected_into_context\` PASSED (was \`DID NOT RAISE NotImplementedError\`)
- \`test_empty_memory_not_injected\` PASSED (was \`DID NOT RAISE NotImplementedError\`)

No regressions in retry_mechanism, error_handler, or dag_executor tests.

## Wider impact

The retry_mechanism fix is **not test-only** — production agents that legitimately raise NotImplementedError (#2869 agent dispatcher stubs) will now fail-fast instead of consuming retry budget on an unfixable error. Better signal for ops + faster failure for callers.

## Closes

- #7010 cluster 5 (2 of 15 failures resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)