### PR TITLE
ci(deps): add semver-major ignores to autobot_shared + autobot-slm-backend pip (closes #7200)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,11 @@ updates:
     labels:
       - "dependencies"
       - "backend"
+    ignore:
+      - dependency-name: "pydantic"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "pydantic-settings"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/autobot-slm-backend"
@@ -41,6 +46,11 @@ updates:
     labels:
       - "dependencies"
       - "backend"
+    ignore:
+      - dependency-name: "pydantic"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "sqlalchemy"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/autobot-frontend"


### PR DESCRIPTION
Closes #7200. Self-review of #7194 caught immediately after merge.

## Anti-pattern self-violation

I literally just wrote \`feedback_grep_misses_implicit_refs.md\` (\"audit-only-touched-dir misses broader coverage\") and re-violated it in #7194 — limited that audit to the 6 entries from #7187, missed the 2 pre-existing entries with the same risk.

## Coverage gap

| Entry | Has ignores? | Has risky deps? |
|-------|--------------|-----------------|
| \`/autobot_shared\` | ❌ | ✅ pydantic + pydantic-settings |
| \`/autobot-slm-backend\` | ❌ | ✅ pydantic + sqlalchemy |

## Fix

Mirrors existing \`/autobot-backend\` pattern. After this PR all pip ecosystems with risky deps are protected:

| Entry | Ignores |
|-------|---------|
| \`/autobot-backend\` | numpy, pydantic, sqlalchemy |
| \`/autobot_shared\` | **pydantic, pydantic-settings** ← new |
| \`/autobot-slm-backend\` | **pydantic, sqlalchemy** ← new |
| \`/autobot-npu-worker\` | torch, numpy |
| \`/autobot-tts-worker\` | torch, numpy |
| \`/autobot-infrastructure/shared/docker/ai-stack\` | torch, numpy, pydantic, sqlalchemy |
| \`/autobot-infrastructure/autobot-npu-worker/docker\` | numpy, pydantic |

## Net diff

+10 lines (2 ignore blocks × 5 lines each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)