### PR TITLE
fix(backend): wrap markdownify hard-import with optional_import (#7166)

### DIFF
--- a/autobot-backend/system_integration.py
+++ b/autobot-backend/system_integration.py
@@ -9,7 +9,17 @@ import subprocess  # nosec B404 - required for system commands
 from typing import Any, Dict, List, Optional
 
 import aiohttp  # Import aiohttp for async web fetching
-from markdownify import markdownify as md  # Import markdownify for HTML to Markdown conversion
+
+# #7166: markdownify is an optional dependency. Hard-import made the whole
+# module unimportable in any environment that didn't install it (any module
+# that imports SystemIntegration inherited the requirement). Use the
+# project-standard MissingDep pattern (#6691) so the module loads even when
+# the dep is absent; calls to md() raise ImportError with a clear message
+# at the actual usage point.
+from autobot_shared.missing_dep import optional_import
+
+globals().update(optional_import("markdownify", ["markdownify"]))
+md = markdownify  # type: ignore[name-defined]  # noqa: F821 — populated by optional_import
 
 from autobot_shared.http_client import get_http_client
 


### PR DESCRIPTION
## Summary

\`system_integration.py:12\` hard-imported \`markdownify\` with no guard. Any module that imported \`SystemIntegration\` (worker_node, orchestrator, etc.) inherited the requirement, breaking import in any environment that didn't install the optional dep.

Migrated to the project-standard \`MissingDep\` / \`optional_import\` pattern (#6691). Module now loads regardless; calls to \`md()\` raise \`ImportError\` with a clear message at the actual usage point.

## Test plan

- [x] py_compile clean
- [x] Live verify WITH markdownify: \`md('<h1>Hello</h1>')\` → \`'Hello\\n====='\`
- [x] Live verify WITHOUT: module loads, \`md\` is \`MissingDep('markdownify')\` sentinel, \`not md\` is truthy
- [x] Sweep grep (per issue body): \`grep -rnE '^from (markdownify|playwright|opencv|whisper|tiktoken|cv2|easyocr) '\` returns 1 hit (this file). No other instances of the pattern.

## Out of scope

- CLAUDE_RULES.md doc update — pattern already documented in \`autobot_shared/missing_dep.py\` docstring and via #6691 / #7007

Closes #7166