### PR TITLE
fix(orchestration): build_dag accepts both edge shapes (#7010 cluster 3 cont.)

### DIFF
--- a/autobot-backend/orchestration/dag_executor.py
+++ b/autobot-backend/orchestration/dag_executor.py
@@ -773,5 +773,40 @@ def workflow_has_condition_nodes(
 
 
 def build_dag(steps: List[Dict[str, Any]], edges: List[Dict[str, Any]]) -> WorkflowDAG:
-    """Construct a WorkflowDAG from workflow API payloads."""
-    return WorkflowDAG(steps, edges)
+    """Construct a WorkflowDAG from workflow API payloads.
+
+    #7010 cluster 3: tolerates both edge shapes —
+      - Canonical: ``{"source": ..., "target": ..., "label": ...}``
+      - API-facing: ``{"from": ..., "to": ..., "condition": "true"|"false"|None}``
+
+    The API shape is what reaches /api/workflow-automation/execute via the
+    #3172 payload contract; translating here lets callers pass the raw
+    payload without an explicit adapter.
+    """
+
+    def _condition_to_label(value: Any) -> Optional[bool]:
+        if value is None or isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            lower = value.lower()
+            if lower in ("true", "yes"):
+                return True
+            if lower in ("false", "no"):
+                return False
+        return None
+
+    normalized: List[Dict[str, Any]] = []
+    for raw in edges:
+        if "source" in raw and "target" in raw:
+            normalized.append(raw)
+            continue
+        if "from" in raw and "to" in raw:
+            label = _condition_to_label(raw.get("condition"))
+            normalized.append(
+                {"source": raw["from"], "target": raw["to"], "label": label}
+            )
+            continue
+        # Malformed entry — let WorkflowDAG's warn-and-skip handle it.
+        normalized.append(raw)
+
+    return WorkflowDAG(steps, normalized)


### PR DESCRIPTION
## Summary

Fixes 1 more of the cluster-3 sub-tests in [#7010](https://github.com/mrveiss/AutoBot-AI/issues/7010) — the DAG-path notification test. Combined with [#7186](https://github.com/mrveiss/AutoBot-AI/pull/7186), 4 of 6 cluster-3 tests now pass.

## The bug

\`build_dag()\` assumed canonical edge shape \`{"source": ..., "target": ..., "label": ...}\`. The API contract (#3172 \`/api/workflow-automation/execute\`) uses \`{"from": ..., "to": ..., "condition": "true"|"false"|None}\`. Test \`test_dag_path_fires_send_workflow_notification\` passes the API shape; \`WorkflowDAG.__init__:153\` raised \`KeyError: 'source'\`.

## Fix

\`build_dag()\` normalizes both shapes:

\`\`\`python
def build_dag(steps, edges):
    normalized = []
    for raw in edges:
        if "source" in raw and "target" in raw:
            normalized.append(raw)  # canonical pass-through
        elif "from" in raw and "to" in raw:
            normalized.append({
                "source": raw["from"],
                "target": raw["to"],
                "label": _condition_to_label(raw.get("condition")),
            })
        else:
            normalized.append(raw)  # let WorkflowDAG warn-and-skip
    return WorkflowDAG(steps, normalized)
\`\`\`

\`_condition_to_label("true")\` → \`True\`, \`_condition_to_label("false")\` → \`False\`, \`None\` → \`None\`. Existing \`bool\` values pass through.

## Verification

\`\`\`bash
$ pytest autobot-backend/orchestration/execution_modes_test.py::TestWorkflowExecutorDebugMode::test_dag_path_fires_send_workflow_notification
1 passed in 0.77s

$ pytest autobot-backend/orchestration/dag_executor_test.py
32 passed in 0.70s  (no regression)
\`\`\`

## Remaining cluster-3 sub-tests (2 of 6)

Two debug-mode tests still need investigation — separate from this PR:

- \`test_debug_mode_skip_marks_step_skipped\` — KeyError 'skipped' (skip signal needs to set \`step_results[id]["skipped"] = True\`)
- \`test_debug_mode_without_controller_falls_back_to_normal\` — fallback must log a warning containing "debug_controller"

Both are around DebugController internals; will file as follow-up sub-issue.

## Closes

- #7010 cluster 3 partial — 4 of 6 sub-tests passing across [#7186](https://github.com/mrveiss/AutoBot-AI/pull/7186) + this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)