### PR TITLE
fix(ansible/browser): use libasound2t64 on noble (closes #7207)

### DIFF
--- a/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
@@ -102,22 +102,20 @@
 # ============================================================
 - name: "Browser | Install Playwright system dependencies"
   apt:
-    name:
-      - python3
-      - python3-pip
-      - python3-venv
-      - libnss3
-      - libatk1.0-0
-      - libatk-bridge2.0-0
-      - libcups2
-      - libdrm2
-      - libxkbcommon0
-      - libxcomposite1
-      - libxdamage1
-      - libxfixes3
-      - libxrandr2
-      - libgbm1
-      - libasound2
+    # #7207: Ubuntu 24.04 (noble) renamed several libs with `t64` suffix as
+    # part of the time_t 64-bit transition. libasound2 → libasound2t64 (the
+    # transitional virtual package is missing on arm64 noble). Other libs
+    # in this list kept their original names — only libasound2 needs the
+    # conditional rename for now.
+    name: >-
+      {{ ['python3', 'python3-pip', 'python3-venv',
+          'libnss3', 'libatk1.0-0', 'libatk-bridge2.0-0',
+          'libcups2', 'libdrm2', 'libxkbcommon0',
+          'libxcomposite1', 'libxdamage1', 'libxfixes3',
+          'libxrandr2', 'libgbm1']
+          + (['libasound2t64']
+             if ansible_facts['distribution_release'] == 'noble'
+             else ['libasound2']) }}
     state: present
   become: yes
   tags: ['browser', 'packages']


### PR DESCRIPTION
## Summary

Closes #7207. Provision Phase 6 fails on Ubuntu 24.04 because \`libasound2\` was renamed to \`libasound2t64\` (time_t 64-bit transition) and the transitional virtual package is missing on arm64 noble.

## Fix

Build apt name list dynamically — append \`libasound2t64\` on noble, \`libasound2\` on jammy/older. Other libs in the Playwright deps list kept their original names; only libasound2 needs the conditional.

## Test plan

- [x] YAML parse
- [ ] Re-run on DGX Spark — Provision Phase 6 \"Install Playwright system dependencies\" succeeds (to verify after merge)
- [x] No regression on jammy — fact resolves to \`libasound2\`

## Reproduced on

- 192.168.88.96 (DGX Spark, Ubuntu 24.04 noble, ARM64) — 2026-05-07T~21Z

🤖 Generated with [Claude Code](https://claude.com/claude-code)