### PR TITLE
ci(deps): comprehensive pip ignore audit — 14 missing entries across 7 dirs (closes #7210)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "sqlalchemy"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "fastapi"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "torch"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/autobot_shared"
@@ -35,6 +39,10 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "pydantic-settings"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "fastapi"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "starlette"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/autobot-slm-backend"
@@ -50,6 +58,10 @@ updates:
       - dependency-name: "pydantic"
         update-types: ["version-update:semver-major"]
       - dependency-name: "sqlalchemy"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "fastapi"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "pydantic-settings"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
@@ -245,6 +257,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "numpy"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "fastapi"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/autobot-infrastructure/shared/docker/ai-stack"
@@ -265,6 +279,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "sqlalchemy"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "fastapi"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/autobot-infrastructure/autobot-npu-worker/docker"
@@ -280,6 +296,8 @@ updates:
       - dependency-name: "numpy"
         update-types: ["version-update:semver-major"]
       - dependency-name: "pydantic"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "fastapi"
         update-types: ["version-update:semver-major"]
 
   # === #7182 P2: Root-level manifests ===
@@ -297,3 +315,14 @@ updates:
       - "dependencies"
       - "backend"
       - "devops"
+    ignore:
+      - dependency-name: "fastapi"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "numpy"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "pydantic"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "sqlalchemy"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "starlette"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Closes #7210. Comprehensive close of the iterative ignore-audit cycle.

## What this fixes

PR #7194 / #7201 added some ignores. A reproducible audit (find risky deps in manifests, diff vs ignored deps) revealed **14 more missing entries across 7 directories** — including \`/autobot-backend\` missing \`torch\`, the exact dep that caused #7018.

## Audit results before/after

| Directory | Before | After (this PR) |
|-----------|--------|-----------------|
| \`/autobot-backend\` | numpy, pydantic, sqlalchemy | + fastapi, torch |
| \`/autobot_shared\` | pydantic, pydantic-settings | + fastapi, starlette |
| \`/autobot-slm-backend\` | pydantic, sqlalchemy | + fastapi, pydantic-settings |
| \`/autobot-tts-worker\` | numpy, torch | + fastapi |
| \`/autobot-infrastructure/shared/docker/ai-stack\` | numpy, pydantic, sqlalchemy, torch | + fastapi |
| \`/autobot-infrastructure/autobot-npu-worker/docker\` | numpy, pydantic | + fastapi |
| \`/\` (root) | (none) | + fastapi, numpy, pydantic, sqlalchemy, starlette |

**Total additions: 14 ignore entries.**

## Verification

\`\`\`bash
$ python3 audit.py
Total missing: 0
\`\`\`

## Why 5 PRs to close one audit

This is the 5th instance of audit-only-touched-dir this session (memory: \`feedback_grep_misses_implicit_refs.md\`). Each prior fix scoped to the dirs I'd just touched, missing broader coverage. **This PR closes the cycle by doing the comprehensive cross-reference up front.**

#7182 comment proposed a \`tools/audit/dependabot-coverage.py\` script that would mechanize this audit. That's the proper long-term fix — captured for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)