### PR TITLE
feat(workflow): lifecycle methods on canonical WorkflowTask + TaskStatus to autobot_shared (closes #7121, partial #6520)

### DIFF
--- a/autobot-backend/constants/status_enums.py
+++ b/autobot-backend/constants/status_enums.py
@@ -1,224 +1,32 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""
-Centralized Status and Category Enums
+"""Re-export shim for the centralized status enums (#7121, partial #6520).
 
-Issue #670: Consolidate duplicate string literals into type-safe enums.
-This module provides shared enums to replace hardcoded status strings
-throughout the codebase.
+Original location: ``autobot-backend/constants/status_enums.py`` (Issue #670).
+Moved 2026-05-07 to ``autobot_shared.status_enums`` so canonical workflow
+types in ``autobot_shared.workflow`` can use the same enums without
+``autobot_shared`` taking a dependency on ``autobot-backend``. This shim
+preserves the original import path ``from constants.status_enums import X``
+for the 15+ existing callers.
 
-Usage:
-    from constants.status_enums import TaskStatus, Severity, Priority
-
-    status = TaskStatus.PENDING
-    if status == TaskStatus.COMPLETED:
-        ...
-
-    # String comparison still works
-    if status.value == "completed":
-        ...
+New code should import directly from ``autobot_shared.status_enums``.
 """
 
-from enum import Enum
-
-
-class TaskStatus(Enum):
-    """
-    Task execution status enumeration.
-
-    Used across orchestration, workflows, tools, and agent systems.
-    Replaces hardcoded strings: "pending", "active", "completed", "failed", etc.
-    """
-
-    PENDING = "pending"
-    ACTIVE = "active"  # Alias for IN_PROGRESS in some contexts
-    IN_PROGRESS = "in_progress"
-    RUNNING = "running"  # Alias for IN_PROGRESS
-    COMPLETED = "completed"
-    PARTIALLY_COMPLETED = "partially_completed"
-    FAILED = "failed"
-    CANCELLED = "cancelled"
-    SKIPPED = "skipped"
-    PAUSED = "paused"
-    RETRYING = "retrying"
-    BLOCKED = "blocked"
-    WAITING = "waiting"
-
-    @classmethod
-    def is_terminal(cls, status: "TaskStatus") -> bool:
-        """Check if status is a terminal state (no further transitions)."""
-        return status in {cls.COMPLETED, cls.FAILED, cls.CANCELLED}
-
-    @classmethod
-    def is_active(cls, status: "TaskStatus") -> bool:
-        """Check if status indicates active work."""
-        return status in {cls.ACTIVE, cls.IN_PROGRESS, cls.RUNNING, cls.RETRYING}
-
-
-class Severity(Enum):
-    """
-    Severity/risk level enumeration.
-
-    Used in security, analytics, logging, and threat detection.
-    Replaces hardcoded strings: "low", "medium", "high", "critical", "unknown".
-    """
-
-    UNKNOWN = "unknown"
-    INFO = "info"
-    LOW = "low"
-    MEDIUM = "medium"
-    HIGH = "high"
-    CRITICAL = "critical"
-
-    @classmethod
-    def from_score(cls, score: float) -> "Severity":
-        """
-        Convert numeric score (0.0-1.0) to severity level.
-
-        Args:
-            score: Risk/severity score between 0.0 and 1.0
-
-        Returns:
-            Corresponding Severity enum value
-        """
-        if score >= 0.9:
-            return cls.CRITICAL
-        elif score >= 0.7:
-            return cls.HIGH
-        elif score >= 0.5:
-            return cls.MEDIUM
-        elif score >= 0.3:
-            return cls.LOW
-        elif score > 0:
-            return cls.INFO
-        return cls.UNKNOWN
-
-    @classmethod
-    def to_score(cls, severity: "Severity") -> float:
-        """Convert severity to representative score."""
-        scores = {
-            cls.UNKNOWN: 0.0,
-            cls.INFO: 0.1,
-            cls.LOW: 0.3,
-            cls.MEDIUM: 0.5,
-            cls.HIGH: 0.7,
-            cls.CRITICAL: 0.9,
-        }
-        return scores.get(severity, 0.0)
-
-
-class Priority(Enum):
-    """
-    Priority level enumeration.
-
-    Used for task scheduling, workflow ordering, and resource allocation.
-    Replaces hardcoded strings: "low", "medium", "high", "normal", "critical".
-    """
-
-    LOW = "low"
-    NORMAL = "normal"
-    MEDIUM = "medium"
-    HIGH = "high"
-    CRITICAL = "critical"
-    URGENT = "urgent"
-
-    @classmethod
-    def from_numeric(cls, value: int) -> "Priority":
-        """
-        Convert numeric priority (1-5) to Priority enum.
-
-        Args:
-            value: Priority value 1-5 (1=low, 5=critical)
-
-        Returns:
-            Corresponding Priority enum value
-        """
-        mapping = {
-            1: cls.LOW,
-            2: cls.NORMAL,
-            3: cls.MEDIUM,
-            4: cls.HIGH,
-            5: cls.CRITICAL,
-        }
-        return mapping.get(value, cls.NORMAL)
-
-    @classmethod
-    def to_numeric(cls, priority: "Priority") -> int:
-        """Convert priority to numeric value (1-5)."""
-        values = {
-            cls.LOW: 1,
-            cls.NORMAL: 2,
-            cls.MEDIUM: 3,
-            cls.HIGH: 4,
-            cls.CRITICAL: 5,
-            cls.URGENT: 5,
-        }
-        return values.get(priority, 2)
-
-
-class LLMProvider(Enum):
-    """
-    LLM provider enumeration.
-
-    Used in ssot_config and throughout LLM integration code.
-    Replaces hardcoded strings: "ollama", "openai", "anthropic", "custom".
-    """
-
-    OLLAMA = "ollama"
-    OPENAI = "openai"
-    ANTHROPIC = "anthropic"
-    AZURE = "azure"
-    CUSTOM = "custom"
-    LOCAL = "local"
-
-    @classmethod
-    def supports_streaming(cls, provider: "LLMProvider") -> bool:
-        """Check if provider supports streaming responses."""
-        return provider in {cls.OLLAMA, cls.OPENAI, cls.ANTHROPIC, cls.AZURE}
-
-    @classmethod
-    def requires_api_key(cls, provider: "LLMProvider") -> bool:
-        """Check if provider requires API key authentication."""
-        return provider in {cls.OPENAI, cls.ANTHROPIC, cls.AZURE}
-
-
-class OperationOutcome(Enum):
-    """
-    Generic operation outcome enumeration.
-
-    Used for tool results, API responses, and operation tracking.
-    """
-
-    SUCCESS = "success"
-    FAILURE = "failure"
-    PARTIAL = "partial"
-    SKIPPED = "skipped"
-    TIMEOUT = "timeout"
-    ERROR = "error"
-    PENDING = "pending"
-
-
-class HealthStatus(Enum):
-    """
-    Service/component health status.
-
-    Used in monitoring, health checks, and service discovery.
-    """
-
-    HEALTHY = "healthy"
-    DEGRADED = "degraded"
-    UNHEALTHY = "unhealthy"
-    UNKNOWN = "unknown"
-    STARTING = "starting"
-    STOPPING = "stopping"
-
+from autobot_shared.status_enums import (
+    HealthStatus,
+    LLMProvider,
+    OperationOutcome,
+    Priority,
+    Severity,
+    TaskStatus,
+)
 
 __all__ = [
-    "TaskStatus",
-    "Severity",
-    "Priority",
+    "HealthStatus",
     "LLMProvider",
     "OperationOutcome",
-    "HealthStatus",
+    "Priority",
+    "Severity",
+    "TaskStatus",
 ]

--- a/autobot-backend/enhanced_orchestration/types.py
+++ b/autobot-backend/enhanced_orchestration/types.py
@@ -22,78 +22,21 @@ if TYPE_CHECKING:
 from autobot_shared.workflow import ExecutionStrategy as ExecutionStrategy
 from autobot_shared.workflow import WorkflowPlan as _SharedWorkflowPlan
 from autobot_shared.workflow import WorkflowTask
-from constants.status_enums import TaskStatus
 from orchestration.types import AgentCapability  # single canonical definition (#6192)
 
 # Module-level frozenset for fallback tier checks
 FALLBACK_TIERS: FrozenSet[str] = frozenset({"basic", "emergency"})
 
 
-class AgentTask(WorkflowTask):
-    """Workflow task with execution lifecycle methods.
-
-    Inherits every field from ``autobot_shared.workflow.WorkflowTask`` (#6951
-    Phase 1b). The methods below were extracted under Issue #372 to reduce
-    feature envy in the runner; they live in this subclass — not on the
-    canonical type — because they encode an execution-runtime concern that
-    the shared shape intentionally avoids.
-    """
-
-    def start_execution(self) -> None:
-        """Mark task as started (Issue #372)."""
-        self.start_time = time.time()
-        self.status = TaskStatus.RUNNING.value
-
-    def complete_execution(self, result: Dict[str, Any]) -> None:
-        """Mark task as completed with result (Issue #372)."""
-        self.end_time = time.time()
-        self.status = TaskStatus.COMPLETED.value
-        self.outputs = result
-
-    def fail_execution(self, error_msg: str) -> None:
-        """Mark task as failed with error (Issue #372)."""
-        self.status = TaskStatus.FAILED.value
-        self.error = error_msg
-
-    def get_execution_time(self) -> float:
-        """Get execution time in seconds (Issue #372)."""
-        if self.start_time and self.end_time:
-            return self.end_time - self.start_time
-        return 0.0
-
-    def can_retry(self) -> bool:
-        """Check if task can be retried (Issue #372)."""
-        return self.retry_count < self.max_retries
-
-    def increment_retry(self) -> None:
-        """Increment retry counter (Issue #372)."""
-        self.retry_count += 1
-
-    def get_enhanced_inputs(self, context: Dict[str, Any]) -> Dict[str, Any]:
-        """Get inputs enhanced with context (Issue #372)."""
-        return {
-            **self.inputs,
-            "context": context,
-            "task_id": self.task_id,
-            "workflow_metadata": self.metadata,
-        }
-
-    def to_completed_result(self, result: Dict[str, Any]) -> Dict[str, Any]:
-        """Build completed result dict (Issue #372)."""
-        return {
-            "status": "completed",
-            "output": result,
-            "execution_time": self.get_execution_time(),
-            "agent": self.agent_type,
-        }
-
-    def to_failed_result(self, error_msg: str) -> Dict[str, Any]:
-        """Build failed result dict (Issue #372)."""
-        return {
-            "status": "failed",
-            "error": error_msg,
-            "agent": self.agent_type,
-        }
+# #7121: lifecycle methods (start_execution, complete_execution,
+# fail_execution, get_execution_time, can_retry, increment_retry,
+# get_enhanced_inputs, to_completed_result, to_failed_result) moved
+# to canonical WorkflowTask in autobot_shared/workflow/types.py.
+# AgentTask is now a pure alias preserving the historical name —
+# every consumer of `enhanced_orchestration.types.AgentTask` gets the
+# canonical type with all 9 lifecycle methods inherited automatically.
+# Original extraction: Issue #372 (feature-envy reduction).
+AgentTask = WorkflowTask
 
 
 @dataclass

--- a/autobot_shared/status_enums.py
+++ b/autobot_shared/status_enums.py
@@ -1,0 +1,224 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Centralized Status and Category Enums
+
+Issue #670: Consolidate duplicate string literals into type-safe enums.
+This module provides shared enums to replace hardcoded status strings
+throughout the codebase.
+
+Usage:
+    from constants.status_enums import TaskStatus, Severity, Priority
+
+    status = TaskStatus.PENDING
+    if status == TaskStatus.COMPLETED:
+        ...
+
+    # String comparison still works
+    if status.value == "completed":
+        ...
+"""
+
+from enum import Enum
+
+
+class TaskStatus(Enum):
+    """
+    Task execution status enumeration.
+
+    Used across orchestration, workflows, tools, and agent systems.
+    Replaces hardcoded strings: "pending", "active", "completed", "failed", etc.
+    """
+
+    PENDING = "pending"
+    ACTIVE = "active"  # Alias for IN_PROGRESS in some contexts
+    IN_PROGRESS = "in_progress"
+    RUNNING = "running"  # Alias for IN_PROGRESS
+    COMPLETED = "completed"
+    PARTIALLY_COMPLETED = "partially_completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    SKIPPED = "skipped"
+    PAUSED = "paused"
+    RETRYING = "retrying"
+    BLOCKED = "blocked"
+    WAITING = "waiting"
+
+    @classmethod
+    def is_terminal(cls, status: "TaskStatus") -> bool:
+        """Check if status is a terminal state (no further transitions)."""
+        return status in {cls.COMPLETED, cls.FAILED, cls.CANCELLED}
+
+    @classmethod
+    def is_active(cls, status: "TaskStatus") -> bool:
+        """Check if status indicates active work."""
+        return status in {cls.ACTIVE, cls.IN_PROGRESS, cls.RUNNING, cls.RETRYING}
+
+
+class Severity(Enum):
+    """
+    Severity/risk level enumeration.
+
+    Used in security, analytics, logging, and threat detection.
+    Replaces hardcoded strings: "low", "medium", "high", "critical", "unknown".
+    """
+
+    UNKNOWN = "unknown"
+    INFO = "info"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+    @classmethod
+    def from_score(cls, score: float) -> "Severity":
+        """
+        Convert numeric score (0.0-1.0) to severity level.
+
+        Args:
+            score: Risk/severity score between 0.0 and 1.0
+
+        Returns:
+            Corresponding Severity enum value
+        """
+        if score >= 0.9:
+            return cls.CRITICAL
+        elif score >= 0.7:
+            return cls.HIGH
+        elif score >= 0.5:
+            return cls.MEDIUM
+        elif score >= 0.3:
+            return cls.LOW
+        elif score > 0:
+            return cls.INFO
+        return cls.UNKNOWN
+
+    @classmethod
+    def to_score(cls, severity: "Severity") -> float:
+        """Convert severity to representative score."""
+        scores = {
+            cls.UNKNOWN: 0.0,
+            cls.INFO: 0.1,
+            cls.LOW: 0.3,
+            cls.MEDIUM: 0.5,
+            cls.HIGH: 0.7,
+            cls.CRITICAL: 0.9,
+        }
+        return scores.get(severity, 0.0)
+
+
+class Priority(Enum):
+    """
+    Priority level enumeration.
+
+    Used for task scheduling, workflow ordering, and resource allocation.
+    Replaces hardcoded strings: "low", "medium", "high", "normal", "critical".
+    """
+
+    LOW = "low"
+    NORMAL = "normal"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+    URGENT = "urgent"
+
+    @classmethod
+    def from_numeric(cls, value: int) -> "Priority":
+        """
+        Convert numeric priority (1-5) to Priority enum.
+
+        Args:
+            value: Priority value 1-5 (1=low, 5=critical)
+
+        Returns:
+            Corresponding Priority enum value
+        """
+        mapping = {
+            1: cls.LOW,
+            2: cls.NORMAL,
+            3: cls.MEDIUM,
+            4: cls.HIGH,
+            5: cls.CRITICAL,
+        }
+        return mapping.get(value, cls.NORMAL)
+
+    @classmethod
+    def to_numeric(cls, priority: "Priority") -> int:
+        """Convert priority to numeric value (1-5)."""
+        values = {
+            cls.LOW: 1,
+            cls.NORMAL: 2,
+            cls.MEDIUM: 3,
+            cls.HIGH: 4,
+            cls.CRITICAL: 5,
+            cls.URGENT: 5,
+        }
+        return values.get(priority, 2)
+
+
+class LLMProvider(Enum):
+    """
+    LLM provider enumeration.
+
+    Used in ssot_config and throughout LLM integration code.
+    Replaces hardcoded strings: "ollama", "openai", "anthropic", "custom".
+    """
+
+    OLLAMA = "ollama"
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    AZURE = "azure"
+    CUSTOM = "custom"
+    LOCAL = "local"
+
+    @classmethod
+    def supports_streaming(cls, provider: "LLMProvider") -> bool:
+        """Check if provider supports streaming responses."""
+        return provider in {cls.OLLAMA, cls.OPENAI, cls.ANTHROPIC, cls.AZURE}
+
+    @classmethod
+    def requires_api_key(cls, provider: "LLMProvider") -> bool:
+        """Check if provider requires API key authentication."""
+        return provider in {cls.OPENAI, cls.ANTHROPIC, cls.AZURE}
+
+
+class OperationOutcome(Enum):
+    """
+    Generic operation outcome enumeration.
+
+    Used for tool results, API responses, and operation tracking.
+    """
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    PARTIAL = "partial"
+    SKIPPED = "skipped"
+    TIMEOUT = "timeout"
+    ERROR = "error"
+    PENDING = "pending"
+
+
+class HealthStatus(Enum):
+    """
+    Service/component health status.
+
+    Used in monitoring, health checks, and service discovery.
+    """
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNHEALTHY = "unhealthy"
+    UNKNOWN = "unknown"
+    STARTING = "starting"
+    STOPPING = "stopping"
+
+
+__all__ = [
+    "TaskStatus",
+    "Severity",
+    "Priority",
+    "LLMProvider",
+    "OperationOutcome",
+    "HealthStatus",
+]

--- a/autobot_shared/workflow/types.py
+++ b/autobot_shared/workflow/types.py
@@ -32,9 +32,12 @@ Design choices
   (services/workflow_automation, overseer); the union accommodates both.
 """
 
+import time
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
+
+from autobot_shared.status_enums import TaskStatus
 
 
 class ExecutionStrategy(Enum):
@@ -120,6 +123,70 @@ class WorkflowTask:
     end_time: Optional[float] = None
 
     metadata: Dict[str, Any] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Execution lifecycle (#7121, originally #372 → moved to canonical so
+    # all subclasses + aliases get the same behavior without duplication.
+    # Previously lived on enhanced_orchestration.types.AgentTask only —
+    # the variance gap on `WorkflowPlan.tasks: List[WorkflowTask]` allowed
+    # plain WorkflowTasks in the list to silently lack these methods.)
+    # ------------------------------------------------------------------
+
+    def start_execution(self) -> None:
+        """Mark task as started."""
+        self.start_time = time.time()
+        self.status = TaskStatus.RUNNING.value
+
+    def complete_execution(self, result: Dict[str, Any]) -> None:
+        """Mark task as completed with result."""
+        self.end_time = time.time()
+        self.status = TaskStatus.COMPLETED.value
+        self.outputs = result
+
+    def fail_execution(self, error_msg: str) -> None:
+        """Mark task as failed with error."""
+        self.status = TaskStatus.FAILED.value
+        self.error = error_msg
+
+    def get_execution_time(self) -> float:
+        """Get execution time in seconds (0.0 when not yet finished)."""
+        if self.start_time and self.end_time:
+            return self.end_time - self.start_time
+        return 0.0
+
+    def can_retry(self) -> bool:
+        """Check if task can be retried."""
+        return self.retry_count < self.max_retries
+
+    def increment_retry(self) -> None:
+        """Increment retry counter."""
+        self.retry_count += 1
+
+    def get_enhanced_inputs(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Get inputs enhanced with context (forwarded into agent dispatch)."""
+        return {
+            **self.inputs,
+            "context": context,
+            "task_id": self.task_id,
+            "workflow_metadata": self.metadata,
+        }
+
+    def to_completed_result(self, result: Dict[str, Any]) -> Dict[str, Any]:
+        """Build a completed-result dict for the workflow runner."""
+        return {
+            "status": "completed",
+            "output": result,
+            "execution_time": self.get_execution_time(),
+            "agent": self.agent_type,
+        }
+
+    def to_failed_result(self, error_msg: str) -> Dict[str, Any]:
+        """Build a failed-result dict for the workflow runner."""
+        return {
+            "status": "failed",
+            "error": error_msg,
+            "agent": self.agent_type,
+        }
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to a JSON-compatible dict (#7124).

--- a/autobot_shared/workflow/types_test.py
+++ b/autobot_shared/workflow/types_test.py
@@ -271,3 +271,111 @@ def test_workflow_plan_from_dict_requires_plan_id_goal_tasks():
         del data[missing]
         with pytest.raises(KeyError, match=missing):
             WorkflowPlan.from_dict(data)
+
+
+# ---------------------------------------------------------------------------
+# #7121 — Lifecycle methods on canonical WorkflowTask
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_task_start_execution_marks_running():
+    """start_execution() sets start_time and status='running'."""
+    t = WorkflowTask(task_id="t1")
+    assert t.start_time is None
+    assert t.status == "pending"
+    t.start_execution()
+    assert t.start_time is not None
+    assert t.status == "running"
+
+
+def test_workflow_task_complete_execution_records_result():
+    """complete_execution() sets end_time, status='completed', and outputs."""
+    t = WorkflowTask(task_id="t1")
+    t.start_execution()
+    t.complete_execution({"answer": 42})
+    assert t.end_time is not None
+    assert t.status == "completed"
+    assert t.outputs == {"answer": 42}
+
+
+def test_workflow_task_fail_execution_records_error():
+    """fail_execution() sets status='failed' and error message."""
+    t = WorkflowTask(task_id="t1")
+    t.fail_execution("network down")
+    assert t.status == "failed"
+    assert t.error == "network down"
+
+
+def test_workflow_task_get_execution_time_zero_until_complete():
+    """get_execution_time() returns 0.0 until both start and end are set."""
+    t = WorkflowTask(task_id="t1")
+    assert t.get_execution_time() == 0.0
+    t.start_execution()
+    assert t.get_execution_time() == 0.0  # no end yet
+    import time as _time
+    _time.sleep(0.001)
+    t.complete_execution({})
+    assert t.get_execution_time() > 0.0
+
+
+def test_workflow_task_retry_methods():
+    """can_retry() respects max_retries; increment_retry() advances the counter."""
+    t = WorkflowTask(task_id="t1", max_retries=2)
+    assert t.can_retry()                # 0 < 2
+    t.increment_retry()
+    assert t.retry_count == 1
+    assert t.can_retry()                # 1 < 2
+    t.increment_retry()
+    assert t.retry_count == 2
+    assert not t.can_retry()            # 2 == 2
+
+
+def test_workflow_task_get_enhanced_inputs_merges_context():
+    """get_enhanced_inputs() returns inputs + context + task_id + workflow_metadata."""
+    t = WorkflowTask(
+        task_id="t1",
+        inputs={"x": 1},
+        metadata={"workflow_id": "wf1"},
+    )
+    enhanced = t.get_enhanced_inputs({"runtime_key": "v"})
+    assert enhanced["x"] == 1
+    assert enhanced["context"] == {"runtime_key": "v"}
+    assert enhanced["task_id"] == "t1"
+    assert enhanced["workflow_metadata"] == {"workflow_id": "wf1"}
+
+
+def test_workflow_task_to_completed_result_shape():
+    """to_completed_result() builds the runner's success-result dict."""
+    t = WorkflowTask(task_id="t1", agent_type="researcher")
+    t.start_execution()
+    import time as _time
+    _time.sleep(0.001)
+    t.complete_execution({"answer": "yes"})
+    res = t.to_completed_result({"answer": "yes"})
+    assert res["status"] == "completed"
+    assert res["output"] == {"answer": "yes"}
+    assert res["execution_time"] > 0.0
+    assert res["agent"] == "researcher"
+
+
+def test_workflow_task_to_failed_result_shape():
+    """to_failed_result() builds the runner's failure-result dict."""
+    t = WorkflowTask(task_id="t1", agent_type="researcher")
+    res = t.to_failed_result("timeout after 30s")
+    assert res["status"] == "failed"
+    assert res["error"] == "timeout after 30s"
+    assert res["agent"] == "researcher"
+
+
+def test_lifecycle_methods_inherited_by_subclasses_and_aliases():
+    """#7121 closes the variance gap: all aliases/subclasses now have the methods."""
+    # Plain canonical
+    plain = WorkflowTask(task_id="plain")
+    plain.start_execution()
+    assert plain.status == "running"
+
+    # Alias path: workflow_templates.WorkflowStep is `WorkflowStep = WorkflowTask`
+    # (#6951 Phase 2A). It must inherit lifecycle methods automatically.
+    # Smoke-checked by importer; can't run from autobot_shared without deps.
+
+    # Subclass would also work — covered by enhanced_orchestration tests.


### PR DESCRIPTION
## Summary

Closes [#7121](https://github.com/mrveiss/AutoBot-AI/issues/7121). The "blocked on #6520" framing was wrong — the actual blocker was a single enum location, not the full status-enum consolidation. Solving that as part of this PR.

## Two coordinated moves

### 1. Move TaskStatus to autobot_shared (partial #6520)

\`autobot-backend/constants/status_enums.py\` → \`autobot_shared/status_enums.py\`. The original path becomes a re-export shim:

\`\`\`python
# autobot-backend/constants/status_enums.py (after)
from autobot_shared.status_enums import (
    HealthStatus, LLMProvider, OperationOutcome,
    Priority, Severity, TaskStatus,
)
\`\`\`

15+ existing callers keep working unchanged. \`TaskStatus\` is now importable from \`autobot_shared\` without inverting the layering — which was the actual blocker for #7121.

### 2. Move lifecycle methods to canonical (closes #7121)

9 methods migrate from \`enhanced_orchestration.types.AgentTask\` to canonical \`autobot_shared.workflow.WorkflowTask\`:

\`\`\`
start_execution()      complete_execution(result)    fail_execution(error)
get_execution_time()   can_retry()                   increment_retry()
get_enhanced_inputs()  to_completed_result(result)   to_failed_result(error)
\`\`\`

\`AgentTask\` collapses to a pure alias:

\`\`\`python
# autobot-backend/enhanced_orchestration/types.py (after)
AgentTask = WorkflowTask
\`\`\`

## Variance gap closed

**Before:** \`WorkflowPlan.tasks: List[WorkflowTask]\` accepted both plain \`WorkflowTask\` (no lifecycle methods) and \`AgentTask\` subclass (with methods). A caller iterating expecting \`task.start_execution()\` could get a silent \`AttributeError\` if a plain WorkflowTask leaked into the list.

**After:** every WorkflowTask instance — plain, aliased (\`workflow_templates.WorkflowStep\`, \`orchestration.types.WorkflowStep\`), or formerly-subclassed (\`AgentTask\`) — has all 9 methods. No variance gap.

\`\`\`python
# Smoke verification (passes after this PR)
plan = WorkflowPlan(plan_id="p1", goal="g", tasks=[
    WorkflowTask(task_id="t1"),  # plain canonical
])
for t in plan.tasks:
    t.start_execution()         # was AttributeError pre-PR
    t.complete_execution({})
\`\`\`

## Verification

\`\`\`bash
$ pytest autobot_shared/workflow/types_test.py
29 passed in 0.08s   # 20 existing + 9 new lifecycle tests

$ pytest autobot-backend/enhanced_orchestration/
57 passed, 1 warning in 0.48s   # no regression on AgentTask callers

$ python3 -c "
from autobot_shared.status_enums import TaskStatus as A
from constants.status_enums import TaskStatus as B
assert A is B  # identical enum via both paths
"
\`\`\`

## What this means for #6520

Partial close. The TaskStatus enum now has a single canonical home in \`autobot_shared\`, but **the other 5 duplicate TaskStatus enums** (in \`a2a/types.py\`, \`utils/task_queue.py\`, \`enhanced_memory_manager_async.py\`, \`services/agent_analytics.py\`, \`services/knowledge/task_status_manager.py\`) still need their own per-call-site consolidation — those each have additional fields or domain-specific values. Out of scope for this PR; remains tracked under #6520.

## Closes

- #7121 — lifecycle methods on canonical
- #6520 partial — canonical TaskStatus now in autobot_shared

🤖 Generated with [Claude Code](https://claude.com/claude-code)