### PR TITLE
fix(tests): repoint 9 src.* mock paths #7176 missed (#6987 part 5/N)

### DIFF
--- a/autobot-backend/security/security_edge_cases_test.py
+++ b/autobot-backend/security/security_edge_cases_test.py
@@ -322,7 +322,7 @@ class TestSecurityEdgeCases:
 
         for bypass_config in bypass_attempts:
             with patch(
-                "src.enhanced_security_layer.global_config_manager"
+                "enhanced_security_layer.global_config_manager"
             ) as mock_config:
                 # Simulate config change during runtime
                 modified_config = original_config.copy()

--- a/autobot-backend/services/terminal_history_service_test.py
+++ b/autobot-backend/services/terminal_history_service_test.py
@@ -26,7 +26,7 @@ class TestTerminalHistoryService:
     def service(self, mock_redis):
         """Create history service with mocked Redis."""
         with patch(
-            "src.services.terminal_history_service.get_redis_client",
+            "autobot_shared.redis_client.get_async_redis_client",
             return_value=mock_redis,
         ):
             from services.terminal_history_service import TerminalHistoryService

--- a/autobot-backend/user_management/middleware/rate_limit_test.py
+++ b/autobot-backend/user_management/middleware/rate_limit_test.py
@@ -35,7 +35,7 @@ async def test_check_rate_limit_allows_under_threshold(mock_redis):
     mock_redis.get = AsyncMock(return_value="2")  # 2 attempts
 
     with patch(
-        "src.user_management.middleware.rate_limit.get_redis_client",
+        "autobot_shared.redis_client.get_async_redis_client",
         return_value=mock_redis,
     ):
         limiter = PasswordChangeRateLimiter()
@@ -58,7 +58,7 @@ async def test_check_rate_limit_blocks_exceeded(mock_redis):
     mock_redis.ttl = AsyncMock(return_value=1620)  # 27 minutes
 
     with patch(
-        "src.user_management.middleware.rate_limit.get_redis_client",
+        "autobot_shared.redis_client.get_async_redis_client",
         return_value=mock_redis,
     ):
         limiter = PasswordChangeRateLimiter()
@@ -79,7 +79,7 @@ async def test_record_attempt_increments_on_failure(mock_redis):
     mock_redis.expire = AsyncMock()
 
     with patch(
-        "src.user_management.middleware.rate_limit.get_redis_client",
+        "autobot_shared.redis_client.get_async_redis_client",
         return_value=mock_redis,
     ):
         limiter = PasswordChangeRateLimiter()
@@ -99,7 +99,7 @@ async def test_record_attempt_clears_on_success(mock_redis):
     mock_redis.delete = AsyncMock(return_value=1)
 
     with patch(
-        "src.user_management.middleware.rate_limit.get_redis_client",
+        "autobot_shared.redis_client.get_async_redis_client",
         return_value=mock_redis,
     ):
         limiter = PasswordChangeRateLimiter()

--- a/autobot-backend/user_management/services/session_service_test.py
+++ b/autobot-backend/user_management/services/session_service_test.py
@@ -46,7 +46,7 @@ async def test_add_token_to_blacklist(mock_redis):
     token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test"
 
     with patch(
-        "src.user_management.services.session_service.get_redis_client",
+        "autobot_shared.redis_client.get_async_redis_client",
         return_value=mock_redis,
     ):
         service = SessionService()
@@ -69,7 +69,7 @@ async def test_is_token_blacklisted(mock_redis):
     mock_redis.sismember = AsyncMock(return_value=True)
 
     with patch(
-        "src.user_management.services.session_service.get_redis_client",
+        "autobot_shared.redis_client.get_async_redis_client",
         return_value=mock_redis,
     ):
         service = SessionService()
@@ -95,7 +95,7 @@ async def test_invalidate_user_sessions_except_current(mock_redis):
     mock_redis.expire = AsyncMock()
 
     with patch(
-        "src.user_management.services.session_service.get_redis_client",
+        "autobot_shared.redis_client.get_async_redis_client",
         return_value=mock_redis,
     ):
         service = SessionService()


### PR DESCRIPTION
## Summary

PR #7176's mechanical sed-based bulk fix matched single-line \`patch(\"src...\")\` calls only. 9 sites in 4 files use multi-line \`patch(\\n  \"src...\",\\n  ...\\n)\` form and slipped through.

## Sites fixed

| File | Sites | Target after fix |
|---|---|---|
| \`security/security_edge_cases_test.py:325\` | 1 | \`enhanced_security_layer.global_config_manager\` (drop src.) |
| \`services/terminal_history_service_test.py:29\` | 1 | \`autobot_shared.redis_client.get_async_redis_client\` (canonical source) |
| \`user_management/middleware/rate_limit_test.py\` | 4 | \`autobot_shared.redis_client.get_async_redis_client\` |
| \`user_management/services/session_service_test.py\` | 3 | \`autobot_shared.redis_client.get_async_redis_client\` |

Per PR #7181 lesson: drop-prefix isn't always right. Production code at \`rate_limit.py:18\` and \`session_service.py:16\` does \`from autobot_shared.redis_client import get_async_redis_client\` — so the canonical mock target is on \`autobot_shared\`.

## Verification

\`\`\`
$ grep -rn 'patch.*\"src\\.' autobot-backend --include='*.py' | grep -v __pycache__
(empty — all src.* prefixes gone)
\`\`\`

## Pre-existing test-pattern bug surfaced (filing follow-up)

With patches now resolving, rate_limit/session_service tests fail because they use \`patch(..., return_value=mock_redis)\` for async functions. Production does \`await get_async_redis_client(...)\` — \`await mock_redis\` returns the default AsyncMock, not mock_redis. Same bug class as #7069 (return-shape mismatch). Following with separate tracker.

Closes part 5/N of #6987 (24 of 48 sites cleaned across PRs)