### PR TITLE
feat(frontend): wire AutomationWorkflowStep into useWorkflowBuilder.WorkflowStep (closes #7123)

### DIFF
--- a/autobot-frontend/src/composables/useWorkflowBuilder.ts
+++ b/autobot-frontend/src/composables/useWorkflowBuilder.ts
@@ -28,16 +28,16 @@ const logger = createLogger('useWorkflowBuilder');
 // TYPE DEFINITIONS
 // ==================================================================================
 
-/** Workflow step status */
-export type WorkflowStepStatus =
-  | 'pending'
-  | 'waiting_approval'
-  | 'approved'
-  | 'executing'
-  | 'completed'
-  | 'skipped'
-  | 'failed'
-  | 'paused';
+// #7123: WorkflowStepStatus, RiskLevel, and the runtime step shape are
+// now defined canonically in @/types/workflowTemplates. Imported here for
+// in-file use AND re-exported so existing import paths
+// (`useWorkflowBuilder.WorkflowStepStatus`, etc.) keep working.
+import type {
+  WorkflowStepStatus,
+  RiskLevel,
+  AutomationWorkflowStep,
+} from '@/types/workflowTemplates'
+export type { WorkflowStepStatus, RiskLevel, AutomationWorkflowStep }
 
 /** Automation execution modes */
 export type AutomationMode = 'manual' | 'semi_automatic' | 'automatic';
@@ -63,24 +63,18 @@ export type ExecutionStrategy =
   | 'collaborative'
   | 'adaptive';
 
-/** Risk level */
-export type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
-
-/** Workflow step definition */
-export interface WorkflowStep {
-  step_id: string;
-  command: string;
-  description: string;
-  explanation?: string;
-  requires_confirmation: boolean;
-  risk_level: RiskLevel;
-  estimated_duration: number;
-  dependencies?: string[];
-  status: WorkflowStepStatus;
-  execution_result?: Record<string, unknown>;
-  started_at?: string;
-  completed_at?: string;
-}
+/**
+ * Workflow step definition (#7123).
+ *
+ * Alias to the canonical `AutomationWorkflowStep` from
+ * `@/types/workflowTemplates`. The 6+ consumers (`WorkflowRunner.vue`,
+ * `WorkflowLiveDashboard.vue`, `OrchestrationVisualizer.vue`,
+ * `WorkflowCanvas.vue`, `WorkflowBuilderView.vue`, this composable's
+ * helpers) keep their `import { WorkflowStep }` path but now resolve to
+ * a single source of truth that mirrors backend
+ * `services/workflow_automation/WorkflowStep.to_status_dict()`.
+ */
+export type WorkflowStep = AutomationWorkflowStep;
 
 /** Workflow phase from state machine (#1380) */
 export type WorkflowPhase =
@@ -652,7 +646,7 @@ export function useWorkflowBuilder() {
       description: 'Update and upgrade system packages',
       category: 'System',
       icon: 'fas fa-sync-alt',
-      steps: [{ command: 'sudo apt update && sudo apt upgrade -y', description: 'Update system', risk_level: 'medium', requires_confirmation: true, estimated_duration: 120 }],
+      steps: [{ command: 'sudo apt update && sudo apt upgrade -y', description: 'Update system', risk_level: 'medium', requires_confirmation: true, estimated_duration: 120, started_at: null, completed_at: null }],
     },
     {
       id: 'security_scan',
@@ -660,7 +654,7 @@ export function useWorkflowBuilder() {
       description: 'Run security scanning workflow',
       category: 'Security',
       icon: 'fas fa-shield-alt',
-      steps: [{ command: 'sudo lynis audit system', description: 'System security audit', risk_level: 'low', requires_confirmation: false, estimated_duration: 300 }],
+      steps: [{ command: 'sudo lynis audit system', description: 'System security audit', risk_level: 'low', requires_confirmation: false, estimated_duration: 300, started_at: null, completed_at: null }],
     },
   ];
 

--- a/autobot-frontend/src/types/workflowTemplates.ts
+++ b/autobot-frontend/src/types/workflowTemplates.ts
@@ -47,18 +47,50 @@ export interface TemplateStep {
 }
 
 /**
+ * Runtime workflow step status — string union mirroring
+ * `services/workflow_automation/models.py:WorkflowStepStatus`.
+ *
+ * #7123: declared here as the canonical types module. The previous local
+ * declaration in `composables/useWorkflowBuilder.ts` is now a re-export
+ * pointing at this definition (single source of truth).
+ */
+export type WorkflowStepStatus =
+  | 'pending'
+  | 'waiting_approval'
+  | 'approved'
+  | 'executing'
+  | 'completed'
+  | 'skipped'
+  | 'failed'
+  | 'paused'
+
+/**
  * Runtime workflow step — matches backend
  * `services/workflow_automation/WorkflowStep.to_status_dict()`. Used by the
  * shell+vision execution path with risk levels and confirmation gating.
  * Distinct from `TemplateStep` per #7044 split.
+ *
+ * #7123: extended to be the canonical runtime shape consumed across the
+ * frontend. The previous local `WorkflowStep` interface in
+ * `composables/useWorkflowBuilder.ts` is now `type WorkflowStep = AutomationWorkflowStep`.
+ *
+ * Field nullability matches backend payload exactly:
+ * - `started_at` / `completed_at` are `string | null` (backend always sends
+ *   the key, with ISO-8601 string when set, null otherwise).
+ * - `risk_level` is required (backend always emits it; the previous
+ *   optional ? was a guess that masked the bug #7044 documented).
  */
 export interface AutomationWorkflowStep {
   step_id: string
   command: string
   description: string
-  status: string
+  explanation?: string
+  status: WorkflowStepStatus
   requires_confirmation: boolean
-  risk_level?: RiskLevel
+  risk_level: RiskLevel
+  estimated_duration: number
+  dependencies?: string[]
+  execution_result?: Record<string, unknown>
   started_at: string | null
   completed_at: string | null
 }


### PR DESCRIPTION
## Summary

Closes [#7123](https://github.com/mrveiss/issue-7123). Solves both blockers from the earlier reverted attempt.

## Blockers + solutions

### Blocker 1: \`started_at/completed_at\` nullability mismatch

| Old (useWorkflowBuilder) | Old (workflowTemplates) |
|---|---|
| \`started_at?: string\` (optional, undefined when missing) | \`started_at: string \| null\` (required, null when not set) |
| \`completed_at?: string\` | \`completed_at: string \| null\` |

These are different runtime contracts (\`undefined\` vs \`null\`). Backend's \`to_status_dict()\` emits \`null\` for unset values, so \`string | null\` is correct.

**Fix:** \`AutomationWorkflowStep\` (canonical) keeps \`string | null\`. The 2 object-literal call sites in \`useWorkflowBuilder.ts\` (lines 649, 657 — fallback templates) explicitly set \`started_at: null, completed_at: null\` to match the contract.

### Blocker 2: Duplicate \`WorkflowStepStatus\` / \`RiskLevel\` definitions

Both \`useWorkflowBuilder.ts\` and \`workflowTemplates.ts\` declared parallel \`type WorkflowStepStatus = | 'pending' | ...\` unions with identical values.

**Fix:** \`workflowTemplates.ts\` is the canonical home; \`useWorkflowBuilder.ts\` re-exports both types so 6+ existing consumers keep their import path.

## What landed

- **\`workflowTemplates.ts\`**:
  - \`WorkflowStepStatus\` declared canonically (8-state union)
  - \`AutomationWorkflowStep\` extended to runtime superset: added \`explanation?\`, \`dependencies?\`, \`estimated_duration\`, \`execution_result?\`. Tightened \`status: WorkflowStepStatus\` (was \`string\`), \`risk_level: RiskLevel\` (was \`?\`)
- **\`useWorkflowBuilder.ts\`**:
  - \`type WorkflowStep = AutomationWorkflowStep\` alias replaces 14-field interface
  - Re-exports \`WorkflowStepStatus, RiskLevel, AutomationWorkflowStep\` so existing import paths work
  - 2 fallback-template object literals fixed with \`started_at: null, completed_at: null\`

## Verification

\`\`\`bash
$ npx vue-tsc --noEmit -p tsconfig.app.json
2096 errors   # IDENTICAL to Dev_new_gui baseline; 0 new errors
\`\`\`

Pre-existing 2096 errors are unrelated (vue/vue-i18n module typing, implicit-any in OrchestrationVisualizer/WorkflowCanvas). None added or removed by this PR.

## #6836 integration check

\`AutomationWorkflowStep\` previously had 0 production callers (was just a declaration). Now has **1+ production caller** via \`WorkflowStep = AutomationWorkflowStep\` in \`useWorkflowBuilder.ts\`, consumed by all 6 runtime view files (\`WorkflowRunner.vue\`, \`WorkflowLiveDashboard.vue\`, \`OrchestrationVisualizer.vue\`, \`WorkflowCanvas.vue\`, \`WorkflowBuilderView.vue\`, plus the composable's helpers). Integration check satisfied.

## Closes

- #7123 — \`AutomationWorkflowStep\` wired into \`useWorkflowBuilder.WorkflowStep\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)