### PR TITLE
fix(test/worker): assert on envelope-wrapped result shape (#7154)

### DIFF
--- a/autobot-backend/worker_node_test.py
+++ b/autobot-backend/worker_node_test.py
@@ -117,8 +117,11 @@ class TestWorkerNodeRefactored:
 
         result = await worker_node.execute_task(task_payload)
 
+        # #7154: worker_node now wraps every response in a {status, message,
+        # data} envelope. The actual response sits at result["data"]["response"].
         assert result["status"] == "success"
-        assert "response" in result
+        assert "data" in result
+        assert "response" in result["data"]
         worker_node.llm_interface.chat_completion.assert_called_once()
         worker_node.security_layer.audit_log.assert_called()
 
@@ -137,8 +140,10 @@ class TestWorkerNodeRefactored:
 
         result = await worker_node.execute_task(task_payload)
 
+        # #7154: worker_node envelope — actual results at result["data"]["results"].
         assert result["status"] == "success"
-        assert "results" in result
+        assert "data" in result
+        assert "results" in result["data"]
         worker_node.knowledge_base.search.assert_called_once_with("test query", 5)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

\`worker_node\` was refactored to wrap task results in \`{status, message, data}\` envelopes. Two tests still asserted on the unwrapped shape and were failing silently on stale-mock-luck (per #6987 sweep). Updated both to drill through \`result["data"]\`.

## Test plan

- [x] \`pytest -k 'test_llm_chat_completion_success or test_kb_search_success'\` → 2/2 pass
- [x] Envelope-consistency audit: traced \`execute_task → task_executor.execute → handlers\`. Per-handler envelope wrapping is consistent for task results. Unwrapped helper-method returns (worker_node.py:104, 206, 215, ...) are internal helpers, not user-facing — no drift surface to file as follow-up.

Closes #7154