### PR TITLE
security(P1): fix 2 regressions + 2 test rots in EnhancedSecurityLayer (#7161)

### DIFF
--- a/autobot-backend/enhanced_security_layer.py
+++ b/autobot-backend/enhanced_security_layer.py
@@ -26,9 +26,7 @@ HIGH_RISK_COMMAND_RISKS = {CommandRisk.HIGH, CommandRisk.MODERATE}
 COMMAND_EXECUTION_ACTIONS = {"command_execution_attempt", "command_execution_complete"}
 
 
-def _parse_audit_log_entry(
-    line: str, user: Optional[str] = None
-) -> Optional[Dict[str, Any]]:
+def _parse_audit_log_entry(line: str, user: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """Parse a single audit log line and filter by user (Issue #315: extracted).
 
     Args:
@@ -64,9 +62,7 @@ class EnhancedSecurityLayer:
         # Use centralized config manager
         self.security_config = global_config_manager.get("security_config", {})
         self.enable_auth = self.security_config.get("enable_auth", False)
-        self.enable_command_security = self.security_config.get(
-            "enable_command_security", True
-        )
+        self.enable_command_security = self.security_config.get("enable_command_security", True)
         self.audit_log_file = self.security_config.get(
             "audit_log_file", os.getenv("AUTOBOT_AUDIT_LOG_FILE", "data/audit.log")
         )
@@ -74,9 +70,7 @@ class EnhancedSecurityLayer:
         self.allowed_users = self.security_config.get("allowed_users", {})
 
         # Command security settings
-        self.command_approval_required = self.security_config.get(
-            "command_approval_required", True
-        )
+        self.command_approval_required = self.security_config.get("command_approval_required", True)
         self.use_docker_sandbox = self.security_config.get("use_docker_sandbox", False)
 
         # Initialize secure command executor
@@ -115,11 +109,17 @@ class EnhancedSecurityLayer:
         # Load custom policies from config if available
         custom_policies = self.security_config.get("command_policies", {})
 
+        # #7161: SAFE_COMMANDS / FORBIDDEN_COMMANDS are frozensets after the
+        # #765 centralized-command-patterns refactor. The previous .update()
+        # calls crashed with AttributeError on any deployment that supplied
+        # `command_policies` in config — silently broken because no test
+        # exercised this path until #6987 fixed the src.* mocks. Now we
+        # rebuild the attribute as a mutable set merging defaults + customs.
         if "safe_commands" in custom_policies:
-            policy.safe_commands.update(custom_policies["safe_commands"])
+            policy.safe_commands = set(policy.safe_commands) | set(custom_policies["safe_commands"])
 
         if "forbidden_commands" in custom_policies:
-            policy.forbidden_commands.update(custom_policies["forbidden_commands"])
+            policy.forbidden_commands = set(policy.forbidden_commands) | set(custom_policies["forbidden_commands"])
 
         if "allowed_paths" in custom_policies:
             from pathlib import Path
@@ -128,9 +128,7 @@ class EnhancedSecurityLayer:
 
         return policy
 
-    def _log_approval_request(
-        self, command_id: str, approval_data: Dict[str, Any]
-    ) -> None:
+    def _log_approval_request(self, command_id: str, approval_data: Dict[str, Any]) -> None:
         """Log command approval request to audit log. Issue #620."""
         self.audit_log(
             action="command_approval_request",
@@ -144,9 +142,7 @@ class EnhancedSecurityLayer:
             },
         )
 
-    def _check_auto_approve_moderate(
-        self, command_id: str, approval_data: Dict[str, Any]
-    ) -> Optional[bool]:
+    def _check_auto_approve_moderate(self, command_id: str, approval_data: Dict[str, Any]) -> Optional[bool]:
         """Check if moderate risk command should be auto-approved. Issue #620.
 
         Returns:
@@ -220,9 +216,7 @@ class EnhancedSecurityLayer:
             self.approval_results[command_id] = approved
             self.pending_approvals[command_id].set()
 
-    def _handle_deprecated_role(
-        self, user_role: str, action_type: str, resource: Optional[str]
-    ) -> str:
+    def _handle_deprecated_role(self, user_role: str, action_type: str, resource: Optional[str]) -> str:
         """Handle deprecated privileged roles by logging and downgrading. Issue #620.
 
         Args:
@@ -261,9 +255,7 @@ class EnhancedSecurityLayer:
             return True
         return False
 
-    def _check_wildcard_permissions(
-        self, action_type: str, role_permissions: List[str]
-    ) -> bool:
+    def _check_wildcard_permissions(self, action_type: str, role_permissions: List[str]) -> bool:
         """Check if action matches any wildcard permissions. Issue #620.
 
         Args:
@@ -280,9 +272,7 @@ class EnhancedSecurityLayer:
                     return True
         return False
 
-    def check_permission(
-        self, user_role: str, action_type: str, resource: Optional[str] = None
-    ) -> bool:
+    def check_permission(self, user_role: str, action_type: str, resource: Optional[str] = None) -> bool:
         """
         Enhanced permission checking that includes command execution permissions
         SECURITY FIX: Removed god mode bypass - all roles use granular RBAC
@@ -296,9 +286,17 @@ class EnhancedSecurityLayer:
 
         role_permissions = self.roles.get(user_role, {}).get("permissions", [])
 
+        # #7161: previously the shell_execute special-case checked ONLY
+        # configured `self.roles` permissions, ignoring `_get_default_role_permissions()`.
+        # Roles like 'admin' that have `allow_shell_execute` only in defaults
+        # (not configured) were denied shell access. Now combine both sources
+        # so the special-case respects defaults too.
+        default_permissions = self._get_default_role_permissions(user_role)
+        all_permissions = list(role_permissions) + list(default_permissions)
+
         # Special handling for command execution
         if action_type == "allow_shell_execute":
-            return self._check_shell_execute_permission(role_permissions)
+            return self._check_shell_execute_permission(all_permissions)
 
         # Direct permission check
         if action_type in role_permissions:
@@ -309,19 +307,13 @@ class EnhancedSecurityLayer:
             return True
 
         # Check default role permissions
-        default_permissions = self._get_default_role_permissions(user_role)
         if action_type in default_permissions:
             return True
 
-        logger.warning(
-            f"Permission DENIED for role '{user_role}' to perform "
-            f"action '{action_type}'"
-        )
+        logger.warning(f"Permission DENIED for role '{user_role}' to perform " f"action '{action_type}'")
         return False
 
-    def _create_permission_denied_result(
-        self, command: str, user: str, user_role: str
-    ) -> Dict[str, Any]:
+    def _create_permission_denied_result(self, command: str, user: str, user_role: str) -> Dict[str, Any]:
         """
         Create a permission denied result for command execution.
 
@@ -381,10 +373,7 @@ class EnhancedSecurityLayer:
         if "allow_shell_execute_safe" in role_permissions and risk != CommandRisk.SAFE:
             # User can only execute safe commands without approval
             return True
-        elif (
-            "allow_shell_execute" in role_permissions
-            and risk in HIGH_RISK_COMMAND_RISKS
-        ):
+        elif "allow_shell_execute" in role_permissions and risk in HIGH_RISK_COMMAND_RISKS:
             # User has shell execute permission but high-risk commands need approval
             return True
 
@@ -435,9 +424,7 @@ class EnhancedSecurityLayer:
 
         return default_role_permissions.get(user_role, [])
 
-    def _log_command_attempt(
-        self, command: str, user: str, user_role: str, force_approval: bool
-    ) -> None:
+    def _log_command_attempt(self, command: str, user: str, user_role: str, force_approval: bool) -> None:
         """Log command execution attempt to audit log. Issue #620."""
         self.audit_log(
             action="command_execution_attempt",
@@ -464,9 +451,7 @@ class EnhancedSecurityLayer:
             "security": {"enabled": False},
         }
 
-    def _log_command_complete(
-        self, command: str, user: str, result: Dict[str, Any]
-    ) -> None:
+    def _log_command_complete(self, command: str, user: str, result: Dict[str, Any]) -> None:
         """Log command execution completion to audit log. Issue #620."""
         self.audit_log(
             action="command_execution_complete",
@@ -479,9 +464,7 @@ class EnhancedSecurityLayer:
             },
         )
 
-    async def execute_command(
-        self, command: str, user: str, user_role: str
-    ) -> Dict[str, Any]:
+    async def execute_command(self, command: str, user: str, user_role: str) -> Dict[str, Any]:
         """
         Execute a command with security checks and audit logging
 
@@ -500,9 +483,7 @@ class EnhancedSecurityLayer:
         self._log_command_attempt(command, user, user_role, force_approval)
 
         if self.enable_command_security:
-            result = await self.command_executor.run_shell_command(
-                command, force_approval=force_approval
-            )
+            result = await self.command_executor.run_shell_command(command, force_approval=force_approval)
         else:
             result = await self._execute_basic_command(command)
 
@@ -526,9 +507,7 @@ class EnhancedSecurityLayer:
         except Exception as e:
             logger.error("Failed to write to audit log: %s", e)
 
-    def get_command_history(
-        self, user: Optional[str] = None, limit: int = 100
-    ) -> List[Dict[str, Any]]:
+    def get_command_history(self, user: Optional[str] = None, limit: int = 100) -> List[Dict[str, Any]]:
         """
         Get command execution history from audit log
 
@@ -616,10 +595,7 @@ if __name__ == "__main__":
         logger.info("Command History:")
         history = security.get_command_history(limit=10)
         for entry in history:
-            logger.info(
-                f"- {entry['timestamp']}: {entry['user']} - "
-                f"{entry['action']} - {entry['outcome']}"
-            )
+            logger.info(f"- {entry['timestamp']}: {entry['user']} - " f"{entry['action']} - {entry['outcome']}")
             if "command" in entry.get("details", {}):
                 logger.info(f"  Command: {entry['details']['command']}")
 

--- a/autobot-backend/enhanced_security_layer_test.py
+++ b/autobot-backend/enhanced_security_layer_test.py
@@ -85,14 +85,31 @@ class TestEnhancedSecurityLayer:
         assert self.security.check_permission("user", "allow_shell_execute") is True
         assert self.security.check_permission("guest", "allow_all") is True
 
-    def test_check_permission_god_mode(self):
-        """Test GOD MODE permissions"""
+    def test_deprecated_privileged_roles_downgrade_to_admin(self):
+        """#7161 / #744: god/superuser/root are deprecated and downgraded.
+
+        Previously this test ('test_check_permission_god_mode') asserted
+        unrestricted "god mode" access including auto-granted
+        ``dangerous_action`` — a security anti-pattern. Issue #744
+        explicitly removed the god-mode bypass: privileged role names get
+        downgraded to 'admin' via ``_handle_deprecated_role`` and inherit
+        admin's RBAC permissions (no wildcard for arbitrary actions).
+
+        Pin the new contract: deprecated roles get admin-equivalent access
+        for legitimate actions (``allow_shell_execute``), but NOT for
+        arbitrary unmapped actions (no god-bypass wildcard).
+        """
         self.security.enable_auth = True
 
-        god_roles = ["god", "superuser", "root"]
-        for role in god_roles:
-            assert self.security.check_permission(role, "allow_shell_execute") is True
-            assert self.security.check_permission(role, "dangerous_action") is True
+        for role in ["god", "superuser", "root"]:
+            # Deprecated roles inherit admin perms — admin has shell_execute.
+            assert (
+                self.security.check_permission(role, "allow_shell_execute") is True
+            ), f"deprecated role {role!r} should inherit admin shell-execute"
+            # No god-bypass: unmapped action_type is denied (not auto-True).
+            assert (
+                self.security.check_permission(role, "dangerous_action") is False
+            ), f"deprecated role {role!r} must NOT auto-grant unmapped actions"
 
     def test_check_permission_shell_execute(self):
         """Test shell execution permissions"""
@@ -100,9 +117,7 @@ class TestEnhancedSecurityLayer:
 
         # Test different roles for shell execution
         assert self.security.check_permission("admin", "allow_shell_execute") is True
-        assert (
-            self.security.check_permission("developer", "allow_shell_execute") is True
-        )
+        assert self.security.check_permission("developer", "allow_shell_execute") is True
         assert self.security.check_permission("user", "allow_shell_execute") is False
         assert self.security.check_permission("guest", "allow_shell_execute") is False
 
@@ -111,9 +126,7 @@ class TestEnhancedSecurityLayer:
         self.security.enable_auth = True
 
         # Developer should have safe shell execution permission
-        assert (
-            self.security.check_permission("developer", "allow_shell_execute") is True
-        )
+        assert self.security.check_permission("developer", "allow_shell_execute") is True
 
         # User should not have shell execution permission
         assert self.security.check_permission("user", "allow_shell_execute") is False
@@ -121,19 +134,11 @@ class TestEnhancedSecurityLayer:
     def test_check_permission_custom_roles(self):
         """Test permission checking with custom role configuration"""
         self.security.enable_auth = True
-        self.security.roles = {
-            "custom_role": {"permissions": ["allow_shell_execute", "custom_permission"]}
-        }
+        self.security.roles = {"custom_role": {"permissions": ["allow_shell_execute", "custom_permission"]}}
 
-        assert (
-            self.security.check_permission("custom_role", "allow_shell_execute") is True
-        )
-        assert (
-            self.security.check_permission("custom_role", "custom_permission") is True
-        )
-        assert (
-            self.security.check_permission("custom_role", "forbidden_action") is False
-        )
+        assert self.security.check_permission("custom_role", "allow_shell_execute") is True
+        assert self.security.check_permission("custom_role", "custom_permission") is True
+        assert self.security.check_permission("custom_role", "forbidden_action") is False
 
     def test_check_permission_wildcard(self):
         """Test wildcard permission matching"""
@@ -146,7 +151,12 @@ class TestEnhancedSecurityLayer:
         assert self.security.check_permission("test_role", "api.write.users") is False
 
     def test_get_default_role_permissions(self):
-        """Test default role permissions"""
+        """Test default role permissions.
+
+        #7161 / #744: guest role was REMOVED as a security vulnerability —
+        unauthenticated requests must be rejected, not assigned default
+        permissions. Tests now pin the post-#744 contract.
+        """
         default_perms = self.security._get_default_role_permissions("developer")
         assert "allow_shell_execute_safe" in default_perms
         assert "allow_kb_write" in default_perms
@@ -155,9 +165,15 @@ class TestEnhancedSecurityLayer:
         assert "allow_shell_execute" not in user_perms
         assert "allow_kb_read" in user_perms
 
+        # #744: guest is REMOVED — empty permissions list returned.
+        # Unauthenticated requests must be rejected upstream, not granted
+        # any default access here.
         guest_perms = self.security._get_default_role_permissions("guest")
-        assert "files.view" in guest_perms
-        assert len(guest_perms) == 1  # Very limited permissions
+        assert guest_perms == [], (
+            "guest role was removed by #744 as a security vulnerability; "
+            "_get_default_role_permissions('guest') must return [] so "
+            "unauthenticated requests are rejected upstream"
+        )
 
     @pytest.mark.asyncio
     async def test_command_approval_callback_auto_approve(self):
@@ -185,9 +201,7 @@ class TestEnhancedSecurityLayer:
         }
 
         # Start approval in background
-        approval_task = asyncio.create_task(
-            self.security._command_approval_callback(approval_data)
-        )
+        approval_task = asyncio.create_task(self.security._command_approval_callback(approval_data))
 
         # Wait a moment then approve
         await asyncio.sleep(0.1)
@@ -254,9 +268,7 @@ class TestEnhancedSecurityLayer:
     @pytest.mark.asyncio
     async def test_execute_command_with_permission(self):
         """Test command execution with proper permissions"""
-        with patch.object(
-            self.security.command_executor, "run_shell_command"
-        ) as mock_run:
+        with patch.object(self.security.command_executor, "run_shell_command") as mock_run:
             mock_run.return_value = {
                 "stdout": "file1 file2",
                 "stderr": "",
@@ -265,9 +277,7 @@ class TestEnhancedSecurityLayer:
                 "security": {"risk": "safe"},
             }
 
-            result = await self.security.execute_command(
-                "ls -la", "admin_user", "admin"
-            )
+            result = await self.security.execute_command("ls -la", "admin_user", "admin")
 
             assert result["status"] == "success"
             assert result["stdout"] == "file1 file2"
@@ -278,14 +288,10 @@ class TestEnhancedSecurityLayer:
         """Test command execution with forced approval for restricted roles"""
         self.security.enable_auth = True
 
-        with patch.object(
-            self.security.command_executor, "assess_command_risk"
-        ) as mock_assess:
+        with patch.object(self.security.command_executor, "assess_command_risk") as mock_assess:
             mock_assess.return_value = (CommandRisk.HIGH, ["High risk command"])
 
-            with patch.object(
-                self.security.command_executor, "run_shell_command"
-            ) as mock_run:
+            with patch.object(self.security.command_executor, "run_shell_command") as mock_run:
                 mock_run.return_value = {
                     "stdout": "",
                     "stderr": "Command execution denied by user",
@@ -295,9 +301,7 @@ class TestEnhancedSecurityLayer:
                 }
 
                 # Developer can only execute safe commands without approval
-                await self.security.execute_command(
-                    "rm file.txt", "dev_user", "developer"
-                )
+                await self.security.execute_command("rm file.txt", "dev_user", "developer")
 
                 # Should force approval for non-safe command
                 mock_run.assert_called_once_with("rm file.txt", force_approval=True)
@@ -313,9 +317,7 @@ class TestEnhancedSecurityLayer:
             mock_process.returncode = 0
             mock_subprocess.return_value = mock_process
 
-            result = await self.security.execute_command(
-                "echo hello", "test_user", "user"
-            )
+            result = await self.security.execute_command("echo hello", "test_user", "user")
 
             assert result["status"] == "success"
             assert result["stdout"] == "output"
@@ -346,9 +348,7 @@ class TestEnhancedSecurityLayer:
         self.security.audit_log_file = "/invalid/path/audit.log"
 
         # Should not raise exception
-        self.security.audit_log(
-            action="test_action", user="test_user", outcome="success", details={}
-        )
+        self.security.audit_log(action="test_action", user="test_user", outcome="success", details={})
 
     def test_get_command_history_empty(self):
         """Test getting command history when empty"""
@@ -472,9 +472,7 @@ class TestEnhancedSecurityLayerIntegration:
             mock_process.returncode = 0
             mock_subprocess.return_value = mock_process
 
-            result = await self.security.execute_command(
-                "echo 'hello world'", "test_user", "admin"
-            )
+            result = await self.security.execute_command("echo 'hello world'", "test_user", "admin")
 
             assert result["status"] == "success"
             assert result["stdout"] == "hello world"


### PR DESCRIPTION
## Summary

P1 SECURITY — 4 tests in \`enhanced_security_layer_test.py\` had been silently passing on stale-mock-luck during the entire #6987 src.* bug window. After #6987 made mocks actually apply, they failed. Triaged as **2 real regressions + 2 test rots**:

### Regression 1 — \`_create_security_policy\` mutates frozenset
After #765 made \`SAFE_COMMANDS\` / \`FORBIDDEN_COMMANDS\` frozensets, \`_create_security_policy\` crashes with \`AttributeError\` on any deployment that supplies \`command_policies\` in config. Production code was untested through this path because \`test_create_security_policy\` had broken mocks.
**Fix:** rebuild as mutable set merging defaults + customs.

### Regression 2 — \`_check_shell_execute_permission\` ignores defaults
\`check_permission\` early-returned for shell_execute using ONLY \`self.roles.get(...)\` configured permissions, never consulting \`_get_default_role_permissions()\`. Roles like 'admin' that have \`allow_shell_execute\` in DEFAULTS but not in configured roles (typical) were denied shell access.
**Fix:** combine role_permissions + default_permissions before the special-case.

### Test Rot 1 — \`test_check_permission_god_mode\` (renamed)
Asserted unrestricted "god mode" with auto-granted \`dangerous_action\`. #744 explicitly removed god/superuser/root as security vulnerabilities — they get downgraded to 'admin'. Renamed to \`test_deprecated_privileged_roles_downgrade_to_admin\` and pinned the new contract: deprecated roles get admin shell-execute but NOT auto-granted unmapped actions.

### Test Rot 2 — \`test_get_default_role_permissions\` (guest assertion)
#744 removed guest role entirely. Updated to assert \`guest_perms == []\` so unauthenticated requests are rejected upstream.

## Test plan

- [x] All 4 originally-failing tests now pass
- [x] Full file: 27/27 pass — no regressions from production fixes
- [x] Black-formatted

Closes #7161