### PR TITLE
fix(frontend): vue-tsc regression-guard CI + worktree-gotcha doc note (closes #7227)

### DIFF
--- a/.github/workflows/frontend-typecheck-regression.yml
+++ b/.github/workflows/frontend-typecheck-regression.yml
@@ -1,0 +1,84 @@
+# #7227: vue-tsc regression guard.
+#
+# Runs `vue-tsc --noEmit -p tsconfig.app.json` on every PR that touches
+# the frontend. Fails if the error count exceeds the documented baseline
+# of 248 (real type-debt as of 2026-05-09; see #7227 for the breakdown).
+#
+# This is a *count-based* gate rather than a strict "0 errors required"
+# gate because the existing 248 errors are a known long-tail of unknown
+# / type-incompatibility issues that need per-cluster cleanup PRs (see
+# top-files breakdown in #7227 issue body). Each cleanup PR can reduce
+# the baseline; this gate ensures no PR introduces new ones.
+#
+# When fixing a cluster:
+#   1. Reduce errors → re-run gate locally, count drops below 248
+#   2. Update the BASELINE constant below to the new count
+#   3. Commit the workflow update with the cleanup PR
+#
+# Security: this workflow does NOT interpolate any untrusted GitHub
+# event data into run: commands. All inputs are static repo paths.
+
+name: frontend-typecheck-regression
+
+on:
+  pull_request:
+    paths:
+      - 'autobot-frontend/src/**/*.ts'
+      - 'autobot-frontend/src/**/*.vue'
+      - 'autobot-frontend/tsconfig*.json'
+      - 'autobot-frontend/package*.json'
+      - '.github/workflows/frontend-typecheck-regression.yml'
+  push:
+    branches: [Dev_new_gui]
+    paths:
+      - 'autobot-frontend/src/**/*.ts'
+      - 'autobot-frontend/src/**/*.vue'
+
+permissions:
+  contents: read
+
+jobs:
+  vue-tsc-baseline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8  # v4.0.1
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: autobot-frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: autobot-frontend
+        run: npm ci --no-audit --no-fund
+
+      - name: Run vue-tsc and check error count
+        working-directory: autobot-frontend
+        env:
+          BASELINE: 248
+        run: |
+          set +e
+          # Use a pipeline-safe pattern so vue-tsc's exit code doesn't break the count
+          ERRORS=$(npx vue-tsc --noEmit -p tsconfig.app.json 2>&1 | grep -cE "error TS")
+          echo "BASELINE: $BASELINE errors (see #7227 for breakdown)"
+          echo "CURRENT:  $ERRORS errors"
+          if [ "$ERRORS" -gt "$BASELINE" ]; then
+            echo ""
+            echo "❌ Regression: $ERRORS > $BASELINE errors"
+            echo "This PR introduced $((ERRORS - BASELINE)) new TypeScript errors."
+            echo "Run \`npx vue-tsc --noEmit -p tsconfig.app.json\` locally to inspect."
+            exit 1
+          fi
+          if [ "$ERRORS" -lt "$BASELINE" ]; then
+            echo ""
+            echo "✅ Improvement: $ERRORS < $BASELINE errors"
+            echo "Reduce BASELINE in .github/workflows/frontend-typecheck-regression.yml to $ERRORS to lock in the gain."
+          else
+            echo ""
+            echo "✅ No regression: $ERRORS == $BASELINE"
+          fi
+          exit 0

--- a/autobot-frontend/README.md
+++ b/autobot-frontend/README.md
@@ -29,6 +29,23 @@ npm run dev
 npm run build
 ```
 
+### Type-Check Only (vue-tsc)
+
+```bash
+# From autobot-frontend/
+npx vue-tsc --noEmit -p tsconfig.app.json
+# Expected: 248 errors (real type-debt, baseline tracked in
+# .github/workflows/frontend-typecheck-regression.yml; PRs may not
+# exceed this count — see #7227 for the cleanup plan).
+```
+
+> **Worktree gotcha (#7227):** when working in a fresh `git worktree
+> add ...` checkout, run `npm install` *inside* the worktree's
+> `autobot-frontend/` before `vue-tsc`. Without it, `node_modules` is
+> empty and ~1850 spurious "Cannot find module 'vue'" errors appear on
+> top of the real 248. Don't be misled by the inflated count from a
+> worktree without `npm install`.
+
 ### Run Unit Tests with [Vitest](https://vitest.dev/)
 
 ```bash


### PR DESCRIPTION
## Summary

Closes [#7227](https://github.com/mrveiss/AutoBot-AI/issues/7227). Two-part resolution: corrected the false 2096-error baseline + added a CI guard so the real 248-error baseline can't grow.

## Root cause: worktree + npm install gotcha

The 2096 figure I cited in the original issue body was a **worktree artifact**. Fresh \`git worktree add\` checkouts don't run \`npm install\`, so \`node_modules/vue\`, \`node_modules/vue-i18n\`, \`node_modules/@vue/tsconfig\` are missing. vue-tsc then emits ~1850 spurious TS2307 errors layered on top of the real type-debt.

| Setup | vue-tsc errors |
|---|---|
| Fresh worktree (no \`npm install\`) | 2096 |
| Main checkout (with \`npm install\`) | **248** ← real baseline |

## The real 248 by category

| Code | Count | Meaning |
|---|---|---|
| TS18046 | 76 | "X is of type unknown" |
| TS2322 | 67 | Type assignment incompatibility |
| TS2339 | 39 | Property doesn't exist |
| TS2353 | 21 | Extra property in object literal |
| (other) | 45 | Mixed |

**Top files:**
\`\`\`
15  src/composables/useApi.ts
14  src/composables/useBatchProcessing.ts
14  src/components/ui/Icon.stories.ts
11  src/components/analytics/CodeReviewDashboard.vue
10  src/composables/useOverseerAgent.ts
\`\`\`

Each cluster is per-PR cleanup work; this PR doesn't fix individual errors but installs the regression guard so future PRs can't introduce new ones.

## What this PR adds

### 1. \`.github/workflows/frontend-typecheck-regression.yml\`

Runs \`vue-tsc --noEmit\` after \`npm ci\` on every PR touching frontend code. Fails when error count exceeds \`BASELINE=248\`. Reports improvement when count drops and asks contributor to bump BASELINE down to lock in the gain.

### 2. \`autobot-frontend/README.md\`

Added "Type-Check Only (vue-tsc)" subsection + worktree gotcha note so future contributors don't repeat the 2096 misdiagnosis.

## Verification

\`\`\`bash
$ cd autobot-frontend
$ npx vue-tsc --noEmit -p tsconfig.app.json | grep -cE "error TS"
248   # matches BASELINE
\`\`\`

The CI workflow itself was tested by validating YAML syntax + manual logic review (count > BASELINE → exit 1; count == BASELINE → exit 0; count < BASELINE → exit 0 + "lock the gain" message).

## Closes

- #7227 — vue-tsc baseline reconciled to 248 (real); regression guard active; per-cluster cleanup tracked in issue body

🤖 Generated with [Claude Code](https://claude.com/claude-code)