### PR TITLE
fix(ansible/browser): t64 audit for noble — add defensive libatk1.0-0t64 (closes #7220)

### DIFF
--- a/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
@@ -102,20 +102,27 @@
 # ============================================================
 - name: "Browser | Install Playwright system dependencies"
   apt:
-    # #7207: Ubuntu 24.04 (noble) renamed several libs with `t64` suffix as
-    # part of the time_t 64-bit transition. libasound2 → libasound2t64 (the
-    # transitional virtual package is missing on arm64 noble). Other libs
-    # in this list kept their original names — only libasound2 needs the
-    # conditional rename for now.
+    # Ubuntu 24.04 (noble) renamed several libs with `t64` suffix as part of
+    # the time_t 64-bit transition. The transitional virtual packages are
+    # missing on arm64 noble (DGX Spark + ARM64 servers).
+    #
+    # Audit (#7220):
+    #   libasound2 — confirmed broken on arm64 noble (#7207)
+    #   libatk1.0-0 — packages.ubuntu.com returns HTTP 500 on arm64 noble
+    #     (suspect; defensive rename applied)
+    #   libcups2, libatk-bridge2.0-0 — both forms exist on noble (transitional
+    #     packages still present); no rename needed yet
+    #   Other libs (libnss3, libdrm2, libxkbcommon0, libxcomposite1,
+    #     libxdamage1, libxfixes3, libxrandr2, libgbm1) kept original names
     name: >-
       {{ ['python3', 'python3-pip', 'python3-venv',
-          'libnss3', 'libatk1.0-0', 'libatk-bridge2.0-0',
+          'libnss3', 'libatk-bridge2.0-0',
           'libcups2', 'libdrm2', 'libxkbcommon0',
           'libxcomposite1', 'libxdamage1', 'libxfixes3',
           'libxrandr2', 'libgbm1']
-          + (['libasound2t64']
+          + (['libasound2t64', 'libatk1.0-0t64']
              if ansible_facts['distribution_release'] == 'noble'
-             else ['libasound2']) }}
+             else ['libasound2', 'libatk1.0-0']) }}
     state: present
   become: yes
   tags: ['browser', 'packages']


### PR DESCRIPTION
## Summary

Closes #7220. Audit per acceptance criteria — queried upstream \`packages.ubuntu.com\` for arm64 noble availability of all libXY deps in the Playwright role.

## Audit results

| Lib | arm64 noble HTTP | t64 variant | Action |
|---|---|---|---|
| libasound2 | confirmed broken (#7207) | exists | already fixed in #7207 |
| **libatk1.0-0** | **HTTP 500 (suspect)** | **exists** | **defensive rename to t64** |
| libcups2 | 200 | 200 | no change (transitional works) |
| libatk-bridge2.0-0 | 200 | 200 | no change |
| libnss3, libdrm2, libxkbcommon0, libx{composite,damage,fixes}*, libxrandr2, libgbm1 | 200 | n/a | no change |

## Acceptance criteria

- [x] Audit grep returns full list of libXY package names
- [x] Each one verified against noble's apt repo
- [x] Defensive rename for libatk1.0-0 (suspect, not confirmed broken on user's install)
- [ ] Centralized fact map across all roles — deferred (only browser role uses these libs today; no DRY win yet)
- [ ] CI noble container test — deferred (smoke-test workflow already runs install end-to-end per PR)

## Test plan

- [x] YAML parse
- [ ] User's next DGX install verifies Phase 6 still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)