### PR TITLE
refactor(frontend): rename useWorkflowBuilder.WorkflowPlan → OrchestratorWorkflowPlan (closes #7228)

### DIFF
--- a/autobot-frontend/src/composables/useWorkflowBuilder.ts
+++ b/autobot-frontend/src/composables/useWorkflowBuilder.ts
@@ -204,8 +204,26 @@ export interface WorkflowExecutionResult {
   details: Record<string, unknown>;
 }
 
-/** Workflow plan */
-export interface WorkflowPlan {
+/**
+ * Orchestrator workflow plan — preview returned from `/api/orchestrator/*`
+ * for the multi-agent planning surface.
+ *
+ * #7228: renamed from `WorkflowPlan` to disambiguate from the canonical
+ * runtime `WorkflowPlan` in `@/types/workflowTemplates` (which mirrors
+ * backend `autobot_shared.workflow.WorkflowPlan`). The two shapes serve
+ * different concerns:
+ *   - `OrchestratorWorkflowPlan` (this) — UI preview from the
+ *     orchestrator endpoint; partial fields, inline task shape, no
+ *     runtime state.
+ *   - `WorkflowPlan` (canonical, in `@/types/workflowTemplates`) —
+ *     full runtime execution plan with fallback_plans,
+ *     approval_required, dependencies_graph, and the richer task
+ *     field set inherited from `WorkflowTask`.
+ *
+ * Both exist legitimately; the rename prevents future contributors from
+ * accidentally treating them as interchangeable.
+ */
+export interface OrchestratorWorkflowPlan {
   plan_id: string;
   goal: string;
   strategy: ExecutionStrategy;
@@ -292,7 +310,7 @@ class WorkflowBuilderApiClient {
   async createWorkflowPlan(
     goal: string,
     context?: Record<string, unknown>
-  ): Promise<ApiResponse<{ status: string; plan: WorkflowPlan; task_count: number }>> {
+  ): Promise<ApiResponse<{ status: string; plan: OrchestratorWorkflowPlan; task_count: number }>> {
     return this.request(`${getApiBase()}/orchestrator/workflow/plan`, {
       method: 'POST',
       body: JSON.stringify({ goal, context }),
@@ -570,7 +588,7 @@ export function useWorkflowBuilder() {
   const activeWorkflows = ref<ActiveWorkflow[]>([]);
   const completedWorkflows = ref<ActiveWorkflow[]>([]);
   const currentWorkflow = ref<ActiveWorkflow | null>(null);
-  const workflowPlan = ref<WorkflowPlan | null>(null);
+  const workflowPlan = ref<OrchestratorWorkflowPlan | null>(null);
   const pendingApproval = ref<PlanApprovalRequest | null>(null);
 
   // Orchestration data
@@ -799,7 +817,7 @@ export function useWorkflowBuilder() {
   async function createPlan(
     goal: string,
     context?: Record<string, unknown>
-  ): Promise<WorkflowPlan | null> {
+  ): Promise<OrchestratorWorkflowPlan | null> {
     errors.value = [];
     return wrapLoading(async () => {
       const response = await apiClient.createWorkflowPlan(goal, context);


### PR DESCRIPTION
## Summary

Closes [#7228](https://github.com/mrveiss/AutoBot-AI/issues/7228). Disambiguates the two legitimately-distinct \`WorkflowPlan\` shapes by renaming the orchestrator-preview one.

## Two shapes, one name

| Concept | Type | Source |
|---|---|---|
| **Orchestrator preview** (multi-agent planning UI) | \`useWorkflowBuilder.WorkflowPlan\` | hand-written from \`/api/orchestrator/*\` payload |
| **Runtime execution plan** | \`@/types/workflowTemplates.WorkflowPlan\` | codegen-mirrored from \`autobot_shared.workflow.WorkflowPlan\` |

Both legitimate, but the shared name was a future-bug magnet. Renaming the local one to \`OrchestratorWorkflowPlan\` keeps the canonical name reserved for the runtime concept.

## Scope

5 internal sites in \`useWorkflowBuilder.ts\`:
- interface declaration
- \`ApiClient.createWorkflowPlan()\` return type
- \`workflowPlan\` ref
- exported helper function return type
- inner \`createWorkflowPlan()\` helper

**Zero external consumers** — verified by grep \`from '@/composables/useWorkflowBuilder'\` imports across \`src/\` return no \`WorkflowPlan\` in the import list. (Other \`useWorkflowBuilder\`-imported types like \`ActiveWorkflow\`, \`WorkflowTemplate\`, \`AgentPerformance\` are imported by views/components — \`WorkflowPlan\` was not.)

## Verification

\`\`\`bash
$ cd autobot-frontend
$ grep -rn "from '@/composables/useWorkflowBuilder'" src/ | grep WorkflowPlan
# (empty — no external consumers)

$ npx vue-tsc --noEmit -p tsconfig.app.json | grep -cE "error TS"
# Baseline preserved; no new TypeScript errors
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)