### PR TITLE
refactor(ansible): shared idempotent apt-repository helper across 7 roles (closes #7218)

### DIFF
--- a/autobot-slm-backend/ansible/roles/_shared/tasks/add_apt_repository_idempotent.yml
+++ b/autobot-slm-backend/ansible/roles/_shared/tasks/add_apt_repository_idempotent.yml
@@ -1,0 +1,95 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+---
+# Idempotent apt repository add — preserves device-shipped repo (#7218).
+#
+# Closes #7218 — composability follow-up to #7144's `add_ppa_if_missing`
+# helper in install.sh. Same conflict-prevention semantics, applicable to
+# any role that adds an apt repository (Grafana, NodeSource, PostgreSQL
+# pgdg, OpenVINO, Docker, etc.).
+#
+# Why: DGX Spark and other AI workstation images ship many PPAs/repos
+# pre-configured (deb822 .sources format with inline GPG key). Re-adding
+# via apt_repository creates a legacy .list duplicate with mismatched
+# Signed-By, and `apt-get update` then aborts with:
+#   E:Conflicting values set for option Signed-By regarding source <url>
+#
+# This task:
+#   1. Greps /etc/apt/sources.list.d/ for the repo's URL pattern
+#   2. If found → skip apt_repository (preserve device-shipped config)
+#      and sweep any stale legacy `.list` duplicate that would conflict
+#   3. If not found → call apt_repository as normal
+#
+# Contract:
+#   apt_repo_match    (str)       Substring grep pattern that uniquely
+#                                 identifies this repo in source files.
+#                                 e.g. "ansible/ansible", "grafana.com/oss",
+#                                 "nodesource.com", "postgresql.org/pub".
+#   apt_repo_spec     (str)       Repo line for ansible.builtin.apt_repository
+#                                 (e.g. "ppa:ansible/ansible" or full
+#                                 "deb https://... main"). Used only when
+#                                 the repo isn't already configured.
+#   apt_repo_filename (str)       Filename for new repo entries (without
+#                                 .list suffix). Used by apt_repository's
+#                                 `filename:` parameter and by stale-dup
+#                                 sweep matching.
+#   apt_repo_label    (str)       Friendly name for log messages, e.g.
+#                                 "Grafana", "NodeSource", "PostgreSQL pgdg".
+#
+# Example:
+#   - include_tasks: ../../_shared/tasks/add_apt_repository_idempotent.yml
+#     vars:
+#       apt_repo_match: "grafana.com/oss"
+#       apt_repo_spec: "deb https://packages.grafana.com/oss/deb stable main"
+#       apt_repo_filename: "grafana"
+#       apt_repo_label: "Grafana"
+
+- name: "{{ apt_repo_label }} | Detect existing apt repo for {{ apt_repo_match }}"
+  ansible.builtin.shell: >-
+    grep -rqs -- "{{ apt_repo_match }}" /etc/apt/sources.list.d/ 2>/dev/null
+    && echo PRESENT
+    || echo MISSING
+  register: _apt_repo_present
+  changed_when: false
+  failed_when: false
+  become: true
+  tags: ['packages']
+
+- name: "{{ apt_repo_label }} | Sweep stale legacy .list duplicate when device-shipped .sources exists"
+  # If a .sources file is present AND a sibling .list file exists for the
+  # same repo, the two diverge on Signed-By and apt-get update aborts. The
+  # .sources is the canonical (deb822 + inline key) form; remove the .list.
+  ansible.builtin.shell: |
+    set -e
+    SOURCES_HIT=$(find /etc/apt/sources.list.d/ -maxdepth 1 -name '*.sources' \
+                  -exec grep -lq -- "{{ apt_repo_match }}" {} \; -print 2>/dev/null | head -1)
+    if [ -n "$SOURCES_HIT" ]; then
+      for f in /etc/apt/sources.list.d/{{ apt_repo_filename }}.list \
+               /etc/apt/sources.list.d/ppa_*{{ apt_repo_filename }}*.list; do
+        if [ -f "$f" ]; then
+          rm -f "$f"
+          echo "Removed stale duplicate $f"
+        fi
+      done
+    fi
+  register: _apt_repo_sweep
+  changed_when: "'Removed stale duplicate' in _apt_repo_sweep.stdout"
+  become: true
+  when: _apt_repo_present.stdout | trim == 'PRESENT'
+  tags: ['packages']
+
+- name: "{{ apt_repo_label }} | Preserve device-shipped repo (skip apt_repository)"
+  ansible.builtin.debug:
+    msg: "{{ apt_repo_label }} repo already configured at /etc/apt/sources.list.d/ — preserving device-shipped config"
+  when: _apt_repo_present.stdout | trim == 'PRESENT'
+  tags: ['packages']
+
+- name: "{{ apt_repo_label }} | Add apt repository (not previously configured)"
+  ansible.builtin.apt_repository:
+    repo: "{{ apt_repo_spec }}"
+    state: present
+    filename: "{{ apt_repo_filename }}"
+  become: true
+  when: _apt_repo_present.stdout | trim == 'MISSING'
+  tags: ['packages']

--- a/autobot-slm-backend/ansible/roles/agent_config/tasks/openvino.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/tasks/openvino.yml
@@ -9,11 +9,14 @@
     url: https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
     state: present
 
-- name: Add OpenVINO repository
-  apt_repository:
-    repo: "deb https://apt.repos.intel.com/openvino/{{ openvino_version }} ubuntu22 main"
-    state: present
-    filename: intel-openvino
+# #7218: idempotent repo-add — preserve device-shipped OpenVINO repo if present
+- name: "Add OpenVINO repository (idempotent, #7218)"
+  ansible.builtin.include_tasks: ../../_shared/tasks/add_apt_repository_idempotent.yml
+  vars:
+    apt_repo_match: "apt.repos.intel.com/openvino"
+    apt_repo_spec: "deb https://apt.repos.intel.com/openvino/{{ openvino_version }} ubuntu22 main"
+    apt_repo_filename: "intel-openvino"
+    apt_repo_label: "OpenVINO"
 
 # #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
 - name: agent_config openvino | Refresh apt cache after OpenVINO repo add (best-effort, bounded; #6719)

--- a/autobot-slm-backend/ansible/roles/docker/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/docker/tasks/main.yml
@@ -69,17 +69,18 @@
     - not _docker_gpg_stat.stat.exists
   tags: ['docker', 'packages']
 
-- name: "Docker | Add Docker APT repository (Debian)"
-  ansible.builtin.apt_repository:
-    repo: >-
+# #7218: idempotent repo-add — preserve device-shipped Docker repo if present.
+# Refresh handled by the bounded-shell task below (#6719).
+- name: "Docker | Add Docker APT repository (Debian, idempotent, #7218)"
+  ansible.builtin.include_tasks: ../../_shared/tasks/add_apt_repository_idempotent.yml
+  vars:
+    apt_repo_match: "download.docker.com"
+    apt_repo_spec: >-
       deb [arch={{ docker_apt_repo_arch }} signed-by={{ docker_apt_gpg_key_path }}]
       https://download.docker.com/linux/{{ ansible_facts['distribution'] | lower }}
       {{ ansible_facts['distribution_release'] }} {{ docker_apt_repo_channel }}
-    state: present
-    filename: docker
-    # #6719: refresh handled by the bounded-shell task below; the apt module's
-    # update_cache aborts on flaky third-party PPAs.
-    update_cache: false
+    apt_repo_filename: "docker"
+    apt_repo_label: "Docker"
   when: _docker_is_debian | bool
   tags: ['docker', 'packages']
 

--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/grafana.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/grafana.yml
@@ -46,14 +46,15 @@
     - ansible_facts['os_family'] == "Debian"
     - _grafana_installed.rc != 0
 
-- name: Add Grafana repository
-  ansible.builtin.apt_repository:
-    repo: "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com stable main"
-    state: present
-    filename: grafana
-    # #6719: refresh handled by the bounded-shell task below; the apt module's
-    # update_cache aborts on flaky third-party PPAs.
-    update_cache: false
+# #7218: idempotent repo-add — preserve device-shipped Grafana repo if present.
+# Refresh handled by the bounded-shell task below (#6719).
+- name: "Add Grafana repository (idempotent, #7218)"
+  ansible.builtin.include_tasks: ../../_shared/tasks/add_apt_repository_idempotent.yml
+  vars:
+    apt_repo_match: "apt.grafana.com"
+    apt_repo_spec: "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com stable main"
+    apt_repo_filename: "grafana"
+    apt_repo_label: "Grafana (monitoring)"
   when:
     - ansible_facts['os_family'] == "Debian"
     - _grafana_installed.rc != 0

--- a/autobot-slm-backend/ansible/roles/postgresql/tasks/install.yml
+++ b/autobot-slm-backend/ansible/roles/postgresql/tasks/install.yml
@@ -47,12 +47,14 @@
   become: true
   when: _pg_installed.rc != 0
 
-- name: Add PostgreSQL APT repository
-  ansible.builtin.apt_repository:
-    repo: "deb [signed-by=/usr/share/keyrings/pgdg.asc] https://apt.postgresql.org/pub/repos/apt {{ _pgdg_release }}-pgdg main"
-    state: present
-    filename: pgdg
-  become: true
+# #7218: idempotent repo-add — preserve device-shipped pgdg repo if present
+- name: "PostgreSQL | Add PostgreSQL APT repository (idempotent, #7218)"
+  ansible.builtin.include_tasks: ../../_shared/tasks/add_apt_repository_idempotent.yml
+  vars:
+    apt_repo_match: "apt.postgresql.org"
+    apt_repo_spec: "deb [signed-by=/usr/share/keyrings/pgdg.asc] https://apt.postgresql.org/pub/repos/apt {{ _pgdg_release }}-pgdg main"
+    apt_repo_filename: "pgdg"
+    apt_repo_label: "PostgreSQL pgdg"
   when: _pg_installed.rc != 0
 
 # #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.

--- a/autobot-slm-backend/ansible/roles/python312/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/python312/tasks/main.yml
@@ -25,11 +25,14 @@
   when: _py312_check.rc != 0
   tags: ['deps', 'python312']
 
-- name: "python312 | Add deadsnakes PPA"
-  ansible.builtin.apt_repository:
-    repo: ppa:deadsnakes/ppa
-    state: present
-  become: true
+# #7218: idempotent repo-add — preserve device-shipped PPA if present
+- name: "python312 | Add deadsnakes PPA (idempotent, #7218)"
+  ansible.builtin.include_tasks: ../../_shared/tasks/add_apt_repository_idempotent.yml
+  vars:
+    apt_repo_match: "deadsnakes/ppa"
+    apt_repo_spec: "ppa:deadsnakes/ppa"
+    apt_repo_filename: "deadsnakes"
+    apt_repo_label: "deadsnakes (Python 3.12)"
   when: _py312_check.rc != 0
   tags: ['deps', 'python312']
 

--- a/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
@@ -32,12 +32,14 @@
          else 'jammy' }}
   tags: ['redis', 'packages']
 
-- name: "Redis | Add Redis Stack repository"
-  apt_repository:
-    repo: "deb https://packages.redis.io/deb {{ redis_stack_suite }} main"
-    state: present
-    filename: redis
-  become: yes
+# #7218: idempotent repo-add — preserve device-shipped repo if present
+- name: "Redis | Add Redis Stack repository (idempotent, #7218)"
+  ansible.builtin.include_tasks: ../../_shared/tasks/add_apt_repository_idempotent.yml
+  vars:
+    apt_repo_match: "packages.redis.io"
+    apt_repo_spec: "deb https://packages.redis.io/deb {{ redis_stack_suite }} main"
+    apt_repo_filename: "redis"
+    apt_repo_label: "Redis Stack"
   when: _redis_installed.rc != 0
   tags: ['redis', 'packages']
 

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/grafana.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/grafana.yml
@@ -16,14 +16,15 @@
   when: grafana_install | bool
   tags: ['grafana', 'packages']
 
-- name: "Grafana | Add Grafana APT repository"
-  ansible.builtin.apt_repository:
-    repo: deb https://apt.grafana.com stable main
-    state: present
-    filename: grafana
-    # #6719: refresh handled by the bounded-shell task below; the apt module's
-    # update_cache aborts on flaky third-party PPAs.
-    update_cache: false
+# #7218: idempotent repo-add — preserve device-shipped Grafana repo if present.
+# Refresh handled by the bounded-shell task below (#6719).
+- name: "Grafana | Add Grafana APT repository (idempotent, #7218)"
+  ansible.builtin.include_tasks: ../../_shared/tasks/add_apt_repository_idempotent.yml
+  vars:
+    apt_repo_match: "apt.grafana.com"
+    apt_repo_spec: "deb https://apt.grafana.com stable main"
+    apt_repo_filename: "grafana"
+    apt_repo_label: "Grafana"
   when: grafana_install | bool
   tags: ['grafana', 'packages']
 


### PR DESCRIPTION
## Summary

Closes #7218. Composability follow-up to #7144's \`add_ppa_if_missing\` helper in install.sh.

## Files

New: \`autobot-slm-backend/ansible/roles/_shared/tasks/add_apt_repository_idempotent.yml\`

Refactored sites (7 of 8 \`apt_repository\` invocations across roles):
- python312, redis, slm_manager/grafana, monitoring/grafana, docker, postgresql, agent_config/openvino

NOT refactored: \`slm_manager/tasks/main.yml\` (ansible/ansible PPA) already uses #7140's \"always sweep + re-add\" approach by design.

## Pattern

Shared task:
1. greps \`/etc/apt/sources.list.d/\` for the repo URL pattern
2. If found: sweep stale legacy \`.list\` dups + skip apt_repository (preserve device-shipped config)
3. If not found: call apt_repository as normal

## Test plan

- [x] All 8 changed YAML files parse cleanly
- [ ] Smoke-test CI runs full install path; will catch any include_tasks regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)