### PR TITLE
ci(lint): pre-commit hook for git safe.directory + fix 7 missed sites (closes #7219)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,22 @@ repos:
         stages: [pre-commit]
         description: "Use autobot_shared.time_utils.utc_timestamp() instead of datetime.utcnow().isoformat()"
 
+  # AutoBot custom: regression-prevention for #7150 git safe.directory migration.
+  # When code_source/ is owned by `autobot` (cloned by install.sh) and the
+  # Ansible playbook runs as root via sudo, git 2.35+ aborts read-only
+  # operations with rc=128 ("dubious ownership"). #7150 fixed 17 sites
+  # mechanically; #7219 found 7 more in update-all-nodes.yml (top-level vs
+  # playbooks/ basename collision). This guard blocks future regressions.
+  - repo: local
+    hooks:
+      - id: git-safe-directory-required
+        name: Block unguarded `git -C {{ git_repo_root }}` (#7150 #7219)
+        entry: tools/lint/check_git_safe_directory.py
+        language: python
+        files: \.(yml|yaml)$
+        stages: [pre-commit]
+        description: "Pass -c safe.directory={{ git_repo_root }} to every git -C invocation against code_source"
+
   # AutoBot custom: regression-prevention for #7180. ansible-core 2.24 will
   # remove INJECT_FACTS_AS_VARS, breaking any `{{ ansible_X }}` reference
   # to an auto-injected fact (date_time, default_ipv4, hostname,

--- a/autobot-slm-backend/ansible/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/update-all-nodes.yml
@@ -77,14 +77,14 @@
       tags: [always]
 
     - name: "[PRE-FLIGHT] Get current git branch"
-      command: git -C {{ git_repo_root }} branch --show-current
+      command: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} branch --show-current
       register: git_branch
       changed_when: false
       tags: [always]
 
     - name: "[PRE-FLIGHT] Resolve deploy ref to commit"
       command: >-
-        git -C {{ git_repo_root }}
+        git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }}
         log -1 --format='%h %s' {{ deploy_ref }}
       register: deploy_info
       changed_when: false
@@ -92,14 +92,14 @@
 
     - name: "[PRE-FLIGHT] Get deploy commit SHA"
       command: >-
-        git -C {{ git_repo_root }}
+        git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }}
         rev-parse --short {{ deploy_ref }}
       register: deploy_commit
       changed_when: false
       tags: [always]
 
     - name: "[PRE-FLIGHT] Check for uncommitted changes"
-      command: git -C {{ git_repo_root }} status --porcelain
+      command: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} status --porcelain
       register: git_dirty
       changed_when: false
       tags: [always]
@@ -139,7 +139,7 @@
 
     - name: "[PRE-FLIGHT] Create component archives"
       shell: >-
-        git -C {{ git_repo_root }} archive {{ deploy_ref }}
+        git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} archive {{ deploy_ref }}
         -- {{ item.path }} | gzip > {{ deploy_tmp }}/{{ item.name }}.tar.gz
       loop:
         - { name: slm-backend, path: autobot-slm-backend/ }
@@ -159,14 +159,14 @@
     # strip-components=1 removes the leading autobot-slm-backend/ path prefix.
     - name: "[PRE-FLIGHT] Create slm-agent code archive"
       shell: >-
-        git -C {{ git_repo_root }} archive {{ deploy_ref }}
+        git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} archive {{ deploy_ref }}
         -- autobot-slm-backend/slm/agent/ | gzip > {{ deploy_tmp }}/slm-agent.tar.gz
       changed_when: true
       tags: [always, slm-agent]
 
     - name: "[PRE-FLIGHT] Create AI Stack archive"
       shell: >-
-        git -C {{ git_repo_root }} archive {{ deploy_ref }}
+        git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} archive {{ deploy_ref }}
         -- autobot-infrastructure/shared/docker/ai-stack/
         | gzip > {{ deploy_tmp }}/ai-stack.tar.gz
       changed_when: true

--- a/tools/lint/check_git_safe_directory.py
+++ b/tools/lint/check_git_safe_directory.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Regression-prevention check for the #7150 git safe.directory migration.
+
+Blocks new occurrences of `git -C {{ git_repo_root }}` (or with a literal
+absolute path under /opt/autobot/code_source) in Ansible YAML that don't
+also pass `-c safe.directory={{ git_repo_root }}`.
+
+Why: when `code_source/` is owned by `autobot` (cloned by install.sh) and
+the Ansible playbook runs as root via sudo, git 2.35+ aborts read-only
+operations with rc=128 ("dubious ownership"). #7150 fixed 17 invocations
+across 3 playbooks; #7219 found 7 more in update-all-nodes.yml that the
+original sed missed because two files share the basename. Without this
+guard, regressions are likely.
+
+Acceptable forms:
+  git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} log -1
+  git -c safe.directory=/opt/autobot/code_source -C ... ...
+
+Blocked form:
+  git -C {{ git_repo_root }} log -1
+  git -C /opt/autobot/code_source ...
+
+Exit:
+  0 — clean
+  1 — unguarded git command found
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# `git -C <repo>` where <repo> is git_repo_root or /opt/autobot/code_source.
+# Captures the flags between `git` and `-C` so we can check for `-c safe.directory`.
+# No \b after the closing `}}` — those aren't word chars so the boundary doesn't match;
+# rely on the literal terminator instead.
+PATTERN = re.compile(
+    r"\bgit\s+(?P<flags>[^\n]*?)-C\s+"
+    r"(?:\{\{\s*git_repo_root\s*\}\}|/opt/autobot/code_source(?=[\s/]))"
+)
+SAFE_FLAG = re.compile(r"-c\s+safe\.directory\s*=")
+
+ALLOWLIST = frozenset(
+    {
+        "tools/lint/check_git_safe_directory.py",
+        "tools/lint/check_git_safe_directory_test.py",
+    }
+)
+
+
+def iter_ansible_files(root: Path) -> Iterable[Path]:
+    skip_dirs = {".git", "__pycache__", "node_modules", ".worktrees", "venv", ".venv"}
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix not in {".yml", ".yaml"}:
+            continue
+        if any(part in skip_dirs for part in path.parts):
+            continue
+        yield path
+
+
+def find_violations(path: Path) -> List[Tuple[int, str]]:
+    try:
+        rel = path.resolve().relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        rel = ""
+    if rel in ALLOWLIST:
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    violations: List[Tuple[int, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        match = PATTERN.search(line)
+        if match and not SAFE_FLAG.search(match.group("flags")):
+            violations.append((lineno, line.strip()[:140]))
+    return violations
+
+
+def main(paths: List[str]) -> int:
+    if paths:
+        targets = [Path(p) for p in paths]
+        files = [p for p in targets if p.is_file() and p.suffix in {".yml", ".yaml"}]
+    else:
+        files = list(iter_ansible_files(REPO_ROOT / "autobot-slm-backend" / "ansible"))
+
+    found = False
+    for path in files:
+        for lineno, snippet in find_violations(path):
+            rel = path.relative_to(REPO_ROOT).as_posix() if path.is_absolute() else str(path)
+            print(
+                f"{rel}:{lineno}: unguarded `git -C {{{{ git_repo_root }}}}` (#7150) — "
+                f"prepend `-c safe.directory={{{{ git_repo_root }}}}`\n  {snippet}",
+                file=sys.stderr,
+            )
+            found = True
+
+    if found:
+        print(
+            "\n--- BLOCKED ---\n"
+            "On hosts where code_source is owned by a different user than the\n"
+            "Ansible run-as user, git 2.35+ aborts with rc=128 'dubious ownership'.\n"
+            "Use:  git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} ...\n"
+            "See #7150 (initial 17-site migration) and #7219 (lint guard).",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/lint/check_git_safe_directory_test.py
+++ b/tools/lint/check_git_safe_directory_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for check_git_safe_directory (#7219)."""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_git_safe_directory import find_violations  # noqa: E402
+
+
+def _write(tmp: Path, name: str, body: str) -> Path:
+    p = tmp / name
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def test_unguarded_blocked() -> None:
+    body = "      command: git -C {{ git_repo_root }} log -1 --format='%h %s'\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "bad.yml", body)
+        violations = find_violations(f)
+        assert len(violations) == 1
+
+
+def test_guarded_passes() -> None:
+    body = "      command: git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} log -1\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "ok.yml", body)
+        assert find_violations(f) == []
+
+
+def test_unguarded_literal_path_blocked() -> None:
+    body = "      cmd: git -C /opt/autobot/code_source status --porcelain\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "bad.yml", body)
+        violations = find_violations(f)
+        assert len(violations) == 1
+
+
+def test_guarded_literal_path_passes() -> None:
+    body = "      cmd: git -c safe.directory=/opt/autobot/code_source -C /opt/autobot/code_source status\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "ok.yml", body)
+        assert find_violations(f) == []
+
+
+def test_git_other_dir_unaffected() -> None:
+    """git -C of an UNrelated dir doesn't trigger the check."""
+    body = "      cmd: git -C /tmp/some_repo log\n"
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "ok.yml", body)
+        assert find_violations(f) == []
+
+
+def test_multiline_play_with_guard_passes() -> None:
+    body = (
+        "      cmd: >-\n"
+        "        git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }}\n"
+        "        log -1 --format='%h %s'\n"
+    )
+    with tempfile.TemporaryDirectory() as d:
+        f = _write(Path(d), "ok.yml", body)
+        # Single-line-only check; multi-line >- folded form should be on one line by the time YAML parses it.
+        # Per-line check: the line containing `git -C` must have `-c safe.directory` on the SAME line.
+        # In the above sample, both are on the same line — should pass.
+        assert find_violations(f) == []
+
+
+if __name__ == "__main__":
+    test_unguarded_blocked()
+    test_guarded_passes()
+    test_unguarded_literal_path_blocked()
+    test_guarded_literal_path_passes()
+    test_git_other_dir_unaffected()
+    test_multiline_play_with_guard_passes()
+    print("All tests passed.")


### PR DESCRIPTION
## Summary

Closes #7219 with two-part fix:

1. **Bug fix**: discovered #7150's sed missed 7 more sites in \`autobot-slm-backend/ansible/update-all-nodes.yml\` (top-level) due to basename collision with \`playbooks/update-all-nodes.yml\`. Fixed.

2. **Lint guard**: pre-commit hook prevents future regressions of the same class.

## Why

When code_source is owned by \`autobot\` (cloned by install.sh) and Ansible runs as root via sudo, git 2.35+ aborts read-only operations with rc=128. Without this guard, sed-by-basename will silently leave duplicates unguarded.

## Test plan

- [x] 6/6 unit tests pass
- [x] Live scan returns 0 violations (post fix)
- [x] Hook self-allowlists itself
- [x] Tested: unguarded blocked, guarded passes, literal path blocked, multi-line forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)