### PR TITLE
refactor(status): consolidate 5 TaskStatus duplicates into canonical (closes #6520)

### DIFF
--- a/autobot-backend/a2a/__init__.py
+++ b/autobot-backend/a2a/__init__.py
@@ -20,7 +20,7 @@ from .capability_verifier import CapabilityReport, verify_local_card, verify_rem
 from .security import SecurityCardSigner
 from .task_manager import TaskManager, get_task_manager
 from .tracing import TraceContext, extract_caller_id, new_trace_id
-from .types import AgentCard, AgentSkill, Task, TaskArtifact, TaskState, TaskStatus
+from .types import AgentCard, AgentSkill, Task, TaskArtifact, TaskState, A2ATaskStatus
 
 __all__ = [
     "AgentCard",
@@ -28,7 +28,7 @@ __all__ = [
     "Task",
     "TaskArtifact",
     "TaskState",
-    "TaskStatus",
+    "A2ATaskStatus",
     "TaskManager",
     "get_task_manager",
     "build_agent_card",

--- a/autobot-backend/a2a/task_manager.py
+++ b/autobot-backend/a2a/task_manager.py
@@ -37,7 +37,7 @@ from autobot_shared.ssot_config import config
 from autobot_shared.time_utils import now_utc
 
 from .tracing import TraceContext, TraceEvent, new_trace_id
-from .types import Task, TaskArtifact, TaskState, TaskStatus
+from .types import A2ATaskStatus, Task, TaskArtifact, TaskState
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +90,7 @@ def _task_to_json(task: Task) -> str:
 def _task_from_json(raw: str) -> Task:
     """Deserialise a Task from JSON.  TraceContext events are NOT reloaded here."""
     d = json.loads(raw)
-    status = TaskStatus(
+    status = A2ATaskStatus(
         state=TaskState(d["status"]["state"]),
         message=d["status"].get("message"),
         timestamp=d["status"]["timestamp"],
@@ -192,7 +192,7 @@ class TaskManager:
 
         task = Task(
             id=task_id,
-            status=TaskStatus(state=TaskState.SUBMITTED),
+            status=A2ATaskStatus(state=TaskState.SUBMITTED),
             input=input_text,
             context=context,
             trace_context=tc,
@@ -263,7 +263,7 @@ class TaskManager:
             )
             return task
 
-        task.status = TaskStatus(state=state, message=message)
+        task.status = A2ATaskStatus(state=state, message=message)
         task.updated_at = _utcnow()
         event = TraceEvent(
             event="task.state_transition",
@@ -297,7 +297,7 @@ class TaskManager:
             return False
         if task.status.state in _TERMINAL_STATES:
             return False
-        task.status = TaskStatus(state=TaskState.CANCELLED)
+        task.status = A2ATaskStatus(state=TaskState.CANCELLED)
         task.updated_at = _utcnow()
         event = TraceEvent(event="task.cancelled")
         if task.trace_context:

--- a/autobot-backend/a2a/types.py
+++ b/autobot-backend/a2a/types.py
@@ -119,8 +119,13 @@ class TaskArtifact:
 
 
 @dataclass
-class TaskStatus:
-    """Represents the current status of a task."""
+class A2ATaskStatus:
+    """A2A protocol task status (state + message + timestamp).
+
+    Renamed from TaskStatus for #6520 to disambiguate from the canonical
+    `autobot_shared.status_enums.TaskStatus` enum, which is a different
+    concept (lifecycle state enum vs. this dataclass tracking record).
+    """
 
     state: TaskState
     message: Optional[str] = None
@@ -146,7 +151,7 @@ class Task:
     """
 
     id: str
-    status: TaskStatus
+    status: A2ATaskStatus
     input: str
     context: Optional[Dict[str, Any]] = None
     artifacts: List[TaskArtifact] = field(default_factory=list)

--- a/autobot-backend/enhanced_memory_manager_async.py
+++ b/autobot-backend/enhanced_memory_manager_async.py
@@ -19,18 +19,9 @@ from typing import Any, Dict, List, Optional
 
 import aiosqlite
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.status_enums import TaskStatus
 
 logger = logging.getLogger(__name__)
-
-
-class TaskStatus(Enum):
-    """Task execution status enumeration"""
-
-    PENDING = "pending"
-    IN_PROGRESS = "in_progress"
-    COMPLETED = "completed"
-    FAILED = "failed"
-    CANCELLED = "cancelled"
 
 
 class Priority(Enum):

--- a/autobot-backend/services/agent_analytics.py
+++ b/autobot-backend/services/agent_analytics.py
@@ -26,6 +26,7 @@ from typing import Any, AsyncGenerator, Dict, List, Optional
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.redis_client import RedisDatabase
 from autobot_shared.redis_mixin import AsyncRedisClientMixin
+from autobot_shared.status_enums import TaskStatus
 from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
 from constants.ttl_constants import TTL_1_HOUR, TTL_30_DAYS
 
@@ -43,17 +44,6 @@ class AgentType(str, Enum):
     BROWSER = "browser"
     WORKFLOW = "workflow"
     CUSTOM = "custom"
-
-
-class TaskStatus(str, Enum):
-    """Task execution status"""
-
-    PENDING = "pending"
-    RUNNING = "running"
-    COMPLETED = "completed"
-    FAILED = "failed"
-    CANCELLED = "cancelled"
-    TIMEOUT = "timeout"
 
 
 @dataclass

--- a/autobot-backend/services/knowledge/task_status_manager.py
+++ b/autobot-backend/services/knowledge/task_status_manager.py
@@ -26,7 +26,7 @@ TASK_TTL_SECONDS = 86400  # 24 hours
 
 
 @dataclass
-class TaskStatus:
+class TaskStatusRecord:
     """Task status information for background operations."""
     task_id: str
     status: str  # "queued", "running", "completed", "failed"
@@ -55,7 +55,7 @@ class TaskStatusManager:
         return f"{TASK_STATUS_PREFIX}{task_id}"
 
     @classmethod
-    async def create_task(cls, task_id: str, message: str, total_items: int = 0) -> TaskStatus:
+    async def create_task(cls, task_id: str, message: str, total_items: int = 0) -> TaskStatusRecord:
         """
         Create a new task status in Redis.
 
@@ -65,9 +65,9 @@ class TaskStatusManager:
             total_items: Total items to process (for progress tracking)
 
         Returns:
-            TaskStatus object
+            TaskStatusRecord object
         """
-        status = TaskStatus(
+        status = TaskStatusRecord(
             task_id=task_id,
             status="queued",
             message=message,
@@ -90,7 +90,7 @@ class TaskStatusManager:
         items_total: int = None,
         error: str = None,
         elapsed_seconds: float = None,
-    ) -> TaskStatus:
+    ) -> TaskStatusRecord:
         """
         Update task status in Redis.
 
@@ -105,12 +105,12 @@ class TaskStatusManager:
             elapsed_seconds: Elapsed time
 
         Returns:
-            Updated TaskStatus
+            Updated TaskStatusRecord
         """
         existing = await cls.get_task(task_id)
         if not existing:
             # Create if doesn't exist
-            existing = TaskStatus(task_id=task_id, status="running", message="")
+            existing = TaskStatusRecord(task_id=task_id, status="running", message="")
 
         # Update fields
         existing.status = status
@@ -133,12 +133,12 @@ class TaskStatusManager:
         return existing
 
     @classmethod
-    async def get_task(cls, task_id: str) -> Optional[TaskStatus]:
+    async def get_task(cls, task_id: str) -> Optional[TaskStatusRecord]:
         """
         Retrieve task status from Redis.
 
         Returns:
-            TaskStatus or None if not found
+            TaskStatusRecord or None if not found
         """
         try:
             redis_client = get_redis_client()
@@ -150,13 +150,13 @@ class TaskStatusManager:
                 return None
 
             task_dict = json.loads(data)
-            return TaskStatus(**task_dict)
+            return TaskStatusRecord(**task_dict)
         except Exception as e:
             logger.error("[%s] Error retrieving task status: %s", task_id, e)
             return None
 
     @classmethod
-    async def _save_to_redis(cls, task_status: TaskStatus) -> bool:
+    async def _save_to_redis(cls, task_status: TaskStatusRecord) -> bool:
         """
         Save task status to Redis with TTL.
 
@@ -183,12 +183,12 @@ class TaskStatusManager:
         message: str,
         items_processed: int,
         elapsed_seconds: float,
-    ) -> TaskStatus:
+    ) -> TaskStatusRecord:
         """
         Mark task as completed.
 
         Returns:
-            Final TaskStatus
+            Final TaskStatusRecord
         """
         return await cls.update_task(
             task_id=task_id,
@@ -200,12 +200,12 @@ class TaskStatusManager:
         )
 
     @classmethod
-    async def fail_task(cls, task_id: str, error_message: str) -> TaskStatus:
+    async def fail_task(cls, task_id: str, error_message: str) -> TaskStatusRecord:
         """
         Mark task as failed.
 
         Returns:
-            Final TaskStatus with error
+            Final TaskStatusRecord with error
         """
         return await cls.update_task(
             task_id=task_id,

--- a/autobot-backend/services/knowledge/task_status_manager_test.py
+++ b/autobot-backend/services/knowledge/task_status_manager_test.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from services.knowledge.task_status_manager import (
-    TaskStatus,
+    TaskStatusRecord,
     TaskStatusManager,
 )
 
@@ -157,8 +157,8 @@ class TestTaskStatusManager:
 
     @pytest.mark.asyncio
     async def test_task_status_dataclass(self):
-        """Test TaskStatus dataclass."""
-        status = TaskStatus(
+        """Test TaskStatusRecord dataclass."""
+        status = TaskStatusRecord(
             task_id="test-123",
             status="running",
             message="Processing",
@@ -177,7 +177,7 @@ class TestTaskStatusManager:
         mock_redis_client.setex.side_effect = Exception("Redis connection failed")
 
         with patch("services.knowledge.task_status_manager.get_redis_client", return_value=mock_redis_client):
-            status = TaskStatus(
+            status = TaskStatusRecord(
                 task_id=sample_task_id,
                 status="running",
                 message="Test",

--- a/autobot-backend/tests/api/test_knowledge_population_docs.py
+++ b/autobot-backend/tests/api/test_knowledge_population_docs.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Tests for populate_autobot_docs endpoint and TaskStatus dataclass.
+Tests for populate_autobot_docs endpoint and TaskStatusRecord dataclass.
 
 Tests for GitHub issue #4103: Background task for documentation indexing.
 Ensures populate_autobot_docs returns immediately with task_id.
@@ -14,10 +14,10 @@ import pytest
 
 
 def test_task_status_dataclass_initialization():
-    """Test TaskStatus dataclass initialization with default values."""
-    from services.knowledge.task_status_manager import TaskStatus
+    """Test TaskStatusRecord dataclass initialization with default values."""
+    from services.knowledge.task_status_manager import TaskStatusRecord
 
-    task = TaskStatus(task_id="test-task-123", status="queued", message="Documentation indexing started")
+    task = TaskStatusRecord(task_id="test-task-123", status="queued", message="Documentation indexing started")
 
     # Verify all fields are initialized correctly
     assert task.task_id == "test-task-123"
@@ -32,10 +32,10 @@ def test_task_status_dataclass_initialization():
 
 
 def test_task_status_dataclass_custom_values():
-    """Test TaskStatus dataclass with custom field values."""
-    from services.knowledge.task_status_manager import TaskStatus
+    """Test TaskStatusRecord dataclass with custom field values."""
+    from services.knowledge.task_status_manager import TaskStatusRecord
 
-    task = TaskStatus(
+    task = TaskStatusRecord(
         task_id="test-task-456",
         status="running",
         message="Indexing files",
@@ -54,11 +54,11 @@ def test_task_status_dataclass_custom_values():
 
 
 def test_task_status_dataclass_with_error():
-    """Test TaskStatus dataclass with error information."""
-    from services.knowledge.task_status_manager import TaskStatus
+    """Test TaskStatusRecord dataclass with error information."""
+    from services.knowledge.task_status_manager import TaskStatusRecord
 
     error_message = "Failed to read documentation file"
-    task = TaskStatus(
+    task = TaskStatusRecord(
         task_id="test-task-error", status="failed", message="Documentation indexing failed", error=error_message
     )
 

--- a/autobot-backend/utils/task_queue.py
+++ b/autobot-backend/utils/task_queue.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from autobot_shared.missing_dep import MissingDep as _MissingDep
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.status_enums import TaskStatus
 from autobot_shared.time_utils import parse_utc_iso
 
 try:
@@ -46,17 +47,6 @@ ErrorCategory = None
 # except ImportError:
 def log_performance_metric(*args, **kwargs):
     """Log performance metric placeholder until logging_config module is created."""
-
-
-class TaskStatus(Enum):
-    """Task execution status."""
-
-    PENDING = "pending"
-    RUNNING = "running"
-    COMPLETED = "completed"
-    FAILED = "failed"
-    CANCELLED = "cancelled"
-    RETRY = "retry"
 
 
 class TaskPriority(Enum):

--- a/autobot_shared/status_enums.py
+++ b/autobot_shared/status_enums.py
@@ -42,8 +42,10 @@ class TaskStatus(Enum):
     SKIPPED = "skipped"
     PAUSED = "paused"
     RETRYING = "retrying"
+    RETRY = "retry"  # Alias for RETRYING (#6520: utils/task_queue used RETRY)
     BLOCKED = "blocked"
     WAITING = "waiting"
+    TIMEOUT = "timeout"  # #6520: services/agent_analytics + subagent_manager use TIMEOUT
 
     @classmethod
     def is_terminal(cls, status: "TaskStatus") -> bool:


### PR DESCRIPTION
## Summary

Eliminates the 5 disjoint \`TaskStatus\` definitions identified in #6520 by either consolidating into the canonical \`autobot_shared.status_enums.TaskStatus\` enum, or — where the local type was a different concept — renaming to disambiguate.

## Changes

**Canonical enum (autobot_shared/status_enums.py):**
- \`+ RETRY\` — alias of \`RETRYING\` (utils/task_queue used this value)
- \`+ TIMEOUT\` — agent_analytics + subagent_manager use this value

**Replaced (3 enum-style duplicates → canonical import):**
- \`autobot-backend/utils/task_queue.py\` (1 importer)
- \`autobot-backend/enhanced_memory_manager_async.py\` (12 importers)
- \`autobot-backend/services/agent_analytics.py\` (6 importers)

All 3 had local \`class TaskStatus(Enum)\` (or \`(str, Enum)\`); all callers consistently use \`.value\` for serialization, so the plain canonical Enum is a drop-in replacement (verified by grep — no raw \`TaskStatus.X == "string"\` comparisons exist).

**Renamed (2 dataclass-style — different concept):**
- \`autobot-backend/a2a/types.py\`: \`TaskStatus\` → \`A2ATaskStatus\` (state + message + timestamp tracking record per A2A spec §4.2)
- \`services/knowledge/task_status_manager.py\`: \`TaskStatus\` → \`TaskStatusRecord\` (Redis-tracked progress record for long-running operations)

These two are dataclasses with distinct shapes (state machine record + progress tracker), not enums — consolidating them into the canonical enum would lose information. Renaming disambiguates from the lifecycle-state enum.

## Test plan

- [x] \`py_compile\` clean across all 10 modified files
- [x] Smoke-imported all 21 importers of the 5 modified modules (20 OK; 1 failure unrelated: missing \`celery\` in test env)
- [x] \`from constants.status_enums import TaskStatus\` (legacy shim from #7212) still resolves to canonical
- [x] Old names (\`a2a.TaskStatus\`, \`task_status_manager.TaskStatus\`) verified no longer importable
- [x] Canonical \`TaskStatus\` covers all values from all 5 duplicates: PENDING, RUNNING, IN_PROGRESS, COMPLETED, FAILED, CANCELLED, RETRY, RETRYING, TIMEOUT (+ pre-existing ACTIVE, PAUSED, BLOCKED, WAITING, SKIPPED, PARTIALLY_COMPLETED)

Closes #6520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)