### PR TITLE
ci: extend ansible-role-facts-test trigger paths (closes #7223)

### DIFF
--- a/.github/workflows/ansible-role-facts-test.yml
+++ b/.github/workflows/ansible-role-facts-test.yml
@@ -19,9 +19,14 @@ name: ansible-role-facts-test
 on:
   pull_request:
     paths:
+      - 'autobot-slm-backend/ansible/ansible.cfg'
       - 'autobot-slm-backend/ansible/inventory/group_vars/**'
       - 'autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml'
+      - 'autobot-slm-backend/ansible/playbooks/pre-flight-code-sync.yml'
+      - 'autobot-slm-backend/ansible/playbooks/update-all-nodes.yml'
+      - 'autobot-slm-backend/ansible/update-all-nodes.yml'
       - 'autobot-slm-backend/ansible/roles/*/tasks/clean.yml'
+      - 'autobot-slm-backend/ansible/roles/_shared/tasks/**'
       - 'autobot-slm-backend/ansible/tests/**'
       - '.github/workflows/ansible-role-facts-test.yml'
   push:
@@ -29,9 +34,14 @@ on:
       - Dev_new_gui
       - main
     paths:
+      - 'autobot-slm-backend/ansible/ansible.cfg'
       - 'autobot-slm-backend/ansible/inventory/group_vars/**'
       - 'autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml'
+      - 'autobot-slm-backend/ansible/playbooks/pre-flight-code-sync.yml'
+      - 'autobot-slm-backend/ansible/playbooks/update-all-nodes.yml'
+      - 'autobot-slm-backend/ansible/update-all-nodes.yml'
       - 'autobot-slm-backend/ansible/roles/*/tasks/clean.yml'
+      - 'autobot-slm-backend/ansible/roles/_shared/tasks/**'
       - 'autobot-slm-backend/ansible/tests/**'
 
 jobs:


### PR DESCRIPTION
## Summary

Closes #7223. Audit found \`ansible-role-facts-test.yml\` trigger paths narrower than what the workflow validates. Added 5 missing paths.

## Missing paths fixed

| Path | Why |
|---|---|
| \`ansible.cfg\` | Validates callback config (#7137 added this, lost in squash-merge) |
| \`playbooks/pre-flight-code-sync.yml\` | tested via test_clean_yml_loops |
| \`playbooks/update-all-nodes.yml\` | shares git_repo_root code path |
| \`update-all-nodes.yml\` | top-level (basename collision) |
| \`roles/_shared/tasks/**\` | shared clean.yml + apt-repo tasks (#7058 #7218) |

## Other audits

- autoresearch-image.yml — narrower than ideal (separate scope)
- frontend-codegen-drift / test / visual-regression — cosmetic duplicates only

🤖 Generated with [Claude Code](https://claude.com/claude-code)