### PR TITLE
fix(ci): pydantic[email] in CI framework reqs to unblock startup-import-smoke (#7225)

### DIFF
--- a/requirements-ci/framework.txt
+++ b/requirements-ci/framework.txt
@@ -4,5 +4,5 @@ fastapi==0.121.0
 starlette==0.49.1
 python-multipart==0.0.27
 uvicorn==0.35.0
-pydantic==2.12.3
+pydantic[email]==2.12.3
 websockets==15.0.1


### PR DESCRIPTION
## Summary

Partial fix for #7225. Unblocks the most-impactful pre-existing failure on \`Dev_new_gui\` (\`startup-import-smoke\`).

## Cause

\`requirements-ci/framework.txt\` pinned \`pydantic==2.12.3\` without [email] extras → 40+ test failures with \`ImportError: email-validator is not installed\` on every PR.

## Fix

Pin \`pydantic[email]==2.12.3\`. Same version, adds email-validator transitively.

## Remaining

- \`submit-pypi\` failure (cause unknown, separate investigation)
- \`code-quality\` failure (cause unknown, separate investigation)
- \`CodeQL\` 3s setup failure (likely config issue)

These remain in #7225 body for follow-up; this PR closes the highest-impact part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)