### PR TITLE
fix(audit-script): correct worktree-from-internal skip + entry-point runner filter (#7128b, #7109, #6872 follow-up)

### DIFF
--- a/pipeline-scripts/audit-unwired-trackers.py
+++ b/pipeline-scripts/audit-unwired-trackers.py
@@ -134,8 +134,43 @@ def is_test_path(path: Path) -> bool:
     return path.name.startswith("test_") and path.suffix == ".py"
 
 
+# Entry-point script conventions — these are designed to be invoked from
+# the command line, not imported, so 0 callers is correct-by-design.
+ENTRY_POINT_NAME_PREFIXES = ("run_",)
+ENTRY_POINT_DIR_NAMES = frozenset({"demos", "scripts", "bin"})
+
+
+def is_entry_point_script(path: Path) -> bool:
+    """True for command-line runner scripts that don't expect callers (#7128b).
+
+    Examples flagged:
+    - autobot-backend/intelligence/demos/run_intelligent_agent.py (run_*.py prefix)
+    - any *.py whose path includes a `demos/`, `scripts/`, or `bin/` segment.
+
+    Match rule: ``path.parts`` must contain one of `ENTRY_POINT_DIR_NAMES`,
+    OR `path.name` must start with one of `ENTRY_POINT_NAME_PREFIXES`. We
+    use parts-based matching so relative paths starting with the convention
+    (e.g. ``bin/server.py``) are caught alongside nested ones.
+    """
+    if path.suffix != ".py":
+        return False
+    if path.name.startswith(ENTRY_POINT_NAME_PREFIXES):
+        return True
+    return any(part in ENTRY_POINT_DIR_NAMES for part in path.parts)
+
+
 def should_skip_path(path: Path) -> bool:
-    s = str(path)
+    """Skip caches/build dirs/worktrees/migrations.
+
+    Match against the *relative* path under REPO_ROOT so that running the
+    audit from inside a worktree doesn't cause every file to false-positive
+    on the `.worktrees/` fragment in the absolute path (#7128b).
+    """
+    try:
+        rel = path.relative_to(REPO_ROOT)
+        s = "/" + str(rel)
+    except ValueError:
+        s = str(path)
     return any(frag in s for frag in SKIP_PATH_FRAGMENTS)
 
 
@@ -310,6 +345,11 @@ def scan() -> list[Finding]:
         for pattern in SOURCE_GLOBS:
             for f in base.rglob(pattern):
                 if should_skip_path(f) or is_test_path(f):
+                    continue
+                # #7128b: entry-point scripts (run_*.py, /demos/, /scripts/,
+                # /bin/) are designed to be invoked from CLI; 0 callers is
+                # by-design, not unwired.
+                if is_entry_point_script(f):
                     continue
                 # #7109: skip files registered via router_registry tuples;
                 # they're wired at runtime via dotted-path lookup which the

--- a/pipeline-scripts/test_audit_unwired_trackers.py
+++ b/pipeline-scripts/test_audit_unwired_trackers.py
@@ -105,22 +105,41 @@ def test_is_test_path(path: Path, is_test: bool) -> None:
 
 
 @pytest.mark.parametrize(
-    "path,should_skip",
+    "rel,should_skip",
     [
         # Fragments require a leading separator — the audit's intent is to
         # skip paths that *contain* these as directory segments, never as
         # filename prefixes (e.g. a real "build_*.py" production file).
-        (Path("/repo/autobot-backend/__pycache__/foo.cpython-310.pyc"), True),
-        (Path("/repo/autobot-frontend/node_modules/x/index.ts"), True),
-        (Path("/repo/.worktrees/issue-1234/foo.py"), True),
-        (Path("/repo/autobot-backend/dist/bundle.js"), True),
-        (Path("/repo/autobot-backend/build/out.js"), True),
-        (Path("/repo/autobot-backend/migrations/0001_init.py"), True),
-        (Path("/repo/autobot-backend/foo.py"), False),
+        ("autobot-backend/__pycache__/foo.cpython-310.pyc", True),
+        ("autobot-frontend/node_modules/x/index.ts", True),
+        (".worktrees/issue-1234/foo.py", True),
+        ("autobot-backend/dist/bundle.js", True),
+        ("autobot-backend/build/out.js", True),
+        ("autobot-backend/migrations/0001_init.py", True),
+        ("autobot-backend/foo.py", False),
     ],
 )
-def test_should_skip_path(path: Path, should_skip: bool) -> None:
-    assert audit.should_skip_path(path) is should_skip
+def test_should_skip_path(rel: str, should_skip: bool) -> None:
+    """Paths are checked relative to REPO_ROOT (#7128b: previously absolute,
+    which caused false-positives when the audit ran from inside a worktree)."""
+    p = audit.REPO_ROOT / rel
+    assert audit.should_skip_path(p) is should_skip
+
+
+def test_should_skip_path_handles_running_from_worktree() -> None:
+    """Regression: when REPO_ROOT itself contains `.worktrees/`, files INSIDE
+    that REPO_ROOT must NOT be auto-skipped (#7128b)."""
+    # Simulate: REPO_ROOT = /home/foo/repo/.worktrees/issue-X
+    # File:    /home/foo/repo/.worktrees/issue-X/autobot-backend/auth_rbac.py
+    # Should NOT be skipped — the .worktrees/ in REPO_ROOT itself is irrelevant.
+    fake_root = Path("/home/foo/repo/.worktrees/issue-X")
+    p = fake_root / "autobot-backend" / "auth_rbac.py"
+    with patch.object(audit, "REPO_ROOT", fake_root):
+        assert audit.should_skip_path(p) is False
+    # But a *nested* worktree under that fake_root should still be skipped:
+    nested = fake_root / ".worktrees" / "issue-Y" / "autobot-backend" / "x.py"
+    with patch.object(audit, "REPO_ROOT", fake_root):
+        assert audit.should_skip_path(nested) is True
 
 
 # ---------------------------------------------------------------------------
@@ -351,6 +370,60 @@ def test_scan_skips_router_registry_modules(tmp_path: Path) -> None:
         findings = audit.scan()
 
     assert findings == [], f"api/captcha.py should be filtered as registry-wired, got {findings}"
+
+
+# ---------------------------------------------------------------------------
+# is_entry_point_script — #7128b runner-script + demos/scripts/bin filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path,is_entry",
+    [
+        # run_*.py prefix style (the case that flagged my own runners post-#7127)
+        (Path("autobot-backend/intelligence/demos/run_intelligent_agent.py"), True),
+        (Path("autobot-backend/intelligence/demos/run_streaming_executor.py"), True),
+        (Path("scripts/run_smoke.py"), True),
+        # /demos/, /scripts/, /bin/ directory conventions
+        (Path("autobot-backend/intelligence/demos/__init__.py"), True),
+        (Path("autobot-backend/scripts/migrate_data.py"), True),
+        (Path("bin/server.py"), True),
+        # Non-entry-point production code
+        (Path("autobot-backend/api/captcha.py"), False),
+        (Path("autobot-backend/intelligence/intelligent_agent.py"), False),
+        # Edge: a non-py file should not match (the filter is .py-only)
+        (Path("autobot-frontend/run_thing.ts"), False),
+        # Edge: 'demoscope.py' contains 'demos' substring but not '/demos/'
+        (Path("autobot-backend/utils/demoscope.py"), False),
+    ],
+)
+def test_is_entry_point_script(path: Path, is_entry: bool) -> None:
+    assert audit.is_entry_point_script(path) is is_entry
+
+
+def test_scan_skips_entry_point_runners(tmp_path: Path) -> None:
+    """Reproduces the post-#7127 false-positive: runner scripts cite #7127
+    (closed) and have 0 callers by design — they shouldn't be flagged.
+    """
+    fake_root = tmp_path
+    backend = fake_root / "autobot-backend"
+    demos = backend / "intelligence" / "demos"
+    demos.mkdir(parents=True)
+    (demos / "run_intelligent_agent.py").write_text(
+        '"""Standalone demo runner (#7127)."""\n',
+        encoding="utf-8",
+    )
+    registry_dir = backend / "initialization" / "router_registry"
+    registry_dir.mkdir(parents=True)
+    (registry_dir / "feature_routers.py").write_text("X = []\n", encoding="utf-8")
+
+    with patch.object(audit, "REPO_ROOT", fake_root), \
+         patch.object(audit, "ROUTER_REGISTRY_DIR", registry_dir), \
+         patch.object(audit, "fetch_closed_tracker_set", return_value={7127}), \
+         patch.object(audit, "grep_count_production_callers", return_value=0):
+        findings = audit.scan()
+
+    assert findings == [], f"runner script should be skipped as entry-point, got {findings}"
 
 
 def test_scan_still_flags_truly_orphaned_module(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

#7168 (originally for #7128) was closed with a stale "0 findings" proof — the script was being run from inside a worktree where every absolute path contains \`/.worktrees/\`, hitting \`SKIP_PATH_FRAGMENTS\` and silently dropping ALL findings. The real count post-#7168 was actually 165 on \`Dev_new_gui\`, not 0. **My closure proof was bogus** — filing this fix to set the record straight.

## Two bugs fixed

### 1. Worktree-relative skip check
\`should_skip_path()\` matched against the absolute path string. When REPO_ROOT itself sits under \`.worktrees/\` (i.e. the audit is run from inside an isolated worktree, which is the *normal* parallel-work pattern this codebase uses), every file's absolute path contained \`/.worktrees/\` → filter triggered → 0 findings. Fix: match against the path relative to REPO_ROOT.

### 2. Entry-point script filter
\`intelligence/demos/run_intelligent_agent.py\` (created by #7127) cites its tracker in the docstring and has 0 callers by design — runners are designed to be invoked from CLI, not imported. The audit was flagging them. Fix: new helper \`is_entry_point_script(path)\` skips files whose name starts with \`run_\` OR whose path contains a \`demos/\`, \`scripts/\`, or \`bin/\` directory segment.

## Verification

\`\`\`bash
$ python3 pipeline-scripts/audit-unwired-trackers.py
❌ 110 unwired-tracker finding(s)
# Down from 165, remaining are real-or-different-FP-class
# (lazy imports, dataclass field refs, importlib strings — separate gaps)

$ python3 -m pytest pipeline-scripts/test_audit_unwired_trackers.py -q
63 passed in 0.26s
\`\`\`

## Test deltas

- \`test_should_skip_path\` parametrize cases switched from absolute paths to REPO_ROOT-relative inputs (matches the new contract).
- New \`test_should_skip_path_handles_running_from_worktree\` regression test pins the fix — paths inside REPO_ROOT (even if REPO_ROOT itself sits under \`.worktrees/\`) are not auto-skipped, but nested worktrees inside REPO_ROOT still are.
- New \`test_is_entry_point_script\` (10 parametrize cases) covers the runner-script filter with edge cases (e.g. \`utils/demoscope.py\` correctly NOT flagged).
- New \`test_scan_skips_entry_point_runners\` end-to-end regression for the post-#7127 false-positive.

## Why this matters

Without this fix, the audit script reports 0 findings on every parallel-work session (because we always run from \`.worktrees/issue-XXXX\`), so the #6872 backlog-filing goal is masked. **This silently broke the entire #6836 closure-gate process** — every "audit clean" claim by anyone running from a worktree was a false negative.

Refs #7128 (the original test-file-filter issue, now refined)
Refs #7109 (the registry-detection sibling)
Refs #6872 (audit script bulk-filing — needs this fix to produce real counts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)