### PR TITLE
fix(test/marketplace): unblock collection — repoint imports past #6534 enum migration (#7237)

### DIFF
--- a/autobot-backend/tests/api/test_marketplace.py
+++ b/autobot-backend/tests/api/test_marketplace.py
@@ -22,15 +22,12 @@ import pytest
 from fastapi import HTTPException
 
 from api.marketplace import (
-    InstallRequest,
-    MarketplaceCatalogResponse,
-    MarketplaceEntry,
+    CatalogCategory,
+    CatalogSort,
     _BUILTIN_CATALOG,
     _CATALOG_KEY,
     _CATALOG_TTL,
     _INSTALLED_KEY,
-    _VALID_CATEGORIES,
-    _VALID_SORT,
     _get_catalog,
     _plugin_source_url,
     get_catalog_entry,
@@ -40,6 +37,17 @@ from api.marketplace import (
     list_installed,
     uninstall_plugin,
 )
+from api.schemas_workflows import (
+    InstallRequest,
+    MarketplaceCatalogResponse,
+    MarketplaceEntry,
+)
+
+# Derived from CatalogCategory / CatalogSort enums (#6534) — replaces the
+# pre-enum ``_VALID_CATEGORIES`` / ``_VALID_SORT`` constants the tests used
+# to import from api.marketplace before the enum migration.
+_VALID_CATEGORIES = {c.value for c in CatalogCategory}
+_VALID_SORT = {s.value for s in CatalogSort}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR #7234 (#7216) made the async-mock patches actually fire, which then surfaced an import-time collection failure in \`tests/api/test_marketplace.py\`. **Test file imported 5 symbols that no longer exist** in production:

| Symbol | Where it went |
|---|---|
| \`_VALID_CATEGORIES\` | replaced by \`CatalogCategory\` enum (#6534) |
| \`_VALID_SORT\` | replaced by \`CatalogSort\` enum (#6534) |
| \`InstallRequest\` | moved to \`api.schemas_workflows\` |
| \`MarketplaceCatalogResponse\` | moved to \`api.schemas_workflows\` |
| \`MarketplaceEntry\` | moved to \`api.schemas_workflows\` |

## Fix

- Import the enums + schemas from their canonical post-#6534 locations
- Derive \`_VALID_CATEGORIES = {c.value for c in CatalogCategory}\` locally — a future enum addition flows through the existing assertions

## Verification

\`\`\`
# Before
$ pytest tests/api/test_marketplace.py
collection: 0 tests, ImportError

# After
$ pytest tests/api/test_marketplace.py
============== 12 failed, 36 passed in 1.91s ==============
\`\`\`

**48 tests now collect (was 0). 36 pass.** The 12 failures are a separate pre-existing bug class — \`list_catalog()\` uses FastAPI \`Query(...)\` annotations and tests pass raw kwargs that bypass Pydantic unwrapping. Filing as separate tracker.

Closes #7237