### PR TITLE
fix(deploy): loosen autobot-celery-beat dependency on celery worker (#6580)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2
@@ -12,9 +12,15 @@
 # lock, but production deploys this on exactly one host.
 [Unit]
 Description=AutoBot Celery Beat (periodic scheduler)
+# #6580: Beat enqueues to Redis; the worker consumes from there. They
+# communicate via the broker, not directly. The previous Requires=
+# autobot-celery.service caused systemd to STOP Beat whenever the worker
+# stopped (crashes, deploy, max_tasks_per_child rotation) — schedules
+# would silently miss their windows because the schedule file's next-run
+# timestamp advances even on shutdown. After= keeps start-order ordering;
+# Wants= softens the dependency so Beat survives worker restarts.
 After=network-online.target redis-stack-server.service autobot-celery.service
-Wants=network-online.target redis-stack-server.service
-Requires=autobot-celery.service
+Wants=network-online.target redis-stack-server.service autobot-celery.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Summary

Replace \`Requires=autobot-celery.service\` (hard binding) with \`Wants=autobot-celery.service\` (soft preference) in \`autobot-celery-beat.service.j2\`. \`After=\` is preserved for cold-boot ordering.

Beat enqueues to Redis; the worker consumes from there — they communicate via the broker, not directly. The previous hard dependency stopped Beat whenever the worker stopped (crashes, deploys, max_tasks_per_child rotation), causing scheduled tasks to silently miss their fire windows.

## Test plan

- [x] Diff is the intended single-line change (Requires removed, Wants extended) plus an explanatory comment
- [ ] Live verify post-deploy: stop \`autobot-celery.service\`, confirm \`autobot-celery-beat.service\` keeps running
- [ ] Live verify: a scheduled task fires at the correct time during a worker outage and is consumed when worker returns

Closes #6580