### PR TITLE
feat(plugin-sdk): declarative required_env field on PluginManifest (#6971)

### DIFF
--- a/autobot-backend/plugin_manager.py
+++ b/autobot-backend/plugin_manager.py
@@ -89,8 +89,8 @@ class PluginEnvStatusEntry(BaseModel):
     secret: bool
     required: bool
     description: str
-    docs_url: Optional[str]
-    obtain_steps: List[str]
+    docs_url: Optional[str] = None
+    obtain_steps: List[str] = []
 
 
 class PluginEnvStatusResponse(BaseModel):

--- a/autobot-backend/plugin_manager.py
+++ b/autobot-backend/plugin_manager.py
@@ -82,6 +82,24 @@ class PluginInstallResponse(BaseModel):
     message: str = Field(..., description="Human-readable status message")
 
 
+class PluginEnvStatusEntry(BaseModel):
+    """Per-env-var status (never contains the actual value)."""
+
+    configured: bool
+    secret: bool
+    required: bool
+    description: str
+    docs_url: Optional[str]
+    obtain_steps: List[str]
+
+
+class PluginEnvStatusResponse(BaseModel):
+    """Response for GET /plugins/{plugin_name}/env-status."""
+
+    plugin_name: str
+    env_vars: Dict[str, PluginEnvStatusEntry]
+
+
 @router.post(
     "/plugins/install/upload",
     status_code=status.HTTP_201_CREATED,
@@ -427,6 +445,36 @@ async def update_plugin_config(
         "status": "success",
         "message": f"Configuration updated for plugin: {plugin_name}",
     }
+
+
+@router.get("/plugins/{plugin_name}/env-status")
+@with_error_handling(error_code_prefix="PLUGIN_ENV_STATUS")
+async def get_plugin_env_status(
+    plugin_name: str,
+    admin_check: bool = Depends(check_admin_permission),
+) -> PluginEnvStatusResponse:
+    """
+    Return per-env-var configuration status for a loaded plugin.
+
+    The response never contains env-var values, only the configured/missing
+    state and manifest metadata. Designed for host UIs to surface install
+    requirements without leaking secrets.
+
+    Issue #6971.
+    """
+    loader = get_plugin_loader()
+    status_data = loader.get_env_status(plugin_name)
+    if status_data is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Plugin not found: {plugin_name}",
+        )
+    return PluginEnvStatusResponse(
+        plugin_name=plugin_name,
+        env_vars={
+            k: PluginEnvStatusEntry(**v) for k, v in status_data.items()
+        },
+    )
 
 
 async def _save_plugin_config(plugin_name: str, config: Dict) -> None:

--- a/autobot-backend/plugin_manager.py
+++ b/autobot-backend/plugin_manager.py
@@ -67,9 +67,7 @@ class PluginInstallGitRequest(BaseModel):
     """Install a plugin from a Git URL."""
 
     url: str = Field(..., description="HTTP(S) Git repository URL")
-    ref: Optional[str] = Field(
-        default=None, description="Branch or tag to clone (default: HEAD)"
-    )
+    ref: Optional[str] = Field(default=None, description="Branch or tag to clone (default: HEAD)")
 
 
 class PluginInstallResponse(BaseModel):
@@ -471,9 +469,7 @@ async def get_plugin_env_status(
         )
     return PluginEnvStatusResponse(
         plugin_name=plugin_name,
-        env_vars={
-            k: PluginEnvStatusEntry(**v) for k, v in status_data.items()
-        },
+        env_vars={k: PluginEnvStatusEntry(**v) for k, v in status_data.items()},
     )
 
 

--- a/autobot-backend/tests/api/test_plugin_manager.py
+++ b/autobot-backend/tests/api/test_plugin_manager.py
@@ -1,0 +1,80 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""
+Unit tests for the plugin manager FastAPI endpoints (Issue #6971).
+
+Covers GET /plugins/{plugin_name}/env-status — env-var configuration
+status without leaking values.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.mark.asyncio
+async def test_env_status_endpoint_returns_status_for_loaded_plugin(monkeypatch):
+    from plugin_manager import get_plugin_env_status
+
+    fake_loader = MagicMock()
+    fake_loader.get_env_status.return_value = {
+        "MY_API_KEY": {
+            "configured": True,
+            "secret": True,
+            "required": False,
+            "description": "API key",
+            "docs_url": "https://example.com/keys",
+            "obtain_steps": ["Sign in", "Generate"],
+        }
+    }
+
+    with patch("plugin_manager.get_plugin_loader", return_value=fake_loader):
+        result = await get_plugin_env_status(
+            plugin_name="my-plugin",
+            admin_check=True,
+        )
+
+    assert result.plugin_name == "my-plugin"
+    assert "MY_API_KEY" in result.env_vars
+    entry = result.env_vars["MY_API_KEY"]
+    assert entry.configured is True
+    assert entry.secret is True
+    assert entry.docs_url == "https://example.com/keys"
+    assert entry.obtain_steps == ["Sign in", "Generate"]
+
+
+@pytest.mark.asyncio
+async def test_env_status_endpoint_404_for_unknown_plugin(monkeypatch):
+    from plugin_manager import get_plugin_env_status
+
+    fake_loader = MagicMock()
+    fake_loader.get_env_status.return_value = None
+
+    with patch("plugin_manager.get_plugin_loader", return_value=fake_loader):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_plugin_env_status(
+                plugin_name="does-not-exist",
+                admin_check=True,
+            )
+
+    assert exc_info.value.status_code == 404
+    assert "does-not-exist" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_env_status_endpoint_returns_empty_for_plugin_without_required_env(monkeypatch):
+    from plugin_manager import get_plugin_env_status
+
+    fake_loader = MagicMock()
+    fake_loader.get_env_status.return_value = {}
+
+    with patch("plugin_manager.get_plugin_loader", return_value=fake_loader):
+        result = await get_plugin_env_status(
+            plugin_name="simple-plugin",
+            admin_check=True,
+        )
+
+    assert result.plugin_name == "simple-plugin"
+    assert result.env_vars == {}

--- a/autobot-backend/tests/api/test_plugin_manager.py
+++ b/autobot-backend/tests/api/test_plugin_manager.py
@@ -13,11 +13,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
+from plugin_manager import get_plugin_env_status
+
 
 @pytest.mark.asyncio
-async def test_env_status_endpoint_returns_status_for_loaded_plugin(monkeypatch):
-    from plugin_manager import get_plugin_env_status
-
+async def test_env_status_endpoint_returns_status_for_loaded_plugin():
     fake_loader = MagicMock()
     fake_loader.get_env_status.return_value = {
         "MY_API_KEY": {
@@ -46,9 +46,7 @@ async def test_env_status_endpoint_returns_status_for_loaded_plugin(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_env_status_endpoint_404_for_unknown_plugin(monkeypatch):
-    from plugin_manager import get_plugin_env_status
-
+async def test_env_status_endpoint_404_for_unknown_plugin():
     fake_loader = MagicMock()
     fake_loader.get_env_status.return_value = None
 
@@ -64,9 +62,7 @@ async def test_env_status_endpoint_404_for_unknown_plugin(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_env_status_endpoint_returns_empty_for_plugin_without_required_env(monkeypatch):
-    from plugin_manager import get_plugin_env_status
-
+async def test_env_status_endpoint_returns_empty_for_plugin_without_required_env():
     fake_loader = MagicMock()
     fake_loader.get_env_status.return_value = {}
 
@@ -78,3 +74,71 @@ async def test_env_status_endpoint_returns_empty_for_plugin_without_required_env
 
     assert result.plugin_name == "simple-plugin"
     assert result.env_vars == {}
+
+
+@pytest.mark.asyncio
+async def test_env_status_endpoint_with_real_loader_no_mock(monkeypatch):
+    """Integration test: real PluginLoader -> real RequiredEnvVar -> endpoint.
+
+    Catches contract drift between get_env_status's dict shape and
+    PluginEnvStatusEntry's expected fields. If the dict ever loses a
+    field or gains an unrelated one, this test fails at the
+    PluginEnvStatusEntry(**v) boundary.
+    """
+    from plugin_sdk.base import PluginManifest, PluginRegistry, PluginStatus
+    from plugin_sdk.loader import PluginLoader
+
+    # Set the real env var so configured=True
+    monkeypatch.setenv("REAL_INTEGRATION_VAR", "any_value")
+
+    # Build a real plugin manifest with one required_env entry
+    manifest = PluginManifest(
+        name="real-plugin-integration",
+        version="1.0.0",
+        display_name="Real Plugin",
+        description="Integration test plugin.",
+        author="test",
+        entry_point="test.module",
+        required_env=[
+            {
+                "name": "REAL_INTEGRATION_VAR",
+                "description": "Integration test var.",
+                "secret": True,
+                "required": True,
+                "docs_url": "https://example.com/docs",
+                "obtain_steps": ["step1", "step2"],
+            }
+        ],
+    )
+
+    # Register a stub plugin into the real registry so get_env_status finds it
+    PluginRegistry().clear()
+
+    class _StubPlugin:
+        def __init__(self, manifest):
+            self.manifest = manifest
+            self.status = PluginStatus.LOADED
+
+    stub_plugin = _StubPlugin(manifest)
+    PluginRegistry().register(stub_plugin)
+
+    # Real loader, no mocks
+    real_loader = PluginLoader([])
+
+    with patch("plugin_manager.get_plugin_loader", return_value=real_loader):
+        result = await get_plugin_env_status(
+            plugin_name="real-plugin-integration",
+            admin_check=True,
+        )
+
+    # If the loader's dict shape drifts, PluginEnvStatusEntry(**v) raises
+    # a ValidationError before this assertion is reached
+    assert result.plugin_name == "real-plugin-integration"
+    assert "REAL_INTEGRATION_VAR" in result.env_vars
+    entry = result.env_vars["REAL_INTEGRATION_VAR"]
+    assert entry.configured is True
+    assert entry.secret is True
+    assert entry.required is True
+    assert entry.description == "Integration test var."
+    assert entry.docs_url == "https://example.com/docs"
+    assert entry.obtain_steps == ["step1", "step2"]

--- a/autobot_shared/plugin_sdk/base.py
+++ b/autobot_shared/plugin_sdk/base.py
@@ -94,6 +94,10 @@ class PluginManifest(BaseModel):
     dependencies: List[str] = Field(default_factory=list, description="Required plugin names")
     config_schema: Dict[str, Any] = Field(default_factory=dict, description="JSON schema for plugin configuration")
     hooks: List[str] = Field(default_factory=list, description="Hook names this plugin provides")
+    required_env: List[RequiredEnvVar] = Field(
+        default_factory=list,
+        description="Environment variables this plugin needs at runtime",
+    )
 
     @field_validator("version")
     @classmethod

--- a/autobot_shared/plugin_sdk/base.py
+++ b/autobot_shared/plugin_sdk/base.py
@@ -20,6 +20,53 @@ from pydantic import BaseModel, Field, field_validator
 logger = logging.getLogger(__name__)
 
 
+class RequiredEnvVar(BaseModel):
+    """
+    Declares an environment variable a plugin needs at runtime.
+
+    Used in PluginManifest.required_env to surface configuration requirements
+    to operators and host UIs. Values are NEVER returned through the API —
+    only the configured/missing state is reported.
+    """
+
+    name: str = Field(
+        ...,
+        description="Env var name, e.g. 'MY_PLUGIN_API_KEY'",
+    )
+    secret: bool = Field(
+        False,
+        description="If true, host UI hides the value from any preview surface",
+    )
+    required: bool = Field(
+        False,
+        description="If true, the plugin refuses to load when the var is missing",
+    )
+    description: str = Field(
+        ...,
+        description="One-line purpose of the variable",
+    )
+    docs_url: Optional[str] = Field(
+        None,
+        description="URL where the credential is obtained",
+    )
+    obtain_steps: List[str] = Field(
+        default_factory=list,
+        description="Bullet list shown by the host settings UI",
+    )
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Env-var names must be UPPER_SNAKE_CASE starting with a letter."""
+        if not v:
+            raise ValueError("Env var name cannot be empty")
+        if not v[0].isalpha() or not v[0].isupper():
+            raise ValueError("Env var name must start with an uppercase letter")
+        if not all(c.isupper() or c.isdigit() or c == "_" for c in v):
+            raise ValueError("Env var name must be UPPER_SNAKE_CASE")
+        return v
+
+
 class PluginStatus(str, Enum):
     """Plugin lifecycle status."""
 

--- a/autobot_shared/plugin_sdk/base.py
+++ b/autobot_shared/plugin_sdk/base.py
@@ -11,6 +11,7 @@ Issue #730 - Plugin SDK for extensible tool architecture.
 """
 
 import logging
+import re
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -43,6 +44,7 @@ class RequiredEnvVar(BaseModel):
     )
     description: str = Field(
         ...,
+        min_length=1,
         description="One-line purpose of the variable",
     )
     docs_url: Optional[str] = Field(
@@ -57,13 +59,12 @@ class RequiredEnvVar(BaseModel):
     @field_validator("name")
     @classmethod
     def validate_name(cls, v: str) -> str:
-        """Env-var names must be UPPER_SNAKE_CASE starting with a letter."""
-        if not v:
-            raise ValueError("Env var name cannot be empty")
-        if not v[0].isalpha() or not v[0].isupper():
-            raise ValueError("Env var name must start with an uppercase letter")
-        if not all(c.isupper() or c.isdigit() or c == "_" for c in v):
-            raise ValueError("Env var name must be UPPER_SNAKE_CASE")
+        """Env-var names must be ASCII UPPER_SNAKE_CASE starting with a letter."""
+        if not re.fullmatch(r"[A-Z][A-Z0-9_]*", v):
+            raise ValueError(
+                "Env var name must be ASCII UPPER_SNAKE_CASE starting with "
+                "an uppercase letter (e.g. 'MY_PLUGIN_API_KEY')"
+            )
         return v
 
 

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -95,6 +95,22 @@ class PluginLoader:
                 )
                 return None
 
+            # Check required environment variables
+            missing_required, missing_optional = self._check_required_env(manifest)
+            if missing_required:
+                logger.error(
+                    "Cannot load plugin %s: required env vars not set: %s",
+                    manifest.name,
+                    missing_required,
+                )
+                return None
+            if missing_optional:
+                logger.info(
+                    "Plugin %s loaded with optional env vars unset: %s",
+                    manifest.name,
+                    missing_optional,
+                )
+
             # Import plugin module
             plugin_class = self._import_plugin_class(manifest.entry_point)
             if not plugin_class:

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -13,8 +13,9 @@ import importlib
 import importlib.util
 import json
 import logging
+import os
 from pathlib import Path
-from typing import Dict, List, Optional, Type
+from typing import Dict, List, Optional, Tuple, Type
 
 from plugin_sdk.base import BasePlugin, PluginManifest, PluginRegistry, PluginStatus
 
@@ -190,7 +191,7 @@ class PluginLoader:
 
     def _check_required_env(
         self, manifest: PluginManifest
-    ) -> tuple[List[str], List[str]]:
+    ) -> Tuple[List[str], List[str]]:
         """
         Check which env vars declared by the manifest are unset.
 
@@ -198,8 +199,6 @@ class PluginLoader:
             Tuple of (missing_required, missing_optional) env var names.
             An env var set to an empty string is treated as missing.
         """
-        import os
-
         missing_required: List[str] = []
         missing_optional: List[str] = []
         for env in manifest.required_env:

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -205,9 +205,7 @@ class PluginLoader:
                 missing.append(dep)
         return missing
 
-    def _check_required_env(
-        self, manifest: PluginManifest
-    ) -> Tuple[List[str], List[str]]:
+    def _check_required_env(self, manifest: PluginManifest) -> Tuple[List[str], List[str]]:
         """
         Check which env vars declared by the manifest are unset.
 
@@ -225,9 +223,7 @@ class PluginLoader:
                     missing_optional.append(env.name)
         return missing_required, missing_optional
 
-    def get_env_status(
-        self, plugin_name: str
-    ) -> Optional[Dict[str, Dict[str, object]]]:
+    def get_env_status(self, plugin_name: str) -> Optional[Dict[str, Dict[str, object]]]:
         """
         Return per-env-var configuration status for a loaded plugin.
 

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -225,6 +225,37 @@ class PluginLoader:
                     missing_optional.append(env.name)
         return missing_required, missing_optional
 
+    def get_env_status(
+        self, plugin_name: str
+    ) -> Optional[Dict[str, Dict[str, object]]]:
+        """
+        Return per-env-var configuration status for a loaded plugin.
+
+        SECURITY: response NEVER contains env var values, only the
+        configured/missing boolean and the manifest metadata.
+
+        Args:
+            plugin_name: Name of a loaded plugin
+
+        Returns:
+            Dict mapping env-var name to status dict, or None if the
+            plugin is not loaded.
+        """
+        plugin = self.registry.get_plugin(plugin_name)
+        if plugin is None:
+            return None
+        return {
+            env.name: {
+                "configured": bool(os.environ.get(env.name)),
+                "secret": env.secret,
+                "required": env.required,
+                "description": env.description,
+                "docs_url": env.docs_url,
+                "obtain_steps": list(env.obtain_steps),
+            }
+            for env in plugin.manifest.required_env
+        }
+
     def _import_plugin_class(self, entry_point: str) -> Optional[Type[BasePlugin]]:
         """
         Import plugin class from entry point.

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -188,6 +188,28 @@ class PluginLoader:
                 missing.append(dep)
         return missing
 
+    def _check_required_env(
+        self, manifest: PluginManifest
+    ) -> tuple[List[str], List[str]]:
+        """
+        Check which env vars declared by the manifest are unset.
+
+        Returns:
+            Tuple of (missing_required, missing_optional) env var names.
+            An env var set to an empty string is treated as missing.
+        """
+        import os
+
+        missing_required: List[str] = []
+        missing_optional: List[str] = []
+        for env in manifest.required_env:
+            if not os.environ.get(env.name):
+                if env.required:
+                    missing_required.append(env.name)
+                else:
+                    missing_optional.append(env.name)
+        return missing_required, missing_optional
+
     def _import_plugin_class(self, entry_point: str) -> Optional[Type[BasePlugin]]:
         """
         Import plugin class from entry point.

--- a/autobot_shared/plugin_sdk/plugin_sdk_test.py
+++ b/autobot_shared/plugin_sdk/plugin_sdk_test.py
@@ -456,6 +456,7 @@ async def test_load_plugin_returns_none_when_required_env_missing(monkeypatch, c
 
     monkeypatch.delenv("TEST_REQ_LOAD_FAIL", raising=False)
 
+    PluginRegistry().clear()
     loader = PluginLoader([])
     manifest = _make_manifest(
         required_env=[
@@ -475,10 +476,7 @@ async def test_load_plugin_returns_none_when_required_env_missing(monkeypatch, c
         result = await loader.load_plugin(manifest)
 
     assert result is None
-    assert any(
-        "TEST_REQ_LOAD_FAIL" in record.message
-        for record in caplog.records
-    )
+    assert "TEST_REQ_LOAD_FAIL" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -509,10 +507,7 @@ async def test_load_plugin_succeeds_with_optional_env_missing(monkeypatch, caplo
         plugin = await loader.load_plugin(manifest)
 
     assert plugin is not None
-    assert any(
-        "TEST_OPT_LOAD_OK" in record.message
-        for record in caplog.records
-    )
+    assert "TEST_OPT_LOAD_OK" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/autobot_shared/plugin_sdk/plugin_sdk_test.py
+++ b/autobot_shared/plugin_sdk/plugin_sdk_test.py
@@ -12,7 +12,13 @@ Issue #3278 - Plugin and extension system for third-party integrations.
 
 import pytest
 
-from plugin_sdk.base import BasePlugin, PluginManifest, PluginRegistry, PluginStatus
+from plugin_sdk.base import (
+    BasePlugin,
+    PluginManifest,
+    PluginRegistry,
+    PluginStatus,
+    RequiredEnvVar,
+)
 from plugin_sdk.hooks import Hook, HookRegistry
 from plugin_sdk.plugin_manager import PluginManager
 
@@ -76,8 +82,6 @@ def test_manifest_invalid_name():
 
 
 def test_required_env_var_accepts_valid_name():
-    from plugin_sdk.base import RequiredEnvVar
-
     var = RequiredEnvVar(
         name="MY_PLUGIN_API_KEY",
         description="The API key.",
@@ -90,31 +94,41 @@ def test_required_env_var_accepts_valid_name():
 
 
 def test_required_env_var_rejects_lowercase_name():
-    from plugin_sdk.base import RequiredEnvVar
-
     with pytest.raises(Exception):
         RequiredEnvVar(name="my_plugin_api_key", description="x")
 
 
 def test_required_env_var_rejects_leading_digit():
-    from plugin_sdk.base import RequiredEnvVar
-
     with pytest.raises(Exception):
         RequiredEnvVar(name="1MY_KEY", description="x")
 
 
 def test_required_env_var_rejects_special_chars():
-    from plugin_sdk.base import RequiredEnvVar
-
     with pytest.raises(Exception):
         RequiredEnvVar(name="MY-KEY", description="x")
 
 
 def test_required_env_var_rejects_empty_name():
-    from plugin_sdk.base import RequiredEnvVar
-
     with pytest.raises(Exception):
         RequiredEnvVar(name="", description="x")
+
+
+def test_required_env_var_rejects_unicode_letters():
+    """Unicode uppercase letters (e.g. Ω, Ё) are not legal POSIX env var names."""
+    with pytest.raises(Exception):
+        RequiredEnvVar(name="Ω_KEY", description="x")  # Ω
+
+
+def test_required_env_var_rejects_mixed_case_in_middle():
+    """Lowercase chars anywhere in the name are rejected, not just at the start."""
+    with pytest.raises(Exception):
+        RequiredEnvVar(name="MY_key", description="x")
+
+
+def test_required_env_var_rejects_empty_description():
+    """Description must be non-empty (min_length=1)."""
+    with pytest.raises(Exception):
+        RequiredEnvVar(name="MY_KEY", description="")
 
 
 # ---------------------------------------------------------------------------

--- a/autobot_shared/plugin_sdk/plugin_sdk_test.py
+++ b/autobot_shared/plugin_sdk/plugin_sdk_test.py
@@ -132,6 +132,39 @@ def test_required_env_var_rejects_empty_description():
 
 
 # ---------------------------------------------------------------------------
+# PluginManifest.required_env field
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_default_required_env_is_empty_list():
+    """Backward compat: existing plugin.json without the field still parses."""
+    m = _make_manifest()
+    assert m.required_env == []
+
+
+def test_manifest_with_required_env_parses():
+    m = _make_manifest(
+        required_env=[
+            {
+                "name": "MY_API_KEY",
+                "description": "API key for service.",
+                "secret": True,
+                "required": False,
+                "docs_url": "https://example.com/keys",
+                "obtain_steps": ["Sign in", "Generate key"],
+            }
+        ]
+    )
+    assert len(m.required_env) == 1
+    var = m.required_env[0]
+    assert isinstance(var, RequiredEnvVar)
+    assert var.name == "MY_API_KEY"
+    assert var.secret is True
+    assert var.docs_url == "https://example.com/keys"
+    assert var.obtain_steps == ["Sign in", "Generate key"]
+
+
+# ---------------------------------------------------------------------------
 # BasePlugin lifecycle
 # ---------------------------------------------------------------------------
 

--- a/autobot_shared/plugin_sdk/plugin_sdk_test.py
+++ b/autobot_shared/plugin_sdk/plugin_sdk_test.py
@@ -71,6 +71,53 @@ def test_manifest_invalid_name():
 
 
 # ---------------------------------------------------------------------------
+# RequiredEnvVar validation
+# ---------------------------------------------------------------------------
+
+
+def test_required_env_var_accepts_valid_name():
+    from plugin_sdk.base import RequiredEnvVar
+
+    var = RequiredEnvVar(
+        name="MY_PLUGIN_API_KEY",
+        description="The API key.",
+    )
+    assert var.name == "MY_PLUGIN_API_KEY"
+    assert var.secret is False
+    assert var.required is False
+    assert var.docs_url is None
+    assert var.obtain_steps == []
+
+
+def test_required_env_var_rejects_lowercase_name():
+    from plugin_sdk.base import RequiredEnvVar
+
+    with pytest.raises(Exception):
+        RequiredEnvVar(name="my_plugin_api_key", description="x")
+
+
+def test_required_env_var_rejects_leading_digit():
+    from plugin_sdk.base import RequiredEnvVar
+
+    with pytest.raises(Exception):
+        RequiredEnvVar(name="1MY_KEY", description="x")
+
+
+def test_required_env_var_rejects_special_chars():
+    from plugin_sdk.base import RequiredEnvVar
+
+    with pytest.raises(Exception):
+        RequiredEnvVar(name="MY-KEY", description="x")
+
+
+def test_required_env_var_rejects_empty_name():
+    from plugin_sdk.base import RequiredEnvVar
+
+    with pytest.raises(Exception):
+        RequiredEnvVar(name="", description="x")
+
+
+# ---------------------------------------------------------------------------
 # BasePlugin lifecycle
 # ---------------------------------------------------------------------------
 

--- a/autobot_shared/plugin_sdk/plugin_sdk_test.py
+++ b/autobot_shared/plugin_sdk/plugin_sdk_test.py
@@ -442,3 +442,103 @@ async def test_plugin_manager_is_enabled_false_for_unknown():
     pm = PluginManager([])
     assert pm.is_enabled("nonexistent") is False
     await pm.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# PluginLoader.load_plugin integration with required_env
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_plugin_returns_none_when_required_env_missing(monkeypatch, caplog):
+    """Plugin with a missing required env var fails to load with an error log."""
+    from plugin_sdk.loader import PluginLoader
+
+    monkeypatch.delenv("TEST_REQ_LOAD_FAIL", raising=False)
+
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        required_env=[
+            {
+                "name": "TEST_REQ_LOAD_FAIL",
+                "description": "x",
+                "required": True,
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
+    )
+
+    with caplog.at_level("ERROR"):
+        result = await loader.load_plugin(manifest)
+
+    assert result is None
+    assert any(
+        "TEST_REQ_LOAD_FAIL" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_plugin_succeeds_with_optional_env_missing(monkeypatch, caplog):
+    """Plugin with missing optional env var loads, with info log."""
+    from plugin_sdk.loader import PluginLoader
+
+    PluginRegistry().clear()
+    monkeypatch.delenv("TEST_OPT_LOAD_OK", raising=False)
+
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        name="opt-test-plugin",
+        required_env=[
+            {
+                "name": "TEST_OPT_LOAD_OK",
+                "description": "x",
+                "required": False,
+            }
+        ],
+    )
+
+    monkeypatch.setattr(
+        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
+    )
+
+    with caplog.at_level("INFO"):
+        plugin = await loader.load_plugin(manifest)
+
+    assert plugin is not None
+    assert any(
+        "TEST_OPT_LOAD_OK" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_plugin_succeeds_when_all_required_env_set(monkeypatch):
+    """Plugin loads normally when all required env vars are configured."""
+    from plugin_sdk.loader import PluginLoader
+
+    PluginRegistry().clear()
+    monkeypatch.setenv("TEST_REQ_LOAD_PRESENT", "value")
+
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        name="all-set-plugin",
+        required_env=[
+            {
+                "name": "TEST_REQ_LOAD_PRESENT",
+                "description": "x",
+                "required": True,
+            }
+        ],
+    )
+
+    monkeypatch.setattr(
+        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
+    )
+
+    plugin = await loader.load_plugin(manifest)
+    assert plugin is not None
+    assert plugin.manifest.name == "all-set-plugin"

--- a/autobot_shared/plugin_sdk/plugin_sdk_test.py
+++ b/autobot_shared/plugin_sdk/plugin_sdk_test.py
@@ -165,6 +165,93 @@ def test_manifest_with_required_env_parses():
 
 
 # ---------------------------------------------------------------------------
+# PluginLoader._check_required_env
+# ---------------------------------------------------------------------------
+
+
+def test_check_required_env_returns_empty_when_no_required_env(monkeypatch):
+    from plugin_sdk.loader import PluginLoader
+
+    loader = PluginLoader([])
+    manifest = _make_manifest()
+    missing_required, missing_optional = loader._check_required_env(manifest)
+    assert missing_required == []
+    assert missing_optional == []
+
+
+def test_check_required_env_finds_missing_required(monkeypatch):
+    from plugin_sdk.loader import PluginLoader
+
+    monkeypatch.delenv("TEST_REQUIRED_VAR", raising=False)
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        required_env=[
+            {
+                "name": "TEST_REQUIRED_VAR",
+                "description": "Required.",
+                "required": True,
+            }
+        ]
+    )
+    missing_required, missing_optional = loader._check_required_env(manifest)
+    assert missing_required == ["TEST_REQUIRED_VAR"]
+    assert missing_optional == []
+
+
+def test_check_required_env_finds_missing_optional(monkeypatch):
+    from plugin_sdk.loader import PluginLoader
+
+    monkeypatch.delenv("TEST_OPTIONAL_VAR", raising=False)
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        required_env=[
+            {
+                "name": "TEST_OPTIONAL_VAR",
+                "description": "Optional.",
+                "required": False,
+            }
+        ]
+    )
+    missing_required, missing_optional = loader._check_required_env(manifest)
+    assert missing_required == []
+    assert missing_optional == ["TEST_OPTIONAL_VAR"]
+
+
+def test_check_required_env_separates_required_and_optional(monkeypatch):
+    from plugin_sdk.loader import PluginLoader
+
+    monkeypatch.delenv("TEST_REQ_A", raising=False)
+    monkeypatch.delenv("TEST_OPT_B", raising=False)
+    monkeypatch.setenv("TEST_REQ_C", "value")
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        required_env=[
+            {"name": "TEST_REQ_A", "description": "x", "required": True},
+            {"name": "TEST_OPT_B", "description": "x", "required": False},
+            {"name": "TEST_REQ_C", "description": "x", "required": True},
+        ]
+    )
+    missing_required, missing_optional = loader._check_required_env(manifest)
+    assert missing_required == ["TEST_REQ_A"]
+    assert missing_optional == ["TEST_OPT_B"]
+
+
+def test_check_required_env_treats_empty_string_as_missing(monkeypatch):
+    """An env var set to empty string is treated as not configured."""
+    from plugin_sdk.loader import PluginLoader
+
+    monkeypatch.setenv("TEST_EMPTY_VAR", "")
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        required_env=[
+            {"name": "TEST_EMPTY_VAR", "description": "x", "required": True}
+        ]
+    )
+    missing_required, _ = loader._check_required_env(manifest)
+    assert missing_required == ["TEST_EMPTY_VAR"]
+
+
+# ---------------------------------------------------------------------------
 # BasePlugin lifecycle
 # ---------------------------------------------------------------------------
 

--- a/autobot_shared/plugin_sdk/plugin_sdk_test.py
+++ b/autobot_shared/plugin_sdk/plugin_sdk_test.py
@@ -537,3 +537,100 @@ async def test_load_plugin_succeeds_when_all_required_env_set(monkeypatch):
     plugin = await loader.load_plugin(manifest)
     assert plugin is not None
     assert plugin.manifest.name == "all-set-plugin"
+
+
+# ---------------------------------------------------------------------------
+# PluginLoader.get_env_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_env_status_returns_correct_shape(monkeypatch):
+    from plugin_sdk.loader import PluginLoader
+
+    PluginRegistry().clear()
+    monkeypatch.setenv("TEST_STATUS_PRESENT", "actual_secret_value")
+    monkeypatch.delenv("TEST_STATUS_MISSING", raising=False)
+
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        name="status-shape-plugin",
+        required_env=[
+            {
+                "name": "TEST_STATUS_PRESENT",
+                "description": "Set var.",
+                "secret": True,
+                "required": False,
+                "docs_url": "https://example.com",
+                "obtain_steps": ["one", "two"],
+            },
+            {
+                "name": "TEST_STATUS_MISSING",
+                "description": "Unset var.",
+                "secret": False,
+                "required": False,
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
+    )
+    await loader.load_plugin(manifest)
+
+    status = loader.get_env_status("status-shape-plugin")
+    assert status is not None
+    assert set(status.keys()) == {"TEST_STATUS_PRESENT", "TEST_STATUS_MISSING"}
+
+    present = status["TEST_STATUS_PRESENT"]
+    assert present == {
+        "configured": True,
+        "secret": True,
+        "required": False,
+        "description": "Set var.",
+        "docs_url": "https://example.com",
+        "obtain_steps": ["one", "two"],
+    }
+
+    missing = status["TEST_STATUS_MISSING"]
+    assert missing["configured"] is False
+    assert missing["secret"] is False
+    assert missing["docs_url"] is None
+    assert missing["obtain_steps"] == []
+
+
+def test_get_env_status_returns_none_for_unknown_plugin():
+    from plugin_sdk.loader import PluginLoader
+
+    loader = PluginLoader([])
+    assert loader.get_env_status("does-not-exist") is None
+
+
+@pytest.mark.asyncio
+async def test_get_env_status_never_returns_value(monkeypatch):
+    """Critical privacy test: env-var values must NEVER be in the response."""
+    from plugin_sdk.loader import PluginLoader
+
+    PluginRegistry().clear()
+    secret_value = "sk-supersecret-do-not-leak-1234"
+    monkeypatch.setenv("TEST_SECRET_LEAK_CHECK", secret_value)
+
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        name="leak-check-plugin",
+        required_env=[
+            {
+                "name": "TEST_SECRET_LEAK_CHECK",
+                "description": "Sensitive.",
+                "secret": True,
+                "required": True,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
+    )
+    await loader.load_plugin(manifest)
+
+    status = loader.get_env_status("leak-check-plugin")
+    serialized = repr(status)
+    assert secret_value not in serialized

--- a/autobot_shared/plugin_sdk/plugin_sdk_test.py
+++ b/autobot_shared/plugin_sdk/plugin_sdk_test.py
@@ -242,11 +242,7 @@ def test_check_required_env_treats_empty_string_as_missing(monkeypatch):
 
     monkeypatch.setenv("TEST_EMPTY_VAR", "")
     loader = PluginLoader([])
-    manifest = _make_manifest(
-        required_env=[
-            {"name": "TEST_EMPTY_VAR", "description": "x", "required": True}
-        ]
-    )
+    manifest = _make_manifest(required_env=[{"name": "TEST_EMPTY_VAR", "description": "x", "required": True}])
     missing_required, _ = loader._check_required_env(manifest)
     assert missing_required == ["TEST_EMPTY_VAR"]
 
@@ -468,9 +464,7 @@ async def test_load_plugin_returns_none_when_required_env_missing(monkeypatch, c
         ]
     )
 
-    monkeypatch.setattr(
-        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
-    )
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
 
     with caplog.at_level("ERROR"):
         result = await loader.load_plugin(manifest)
@@ -499,9 +493,7 @@ async def test_load_plugin_succeeds_with_optional_env_missing(monkeypatch, caplo
         ],
     )
 
-    monkeypatch.setattr(
-        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
-    )
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
 
     with caplog.at_level("INFO"):
         plugin = await loader.load_plugin(manifest)
@@ -530,9 +522,7 @@ async def test_load_plugin_succeeds_when_all_required_env_set(monkeypatch):
         ],
     )
 
-    monkeypatch.setattr(
-        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
-    )
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
 
     plugin = await loader.load_plugin(manifest)
     assert plugin is not None
@@ -572,9 +562,7 @@ async def test_get_env_status_returns_correct_shape(monkeypatch):
             },
         ],
     )
-    monkeypatch.setattr(
-        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
-    )
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
     await loader.load_plugin(manifest)
 
     status = loader.get_env_status("status-shape-plugin")
@@ -627,9 +615,7 @@ async def test_get_env_status_never_returns_value(monkeypatch):
             }
         ],
     )
-    monkeypatch.setattr(
-        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
-    )
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
     await loader.load_plugin(manifest)
 
     status = loader.get_env_status("leak-check-plugin")
@@ -638,5 +624,6 @@ async def test_get_env_status_never_returns_value(monkeypatch):
     # because all leaf types are primitives; this future-proofs against a
     # maintainer adding a SecretStr-style wrapper whose __repr__ masks values.
     import json
+
     assert secret_value not in repr(status)
     assert secret_value not in json.dumps(status, default=str)

--- a/autobot_shared/plugin_sdk/plugin_sdk_test.py
+++ b/autobot_shared/plugin_sdk/plugin_sdk_test.py
@@ -601,6 +601,7 @@ async def test_get_env_status_returns_correct_shape(monkeypatch):
 def test_get_env_status_returns_none_for_unknown_plugin():
     from plugin_sdk.loader import PluginLoader
 
+    PluginRegistry().clear()
     loader = PluginLoader([])
     assert loader.get_env_status("does-not-exist") is None
 
@@ -632,5 +633,10 @@ async def test_get_env_status_never_returns_value(monkeypatch):
     await loader.load_plugin(manifest)
 
     status = loader.get_env_status("leak-check-plugin")
-    serialized = repr(status)
-    assert secret_value not in serialized
+    # Belt-and-braces: check both repr (any Python serialization) AND
+    # JSON (the actual API serialization path). Today repr catches everything
+    # because all leaf types are primitives; this future-proofs against a
+    # maintainer adding a SecretStr-style wrapper whose __repr__ masks values.
+    import json
+    assert secret_value not in repr(status)
+    assert secret_value not in json.dumps(status, default=str)

--- a/docs/superpowers/plans/2026-05-05-plugin-sdk-required-env.md
+++ b/docs/superpowers/plans/2026-05-05-plugin-sdk-required-env.md
@@ -1,0 +1,1199 @@
+# Plugin SDK `required_env` Field — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `required_env: List[RequiredEnvVar]` field to `PluginManifest` so plugins declare needed environment variables, with loader-level enforcement and a `GET /plugins/{name}/env-status` endpoint that exposes per-var configuration state without ever leaking values.
+
+**Architecture:** Four files modified in lock-step. Pydantic schema (`RequiredEnvVar`) added next to `PluginManifest`. `PluginLoader` gets two methods: `_check_required_env` (used during load to fail-loud on missing required vars) and `get_env_status` (used by API to return safe state dict). New FastAPI endpoint reads `get_env_status` and returns a typed response with no env-var values. Backward compatible: default empty list means all 4 in-tree plugins continue to load identically. TDD throughout, one commit per task.
+
+**Tech Stack:** Python 3.11+, pydantic v2, FastAPI, pytest, pytest-asyncio.
+
+**Spec:** [`docs/superpowers/specs/2026-05-05-plugin-sdk-required-env-design.md`](../specs/2026-05-05-plugin-sdk-required-env-design.md)
+**Issue:** #6971
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+| --- | --- | --- |
+| `autobot_shared/plugin_sdk/base.py` | Modify | `RequiredEnvVar` model + field on `PluginManifest` |
+| `autobot_shared/plugin_sdk/loader.py` | Modify | `_check_required_env` + `get_env_status` + integration with `load_plugin` |
+| `autobot-backend/plugin_manager.py` | Modify | `PluginEnvStatusEntry`/`PluginEnvStatusResponse` models + `GET /plugins/{name}/env-status` endpoint |
+| `autobot_shared/plugin_sdk/plugin_sdk_test.py` | Modify | All SDK-level unit tests (8 test functions added) |
+| `autobot-backend/tests/api/test_plugin_manager.py` | Create | API endpoint tests (2 test functions) |
+
+---
+
+## Task 0: Worktree Setup
+
+**Files:** none (creates `.worktrees/issue-6971/`)
+
+- [ ] **Step 1: Verify main session is on Dev_new_gui and clean**
+
+```bash
+git -C /home/martins/AutoBot-Ai/AutoBot-AI branch --show-current
+git -C /home/martins/AutoBot-Ai/AutoBot-AI status --porcelain
+```
+
+Expected: branch is `Dev_new_gui`, status is empty (clean tree).
+
+- [ ] **Step 2: Create worktree**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI
+git worktree add .worktrees/issue-6971 -b issue-6971 origin/Dev_new_gui
+git -C .worktrees/issue-6971 branch --unset-upstream
+```
+
+Expected: `.worktrees/issue-6971/` exists, on branch `issue-6971` with no upstream.
+
+- [ ] **Step 3: Confirm worktree readiness**
+
+```bash
+git -C /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971 status
+git -C /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971 log --oneline -3
+```
+
+Expected: clean, recent commits visible from Dev_new_gui base.
+
+**All subsequent commands run inside `.worktrees/issue-6971/` via `git -C` or by entering the directory. Never `cd` back to the main checkout — that breaks parallel worktrees per CLAUDE.md.**
+
+---
+
+## Task 1: `RequiredEnvVar` schema (TDD)
+
+**Files:**
+
+- Modify: `autobot_shared/plugin_sdk/base.py`
+- Test: `autobot_shared/plugin_sdk/plugin_sdk_test.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `plugin_sdk_test.py` after the existing `PluginManifest validation` section:
+
+```python
+# ---------------------------------------------------------------------------
+# RequiredEnvVar validation
+# ---------------------------------------------------------------------------
+
+
+def test_required_env_var_accepts_valid_name():
+    from plugin_sdk.base import RequiredEnvVar
+
+    var = RequiredEnvVar(
+        name="MY_PLUGIN_API_KEY",
+        description="The API key.",
+    )
+    assert var.name == "MY_PLUGIN_API_KEY"
+    assert var.secret is False
+    assert var.required is False
+    assert var.docs_url is None
+    assert var.obtain_steps == []
+
+
+def test_required_env_var_rejects_lowercase_name():
+    from plugin_sdk.base import RequiredEnvVar
+
+    with pytest.raises(Exception):
+        RequiredEnvVar(name="my_plugin_api_key", description="x")
+
+
+def test_required_env_var_rejects_leading_digit():
+    from plugin_sdk.base import RequiredEnvVar
+
+    with pytest.raises(Exception):
+        RequiredEnvVar(name="1MY_KEY", description="x")
+
+
+def test_required_env_var_rejects_special_chars():
+    from plugin_sdk.base import RequiredEnvVar
+
+    with pytest.raises(Exception):
+        RequiredEnvVar(name="MY-KEY", description="x")
+
+
+def test_required_env_var_rejects_empty_name():
+    from plugin_sdk.base import RequiredEnvVar
+
+    with pytest.raises(Exception):
+        RequiredEnvVar(name="", description="x")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot_shared/plugin_sdk/plugin_sdk_test.py -v -k required_env_var 2>&1 | tail -20
+```
+
+Expected: 5 tests fail with `ImportError` or `AttributeError` because `RequiredEnvVar` is not defined yet.
+
+- [ ] **Step 3: Implement `RequiredEnvVar`**
+
+In `autobot_shared/plugin_sdk/base.py`, after the imports section and before `class PluginStatus`, add:
+
+```python
+class RequiredEnvVar(BaseModel):
+    """
+    Declares an environment variable a plugin needs at runtime.
+
+    Used in PluginManifest.required_env to surface configuration requirements
+    to operators and host UIs. Values are NEVER returned through the API —
+    only the configured/missing state is reported.
+    """
+
+    name: str = Field(
+        ...,
+        description="Env var name, e.g. 'MY_PLUGIN_API_KEY'",
+    )
+    secret: bool = Field(
+        False,
+        description="If true, host UI hides the value from any preview surface",
+    )
+    required: bool = Field(
+        False,
+        description="If true, the plugin refuses to load when the var is missing",
+    )
+    description: str = Field(
+        ...,
+        description="One-line purpose of the variable",
+    )
+    docs_url: Optional[str] = Field(
+        None,
+        description="URL where the credential is obtained",
+    )
+    obtain_steps: List[str] = Field(
+        default_factory=list,
+        description="Bullet list shown by the host settings UI",
+    )
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Env-var names must be UPPER_SNAKE_CASE starting with a letter."""
+        if not v:
+            raise ValueError("Env var name cannot be empty")
+        if not v[0].isalpha() or not v[0].isupper():
+            raise ValueError("Env var name must start with an uppercase letter")
+        if not all(c.isupper() or c.isdigit() or c == "_" for c in v):
+            raise ValueError("Env var name must be UPPER_SNAKE_CASE")
+        return v
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot_shared/plugin_sdk/plugin_sdk_test.py -v -k required_env_var 2>&1 | tail -10
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+git add autobot_shared/plugin_sdk/base.py autobot_shared/plugin_sdk/plugin_sdk_test.py
+git commit -m "feat(plugin-sdk): add RequiredEnvVar schema with name validator (#6971)"
+```
+
+---
+
+## Task 2: `PluginManifest.required_env` field (TDD)
+
+**Files:**
+
+- Modify: `autobot_shared/plugin_sdk/base.py`
+- Test: `autobot_shared/plugin_sdk/plugin_sdk_test.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `plugin_sdk_test.py` after the `RequiredEnvVar validation` section:
+
+```python
+# ---------------------------------------------------------------------------
+# PluginManifest.required_env field
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_default_required_env_is_empty_list():
+    """Backward compat: existing plugin.json without the field still parses."""
+    m = _make_manifest()
+    assert m.required_env == []
+
+
+def test_manifest_with_required_env_parses():
+    from plugin_sdk.base import RequiredEnvVar
+
+    m = _make_manifest(
+        required_env=[
+            {
+                "name": "MY_API_KEY",
+                "description": "API key for service.",
+                "secret": True,
+                "required": False,
+                "docs_url": "https://example.com/keys",
+                "obtain_steps": ["Sign in", "Generate key"],
+            }
+        ]
+    )
+    assert len(m.required_env) == 1
+    var = m.required_env[0]
+    assert isinstance(var, RequiredEnvVar)
+    assert var.name == "MY_API_KEY"
+    assert var.secret is True
+    assert var.docs_url == "https://example.com/keys"
+    assert var.obtain_steps == ["Sign in", "Generate key"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot_shared/plugin_sdk/plugin_sdk_test.py -v -k manifest_default_required_env or manifest_with_required_env 2>&1 | tail -10
+```
+
+Expected: 2 tests fail because `required_env` is not on `PluginManifest`.
+
+- [ ] **Step 3: Add field to `PluginManifest`**
+
+In `autobot_shared/plugin_sdk/base.py`, inside the `PluginManifest` class, after the `hooks: List[str] = Field(...)` line (line 54), add:
+
+```python
+    required_env: List[RequiredEnvVar] = Field(
+        default_factory=list,
+        description="Environment variables this plugin needs at runtime",
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot_shared/plugin_sdk/plugin_sdk_test.py -v -k "manifest_default_required_env or manifest_with_required_env" 2>&1 | tail -10
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Run full SDK test suite to confirm no regressions**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot_shared/plugin_sdk/plugin_sdk_test.py -v 2>&1 | tail -15
+```
+
+Expected: all existing tests still pass + 7 new ones pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+git add autobot_shared/plugin_sdk/base.py autobot_shared/plugin_sdk/plugin_sdk_test.py
+git commit -m "feat(plugin-sdk): add required_env field to PluginManifest (#6971)"
+```
+
+---
+
+## Task 3: Loader `_check_required_env` (TDD)
+
+**Files:**
+
+- Modify: `autobot_shared/plugin_sdk/loader.py`
+- Test: `autobot_shared/plugin_sdk/plugin_sdk_test.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `plugin_sdk_test.py`. Note: import `PluginLoader` if not already imported (check the existing imports at top of file).
+
+```python
+# ---------------------------------------------------------------------------
+# PluginLoader._check_required_env
+# ---------------------------------------------------------------------------
+
+
+def test_check_required_env_returns_empty_when_no_required_env(monkeypatch):
+    from plugin_sdk.loader import PluginLoader
+
+    loader = PluginLoader([])
+    manifest = _make_manifest()
+    missing_required, missing_optional = loader._check_required_env(manifest)
+    assert missing_required == []
+    assert missing_optional == []
+
+
+def test_check_required_env_finds_missing_required(monkeypatch):
+    from plugin_sdk.loader import PluginLoader
+
+    monkeypatch.delenv("TEST_REQUIRED_VAR", raising=False)
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        required_env=[
+            {
+                "name": "TEST_REQUIRED_VAR",
+                "description": "Required.",
+                "required": True,
+            }
+        ]
+    )
+    missing_required, missing_optional = loader._check_required_env(manifest)
+    assert missing_required == ["TEST_REQUIRED_VAR"]
+    assert missing_optional == []
+
+
+def test_check_required_env_finds_missing_optional(monkeypatch):
+    from plugin_sdk.loader import PluginLoader
+
+    monkeypatch.delenv("TEST_OPTIONAL_VAR", raising=False)
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        required_env=[
+            {
+                "name": "TEST_OPTIONAL_VAR",
+                "description": "Optional.",
+                "required": False,
+            }
+        ]
+    )
+    missing_required, missing_optional = loader._check_required_env(manifest)
+    assert missing_required == []
+    assert missing_optional == ["TEST_OPTIONAL_VAR"]
+
+
+def test_check_required_env_separates_required_and_optional(monkeypatch):
+    from plugin_sdk.loader import PluginLoader
+
+    monkeypatch.delenv("TEST_REQ_A", raising=False)
+    monkeypatch.delenv("TEST_OPT_B", raising=False)
+    monkeypatch.setenv("TEST_REQ_C", "value")
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        required_env=[
+            {"name": "TEST_REQ_A", "description": "x", "required": True},
+            {"name": "TEST_OPT_B", "description": "x", "required": False},
+            {"name": "TEST_REQ_C", "description": "x", "required": True},
+        ]
+    )
+    missing_required, missing_optional = loader._check_required_env(manifest)
+    assert missing_required == ["TEST_REQ_A"]
+    assert missing_optional == ["TEST_OPT_B"]
+
+
+def test_check_required_env_treats_empty_string_as_missing(monkeypatch):
+    """An env var set to empty string is treated as not configured."""
+    from plugin_sdk.loader import PluginLoader
+
+    monkeypatch.setenv("TEST_EMPTY_VAR", "")
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        required_env=[
+            {"name": "TEST_EMPTY_VAR", "description": "x", "required": True}
+        ]
+    )
+    missing_required, _ = loader._check_required_env(manifest)
+    assert missing_required == ["TEST_EMPTY_VAR"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot_shared/plugin_sdk/plugin_sdk_test.py -v -k check_required_env 2>&1 | tail -20
+```
+
+Expected: 5 tests fail with `AttributeError: 'PluginLoader' object has no attribute '_check_required_env'`.
+
+- [ ] **Step 3: Implement `_check_required_env`**
+
+In `autobot_shared/plugin_sdk/loader.py`, after `_check_dependencies` (around line 195), add:
+
+```python
+    def _check_required_env(
+        self, manifest: PluginManifest
+    ) -> tuple[List[str], List[str]]:
+        """
+        Check which env vars declared by the manifest are unset.
+
+        Returns:
+            Tuple of (missing_required, missing_optional) env var names.
+            An env var set to an empty string is treated as missing.
+        """
+        import os
+
+        missing_required: List[str] = []
+        missing_optional: List[str] = []
+        for env in manifest.required_env:
+            if not os.environ.get(env.name):
+                if env.required:
+                    missing_required.append(env.name)
+                else:
+                    missing_optional.append(env.name)
+        return missing_required, missing_optional
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot_shared/plugin_sdk/plugin_sdk_test.py -v -k check_required_env 2>&1 | tail -10
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+git add autobot_shared/plugin_sdk/loader.py autobot_shared/plugin_sdk/plugin_sdk_test.py
+git commit -m "feat(plugin-sdk): _check_required_env returns (missing_required, missing_optional) (#6971)"
+```
+
+---
+
+## Task 4: Loader `load_plugin` integration (TDD)
+
+**Files:**
+
+- Modify: `autobot_shared/plugin_sdk/loader.py`
+- Test: `autobot_shared/plugin_sdk/plugin_sdk_test.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `plugin_sdk_test.py`. These tests use the existing `_ConcretePlugin` and need a way to register that class as a discoverable entry point. Follow the pattern from any existing `load_plugin` tests if present (otherwise mock `_import_plugin_class`).
+
+```python
+# ---------------------------------------------------------------------------
+# PluginLoader.load_plugin integration with required_env
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_plugin_returns_none_when_required_env_missing(monkeypatch, caplog):
+    """Plugin with a missing required env var fails to load with an error log."""
+    from plugin_sdk.loader import PluginLoader
+
+    monkeypatch.delenv("TEST_REQ_LOAD_FAIL", raising=False)
+
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        required_env=[
+            {
+                "name": "TEST_REQ_LOAD_FAIL",
+                "description": "x",
+                "required": True,
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
+    )
+
+    with caplog.at_level("ERROR"):
+        result = await loader.load_plugin(manifest)
+
+    assert result is None
+    assert any(
+        "TEST_REQ_LOAD_FAIL" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_plugin_succeeds_with_optional_env_missing(monkeypatch, caplog):
+    """Plugin with missing optional env var loads, with info log."""
+    from plugin_sdk.base import PluginRegistry
+    from plugin_sdk.loader import PluginLoader
+
+    PluginRegistry().clear()
+    monkeypatch.delenv("TEST_OPT_LOAD_OK", raising=False)
+
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        name="opt-test-plugin",
+        required_env=[
+            {
+                "name": "TEST_OPT_LOAD_OK",
+                "description": "x",
+                "required": False,
+            }
+        ],
+    )
+
+    monkeypatch.setattr(
+        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
+    )
+
+    with caplog.at_level("INFO"):
+        plugin = await loader.load_plugin(manifest)
+
+    assert plugin is not None
+    assert any(
+        "TEST_OPT_LOAD_OK" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_plugin_succeeds_when_all_required_env_set(monkeypatch):
+    """Plugin loads normally when all required env vars are configured."""
+    from plugin_sdk.base import PluginRegistry
+    from plugin_sdk.loader import PluginLoader
+
+    PluginRegistry().clear()
+    monkeypatch.setenv("TEST_REQ_LOAD_PRESENT", "value")
+
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        name="all-set-plugin",
+        required_env=[
+            {
+                "name": "TEST_REQ_LOAD_PRESENT",
+                "description": "x",
+                "required": True,
+            }
+        ],
+    )
+
+    monkeypatch.setattr(
+        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
+    )
+
+    plugin = await loader.load_plugin(manifest)
+    assert plugin is not None
+    assert plugin.manifest.name == "all-set-plugin"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot_shared/plugin_sdk/plugin_sdk_test.py -v -k "load_plugin_returns_none_when_required_env_missing or load_plugin_succeeds_with_optional_env_missing or load_plugin_succeeds_when_all_required_env_set" 2>&1 | tail -15
+```
+
+Expected: 1 fails (loads anyway because the check isn't wired), 2 may pass coincidentally — what matters is the first one fails and the missing-required-env error log isn't emitted.
+
+- [ ] **Step 3: Wire `_check_required_env` into `load_plugin`**
+
+In `autobot_shared/plugin_sdk/loader.py`, inside `load_plugin`, immediately after the dependency check block (around line 99), add:
+
+```python
+            # Check required environment variables
+            missing_required, missing_optional = self._check_required_env(manifest)
+            if missing_required:
+                logger.error(
+                    "Cannot load plugin %s: required env vars not set: %s",
+                    manifest.name,
+                    missing_required,
+                )
+                return None
+            if missing_optional:
+                logger.info(
+                    "Plugin %s loaded with optional env vars unset: %s",
+                    manifest.name,
+                    missing_optional,
+                )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot_shared/plugin_sdk/plugin_sdk_test.py -v -k "load_plugin_returns_none_when_required_env_missing or load_plugin_succeeds_with_optional_env_missing or load_plugin_succeeds_when_all_required_env_set" 2>&1 | tail -10
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+git add autobot_shared/plugin_sdk/loader.py autobot_shared/plugin_sdk/plugin_sdk_test.py
+git commit -m "feat(plugin-sdk): load_plugin enforces required_env at load time (#6971)"
+```
+
+---
+
+## Task 5: Loader `get_env_status` accessor (TDD)
+
+**Files:**
+
+- Modify: `autobot_shared/plugin_sdk/loader.py`
+- Test: `autobot_shared/plugin_sdk/plugin_sdk_test.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `plugin_sdk_test.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# PluginLoader.get_env_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_env_status_returns_correct_shape(monkeypatch):
+    from plugin_sdk.base import PluginRegistry
+    from plugin_sdk.loader import PluginLoader
+
+    PluginRegistry().clear()
+    monkeypatch.setenv("TEST_STATUS_PRESENT", "actual_secret_value")
+    monkeypatch.delenv("TEST_STATUS_MISSING", raising=False)
+
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        name="status-shape-plugin",
+        required_env=[
+            {
+                "name": "TEST_STATUS_PRESENT",
+                "description": "Set var.",
+                "secret": True,
+                "required": False,
+                "docs_url": "https://example.com",
+                "obtain_steps": ["one", "two"],
+            },
+            {
+                "name": "TEST_STATUS_MISSING",
+                "description": "Unset var.",
+                "secret": False,
+                "required": False,
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
+    )
+    await loader.load_plugin(manifest)
+
+    status = loader.get_env_status("status-shape-plugin")
+    assert status is not None
+    assert set(status.keys()) == {"TEST_STATUS_PRESENT", "TEST_STATUS_MISSING"}
+
+    present = status["TEST_STATUS_PRESENT"]
+    assert present == {
+        "configured": True,
+        "secret": True,
+        "required": False,
+        "description": "Set var.",
+        "docs_url": "https://example.com",
+        "obtain_steps": ["one", "two"],
+    }
+
+    missing = status["TEST_STATUS_MISSING"]
+    assert missing["configured"] is False
+    assert missing["secret"] is False
+    assert missing["docs_url"] is None
+    assert missing["obtain_steps"] == []
+
+
+def test_get_env_status_returns_none_for_unknown_plugin():
+    from plugin_sdk.loader import PluginLoader
+
+    loader = PluginLoader([])
+    assert loader.get_env_status("does-not-exist") is None
+
+
+@pytest.mark.asyncio
+async def test_get_env_status_never_returns_value(monkeypatch):
+    """Critical privacy test: env-var values must NEVER be in the response."""
+    from plugin_sdk.base import PluginRegistry
+    from plugin_sdk.loader import PluginLoader
+
+    PluginRegistry().clear()
+    secret_value = "sk-supersecret-do-not-leak-1234"
+    monkeypatch.setenv("TEST_SECRET_LEAK_CHECK", secret_value)
+
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        name="leak-check-plugin",
+        required_env=[
+            {
+                "name": "TEST_SECRET_LEAK_CHECK",
+                "description": "Sensitive.",
+                "secret": True,
+                "required": True,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        loader, "_import_plugin_class", lambda ep: _ConcretePlugin
+    )
+    await loader.load_plugin(manifest)
+
+    status = loader.get_env_status("leak-check-plugin")
+    serialized = repr(status)
+    assert secret_value not in serialized
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot_shared/plugin_sdk/plugin_sdk_test.py -v -k get_env_status 2>&1 | tail -15
+```
+
+Expected: 3 fail with `AttributeError: 'PluginLoader' object has no attribute 'get_env_status'`.
+
+- [ ] **Step 3: Implement `get_env_status`**
+
+In `autobot_shared/plugin_sdk/loader.py`, after `_check_required_env`, add:
+
+```python
+    def get_env_status(
+        self, plugin_name: str
+    ) -> Optional[Dict[str, Dict[str, object]]]:
+        """
+        Return per-env-var configuration status for a loaded plugin.
+
+        SECURITY: response NEVER contains env var values, only the
+        configured/missing boolean and the manifest metadata.
+
+        Args:
+            plugin_name: Name of a loaded plugin
+
+        Returns:
+            Dict mapping env-var name to status dict, or None if the
+            plugin is not loaded.
+        """
+        import os
+
+        plugin = self.registry.get_plugin(plugin_name)
+        if plugin is None:
+            return None
+        return {
+            env.name: {
+                "configured": bool(os.environ.get(env.name)),
+                "secret": env.secret,
+                "required": env.required,
+                "description": env.description,
+                "docs_url": env.docs_url,
+                "obtain_steps": list(env.obtain_steps),
+            }
+            for env in plugin.manifest.required_env
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot_shared/plugin_sdk/plugin_sdk_test.py -v -k get_env_status 2>&1 | tail -10
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Run full SDK test suite for regression**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot_shared/plugin_sdk/plugin_sdk_test.py -v 2>&1 | tail -20
+```
+
+Expected: all SDK tests pass (existing + 18 new from Tasks 1-5).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+git add autobot_shared/plugin_sdk/loader.py autobot_shared/plugin_sdk/plugin_sdk_test.py
+git commit -m "feat(plugin-sdk): get_env_status returns per-var state without values (#6971)"
+```
+
+---
+
+## Task 6: API endpoint `GET /plugins/{name}/env-status` (TDD)
+
+**Files:**
+
+- Modify: `autobot-backend/plugin_manager.py`
+- Create: `autobot-backend/tests/api/test_plugin_manager.py`
+
+- [ ] **Step 1: Write the failing API tests**
+
+Create `autobot-backend/tests/api/test_plugin_manager.py`:
+
+```python
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""
+Unit tests for the plugin manager FastAPI endpoints (Issue #6971).
+
+Covers GET /plugins/{plugin_name}/env-status — env-var configuration
+status without leaking values.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.mark.asyncio
+async def test_env_status_endpoint_returns_status_for_loaded_plugin(monkeypatch):
+    from plugin_manager import get_plugin_env_status
+
+    fake_loader = MagicMock()
+    fake_loader.get_env_status.return_value = {
+        "MY_API_KEY": {
+            "configured": True,
+            "secret": True,
+            "required": False,
+            "description": "API key",
+            "docs_url": "https://example.com/keys",
+            "obtain_steps": ["Sign in", "Generate"],
+        }
+    }
+
+    with patch("plugin_manager.get_plugin_loader", return_value=fake_loader):
+        result = await get_plugin_env_status(
+            plugin_name="my-plugin",
+            admin_check=True,
+        )
+
+    assert result.plugin_name == "my-plugin"
+    assert "MY_API_KEY" in result.env_vars
+    entry = result.env_vars["MY_API_KEY"]
+    assert entry.configured is True
+    assert entry.secret is True
+    assert entry.docs_url == "https://example.com/keys"
+    assert entry.obtain_steps == ["Sign in", "Generate"]
+
+
+@pytest.mark.asyncio
+async def test_env_status_endpoint_404_for_unknown_plugin(monkeypatch):
+    from plugin_manager import get_plugin_env_status
+
+    fake_loader = MagicMock()
+    fake_loader.get_env_status.return_value = None
+
+    with patch("plugin_manager.get_plugin_loader", return_value=fake_loader):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_plugin_env_status(
+                plugin_name="does-not-exist",
+                admin_check=True,
+            )
+
+    assert exc_info.value.status_code == 404
+    assert "does-not-exist" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_env_status_endpoint_returns_empty_for_plugin_without_required_env(monkeypatch):
+    from plugin_manager import get_plugin_env_status
+
+    fake_loader = MagicMock()
+    fake_loader.get_env_status.return_value = {}
+
+    with patch("plugin_manager.get_plugin_loader", return_value=fake_loader):
+        result = await get_plugin_env_status(
+            plugin_name="simple-plugin",
+            admin_check=True,
+        )
+
+    assert result.plugin_name == "simple-plugin"
+    assert result.env_vars == {}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot-backend/tests/api/test_plugin_manager.py -v 2>&1 | tail -10
+```
+
+Expected: 3 fail with `ImportError: cannot import name 'get_plugin_env_status'`.
+
+- [ ] **Step 3: Add response models and endpoint**
+
+In `autobot-backend/plugin_manager.py`, near the top after the existing imports/Pydantic models, add:
+
+```python
+class PluginEnvStatusEntry(BaseModel):
+    """Per-env-var status (never contains the actual value)."""
+
+    configured: bool
+    secret: bool
+    required: bool
+    description: str
+    docs_url: Optional[str]
+    obtain_steps: List[str]
+
+
+class PluginEnvStatusResponse(BaseModel):
+    """Response for GET /plugins/{plugin_name}/env-status."""
+
+    plugin_name: str
+    env_vars: Dict[str, PluginEnvStatusEntry]
+```
+
+Then add the endpoint at the end of the file (after the last existing endpoint):
+
+```python
+@router.get("/plugins/{plugin_name}/env-status")
+@with_error_handling(error_code_prefix="PLUGIN_ENV_STATUS")
+async def get_plugin_env_status(
+    plugin_name: str,
+    admin_check: bool = Depends(check_admin_permission),
+) -> PluginEnvStatusResponse:
+    """
+    Return per-env-var configuration status for a loaded plugin.
+
+    The response never contains env-var values, only the configured/missing
+    state and manifest metadata. Designed for host UIs to surface install
+    requirements without leaking secrets.
+
+    Issue #6971.
+    """
+    loader = get_plugin_loader()
+    status_data = loader.get_env_status(plugin_name)
+    if status_data is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Plugin not found: {plugin_name}",
+        )
+    return PluginEnvStatusResponse(
+        plugin_name=plugin_name,
+        env_vars={
+            k: PluginEnvStatusEntry(**v) for k, v in status_data.items()
+        },
+    )
+```
+
+Verify imports at top of file include `Dict, List, Optional` from `typing` and `BaseModel` from `pydantic`. Add any missing.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot-backend/tests/api/test_plugin_manager.py -v 2>&1 | tail -10
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+git add autobot-backend/plugin_manager.py autobot-backend/tests/api/test_plugin_manager.py
+git commit -m "feat(plugin-manager): GET /plugins/{name}/env-status endpoint (#6971)"
+```
+
+---
+
+## Task 7: Backward-compatibility regression check
+
+**Files:** none modified
+
+- [ ] **Step 1: Verify all 4 in-tree plugin manifests still parse**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+PYTHONPATH=autobot_shared python3 -c "
+import json
+from pathlib import Path
+from plugin_sdk.base import PluginManifest
+
+for f in Path('plugins').rglob('plugin.json'):
+    with open(f) as fp:
+        data = json.load(fp)
+    m = PluginManifest(**data)
+    print(f'  OK: {m.name} v{m.version} (required_env={len(m.required_env)})')
+"
+```
+
+Expected: 4 lines printed (`hello-plugin`, `logger-plugin`, `mcp-wrapper-plugin`, `kb-event-plugin`), each with `required_env=0`. No exceptions.
+
+- [ ] **Step 2: Run full SDK test suite**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot_shared/plugin_sdk/plugin_sdk_test.py -v 2>&1 | tail -20
+```
+
+Expected: all SDK tests pass (existing + ~18 new).
+
+- [ ] **Step 3: Run new API tests**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pytest autobot-backend/tests/api/test_plugin_manager.py -v 2>&1 | tail -10
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 4: Run pre-commit hooks**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+pre-commit run --files \
+    autobot_shared/plugin_sdk/base.py \
+    autobot_shared/plugin_sdk/loader.py \
+    autobot_shared/plugin_sdk/plugin_sdk_test.py \
+    autobot-backend/plugin_manager.py \
+    autobot-backend/tests/api/test_plugin_manager.py 2>&1 | tail -30
+```
+
+Expected: all hooks pass. If any auto-format hook modifies files, re-stage and amend the most recent commit:
+
+```bash
+git add -u
+git commit --amend --no-edit
+```
+
+- [ ] **Step 5: Final commit if any lint fixes were needed**
+
+If pre-commit modified files but the amend already happened above, this step is a no-op. If lint fixes touched multiple commits, *do not* rebase; create one final cleanup commit:
+
+```bash
+git status
+# If clean, skip. Otherwise:
+git add -u
+git commit -m "style: auto-format from pre-commit (#6971)"
+```
+
+---
+
+## Task 8: Push and open PR
+
+**Files:** none modified
+
+- [ ] **Step 1: Push branch**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+git push -u origin issue-6971
+```
+
+Expected: branch pushed; URL printed.
+
+- [ ] **Step 2: Open PR targeting Dev_new_gui**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-6971
+gh pr create \
+    --base Dev_new_gui \
+    --title "feat(plugin-sdk): declarative required_env field on PluginManifest (#6971)" \
+    --body "$(cat <<'EOF'
+## Summary
+
+Adds `required_env: List[RequiredEnvVar]` to `PluginManifest` so plugins declare environment-variable-backed secrets they need, with loader-level enforcement and a host endpoint that surfaces configuration state without leaking values.
+
+Closes #6971.
+
+## What changes
+
+- New `RequiredEnvVar` Pydantic model (UPPER_SNAKE_CASE name validator, opt-in `secret`/`required` flags, `docs_url`/`obtain_steps` for UX surfacing)
+- `PluginManifest.required_env` field with `default_factory=list` — backward compatible
+- `PluginLoader._check_required_env` → returns (missing_required, missing_optional)
+- `PluginLoader.load_plugin` fails loud on missing required env (returns None + error log); logs info on missing optional env
+- `PluginLoader.get_env_status` → returns per-var state dict; **never contains env values**
+- New endpoint `GET /api/plugins/{plugin_name}/env-status` (admin-gated, matches existing patterns)
+
+## Test plan
+
+- [x] 18 new SDK unit tests (`autobot_shared/plugin_sdk/plugin_sdk_test.py`)
+- [x] 3 new API tests (`autobot-backend/tests/api/test_plugin_manager.py`)
+- [x] Privacy test: `test_get_env_status_never_returns_value` asserts secret values cannot appear in serialized response
+- [x] Backward-compat regression: all 4 in-tree plugin manifests parse with `required_env=[]`
+- [x] Pre-commit hooks pass
+- [ ] Reviewer to verify response model serialization through OpenAPI schema generation
+
+## Spec / Plan
+
+- Spec: `docs/superpowers/specs/2026-05-05-plugin-sdk-required-env-design.md`
+- Plan: `docs/superpowers/plans/2026-05-05-plugin-sdk-required-env.md`
+
+## Out of scope (filed separately at PR-merge time)
+
+- Marketplace UI surfacing of `obtain_steps` and `docs_url`
+- Bulk endpoint `GET /plugins/env-status` returning all plugins
+
+## Related
+
+- Discovered while designing the ARC Prize Phase 1 plugin
+- Sibling blocker: #6970 (extension-point hook dispatch sites)
+EOF
+)"
+```
+
+Expected: PR URL printed; PR open against `Dev_new_gui`.
+
+- [ ] **Step 3: Verify PR**
+
+```bash
+gh pr view --json number,title,baseRefName,state -q '.'
+```
+
+Expected: PR shows base=`Dev_new_gui`, state=`OPEN`.
+
+---
+
+## Task 9: Post-merge cleanup (after PR is merged)
+
+**Files:** none modified
+
+- [ ] **Step 1: After merge — file follow-up issues mentioned in spec**
+
+```bash
+gh issue create --repo mrveiss/AutoBot-AI \
+    --title "feat(frontend/marketplace): surface plugin required_env in install UI" \
+    --label "tech-debt,frontend" \
+    --body "..."
+```
+
+(Body will reference the merged PR + spec.)
+
+- [ ] **Step 2: Remove worktree**
+
+```bash
+cd /home/martins/AutoBot-Ai/AutoBot-AI
+git worktree remove .worktrees/issue-6971
+git branch -D issue-6971
+```
+
+- [ ] **Step 3: Confirm closure with proof comment on #6971**
+
+Per CLAUDE.md "Issue Closure Verification Gate":
+
+```bash
+gh api repos/mrveiss/AutoBot-AI/issues/6971/comments -f body="✅ Closed with proof of implementation
+
+**Commit(s):** <merged-PR-merge-commit-hash>
+
+**Acceptance Criteria Met:**
+- ✅ RequiredEnvVar schema added with UPPER_SNAKE_CASE validator
+- ✅ PluginManifest.required_env field with backward-compatible default
+- ✅ Loader fails loud on missing required env (test: test_load_plugin_returns_none_when_required_env_missing)
+- ✅ Loader logs info on missing optional env (test: test_load_plugin_succeeds_with_optional_env_missing)
+- ✅ get_env_status returns shape with no values (test: test_get_env_status_never_returns_value)
+- ✅ GET /plugins/{name}/env-status endpoint (3 API tests pass)
+- ✅ All 4 in-tree plugins still load (regression check passed)
+- ✅ Pre-commit hooks pass
+- ✅ Follow-up issue filed: <issue-number-from-Step-1>"
+```
+
+---
+
+## Self-Review Findings
+
+**Spec coverage check:**
+
+| Spec section | Implementation task |
+| --- | --- |
+| `RequiredEnvVar` model + name validator | Task 1 |
+| `PluginManifest.required_env` field with default empty | Task 2 |
+| `PluginLoader._check_required_env` returning `(missing_required, missing_optional)` | Task 3 |
+| `load_plugin` fails loud on required, logs on optional | Task 4 |
+| `PluginLoader.get_env_status` never returns values | Task 5 |
+| `GET /api/plugins/{name}/env-status` endpoint with auth + decorators | Task 6 |
+| 11 SDK tests + 2 API tests | Tasks 1-6 (18 SDK tests, 3 API tests — exceeds spec) |
+| Existing 4 in-tree plugins still load | Task 7 |
+| No new mypy/pyright errors | Pre-commit hooks (Task 7 Step 4) |
+| No new pre-commit failures | Task 7 Step 4 |
+
+**Placeholder scan:** every step has actual code/commands; no TBD/TODO/"add error handling" patterns. Verified.
+
+**Type consistency:** `RequiredEnvVar` field names (`name`, `secret`, `required`, `description`, `docs_url`, `obtain_steps`) match across schema (Task 1), get_env_status return shape (Task 5), and `PluginEnvStatusEntry` API model (Task 6). Verified.
+
+**One gap caught during review:** the spec said "11 SDK tests"; this plan ships 18. The extras come from splitting some compound tests (e.g., separating "rejects lowercase" / "rejects leading digit" / "rejects special chars" / "rejects empty" into 4 tests instead of 1) and adding a privacy-leak test that wasn't enumerated in the spec. More tests is better, no spec violation.

--- a/docs/superpowers/specs/2026-05-05-plugin-sdk-required-env-design.md
+++ b/docs/superpowers/specs/2026-05-05-plugin-sdk-required-env-design.md
@@ -1,0 +1,264 @@
+# Plugin SDK — `required_env` Field on PluginManifest
+
+**Date:** 2026-05-05
+**Author:** mrveiss
+**Status:** Draft (pending review)
+**Issue:** #6971
+**Discovered during:** ARC Prize plugin design ([`docs/superpowers/specs/2026-05-05-arc-prize-plugin-design.md`](2026-05-05-arc-prize-plugin-design.md))
+
+---
+
+## Problem Statement
+
+`PluginManifest` ([`autobot_shared/plugin_sdk/base.py`](../../autobot_shared/plugin_sdk/base.py)) has no way for a plugin to declare the environment-variable-backed secrets it needs. Plugins requiring API keys (e.g., the upcoming ARC Prize plugin needs `ARC_PRIZE_API_KEY`) currently must:
+
+1. Read env vars in `initialize()` themselves
+2. Document the var name in their README and hope operators read it
+3. Implement their own settings-status UI reflecting whether the var is set
+
+Each plugin re-invents the same pattern. The result is inconsistent install UX and no central place for the host UI to surface "plugin X needs key Y, get it at Z."
+
+## Goals
+
+- Let plugins declare required env vars in `plugin.json` with metadata (description, docs URL, how to obtain)
+- Have the loader fail loudly when a `required=true` var is missing, succeed quietly when an `optional` var is missing (with an info log)
+- Expose per-plugin env-status via the existing plugins API for UI consumption
+- Never echo secret values back through the API
+
+## Non-Goals
+
+- Marketplace UI surfacing of `obtain_steps` / `docs_url` (separate frontend issue, filed at PR time)
+- Bulk endpoint listing all plugins' env status (per-plugin covers the immediate consumer; bulk added if needed)
+- Migration of existing core plugins to use `required_env` (none of them need it; migrated only when they do)
+- Encrypting / vaulting env values (env-var-only is the established AutoBot secrets pattern)
+
+---
+
+## Design
+
+### 1. New schema: `RequiredEnvVar`
+
+Added to `autobot_shared/plugin_sdk/base.py`:
+
+```python
+class RequiredEnvVar(BaseModel):
+    """Declares an environment variable a plugin needs at runtime."""
+
+    name: str = Field(..., description="Env var name, e.g. 'MY_PLUGIN_API_KEY'")
+    secret: bool = Field(False, description="If true, host UI hides the value")
+    required: bool = Field(False, description="If true, plugin refuses to load without it")
+    description: str = Field(..., description="One-line purpose of the variable")
+    docs_url: Optional[str] = Field(None, description="URL where the credential is obtained")
+    obtain_steps: List[str] = Field(
+        default_factory=list,
+        description="Bullet list shown by the host settings UI",
+    )
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Env-var names: uppercase letters, digits, underscores; must start with letter."""
+        if not v:
+            raise ValueError("Env var name cannot be empty")
+        if not v[0].isalpha() or not v[0].isupper():
+            raise ValueError("Env var name must start with an uppercase letter")
+        if not all(c.isupper() or c.isdigit() or c == "_" for c in v):
+            raise ValueError("Env var name must be UPPER_SNAKE_CASE")
+        return v
+```
+
+### 2. PluginManifest extension
+
+```python
+class PluginManifest(BaseModel):
+    # ... existing fields ...
+    required_env: List[RequiredEnvVar] = Field(
+        default_factory=list,
+        description="Environment variables this plugin needs at runtime",
+    )
+```
+
+Default empty list — opt-in for existing plugins; nothing breaks for any current plugin.
+
+### 3. Loader behavior — `autobot_shared/plugin_sdk/loader.py`
+
+Add a method:
+
+```python
+def _check_required_env(
+    self, manifest: PluginManifest
+) -> tuple[list[str], list[str]]:
+    """Return (missing_required, missing_optional) env var names."""
+    missing_required: list[str] = []
+    missing_optional: list[str] = []
+    for env in manifest.required_env:
+        if not os.environ.get(env.name):
+            (missing_required if env.required else missing_optional).append(env.name)
+    return missing_required, missing_optional
+```
+
+Call from `load_plugin` before instantiation:
+
+```python
+missing_required, missing_optional = self._check_required_env(manifest)
+if missing_required:
+    logger.error(
+        "Cannot load plugin %s: required env vars not set: %s",
+        manifest.name, missing_required,
+    )
+    return None
+if missing_optional:
+    logger.info(
+        "Plugin %s loaded with optional env vars unset: %s",
+        manifest.name, missing_optional,
+    )
+```
+
+Add accessor:
+
+```python
+def get_env_status(self, plugin_name: str) -> Optional[Dict[str, Dict[str, Any]]]:
+    """Return per-env-var configuration status for a loaded plugin.
+
+    Never returns the env var *values* — only whether they are configured
+    and the manifest metadata. Designed to be safe to expose via API.
+    """
+    plugin = self.registry.get_plugin(plugin_name)
+    if plugin is None:
+        return None
+    return {
+        env.name: {
+            "configured": bool(os.environ.get(env.name)),
+            "secret": env.secret,
+            "required": env.required,
+            "description": env.description,
+            "docs_url": env.docs_url,
+            "obtain_steps": env.obtain_steps,
+        }
+        for env in plugin.manifest.required_env
+    }
+```
+
+### 4. API endpoint — `autobot-backend/plugin_manager.py`
+
+Match the conventions of existing endpoints in the file (auth via `check_admin_permission`, error wrapping via `@with_error_handling`, decorator order per memory #6352 — `@with_error_handling` must be BELOW `@router.get`):
+
+```python
+class PluginEnvStatusEntry(BaseModel):
+    configured: bool
+    secret: bool
+    required: bool
+    description: str
+    docs_url: Optional[str]
+    obtain_steps: List[str]
+
+class PluginEnvStatusResponse(BaseModel):
+    plugin_name: str
+    env_vars: Dict[str, PluginEnvStatusEntry]
+
+
+@router.get("/plugins/{plugin_name}/env-status")
+@with_error_handling(error_code_prefix="PLUGIN_ENV_STATUS")
+async def get_plugin_env_status(
+    plugin_name: str,
+    admin_check: bool = Depends(check_admin_permission),
+) -> PluginEnvStatusResponse:
+    """Return per-env-var configuration status for a loaded plugin.
+
+    The response never contains env-var values, only configuration state.
+    """
+    loader = get_plugin_loader()
+    status_data = loader.get_env_status(plugin_name)
+    if status_data is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Plugin not found: {plugin_name}",
+        )
+    return PluginEnvStatusResponse(
+        plugin_name=plugin_name,
+        env_vars={k: PluginEnvStatusEntry(**v) for k, v in status_data.items()},
+    )
+```
+
+Auth: `Depends(check_admin_permission)` matches `GET /plugins`, `POST /plugins/{plugin_name}/load`, and the rest of the file.
+
+Response shape:
+
+```json
+{
+  "plugin_name": "arc-prize",
+  "env_vars": {
+    "ARC_PRIZE_API_KEY": {
+      "configured": false,
+      "secret": true,
+      "required": false,
+      "description": "ARC Prize API key.",
+      "docs_url": "https://docs.arcprize.org/api-keys",
+      "obtain_steps": ["Sign in at arcprize.org", "Visit Settings → API Keys", "Generate a 'data-access' scope key"]
+    }
+  }
+}
+```
+
+### 5. Tests — `autobot_shared/plugin_sdk/plugin_sdk_test.py`
+
+Add the following test cases (TDD: written before implementation):
+
+- `test_required_env_var_validates_uppercase_name` — rejects lowercase, leading digit, mixed-case
+- `test_required_env_var_accepts_valid_name` — `MY_PLUGIN_API_KEY` accepted
+- `test_manifest_default_required_env_empty` — backward compat: existing plugin.json without the field still parses
+- `test_manifest_with_required_env_parses` — JSON with `required_env` array deserializes to typed list
+- `test_load_plugin_fails_when_required_env_missing` — using monkeypatch to clear env, plugin load returns None, error log emitted
+- `test_load_plugin_succeeds_when_required_env_set` — monkeypatch sets env, plugin loads
+- `test_load_plugin_succeeds_with_optional_env_missing` — plugin loads, info log emitted with the missing var name
+- `test_load_plugin_fails_with_mix_of_required_and_optional` — only the required-missing one blocks load
+- `test_get_env_status_returns_correct_shape` — keys: configured, secret, required, description, docs_url, obtain_steps
+- `test_get_env_status_returns_none_for_unknown_plugin` — None returned for non-existent plugin
+- `test_get_env_status_never_returns_value` — even if configured, response shape has only `configured: bool`, never the actual env value
+
+Plus one API-level test in `autobot-backend/tests/test_plugin_manager_api.py` (or wherever existing plugin API tests live):
+
+- `test_env_status_endpoint_returns_status_for_loaded_plugin`
+- `test_env_status_endpoint_404_for_unknown_plugin`
+
+---
+
+## Migration / Compatibility
+
+- **Backward compatible.** `required_env` defaults to empty list. Every existing `plugin.json` (4 in-tree plugins) continues to load identically.
+- No database changes.
+- No frontend changes in this PR.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Operator sets `required_env.name = "PATH"` (or any system-critical var) accidentally creating a "required" gate that's always satisfied | Acceptable — env vars are the existing secrets contract; a misuse is the operator's problem, not the SDK's |
+| Endpoint accidentally exposes secret values | Loader's `get_env_status` returns `configured: bool` only; never reads `os.environ.get(name)` *value* outside the boolean cast |
+| `required=true` in a `plugin.json` written by a third-party makes the plugin un-installable in environments without the var | Working as intended — that's the contract. Operator must set the var or the plugin doesn't load. |
+
+---
+
+## Out of Scope (filed at PR-merge time)
+
+- `feat(frontend/marketplace): surface plugin required_env in install UI` — display `obtain_steps` and `docs_url` in the marketplace plugin-detail view
+- `feat(plugin-sdk): bulk env-status endpoint GET /plugins/env-status` — if/when a UI consumer needs all-plugins-in-one-call
+
+---
+
+## Acceptance Criteria
+
+- [ ] `RequiredEnvVar` schema added to `autobot_shared/plugin_sdk/base.py` with name validator
+- [ ] `PluginManifest.required_env: List[RequiredEnvVar] = []` field added
+- [ ] `PluginLoader._check_required_env` returns `(missing_required, missing_optional)`
+- [ ] `PluginLoader.load_plugin` fails loud (returns None + error log) on missing required env
+- [ ] `PluginLoader.load_plugin` logs info on missing optional env
+- [ ] `PluginLoader.get_env_status` returns per-var status dict; never returns env var values
+- [ ] `GET /api/plugins/{plugin_name}/env-status` endpoint implemented in `autobot-backend/plugin_manager.py`
+- [ ] All 11 SDK tests pass
+- [ ] Both API tests pass
+- [ ] All existing 4 in-tree plugins still load identically (regression check)
+- [ ] No new mypy / pyright errors
+- [ ] No new pre-commit hook failures


### PR DESCRIPTION
## Summary

Adds `required_env: List[RequiredEnvVar]` to `PluginManifest` so plugins declare environment-variable-backed secrets they need, with loader-level enforcement and a host endpoint that surfaces configuration state without leaking values.

Closes #6971.

## What changes

**Plugin SDK** (`autobot_shared/plugin_sdk/`):
- New `RequiredEnvVar` Pydantic model — strict ASCII UPPER_SNAKE_CASE name validator (closes a Unicode-letter bypass: Python's `str.isupper()` returns True for `Ω`, `Ё`, etc.), `min_length=1` description, opt-in `secret`/`required` flags, `docs_url`/`obtain_steps` for UX surfacing
- `PluginManifest.required_env` field with `default_factory=list` — backward compatible (all 5 in-tree plugins continue to load)
- `PluginLoader._check_required_env` returns `(missing_required, missing_optional)` — empty-string env vars treated as missing
- `PluginLoader.load_plugin` fails loud on missing required env (returns None + error log); logs info on missing optional env
- `PluginLoader.get_env_status(plugin_name)` returns per-var state dict — **never contains env values** (privacy contract enforced by structure: only `bool(os.environ.get(name))`, never the value itself)

**Backend** (`autobot-backend/plugin_manager.py`):
- New typed response models: `PluginEnvStatusEntry` and `PluginEnvStatusResponse`
- New endpoint `GET /api/plugins/{plugin_name}/env-status` (admin-gated via `Depends(check_admin_permission)`, decorator order `@router.get` above `@with_error_handling` per memory #6352)
- Returns 404 when `get_env_status` returns None (unknown plugin)

## Test plan

- [x] **44 tests** pass (40 SDK + 4 API)
- [x] Privacy-leak test: `test_get_env_status_never_returns_value` asserts secret string `sk-supersecret-do-not-leak-1234` does not appear in `repr(status)` OR `json.dumps(status, default=str)` — belt-and-braces against future `SecretStr`-style wrappers
- [x] Backward-compat regression: all 5 in-tree plugins (`hello-plugin`, `logger-plugin`, `mcp-wrapper-plugin`, `kb-event-plugin`, `telemetry-prompt-middleware`) still parse with `required_env=[]`
- [x] Integration test (`test_env_status_endpoint_with_real_loader_no_mock`) wires real `PluginLoader` + real `PluginManifest` + real `PluginRegistry` through the endpoint to catch contract drift between `get_env_status` and `PluginEnvStatusEntry`
- [x] Validator unit tests: rejects lowercase, leading digit, special chars, empty, Unicode letters (`Ω`), mid-string lowercase
- [x] Loader integration tests: missing required → load fails with error log; missing optional → loads with info log; all set → loads cleanly
- [x] `black --check` clean, `isort --check` clean, `py_compile` clean

## Spec / Plan

- Spec: [`docs/superpowers/specs/2026-05-05-plugin-sdk-required-env-design.md`](docs/superpowers/specs/2026-05-05-plugin-sdk-required-env-design.md)
- Plan: [`docs/superpowers/plans/2026-05-05-plugin-sdk-required-env.md`](docs/superpowers/plans/2026-05-05-plugin-sdk-required-env.md)

## Out of scope (filed as follow-up issues at merge time)

- `feat(frontend/marketplace): surface plugin required_env in install UI` — display `obtain_steps` and `docs_url` in marketplace plugin-detail view
- `feat(plugin-sdk): bulk env-status endpoint GET /plugins/env-status` — single-plugin endpoint covers immediate consumer
- `refactor(plugin-sdk): use HttpUrl for RequiredEnvVar.docs_url` — currently `Optional[str]`; pydantic v2 `HttpUrl` would add validation but changes downstream serialization
- `refactor(plugin-sdk): use TypedDict for get_env_status return shape` — currently `Dict[str, Dict[str, object]]`
- `refactor(plugin-sdk): use ValidationError instead of generic Exception in pytest.raises` — file-wide style change

## Related

- Discovered while designing the ARC Prize Phase 1 plugin
- Sibling blocker: #6970 (extension-point hook dispatch sites)
- Sibling discoveries (filed): #6972 (frontend module mounting), #6973 (Status enum consolidation), #6486 (event-bus consolidation, existing)

## Notes for reviewers

The branch was cut from `Dev_new_gui` at `67fa4c8c6` (early in the day) and is now ~108 commits behind tip. None of those upstream commits touch `autobot_shared/plugin_sdk/` or `autobot-backend/plugin_manager.py` — verified clean by inspecting the upstream commits' subjects. If a rebase is preferred before merge, happy to do it; otherwise GitHub's merge will handle the branches independently.