### PR TITLE
fix(ansible/redis): TLS lines conditional on cert existence (#6701)

### DIFF
--- a/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
@@ -133,6 +133,29 @@
   become: yes
   tags: ['redis', 'configuration']
 
+# #6701: Stat each TLS cert before rendering redis.conf so the template
+# only emits tls-* directives when the certs actually exist. Mirrors the
+# #6677 pattern from roles/backend/tasks/main.yml — installs without TLS
+# (or where distribute-tls-certs.yml hasn't run yet) won't crash redis-server
+# at boot with "Cannot read CA certificate".
+- name: "Redis | Stat TLS server cert (#6701)"
+  ansible.builtin.stat:
+    path: "{{ redis_tls_cert_dir }}/server-cert.pem"
+  register: redis_tls_server_cert
+  tags: ['redis', 'configuration']
+
+- name: "Redis | Stat TLS server key (#6701)"
+  ansible.builtin.stat:
+    path: "{{ redis_tls_cert_dir }}/server-key.pem"
+  register: redis_tls_server_key
+  tags: ['redis', 'configuration']
+
+- name: "Redis | Stat TLS CA cert (#6701)"
+  ansible.builtin.stat:
+    path: "{{ redis_tls_cert_dir }}/ca-cert.pem"
+  register: redis_tls_ca_cert
+  tags: ['redis', 'configuration']
+
 - name: "Redis | Configure Redis Stack"
   template:
     src: redis-stack.conf.j2

--- a/autobot-slm-backend/ansible/roles/redis/templates/redis.conf.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/redis.conf.j2
@@ -13,12 +13,25 @@ port {{ redis_port }}
 protected-mode no
 
 # TLS Configuration (Issue #725: mTLS support)
-{% if redis_tls_enabled | default(false) | bool %}
+# #6701: TLS lines are gated on a per-file stat (registered by tasks/main.yml)
+# in addition to redis_tls_enabled. Without the stat guard, deployments where
+# distribute-tls-certs.yml hasn't run (or the cert was rotated out) crash
+# redis-server at boot with "Cannot read CA certificate". Mirror of the
+# #6677 backend.env.j2 pattern.
+{% if redis_tls_enabled | default(false) | bool
+      and (redis_tls_server_cert.stat.exists | default(false))
+      and (redis_tls_server_key.stat.exists | default(false))
+      and (redis_tls_ca_cert.stat.exists | default(false)) %}
 tls-port {{ redis_tls_port }}
 tls-cert-file {{ redis_tls_cert_dir }}/server-cert.pem
 tls-key-file {{ redis_tls_cert_dir }}/server-key.pem
 tls-ca-cert-file {{ redis_tls_cert_dir }}/ca-cert.pem
 tls-auth-clients {{ redis_tls_auth_clients | default('optional') }}
+{% else %}
+# TLS intentionally unset (#6701): one or more of server-cert.pem,
+# server-key.pem, ca-cert.pem is missing at deploy time. Run
+# distribute-tls-certs.yml to provision and re-deploy this role to
+# pick them up. Plain-port redis remains available for non-TLS clients.
 {% endif %}
 
 {% if redis_password | length > 0 %}


### PR DESCRIPTION
## Summary

Mirror of the #6677 stat-and-conditional pattern for \`roles/redis/templates/redis.conf.j2\`. TLS lines (\`tls-port\`, \`tls-cert-file\`, \`tls-key-file\`, \`tls-ca-cert-file\`, \`tls-auth-clients\`) are now gated on both \`redis_tls_enabled\` AND per-file stat existence. When any of the three certs is missing on the target host, the TLS block is replaced with an explanatory comment and plain-port redis remains available.

Three new \`stat\` tasks in \`tasks/main.yml\` register \`redis_tls_server_cert\`, \`redis_tls_server_key\`, \`redis_tls_ca_cert\` before the template runs.

## Test plan

- [x] YAML syntax: \`yaml.safe_load(tasks/main.yml)\` → OK
- [x] Diff is minimal (template + 3 stat tasks)
- [ ] Live verify on a host without certs — redis still starts
- [ ] Live verify on a host with certs — TLS lines emitted as before

## Discovery filed

[#7257](https://github.com/mrveiss/AutoBot-AI/issues/7257) — \`redis.conf.j2\` is not currently referenced by any Ansible task. The fix here applies the conditional pattern preemptively; the actually-deployed \`enable-tls.yml\` path already has a Fail-if-missing precheck.

Closes #6701