### PR TITLE
fix(test/workflow): UTC ISO suffix is +00:00, not Z (#7238)

### DIFF
--- a/autobot-backend/services/workflow_versioning_test.py
+++ b/autobot-backend/services/workflow_versioning_test.py
@@ -584,8 +584,16 @@ class TestSummaryHelper:
 
 
 class TestUtcNow:
-    def test_returns_iso_string_with_z_suffix(self):
+    def test_returns_iso_string_with_offset_suffix(self):
+        # _utc_now is an alias for autobot_shared.time_utils.utc_timestamp,
+        # which returns ISO-8601 with ``+00:00`` offset and microsecond
+        # precision per the #5178 datetime migration. Format:
+        # ``YYYY-MM-DDTHH:MM:SS.ffffff+00:00``
+        from datetime import datetime
+
         ts = _utc_now()
-        assert ts.endswith("Z")
+        assert ts.endswith("+00:00")
         assert "T" in ts
-        assert len(ts) == 20  # YYYY-MM-DDTHH:MM:SSZ
+        # Round-trip parse confirms the string is valid ISO-8601 + tz-aware.
+        parsed = datetime.fromisoformat(ts)
+        assert parsed.tzinfo is not None


### PR DESCRIPTION
## Summary

\`services/workflow_versioning.py\` aliases \`_utc_now\` to \`autobot_shared.time_utils.utc_timestamp\`, which per the #5178 datetime migration returns:

\`\`\`
YYYY-MM-DDTHH:MM:SS.ffffff+00:00
\`\`\`

The test asserted the legacy \`Z\`-suffix shape (\`ts.endswith(\"Z\")\`, \`len(ts) == 20\`) — both false since #5178. Hidden behind #7237's collection failure until #7234 (#7216 async-mock fix) unblocked it.

## Fix

Test asserts the actual contract:
- \`+00:00\` suffix
- \`T\` separator present
- Round-trip parse via \`datetime.fromisoformat\` confirms valid ISO-8601 + tz-aware

Renamed test method to match the new assertion (\`with_z_suffix\` → \`with_offset_suffix\`).

## Verification

\`\`\`
$ pytest services/workflow_versioning_test.py
============================== 35 passed in 0.60s ==============================
\`\`\`

35/35 (was 34/35 with this test failing).

Closes #7238