### PR TITLE
refactor(types): consolidate 11 Severity/Risk/Level enums onto canonical (closes #6689)

### DIFF
--- a/autobot-backend/api/analytics_architecture.py
+++ b/autobot-backend/api/analytics_architecture.py
@@ -47,6 +47,7 @@ from api.schemas_analytics import (
     PatternType,
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.status_enums import Severity
 
 logger = logging.getLogger(__name__)
 
@@ -68,16 +69,6 @@ NAMING_CONSISTENCY_PATTERN_TYPES = {
     PatternType.FACTORY,
 }
 CLASS_SUFFIX_INDICATORS = {"Repository", "Repo", "Service", "Factory"}
-
-
-class Severity(str, Enum):
-    """Severity of pattern violations."""
-
-    INFO = "info"
-    LOW = "low"
-    MEDIUM = "medium"
-    HIGH = "high"
-    CRITICAL = "critical"
 
 
 # Pattern indicators for detection

--- a/autobot-backend/api/analytics_debt.py
+++ b/autobot-backend/api/analytics_debt.py
@@ -29,6 +29,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.redis_utils import decode_redis_value as _decode_redis_value
+from autobot_shared.status_enums import Severity as DebtSeverity  # #6689 consolidation
 from constants.ttl_constants import TTL_30_DAYS
 from api.schemas_common import DataResponse, SuccessResponse
 
@@ -75,15 +76,6 @@ class DebtCategory(str, Enum):
     OUTDATED_DEPS = "outdated_dependencies"
     HARDCODED_VALUES = "hardcoded_values"
     DEAD_CODE = "dead_code"
-
-
-class DebtSeverity(str, Enum):
-    """Severity levels for debt items"""
-
-    CRITICAL = "critical"
-    HIGH = "high"
-    MEDIUM = "medium"
-    LOW = "low"
 
 
 @dataclass

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -13,8 +13,16 @@ from fastapi import Query
 from pydantic import BaseModel, Field
 
 from api.schemas_common import SuccessMessageResponse
+from autobot_shared.status_enums import RiskLevel, Severity
 from constants import PATH
 from type_defs.common import Metadata
+
+# #6689 consolidation: 5 severity-shape enums collapsed onto canonical Severity.
+# Aliases preserve external API names (FastAPI / OpenAPI / frontend codegen).
+ImpactLevel = Severity
+IssueSeverity = Severity
+CostLevel = Severity
+DFASeverity = Severity
 
 
 # ---------------------------------------------------------------------------
@@ -2576,15 +2584,6 @@ class EngagementMetricsResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class ImpactLevel(str, Enum):
-    """Impact level of performance issues."""
-
-    CRITICAL = "critical"
-    HIGH = "high"
-    MEDIUM = "medium"
-    LOW = "low"
-
-
 class PerformancePatternCategory(str, Enum):
     """Categories of performance patterns."""
 
@@ -2743,16 +2742,6 @@ class EdgeType(str, Enum):
     RETURN_EDGE = "return_edge"
 
 
-class IssueSeverity(str, Enum):
-    """Severity levels for detected issues."""
-
-    CRITICAL = "critical"
-    HIGH = "high"
-    MEDIUM = "medium"
-    LOW = "low"
-    INFO = "info"
-
-
 class IssueType(str, Enum):
     """Types of control flow issues."""
 
@@ -2818,15 +2807,6 @@ class OptimizationType(str, Enum):
     REDUCE_CONTEXT = "reduce_context"
     BATCH_REQUESTS = "batch_requests"
     TEMPLATE_REUSE = "template_reuse"
-
-
-class CostLevel(str, Enum):
-    """Cost level classification."""
-
-    LOW = "low"
-    MEDIUM = "medium"
-    HIGH = "high"
-    CRITICAL = "critical"
 
 
 class PromptAnalysisRequest(BaseModel):
@@ -3150,16 +3130,6 @@ class VulnerabilityType(str, Enum):
     HARDCODED_SECRET = "hardcoded_secret"  # nosec B105
 
 
-class DFASeverity(str, Enum):
-    """Vulnerability severity levels."""
-
-    CRITICAL = "critical"
-    HIGH = "high"
-    MEDIUM = "medium"
-    LOW = "low"
-    INFO = "info"
-
-
 class DFAAnalyzeRequest(BaseModel):
     """Request model for code analysis."""
 
@@ -3367,20 +3337,11 @@ class DebtSummary(BaseModel):
 # analytics_bug_prediction.py schemas
 # ---------------------------------------------------------------------------
 
-from enum import Enum as _BugPredEnum
+# RiskLevel is the canonical Severity enum (#6689 consolidation).
+# Imported above; keep module-level so Pydantic field annotations resolve.
 
 
-class RiskLevel(str, _BugPredEnum):
-    """Bug risk levels."""
-
-    CRITICAL = "critical"
-    HIGH = "high"
-    MEDIUM = "medium"
-    LOW = "low"
-    MINIMAL = "minimal"
-
-
-class RiskFactor(str, _BugPredEnum):
+class RiskFactor(str, Enum):
     """Factors contributing to bug risk."""
 
     COMPLEXITY = "complexity"

--- a/autobot-backend/code_intelligence/base_analyzer.py
+++ b/autobot-backend/code_intelligence/base_analyzer.py
@@ -19,6 +19,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Pattern, Set
 
+from autobot_shared.status_enums import Severity as IssueSeverity  # noqa: F401  # #6689 consolidation
+
 logger = logging.getLogger(__name__)
 
 # Issue #380: Pre-compiled regex patterns for string literal extraction
@@ -55,16 +57,6 @@ class Language(Enum):
     JSON = "json"
     GO = "go"
     UNKNOWN = "unknown"
-
-
-class IssueSeverity(Enum):
-    """Unified severity levels across all analyzers."""
-
-    INFO = "info"
-    LOW = "low"
-    MEDIUM = "medium"
-    HIGH = "high"
-    CRITICAL = "critical"
 
 
 class IssueCategory(Enum):

--- a/autobot-backend/code_intelligence/bug_predictor.py
+++ b/autobot-backend/code_intelligence/bug_predictor.py
@@ -89,14 +89,7 @@ def _calculate_threshold_score(
 # ============================================================================
 
 
-class RiskLevel(Enum):
-    """Bug risk levels."""
-
-    CRITICAL = "critical"
-    HIGH = "high"
-    MEDIUM = "medium"
-    LOW = "low"
-    MINIMAL = "minimal"
+from autobot_shared.status_enums import RiskLevel  # noqa: E402  # #6689 consolidation
 
 
 class RiskFactor(Enum):

--- a/autobot-backend/intelligence/goal_processor.py
+++ b/autobot-backend/intelligence/goal_processor.py
@@ -36,13 +36,7 @@ class GoalCategory(Enum):
     UNKNOWN = "unknown"
 
 
-class RiskLevel(Enum):
-    """Risk levels for different operations."""
-
-    LOW = "low"
-    MEDIUM = "medium"
-    HIGH = "high"
-    CRITICAL = "critical"
+from autobot_shared.status_enums import RiskLevel  # noqa: E402  # #6689 consolidation
 
 
 @dataclass

--- a/autobot_shared/status_enums.py
+++ b/autobot_shared/status_enums.py
@@ -60,14 +60,21 @@ class TaskStatus(Enum):
 
 class Severity(Enum):
     """
-    Severity/risk level enumeration.
+    Severity / risk-level enumeration.
 
-    Used in security, analytics, logging, and threat detection.
-    Replaces hardcoded strings: "low", "medium", "high", "critical", "unknown".
+    Canonical enum for severity, risk, and impact concepts across the
+    codebase. Used in security, analytics, code-intelligence, logging,
+    and threat detection.
+
+    Replaces hardcoded strings ("low", "medium", "high", "critical",
+    "unknown", "info", "minimal") and consolidates 10+ duplicate enums
+    (#6689): Severity, IssueSeverity, DFASeverity, ImpactLevel, CostLevel,
+    DebtSeverity, RiskLevel — all collapse to this enum.
     """
 
     UNKNOWN = "unknown"
     INFO = "info"
+    MINIMAL = "minimal"
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
@@ -102,12 +109,19 @@ class Severity(Enum):
         scores = {
             cls.UNKNOWN: 0.0,
             cls.INFO: 0.1,
+            cls.MINIMAL: 0.2,
             cls.LOW: 0.3,
             cls.MEDIUM: 0.5,
             cls.HIGH: 0.7,
             cls.CRITICAL: 0.9,
         }
         return scores.get(severity, 0.0)
+
+
+# Risk-level alias — semantic shortcut for callers reasoning about "risk"
+# rather than "severity"; canonically the same enum (#6689). Use whichever
+# name reads clearer at the call site.
+RiskLevel = Severity
 
 
 class Priority(Enum):
@@ -219,6 +233,7 @@ class HealthStatus(Enum):
 __all__ = [
     "TaskStatus",
     "Severity",
+    "RiskLevel",
     "Priority",
     "LLMProvider",
     "OperationOutcome",


### PR DESCRIPTION
## Summary

Eliminates 11 of 17 duplicate severity/risk/level enums identified in #6689. Canonical \`autobot_shared.status_enums.Severity\` gains \`MINIMAL\` + \`RiskLevel\` alias. Remaining 6 documented as legitimate domain concepts; 3 deferred to follow-ups.

## Canonical changes

\`autobot_shared/status_enums.py\`:
- \`+ MINIMAL = \"minimal\"\` (covers 5-tier risk-level scales)
- \`+ RiskLevel = Severity\` (alias for risk-context callers)
- \`to_score()\` updated for MINIMAL = 0.2

## Consolidated (11 enums → canonical)

| File | Enum | Tier |
|------|------|------|
| api/analytics_architecture.py | Severity | 5 |
| code_intelligence/base_analyzer.py | IssueSeverity | 5 (4 importers) |
| api/schemas_analytics.py | IssueSeverity | 5 |
| api/schemas_analytics.py | DFASeverity | 5 |
| api/schemas_analytics.py | ImpactLevel | 4 |
| api/schemas_analytics.py | CostLevel | 4 |
| api/schemas_analytics.py | RiskLevel | 5 (MINIMAL) |
| api/analytics_debt.py | DebtSeverity | 4 |
| intelligence/goal_processor.py | RiskLevel | 4 |
| code_intelligence/bug_predictor.py | RiskLevel | 5 (MINIMAL) |

Aliases preserved for FastAPI/OpenAPI/codegen compat: \`IssueSeverity = Severity\`, etc.

## Kept (6 legitimate domain concepts)

- \`CheckSeverity\` (BLOCK/WARN/INFO — gate actions)
- \`ConfidenceLevel\` (5-tier confidence)
- \`ReviewSeverity\` (CRITICAL/WARNING/INFO/SUGGESTION)
- \`ConsistencyLevel\`, \`TaintLevel\` (DFA security)
- \`DiagnosticSeverity\` (LSP protocol)

## Deferred (follow-ups filed)

- #7253 \`anti_pattern_detector.Severity\` — .score() int incompatibility
- #7255 \`causal_inference_engine.Severity\` — different concept (CRITICAL/DEGRADED/WARNING)
- #7258 \`command_execution.RiskLevel\` — uppercase wire format

## Test plan

- [x] py_compile clean (7 modified files)
- [x] Smoke-import green (13/13 callers including 4 analyzer subclasses)
- [x] Pydantic \`FileRisk\` schema validates with canonical RiskLevel
- [x] \`.value\` access intact (\`IssueSeverity.HIGH.value == \"high\"\`)
- [x] Net diff: -62 LOC

Closes #6689.

🤖 Generated with [Claude Code](https://claude.com/claude-code)