### PR TITLE
feat(tests): canonical make_async_redis() + patch_async_redis() fixtures (#7264)

### DIFF
--- a/autobot-backend/tests/fixtures/__init__.py
+++ b/autobot-backend/tests/fixtures/__init__.py
@@ -15,7 +15,9 @@ from .mocks import (
     MockLLMInterface,
     MockLLMService,
     MockWorkerNode,
+    make_async_redis,
     make_llm_response,
+    patch_async_redis,
 )
 
 __all__ = [
@@ -25,4 +27,6 @@ __all__ = [
     "MockLLMService",
     "MockWorkerNode",
     "make_llm_response",
+    "make_async_redis",
+    "patch_async_redis",
 ]

--- a/autobot-backend/tests/fixtures/mocks.py
+++ b/autobot-backend/tests/fixtures/mocks.py
@@ -19,6 +19,7 @@ Provides mock implementations of core components for tests and the
 - MockWorkerNode       - Mock NPU/worker node for distributed-flow tests.
 """
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -131,6 +132,163 @@ def make_llm_response(
 # New code should use `make_llm_response` directly.
 def _build_mock_response(content: str):
     return make_llm_response(content=content)
+
+
+def make_async_redis(
+    *,
+    get_returns: Any = None,
+    set_returns: Any = True,
+    setex_returns: Any = True,
+    delete_returns: int = 1,
+    expire_returns: bool = True,
+    exists_returns: int = 0,
+    incr_returns: int = 1,
+    decr_returns: int = 0,
+    keys_returns: Optional[List[bytes]] = None,
+    ttl_returns: int = -1,
+    # Hash ops
+    hget_returns: Any = None,
+    hset_returns: int = 1,
+    hgetall_returns: Optional[Dict[bytes, bytes]] = None,
+    hkeys_returns: Optional[List[bytes]] = None,
+    hvals_returns: Optional[List[bytes]] = None,
+    hdel_returns: int = 1,
+    hexists_returns: int = 0,
+    # Set ops
+    sadd_returns: int = 1,
+    srem_returns: int = 1,
+    smembers_returns: Optional[set] = None,
+    sismember_returns: bool = False,
+    # List ops
+    lrange_returns: Optional[List[bytes]] = None,
+    lpush_returns: int = 1,
+    rpush_returns: int = 1,
+    llen_returns: int = 0,
+    # Sorted-set ops
+    zadd_returns: int = 1,
+    zcard_returns: int = 0,
+    zrange_returns: Optional[List[bytes]] = None,
+    zrangebyscore_returns: Optional[List[bytes]] = None,
+    zrevrange_returns: Optional[List[bytes]] = None,
+    zremrangebyrank_returns: int = 0,
+    # Pub/sub
+    publish_returns: int = 0,
+    **extra_methods: Any,
+) -> "AsyncMock":
+    """Build an async-redis-shaped ``AsyncMock`` for tests (canonical, #7264).
+
+    Replaces the 11+ ad-hoc ``_make_redis*()`` helpers across the test
+    tree. All redis methods are pre-configured as ``AsyncMock`` so
+    ``await redis.X(...)`` works correctly — the same lesson as #7216
+    (``return_value=`` alone isn't awaitable).
+
+    Defaults pick the common "empty/healthy" shape:
+
+      - get/hget/hgetall/keys/smembers/lrange/zrange → empty/None
+      - set/setex/expire → True
+      - sadd/srem/zadd/lpush/rpush/incr/hset/delete → ``1`` (one element changed)
+      - sismember/hexists/exists → ``0/False`` (not present)
+
+    Override per call via the corresponding ``X_returns`` kwarg. For methods
+    not pre-configured (e.g. project-specific Redis modules), pass via
+    ``**extra_methods`` — each becomes ``AsyncMock(return_value=value)``::
+
+        redis = make_async_redis(get_returns=b"hello", xadd=("stream", "1-0"))
+
+    Args:
+        \\*_returns: per-method return value overrides (see method names above).
+        \\**extra_methods: arbitrary additional method names → return values.
+
+    Returns:
+        An ``AsyncMock`` matching the redis-py async client surface.
+    """
+    from unittest.mock import AsyncMock
+
+    redis = AsyncMock()
+
+    # Defaults — picks the empty/healthy shape callers usually want.
+    redis.get = AsyncMock(return_value=get_returns)
+    redis.set = AsyncMock(return_value=set_returns)
+    redis.setex = AsyncMock(return_value=setex_returns)
+    redis.delete = AsyncMock(return_value=delete_returns)
+    redis.expire = AsyncMock(return_value=expire_returns)
+    redis.exists = AsyncMock(return_value=exists_returns)
+    redis.incr = AsyncMock(return_value=incr_returns)
+    redis.decr = AsyncMock(return_value=decr_returns)
+    redis.keys = AsyncMock(return_value=keys_returns or [])
+    redis.ttl = AsyncMock(return_value=ttl_returns)
+
+    redis.hget = AsyncMock(return_value=hget_returns)
+    redis.hset = AsyncMock(return_value=hset_returns)
+    redis.hgetall = AsyncMock(return_value=hgetall_returns or {})
+    redis.hkeys = AsyncMock(return_value=hkeys_returns or [])
+    redis.hvals = AsyncMock(return_value=hvals_returns or [])
+    redis.hdel = AsyncMock(return_value=hdel_returns)
+    redis.hexists = AsyncMock(return_value=hexists_returns)
+
+    redis.sadd = AsyncMock(return_value=sadd_returns)
+    redis.srem = AsyncMock(return_value=srem_returns)
+    redis.smembers = AsyncMock(return_value=smembers_returns or set())
+    redis.sismember = AsyncMock(return_value=sismember_returns)
+
+    redis.lrange = AsyncMock(return_value=lrange_returns or [])
+    redis.lpush = AsyncMock(return_value=lpush_returns)
+    redis.rpush = AsyncMock(return_value=rpush_returns)
+    redis.llen = AsyncMock(return_value=llen_returns)
+
+    redis.zadd = AsyncMock(return_value=zadd_returns)
+    redis.zcard = AsyncMock(return_value=zcard_returns)
+    redis.zrange = AsyncMock(return_value=zrange_returns or [])
+    redis.zrangebyscore = AsyncMock(return_value=zrangebyscore_returns or [])
+    redis.zrevrange = AsyncMock(return_value=zrevrange_returns or [])
+    redis.zremrangebyrank = AsyncMock(return_value=zremrangebyrank_returns)
+
+    redis.publish = AsyncMock(return_value=publish_returns)
+
+    for method_name, value in extra_methods.items():
+        setattr(redis, method_name, AsyncMock(return_value=value))
+
+    return redis
+
+
+@contextmanager
+def patch_async_redis(target: str, redis: Optional["AsyncMock"] = None):
+    """Context manager: patch ``get_async_redis_client`` at ``target`` with
+    correct ``AsyncMock`` wrapping (canonical, #7264).
+
+    Production code does ``await get_async_redis_client(database="...")``,
+    so the patched callable must itself be an ``AsyncMock`` whose call
+    returns the redis mock when awaited. Bare ``patch(target,
+    return_value=redis)`` returns the default AsyncMock when awaited —
+    that's the #7216 bug. This helper applies the correct shape and
+    yields the **inner redis mock** so callers can configure per-call
+    behavior::
+
+        with patch_async_redis("api.foo.get_async_redis_client") as redis:
+            redis.get = AsyncMock(return_value=b"hit")
+            result = await foo()
+            redis.get.assert_awaited_once_with("key")
+
+    Or pass a pre-configured redis::
+
+        redis = make_async_redis(get_returns=b"value")
+        with patch_async_redis("api.foo.get_async_redis_client", redis=redis):
+            ...
+
+    Args:
+        target: dotted path to ``get_async_redis_client`` on the module
+            that production code imports it from.
+        redis: pre-configured ``AsyncMock`` (default: ``make_async_redis()``).
+
+    Yields:
+        The redis mock — production's ``await get_async_redis_client(...)``
+        receives this same object.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    redis = redis if redis is not None else make_async_redis()
+    with patch(target, new=AsyncMock(return_value=redis)):
+        yield redis
 
 
 class MockLLMService:
@@ -324,4 +482,6 @@ __all__ = [
     "MockKnowledgeBase",
     "MockWorkerNode",
     "make_llm_response",
+    "make_async_redis",
+    "patch_async_redis",
 ]

--- a/autobot-backend/tests/fixtures/test_make_async_redis.py
+++ b/autobot-backend/tests/fixtures/test_make_async_redis.py
@@ -1,0 +1,197 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Contract tests for ``tests.fixtures.mocks.make_async_redis`` and
+``patch_async_redis`` (#7264).
+
+Pins the canonical async-redis fixture's behavior so the 11+ ad-hoc
+``_make_redis*()`` helpers across the test tree can migrate onto it
+with confidence.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from tests.fixtures import make_async_redis, patch_async_redis
+
+
+# ---------------------------------------------------------------------------
+# make_async_redis — defaults + override + extras
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_get_returns_none() -> None:
+    """Empty/healthy default — production reads of unset keys see None."""
+    redis = make_async_redis()
+    assert await redis.get("anything") is None
+
+
+@pytest.mark.asyncio
+async def test_default_set_setex_expire_succeed() -> None:
+    """Write defaults assume success — most callers don't gate on the
+    return value, but those that do expect truthy on success."""
+    redis = make_async_redis()
+    assert await redis.set("k", "v") is True
+    assert await redis.setex("k", 60, "v") is True
+    assert await redis.expire("k", 60) is True
+
+
+@pytest.mark.asyncio
+async def test_default_sadd_srem_return_one() -> None:
+    """1 = one element added/removed — matches what redis-py returns."""
+    redis = make_async_redis()
+    assert await redis.sadd("set", "x") == 1
+    assert await redis.srem("set", "x") == 1
+
+
+@pytest.mark.asyncio
+async def test_default_smembers_returns_empty_set() -> None:
+    redis = make_async_redis()
+    assert await redis.smembers("set") == set()
+
+
+@pytest.mark.asyncio
+async def test_default_sismember_returns_false() -> None:
+    redis = make_async_redis()
+    assert await redis.sismember("set", "x") is False
+
+
+@pytest.mark.asyncio
+async def test_default_hash_ops_empty() -> None:
+    redis = make_async_redis()
+    assert await redis.hget("h", "k") is None
+    assert await redis.hgetall("h") == {}
+    assert await redis.hkeys("h") == []
+    assert await redis.hvals("h") == []
+    assert await redis.hexists("h", "k") == 0
+
+
+@pytest.mark.asyncio
+async def test_default_list_ops_empty() -> None:
+    redis = make_async_redis()
+    assert await redis.lrange("list", 0, -1) == []
+    assert await redis.llen("list") == 0
+
+
+@pytest.mark.asyncio
+async def test_default_sorted_set_ops_empty() -> None:
+    redis = make_async_redis()
+    assert await redis.zrange("z", 0, -1) == []
+    assert await redis.zrangebyscore("z", 0, 100) == []
+    assert await redis.zrevrange("z", 0, -1) == []
+    assert await redis.zcard("z") == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-method overrides
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_returns_override() -> None:
+    redis = make_async_redis(get_returns=b"hello")
+    assert await redis.get("any-key") == b"hello"
+
+
+@pytest.mark.asyncio
+async def test_smembers_returns_override() -> None:
+    redis = make_async_redis(smembers_returns={b"a", b"b"})
+    assert await redis.smembers("any-set") == {b"a", b"b"}
+
+
+@pytest.mark.asyncio
+async def test_zrange_returns_override() -> None:
+    redis = make_async_redis(zrange_returns=[b"first", b"second"])
+    assert await redis.zrange("z", 0, -1) == [b"first", b"second"]
+
+
+# ---------------------------------------------------------------------------
+# extra_methods — arbitrary additions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extra_methods_become_async_mocks() -> None:
+    """Methods not in the predefined set (e.g. xadd for streams) can be
+    passed via kwargs and become ``AsyncMock(return_value=value)``."""
+    redis = make_async_redis(xadd=b"1-0", scan_iter=[b"k1", b"k2"])
+    assert await redis.xadd("stream", {"f": "v"}) == b"1-0"
+    assert await redis.scan_iter() == [b"k1", b"k2"]
+
+
+@pytest.mark.asyncio
+async def test_extra_method_takes_precedence_over_default() -> None:
+    """If a caller passes ``get`` via extras (unusual), it overrides the
+    typed parameter. This is a niche case but worth documenting."""
+    redis = make_async_redis(get_returns=b"default", **{"get": b"override"})
+    # **extras runs after the typed args, so it wins.
+    assert await redis.get("k") == b"override"
+
+
+# ---------------------------------------------------------------------------
+# patch_async_redis — context manager
+# ---------------------------------------------------------------------------
+
+
+# Simulate production code that imports + awaits get_async_redis_client.
+async def _fake_production_function():
+    """Replicates the production pattern: ``await get_async_redis_client(...)``"""
+    from autobot_shared.redis_client import get_async_redis_client
+
+    redis = await get_async_redis_client(database="main")
+    return await redis.get("test-key")
+
+
+@pytest.mark.asyncio
+async def test_patch_async_redis_basic_use() -> None:
+    """The patched callable returns the mock when awaited — the #7216
+    bug class (``patch(..., return_value=mock)`` returns default
+    AsyncMock when awaited) cannot recur with this helper."""
+    with patch_async_redis(
+        "autobot_shared.redis_client.get_async_redis_client"
+    ) as redis:
+        redis.get = AsyncMock(return_value=b"hit")
+        result = await _fake_production_function()
+        assert result == b"hit"
+
+
+@pytest.mark.asyncio
+async def test_patch_async_redis_with_preconfigured() -> None:
+    """Passing a pre-configured redis lets callers set up state
+    declaratively and reuse the same mock across multiple patches."""
+    redis = make_async_redis(get_returns=b"shared")
+    with patch_async_redis(
+        "autobot_shared.redis_client.get_async_redis_client", redis=redis
+    ):
+        assert await _fake_production_function() == b"shared"
+
+
+@pytest.mark.asyncio
+async def test_patch_async_redis_returns_async_callable() -> None:
+    """Regression pin for #7216 — the patched object MUST be itself
+    awaitable so production's ``await get_async_redis_client(...)`` returns
+    the redis mock (NOT the default AsyncMock that bare ``return_value=``
+    would have given).
+    """
+    from autobot_shared.redis_client import get_async_redis_client as orig
+
+    with patch_async_redis(
+        "autobot_shared.redis_client.get_async_redis_client"
+    ) as redis:
+        # The patched function is now an AsyncMock; awaiting it returns redis.
+        from autobot_shared.redis_client import get_async_redis_client
+        awaited = await get_async_redis_client(database="main")
+        assert awaited is redis  # ← THE pin: not just truthy, the same object
+
+
+def test_factory_re_exported_from_fixtures_package() -> None:
+    """Documented import path: ``from tests.fixtures import make_async_redis``."""
+    import tests.fixtures as fixtures
+
+    assert "make_async_redis" in fixtures.__all__
+    assert "patch_async_redis" in fixtures.__all__
+    assert callable(fixtures.make_async_redis)
+    assert callable(fixtures.patch_async_redis)


### PR DESCRIPTION
## Summary

Composability follow-up to #7216 / PR #7234. After consolidating 77 sites onto \`patch(..., new=AsyncMock(return_value=mock_redis))\`, **11+ test files still rolled their own \`_make_redis*()\` helper** with slightly different defaults each. This PR extracts the canonical shape (matching the #7134 \`make_llm_response\` precedent).

## API

### \`make_async_redis(*, get_returns=None, ..., **extra_methods)\`

Builds an AsyncMock with sensible defaults for the top ~30 redis methods (per grep over all \`*test*.py\`: get×170, hgetall×47, set×46, hset×33, expire×29, ...). Per-method override via \`X_returns=\` kwargs. Less common methods via \`**extra_methods\`.

### \`@contextmanager patch_async_redis(target, redis=None)\`

Context manager that applies the correct \`patch(target, new=AsyncMock(return_value=redis))\` shape and **yields the inner redis mock** so callers can configure it. Eliminates the #7216 footgun.

\`\`\`python
with patch_async_redis(\"api.foo.get_async_redis_client\") as redis:
    redis.get = AsyncMock(return_value=b\"hit\")
    result = await production_function()
    redis.get.assert_awaited_once_with(\"key\")
\`\`\`

## Bug caught during implementation (regression pin in tests)

First version of \`patch_async_redis\` returned the patch object directly — but \`with patch(...) as X\` yields the patched \`new\` object, NOT the inner mock. Caught by my own contract test \`test_patch_async_redis_basic_use\`. Fixed via \`@contextmanager\` that explicitly yields the redis mock. The contract test now serves as the regression pin: any future rewrite that drops the contextmanager form will fail.

## Verification

\`\`\`
$ python3 -m pytest tests/fixtures/test_make_async_redis.py -xvs
============================== 17 passed in 1.25s ==============================
\`\`\`

## Migration

This PR adds the fixture + tests + docs only. The 11+ ad-hoc \`_make_redis*()\` helpers migrate incrementally in separate PRs (per the [layered-rot lesson](https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/.claude/projects/feedback_layered_test_rot.md) — each migration may surface its own pre-existing rot).

Closes #7264