### PR TITLE
feat(codegen): extend MANIFEST to cover WorkflowStepStatus + RiskLevel (closes #7226)

### DIFF
--- a/.github/workflows/frontend-codegen-drift.yml
+++ b/.github/workflows/frontend-codegen-drift.yml
@@ -12,6 +12,9 @@
 # months). Codegen + this guard makes the drift impossible to introduce
 # silently.
 #
+# #7226: extended path filter to cover all MANIFEST sources
+# (status_enums + workflow_automation models).
+#
 # Security: this workflow does NOT interpolate any untrusted GitHub
 # event data (no issue titles, PR bodies, commit messages, head_ref,
 # etc.) into run: commands. All inputs are static repo paths.
@@ -21,7 +24,11 @@ name: frontend-codegen-drift
 on:
   pull_request:
     paths:
+      # Canonical sources covered by MANIFEST (#7122 / #7226)
       - 'autobot_shared/workflow/types.py'
+      - 'autobot_shared/status_enums.py'
+      - 'autobot-backend/services/workflow_automation/models.py'
+      # Codegen output + tooling
       - 'autobot-frontend/src/types/_generated/**'
       - 'autobot-infrastructure/shared/scripts/gen_frontend_types.py'
       - '.github/workflows/frontend-codegen-drift.yml'
@@ -29,6 +36,8 @@ on:
     branches: [Dev_new_gui]
     paths:
       - 'autobot_shared/workflow/types.py'
+      - 'autobot_shared/status_enums.py'
+      - 'autobot-backend/services/workflow_automation/models.py'
       - 'autobot-frontend/src/types/_generated/**'
       - 'autobot-infrastructure/shared/scripts/gen_frontend_types.py'
 

--- a/autobot-frontend/src/types/_generated/workflow.ts
+++ b/autobot-frontend/src/types/_generated/workflow.ts
@@ -73,3 +73,26 @@ export interface WorkflowPlan {
   created_at_epoch: number | null;
   metadata: Record<string, unknown>;
 }
+
+/** Generated from `services.workflow_automation.models.WorkflowStepStatus` */
+export type WorkflowStepStatus =
+  | 'pending'
+  | 'waiting_approval'
+  | 'approved'
+  | 'executing'
+  | 'completed'
+  | 'skipped'
+  | 'failed'
+  | 'paused';
+
+/** Generated from `autobot_shared.status_enums.Severity` */
+export type Severity =
+  | 'unknown'
+  | 'info'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'critical';
+
+/** Generated alias — same union as `Severity` (#6689 / #7226) */
+export type RiskLevel = Severity;

--- a/autobot-frontend/src/types/workflowTemplates.ts
+++ b/autobot-frontend/src/types/workflowTemplates.ts
@@ -14,17 +14,23 @@
 
 export type TemplateCategory = 'security' | 'research' | 'development' | 'system_admin' | 'analysis' | 'community'
 export type TaskComplexity = 'simple' | 'moderate' | 'complex' | 'research' | 'security_scan' | 'install'
-export type RiskLevel = 'low' | 'medium' | 'high' | 'critical'
 
 /**
- * Structured prompt spec — mirrors backend autobot_shared.workflow.PromptSpec (#6951 Phase 1b).
+ * Generated unions/types — single source of truth is the canonical Python
+ * (#7122 / #7226). Re-exported here so consumers keep a stable import path
+ * (`@/types/workflowTemplates`) regardless of how the backing classes are
+ * sourced (shared dataclasses, backend enums, etc.).
  *
- * #7122: re-exports the auto-generated definition from `_generated/workflow.ts`
- * so this hand-written file and the codegen output stay in lockstep. The
- * `frontend-codegen-drift` CI check fails if the generated file goes stale.
+ * The `frontend-codegen-drift` CI check fails if the generated file goes stale.
  */
-import type { PromptSpec, WorkflowTask, WorkflowPlan } from './_generated/workflow'
-export type { PromptSpec, WorkflowTask, WorkflowPlan }
+import type {
+  PromptSpec,
+  WorkflowTask,
+  WorkflowPlan,
+  WorkflowStepStatus,
+  RiskLevel,
+} from './_generated/workflow'
+export type { PromptSpec, WorkflowTask, WorkflowPlan, WorkflowStepStatus, RiskLevel }
 
 /**
  * Static template step — matches backend `_template_step_dict()` from
@@ -47,24 +53,6 @@ export interface TemplateStep {
   tools_allowed: string[] | null
   tools_denied: string[]
 }
-
-/**
- * Runtime workflow step status — string union mirroring
- * `services/workflow_automation/models.py:WorkflowStepStatus`.
- *
- * #7123: declared here as the canonical types module. The previous local
- * declaration in `composables/useWorkflowBuilder.ts` is now a re-export
- * pointing at this definition (single source of truth).
- */
-export type WorkflowStepStatus =
-  | 'pending'
-  | 'waiting_approval'
-  | 'approved'
-  | 'executing'
-  | 'completed'
-  | 'skipped'
-  | 'failed'
-  | 'paused'
 
 /**
  * Runtime workflow step — matches backend

--- a/autobot-infrastructure/shared/scripts/gen_frontend_types.py
+++ b/autobot-infrastructure/shared/scripts/gen_frontend_types.py
@@ -57,19 +57,56 @@ OUTPUT_PATH = REPO_ROOT / "autobot-frontend" / "src" / "types" / "_generated" / 
 # ---------------------------------------------------------------------------
 
 # Each entry: (module path, attr name)
+#
+# How to extend (#7226 cookbook):
+#
+#   1. Identify the canonical Python source. For dataclasses this is a
+#      `@dataclass`; for enums this is a `class X(Enum):` or
+#      `class X(str, Enum):`. Pydantic models are NOT supported — convert
+#      to a dataclass first or wait for OpenAPI-based codegen (deferred).
+#
+#   2. Append `(module_path, ClassName)` to MANIFEST below. The module
+#      must be importable from the repo root with `autobot_shared/` and
+#      `autobot-backend/` on sys.path.
+#
+#   3. Re-run codegen and commit the regenerated TS:
+#        python3 autobot-infrastructure/shared/scripts/gen_frontend_types.py
+#
+#   4. Update frontend imports to consume from `@/types/_generated/workflow`
+#      (re-export from `@/types/workflowTemplates` if a stable public path
+#      is preferred).
+#
+#   5. CI's `frontend-codegen-drift` job will fail if the committed file
+#      drifts from the source.
 MANIFEST: List[Tuple[str, str]] = [
     ("autobot_shared.workflow.types", "PromptSpec"),
     ("autobot_shared.workflow.types", "ExecutionStrategy"),
     ("autobot_shared.workflow.types", "WorkflowTask"),
     ("autobot_shared.workflow.types", "WorkflowPlan"),
+    # #7226: extend MANIFEST to cover hand-written types prone to drift
+    ("services.workflow_automation.models", "WorkflowStepStatus"),
+    ("autobot_shared.status_enums", "Severity"),  # exported as RiskLevel via alias below
 ]
 
 
+# Aliases emitted alongside their backing class — TypeScript can't have
+# two type names point at the same union literal without a duplication,
+# so we emit `export type RiskLevel = Severity;` after the source class.
+# Map: source class name → list of alias names to emit.
+ALIASES: Dict[str, List[str]] = {
+    "Severity": ["RiskLevel"],
+}
+
+
 def _ensure_autobot_shared_on_path() -> None:
-    """Add ``autobot_shared`` to sys.path so the script can import it standalone."""
+    """Add ``autobot_shared`` and ``autobot-backend`` to sys.path so the script
+    can import canonical and (#7226) backend modules standalone."""
     shared = REPO_ROOT / "autobot_shared"
     if str(shared.parent) not in sys.path:
         sys.path.insert(0, str(shared.parent))
+    backend = REPO_ROOT / "autobot-backend"
+    if backend.is_dir() and str(backend) not in sys.path:
+        sys.path.insert(0, str(backend))
 
 
 # ---------------------------------------------------------------------------
@@ -154,21 +191,29 @@ def _ts_type(py_type: Any, known_names: Set[str]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _render_enum(cls: type) -> str:
+def _render_enum(cls: type, source: str) -> str:
     """Emit a TypeScript string union for a Python Enum."""
     members = [f"  | '{m.value}'" for m in cls]
     body = "\n".join(members)
     return (
-        f"/** Generated from `autobot_shared.workflow.types.{cls.__name__}` */\n"
+        f"/** Generated from `{source}.{cls.__name__}` */\n"
         f"export type {cls.__name__} =\n{body};\n"
     )
 
 
-def _render_dataclass(cls: type, known_names: Set[str]) -> str:
+def _render_alias(name: str, target: str, source_cls: str) -> str:
+    """Emit a TypeScript type alias re-exporting an existing union."""
+    return (
+        f"/** Generated alias — same union as `{source_cls}` (#6689 / #7226) */\n"
+        f"export type {name} = {target};\n"
+    )
+
+
+def _render_dataclass(cls: type, known_names: Set[str], source: str) -> str:
     """Emit a TypeScript interface for a Python dataclass."""
     type_hints = typing.get_type_hints(cls, include_extras=False)
     lines = [
-        f"/** Generated from `autobot_shared.workflow.types.{cls.__name__}` */",
+        f"/** Generated from `{source}.{cls.__name__}` */",
         f"export interface {cls.__name__} {{",
     ]
     for f in dataclasses.fields(cls):
@@ -204,7 +249,7 @@ HEADER = """// AutoBot - AI-Powered Automation Platform
 def generate() -> str:
     """Run the manifest and produce the full TS output as a string."""
     _ensure_autobot_shared_on_path()
-    classes: List[type] = []
+    entries: List[Tuple[str, type]] = []
     for module_path, attr in MANIFEST:
         spec = importlib.util.find_spec(module_path)
         if spec is None:
@@ -213,18 +258,24 @@ def generate() -> str:
         cls = getattr(module, attr, None)
         if cls is None:
             raise SystemExit(f"{module_path}.{attr} not found")
-        classes.append(cls)
+        entries.append((module_path, cls))
 
-    known_names = {c.__name__ for c in classes}
+    known_names = {c.__name__ for _, c in entries}
+    # Aliases are also valid known names so dataclasses referencing them resolve.
+    for source, alias_list in ALIASES.items():
+        known_names.update(alias_list)
 
     parts: List[str] = [HEADER]
-    for cls in classes:
+    for module_path, cls in entries:
         if isinstance(cls, type) and issubclass(cls, Enum):
-            parts.append(_render_enum(cls))
+            parts.append(_render_enum(cls, module_path))
         elif dataclasses.is_dataclass(cls):
-            parts.append(_render_dataclass(cls, known_names))
+            parts.append(_render_dataclass(cls, known_names, module_path))
         else:
             raise SystemExit(f"Unsupported class kind: {cls!r}")
+        # Emit any aliases declared for this class
+        for alias_name in ALIASES.get(cls.__name__, []):
+            parts.append(_render_alias(alias_name, cls.__name__, cls.__name__))
     return "\n".join(parts)
 
 


### PR DESCRIPTION
## Summary

Extends #7122 codegen MANIFEST to cover two of the most-fragile hand-written frontend types per #7226 acceptance criteria:

- \`services.workflow_automation.models.WorkflowStepStatus\` (8-value Enum)
- \`autobot_shared.status_enums.Severity\` (Enum, exported as \`RiskLevel\` via alias)

## Acceptance criteria from #7226

- [x] **Decision:** Approach 1 (Add to MANIFEST) — appropriate for these two enums; Approach 2 (OpenAPI) deferred per scope discussion
- [x] **WorkflowStepStatus and RiskLevel covered by codegen** — both now in the generated file
- [x] **CI drift guard remains green** — \`frontend-codegen-drift.yml\` path filter extended to trigger on the new sources
- [x] **Cookbook documented** — extended docstring in \`gen_frontend_types.py\` MANIFEST section

## Codegen enhancements

- New \`ALIASES\` dict supports multi-name enums (e.g. Severity → RiskLevel) without re-emitting the union
- \`sys.path\` setup includes \`autobot-backend/\` so backend modules import standalone
- Per-class source comment now reflects actual module path (was hardcoded)
- Cookbook docstring for adding new types

## Frontend changes

\`workflowTemplates.ts\`:
- Re-exports \`WorkflowStepStatus\` + \`RiskLevel\` from \`_generated/workflow.ts\` (single source of truth)
- Removed hand-written 8-value WorkflowStepStatus union
- Removed hand-written 4-value RiskLevel union

## Test plan

- [x] \`gen_frontend_types.py --check\` passes
- [x] Generated TS contains \`WorkflowStepStatus\` (8 values), \`Severity\` (6 values), \`RiskLevel\` alias
- [x] Existing \`useWorkflowBuilder.ts\` import chain unchanged

## Deferred (out of scope)

- OpenAPI-based codegen for FastAPI \`response_model=\` (larger play)
- Per-method codegen for \`to_status_dict()\` style emitters (needs AST walker)

Closes #7226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)