### PR TITLE
refactor(security): consolidate per-IP rate limit into autobot_shared.rate_limit (closes #7271 + #7270)

### DIFF
--- a/autobot-backend/a2a/a2a_security_test.py
+++ b/autobot-backend/a2a/a2a_security_test.py
@@ -86,9 +86,7 @@ class TestSecurityCardSigner:
     def test_sign_raises_without_secret(self):
         from a2a.security import SecurityCardSigner
 
-        with patch(
-            "a2a.security._get_secret", side_effect=RuntimeError("AUTOBOT_A2A_SECRET")
-        ):
+        with patch("a2a.security._get_secret", side_effect=RuntimeError("AUTOBOT_A2A_SECRET")):
             with pytest.raises(RuntimeError, match="AUTOBOT_A2A_SECRET"):
                 SecurityCardSigner.sign({})
 
@@ -255,9 +253,7 @@ class TestCapabilityVerifier:
         with patch("a2a.capability_verifier._fetch_and_verify") as mock_fetch:
             from a2a.capability_verifier import CapabilityReport
 
-            mock_fetch.return_value = CapabilityReport(
-                verified=False, warnings=["Network error"]
-            )
+            mock_fetch.return_value = CapabilityReport(verified=False, warnings=["Network error"])
             report = await verify_remote_card("https://unreachable.invalid")
         assert report.verified is False
 
@@ -297,34 +293,71 @@ class TestCapabilityVerifier:
 
 
 class TestRateLimiting:
+    """Rate-limit tests — use the in-process fallback path of the shared
+    IPRateLimiter so tests don't require a live Redis. The limiter logic
+    itself is comprehensively tested in
+    ``autobot_shared/rate_limit_test.py`` (#7271). These tests only verify
+    a2a's wiring + that the shared limiter behaves correctly when stubbed
+    to use the fallback path.
+
+    Pre-#7271 this file directly poked module-level globals
+    (``_rate_buckets``, ``_check_rate_limit``, ``_RATE_LIMIT``). Those
+    symbols were collapsed into ``_a2a_limiter`` (an IPRateLimiter
+    instance); tests now exercise the limiter's public API.
+    """
+
     def teardown_method(self):
-        from api.a2a import _rate_buckets
+        from api.a2a import _a2a_limiter
 
-        _rate_buckets.clear()
+        _a2a_limiter._reset_inprocess()
 
-    def test_within_limit_passes(self):
-        from api.a2a import _check_rate_limit
+    @pytest.mark.asyncio
+    async def test_within_limit_passes(self):
+        from unittest.mock import AsyncMock, patch
 
-        for _ in range(5):
-            _check_rate_limit("1.2.3.4")  # should not raise
+        from api.a2a import _a2a_limiter
 
-    def test_exceeds_limit_raises(self):
+        # Stub Redis to None → forces in-process fallback path.
+        with patch(
+            "autobot_shared.redis_client.get_async_redis_client",
+            new=AsyncMock(return_value=None),
+        ):
+            for _ in range(5):
+                await _a2a_limiter.check_or_429("1.2.3.4")  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_exceeds_limit_raises(self):
+        from unittest.mock import AsyncMock, patch
+
         from fastapi import HTTPException
 
-        from api.a2a import _RATE_LIMIT, _check_rate_limit, _rate_buckets
+        from api.a2a import _a2a_limiter
 
+        # Pre-seed the in-process bucket at the limit.
         now = time.time()
-        _rate_buckets["9.9.9.9"] = [now] * _RATE_LIMIT
-        with pytest.raises(HTTPException) as exc_info:
-            _check_rate_limit("9.9.9.9")
-        assert exc_info.value.status_code == 429
+        _a2a_limiter._inprocess_buckets["9.9.9.9"] = [now] * _a2a_limiter.limit
+        with patch(
+            "autobot_shared.redis_client.get_async_redis_client",
+            new=AsyncMock(return_value=None),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _a2a_limiter.check_or_429("9.9.9.9")
+            assert exc_info.value.status_code == 429
 
-    def test_old_entries_expire(self):
-        from api.a2a import _RATE_LIMIT, _check_rate_limit, _rate_buckets
+    @pytest.mark.asyncio
+    async def test_old_entries_expire(self):
+        from unittest.mock import AsyncMock, patch
 
-        old_time = time.time() - 120  # 2 minutes ago
-        _rate_buckets["5.5.5.5"] = [old_time] * _RATE_LIMIT
-        _check_rate_limit("5.5.5.5")  # should NOT raise — entries are stale
+        from api.a2a import _a2a_limiter
+
+        # Entries from 2 minutes ago — outside the 60s sliding window.
+        old_time = time.time() - 120
+        _a2a_limiter._inprocess_buckets["5.5.5.5"] = [old_time] * _a2a_limiter.limit
+        with patch(
+            "autobot_shared.redis_client.get_async_redis_client",
+            new=AsyncMock(return_value=None),
+        ):
+            await _a2a_limiter.check_or_429("5.5.5.5")  # should NOT raise — entries are stale
 
 
 # ---------------------------------------------------------------------------
@@ -340,11 +373,7 @@ class TestJwtSubExtraction:
         from api.a2a import _extract_jwt_sub
 
         header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=").decode()
-        payload = (
-            base64.urlsafe_b64encode(json.dumps({"sub": "user42"}).encode())
-            .rstrip(b"=")
-            .decode()
-        )
+        payload = base64.urlsafe_b64encode(json.dumps({"sub": "user42"}).encode()).rstrip(b"=").decode()
         token = f"Bearer {header}.{payload}.fakesig"
         assert _extract_jwt_sub(token) == "user42"
 

--- a/autobot-backend/api/a2a.py
+++ b/autobot-backend/api/a2a.py
@@ -62,39 +62,22 @@ router = APIRouter(
 )
 
 # ---------------------------------------------------------------------------
-# Rate limiting (simple in-process token bucket per IP)
+# Rate limiting — per-IP sliding window via shared IPRateLimiter (#7270/#7271)
 # ---------------------------------------------------------------------------
+#
+# #7270: pre-fix, this was an in-process dict with the same multi-worker
+# undercount that #6588 fixed for /v1/chat/completions. State is now shared
+# across all uvicorn workers via Redis sorted-set; the in-process fallback
+# is reserved for Redis outages only.
 
-_RATE_LIMIT = int(os.environ.get("AUTOBOT_A2A_RATE_LIMIT", "30"))  # per minute
-_RATE_BUCKET_MAX_KEYS = 10_000  # evict stale entries when dict exceeds this size
-_rate_buckets: Dict[str, list] = {}  # ip → [timestamps]
+from autobot_shared.rate_limit import IPRateLimiter
 
-
-def _check_rate_limit(remote_addr: str) -> None:
-    """
-    Enforce a per-IP rate limit on task submissions.
-
-    Raises HTTP 429 if the caller has exceeded _RATE_LIMIT requests/minute.
-    Uses a sliding window stored in _rate_buckets (in-process, per worker).
-
-    Stale entries (IPs whose entire window has expired) are evicted when the
-    dict exceeds _RATE_BUCKET_MAX_KEYS to prevent unbounded memory growth.
-    """
-    now = time.time()
-    window_start = now - 60
-    bucket = [t for t in _rate_buckets.get(remote_addr, []) if t > window_start]
-    if len(bucket) >= _RATE_LIMIT:
-        raise HTTPException(
-            status_code=429,
-            detail=f"A2A rate limit exceeded ({_RATE_LIMIT} tasks/min). Try again later.",
-        )
-    bucket.append(now)
-    _rate_buckets[remote_addr] = bucket
-    if len(_rate_buckets) > _RATE_BUCKET_MAX_KEYS:
-        cutoff = now - 60
-        stale = [ip for ip, ts in _rate_buckets.items() if not any(t > cutoff for t in ts)]
-        for ip in stale:
-            del _rate_buckets[ip]
+_a2a_limiter = IPRateLimiter(
+    key_prefix="ratelimit:a2a",
+    limit_env="AUTOBOT_A2A_RATE_LIMIT",
+    default_limit=30,
+    window_seconds=60,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -180,9 +163,7 @@ async def get_signed_agent_card(request: Request) -> Dict[str, Any]:
     try:
         signed = SecurityCardSigner.sign(card.to_dict())
     except RuntimeError as exc:
-        raise HTTPException(
-            status_code=503, detail="Service temporarily unavailable"
-        ) from exc
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable") from exc
     return signed
 
 
@@ -222,7 +203,7 @@ async def submit_task(
     Poll GET /tasks/{id} to retrieve results.
     """
     addr = _remote_addr(request)
-    _check_rate_limit(addr)
+    await _a2a_limiter.check_or_429(addr)
 
     jwt_sub = _extract_jwt_sub(authorization)
     caller_id = extract_caller_id(x_a2a_agent_id, jwt_sub, addr)
@@ -383,9 +364,7 @@ async def stream_task_events(task_id: str) -> StreamingResponse:
                                 await queue.put(None)  # sentinel — stop the loop
                                 return
                         except Exception:
-                            logger.debug(
-                                "Could not parse pub/sub payload for task %s", task_id
-                            )
+                            logger.debug("Could not parse pub/sub payload for task %s", task_id)
             except Exception as exc:
                 logger.warning("pubsub listener error for task %s: %s", task_id, exc)
                 await queue.put(None)  # unblock the outer loop on Redis failure

--- a/autobot-backend/api/openai_compat.py
+++ b/autobot-backend/api/openai_compat.py
@@ -50,91 +50,21 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["openai-compat"])
 
 # ---------------------------------------------------------------------------
-# Rate limiting — per-IP sliding window via Redis sorted-set (#6588)
+# Rate limiting — per-IP sliding window via shared IPRateLimiter (#7271)
 # ---------------------------------------------------------------------------
+#
+# #6588 originally hand-rolled the Redis sorted-set + in-process fallback
+# directly here. #7271 extracted that into autobot_shared/rate_limit.py so
+# it can be reused by /a2a (#7270) and any future per-IP limiter.
 
-_OAI_RATE_LIMIT = int(os.environ.get("AUTOBOT_OAI_RATE_LIMIT", "60"))  # per minute
-_OAI_RATE_BUCKET_MAX_KEYS = 10_000
-# #6588: in-process fallback only — used when Redis is unavailable. Production
-# uses the Redis sorted-set path so all uvicorn workers share state.
-_oai_rate_buckets: Dict[str, list] = {}
+from autobot_shared.rate_limit import IPRateLimiter
 
-
-def _check_oai_rate_limit_inprocess(remote_addr: str) -> None:
-    """Fallback per-IP rate limit when Redis is unavailable (#6588).
-
-    Per-process state — does NOT enforce the documented limit across uvicorn
-    workers. Only used when Redis is unreachable; the Redis path is the
-    production-correct enforcement.
-    """
-    now = time.time()
-    window_start = now - 60
-    bucket = [t for t in _oai_rate_buckets.get(remote_addr, []) if t > window_start]
-    if len(bucket) >= _OAI_RATE_LIMIT:
-        raise HTTPException(
-            status_code=429,
-            detail=f"Rate limit exceeded ({_OAI_RATE_LIMIT} requests/min). Try again later.",
-        )
-    bucket.append(now)
-    _oai_rate_buckets[remote_addr] = bucket
-    if len(_oai_rate_buckets) > _OAI_RATE_BUCKET_MAX_KEYS:
-        cutoff = now - 60
-        stale = [ip for ip, ts in _oai_rate_buckets.items() if not any(t > cutoff for t in ts)]
-        for ip in stale:
-            del _oai_rate_buckets[ip]
-
-
-async def _check_oai_rate_limit(remote_addr: str) -> None:
-    """Enforce a per-IP rate limit on /v1/chat/completions requests.
-
-    #6588: state is shared across all uvicorn workers via Redis sorted-set
-    (per-IP key, score=timestamp). Previous in-process dict made the effective
-    limit 4× the configured value under ``backend_workers: 4`` because each
-    worker had its own state. The Redis sliding window:
-
-      ZREMRANGEBYSCORE  ratelimit:oai:<ip>  0  (now-60)   # drop expired
-      ZADD              ratelimit:oai:<ip>  now  uuid
-      ZCARD             ratelimit:oai:<ip>                # current count
-      EXPIRE            ratelimit:oai:<ip>  120           # auto-evict idle keys
-
-    All four ops are pipelined atomically. If Redis is unreachable the helper
-    falls back to ``_check_oai_rate_limit_inprocess`` so the endpoint stays
-    responsive (degraded mode logs a warning).
-
-    Raises HTTPException(429) if the caller has exceeded ``_OAI_RATE_LIMIT``
-    requests in the last 60 seconds.
-    """
-    from autobot_shared.redis_client import get_async_redis_client
-
-    redis = await get_async_redis_client()
-    if redis is None:
-        logger.warning(
-            "Redis unavailable for OAI rate-limit; falling back to in-process bucket (per-worker, undercounts under multi-worker)"
-        )
-        _check_oai_rate_limit_inprocess(remote_addr)
-        return
-
-    key = f"ratelimit:oai:{remote_addr}"
-    now = time.time()
-    window_start = now - 60
-    try:
-        async with redis.pipeline(transaction=False) as pipe:
-            pipe.zremrangebyscore(key, 0, window_start)
-            pipe.zadd(key, {f"{now}:{uuid4()}": now})
-            pipe.zcard(key)
-            pipe.expire(key, 120)
-            results = await pipe.execute()
-        count = int(results[2])
-    except Exception as exc:
-        logger.warning("Redis OAI rate-limit pipeline failed (%s) — falling back to in-process", exc)
-        _check_oai_rate_limit_inprocess(remote_addr)
-        return
-
-    if count > _OAI_RATE_LIMIT:
-        raise HTTPException(
-            status_code=429,
-            detail=f"Rate limit exceeded ({_OAI_RATE_LIMIT} requests/min). Try again later.",
-        )
+_oai_limiter = IPRateLimiter(
+    key_prefix="ratelimit:oai",
+    limit_env="AUTOBOT_OAI_RATE_LIMIT",
+    default_limit=60,
+    window_seconds=60,
+)
 
 
 def _remote_addr(request: Request) -> str:
@@ -304,7 +234,7 @@ async def chat_completions(
     OpenAI-format response (streaming or non-streaming).
     """
     _get_user(request)
-    await _check_oai_rate_limit(_remote_addr(request))
+    await _oai_limiter.check_or_429(_remote_addr(request))
 
     registry = get_provider_registry()
     llm_request = _build_llm_request(body)

--- a/autobot-backend/api/openai_compat_test.py
+++ b/autobot-backend/api/openai_compat_test.py
@@ -2,174 +2,41 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Unit tests for openai_compat._check_oai_rate_limit (Issue #6588).
+Integration tests for the openai_compat rate-limit wiring (#7271).
 
-Background: rate-limit state used to live in a per-process dict, so under
-``backend_workers: 4`` the effective limit was 4× the configured value
-(each worker tracked its own state). #6588 migrates the state to a Redis
-sorted-set so all workers share enforcement.
+Per-IP rate-limit logic itself lives in
+``autobot_shared.rate_limit.IPRateLimiter`` and is comprehensively tested
+in ``autobot_shared/rate_limit_test.py`` (covers Redis path, in-process
+fallback, env-driven limit, etc.).
 
-Tests pin:
-  * Redis path: ZREMRANGEBYSCORE + ZADD + ZCARD + EXPIRE pipelined
-  * Below-limit: no 429
-  * At-limit: HTTPException 429
-  * Redis unavailable: falls back to in-process bucket (degraded mode)
-  * Pipeline error: falls back to in-process bucket (degraded mode)
+This file pins the openai_compat-specific configuration of that helper:
+the right key prefix, the right env var, and that the helper is the same
+instance referenced by the request handler.
+
+Pre-#7271 this file tested the standalone ``_check_oai_rate_limit``
+function shipped in #6588. That function was extracted into the shared
+helper, so the tests are now at the helper-level and the integration
+tests below pin the per-endpoint configuration.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
-from fastapi import HTTPException
+from autobot_shared.rate_limit import IPRateLimiter
 
 from api import openai_compat
 
 
-class _FakePipeline:
-    """Minimal async-context-manager pipeline mock for redis.pipeline()."""
+class TestOAIRateLimitWiring:
+    """Issue #7271: openai_compat uses the shared IPRateLimiter."""
 
-    def __init__(self, zcard_result: int) -> None:
-        self._zcard_result = zcard_result
-        self.commands: list = []
+    def test_module_exposes_limiter_instance(self):
+        """``_oai_limiter`` must be an IPRateLimiter (not the legacy func)."""
+        assert isinstance(openai_compat._oai_limiter, IPRateLimiter)
 
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        return False
-
-    def zremrangebyscore(self, *args, **kwargs):
-        self.commands.append(("zremrangebyscore", args, kwargs))
-        return self
-
-    def zadd(self, *args, **kwargs):
-        self.commands.append(("zadd", args, kwargs))
-        return self
-
-    def zcard(self, *args, **kwargs):
-        self.commands.append(("zcard", args, kwargs))
-        return self
-
-    def expire(self, *args, **kwargs):
-        self.commands.append(("expire", args, kwargs))
-        return self
-
-    async def execute(self):
-        # ZREMRANGEBYSCORE → int dropped, ZADD → int added,
-        # ZCARD → int count, EXPIRE → bool. Index 2 is the count.
-        return [0, 1, self._zcard_result, True]
-
-
-def _fake_redis(zcard_result: int) -> MagicMock:
-    fake = MagicMock()
-    fake.pipeline = MagicMock(return_value=_FakePipeline(zcard_result))
-    return fake
-
-
-class TestCheckOAIRateLimit:
-    """Issue #6588: Redis-backed sliding window."""
-
-    @pytest.mark.asyncio
-    async def test_below_limit_does_not_raise(self):
-        with (
-            patch.object(
-                openai_compat,
-                "_OAI_RATE_LIMIT",
-                60,
-            ),
-            patch(
-                "autobot_shared.redis_client.get_async_redis_client",
-                new=AsyncMock(return_value=_fake_redis(zcard_result=10)),
-            ),
-        ):
-            # Under the limit, no exception.
-            await openai_compat._check_oai_rate_limit("1.2.3.4")
-
-    @pytest.mark.asyncio
-    async def test_at_limit_raises_429(self):
-        with (
-            patch.object(
-                openai_compat,
-                "_OAI_RATE_LIMIT",
-                5,
-            ),
-            patch(
-                "autobot_shared.redis_client.get_async_redis_client",
-                new=AsyncMock(return_value=_fake_redis(zcard_result=6)),
-            ),
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await openai_compat._check_oai_rate_limit("9.9.9.9")
-            assert exc_info.value.status_code == 429
-            assert "Rate limit exceeded" in exc_info.value.detail
-
-    @pytest.mark.asyncio
-    async def test_pipeline_uses_correct_key_and_ops(self):
-        """Verify the pipeline is built with the right key + 4 ops."""
-        fake_pipe = _FakePipeline(zcard_result=1)
-        fake_redis = MagicMock()
-        fake_redis.pipeline = MagicMock(return_value=fake_pipe)
-
-        with patch(
-            "autobot_shared.redis_client.get_async_redis_client",
-            new=AsyncMock(return_value=fake_redis),
-        ):
-            await openai_compat._check_oai_rate_limit("203.0.113.1")
-
-        # All 4 ops were enqueued in order.
-        op_names = [c[0] for c in fake_pipe.commands]
-        assert op_names == ["zremrangebyscore", "zadd", "zcard", "expire"]
-
-        # Each op uses the per-IP key.
-        for _, args, _ in fake_pipe.commands:
-            assert args[0] == "ratelimit:oai:203.0.113.1"
-
-    @pytest.mark.asyncio
-    async def test_redis_unavailable_falls_back_to_inprocess(self, caplog):
-        """Redis None → fallback to per-process bucket (degraded mode)."""
-        import logging
-
-        # Reset in-process bucket for clean state.
-        openai_compat._oai_rate_buckets.clear()
-
-        with (
-            patch.object(openai_compat, "_OAI_RATE_LIMIT", 60),
-            patch(
-                "autobot_shared.redis_client.get_async_redis_client",
-                new=AsyncMock(return_value=None),
-            ),
-        ):
-            with caplog.at_level(logging.WARNING, logger="api.openai_compat"):
-                await openai_compat._check_oai_rate_limit("8.8.8.8")
-        # Bucket got the IP recorded in fallback path.
-        assert "8.8.8.8" in openai_compat._oai_rate_buckets
-        assert any("Redis unavailable" in r.getMessage() for r in caplog.records)
-
-    @pytest.mark.asyncio
-    async def test_pipeline_error_falls_back_to_inprocess(self, caplog):
-        """Redis pipeline raises → fallback to per-process bucket."""
-        import logging
-
-        openai_compat._oai_rate_buckets.clear()
-
-        class _BrokenPipeline:
-            async def __aenter__(self):
-                raise RuntimeError("redis down mid-pipeline")
-
-            async def __aexit__(self, *a):
-                return False
-
-        broken = MagicMock()
-        broken.pipeline = MagicMock(return_value=_BrokenPipeline())
-
-        with (
-            patch.object(openai_compat, "_OAI_RATE_LIMIT", 60),
-            patch(
-                "autobot_shared.redis_client.get_async_redis_client",
-                new=AsyncMock(return_value=broken),
-            ),
-        ):
-            with caplog.at_level(logging.WARNING, logger="api.openai_compat"):
-                await openai_compat._check_oai_rate_limit("4.4.4.4")
-        assert "4.4.4.4" in openai_compat._oai_rate_buckets
-        assert any("pipeline failed" in r.getMessage() for r in caplog.records)
+    def test_limiter_uses_oai_specific_config(self):
+        """The instance is configured for the /v1/chat/completions endpoint."""
+        limiter = openai_compat._oai_limiter
+        # #6588 / #7271: prefix shared across uvicorn workers via Redis key.
+        assert limiter._key_prefix == "ratelimit:oai"
+        # AUTOBOT_OAI_RATE_LIMIT env var; default 60/min preserved.
+        assert limiter._limit_env == "AUTOBOT_OAI_RATE_LIMIT"
+        assert limiter._default_limit == 60
+        assert limiter._window_seconds == 60

--- a/autobot_shared/rate_limit.py
+++ b/autobot_shared/rate_limit.py
@@ -1,0 +1,182 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Shared per-key sliding-window rate limiter (#7271).
+
+Consolidates the duplicated implementation that previously lived (with
+subtle differences and at least one P1 bug) in:
+
+  * autobot-backend/api/openai_compat.py:_check_oai_rate_limit  (#6588)
+  * autobot-backend/api/a2a.py:_check_rate_limit                (#7270)
+
+State is shared across all uvicorn workers via a Redis sorted-set keyed
+by ``f"{key_prefix}:{key}"``. Pipeline of:
+
+    ZREMRANGEBYSCORE  <key>  0  (now - window_seconds)   # drop expired
+    ZADD              <key>  now  uuid                   # record this request
+    ZCARD             <key>                              # count after add
+    EXPIRE            <key>  2 * window_seconds          # auto-evict idle keys
+
+If Redis is unavailable (or the pipeline raises), the limiter falls back
+to a per-process in-memory bucket so the endpoint stays responsive.
+Degraded mode logs a warning and accepts the per-worker undercount —
+strictly better than fail-closed for /v1/chat/completions.
+
+Usage::
+
+    from autobot_shared.rate_limit import IPRateLimiter
+
+    _oai_limiter = IPRateLimiter(
+        key_prefix="ratelimit:oai",
+        limit_env="AUTOBOT_OAI_RATE_LIMIT",
+        default_limit=60,
+        window_seconds=60,
+    )
+
+    @router.post("/v1/chat/completions")
+    async def chat_completions(...):
+        await _oai_limiter.check_or_429(remote_addr)
+        ...
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+from fastapi import HTTPException
+
+logger = logging.getLogger(__name__)
+
+# Default cap on the in-process fallback bucket — prevents unbounded memory
+# growth when Redis has been unavailable for an extended window.
+_DEFAULT_BUCKET_MAX_KEYS = 10_000
+
+
+class IPRateLimiter:
+    """Per-key sliding-window rate limiter, Redis-backed with in-process fallback.
+
+    Args:
+        key_prefix: Stable prefix for Redis keys (e.g. ``"ratelimit:oai"``).
+            The full key is ``f"{key_prefix}:{key}"`` where *key* is whatever
+            is passed to :meth:`check_or_429` (typically a remote IP).
+        limit_env: Environment variable name to read the limit from. If unset
+            or unparseable, *default_limit* is used.
+        default_limit: Fallback limit when *limit_env* is unset or invalid.
+        window_seconds: Sliding window size (default 60).
+        bucket_max_keys: Cap on the in-process fallback bucket size before
+            stale-key eviction kicks in. Only applies to the fallback path.
+
+    The Redis path is the production-correct enforcement; the in-process
+    path exists only so the endpoint stays responsive during Redis outages.
+    """
+
+    def __init__(
+        self,
+        *,
+        key_prefix: str,
+        limit_env: str,
+        default_limit: int,
+        window_seconds: int = 60,
+        bucket_max_keys: int = _DEFAULT_BUCKET_MAX_KEYS,
+    ) -> None:
+        self._key_prefix = key_prefix
+        self._limit_env = limit_env
+        self._default_limit = default_limit
+        self._window_seconds = window_seconds
+        self._bucket_max_keys = bucket_max_keys
+        # Per-process fallback only — production uses Redis sorted-set.
+        self._inprocess_buckets: Dict[str, List[float]] = {}
+
+    @property
+    def limit(self) -> int:
+        """Read the limit from env each call so dynamic config is respected."""
+        try:
+            return int(os.environ.get(self._limit_env, self._default_limit))
+        except (TypeError, ValueError):
+            return self._default_limit
+
+    def _redis_key(self, key: str) -> str:
+        return f"{self._key_prefix}:{key}"
+
+    async def check_or_429(self, key: str) -> None:
+        """Enforce the limit; raise ``HTTPException(429)`` if exceeded.
+
+        Tries Redis first. On Redis unavailability or pipeline error, falls
+        back to the in-process bucket and logs a warning.
+
+        Args:
+            key: Stable per-caller identifier — typically remote IP. Combined
+                with *key_prefix* to form the Redis key.
+        """
+        from autobot_shared.redis_client import get_async_redis_client
+
+        redis = await get_async_redis_client()
+        if redis is None:
+            logger.warning(
+                "Redis unavailable for %s rate-limit; falling back to in-process bucket "
+                "(per-worker, undercounts under multi-worker)",
+                self._key_prefix,
+            )
+            self._check_inprocess_or_429(key)
+            return
+
+        full_key = self._redis_key(key)
+        now = time.time()
+        window_start = now - self._window_seconds
+        try:
+            async with redis.pipeline(transaction=False) as pipe:
+                pipe.zremrangebyscore(full_key, 0, window_start)
+                pipe.zadd(full_key, {f"{now}:{uuid4()}": now})
+                pipe.zcard(full_key)
+                pipe.expire(full_key, 2 * self._window_seconds)
+                results = await pipe.execute()
+            count = int(results[2])
+        except Exception as exc:
+            logger.warning(
+                "Redis %s rate-limit pipeline failed (%s) — falling back to in-process",
+                self._key_prefix,
+                exc,
+            )
+            self._check_inprocess_or_429(key)
+            return
+
+        if count > self.limit:
+            raise HTTPException(
+                status_code=429,
+                detail=f"Rate limit exceeded ({self.limit} requests/{self._window_seconds}s). Try again later.",
+            )
+
+    def _check_inprocess_or_429(self, key: str) -> None:
+        """Per-process fallback (#6588 pattern, retained for outage handling).
+
+        State is per-worker — does NOT enforce the documented limit across
+        uvicorn workers. Only used when Redis is unreachable.
+        """
+        now = time.time()
+        window_start = now - self._window_seconds
+        bucket = [t for t in self._inprocess_buckets.get(key, []) if t > window_start]
+        limit = self.limit
+        if len(bucket) >= limit:
+            raise HTTPException(
+                status_code=429,
+                detail=f"Rate limit exceeded ({limit} requests/{self._window_seconds}s). Try again later.",
+            )
+        bucket.append(now)
+        self._inprocess_buckets[key] = bucket
+        if len(self._inprocess_buckets) > self._bucket_max_keys:
+            cutoff = now - self._window_seconds
+            stale = [k for k, ts in self._inprocess_buckets.items() if not any(t > cutoff for t in ts)]
+            for k in stale:
+                del self._inprocess_buckets[k]
+
+    # Test/debug helper — production code should not depend on this.
+    def _reset_inprocess(self) -> None:  # pragma: no cover
+        self._inprocess_buckets.clear()
+
+
+__all__ = ["IPRateLimiter"]

--- a/autobot_shared/rate_limit_test.py
+++ b/autobot_shared/rate_limit_test.py
@@ -1,0 +1,232 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for autobot_shared.rate_limit.IPRateLimiter (#7271).
+
+This module replaces the per-file rate-limit tests that used to live in
+``autobot-backend/api/openai_compat_test.py`` (#6588). The shared helper
+is exercised here once; both consumers (``openai_compat._oai_limiter`` and
+``a2a._a2a_limiter``) get their behavior covered by these tests through
+the helper.
+
+Tests cover:
+  * Below-limit: no raise
+  * At-limit: HTTPException 429
+  * Pipeline: ZREMRANGEBYSCORE + ZADD + ZCARD + EXPIRE in correct order
+  * Pipeline: per-instance key prefix is honored
+  * Redis unavailable: in-process fallback (degraded mode)
+  * Pipeline error: in-process fallback (degraded mode)
+  * Limit re-read from env each call (dynamic config)
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from autobot_shared.rate_limit import IPRateLimiter
+
+
+class _FakePipeline:
+    """Minimal async-context-manager pipeline mock for redis.pipeline()."""
+
+    def __init__(self, zcard_result: int) -> None:
+        self._zcard_result = zcard_result
+        self.commands: list = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def zremrangebyscore(self, *args, **kwargs):
+        self.commands.append(("zremrangebyscore", args, kwargs))
+        return self
+
+    def zadd(self, *args, **kwargs):
+        self.commands.append(("zadd", args, kwargs))
+        return self
+
+    def zcard(self, *args, **kwargs):
+        self.commands.append(("zcard", args, kwargs))
+        return self
+
+    def expire(self, *args, **kwargs):
+        self.commands.append(("expire", args, kwargs))
+        return self
+
+    async def execute(self):
+        # ZREMRANGEBYSCORE → int dropped, ZADD → int added,
+        # ZCARD → int count, EXPIRE → bool. Index 2 is the count.
+        return [0, 1, self._zcard_result, True]
+
+
+def _fake_redis(zcard_result: int) -> MagicMock:
+    fake = MagicMock()
+    fake.pipeline = MagicMock(return_value=_FakePipeline(zcard_result))
+    return fake
+
+
+def _make_limiter(prefix: str = "ratelimit:test", default_limit: int = 60) -> IPRateLimiter:
+    return IPRateLimiter(
+        key_prefix=prefix,
+        limit_env="UNIT_TEST_RATE_LIMIT",
+        default_limit=default_limit,
+        window_seconds=60,
+    )
+
+
+class TestIPRateLimiterRedisPath:
+    """Issue #7271: shared limiter — Redis pipeline + 429 enforcement."""
+
+    @pytest.mark.asyncio
+    async def test_below_limit_does_not_raise(self):
+        limiter = _make_limiter(default_limit=60)
+        with patch(
+            "autobot_shared.redis_client.get_async_redis_client",
+            new=AsyncMock(return_value=_fake_redis(zcard_result=10)),
+        ):
+            await limiter.check_or_429("1.2.3.4")  # no exception
+
+    @pytest.mark.asyncio
+    async def test_at_limit_raises_429(self):
+        limiter = _make_limiter(default_limit=5)
+        with patch(
+            "autobot_shared.redis_client.get_async_redis_client",
+            new=AsyncMock(return_value=_fake_redis(zcard_result=6)),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await limiter.check_or_429("9.9.9.9")
+            assert exc_info.value.status_code == 429
+            assert "Rate limit exceeded" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_pipeline_uses_correct_key_and_ops(self):
+        """Pipeline must build (key, 4 ops) in the documented order."""
+        fake_pipe = _FakePipeline(zcard_result=1)
+        fake_redis = MagicMock()
+        fake_redis.pipeline = MagicMock(return_value=fake_pipe)
+
+        limiter = _make_limiter(prefix="ratelimit:oai")
+        with patch(
+            "autobot_shared.redis_client.get_async_redis_client",
+            new=AsyncMock(return_value=fake_redis),
+        ):
+            await limiter.check_or_429("203.0.113.1")
+
+        op_names = [c[0] for c in fake_pipe.commands]
+        assert op_names == ["zremrangebyscore", "zadd", "zcard", "expire"]
+
+        # Each op uses the per-instance key prefix.
+        for _, args, _ in fake_pipe.commands:
+            assert args[0] == "ratelimit:oai:203.0.113.1"
+
+    @pytest.mark.asyncio
+    async def test_per_instance_prefix_keeps_buckets_independent(self):
+        """Two limiters with different prefixes must keep keys separate."""
+        oai_pipe = _FakePipeline(zcard_result=1)
+        a2a_pipe = _FakePipeline(zcard_result=1)
+        oai_redis = MagicMock(pipeline=MagicMock(return_value=oai_pipe))
+        a2a_redis = MagicMock(pipeline=MagicMock(return_value=a2a_pipe))
+
+        oai = _make_limiter(prefix="ratelimit:oai")
+        a2a = _make_limiter(prefix="ratelimit:a2a")
+
+        with patch(
+            "autobot_shared.redis_client.get_async_redis_client",
+            new=AsyncMock(return_value=oai_redis),
+        ):
+            await oai.check_or_429("8.8.8.8")
+        with patch(
+            "autobot_shared.redis_client.get_async_redis_client",
+            new=AsyncMock(return_value=a2a_redis),
+        ):
+            await a2a.check_or_429("8.8.8.8")
+
+        assert oai_pipe.commands[0][1][0] == "ratelimit:oai:8.8.8.8"
+        assert a2a_pipe.commands[0][1][0] == "ratelimit:a2a:8.8.8.8"
+
+
+class TestIPRateLimiterFallback:
+    """Issue #7271: shared limiter — in-process fallback paths."""
+
+    @pytest.mark.asyncio
+    async def test_redis_unavailable_falls_back_to_inprocess(self, caplog):
+        """Redis None → fallback to per-process bucket (degraded mode)."""
+        import logging
+
+        limiter = _make_limiter(prefix="ratelimit:fb1", default_limit=60)
+        with patch(
+            "autobot_shared.redis_client.get_async_redis_client",
+            new=AsyncMock(return_value=None),
+        ):
+            with caplog.at_level(logging.WARNING, logger="autobot_shared.rate_limit"):
+                await limiter.check_or_429("8.8.8.8")
+        assert "8.8.8.8" in limiter._inprocess_buckets
+        assert any("Redis unavailable" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_pipeline_error_falls_back_to_inprocess(self, caplog):
+        """Redis pipeline raises → fallback to per-process bucket."""
+        import logging
+
+        class _BrokenPipeline:
+            async def __aenter__(self):
+                raise RuntimeError("redis down mid-pipeline")
+
+            async def __aexit__(self, *a):
+                return False
+
+        broken = MagicMock()
+        broken.pipeline = MagicMock(return_value=_BrokenPipeline())
+
+        limiter = _make_limiter(prefix="ratelimit:fb2", default_limit=60)
+        with patch(
+            "autobot_shared.redis_client.get_async_redis_client",
+            new=AsyncMock(return_value=broken),
+        ):
+            with caplog.at_level(logging.WARNING, logger="autobot_shared.rate_limit"):
+                await limiter.check_or_429("4.4.4.4")
+        assert "4.4.4.4" in limiter._inprocess_buckets
+        assert any("pipeline failed" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_inprocess_at_limit_raises_429(self):
+        """In-process fallback respects the limit too."""
+        limiter = _make_limiter(prefix="ratelimit:fb3", default_limit=2)
+        # Pre-seed bucket so the next call exceeds the limit.
+        import time as _time
+
+        now = _time.time()
+        limiter._inprocess_buckets["7.7.7.7"] = [now, now]  # already at limit
+
+        with patch(
+            "autobot_shared.redis_client.get_async_redis_client",
+            new=AsyncMock(return_value=None),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await limiter.check_or_429("7.7.7.7")
+            assert exc_info.value.status_code == 429
+
+
+class TestIPRateLimiterConfig:
+    """Issue #7271: limit is read from env each call (dynamic config)."""
+
+    def test_limit_property_reads_env(self, monkeypatch):
+        limiter = _make_limiter(default_limit=60)
+        monkeypatch.setenv("UNIT_TEST_RATE_LIMIT", "120")
+        assert limiter.limit == 120
+        monkeypatch.setenv("UNIT_TEST_RATE_LIMIT", "5")
+        assert limiter.limit == 5
+
+    def test_limit_falls_back_to_default_when_env_unparseable(self, monkeypatch):
+        limiter = _make_limiter(default_limit=60)
+        monkeypatch.setenv("UNIT_TEST_RATE_LIMIT", "not-a-number")
+        assert limiter.limit == 60
+
+    def test_limit_uses_default_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("UNIT_TEST_RATE_LIMIT", raising=False)
+        limiter = _make_limiter(default_limit=60)
+        assert limiter.limit == 60


### PR DESCRIPTION
## Summary

Closes [#7271](https://github.com/mrveiss/AutoBot-AI/issues/7271) (consolidation) AND [#7270](https://github.com/mrveiss/AutoBot-AI/issues/7270) (a2a.py P1 multi-worker rate-limit bug).

\`\`\`
api/openai_compat.py:_check_oai_rate_limit  (#6588 — Redis path, just shipped)
api/a2a.py:_check_rate_limit                 (still in-process, P1 bug per #7270)
\`\`\`

Both implementations were 80%+ identical. Rather than copy-paste the #6588 fix into a2a.py, extracted the helper:

\`\`\`python
# autobot_shared/rate_limit.py
class IPRateLimiter:
    def __init__(self, *, key_prefix, limit_env, default_limit, window_seconds=60): ...
    async def check_or_429(self, key: str) -> None:
        # Redis sorted-set + in-process fallback on Redis outage
\`\`\`

## Test plan

- [x] \`pytest autobot_shared/rate_limit_test.py\` → 10/10 (Redis path, fallback paths, env-driven limit, prefix isolation)
- [x] \`pytest autobot-backend/api/openai_compat_test.py\` → 2/2 (wiring tests)
- [x] \`pytest autobot-backend/a2a/a2a_security_test.py::TestRateLimiting\` → 3/3 (rewritten to use shared limiter via in-process fallback)
- [x] py_compile clean; black-formatted (-line-length=120)
- [ ] Live verify post-deploy: send 240 req/min from one IP to /v1/chat/completions with limit=60 → expect ~180 get 429
- [ ] Live verify post-deploy: same shape on /api/a2a/tasks with limit=30

## Out of scope

\`utils/conversation_rate_limiter.py\` and \`utils/claude_api_optimization_suite.py\` are different shape (outbound API budget tracking with payload size, not per-IP HTTP limiting). They stay as-is.

## Closes

- #7271 — refactor: consolidate 4+ in-process rate-limit implementations  
- #7270 — security(P1): a2a.py multi-worker undercount (now fixed via the shared helper)