### PR TITLE
fix(audit-script): catch dynamic import() / require() / .d.ts FP classes (#6872 part 2)

### DIFF
--- a/pipeline-scripts/audit-unwired-trackers.py
+++ b/pipeline-scripts/audit-unwired-trackers.py
@@ -159,6 +159,14 @@ def is_entry_point_script(path: Path) -> bool:
     return any(part in ENTRY_POINT_DIR_NAMES for part in path.parts)
 
 
+def is_ambient_type_declaration(path: Path) -> bool:
+    """TypeScript ``.d.ts`` files are wired via ``tsconfig.json`` ``include`` paths,
+    not via explicit imports. Without this skip, every ambient-types file is
+    flagged with 0 callers (#6872b — sibling FP class to entry-point scripts).
+    """
+    return path.name.endswith(".d.ts")
+
+
 def should_skip_path(path: Path) -> bool:
     """Skip caches/build dirs/worktrees/migrations.
 
@@ -232,10 +240,31 @@ def extract_tracker_refs(file_path: Path) -> list[int]:
 
 
 def grep_count_production_callers(stem: str, self_path: Path) -> int:
-    """Return number of production import lines referencing `stem`."""
+    """Return number of production import lines referencing `stem`.
+
+    Catches both static and dynamic-loading patterns (#6872b widening):
+    - ``from X import Y`` — Python static
+    - ``import X`` — Python static
+    - ``import('@/path/X.vue')`` — JS/TS dynamic ES-module import
+    - ``require('./X')`` — CommonJS / Vite require
+    - ``importlib.import_module("X")`` — Python dynamic
+    - ``__import__("X")`` — Python dynamic
+
+    The first two require a literal space after the keyword; the dynamic
+    forms allow any character before the stem inside the call-arg parens
+    so paths like ``@/views/CustomDashboard.vue`` and dotted module paths
+    like ``autobot.foo`` both register as callers.
+    """
     if stem in AMBIGUOUS_STEMS:
         return -1  # skip
-    pattern = rf"from .*\b{stem}\b|import .*\b{stem}\b"
+    pattern = (
+        rf"from .*\b{stem}\b"  # py static `from X import …`
+        rf"|import .*\b{stem}\b"  # py/ts static `import X` (note: requires space)
+        rf"|import\([^)]*\b{stem}\b"  # ts/js dynamic `import('…/X')`
+        rf"|require\([^)]*\b{stem}\b"  # ts/js cjs `require('./X')`
+        rf"|importlib\.[a-z_]+\([^)]*\b{stem}\b"  # py `importlib.import_module(…)`
+        rf"|__import__\([^)]*\b{stem}\b"  # py `__import__(…)`
+    )
     cmd = [
         "grep",
         "-rn",
@@ -350,6 +379,10 @@ def scan() -> list[Finding]:
                 # /bin/) are designed to be invoked from CLI; 0 callers is
                 # by-design, not unwired.
                 if is_entry_point_script(f):
+                    continue
+                # #6872b: TypeScript ambient declaration (.d.ts) files are
+                # wired via tsconfig.json include paths, not via imports.
+                if is_ambient_type_declaration(f):
                     continue
                 # #7109: skip files registered via router_registry tuples;
                 # they're wired at runtime via dotted-path lookup which the

--- a/pipeline-scripts/test_audit_unwired_trackers.py
+++ b/pipeline-scripts/test_audit_unwired_trackers.py
@@ -203,6 +203,58 @@ def test_grep_count_handles_timeout() -> None:
 
 
 # ---------------------------------------------------------------------------
+# grep regex coverage — #6872b widening for dynamic-import patterns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "caller_line,stem,should_match",
+    [
+        # Static patterns — already worked pre-#6872b
+        ("from auth_rbac import require_permission", "auth_rbac", True),
+        ("import auth_rbac", "auth_rbac", True),
+        # JS/TS dynamic ES-module imports — the FP class this PR fixes
+        ("    component: () => import('@/views/CustomDashboard.vue'),", "CustomDashboard", True),
+        ("const m = await import('./modules/MyModule.js')", "MyModule", True),
+        # CommonJS / Vite require()
+        ("const x = require('./helpers/MyHelper.ts')", "MyHelper", True),
+        # Python dynamic loaders
+        ("mod = importlib.import_module('autobot.foo')", "foo", True),
+        ("mod = __import__('my_module')", "my_module", True),
+        # Negative: stem appearing only in unrelated code (no import-shape) doesn't match
+        ("logger.info('message about CustomDashboard usage')", "CustomDashboard", False),
+        ("self.helper = MyHelper()", "MyHelper", False),
+    ],
+)
+def test_grep_count_regex_pattern_shapes(
+    caller_line: str, stem: str, should_match: bool, tmp_path: Path
+) -> None:
+    """Verify the regex used by grep matches both static and dynamic imports.
+
+    Constructs the same regex the script uses and runs it via Python's `re`
+    so the test isn't coupled to system grep's specific dialect.
+    """
+    import re
+
+    # Mirror the script's pattern construction exactly
+    pattern = (
+        rf"from .*\b{stem}\b"
+        rf"|import .*\b{stem}\b"
+        rf"|import\([^)]*\b{stem}\b"
+        rf"|require\([^)]*\b{stem}\b"
+        rf"|importlib\.[a-z_]+\([^)]*\b{stem}\b"
+        rf"|__import__\([^)]*\b{stem}\b"
+    )
+    matched = re.search(pattern, caller_line) is not None
+    assert matched is should_match, (
+        f"pattern: {pattern!r}\n"
+        f"line:    {caller_line!r}\n"
+        f"stem:    {stem!r}\n"
+        f"expected match={should_match}, got match={matched}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # fetch_closed_tracker_set — gh JSON parsing + error path
 # ---------------------------------------------------------------------------
 
@@ -375,6 +427,22 @@ def test_scan_skips_router_registry_modules(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # is_entry_point_script — #7128b runner-script + demos/scripts/bin filter
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path,is_dts",
+    [
+        (Path("autobot-frontend/src/types/global.d.ts"), True),
+        (Path("autobot-frontend/src/config/AppConfig.d.ts"), True),
+        # Negative: regular .ts file
+        (Path("autobot-frontend/src/utils/helper.ts"), False),
+        # Negative: filename ends in .d.ts but it's a directory marker (.d.ts in path component)
+        # This shouldn't ever happen but let's be explicit:
+        (Path("autobot-frontend/src/types/foo.ts"), False),
+    ],
+)
+def test_is_ambient_type_declaration(path: Path, is_dts: bool) -> None:
+    assert audit.is_ambient_type_declaration(path) is is_dts
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Real audit count post-#7244 was **105** (not the masked-0 from the closure proof on #7128 — see #7244 for the postmortem). Sampling those 105 surfaced two more FP classes:

1. **Dynamic ES-module imports** in TS/Vue routers: \`() => import('@/views/CustomDashboard.vue')\`. The audit's regex required a literal space after \`import\` — missing the \`(\` form. \`CustomDashboard.vue\` was flagged with 0 callers despite being wired in \`router/index.ts:554\`.

2. **TypeScript ambient declaration files** (\`.d.ts\`). These are wired via \`tsconfig.json\` \`include\` paths, never via \`import\` — 0-caller reports are by design.

## Fixes

### \`grep_count_production_callers\` regex widened to also match:
| Pattern | Catches |
|---|---|
| \`import\(...X)\` | JS/TS dynamic ES-module imports |
| \`require\(...X)\` | CommonJS / Vite |
| \`importlib.<fn>(...X)\` | Python dynamic |
| \`__import__(...X)\` | Python dynamic |

### New \`is_ambient_type_declaration(path)\` helper
Skips \`*.d.ts\` files in \`scan()\` — same pattern as #7128b's \`is_entry_point_script\`.

## Test deltas

- **+9 parametrized cases** for the widened regex covering each new shape with positive + negative coverage (e.g. \`logger.info('CustomDashboard usage')\` correctly does NOT match).
- **+4 cases** for \`is_ambient_type_declaration\`.
- **76/76 audit-script tests pass.**

## Audit count drop

| Stage | Count | Notes |
|---|---|---|
| Original (pre-fixes) | 252 | feature_routers.py + test_*.py + worktree-skip all conspired |
| After #7168 (test-prefix + registry) | 165 | worktree-skip still hid real count |
| After #7244 (entry-point + worktree-skip) | 105 | actual real count exposed |
| After this PR | **85** | dynamic-imports + .d.ts excluded |

The remaining 85 are increasingly likely to be **genuine wire-in candidates** rather than FPs. Bulk-filing per #6872's original intent is now closer to safe.

## Acceptance criteria

- [x] Widen \`grep_count_production_callers\` for the dynamic-import patterns explicitly called out in #7109's discovery body
- [x] Skip \`.d.ts\` ambient declarations
- [x] Tests cover the new patterns + edge cases (don't false-positive on log messages mentioning the stem)
- [x] Re-running audit shows count drop with no false-negatives introduced (sample-checked 5 of the remaining 85)

Refs #6872 (parent), #7109 (the gap was explicitly listed in this issue's body), #7244 (companion fix that exposed the real count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)