### PR TITLE
fix(system-health): reject sync probes at registration time (#6918)

### DIFF
--- a/autobot-backend/api/system_health.py
+++ b/autobot-backend/api/system_health.py
@@ -64,22 +64,33 @@ def register_health_probe(name: str) -> Callable[[ProbeFn], ProbeFn]:
     Re-registering the same name overwrites and logs a warning — the
     rightmost import wins. This avoids duplicate-registration crashes when a
     module is reloaded (e.g. tests).
+
+    #6918: rejects sync probes at registration time. ``_run_probe`` enforces
+    ``_PROBE_TIMEOUT_S`` via ``asyncio.wait_for``, but ``wait_for`` only
+    cancels at ``await`` points — a sync probe that blocks the event loop
+    (e.g. ``time.sleep``, sync ``redis.ping``) holds the aggregator past the
+    timeout. The aggregator's documented invariant ("a slow component
+    cannot hold the aggregator hostage") is only true when every probe is
+    properly async. Catch the obvious case at registration; this shifts a
+    silent-prod-hang into an immediate import-time TypeError.
     """
 
     def _decorate(fn: ProbeFn) -> ProbeFn:
-        if name in _PROBES:
-            logger.warning(
-                "register_health_probe: %r already registered, overwriting", name
+        if not asyncio.iscoroutinefunction(fn):
+            raise TypeError(
+                f"register_health_probe({name!r}): probe must be `async def` — "
+                f"sync probes block the event loop and cannot be cancelled by "
+                f"the {_PROBE_TIMEOUT_S}s timeout. See #6918."
             )
+        if name in _PROBES:
+            logger.warning("register_health_probe: %r already registered, overwriting", name)
         _PROBES[name] = fn
         return fn
 
     return _decorate
 
 
-async def _run_probe(
-    name: str, fn: ProbeFn, request: Optional[Request]
-) -> ComponentHealth:
+async def _run_probe(name: str, fn: ProbeFn, request: Optional[Request]) -> ComponentHealth:
     started = time.perf_counter()
     try:
         result = await asyncio.wait_for(fn(request), timeout=_PROBE_TIMEOUT_S)
@@ -99,11 +110,7 @@ async def _run_probe(
             latency_ms=round((time.perf_counter() - started) * 1000, 2),
         )
     if result.latency_ms is None:
-        result = result.model_copy(
-            update={
-                "latency_ms": round((time.perf_counter() - started) * 1000, 2)
-            }
-        )
+        result = result.model_copy(update={"latency_ms": round((time.perf_counter() - started) * 1000, 2)})
     return result
 
 
@@ -261,13 +268,9 @@ def probe_app_state(probe_name: str, attr: str) -> ProbeFn:
     return _probe
 
 
-def register_singleton_probe(
-    name: str, getter: Callable, *, async_getter: bool = False
-) -> None:
+def register_singleton_probe(name: str, getter: Callable, *, async_getter: bool = False) -> None:
     """One-line wrapper: build + register a singleton-resolve probe."""
-    register_health_probe(name)(
-        probe_singleton(name, getter, async_getter=async_getter)
-    )
+    register_health_probe(name)(probe_singleton(name, getter, async_getter=async_getter))
 
 
 def register_redis_probe(name: str, *, database: str = "main") -> None:

--- a/autobot-backend/api/system_health_test.py
+++ b/autobot-backend/api/system_health_test.py
@@ -1,0 +1,84 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for system_health.register_health_probe sync-probe rejection (#6918).
+
+Background: ``_run_probe`` enforces ``_PROBE_TIMEOUT_S`` via ``asyncio.wait_for``
+but ``wait_for`` only cancels at ``await`` points. A sync probe that blocks
+the event loop (e.g. ``time.sleep``) holds the aggregator past the timeout.
+The fix rejects sync probes at registration time so the failure shows up at
+import time as ``TypeError`` rather than a silent prod hang.
+"""
+
+import pytest
+
+from api.system_health import _PROBES, register_health_probe
+
+
+class TestRegisterHealthProbeSyncRejection:
+    """Issue #6918: sync probes must be rejected at registration time."""
+
+    def teardown_method(self):
+        # Don't leak test-registered probes into other test files.
+        for name in list(_PROBES.keys()):
+            if name.startswith("test_6918_"):
+                del _PROBES[name]
+
+    def test_async_probe_registers_successfully(self):
+        async def my_async_probe(request):
+            from api.system_health import ComponentHealth
+
+            return ComponentHealth(name="test_6918_a", status="ok")
+
+        # Should NOT raise.
+        decorated = register_health_probe("test_6918_a")(my_async_probe)
+        assert "test_6918_a" in _PROBES
+        assert decorated is my_async_probe  # decorator returns the original fn
+
+    def test_sync_probe_raises_typeerror(self):
+        def my_sync_probe(request):
+            from api.system_health import ComponentHealth
+
+            return ComponentHealth(name="test_6918_b", status="ok")
+
+        with pytest.raises(TypeError, match="must be `async def`"):
+            register_health_probe("test_6918_b")(my_sync_probe)
+
+        # Crucially: the rejected probe is NOT in the registry.
+        assert "test_6918_b" not in _PROBES
+
+    def test_sync_probe_error_mentions_issue_number(self):
+        """Error message points contributors to the issue for context."""
+
+        def sleeper(request):
+            import time
+
+            time.sleep(5)  # the exact pattern that motivated #6918
+
+        with pytest.raises(TypeError) as exc_info:
+            register_health_probe("test_6918_c")(sleeper)
+        assert "#6918" in str(exc_info.value)
+
+    def test_lambda_probe_rejected(self):
+        """Lambdas (also sync) must be rejected — narrow but real footgun."""
+        with pytest.raises(TypeError, match="must be `async def`"):
+            register_health_probe("test_6918_d")(lambda r: None)
+
+    def test_async_probe_after_failed_registration_succeeds(self):
+        """Failed registration must not corrupt registry state."""
+
+        def bad(request):
+            return None
+
+        with pytest.raises(TypeError):
+            register_health_probe("test_6918_e")(bad)
+
+        async def good(request):
+            from api.system_health import ComponentHealth
+
+            return ComponentHealth(name="test_6918_e", status="ok")
+
+        # Same name; should now succeed since the bad one was rejected.
+        register_health_probe("test_6918_e")(good)
+        assert "test_6918_e" in _PROBES


### PR DESCRIPTION
## Summary

\`_run_probe\` enforces \`_PROBE_TIMEOUT_S\` (2s) via \`asyncio.wait_for\` — but \`wait_for\` only cancels at \`await\` points. A sync probe blocking the event loop holds the aggregator past the timeout, contradicting the documented "a slow component cannot hold the aggregator hostage" invariant.

Picked **Option B** from the issue ("Validate at registration time") — cheapest defensive fix. \`register_health_probe\` now raises \`TypeError\` with a pointer to #6918 when given a non-coroutine function. Failure shifts from a silent prod hang to an immediate import-time error.

## Test plan

- [x] \`pytest autobot-backend/api/system_health_test.py -xvs\` → 5/5 pass:
  - async probe registers OK
  - sync probe raises TypeError
  - error message points to #6918
  - lambda probe rejected
  - failed registration doesn't corrupt registry
- [x] **Audit:** grep'd all \`@register_health_probe\` usages — every existing probe is \`async def\`. Boot-safe.
- [x] py_compile clean; black-formatted

## Out of scope

- Option A (\`asyncio.shield\` + threadpool) — invasive runtime cost, unjustified when registration-time check works.
- Option C (CI lint flagging \`time.sleep\`/sync \`requests\` inside probes) — covered conceptually by #7083 actionlint umbrella + the new TypeError surfaces at module import time.

Closes #6918