### PR TITLE
feat(tools/lint): pre-commit hook flagging patch("src.*") mock paths (closes #7165, #7173)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,25 @@ repos:
         stages: [pre-commit]
         description: "Use autobot_shared.time_utils.utc_timestamp() instead of datetime.utcnow().isoformat()"
 
+  # AutoBot custom: regression-prevention for #6987 broken `src.*` mock paths.
+  # autobot-backend has no `src/` package; ``patch("src.foo.bar")`` silently
+  # no-ops (ModuleNotFoundError swallowed by `with` cleanup). Production
+  # code runs unmocked, tests pass on stale-mock-luck. #6987 found 48 such
+  # sites that masked years of real production drift (#7147, #7154, #7161,
+  # #7216, #7237, #7251, …). #6987 fixed the 48 existing violations; this
+  # hook prevents the next contributor from reintroducing the pattern.
+  # AST-based detection covers all import forms: patch(), mock.patch(),
+  # unittest.mock.patch(), patch.object(), and target= kwarg.
+  - repo: local
+    hooks:
+      - id: no-src-mock-path
+        name: Block patch("src.*") mock paths in tests (#6987 / #7165)
+        entry: tools/lint/check_no_src_mock_path.py
+        language: python
+        files: (_test\.py|test_.*\.py)$
+        stages: [pre-commit]
+        description: "patch('src.…') silently no-ops — autobot-backend has no src/ package"
+
   # AutoBot custom: regression-prevention for #7150 git safe.directory migration.
   # When code_source/ is owned by `autobot` (cloned by install.sh) and the
   # Ansible playbook runs as root via sudo, git 2.35+ aborts read-only

--- a/tools/lint/check_no_src_mock_path.py
+++ b/tools/lint/check_no_src_mock_path.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Regression-prevention check for the #6987 ``patch("src.*")`` mock-path bug.
+
+Background
+----------
+#6987 found 48 test sites using ``patch("src.module.foo", ...)``. The
+``autobot-backend`` package has no ``src/`` directory — these patches
+silently no-op'd. ``patch.start()`` either raised ``ModuleNotFoundError``
+(swallowed by ``with`` cleanup) or returned a placeholder MagicMock that
+never installed. Production code ran unmocked, and tests passed on
+stale-mock-luck. This masked years of real production drift (#7147,
+#7154, #7161, #7216, #7237, #7251, …).
+
+This hook AST-scans test files for ``patch(target=...)`` calls whose
+target is a string literal starting with ``"src."`` and flags them at
+commit time, preventing the pattern from being reintroduced.
+
+Scope
+-----
+Only files matching ``*_test.py`` or ``test_*.py`` are scanned — the
+pattern is test-only by design.
+
+Detected forms
+--------------
+* ``patch("src.foo.bar")``                   (from unittest.mock import patch)
+* ``patch.object("src.foo.bar", ...)``       (object form)
+* ``mock.patch("src.foo.bar")``              (qualified)
+* ``unittest.mock.patch("src.foo.bar")``     (fully qualified)
+* ``patch(target="src.foo.bar")``            (kwarg form)
+
+Allowlist
+---------
+None — there is no legitimate ``src.`` package in this repo.
+
+Exit code
+---------
+  0 — clean (no banned patterns found in scanned files)
+  1 — banned patterns found (PR/commit blocked)
+  2 — usage error
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+# tools/lint/ is not a Python package; ensure sibling module is importable
+# regardless of invocation mode (script / importlib from tests).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _scan_helpers import iter_python_files  # noqa: E402
+
+# Files exempt from the check.
+ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # The hook itself + tests reference the patterns as strings.
+        "tools/lint/check_no_src_mock_path.py",
+        "tools/lint/check_no_src_mock_path_test.py",
+    }
+)
+
+
+def _is_test_file(rel_path: str) -> bool:
+    """Return True if path matches the test naming convention."""
+    name = Path(rel_path).name
+    return name.endswith("_test.py") or name.startswith("test_")
+
+
+def _is_patch_call(node: ast.Call) -> bool:
+    """Return True if ``node`` is a call to ``patch`` or ``patch.object``.
+
+    Covers all import forms:
+      - ``patch(...)``                              (Name)
+      - ``patch.object(...)``                       (Attribute on Name)
+      - ``mock.patch(...)``                         (Attribute, attr=patch)
+      - ``mock.patch.object(...)``                  (Attribute, attr=object on patch)
+      - ``unittest.mock.patch(...)``                (chained Attribute)
+      - ``unittest.mock.patch.object(...)``
+    """
+    func = node.func
+
+    # patch(...) — direct call
+    if isinstance(func, ast.Name) and func.id == "patch":
+        return True
+
+    # patch.object(...) — attribute access on Name "patch"
+    if isinstance(func, ast.Attribute):
+        # X.patch(...) or X.patch.object(...)
+        if func.attr == "patch":
+            return True
+        # patch.object(...) or X.patch.object(...) → outer .object on .patch
+        if func.attr == "object" and isinstance(func.value, ast.Attribute) and func.value.attr == "patch":
+            return True
+        if func.attr == "object" and isinstance(func.value, ast.Name) and func.value.id == "patch":
+            return True
+
+    return False
+
+
+def _extract_target(node: ast.Call) -> tuple[ast.AST | None, str | None]:
+    """Return (literal-node, string-value) of the patch target if a string literal.
+
+    The target is the first positional arg, or the ``target=`` keyword. Returns
+    ``(None, None)`` if not a string literal (e.g. ``patch(SOME_CONST)`` —
+    can't statically resolve).
+    """
+    # Positional first arg
+    if node.args:
+        arg = node.args[0]
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            return arg, arg.value
+
+    # target= kwarg
+    for kw in node.keywords:
+        if kw.arg == "target" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            return kw.value, kw.value.value
+
+    return None, None
+
+
+def _scan_file(path: Path, source: str) -> list[tuple[int, str]]:
+    """Return [(line_no, message), …] for any banned ``src.*`` patch target."""
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []  # let other linters handle
+
+    findings: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_patch_call(node):
+            continue
+        literal_node, target = _extract_target(node)
+        if target is None:
+            continue
+        if target.startswith("src."):
+            findings.append(
+                (
+                    literal_node.lineno if literal_node else node.lineno,
+                    (
+                        f'patch("{target}") — autobot-backend has no `src/` package; '
+                        "this mock target will fail to import and silently no-op. "
+                        "Use the actual production import path (e.g. "
+                        '`patch("autobot_backend.module.foo")` or the consumer '
+                        "namespace where the symbol is bound). See #6987."
+                    ),
+                )
+            )
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    repo_root = Path(__file__).resolve().parents[2]
+    files = iter_python_files(args, repo_root)
+
+    total_violations = 0
+    for f in files:
+        try:
+            rel = f.resolve().relative_to(repo_root)
+        except ValueError:
+            rel = f
+        rel_str = str(rel).replace("\\", "/")
+
+        if rel_str in ALLOWLIST:
+            continue
+        if not _is_test_file(rel_str):
+            continue
+
+        try:
+            source = f.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        for line_no, message in _scan_file(f, source):
+            print(
+                f"[no-src-mock-path] {rel_str}:{line_no}: {message}",
+                file=sys.stderr,
+            )
+            total_violations += 1
+
+    if total_violations:
+        print(
+            f"\n[no-src-mock-path] {total_violations} banned patch target(s) found. "
+            f"See per-line fix suggestions above. Rationale: #6987.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lint/check_no_src_mock_path_test.py
+++ b/tools/lint/check_no_src_mock_path_test.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Unit tests for tools/lint/check_no_src_mock_path.py (#7165 / #6987 AC3)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent / "check_no_src_mock_path.py"
+_SPEC = importlib.util.spec_from_file_location("check_src_mock_path", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+hook = importlib.util.module_from_spec(_SPEC)
+sys.modules["check_src_mock_path"] = hook
+_SPEC.loader.exec_module(hook)
+
+
+def _scan(source: str, name: str = "fake_test.py") -> list[tuple[int, str]]:
+    return hook._scan_file(Path(name), source)
+
+
+# ---------------------------------------------------------------------------
+# Banned patterns: patch("src.*") in all forms
+# ---------------------------------------------------------------------------
+
+
+def test_flags_patch_with_src_prefix() -> None:
+    """The canonical bug: ``patch("src.foo.bar")`` from #6987."""
+    src = """
+from unittest.mock import patch
+
+def test_foo():
+    with patch("src.module.func", return_value=1):
+        pass
+"""
+    findings = _scan(src)
+    assert len(findings) == 1
+    assert "src.module.func" in findings[0][1]
+    assert "#6987" in findings[0][1]
+
+
+def test_flags_qualified_mock_patch() -> None:
+    """``mock.patch("src.…")`` — qualified import form."""
+    src = """
+from unittest import mock
+
+def test_foo():
+    with mock.patch("src.foo.bar"):
+        pass
+"""
+    findings = _scan(src)
+    assert len(findings) == 1
+    assert "src.foo.bar" in findings[0][1]
+
+
+def test_flags_fully_qualified_unittest_mock_patch() -> None:
+    """``unittest.mock.patch("src.…")`` — fully qualified."""
+    src = """
+import unittest.mock
+
+def test_foo():
+    with unittest.mock.patch("src.foo.bar"):
+        pass
+"""
+    findings = _scan(src)
+    assert len(findings) == 1
+
+
+def test_flags_patch_object_with_src_target() -> None:
+    """``patch.object("src.…")`` — object form. Less common but valid syntax."""
+    src = """
+from unittest.mock import patch
+
+def test_foo():
+    with patch.object("src.module", "attr"):
+        pass
+"""
+    findings = _scan(src)
+    assert len(findings) == 1
+
+
+def test_flags_kwarg_target() -> None:
+    """``patch(target="src.…")`` — keyword form."""
+    src = """
+from unittest.mock import patch
+
+def test_foo():
+    with patch(target="src.module.func"):
+        pass
+"""
+    findings = _scan(src)
+    assert len(findings) == 1
+    assert "src.module.func" in findings[0][1]
+
+
+def test_flags_multiple_violations_in_one_file() -> None:
+    """Hook reports each violation separately."""
+    src = """
+from unittest.mock import patch
+
+def test_a():
+    with patch("src.alpha"):
+        pass
+
+def test_b():
+    with patch("src.beta"):
+        pass
+"""
+    findings = _scan(src)
+    assert len(findings) == 2
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — should NOT flag
+# ---------------------------------------------------------------------------
+
+
+def test_does_not_flag_legitimate_patch_paths() -> None:
+    """``patch("autobot_backend.foo")`` is the correct form — must not flag."""
+    src = """
+from unittest.mock import patch
+
+def test_foo():
+    with patch("autobot_backend.module.func"):
+        pass
+"""
+    assert _scan(src) == []
+
+
+def test_does_not_flag_paths_containing_src_substring_elsewhere() -> None:
+    """Paths like ``foo.src_helper`` shouldn't trip — only the ``src.`` prefix."""
+    src = """
+from unittest.mock import patch
+
+def test_foo():
+    with patch("foo.src_helper"):
+        pass
+
+def test_bar():
+    with patch("module.with.src.in.middle"):
+        pass
+"""
+    assert _scan(src) == []
+
+
+def test_does_not_flag_dynamic_target() -> None:
+    """``patch(SOME_CONST)`` — non-literal, can't statically resolve."""
+    src = """
+from unittest.mock import patch
+
+TARGET = "src.module.foo"
+
+def test_foo():
+    with patch(TARGET):
+        pass
+"""
+    # Hook only flags string-literal targets — dynamic refs out of scope.
+    assert _scan(src) == []
+
+
+def test_does_not_flag_patch_dict() -> None:
+    """``patch.dict(...)`` patches mappings, not import targets — different semantic."""
+    src = """
+from unittest.mock import patch
+
+def test_foo():
+    with patch.dict("src.module.CONFIG", {"key": "val"}):
+        pass
+"""
+    # patch.dict mutates a mapping; "src." here would be a dict-import attribute,
+    # not a module-resolution target. Out of scope for this hook.
+    assert _scan(src) == []
+
+
+def test_does_not_flag_syntax_error_files() -> None:
+    """Files with syntax errors are skipped silently — other linters handle them."""
+    src = """
+from unittest.mock import patch
+
+def test_foo(:  # syntax error
+    with patch("src.foo"):
+        pass
+"""
+    assert _scan(src) == []
+
+
+# ---------------------------------------------------------------------------
+# File-name scoping
+# ---------------------------------------------------------------------------
+
+
+def test_test_file_predicate_for_underscore_test_suffix() -> None:
+    assert hook._is_test_file("autobot-backend/foo_test.py") is True
+
+
+def test_test_file_predicate_for_test_underscore_prefix() -> None:
+    assert hook._is_test_file("autobot-backend/tests/test_foo.py") is True
+
+
+def test_test_file_predicate_rejects_non_test_files() -> None:
+    assert hook._is_test_file("autobot-backend/api/marketplace.py") is False
+    assert hook._is_test_file("autobot-backend/utils/testing_helpers.py") is False


### PR DESCRIPTION
## Summary

Adds a pre-commit hook that AST-scans test files for the ``patch(\"src.…\")`` mock-path pattern that caused the entire #6987 layered-rot cascade. Closes both #7165 (hook design) and #7173 (duplicate tracker — same hook, less detail).

## Why this matters

#6987's broken ``src.*`` mock paths silently no-op'd for an extended period — production code ran unmocked, tests passed on stale-mock-luck. Fixing the 48 sites surfaced ~27 hidden production bugs across 5+ rounds (#7147, #7154, #7161, #7216, #7237, #7251, …). Per `feedback_layered_test_rot.md`: each fix exposed the next layer of pre-existing rot. This hook prevents the entire pattern from being reintroduced.

## Implementation

- **`tools/lint/check_no_src_mock_path.py`** — AST-based check matching all `patch(...)` import forms:
  - `patch("src.foo")` (direct)
  - `mock.patch("src.foo")` (qualified)
  - `unittest.mock.patch("src.foo")` (fully qualified)
  - `patch.object("src.foo", ...)` (object form)
  - `patch(target="src.foo")` (kwarg form)
- Scoped to `*_test.py` / `test_*.py` files only (test-only pattern).
- Skips dynamic targets (`patch(SOME_CONST)`) — string-literal only, statically resolvable.
- Skips `patch.dict("src.foo", ...)` — different semantic (mutates a mapping, not an import target).
- Helpful error message including production fix examples + #6987 reference.
- **`tools/lint/check_no_src_mock_path_test.py`** — 14 unit tests covering all positive + negative cases.
- Registered in `.pre-commit-config.yaml` next to the other AutoBot regression-prevention hooks.

## Test plan

- [x] `pytest tools/lint/check_no_src_mock_path_test.py` → 14/14 passed
- [x] `python3 tools/lint/check_no_src_mock_path.py` (full codebase) → exit 0 (zero current violations — all 48 from #6987 fixed)
- [x] Synthetic violation (`patch(\"src.module.func\")`) → exit 1 with clear error message
- [x] Synthetic legitimate paths (`patch(\"autobot_backend.module.func\")`, `patch(\"api.marketplace.get_async_redis_client\")`) → exit 0

## Refs

- Closes #7165 (this hook)
- Closes #7173 (duplicate)
- Parent: #6987
- Cascade caught: #7147, #7154, #7161, #7216, #7237, #7251
- Pattern: `feedback_layered_test_rot.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)