### PR TITLE
fix(plugins): harden _remote_plugin_to_entry against bad remote payloads (#6525)

### DIFF
--- a/autobot-backend/api/marketplace.py
+++ b/autobot-backend/api/marketplace.py
@@ -12,7 +12,7 @@ Issue #1803 - Plugin and agent marketplace: package, share, and install extensio
 import json
 import logging
 from enum import Enum
-from typing import Any
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
@@ -53,6 +53,7 @@ class CatalogSort(str, Enum):
     RATING = "rating"
     NAME = "name"
     NEWEST = "newest"
+
 
 logger = logging.getLogger(__name__)
 
@@ -155,25 +156,88 @@ _BUILTIN_CATALOG: list[dict[str, Any]] = [
     },
 ]
 
+
+def _coerce_str(value: Any, fallback: str = "") -> str:
+    """Return ``value`` if it's a string, otherwise ``fallback``.
+
+    #6525: untrusted external catalogs may emit ``None`` or non-string types
+    where strings are expected. ``dict.get(key, default)`` only fires the
+    default when the key is *missing* — present-but-null returns the stored
+    ``None`` and downstream ``.replace``/``.title`` calls crash. This coercion
+    keeps the response shape strict-string regardless of remote sloppiness.
+    """
+    return value if isinstance(value, str) else fallback
+
+
+def _coerce_list(value: Any) -> list:
+    """Return ``value`` if it's a list, else an empty list. (#6525)"""
+    return value if isinstance(value, list) else []
+
+
 def _remote_plugin_to_entry(plugin: dict[str, Any], source_name: str) -> dict[str, Any]:
     """Issue #6481: shape an external CatalogPlugin dict to look like a
     MarketplaceEntry. Missing fields get safe defaults so the existing
-    response model and frontend continue to work."""
+    response model and frontend continue to work.
+
+    #6525: hardened against three failure modes:
+      1. ``dict.get(key, default)`` does NOT fire ``default`` when the key
+         exists with value ``None``. ``_coerce_str`` / ``_coerce_list``
+         enforce the type contract regardless of remote payload shape.
+      2. ``str.title()`` butchers acronyms (``"GIT-tools"`` → ``"Git Tools"``)
+         and apostrophes (``"don't"`` → ``"Don'T"``). Prefer an
+         upstream-provided ``display_name`` when present; fall back to the
+         raw ``name`` (untransformed) only when no display_name is supplied.
+      3. (Caller side) one bad entry must not 500 the whole catalog —
+         see ``_safe_remote_plugin_to_entry`` wrapper.
+    """
+    raw_name = _coerce_str(plugin.get("name"))
+    raw_display = _coerce_str(plugin.get("display_name"))
     return {
-        "name": plugin.get("name", ""),
-        "version": plugin.get("version", ""),
-        "display_name": plugin.get("name", "").replace("-", " ").title(),
-        "description": plugin.get("description", ""),
-        "author": plugin.get("author", source_name),
-        "category": plugin.get("category", CatalogCategory.OTHER.value),
-        "tags": plugin.get("tags", []),
+        "name": raw_name,
+        "version": _coerce_str(plugin.get("version")),
+        # #6525: prefer upstream display_name; fall back to raw name (no
+        # destructive .title() transform). Keeps acronyms + apostrophes
+        # + non-Latin scripts intact.
+        "display_name": raw_display or raw_name,
+        "description": _coerce_str(plugin.get("description")),
+        "author": _coerce_str(plugin.get("author"), fallback=source_name),
+        "category": _coerce_str(plugin.get("category"), fallback=CatalogCategory.OTHER.value),
+        "tags": _coerce_list(plugin.get("tags")),
         "entry_point": "",
         "dependencies": [],
         "hooks": [],
         "downloads": 0,
         "rating": 0.0,
-        "source_url": plugin.get("git_url", ""),
+        "source_url": _coerce_str(plugin.get("git_url")),
     }
+
+
+def _safe_remote_plugin_to_entry(plugin: Any, source_name: str) -> Optional[dict[str, Any]]:
+    """Per-item wrapper that turns one bad plugin into a logged skip.
+
+    #6525: pre-fix, ``[_remote_plugin_to_entry(p, ...) for p in remote_plugins]``
+    let any single malformed entry from a user-added remote marketplace
+    raise mid-comprehension and 500 the entire ``/catalog?source_id=...``
+    response — trivial DoS surface. Now per-item: bad entries are logged
+    and skipped; good entries flow through.
+    """
+    if not isinstance(plugin, dict):
+        logger.warning("Skipping non-dict catalog entry from %r: %r", source_name, type(plugin).__name__)
+        return None
+    try:
+        return _remote_plugin_to_entry(plugin, source_name)
+    except Exception as exc:
+        # Defensive: even with the type coercions above, a future field
+        # added in the remote schema could still raise something we
+        # didn't anticipate. Log identifiable context, drop the entry.
+        identifier = plugin.get("name") if isinstance(plugin.get("name"), str) else "<unknown>"
+        logger.warning(
+            "Skipping malformed catalog entry %r from %r: %s",
+            identifier,
+            source_name,
+            exc,
+        )
+        return None
 
 
 async def _get_catalog() -> list[dict[str, Any]]:
@@ -245,7 +309,15 @@ async def list_catalog(
                 detail=f"Marketplace source '{source.name}' has no catalog URL configured",
             )
         remote_plugins = await fetch_remote_catalog(source.url)
-        catalog = [_remote_plugin_to_entry(p, source.name) for p in remote_plugins]
+        # #6525: per-item wrapper drops malformed entries instead of failing
+        # the whole catalog. One bad apple from a user-added remote
+        # marketplace no longer 500s the response.
+        catalog = [
+            entry
+            for p in remote_plugins
+            for entry in (_safe_remote_plugin_to_entry(p, source.name),)
+            if entry is not None
+        ]
 
     # Filter by category
     if category != CatalogCategory.ALL:
@@ -255,7 +327,8 @@ async def list_catalog(
     if search:
         q = search.lower()
         catalog = [
-            e for e in catalog
+            e
+            for e in catalog
             if q in e.get("name", "").lower()
             or q in e.get("description", "").lower()
             or any(q in t.lower() for t in e.get("tags", []))
@@ -336,8 +409,6 @@ async def list_categories() -> dict[str, list[str]]:
 # ---------------------------------------------------------------------------
 
 
-
-
 async def _get_installed() -> set[str]:
     """Return the set of installed plugin names from Redis."""
     try:
@@ -393,10 +464,7 @@ async def install_plugin(body: InstallRequest) -> dict[str, str]:
         await redis.sadd(_INSTALLED_KEY, body.plugin_name)
         # Bump download counter in cached catalog
         updated = [
-            {**e, "downloads": e.get("downloads", 0) + 1}
-            if e.get("name") == body.plugin_name
-            else e
-            for e in catalog
+            {**e, "downloads": e.get("downloads", 0) + 1} if e.get("name") == body.plugin_name else e for e in catalog
         ]
         await redis.set(_CATALOG_KEY, json.dumps(updated), ex=_CATALOG_TTL)
     except Exception as exc:

--- a/autobot-backend/api/marketplace_test.py
+++ b/autobot-backend/api/marketplace_test.py
@@ -1,0 +1,143 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for marketplace remote-catalog hardening (Issue #6525).
+
+Three defects in the pre-fix ``_remote_plugin_to_entry`` adapter:
+  1. ``dict.get(key, default)`` returns the stored value when the key is
+     present-but-null — so ``{"name": None}.get("name", "")`` returns None
+     and downstream ``.replace``/``.title`` crashed.
+  2. Single malformed entry from a user-added remote 500s the whole
+     ``/catalog?source_id=...`` request — trivial DoS surface.
+  3. ``str.title()`` butchers acronyms (``"GIT-tools"`` → ``"Git Tools"``)
+     and apostrophes (``"don't-panic"`` → ``"Don'T Panic"``).
+"""
+
+import logging
+
+import pytest
+
+from api.marketplace import (
+    _coerce_list,
+    _coerce_str,
+    _remote_plugin_to_entry,
+    _safe_remote_plugin_to_entry,
+)
+
+
+class TestCoerceHelpers:
+    """#6525: type coercion contracts."""
+
+    def test_coerce_str_passes_string_through(self):
+        assert _coerce_str("hello") == "hello"
+
+    def test_coerce_str_returns_fallback_for_none(self):
+        assert _coerce_str(None) == ""
+        assert _coerce_str(None, fallback="x") == "x"
+
+    def test_coerce_str_returns_fallback_for_non_string(self):
+        assert _coerce_str(42) == ""
+        assert _coerce_str([], fallback="lst") == "lst"
+        assert _coerce_str({"a": 1}) == ""
+
+    def test_coerce_list_passes_list_through(self):
+        assert _coerce_list(["a", "b"]) == ["a", "b"]
+
+    def test_coerce_list_returns_empty_for_non_list(self):
+        assert _coerce_list(None) == []
+        assert _coerce_list("string") == []
+        assert _coerce_list({"k": "v"}) == []
+
+
+class TestRemotePluginToEntryHardening:
+    """#6525: type-coerce all string fields against null/non-string remotes."""
+
+    def test_null_name_does_not_crash(self):
+        """Pre-fix: AttributeError on .replace(...) of None. Now coerced to ''."""
+        entry = _remote_plugin_to_entry({"name": None, "version": "1.0"}, "src")
+        assert entry["name"] == ""
+        assert entry["display_name"] == ""
+
+    def test_null_tags_becomes_empty_list(self):
+        entry = _remote_plugin_to_entry({"name": "ok", "tags": None}, "src")
+        assert entry["tags"] == []
+
+    def test_non_string_category_falls_back_to_default(self):
+        """A remote sending category=123 must not propagate an int into the response."""
+        entry = _remote_plugin_to_entry({"name": "ok", "category": 123}, "src")
+        # Should fall back to the OTHER default since 123 is not a string.
+        assert entry["category"] == "other"
+
+    def test_null_author_falls_back_to_source_name(self):
+        entry = _remote_plugin_to_entry({"name": "ok", "author": None}, "alt-source")
+        assert entry["author"] == "alt-source"
+
+    def test_display_name_preserves_acronyms_and_apostrophes(self):
+        """Pre-fix str.title() butchered these; now we use upstream display_name
+        when supplied, else fall back to raw name (untransformed)."""
+        # Upstream display_name preserved verbatim.
+        entry = _remote_plugin_to_entry(
+            {"name": "git-tools", "display_name": "GIT Tools"},
+            "src",
+        )
+        assert entry["display_name"] == "GIT Tools"
+
+        # No display_name → raw name kept verbatim (no .title()).
+        entry = _remote_plugin_to_entry({"name": "don't-panic"}, "src")
+        assert entry["display_name"] == "don't-panic"
+
+        # No display_name → keep ALL-CAPS acronym intact.
+        entry = _remote_plugin_to_entry({"name": "GIT-tools"}, "src")
+        assert entry["display_name"] == "GIT-tools"
+
+
+class TestSafeRemotePluginToEntry:
+    """#6525: per-item wrapper turns one bad plugin into a logged skip."""
+
+    def test_dict_entry_passes_through(self):
+        entry = _safe_remote_plugin_to_entry({"name": "ok", "version": "1.0"}, "src")
+        assert entry is not None
+        assert entry["name"] == "ok"
+
+    def test_non_dict_entry_returns_none_with_log(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="api.marketplace"):
+            assert _safe_remote_plugin_to_entry("not-a-dict", "src") is None
+            assert _safe_remote_plugin_to_entry(None, "src") is None
+            assert _safe_remote_plugin_to_entry(42, "src") is None
+        assert any("Skipping non-dict catalog entry" in r.getMessage() for r in caplog.records)
+
+    def test_dos_proof_one_bad_apple_does_not_break_others(self):
+        """The exact DoS scenario from the issue: one bad entry between two good ones."""
+        remote = [
+            {"name": "good-plugin", "version": "1.0"},
+            {"name": None, "version": "1.0"},  # was: AttributeError on .replace
+            {"name": "another", "version": "1.0"},
+        ]
+        # Pre-fix this list comp crashed on item 1, returning none of the good ones.
+        catalog = [entry for p in remote for entry in (_safe_remote_plugin_to_entry(p, "src"),) if entry is not None]
+        # Even with the new coercion, ``{"name": None}`` produces a valid entry
+        # (name=""), but it's still a real entry — only structurally broken
+        # entries are filtered. So expect 3 here, not 2. The DoS-proof is that
+        # the comprehension does not raise.
+        assert len(catalog) == 3
+        names = {e["name"] for e in catalog}
+        assert "good-plugin" in names
+        assert "another" in names
+
+    def test_truly_broken_entry_is_logged_and_skipped(self, caplog):
+        """A non-dict in the remote payload is dropped, not crashing."""
+        remote = [
+            {"name": "good"},
+            "totally-broken-string",
+            42,
+            {"name": "good2"},
+        ]
+        with caplog.at_level(logging.WARNING, logger="api.marketplace"):
+            catalog = [
+                entry for p in remote for entry in (_safe_remote_plugin_to_entry(p, "src"),) if entry is not None
+            ]
+        assert len(catalog) == 2
+        # Two warnings — one per dropped non-dict.
+        warnings = [r for r in caplog.records if "Skipping non-dict" in r.getMessage()]
+        assert len(warnings) == 2


### PR DESCRIPTION
## Summary

Three defects in the pre-fix adapter for untrusted external catalog payloads:

1. **\`dict.get\` default vs present-but-null** — \`{"name": None}.get("name", "")\` returns \`None\`, then \`.replace(...)\` crashed. New \`_coerce_str\` / \`_coerce_list\` helpers enforce string/list contracts regardless of remote shape.
2. **Single bad entry 500s the whole catalog** — list comprehension had no per-item handling. New \`_safe_remote_plugin_to_entry\` wraps each entry, logs + drops bad ones, lets good ones through.
3. **\`str.title()\` butchered display names** — \`"GIT-tools"\` → \`"Git Tools"\` (acronym lost), \`"don't-panic"\` → \`"Don'T Panic"\`. Now prefer upstream-provided \`display_name\`, fall back to raw \`name\` (untransformed).

## Test plan

- [x] \`pytest autobot-backend/api/marketplace_test.py -xvs\` → 14/14 pass
  - 5 helper-coercion tests
  - 5 hardening tests (null name, null tags, non-string category, null author, display_name preservation)
  - 4 safe-wrapper tests including the exact DoS proof from the issue
- [x] py_compile clean; black-formatted
- [ ] Live verify post-deploy: GET /catalog?source_id=<custom-with-malformed> returns the good entries with bad ones logged + skipped

Closes #6525