### PR TITLE
fix(test/utils): patch event_manager.get_event_manager (lazy_singleton accessor) (#7184)

### DIFF
--- a/autobot-backend/utils/file_locking_test.py
+++ b/autobot-backend/utils/file_locking_test.py
@@ -65,10 +65,19 @@ class TestWebsocketsNPUEventsLocking:
         errors = []
         call_count = {"count": 0}
 
-        # Mock the event_manager to avoid actual subscriptions
+        # Mock the event_manager to avoid actual subscriptions.
+        # #7184: pre-fix patched ``event_manager.event_manager`` (a stale
+        # module-level singleton attribute that no longer exists after the
+        # lazy_singleton refactor — see event_manager.py:102 where
+        # ``get_event_manager = lazy_singleton(EventManager)``). Patch the
+        # canonical accessor and configure the singleton it returns so
+        # init_npu_worker_websocket's repeated ``get_event_manager().subscribe(...)``
+        # calls hit the mock instead of the real EventManager.
         with patch.object(websockets, "broadcast_npu_worker_event", MagicMock()):
-            with patch("event_manager.event_manager") as mock_em:
+            with patch("event_manager.get_event_manager") as mock_get_em:
+                mock_em = MagicMock()
                 mock_em.subscribe = MagicMock()
+                mock_get_em.return_value = mock_em
 
                 def init_websocket():
                     try:


### PR DESCRIPTION
## Summary

#7184 had two symptoms; one resolved transitively, one needed a real fix.

**Symptom 1 (NetworkConstants ImportError) — resolved transitively.** Verified \`pytest --collect-only\` on all 11 affected test files: 182 tests collect cleanly, no ImportError. The transient circular-import was likely caused by partial-module state from the broken \`src.*\` mocks; #6987 fixing the trigger condition resolved this side-effect.

**Symptom 2 (event_manager test rot) — fixed in this PR.** \`file_locking_test.py:test_concurrent_init_npu_worker_websocket\` patched \`event_manager.event_manager\` — a deleted module-level singleton that was renamed to the \`lazy_singleton\` accessor \`get_event_manager\` (event_manager.py:102). Production at \`api/websockets.py:864-873\` calls \`get_event_manager().subscribe(...)\` repeatedly. Updated the test to patch the canonical accessor.

## Test plan

- [x] \`pytest autobot-backend/utils/file_locking_test.py\` → 27/27 pass
- [x] \`pytest --collect-only\` on all 11 #7184-affected files → 182 collected, 0 errors
- [x] Direct import \`from autobot_shared.network_constants import NetworkConstants\` → OK

Closes #7184