### PR TITLE
fix(format): make targets need 'bash scripts/format.sh' (closes #7361)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ test-e2e:
 
 ## Format Python with project-pinned Black + isort settings (#7249)
 format:
-	@scripts/format.sh
+	@bash scripts/format.sh
 
 ## Same as `make format` but exits non-zero if anything would change (CI mode)
 format-check:
-	@scripts/format.sh --check
+	@bash scripts/format.sh --check
 
 ## Show this help
 help:

--- a/docs/developer/CLAUDE_WORKFLOW.md
+++ b/docs/developer/CLAUDE_WORKFLOW.md
@@ -237,10 +237,11 @@ python -m pytest tests/$(dirname <changed_file>) -x -q
 # Use the project wrapper — it pins target-version=py312 + line-length=120
 # so a host running Python 3.10 doesn't produce spurious diffs (#7249).
 make format-check
-# Or, equivalently, for the whole tree:
-scripts/format.sh --check
+# Or, equivalently, for the whole tree (note: `bash` prefix because
+# scripts/*.sh files in this repo are committed without the exec bit):
+bash scripts/format.sh --check
 # For a specific file:
-scripts/format.sh path/to/file.py
+bash scripts/format.sh path/to/file.py
 npm run lint --prefix autobot-vue 2>&1 | grep "error"
 ```
 


### PR DESCRIPTION
## Summary

PR #7262 added `make format` and `make format-check` targets that invoke `scripts/format.sh` directly. But `scripts/*.sh` files in this repo are committed without the executable bit (`100644`) — verified across all sibling scripts.

**Symptom on a fresh clone:**
```
$ make format-check
make: scripts/format.sh: Permission denied
make: *** [Makefile:41: format-check] Error 127
```

**Fix:** prepend `bash` to both make recipes, matching the repo convention. Also update CLAUDE_WORKFLOW.md Gate 4 example to use `bash scripts/format.sh` consistently with a parenthetical noting the convention.

**Verified after fix:**
```
$ make format-check
…
2429 files would be left unchanged.
$ echo $?
0
```

Closes #7361

🤖 Generated with [Claude Code](https://claude.com/claude-code)
