### PR TITLE
test(chat_history/cache): pin TTL resolver + document env-var override (#6743)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,6 +154,13 @@ AUTOBOT_REDIS_DB_TESTING=13
 # Redis authentication (leave empty if no password)
 AUTOBOT_REDIS_PASSWORD=
 
+# Chat session cache TTL (seconds). Default 86400 (24h) — matches sibling
+# chat:conversation:* TTL. Lower values reduce Redis memory at the cost of
+# more cache evictions; higher values raise memory but reduce disk fallback
+# pressure. Range >0; non-int / non-positive values fall back to default
+# with a logged warning. Issue #6743.
+# AUTOBOT_CHAT_SESSION_CACHE_TTL=86400
+
 
 # =============================================================================
 # LLM MODEL CONFIGURATION - SINGLE SOURCE OF TRUTH

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ You are the world's best AI developer working on AutoBot. Every decision must op
 
 **Encoding:** Always `encoding='utf-8'` explicitly.
 
+**Cache TTL overrides:** Hard-coded Redis TTLs are bugs (#6743). For tunable surfaces use a module-level constant resolved from an env var with a logged-fallback default — e.g. `AUTOBOT_CHAT_SESSION_CACHE_TTL` → `chat_history.cache._CHAT_SESSION_CACHE_TTL` (24h default). See [`autobot-backend/chat_history/cache.py`](autobot-backend/chat_history/cache.py) for the canonical resolver pattern.
+
 **Copyright:** `mrveiss` is sole owner/author of all AutoBot code.
 
 ---

--- a/autobot-backend/chat_history/cache_test.py
+++ b/autobot-backend/chat_history/cache_test.py
@@ -1,0 +1,74 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""#6743: TTL resolution tests for chat_history.cache.
+
+Pin the regression: chat:session:* keys must use a configurable TTL with
+24h default and `AUTOBOT_CHAT_SESSION_CACHE_TTL` env-var override. See AC
+#4 of issue #6743.
+"""
+
+import importlib
+import logging
+import os
+
+import pytest
+
+
+def _reload_cache_with_env(env_value):
+    """Reload cache module with given env-var value (None = unset)."""
+    if env_value is None:
+        os.environ.pop("AUTOBOT_CHAT_SESSION_CACHE_TTL", None)
+    else:
+        os.environ["AUTOBOT_CHAT_SESSION_CACHE_TTL"] = env_value
+    import chat_history.cache as cache_mod
+
+    importlib.reload(cache_mod)
+    return cache_mod
+
+
+@pytest.fixture(autouse=True)
+def _restore_env():
+    saved = os.environ.get("AUTOBOT_CHAT_SESSION_CACHE_TTL")
+    yield
+    if saved is None:
+        os.environ.pop("AUTOBOT_CHAT_SESSION_CACHE_TTL", None)
+    else:
+        os.environ["AUTOBOT_CHAT_SESSION_CACHE_TTL"] = saved
+    import chat_history.cache as cache_mod
+
+    importlib.reload(cache_mod)
+
+
+def test_default_ttl_is_24_hours():
+    cache_mod = _reload_cache_with_env(None)
+    assert cache_mod._CHAT_SESSION_CACHE_TTL == 86_400
+
+
+def test_env_var_override_accepts_positive_int():
+    cache_mod = _reload_cache_with_env("7200")
+    assert cache_mod._CHAT_SESSION_CACHE_TTL == 7200
+
+
+def test_env_var_non_integer_falls_back_with_warning(caplog):
+    with caplog.at_level(logging.WARNING, logger="chat_history.cache"):
+        cache_mod = _reload_cache_with_env("not-a-number")
+    assert cache_mod._CHAT_SESSION_CACHE_TTL == 86_400
+    assert any("not an integer" in r.getMessage() for r in caplog.records)
+
+
+def test_env_var_zero_or_negative_falls_back_with_warning(caplog):
+    with caplog.at_level(logging.WARNING, logger="chat_history.cache"):
+        cache_mod = _reload_cache_with_env("0")
+    assert cache_mod._CHAT_SESSION_CACHE_TTL == 86_400
+    assert any("must be positive" in r.getMessage() for r in caplog.records)
+
+
+def test_no_3600_literal_in_module_source():
+    """Pin the regression: original bug was `setex(key, 3600, ...)`."""
+    import inspect
+
+    import chat_history.cache as cache_mod
+
+    src = inspect.getsource(cache_mod.CacheMixin._async_cache_session)
+    assert "3600" not in src, "TTL must not be a 3600 literal in _async_cache_session"

--- a/autobot-backend/intelligence/tool_selector_test.py
+++ b/autobot-backend/intelligence/tool_selector_test.py
@@ -103,8 +103,8 @@ def test_tool_selector_system_merge_preserves_all_intents() -> None:
 
 def test_processed_goal_has_parameters_field() -> None:
     """``goal.parameters`` is read by ``tool_selector._format_command``."""
-    from intelligence.goal_processor import GoalCategory, ProcessedGoal
     from autobot_shared.status_enums import RiskLevel
+    from intelligence.goal_processor import GoalCategory, ProcessedGoal
 
     field_names = {f.name for f in dataclasses.fields(ProcessedGoal)}
     assert "parameters" in field_names, "#7245: ProcessedGoal.parameters required by tool_selector — missing"


### PR DESCRIPTION
## Summary

PR #6750 fixed the hard-coded 1h TTL but left two ACs of #6743 unmet:

- **AC #3** "Env-var override path documented in CLAUDE_RULES.md essential-patterns table" — no doc surface
- **AC #4** "Add a unit test that asserts the TTL applied matches the configured value" — no test coverage

This PR closes both gaps without touching the production logic.

## Changes

- `autobot-backend/chat_history/cache_test.py` (new) — 5 regression cases pinning the resolver + a guard against re-introducing a literal `3600`
- `.env.example` — `AUTOBOT_CHAT_SESSION_CACHE_TTL` documented in the Redis-DB block with the memory/eviction trade-off
- `CLAUDE.md` — Essential Patterns gains a "Cache TTL overrides" line pointing at the canonical resolver

## Test plan

- [x] `python3 -m pytest autobot-backend/chat_history/cache_test.py` — 5/5 pass locally
- [ ] CI green: smoke-test, startup-import-smoke, code-quality, Analyze Python

Closes #6743

🤖 Generated with [Claude Code](https://claude.com/claude-code)