### PR TITLE
fix(plugins): relocate marketplace_sources off /plugins prefix (#6523)

### DIFF
--- a/autobot-backend/api/marketplace_sources.py
+++ b/autobot-backend/api/marketplace_sources.py
@@ -146,7 +146,7 @@ async def _resolve_safe_ip(host: str) -> str:
 
 
 @router.get(
-    "/marketplaces",
+    "",
     response_model=MarketplaceSourcesResponse,
 )
 @with_error_handling(
@@ -164,7 +164,7 @@ async def list_marketplaces(
 
 
 @router.post(
-    "/marketplaces",
+    "",
     status_code=status.HTTP_201_CREATED,
     response_model=MarketplaceSource,
 )
@@ -204,7 +204,7 @@ async def add_marketplace(
 
 
 @router.delete(
-    "/marketplaces/{source_id}",
+    "/{source_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     response_model=None,
 )

--- a/autobot-backend/api/marketplace_sources_routes_test.py
+++ b/autobot-backend/api/marketplace_sources_routes_test.py
@@ -1,0 +1,70 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""#6523: regression tests for marketplace_sources router prefix.
+
+Pin the fix: marketplace_sources routes must be reachable under their
+own prefix (`/marketplace-sources`) rather than under `/plugins`, where
+they were shadowed by `plugin_manager`'s `/plugins/{plugin_name}`
+wildcard (registered earlier — first-match wins under Starlette).
+"""
+
+import pytest
+
+
+def _registered_paths(router):
+    """Extract path strings from an APIRouter's routes."""
+    return [r.path for r in router.routes]
+
+
+def test_marketplace_sources_router_has_no_inner_marketplaces_prefix():
+    """Inner routes use root + `/{source_id}`; the `/marketplace-sources`
+    prefix is applied at registration time, not duplicated inside the file.
+
+    Pre-#6523: inner paths were `/marketplaces` + `/marketplaces/{source_id}`,
+    which combined with prefix `/plugins` produced `/plugins/marketplaces` —
+    masked by `plugin_manager`'s wildcard catch.
+    """
+    from api.marketplace_sources import router
+
+    paths = _registered_paths(router)
+    # Three routes: list, add (both ""), delete ("/{source_id}").
+    assert "" in paths, f"Expected empty inner-path for list/add; got {paths}"
+    assert "/{source_id}" in paths, f"Expected /{{source_id}} for delete; got {paths}"
+    # Pin the regression: the buggy inner shape must not return.
+    assert "/marketplaces" not in paths, (
+        "Inner path `/marketplaces` would re-create the #6523 collision when " "combined with prefix `/plugins`."
+    )
+    assert "/marketplaces/{source_id}" not in paths
+
+
+def test_feature_routers_registers_marketplace_sources_off_plugins():
+    """Registry config must NOT mount marketplace_sources under `/plugins`.
+
+    Re-introducing prefix `/plugins` would let `plugin_manager`'s
+    wildcard `/plugins/{plugin_name}` shadow these routes again.
+    """
+    from initialization.router_registry.feature_routers import (
+        FEATURE_ROUTER_CONFIGS,
+    )
+
+    by_name = {entry[0]: entry for entry in FEATURE_ROUTER_CONFIGS}
+    assert "api.marketplace_sources" in by_name, "marketplace_sources missing from registry"
+    _, prefix, _, _ = by_name["api.marketplace_sources"]
+    assert prefix != "/plugins", "#6523 regression: prefix `/plugins` collides with plugin_manager wildcard"
+    assert prefix == "/marketplace-sources", f"Expected `/marketplace-sources`; got {prefix!r}"
+
+
+def test_plugin_manager_wildcard_still_present():
+    """Sanity check: plugin_manager's `/plugins/{plugin_name}` wildcard
+    still exists — we did NOT fix the collision by removing the wildcard
+    side, only by relocating marketplace_sources off the conflicting prefix.
+    """
+    pytest.importorskip("plugin_manager")
+    from plugin_manager import router
+
+    paths = _registered_paths(router)
+    assert any("/plugins/{plugin_name}" in p for p in paths), (
+        "plugin_manager wildcard expected — if removed, the #6523 fix "
+        "rationale changes (fix shouldn't be reverted casually)."
+    )

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -479,7 +479,9 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
     # Issue #1803: Plugin and agent marketplace — community catalog
     ("api.marketplace", "/marketplace", ["marketplace", "plugins"], "marketplace"),
     # Issue #6481: User-extensible marketplace sources (custom marketplaces)
-    ("api.marketplace_sources", "/plugins", ["marketplace", "plugins"], "marketplace_sources"),
+    # #6523: prefix moved off `/plugins` (was shadowed by plugin_manager's
+    # `/plugins/{plugin_name}` wildcard). Routes now under `/marketplace-sources`.
+    ("api.marketplace_sources", "/marketplace-sources", ["marketplace", "plugins"], "marketplace_sources"),
     # Issue #5070: verbatim conversational-memory lane
     ("api.verbatim_memory", "/verbatim-memory", ["memory"], "verbatim_memory"),
     # Issue #5071: per-agent diary with background append and runtime discovery

--- a/autobot-frontend/src/composables/useMarketplaceSources.ts
+++ b/autobot-frontend/src/composables/useMarketplaceSources.ts
@@ -34,7 +34,7 @@ export function useMarketplaceSources() {
     error.value = null
     loading.value = true
     try {
-      const data = await ApiClient.get(`${getApiBase()}/plugins/marketplaces`) as ListResponse
+      const data = await ApiClient.get(`${getApiBase()}/marketplace-sources`) as ListResponse
       sources.value = data.sources ?? []
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Failed to list marketplace sources'
@@ -49,7 +49,7 @@ export function useMarketplaceSources() {
     error.value = null
     try {
       const data = await ApiClient.post(
-        `${getApiBase()}/plugins/marketplaces`,
+        `${getApiBase()}/marketplace-sources`,
         payload,
       ) as MarketplaceSource
       await listSources()
@@ -65,7 +65,7 @@ export function useMarketplaceSources() {
   async function deleteSource(id: string): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.delete(`${getApiBase()}/plugins/marketplaces/${id}`)
+      await ApiClient.delete(`${getApiBase()}/marketplace-sources/${id}`)
       await listSources()
       return true
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary

`api.marketplace_sources` was registered with prefix `/plugins`, but `plugin_manager` (registered earlier with prefix `""`) already owns that namespace via `/plugins/{plugin_name}` wildcard. Starlette resolves first-match-wins, so `GET /api/plugins/marketplaces` was captured by plugin_manager and returned `404 Plugin not found: marketplaces`. Manage Sources modal was unusable.

## Fix

- Registry prefix `/plugins` → `/marketplace-sources`
- Inner routes `/marketplaces` → `""` and `/marketplaces/{source_id}` → `/{source_id}` (cleaner REST shape)
- Frontend `useMarketplaceSources.ts` updated for 3 call sites
- 3 regression tests in `marketplace_sources_routes_test.py` pin the prefix + inner-path shape

## Test plan

- [x] `python3 -m pytest autobot-backend/api/marketplace_sources_routes_test.py` — 3/3 pass
- [ ] CI green

Closes #6523

🤖 Generated with [Claude Code](https://claude.com/claude-code)