### PR TITLE
fix(plugins): make install/detail endpoints source-aware (#6524)

### DIFF
--- a/autobot-backend/api/marketplace.py
+++ b/autobot-backend/api/marketplace.py
@@ -259,6 +259,48 @@ async def _get_catalog() -> list[dict[str, Any]]:
     return _BUILTIN_CATALOG
 
 
+async def _resolve_catalog(source_id: str) -> list[dict[str, Any]]:
+    """#6524: shared catalog resolver used by list/detail/install endpoints.
+
+    For ``source_id == BUILTIN_SOURCE_ID`` returns the cached built-in catalog
+    (Redis-cached, seeded from ``_BUILTIN_CATALOG``). Otherwise looks up the
+    user-added source by id, fetches its remote catalog, and wraps each entry
+    via ``_safe_remote_plugin_to_entry`` to drop malformed payloads (#6525).
+
+    Raises ``HTTPException(404)`` for unknown source_id and ``HTTPException(422)``
+    for sources missing a catalog URL — preserves the same error semantics
+    that ``list_catalog`` already surfaced (#6527 contract).
+    """
+    if source_id == BUILTIN_SOURCE_ID:
+        return await _get_catalog()
+
+    from api.marketplace_sources import (  # local import: avoid cycle
+        fetch_remote_catalog,
+        get_source_by_id,
+    )
+
+    source = await get_source_by_id(source_id)
+    if source is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Marketplace source '{source_id}' not found",
+        )
+    if not source.url:
+        # Issue #6527: do NOT silently substitute the built-in catalog —
+        # surface the misconfiguration so the operator can fix the source.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Marketplace source '{source.name}' has no catalog URL configured",
+        )
+    remote_plugins = await fetch_remote_catalog(source.url)
+    # #6525: per-item wrapper drops malformed entries instead of failing
+    # the whole catalog. One bad apple from a user-added remote
+    # marketplace no longer 500s the response.
+    return [
+        entry for p in remote_plugins for entry in (_safe_remote_plugin_to_entry(p, source.name),) if entry is not None
+    ]
+
+
 @router.get("/catalog", response_model=MarketplaceCatalogResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -286,37 +328,7 @@ async def list_catalog(
     Issue #6481: ?source_id= selects which marketplace catalog to query.
     Issue #6534: category/sort_by validated by Pydantic via CatalogCategory/CatalogSort enums.
     """
-    if source_id == BUILTIN_SOURCE_ID:
-        catalog = await _get_catalog()
-    else:
-        from api.marketplace_sources import (  # local import: avoid cycle
-            fetch_remote_catalog,
-            get_source_by_id,
-        )
-
-        source = await get_source_by_id(source_id)
-        if source is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Marketplace source '{source_id}' not found",
-            )
-        if not source.url:
-            # Issue #6527: do NOT silently substitute the built-in catalog —
-            # surface the misconfiguration so the operator can fix the source.
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Marketplace source '{source.name}' has no catalog URL configured",
-            )
-        remote_plugins = await fetch_remote_catalog(source.url)
-        # #6525: per-item wrapper drops malformed entries instead of failing
-        # the whole catalog. One bad apple from a user-added remote
-        # marketplace no longer 500s the response.
-        catalog = [
-            entry
-            for p in remote_plugins
-            for entry in (_safe_remote_plugin_to_entry(p, source.name),)
-            if entry is not None
-        ]
+    catalog = await _resolve_catalog(source_id)
 
     # Filter by category
     if category != CatalogCategory.ALL:
@@ -366,13 +378,24 @@ async def list_catalog(
     operation="get_catalog_entry",
     error_code_prefix="MARKETPLACE",
 )
-async def get_catalog_entry(plugin_name: str) -> MarketplaceEntry:
+async def get_catalog_entry(
+    plugin_name: str,
+    source_id: str = Query(
+        default=BUILTIN_SOURCE_ID,
+        description=f"Marketplace source id; '{BUILTIN_SOURCE_ID}' or a user-added source UUID (#6481, #6524)",
+    ),
+    # #6524: align auth posture with list_catalog — non-builtin source_id
+    # triggers a server-side fetch of arbitrary URLs (SSRF surface).
+    user: dict = Depends(get_current_user),
+) -> MarketplaceEntry:
     """
     Get a single marketplace catalog entry by name.
 
     Issue #1803: Plugin and agent marketplace.
+    Issue #6524: ?source_id= selects which marketplace catalog to query —
+    detail endpoint must agree with list_catalog and install_plugin.
     """
-    catalog = await _get_catalog()
+    catalog = await _resolve_catalog(source_id)
     entry = next((e for e in catalog if e.get("name") == plugin_name), None)
 
     if not entry:
@@ -441,16 +464,23 @@ async def list_installed() -> dict[str, list[str]]:
     operation="install_plugin",
     error_code_prefix="MARKETPLACE",
 )
-async def install_plugin(body: InstallRequest) -> dict[str, str]:
+async def install_plugin(
+    body: InstallRequest,
+    user: dict = Depends(get_current_user),
+) -> dict[str, str]:
     """
     Mark a catalog plugin as installed.
 
-    Validates the plugin exists in the catalog then records it in the
-    installed set in Redis so the UI can reflect installation state.
+    Validates the plugin exists in the resolved catalog (built-in or the
+    user-added marketplace identified by ``body.source_id``) then records
+    it in the installed set in Redis so the UI can reflect installation state.
 
     Issue #1803: Plugin and agent marketplace.
+    Issue #6524: source_id required so install resolves against the same
+    catalog the user was browsing — fixes the headline 404 on every
+    custom-marketplace install.
     """
-    catalog = await _get_catalog()
+    catalog = await _resolve_catalog(body.source_id)
     entry = next((e for e in catalog if e.get("name") == body.plugin_name), None)
     if not entry:
         raise HTTPException(
@@ -461,11 +491,14 @@ async def install_plugin(body: InstallRequest) -> dict[str, str]:
     try:
         redis = await get_async_redis_client(database="main")
         await redis.sadd(_INSTALLED_KEY, body.plugin_name)
-        # Bump download counter in cached catalog
-        updated = [
-            {**e, "downloads": e.get("downloads", 0) + 1} if e.get("name") == body.plugin_name else e for e in catalog
-        ]
-        await redis.set(_CATALOG_KEY, json.dumps(updated), ex=_CATALOG_TTL)
+        # Bump download counter in cached catalog — only meaningful for the
+        # built-in catalog (remote catalogs are read-only). Skip otherwise.
+        if body.source_id == BUILTIN_SOURCE_ID:
+            updated = [
+                {**e, "downloads": e.get("downloads", 0) + 1} if e.get("name") == body.plugin_name else e
+                for e in catalog
+            ]
+            await redis.set(_CATALOG_KEY, json.dumps(updated), ex=_CATALOG_TTL)
     except Exception as exc:
         logger.error("Marketplace: install failed for %s: %s", body.plugin_name, exc)
         raise HTTPException(
@@ -473,7 +506,11 @@ async def install_plugin(body: InstallRequest) -> dict[str, str]:
             detail="Failed to record plugin installation",
         ) from exc
 
-    logger.info("Marketplace: installed plugin %s", body.plugin_name)
+    logger.info(
+        "Marketplace: installed plugin %s from source %s",
+        body.plugin_name,
+        body.source_id,
+    )
     return {"status": "installed", "plugin": body.plugin_name}
 
 

--- a/autobot-backend/api/marketplace_source_aware_test.py
+++ b/autobot-backend/api/marketplace_source_aware_test.py
@@ -1,0 +1,102 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""#6524: regression tests for source-aware install + detail endpoints.
+
+Pin the fix: ``install_plugin`` and ``get_catalog_entry`` must resolve
+against the same catalog the user was browsing — they were both hard-wired
+to the built-in catalog via ``_get_catalog()``, which made every install
+from a user-added marketplace 404.
+"""
+
+import inspect
+from typing import get_type_hints
+
+import pytest
+
+
+def test_install_request_has_source_id_field():
+    """``InstallRequest`` must accept ``source_id`` so the API can route
+    the install to the correct catalog.
+
+    Default = ``BUILTIN_SOURCE_ID`` so existing builtin-only callers don't
+    break — opt-in for custom-marketplace installs.
+    """
+    from api.schemas_workflows import InstallRequest
+
+    fields = InstallRequest.model_fields
+    assert (
+        "source_id" in fields
+    ), "#6524: InstallRequest.source_id missing — install endpoint cannot route to custom catalogs"
+    # Default ensures backward compat: a body with only `plugin_name` still
+    # validates and resolves against the built-in catalog.
+    default = fields["source_id"].default
+    assert default == "builtin", f"Expected builtin default; got {default!r}"
+
+
+def test_resolve_catalog_helper_exists():
+    """The shared resolver must exist so list/detail/install all share
+    the same source-routing logic — preventing future drift like the
+    original #6524 split-brain (list source-aware; install was not).
+    """
+    from api import marketplace as mod
+
+    assert hasattr(mod, "_resolve_catalog"), "#6524: shared `_resolve_catalog` helper missing"
+    assert inspect.iscoroutinefunction(mod._resolve_catalog), "_resolve_catalog must be async"
+
+
+def test_get_catalog_entry_takes_source_id_query_param():
+    """Detail endpoint must accept ``?source_id=`` so deep-links from a
+    custom marketplace catalog work.
+    """
+    from api.marketplace import get_catalog_entry
+
+    sig = inspect.signature(get_catalog_entry)
+    assert "source_id" in sig.parameters, "#6524: get_catalog_entry must accept source_id Query param"
+
+
+def test_install_plugin_takes_install_request_body():
+    """``install_plugin`` body type must be ``InstallRequest`` so the new
+    ``source_id`` field arrives. Pin against accidental signature drift
+    (e.g. someone replacing it with a plain dict body).
+    """
+    from api.marketplace import install_plugin
+    from api.schemas_workflows import InstallRequest
+
+    sig = inspect.signature(install_plugin)
+    body_param = sig.parameters.get("body")
+    assert body_param is not None, "#6524: install_plugin must keep `body` parameter"
+    assert (
+        body_param.annotation is InstallRequest
+    ), f"#6524: body annotation must be InstallRequest; got {body_param.annotation!r}"
+
+
+def test_install_plugin_no_longer_hardcoded_to_builtin_catalog():
+    """The bug shape was ``catalog = await _get_catalog()`` inside
+    ``install_plugin`` (and ``get_catalog_entry``) — flat call against the
+    built-in catalog regardless of which marketplace the user was browsing.
+
+    Pin against re-introduction: install_plugin source must call
+    ``_resolve_catalog`` (which routes by source_id), not ``_get_catalog``.
+    """
+    from api.marketplace import install_plugin
+
+    src = inspect.getsource(install_plugin)
+    assert "_resolve_catalog" in src, (
+        "#6524 regression: install_plugin must call _resolve_catalog(source_id), "
+        "not the legacy _get_catalog() that returned only the built-in catalog."
+    )
+    # Original bug shape: bare `_get_catalog()` call without arguments.
+    assert "await _get_catalog()" not in src, (
+        "#6524 regression: install_plugin must NOT use `await _get_catalog()` — "
+        "that's the bug shape that hard-coded routing to the built-in catalog."
+    )
+
+
+def test_get_catalog_entry_no_longer_hardcoded_to_builtin_catalog():
+    """Same regression guard for the detail endpoint."""
+    from api.marketplace import get_catalog_entry
+
+    src = inspect.getsource(get_catalog_entry)
+    assert "_resolve_catalog" in src, "#6524: get_catalog_entry must call _resolve_catalog"
+    assert "await _get_catalog()" not in src, "#6524: get_catalog_entry must NOT use bare _get_catalog()"

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -1880,6 +1880,13 @@ class InstallRequest(BaseModel):
     """Request body for installing a marketplace plugin."""
 
     plugin_name: str = Field(..., description="Name of the plugin to install from catalog")
+    # #6524: source_id required so install resolves against the same catalog
+    # the user was browsing. Without it, custom marketplace plugins all
+    # 404'd because we'd resolve against the built-in catalog only.
+    source_id: str = Field(
+        default="builtin",
+        description="Marketplace source id; 'builtin' or a user-added source UUID (#6481)",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-frontend/src/views/MarketplaceView.vue
+++ b/autobot-frontend/src/views/MarketplaceView.vue
@@ -338,7 +338,12 @@ async function handleInstall(name: string): Promise<void> {
   actionLoading.value[name] = true
   error.value = null
   try {
-    await ApiClient.post(`${getApiBase()}/marketplace/install`, { plugin_name: name })
+    // #6524: include source_id so backend resolves against the same catalog
+    // the user was browsing (otherwise plugins from custom marketplaces 404).
+    await ApiClient.post(`${getApiBase()}/marketplace/install`, {
+      plugin_name: name,
+      source_id: selectedSourceId.value,
+    })
     installedNames.value = new Set([...installedNames.value, name])
     await fetchCatalog()
   } catch (err) {


### PR DESCRIPTION
## Summary

`install_plugin` and `get_catalog_entry` both called `await _get_catalog()` directly, ignoring the source the user was browsing. Every install from a user-added marketplace returned `404 Plugin not found in marketplace`.

## Fix

- Extract `_resolve_catalog(source_id)` shared helper — built-in path returns cached catalog, custom path fetches remote with `_safe_remote_plugin_to_entry` wrapper (#6525)
- `InstallRequest.source_id: str = "builtin"` — backward-compatible default
- `get_catalog_entry` gets `?source_id=` Query param + auth gate (mirrors `list_catalog`)
- `install_plugin` gets auth gate (consistency); download bump gated on builtin source (remote catalogs are read-only)
- Frontend `MarketplaceView.handleInstall` sends `selectedSourceId.value`

## Filed as follow-up (out of scope)

The issue's "persist source identifier with installed name" suggestion is a storage refactor with migration risk — will be filed separately so it can be reviewed independently.

## Test plan

- [x] `python3 -m pytest autobot-backend/api/marketplace_source_aware_test.py` — 6/6 pass locally
- [ ] CI green: smoke-test, startup-import-smoke, code-quality

Closes #6524

🤖 Generated with [Claude Code](https://claude.com/claude-code)