### PR TITLE
fix(test/notif): migrate to canonical async-redis fixture + fix wrong-namespace patch (#7280 round 2)

### DIFF
--- a/autobot-backend/tests/services/test_workflow_notification_persistence.py
+++ b/autobot-backend/tests/services/test_workflow_notification_persistence.py
@@ -23,6 +23,7 @@ from services.workflow_automation.persistence import (
     load_notification_config,
     save_notification_config,
 )
+from tests.fixtures import make_async_redis, patch_async_redis
 
 # ===========================================================================
 # Helpers
@@ -45,12 +46,12 @@ def _make_config(**kwargs) -> NotificationConfig:
     return NotificationConfig(**defaults)
 
 
-def _make_redis(get_return=None):
-    mock = AsyncMock()
-    mock.set = AsyncMock(return_value=True)
-    mock.get = AsyncMock(return_value=get_return)
-    mock.delete = AsyncMock(return_value=1)
-    return mock
+# Migrated to canonical ``make_async_redis()`` / ``patch_async_redis()``
+# from ``tests.fixtures`` (#7280 round 2). Local ``_make_redis()`` removed.
+# Critical fix surfaced by migration: production imports
+# ``get_async_redis_client`` (async) but tests patched ``get_redis_client``
+# (sync, doesn't exist in the consumer namespace) — patches AttributeError'd
+# at runtime, all 7 affected tests were broken pre-migration.
 
 
 # ===========================================================================
@@ -61,10 +62,10 @@ def _make_redis(get_return=None):
 @pytest.mark.asyncio
 async def test_save_persists_json_to_redis():
     config = _make_config()
-    redis_mock = _make_redis()
-    with patch(
-        "services.workflow_automation.persistence.get_redis_client",
-        return_value=redis_mock,
+    redis_mock = make_async_redis()
+    with patch_async_redis(
+        "services.workflow_automation.persistence.get_async_redis_client",
+        redis=redis_mock,
     ):
         await save_notification_config(_WF_ID, config)
 
@@ -80,10 +81,10 @@ async def test_save_persists_json_to_redis():
 
 @pytest.mark.asyncio
 async def test_save_none_deletes_key():
-    redis_mock = _make_redis()
-    with patch(
-        "services.workflow_automation.persistence.get_redis_client",
-        return_value=redis_mock,
+    redis_mock = make_async_redis()
+    with patch_async_redis(
+        "services.workflow_automation.persistence.get_async_redis_client",
+        redis=redis_mock,
     ):
         await save_notification_config(_WF_ID, None)
 
@@ -94,8 +95,8 @@ async def test_save_none_deletes_key():
 @pytest.mark.asyncio
 async def test_save_graceful_when_redis_unavailable():
     with patch(
-        "services.workflow_automation.persistence.get_redis_client",
-        return_value=None,
+        "services.workflow_automation.persistence.get_async_redis_client",
+        new=AsyncMock(return_value=None),
     ):
         await save_notification_config(_WF_ID, _make_config())
 
@@ -109,10 +110,10 @@ async def test_save_graceful_when_redis_unavailable():
 async def test_load_returns_config_from_redis():
     config = _make_config()
     raw_json = json.dumps(asdict(config)).encode("utf-8")
-    redis_mock = _make_redis(get_return=raw_json)
-    with patch(
-        "services.workflow_automation.persistence.get_redis_client",
-        return_value=redis_mock,
+    redis_mock = make_async_redis(get_returns=raw_json)
+    with patch_async_redis(
+        "services.workflow_automation.persistence.get_async_redis_client",
+        redis=redis_mock,
     ):
         result = await load_notification_config(_WF_ID)
 
@@ -124,10 +125,10 @@ async def test_load_returns_config_from_redis():
 
 @pytest.mark.asyncio
 async def test_load_returns_none_when_key_missing():
-    redis_mock = _make_redis(get_return=None)
-    with patch(
-        "services.workflow_automation.persistence.get_redis_client",
-        return_value=redis_mock,
+    redis_mock = make_async_redis(get_returns=None)
+    with patch_async_redis(
+        "services.workflow_automation.persistence.get_async_redis_client",
+        redis=redis_mock,
     ):
         result = await load_notification_config(_WF_ID)
 
@@ -137,8 +138,8 @@ async def test_load_returns_none_when_key_missing():
 @pytest.mark.asyncio
 async def test_load_returns_none_when_redis_unavailable():
     with patch(
-        "services.workflow_automation.persistence.get_redis_client",
-        return_value=None,
+        "services.workflow_automation.persistence.get_async_redis_client",
+        new=AsyncMock(return_value=None),
     ):
         result = await load_notification_config(_WF_ID)
 
@@ -147,10 +148,10 @@ async def test_load_returns_none_when_redis_unavailable():
 
 @pytest.mark.asyncio
 async def test_load_returns_none_on_malformed_json():
-    redis_mock = _make_redis(get_return=b"not-valid-json")
-    with patch(
-        "services.workflow_automation.persistence.get_redis_client",
-        return_value=redis_mock,
+    redis_mock = make_async_redis(get_returns=b"not-valid-json")
+    with patch_async_redis(
+        "services.workflow_automation.persistence.get_async_redis_client",
+        redis=redis_mock,
     ):
         result = await load_notification_config(_WF_ID)
 


### PR DESCRIPTION
## Summary

#7280 round 2: migrates ``tests/services/test_workflow_notification_persistence.py`` to the canonical ``make_async_redis()`` / ``patch_async_redis()`` fixture **and** fixes a pre-existing latent bug surfaced by the migration.

## CRITICAL: Layered rot caught

7 of 13 tests in this file were FAILING with ``AttributeError`` at ``patch.start()``:

```
$ pytest tests/services/test_workflow_notification_persistence.py  # before this PR
============= 7 failed, 6 passed in 6.49s =============
AttributeError: <module 'services.workflow_automation.persistence' ...> does
not have the attribute 'get_redis_client'
```

Production imports ``get_async_redis_client`` (async, line 19 of ``persistence.py``); tests patched ``get_redis_client`` (sync, doesn't exist in the consumer namespace). Patches never installed.

This is exactly the layered-rot pattern from ``feedback_layered_test_rot.md``: the migration forced re-running each file's contract, surfacing a wrong-namespace patch that had been silently failing under the broader #6987 noise.

## After

```
$ pytest tests/services/test_workflow_notification_persistence.py
============= 13 passed in 4.51s =============
```

## Changes

- **Removed** local ``_make_redis(get_return=...)`` helper (6 LOC).
- **Added** ``from tests.fixtures import make_async_redis, patch_async_redis``.
- **Fixed namespace**: 7 patches now target ``get_async_redis_client`` (production's actual import) instead of ``get_redis_client``.
- **Adopted canonical**: 5 mock-redis sites now use ``patch_async_redis(...)``; 2 redis-unavailable sites use raw ``patch(..., new=AsyncMock(return_value=None))`` because the canonical fixture always installs an async-mock-redis (``None`` is needed to exercise the unavailable branch).

Net: -1 LOC, 7 broken tests fixed, file unified onto canonical pattern.

## Test plan

- [x] ``pytest tests/services/test_workflow_notification_persistence.py`` — 13/13 passed (was 6 passed / 7 failed)

## Refs

- Refs #7280 (parent migration tracker; round 2 of N)
- Refs #7165 (preventive lint hook — would have caught this if extended for runtime resolution per #7336)
- Pattern: ``feedback_layered_test_rot.md``

🤖 Generated with [Claude Code](https://claude.com/claude-code)