### PR TITLE
refactor(test/knowledge): migrate knowledge_base_async_test.py to canonical fixture (#7280 round 3)

### DIFF
--- a/autobot-backend/knowledge/knowledge_base_async_test.py
+++ b/autobot-backend/knowledge/knowledge_base_async_test.py
@@ -21,26 +21,21 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.fixtures import make_async_redis
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Patch paths
 # ---------------------------------------------------------------------------
 
+# These patch the canonical source (``autobot_shared.redis_client``) rather
+# than a consumer namespace because ``KnowledgeBase._init_redis_connections``
+# imports ``get_async_redis_client`` lazily inside the method body
+# (``knowledge/base.py:322``) — there is no module-top binding to patch in
+# the consumer namespace at patch time.
 _SYNC_CLIENT_PATH = "autobot_shared.redis_client.get_redis_client"
 _ASYNC_CLIENT_PATH = "autobot_shared.redis_client.get_async_redis_client"
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_mock_redis() -> AsyncMock:
-    """Return an AsyncMock that behaves like redis.asyncio.Redis."""
-    client = AsyncMock()
-    client.ping = AsyncMock(return_value=True)
-    return client
 
 
 # ---------------------------------------------------------------------------
@@ -50,7 +45,11 @@ def _make_mock_redis() -> AsyncMock:
 
 @pytest.fixture
 def mock_async_redis():
-    return _make_mock_redis()
+    # Migrated to canonical ``make_async_redis()`` (#7280 round 3).
+    # ``ping=True`` flows through ``**extra_methods`` to attach
+    # ``AsyncMock(return_value=True)`` — ``ping`` is not in the canonical
+    # fixture's core defaults.
+    return make_async_redis(ping=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

#7280 round 3: clean migration of ``knowledge/knowledge_base_async_test.py`` to canonical ``make_async_redis()`` fixture from ``tests.fixtures``.

## Changes

- **Removed** local ``_make_mock_redis()`` helper (5 LOC).
- **Added** ``from tests.fixtures import make_async_redis``.
- **Replaced**: fixture body now calls ``make_async_redis(ping=True)`` — ``ping`` flows through ``**extra_methods`` (documented escape hatch).
- **Documented** patch path choice: the two ``_*_CLIENT_PATH`` constants intentionally target the canonical source, not a consumer namespace, because ``KnowledgeBase._init_redis_connections()`` lazy-imports inside the method body (``knowledge/base.py:322``). Added an inline comment so the next migrator doesn't accidentally repoint to a non-existent consumer namespace (inverse of #7215).

Net: -1 LOC.

## Test plan

- [x] ``pytest knowledge/knowledge_base_async_test.py`` — 5/5 passed before AND after migration

## #7280 progress

- ✅ Round 1: ``services/workflow_versioning_test.py`` (PR #7340 merged) — 35/35 pass
- ✅ Round 2: ``tests/services/test_workflow_notification_persistence.py`` (PR #7374 merged) — **7 latent bugs fixed**
- ✅ Round 3: ``knowledge/knowledge_base_async_test.py`` (this PR) — clean migration

## Refs

- Refs #7280 (parent)
- Refs #7339 (scope refinement; this file is a clean candidate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)