### PR TITLE
fix(security): detect dangerous env-var prefix injection (#7375)

### DIFF
--- a/autobot-backend/secure_command_executor.py
+++ b/autobot-backend/secure_command_executor.py
@@ -9,6 +9,7 @@ Implements security measures to prevent arbitrary command execution
 import asyncio
 import logging
 import os
+import re
 import shlex
 from enum import Enum
 from pathlib import Path
@@ -33,6 +34,80 @@ if TYPE_CHECKING:
     from services.permission_matcher import PermissionMatcher
 
 logger = logging.getLogger(__name__)
+
+
+# #7375: env-var prefix injection — surfaced by #7367 test rot triage.
+# Production previously classified `PATH=/x:$PATH ls` and
+# `LD_PRELOAD=/x.so ls` as MODERATE because the base-command lookup hit
+# `ls` (a SAFE/MODERATE command) without parsing the env-var prefix as a
+# distinct injection vector. Both are real attacker techniques:
+#   - PATH manipulation shadows standard binaries (sudo helpers, cron,
+#     login shells) by prepending an attacker-controlled directory.
+#   - LD_PRELOAD / LD_LIBRARY_PATH / DYLD_INSERT_LIBRARIES hijack any
+#     dynamic-linker symbol before the target binary runs — used in
+#     container-escape and privilege-escalation chains.
+#   - IFS / BASH_ENV / ENV affect shell parsing in subshells.
+#   - PYTHONPATH / PERL5LIB / RUBYLIB / NODE_PATH inject malicious
+#     libraries into interpreter startup.
+_ENV_VAR_PREFIX_RE = re.compile(r"^\s*(?:[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|\"[^\"]*\"|\S*)\s+)+")
+_DANGEROUS_ENV_VARS = frozenset(
+    {
+        # Linker / loader hijack
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+        "LD_AUDIT",
+        "DYLD_INSERT_LIBRARIES",
+        "DYLD_LIBRARY_PATH",
+        # Path / executable resolution
+        "PATH",
+        # Shell parsing / startup
+        "IFS",
+        "BASH_ENV",
+        "ENV",
+        "PROMPT_COMMAND",
+        # Interpreter library paths
+        "PYTHONPATH",
+        "PERL5LIB",
+        "RUBYLIB",
+        "NODE_PATH",
+        "GEM_PATH",
+        # Process tracing
+        "LD_DEBUG",
+    }
+)
+
+
+def _check_dangerous_env_var_prefix(command: str) -> Optional[List[str]]:
+    """#7375: detect env-var prefix injection BEFORE base-command lookup.
+
+    Returns a list of dangerous env-var names found prefixed in the
+    command, or ``None`` if none. The caller upgrades the risk to
+    ``CommandRisk.FORBIDDEN`` since these prefixes shadow the linker /
+    interpreter / shell startup independent of the command they wrap.
+    """
+    match = _ENV_VAR_PREFIX_RE.match(command)
+    if not match:
+        return None
+    prefix = match.group(0)
+    flagged: List[str] = []
+    # Per-assignment: split by `=` to get the var name, ignore the value.
+    # We use `shlex.split` because values may contain quoted strings with
+    # whitespace (e.g. `PROMPT_COMMAND='rm -rf /'`) — naive `prefix.split()`
+    # would tokenize on space and miss the var-name extraction.
+    try:
+        tokens = shlex.split(prefix)
+    except ValueError:
+        # Malformed quoting — fall back to whitespace split; if the prefix
+        # is truly malformed it'll fail base-command validation downstream.
+        tokens = prefix.split()
+    for token in tokens:
+        if "=" not in token:
+            continue
+        var_name = token.split("=", 1)[0]
+        if var_name in _DANGEROUS_ENV_VARS:
+            flagged.append(var_name)
+    return flagged or None
+
 
 # Issue #765: Path constants now imported from security.command_patterns
 
@@ -461,6 +536,18 @@ class SecureCommandExecutor:
         Returns:
             (risk_level, list_of_reasons)
         """
+        # #7375: env-var prefix injection check runs FIRST. `PATH=/x ls`
+        # would otherwise resolve to base_command `ls` (SAFE/MODERATE) and
+        # miss the linker/path hijack entirely. Also catches malformed
+        # commands like `PROMPT_COMMAND='rm -rf /' bash` where
+        # _extract_command_name returns empty — we want the more specific
+        # FORBIDDEN reason ("Dangerous env-var prefix: PROMPT_COMMAND")
+        # rather than the generic "Empty or malformed command".
+        dangerous_env_vars = _check_dangerous_env_var_prefix(command)
+        if dangerous_env_vars:
+            reasons = [f"Dangerous env-var prefix: {var}" for var in dangerous_env_vars]
+            return CommandRisk.FORBIDDEN, reasons
+
         base_command = self._extract_command_name(command)
 
         if not base_command:

--- a/autobot-backend/secure_command_executor_env_prefix_test.py
+++ b/autobot-backend/secure_command_executor_env_prefix_test.py
@@ -1,0 +1,97 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""#7375: env-var prefix injection detection in SecureCommandExecutor.
+
+Surfaced by #7367 test rot triage: `PATH=/malicious:$PATH ls` and
+`LD_PRELOAD=/x.so ls` previously classified as MODERATE because the
+risk assessor anchored on the base command (`ls` — SAFE/MODERATE) and
+didn't parse the env-var prefix as a distinct injection vector.
+
+Both are real attacker techniques (PATH-shadowing of standard binaries,
+linker hijack of any dynamic symbol) and must classify as FORBIDDEN.
+"""
+
+import pytest
+
+from secure_command_executor import CommandRisk, SecureCommandExecutor
+
+
+@pytest.fixture
+def executor() -> SecureCommandExecutor:
+    return SecureCommandExecutor()
+
+
+@pytest.mark.parametrize(
+    "command, flagged_var",
+    [
+        # Linker / loader hijack family — dominant container-escape and
+        # privilege-escalation technique
+        ("LD_PRELOAD=/malicious.so ls", "LD_PRELOAD"),
+        ("LD_LIBRARY_PATH=/malicious /usr/bin/cat /etc/shadow", "LD_LIBRARY_PATH"),
+        ("LD_AUDIT=/x.so /bin/true", "LD_AUDIT"),
+        ("DYLD_INSERT_LIBRARIES=/x.dylib /usr/bin/whoami", "DYLD_INSERT_LIBRARIES"),
+        ("DYLD_LIBRARY_PATH=/x /usr/bin/whoami", "DYLD_LIBRARY_PATH"),
+        # PATH manipulation — shadow standard binaries (sudo helpers, cron
+        # login shells) by prepending an attacker-controlled directory
+        ("PATH=/malicious:$PATH ls", "PATH"),
+        ("PATH=/x sudo whoami", "PATH"),
+        # Shell parsing / startup manipulation — affects subshells
+        ("IFS=. ls", "IFS"),
+        ("BASH_ENV=/malicious bash -c ls", "BASH_ENV"),
+        ("ENV=/malicious sh -c ls", "ENV"),
+        ("PROMPT_COMMAND='rm -rf /' bash", "PROMPT_COMMAND"),
+        # Interpreter library path injection
+        ("PYTHONPATH=/malicious python3 -c 'pass'", "PYTHONPATH"),
+        ("PERL5LIB=/malicious perl -e ''", "PERL5LIB"),
+        ("RUBYLIB=/x ruby -e ''", "RUBYLIB"),
+        ("NODE_PATH=/x node -e 'process.exit(0)'", "NODE_PATH"),
+        ("GEM_PATH=/x gem list", "GEM_PATH"),
+        # Process-tracing leak
+        ("LD_DEBUG=all /usr/bin/ssh user@host", "LD_DEBUG"),
+    ],
+)
+def test_dangerous_env_var_prefix_classifies_as_forbidden(
+    executor: SecureCommandExecutor, command: str, flagged_var: str
+) -> None:
+    """All dangerous env-var families must return FORBIDDEN regardless
+    of the wrapped base command — the prefix itself is the injection."""
+    risk, reasons = executor.assess_command_risk(command)
+    assert risk == CommandRisk.FORBIDDEN, (
+        f"#7375: `{command}` must classify as FORBIDDEN (env-var prefix "
+        f"injection) — got {risk.value}. Reasons: {reasons}"
+    )
+    assert any(flagged_var in r for r in reasons), f"Expected reason mentioning {flagged_var}; got {reasons}"
+
+
+def test_benign_env_var_prefix_does_not_classify_as_forbidden(
+    executor: SecureCommandExecutor,
+) -> None:
+    """Env-var prefixes that don't shadow linker / shell startup / interpreter
+    library paths should NOT be flagged as FORBIDDEN by this check.
+
+    `FOO=bar ls` is application-level config and is benign on its own;
+    falls through to the base-command lookup (`ls` → SAFE/MODERATE)."""
+    risk, _ = executor.assess_command_risk("FOO=bar ls")
+    assert risk != CommandRisk.FORBIDDEN, "Generic env-var prefix shouldn't auto-FORBID"
+
+
+def test_no_env_var_prefix_unaffected(executor: SecureCommandExecutor) -> None:
+    """Plain commands without any env-var prefix go through the normal
+    risk path — pin against accidental over-eager regex matching."""
+    risk, _ = executor.assess_command_risk("ls -la /tmp")
+    assert risk == CommandRisk.SAFE
+
+
+def test_export_assignment_not_treated_as_prefix(executor: SecureCommandExecutor) -> None:
+    """`export PATH=/x; ls` is a separate injection vector (shell
+    builtin), not the prefix-form this check targets. Pin so adding it
+    here later is a deliberate choice, not accidental scope creep."""
+    risk, _ = executor.assess_command_risk("export PATH=/x; ls")
+    # We expect this to be flagged via the existing `_check_dangerous_patterns`
+    # path (`;` separator) rather than the env-var prefix path. The risk
+    # itself may still be FORBIDDEN/HIGH from that side — what we care about
+    # is that `_check_dangerous_env_var_prefix` does NOT match this shape.
+    from secure_command_executor import _check_dangerous_env_var_prefix
+
+    assert _check_dangerous_env_var_prefix("export PATH=/x; ls") is None


### PR DESCRIPTION
## Summary

`assess_command_risk` previously classified `PATH=/x:$PATH ls` and `LD_PRELOAD=/x.so ls` as MODERATE because the base-command lookup hit `ls` (SAFE/MODERATE) without parsing the env-var prefix as a distinct injection vector. Both are real attacker techniques surfaced during #7367 test rot triage.

## Fix

`_check_dangerous_env_var_prefix(command)` runs BEFORE base-command extraction. Detects 15 dangerous env-var names across 5 attack families:

- **Linker hijack**: `LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`
- **Path manipulation**: `PATH`
- **Shell parsing**: `IFS`, `BASH_ENV`, `ENV`, `PROMPT_COMMAND`
- **Interpreter injection**: `PYTHONPATH`, `PERL5LIB`, `RUBYLIB`, `NODE_PATH`, `GEM_PATH`
- **Process tracing**: `LD_DEBUG`

Uses regex with quoted-value handling + `shlex.split` for proper tokenization (`PROMPT_COMMAND='rm -rf /' bash` and similar).

## Test plan

- [x] 20 regression cases in `secure_command_executor_env_prefix_test.py` — 20/20 PASSED locally
- [x] Benign env vars (`FOO=bar ls`) NOT flagged
- [x] Plain commands (`ls -la /tmp`) unaffected
- [x] `export PATH=/x; ls` (separate vector) explicitly NOT in scope of this check
- [ ] CI green

## Cross-references

- Discovered via #7367 phase 1 (PR #7377) test rot triage
- Re-enable the 2 cases dropped from `test_command_injection_attempts` in a follow-up phase once this lands

Closes #7375

🤖 Generated with [Claude Code](https://claude.com/claude-code)