### PR TITLE
fix(test/retrieval_learner): scope hset assertion to pattern keys (#7386)

### DIFF
--- a/autobot-backend/tests/knowledge/search_components/retrieval_learner_test.py
+++ b/autobot-backend/tests/knowledge/search_components/retrieval_learner_test.py
@@ -217,7 +217,16 @@ class TestConsumeFeedbackStream:
 
     @pytest.mark.asyncio
     async def test_neutral_event_not_distilled(self):
-        """Identical retrieved and ranked IDs → not successful → no hset call."""
+        """Identical retrieved and ranked IDs → not successful → no PATTERN hset.
+
+        #7386: production legitimately calls ``redis.hset(_CURSOR_HASH_KEY, ...)``
+        after processing any event — cursor advance is required for correctness
+        so the next ``consume_feedback_stream`` call doesn't re-process the
+        same events. The original assertion ``not redis.hset.called`` was too
+        coarse — it caught the cursor-save call as well as the (absent)
+        pattern hset. Assert specifically that no hset hit the
+        ``rag:retrieval:pattern:*`` namespace.
+        """
         redis = _make_redis_mock()
         ids = ["a", "b", "c"]
         fields = _make_feedback_fields(retrieved=ids, ranked=ids, complexity="simple")
@@ -226,7 +235,17 @@ class TestConsumeFeedbackStream:
         learner = _make_learner(redis)
         await learner.consume_feedback_stream("2026-01-01")
 
-        assert not redis.hset.called
+        # Cursor save (`rag:rl:cursors`) is allowed; pattern persistence
+        # (`rag:retrieval:pattern:*`) is what neutral events MUST NOT trigger.
+        pattern_hset_calls = [
+            call
+            for call in redis.hset.call_args_list
+            if call.args and isinstance(call.args[0], str) and call.args[0].startswith("rag:retrieval:pattern:")
+        ]
+        assert not pattern_hset_calls, (
+            f"#7386: neutral event triggered pattern persistence — "
+            f"unexpected hset calls to pattern keys: {pattern_hset_calls}"
+        )
 
     @pytest.mark.asyncio
     async def test_cursor_advances_after_processing(self):


### PR DESCRIPTION
## Summary

Triage verdict: **test rot**, not regression.

`test_neutral_event_not_distilled` was asserting `not redis.hset.called` — too coarse. Production correctly skips `_distil_pattern` for neutral events but ALSO calls `redis.hset(_CURSOR_HASH_KEY, ...)` in `_save_cursor` to advance the resume cursor (required for correctness — otherwise the next `consume_feedback_stream` call re-processes the same events forever).

## Fix

Filter `redis.hset.call_args_list` for calls targeting the `rag:retrieval:pattern:*` namespace (the actual pattern-persistence surface) and assert that list is empty. Cursor saves to `rag:rl:cursors` are allowed — that contract is documented by sibling test `test_cursor_advances_after_processing`.

## Test plan

- [x] `pytest autobot-backend/tests/knowledge/search_components/retrieval_learner_test.py::TestConsumeFeedbackStream` — 4/4 pass
- [x] Full file: 45/45 pass in 0.95s
- [ ] CI green: smoke-test, startup-import-smoke, code-quality

Closes #7386
References #7367 #7280

🤖 Generated with [Claude Code](https://claude.com/claude-code)