### PR TITLE
refactor(test/retrieval_learner): migrate sister files to canonical async-redis fixture (#7280 round 5)

### DIFF
--- a/autobot-backend/tests/knowledge/search_components/retrieval_learner_test.py
+++ b/autobot-backend/tests/knowledge/search_components/retrieval_learner_test.py
@@ -18,6 +18,7 @@ from knowledge.search_components.retrieval_learner import (
     _ucb1_score,
     get_retrieval_learner,
 )
+from tests.fixtures import make_async_redis
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -25,15 +26,10 @@ from knowledge.search_components.retrieval_learner import (
 
 
 def _make_redis_mock() -> AsyncMock:
-    """Return a Redis mock with sensible defaults."""
-    redis = AsyncMock()
-    redis.xrange = AsyncMock(return_value=[])
-    redis.hgetall = AsyncMock(return_value={})
-    redis.hset = AsyncMock()
-    redis.expire = AsyncMock()
-    redis.delete = AsyncMock()
-    redis.scan = AsyncMock(return_value=(0, []))
-    return redis
+    # Migrated to canonical ``make_async_redis()`` (#7280 round 5).
+    # ``hgetall``, ``hset``, ``expire``, ``delete`` are canonical defaults;
+    # ``xrange=[]`` and ``scan=(0, [])`` flow through ``**extra_methods``.
+    return make_async_redis(xrange=[], scan=(0, []))
 
 
 def _make_learner(redis: AsyncMock) -> RetrievalLearner:

--- a/autobot-backend/tests/knowledge/search_components/retrieval_learner_user_scoped_test.py
+++ b/autobot-backend/tests/knowledge/search_components/retrieval_learner_user_scoped_test.py
@@ -27,6 +27,7 @@ from knowledge.search_components.retrieval_learner import (
     _compute_pattern_hash,
     get_retrieval_learner,
 )
+from tests.fixtures import make_async_redis
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -37,15 +38,11 @@ _USER_B = "user-bob-456"
 
 
 def _make_redis_mock() -> AsyncMock:
-    redis = AsyncMock()
-    redis.xrange = AsyncMock(return_value=[])
-    redis.xadd = AsyncMock()
-    redis.hgetall = AsyncMock(return_value={})
-    redis.hset = AsyncMock()
-    redis.expire = AsyncMock()
-    redis.delete = AsyncMock()
-    redis.scan = AsyncMock(return_value=(0, []))
-    return redis
+    # Migrated to canonical ``make_async_redis()`` (#7280 round 5).
+    # ``hgetall``, ``hset``, ``expire``, ``delete`` are canonical defaults;
+    # ``xrange=[]``, ``xadd`` (no-op), and ``scan=(0, [])`` flow through
+    # ``**extra_methods``.
+    return make_async_redis(xrange=[], xadd=None, scan=(0, []))
 
 
 def _make_learner(redis: AsyncMock) -> RetrievalLearner:


### PR DESCRIPTION
## Summary

#7280 round 5: clean migration of two sister test files under ``tests/knowledge/search_components/`` to canonical ``make_async_redis()`` from ``tests.fixtures``.

## Changes

- **`retrieval_learner_test.py`** — 18 call sites
- **`retrieval_learner_user_scoped_test.py`** — 17 call sites (adds ``xadd``)

In both files: kept ``_make_redis_mock()`` as a thin wrapper that returns ``make_async_redis(xrange=[], scan=(0, []))`` — avoids 35 call-site rewrites while still removing the ad-hoc 8-line helper. Same end state (no more ad-hoc fixture, canonical-backed) with smaller blast radius.

``hgetall``, ``hset``, ``expire``, ``delete`` are canonical defaults; ``xrange``, ``xadd``, ``scan`` flow through ``**extra_methods``.

Net: -7 LOC across both files (reduced helper bodies).

## Test plan

- [x] ``pytest tests/knowledge/search_components/retrieval_learner_test.py tests/knowledge/search_components/retrieval_learner_user_scoped_test.py`` — same 1 failed / 59 passed before AND after (no regressions)

## Pre-existing failure (NOT introduced by this PR)

``test_neutral_event_not_distilled`` was already failing on Dev_new_gui before this migration. Filed as **#7386** for RAG-domain triage. The migration touched only the local helper definition — call sites unchanged — so the failure is pre-existing.

## #7280 progress

- ✅ Round 1: ``services/workflow_versioning_test.py`` (PR #7340 merged, 17 sites)
- ✅ Round 2: ``tests/services/test_workflow_notification_persistence.py`` (PR #7374 merged, **7 latent bugs fixed**)
- ✅ Round 3: ``knowledge/knowledge_base_async_test.py`` (PR #7381 merged)
- ✅ Round 4: ``services/mesh_brain/edge_learner_test.py`` (PR #7383 merged, 28 tests, 9 sites)
- ✅ Round 5: this PR — 2 files, 35 sites
- **Cumulative**: 5 files, ~96 sites migrated; 1 pre-existing test bug surfaced (#7386); 1 latent infra bug fixed (round 2's 7 broken tests)

## Refs

- Refs #7280 (parent)
- Refs #7339 (scope refinement)
- Refs #7386 (pre-existing failure, not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)