### PR TITLE
fix(security): argument-aware risk for docker/find/DNS attack flags (#7384)

### DIFF
--- a/autobot-backend/secure_command_executor.py
+++ b/autobot-backend/secure_command_executor.py
@@ -77,6 +77,96 @@ _DANGEROUS_ENV_VARS = frozenset(
 )
 
 
+# #7384: argument-aware risk for tools whose base command is allowlisted
+# but whose flags / arguments elevate them to attack vectors.
+# Same family as #7375 (env-var prefix) — the base command (`docker`,
+# `find`, `dig`) lookup says SAFE/MODERATE, but specific argument shapes
+# turn them into container-escape, SUID-recon, or DNS-tunneling vectors.
+_DOCKER_ESCAPE_FLAGS = (
+    "--privileged",
+    "--net=host",
+    "--network=host",
+    "--pid=host",
+    "--ipc=host",
+    "--uts=host",
+    "--userns=host",
+    "--cap-add",
+    "-v /:",
+    "--volume=/:",
+    "--device=",
+    "--security-opt=seccomp=unconfined",
+    "--security-opt=apparmor=unconfined",
+)
+# `find` argument shapes that signal SUID / setgid recon — used to locate
+# privilege-escalation primitives. The wrapped `find` itself is benign
+# (allowlisted MODERATE); these argument shapes elevate to HIGH.
+_FIND_SUID_RECON_PATTERNS = (
+    "-perm -4000",  # setuid bit (-4000)
+    "-perm -2000",  # setgid bit (-2000)
+    "-perm -u+s",  # setuid (symbolic)
+    "-perm -g+s",  # setgid (symbolic)
+    "-perm /4000",
+    "-perm /2000",
+)
+# DNS-recon / DNS-tunneling vectors. Real attacker techniques for
+# infiltration channels and external host enumeration. Worth at least
+# MODERATE so they're audit-logged.
+_DNS_RECON_COMMANDS = frozenset({"dig", "nslookup", "host", "whois", "drill"})
+
+
+def _check_argument_aware_risk(command: str) -> Optional[Tuple["CommandRisk", List[str]]]:
+    """#7384: detect attack vectors that base-command lookup misses.
+
+    Returns ``(risk, reasons)`` for argument-shape-elevated commands,
+    or ``None`` if no argument-aware rule fires. The caller short-circuits
+    risk assessment so the more-specific reason wins over the generic
+    base-command classification.
+    """
+    # Tokenise once; we use string membership for flag checks but a
+    # token list for first-token (DNS) detection.
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        # Malformed quoting; let the standard path handle it.
+        return None
+    if not tokens:
+        return None
+
+    # 1. Docker escape flags — `docker run --privileged …` etc.
+    if tokens[0] == "docker":
+        flagged_docker: List[str] = []
+        # Cheap substring check for compound flags (`-v /:`, `--cap-add SYS_ADMIN`).
+        for flag in _DOCKER_ESCAPE_FLAGS:
+            if flag in command:
+                flagged_docker.append(flag)
+        # `--cap-add` may appear with `=` or as a separate arg — if any
+        # token equals it AND a sibling token is supplied, count as flag.
+        if "--cap-add" in tokens or any(t.startswith("--cap-add=") for t in tokens):
+            if "--cap-add" not in flagged_docker:
+                flagged_docker.append("--cap-add")
+        if flagged_docker:
+            return (
+                CommandRisk.FORBIDDEN,
+                [f"Docker escape flag: {flag}" for flag in flagged_docker],
+            )
+
+    # 2. `find` SUID / setgid recon.
+    if tokens[0] == "find":
+        for pattern in _FIND_SUID_RECON_PATTERNS:
+            if pattern in command:
+                return (CommandRisk.HIGH, [f"SUID/setgid recon: {pattern}"])
+
+    # 3. DNS recon — first token (no env-var prefix has reached here, so
+    # tokens[0] is the actual base command).
+    if tokens[0] in _DNS_RECON_COMMANDS:
+        return (
+            CommandRisk.MODERATE,
+            [f"DNS-recon command: {tokens[0]} (audit-logged)"],
+        )
+
+    return None
+
+
 def _check_dangerous_env_var_prefix(command: str) -> Optional[List[str]]:
     """#7375: detect env-var prefix injection BEFORE base-command lookup.
 
@@ -547,6 +637,15 @@ class SecureCommandExecutor:
         if dangerous_env_vars:
             reasons = [f"Dangerous env-var prefix: {var}" for var in dangerous_env_vars]
             return CommandRisk.FORBIDDEN, reasons
+
+        # #7384: argument-aware risk for tools whose base command is
+        # allowlisted but whose flags / arguments elevate them to attack
+        # vectors — `docker run --privileged`, `find -perm -4000`, `dig`.
+        # Same family as the env-var check above; runs before base-command
+        # lookup so the more-specific reason wins.
+        arg_aware = _check_argument_aware_risk(command)
+        if arg_aware is not None:
+            return arg_aware
 
         base_command = self._extract_command_name(command)
 

--- a/autobot-backend/secure_command_executor_argument_aware_test.py
+++ b/autobot-backend/secure_command_executor_argument_aware_test.py
@@ -1,0 +1,174 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""#7384 sub-fixes: argument-aware risk for tools whose base command is
+allowlisted but whose flags / arguments elevate them to attack vectors.
+
+Three families covered:
+
+1. **Docker escape flags** — `docker run --privileged`, `--net=host`,
+   `--cap-add=SYS_ADMIN`, `-v /:/host`, `--device=` etc. Container-escape
+   is a real attack chain; these flags turn an allowlisted `docker` base
+   command into a host-takeover vector.
+
+2. **`find` SUID/setgid recon** — `find / -perm -4000` enumerates setuid
+   binaries (privilege-escalation primitives). `find` is allowlisted as
+   MODERATE for normal use; the recon argument shape elevates to HIGH.
+
+3. **DNS recon** — `dig`, `nslookup`, `host`, `whois`, `drill`. Real
+   data-exfiltration / external-host enumeration channels (DNS tunnelling,
+   subdomain takeover prep). Worth at least MODERATE so they're audit-logged.
+
+Same architectural pattern as #7375 (env-var prefix detection): parse
+arguments BEFORE base-command lookup so the more-specific reason wins.
+"""
+
+import pytest
+
+from secure_command_executor import CommandRisk, SecureCommandExecutor
+
+
+@pytest.fixture
+def executor() -> SecureCommandExecutor:
+    return SecureCommandExecutor()
+
+
+# ---------------------------------------------------------------------------
+# 1. Docker escape flags
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command, expected_flag",
+    [
+        ("docker run --privileged alpine", "--privileged"),
+        ("docker run --net=host alpine", "--net=host"),
+        ("docker run --network=host alpine", "--network=host"),
+        ("docker run --pid=host alpine", "--pid=host"),
+        ("docker run --ipc=host alpine", "--ipc=host"),
+        ("docker run --cap-add=SYS_ADMIN alpine", "--cap-add"),
+        ("docker run --cap-add SYS_PTRACE alpine", "--cap-add"),
+        ("docker run -v /:/host alpine", "-v /:"),
+        ("docker run --volume=/:/host alpine", "--volume=/:"),
+        ("docker run --device=/dev/mem alpine", "--device="),
+        ("docker run --security-opt=seccomp=unconfined alpine", "--security-opt=seccomp=unconfined"),
+        ("docker run --userns=host alpine", "--userns=host"),
+    ],
+)
+def test_docker_escape_flag_classifies_as_forbidden(
+    executor: SecureCommandExecutor, command: str, expected_flag: str
+) -> None:
+    """Container-escape flags must classify as FORBIDDEN regardless of the
+    wrapped command — `docker` itself is allowlisted, the flag is the
+    injection."""
+    risk, reasons = executor.assess_command_risk(command)
+    assert risk == CommandRisk.FORBIDDEN, (
+        f"#7384: `{command}` must classify as FORBIDDEN (docker escape " f"flag) — got {risk.value}. Reasons: {reasons}"
+    )
+    assert any(expected_flag in r for r in reasons), f"Expected reason mentioning {expected_flag}; got {reasons}"
+
+
+def test_benign_docker_run_unaffected(executor: SecureCommandExecutor) -> None:
+    """Plain `docker run alpine echo hi` must NOT be flagged — only escape
+    flags trigger the FORBIDDEN classification."""
+    risk, _ = executor.assess_command_risk("docker run alpine echo hi")
+    # The base `docker` command may be MODERATE or HIGH depending on the
+    # production allowlist, but it must NOT be FORBIDDEN purely on the
+    # absence of escape flags.
+    assert risk != CommandRisk.FORBIDDEN, "Benign docker run shouldn't auto-FORBID"
+
+
+# ---------------------------------------------------------------------------
+# 2. find SUID/setgid recon
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command, expected_pattern",
+    [
+        ("find / -perm -4000 2>/dev/null", "-perm -4000"),
+        ("find / -perm -2000 -type f", "-perm -2000"),
+        ("find / -perm -u+s", "-perm -u+s"),
+        ("find / -perm -g+s", "-perm -g+s"),
+        ("find / -perm /4000", "-perm /4000"),
+        ("find /usr/bin -perm /2000", "-perm /2000"),
+    ],
+)
+def test_find_suid_recon_classifies_as_high(
+    executor: SecureCommandExecutor, command: str, expected_pattern: str
+) -> None:
+    """SUID/setgid enumeration is reconnaissance for privilege-escalation
+    primitives. `find` itself is allowlisted but the recon argument shape
+    elevates to HIGH."""
+    risk, reasons = executor.assess_command_risk(command)
+    assert risk == CommandRisk.HIGH, (
+        f"#7384: `{command}` must classify as HIGH (SUID recon) — " f"got {risk.value}. Reasons: {reasons}"
+    )
+    assert any(expected_pattern in r for r in reasons), f"Expected reason mentioning {expected_pattern}; got {reasons}"
+
+
+def test_benign_find_unaffected(executor: SecureCommandExecutor) -> None:
+    """Plain `find . -name '*.txt'` must NOT trigger the SUID-recon
+    classification."""
+    risk, _ = executor.assess_command_risk("find . -name '*.txt'")
+    assert risk != CommandRisk.HIGH or "SUID/setgid recon" not in str(risk)
+
+
+# ---------------------------------------------------------------------------
+# 3. DNS-recon commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command, expected_cmd",
+    [
+        ("dig @8.8.8.8 malicious.com", "dig"),
+        ("nslookup malicious.com", "nslookup"),
+        ("host malicious.com", "host"),
+        ("whois malicious.com", "whois"),
+        ("drill @1.1.1.1 malicious.com", "drill"),
+    ],
+)
+def test_dns_recon_classifies_at_least_moderate(
+    executor: SecureCommandExecutor, command: str, expected_cmd: str
+) -> None:
+    """DNS-recon commands must classify at least MODERATE so they're
+    audit-logged. They're real exfiltration / enumeration vectors but
+    not always blockable in a developer-tools context."""
+    risk, reasons = executor.assess_command_risk(command)
+    assert risk in (CommandRisk.MODERATE, CommandRisk.HIGH, CommandRisk.CRITICAL, CommandRisk.FORBIDDEN), (
+        f"#7384: `{command}` must classify at least MODERATE (DNS recon) — " f"got {risk.value}. Reasons: {reasons}"
+    )
+    assert any(expected_cmd in r for r in reasons), f"Expected reason mentioning {expected_cmd}; got {reasons}"
+
+
+# ---------------------------------------------------------------------------
+# Architectural guard
+# ---------------------------------------------------------------------------
+
+
+def test_argument_aware_check_runs_before_base_command_lookup() -> None:
+    """Pin the architectural decision: argument-aware checks fire BEFORE
+    the base-command allowlist. Otherwise `docker run --privileged …`
+    would resolve as MODERATE (docker is allowlisted) and miss the
+    elevation.
+
+    Scoped to `assess_command_risk` body only — `_extract_command_name`
+    appears in many sibling helpers; we want the order WITHIN
+    `assess_command_risk` itself.
+    """
+    import inspect
+
+    import secure_command_executor as mod
+
+    src = inspect.getsource(mod.SecureCommandExecutor.assess_command_risk)
+    arg_aware_pos = src.find("_check_argument_aware_risk")
+    base_lookup_pos = src.find("base_command = self._extract_command_name")
+    assert arg_aware_pos != -1, "_check_argument_aware_risk must be wired into assess_command_risk"
+    assert base_lookup_pos != -1, "base_command extraction must be present in assess_command_risk"
+    assert arg_aware_pos < base_lookup_pos, (
+        "#7384: _check_argument_aware_risk must run BEFORE the "
+        "`base_command = self._extract_command_name(...)` call inside "
+        "assess_command_risk so argument-elevated risks override the "
+        "allowlisted base command."
+    )


### PR DESCRIPTION
## Summary

Three sub-fixes from #7384's 5-gap list — same architectural pattern as #7375 (env-var prefix detection): parse arguments BEFORE base-command lookup so the more-specific reason wins.

| Sub-fix | Vector | Old | New |
|---|---|---|---|
| #4 | docker `--privileged`, `--net=host`, `--cap-add=`, `-v /:`, `--device=`, … (13 flags) | MODERATE | **FORBIDDEN** |
| #1 | `find -perm -4000` SUID enumeration (6 variants) | MODERATE | **HIGH** |
| #5 | `dig`, `nslookup`, `host`, `whois`, `drill` | SAFE | **MODERATE** (audit-log) |

## Architecture

Single `_check_argument_aware_risk(command)` consolidates all three rules — same shlex parse, same pre-base-command position. Wired between `_check_dangerous_env_var_prefix` (#7375) and `_extract_command_name`. Pinned by `test_argument_aware_check_runs_before_base_command_lookup`.

## Test plan

- [x] 26 regression cases in `secure_command_executor_argument_aware_test.py` — 26/26 pass locally
- [x] Benign cases (`docker run alpine echo hi`, `find . -name '*.txt'`) NOT affected
- [ ] CI green

## Out of scope (left in #7384)

- Sub-fix #2: `authenticate_user(None, ...)` returns None (separate API contract bug)
- Sub-fix #3: `check_permission` signature drift (separate refactor)
- `security_edge_cases_test.py` xfails NOT removed — test arrays contain commands beyond these 3 sub-fixes (`chmod +s`, `mount`, `curl`, `wget`, `nc`, `nmap`)

References #7384 #7375 #7367

🤖 Generated with [Claude Code](https://claude.com/claude-code)