### PR TITLE
feat(test/fixtures): extend make_async_redis with pipeline + scan_iter support (closes #7339)

### DIFF
--- a/autobot-backend/tests/fixtures/__init__.py
+++ b/autobot-backend/tests/fixtures/__init__.py
@@ -17,6 +17,7 @@ from .mocks import (
     MockWorkerNode,
     make_async_redis,
     make_llm_response,
+    make_redis_pipeline,
     patch_async_redis,
 )
 
@@ -28,5 +29,6 @@ __all__ = [
     "MockWorkerNode",
     "make_llm_response",
     "make_async_redis",
+    "make_redis_pipeline",
     "patch_async_redis",
 ]

--- a/autobot-backend/tests/fixtures/mocks.py
+++ b/autobot-backend/tests/fixtures/mocks.py
@@ -132,6 +132,42 @@ def _build_mock_response(content: str):
     return make_llm_response(content=content)
 
 
+def make_redis_pipeline(execute_returns: Any = None) -> "AsyncMock":
+    """Build an async-redis pipeline mock (canonical, #7339).
+
+    Supports both common pipeline usage patterns:
+
+    1. **Async context manager** —
+       ``async with redis.pipeline() as pipe: pipe.X(...); await pipe.execute()``
+    2. **Direct caller** —
+       ``pipe = redis.pipeline(); pipe.X(...); result = await pipe.execute()``
+
+    Buffered ops (``xadd``, ``hset``, etc.) are auto-created child
+    AsyncMocks via the parent's child-spawning behavior — sufficient for
+    both ``pipe.X(...)`` (returns coroutine, ignored by buffered code that
+    doesn't await) and ``await pipe.X(...)`` (returns AsyncMock from the
+    awaited coroutine).
+
+    ``pipe.execute()`` is async (always awaited in production).
+
+    Args:
+        execute_returns: value returned by ``await pipe.execute()``.
+            Default ``[]`` if ``None``. Pass a list of per-op results to
+            simulate multi-op pipeline returns (e.g. ``[1, 1, 1]`` for
+            three writes).
+
+    Returns:
+        An ``AsyncMock`` representing a redis pipeline.
+    """
+    from unittest.mock import AsyncMock
+
+    pipe = AsyncMock()
+    pipe.__aenter__ = AsyncMock(return_value=pipe)
+    pipe.__aexit__ = AsyncMock(return_value=False)
+    pipe.execute = AsyncMock(return_value=execute_returns if execute_returns is not None else [])
+    return pipe
+
+
 def make_async_redis(
     *,
     get_returns: Any = None,
@@ -171,6 +207,9 @@ def make_async_redis(
     zremrangebyrank_returns: int = 0,
     # Pub/sub
     publish_returns: int = 0,
+    # Pipeline + scan-iter (#7339)
+    pipeline: Optional["AsyncMock"] = None,
+    scan_iter_keys: Optional[List[bytes]] = None,
     **extra_methods: Any,
 ) -> "AsyncMock":
     """Build an async-redis-shaped ``AsyncMock`` for tests (canonical, #7264).
@@ -193,14 +232,30 @@ def make_async_redis(
 
         redis = make_async_redis(get_returns=b"hello", xadd=("stream", "1-0"))
 
+    For pipeline support (sync ``redis.pipeline()`` returning an async
+    context manager), pass an ``AsyncMock`` built via ``make_redis_pipeline()``
+    (#7339)::
+
+        pipe = make_redis_pipeline(execute_returns=[1, 1, 1])
+        redis = make_async_redis(pipeline=pipe)
+
+    For ``redis.scan_iter()`` (an async generator, not a coroutine), pass
+    a list of keys via ``scan_iter_keys=`` (#7339)::
+
+        redis = make_async_redis(scan_iter_keys=[b"key:1", b"key:2"])
+
     Args:
         \\*_returns: per-method return value overrides (see method names above).
+        pipeline: pre-built pipeline mock (use ``make_redis_pipeline()``).
+            Attached as a sync-callable ``redis.pipeline`` returning the mock.
+        scan_iter_keys: keys to yield from ``redis.scan_iter(match=…, count=…)``.
+            Use ``[]`` for an empty stream (skips override; AsyncMock default).
         \\**extra_methods: arbitrary additional method names → return values.
 
     Returns:
         An ``AsyncMock`` matching the redis-py async client surface.
     """
-    from unittest.mock import AsyncMock
+    from unittest.mock import AsyncMock, MagicMock
 
     redis = AsyncMock()
 
@@ -242,6 +297,25 @@ def make_async_redis(
     redis.zremrangebyrank = AsyncMock(return_value=zremrangebyrank_returns)
 
     redis.publish = AsyncMock(return_value=publish_returns)
+
+    # Pipeline support (#7339): redis.pipeline() is SYNC in redis-py, returning
+    # a pipeline object whose execute() is async. Wrapping with MagicMock keeps
+    # the call sync; the inner pipe is an AsyncMock built by make_redis_pipeline().
+    if pipeline is not None:
+        redis.pipeline = MagicMock(return_value=pipeline)
+
+    # scan_iter support (#7339): redis.scan_iter() is an ASYNC GENERATOR, not a
+    # coroutine. AsyncMock can't directly produce one, so we attach a real
+    # async-generator function. Accepts arbitrary kwargs (match, count, _type)
+    # so callers passing real redis-py kwargs don't TypeError.
+    if scan_iter_keys is not None:
+        keys_snapshot = list(scan_iter_keys)
+
+        async def _scan_iter(*_args: Any, **_kwargs: Any):
+            for k in keys_snapshot:
+                yield k
+
+        redis.scan_iter = _scan_iter
 
     for method_name, value in extra_methods.items():
         setattr(redis, method_name, AsyncMock(return_value=value))
@@ -481,5 +555,6 @@ __all__ = [
     "MockWorkerNode",
     "make_llm_response",
     "make_async_redis",
+    "make_redis_pipeline",
     "patch_async_redis",
 ]

--- a/autobot-backend/tests/fixtures/test_make_async_redis.py
+++ b/autobot-backend/tests/fixtures/test_make_async_redis.py
@@ -189,3 +189,138 @@ def test_factory_re_exported_from_fixtures_package() -> None:
     assert "patch_async_redis" in fixtures.__all__
     assert callable(fixtures.make_async_redis)
     assert callable(fixtures.patch_async_redis)
+
+
+# ---------------------------------------------------------------------------
+# make_redis_pipeline + pipeline= kwarg (#7339)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pipeline_async_context_manager_pattern() -> None:
+    """``async with redis.pipeline() as pipe: ... await pipe.execute()`` —
+    the most common pipeline usage in production async-redis code."""
+    from tests.fixtures import make_redis_pipeline
+
+    pipe = make_redis_pipeline(execute_returns=[1, 1, 1])
+    redis = make_async_redis(pipeline=pipe)
+
+    # Production code shape: redis.pipeline() is SYNC, returns a context manager.
+    p = redis.pipeline()
+    assert p is pipe  # not an awaitable — sync call
+
+    async with p as inner:
+        assert inner is pipe  # __aenter__ returns the pipe itself
+        # Buffered ops — pipe.X(...) is a coroutine; in real redis-py these
+        # don't need await but AsyncMock auto-awaits via the parent's child-
+        # spawning behavior. Both shapes (await/no-await) work for tests.
+        await inner.xadd("stream", {"k": "v"})
+        result = await inner.execute()
+
+    assert result == [1, 1, 1]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_direct_caller_pattern() -> None:
+    """``pipe = redis.pipeline(); pipe.X(...); await pipe.execute()`` —
+    no async-with, just direct call + await on execute."""
+    from tests.fixtures import make_redis_pipeline
+
+    pipe = make_redis_pipeline(execute_returns=["xadd-id-1", 1])
+    redis = make_async_redis(pipeline=pipe)
+
+    p = redis.pipeline()
+    await p.xadd("rag:stream", {"data": "x"})
+    await p.hset("rag:meta:1", mapping={"k": "v"})
+    result = await p.execute()
+
+    assert result == ["xadd-id-1", 1]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_execute_default_empty_list() -> None:
+    """Default ``execute_returns=None`` → empty list (matches the
+    "no buffered writes / nothing to report" common case)."""
+    from tests.fixtures import make_redis_pipeline
+
+    pipe = make_redis_pipeline()
+    redis = make_async_redis(pipeline=pipe)
+
+    result = await redis.pipeline().execute()
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_redis_without_pipeline_kwarg_has_default_async_pipeline() -> None:
+    """When no ``pipeline=`` is passed, ``redis.pipeline`` is the default
+    AsyncMock-spawned attribute. Production that doesn't use pipeline
+    won't trip; production that does use it gets a no-op AsyncMock that
+    won't error on access patterns."""
+    redis = make_async_redis()
+    # No assertion that pipeline is callable — just that accessing it
+    # doesn't raise. Real pipeline usage requires the explicit kwarg.
+    assert redis.pipeline is not None
+
+
+def test_make_redis_pipeline_re_exported() -> None:
+    """Documented import path: ``from tests.fixtures import make_redis_pipeline``."""
+    import tests.fixtures as fixtures
+
+    assert "make_redis_pipeline" in fixtures.__all__
+    assert callable(fixtures.make_redis_pipeline)
+
+
+# ---------------------------------------------------------------------------
+# scan_iter_keys (#7339)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scan_iter_yields_provided_keys() -> None:
+    """``scan_iter_keys=[…]`` attaches a real async-generator returning
+    those keys. Production: ``async for key in redis.scan_iter(match=…): ...``."""
+    redis = make_async_redis(scan_iter_keys=[b"key:1", b"key:2", b"key:3"])
+
+    collected = []
+    async for k in redis.scan_iter(match="key:*"):
+        collected.append(k)
+
+    assert collected == [b"key:1", b"key:2", b"key:3"]
+
+
+@pytest.mark.asyncio
+async def test_scan_iter_accepts_arbitrary_kwargs() -> None:
+    """Real ``redis.scan_iter`` takes ``match=``, ``count=``, ``_type=``.
+    The fixture must accept any kwargs without TypeError."""
+    redis = make_async_redis(scan_iter_keys=[b"a"])
+
+    # Production may call with various kwarg combinations.
+    async for _ in redis.scan_iter(match="a:*", count=100, _type="string"):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_scan_iter_empty_list_yields_nothing() -> None:
+    """``scan_iter_keys=[]`` → empty stream (the no-keys-match case)."""
+    redis = make_async_redis(scan_iter_keys=[])
+
+    collected = []
+    async for k in redis.scan_iter():
+        collected.append(k)
+    assert collected == []
+
+
+@pytest.mark.asyncio
+async def test_scan_iter_snapshot_is_independent_of_caller_mutation() -> None:
+    """Mutating the input list after fixture creation must NOT affect the
+    yielded keys — the fixture takes a snapshot."""
+    keys = [b"a", b"b"]
+    redis = make_async_redis(scan_iter_keys=keys)
+
+    keys.append(b"c")  # mutate after fixture creation
+    keys.clear()  # then clear
+
+    collected = []
+    async for k in redis.scan_iter():
+        collected.append(k)
+    assert collected == [b"a", b"b"]  # original snapshot, not mutated list


### PR DESCRIPTION
## Summary

Closes #7339 — extends the canonical async-redis test fixture (\`tests/fixtures/mocks.py\`) with two extensions that unblock the remaining 4-6 #7280 migration files.

## Changes

### 1. \`make_redis_pipeline(execute_returns=...)\` — new helper

Builds an async-redis pipeline mock supporting both common usage patterns:

- **Async context manager**: \`async with redis.pipeline() as pipe: ... await pipe.execute()\`
- **Direct caller**: \`pipe = redis.pipeline(); pipe.X(...); await pipe.execute()\`

Buffered ops (\`xadd\`, \`hset\`, etc.) auto-spawn AsyncMock children via the parent's child-spawning behavior — sufficient for both \`pipe.X(...)\` (returns coroutine) and \`await pipe.X(...)\` (awaits to AsyncMock). \`pipe.execute()\` is always async.

### 2. \`make_async_redis(pipeline=..., scan_iter_keys=...)\` — new kwargs

- **\`pipeline=\`**: attaches the pre-built pipeline as a **sync-callable** \`redis.pipeline\` (real redis-py: pipeline() is sync, execute() is async — that's the bit \`make_async_redis\` got wrong by default).
- **\`scan_iter_keys=\`**: attaches a real async-generator function that accepts arbitrary kwargs (\`match=\`, \`count=\`, \`_type=\`) and yields the provided keys. Takes a **snapshot** of the input list — mutating it after fixture creation doesn't affect yielded keys.

## Test plan

- [x] 9 new unit tests in \`tests/fixtures/test_make_async_redis.py\`:
  - **Pipeline (5)**: async-with pattern, direct-caller pattern, \`execute_returns=None → []\`, default pipeline attribute, re-export check
  - **scan_iter (4)**: basic yield, arbitrary kwargs (no TypeError), empty list, snapshot-independence
- [x] All 26 fixture tests pass:
  \`\`\`
  $ pytest tests/fixtures/test_make_async_redis.py
  ============== 26 passed in 1.57s ==============
  \`\`\`
- [x] 17 pre-existing tests still pass (no regressions)

## Unblocks #7280 migrations

| File | Pattern | Status post-merge |
|---|---|---|
| \`services/audit/audit_log_test.py\` | pipeline | ✅ Unblocked |
| \`services/audit_logger_test.py\` | pipeline | ✅ Unblocked |
| \`tests/services/rag_service_events_test.py\` | pipeline | ✅ Unblocked |
| \`services/knowledge/test_synthesis_provenance.py\` | pipeline | ✅ Unblocked |
| \`tests/memory/test_working_memory.py\` | scan_iter | ✅ Unblocked |

## Refs

- Closes #7339 (this issue)
- Refs #7280 (parent migration tracker — round 6+ now unblocked)
- Refs #7264 (canonical fixture intro)
- Refs \`feedback_layered_test_rot.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)