### PR TITLE
refactor(test/audit): migrate audit_log_test.py to canonical pipeline fixture (#7280 round 6)

### DIFF
--- a/autobot-backend/services/audit/audit_log_test.py
+++ b/autobot-backend/services/audit/audit_log_test.py
@@ -11,7 +11,7 @@ Tests cover:
 """
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -22,6 +22,7 @@ from services.audit.audit_log import (
     query_audit_log,
     record_event,
 )
+from tests.fixtures import make_async_redis, make_redis_pipeline
 
 # ---------------------------------------------------------------------------
 # Module-level stubs — keep import chain clean without a full backend venv
@@ -34,20 +35,16 @@ from services.audit.audit_log import (
 
 
 def _make_pipeline_mock():
-    """Return an async pipeline mock that supports context manager + execute."""
-    pipe = AsyncMock()
-    pipe.__aenter__ = AsyncMock(return_value=pipe)
-    pipe.__aexit__ = AsyncMock(return_value=False)
-    pipe.execute = AsyncMock(return_value=[1, 1, 1, 1, 1])
-    return pipe
+    # Migrated to canonical ``make_redis_pipeline()`` (#7280 round 6, post-#7339).
+    return make_redis_pipeline(execute_returns=[1, 1, 1, 1, 1])
 
 
 def _make_redis_mock(pipeline=None):
-    """Return a minimal async Redis mock with pipeline and zrangebyscore."""
-    redis_mock = AsyncMock()
-    redis_mock.pipeline = MagicMock(return_value=pipeline or _make_pipeline_mock())
-    redis_mock.zrangebyscore = AsyncMock(return_value=[])
-    return redis_mock
+    # Migrated to canonical ``make_async_redis(pipeline=...)`` (#7280 round 6).
+    return make_async_redis(
+        pipeline=pipeline or _make_pipeline_mock(),
+        zrangebyscore_returns=[],
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

#7280 round 6: first migration using the **pipeline support** landed in #7339 (PR #7397). Migrates ``services/audit/audit_log_test.py`` to canonical ``make_redis_pipeline()`` + ``make_async_redis(pipeline=...)`` from ``tests.fixtures``.

## Changes

- **Replaced** local ``_make_pipeline_mock()`` (5 LOC) → thin wrapper around ``make_redis_pipeline(execute_returns=[1, 1, 1, 1, 1])``.
- **Replaced** local ``_make_redis_mock(pipeline=None)`` (5 LOC) → thin wrapper around ``make_async_redis(pipeline=..., zrangebyscore_returns=[])``.
- Removed unused ``MagicMock`` import.
- Helpers retained as thin wrappers (call sites unchanged) — same pattern as round 5.

Net: -3 LOC.

## Test plan

- [x] Same 1 failed / 11 passed before AND after migration (no regressions). Migration touches only helper bodies.

## Pre-existing failure (NOT introduced by this PR)

``TestAuditAction::test_all_required_values_present`` was already failing on Dev_new_gui — production has ``AuditAction.SESSION_EXPORT`` but the test's hardcoded ``required`` set is stale. One-line cleanup tracked as **#7399**.

## #7339 validation

This PR is the first real-world consumer of the pipeline-support extension landed in #7397. Confirms:
- ``make_redis_pipeline(execute_returns=[…])`` produces a 5-op pipeline that production's ``async with`` and ``await pipe.execute()`` both consume correctly.
- ``make_async_redis(pipeline=…)`` correctly wires the sync-callable ``redis.pipeline()`` returning the pipe.

## #7280 progress

- ✅ Round 1: ``services/workflow_versioning_test.py`` (PR #7340)
- ✅ Round 2: ``tests/services/test_workflow_notification_persistence.py`` (PR #7374) — 7 latent bugs fixed
- ✅ Round 3: ``knowledge/knowledge_base_async_test.py`` (PR #7381)
- ✅ Round 4: ``services/mesh_brain/edge_learner_test.py`` (PR #7383)
- ✅ Round 5: ``retrieval_learner`` × 2 (PR #7388) — #7386 surfaced
- ✅ Round 6: this PR (audit_log_test) — #7399 surfaced
- 4 more pipeline-blocked files remain (audit_logger, rag_service_events, test_synthesis_provenance, working_memory)

## Refs

- Refs #7280 (parent)
- Refs #7339 (pipeline support), #7397 (its PR)
- Refs #7399 (pre-existing test rot, not introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)