### PR TITLE
docs(schemas/sandbox-files): annotate 7 FileSandbox* classes as deferred wire-in to #7409 (#6676)

### DIFF
--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -646,8 +646,33 @@ class DatabaseMCPStatusResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Sandbox-scoped file API response models — DEFERRED WIRE-IN to #7409
+# ---------------------------------------------------------------------------
+#
+# The 7 ``FileSandbox*`` classes below describe the response shape for
+# endpoints under ``/api/sandbox/files/*`` that don't yet exist. They were
+# orphaned by the #6042 migration and tracked under #6676.
+#
+# Disposition (#6676 closure): deferred-wire-in per CLAUDE.md — these are
+# scaffolding for a planned third file-API surface (sandbox-scoped CRUD,
+# distinct from ``api/files.py``'s workspace scope and ``api/sandbox.py``'s
+# code-execution scope). The wire-in plan lives at #7409: add
+# ``api/sandbox_files.py`` + register in ``feature_routers.py``, give each
+# class ≥1 production caller, surface a ``useSandboxFiles`` composable.
+#
+# Until #7409 lands, these classes are intentionally caller-less. The
+# closure-gate audit (``audit-unwired-trackers.py``) will keep flagging
+# them; that's expected — the cure is implementing #7409, not deleting.
+# ---------------------------------------------------------------------------
+
+
 class FileSandboxViewResponse(BaseModel):
-    """Response for GET /files/view/{path}."""
+    """Response for GET /api/sandbox/files/view/{path}.
+
+    Wire-in deferred to #7409 (the endpoint hosting this response model
+    is part of the planned ``/api/sandbox/files/*`` surface).
+    """
 
     file_info: Any
     content: Optional[str] = None
@@ -655,14 +680,20 @@ class FileSandboxViewResponse(BaseModel):
 
 
 class FileSandboxRenameResponse(BaseModel):
-    """Response for POST /files/rename."""
+    """Response for POST /api/sandbox/files/rename.
+
+    Wire-in deferred to #7409.
+    """
 
     message: str
     item_info: Any
 
 
 class FileSandboxPreviewResponse(BaseModel):
-    """Response for GET /files/preview."""
+    """Response for GET /api/sandbox/files/preview.
+
+    Wire-in deferred to #7409.
+    """
 
     type: str
     url: str
@@ -673,27 +704,39 @@ class FileSandboxPreviewResponse(BaseModel):
 
 
 class FileSandboxDeleteResponse(BaseModel):
-    """Response for DELETE /files/delete."""
+    """Response for DELETE /api/sandbox/files/delete.
+
+    Wire-in deferred to #7409.
+    """
 
     message: str
 
 
 class FileSandboxCreateDirResponse(BaseModel):
-    """Response for POST /files/create_directory."""
+    """Response for POST /api/sandbox/files/create_directory.
+
+    Wire-in deferred to #7409.
+    """
 
     message: str
     directory_info: Any
 
 
 class FileSandboxTreeResponse(BaseModel):
-    """Response for GET /files/tree."""
+    """Response for GET /api/sandbox/files/tree.
+
+    Wire-in deferred to #7409.
+    """
 
     path: str
     tree: List[Any]
 
 
 class FileSandboxStatsResponse(BaseModel):
-    """Response for GET /files/stats."""
+    """Response for GET /api/sandbox/files/stats.
+
+    Wire-in deferred to #7409.
+    """
 
     sandbox_root: str
     total_files: int


### PR DESCRIPTION
## Summary

#6676 proposed two paths: (a) wire-in or (b) retire 7 \`FileSandbox*\` response models. The default action ("retire if no domain owner response") conflicts with CLAUDE.md's \`Never delete code — wire it in (ABSOLUTE)\` rule.

This PR resolves the conflict via the **deferred-wire-in pattern** explicitly documented in CLAUDE.md's closure-verification gate:

> if a new module is genuinely infrastructure-only (Protocol, scaffold) and has no caller by design, file a follow-up wire-in issue first and reference it in the closure comment under \`### Wire-in deferred to #NNNN\`.

## Changes

- **#7409 filed** (newly): the wire-in plan for \`/api/sandbox/files/*\` endpoints + frontend composable
- **File-level block comment** above the 7 classes documents the disposition, references #6676 + #7409, and notes that audit-script flagging will continue until #7409 lands
- **Each class docstring** updated to add \`Wire-in deferred to #7409\` line + correct the endpoint path (\`/files/…\` → \`/api/sandbox/files/…\` per the planned routing)
- **No code changes** — docstring updates only, no behavior change

## Why deferred-wire-in beats both alternatives

| Path | Issue |
|------|-------|
| Retire (delete) | Forbidden by CLAUDE.md \`Never delete code\` rule |
| Wire-in here | Real feature work — endpoints + frontend view, requires owner input on UX placement |
| **Deferred wire-in** ✅ | Preserves code, documents the path, satisfies the closure-gate via the explicit deliberate-deferral override |

## Acceptance criteria (from #6676)

- [x] Domain decision recorded — option (a) wire-in via #7409
- [x] Wire-in plan filed at #7409 with endpoint inventory + integration plan
- [x] Each affected class annotated with \`Wire-in deferred to #7409\`

## Verification

- \`py_compile\` clean
- \`grep -rn "FileSandbox" autobot-backend\` shows the 7 classes still present, no callers (expected pre-#7409)
- No behavior change

Closes #6676
Tracks #7409 (the wire-in implementation tracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)