### PR TITLE
refactor(test/audit): migrate audit_logger_test.py to canonical pipeline fixture (#7280 round 7)

### DIFF
--- a/autobot-backend/services/audit_logger_test.py
+++ b/autobot-backend/services/audit_logger_test.py
@@ -13,6 +13,8 @@ import sys
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from tests.fixtures import make_async_redis, make_redis_pipeline
+
 import pytest
 
 # Stub heavy/optional imports that are pulled in by the models package on collection.
@@ -77,21 +79,16 @@ from services.audit_logger import (  # noqa: E402
 
 
 def _make_pipeline_mock():
-    """Return a mock that supports async pipeline context manager + zadd/expire/delete."""
-    pipe = AsyncMock()
-    pipe.__aenter__ = AsyncMock(return_value=pipe)
-    pipe.__aexit__ = AsyncMock(return_value=False)
-    pipe.execute = AsyncMock(return_value=[])
-    return pipe
+    # Migrated to canonical ``make_redis_pipeline()`` (#7280 round 7, post-#7339).
+    return make_redis_pipeline()
 
 
 def _make_redis_mock(pipeline=None):
-    """Return a minimal async Redis mock with pipeline support."""
-    redis = AsyncMock()
-    redis.pipeline = MagicMock(return_value=pipeline or _make_pipeline_mock())
-    redis.zrange = AsyncMock(return_value=[])
-    redis.zcard = AsyncMock(return_value=0)
-    return redis
+    # Migrated to canonical ``make_async_redis(pipeline=...)`` (#7280 round 7).
+    return make_async_redis(
+        pipeline=pipeline or _make_pipeline_mock(),
+        zrange_returns=[],
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

#7280 round 7: sister migration to round 6 (PR #7408). Migrates ``services/audit_logger_test.py`` to canonical pipeline fixture from #7339.

## Changes

- **Replaced** local ``_make_pipeline_mock()`` (5 LOC) → ``make_redis_pipeline()`` 1-line wrapper.
- **Replaced** local ``_make_redis_mock(pipeline=None)`` (5 LOC) → ``make_async_redis(pipeline=..., zrange_returns=[])`` 1-line wrapper.
- ``zcard_returns=0`` is the canonical default; no override needed.

Net: -3 LOC, helpers reduced to thin wrappers, call sites unchanged.

## Test plan

- [x] ``pytest services/audit_logger_test.py`` — 15/15 passed before AND after migration

## #7280 progress

- ✅ Rounds 1-7: 7 files, ~120+ sites migrated
- ✅ Both audit-logger sister files now use canonical pipeline fixture (rounds 6 + 7)
- 3 pipeline-blocked files remaining: rag_service_events, test_synthesis_provenance, working_memory (scan_iter)

## Refs

- Refs #7280 (parent)
- Refs #7339 / PR #7397 (pipeline support)
- Sister: PR #7408 (round 6 — audit_log_test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)