### PR TITLE
fix(test/audit): add SESSION_EXPORT to required AuditAction set (#7399)

### DIFF
--- a/autobot-backend/services/audit/audit_log_test.py
+++ b/autobot-backend/services/audit/audit_log_test.py
@@ -57,6 +57,7 @@ class TestAuditAction:
         required = {
             "SESSION_CREATE",
             "SESSION_DELETE",
+            "SESSION_EXPORT",  # #7399: added after the test was written
             "KNOWLEDGE_ADD",
             "KNOWLEDGE_REMOVE",
             "API_KEY_CREATE",


### PR DESCRIPTION
## Summary

Test rot — production added `AuditAction.SESSION_EXPORT` since `TestAuditAction.test_all_required_values_present` was written; the hardcoded `required` set never updated.

One-line fix.

## Verified

```
autobot-backend/services/audit/audit_log_test.py::TestAuditAction
  2 passed in 0.68s
```

Closes #7399
References #7367 #7280

🤖 Generated with [Claude Code](https://claude.com/claude-code)