### PR TITLE
refactor(types): consolidate anti_pattern_detector.Severity onto canonical (closes #7253)

### DIFF
--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -26,6 +26,24 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from autobot_shared.status_enums import Severity  # #7253: consolidated onto canonical (#6689)
+
+# Anti-pattern severity → 0-100 integer score. Kept as a module-level helper
+# rather than an enum method so the canonical `Severity` enum stays clean
+# (canonical `to_score()` returns 0.0–0.9 floats, a different scale).
+_ANTI_PATTERN_SCORES: Dict[Severity, int] = {
+    Severity.CRITICAL: 100,
+    Severity.HIGH: 75,
+    Severity.MEDIUM: 50,
+    Severity.LOW: 25,
+}
+
+
+def anti_pattern_score(severity: Severity) -> int:
+    """Numeric anti-pattern score for `severity` (higher = worse, 0-100 scale)."""
+    return _ANTI_PATTERN_SCORES[severity]
+
+
 # Initialize configuration
 logger = logging.getLogger(__name__)
 
@@ -55,25 +73,6 @@ _ENTRY_POINT_SUFFIXES = (
     "API",
     "Router",
 )
-
-
-class Severity(Enum):
-    """Anti-pattern severity levels"""
-
-    CRITICAL = "critical"
-    HIGH = "high"
-    MEDIUM = "medium"
-    LOW = "low"
-
-    def score(self) -> int:
-        """Numeric score for severity (higher = worse)"""
-        scores = {
-            Severity.CRITICAL: 100,
-            Severity.HIGH: 75,
-            Severity.MEDIUM: 50,
-            Severity.LOW: 25,
-        }
-        return scores[self]
 
 
 class AntiPatternType(Enum):
@@ -119,7 +118,7 @@ class AntiPatternInstance:
         return {
             "pattern_type": self.pattern_type.value,
             "severity": self.severity.value,
-            "severity_score": self.severity.score(),
+            "severity_score": anti_pattern_score(self.severity),
             "file_path": self.file_path,
             "line_number": self.line_number,
             "entity_name": self.entity_name,
@@ -1709,7 +1708,7 @@ if __name__ == "__main__":
             print(f"\n{'='*60}")  # noqa: print
             print("TOP ISSUES (by severity)")  # noqa: print
             print(f"{'='*60}")  # noqa: print
-            sorted_patterns = sorted(report.anti_patterns, key=lambda x: x.severity.score(), reverse=True)
+            sorted_patterns = sorted(report.anti_patterns, key=lambda x: anti_pattern_score(x.severity), reverse=True)
             for ap in sorted_patterns[:10]:
                 print(f"\n[{ap.severity.value.upper()}] {ap.pattern_type.value}")  # noqa: print
                 print(f"  Entity: {ap.entity_name}")  # noqa: print


### PR DESCRIPTION
## Summary

Last of the 12 Severity-cluster duplicates from #6689. The local \`Severity\` enum had a \`.score()\` method returning int 25-100, incompatible with canonical \`Severity.to_score()\` which returns float 0.0-0.9 — that mismatch blocked the original consolidation in #7261.

## Approach

Extract the int-score mapping out of the enum into a module-level helper, keeping the canonical enum clean:

\`\`\`python
from autobot_shared.status_enums import Severity

_ANTI_PATTERN_SCORES: Dict[Severity, int] = {
    Severity.CRITICAL: 100, Severity.HIGH: 75, Severity.MEDIUM: 50, Severity.LOW: 25,
}

def anti_pattern_score(severity: Severity) -> int:
    return _ANTI_PATTERN_SCORES[severity]
\`\`\`

Two call sites updated in the same file:
- \`self.severity.score()\` → \`anti_pattern_score(self.severity)\`
- \`key=lambda x: x.severity.score()\` → \`key=lambda x: anti_pattern_score(x.severity)\`

## Verification

- [x] \`Severity is autobot_shared.status_enums.Severity\` (smoke)
- [x] \`anti_pattern_score(Severity.CRITICAL) == 100\` (HIGH=75, MEDIUM=50, LOW=25)
- [x] flake8 + black + isort clean
- [x] 0 external importers per #6689 audit — no caller-site impact

Closes #7253. Completes the #6689 Severity arc — all 12 local Severity duplicates now collapsed onto canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)