### PR TITLE
fix(security): export VAR= form + chained-cmd separator + SHELL hardening (#7406)

### DIFF
--- a/autobot-backend/secure_command_executor.py
+++ b/autobot-backend/secure_command_executor.py
@@ -65,6 +65,10 @@ _DANGEROUS_ENV_VARS = frozenset(
         "BASH_ENV",
         "ENV",
         "PROMPT_COMMAND",
+        # #7406: SHELL controls which interpreter `sudo -E` (and other env-
+        # preserving wrappers) invoke — `SHELL=/bin/sh; sudo -E sh` is a
+        # real escalation chain.
+        "SHELL",
         # Interpreter library paths
         "PYTHONPATH",
         "PERL5LIB",
@@ -112,6 +116,17 @@ _FIND_SUID_RECON_PATTERNS = (
 # infiltration channels and external host enumeration. Worth at least
 # MODERATE so they're audit-logged.
 _DNS_RECON_COMMANDS = frozenset({"dig", "nslookup", "host", "whois", "drill"})
+
+# #7406: ordering for CommandRisk so chained-command detection can pick the
+# strictest risk across sub-commands. Strings are used here because the enum
+# class is defined later in this module; the caller compares via this lookup.
+_RISK_ORDER: Dict[str, int] = {
+    "safe": 0,
+    "moderate": 1,
+    "high": 2,
+    "critical": 3,
+    "forbidden": 4,
+}
 
 
 def _check_argument_aware_risk(command: str) -> Optional[Tuple["CommandRisk", List[str]]]:
@@ -163,6 +178,52 @@ def _check_argument_aware_risk(command: str) -> Optional[Tuple["CommandRisk", Li
             CommandRisk.MODERATE,
             [f"DNS-recon command: {tokens[0]} (audit-logged)"],
         )
+
+    # 4. #7406: `export VAR=value` shell-builtin form. Sibling of the
+    # prefix-form #7375 check — same dangerous-var list, different syntax.
+    # `export PATH=/x; ls` persists the var in the current shell so every
+    # subsequent command runs with the attacker-controlled PATH.
+    if tokens[0] == "export":
+        for token in tokens[1:]:
+            if "=" not in token:
+                continue
+            # Strip trailing shell separators (`;`, `&`, `&&`, etc.) that
+            # shlex.split keeps glued to the value (e.g. `SHELL=/bin/sh;`).
+            value_part = token.split("=", 1)[1].rstrip(";&|")
+            var = token.split("=", 1)[0]
+            if var in _DANGEROUS_ENV_VARS:
+                return (
+                    CommandRisk.FORBIDDEN,
+                    [f"export of dangerous env-var: {var}={value_part!r}"],
+                )
+
+    # 5. #7406: `cmd1; cmd2` chained-command separator with a high-risk
+    # right-hand side. shlex.split keeps `;` glued to the preceding token,
+    # so split on it manually and recurse on each sub-command. Take the
+    # highest risk seen across all sub-commands.
+    if any(";" in t for t in tokens):
+        # Re-split on the raw `;` separator to get the actual sub-command
+        # boundaries (shlex preserves `;` as a literal — strip it back out).
+        sub_commands = [s.strip() for s in command.split(";") if s.strip()]
+        if len(sub_commands) > 1:
+            from typing import cast
+
+            highest_risk: Optional["CommandRisk"] = None
+            all_reasons: List[str] = []
+            for sub in sub_commands:
+                sub_result = _check_argument_aware_risk(sub)
+                if sub_result is None:
+                    continue
+                sub_risk, sub_reasons = sub_result
+                # Take the strictest risk (FORBIDDEN > HIGH > MODERATE > SAFE).
+                if highest_risk is None or _RISK_ORDER[sub_risk.value] > _RISK_ORDER[highest_risk.value]:
+                    highest_risk = sub_risk
+                all_reasons.extend(sub_reasons)
+            if highest_risk is not None:
+                return (
+                    cast("CommandRisk", highest_risk),
+                    [f"Chained command (`;` separator): {r}" for r in all_reasons],
+                )
 
     return None
 

--- a/autobot-backend/secure_command_executor_export_chain_test.py
+++ b/autobot-backend/secure_command_executor_export_chain_test.py
@@ -1,0 +1,124 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""#7406: extends #7375/#7384 argument-aware risk pattern with two more
+shapes that the prefix-form / first-token-only rules missed:
+
+1. ``export VAR=value`` shell-builtin form. Sibling of the prefix-form
+   #7375 check (`PATH=/x ls`) — same dangerous-var list, different
+   syntax. Persists the var in the current shell so subsequent commands
+   inherit it. Real chain: ``export PATH=/x:$PATH; ls`` shadows ``ls``
+   with attacker-controlled PATH.
+
+2. ``cmd1; cmd2`` chained-command separator. Recurses
+   `_check_argument_aware_risk` on each sub-command and takes the
+   strictest risk. Without this, ``benign_cmd; sudo cmd`` was masked by
+   the LHS classification.
+
+3. ``SHELL`` added to the dangerous-env-var list — sudo's `-E` flag
+   preserves SHELL, so ``export SHELL=/bin/sh; sudo -E sh`` runs sudo's
+   target with attacker-controlled $SHELL.
+"""
+
+import pytest
+
+from secure_command_executor import CommandRisk, SecureCommandExecutor
+
+
+@pytest.fixture
+def executor() -> SecureCommandExecutor:
+    return SecureCommandExecutor()
+
+
+# ---------------------------------------------------------------------------
+# 1. export VAR= form (sibling of prefix-form #7375)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command, expected_var",
+    [
+        ("export PATH=/malicious:$PATH", "PATH"),
+        ("export LD_PRELOAD=/x.so", "LD_PRELOAD"),
+        ("export LD_LIBRARY_PATH=/x", "LD_LIBRARY_PATH"),
+        ("export PYTHONPATH=/malicious", "PYTHONPATH"),
+        ("export PERL5LIB=/x", "PERL5LIB"),
+        ("export IFS=.", "IFS"),
+        ("export BASH_ENV=/malicious", "BASH_ENV"),
+        ("export ENV=/malicious", "ENV"),
+        ("export SHELL=/bin/sh", "SHELL"),
+        ("export DYLD_INSERT_LIBRARIES=/x.dylib", "DYLD_INSERT_LIBRARIES"),
+    ],
+)
+def test_export_dangerous_var_classifies_as_forbidden(
+    executor: SecureCommandExecutor, command: str, expected_var: str
+) -> None:
+    """`export DANGEROUS_VAR=value` must classify as FORBIDDEN —
+    attacker can persist linker/path/shell-startup hijacks for the
+    rest of the shell session."""
+    risk, reasons = executor.assess_command_risk(command)
+    assert risk == CommandRisk.FORBIDDEN, (
+        f"#7406: `{command}` must be FORBIDDEN (export of dangerous env-var) — " f"got {risk.value}. Reasons: {reasons}"
+    )
+    assert any(expected_var in r for r in reasons), f"Expected reason to mention {expected_var}; got {reasons}"
+
+
+def test_export_benign_var_unaffected(executor: SecureCommandExecutor) -> None:
+    """`export FOO=bar` must NOT auto-FORBID — only dangerous vars."""
+    risk, _ = executor.assess_command_risk("export FOO=bar")
+    assert risk != CommandRisk.FORBIDDEN, "Generic export shouldn't auto-FORBID"
+
+
+# ---------------------------------------------------------------------------
+# 2. Chained-command separator (`;`)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command, expected_risk",
+    [
+        # LHS benign, RHS escalates via dangerous export → FORBIDDEN
+        ("ls; export LD_PRELOAD=/x.so", CommandRisk.FORBIDDEN),
+        # LHS dangerous export, RHS benign → FORBIDDEN (LHS dominates)
+        ("export PATH=/x:$PATH; ls", CommandRisk.FORBIDDEN),
+        # LHS benign, RHS docker escape → FORBIDDEN
+        ("ls; docker run --privileged alpine", CommandRisk.FORBIDDEN),
+        # LHS DNS recon, RHS benign → MODERATE (DNS recon is the strictest)
+        ("dig @8.8.8.8 example.com; echo done", CommandRisk.MODERATE),
+        # The original #7406 reproducer
+        ("export SHELL=/bin/sh; sudo -E sh", CommandRisk.FORBIDDEN),
+    ],
+)
+def test_chained_command_takes_strictest_risk(
+    executor: SecureCommandExecutor, command: str, expected_risk: CommandRisk
+) -> None:
+    """`cmd1; cmd2` must classify at the strictest risk seen across
+    sub-commands — otherwise an attacker prepends a benign command to
+    bypass risk assessment."""
+    risk, reasons = executor.assess_command_risk(command)
+    assert risk == expected_risk, (
+        f"#7406: `{command}` chained-command must classify {expected_risk.value} — "
+        f"got {risk.value}. Reasons: {reasons}"
+    )
+
+
+def test_single_command_with_no_separator_unaffected(executor: SecureCommandExecutor) -> None:
+    """Plain `ls -la /tmp` (no `;`) must not enter the chained-command
+    code path — pin against accidental over-eager `;` matching."""
+    risk, _ = executor.assess_command_risk("ls -la /tmp")
+    assert risk == CommandRisk.SAFE
+
+
+# ---------------------------------------------------------------------------
+# 3. SHELL var added to _DANGEROUS_ENV_VARS (prefix form)
+# ---------------------------------------------------------------------------
+
+
+def test_shell_var_in_prefix_form_classifies_as_forbidden(executor: SecureCommandExecutor) -> None:
+    """Prefix form `SHELL=/bin/sh sudo cmd` must classify FORBIDDEN —
+    sudo's `-E` flag preserves SHELL into the privileged environment."""
+    risk, reasons = executor.assess_command_risk("SHELL=/bin/sh sudo -E cmd")
+    assert risk == CommandRisk.FORBIDDEN, (
+        f"#7406: SHELL var in prefix form must be FORBIDDEN — got {risk.value}. " f"Reasons: {reasons}"
+    )
+    assert any("SHELL" in r for r in reasons), f"Expected reason to mention SHELL; got {reasons}"

--- a/autobot-backend/security/security_edge_cases_test.py
+++ b/autobot-backend/security/security_edge_cases_test.py
@@ -143,10 +143,6 @@ class TestSecurityEdgeCases:
             result = await self.security.execute_command(malicious_command, user="developer", user_role="developer")
             assert not result.get("success", False), f"Injection attempt succeeded: {malicious_command}"
 
-    @pytest.mark.xfail(
-        reason="#7384: `find -perm -4000` classifies as MODERATE — argument-aware risk assessment needed",
-        strict=True,
-    )
     async def test_privilege_escalation_attempts(self):
         """Test various privilege escalation techniques"""
         escalation_attempts = [


### PR DESCRIPTION
## Summary

Extends #7375/#7384 argument-aware risk pattern with three more shapes:

| # | Shape | Old | New |
|---|---|---|---|
| 1 | `export DANGEROUS_VAR=value` | (allowlisted) | **FORBIDDEN** |
| 2 | `cmd1; cmd2` chained-command | LHS-only classification | **strictest of all sub-commands** |
| 3 | `SHELL` in `_DANGEROUS_ENV_VARS` | not in list | covered by both prefix + export forms |

The original #7406 reproducer `export SHELL=/bin/sh; sudo -E sh` now classifies FORBIDDEN via two independent rules (export-of-SHELL + chained-cmd-with-sudo).

## Test plan

- [x] 18 regression cases in `secure_command_executor_export_chain_test.py` — all pass
- [x] `security_edge_cases_test.py::TestSecurityEdgeCases` — un-xfailed `test_privilege_escalation_attempts`; now 12 passed + 2 xfailed (was 9+5 baseline)
- [x] Negative tests for benign cases (`export FOO=bar`, `ls -la /tmp`) — risk preserved
- [ ] CI green

## #7384 closure status

**4 of 5 #7384 sub-fixes now landed in production** (3 in PR #7393, this 1 here).

Sub-fix #2 (`authenticate_user(None, ...)`) and #3 (`check_permission` signature) are test rot, fixed in PR #7407 (in CI).

## Out of scope

`test_docker_sandbox_escape_attempts` and `test_network_command_restrictions` xfails remain — their test arrays contain commands beyond the 4 covered sub-fixes (`chmod +s`, `mount`, `curl`, `wget`, `nc`, `nmap`, `masscan`).

Closes #7406
References #7375 #7384 #7367

🤖 Generated with [Claude Code](https://claude.com/claude-code)