### PR TITLE
refactor(types): rename causal_inference_engine.Severity → CausalSeverity (closes #7255)

### DIFF
--- a/autobot-backend/services/causal_inference_engine.py
+++ b/autobot-backend/services/causal_inference_engine.py
@@ -21,7 +21,7 @@ Reports include:
 - Confounders (multi-factor contributors)
 - Interventions (ranked by likelihood × cost)
 - Recommendations (IMMEDIATE, SHORT_TERM, LONG_TERM)
-- Severity (CRITICAL, DEGRADED, WARNING)
+- CausalSeverity (CRITICAL, DEGRADED, WARNING)
 """
 
 import logging
@@ -44,7 +44,7 @@ from services.root_cause_analyzer import (
 logger = logging.getLogger(__name__)
 
 
-class Severity(str, Enum):
+class CausalSeverity(str, Enum):
     """Error severity levels."""
 
     CRITICAL = "critical"  # Immediate action required
@@ -86,7 +86,7 @@ class CausalAnalysisReport:
     causal_chain: List[CausalEvent] = field(default_factory=list)
     confounders: List[CausalEvent] = field(default_factory=list)
     interventions: List[Intervention] = field(default_factory=list)
-    severity: Severity = Severity.WARNING
+    severity: CausalSeverity = CausalSeverity.WARNING
     confidence: float = 0.0
     chain_depth: int = 0
     confounding_strength: float = 0.0  # 0.0-1.0, how much confounders matter
@@ -638,7 +638,7 @@ class CausalInferenceEngine:
         report: RootCauseReport,
         confounding_strength: float,
         interventions: List[Intervention],
-    ) -> Severity:
+    ) -> CausalSeverity:
         """
         Assess error severity based on analysis results.
 
@@ -652,29 +652,29 @@ class CausalInferenceEngine:
             interventions: Generated interventions
 
         Returns:
-            Severity level
+            CausalSeverity level
         """
         # Start with confidence-based baseline
         if report.chain_depth >= 3 and report.confidence >= 0.7:
-            base_severity = Severity.CRITICAL
+            base_severity = CausalSeverity.CRITICAL
         elif report.chain_depth >= 2 and report.confidence >= 0.5:
-            base_severity = Severity.DEGRADED
+            base_severity = CausalSeverity.DEGRADED
         else:
-            base_severity = Severity.WARNING
+            base_severity = CausalSeverity.WARNING
 
         # Upgrade to CRITICAL if multi-factor
-        if confounding_strength >= 0.5 and base_severity == Severity.DEGRADED:
-            base_severity = Severity.CRITICAL
+        if confounding_strength >= 0.5 and base_severity == CausalSeverity.DEGRADED:
+            base_severity = CausalSeverity.CRITICAL
 
         # Downgrade if high-confidence interventions exist
         if interventions and interventions[0].predicted_success_rate >= 0.8 and interventions[0].confidence >= 0.8:
             # High-confidence fix available, not critical
-            if base_severity == Severity.CRITICAL:
-                base_severity = Severity.DEGRADED
+            if base_severity == CausalSeverity.CRITICAL:
+                base_severity = CausalSeverity.DEGRADED
 
         return base_severity
 
-    def _generate_recommendations(self, interventions: List[Intervention], severity: Severity) -> List[str]:
+    def _generate_recommendations(self, interventions: List[Intervention], severity: CausalSeverity) -> List[str]:
         """
         Generate human-readable recommendations ranked by priority.
 
@@ -702,9 +702,9 @@ class CausalInferenceEngine:
 
         # Generate urgency prefix based on severity
         urgency = ""
-        if severity == Severity.CRITICAL:
+        if severity == CausalSeverity.CRITICAL:
             urgency = "[URGENT] "
-        elif severity == Severity.DEGRADED:
+        elif severity == CausalSeverity.DEGRADED:
             urgency = "[ACTION] "
 
         # Add immediate actions

--- a/autobot-backend/services/causal_inference_engine_examples.py
+++ b/autobot-backend/services/causal_inference_engine_examples.py
@@ -23,14 +23,14 @@ Each scenario includes:
 - Confounders
 - Interventions
 - Recommendations
-- Severity assessment
+- CausalSeverity assessment
 """
 
 from services.causal_inference_engine import (
     CausalAnalysisReport,
+    CausalSeverity,
     Intervention,
     RecommendationType,
-    Severity,
 )
 from services.root_cause_analyzer import CausalEvent
 
@@ -553,7 +553,7 @@ def create_example_report_1() -> CausalAnalysisReport:
             )
             for interv in EXAMPLE_1_POOL_EXHAUSTION["interventions"]
         ],
-        severity=Severity(EXAMPLE_1_POOL_EXHAUSTION["severity"]),
+        severity=CausalSeverity(EXAMPLE_1_POOL_EXHAUSTION["severity"]),
         confidence=EXAMPLE_1_POOL_EXHAUSTION["confidence"],
         chain_depth=len(EXAMPLE_1_POOL_EXHAUSTION["causal_chain"]),
         confounding_strength=EXAMPLE_1_POOL_EXHAUSTION["confounding_strength"],

--- a/autobot-backend/tests/services/test_causal_inference_engine.py
+++ b/autobot-backend/tests/services/test_causal_inference_engine.py
@@ -8,7 +8,7 @@ Issue #4069: Tests production-grade causal analysis with:
 - Chain traversal and confounder detection
 - Intervention prediction and ranking
 - Confidence scoring
-- Severity assessment
+- CausalSeverity assessment
 - Recommendation generation
 
 Test scenarios:
@@ -27,9 +27,9 @@ import pytest
 from services.causal_inference_engine import (
     CausalAnalysisReport,
     CausalInferenceEngine,
+    CausalSeverity,
     Intervention,
     RecommendationType,
-    Severity,
 )
 from services.root_cause_analyzer import CausalEvent, RootCauseReport
 
@@ -426,7 +426,7 @@ class TestSeverityAssessment:
         ]
 
         severity = engine._assess_severity(report, 0.6, interventions)
-        assert severity == Severity.CRITICAL
+        assert severity == CausalSeverity.CRITICAL
 
     def test_warning_severity(self):
         """Shallow chain, low confidence should be WARNING."""
@@ -456,7 +456,7 @@ class TestSeverityAssessment:
         interventions = []
 
         severity = engine._assess_severity(report, 0.0, interventions)
-        assert severity == Severity.WARNING
+        assert severity == CausalSeverity.WARNING
 
 
 class TestRecommendationGeneration:
@@ -502,7 +502,7 @@ class TestRecommendationGeneration:
             ),
         ]
 
-        recommendations = engine._generate_recommendations(interventions, Severity.DEGRADED)
+        recommendations = engine._generate_recommendations(interventions, CausalSeverity.DEGRADED)
 
         assert len(recommendations) >= 2
         # Check order: IMMEDIATE comes before SHORT_TERM comes before LONG_TERM
@@ -538,7 +538,7 @@ class TestRecommendationGeneration:
             )
         ]
 
-        recommendations = engine._generate_recommendations(interventions, Severity.WARNING)
+        recommendations = engine._generate_recommendations(interventions, CausalSeverity.WARNING)
 
         # Should have fallback or empty recommendations
         assert len(recommendations) >= 0
@@ -713,7 +713,7 @@ class TestAnalyzeFailure:
 
         assert report.confounding_strength > 0
         assert len(report.confounders) > 0
-        assert report.severity in [Severity.CRITICAL, Severity.DEGRADED]
+        assert report.severity in [CausalSeverity.CRITICAL, CausalSeverity.DEGRADED]
 
     @pytest.mark.asyncio
     async def test_analysis_graceful_degradation(self):
@@ -768,7 +768,7 @@ class TestReportSerialization:
                     confidence=0.9,
                 )
             ],
-            severity=Severity.DEGRADED,
+            severity=CausalSeverity.DEGRADED,
             confidence=0.75,
             analysis_status="success",
             recommendations=["Test recommendation"],


### PR DESCRIPTION
## Summary

Disambiguates from canonical \`Severity\` (which lives at \`autobot_shared.status_enums\`).

The local \`Severity\` enum has values CRITICAL/DEGRADED/WARNING which don't match canonical's 7-tier UNKNOWN/INFO/MINIMAL/LOW/MEDIUM/HIGH/CRITICAL. It's actually a service-impact / error-state concept — different from the generic severity scale. Per #7255, rename rather than consolidate.

## Changes

Mechanical sed replacement \`Severity\` → \`CausalSeverity\` across 3 files:
- \`autobot-backend/services/causal_inference_engine.py\` (15 references)
- \`autobot-backend/services/causal_inference_engine_examples.py\` (3 references)
- \`autobot-backend/tests/services/test_causal_inference_engine.py\` (8 references)

Wire format unchanged — string values still \"critical\"/\"degraded\"/\"warning\".

## Verification

- [x] 5/5 smoke imports green: causal_inference_engine, examples, tests, api.diagnostics, services.grounded_agent
- [x] flake8 + black + isort clean
- [x] \`.value\` access produces same strings as before — no JSON wire-format change

## Why not consolidate

\`HealthStatus\` (HEALTHY/DEGRADED/UNHEALTHY/UNKNOWN/STARTING/STOPPING) was considered as the consolidation target but rejected:
- WARNING tier doesn't map to HealthStatus
- CRITICAL semantics differ between health-check and causal-error contexts

Closes #7255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)