### PR TITLE
refactor(types): document command_execution.RiskLevel + bridge to canonical (closes #7258)

### DIFF
--- a/autobot-backend/models/command_execution.py
+++ b/autobot-backend/models/command_execution.py
@@ -45,12 +45,36 @@ _FINISHED_COMMAND_STATES = frozenset(
 
 
 class RiskLevel(Enum):
-    """Command risk assessment levels"""
+    """Command risk assessment levels.
+
+    #7258: Intentionally distinct from canonical
+    `autobot_shared.status_enums.RiskLevel` (= Severity). The wire format
+    here is uppercase ("LOW"/"MEDIUM"/"HIGH"/"CRITICAL") because legacy
+    Redis/SQLite records and 8+ producer call sites already serialize
+    that way; switching to canonical lowercase would require a data
+    migration of historical records.
+
+    Use `to_canonical()` to convert at boundaries (e.g. when emitting to
+    new APIs that expect canonical Severity).
+    """
 
     LOW = "LOW"
     MEDIUM = "MEDIUM"
     HIGH = "HIGH"
     CRITICAL = "CRITICAL"
+
+    def to_canonical(self):
+        """Convert to canonical Severity (lowercase-valued, #6689).
+
+        Bridge for new APIs that expect the canonical
+        `autobot_shared.status_enums.RiskLevel` (= Severity). Returns the
+        member with the same NAME — e.g. RiskLevel.HIGH → Severity.HIGH,
+        whose `.value` is "high" (canonical lowercase).
+        """
+        # Lazy import to avoid circular dependency at module load time
+        from autobot_shared.status_enums import Severity
+
+        return Severity[self.name]
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Per #7258 (Option 2 — \"Keep + document\"): the local \`RiskLevel\` uses uppercase wire format (\"LOW\"/\"MEDIUM\"/\"HIGH\"/\"CRITICAL\") that's intentionally incompatible with canonical \`autobot_shared.status_enums.RiskLevel\` (lowercase). 8+ producer call sites serialize uppercase to Redis/SQLite — wire-format migration would require coordinated data migration.

## Changes

- Explicit docstring documenting why this stays distinct from canonical (legacy wire format)
- New \`to_canonical()\` instance method providing a bridge: \`RiskLevel.HIGH.to_canonical()\` returns \`Severity.HIGH\` (canonical lowercase). NAME-based lookup means values map cleanly even though wire format differs.

## Why not consolidate

- 8+ producer call sites use uppercase wire format
- Historical Redis/SQLite records serialized uppercase
- Migration requires coordinated data migration plan (separate effort)

## Verification

- [x] \`RiskLevel.HIGH.value == \"HIGH\"\` (uppercase intact)
- [x] \`RiskLevel.HIGH.to_canonical() is Severity.HIGH\`
- [x] \`RiskLevel.HIGH.to_canonical().value == \"high\"\` (bridge works)
- [x] 3/3 smoke imports green (engine + 2 importers)
- [x] flake8 + black + isort clean

Closes #7258. Bridge gives new APIs a clear path to canonical without breaking legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)