### PR TITLE
fix(ci/visual-regression): bump test timeout + upload first-run baselines (#7410)

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -108,6 +108,20 @@ jobs:
             echo "first_run=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Upload generated baselines on first run
+        # When --update-snapshots ran (no committed baselines yet), expose
+        # the generated PNGs as an artifact so a maintainer can pull them
+        # locally and commit. Without this step the warning message
+        # "Pull this branch + commit the generated baselines" is
+        # unactionable since the screenshots never escape the CI runner.
+        if: steps.visual.outputs.first_run == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: visual-regression-generated-baselines-${{ github.run_id }}
+          path: autobot-frontend/tests/visual/__screenshots__/
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Upload Playwright HTML report on failure
         if: failure() || steps.visual.outcome == 'failure'
         uses: actions/upload-artifact@v7

--- a/autobot-frontend/playwright.visual.config.ts
+++ b/autobot-frontend/playwright.visual.config.ts
@@ -28,14 +28,24 @@ export default defineConfig({
   workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI ? 'github' : [['html', { open: 'never' }]],
 
+  // The single test in storybook-stories.spec.ts loops through every
+  // discovered story (one iframe load + screenshot per story). Default
+  // 30s test timeout is exceeded once there are more than ~15 stories.
+  // Budget 5 minutes per project for headroom on slower CI runners.
+  timeout: 300_000,
+
   // Snapshot baselines live next to the tests, organized per OS to avoid
   // cross-platform rendering noise. Engineers regenerate locally on the
   // OS they develop on; CI runs Linux baselines.
   snapshotPathTemplate: '{testDir}/__screenshots__/{testFilePath}/{arg}-{platform}{ext}',
 
-  // Pixel-diff tolerance — small enough to catch real layout drift, large
-  // enough to ignore subpixel font rendering jitter across machines.
   expect: {
+    // Per-screenshot expect timeout. Default 5s is too tight for the
+    // first paint of complex stories on a cold CI runner.
+    timeout: 30_000,
+    // Pixel-diff tolerance — small enough to catch real layout drift,
+    // large enough to ignore subpixel font rendering jitter across
+    // machines.
     toHaveScreenshot: {
       maxDiffPixels: 100,
       threshold: 0.2,


### PR DESCRIPTION
Closes #7410.

## Summary
Two fixes to make the `Storybook visual regression` CI job actually useful instead of decoratively-red on every PR.

## Problem (per #7410)
- Every PR run failed with `Test timeout of 30000ms exceeded` on both `chromium-light` and `chromium-dark` projects. Cause: the single test loops through all stories (one iframe load + screenshot per story) and Playwright's default 30s test timeout is exceeded once stories grow beyond ~15. We have 38.
- The first-run warning told users to "Pull this branch + commit the generated baselines" — but the workflow never uploaded those generated baselines. The advice was unactionable.

## Changes

### `autobot-frontend/playwright.visual.config.ts`
- Add `timeout: 300_000` (5 min/project) at top level
- Add `expect.timeout: 30_000` (per-screenshot expect)
- Keep the existing single-test-loops-all-stories pattern (documented in the spec to dodge a storybook-not-yet-running race at test-collection time)

### `.github/workflows/visual-regression.yml`
- Add an `Upload generated baselines on first run` step that publishes `autobot-frontend/tests/visual/__screenshots__/` as a workflow artifact when `steps.visual.outputs.first_run == 'true'`
- Now a maintainer can download the artifact, review, and commit baselines manually

## Out of scope
Phase B per #7410 — snapshot threshold tuning, "regenerate baselines" workflow doc, and the actual baseline PNG commit — deferred to follow-ups. Committing thousands of binary PNG files needs human review of the auto-generated set, not automation.

## Test plan
- [x] `tsc --noEmit` accepts the config file (no syntax errors)
- [x] `yamllint` reports no new warnings/errors vs base (all 3 reports are pre-existing)
- [ ] CI run on this PR completes the visual regression job inside 5 min instead of timing out at 30s
- [ ] Workflow uploads `visual-regression-generated-baselines-<run_id>` artifact (the `first_run=true` branch will hit since baselines aren't committed yet)
- [ ] Maintainer downloads artifact, reviews, commits in a follow-up PR (Phase B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)