### PR TITLE
fix(test/skills): migrate LLMInterface patches to get_llm_service factory (#7398)

### DIFF
--- a/autobot-backend/skills/builtin/skill_researcher_test.py
+++ b/autobot-backend/skills/builtin/skill_researcher_test.py
@@ -114,11 +114,14 @@ async def test_research_requires_capability():
 
 @pytest.mark.asyncio
 async def test_research_fails_gracefully_without_llm():
-    with patch("skills.builtin.skill_researcher.LLMInterface", None):
+    # #7398: production uses `get_llm_service` factory; checks `is None` for
+    # absent-import fallback. Error message updated to match the new
+    # canonical name ("LLMService not available").
+    with patch("skills.builtin.skill_researcher.get_llm_service", None):
         skill = SkillResearcherSkill()
         result = await skill.execute("research_capability", {"capability": "test"})
     assert result["success"] is False
-    assert "LLMInterface" in result["error"]
+    assert "LLMService" in result["error"]
 
 
 # ---------------------------------------------------------------------------
@@ -145,8 +148,10 @@ async def test_research_returns_structured_findings():
         # First 3 calls: source queries; 4th: synthesis
         return synthesis_response if call_count > 3 else source_response
 
-    with patch("skills.builtin.skill_researcher.LLMInterface") as MockLLM:
-        MockLLM.return_value.chat_completion = mock_chat
+    # #7398: production uses `get_llm_service()` factory; mock returns instance.
+    with patch("skills.builtin.skill_researcher.get_llm_service") as mock_get_llm:
+        # #7398: production calls `llm.chat(...)` (not `chat_completion`).
+        mock_get_llm.return_value.chat = mock_chat
         skill = SkillResearcherSkill()
         result = await skill.execute("research_capability", {"capability": "voice transcription"})
 
@@ -180,8 +185,10 @@ async def test_research_continues_when_some_queries_fail():
             )
         return _mock_llm_response("content")
 
-    with patch("skills.builtin.skill_researcher.LLMInterface") as MockLLM:
-        MockLLM.return_value.chat_completion = mock_chat
+    # #7398: production uses `get_llm_service()` factory; mock returns instance.
+    with patch("skills.builtin.skill_researcher.get_llm_service") as mock_get_llm:
+        # #7398: production calls `llm.chat(...)` (not `chat_completion`).
+        mock_get_llm.return_value.chat = mock_chat
         skill = SkillResearcherSkill()
         result = await skill.execute("research_capability", {"capability": "voice transcription"})
 
@@ -201,8 +208,10 @@ async def test_research_returns_empty_findings_when_synthesis_fails():
     async def mock_chat(messages, llm_type="task"):
         raise RuntimeError("LLM down")
 
-    with patch("skills.builtin.skill_researcher.LLMInterface") as MockLLM:
-        MockLLM.return_value.chat_completion = mock_chat
+    # #7398: production uses `get_llm_service()` factory; mock returns instance.
+    with patch("skills.builtin.skill_researcher.get_llm_service") as mock_get_llm:
+        # #7398: production calls `llm.chat(...)` (not `chat_completion`).
+        mock_get_llm.return_value.chat = mock_chat
         skill = SkillResearcherSkill()
         result = await skill.execute("research_capability", {"capability": "voice transcription"})
 

--- a/autobot-backend/skills/builtin/skill_router_test.py
+++ b/autobot-backend/skills/builtin/skill_router_test.py
@@ -112,9 +112,12 @@ async def test_llm_rerank_parses_json_response():
         },
     ]
 
-    with patch("skills.builtin.skill_router.LLMInterface") as MockLLM:
-        instance = MockLLM.return_value
-        instance.chat_completion = AsyncMock(return_value=mock_response)
+    # #7398: production uses `get_llm_service()` (factory) not `LLMInterface` directly.
+    with patch("skills.builtin.skill_router.get_llm_service") as mock_get_llm:
+        instance = MagicMock()
+        # #7398: production calls `llm.chat(...)` (not `chat_completion`).
+        instance.chat = AsyncMock(return_value=mock_response)
+        mock_get_llm.return_value = instance
 
         skill = SkillRouterSkill()
         name, reason = await skill._llm_rerank("analyze this pdf", candidates)
@@ -134,9 +137,12 @@ async def test_llm_rerank_handles_markdown_code_block():
         {"name": "code-review", "description": "Review code", "tags": [], "tools": []},
     ]
 
-    with patch("skills.builtin.skill_router.LLMInterface") as MockLLM:
-        instance = MockLLM.return_value
-        instance.chat_completion = AsyncMock(return_value=mock_response)
+    # #7398: production uses `get_llm_service()` (factory) not `LLMInterface` directly.
+    with patch("skills.builtin.skill_router.get_llm_service") as mock_get_llm:
+        instance = MagicMock()
+        # #7398: production calls `llm.chat(...)` (not `chat_completion`).
+        instance.chat = AsyncMock(return_value=mock_response)
+        mock_get_llm.return_value = instance
 
         skill = SkillRouterSkill()
         name, reason = await skill._llm_rerank("review my code", candidates)
@@ -166,10 +172,12 @@ async def test_find_skill_enables_best_match_via_llm():
 
     with (
         patch("skills.builtin.skill_router.get_skill_registry", return_value=mock_registry),
-        patch("skills.builtin.skill_router.LLMInterface") as MockLLM,
+        patch("skills.builtin.skill_router.get_llm_service") as mock_get_llm,
     ):
-        instance = MockLLM.return_value
-        instance.chat_completion = AsyncMock(return_value=mock_llm_response)
+        # #7398: production uses `get_llm_service()` factory; mock returns instance.
+        instance = MagicMock()
+        mock_get_llm.return_value = instance
+        instance.chat = AsyncMock(return_value=mock_llm_response)
 
         skill = SkillRouterSkill()
         skill.apply_config({"top_k": 5, "auto_enable": True})
@@ -200,10 +208,12 @@ async def test_find_skill_falls_back_to_keyword_on_llm_error():
 
     with (
         patch("skills.builtin.skill_router.get_skill_registry", return_value=mock_registry),
-        patch("skills.builtin.skill_router.LLMInterface") as MockLLM,
+        patch("skills.builtin.skill_router.get_llm_service") as mock_get_llm,
     ):
-        instance = MockLLM.return_value
-        instance.chat_completion = AsyncMock(side_effect=Exception("LLM timeout"))
+        # #7398: production uses `get_llm_service()` factory; mock returns instance.
+        instance = MagicMock()
+        mock_get_llm.return_value = instance
+        instance.chat = AsyncMock(side_effect=Exception("LLM timeout"))
 
         skill = SkillRouterSkill()
         skill.apply_config({"top_k": 5, "auto_enable": True})
@@ -233,10 +243,12 @@ async def test_find_skill_dry_run_does_not_enable():
 
     with (
         patch("skills.builtin.skill_router.get_skill_registry", return_value=mock_registry),
-        patch("skills.builtin.skill_router.LLMInterface") as MockLLM,
+        patch("skills.builtin.skill_router.get_llm_service") as mock_get_llm,
     ):
-        instance = MockLLM.return_value
-        instance.chat_completion = AsyncMock(return_value=mock_llm_response)
+        # #7398: production uses `get_llm_service()` factory; mock returns instance.
+        instance = MagicMock()
+        mock_get_llm.return_value = instance
+        instance.chat = AsyncMock(return_value=mock_llm_response)
 
         skill = SkillRouterSkill()
         skill.apply_config({"top_k": 5, "auto_enable": True})

--- a/autobot-backend/skills/generator_test.py
+++ b/autobot-backend/skills/generator_test.py
@@ -25,14 +25,24 @@ def anyio_backend():
 
 @pytest.mark.anyio
 async def test_generator_returns_skill_package():
-    """Generator calls LLM and returns structured skill package dict."""
+    """Generator calls LLM and returns structured skill package dict.
+
+    #7398: production calls `self._llm.chat(...)` and parses
+    `response.content` as JSON. The previous test mocked
+    `generate_structured` (a method that doesn't exist on the LLM
+    service and never did) — fix the mock to match the real contract.
+    """
+    import json
+
     mock_llm = AsyncMock()
-    mock_llm.generate_structured = AsyncMock(
-        return_value={
+    mock_response = AsyncMock()
+    mock_response.content = json.dumps(
+        {
             "skill_md": VALID_SKILL_MD,
             "skill_py": VALID_SKILL_PY,
         }
     )
+    mock_llm.chat = AsyncMock(return_value=mock_response)
     gen = SkillGenerator(llm=mock_llm)
     pkg = await gen.generate("parse PDF documents")
     assert pkg["name"] == "pdf-parser"


### PR DESCRIPTION
## Summary

10 tests across 3 files were failing on Dev_new_gui — patches referenced `LLMInterface` which was removed during #3185 LLM consolidation (replaced by `get_llm_service()` factory).

## Triage: test rot

Production code is correct (`get_llm_service()` + `llm.chat(...)`). Tests encoded the pre-#3185 API and weren't migrated alongside the source.

## Fix

Two mechanical changes per test file:

| Change | Old | New |
|---|---|---|
| Patch path | `skills.X.LLMInterface` | `skills.X.get_llm_service` |
| Method name | `chat_completion` | `chat` |

Plus `generator_test.py`: mock `chat` returning a JSON-stringified `response.content` instead of a non-existent `generate_structured`.

## Verified

```
33 passed in 0.64s
```

Was: 10 failed, 23 passed.

Closes #7398
References #3185 (source migration), `feedback_grep_misses_implicit_refs.md` (pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)