### PR TITLE
refactor(test/rag): migrate rag_service_events_test.py to canonical fixture (#7280 round 8)

### DIFF
--- a/autobot-backend/tests/services/rag_service_events_test.py
+++ b/autobot-backend/tests/services/rag_service_events_test.py
@@ -10,6 +10,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.fixtures import make_async_redis
+
 # =============================================================================
 # _emit_retrieval_feedback Tests
 # =============================================================================
@@ -152,13 +154,12 @@ class TestStoreFeedbackInStream:
         return svc
 
     def _make_redis_mock(self, xadd_side_effect=None):
-        """Build an async Redis mock that get_redis_client will return when awaited."""
-        mock_redis = AsyncMock()
-        mock_redis.xadd = AsyncMock(
-            return_value=b"1234-0",
-            side_effect=xadd_side_effect,
-        )
-        mock_redis.expire = AsyncMock(return_value=True)
+        # Migrated to canonical ``make_async_redis()`` (#7280 round 8).
+        # ``side_effect`` requires a post-set since canonical's ``**extra_methods``
+        # only configures ``return_value``.
+        mock_redis = make_async_redis(xadd=b"1234-0")
+        if xadd_side_effect is not None:
+            mock_redis.xadd = AsyncMock(return_value=b"1234-0", side_effect=xadd_side_effect)
         return mock_redis
 
     @pytest.mark.asyncio
@@ -356,10 +357,8 @@ class TestComplexityInStoreFeedbackInStream:
         return svc
 
     def _make_redis_mock(self):
-        mock_redis = AsyncMock()
-        mock_redis.xadd = AsyncMock(return_value=b"1234-0")
-        mock_redis.expire = AsyncMock(return_value=True)
-        return mock_redis
+        # Migrated to canonical ``make_async_redis()`` (#7280 round 8).
+        return make_async_redis(xadd=b"1234-0")
 
     @pytest.mark.asyncio
     async def test_stream_entry_contains_complexity_field(self):


### PR DESCRIPTION
## Summary

#7280 round 8: migrates ``tests/services/rag_service_events_test.py`` to canonical ``make_async_redis()`` from ``tests.fixtures``.

## Changes

- **Replaced TWO** local ``_make_redis_mock()`` definitions (in ``TestStoreFeedbackInStream`` and ``TestComplexityInStoreFeedbackInStream``) → thin wrappers delegating to ``make_async_redis(xadd=b"1234-0")``.
- ``expire`` default is ``True`` in canonical — no override needed.
- The ``xadd_side_effect`` parameter (used by 1 test for ``ConnectionError`` injection) post-builds to override since canonical's ``**extra_methods`` only configures ``return_value``, not ``side_effect``.

## Surprise

This file was classified as "pipeline-blocked" in #7339's table, but the helpers don't actually use ``pipeline`` — only ``xadd`` + ``expire``. The pre-#7339 grep on ``_make_pipeline_mock`` matched ``_make_redis_mock`` (substring match). The file migrates cleanly without needing the pipeline extension at all — could have been done as part of round 5 but the misclassification deferred it.

## Test plan

- [x] ``pytest tests/services/rag_service_events_test.py`` — 38/38 passed before AND after migration

## #7280 progress

- ✅ Rounds 1-8: 8 files migrated, ~150+ sites
- 2 pipeline-blocked remaining: ``test_synthesis_provenance.py``, ``test_working_memory.py`` (scan_iter)

## Refs

- Refs #7280 (parent)
- Refs #7339 (canonical fixture extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)