### PR TITLE
fix(rag): defensive embedding-provenance guard at ChromaDB write chokepoint (#6514 MVP)

### DIFF
--- a/autobot-backend/utils/async_chromadb_client.py
+++ b/autobot-backend/utils/async_chromadb_client.py
@@ -96,7 +96,29 @@ class AsyncChromaCollection:
             embeddings: Optional list of embedding vectors
             metadatas: Optional list of metadata dicts
             documents: Optional list of document strings
+
+        #6514: if the collection metadata declares an embedding-provenance
+        tag (model_name + dim), this guard rejects writes whose vector
+        dim doesn't match. Stops silent cross-model contamination at the
+        chokepoint instead of letting it land in the index and
+        corrupt cosine-distance recall at query time.
+
+        Untagged (legacy) collections fall through unchanged — the guard
+        only fires when a writer-side caller has tagged the collection.
         """
+        if embeddings is not None:
+            from autobot_shared.embedding_provenance import (
+                provenance_from_metadata,
+                validate_vectors_against_provenance,
+            )
+
+            provenance = provenance_from_metadata(self._collection.metadata)
+            if provenance is not None:
+                # Raises EmbeddingMismatchError (subclass of ValueError) on
+                # cross-model write attempts. Caller catches the type or
+                # the existing `except ValueError:` block degrades it.
+                validate_vectors_against_provenance(embeddings, provenance)
+
         await asyncio.to_thread(
             self._collection.add,
             ids=ids,

--- a/autobot-backend/utils/async_chromadb_client_provenance_test.py
+++ b/autobot-backend/utils/async_chromadb_client_provenance_test.py
@@ -1,0 +1,93 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""#6514: integration test for the AsyncChromaCollection.add() provenance guard.
+
+The guard reads ``collection.metadata`` for the autobot.embedding_provenance
+namespace; if a (model_name, dim) tag is present, writes whose embedding
+dim doesn't match get rejected with ``EmbeddingMismatchError`` BEFORE the
+underlying Chroma `add()` call runs.
+
+Untagged (legacy) collections fall through unchanged — the guard is
+opt-in via the metadata tag, so existing collections aren't disturbed.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from autobot_shared.embedding_provenance import (
+    EmbeddingMismatchError,
+    EmbeddingProvenance,
+    provenance_to_metadata,
+)
+from utils.async_chromadb_client import AsyncChromaCollection
+
+
+def _stub_chroma_collection(metadata=None):
+    """Build a MagicMock that walks like a Chroma Collection."""
+    mock = MagicMock()
+    mock.name = "test_collection"
+    mock.metadata = metadata
+    mock.add = MagicMock(return_value=None)
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_add_passes_through_when_collection_is_untagged():
+    """Legacy collections (no provenance metadata) get no extra validation."""
+    raw = _stub_chroma_collection(metadata={"hnsw:space": "cosine"})  # no tags
+    coll = AsyncChromaCollection(raw)
+    await coll.add(ids=["a"], embeddings=[[0.0] * 384])
+    raw.add.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_add_passes_when_dim_matches_provenance():
+    p = EmbeddingProvenance("microsoft/codebert-base", 768)
+    raw = _stub_chroma_collection(metadata=provenance_to_metadata(p))
+    coll = AsyncChromaCollection(raw)
+    await coll.add(ids=["a"], embeddings=[[0.0] * 768])
+    raw.add.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_add_rejects_cross_model_dim_mismatch():
+    """The original #6514 reproducer at the chokepoint: collection tagged
+    for codebert (768-dim), nomic writer (384-dim) tries to add — guard
+    raises before the underlying Chroma add() runs."""
+    p = EmbeddingProvenance("microsoft/codebert-base", 768)
+    raw = _stub_chroma_collection(metadata=provenance_to_metadata(p))
+    coll = AsyncChromaCollection(raw)
+    with pytest.raises(EmbeddingMismatchError, match="dim 384.*expects dim 768"):
+        await coll.add(ids=["a"], embeddings=[[0.0] * 384])
+    # Crucial: the underlying Chroma write must NOT have been called —
+    # the guard fires BEFORE the index is touched.
+    raw.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_add_without_embeddings_skips_validation():
+    """When embeddings=None (caller relies on Chroma's embedding_function
+    for documents=...), the dim guard has nothing to check. The underlying
+    Chroma call is what enforces dim consistency in that path; this guard
+    is opt-in for caller-supplied vectors."""
+    p = EmbeddingProvenance("codebert", 768)
+    raw = _stub_chroma_collection(metadata=provenance_to_metadata(p))
+    coll = AsyncChromaCollection(raw)
+    await coll.add(ids=["a"], documents=["hello"])
+    raw.add.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_add_rejects_partial_batch_mismatch():
+    """Batch with one bad vector: fail-fast on the first mismatched index."""
+    p = EmbeddingProvenance("codebert", 768)
+    raw = _stub_chroma_collection(metadata=provenance_to_metadata(p))
+    coll = AsyncChromaCollection(raw)
+    with pytest.raises(EmbeddingMismatchError, match="vector at index 1"):
+        await coll.add(
+            ids=["a", "b", "c"],
+            embeddings=[[0.0] * 768, [0.0] * 384, [0.0] * 768],
+        )
+    raw.add.assert_not_called()

--- a/autobot_shared/embedding_provenance.py
+++ b/autobot_shared/embedding_provenance.py
@@ -1,0 +1,179 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""#6514: ChromaDB collection provenance — pin which embedding model wrote
+each collection so silent cross-model contamination is detectable.
+
+## Why
+
+Two paths in the codebase write embeddings to ChromaDB collections using
+different models with incompatible vector spaces:
+
+  - ``autobot-backend/code_embedding_generator.py`` — `microsoft/codebert-base`
+    (768-dim, transformer)
+  - ``autobot-backend/background_vectorization.py`` — `DEFAULT_EMBEDDING_MODEL`
+    (`nomic-embed-text` per memory; different dim and different vector space)
+
+ChromaDB doesn't validate dim/model match across writes — it accepts any
+vector and computes cosine distance regardless. So a query embedded with
+model A against a collection contaminated with model-B writes returns
+mathematically meaningless results, with no error or warning. RAG over
+code is silently degraded.
+
+## What this module provides
+
+The minimum-viable defensive surface to fail-fast on mismatched writes:
+
+1. ``EmbeddingProvenance`` dataclass — `(model_name, dim)` pair.
+2. ``EmbeddingMismatchError`` — explicit error raised on mismatch.
+3. ``provenance_to_metadata(provenance)`` — turn provenance into a
+   ChromaDB-compatible ``metadata`` dict (only str/int/float values
+   allowed by Chroma).
+4. ``provenance_from_metadata(metadata)`` — extract provenance from an
+   existing collection's metadata; returns ``None`` if the collection
+   was created before tagging was wired up (preserves backwards compat
+   for legacy collections).
+5. ``validate_vectors_against_provenance(vectors, provenance)`` —
+   guard at write time. Raises ``EmbeddingMismatchError`` if any vector's
+   dim doesn't match the collection's recorded dim.
+
+The helper is callable side; production wiring lives in the ChromaDB
+client wrapper(s) — one chokepoint per collection.add() path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional, Sequence
+
+__all__ = [
+    "EmbeddingMismatchError",
+    "EmbeddingProvenance",
+    "provenance_to_metadata",
+    "provenance_from_metadata",
+    "validate_vectors_against_provenance",
+    "PROVENANCE_METADATA_PREFIX",
+]
+
+
+# Metadata-key prefix so this module's keys don't collide with whatever
+# else the caller has already written to ``collection.metadata`` (e.g.
+# `hnsw:space` is a reserved Chroma key).
+PROVENANCE_METADATA_PREFIX = "autobot.embedding_provenance"
+
+
+class EmbeddingMismatchError(ValueError):
+    """Raised when a vector's provenance doesn't match its collection's.
+
+    Subclass of ``ValueError`` so existing ``try: ... except ValueError``
+    blocks degrade gracefully (return 4xx instead of 500), but callers
+    that want explicit handling can catch the more specific type.
+    """
+
+
+@dataclass(frozen=True)
+class EmbeddingProvenance:
+    """Identifies the embedding model used to populate a collection.
+
+    Pinning is by ``(model_name, dim)`` — both are required because:
+
+      - ``model_name`` alone misses cross-version drift (a new
+        codebert-base release with the same name but different layer
+        layout would silently break recall).
+      - ``dim`` alone misses model swaps that happen to share dim
+        (e.g. ``nomic-embed-text`` and ``all-MiniLM-L6-v2`` are both
+        384-dim but live in different vector spaces).
+    """
+
+    model_name: str
+    dim: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.model_name, str) or not self.model_name:
+            raise ValueError("EmbeddingProvenance.model_name must be a non-empty string")
+        if not isinstance(self.dim, int) or self.dim <= 0:
+            raise ValueError(f"EmbeddingProvenance.dim must be a positive int; got {self.dim!r}")
+
+
+def provenance_to_metadata(provenance: EmbeddingProvenance) -> Dict[str, Any]:
+    """Render provenance as a ChromaDB collection-metadata dict.
+
+    ChromaDB's metadata only accepts str/int/float values — no nesting,
+    no lists. Use a flat namespace prefix to avoid colliding with
+    reserved keys like ``hnsw:space``.
+    """
+    return {
+        f"{PROVENANCE_METADATA_PREFIX}.model_name": provenance.model_name,
+        f"{PROVENANCE_METADATA_PREFIX}.dim": int(provenance.dim),
+    }
+
+
+def provenance_from_metadata(metadata: Optional[Dict[str, Any]]) -> Optional[EmbeddingProvenance]:
+    """Recover provenance from a collection's metadata dict.
+
+    Returns ``None`` if the metadata is missing both provenance keys —
+    treat as untagged (legacy collection). Returns ``None`` if EITHER
+    key is missing or malformed (defensive: don't half-validate).
+    """
+    if not metadata:
+        return None
+    model_key = f"{PROVENANCE_METADATA_PREFIX}.model_name"
+    dim_key = f"{PROVENANCE_METADATA_PREFIX}.dim"
+    if model_key not in metadata or dim_key not in metadata:
+        return None
+    model_name = metadata.get(model_key)
+    dim_raw = metadata.get(dim_key)
+    if not isinstance(model_name, str) or not model_name:
+        return None
+    try:
+        dim = int(dim_raw)
+    except (TypeError, ValueError):
+        return None
+    if dim <= 0:
+        return None
+    return EmbeddingProvenance(model_name=model_name, dim=dim)
+
+
+def validate_vectors_against_provenance(
+    vectors: Sequence[Sequence[float]],
+    provenance: EmbeddingProvenance,
+) -> None:
+    """Raise ``EmbeddingMismatchError`` if any vector's dim doesn't match.
+
+    ``vectors`` may be any sized sequence (list, numpy array, etc.) —
+    we only need ``len()``. Empty input is a no-op (no vectors to check).
+
+    Note: we can't validate ``model_name`` from a vector alone (that's
+    a metadata-only check the caller does at registration time). The
+    runtime guard is dim-only — but that's enough to catch the common
+    contamination case from the #6514 reproducer (768 vs 384-dim).
+    """
+    if not vectors:
+        return
+    expected_dim = provenance.dim
+    for i, vec in enumerate(vectors):
+        try:
+            actual_dim = len(vec)
+        except TypeError as exc:
+            raise EmbeddingMismatchError(
+                f"#6514: vector at index {i} is not a sequence (type {type(vec).__name__}) — "
+                f"cannot validate against provenance {provenance!r}"
+            ) from exc
+        if actual_dim != expected_dim:
+            raise EmbeddingMismatchError(
+                f"#6514: vector at index {i} has dim {actual_dim} but collection "
+                f"provenance expects dim {expected_dim} (model {provenance.model_name!r}). "
+                f"Cross-model writes to a single ChromaDB collection produce mathematically "
+                f"meaningless cosine distances at query time — re-embed with the registered "
+                f"model or write to a separate collection."
+            )
+
+
+def _safe_iter_vectors(maybe_iterable: Any) -> Iterable[Sequence[float]]:
+    """Best-effort coercion for callers that pass numpy arrays etc."""
+    if maybe_iterable is None:
+        return ()
+    try:
+        return list(maybe_iterable)
+    except TypeError:
+        return ()

--- a/autobot_shared/embedding_provenance_test.py
+++ b/autobot_shared/embedding_provenance_test.py
@@ -1,0 +1,201 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""#6514: regression tests for embedding-provenance defensive validation.
+
+Pins the contract that prevents the silent cross-model contamination
+described in the original issue body — two paths writing to the same
+ChromaDB collection with different (model_name, dim) pairs.
+"""
+
+import pytest
+
+from autobot_shared.embedding_provenance import (
+    PROVENANCE_METADATA_PREFIX,
+    EmbeddingMismatchError,
+    EmbeddingProvenance,
+    provenance_from_metadata,
+    provenance_to_metadata,
+    validate_vectors_against_provenance,
+)
+
+# ---------------------------------------------------------------------------
+# EmbeddingProvenance dataclass — input validation
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingProvenance:
+    def test_valid_construction(self):
+        p = EmbeddingProvenance(model_name="microsoft/codebert-base", dim=768)
+        assert p.model_name == "microsoft/codebert-base"
+        assert p.dim == 768
+
+    def test_frozen(self):
+        p = EmbeddingProvenance("nomic-embed-text", 768)
+        with pytest.raises((AttributeError, TypeError)):
+            p.dim = 384  # type: ignore[misc]  # frozen=True prohibits
+
+    def test_empty_model_name_rejected(self):
+        with pytest.raises(ValueError, match="non-empty string"):
+            EmbeddingProvenance(model_name="", dim=768)
+
+    def test_non_string_model_name_rejected(self):
+        with pytest.raises(ValueError, match="non-empty string"):
+            EmbeddingProvenance(model_name=None, dim=768)  # type: ignore[arg-type]
+
+    def test_zero_dim_rejected(self):
+        with pytest.raises(ValueError, match="positive int"):
+            EmbeddingProvenance(model_name="x", dim=0)
+
+    def test_negative_dim_rejected(self):
+        with pytest.raises(ValueError, match="positive int"):
+            EmbeddingProvenance(model_name="x", dim=-1)
+
+    def test_non_int_dim_rejected(self):
+        with pytest.raises(ValueError, match="positive int"):
+            EmbeddingProvenance(model_name="x", dim="768")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: provenance ↔ metadata
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceMetadataRoundTrip:
+    def test_to_metadata_returns_chroma_compatible_dict(self):
+        p = EmbeddingProvenance("microsoft/codebert-base", 768)
+        m = provenance_to_metadata(p)
+        # Chroma only accepts str / int / float — no nesting, no lists.
+        for key, value in m.items():
+            assert isinstance(key, str)
+            assert isinstance(value, (str, int, float))
+
+    def test_metadata_keys_use_namespace_prefix(self):
+        """Avoid collision with reserved Chroma keys like ``hnsw:space``."""
+        p = EmbeddingProvenance("nomic-embed-text", 384)
+        m = provenance_to_metadata(p)
+        for key in m:
+            assert key.startswith(PROVENANCE_METADATA_PREFIX)
+
+    def test_round_trip(self):
+        p = EmbeddingProvenance("microsoft/codebert-base", 768)
+        recovered = provenance_from_metadata(provenance_to_metadata(p))
+        assert recovered == p
+
+    def test_from_metadata_returns_none_for_legacy_untagged_collection(self):
+        # Existing Chroma collections have only `hnsw:space` etc. — they
+        # predate the tagging system. provenance_from_metadata must return
+        # None instead of raising so legacy callers still work.
+        legacy_metadata = {"hnsw:space": "cosine", "description": "old collection"}
+        assert provenance_from_metadata(legacy_metadata) is None
+
+    def test_from_metadata_returns_none_when_metadata_is_none(self):
+        assert provenance_from_metadata(None) is None
+
+    def test_from_metadata_returns_none_when_metadata_is_empty(self):
+        assert provenance_from_metadata({}) is None
+
+    def test_from_metadata_returns_none_on_partial_tags(self):
+        # Half-tagged: only model_name, no dim — defensive null return,
+        # not a malformed-data exception.
+        partial = {f"{PROVENANCE_METADATA_PREFIX}.model_name": "x"}
+        assert provenance_from_metadata(partial) is None
+
+    def test_from_metadata_returns_none_on_corrupt_dim(self):
+        m = {
+            f"{PROVENANCE_METADATA_PREFIX}.model_name": "x",
+            f"{PROVENANCE_METADATA_PREFIX}.dim": "not-a-number",
+        }
+        assert provenance_from_metadata(m) is None
+
+    def test_from_metadata_handles_float_dim_string(self):
+        # Chroma may stringify ints in some serialization paths — accept
+        # ``int(value)`` parses.
+        m = {
+            f"{PROVENANCE_METADATA_PREFIX}.model_name": "x",
+            f"{PROVENANCE_METADATA_PREFIX}.dim": "768",
+        }
+        recovered = provenance_from_metadata(m)
+        assert recovered is not None
+        assert recovered.dim == 768
+
+
+# ---------------------------------------------------------------------------
+# validate_vectors_against_provenance — runtime guard
+# ---------------------------------------------------------------------------
+
+
+class TestValidateVectorsAgainstProvenance:
+    def test_matching_dim_passes_silently(self):
+        p = EmbeddingProvenance("codebert", 768)
+        vectors = [[0.1] * 768, [0.2] * 768]
+        # Must not raise.
+        validate_vectors_against_provenance(vectors, p)
+
+    def test_mismatched_dim_raises_embedding_mismatch_error(self):
+        p = EmbeddingProvenance("codebert", 768)
+        # nomic-embed-text and codebert in the same collection: classic
+        # #6514 contamination shape.
+        vectors = [[0.1] * 384]
+        with pytest.raises(EmbeddingMismatchError, match="dim 384.*expects dim 768"):
+            validate_vectors_against_provenance(vectors, p)
+
+    def test_first_mismatch_in_batch_is_raised(self):
+        # Batch write where only one vector is wrong — fail-fast on
+        # the first mismatch with the offending index in the message.
+        p = EmbeddingProvenance("codebert", 768)
+        vectors = [[0.0] * 768, [0.0] * 768, [0.0] * 384, [0.0] * 768]
+        with pytest.raises(EmbeddingMismatchError, match="vector at index 2"):
+            validate_vectors_against_provenance(vectors, p)
+
+    def test_empty_input_is_noop(self):
+        p = EmbeddingProvenance("codebert", 768)
+        validate_vectors_against_provenance([], p)
+        # No exception.
+
+    def test_non_sized_vector_raises(self):
+        # Caller passed an int instead of a vector — surfaces as a
+        # mismatch error, not an opaque TypeError downstream.
+        p = EmbeddingProvenance("codebert", 768)
+        with pytest.raises(EmbeddingMismatchError, match="not a sequence"):
+            validate_vectors_against_provenance([42], p)  # type: ignore[list-item]
+
+    def test_embedding_mismatch_error_is_value_error_subclass(self):
+        # Subclass of ValueError so existing `except ValueError:` blocks
+        # still catch it — preserves error-handling contracts in callers
+        # that don't yet know about the new specific type.
+        assert issubclass(EmbeddingMismatchError, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# Reproducer: the original #6514 silent-contamination shape
+# ---------------------------------------------------------------------------
+
+
+class TestIssue6514Reproducer:
+    """Pin the original failure mode: two paths writing to the same
+    collection with incompatible models. Once tagged, the second
+    writer's batch must raise rather than silently corrupting recall."""
+
+    def test_codebert_collection_rejects_nomic_writes(self):
+        # 1. Path A creates a collection tagged for codebert (768-dim).
+        codebert = EmbeddingProvenance("microsoft/codebert-base", 768)
+        codebert_metadata = provenance_to_metadata(codebert)
+
+        # 2. Path B tries to write nomic vectors (e.g. 384-dim) into
+        # the same collection. Production guard reads provenance and
+        # validates. Without the fix, this would silently corrupt.
+        recovered = provenance_from_metadata(codebert_metadata)
+        assert recovered == codebert
+
+        nomic_vectors = [[0.5] * 384]
+        with pytest.raises(EmbeddingMismatchError):
+            validate_vectors_against_provenance(nomic_vectors, recovered)
+
+    def test_codebert_collection_accepts_codebert_writes(self):
+        codebert = EmbeddingProvenance("microsoft/codebert-base", 768)
+        recovered = provenance_from_metadata(provenance_to_metadata(codebert))
+        assert recovered is not None
+        codebert_vectors = [[0.5] * 768]
+        # Same model + dim → passes silently.
+        validate_vectors_against_provenance(codebert_vectors, recovered)


### PR DESCRIPTION
## Summary

#6514 P1: two embedding paths (`microsoft/codebert-base` 768-dim transformer + Ollama `nomic-embed-text` different space) write to the same ChromaDB collections. Cosine distance across models is mathematically meaningless → silent RAG degradation with no log/metric.

This PR ships the **fail-fast defensive primitive**: tag collections with `EmbeddingProvenance(model_name, dim)`; reject cross-model writes at the `AsyncChromaCollection.add()` chokepoint with `EmbeddingMismatchError`. Untagged (legacy) collections pass through unchanged — opt-in via metadata tag.

## What's in scope

- `autobot_shared/embedding_provenance.py` — new module: dataclass + serializer + validator
- `autobot-backend/utils/async_chromadb_client.py` — chokepoint guard reads metadata, validates dim
- 29 regression tests (24 unit + 5 integration); both files include the original #6514 reproducer

## Out of scope (filed as #7427)

Wire-in: tagging existing `get_or_create_collection` call sites in the writer paths needs audit + single-model decision for shared collections + migration for legacy data.

Other #6514 ACs (re-indexing migration, recall benchmark, metrics, policy docs) will be filed as separate follow-ups when each gets attention.

## Test plan

- [x] `pytest autobot_shared/embedding_provenance_test.py autobot-backend/utils/async_chromadb_client_provenance_test.py` — 29/29 pass
- [x] Reproducer pinned: codebert 768-dim collection rejects nomic 384-dim writes
- [x] Legacy (untagged) collections unaffected
- [ ] CI green

References #6514 #7427

🤖 Generated with [Claude Code](https://claude.com/claude-code)