### PR TITLE
feat(orchestration/planner): wire StrategyPlanner → skill_router for plan-time skill resolution (#7268 Phase 1)

### DIFF
--- a/autobot-backend/enhanced_orchestration/workflow_planning.py
+++ b/autobot-backend/enhanced_orchestration/workflow_planning.py
@@ -18,7 +18,7 @@ is tracked separately in #6820.
 import logging
 import re
 import uuid
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Optional, Set
 
 from .types import AgentCapability, AgentTask, ExecutionStrategy, WorkflowPlan
 
@@ -36,9 +36,23 @@ class StrategyPlanner:
             agent_capabilities: Mapping of agent types to their capabilities
         """
         self.agent_capabilities = agent_capabilities
+        # #7268 Phase 1: lazily-instantiated skill_router for plan-time binding.
+        # Created on first ``build_workflow_plan`` call and cached for the
+        # planner's lifetime. Each lookup is ``dry_run=True`` so no skill is
+        # auto-enabled and no Phase 3 gap-fill runs at plan time.
+        self._skill_router_skill: Optional[Any] = None
 
-    def build_workflow_plan(self, goal: str, plan_data: Dict[str, Any]) -> WorkflowPlan:
-        """Build workflow plan from parsed data"""
+    async def build_workflow_plan(self, goal: str, plan_data: Dict[str, Any]) -> WorkflowPlan:
+        """Build workflow plan from parsed data.
+
+        #7268 Phase 1, ADR-006: Skill-Bound Planning. After each task is
+        constructed from the LLM-parsed plan_data, attempt to resolve a
+        concrete skill via skill_router (dry_run mode — no auto-enable, no
+        Phase 3 gap-fill). When a skill matches, attach ``skill_name`` and
+        ``skill_action`` to the task so Phase 2 (WorkflowExecutor
+        consumption) can dispatch via ``SkillRegistry`` instead of (or in
+        addition to) capability-based agent routing.
+        """
         plan_id = str(uuid.uuid4())
 
         # Create tasks
@@ -66,6 +80,12 @@ class StrategyPlanner:
                 capabilities_required=caps_required,
             )
 
+            # #7268 Phase 1: bind a skill at plan time when one matches.
+            # Best-effort; failures (no registry, network error, malformed
+            # response) leave skill_name=None so legacy capability-based
+            # routing continues to work unchanged.
+            await self._bind_skill_to_task(task, task_data, goal)
+
             tasks.append(task)
             dependencies_graph[task_id] = task.dependencies
 
@@ -85,6 +105,77 @@ class StrategyPlanner:
             estimated_total_duration_seconds=plan_data.get("estimated_duration", 60.0),
             resource_requirements=plan_data.get("resource_requirements", {}),
             success_criteria=plan_data.get("success_criteria", ["All tasks completed"]),
+        )
+
+    def _get_skill_router(self) -> Optional[Any]:
+        """Lazily instantiate ``SkillRouterSkill`` for plan-time lookups (#7268).
+
+        Returns ``None`` if instantiation fails (skills package import error,
+        registry unavailable, etc.) — caller treats that as "no skill match"
+        and leaves ``skill_name=None`` on the task. Cached after first success.
+        """
+        if self._skill_router_skill is not None:
+            return self._skill_router_skill
+        try:
+            from skills.builtin.skill_router import SkillRouterSkill
+
+            self._skill_router_skill = SkillRouterSkill()
+            return self._skill_router_skill
+        except Exception as exc:  # noqa: BLE001 — best-effort init
+            logger.debug("skill_router unavailable for plan-time binding: %s", exc)
+            return None
+
+    async def _bind_skill_to_task(
+        self, task: "AgentTask", task_data: Dict[str, Any], goal: str
+    ) -> None:
+        """Resolve a concrete skill for this task via skill_router (#7268 Phase 1).
+
+        Uses ``dry_run=True`` so the registry is not mutated at plan time
+        (no auto-enable) and the Phase 3 gap-fill loop does not fire (no
+        synchronous LLM-driven skill creation during planning). The task
+        description used for routing is, in priority order:
+
+        1. ``task_data["task"]`` — explicit task description from plan_data
+        2. ``task_data["explanation"]`` — LLM-provided rationale
+        3. ``f"{task.action} (in workflow: {goal})"`` — synthesized fallback
+
+        Failures and "no match" cases leave ``skill_name=None``.
+        """
+        router = self._get_skill_router()
+        if router is None:
+            return
+
+        task_desc = (
+            task_data.get("task")
+            or task_data.get("explanation")
+            or f"{task.action} (in workflow: {goal})"
+        )
+        try:
+            result = await router.execute(
+                "find_skill",
+                {"task": task_desc, "dry_run": True},
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort resolution
+            logger.debug("skill_router lookup raised for task %s: %s", task.task_id, exc)
+            return
+
+        if not isinstance(result, dict) or not result.get("success"):
+            return
+
+        skill_name = result.get("enabled_skill")
+        if not skill_name:
+            return
+
+        # Action defaults to ``"execute"`` — Phase 2 (WorkflowExecutor
+        # consumption) can refine this once the dispatch contract is decided.
+        task.skill_name = skill_name
+        task.skill_action = task_data.get("skill_action") or "execute"
+        task.skill_resolution_method = result.get("method")
+        logger.debug(
+            "bound skill '%s' to task %s (method=%s)",
+            skill_name,
+            task.task_id,
+            task.skill_resolution_method,
         )
 
     def create_fallback_plan(self, goal: str) -> Dict[str, Any]:

--- a/autobot-backend/enhanced_orchestration/workflow_planning_test.py
+++ b/autobot-backend/enhanced_orchestration/workflow_planning_test.py
@@ -1,0 +1,170 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for #7268 Phase 1 — StrategyPlanner skill_router plan-time binding.
+
+Pins the wire-in contract introduced by ADR-006 Phase 1:
+- ``WorkflowTask`` exposes ``skill_name`` / ``skill_action`` / ``skill_resolution_method``
+- ``StrategyPlanner.build_workflow_plan`` is async + invokes skill_router with ``dry_run=True``
+- A successful skill_router result populates the new fields on each task
+- A failure (exception, missing router, ``success: False``) leaves them None
+- Lookup never auto-enables skills or fires Phase 3 gap-fill at plan time
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Make ``autobot-backend`` importable for bare ``enhanced_orchestration.*`` imports.
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# ---------------------------------------------------------------------------
+# Field surface (#7268 Phase 1)
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_task_has_skill_binding_fields() -> None:
+    """Canonical WorkflowTask must expose the 3 skill-binding fields."""
+    from autobot_shared.workflow.types import WorkflowTask
+
+    field_names = {f.name for f in dataclasses.fields(WorkflowTask)}
+    for required in ("skill_name", "skill_action", "skill_resolution_method"):
+        assert required in field_names, f"WorkflowTask missing #{required} (#7268 Phase 1)"
+
+    # Defaults are None — task with no skill binding is the unaltered legacy shape
+    t = WorkflowTask(task_id="x")
+    assert t.skill_name is None
+    assert t.skill_action is None
+    assert t.skill_resolution_method is None
+
+
+# ---------------------------------------------------------------------------
+# StrategyPlanner: async + skill_router invocation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def planner():
+    from enhanced_orchestration.workflow_planning import StrategyPlanner
+
+    return StrategyPlanner(agent_capabilities={})
+
+
+@pytest.fixture
+def plan_data():
+    return {
+        "strategy": "sequential",
+        "tasks": [
+            {
+                "agent": "classifier",
+                "action": "classify",
+                "task": "classify the user's intent",
+            },
+            {
+                "agent": "researcher",
+                "action": "search",
+                "explanation": "search the knowledge base",
+            },
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_workflow_plan_is_async(planner, plan_data) -> None:
+    """build_workflow_plan must be a coroutine (Phase 1 made it async)."""
+    import inspect
+
+    assert inspect.iscoroutinefunction(planner.build_workflow_plan)
+
+
+@pytest.mark.asyncio
+async def test_skill_router_dry_run_only_no_auto_enable(monkeypatch, planner, plan_data) -> None:
+    """Plan-time lookup must always pass ``dry_run=True`` (no auto-enable)."""
+    fake_router = MagicMock()
+    fake_router.execute = AsyncMock(return_value={"success": False})
+    planner._skill_router_skill = fake_router  # bypass lazy init
+
+    await planner.build_workflow_plan("goal", plan_data)
+
+    assert fake_router.execute.call_count == len(plan_data["tasks"])
+    for call in fake_router.execute.call_args_list:
+        args, _kwargs = call
+        assert args[0] == "find_skill"
+        params = args[1]
+        assert params["dry_run"] is True, "Phase 1 must NOT auto-enable at plan time"
+
+
+@pytest.mark.asyncio
+async def test_successful_lookup_populates_skill_fields(monkeypatch, planner, plan_data) -> None:
+    """When skill_router returns success, attach skill_name + method to the task."""
+    fake_router = MagicMock()
+    fake_router.execute = AsyncMock(
+        return_value={
+            "success": True,
+            "enabled_skill": "intent_classifier",
+            "method": "llm",
+            "candidates": [{"name": "intent_classifier", "score": 0.9}],
+        }
+    )
+    planner._skill_router_skill = fake_router
+
+    plan = await planner.build_workflow_plan("test goal", plan_data)
+
+    assert len(plan.tasks) == 2
+    for task in plan.tasks:
+        assert task.skill_name == "intent_classifier"
+        assert task.skill_action == "execute"
+        assert task.skill_resolution_method == "llm"
+
+
+@pytest.mark.asyncio
+async def test_no_match_leaves_skill_fields_none(planner, plan_data) -> None:
+    """``success: False`` keeps skill_name=None — legacy routing fallback."""
+    fake_router = MagicMock()
+    fake_router.execute = AsyncMock(return_value={"success": False, "error": "no match"})
+    planner._skill_router_skill = fake_router
+
+    plan = await planner.build_workflow_plan("goal", plan_data)
+    for task in plan.tasks:
+        assert task.skill_name is None
+        assert task.skill_action is None
+        assert task.skill_resolution_method is None
+
+
+@pytest.mark.asyncio
+async def test_router_exception_leaves_skill_fields_none(planner, plan_data) -> None:
+    """Exception during lookup is best-effort — task still produced, no skill bound."""
+    fake_router = MagicMock()
+    fake_router.execute = AsyncMock(side_effect=RuntimeError("registry offline"))
+    planner._skill_router_skill = fake_router
+
+    plan = await planner.build_workflow_plan("goal", plan_data)
+    for task in plan.tasks:
+        assert task.skill_name is None
+
+
+@pytest.mark.asyncio
+async def test_router_unavailable_silent_fallback(monkeypatch, planner, plan_data) -> None:
+    """If skill_router cannot be instantiated, plan-build still succeeds."""
+    # Force the lazy init to fail by monkeypatching the import path
+    import enhanced_orchestration.workflow_planning as wp
+
+    original = wp.StrategyPlanner._get_skill_router
+
+    def _stub(self):
+        return None
+
+    monkeypatch.setattr(wp.StrategyPlanner, "_get_skill_router", _stub)
+
+    plan = await planner.build_workflow_plan("goal", plan_data)
+    assert len(plan.tasks) == 2
+    for task in plan.tasks:
+        assert task.skill_name is None  # legacy capability-based routing intact

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -745,7 +745,7 @@ class Orchestrator:
             planning_prompt = self._build_planning_prompt(goal)
             response = await get_robust_llm_response(planning_prompt, context)
             plan_data = self._parse_planning_response(response, goal)
-            plan = self._strategy_planner.build_workflow_plan(goal, plan_data)
+            plan = await self._strategy_planner.build_workflow_plan(goal, plan_data)
             self.active_workflows[plan.plan_id] = plan
             return plan
         except Exception as e:

--- a/autobot_shared/workflow/types.py
+++ b/autobot_shared/workflow/types.py
@@ -122,6 +122,17 @@ class WorkflowTask:
     start_time: Optional[float] = None
     end_time: Optional[float] = None
 
+    # Skill binding (#7268 Phase 1, ADR-006: Skill-Bound Planning).
+    # Populated at plan time by StrategyPlanner via skill_router lookup
+    # (dry_run=True — no auto-enable, no Phase 3 gap-fill at plan time).
+    # ``skill_name`` is the registered skill name; ``skill_action`` is the
+    # action to invoke at execute time; ``skill_resolution_method`` records
+    # how it was resolved (``"keyword"`` / ``"llm"`` / ``None``).
+    # WorkflowExecutor consumption of these fields is Phase 2 — deferred.
+    skill_name: Optional[str] = None
+    skill_action: Optional[str] = None
+    skill_resolution_method: Optional[str] = None
+
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

ADR-006 (Skill-Bound Planning) calls for the live planner to consult \`skill_router\` per step at plan time, binding each step to a concrete \`(skill_name, action)\` before the plan is finalized. **Phase 1** of #7268 implements the plan-time binding side.

Phase 2 (executor consumption) and Phase 3 (async gap-fill resume) are filed as **#7430** and **#7431** respectively. #7268 stays open until all three land.

## Conservative defaults chosen for Phase 1

The 3 open ADR-006 questions are deferred to Phase 2/3 where they have less reach. Phase 1 picks the safest defaults:

| Question | Phase 1 choice |
|---|---|
| Sync vs async gap-fill | **Neither at plan time.** \`dry_run=True\` skips Phase 3 — gap-fill becomes Phase 3's (#7431) async-resume problem |
| Cache policy | **Per-planner.** \`SkillRouterSkill\` instance lazy-created + cached for the planner's lifetime |
| Removed-skill behavior | **Deferred to Phase 2 (#7430)** — at execute time, \`WorkflowExecutor\` will check skill availability |

## Changes

- **\`WorkflowTask\`** (canonical) gains 3 fields: \`skill_name\`, \`skill_action\`, \`skill_resolution_method\` — all default \`None\`. Existing constructors unchanged.
- **\`StrategyPlanner.build_workflow_plan\`** becomes \`async\` and invokes a new \`_bind_skill_to_task\` helper after each task is constructed. Helper calls \`skill_router.execute("find_skill", {"task": …, "dry_run": True})\`. Failures are best-effort: any exception, missing router, or \`success: False\` leaves \`skill_name=None\`.
- **\`orchestrator.py:748\`** updated to \`await\` the now-async method (only call site outside the module; already inside \`async def\`).
- **New test file** \`workflow_planning_test.py\` — 7 cases, all pass.

## Test plan

\`\`\`
$ pytest autobot-backend/enhanced_orchestration/workflow_planning_test.py -v
test_workflow_task_has_skill_binding_fields PASSED
test_build_workflow_plan_is_async PASSED
test_skill_router_dry_run_only_no_auto_enable PASSED
test_successful_lookup_populates_skill_fields PASSED
test_no_match_leaves_skill_fields_none PASSED
test_router_exception_leaves_skill_fields_none PASSED
test_router_unavailable_silent_fallback PASSED
7 passed in 0.82s
\`\`\`

## Acceptance criteria addressed (#7268)

- [x] StrategyPlanner.build_workflow_plan iterates each step and resolves via skill_router
- [x] Resolved \`(skill_name, action)\` attached to the step (fields on canonical \`WorkflowTask\`)
- [ ] Phase 3 gap-fill handling — **deferred to #7431** (intentional; \`dry_run=True\` per ADR-006 rec)
- [ ] WorkflowExecutor consumes the bound plan — **deferred to #7430**
- [ ] Integration tests + ADR-006 status flip — deferred to Phase 2/3

## Why this is partial closure, not closure

Per CLAUDE.md's premature-closure rule, #7268 stays **OPEN** until Phases 2 and 3 land. This PR substantially realizes ADR-006 Phase 1 of the planning path; the executor side and the async-resume path are filed as concrete trackers.

Refs #7268, #7430 (Phase 2), #7431 (Phase 3), ADR-006

🤖 Generated with [Claude Code](https://claude.com/claude-code)