### PR TITLE
feat(chat): add fetch_full param to search_web tool (#7404)

### DIFF
--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -112,6 +112,19 @@ WEB_SEARCH_SCHEMA: dict = {
     "type": "object",
     "properties": {
         "query": {"type": "string"},
+        "fetch_full": {
+            "type": "boolean",
+            "description": (
+                "When true, fetches the full markdown of each result page "
+                "in addition to returning search snippets. Default false."
+            ),
+        },
+        "max_pages": {
+            "type": "integer",
+            "description": "Maximum number of result pages to fetch when fetch_full=true. Default 5.",
+            "minimum": 1,
+            "maximum": 10,
+        },
     },
     "required": ["query"],
 }
@@ -618,6 +631,66 @@ async def _try_mcp_dispatch(
             exc_info=True,
         )
         raise
+
+
+async def _fetch_single_page(entry: dict) -> dict:
+    """Fetch full markdown for one search result entry. Issue #7404.
+
+    Attaches ``markdown`` and ``fetch_error`` fields to the entry dict.
+    On robots-policy block: markdown=None, fetch_error="robots_blocked".
+    On any other failure: markdown=None, fetch_error=<error_code>.
+    On success: markdown=<str>, fetch_error=None.
+    Never raises — per-URL failures must not abort the whole fan-out.
+    """
+    from web_fetch import RenderMode, WebFetcher
+
+    url = entry.get("url", "")
+    if not url:
+        return {**entry, "markdown": None, "fetch_error": "no_url"}
+    try:
+        result = await WebFetcher.fetch(url, render=RenderMode.AUTO)
+        if result.success:
+            return {**entry, "markdown": result.markdown, "fetch_error": None}
+        error_code = result.error_code or "unknown"
+        logger.debug("[Issue #7404] Fetch failed for %s: %s", url, error_code)
+        return {**entry, "markdown": None, "fetch_error": error_code}
+    except Exception as exc:
+        logger.warning("[Issue #7404] Unexpected fetch error for %s: %s", url, exc)
+        return {**entry, "markdown": None, "fetch_error": "unknown"}
+
+
+async def _fetch_pages_concurrent(entries: list[dict], max_pages: int) -> list[dict]:
+    """Fan out _fetch_single_page for up to max_pages entries. Issue #7404.
+
+    Uses asyncio.gather so all fetches run concurrently. Individual failures
+    are captured inside _fetch_single_page — this function always returns a
+    full list of the same length as entries[:max_pages].
+    """
+    capped = entries[:max_pages]
+    return list(await asyncio.gather(*(_fetch_single_page(e) for e in capped)))
+
+
+def _format_full_search_results(query: str, entries: list[dict]) -> str:
+    """Format enriched search entries (with markdown) into a human-readable string.
+
+    Issue #7404. Entries that failed to fetch include a fetch_error note instead
+    of the markdown body. The overall call always succeeds (partial failures OK).
+    """
+    lines = [f'Web search results for "{query}" (full page content):\n']
+    for i, entry in enumerate(entries, 1):
+        title = entry.get("title", "No title")
+        url = entry.get("url", "")
+        snippet = entry.get("snippet", entry.get("description", ""))
+        lines.append(f"{i}. **{title}**\n   {url}\n   {snippet}")
+        markdown = entry.get("markdown")
+        fetch_error = entry.get("fetch_error")
+        if markdown:
+            lines.append(f"\n   --- Full page ---\n{markdown[:4000]}\n   --- End ---\n")
+        elif fetch_error:
+            lines.append(f"\n   [Page fetch failed: {fetch_error}]\n")
+        else:
+            lines.append("")
+    return "\n".join(lines)
 
 
 class ToolHandlerMixin:
@@ -1763,6 +1836,8 @@ class ToolHandlerMixin:
         """
         params = tool_call.get("params", {})
         query = params.get("query", "").strip()
+        fetch_full: bool = bool(params.get("fetch_full", False))
+        max_pages: int = min(max(int(params.get("max_pages", 5)), 1), 10)
         description = tool_call.get("description", f"Web search: {query}")
 
         if not query:
@@ -1775,7 +1850,7 @@ class ToolHandlerMixin:
             )
             return
 
-        logger.info("[Issue #2306] Web search: query=%s", query)
+        logger.info("[Issue #2306] Web search: query=%s fetch_full=%s max_pages=%d", query, fetch_full, max_pages)
 
         yield WorkflowMessage(
             type="tool_execution",
@@ -1795,7 +1870,10 @@ class ToolHandlerMixin:
             return
 
         try:
-            results = await self._execute_web_search(query)
+            if fetch_full:
+                results = await self._execute_web_search_full(query, max_pages)
+            else:
+                results = await self._execute_web_search(query)
 
             # Issue #4261: Wire AFTER_TOOL_EXECUTE hook for web_search
             results = await _emit_after_tool_execute("web_search", results, session_id, {})
@@ -1808,6 +1886,7 @@ class ToolHandlerMixin:
                     "tool": "web_search",
                     "query": query,
                     "status": "success",
+                    "fetch_full": fetch_full,
                 },
             )
         except Exception as e:
@@ -1837,6 +1916,37 @@ class ToolHandlerMixin:
 
         # Fallback: browser VM with DuckDuckGo HTML
         return await self._web_search_via_browser_vm(query)
+
+    async def _execute_web_search_full(self, query: str, max_pages: int) -> str:
+        """Search + full-page fetch mode. Issue #7404.
+
+        Gets structured entries from Playwright, fans out WebFetcher.fetch
+        concurrently for each URL, attaches markdown (or fetch_error) per entry.
+        Always returns 200 — per-URL failures are surfaced in fetch_error field.
+        """
+        entries = await self._web_search_structured_entries(query, max_pages)
+        if not entries:
+            return await self._execute_web_search(query)
+        enriched = await _fetch_pages_concurrent(entries, max_pages)
+        return _format_full_search_results(query, enriched)
+
+    async def _web_search_structured_entries(self, query: str, max_pages: int) -> list[dict]:
+        """Return raw search result entries [{title, url, snippet}]. Issue #7404.
+
+        Delegates to the Playwright search backend (the same backend used by
+        _web_search_via_playwright) and returns up to max_pages raw dicts.
+        Returns [] when the Playwright service is unavailable.
+        """
+        try:
+            from services.playwright_service import search_web_embedded
+
+            result = await search_web_embedded(query, max_results=max_pages)
+            if not result.get("success", False):
+                return []
+            return result.get("results", [])[:max_pages]
+        except Exception as exc:
+            logger.debug("[Issue #7404] Playwright structured search unavailable: %s", exc)
+            return []
 
     async def _web_search_via_playwright(self, query: str) -> str:
         """Search via Playwright service. Returns formatted text or empty string. Issue #2306."""

--- a/autobot-backend/tests/unit/test_search_web_fetch_full.py
+++ b/autobot-backend/tests/unit/test_search_web_fetch_full.py
@@ -1,0 +1,263 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for search_web fetch_full mode. Issue #7404.
+
+Covers:
+- Backward compat: fetch_full=False returns identical shape to current.
+- Happy path: fetch_full=True returns each result with markdown populated.
+- Partial failure: one URL failing does not fail the whole call.
+- Robots-disallowed URL returns markdown=None, fetch_error="robots_blocked".
+- max_pages cap honored.
+- WEB_SEARCH_SCHEMA updated with fetch_full/max_pages.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from chat_workflow.tool_handler import (
+    WEB_SEARCH_SCHEMA,
+    _fetch_pages_concurrent,
+    _fetch_single_page,
+    _format_full_search_results,
+)
+from web_fetch.types import ERR_ROBOTS_BLOCKED, FetchResult, RenderMode
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestWebSearchSchemaUpdated:
+    def test_fetch_full_in_schema(self) -> None:
+        props = WEB_SEARCH_SCHEMA["properties"]
+        assert "fetch_full" in props, "fetch_full must be in WEB_SEARCH_SCHEMA properties"
+        assert props["fetch_full"]["type"] == "boolean"
+
+    def test_max_pages_in_schema(self) -> None:
+        props = WEB_SEARCH_SCHEMA["properties"]
+        assert "max_pages" in props, "max_pages must be in WEB_SEARCH_SCHEMA properties"
+        assert props["max_pages"]["type"] == "integer"
+        assert props["max_pages"]["minimum"] == 1
+        assert props["max_pages"]["maximum"] == 10
+
+    def test_query_still_required(self) -> None:
+        assert WEB_SEARCH_SCHEMA["required"] == ["query"]
+
+    def test_fetch_full_not_required(self) -> None:
+        assert "fetch_full" not in WEB_SEARCH_SCHEMA.get("required", [])
+
+    def test_max_pages_not_required(self) -> None:
+        assert "max_pages" not in WEB_SEARCH_SCHEMA.get("required", [])
+
+
+# ---------------------------------------------------------------------------
+# _fetch_single_page unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchSinglePage:
+    @pytest.mark.asyncio
+    async def test_success_attaches_markdown(self) -> None:
+        entry = {"title": "Example", "url": "https://example.com", "snippet": "A page"}
+        ok_result = FetchResult(
+            url="https://example.com",
+            success=True,
+            markdown="# Hello\n\nSome content.",
+            render_mode=RenderMode.AUTO,
+            source="jina",
+        )
+        with patch("web_fetch.fetcher.WebFetcher.fetch", return_value=ok_result):
+            result = await _fetch_single_page(entry)
+
+        assert result["markdown"] == "# Hello\n\nSome content."
+        assert result["fetch_error"] is None
+        assert result["title"] == "Example"
+        assert result["url"] == "https://example.com"
+
+    @pytest.mark.asyncio
+    async def test_robots_blocked_returns_error_code(self) -> None:
+        entry = {"title": "Blocked", "url": "https://blocked.com/private", "snippet": ""}
+        blocked_result = FetchResult(
+            url="https://blocked.com/private",
+            success=False,
+            error_code=ERR_ROBOTS_BLOCKED,
+        )
+        with patch("web_fetch.fetcher.WebFetcher.fetch", return_value=blocked_result):
+            result = await _fetch_single_page(entry)
+
+        assert result["markdown"] is None
+        assert result["fetch_error"] == ERR_ROBOTS_BLOCKED
+
+    @pytest.mark.asyncio
+    async def test_http_500_returns_error_code(self) -> None:
+        entry = {"title": "Error", "url": "https://server-error.com", "snippet": ""}
+        error_result = FetchResult(
+            url="https://server-error.com",
+            success=False,
+            error_code="http_error",
+            status_code=500,
+        )
+        with patch("web_fetch.fetcher.WebFetcher.fetch", return_value=error_result):
+            result = await _fetch_single_page(entry)
+
+        assert result["markdown"] is None
+        assert result["fetch_error"] == "http_error"
+
+    @pytest.mark.asyncio
+    async def test_exception_in_fetch_returns_unknown_error(self) -> None:
+        entry = {"title": "Crash", "url": "https://crash.com", "snippet": ""}
+        with patch("web_fetch.fetcher.WebFetcher.fetch", side_effect=RuntimeError("boom")):
+            result = await _fetch_single_page(entry)
+
+        assert result["markdown"] is None
+        assert result["fetch_error"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_missing_url_returns_no_url_error(self) -> None:
+        entry = {"title": "No URL", "snippet": "no link here"}
+        result = await _fetch_single_page(entry)
+        assert result["markdown"] is None
+        assert result["fetch_error"] == "no_url"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_pages_concurrent — partial failure test
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPagesConcurrent:
+    @pytest.mark.asyncio
+    async def test_partial_failure_does_not_abort_call(self) -> None:
+        """One URL with HTTP 500 must not prevent other URLs from being fetched."""
+        entries = [
+            {"title": "Good 1", "url": "https://good1.com", "snippet": ""},
+            {"title": "Bad",    "url": "https://bad.com",   "snippet": ""},
+            {"title": "Good 2", "url": "https://good2.com", "snippet": ""},
+        ]
+
+        async def fake_fetch_side_effect(url, render):
+            if "bad" in url:
+                return FetchResult(url=url, success=False, error_code="http_error", status_code=500)
+            return FetchResult(url=url, success=True, markdown=f"Content for {url}", render_mode=RenderMode.AUTO, source="jina")
+
+        with patch("web_fetch.fetcher.WebFetcher.fetch", side_effect=fake_fetch_side_effect):
+            results = await _fetch_pages_concurrent(entries, max_pages=3)
+
+        assert len(results) == 3
+        assert results[0]["markdown"] is not None
+        assert results[1]["markdown"] is None
+        assert results[1]["fetch_error"] == "http_error"
+        assert results[2]["markdown"] is not None
+
+    @pytest.mark.asyncio
+    async def test_max_pages_cap_respected(self) -> None:
+        """Only max_pages entries should be fetched, even if more entries are provided."""
+        entries = [{"title": f"Page {i}", "url": f"https://p{i}.com", "snippet": ""} for i in range(8)]
+        ok = FetchResult(url="x", success=True, markdown="content", render_mode=RenderMode.AUTO, source="jina")
+
+        with patch("web_fetch.fetcher.WebFetcher.fetch", return_value=ok):
+            results = await _fetch_pages_concurrent(entries, max_pages=3)
+
+        assert len(results) == 3
+
+
+# ---------------------------------------------------------------------------
+# _format_full_search_results
+# ---------------------------------------------------------------------------
+
+
+class TestFormatFullSearchResults:
+    def test_includes_title_and_url(self) -> None:
+        entries = [{"title": "Example", "url": "https://example.com", "snippet": "desc", "markdown": "# Hello", "fetch_error": None}]
+        output = _format_full_search_results("test query", entries)
+        assert "Example" in output
+        assert "https://example.com" in output
+        assert "# Hello" in output
+
+    def test_failed_entry_shows_fetch_error(self) -> None:
+        entries = [{"title": "Blocked", "url": "https://blocked.com", "snippet": "", "markdown": None, "fetch_error": "robots_blocked"}]
+        output = _format_full_search_results("test query", entries)
+        assert "robots_blocked" in output
+        assert "[Page fetch failed:" in output
+
+    def test_markdown_truncated_at_4000_chars(self) -> None:
+        long_md = "x" * 5000
+        entries = [{"title": "Long", "url": "https://long.com", "snippet": "", "markdown": long_md, "fetch_error": None}]
+        output = _format_full_search_results("q", entries)
+        # 4000 x's should appear, but not all 5000
+        assert "x" * 4000 in output
+        assert "x" * 4001 not in output
+
+
+# ---------------------------------------------------------------------------
+# Integration test: ToolHandlerMixin._execute_web_search_full
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteWebSearchFull:
+    @pytest.mark.asyncio
+    async def test_full_search_happy_path(self) -> None:
+        """fetch_full=True returns formatted results with markdown per entry."""
+        from chat_workflow.tool_handler import ToolHandlerMixin
+
+        mixin = ToolHandlerMixin.__new__(ToolHandlerMixin)
+        fake_entries = [
+            {"title": "Page A", "url": "https://a.com", "snippet": "Snippet A"},
+            {"title": "Page B", "url": "https://b.com", "snippet": "Snippet B"},
+        ]
+        ok_result = FetchResult(url="x", success=True, markdown="Full content here.", render_mode=RenderMode.AUTO, source="jina")
+
+        with (
+            patch.object(mixin, "_web_search_structured_entries", return_value=fake_entries),
+            patch("web_fetch.fetcher.WebFetcher.fetch", return_value=ok_result),
+        ):
+            result = await mixin._execute_web_search_full("my query", max_pages=5)
+
+        assert "Page A" in result
+        assert "Page B" in result
+        assert "Full content here." in result
+        assert "full page content" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_full_search_falls_back_when_no_entries(self) -> None:
+        """When no structured entries found, falls back to _execute_web_search."""
+        from chat_workflow.tool_handler import ToolHandlerMixin
+
+        mixin = ToolHandlerMixin.__new__(ToolHandlerMixin)
+
+        with (
+            patch.object(mixin, "_web_search_structured_entries", return_value=[]),
+            patch.object(mixin, "_execute_web_search", return_value="Fallback results") as mock_fallback,
+        ):
+            result = await mixin._execute_web_search_full("no results query", max_pages=5)
+
+        mock_fallback.assert_called_once_with("no results query")
+        assert result == "Fallback results"
+
+    @pytest.mark.asyncio
+    async def test_backward_compat_execute_web_search_unchanged(self) -> None:
+        """_execute_web_search (no fetch_full) returns same string shape as before."""
+        from chat_workflow.tool_handler import ToolHandlerMixin
+
+        mixin = ToolHandlerMixin.__new__(ToolHandlerMixin)
+
+        with patch.object(mixin, "_web_search_via_playwright", return_value='Web search results for "q":\n\n1. Example'):
+            result = await mixin._execute_web_search("q")
+
+        assert "Web search results" in result
+        assert "Example" in result
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _async_result(val):
+    """Wrap a synchronous value in an awaitable."""
+    return val


### PR DESCRIPTION
Closes #7404. Part of epic #7396.

## Summary

Extends `tool_handler.search_web()` with `fetch_full` and `max_pages` parameters. When `fetch_full=True`, fans out top N result URLs through `WebFetcher.fetch()` and attaches `markdown` field per result. Eliminates the N+1 round-trip pattern (search → LLM picks URL → separate fetch tool call).

## Files changed

- `chat_workflow/tool_handler.py` — schema update, branch logic, 3 new helpers, 2 new methods
- `tests/unit/test_search_web_fetch_full.py` — new file, 18 tests

## Tool schema (LLM-visible)

`search_web(query, fetch_full=False, max_pages=5)` — both new params optional, `query` remains the only required field.

## Tests: 18/18 new + 124/124 existing web_fetch — no regressions

## Acceptance criteria — all met

- [x] `search_web(query, fetch_full=False)` returns identical shape (backward compat)
- [x] `search_web(query, fetch_full=True)` returns each result with `markdown` populated
- [x] Failure on one URL doesn't fail the whole call
- [x] Robots-disallowed URL returns `markdown=None, fetch_error="robots_blocked"`
- [x] Tool schema updated (5 schema tests)
- [x] `max_pages` cap honored

## Discoveries (file as separate issues)

1. `_web_search_via_playwright` and `_web_search_structured_entries` both call `search_web_embedded` — duplicated Playwright service calls
2. `_web_search_via_playwright` hardcodes `max_results=5` while `_web_search_structured_entries` passes `max_pages` — inconsistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)