### PR TITLE
feat(orchestration/executor): wire skill_name dispatch into WorkflowExecutor (#7430 / #7268 Phase 2)

### DIFF
--- a/autobot-backend/enhanced_orchestration/workflow_runner.py
+++ b/autobot-backend/enhanced_orchestration/workflow_runner.py
@@ -179,6 +179,15 @@ class WorkflowRunner:
         task.start_execution()
         try:
             async with self.resource_semaphore:
+                # #7430 Phase 2: if StrategyPlanner bound a skill at plan time
+                # (#7268 Phase 1), dispatch via SkillRegistry instead of the
+                # capability-based agent path. ADR-006 default: skill-bound
+                # execution **replaces** agent dispatch — the skill is the
+                # concrete implementation. Removed/disabled skill at execute
+                # time fails the step (don't silently re-route at execute time;
+                # plans should re-plan instead, per #7431 Q3).
+                if task.skill_name:
+                    return await self._dispatch_via_skill(task, context)
                 agent = await self._agent_router.get_agent_instance(task.agent_type)
                 if not agent:
                     raise Exception(f"Agent {task.agent_type} not available")
@@ -194,6 +203,54 @@ class WorkflowRunner:
             return await self._handle_task_timeout(task, context)
         except Exception as e:
             return self._handle_task_exception(task, e)
+
+    async def _dispatch_via_skill(
+        self, task: AgentTask, context: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Dispatch task via the bound skill (#7430 Phase 2 of #7268 / ADR-006).
+
+        Caller already holds ``self.resource_semaphore`` and called
+        ``task.start_execution()``. We enforce the same timeout behavior as
+        the legacy agent path so resource accounting + perf metrics stay
+        consistent.
+
+        Failure modes:
+        - Skill not registered (or registered but disabled) → raise
+          ``RuntimeError`` so the existing ``_handle_task_exception`` path
+          surfaces it as a failed task. This is the explicit ADR-006 choice
+          per #7431 Q3 — fail the step, don't re-route at execute time.
+        - Skill ``execute`` raises → propagate up; same handler.
+        - Skill ``execute`` times out → propagate ``asyncio.TimeoutError``;
+          same handler.
+        """
+        # Lazy import — avoids circular dep if skills imports orchestration
+        from skills.registry import get_skill_registry
+
+        registry = get_skill_registry()
+        skill = registry.get(task.skill_name)
+        if skill is None:
+            raise RuntimeError(
+                f"Skill '{task.skill_name}' bound at plan time is not registered "
+                f"(registry may have been mutated between plan and execute). "
+                f"Failing step per ADR-006 'fail-don't-reroute' policy."
+            )
+        if not skill.enabled:
+            raise RuntimeError(
+                f"Skill '{task.skill_name}' is registered but disabled at execute time. "
+                f"Failing step per ADR-006 'fail-don't-reroute' policy."
+            )
+
+        enhanced_inputs = task.get_enhanced_inputs(context)
+        action = task.skill_action or "execute"
+        result = await asyncio.wait_for(
+            skill.execute(action, enhanced_inputs),
+            timeout=task.timeout_seconds,
+        )
+        task.complete_execution(result)
+        # Perf-tracker key uses skill_name — agent_type may still be set on
+        # the task for legacy reasons but the actual dispatch was the skill.
+        self._perf.update(f"skill:{task.skill_name}", True, task.get_execution_time())
+        return task.to_completed_result(result)
 
     async def _publish_workflow_event(self, workflow_id: str, event_type: str, data: Dict[str, Any]) -> None:
         await _get_event_manager().publish(

--- a/autobot-backend/enhanced_orchestration/workflow_runner_test.py
+++ b/autobot-backend/enhanced_orchestration/workflow_runner_test.py
@@ -163,3 +163,137 @@ def test_get_performance_report_shape():
     assert "agent_performance" in report
     assert report["active_workflows"] == 1
     assert "capabilities_coverage" in report
+
+
+# ---------------------------------------------------------------------------
+# #7430 Phase 2 — skill_name executor consumption (ADR-006 Phase 2 of #7268)
+# ---------------------------------------------------------------------------
+
+
+def _skill_bound_task(task_id: str, skill_name: str = "intent_classifier", action: str = "execute") -> AgentTask:
+    """Build an AgentTask with Phase-1 skill binding fields populated."""
+    t = _task(task_id)
+    t.skill_name = skill_name
+    t.skill_action = action
+    t.skill_resolution_method = "llm"
+    return t
+
+
+@pytest.mark.asyncio
+async def test_skill_bound_task_dispatches_via_skill_not_agent():
+    """A task with `skill_name` set must dispatch via SkillRegistry, NOT the agent path."""
+    runner = _make_runner()
+
+    # Skill registry mock returning an enabled skill that runs successfully
+    fake_skill = MagicMock()
+    fake_skill.enabled = True
+    fake_skill.execute = AsyncMock(return_value={"ok": True, "output": "classified"})
+
+    fake_registry = MagicMock()
+    fake_registry.get = MagicMock(return_value=fake_skill)
+
+    task = _skill_bound_task("t-skill", "intent_classifier", "classify")
+
+    with patch("skills.registry.get_skill_registry", return_value=fake_registry):
+        result = await runner._execute_single_agent_task(task, {})
+
+    # Skill was dispatched
+    fake_skill.execute.assert_awaited_once()
+    args, _ = fake_skill.execute.call_args
+    assert args[0] == "classify"  # action passed
+    # The agent path was NOT taken
+    runner._agent_router.get_agent_instance.assert_not_called()
+    # Perf metric uses the skill: prefix, not the agent_type
+    runner._perf.update.assert_called_with("skill:intent_classifier", True, pytest.approx(0.0, abs=10.0))
+    # Result reflects success
+    assert result.get("status") == "completed"
+
+
+@pytest.mark.asyncio
+async def test_unbound_task_falls_through_to_legacy_agent_path():
+    """A task with `skill_name=None` must use the existing capability-based agent dispatch."""
+    runner = _make_runner()
+
+    # Agent path mock
+    fake_agent = MagicMock()
+    fake_agent.process_request = AsyncMock(return_value={"ok": True, "via": "agent"})
+    runner._agent_router.get_agent_instance = AsyncMock(return_value=fake_agent)
+
+    task = _task("t-legacy")
+    assert task.skill_name is None  # regression guard for default
+
+    # Patch the skill registry import — it must NOT be called for unbound tasks
+    with patch("skills.registry.get_skill_registry") as mock_registry:
+        result = await runner._execute_single_agent_task(task, {})
+        mock_registry.assert_not_called()
+
+    # Agent path was taken
+    fake_agent.process_request.assert_awaited_once()
+    runner._agent_router.get_agent_instance.assert_awaited_once()
+    assert result.get("status") == "completed"
+
+
+@pytest.mark.asyncio
+async def test_bound_skill_missing_at_execute_time_fails_step():
+    """If the bound skill was unregistered between plan and execute, fail the step.
+
+    ADR-006 explicit choice (#7431 Q3): fail-don't-reroute. This ensures
+    plans can be re-planned by upstream callers, rather than silently
+    drifting between intent and execution.
+    """
+    runner = _make_runner()
+
+    fake_registry = MagicMock()
+    fake_registry.get = MagicMock(return_value=None)  # skill gone
+
+    task = _skill_bound_task("t-orphan", "removed_skill")
+
+    with patch("skills.registry.get_skill_registry", return_value=fake_registry):
+        result = await runner._execute_single_agent_task(task, {})
+
+    # Failed result, not a silent fallback to agent path
+    assert result.get("status") == "failed"
+    runner._agent_router.get_agent_instance.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bound_skill_disabled_at_execute_time_fails_step():
+    """A skill that's registered but disabled at execute time also fails the step."""
+    runner = _make_runner()
+
+    fake_skill = MagicMock()
+    fake_skill.enabled = False  # disabled mid-flight
+
+    fake_registry = MagicMock()
+    fake_registry.get = MagicMock(return_value=fake_skill)
+
+    task = _skill_bound_task("t-disabled", "disabled_skill")
+
+    with patch("skills.registry.get_skill_registry", return_value=fake_registry):
+        result = await runner._execute_single_agent_task(task, {})
+
+    assert result.get("status") == "failed"
+    runner._agent_router.get_agent_instance.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bound_skill_default_action_is_execute():
+    """If `skill_action` is None on the task, default action is 'execute' per Phase 1."""
+    runner = _make_runner()
+
+    fake_skill = MagicMock()
+    fake_skill.enabled = True
+    fake_skill.execute = AsyncMock(return_value={"ok": True})
+
+    fake_registry = MagicMock()
+    fake_registry.get = MagicMock(return_value=fake_skill)
+
+    task = _task("t-default-action")
+    task.skill_name = "some_skill"
+    task.skill_action = None  # not set by Phase 1's `or "execute"` fallback
+
+    with patch("skills.registry.get_skill_registry", return_value=fake_registry):
+        await runner._execute_single_agent_task(task, {})
+
+    args, _ = fake_skill.execute.call_args
+    assert args[0] == "execute"


### PR DESCRIPTION
## Summary

ADR-006 Phase 2: complete the skill-bound planning loop by having \`WorkflowExecutor\` consume the \`skill_name\` field that #7268 Phase 1 populates at plan time. When a task has a bound skill, dispatch via \`SkillRegistry.get(skill_name).execute(action, params)\` instead of the capability-based agent path.

## Architectural decision (ADR-006 Q3)

**Fail the step on removed/disabled skill at execute time** — don't re-route. Re-routing at execute time loses planning intent and complicates traceability. Failures bubble up so upstream callers can re-plan via #7431 (Phase 3 async resume) once that ships.

## Changes

- **\`WorkflowRunner._execute_single_agent_task\`** short-circuits to \`_dispatch_via_skill\` when \`task.skill_name\` is set. Unbound tasks fall through to existing capability-based agent dispatch unchanged.
- **New \`_dispatch_via_skill\`**: looks up skill via \`skills.registry.get_skill_registry()\`, validates registered + enabled, runs \`await skill.execute(skill_action or "execute", enhanced_inputs)\` with the same \`timeout_seconds\` + resource-semaphore semantics as the legacy path.
- **Failure modes** (missing skill, disabled skill, exception during execute) all flow through the existing \`_handle_task_exception\` path. Raised messages explicitly call out the fail-don't-reroute policy.
- **Lazy import** of \`skills.registry\` to avoid any circular-dep risk.
- **Perf metrics** use \`f"skill:{name}"\` as the key so skill-vs-agent stats stay separable in the perf report.

## Test plan

\`\`\`
$ pytest autobot-backend/enhanced_orchestration/workflow_runner_test.py -q
11 passed in 0.54s
\`\`\`

5 new tests pinning the contract:
- \`test_skill_bound_task_dispatches_via_skill_not_agent\` — happy path
- \`test_unbound_task_falls_through_to_legacy_agent_path\` — regression guard for legacy
- \`test_bound_skill_missing_at_execute_time_fails_step\` — fail-don't-reroute proof for unregistered skill
- \`test_bound_skill_disabled_at_execute_time_fails_step\` — fail-don't-reroute proof for disabled skill
- \`test_bound_skill_default_action_is_execute\` — null-action defaults to \`"execute"\` (matches Phase 1's \`or "execute"\` fallback)

## Acceptance criteria addressed (#7430)

- [x] WorkflowExecutor checks \`task.skill_name\` first; if set, dispatches via SkillRegistry — **chose "instead of"** per ADR-006
- [x] Unit test: skill-bound task dispatches to skill, NOT legacy agent
- [x] Unit test: unbound task falls through to legacy agent path
- [ ] **Integration test**: known-skill plans+executes end-to-end — deferred (requires populated SkillRegistry, env setup out of scope for this PR)

## Phase 3 still pending (#7431)

Phase 1's lenient mode (\`skill_name=None\` on no-match) keeps legacy routing the default. Phase 3 will add the strict-mode plan state \`BLOCKED_ON_SKILL_GENERATION\` + async gap-fill resume worker. Phase 2 (this PR) is independent — executor logic doesn't change between Phase 1 lenient and Phase 3 strict.

Refs #7268 (parent), #7430 (this Phase 2), #7431 (Phase 3), ADR-006

🤖 Generated with [Claude Code](https://claude.com/claude-code)