### PR TITLE
refactor(test/knowledge): migrate test_synthesis_provenance.py — partial canonical (#7280 round 10)

### DIFF
--- a/autobot-backend/services/knowledge/test_synthesis_provenance.py
+++ b/autobot-backend/services/knowledge/test_synthesis_provenance.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from services.knowledge.synthesis_provenance import SynthesisProvenanceLog
+from tests.fixtures import make_async_redis
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -25,18 +26,30 @@ _STREAM_KEY = "kb:synthesis:log"
 def _make_redis_mock(xadd_result=b"1-1", xrevrange_result=None):
     """Return an async Redis mock with xadd / xrevrange stubbed.
 
-    pipeline() returns a synchronous MagicMock whose xadd/hset are tracked
-    and whose execute() is an AsyncMock (pipeline.execute is awaited).
+    Pipeline shape is hand-built (NOT via canonical ``make_redis_pipeline()``)
+    because production code here uses **buffered-pipeline semantics**:
+    ``pipe.xadd(...)`` and ``pipe.hset(...)`` are SYNC ``MagicMock`` calls
+    (no ``await``) that just queue the op locally; only ``pipe.execute()``
+    is async. The canonical ``make_redis_pipeline()`` builds an AsyncMock-
+    based pipe whose ``xadd``/``hset`` auto-spawn AsyncMock children — that
+    works for tests that ``await pipe.xadd(...)``, but here production
+    calls them sync, so the queue ops would be coroutine leaks.
+
+    ``mock._pipe`` is exposed for ``assert_called_once`` assertions on the
+    buffered ops.
     """
-    mock = AsyncMock()
-    # xrevrange is still called directly on the redis client
-    mock.xrevrange = AsyncMock(return_value=xrevrange_result or [])
     # pipeline() is a sync call — return a MagicMock with async execute
     pipe_mock = MagicMock()
     pipe_mock.xadd = MagicMock(return_value=None)
     pipe_mock.hset = MagicMock(return_value=None)
     pipe_mock.execute = AsyncMock(return_value=[xadd_result, 1])
-    mock.pipeline = MagicMock(return_value=pipe_mock)
+
+    # Migrated to canonical ``make_async_redis(pipeline=…)`` (#7280 round 10)
+    # for the redis surface; pipe shape kept hand-built per docstring above.
+    mock = make_async_redis(
+        pipeline=pipe_mock,
+        xrevrange=xrevrange_result or [],
+    )
     mock._pipe = pipe_mock  # expose for assertions
     return mock
 


### PR DESCRIPTION
## Summary

#7280 round 10 — last clean candidate from the original 19-file list. Migrates the redis surface to canonical ``make_async_redis(pipeline=…)`` but keeps the pipeline shape hand-built because production uses **buffered-pipeline semantics** that the canonical ``make_redis_pipeline()`` (AsyncMock-based) does not match.

## Why partial migration

Production code:
\`\`\`python
pipe.xadd(stream, fields)    # SYNC — buffered queue, no await
pipe.hset(key, mapping)       # SYNC — buffered queue, no await
result = await pipe.execute() # ASYNC — flushes the queue
\`\`\`

Canonical ``make_redis_pipeline()`` builds an ``AsyncMock``-based pipe whose ``xadd``/``hset`` auto-spawn AsyncMock children. That works for tests that ``await pipe.xadd(...)``, but here production calls them sync — the auto-spawned coroutines would leak (never awaited or ``.close()``-d).

Hand-built ``MagicMock(return_value=None)`` for the buffered ops keeps sync semantics. Documented in the helper docstring.

## Changes

- Replaced ``mock = AsyncMock()`` + manual ``mock.xrevrange`` / ``mock.pipeline`` setup → ``make_async_redis(pipeline=pipe_mock, xrevrange=…)``.
- Pipe construction unchanged (sync MagicMock buffered ops, async execute).
- Helper docstring documents the WHY for the partial migration.

Net: +13 LOC (the docstring); helper body is shorter.

## Test plan

- [x] ``pytest services/knowledge/test_synthesis_provenance.py`` — 20/20 passed before AND after migration

## #7280 — DONE

Round 10 is the last clean candidate from the original 19-file list. Remaining files don't migrate by design:

| File | Pattern | Why not migrated |
|---|---|---|
| ``rl_router_test.py`` | Stateful dict-backed redis | Out of scope (different concern) |
| ``a2a_test.py`` | Stateful dict-backed redis | Out of scope |
| ``workflow_memory_test.py`` | Sync MagicMock redis | Out of scope |
| ``collaboration_coordinator_test.py`` | Pubsub-stateful generator | Out of scope |
| ``test_marketplace.py`` (TestPluginSourceUrl helpers) | Already on patch_async_redis | Done by #6987 chain |

**Cumulative #7280 metrics across 10 rounds:**
- ✅ 10 files migrated
- ✅ ~150+ call sites unified onto canonical fixture
- ✅ **15 latent infra bugs fixed** (7 round 2 + 8 round 9, both wrong-namespace patches)
- ✅ 2 pre-existing test bugs surfaced (#7386, #7399)
- ✅ #7339 keystone fixture extension shipped + consumed by 4 rounds (6, 7, 9, 10)
- ✅ Original 11+ ad-hoc helpers reduced to 0 in scope

## Refs

- Refs #7280 (parent — should be closed after this PR merges)
- Refs #7339 (canonical fixture extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)