### PR TITLE
fix(async): pre-commit hook blocking sync I/O in async paths (#7444 gate)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -227,6 +227,23 @@ repos:
         stages: [pre-commit]
         description: "Ensure @router.* is OUTERMOST and @with_error_handling is not stacked (#6558, #6633)"
 
+  # AutoBot custom: regression-prevention for #7444 (blocking I/O in async).
+  # 159 production violations exist as of filing — `requests.get/...` and
+  # `Path.read_text/write_text` calls inside `async def` bodies block the
+  # event loop and cause intermittent latency spikes under concurrent load.
+  # This hook stops NEW violations from landing while the existing 159 are
+  # migrated separately. Pre-commit only runs on changed files, so existing
+  # violations don't trigger unless the file is touched.
+  - repo: local
+    hooks:
+      - id: no-blocking-io-in-async
+        name: Block sync I/O calls inside async def (#7444)
+        entry: tools/lint/check_no_blocking_io_in_async.py
+        language: python
+        files: ^(autobot-backend|autobot_shared|autobot-slm-backend)/.*\.py$
+        stages: [pre-commit]
+        description: "Block requests.* and Path.read_text/write_text inside async def bodies (#7444)"
+
   # Python-specific checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/tools/lint/check_no_blocking_io_in_async.py
+++ b/tools/lint/check_no_blocking_io_in_async.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Pre-commit hook: block synchronous blocking I/O calls inside ``async def`` bodies.
+
+#7444: 159 production blocking-I/O call sites were found across the backend:
+
+  - 55× `requests.get/post/put/...` inside async functions (canonical: `httpx.AsyncClient`)
+  - 78× `Path(...).read_text()` / `.write_text()` / `.read_bytes()` / `.write_bytes()`
+    inside async functions (canonical: `aiofiles` or `await asyncio.to_thread(...)`)
+
+These block the event loop — under concurrent load this causes timeouts, request
+stalls, and intermittent latency spikes. Already-suspected source of production
+backend latency (per the umbrella issue #5060).
+
+This hook is a fail-fast gate: it walks ``async def`` bodies via AST and flags
+any direct call to one of the banned patterns. It does NOT migrate the existing
+violations — those are tracked in 3 cluster follow-up issues. Pre-commit only
+runs on changed files, so the gate stops NEW violations from landing while the
+backlog of existing violations is migrated separately.
+
+## Banned patterns
+
+  - ``requests.get(...)``, ``requests.post(...)``, etc. — anywhere inside an
+    ``async def``. The HTTP client must be ``httpx.AsyncClient`` or the
+    project's existing ``aiohttp`` shared client.
+  - ``<expr>.read_text(...)`` / ``.write_text(...)`` / ``.read_bytes(...)`` /
+    ``.write_bytes(...)`` — these are sync filesystem calls (typically on
+    ``pathlib.Path`` instances). Inside an async path, use ``aiofiles`` for
+    streaming or ``await asyncio.to_thread(p.read_text)`` for one-shot reads.
+
+## Allowlist
+
+A line containing ``# noqa: ASYNC_BLOCKING_IO`` (case-insensitive) on the
+violating call's line is exempt. Use sparingly with a justification comment —
+e.g. when the call truly runs in a thread already (rare).
+
+## Scope
+
+  - ``autobot-backend/**/*.py``
+  - ``autobot_shared/**/*.py``
+  - ``autobot-slm-backend/**/*.py``
+
+Excludes: ``__pycache__``, ``.worktrees``, ``.venv``, ``node_modules``, etc.
+(via ``_scan_helpers.iter_python_files``).
+
+## Exit codes
+
+  - 0 — clean
+  - 1 — violations found (printed to stderr with file:line and replacement guidance)
+
+## Background
+
+  - Umbrella: #5060 (correctness primitives)
+  - This hook: #7444
+  - Migration follow-ups (existing violations): filed alongside the hook PR
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _scan_helpers import iter_python_files  # noqa: E402
+
+HOOK_ID = "no-blocking-io-in-async"
+
+# `requests` library functions that perform sync HTTP. ``request`` is the
+# generic dispatcher; the others are convenience wrappers. All block the
+# event loop when called inside an ``async def``.
+_REQUESTS_FORBIDDEN_ATTRS: frozenset[str] = frozenset(
+    {"get", "post", "put", "patch", "delete", "head", "options", "request"}
+)
+
+# Sync I/O methods commonly called on ``pathlib.Path`` instances. We can't
+# always prove the receiver is a Path at static-analysis time without type
+# info, so we flag the method name everywhere — false positives are rare and
+# the noqa allowlist handles them.
+_PATH_FORBIDDEN_METHODS: frozenset[str] = frozenset({"read_text", "write_text", "read_bytes", "write_bytes"})
+
+NOQA_TOKEN = "noqa: async_blocking_io"
+
+
+class _Violation:
+    __slots__ = ("path", "line", "col", "kind", "snippet")
+
+    def __init__(self, path: Path, line: int, col: int, kind: str, snippet: str) -> None:
+        self.path = path
+        self.line = line
+        self.col = col
+        self.kind = kind
+        self.snippet = snippet
+
+    def format(self) -> str:
+        guidance = _GUIDANCE.get(self.kind, "")
+        return f"{self.path}:{self.line}:{self.col}: {self.kind}: {self.snippet}\n{guidance}"
+
+
+_GUIDANCE = {
+    "requests.*": (
+        "  → Replace with `httpx.AsyncClient`. Share a single client instance per\n"
+        "    service via `lazy_singleton` (see `autobot_shared.lazy_singleton`).\n"
+        "    Or use the existing `aiohttp` clients where already present.\n"
+        "    See #7444 migration follow-ups."
+    ),
+    "Path.read/write_text/bytes": (
+        "  → Replace with `aiofiles` for streaming, or wrap a one-shot call:\n"
+        "      content = await asyncio.to_thread(path.read_text, encoding='utf-8')\n"
+        "    See #7444 migration follow-ups."
+    ),
+}
+
+
+class _AsyncBlockingIOVisitor(ast.NodeVisitor):
+    """Walks the AST and records banned calls inside ``async def`` bodies."""
+
+    def __init__(self, path: Path, source_lines: List[str]) -> None:
+        self.path = path
+        self.source_lines = source_lines
+        self.violations: List[_Violation] = []
+        # Tracks whether the current node is nested inside an `async def`.
+        # We don't ban inside sync `def` (those run synchronously by design).
+        self._async_depth = 0
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._async_depth += 1
+        try:
+            self.generic_visit(node)
+        finally:
+            self._async_depth -= 1
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        # Sync functions nested inside async ones are NOT in async context —
+        # they run synchronously when called. Reset depth for the sync sub-tree.
+        saved = self._async_depth
+        self._async_depth = 0
+        try:
+            self.generic_visit(node)
+        finally:
+            self._async_depth = saved
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if self._async_depth > 0:
+            self._maybe_record(node)
+        self.generic_visit(node)
+
+    def _maybe_record(self, node: ast.Call) -> None:
+        if not isinstance(node.func, ast.Attribute):
+            return
+        attr = node.func.attr
+        # Pattern 1: requests.{get,post,...}
+        if (
+            attr in _REQUESTS_FORBIDDEN_ATTRS
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "requests"
+        ):
+            self._record(node, "requests.*")
+            return
+        # Pattern 2: <anything>.read_text() / write_text() / read_bytes() / write_bytes()
+        if attr in _PATH_FORBIDDEN_METHODS:
+            self._record(node, "Path.read/write_text/bytes")
+
+    def _record(self, node: ast.Call, kind: str) -> None:
+        line_idx = node.lineno - 1
+        if 0 <= line_idx < len(self.source_lines):
+            line_text = self.source_lines[line_idx]
+            if NOQA_TOKEN in line_text.lower():
+                return  # Allowlisted with explicit acknowledgment.
+            snippet = line_text.strip()
+        else:
+            snippet = "<source line not available>"
+        self.violations.append(
+            _Violation(
+                path=self.path,
+                line=node.lineno,
+                col=node.col_offset,
+                kind=kind,
+                snippet=snippet,
+            )
+        )
+
+
+def check_file(path: Path) -> List[_Violation]:
+    """Return any blocking-I/O-in-async violations found in ``path``."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        # Don't fail the hook on unparseable files — flake8 will catch them.
+        return []
+    visitor = _AsyncBlockingIOVisitor(path, source.splitlines())
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def main(argv: List[str]) -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    files = list(iter_python_files(argv, repo_root))
+    # Restrict to backend roots — frontend tooling sometimes ships .py snippets
+    # in test fixtures that aren't part of the backend async surface.
+    backend_roots = ("autobot-backend", "autobot_shared", "autobot-slm-backend")
+    files = [f for f in files if any(part in backend_roots for part in f.relative_to(repo_root).parts[:1])]
+
+    all_violations: List[_Violation] = []
+    for path in files:
+        all_violations.extend(check_file(path))
+
+    if not all_violations:
+        return 0
+
+    print(
+        f"\n[{HOOK_ID}] Found {len(all_violations)} blocking-I/O call(s) inside `async def` " "bodies (#7444):\n",
+        file=sys.stderr,
+    )
+    for v in all_violations:
+        print(v.format(), file=sys.stderr)
+    print(
+        f"\nIf the call genuinely runs in a thread (rare), append " f"`# {NOQA_TOKEN}` to that line.\n",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/lint/check_no_blocking_io_in_async_test.py
+++ b/tools/lint/check_no_blocking_io_in_async_test.py
@@ -1,0 +1,248 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for #7444 lint hook — blocking I/O in async paths."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from tools.lint.check_no_blocking_io_in_async import check_file
+
+
+def _write(tmp_path: Path, source: str) -> Path:
+    """Write `source` (after dedenting) to a fresh .py file in tmp_path."""
+    p = tmp_path / "sample.py"
+    p.write_text(textwrap.dedent(source).lstrip(), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# requests.* in async def — must flag
+# ---------------------------------------------------------------------------
+
+
+class TestRequestsInAsync:
+    def test_requests_get_inside_async_def_is_flagged(self, tmp_path: Path) -> None:
+        src = """
+        import requests
+
+        async def fetch():
+            r = requests.get("https://example.com")
+            return r.text
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert len(violations) == 1
+        assert violations[0].kind == "requests.*"
+        assert "requests.get" in violations[0].snippet
+
+    def test_all_forbidden_requests_methods_are_flagged(self, tmp_path: Path) -> None:
+        src = """
+        import requests
+
+        async def all_methods():
+            requests.get("u")
+            requests.post("u")
+            requests.put("u")
+            requests.patch("u")
+            requests.delete("u")
+            requests.head("u")
+            requests.options("u")
+            requests.request("GET", "u")
+        """
+        violations = check_file(_write(tmp_path, src))
+        # 8 lines of requests.* — all flagged.
+        assert len(violations) == 8
+
+    def test_requests_in_sync_def_is_not_flagged(self, tmp_path: Path) -> None:
+        src = """
+        import requests
+
+        def fetch_sync():
+            return requests.get("https://example.com").text
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert violations == []
+
+    def test_requests_in_sync_function_nested_in_async_is_not_flagged(self, tmp_path: Path) -> None:
+        # A sync function defined inside an async function runs synchronously
+        # when called — not in async context. Don't flag.
+        src = """
+        import requests
+
+        async def outer():
+            def helper():
+                return requests.get("u")
+            return helper
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# Path.read_text / write_text in async def — must flag
+# ---------------------------------------------------------------------------
+
+
+class TestPathIOInAsync:
+    def test_read_text_inside_async_is_flagged(self, tmp_path: Path) -> None:
+        src = """
+        from pathlib import Path
+
+        async def load():
+            content = Path("/etc/config").read_text()
+            return content
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert len(violations) == 1
+        assert violations[0].kind == "Path.read/write_text/bytes"
+
+    def test_write_text_inside_async_is_flagged(self, tmp_path: Path) -> None:
+        src = """
+        from pathlib import Path
+
+        async def save(p):
+            p.write_text("data")
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert len(violations) == 1
+        assert violations[0].kind == "Path.read/write_text/bytes"
+
+    def test_read_bytes_and_write_bytes_are_flagged(self, tmp_path: Path) -> None:
+        src = """
+        async def io_ops(p):
+            data = p.read_bytes()
+            p.write_bytes(b"x")
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert len(violations) == 2
+
+    def test_read_text_in_sync_def_is_not_flagged(self, tmp_path: Path) -> None:
+        src = """
+        from pathlib import Path
+
+        def load_sync():
+            return Path("/etc").read_text()
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# noqa: async_blocking_io allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestNoqaAllowlist:
+    def test_noqa_marker_suppresses_violation(self, tmp_path: Path) -> None:
+        src = """
+        import requests
+
+        async def fetch():
+            r = requests.get("https://example.com")  # noqa: async_blocking_io
+            return r.text
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert violations == []
+
+    def test_noqa_marker_is_case_insensitive(self, tmp_path: Path) -> None:
+        src = """
+        import requests
+
+        async def fetch():
+            r = requests.get("u")  # noqa: ASYNC_BLOCKING_IO
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert violations == []
+
+    def test_noqa_only_suppresses_its_own_line(self, tmp_path: Path) -> None:
+        src = """
+        import requests
+
+        async def fetch():
+            r1 = requests.get("u")  # noqa: async_blocking_io
+            r2 = requests.get("u")  # NOT allowlisted
+            return r1, r2
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert len(violations) == 1
+        assert "NOT allowlisted" in violations[0].snippet
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — must NOT flag
+# ---------------------------------------------------------------------------
+
+
+class TestNegativeCases:
+    def test_aiofiles_open_in_async_is_not_flagged(self, tmp_path: Path) -> None:
+        # aiofiles is the canonical async file path — must pass.
+        src = """
+        import aiofiles
+
+        async def load(path):
+            async with aiofiles.open(path, "r") as f:
+                return await f.read()
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert violations == []
+
+    def test_httpx_async_client_is_not_flagged(self, tmp_path: Path) -> None:
+        src = """
+        import httpx
+
+        async def fetch():
+            async with httpx.AsyncClient() as client:
+                r = await client.get("u")
+            return r.text
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert violations == []
+
+    def test_to_thread_wrapped_path_read_text_is_not_flagged(self, tmp_path: Path) -> None:
+        # `asyncio.to_thread(p.read_text)` passes the bound method as a
+        # callable — the read_text attribute access is NOT a Call node so
+        # the AST visitor correctly skips it. This is the canonical
+        # async-safe pattern; pin it so a future regression of the
+        # detection logic can't accidentally flag it.
+        src = """
+        import asyncio
+        from pathlib import Path
+
+        async def safe_read(p: Path):
+            return await asyncio.to_thread(p.read_text)
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert violations == []
+
+    def test_to_thread_wrapped_path_read_text_with_call_is_flagged(self, tmp_path: Path) -> None:
+        # Calling read_text() inside to_thread's first arg IS a Call node
+        # at AST analysis time and DOES execute the read sync — flag this
+        # mistake. (Correct usage is to pass the unbound method, not call it.)
+        src = """
+        import asyncio
+        from pathlib import Path
+
+        async def buggy_read(p: Path):
+            # to_thread receives the result of read_text(), not the function.
+            # The read happens sync BEFORE to_thread schedules anything.
+            return await asyncio.to_thread(p.read_text())
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert len(violations) == 1
+
+    def test_unparseable_file_is_silently_skipped(self, tmp_path: Path) -> None:
+        # SyntaxError shouldn't crash the hook — flake8 catches those.
+        src = """
+        async def broken(:
+            pass
+        """
+        violations = check_file(_write(tmp_path, src))
+        assert violations == []
+
+    def test_empty_file_is_clean(self, tmp_path: Path) -> None:
+        violations = check_file(_write(tmp_path, ""))
+        assert violations == []


### PR DESCRIPTION
## Summary

#7444 documents 159 blocking-I/O production call sites that stall the event loop under concurrent load. This PR ships the **fail-fast gate**: an AST-based pre-commit hook that flags `requests.*` and `Path.read/write_text/bytes` inside `async def` bodies.

Existing 159 violations are tracked in 3 cluster follow-ups (**#7466**, **#7467**, **#7469**) and migrated separately. Pre-commit only runs on changed files, so this PR doesn't break CI on legacy violations.

## What's added

- `tools/lint/check_no_blocking_io_in_async.py` — AST visitor + violation reporter with replacement guidance
- `tools/lint/check_no_blocking_io_in_async_test.py` — 17 regression cases
- `.pre-commit-config.yaml` — registers the hook for `autobot-backend|autobot_shared|autobot-slm-backend`
- `# noqa: async_blocking_io` (case-insensitive) per-line allowlist

## Test plan

- [x] 17/17 tests pass locally
- [x] AST visitor correctly handles nested sync-def-in-async (resets context)
- [x] `to_thread(p.read_text)` (bound method) NOT flagged
- [x] `to_thread(p.read_text())` (mistaken call) IS flagged
- [ ] CI green

Closes #7444 (gate scope)
References #5060 umbrella · cluster follow-ups #7466 #7467 #7469

🤖 Generated with [Claude Code](https://claude.com/claude-code)