### PR TITLE
fix(ansible/provision): ensure SLM frontend node_modules before rebuild (closes #7472)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
@@ -448,6 +448,20 @@
     # Without this, the SLM login page calls /api/auth/login which nginx routes
     # to the user backend (port 8001) → 502 in co-located mode.
     # Must run BEFORE nginx test/reload so the new assets are served immediately.
+    #
+    # #7472: ensure node_modules exists before build — provisioning may run
+    # standalone (re-provision after disk wipe, fresh install where this
+    # phase races deploy-slm-manager's npm install). Without this, build
+    # fails with `sh: 1: vite: not found` (rc=127). Idempotent no-op when
+    # deps already installed.
+    - name: "SLM | Ensure SLM frontend node_modules exist (#7472)"
+      community.general.npm:
+        path: "{{ slm_frontend_dir | default('/opt/autobot/autobot-slm-frontend') }}"
+        state: present
+      become_user: "{{ slm_user | default('autobot') }}"
+      when: _is_slm_frontend_colocated | bool
+      tags: ['frontend', 'slm-nginx', 'provision']
+
     - name: "SLM | Rebuild SLM frontend with co-located API prefix (#3268)"
       ansible.builtin.command:
         cmd: npm run build


### PR DESCRIPTION
## Summary

Closes #7472. \`provision-fleet-roles.yml\` Phase 4c (\"SLM Nginx Co-location Update\") fails on Hyper-V with \`sh: 1: vite: not found\` because \`npm run build\` ran without ensuring node_modules existed first.

## Fix

Add \`npm install\` step before \`npm run build\`. Idempotent — fast no-op when deps are current. Same pattern as \`slm_manager/tasks/main.yml:404-422\`.

## Reproduced on

192.168.168.21 (Hyper-V), 2026-05-10T12:20Z.

## Test plan

- [x] YAML parse
- [ ] Re-run on Hyper-V — Phase 4c succeeds (verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)