### PR TITLE
fix(async): hoist asyncio-run-or-schedule defensive helper to autobot_shared (#7469 round 1)

### DIFF
--- a/autobot-backend/memory/compat.py
+++ b/autobot-backend/memory/compat.py
@@ -56,26 +56,15 @@ class EnhancedMemoryManager(UnifiedMemoryManager):
         """
         Run async coroutine synchronously (Issue #742 - backward compat helper).
 
-        Handles both sync and async contexts by detecting if an event loop
-        is already running and using a thread executor in that case.
-
-        Args:
-            coro: Coroutine to run synchronously
-
-        Returns:
-            Result of the coroutine
+        #7469: this helper now delegates to ``autobot_shared.async_compat.run_or_schedule``
+        which carries the same try-loop / threadpool defensive pattern,
+        deduplicated across the codebase. Behavior is identical; one
+        source of truth ensures all callers stay in sync if the pattern
+        ever needs an update.
         """
-        try:
-            asyncio.get_running_loop()
-            # Already in async context - use thread executor
-            import concurrent.futures
+        from autobot_shared.async_compat import run_or_schedule
 
-            with concurrent.futures.ThreadPoolExecutor() as pool:
-                future = pool.submit(asyncio.run, coro)
-                return future.result()
-        except RuntimeError:
-            # No running loop - safe to use asyncio.run
-            return asyncio.run(coro)
+        return run_or_schedule(coro)
 
     def create_task_record(
         self,

--- a/autobot-backend/memory/manager.py
+++ b/autobot-backend/memory/manager.py
@@ -189,17 +189,11 @@ class UnifiedMemoryManager:
 
         For async code, prefer using: await manager.log_task(record)
         """
-        try:
-            asyncio.get_running_loop()
-            # Already in async context - use thread executor
-            import concurrent.futures
+        # #7469: delegate to the shared run_or_schedule helper that
+        # centralizes the try-loop / threadpool defensive pattern.
+        from autobot_shared.async_compat import run_or_schedule
 
-            with concurrent.futures.ThreadPoolExecutor() as pool:
-                future = pool.submit(asyncio.run, self.log_task(record))
-                return future.result()
-        except RuntimeError:
-            # No running loop - safe to use asyncio.run
-            return asyncio.run(self.log_task(record))
+        return run_or_schedule(self.log_task(record))
 
     async def update_task_status(self, task_id: str, status: TaskStatus, **kwargs) -> bool:
         """

--- a/autobot-backend/utils/error_boundaries/boundary_manager.py
+++ b/autobot-backend/utils/error_boundaries/boundary_manager.py
@@ -428,8 +428,15 @@ class ErrorBoundaryManager:
         try:
             yield context
         except Exception as e:
-            # Handle synchronous errors
-            asyncio.run(self.handle_error(e, context))
+            # Handle synchronous errors.
+            # #7469: defensive run_or_schedule because this sync ctxmgr can
+            # be entered from an already-running event loop via a sync
+            # caller dispatched from async — bare asyncio.run() would
+            # raise "asyncio.run() cannot be called from a running event
+            # loop" and the original exception would be lost.
+            from autobot_shared.async_compat import run_or_schedule
+
+            run_or_schedule(self.handle_error(e, context))
             # Re-raise the handled exception
             raise
 

--- a/autobot-backend/utils/error_boundaries/decorators.py
+++ b/autobot-backend/utils/error_boundaries/decorators.py
@@ -14,6 +14,7 @@ import logging
 import time
 from typing import Callable
 
+from autobot_shared.async_compat import run_or_schedule
 from fastapi import HTTPException
 
 from constants.threshold_constants import RetryConfig, exponential_backoff_delay
@@ -93,11 +94,15 @@ def _handle_sync_attempt(
         return (True, result)
     except Exception as e:
         if attempt == max_retries:
-            return (True, asyncio.run(manager.handle_error(e, context)))
+            # #7469: defensive sync/async-context handler. Bare asyncio.run()
+            # crashes when this sync wrapper is dispatched from a running
+            # event loop (e.g. via loop.run_in_executor with shared thread).
+            return (True, run_or_schedule(manager.handle_error(e, context)))
         if recovery_strategy == RecoveryStrategy.RETRY:
             time.sleep(exponential_backoff_delay(attempt))
             return (False, None)
-        return (True, asyncio.run(manager.handle_error(e, context)))
+        # #7469: same defensive pattern as the max-retries branch above.
+        return (True, run_or_schedule(manager.handle_error(e, context)))
 
 
 def _create_async_boundary_wrapper(

--- a/autobot_shared/async_compat.py
+++ b/autobot_shared/async_compat.py
@@ -1,0 +1,95 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""#7469: shared defensive helper for ``asyncio.run()`` re-entrancy.
+
+## Why
+
+``asyncio.run(coro)`` cannot be called from inside an already-running event
+loop — it raises ``RuntimeError: asyncio.run() cannot be called from a
+running event loop`` and crashes the caller. This happens silently and
+intermittently for sync code paths that *sometimes* run from sync
+entrypoints and *sometimes* run from async contexts:
+
+  - Error-boundary decorators wrapping mixed sync/async functions
+  - Celery worker callbacks that schedule async writes
+  - GUI button handlers that may dispatch into async services
+
+Several places in the codebase already implemented the defensive
+try-loop-running pattern locally (``autobot-backend/memory/compat.py``,
+``autobot-backend/memory/manager.py``). This module hoists the pattern
+into ``autobot_shared`` so all callers share one implementation.
+
+## Contract
+
+  ``run_or_schedule(coro)`` runs ``coro`` to completion and returns its
+  result, regardless of whether the caller is in a sync or async context:
+
+  1. **No event loop in the current thread** → ``asyncio.run(coro)``
+     directly. Standard sync-entry behavior.
+  2. **Event loop is running in the current thread** → schedule the coro
+     in a ThreadPoolExecutor that owns its own loop, then block until
+     it returns. This is the only safe option because the current loop
+     is busy and we can't await without making the caller async.
+
+The threadpool-detour costs a thread spawn per call (and gives up
+asyncio's I/O concurrency for the duration of the coro). Use it only at
+the sync/async boundary — never as a substitute for ``await`` inside
+async code.
+
+## Migration target
+
+Replace this pattern:
+
+```python
+try:
+    asyncio.get_running_loop()
+    # Already in async context — error
+    ...
+except RuntimeError:
+    return asyncio.run(coro)
+```
+
+With:
+
+```python
+from autobot_shared.async_compat import run_or_schedule
+return run_or_schedule(coro)
+```
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+from typing import Any, Coroutine, TypeVar
+
+__all__ = ["run_or_schedule"]
+
+
+T = TypeVar("T")
+
+
+def run_or_schedule(coro: Coroutine[Any, Any, T]) -> T:
+    """Run ``coro`` to completion from either sync or async context.
+
+    See module docstring for the full contract. Sync entry: uses
+    ``asyncio.run``. Already-in-loop entry: spawns a thread pool that
+    owns its own loop, runs ``coro`` there, and blocks for the result.
+
+    Raises whatever ``coro`` raises (after unwrapping the
+    concurrent.futures.Future indirection in the threaded path).
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No loop in this thread — standard sync entry.
+        return asyncio.run(coro)
+
+    # Loop is running. Hand off to a worker thread that creates its own
+    # loop. Single-shot ThreadPoolExecutor with one worker; the future
+    # blocks the calling thread which is what we want at the sync/async
+    # boundary.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(asyncio.run, coro)
+        return future.result()

--- a/autobot_shared/async_compat_test.py
+++ b/autobot_shared/async_compat_test.py
@@ -1,0 +1,115 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""#7469: regression tests for run_or_schedule defensive re-entrancy helper."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from autobot_shared.async_compat import run_or_schedule
+
+# ---------------------------------------------------------------------------
+# Sync-entry path: no event loop running
+# ---------------------------------------------------------------------------
+
+
+class TestSyncEntry:
+    def test_returns_coro_result_when_no_loop_running(self):
+        async def echo(value: int) -> int:
+            return value * 2
+
+        assert run_or_schedule(echo(21)) == 42
+
+    def test_propagates_exception_from_coro(self):
+        async def failing() -> None:
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            run_or_schedule(failing())
+
+    def test_runs_io_bound_coro(self):
+        # Confirm asyncio.run actually drives the loop (sleep would hang
+        # if there was no scheduler).
+        async def sleep_and_return() -> str:
+            await asyncio.sleep(0.001)
+            return "ok"
+
+        assert run_or_schedule(sleep_and_return()) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# In-loop path: caller is inside a running event loop
+# ---------------------------------------------------------------------------
+
+
+class TestInLoopEntry:
+    @pytest.mark.asyncio
+    async def test_returns_coro_result_from_async_context(self):
+        # The original re-entrancy crash: asyncio.run(coro) from inside
+        # an async function raises RuntimeError. run_or_schedule must
+        # detour through a thread pool and succeed.
+        async def echo(value: int) -> int:
+            return value + 100
+
+        # Calling the SYNC helper from an ASYNC test function exercises
+        # the "running loop detected" branch. We can't await it (it's
+        # sync) — that's the point of the helper.
+        result = run_or_schedule(echo(1))
+        assert result == 101
+
+    @pytest.mark.asyncio
+    async def test_propagates_exception_through_threadpool(self):
+        async def failing() -> None:
+            raise RuntimeError("inner")
+
+        with pytest.raises(RuntimeError, match="inner"):
+            run_or_schedule(failing())
+
+    @pytest.mark.asyncio
+    async def test_threadpool_path_runs_io_bound_coro(self):
+        async def sleep_and_return() -> str:
+            await asyncio.sleep(0.001)
+            return "from-thread"
+
+        result = run_or_schedule(sleep_and_return())
+        assert result == "from-thread"
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: multiple sync entries in parallel threads
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrent:
+    def test_independent_calls_in_separate_threads_dont_interfere(self):
+        # Each thread has no running loop → each takes the sync-entry
+        # path. Confirm they all complete cleanly without sharing state.
+        results: list[int] = []
+        errors: list[BaseException] = []
+        lock = threading.Lock()
+
+        async def compute(i: int) -> int:
+            await asyncio.sleep(0.001)
+            return i * i
+
+        def worker(i: int) -> None:
+            try:
+                value = run_or_schedule(compute(i))
+                with lock:
+                    results.append(value)
+            except BaseException as e:
+                with lock:
+                    errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        assert sorted(results) == [0, 1, 4, 9, 16, 25, 36, 49]


### PR DESCRIPTION
## Summary

#7469 round 1: shared defensive helper + migrate the 4 highest-risk `asyncio.run()` non-main sites (error-boundary library code + the 2 existing-but-duplicated defensive paths in `memory/`).

## What's added

- `autobot_shared/async_compat.run_or_schedule(coro)` — sync-entry uses `asyncio.run`; in-loop entry detours through a single-worker thread pool with its own loop.
- 7 regression tests (sync entry, in-loop entry, exception propagation, I/O-bound coros, 8-thread concurrency).

## Migrated sites (4)

| Site | Risk |
|---|---|
| `error_boundaries/decorators.py` (2 sites in retry/recover) | Sync wrapper dispatched from `loop.run_in_executor` would crash on bare `asyncio.run` |
| `error_boundaries/boundary_manager.py` (sync `error_boundary` ctxmgr) | Same risk on sync `with` block entered from async via threadpool |
| `memory/compat.py` (`_run_sync`) | Already had the defensive pattern locally — deduplicated to shared helper |
| `memory/manager.py` (sync `log_task_sync` path) | Same dedup |

## Out of scope (left in #7469)

Remaining ~22 sites need per-site classification (CLI safe-sync, cascade-to-await, defensive-guard) before migration. Each gets its own PR after triage.

## Test plan

- [x] 7/7 helper tests pass
- [x] All 4 migrated modules import cleanly
- [ ] CI green

References #7469 #7444 #5060

🤖 Generated with [Claude Code](https://claude.com/claude-code)