### PR TITLE
refactor(web_fetch): remove unreachable defensive guard in is_allowed (closes #7461)

### DIFF
--- a/autobot-backend/web_fetch/robots.py
+++ b/autobot-backend/web_fetch/robots.py
@@ -76,15 +76,17 @@ class RobotsCache:
     async def is_allowed(self, url: str, user_agent: str = _USER_AGENT) -> bool:
         """Return True if user_agent is allowed to fetch url per robots.txt.
 
-        Fail-open: returns True when robots.txt is unreachable.
+        Fail-open: ``_fetch_robots_text`` returns ``""`` on any error and
+        ``_parse_robots`` parses an empty string into a permissive
+        ``RobotFileParser`` whose ``can_fetch`` returns True for every URL.
+        No explicit None guard needed — ``_get_parser`` always returns a
+        parser (#7461).
         """
         domain = _extract_domain(url)
         parser = await self._get_parser(domain)
-        if parser is None:
-            return True
         return parser.can_fetch(user_agent, url)
 
-    async def _get_parser(self, domain: str) -> Optional[urllib.robotparser.RobotFileParser]:
+    async def _get_parser(self, domain: str) -> urllib.robotparser.RobotFileParser:
         """Return cached parser for domain, fetching and caching if needed."""
         async with self._lock:
             if domain in self._local:


### PR DESCRIPTION
## Summary

Closes #7461 — removes the unreachable ``if parser is None: return True`` guard in ``RobotsCache.is_allowed()`` and tightens the ``_get_parser()`` return type from ``Optional[RobotFileParser]`` to ``RobotFileParser``.

## Why this is safe

``_get_parser()`` was declared ``Optional`` but every code path returns a parser:
- ``_load_from_redis`` → ``Optional[str]`` (None falls through to fetch)
- ``_fetch_robots_text`` → ``str`` (returns ``""`` on any error)
- ``_parse_robots(text, domain)`` → always returns a ``RobotFileParser``

The ``parser is None`` check was unreachable.

## Behavior preserved

``_parse_robots('')`` produces a permissive parser whose ``can_fetch`` returns ``True`` for every URL — verified manually:

\`\`\`python
>>> _parse_robots('', 'https://example.com').can_fetch('agent', 'https://example.com/foo')
True
>>> _parse_robots('User-agent: *\nDisallow: /', ...).can_fetch(..., ...)
False
\`\`\`

The fail-open semantic the original guard documented (`return True when robots.txt is unreachable`) still works — empty robots.txt → empty disallow rules → permissive parser. Updated the docstring to describe how the fail-open arises from parser semantics, not from a None check.

## Test plan

- [x] ``py_compile`` passes
- [x] Black-clean
- [x] Manual probe: empty robots.txt parses permissive (returns True), explicit disallow parses restrictive (returns False)
- ⏭️ No web_fetch unit tests exist for this module today; the fix is type-narrowing + dead-code removal, no behavior change

Net: -2 LOC body, +better docstring.

## Refs

- Closes #7461
- Refs #7400 (where this was discovered during another web_fetch touch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)