### PR TITLE
perf(web_fetch): collapse _fetch_bs4 double round-trip into single request (closes #7459)

### DIFF
--- a/autobot-backend/web_fetch/fetcher.py
+++ b/autobot-backend/web_fetch/fetcher.py
@@ -145,7 +145,14 @@ async def _fetch_jina(url: str, timeout: float) -> Optional[str]:
 
 
 async def _fetch_bs4(url: str, timeout: float) -> tuple[Optional[str], Optional[int]]:
-    """Fetch raw HTML via aiohttp. Returns (html, status_code) or (None, None)."""
+    """Fetch raw HTML via aiohttp. Returns (html, status_code) or (None, None).
+
+    Single round-trip (#7459): streams the response body in 64 KiB chunks,
+    enforces ``WEB_FETCH_MAX_BYTES``, and returns ``("", status)`` for empty
+    bodies — the prior implementation issued a 1-byte probe request and
+    then re-fetched the full URL, doubling HTTP load on every fast-path
+    attempt.
+    """
     import aiohttp
 
     headers = {"User-Agent": _USER_AGENT}
@@ -158,21 +165,13 @@ async def _fetch_bs4(url: str, timeout: float) -> tuple[Optional[str], Optional[
                 allow_redirects=True,
                 max_redirects=_MAX_REDIRECTS,
             ) as resp:
-                if len(await resp.content.read(1)) == 0:
-                    return "", resp.status
-                # Re-fetch with full content
-        async with aiohttp.ClientSession(headers=headers) as session:
-            async with session.get(
-                url,
-                timeout=aio_timeout,
-                allow_redirects=True,
-                max_redirects=_MAX_REDIRECTS,
-            ) as resp:
                 content = b""
                 async for chunk in resp.content.iter_chunked(65536):
                     content += chunk
                     if len(content) > WEB_FETCH_MAX_BYTES:
                         return None, None  # too large
+                if not content:
+                    return "", resp.status
                 html = content.decode("utf-8", errors="replace")
                 return html, resp.status
     except aiohttp.TooManyRedirects:


### PR DESCRIPTION
## Summary

Closes #7459 — eliminates the double-HTTP-round-trip in ``_fetch_bs4``. Single-round-trip rewrite that halves HTTP load and ~halves fast-path latency.

## Bug

``_fetch_bs4`` issued **TWO HTTP requests** per call:

\`\`\`python
async with session.get(url, ...) as resp:
    if len(await resp.content.read(1)) == 0:
        return "", resp.status
    # Re-fetch with full content       ← THE BUG: leaves the with, opens NEW session
async with aiohttp.ClientSession(...) as session:  # second session!
    async with session.get(url, ...) as resp:      # second request to same URL!
        ...
\`\`\`

The 1-byte probe was abandoned (with-block exits → connection closed), then a fresh session re-issued the same request to read the full body. Every BS4-eligible URL paid the cost twice.

## Fix

Single ``session.get(url, ...)`` that streams the body in 64 KiB chunks. Empty-body detection via ``if not content`` *after* the stream finishes — same return shape, no probe needed.

## Behavior preserved

| Case | Old | New |
|---|---|---|
| Empty body | ``("", status)`` | ``("", status)`` |
| Non-empty OK | ``(html, status)`` | ``(html, status)`` |
| Too large | ``(None, None)`` | ``(None, None)`` |
| TooManyRedirects | ``(None, None)`` | ``(None, None)`` |
| Other error | ``(None, None)`` | ``(None, None)`` |

## Test plan

- [x] ``py_compile`` passes
- [x] Black-clean
- ⏭️ No unit tests for ``_fetch_bs4`` exist today (network-bound; mocked aiohttp would be next-round work). The fix is structural — same return shape, observably equivalent paths. The issue itself notes priority P3 and recommends measuring real impact after #7400 lands.

Net: -1 LOC body, +better docstring noting the fix.

## Refs

- Closes #7459
- Refs #7400-#7405 (consumers that benefit from the latency improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)