### PR TITLE
fix(async): migrate 3 cascade-required asyncio.run sites to run_or_schedule (#7469 round 2)

### DIFF
--- a/autobot-backend/project_state_tracking/tracking.py
+++ b/autobot-backend/project_state_tracking/tracking.py
@@ -149,11 +149,18 @@ def _schedule_error_tracking(error: Exception, context: Dict[str, Any]) -> None:
 
 
 def _run_error_tracking(error: Exception, context: Dict[str, Any]) -> None:
-    """Run error tracking in new event loop"""
-    # Import here to avoid circular imports
-    from . import track_system_error
+    """Run error tracking from sync error handlers.
 
-    asyncio.run(track_system_error(error, context))
+    #7469: was bare asyncio.run() — crashes if this sync helper is
+    invoked from an async caller (e.g. an exception handler on an
+    async path that delegates via thread executor). The shared
+    run_or_schedule helper handles both sync and in-loop contexts.
+    """
+    # Import here to avoid circular imports.
+    from . import track_system_error
+    from autobot_shared.async_compat import run_or_schedule
+
+    run_or_schedule(track_system_error(error, context))
 
 
 def error_tracking_decorator(func: Callable) -> Callable:

--- a/autobot-backend/system_integration.py
+++ b/autobot-backend/system_integration.py
@@ -276,11 +276,14 @@ class SystemIntegration:
 
     def _manage_linux_service_elevated(self, service_name: str, action: str) -> Dict[str, Any]:
         """Manage Linux service with elevation (Issue #665: extracted helper)."""
-        import asyncio
-
+        from autobot_shared.async_compat import run_or_schedule
         from elevation_wrapper import execute_with_elevation
 
-        elevation_result = asyncio.run(
+        # #7469: was bare asyncio.run() — crashes if this sync helper is
+        # ever invoked from an async caller (e.g. via thread executor
+        # dispatched from an HTTP handler). run_or_schedule uses the
+        # threadpool detour in that case; behavior identical otherwise.
+        elevation_result = run_or_schedule(
             execute_with_elevation(
                 f"systemctl {action} {service_name}",
                 operation=f"Manage service: {service_name}",

--- a/autobot-backend/utils/semantic_chunker.py
+++ b/autobot-backend/utils/semantic_chunker.py
@@ -408,23 +408,17 @@ class AutoBotSemanticChunker(SemanticChunkerBase):
 
         Live callers: `npu_semantic_search._generate_fallback_embedding` and
         `autobot-infrastructure/.../npu_performance_measurement.py`.
-        """
-        import asyncio
 
-        try:
-            asyncio.get_running_loop()
-            # Running loop -> sync encode inline (blocking; caller accepted this path)
-            logger.warning(
-                "Using sync embedding method in async context. " "Use _compute_sentence_embeddings_async instead."
-            )
-            logger.warning("WARNING: Model initialization may block event loop - use async method instead")
-            if self._embedding_model is None:
-                self._sync_initialize_model()
-            embeddings = self._embedding_model.encode(sentences, convert_to_tensor=False)
-            return np.array(embeddings)
-        except RuntimeError:
-            # No running loop -> delegate to async variant
-            return asyncio.run(self._compute_sentence_embeddings_async(sentences))
+        #7469: previously this had a hand-rolled try-loop / sync-fallback
+        pattern that BLOCKED the event loop on the in-async path
+        (running encoder synchronously inline). Migrated to the shared
+        ``run_or_schedule`` helper which uses a threadpool detour in
+        the in-async case — same final result, doesn't block the loop.
+        Caller still sees the same return shape.
+        """
+        from autobot_shared.async_compat import run_or_schedule
+
+        return run_or_schedule(self._compute_sentence_embeddings_async(sentences))
 
     # ------------------------------------------------------------------
     # Coherence scoring (CPU-only utility — not on hot chunk_text path)


### PR DESCRIPTION
## Summary

Round 2 of #7469 sprint. PR #7474 (round 1, merged) shipped the shared `run_or_schedule` helper + 4 error-boundary migrations. This round migrates the 3 cascade-required sites:

| Site | Old behavior | New behavior |
|---|---|---|
| `utils/semantic_chunker.py:406` | Hand-rolled try-loop with SYNC FALLBACK that blocked the event loop on async path | `run_or_schedule` — threadpool detour, no blocking |
| `system_integration.py:283` | Bare `asyncio.run` in sync helper | Crash-safe via `run_or_schedule` |
| `project_state_tracking/tracking.py:151` | Bare `asyncio.run` in sync error helper | Crash-safe via `run_or_schedule` |

## Test plan

- [x] All 3 modules import cleanly with PYTHONPATH=autobot-backend
- [ ] CI green

## Remaining sites

5 PKI CLI + 1 Celery memory_tasks + 1 service_registry_cli — sync-entry sites that need assert-and-document passes (no functional change). Each will get a dedicated mini-PR. #7469 stays open as sprint tracker.

References #7469 #7474 #7444

🤖 Generated with [Claude Code](https://claude.com/claude-code)