### PR TITLE
fix(scripts): adopt set -euo pipefail in start-services.sh (closes #7455)

### DIFF
--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -10,7 +10,7 @@
 #   - SLM GUI: https://${AUTOBOT_SLM_HOST}/orchestration
 #   - systemctl commands directly
 
-set -e
+set -euo pipefail
 
 # Colors
 RED='\033[0;31m'
@@ -186,19 +186,19 @@ open_gui() {
 # Main
 case "${1:-}" in
     start)
-        start_services "$2"
+        start_services "${2:-}"
         ;;
     stop)
-        stop_services "$2"
+        stop_services "${2:-}"
         ;;
     restart)
-        restart_services "$2"
+        restart_services "${2:-}"
         ;;
     status)
-        show_status "$2"
+        show_status "${2:-}"
         ;;
     logs)
-        show_logs "$2"
+        show_logs "${2:-}"
         ;;
     gui)
         open_gui


### PR DESCRIPTION
## Summary

Closes #7455 — hardens \`scripts/start-services.sh\` to canonical \`set -euo pipefail\` per the #7066 cascade.

## Changes

- **Line 13**: \`set -e\` → \`set -euo pipefail\`
- **Lines 189/192/195/198/201** (dispatch): \`"$2"\` → \`"${2:-}"\` at 5 sites — under \`-u\`, calling \`./start-services.sh start\` (no service arg) would otherwise fail with "unbound variable". The \`get_services\` callee already uses \`\${1:-all}\` to default empty → \`all\`, so passing \`""\` preserves the documented "default to all services" behavior.

Net: 6 insertions, 6 deletions (same-line edits).

## Test plan

\`\`\`
$ bash -n scripts/start-services.sh        # ✅ syntax OK
$ bash scripts/start-services.sh help      # ✅ shows usage
$ bash scripts/start-services.sh ""        # ✅ shows usage (empty arg)
$ bash scripts/start-services.sh           # ✅ shows usage (no args)
\`\`\`

All three "no service" paths run cleanly under strict mode without the \`-u\` trap firing.

## Out of scope

The issue's AC#3 (pre-commit shellcheck rule) would require adding shellcheck as a pre-commit dependency and configuring per-file rules. Filed for separate work — keeps this PR focused on the one-line gap that the issue title specifies.

## Refs

- Closes #7455
- Refs #7066 (pipefail cascade root cause that motivated this canonical pattern)
- Refs #5060 (canonical-style umbrella)

🤖 Generated with [Claude Code](https://claude.com/claude-code)