### PR TITLE
fix(async): migrate sync-entry asyncio.run sites to run_or_schedule (#7469 round 3)

### DIFF
--- a/autobot-backend/pki/cli.py
+++ b/autobot-backend/pki/cli.py
@@ -133,13 +133,20 @@ def _execute_command(args: argparse.Namespace, parser: argparse.ArgumentParser) 
     Execute the CLI command based on parsed arguments.
 
     Issue #620.
+    #7469: bare ``asyncio.run`` replaced with ``run_or_schedule`` for
+    defense-in-depth. CLI is a sync entrypoint, but the helper costs
+    nothing in that path (only goes through threadpool when a loop is
+    already running) and survives if a future caller imports
+    ``_execute_command`` from async code.
 
     Args:
         args: Parsed command line arguments
         parser: The argument parser (for help display)
     """
+    from autobot_shared.async_compat import run_or_schedule
+
     if args.command == "setup":
-        success = asyncio.run(
+        success = run_or_schedule(
             run_pki_setup(
                 force=args.force,
                 distribute=not args.no_dist,
@@ -149,14 +156,14 @@ def _execute_command(args: argparse.Namespace, parser: argparse.ArgumentParser) 
         sys.exit(0 if success else 1)
 
     elif args.command == "status":
-        asyncio.run(run_status())
+        run_or_schedule(run_status())
 
     elif args.command == "renew":
-        success = asyncio.run(run_renew(args.certificates or None))
+        success = run_or_schedule(run_renew(args.certificates or None))
         sys.exit(0 if success else 1)
 
     elif args.command == "verify":
-        asyncio.run(run_verify())
+        run_or_schedule(run_verify())
 
     else:
         parser.print_help()

--- a/autobot-backend/tasks/memory_tasks.py
+++ b/autobot-backend/tasks/memory_tasks.py
@@ -14,15 +14,17 @@ Design decisions:
 - acks_late=True on all tasks — message is only removed from queue after
   successful completion, preventing data loss on worker crash.
 - max_retries + retry(countdown=N) — all tasks are idempotent so safe retry.
-- asyncio.run() — Celery workers are synchronous; async calls use asyncio.run().
+- run_or_schedule() — Celery workers are synchronous; the shared helper from
+  ``autobot_shared.async_compat`` defends against re-entrancy if a worker
+  ever runs inside an already-active event loop (#7469).
 - Deferred imports inside task bodies to avoid circular-import issues at
   module load time (Celery autodiscovers this module before the app is fully
   initialised).
 """
 
-import asyncio
 import logging
 
+from autobot_shared.async_compat import run_or_schedule
 from celery_app import celery_app
 
 logger = logging.getLogger(__name__)
@@ -200,7 +202,7 @@ def write_verbatim_task(
         Dict with ``chunk_id`` and ``status``.
     """
     try:
-        chunk_id = asyncio.run(_async_write_verbatim(session_id, turn, role, text, timestamp, user_id))
+        chunk_id = run_or_schedule(_async_write_verbatim(session_id, turn, role, text, timestamp, user_id))
         logger.debug(
             "memory.write_verbatim: stored chunk %s (session=%s turn=%d role=%s)",
             chunk_id,
@@ -247,7 +249,7 @@ def extract_facts_task(
         Dict with ``status`` and ``facts_count``.
     """
     try:
-        facts_count = asyncio.run(_async_extract_facts(session_id, conversation_text, user_id))
+        facts_count = run_or_schedule(_async_extract_facts(session_id, conversation_text, user_id))
         logger.info(
             "memory.extract_facts: extracted %d facts (session=%s)",
             facts_count,
@@ -292,7 +294,7 @@ def update_graph_task(
         Dict with ``status``, ``entities_written``, ``relations_written``.
     """
     try:
-        result = asyncio.run(_async_update_graph(session_id, entities, relations))
+        result = run_or_schedule(_async_update_graph(session_id, entities, relations))
         logger.info(
             "memory.update_graph: wrote %d entities, %d relations (session=%s)",
             result.get("entities_written", 0),
@@ -337,7 +339,7 @@ def compact_snapshot_task(
         Dict with ``status`` and ``session_id``.
     """
     try:
-        asyncio.run(_async_compact_snapshot(session_id, conversation_snapshot, user_id))
+        run_or_schedule(_async_compact_snapshot(session_id, conversation_snapshot, user_id))
         logger.info(
             "memory.compact_snapshot: saved snapshot for session=%s (%d chars)",
             session_id,

--- a/autobot-backend/utils/service_registry_cli.py
+++ b/autobot-backend/utils/service_registry_cli.py
@@ -373,7 +373,13 @@ def _dispatch_command(args: argparse.Namespace) -> int:
     if args.command in sync_commands:
         return sync_commands[args.command](args)
     elif args.command in async_commands:
-        return asyncio.run(async_commands[args.command](args))
+        # #7469: bare asyncio.run() replaced with run_or_schedule for
+        # defense-in-depth. CLI is sync entrypoint, but the helper costs
+        # nothing in that case and survives if a future caller imports
+        # this dispatch from async code.
+        from autobot_shared.async_compat import run_or_schedule
+
+        return run_or_schedule(async_commands[args.command](args))
     else:
         print_status("error", f"Unknown command: {args.command}")
         return 1


### PR DESCRIPTION
## Summary

Round 3 of #7469 sprint. Migrates the 10 sync-entry sites for defense-in-depth.

| File | Sites |
|---|---|
| `pki/cli.py` (`_execute_command`) | 4 — setup, status, renew, verify |
| `tasks/memory_tasks.py` | 4 — verbatim, extract_facts, update_graph, compact_snapshot |
| `utils/service_registry_cli.py` | 1 — async-command dispatch |

`run_or_schedule` costs nothing in the no-loop case (short-circuits to `asyncio.run`); it adds defense-in-depth if any of these dispatches gets imported from async code in the future.

## Sprint tally

| Round | Sites | Type |
|---|---|---|
| 1 (PR #7474) | 4 | Error-boundary library + memory dedup |
| 2 (PR #7483) | 3 | Cascade-required (semantic_chunker, system_integration, tracking) |
| 3 (this) | 10 | Sync-entry (CLI, Celery) |
| **Total** | **17** | |

Remaining ~9 grep hits are all inside `if __name__ == "__main__":` blocks — correct usage, out of scope. **#7469 ready to close after this merges.**

## Test plan

- [x] All 3 modules import cleanly (PYTHONPATH=autobot-backend)
- [ ] CI green

References #7469 #7474 #7483 #7444

🤖 Generated with [Claude Code](https://claude.com/claude-code)