### PR TITLE
refactor(media/link): extract _parse_jina_output to autobot_shared.jina_parser (closes #7460)

### DIFF
--- a/autobot-backend/media/link/pipeline.py
+++ b/autobot-backend/media/link/pipeline.py
@@ -548,54 +548,10 @@ def _record_jina_success() -> None:
     _jina_failures_in_window.clear()
 
 
-def _parse_jina_output(content: str) -> Tuple[str, str]:
-    """Parse Jina Reader output into (title, body).
-
-    Jina Reader output format::
-
-        Title: Actual Page Title Here
-        URL Source: https://...
-
-        Markdown body starts here...
-
-    We scan the first ~10 lines for a ``Title:`` prefix, then strip the
-    metadata header (everything up to and including the first blank line
-    after the metadata block) from the body. If no ``Title:`` prefix is
-    found, title falls back to the first non-empty line of the body and
-    no header is stripped.
-    """
-    if not content:
-        return "", ""
-
-    lines = content.splitlines()
-    title = ""
-    metadata_end_idx = -1  # index of the blank line after metadata block
-
-    # Scan up to the first 10 lines for a Title: prefix and the metadata block end.
-    scan_limit = min(len(lines), 10)
-    for idx in range(scan_limit):
-        line = lines[idx]
-        stripped = line.strip()
-        if not stripped and title:
-            # Blank line AFTER a Title line — end of metadata header.
-            metadata_end_idx = idx
-            break
-        match = re.match(r"^([A-Za-z][A-Za-z0-9 _-]*):\s*(.+)$", stripped)
-        if match:
-            key = match.group(1).strip().lower()
-            if key == "title" and not title:
-                title = match.group(2).strip()[:200]
-            # Continue scanning — could be Title, URL Source, etc.
-
-    if title and metadata_end_idx >= 0:
-        # Strip metadata header (header lines + the blank separator).
-        body = "\n".join(lines[metadata_end_idx + 1 :]).lstrip("\n")
-        return title, body
-
-    if title:
-        # Title found but no blank-line separator — return title + full content.
-        return title, content
-
-    # Fallback: no Title: prefix. Use first non-empty line as title.
-    first_nonempty = next((ln.strip() for ln in lines if ln.strip()), "")
-    return first_nonempty[:200], content
+# Extracted to ``autobot_shared.jina_parser.parse_jina_output`` (#7460) so
+# that ``web_fetch/extractors.py`` and other consumers can import it
+# without triggering this module's heavy import chain
+# (``knowledge.query_sanitizer`` + further deps). Re-exported here under
+# the original ``_parse_jina_output`` name to preserve the existing 4
+# test imports in ``pipeline_test.py``.
+from autobot_shared.jina_parser import parse_jina_output as _parse_jina_output

--- a/autobot-backend/web_fetch/fetcher.py
+++ b/autobot-backend/web_fetch/fetcher.py
@@ -30,15 +30,14 @@ from web_fetch.extractors import _MIN_CONTENT_CHARS, extract_markdown, is_spa_co
 def _parse_jina_markdown(jina_text: str) -> tuple:
     """Extract (title, markdown) from Jina Reader response.
 
-    Delegates to media.link.pipeline._parse_jina_output when available,
-    falling back to using the raw text as markdown.
+    Delegates to ``autobot_shared.jina_parser.parse_jina_output``. #7460
+    extracted the parser from ``media.link.pipeline`` so it imports
+    cleanly without the prior try/except fallback (which masked real
+    import errors and silently returned ``("", jina_text)``).
     """
-    try:
-        from media.link.pipeline import _parse_jina_output
+    from autobot_shared.jina_parser import parse_jina_output
 
-        return _parse_jina_output(jina_text)
-    except Exception:
-        return "", jina_text
+    return parse_jina_output(jina_text)
 
 
 from web_fetch.types import (

--- a/autobot_shared/jina_parser.py
+++ b/autobot_shared/jina_parser.py
@@ -1,0 +1,87 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Pure-text parser for Jina Reader response output.
+
+Extracted from ``autobot-backend/media/link/pipeline.py`` (#7460) so that
+``autobot-backend/web_fetch/extractors.py`` and other consumers can import
+the parser without dragging in ``media.link.pipeline``'s heavy import
+chain (``knowledge.query_sanitizer`` + further deps). The function is pure
+text → tuple — zero side-effects, zero I/O — which is exactly the kind of
+utility that belongs in ``autobot_shared``.
+
+Jina Reader output format::
+
+    Title: Actual Page Title Here
+    URL Source: https://...
+
+    Markdown body starts here...
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+# Match ``Header-Name: value`` style metadata lines (Jina prepends a small
+# block: ``Title:``, ``URL Source:``, optional others). Pinned letters/digits/
+# space/underscore/hyphen so we don't accidentally match arbitrary text that
+# happens to contain a colon (e.g. URLs in markdown body).
+_METADATA_LINE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9 _-]*):\s*(.+)$")
+
+# Hard cap to avoid mis-detected metadata blocks pulling 100s of lines into
+# the title scan. 10 lines covers the realistic Jina header surface.
+_METADATA_SCAN_LIMIT = 10
+
+# Bound title length to avoid pathological inputs blowing memory caches.
+_TITLE_MAX_LEN = 200
+
+
+def parse_jina_output(content: str) -> Tuple[str, str]:
+    """Parse Jina Reader output into ``(title, body)``.
+
+    Scans the first ~10 lines for a ``Title:`` prefix, then strips the
+    metadata header (everything up to and including the first blank line
+    after the metadata block) from the body. If no ``Title:`` prefix is
+    found, the title falls back to the first non-empty line of the body and
+    no header is stripped.
+
+    Returns ``("", "")`` for empty input.
+    """
+    if not content:
+        return "", ""
+
+    lines = content.splitlines()
+    title = ""
+    metadata_end_idx = -1  # index of the blank line after metadata block
+
+    scan_limit = min(len(lines), _METADATA_SCAN_LIMIT)
+    for idx in range(scan_limit):
+        line = lines[idx]
+        stripped = line.strip()
+        if not stripped and title:
+            # Blank line AFTER a Title line — end of metadata header.
+            metadata_end_idx = idx
+            break
+        match = _METADATA_LINE_RE.match(stripped)
+        if match:
+            key = match.group(1).strip().lower()
+            if key == "title" and not title:
+                title = match.group(2).strip()[:_TITLE_MAX_LEN]
+            # Continue scanning — could be Title, URL Source, etc.
+
+    if title and metadata_end_idx >= 0:
+        # Strip metadata header (header lines + the blank separator).
+        body = "\n".join(lines[metadata_end_idx + 1 :]).lstrip("\n")
+        return title, body
+
+    if title:
+        # Title found but no blank-line separator — return title + full content.
+        return title, content
+
+    # Fallback: no Title: prefix. Use first non-empty line as title.
+    first_nonempty = next((ln.strip() for ln in lines if ln.strip()), "")
+    return first_nonempty[:_TITLE_MAX_LEN], content
+
+
+__all__ = ["parse_jina_output"]

--- a/autobot_shared/jina_parser_test.py
+++ b/autobot_shared/jina_parser_test.py
@@ -1,0 +1,75 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Contract tests for ``autobot_shared.jina_parser`` (#7460).
+
+Validates the extracted Jina Reader parser. Full-coverage tests for
+the ``media.link.pipeline._parse_jina_output`` re-export shim still live
+in ``autobot-backend/media/link/pipeline_test.py`` — these tests
+specifically pin the import-isolation contract that motivated the
+extraction (the function must be importable without dragging in any
+backend dependencies).
+"""
+
+from __future__ import annotations
+
+from autobot_shared.jina_parser import parse_jina_output
+
+
+def test_empty_input_returns_empty_pair() -> None:
+    assert parse_jina_output("") == ("", "")
+
+
+def test_title_and_body_parsed_with_metadata_block() -> None:
+    raw = "Title: My Article\n" "URL Source: https://example.com/x\n" "\n" "First paragraph.\n" "Second paragraph.\n"
+    title, body = parse_jina_output(raw)
+    assert title == "My Article"
+    # ``splitlines()`` strips trailing newline; the parser preserves
+    # only inter-line newlines, not a trailing one.
+    assert body == "First paragraph.\nSecond paragraph."
+
+
+def test_no_title_falls_back_to_first_nonempty_line() -> None:
+    raw = "Hello\nWorld\n"
+    title, body = parse_jina_output(raw)
+    assert title == "Hello"
+    assert body == raw  # body unchanged when no Title: header
+
+
+def test_title_truncated_at_200_chars() -> None:
+    long = "x" * 500
+    raw = f"Title: {long}\n\nbody"
+    title, _ = parse_jina_output(raw)
+    assert len(title) == 200
+
+
+def test_title_without_blank_separator_returns_full_content_as_body() -> None:
+    """If the Title: line isn't followed by a blank line, the body is the
+    full input (we couldn't safely strip the header)."""
+    raw = "Title: Foo\nNo blank line — body starts immediately.\n"
+    title, body = parse_jina_output(raw)
+    assert title == "Foo"
+    assert body == raw
+
+
+def test_extracted_module_has_zero_backend_dependencies() -> None:
+    """The whole point of #7460: the parser must import without pulling in
+    autobot-backend's heavy chain. This test imports
+    ``autobot_shared.jina_parser`` in a fresh context and confirms its
+    transitive imports are stdlib-only.
+    """
+    import importlib
+    import sys
+
+    # Drop any cached version
+    sys.modules.pop("autobot_shared.jina_parser", None)
+    mod = importlib.import_module("autobot_shared.jina_parser")
+
+    # The module's transitive imports should be stdlib-only.
+    # (re, typing, __future__) — zero autobot-backend / autobot_shared deps
+    # beyond the future-import. We assert by checking the module doesn't
+    # import anything from media.link or knowledge.
+    src = open(mod.__file__, encoding="utf-8").read()  # noqa: SIM115
+    assert "from media.link" not in src
+    assert "from knowledge" not in src
+    assert "from autobot_shared" not in src  # no sibling cross-deps either


### PR DESCRIPTION
## Summary

Closes #7460 — extracts ``_parse_jina_output`` from ``media/link/pipeline.py`` to a new ``autobot_shared.jina_parser`` module so ``web_fetch/fetcher.py`` (and other future consumers) can import it cleanly without the prior try/except fallback that masked silent failures.

## Why this matters

Before this PR, ``web_fetch/fetcher.py:_parse_jina_markdown`` had:

\`\`\`python
def _parse_jina_markdown(jina_text: str) -> tuple:
    try:
        from media.link.pipeline import _parse_jina_output
        return _parse_jina_output(jina_text)
    except Exception:
        return "", jina_text     # ← silent failure mode
\`\`\`

The try/except was needed because ``media.link.pipeline`` pulls in ``knowledge.query_sanitizer`` + further deps. Any genuine import error (deps missing, circular import, etc.) would silently degrade Jina output to ``("", jina_text)`` with no title — **degrading without telling anyone**.

## Changes

1. **New module**: ``autobot_shared/jina_parser.py``
   - Public function: ``parse_jina_output(content) → (title, body)``
   - Pure-text utility (re + typing only — zero backend deps)
   - Module constants extracted (``_METADATA_LINE_RE``, ``_METADATA_SCAN_LIMIT``, ``_TITLE_MAX_LEN``) with rationale comments
2. **Re-export**: ``media/link/pipeline.py`` now does ``from autobot_shared.jina_parser import parse_jina_output as _parse_jina_output`` — preserves the 4 existing test imports in ``pipeline_test.py``.
3. **web_fetch/fetcher.py**: drops the try/except, imports directly from ``autobot_shared.jina_parser``. Silent-failure mode removed.

## Tests

- **6 new** contract tests in ``autobot_shared/jina_parser_test.py`` — including an **import-isolation test** that pins the source-level contract (no ``media.link`` / ``knowledge`` / ``autobot_shared`` cross-deps) that motivated the extraction.
- **34 existing** ``pipeline_test.py::test_*jina*`` tests still pass via the re-export shim.

\`\`\`
$ pytest autobot_shared/jina_parser_test.py autobot-backend/media/link/pipeline_test.py -k jina
============== 40 passed in 1.61s ==============
\`\`\`

## Refs

- Closes #7460
- Refs #7400 (the issue this surfaced from — web_fetch wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)