### PR TITLE
fix(async): codebase-wide asyncio.run → run_or_schedule consistency sweep (#7469 round 4)

### DIFF
--- a/autobot-backend/advanced_rag_optimizer.py
+++ b/autobot-backend/advanced_rag_optimizer.py
@@ -969,6 +969,7 @@ class AdvancedRAGOptimizer:
 
 # Global instance for system integration (thread-safe)
 import asyncio as _asyncio_lock
+from autobot_shared.async_compat import run_or_schedule
 
 _rag_optimizer_instance = None
 _rag_optimizer_lock = _asyncio_lock.Lock()
@@ -1028,4 +1029,4 @@ if __name__ == "__main__":
                 print(f"  Hybrid Score: {result.hybrid_score:.3f}")  # noqa: print
                 print(f"  Content: {result.content[:200]}...")  # noqa: print
 
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/agents/classification_agent.py
+++ b/autobot-backend/agents/classification_agent.py
@@ -26,6 +26,7 @@ from workflow_classifier import WorkflowClassifier
 
 from .base_agent import AgentRequest
 from .standardized_agent import StandardizedAgent
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -540,4 +541,4 @@ if __name__ == "__main__":
         else:
             print("Usage: python3 classification_agent.py 'message' or --interactive")  # noqa: print  # noqa: print
 
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/agents/gemma_classification_agent.py
+++ b/autobot-backend/agents/gemma_classification_agent.py
@@ -25,6 +25,7 @@ from workflow_classifier import WorkflowClassifier
 
 from .base_agent import AgentRequest
 from .standardized_agent import StandardizedAgent
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -475,4 +476,4 @@ if __name__ == "__main__":
                 "Usage: python gemma_classification_agent.py 'message' or --interactive or --benchmark"
             )
 
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/agents/man_page_knowledge_integrator.py
+++ b/autobot-backend/agents/man_page_knowledge_integrator.py
@@ -626,6 +626,7 @@ class ManPageKnowledgeIntegrator:
 
 # Global integrator instance (thread-safe)
 import asyncio as _asyncio_lock
+from autobot_shared.async_compat import run_or_schedule
 
 _integrator_instance: Optional[ManPageKnowledgeIntegrator] = None
 _integrator_lock = _asyncio_lock.Lock()
@@ -690,4 +691,4 @@ if __name__ == "__main__":
         if successful_commands:
             print(f"  Sample successful commands: {', '.join(successful_commands)}")  # noqa: print  # noqa: print
 
-    asyncio.run(test_integration())
+    run_or_schedule(test_integration())

--- a/autobot-backend/api/chat_knowledge.py
+++ b/autobot-backend/api/chat_knowledge.py
@@ -68,6 +68,7 @@ from chat_history import ChatHistoryManager
 from knowledge_base import KnowledgeBase
 from services.llm_service import get_llm_service
 from type_defs.common import Metadata
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -1028,4 +1029,4 @@ if __name__ == "__main__":
 
         logger.info("Demo completed!")
 
-    asyncio.run(demo())
+    run_or_schedule(demo())

--- a/autobot-backend/api/codebase_analytics/cross_file_analysis.py
+++ b/autobot-backend/api/codebase_analytics/cross_file_analysis.py
@@ -22,6 +22,7 @@ import asyncio
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional  # noqa: F401  (List used in pub API)
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +154,6 @@ def schedule_cross_file_analysis(
         loop.create_task(run_cross_file_analysis(root_path, source_id))
     except RuntimeError:
         try:
-            asyncio.run(run_cross_file_analysis(root_path, source_id))
+            run_or_schedule(run_cross_file_analysis(root_path, source_id))
         except Exception as exc:  # pragma: no cover
             logger.warning("[#6747] Cross-file analysis scheduling failed: %s", exc)

--- a/autobot-backend/api/codebase_analytics/indexing_worker.py
+++ b/autobot-backend/api/codebase_analytics/indexing_worker.py
@@ -27,6 +27,7 @@ for _p in [str(_BACKEND_ROOT.parent), str(_SHARED_ROOT), str(_BACKEND_ROOT)]:
         sys.path.insert(0, _p)
 
 from api.codebase_analytics.scanner import do_indexing_with_progress  # noqa: E402
+from autobot_shared.async_compat import run_or_schedule
 
 logging.basicConfig(
     level=logging.INFO,
@@ -58,7 +59,7 @@ def main() -> None:
         root_path,
         source_id,
     )
-    asyncio.run(do_indexing_with_progress(task_id, root_path, source_id=source_id))
+    run_or_schedule(do_indexing_with_progress(task_id, root_path, source_id=source_id))
     logger.info("[Worker] Indexing task=%s finished", task_id)
 
 

--- a/autobot-backend/api/codebase_analytics/progress_tracker.py
+++ b/autobot-backend/api/codebase_analytics/progress_tracker.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional, Tuple
 
 from autobot_shared.redis_client import get_async_redis_client
 from constants.ttl_constants import TTL_24_HOURS
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -406,7 +407,7 @@ def _mark_task_completed(
         loop.create_task(_invalidate_quality_cache())
     except RuntimeError:
         # No running loop (called from a sync context); run a one-shot
-        asyncio.run(_invalidate_quality_cache())
+        run_or_schedule(_invalidate_quality_cache())
 
 
 def _mark_task_failed(task_id: str, error: Exception, indexing_tasks: Dict) -> None:

--- a/autobot-backend/benchmarks/cache_benchmark.py
+++ b/autobot-backend/benchmarks/cache_benchmark.py
@@ -15,6 +15,7 @@ import time
 from typing import Any, Dict, List
 
 from llm_interface_pkg.cache import CachedResponse, LLMResponseCache
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -114,4 +115,4 @@ async def run_benchmark(num_entries: int = 100, num_reads: int = 1000) -> Dict[s
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    asyncio.run(run_benchmark())
+    run_or_schedule(run_benchmark())

--- a/autobot-backend/circuit_breaker.py
+++ b/autobot-backend/circuit_breaker.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from autobot_shared.singleton_factory import lazy_singleton
 from constants import CircuitBreakerDefaults
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -612,4 +613,4 @@ if __name__ == "__main__":
         print(f"Success rate: {cb_state['recent_performance'].get('success_rate', 0):.1%}")  # noqa: print
 
     # Run example
-    asyncio.run(example_usage())
+    run_or_schedule(example_usage())

--- a/autobot-backend/code_analysis/scripts/analyze_architecture.py
+++ b/autobot-backend/code_analysis/scripts/analyze_architecture.py
@@ -14,6 +14,7 @@ import json
 from pathlib import Path
 
 from architectural_pattern_analyzer import ArchitecturalPatternAnalyzer
+from autobot_shared.async_compat import run_or_schedule
 
 
 async def analyze_architectural_patterns():
@@ -475,4 +476,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/scripts/analyze_code_quality.py
+++ b/autobot-backend/code_analysis/scripts/analyze_code_quality.py
@@ -15,6 +15,7 @@ import json
 from pathlib import Path
 
 from code_quality_dashboard import CodeQualityDashboard
+from autobot_shared.async_compat import run_or_schedule
 
 
 def _print_executive_metrics(metrics: dict, issues: dict, report: dict) -> None:
@@ -428,4 +429,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/scripts/analyze_critical_env_vars.py
+++ b/autobot-backend/code_analysis/scripts/analyze_critical_env_vars.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from constants.network_constants import NetworkConstants
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -344,4 +345,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/scripts/analyze_duplicates.py
+++ b/autobot-backend/code_analysis/scripts/analyze_duplicates.py
@@ -15,6 +15,7 @@ import logging
 from pathlib import Path
 
 from code_analyzer import CodeAnalyzer
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -369,4 +370,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/scripts/analyze_env_vars.py
+++ b/autobot-backend/code_analysis/scripts/analyze_env_vars.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from env_analyzer import EnvironmentAnalyzer
 
 from constants.network_constants import NetworkConstants
+from autobot_shared.async_compat import run_or_schedule
 
 
 def _print_analysis_summary(results: dict) -> None:
@@ -197,4 +198,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/scripts/analyze_frontend.py
+++ b/autobot-backend/code_analysis/scripts/analyze_frontend.py
@@ -12,6 +12,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent))
 
 from frontend_analyzer import FrontendAnalyzer
+from autobot_shared.async_compat import run_or_schedule
 
 
 def _print_analysis_summary(results: dict) -> None:
@@ -389,4 +390,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/scripts/analyze_performance.py
+++ b/autobot-backend/code_analysis/scripts/analyze_performance.py
@@ -8,6 +8,7 @@ import json
 from pathlib import Path
 
 from performance_analyzer import PerformanceAnalyzer
+from autobot_shared.async_compat import run_or_schedule
 
 
 def _print_perf_summary(results: dict) -> None:
@@ -219,4 +220,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/scripts/generate_patches.py
+++ b/autobot-backend/code_analysis/scripts/generate_patches.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from automated_fix_generator import AutomatedFixGenerator
 from code_quality_dashboard import CodeQualityDashboard
+from autobot_shared.async_compat import run_or_schedule
 
 
 def _print_fix_summary_stats(fix_results: dict) -> None:
@@ -321,4 +322,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from autobot_shared.status_enums import Severity  # #7253: consolidated onto canonical (#6689)
+from autobot_shared.async_compat import run_or_schedule
 
 # Anti-pattern severity → 0-100 integer score. Kept as a module-level helper
 # rather than an enum method so the canonical `Severity` enum stays clean
@@ -1716,4 +1717,4 @@ if __name__ == "__main__":
                 print(f"  {ap.description}")  # noqa: print
                 print(f"  Suggestion: {ap.suggestion}")  # noqa: print
 
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/src/api_consistency_analyzer.py
+++ b/autobot-backend/code_analysis/src/api_consistency_analyzer.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from constants.ttl_constants import TTL_1_HOUR
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -859,4 +860,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/src/architectural_pattern_analyzer.py
+++ b/autobot-backend/code_analysis/src/architectural_pattern_analyzer.py
@@ -28,6 +28,7 @@ from .architectural_analysis import (
     IssueDetector,
     PatternDetector,
 )
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -230,4 +231,4 @@ async def main():
 if __name__ == "__main__":
     import asyncio
 
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/src/code_analyzer.py
+++ b/autobot-backend/code_analysis/src/code_analyzer.py
@@ -18,6 +18,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
 from constants.ttl_constants import TTL_1_HOUR
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -604,4 +605,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/src/code_quality_dashboard.py
+++ b/autobot-backend/code_analysis/src/code_quality_dashboard.py
@@ -21,6 +21,7 @@ from security_analyzer import SecurityAnalyzer
 from testing_coverage_analyzer import TestingCoverageAnalyzer
 
 from constants.ttl_constants import TTL_30_DAYS
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -829,4 +830,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/src/env_analyzer.py
+++ b/autobot-backend/code_analysis/src/env_analyzer.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from autobot_shared.ssot_config import QUALITY_MODEL
+from autobot_shared.async_compat import run_or_schedule
 
 # Issue #542: Handle imports for both standalone execution and backend import
 # When imported from backend, project root is in sys.path
@@ -1649,4 +1650,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/src/frontend_analyzer.py
+++ b/autobot-backend/code_analysis/src/frontend_analyzer.py
@@ -12,6 +12,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from autobot_shared.async_compat import run_or_schedule
 
 # Add AutoBot root to path for imports
 autobot_root = Path(__file__).parent.parent.parent
@@ -837,4 +838,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/src/ownership_analyzer.py
+++ b/autobot-backend/code_analysis/src/ownership_analyzer.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from autobot_shared.async_compat import run_or_schedule
 
 # Issue #542: Handle imports for both standalone execution and backend import
 _project_root = Path(__file__).resolve().parents[3]
@@ -865,4 +866,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/src/patch_generator.py
+++ b/autobot-backend/code_analysis/src/patch_generator.py
@@ -10,6 +10,7 @@ import re
 import time
 from dataclasses import dataclass
 from typing import Any, Dict, List
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -734,4 +735,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/src/performance_analyzer.py
+++ b/autobot-backend/code_analysis/src/performance_analyzer.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from constants.ttl_constants import TTL_1_HOUR
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -735,4 +736,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/src/security_analyzer.py
+++ b/autobot-backend/code_analysis/src/security_analyzer.py
@@ -12,6 +12,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -855,4 +856,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/code_analysis/src/testing_coverage_analyzer.py
+++ b/autobot-backend/code_analysis/src/testing_coverage_analyzer.py
@@ -12,6 +12,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -869,4 +870,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/context_aware_decision/examples_counterfactual.py
+++ b/autobot-backend/context_aware_decision/examples_counterfactual.py
@@ -17,6 +17,7 @@ from .counterfactual_reasoner import CounterfactualReasoner
 from .decision_engine import DecisionEngine
 from .models import ContextElement, DecisionContext
 from .types import ContextType, DecisionType
+from autobot_shared.async_compat import run_or_schedule
 
 # =============================================================================
 # Example 1: Network Timeout Scenario
@@ -360,4 +361,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/database/migrations/001_create_conversation_files.py
+++ b/autobot-backend/database/migrations/001_create_conversation_files.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 from constants.path_constants import PATH
 from constants.threshold_constants import TimingConstants
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -511,8 +512,8 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) > 1 and sys.argv[1] == "down":
-        exit_code = asyncio.run(rollback_migration())
+        exit_code = run_or_schedule(rollback_migration())
     else:
-        exit_code = asyncio.run(run_migration())
+        exit_code = run_or_schedule(run_migration())
 
     sys.exit(exit_code)

--- a/autobot-backend/enhanced_project_state_tracker.py
+++ b/autobot-backend/enhanced_project_state_tracker.py
@@ -44,6 +44,7 @@ from project_state_tracking import (  # Types and enums; Models; Database; Main 
     track_system_error,
     track_user_action,
 )
+from autobot_shared.async_compat import run_or_schedule
 
 __all__ = [
     # Types
@@ -106,4 +107,4 @@ if __name__ == "__main__":
             print(f"Unknown command: {command}")  # noqa: print
             print("Available commands: snapshot, summary, report, metrics, test-tracking, export")  # noqa: print
 
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/enhanced_security_layer.py
+++ b/autobot-backend/enhanced_security_layer.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional
 # Import the centralized ConfigManager
 from config import config as global_config_manager
 from secure_command_executor import CommandRisk, SecureCommandExecutor, SecurityPolicy
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -599,4 +600,4 @@ if __name__ == "__main__":
             if "command" in entry.get("details", {}):
                 logger.info(f"  Command: {entry['details']['command']}")
 
-    asyncio.run(test_security())
+    run_or_schedule(test_security())

--- a/autobot-backend/event_manager.py
+++ b/autobot-backend/event_manager.py
@@ -10,6 +10,7 @@ import yaml
 
 from autobot_shared.singleton_factory import lazy_singleton
 from constants.path_constants import PATH
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -124,4 +125,4 @@ if __name__ == "__main__":
         # Test debug publish
         await get_event_manager().debug_publish("debug_info", {"message": "This is a debug message."})
 
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/gui_controller.py
+++ b/autobot-backend/gui_controller.py
@@ -9,6 +9,7 @@ import subprocess
 import pyautogui
 
 from constants.threshold_constants import TimingConstants
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -168,4 +169,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/intelligence/demos/run_intelligent_agent.py
+++ b/autobot-backend/intelligence/demos/run_intelligent_agent.py
@@ -38,6 +38,7 @@ from tests.fixtures.mocks import (  # noqa: E402
     MockLLMService,
     MockWorkerNode,
 )
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger("intelligence.demos.run_intelligent_agent")
 
@@ -77,7 +78,7 @@ async def _demo() -> None:
 
 def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    asyncio.run(_demo())
+    run_or_schedule(_demo())
     return 0
 
 

--- a/autobot-backend/intelligence/demos/run_streaming_executor.py
+++ b/autobot-backend/intelligence/demos/run_streaming_executor.py
@@ -37,6 +37,7 @@ from tests.fixtures.mocks import (  # noqa: E402
     MockCommandValidator,
     MockLLMService,
 )
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger("intelligence.demos.run_streaming_executor")
 
@@ -79,7 +80,7 @@ async def _demo() -> None:
 
 def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    asyncio.run(_demo())
+    run_or_schedule(_demo())
     return 0
 
 

--- a/autobot-backend/intelligence/goal_processor.py
+++ b/autobot-backend/intelligence/goal_processor.py
@@ -37,6 +37,7 @@ class GoalCategory(Enum):
 
 
 from autobot_shared.status_enums import RiskLevel  # noqa: E402  # #6689 consolidation
+from autobot_shared.async_compat import run_or_schedule
 
 
 @dataclass
@@ -604,4 +605,4 @@ if __name__ == "__main__":
         for suggestion in similar:
             print(f"- {suggestion.explanation} " f"(confidence: {suggestion.confidence:.2f})")  # noqa: print
 
-    asyncio.run(test_processor())
+    run_or_schedule(test_processor())

--- a/autobot-backend/intelligence/os_detector.py
+++ b/autobot-backend/intelligence/os_detector.py
@@ -496,6 +496,7 @@ class OSDetector:
 
 
 from autobot_shared.singleton_factory import async_lazy_singleton
+from autobot_shared.async_compat import run_or_schedule
 
 get_os_detector = async_lazy_singleton(OSDetector)
 
@@ -551,4 +552,4 @@ if __name__ == "__main__":
                 if len(tools) > 5:
                     logger.info("  ... and {len(tools) - 5} more")
 
-    asyncio.run(test_detector())
+    run_or_schedule(test_detector())

--- a/autobot-backend/knowledge_sync_incremental.py
+++ b/autobot-backend/knowledge_sync_incremental.py
@@ -36,6 +36,7 @@ from autobot_shared.logging_manager import get_llm_logger
 from constants.threshold_constants import TimingConstants
 from knowledge_base import KnowledgeBase
 from utils.semantic_chunker_gpu import get_gpu_semantic_chunker
+from autobot_shared.async_compat import run_or_schedule
 
 logger = get_llm_logger("knowledge_sync_incremental")
 
@@ -826,4 +827,4 @@ if __name__ == "__main__":
                 f"in {metrics.total_processing_time:.3f}s"
             )
 
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/llm_self_awareness.py
+++ b/autobot-backend/llm_self_awareness.py
@@ -634,6 +634,7 @@ You should be aware of your current capabilities and limitations based on the sy
 
 # Global instance (thread-safe)
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.async_compat import run_or_schedule
 
 _llm_self_awareness = lazy_singleton(LLMSelfAwareness)
 
@@ -669,4 +670,4 @@ if __name__ == "__main__":
         print("\n--- Phase-Aware Response ---")  # noqa: print
         print(json.dumps(response, indent=2))  # noqa: print
 
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/mcp/autobot_mcp_main.py
+++ b/autobot-backend/mcp/autobot_mcp_main.py
@@ -19,6 +19,7 @@ import asyncio
 import sys
 
 from mcp.autobot_server import AutoBotMCPServer
+from autobot_shared.async_compat import run_or_schedule
 
 
 async def main() -> None:
@@ -37,4 +38,4 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/migrations/env.py
+++ b/autobot-backend/migrations/env.py
@@ -24,6 +24,7 @@ from user_management.config import get_deployment_config
 
 # Import models to register with SQLAlchemy
 from user_management.models import Base
+from autobot_shared.async_compat import run_or_schedule
 
 # this is the Alembic Config object
 config = context.config
@@ -114,7 +115,7 @@ async def run_async_migrations() -> None:
 
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
-    asyncio.run(run_async_migrations())
+    run_or_schedule(run_async_migrations())
 
 
 if context.is_offline_mode():

--- a/autobot-backend/pki/cli.py
+++ b/autobot-backend/pki/cli.py
@@ -16,7 +16,7 @@ Usage:
 
     # From setup.py
     from pki.cli import run_pki_setup
-    asyncio.run(run_pki_setup())
+    run_or_schedule(run_pki_setup())
 """
 
 import argparse
@@ -32,6 +32,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from pki.manager import PKIManager, setup_pki
+from autobot_shared.async_compat import run_or_schedule
 
 logging.basicConfig(
     level=logging.INFO,

--- a/autobot-backend/protocols/agent_communication.py
+++ b/autobot-backend/protocols/agent_communication.py
@@ -55,6 +55,7 @@ def _parse_priority(priority: Any) -> "MessagePriority":
 
 # noqa: E402
 from autobot_shared.redis_client import get_redis_client  # noqa: E402
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -796,6 +797,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.test:
-        asyncio.run(test_communication_protocol())
+        run_or_schedule(test_communication_protocol())
     else:
         logger.info("Use --test to run the communication protocol test")

--- a/autobot-backend/retry_mechanism.py
+++ b/autobot-backend/retry_mechanism.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Dict, Optional
 from autobot_shared.singleton_factory import lazy_singleton
 from constants.threshold_constants import RetryConfig as ThresholdRetryConfig
 from constants.threshold_constants import TimingConstants
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -573,4 +574,4 @@ if __name__ == "__main__":
         logger.info("Retry statistics: %s", retry_mechanism.get_stats())
 
     # Run example
-    asyncio.run(example_usage())
+    run_or_schedule(example_usage())

--- a/autobot-backend/rlm/benchmark.py
+++ b/autobot-backend/rlm/benchmark.py
@@ -30,6 +30,7 @@ from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
 from autobot_shared.ssot_config import config as _ssot_config
 from rlm.evaluator import ResponseQualityEvaluator
 from rlm.types import RLMConfig
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -355,4 +356,4 @@ if __name__ == "__main__":
         else:
             logger.info(output)
 
-    asyncio.run(_main())
+    run_or_schedule(_main())

--- a/autobot-backend/secure_command_executor.py
+++ b/autobot-backend/secure_command_executor.py
@@ -27,6 +27,7 @@ from security.command_patterns import (
 )
 from services.tool_output_filter import get_tool_output_filter
 from utils.command_utils import execute_shell_command
+from autobot_shared.async_compat import run_or_schedule
 
 # Permission system imports (lazy to avoid circular imports)
 if TYPE_CHECKING:
@@ -1224,4 +1225,4 @@ if __name__ == "__main__":
                 f"executed: {entry['executed']})"
             )
 
-    asyncio.run(test_commands())
+    run_or_schedule(test_commands())

--- a/autobot-backend/security/threat_intelligence.py
+++ b/autobot-backend/security/threat_intelligence.py
@@ -28,6 +28,7 @@ from urllib.parse import urlparse
 import aiohttp
 
 from autobot_shared.http_client import get_http_client
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -785,4 +786,4 @@ if __name__ == "__main__":
             if result.urlvoid_score is not None:
                 logger.info("    URLVoid: {result.urlvoid_score:.2f}")
 
-    asyncio.run(test_threat_intel())
+    run_or_schedule(test_threat_intel())

--- a/autobot-backend/services/mcp_bridge_workers/worker_entrypoint.py
+++ b/autobot-backend/services/mcp_bridge_workers/worker_entrypoint.py
@@ -34,6 +34,7 @@ import os
 import resource
 import sys
 from typing import Any, Dict
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger("mcp_worker")
 
@@ -178,7 +179,7 @@ def main() -> None:
         print("usage: worker_entrypoint.py <bridge_module>", file=sys.stderr)
         sys.exit(2)
     _apply_rlimits()
-    asyncio.run(_serve(sys.argv[1]))
+    run_or_schedule(_serve(sys.argv[1]))
 
 
 if __name__ == "__main__":

--- a/autobot-backend/utils/adaptive_timeouts.py
+++ b/autobot-backend/utils/adaptive_timeouts.py
@@ -11,6 +11,7 @@ import logging
 import time
 from enum import Enum
 from typing import Any, Callable, Dict, Optional
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -435,4 +436,4 @@ if __name__ == "__main__":
         log_adaptive_timeout_metrics(300, 60, "command_execution")
 
     # Run test
-    asyncio.run(test_timeout_optimization())
+    run_or_schedule(test_timeout_optimization())

--- a/autobot-backend/utils/claude_api_integration.py
+++ b/autobot-backend/utils/claude_api_integration.py
@@ -24,6 +24,7 @@ from .request_batcher import (
     RequestPriority,
     create_batcher,
 )
+from autobot_shared.async_compat import run_or_schedule
 
 # Import our components
 
@@ -582,4 +583,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/utils/claude_api_optimization_suite.py
+++ b/autobot-backend/utils/claude_api_optimization_suite.py
@@ -845,6 +845,7 @@ class ClaudeAPIOptimizationSuite:
 
 # Global optimization suite instance (thread-safe)
 import threading
+from autobot_shared.async_compat import run_or_schedule
 
 _global_optimization_suite: Optional[ClaudeAPIOptimizationSuite] = None
 _global_optimization_suite_lock = threading.Lock()
@@ -963,4 +964,4 @@ async def example_usage():
 
 if __name__ == "__main__":
     # Run example
-    asyncio.run(example_usage())
+    run_or_schedule(example_usage())

--- a/autobot-backend/utils/error_boundary_examples.py
+++ b/autobot-backend/utils/error_boundary_examples.py
@@ -28,6 +28,7 @@ from autobot_shared.error_boundaries import (
     with_error_boundary,
 )
 from constants.threshold_constants import TimingConstants  # noqa: E402
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -296,4 +297,4 @@ if __name__ == "__main__":
     CustomRecoveryHandler()
 
     # Run examples
-    asyncio.run(run_examples())
+    run_or_schedule(run_examples())

--- a/autobot-backend/utils/gpu_acceleration_optimizer.py
+++ b/autobot-backend/utils/gpu_acceleration_optimizer.py
@@ -46,6 +46,7 @@ from utils.gpu_optimization import (  # noqa: F401
     run_comprehensive_benchmark,
 )
 from utils.performance_monitor import performance_monitor
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -409,4 +410,4 @@ if __name__ == "__main__":
         optimization = await optimize_gpu_for_multimodal()
         print(f"Optimization Result: " f"{json.dumps(asdict(optimization), indent=2, default=str)}")  # noqa: print
 
-    asyncio.run(test_gpu_optimization())
+    run_or_schedule(test_gpu_optimization())

--- a/autobot-backend/utils/graceful_degradation.py
+++ b/autobot-backend/utils/graceful_degradation.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional
 import aiofiles
 
 from constants.threshold_constants import TimingConstants
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -699,4 +700,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/utils/hardware_metrics.py
+++ b/autobot-backend/utils/hardware_metrics.py
@@ -21,6 +21,7 @@ import psutil
 
 # Import existing monitoring infrastructure
 from constants.api_constants import PATH_API_HEALTH
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -1525,4 +1526,4 @@ if __name__ == "__main__":
         print(f"Optimization recommendations: {json.dumps(recommendations, indent=2)}")  # noqa: print  # noqa: print
 
     # Run test
-    asyncio.run(test_phase9_monitoring())
+    run_or_schedule(test_phase9_monitoring())

--- a/autobot-backend/utils/llm_config_sync.py
+++ b/autobot-backend/utils/llm_config_sync.py
@@ -18,6 +18,7 @@ import asyncio
 import logging
 
 from type_defs.common import Metadata
+from autobot_shared.async_compat import run_or_schedule
 
 # Import network constants
 
@@ -308,4 +309,4 @@ if __name__ == "__main__":
 
         logger.info(json.dumps(result, indent=2))
 
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/utils/long_running_operations_framework.py
+++ b/autobot-backend/utils/long_running_operations_framework.py
@@ -54,6 +54,7 @@ from utils.long_running_operations import (  # Types and dataclasses; Managers
     OperationStatus,
     OperationType,
 )
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -508,4 +509,4 @@ if __name__ == "__main__":
             await manager.stop_background_processor()
 
     # Run example
-    asyncio.run(example_usage())
+    run_or_schedule(example_usage())

--- a/autobot-backend/utils/operation_timeout_integration.py
+++ b/autobot-backend/utils/operation_timeout_integration.py
@@ -40,6 +40,7 @@ from .long_running_operations_framework import (
     execute_codebase_indexing,
     execute_comprehensive_test_suite,
 )
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -724,4 +725,4 @@ if __name__ == "__main__":
             await operation_integration_manager.shutdown()
 
     # Run example
-    asyncio.run(example_integration())
+    run_or_schedule(example_integration())

--- a/autobot-backend/utils/performance_monitor.py
+++ b/autobot-backend/utils/performance_monitor.py
@@ -80,6 +80,7 @@ from utils.performance_monitoring.types import (
     DEFAULT_PERFORMANCE_BASELINES,
     DEFAULT_RETENTION_HOURS,
 )
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -192,4 +193,4 @@ if __name__ == "__main__":
         print(f"Optimization recommendations: {json.dumps(recommendations, indent=2)}")  # noqa: print  # noqa: print
 
     # Run test
-    asyncio.run(test_monitoring())
+    run_or_schedule(test_monitoring())

--- a/autobot-backend/utils/redis_compatibility.py
+++ b/autobot-backend/utils/redis_compatibility.py
@@ -16,6 +16,7 @@ from redis.exceptions import RedisError
 from autobot_shared.logging_manager import get_logger
 
 from .async_redis_manager import get_redis_manager
+from autobot_shared.async_compat import run_or_schedule
 
 logger = get_logger(__name__, "backend")
 
@@ -467,4 +468,4 @@ async def migrate_sync_to_async_example():
 
 if __name__ == "__main__":
     # Run migration example (logging configured via centralized logging_manager)
-    asyncio.run(migrate_sync_to_async_example())
+    run_or_schedule(migrate_sync_to_async_example())

--- a/autobot-backend/utils/request_batcher.py
+++ b/autobot-backend/utils/request_batcher.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from autobot_shared.ssot_config import config as _ssot_config
 from constants.threshold_constants import TimingConstants
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -747,4 +748,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_or_schedule(main())

--- a/autobot-backend/utils/service_registry_cli.py
+++ b/autobot-backend/utils/service_registry_cli.py
@@ -23,6 +23,7 @@ import sys
 import time
 
 from .service_registry import ServiceStatus, get_service_registry, get_service_url
+from autobot_shared.async_compat import run_or_schedule
 
 
 def print_header(title: str):

--- a/autobot-backend/utils/timeout_migration_examples.py
+++ b/autobot-backend/utils/timeout_migration_examples.py
@@ -37,6 +37,7 @@ from .long_running_operations_framework import (
     OperationType,
 )
 from .operation_timeout_integration import operation_integration_manager
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -1015,4 +1016,4 @@ if __name__ == "__main__":
             print("Operation integration manager not available")  # noqa: print
 
     # Run demonstration
-    asyncio.run(demonstration())
+    run_or_schedule(demonstration())

--- a/autobot-backend/utils/todowrite_optimizer.py
+++ b/autobot-backend/utils/todowrite_optimizer.py
@@ -721,6 +721,7 @@ class TodoWriteInterceptor:
 
 # Global optimizer instance for easy access (thread-safe)
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.async_compat import run_or_schedule
 
 _global_optimizer = lazy_singleton(TodoWriteOptimizer)
 
@@ -800,4 +801,4 @@ async def example_usage():
 
 if __name__ == "__main__":
     # Run example
-    asyncio.run(example_usage())
+    run_or_schedule(example_usage())

--- a/autobot-backend/utils/tool_pattern_analyzer.py
+++ b/autobot-backend/utils/tool_pattern_analyzer.py
@@ -843,6 +843,7 @@ class ToolPatternAnalyzer:
 
 # Global analyzer instance (thread-safe)
 import threading
+from autobot_shared.async_compat import run_or_schedule
 
 _global_analyzer: Optional[ToolPatternAnalyzer] = None
 _global_analyzer_lock = threading.Lock()
@@ -912,4 +913,4 @@ if __name__ == "__main__":
         insights = await get_optimization_insights()
         print(json.dumps(insights, indent=2, default=str))  # noqa: print
 
-    asyncio.run(example())
+    run_or_schedule(example())

--- a/autobot-backend/voice_interface.py
+++ b/autobot-backend/voice_interface.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, Optional
 import yaml
 
 from autobot_shared.missing_dep import MissingDep as _MissingDep
+from autobot_shared.async_compat import run_or_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -904,4 +905,4 @@ if __name__ == "__main__":
         #         await asyncio.sleep(0.1)  # Small delay to prevent
         #         # busy-waiting
 
-    asyncio.run(test_voice_interface())
+    run_or_schedule(test_voice_interface())


### PR DESCRIPTION
## Summary

Final sweep of #7469 sprint. Migrates the remaining 70 files (overwhelmingly `__main__` blocks: CLI demos, test entries, analysis scripts, worker entrypoints) to use the shared `run_or_schedule` helper.

## Why "safe" __main__ blocks

Each was already safe (Python guarantees `__main__` only runs as script entry), but codebase-wide consistency unlocks:

1. **Lint hook tightening** — future iteration of `tools/lint/check_no_blocking_io_in_async.py` (PR #7471) can ban bare `asyncio.run` codebase-wide.
2. **Doc simplification** — one canonical pattern instead of "use asyncio.run in __main__, run_or_schedule everywhere else".

`run_or_schedule` short-circuits to `asyncio.run` when no loop is running, so runtime behavior is identical.

## Migration tooling

AST-based one-shot script (not committed):
- AST scan finds `asyncio.run(...)` Call nodes
- Regex substitution `\basyncio\.run\(` → `run_or_schedule(`
- Helper import inserted AFTER the last top-level Import / ImportFrom (AST `end_lineno` — robust to multi-line docstrings, try/except blocks)
- Re-parse before write to confirm validity

**70 files modified, 0 syntax errors.**

## Sprint final tally

| Round | Sites | Type |
|---|---|---|
| 1 (PR #7474, merged) | 4 | Error-boundary library + memory dedup |
| 2 (PR #7483) | 3 | Cascade-required |
| 3 (PR #7485) | 10 | Sync-entry CLI/Celery |
| 4 (this) | 70 | __main__ blocks + defensive-pattern dedup |
| **Total** | **87 sites** | All `asyncio.run` callsites now flow through one helper |

## Test plan

- [x] All 70 modified files pass AST parse
- [x] Spot-check 10/11 imports clean (1 pre-existing pyttsx3 optional-dep, unrelated)
- [ ] CI green

Closes #7469 once merged.
References #7474 #7483 #7485 #7444 #5060

🤖 Generated with [Claude Code](https://claude.com/claude-code)