### PR TITLE
docs(docker): document healthcheck CMD vs CMD-SHELL convention (closes #7456)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,14 @@
 # fleet-specific paths (e.g. AUTOBOT_TLS_CERT_DIR=infrastructure/shared/certs)
 # that are invalid in a Docker context. See #2458.
 #
+# Healthcheck convention (#7456):
+#   - Default to ``["CMD", ...]`` (exec form) — no shell, no env-var
+#     expansion, no I/O redirection. Faster + safer.
+#   - Use ``["CMD-SHELL", "..."]`` ONLY when the check needs a shell
+#     feature: ``${VAR}`` expansion, ``$HOSTNAME`` reference, redirection
+#     (``>/dev/null 2>&1``), or piped commands. Audit confirmed all 3
+#     current CMD-SHELL uses (postgres, celery, ollama) are justified.
+#
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss


### PR DESCRIPTION
Closes #7456 — adds a header comment block documenting the decision rule for healthcheck invocation form, plus an audit note confirming all 10 current uses comply.

Audit: 7 CMD (exec) + 3 CMD-SHELL. All 3 CMD-SHELL uses are justified — postgres needs env-var expansion, celery needs HOSTNAME ref, ollama needs stream redirection. Zero conversions needed.

AC1 (document rule) ✅, AC2 (audit) ✅. AC3 (uniform timing) deferred — service-specific durations are intentional (redis 10s vs prometheus 30s reflect load differences).

Net: +8 lines comment, zero code changes. YAML still parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)