### PR TITLE
perf(chat/search_web): eliminate duplicate Playwright call in fetch_full fallback (closes #7478)

### DIFF
--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -1923,10 +1923,17 @@ class ToolHandlerMixin:
         Gets structured entries from Playwright, fans out WebFetcher.fetch
         concurrently for each URL, attaches markdown (or fetch_error) per entry.
         Always returns 200 — per-URL failures are surfaced in fetch_error field.
+
+        On empty entries (Playwright unavailable or zero results) we fall back
+        directly to ``_web_search_via_browser_vm`` rather than re-routing
+        through ``_execute_web_search``. The latter would re-issue a Playwright
+        call via ``_web_search_via_playwright`` — wasteful when
+        ``_web_search_structured_entries`` already determined Playwright
+        unavailable (#7478).
         """
         entries = await self._web_search_structured_entries(query, max_pages)
         if not entries:
-            return await self._execute_web_search(query)
+            return await self._web_search_via_browser_vm(query)
         enriched = await _fetch_pages_concurrent(entries, max_pages)
         return _format_full_search_results(query, enriched)
 

--- a/autobot-backend/tests/unit/test_search_web_fetch_full.py
+++ b/autobot-backend/tests/unit/test_search_web_fetch_full.py
@@ -26,7 +26,6 @@ from chat_workflow.tool_handler import (
 )
 from web_fetch.types import ERR_ROBOTS_BLOCKED, FetchResult, RenderMode
 
-
 # ---------------------------------------------------------------------------
 # Schema validation
 # ---------------------------------------------------------------------------
@@ -136,14 +135,16 @@ class TestFetchPagesConcurrent:
         """One URL with HTTP 500 must not prevent other URLs from being fetched."""
         entries = [
             {"title": "Good 1", "url": "https://good1.com", "snippet": ""},
-            {"title": "Bad",    "url": "https://bad.com",   "snippet": ""},
+            {"title": "Bad", "url": "https://bad.com", "snippet": ""},
             {"title": "Good 2", "url": "https://good2.com", "snippet": ""},
         ]
 
         async def fake_fetch_side_effect(url, render):
             if "bad" in url:
                 return FetchResult(url=url, success=False, error_code="http_error", status_code=500)
-            return FetchResult(url=url, success=True, markdown=f"Content for {url}", render_mode=RenderMode.AUTO, source="jina")
+            return FetchResult(
+                url=url, success=True, markdown=f"Content for {url}", render_mode=RenderMode.AUTO, source="jina"
+            )
 
         with patch("web_fetch.fetcher.WebFetcher.fetch", side_effect=fake_fetch_side_effect):
             results = await _fetch_pages_concurrent(entries, max_pages=3)
@@ -173,21 +174,39 @@ class TestFetchPagesConcurrent:
 
 class TestFormatFullSearchResults:
     def test_includes_title_and_url(self) -> None:
-        entries = [{"title": "Example", "url": "https://example.com", "snippet": "desc", "markdown": "# Hello", "fetch_error": None}]
+        entries = [
+            {
+                "title": "Example",
+                "url": "https://example.com",
+                "snippet": "desc",
+                "markdown": "# Hello",
+                "fetch_error": None,
+            }
+        ]
         output = _format_full_search_results("test query", entries)
         assert "Example" in output
         assert "https://example.com" in output
         assert "# Hello" in output
 
     def test_failed_entry_shows_fetch_error(self) -> None:
-        entries = [{"title": "Blocked", "url": "https://blocked.com", "snippet": "", "markdown": None, "fetch_error": "robots_blocked"}]
+        entries = [
+            {
+                "title": "Blocked",
+                "url": "https://blocked.com",
+                "snippet": "",
+                "markdown": None,
+                "fetch_error": "robots_blocked",
+            }
+        ]
         output = _format_full_search_results("test query", entries)
         assert "robots_blocked" in output
         assert "[Page fetch failed:" in output
 
     def test_markdown_truncated_at_4000_chars(self) -> None:
         long_md = "x" * 5000
-        entries = [{"title": "Long", "url": "https://long.com", "snippet": "", "markdown": long_md, "fetch_error": None}]
+        entries = [
+            {"title": "Long", "url": "https://long.com", "snippet": "", "markdown": long_md, "fetch_error": None}
+        ]
         output = _format_full_search_results("q", entries)
         # 4000 x's should appear, but not all 5000
         assert "x" * 4000 in output
@@ -210,7 +229,9 @@ class TestExecuteWebSearchFull:
             {"title": "Page A", "url": "https://a.com", "snippet": "Snippet A"},
             {"title": "Page B", "url": "https://b.com", "snippet": "Snippet B"},
         ]
-        ok_result = FetchResult(url="x", success=True, markdown="Full content here.", render_mode=RenderMode.AUTO, source="jina")
+        ok_result = FetchResult(
+            url="x", success=True, markdown="Full content here.", render_mode=RenderMode.AUTO, source="jina"
+        )
 
         with (
             patch.object(mixin, "_web_search_structured_entries", return_value=fake_entries),
@@ -225,14 +246,29 @@ class TestExecuteWebSearchFull:
 
     @pytest.mark.asyncio
     async def test_full_search_falls_back_when_no_entries(self) -> None:
-        """When no structured entries found, falls back to _execute_web_search."""
+        """When no structured entries found, falls back DIRECTLY to
+        ``_web_search_via_browser_vm`` (NOT through ``_execute_web_search``
+        which would re-issue a Playwright call — see #7478).
+        """
         from chat_workflow.tool_handler import ToolHandlerMixin
 
         mixin = ToolHandlerMixin.__new__(ToolHandlerMixin)
 
         with (
             patch.object(mixin, "_web_search_structured_entries", return_value=[]),
-            patch.object(mixin, "_execute_web_search", return_value="Fallback results") as mock_fallback,
+            patch.object(
+                mixin,
+                "_web_search_via_browser_vm",
+                return_value="Fallback results",
+            ) as mock_fallback,
+            # #7478 regression pin: _execute_web_search must NOT be called on
+            # the empty-entries fallback path. If it were, _web_search_via_playwright
+            # would re-issue the (already-failed) Playwright call.
+            patch.object(
+                mixin,
+                "_execute_web_search",
+                side_effect=AssertionError("_execute_web_search must NOT be called from full-search fallback (#7478)"),
+            ),
         ):
             result = await mixin._execute_web_search_full("no results query", max_pages=5)
 
@@ -246,7 +282,9 @@ class TestExecuteWebSearchFull:
 
         mixin = ToolHandlerMixin.__new__(ToolHandlerMixin)
 
-        with patch.object(mixin, "_web_search_via_playwright", return_value='Web search results for "q":\n\n1. Example'):
+        with patch.object(
+            mixin, "_web_search_via_playwright", return_value='Web search results for "q":\n\n1. Example'
+        ):
             result = await mixin._execute_web_search("q")
 
         assert "Web search results" in result


### PR DESCRIPTION
Closes #7478 — eliminates wasted Playwright service call in the fetch_full empty-entries fallback path.

Bug: `_execute_web_search_full` fell back to `_execute_web_search` on empty entries. The latter then called `_web_search_via_playwright` BEFORE the browser-VM fallback — issuing a SECOND Playwright call when `_web_search_structured_entries` had already determined Playwright unavailable.

Fix: route the empty-entries path directly to `_web_search_via_browser_vm`. Single Playwright call in fetch_full mode regardless of outcome.

Test plan:
- `test_full_search_falls_back_when_no_entries` updated to assert the new direct-fallback path AND pin the regression via `_execute_web_search` AssertionError side_effect
- 18/18 tests in test_search_web_fetch_full.py pass

Net: +9 LOC in tool_handler.py (docstring explaining why), ~30 LOC in test (richer assertions + #7478 regression pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)