### PR TITLE
fix(async/fs): migrate 13 Path.read/write_text sites in async paths to to_thread (closes #7467)

### DIFF
--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -11,6 +11,7 @@ Issue #718: Uses dedicated thread pool for file I/O to prevent blocking
 when the main asyncio thread pool is saturated by indexing operations.
 """
 
+import asyncio
 import logging
 import mimetypes
 import shutil
@@ -1305,6 +1306,8 @@ async def admin_read_file(path: str) -> dict:
     if target.stat().st_size > _ADMIN_MAX_READ_BYTES:
         raise HTTPException(status_code=413, detail="File too large to read inline (> 1 MB)")
     try:
-        return {"content": target.read_text(encoding="utf-8", errors="replace")}  # codeql[py/path-injection]
+        # #7467: was sync `target.read_text(...)` blocking the event loop.
+        content = await asyncio.to_thread(target.read_text, encoding="utf-8", errors="replace")
+        return {"content": content}  # codeql[py/path-injection]
     except PermissionError:
         raise HTTPException(status_code=403, detail="Permission denied")

--- a/autobot-backend/chat_history/layers.py
+++ b/autobot-backend/chat_history/layers.py
@@ -26,6 +26,7 @@ Usage::
     )
 """
 
+import asyncio
 import logging
 import os
 import re
@@ -114,7 +115,9 @@ class Layer1EssentialStory:
             import yaml
 
             yaml_path = Path(__file__).parent.parent / "config" / "context_windows.yaml"
-            data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+            # #7467: was sync `yaml_path.read_text` blocking the event loop.
+            content = await asyncio.to_thread(yaml_path.read_text, encoding="utf-8")
+            data = yaml.safe_load(content)
             model_name = context.get("model_name", "default")
             entry = (data.get("models") or {}).get(model_name) or {}
             if "essential_story_tokens" in entry:

--- a/autobot-backend/code_analysis/scripts/analyze_duplicates.py
+++ b/autobot-backend/code_analysis/scripts/analyze_duplicates.py
@@ -349,7 +349,8 @@ async def create_command_utils_library():
     Issue #1183: library content extracted to module-level constant to reduce function length.
     """
     lib_path = Path("src/utils/command_utils_consolidated.py")
-    lib_path.write_text(_COMMAND_UTILS_LIBRARY_CONTENT, encoding="utf-8")
+    # #7467: was sync `lib_path.write_text` blocking the event loop.
+    await asyncio.to_thread(lib_path.write_text, _COMMAND_UTILS_LIBRARY_CONTENT, encoding="utf-8")
     logger.info(f"Created consolidated command utilities at: {lib_path}")
 
 

--- a/autobot-backend/code_intelligence/bug_predictor.py
+++ b/autobot-backend/code_intelligence/bug_predictor.py
@@ -26,6 +26,7 @@ Issue #554: Enhanced with Vector/Redis/LLM infrastructure:
 - Historical bug pattern learning via embeddings
 """
 
+import asyncio
 import logging
 import re
 import subprocess  # nosec B404 - required for git operations
@@ -1148,7 +1149,8 @@ class BugPredictor(_BaseClass):
 
         path = Path(file_path)
         try:
-            content = path.read_text(encoding="utf-8", errors="ignore")
+            # #7467: was sync `path.read_text` blocking the event loop.
+            content = await asyncio.to_thread(path.read_text, encoding="utf-8", errors="ignore")
             content_sample = content[:1000]
 
             embedding = await self._get_embedding(content_sample)

--- a/autobot-backend/memory/essential_story.py
+++ b/autobot-backend/memory/essential_story.py
@@ -8,6 +8,7 @@ model tier) that is prepended to every LLM system prompt so every model
 has persistent top-memories without requiring a RAG retrieval round-trip.
 """
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -53,7 +54,8 @@ class EssentialStoryGenerator:
     async def _get_token_budget(self, model_name: str) -> int:
         """Read essential_story_tokens from context_windows.yaml for model."""
         try:
-            text = _YAML_PATH.read_text(encoding="utf-8")
+            # #7467: was sync `_YAML_PATH.read_text` blocking the event loop.
+            text = await asyncio.to_thread(_YAML_PATH.read_text, encoding="utf-8")
             data: Dict[str, Any] = yaml.safe_load(text)
             models: Dict[str, Any] = data.get("models", {})
             entry = models.get(model_name) or {}

--- a/autobot-backend/pki/distributor.py
+++ b/autobot-backend/pki/distributor.py
@@ -314,8 +314,10 @@ class CertificateDistributor:
         mode: str = "644",
     ):
         """Copy a file to remote host and set permissions."""
-        # Read local file
-        content = local_path.read_bytes()
+        # Read local file. #7467: was sync `local_path.read_bytes()` —
+        # blocks the event loop on disk I/O during PKI distribution
+        # which runs concurrently across N VMs.
+        content = await asyncio.to_thread(local_path.read_bytes)
 
         # Write to temporary location
         temp_path = f"/tmp/{local_path.name}"  # nosec B108 - remote VM temp dir

--- a/autobot-backend/services/autoresearch/meta_agent.py
+++ b/autobot-backend/services/autoresearch/meta_agent.py
@@ -26,6 +26,7 @@ Safety constraints:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 import uuid
@@ -135,7 +136,8 @@ class MetaAgent:
             A MetaPatch with original and proposed modified content.
         """
         self._validate_target(target_module_path)
-        original_content = target_module_path.read_text(encoding="utf-8")
+        # #7467: was sync `target_module_path.read_text` blocking the event loop.
+        original_content = await asyncio.to_thread(target_module_path.read_text, encoding="utf-8")
         self._validate_size(original_content, target_module_path)
 
         prompt = self._build_prompt(original_content, eval_context)

--- a/autobot-backend/services/knowledge/code_indexer.py
+++ b/autobot-backend/services/knowledge/code_indexer.py
@@ -314,7 +314,9 @@ class CodeIndexer:
                 return result
 
         try:
-            content = Path(file_path).read_bytes()
+            # #7467: was sync `Path(file_path).read_bytes()` blocking the event loop
+            # during code indexing of potentially-large source files.
+            content = await asyncio.to_thread(Path(file_path).read_bytes)
         except OSError as e:
             result.failed += 1
             result.errors.append(str(e))

--- a/autobot-backend/services/knowledge/cognition_seeder.py
+++ b/autobot-backend/services/knowledge/cognition_seeder.py
@@ -211,7 +211,8 @@ class CognitionSeeder:
             return 0
 
         try:
-            content = Path(abs_path).read_text(encoding="utf-8")
+            # #7467: was sync `Path(abs_path).read_text` blocking the event loop.
+            content = await asyncio.to_thread(Path(abs_path).read_text, encoding="utf-8")
         except OSError as exc:
             logger.warning("Cannot read seed file %s: %s", abs_path, exc)
             return 0

--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -964,7 +964,8 @@ class DocIndexerService:
             return result
 
         try:
-            content = file_path.read_text(encoding="utf-8")
+            # #7467: was sync `file_path.read_text` blocking the event loop.
+            content = await asyncio.to_thread(file_path.read_text, encoding="utf-8")
             if not content.strip():
                 result.skipped = 1
                 return result
@@ -988,11 +989,10 @@ class DocIndexerService:
 
     async def _index_single_file_content(self, file_path: str, tier: int, result: IndexResult) -> None:
         """Read, chunk, and index a single file. Helper for index_all (#1385)."""
-        import asyncio
-
         rel_path = os.path.relpath(file_path, self._root_dir)
         try:
-            content = Path(file_path).read_text(encoding="utf-8")
+            # #7467: was sync `Path(file_path).read_text` blocking the event loop.
+            content = await asyncio.to_thread(Path(file_path).read_text, encoding="utf-8")
             if not content.strip():
                 result.skipped += 1
                 return

--- a/autobot-backend/utils/timeout_migration_examples.py
+++ b/autobot-backend/utils/timeout_migration_examples.py
@@ -729,7 +729,8 @@ class ExistingOperationMigrator:
         await asyncio.sleep(TimingConstants.POLL_INTERVAL)  # Simulate processing time
 
         try:
-            content = file_path.read_text(encoding="utf-8", errors="ignore")
+            # #7467: was sync `file_path.read_text` blocking the event loop.
+            content = await asyncio.to_thread(file_path.read_text, encoding="utf-8", errors="ignore")
             return {
                 "path": str(file_path),
                 "size": len(content),
@@ -831,7 +832,8 @@ class ExistingOperationMigrator:
         vulnerabilities: List[Dict[str, Any]] = []
 
         try:
-            content = file_path.read_text(encoding="utf-8", errors="ignore")
+            # #7467: was sync `file_path.read_text` blocking the event loop.
+            content = await asyncio.to_thread(file_path.read_text, encoding="utf-8", errors="ignore")
 
             if "vulnerability" in scan_types:
                 self._check_vulnerability_patterns(content, vulnerabilities)


### PR DESCRIPTION
## Summary

#7467 cluster 2/3 (umbrella #7444). Production audit finds **13 sites** (not the 78 originally reported — discrepancy likely from including test files in the older count). All 13 migrated to `await asyncio.to_thread(method, ...)`.

## Migration pattern

```python
# Before
content = path.read_text(encoding="utf-8")

# After
content = await asyncio.to_thread(path.read_text, encoding="utf-8")
```

Passes the BOUND METHOD (no parens) — the read actually runs in the thread, not synchronously inline.

## Sites by area

| Area | Count |
|---|---|
| Knowledge indexers (doc/code/cognition_seeder) | 4 |
| Examples / migration fixtures | 3 |
| API / chat history / memory config loads | 3 |
| Code analysis / bug prediction | 2 |
| PKI cert distribution | 1 |

5 files needed `import asyncio` added; 6 already had it.

## Cluster status

- #7466 cluster 1/3: closed earlier (audit found 0 sites)
- **#7467 cluster 2/3: this PR**
- #7469 cluster 3/3: sprint complete (87 sites, PRs #7474/#7483/#7485/#7488)

## Test plan

- [x] 0 production sites remain (re-run AST audit)
- [x] All 10 modified modules import cleanly
- [ ] CI green

Closes #7467
References #7444 #5060 #7471

🤖 Generated with [Claude Code](https://claude.com/claude-code)