### PR TITLE
fix(multimodal): LSP exception contract — VisionProcessor + VoiceProcessor (#6755 round 1)

### DIFF
--- a/autobot-backend/multimodal_processor/processors/lsp_exception_contract_test.py
+++ b/autobot-backend/multimodal_processor/processors/lsp_exception_contract_test.py
@@ -1,0 +1,76 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""#6755 LSP exception contract regression tests.
+
+The cross-file analyzer (#6747) flagged ``VisionProcessor.process`` and
+``VoiceProcessor.process`` as ``lsp_exception_contract_changed``: their
+parent ``BaseModalProcessor.process`` only declares ``NotImplementedError``,
+but the subclasses raised ``ValueError`` for unsupported modalities.
+Liskov substitution requires subclasses NOT to raise exceptions outside
+the parent's declared contract — callers handling only the parent's
+exception types would silently miss the ``ValueError`` and crash.
+
+These tests pin the fix shape (return a failure ``ProcessingResult``,
+don't raise) so a future refactor can't silently re-introduce a bare
+``raise ValueError`` inside ``process``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+# ---------------------------------------------------------------------------
+# Source-level guards: pin the no-raise contract on `.process()`
+# ---------------------------------------------------------------------------
+
+
+def _process_source(cls) -> str:
+    return inspect.getsource(cls.process)
+
+
+def test_vision_processor_process_does_not_raise_value_error() -> None:
+    """Pin the LSP fix: the source of ``VisionProcessor.process`` must not
+    contain a bare ``raise ValueError`` for unsupported-modality handling.
+    The fix shape is to return a failure ``ProcessingResult`` instead."""
+    from multimodal_processor.processors.vision import VisionProcessor
+
+    src = _process_source(VisionProcessor)
+    # The early-return shape replaces the original `raise ValueError(...)`.
+    assert "raise ValueError" not in src, (
+        "#6755 regression: VisionProcessor.process re-introduced a bare "
+        "`raise ValueError` — parent BaseModalProcessor.process only declares "
+        "NotImplementedError; LSP requires subclasses NOT to raise outside "
+        "the parent contract. Return a failure ProcessingResult instead."
+    )
+    # Pin the replacement shape so the contract is observable in the source.
+    assert "success=False" in src
+    assert "Unsupported modality" in src
+
+
+def test_voice_processor_process_does_not_raise_value_error() -> None:
+    """Same contract as VisionProcessor — pin both."""
+    from multimodal_processor.processors.voice import VoiceProcessor
+
+    src = _process_source(VoiceProcessor)
+    assert "raise ValueError" not in src, (
+        "#6755 regression: VoiceProcessor.process re-introduced a bare "
+        "`raise ValueError` — return a failure ProcessingResult instead."
+    )
+    assert "success=False" in src
+    assert "Unsupported modality" in src
+
+
+def test_base_processor_process_only_declares_notimplementederror() -> None:
+    """Pin the parent contract — if it ever changes (e.g. starts declaring
+    ValueError), the subclass tests above need to be re-evaluated."""
+    from multimodal_processor.base import BaseModalProcessor
+
+    src = _process_source(BaseModalProcessor)
+    # Parent declares NotImplementedError only. Any other `raise X` in the
+    # parent body would change the LSP contract for ALL subclasses.
+    assert "NotImplementedError" in src
+    raise_lines = [line for line in src.splitlines() if line.strip().startswith("raise ")]
+    # Exactly one `raise` (NotImplementedError); no others.
+    assert len(raise_lines) == 1, f"Parent contract drift: expected 1 `raise`, found {len(raise_lines)}"
+    assert "NotImplementedError" in raise_lines[0]

--- a/autobot-backend/multimodal_processor/processors/vision.py
+++ b/autobot-backend/multimodal_processor/processors/vision.py
@@ -151,16 +151,35 @@ class VisionProcessor(BaseModalProcessor):
             self.logger.debug("GPU cleanup skipped: %s", e)
 
     async def process(self, input_data: MultiModalInput) -> ProcessingResult:
-        """Process visual input (images, screenshots, video)"""
+        """Process visual input (images, screenshots, video).
+
+        #6755 LSP exception contract: parent ``BaseModalProcessor.process``
+        only declares ``NotImplementedError``; subclasses must NOT raise
+        arbitrary exceptions to callers. Unsupported modality is now
+        returned as a failure ``ProcessingResult`` (the same shape the
+        outer ``except`` clause already produces), which keeps the
+        return-type contract intact and matches the #6658 fix pattern.
+        """
         start_time = time.time()
+
+        if input_data.modality_type not in (ModalityType.IMAGE, ModalityType.VIDEO):
+            return ProcessingResult(
+                result_id=f"vision_{input_data.input_id}",
+                input_id=input_data.input_id,
+                modality_type=input_data.modality_type,
+                intent=input_data.intent,
+                success=False,
+                confidence=0.0,
+                result_data=None,
+                processing_time=time.time() - start_time,
+                error_message=f"Unsupported modality: {input_data.modality_type}",
+            )
 
         try:
             if input_data.modality_type == ModalityType.IMAGE:
                 result = await self._process_image(input_data)
-            elif input_data.modality_type == ModalityType.VIDEO:
-                result = await self._process_video(input_data)
             else:
-                raise ValueError(f"Unsupported modality: {input_data.modality_type}")
+                result = await self._process_video(input_data)
 
             processing_time = time.time() - start_time
             confidence = self.calculate_confidence(result)

--- a/autobot-backend/multimodal_processor/processors/voice.py
+++ b/autobot-backend/multimodal_processor/processors/voice.py
@@ -139,7 +139,22 @@ class VoiceProcessor(BaseModalProcessor):
             if input_data.modality_type == ModalityType.AUDIO:
                 result = await self._process_audio(input_data)
             else:
-                raise ValueError(f"Unsupported modality: {input_data.modality_type}")
+                # #6755 LSP exception contract: don't raise — parent
+                # `BaseModalProcessor.process` only declares NotImplementedError;
+                # subclasses must return a failure ProcessingResult, not propagate
+                # ValueError. Same fix pattern as #6658 / VisionProcessor.
+                processing_time = time.time() - start_time
+                return ProcessingResult(
+                    result_id=f"voice_{input_data.input_id}",
+                    input_id=input_data.input_id,
+                    modality_type=input_data.modality_type,
+                    intent=input_data.intent,
+                    success=False,
+                    confidence=0.0,
+                    result_data=None,
+                    processing_time=processing_time,
+                    error_message=f"Unsupported modality: {input_data.modality_type}",
+                )
 
             processing_time = time.time() - start_time
             confidence = self.calculate_confidence(result)


### PR DESCRIPTION
## Summary

Round 1 of #6755 triage sprint. Closes the 2 `lsp_exception_contract_changed` findings — VisionProcessor.process and VoiceProcessor.process were raising `ValueError` outside the parent `BaseModalProcessor.process` contract (which only declares `NotImplementedError`).

Same fix pattern as sibling #6658.

## What changed

Both processors now return a failure `ProcessingResult` for unsupported modalities instead of `raise ValueError`. The outer `except Exception` already converted this to the same shape, so observable behavior is unchanged — but the LSP contract is now correct (a caller handling only `NotImplementedError` would have silently missed `ValueError` before).

## Test plan

- [x] 3 regression tests pin the no-raise contract + parent contract guard
- [x] `pytest 3 passed in 0.36s`
- [ ] CI green

## #6755 cluster status

| Cluster | Count | Status |
|---|---|---|
| `lsp_exception_contract_changed` | 2 | **This PR** |
| `lsp_signature_incompatible` | 38 | Pipeline subclass `__init__` drift — separate round |
| `duplicate_class_shape` | 61 | Per-cluster triage |
| `duplicate_enum` | 432 | Threshold tuning |

References #6755 #6658 #6747

🤖 Generated with [Claude Code](https://claude.com/claude-code)