### PR TITLE
feat(web_fetch): add WebFetcher.fetch_raw_html public API (closes #7476)

### DIFF
--- a/autobot-backend/knowledge/connectors/web_crawler.py
+++ b/autobot-backend/knowledge/connectors/web_crawler.py
@@ -27,7 +27,6 @@ from knowledge.connectors.models import (
 from knowledge.connectors.registry import ConnectorRegistry
 from web_fetch import ERR_CONNECTION, FetchResult, Frontier, RobotsCache, RenderMode, WebFetcher
 from web_fetch.extractors import extract_markdown
-from web_fetch.fetcher import _fetch_bs4
 from web_fetch.frontier import extract_links
 
 logger = logging.getLogger(__name__)
@@ -223,8 +222,8 @@ class WebCrawlerConnector(AbstractConnector):
         """BFS crawl starting from *seed_urls*.
 
         Uses web_fetch.Frontier for BFS queue/dedup, web_fetch.RobotsCache
-        for per-domain robots.txt enforcement, and web_fetch._fetch_bs4 for
-        every URL (single request yields both HTML for link extraction and
+        for per-domain robots.txt enforcement, and ``WebFetcher.fetch_raw_html``
+        for every URL (single request yields both HTML for link extraction and
         content for KB ingest).
 
         Args:
@@ -327,7 +326,7 @@ class WebCrawlerConnector(AbstractConnector):
             if not await fetcher._robots.is_allowed(url):
                 return FetchResult(url=url, success=False, error_code="robots_blocked"), ""
 
-        html, status = await _fetch_bs4(url, timeout=30.0)
+        html, status = await WebFetcher.fetch_raw_html(url, timeout=30.0)
         if html is None or status is None or status >= 400:
             return (
                 FetchResult(url=url, success=False, error_code=ERR_CONNECTION, status_code=status),

--- a/autobot-backend/tests/unit/web_fetch/test_fetcher.py
+++ b/autobot-backend/tests/unit/web_fetch/test_fetcher.py
@@ -337,3 +337,60 @@ class TestCacheIntegration:
         assert result.success is True
         # Verify something was stored in the cache store
         assert len(store) > 0
+
+
+# ---------------------------------------------------------------------------
+# WebFetcher.fetch_raw_html — public API (#7476)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRawHtml:
+    """Contract tests for ``WebFetcher.fetch_raw_html`` — the public alias
+    for ``_fetch_bs4`` introduced in #7476 to replace private-import usage
+    in ``site_mapper.py`` and ``knowledge/connectors/web_crawler.py``."""
+
+    @pytest.mark.asyncio
+    async def test_returns_html_and_status_tuple(self) -> None:
+        with patch(
+            "web_fetch.fetcher._fetch_bs4",
+            return_value=("<html><body>ok</body></html>", 200),
+        ):
+            html, status = await WebFetcher.fetch_raw_html("https://example.com")
+
+        assert html == "<html><body>ok</body></html>"
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_returns_none_tuple_on_error(self) -> None:
+        with patch("web_fetch.fetcher._fetch_bs4", return_value=(None, None)):
+            html, status = await WebFetcher.fetch_raw_html("https://example.com")
+
+        assert html is None
+        assert status is None
+
+    @pytest.mark.asyncio
+    async def test_threads_timeout_through(self) -> None:
+        captured = {}
+
+        async def _capture(url, timeout):
+            captured["url"] = url
+            captured["timeout"] = timeout
+            return ("<html/>", 200)
+
+        with patch("web_fetch.fetcher._fetch_bs4", side_effect=_capture):
+            await WebFetcher.fetch_raw_html("https://example.com", timeout=7.5)
+
+        assert captured == {"url": "https://example.com", "timeout": 7.5}
+
+    @pytest.mark.asyncio
+    async def test_default_timeout_is_30s(self) -> None:
+        captured = {}
+
+        async def _capture(url, timeout):
+            captured["timeout"] = timeout
+            return ("<html/>", 200)
+
+        with patch("web_fetch.fetcher._fetch_bs4", side_effect=_capture):
+            await WebFetcher.fetch_raw_html("https://example.com")
+
+        assert captured["timeout"] == 30.0

--- a/autobot-backend/web_fetch/fetcher.py
+++ b/autobot-backend/web_fetch/fetcher.py
@@ -247,6 +247,32 @@ class WebFetcher:
         instance = cls(redis_client=redis_client, robots_cache=robots_cache)
         return await instance._fetch(url, render, timeout)
 
+    @classmethod
+    async def fetch_raw_html(cls, url: str, timeout: float = 30.0) -> tuple[Optional[str], Optional[int]]:
+        """Fetch raw HTML + status code via aiohttp (no markdown extraction).
+
+        Public API for callers that need the HTML body itself — link
+        extraction (Frontier in sitemap crawl), HTML format pass-through
+        (``POST /knowledge/scrape format=html``), or content-type detection
+        before deciding render mode. Closes the #7476 gap where 3 production
+        modules reached into the private ``_fetch_bs4`` to get raw HTML.
+
+        Bypasses cache, robots, SSRF check, semaphores, and the AUTO render
+        cascade — this is a low-level "give me the bytes" primitive. Callers
+        that need the full FetchResult pipeline should use ``fetch()``.
+
+        Args:
+            url: Absolute URL to fetch.
+            timeout: Per-request timeout in seconds.
+
+        Returns:
+            ``(html, status_code)`` on success. ``(None, None)`` on any error
+            (connection, redirect-limit, non-utf8 body, etc.). ``("", status)``
+            on empty body with a successful status — same shape as ``fetch()``
+            for empty content.
+        """
+        return await _fetch_bs4(url, timeout)
+
     async def _fetch(self, url: str, render: RenderMode, timeout: float) -> FetchResult:
         """Internal fetch dispatcher."""
         # Cache lookup

--- a/autobot-backend/web_fetch/site_mapper.py
+++ b/autobot-backend/web_fetch/site_mapper.py
@@ -172,7 +172,7 @@ async def _crawl_fallback(seed: str, max_urls: int) -> List[SiteMapEntry]:
     discovery is needed here; bodies are NOT fetched to keep this fast.
     robots.txt is always honored in the fallback path.
     """
-    from web_fetch.fetcher import _fetch_bs4
+    from web_fetch.fetcher import WebFetcher
     from web_fetch.frontier import Frontier, extract_links
 
     frontier = Frontier(seed, max_pages=max_urls, max_depth=3, same_origin=True)
@@ -183,7 +183,7 @@ async def _crawl_fallback(seed: str, max_urls: int) -> List[SiteMapEntry]:
         entries.append(SiteMapEntry(url=url, title=None, depth=depth))
         if len(entries) >= max_urls:
             break
-        html, status = await _fetch_bs4(url, timeout=10.0)
+        html, status = await WebFetcher.fetch_raw_html(url, timeout=10.0)
         if html and status is not None and status < 400:
             links = extract_links(html, url, same_origin_only=True)
             frontier.add_links(links, depth + 1)
@@ -196,7 +196,7 @@ async def _crawl_fallback_with_robots(seed: str, max_urls: int, respect_robots: 
     if not respect_robots:
         return await _crawl_fallback(seed, max_urls)
 
-    from web_fetch.fetcher import _fetch_bs4
+    from web_fetch.fetcher import WebFetcher
     from web_fetch.frontier import Frontier, extract_links
     from web_fetch.robots import RobotsCache
 
@@ -219,7 +219,7 @@ async def _crawl_fallback_with_robots(seed: str, max_urls: int, respect_robots: 
         entries.append(SiteMapEntry(url=url, title=None, depth=depth))
         if len(entries) >= max_urls:
             break
-        html, status = await _fetch_bs4(url, timeout=10.0)
+        html, status = await WebFetcher.fetch_raw_html(url, timeout=10.0)
         if html and status is not None and status < 400:
             links = extract_links(html, url, same_origin_only=True)
             frontier.add_links(links, depth + 1)


### PR DESCRIPTION
Closes #7476 — adds public `WebFetcher.fetch_raw_html` classmethod so callers that need raw HTML (link extraction, html-format pass-through) don't have to reach into private `_fetch_bs4`.

Sites migrated:
- web_fetch/site_mapper.py (2 call sites — sitemap crawler)
- knowledge/connectors/web_crawler.py (1 call site — KB ingest crawler)

Internal callers in web_fetch/fetcher.py itself keep using `_fetch_bs4` directly — they ARE the implementation.

Tests: 4 new contract tests in test_fetcher.py (return shape, error case, timeout threading, default). 23/23 pass.

Design: chose the thin-classmethod-alias approach over adding an `html` field to FetchResult (would touch every FetchResult call site). The public method documents what it bypasses (cache, robots, SSRF, AUTO cascade) so callers know it's a low-level primitive distinct from `fetch()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)