### PR TITLE
fix(analyzer + dups): consolidate CircuitState + HardwareDevice + tune enum threshold (#6755 round 3)

### DIFF
--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -1332,7 +1332,15 @@ class AntiPatternDetector:
     )
     _SHAPE_MIN_METHODS = 5
     _SHAPE_JACCARD_THRESHOLD = 0.7
-    _ENUM_JACCARD_THRESHOLD = 0.7
+    # #6755 round 3: bumped from 0.7 to 0.85 to suppress priority-scale
+    # FPs. Enums like ``SandboxSecurityLevel`` (high/low/medium),
+    # ``WorkflowPriority`` (high/low/normal/urgent), ``KnowledgePriority``
+    # (critical/high/low/medium) share value strings but describe
+    # semantically distinct scales — not duplicates. At 0.85, only
+    # near-identical value sets get flagged. Combined with #7501's
+    # parent-child / Protocol-impl exclusions, autobot-backend
+    # ``duplicate_enum`` findings dropped 432 → 3 → 0.
+    _ENUM_JACCARD_THRESHOLD = 0.85
     _ENUM_MIN_VALUES = 3
 
     def _is_enum_class(self, cls_info: ClassInfo) -> bool:

--- a/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
@@ -156,7 +156,11 @@ async def test_duplicate_enum_skips_inheritance_relation(fixture_root):
 
 @pytest.mark.asyncio
 async def test_duplicate_enum_below_threshold_not_flagged(fixture_root):
-    """Two enums with only one shared value (Jaccard < 0.7) must NOT be flagged."""
+    """Two enums with only one shared value must NOT be flagged.
+
+    Jaccard for 1 shared / 7 union = ~0.14 — well below either the
+    historical 0.7 or the #6755 round 3 bumped threshold of 0.85.
+    """
     apd = _load_detector_module()
     _write_module(
         fixture_root,

--- a/autobot-backend/hardware_acceleration.py
+++ b/autobot-backend/hardware_acceleration.py
@@ -12,7 +12,6 @@ import logging
 import os
 import platform
 import subprocess  # nosec B404 - hardware detection requires subprocess
-from enum import Enum
 from typing import Any, Dict
 
 import psutil
@@ -65,12 +64,13 @@ def _parse_nvidia_smi_output(output: str) -> Dict[str, Dict[str, Any]]:
     return devices
 
 
-class AccelerationType(Enum):
-    """Hardware acceleration types in priority order."""
-
-    NPU = "npu"
-    GPU = "gpu"
-    CPU = "cpu"
+# #6755 round 3: ``AccelerationType`` was a duplicate of
+# ``ai_hardware_accelerator.HardwareDevice`` (Jaccard 1.0 — same
+# NPU/GPU/CPU values, just different class name). Re-export the canonical
+# type so the two surfaces stay in sync. ``AccelerationType.NPU`` etc.
+# at call sites continue to work unchanged because ``AccelerationType``
+# IS ``HardwareDevice`` after this re-export.
+from ai_hardware_accelerator import HardwareDevice as AccelerationType  # noqa: E402
 
 
 class HardwareAccelerationManager:

--- a/autobot-backend/npu_integration.py
+++ b/autobot-backend/npu_integration.py
@@ -14,7 +14,6 @@ import asyncio
 import json
 import logging
 from dataclasses import dataclass
-from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 import yaml
@@ -22,7 +21,12 @@ import yaml
 if TYPE_CHECKING:
     from utils.service_client import ServiceHTTPClient
 
+# #6755 round 3: CircuitState was duplicated here (Jaccard 1.0 vs
+# circuit_breaker.CircuitState — same CLOSED/OPEN/HALF_OPEN values).
+# Re-export the canonical type instead of redefining locally so callers
+# keep working unchanged and worker-health code shares one source of truth.
 from autobot_shared.http_client import HTTPClientManager, get_http_client
+from circuit_breaker import CircuitState
 from constants.threshold_constants import LLMDefaults, TimingConstants
 from utils.service_registry import get_service_url
 
@@ -33,12 +37,10 @@ logger = logging.getLogger(__name__)
 USE_AUTHENTICATED_CLIENT = True
 
 
-class CircuitState(Enum):
-    """Circuit breaker states for worker health management"""
-
-    CLOSED = "closed"  # Normal operation
-    OPEN = "open"  # Worker failed, blocking requests
-    HALF_OPEN = "half_open"  # Testing recovery
+# #6755 round 3: ``CircuitState`` is now re-exported from
+# ``circuit_breaker`` at module top — same enum values (closed / open /
+# half_open), used here for worker health management. The local
+# redefinition was flagged Jaccard 1.0 by the cross-file analyzer.
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Round 3 of #6755 sprint. Combined with PR #7495 (round 1) and #7501/PR #7503 (analyzer FPs), takes the cross-file analyzer findings from **533 → 0**.

## What's in this PR

### 2 real consolidations (Jaccard 1.0 duplicates)

| Duplicate | Resolution |
|---|---|
| `CircuitState` in `npu_integration.py` (10 refs) | Re-export `from circuit_breaker import CircuitState` — local refs unchanged |
| `HardwareDevice` (5+ callers) vs `AccelerationType` (1 self) | Alias: `from ai_hardware_accelerator import HardwareDevice as AccelerationType` — `AccelerationType.NPU` etc. still work |

### Threshold tune for priority-scale FPs

3 remaining findings at Jaccard 0.75-0.80 were priority-scale overlaps (`SandboxSecurityLevel` / `WorkflowPriority` / `KnowledgePriority`) — semantically distinct scales sharing some value strings. Bumped `_ENUM_JACCARD_THRESHOLD` from 0.7 to 0.85 to suppress these without missing the real Jaccard-1.0 duplicates.

## #6755 final tally

| Pass | Findings |
|---|---|
| Original | 533 |
| After PR #7495 (LSP exception) + PR #7503 (parent-child/Protocol FPs) | 5 |
| After this round | **0** |

## Test plan

- [x] CircuitState identity check: `npu_integration.CircuitState is circuit_breaker.CircuitState` ✅
- [x] AccelerationType identity check: `hardware_acceleration.AccelerationType is ai_hardware_accelerator.HardwareDevice` ✅
- [x] Full cross-file audit: 0 findings
- [x] Existing analyzer tests: 18/19 pass (1 pre-existing failure filed as #7519)
- [ ] CI green

## Out of scope (discovery follow-ups)

- **#7518** — `_detect_data_clumps` KeyError on `EnhancedSecurityLayer` (pre-existing analyzer bug; `analyze_cross_file_only()` workaround used here)
- **#7519** — `test_lsp_signature_incompatible_required_param_dropped` pre-existing failure (reproduces on unmodified Dev_new_gui)

Closes #6755
References #7495 #7501 #7503 #6779 #6747

🤖 Generated with [Claude Code](https://claude.com/claude-code)