### PR TITLE
fix(ci): bump Node 20 → 22 in CI workflows for oxlint 1.58 vite.config.ts loading (closes #7506)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
 
     - name: Install frontend dependencies
       run: |

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         working-directory: autobot-frontend
@@ -126,7 +126,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         working-directory: autobot-frontend
@@ -169,7 +169,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         working-directory: autobot-frontend

--- a/.github/workflows/frontend-typecheck-regression.yml
+++ b/.github/workflows/frontend-typecheck-regression.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8  # v4.0.1
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: autobot-frontend/package-lock.json
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
 
     - name: Install Frontend dependencies
       run: |

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         working-directory: autobot-frontend


### PR DESCRIPTION
Closes #7506 — frontend lint step fails on every Dev_new_gui push because oxlint 1.58 auto-loads vite.config.ts and Node 20.20.2's TS config-file loader was re-gated.

Scope: 7 sites across 5 workflows updated from node-version: '20' to '22':
- .github/workflows/ci.yml
- .github/workflows/frontend-test.yml (3 sites)
- .github/workflows/frontend-typecheck-regression.yml
- .github/workflows/security.yml
- .github/workflows/visual-regression.yml

## What broke

oxlint 1.58 added auto-discovery of vite.config.{js,ts,mjs,cjs} to derive path aliases. Loading the TS variant under Node 20.20.2 dies:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension '.ts' for vite.config.ts
TypeScript config files require Node.js ^20.19.0 || >=22.18.0.
Detected Node.js v20.20.2.
```

20.20.2 IS in `^20.19.0` by semver, but Node's experimental TS loader was re-gated inside that range. Node 22 sidesteps it.

## Engine constraint unchanged

package.json engines.node stays at `>=20.19.0` because production install scripts (install-bare-metal.sh, install-slm.sh) still install Node 20 via NodeSource on the SLM box. `>=20.19.0` accepts BOTH Node 20.19+ AND Node 22 — CI on 22 and prod on 20 both satisfy it.

If production-install scripts get bumped later, this PR doesn't need to be revised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)