### PR TITLE
chore(ci): clear flake8 F401/F811/F841 pre-existing regressions (#7522)

### DIFF
--- a/autobot-backend/agents/gemma_classification_agent.py
+++ b/autobot-backend/agents/gemma_classification_agent.py
@@ -390,7 +390,6 @@ Respond with valid JSON:
 # CLI test tool
 if __name__ == "__main__":
     import argparse
-    import asyncio
 
     parser = argparse.ArgumentParser(description="Test Gemma Classification Agent")
     parser.add_argument("message", nargs="?", help="Message to classify")

--- a/autobot-backend/api/codebase_analytics/indexing_worker.py
+++ b/autobot-backend/api/codebase_analytics/indexing_worker.py
@@ -12,7 +12,6 @@ Usage (internal — called by _run_indexing_subprocess):
     python indexing_worker.py <task_id> <root_path> [source_id]
 """
 
-import asyncio
 import logging
 import os
 import sys

--- a/autobot-backend/api/knowledge_crawl.py
+++ b/autobot-backend/api/knowledge_crawl.py
@@ -35,7 +35,7 @@ API contract::
 """
 
 import logging
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
@@ -126,7 +126,7 @@ async def crawl_url_endpoint(request: CrawlRequest) -> CrawlResponse:
     round-trip per URL keeps link extraction and content extraction in sync).
     The field is accepted on the wire for forward-compatibility.
     """
-    _render_mode = RenderMode(request.render)  # validate enum; surfaced in future connector update
+    RenderMode(request.render)  # validate enum; surfaced in future connector update
 
     connector = _make_connector(request)
     try:

--- a/autobot-backend/api/knowledge_mcp.py
+++ b/autobot-backend/api/knowledge_mcp.py
@@ -731,7 +731,6 @@ async def mcp_extract_structured_data(
     url = request.get("url")
     schema = request.get("schema")
     render = request.get("render", "auto")
-    ingest = request.get("ingest", False)
 
     if not url or not schema:
         return {"success": False, "error": "url and schema are required"}

--- a/autobot-backend/benchmarks/cache_benchmark.py
+++ b/autobot-backend/benchmarks/cache_benchmark.py
@@ -8,7 +8,6 @@ Inspired by flash-moe's "Trust the OS" finding (removing custom cache = +38%).
 Usage: python -m benchmarks.cache_benchmark
 """
 
-import asyncio
 import logging
 import statistics
 import time

--- a/autobot-backend/context_aware_decision/examples_counterfactual.py
+++ b/autobot-backend/context_aware_decision/examples_counterfactual.py
@@ -10,7 +10,6 @@ to preview consequences before committing to decisions.
 Not included in package; for development and documentation only.
 """
 
-import asyncio
 import time
 
 from autobot_shared.async_compat import run_or_schedule

--- a/autobot-backend/database/migrations/001_create_conversation_files.py
+++ b/autobot-backend/database/migrations/001_create_conversation_files.py
@@ -5,7 +5,6 @@ Created: 2025-09-30
 Description: Initial migration to create conversation-specific file management database
 """
 
-import asyncio
 import logging
 import sqlite3
 from datetime import datetime, timezone

--- a/autobot-backend/enhanced_project_state_tracker.py
+++ b/autobot-backend/enhanced_project_state_tracker.py
@@ -12,7 +12,6 @@ Part of Issue #381 - God Class Refactoring
 Original file: 1,505 lines → Package with focused modules
 """
 
-import asyncio
 import sys
 
 from autobot_shared.async_compat import run_or_schedule

--- a/autobot-backend/intelligence/demos/run_intelligent_agent.py
+++ b/autobot-backend/intelligence/demos/run_intelligent_agent.py
@@ -27,7 +27,6 @@ for _p in (_BACKEND, _REPO_ROOT):
         sys.path.insert(0, _ps)
 # ---------------------------------------------------------------------------
 
-import asyncio  # noqa: E402  (must follow sys.path bootstrap)
 import logging  # noqa: E402
 
 from autobot_shared.async_compat import run_or_schedule

--- a/autobot-backend/intelligence/demos/run_streaming_executor.py
+++ b/autobot-backend/intelligence/demos/run_streaming_executor.py
@@ -25,7 +25,6 @@ for _p in (_BACKEND, _REPO_ROOT):
         sys.path.insert(0, _ps)
 # ---------------------------------------------------------------------------
 
-import asyncio  # noqa: E402  (must follow sys.path bootstrap)
 import logging  # noqa: E402
 
 from autobot_shared.async_compat import run_or_schedule

--- a/autobot-backend/intelligence/goal_processor.py
+++ b/autobot-backend/intelligence/goal_processor.py
@@ -8,7 +8,6 @@ This module processes natural language goals and converts them into
 structured intents for the intelligent agent system.
 """
 
-import asyncio
 import logging
 import re
 from dataclasses import dataclass, field

--- a/autobot-backend/mcp/autobot_mcp_main.py
+++ b/autobot-backend/mcp/autobot_mcp_main.py
@@ -15,7 +15,6 @@ Usage:
     python -m mcp.autobot_mcp_main --http --host 127.0.0.1 --port 9200
 """
 
-import asyncio
 import sys
 
 from autobot_shared.async_compat import run_or_schedule

--- a/autobot-backend/media/link/pipeline.py
+++ b/autobot-backend/media/link/pipeline.py
@@ -36,9 +36,9 @@ import ipaddress
 import logging
 import re
 import time
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import urljoin, urlparse
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin
 
 from knowledge.query_sanitizer import sanitize_document as _sanitize_document
 from media.core.pipeline import BasePipeline

--- a/autobot-backend/memory/compat.py
+++ b/autobot-backend/memory/compat.py
@@ -5,7 +5,6 @@
 Backward Compatibility Wrappers - Drop-in replacements for legacy APIs
 """
 
-import asyncio
 import hashlib
 import logging
 from datetime import datetime, timedelta, timezone

--- a/autobot-backend/migrations/env.py
+++ b/autobot-backend/migrations/env.py
@@ -7,7 +7,6 @@ Alembic Environment Configuration
 This module configures Alembic migrations for the User Management System.
 """
 
-import asyncio
 import os
 import sys
 from logging.config import fileConfig

--- a/autobot-backend/pki/cli.py
+++ b/autobot-backend/pki/cli.py
@@ -20,7 +20,6 @@ Usage:
 """
 
 import argparse
-import asyncio
 import logging
 import sys
 from pathlib import Path
@@ -31,7 +30,6 @@ logger = logging.getLogger(__name__)
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from autobot_shared.async_compat import run_or_schedule
 from pki.manager import PKIManager, setup_pki
 
 logging.basicConfig(

--- a/autobot-backend/rlm/benchmark.py
+++ b/autobot-backend/rlm/benchmark.py
@@ -19,7 +19,6 @@ Usage (programmatic):
     results = await run_benchmark()
 """
 
-import asyncio
 import json
 import logging
 import time

--- a/autobot-backend/system_integration.py
+++ b/autobot-backend/system_integration.py
@@ -8,8 +8,6 @@ import platform
 import subprocess  # nosec B404 - required for system commands
 from typing import Any, Dict, List, Optional
 
-import aiohttp  # Import aiohttp for async web fetching
-
 # #7166: markdownify is an optional dependency. Hard-import made the whole
 # module unimportable in any environment that didn't install it (any module
 # that imports SystemIntegration inherited the requirement). Use the
@@ -21,7 +19,6 @@ from autobot_shared.missing_dep import optional_import
 globals().update(optional_import("markdownify", ["markdownify"]))
 md = markdownify  # type: ignore[name-defined]  # noqa: F821 — populated by optional_import
 
-from autobot_shared.http_client import get_http_client
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_web_research.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_web_research.py
@@ -19,7 +19,7 @@ import pytest
 
 def test_scrape_url_schema_registered() -> None:
     """SCRAPE_URL_SCHEMA is present in _BUILTIN_TOOL_SCHEMAS."""
-    from chat_workflow.tool_handler import SCRAPE_URL_SCHEMA, _BUILTIN_TOOL_SCHEMAS
+    from chat_workflow.tool_handler import _BUILTIN_TOOL_SCHEMAS, SCRAPE_URL_SCHEMA
 
     assert "scrape_url" in _BUILTIN_TOOL_SCHEMAS
     assert _BUILTIN_TOOL_SCHEMAS["scrape_url"] is SCRAPE_URL_SCHEMA
@@ -27,7 +27,7 @@ def test_scrape_url_schema_registered() -> None:
 
 def test_crawl_site_schema_registered() -> None:
     """CRAWL_SITE_SCHEMA is present in _BUILTIN_TOOL_SCHEMAS."""
-    from chat_workflow.tool_handler import CRAWL_SITE_SCHEMA, _BUILTIN_TOOL_SCHEMAS
+    from chat_workflow.tool_handler import _BUILTIN_TOOL_SCHEMAS, CRAWL_SITE_SCHEMA
 
     assert "crawl_site" in _BUILTIN_TOOL_SCHEMAS
     assert _BUILTIN_TOOL_SCHEMAS["crawl_site"] is CRAWL_SITE_SCHEMA
@@ -35,7 +35,7 @@ def test_crawl_site_schema_registered() -> None:
 
 def test_map_site_schema_registered() -> None:
     """MAP_SITE_SCHEMA is present in _BUILTIN_TOOL_SCHEMAS."""
-    from chat_workflow.tool_handler import MAP_SITE_SCHEMA, _BUILTIN_TOOL_SCHEMAS
+    from chat_workflow.tool_handler import _BUILTIN_TOOL_SCHEMAS, MAP_SITE_SCHEMA
 
     assert "map_site" in _BUILTIN_TOOL_SCHEMAS
     assert _BUILTIN_TOOL_SCHEMAS["map_site"] is MAP_SITE_SCHEMA
@@ -43,7 +43,7 @@ def test_map_site_schema_registered() -> None:
 
 def test_extract_structured_data_schema_registered() -> None:
     """EXTRACT_STRUCTURED_DATA_SCHEMA is present in _BUILTIN_TOOL_SCHEMAS."""
-    from chat_workflow.tool_handler import EXTRACT_STRUCTURED_DATA_SCHEMA, _BUILTIN_TOOL_SCHEMAS
+    from chat_workflow.tool_handler import _BUILTIN_TOOL_SCHEMAS, EXTRACT_STRUCTURED_DATA_SCHEMA
 
     assert "extract_structured_data" in _BUILTIN_TOOL_SCHEMAS
     assert _BUILTIN_TOOL_SCHEMAS["extract_structured_data"] is EXTRACT_STRUCTURED_DATA_SCHEMA
@@ -51,7 +51,7 @@ def test_extract_structured_data_schema_registered() -> None:
 
 def test_web_search_schema_unchanged() -> None:
     """Regression: WEB_SEARCH_SCHEMA still present and has required 'query'."""
-    from chat_workflow.tool_handler import WEB_SEARCH_SCHEMA, _BUILTIN_TOOL_SCHEMAS
+    from chat_workflow.tool_handler import _BUILTIN_TOOL_SCHEMAS, WEB_SEARCH_SCHEMA
 
     assert "web_search" in _BUILTIN_TOOL_SCHEMAS
     assert "query" in WEB_SEARCH_SCHEMA["properties"]

--- a/autobot-backend/utils/error_boundaries/boundary_manager.py
+++ b/autobot-backend/utils/error_boundaries/boundary_manager.py
@@ -8,7 +8,6 @@ Issue #381: Extracted from error_boundaries.py god class refactoring.
 Contains the central error boundary management system.
 """
 
-import asyncio
 import json
 import logging
 import threading

--- a/autobot-backend/utils/performance_monitor.py
+++ b/autobot-backend/utils/performance_monitor.py
@@ -173,7 +173,6 @@ async def add_alert_callback(callback):
 # =============================================================================
 
 if __name__ == "__main__":
-    import asyncio
     import json
 
     async def test_monitoring():

--- a/autobot-backend/utils/redis_compatibility.py
+++ b/autobot-backend/utils/redis_compatibility.py
@@ -6,7 +6,6 @@ Redis Compatibility Layer for AutoBot
 Provides backward compatibility for existing code while transitioning to async Redis manager
 """
 
-import asyncio
 import threading
 import warnings
 from typing import Optional, Union

--- a/autobot-backend/utils/service_registry_cli.py
+++ b/autobot-backend/utils/service_registry_cli.py
@@ -17,12 +17,9 @@ Usage:
 """
 
 import argparse
-import asyncio
 import json
 import sys
 import time
-
-from autobot_shared.async_compat import run_or_schedule
 
 from .service_registry import ServiceStatus, get_service_registry, get_service_url
 

--- a/autobot-backend/web_fetch/fetcher.py
+++ b/autobot-backend/web_fetch/fetcher.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import List, Optional
+from typing import Optional
 from urllib.parse import urlparse
 
 from web_fetch.cache import WEB_FETCH_MAX_BYTES, get_cached_result, set_cached_result
@@ -48,7 +48,6 @@ from web_fetch.types import (
     ERR_ROBOTS_BLOCKED,
     ERR_SSRF_BLOCKED,
     ERR_TIMEOUT,
-    ERR_TOO_LARGE,
     ERR_UNKNOWN,
     FetchResult,
     RenderMode,

--- a/autobot-backend/web_fetch/ingest.py
+++ b/autobot-backend/web_fetch/ingest.py
@@ -16,7 +16,6 @@ duplicate that logic.
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/web_fetch/types.py
+++ b/autobot-backend/web_fetch/types.py
@@ -10,7 +10,7 @@ Issue #7400: Foundation package for unified web search/scrape/crawl.
 from __future__ import annotations
 
 import hashlib
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 

--- a/autobot_shared/url_safety_test.py
+++ b/autobot_shared/url_safety_test.py
@@ -12,7 +12,6 @@ import-isolation contract that motivated the extraction.
 
 from __future__ import annotations
 
-import ipaddress
 from unittest.mock import patch
 
 import pytest


### PR DESCRIPTION
## Summary

Clears 35 pre-existing flake8 errors (F401 unused imports, F811 redefinitions, F841 unused locals) on `Dev_new_gui` base that were blocking PR #7521 (security fix for #6838).

This is a prerequisite for the security fix landing cleanly with green CI.

## Changes

- Removed unused `import asyncio` from 20+ files via autoflake
- Surgical removal of `import aiohttp` (had inline comment blocking autoflake)
- Removed unused local variables (`_render_mode`, `ingest`) that triggered F841
- Removed top-level `run_or_schedule` imports from CLI files (were re-imported in functions, causing F811)

## Fixes

Closes #7522 (unblocks #7521)

🤖 Generated with [Claude Code](https://claude.com/claude-code)