### PR TITLE
enhancement(llm): reserve auto model names for tiered LLM routing (#6592)

### DIFF
--- a/autobot-backend/api/marketplace_sources.py
+++ b/autobot-backend/api/marketplace_sources.py
@@ -11,7 +11,6 @@ catalog URLs alongside the built-in AutoBot marketplace.
 from __future__ import annotations
 
 import asyncio
-import ipaddress
 import json
 import logging
 import re
@@ -33,6 +32,7 @@ from api.schemas_workflows import (
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_async_redis_client
+from services.url_validator import URLValidator
 
 logger = logging.getLogger(__name__)
 
@@ -97,53 +97,6 @@ def _validate_source_name(name: str) -> str:
             detail="Source name contains unsupported characters",
         )
     return name
-
-
-async def _resolve_safe_ip(host: str) -> str:
-    """SSRF guard: resolve `host` and reject anything that isn't a global
-    public address. Returns a single IP literal that the caller should
-    connect to directly so a TOCTOU DNS rebind cannot redirect the
-    follow-up request to a private address.
-
-    Blocks: loopback, RFC1918, link-local (incl. AWS metadata
-    169.254.169.254), unique-local IPv6, multicast, reserved.
-    """
-    try:
-        infos = await asyncio.get_event_loop().getaddrinfo(host, None, type=socket.SOCK_STREAM)
-    except (socket.gaierror, OSError) as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Could not resolve marketplace host: {exc}",
-        ) from exc
-    safe_ip: Optional[str] = None
-    for info in infos:
-        ip_str = info[4][0]
-        try:
-            ip = ipaddress.ip_address(ip_str)
-        except ValueError:
-            continue
-        if (
-            ip.is_loopback
-            or ip.is_private
-            or ip.is_link_local
-            or ip.is_multicast
-            or ip.is_reserved
-            or ip.is_unspecified
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Marketplace URL resolves to a non-public address",
-            )
-        # Pick the first global address; we'll connect to it explicitly.
-        if safe_ip is None:
-            safe_ip = ip_str
-    if safe_ip is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Marketplace host has no usable IP",
-        )
-    return safe_ip
-
 
 @router.get(
     "",
@@ -257,7 +210,13 @@ async def _fetch_catalog_document(url: str) -> CatalogDocument:
     # Resolve to a public IP and connect to it directly. The Host header still
     # carries the original hostname for TLS SNI / virtual hosting; the
     # connector resolution map prevents DNS rebinding between resolve and connect.
-    safe_ip = await _resolve_safe_ip(host)
+    try:
+        safe_ip = await URLValidator.resolve_safe_ip(host)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
     timeout = aiohttp.ClientTimeout(total=_FETCH_TIMEOUT_SECONDS)
     resolver_map = {

--- a/autobot-backend/api/openai_compat.py
+++ b/autobot-backend/api/openai_compat.py
@@ -41,11 +41,20 @@ from api.schemas_code import (
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from llm_interface_pkg.models import LLMRequest
+from llm_interface_pkg.tiered_routing.tier_router import get_tiered_router
 from llm_providers.provider_registry import get_provider_registry
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["openai-compat"])
+
+# ---------------------------------------------------------------------------
+# Reserved model names for server-side tiered routing (#6592)
+# ---------------------------------------------------------------------------
+# Callers may pass these instead of a concrete model name to opt into
+# AutoBot's tiered routing.  "auto" uses TieredModelRouter complexity scoring;
+# "auto-fast" forces the simple tier; "auto-quality" forces the complex tier.
+_AUTO_MODEL_NAMES = frozenset({"auto", "auto-fast", "auto-quality"})
 
 # ---------------------------------------------------------------------------
 # Rate limiting — per-IP sliding window via shared IPRateLimiter (#7271)
@@ -97,12 +106,25 @@ def _get_user(request: Request) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _build_llm_request(body: ChatCompletionRequest) -> LLMRequest:
+async def _resolve_auto_model(model: str, messages: list) -> str:
+    """Resolve an auto-* model alias to a concrete model name via TieredModelRouter."""
+    router = get_tiered_router()
+    if model == "auto-fast":
+        return router.get_model_for_tier("simple")
+    if model == "auto-quality":
+        return router.get_model_for_tier("complex")
+    # "auto" — complexity-scored routing
+    selected, _ = router.route(messages, requested_model=model)
+    return selected
+
+
+def _build_llm_request(body: ChatCompletionRequest, resolved_model: Optional[str] = None) -> LLMRequest:
     """Convert OpenAI-format request to AutoBot LLMRequest."""
     messages = [{"role": m.role, "content": m.content} for m in body.messages]
+    effective_model = resolved_model or (body.model if body.model != "autobot-default" else None)
     return LLMRequest(
         messages=messages,
-        model_name=body.model if body.model != "autobot-default" else None,
+        model_name=effective_model,
         temperature=body.temperature,
         max_tokens=body.max_tokens,
         top_p=body.top_p,
@@ -234,8 +256,17 @@ async def chat_completions(
     _get_user(request)
     await _oai_limiter.check_or_429(_remote_addr(request))
 
+    # Resolve auto-* model aliases to concrete model names via tiered routing (#6592)
+    if body.model in _AUTO_MODEL_NAMES:
+        messages_raw = [{"role": m.role, "content": m.content} for m in body.messages]
+        resolved_model = await _resolve_auto_model(body.model, messages_raw)
+    elif body.model == "autobot-default":
+        resolved_model = None  # will be set from provider name below
+    else:
+        resolved_model = body.model
+
     registry = get_provider_registry()
-    llm_request = _build_llm_request(body)
+    llm_request = _build_llm_request(body, resolved_model=resolved_model)
 
     provider = await registry.get_provider_for_request(request=llm_request)
     if provider is None:
@@ -246,8 +277,9 @@ async def chat_completions(
         raise ValueError(f"Provider {provider.provider_name!r} stream_completion must be an async generator function")
 
     completion_id = _make_completion_id()
-    # Use resolved provider name as model echo when caller sent "autobot-default"
-    resolved_model = body.model if body.model != "autobot-default" else provider.provider_name
+    # Echo the concrete model name; fall back to provider name for autobot-default
+    if resolved_model is None:
+        resolved_model = provider.provider_name
 
     if body.stream:
         include_usage = bool(body.stream_options and body.stream_options.include_usage)
@@ -334,5 +366,13 @@ async def list_models(request: Request) -> OAIModelListResponse:
     # Always include a sentinel entry so the list is non-empty
     if not model_cards:
         model_cards.append(OAIModelCard(id="autobot-default", created=created))
+
+    # Prepend reserved auto-routing aliases (#6592)
+    auto_cards = [
+        OAIModelCard(id="auto", created=created, owned_by="autobot"),
+        OAIModelCard(id="auto-fast", created=created, owned_by="autobot"),
+        OAIModelCard(id="auto-quality", created=created, owned_by="autobot"),
+    ]
+    model_cards = auto_cards + [c for c in model_cards if c.id not in _AUTO_MODEL_NAMES]
 
     return OAIModelListResponse(data=model_cards)

--- a/autobot-backend/services/url_validator.py
+++ b/autobot-backend/services/url_validator.py
@@ -5,6 +5,7 @@
 URL validation service for preventing SSRF attacks
 """
 
+import asyncio
 import ipaddress
 import socket
 from typing import List, Optional
@@ -129,3 +130,67 @@ class URLValidator:
         # Validate
         is_safe, _ = self.is_safe_url(url)
         return url if is_safe else None
+
+    @staticmethod
+    async def resolve_safe_ip(host: str, timeout: float = 2.0) -> str:
+        """
+        Async DNS resolution that rejects non-public addresses (SSRF guard).
+        Returns a single IP literal for direct connection, defeating DNS rebind
+        attacks where a second resolution might redirect to a private address.
+
+        Issue #6533: consolidates SSRF guards across marketplace_sources,
+        media/link/pipeline, a2a/capability_verifier, and api/knowledge.
+
+        Blocks: loopback, RFC1918, link-local (incl. cloud metadata IPs),
+        IPv6 unique-local, multicast, reserved, unspecified.
+
+        Args:
+            host: hostname to resolve
+            timeout: DNS timeout in seconds (default 2.0)
+
+        Returns:
+            A single safe public IP address as a string
+
+        Raises:
+            ValueError: if the hostname cannot be resolved, resolves to no
+                usable IPs, or resolves to a non-public address
+        """
+        try:
+            loop = asyncio.get_event_loop()
+            infos = await asyncio.wait_for(
+                loop.getaddrinfo(host, None, type=socket.SOCK_STREAM),
+                timeout=timeout
+            )
+        except asyncio.TimeoutError as exc:
+            raise ValueError(f"DNS resolution timeout for {host}") from exc
+        except (socket.gaierror, OSError) as exc:
+            raise ValueError(f"Cannot resolve hostname {host}: {exc}") from exc
+
+        safe_ip: Optional[str] = None
+        for info in infos:
+            ip_str = info[4][0]
+            try:
+                ip = ipaddress.ip_address(ip_str)
+            except ValueError:
+                continue
+
+            if (
+                ip.is_loopback
+                or ip.is_private
+                or ip.is_link_local
+                or ip.is_multicast
+                or ip.is_reserved
+                or ip.is_unspecified
+            ):
+                raise ValueError(
+                    f"Hostname {host} resolves to a non-public address: {ip_str}"
+                )
+
+            # Pick the first global address; caller will connect to it explicitly
+            if safe_ip is None:
+                safe_ip = ip_str
+
+        if safe_ip is None:
+            raise ValueError(f"Hostname {host} has no usable IP addresses")
+
+        return safe_ip

--- a/autobot-backend/services/url_validator_test.py
+++ b/autobot-backend/services/url_validator_test.py
@@ -1,0 +1,324 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for URLValidator.resolve_safe_ip()
+Issue #6533: Consolidate SSRF-guard implementations into shared helper
+"""
+
+import asyncio
+import socket
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.url_validator import URLValidator
+
+
+@pytest.mark.asyncio
+class TestResolveSafeIP:
+    """Tests for URLValidator.resolve_safe_ip() async DNS-rebind defense."""
+
+    async def test_resolves_public_ipv4(self):
+        """Resolving a public IPv4 should succeed."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            result = await URLValidator.resolve_safe_ip("google.com")
+            assert result == "8.8.8.8"
+
+    async def test_resolves_public_ipv6(self):
+        """Resolving a public IPv6 should succeed."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2001:4860:4860::8888", 0, 0, 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            result = await URLValidator.resolve_safe_ip("google.com")
+            assert result == "2001:4860:4860::8888"
+
+    async def test_picks_first_safe_ip_from_multiple(self):
+        """When multiple public IPs are returned, pick the first."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 0)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.4.4", 0)),
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            result = await URLValidator.resolve_safe_ip("google.com")
+            assert result == "8.8.8.8"
+
+    async def test_rejects_loopback_ipv4(self):
+        """Resolving to 127.0.0.0/8 should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("localhost")
+
+    async def test_rejects_loopback_ipv6(self):
+        """Resolving to ::1 should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 0, 0, 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("localhost")
+
+    async def test_rejects_rfc1918_10(self):
+        """Resolving to 10.0.0.0/8 should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("internal.local")
+
+    async def test_rejects_rfc1918_172(self):
+        """Resolving to 172.16.0.0/12 should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("172.16.0.5", 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("internal.local")
+
+    async def test_rejects_rfc1918_192(self):
+        """Resolving to 192.168.0.0/16 should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.1", 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("router.local")
+
+    async def test_rejects_link_local_ipv4_aws_metadata(self):
+        """Resolving to 169.254.169.254 (AWS metadata) should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("aws-metadata")
+
+    async def test_rejects_link_local_ipv6(self):
+        """Resolving to fe80::/10 should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("fe80::1", 0, 0, 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("link-local")
+
+    async def test_rejects_ipv6_ula_fc(self):
+        """Resolving to fc00::/7 (IPv6 ULA) should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("fc00::1", 0, 0, 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("internal-ipv6")
+
+    async def test_rejects_ipv6_ula_fd(self):
+        """Resolving to fd00::/8 (IPv6 ULA) should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("fd12:3456:789a::1", 0, 0, 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("internal-ipv6")
+
+    async def test_rejects_multicast_ipv4(self):
+        """Resolving to 224.0.0.0/4 should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("224.0.0.1", 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("multicast")
+
+    async def test_rejects_multicast_ipv6(self):
+        """Resolving to ff00::/8 should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("ff02::1", 0, 0, 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("multicast-ipv6")
+
+    async def test_rejects_reserved_ipv4(self):
+        """Resolving to 240.0.0.0/4 should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("240.0.0.1", 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("reserved")
+
+    async def test_rejects_unspecified_ipv4(self):
+        """Resolving to 0.0.0.0 should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("0.0.0.0", 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("unspecified")
+
+    async def test_rejects_unspecified_ipv6(self):
+        """Resolving to :: should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::", 0, 0, 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("unspecified-ipv6")
+
+    async def test_rejects_ipv4_mapped_ipv6_private(self):
+        """Resolving to ::ffff:192.168.1.1 should be rejected."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::ffff:192.168.1.1", 0, 0, 0))
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("ipv4-mapped-private")
+
+    async def test_handles_mixed_responses_rejects_all_if_any_blocked(self):
+        """If any response is blocked, reject the whole resolution."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.1", 0)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 0)),
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("mixed")
+
+    async def test_handles_dns_timeout(self):
+        """DNS timeout should raise ValueError."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.side_effect = asyncio.TimeoutError("timeout")
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="DNS resolution timeout"):
+                await URLValidator.resolve_safe_ip("slow.example.com")
+
+    async def test_handles_dns_resolution_error(self):
+        """DNS resolution error should raise ValueError."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.side_effect = socket.gaierror("Name or service not known")
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="Cannot resolve hostname"):
+                await URLValidator.resolve_safe_ip("nonexistent.invalid")
+
+    async def test_handles_os_error(self):
+        """OS-level errors during DNS resolution should raise ValueError."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.side_effect = OSError("Network is unreachable")
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="Cannot resolve hostname"):
+                await URLValidator.resolve_safe_ip("example.com")
+
+    async def test_handles_no_usable_ips(self):
+        """If all IPs are blocked, raise ValueError on first blocked IP."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 0)),
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="non-public address"):
+                await URLValidator.resolve_safe_ip("all-blocked.local")
+
+    async def test_handles_empty_response(self):
+        """Empty DNS response should raise ValueError."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = []
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            with pytest.raises(ValueError, match="no usable IP"):
+                await URLValidator.resolve_safe_ip("empty.local")
+
+    async def test_honors_timeout_parameter(self):
+        """Should pass custom timeout to getaddrinfo."""
+        with patch("asyncio.wait_for") as mock_wait_for:
+            mock_wait_for.side_effect = asyncio.TimeoutError()
+
+            with pytest.raises(ValueError, match="DNS resolution timeout"):
+                await URLValidator.resolve_safe_ip("example.com", timeout=5.0)
+
+    async def test_skips_invalid_ip_strings(self):
+        """Should skip invalid IP strings and continue."""
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_getaddrinfo = AsyncMock()
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("not-an-ip", 0)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 0)),
+            ]
+            mock_loop.return_value.getaddrinfo = mock_getaddrinfo
+
+            result = await URLValidator.resolve_safe_ip("example.com")
+            assert result == "8.8.8.8"

--- a/autobot-backend/tests/api/test_auth_login_bypass_regression.py
+++ b/autobot-backend/tests/api/test_auth_login_bypass_regression.py
@@ -1,0 +1,394 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Regression tests for GH #6838 — /api/auth/login accepts any credential.
+
+Linked issue: https://github.com/mrveiss/AutoBot-AI/issues/6838
+
+In SINGLE_USER deployment mode the login endpoint skips PostgreSQL auth
+entirely, issuing an admin JWT for any (or no) credential. This is a P0
+security vulnerability because any user with network access can mint an
+admin token.
+
+Fix: gate the any-credential bypass on AUTOBOT_DEV_AUTH_BYPASS=true with a
+loud boot warning; reject wrong credentials in all other cases.
+
+Regression guarantee: tests fail if the any-credential bypass is
+re-introduced without the AUTOBOT_DEV_AUTH_BYPASS env-flag gate.
+"""
+
+import os
+import sys
+import types
+from contextlib import asynccontextmanager
+from typing import Any, Generic, Optional, TypeVar
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+T = TypeVar("T")
+
+# ── Stub api.schemas_agent with minimal pydantic models ──────────────────────
+# api.auth imports LoginRequest/LoginResponse/etc from api.schemas_agent, which
+# has a large import chain. Stub the module with only the types api.auth needs.
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class LoginResponse(BaseModel):
+    success: bool
+    message: str = ""
+    user: dict = {}
+    token: str = ""
+    session_id: str = ""
+
+
+class LogoutRequest(BaseModel):
+    session_id: Optional[str] = None
+
+
+class AuthCheckResponse(BaseModel):
+    authenticated: bool = False
+    user: dict = {}
+
+
+class AuthPermissionResponse(BaseModel):
+    allowed: bool = False
+
+
+class AuthUserInfoResponse(BaseModel):
+    username: str = ""
+    role: str = ""
+
+
+class ChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str
+
+
+class ChangePasswordResponse(BaseModel):
+    success: bool = False
+    message: str = ""
+
+
+class SignupRequest(BaseModel):
+    username: str
+    password: str
+    email: str = ""
+
+
+class SignupResponse(BaseModel):
+    success: bool = False
+    message: str = ""
+
+
+def _ensure_pkg(name: str) -> types.ModuleType:
+    """Ensure a namespace package exists in sys.modules without overriding real packages.
+
+    Sets __path__ to the real package directory (if it exists on the filesystem)
+    so other test files can still import real submodules of the same package.
+    """
+    mod = sys.modules.get(name)
+    if mod is not None:
+        return mod
+    import os as _os
+    mod = types.ModuleType(name)
+    # Point __path__ at the real directory so downstream tests can load real submodules.
+    top_name = name.split(".")[0]
+    for base in sys.path:
+        candidate = _os.path.join(base, top_name)
+        if _os.path.isdir(candidate):
+            mod.__path__ = [candidate]
+            break
+    sys.modules[name] = mod
+    return mod
+
+
+def _register_stub(name: str, attrs: dict) -> types.ModuleType:
+    mod = sys.modules.get(name)
+    if mod is None:
+        mod = types.ModuleType(name)
+        mod.__path__ = []  # mark as leaf stub (no filesystem submodules)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+# Do NOT register 'api' itself — let Python import the real package from
+# autobot-backend/api/ (conftest adds autobot-backend to sys.path). We only
+# stub the two submodules that have deep import chains.
+
+_schemas_agent_stub = types.ModuleType("api.schemas_agent")
+_schemas_agent_stub.__path__ = []
+_schemas_agent_stub.LoginRequest = LoginRequest
+_schemas_agent_stub.LoginResponse = LoginResponse
+_schemas_agent_stub.LogoutRequest = LogoutRequest
+_schemas_agent_stub.AuthCheckResponse = AuthCheckResponse
+_schemas_agent_stub.AuthPermissionResponse = AuthPermissionResponse
+_schemas_agent_stub.AuthUserInfoResponse = AuthUserInfoResponse
+_schemas_agent_stub.ChangePasswordRequest = ChangePasswordRequest
+_schemas_agent_stub.ChangePasswordResponse = ChangePasswordResponse
+_schemas_agent_stub.SignupRequest = SignupRequest
+_schemas_agent_stub.SignupResponse = SignupResponse
+sys.modules["api.schemas_agent"] = _schemas_agent_stub
+
+# Import the real api.schemas_common rather than stubbing it — avoids bleed into
+# other test files that need the full set of exports (SuccessDataResponse, etc.).
+if "api.schemas_common" not in sys.modules:
+    import importlib.util as _ilu
+    _sc_spec = _ilu.spec_from_file_location(
+        "api.schemas_common",
+        str(__file__).replace(
+            "tests/api/test_auth_login_bypass_regression.py",
+            "api/schemas_common.py",
+        ),
+    )
+    if _sc_spec and _sc_spec.loader:
+        _sc_mod = _ilu.module_from_spec(_sc_spec)
+        sys.modules["api.schemas_common"] = _sc_mod
+        try:
+            _sc_spec.loader.exec_module(_sc_mod)
+        except Exception:
+            pass  # fall back to empty stub if load fails
+
+# Passthrough error-handling decorator
+def _passthrough(**_kw):
+    import functools
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        async def wrapper(*args, **kwargs):
+            try:
+                return await fn(*args, **kwargs)
+            except HTTPException:
+                raise
+            except Exception:
+                raise
+
+        return wrapper
+
+    return decorator
+
+
+def _passthrough_sync(**_kw):
+    import functools
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            return fn(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
+if "autobot_shared.error_boundaries" not in sys.modules:
+    _register_stub(
+        "autobot_shared.error_boundaries",
+        {
+            "with_error_handling": _passthrough,
+            "error_boundary": _passthrough_sync,
+            "with_error_boundary": _passthrough_sync,
+            "with_async_error_boundary": _passthrough,
+            "get_error_boundary_manager": MagicMock(),
+            "ErrorCategory": MagicMock(SERVER_ERROR="SERVER_ERROR"),
+        },
+    )
+
+_ensure_pkg("services")
+_register_stub(
+    "services.event_log",
+    {
+        "EventType": MagicMock(USER_LOGIN="USER_LOGIN", USER_LOGOUT="USER_LOGOUT"),
+        "emit": MagicMock(),
+    },
+)
+
+_constants_pkg = _ensure_pkg("constants")
+# Add commonly imported names to the constants stub so transitive imports in
+# other test modules (loaded in the same pytest session) don't fail.
+for _const_name in (
+    "CircuitBreakerDefaults", "SecurityThresholds", "AgentThresholds",
+    "RetryConfig", "TimeoutDefaults", "RateLimitDefaults",
+):
+    if not hasattr(_constants_pkg, _const_name):
+        setattr(_constants_pkg, _const_name, MagicMock())
+_register_stub(
+    "constants.error_constants",
+    {
+        "ERR_INVALID_CREDENTIALS": "Invalid username or password",
+        "ERR_INVALID_TOKEN": "Invalid or expired token",
+    },
+)
+
+_ensure_pkg("utils")
+_register_stub(
+    "utils.catalog_http_exceptions",
+    {
+        "raise_auth_error": MagicMock(
+            side_effect=HTTPException(status_code=401, detail="Auth error")
+        )
+    },
+)
+
+if "auth_middleware" not in sys.modules:
+    _mw = MagicMock()
+    _mw.create_jwt_token.return_value = "fake-token-for-tests"
+    _mw.create_session.return_value = "fake-session-id"
+    _mw.get_user_from_request.return_value = None
+    _register_stub(
+        "auth_middleware",
+        {
+            "get_auth_middleware": MagicMock(return_value=_mw),
+            "check_admin_permission": MagicMock(return_value=True),
+            "get_current_user": MagicMock(return_value={"username": "admin", "role": "admin"}),
+            "raise_auth_error": MagicMock(
+                side_effect=HTTPException(status_code=401, detail="Auth error")
+            ),
+        },
+    )
+
+_register_stub("security_layer", {"SecurityLayer": MagicMock})
+
+_config_pkg = _ensure_pkg("config")
+# Expose `config` and `cfg` attributes so `from config import config` doesn't fail
+# in transitive dependencies of other test modules loaded in the same pytest session.
+if not hasattr(_config_pkg, "config"):
+    _config_pkg.config = MagicMock()
+    _config_pkg.cfg = MagicMock()
+    _config_pkg.get_config_manager = MagicMock(return_value=MagicMock(get=MagicMock(return_value={})))
+_register_stub(
+    "config.manager",
+    {
+        "get_config_manager": MagicMock(
+            return_value=MagicMock(get=MagicMock(return_value={}))
+        )
+    },
+)
+
+# Stub user_management.database without blocking user_management filesystem lookup
+_db_session_mock = AsyncMock()
+
+
+@asynccontextmanager
+async def _stub_db_session():
+    yield _db_session_mock
+
+
+_register_stub(
+    "user_management.database",
+    {"db_session_context": _stub_db_session},
+)
+
+_ensure_pkg("user_management.services")
+_register_stub(
+    "user_management.services.user_service",
+    {"UserService": MagicMock},
+)
+
+# ── import after stubs ────────────────────────────────────────────────────────
+
+from user_management.config import DeploymentMode  # noqa: E402
+from api.auth import login  # noqa: E402
+
+# ── test fixtures ─────────────────────────────────────────────────────────────
+
+_SINGLE_USER_CFG = MagicMock()
+_SINGLE_USER_CFG.mode = DeploymentMode.SINGLE_USER
+
+_MULTI_USER_CFG = MagicMock()
+_MULTI_USER_CFG.mode = DeploymentMode.SINGLE_COMPANY
+
+_WRONG_CREDENTIAL = "definitely-not-the-right-credential"
+_ANY_CREDENTIAL = "anything-in-bypass-mode"
+
+
+def _make_auth_mw():
+    mw = MagicMock()
+    mw.create_jwt_token.return_value = "fake-token-for-tests"
+    mw.create_session.return_value = "fake-session-id"
+    return mw
+
+
+def _make_request():
+    req = MagicMock()
+    req.client.host = "127.0.0.1"
+    return req
+
+
+# ── GH #6838 regression tests ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_single_user_wrong_credential_rejected_without_bypass():
+    """GH #6838: wrong credential must return 401 in SINGLE_USER mode without bypass.
+
+    Pre-fix: any credential authenticated in SINGLE_USER mode (no check at all).
+    Post-fix: only AUTOBOT_DEV_AUTH_BYPASS=true enables the any-credential bypass.
+    """
+    env_no_bypass = {k: v for k, v in os.environ.items() if k != "AUTOBOT_DEV_AUTH_BYPASS"}
+
+    with patch("user_management.config.get_deployment_config", return_value=_SINGLE_USER_CFG):
+        with patch("api.auth.get_auth_middleware", return_value=_make_auth_mw()):
+            with patch("api.auth._emit_event"):
+                with patch.dict(os.environ, env_no_bypass, clear=True):
+                    try:
+                        result = await login(
+                            _make_request(),
+                            LoginRequest(username="admin", password=_WRONG_CREDENTIAL),
+                        )
+                        pytest.fail(
+                            "GH #6838 regression: login accepted wrong credential in "
+                            "SINGLE_USER mode without AUTOBOT_DEV_AUTH_BYPASS=true. "
+                            f"Returned success={result.success}."
+                        )
+                    except HTTPException as exc:
+                        assert exc.status_code == 401, (
+                            f"Expected HTTP 401 for wrong credential, got {exc.status_code}."
+                        )
+
+
+@pytest.mark.asyncio
+async def test_single_user_dev_bypass_allows_any_credential():
+    """GH #6838: AUTOBOT_DEV_AUTH_BYPASS=true must still allow any-credential auth.
+
+    This env-flag is the deliberate opt-in for local development. Verifies
+    the bypass path works correctly after the fix is applied.
+    """
+    with patch("user_management.config.get_deployment_config", return_value=_SINGLE_USER_CFG):
+        with patch("api.auth.get_auth_middleware", return_value=_make_auth_mw()):
+            with patch("api.auth._emit_event"):
+                with patch.dict(os.environ, {"AUTOBOT_DEV_AUTH_BYPASS": "true"}):
+                    result = await login(
+                        _make_request(),
+                        LoginRequest(username="admin", password=_ANY_CREDENTIAL),
+                    )
+
+    assert result.success is True, (
+        "Dev bypass (AUTOBOT_DEV_AUTH_BYPASS=true) must allow any-credential auth."
+    )
+    assert result.token, "A valid token must be returned when dev bypass is active."
+
+
+@pytest.mark.asyncio
+async def test_wrong_credential_rejected_in_multi_user_mode():
+    """GH #6838: wrong credential must return 401 in multi-user mode (baseline check)."""
+    with patch("user_management.config.get_deployment_config", return_value=_MULTI_USER_CFG):
+        with patch(
+            "api.auth._authenticate_and_build_user_data",
+            new_callable=AsyncMock,
+            side_effect=HTTPException(status_code=401, detail="Invalid credentials"),
+        ):
+            with patch("api.auth._emit_event"):
+                with pytest.raises(HTTPException) as exc_info:
+                    await login(
+                        _make_request(),
+                        LoginRequest(username="admin", password=_WRONG_CREDENTIAL),
+                    )
+
+    assert exc_info.value.status_code == 401

--- a/autobot-backend/tests/api/test_onboarding_auth_regression.py
+++ b/autobot-backend/tests/api/test_onboarding_auth_regression.py
@@ -1,0 +1,181 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Regression tests for GH #6568 — /api/onboarding auth enforcement.
+
+Linked issue: https://github.com/mrveiss/AutoBot-AI/issues/6568
+
+Fix applied: commit 9db25020a auth-gates the three privileged endpoints:
+  - GET  /api/onboarding/presets  → Depends(get_current_user)
+  - GET  /api/onboarding/doctor   → Depends(get_current_user)
+  - POST /api/onboarding/apply    → Depends(check_admin_permission)
+  - GET  /api/onboarding/status   → intentionally open (no auth dep)
+
+Regression guarantee: if Depends(...) is removed from any protected route,
+the corresponding test will fail because the endpoint will return 2xx/5xx
+instead of the expected 401.
+"""
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.testclient import TestClient
+
+# ── stub auth_middleware with proper FastAPI-compatible functions ─────────────
+# FastAPI inspects dependency signatures via inspect.signature(). MagicMock
+# has a non-inspectable signature that causes FastAPI to raise 422. Use real
+# functions instead.
+
+
+def _stub_check_admin_permission(request: Request) -> bool:
+    """Default stub: approves all requests (overridden per-test via dependency_overrides)."""
+    return True
+
+
+def _stub_get_current_user(request: Request) -> dict:
+    """Default stub: returns synthetic admin user (overridden per-test)."""
+    return {"username": "test-admin", "role": "admin"}
+
+
+if "auth_middleware" not in sys.modules:
+    _auth_stub = types.ModuleType("auth_middleware")
+    _auth_stub.check_admin_permission = _stub_check_admin_permission
+    _auth_stub.get_current_user = _stub_get_current_user
+    _auth_stub.get_auth_middleware = MagicMock()
+    _auth_stub.raise_auth_error = MagicMock(side_effect=HTTPException(status_code=401))
+    sys.modules["auth_middleware"] = _auth_stub
+
+# Stub onboarding.doctor to avoid psutil import at test-collection time.
+if "onboarding.doctor" not in sys.modules:
+    _doctor_stub = types.ModuleType("onboarding.doctor")
+    _doctor_stub.run_doctor = AsyncMock(return_value={"status": "ok"})
+    sys.modules["onboarding.doctor"] = _doctor_stub
+
+# ── import the real onboarding router (fix applied — has auth deps) ───────────
+from api.onboarding import router as _onboarding_router  # noqa: E402
+
+# ── test helpers ──────────────────────────────────────────────────────────────
+
+
+def _raise_401() -> None:
+    """Simulates an unauthenticated request — returns 401 like the real deps would."""
+    raise HTTPException(status_code=401, detail="Authentication required")
+
+
+def _allow_user() -> dict:
+    return {"username": "test-admin", "role": "admin"}
+
+
+def _allow_admin() -> bool:
+    return True
+
+
+def _make_unauthenticated_client() -> TestClient:
+    """TestClient that overrides BOTH auth deps to reject all requests."""
+    app = FastAPI()
+    app.include_router(_onboarding_router, prefix="/api/onboarding")
+    from auth_middleware import check_admin_permission, get_current_user
+
+    app.dependency_overrides[get_current_user] = _raise_401
+    app.dependency_overrides[check_admin_permission] = _raise_401
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _make_authenticated_client() -> TestClient:
+    """TestClient that overrides both auth deps to allow all requests."""
+    app = FastAPI()
+    app.include_router(_onboarding_router, prefix="/api/onboarding")
+    from auth_middleware import check_admin_permission, get_current_user
+
+    app.dependency_overrides[get_current_user] = _allow_user
+    app.dependency_overrides[check_admin_permission] = _allow_admin
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ── GH #6568 regression: protected routes must enforce auth ──────────────────
+
+
+class TestOnboardingAuthEnforcement:
+    """Privileged endpoints must reject unauthenticated requests.
+
+    Each test overrides the relevant auth dependency to raise 401 and verifies
+    that the endpoint returns 401. If the auth dependency is removed, the
+    override has no effect, the endpoint runs its business logic, and the
+    expected 401 is never returned — causing the assertion to fail.
+    """
+
+    def test_presets_returns_401_without_auth(self):
+        """GET /presets must require auth via get_current_user — GH #6568."""
+        client = _make_unauthenticated_client()
+        resp = client.get("/api/onboarding/presets")
+        assert resp.status_code == 401, (
+            f"GET /api/onboarding/presets returned HTTP {resp.status_code}; expected 401. "
+            "Regression (GH #6568): add Depends(get_current_user) to this route."
+        )
+
+    def test_doctor_returns_401_without_auth(self):
+        """GET /doctor must require auth via get_current_user — GH #6568."""
+        client = _make_unauthenticated_client()
+        resp = client.get("/api/onboarding/doctor")
+        assert resp.status_code == 401, (
+            f"GET /api/onboarding/doctor returned HTTP {resp.status_code}; expected 401. "
+            "Regression (GH #6568): add Depends(get_current_user) to this route."
+        )
+
+    def test_apply_returns_401_without_auth(self):
+        """POST /apply must require auth via check_admin_permission — GH #6568."""
+        client = _make_unauthenticated_client()
+        resp = client.post(
+            "/api/onboarding/apply",
+            json={"preset_name": "chat-simple", "overrides": {}},
+        )
+        assert resp.status_code == 401, (
+            f"POST /api/onboarding/apply returned HTTP {resp.status_code}; expected 401. "
+            "Regression (GH #6568): add Depends(check_admin_permission) to this route."
+        )
+
+
+class TestOnboardingStatusIsOpen:
+    """/status must remain intentionally open — called pre-login by the router guard."""
+
+    def test_status_returns_200_without_auth(self):
+        """/status must succeed even when other auth deps reject — GH #6568.
+
+        The unauthenticated client overrides both auth deps to raise 401.
+        /status carries no auth dependency, so neither override fires, and the
+        endpoint returns its fail-open 200. If /status is accidentally auth-gated
+        this test will see 401 and fail.
+        """
+        client = _make_unauthenticated_client()
+        resp = client.get("/api/onboarding/status")
+        assert resp.status_code == 200, (
+            f"GET /api/onboarding/status returned HTTP {resp.status_code}; expected 200. "
+            "Do NOT add auth to /status — it is intentionally open (GH #6568)."
+        )
+
+
+class TestOnboardingAuthenticatedSuccess:
+    """Auth-gated endpoints must reach business logic when credentials are provided."""
+
+    def test_presets_succeeds_when_authenticated(self):
+        from unittest.mock import patch
+
+        with patch("onboarding.presets.get_all_presets", return_value=[]):
+            client = _make_authenticated_client()
+            resp = client.get("/api/onboarding/presets")
+        assert resp.status_code == 200
+
+    def test_apply_404_for_unknown_preset_when_authenticated(self):
+        """Auth passes → business logic executes → 404 for a missing preset."""
+        from unittest.mock import patch
+
+        with patch("onboarding.presets.get_preset", return_value=None):
+            client = _make_authenticated_client()
+            resp = client.post(
+                "/api/onboarding/apply",
+                json={"preset_name": "no-such-preset", "overrides": {}},
+            )
+        assert resp.status_code == 404

--- a/autobot-backend/tests/intelligence/__init__.py
+++ b/autobot-backend/tests/intelligence/__init__.py
@@ -1,0 +1,3 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss

--- a/autobot-backend/tests/intelligence/test_llm_chat_method_regression.py
+++ b/autobot-backend/tests/intelligence/test_llm_chat_method_regression.py
@@ -1,0 +1,225 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Regression tests for GH #6876 — generate_response() called on LLMInterface.
+
+Linked issue: https://github.com/mrveiss/AutoBot-AI/issues/6876
+
+IntelligentAgent._get_llm_analysis() and StreamingCommandExecutor
+._provide_progress_commentary() / ._provide_completion_commentary() used to
+call self.llm_interface.generate_response(), which does not exist on
+LLMInterface (or its facade). This caused AttributeError in production.
+
+Fix (Phase 2D of #3185): replaced with self.llm_interface.chat([...]).
+
+Regression guarantee: these tests use a strict mock that ONLY exposes chat()
+(no generate_response). If the code is reverted to call generate_response(),
+the mock raises AttributeError and the test fails.
+"""
+
+import importlib.util
+from pathlib import Path
+from typing import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Backend root is three levels up from this test file:
+# tests/intelligence/test_*.py → tests/intelligence/ → tests/ → autobot-backend/
+_BACKEND_ROOT = Path(__file__).parent.parent.parent
+
+
+# ── strict LLM mock without generate_response() ──────────────────────────────
+
+
+class _ChatOnlyLLM:
+    """LLM interface stub that exposes chat() but NOT generate_response().
+
+    Accessing generate_response() on this class raises AttributeError,
+    which is exactly what happened in production with the real LLMInterface.
+    Any code path that still calls generate_response() will trigger that
+    AttributeError and fail the test.
+    """
+
+    def __init__(self, content: str = "Test AI response"):
+        self._content = content
+        self.chat_calls: list = []
+
+    async def chat(self, messages, temperature=0.5, max_tokens=100, **kwargs):
+        self.chat_calls.append(
+            {"messages": messages, "temperature": temperature, "max_tokens": max_tokens}
+        )
+        resp = MagicMock()
+        resp.content = self._content
+        return resp
+
+    def __getattr__(self, name):
+        # Everything other than chat raises AttributeError — mirrors LLMInterface.
+        raise AttributeError(
+            f"'_ChatOnlyLLM' object has no attribute '{name}'. "
+            f"GH #6876 regression: code must call chat(), not {name}()."
+        )
+
+
+# ── module loader helpers ─────────────────────────────────────────────────────
+
+
+def _load_module(relative_path: str, module_alias: str):
+    """Load a backend module by relative path, returning (spec, module).
+
+    Returns (None, None) if the module's dep chain is unavailable — callers
+    should call pytest.skip() in that case.
+    """
+    spec = importlib.util.spec_from_file_location(module_alias, relative_path)
+    if spec is None or spec.loader is None:
+        return None, None
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:
+        return None, exc
+    return spec, mod
+
+
+def _bypass_init(cls, **attrs):
+    """Instantiate cls without calling __init__, then set attrs directly."""
+    obj = object.__new__(cls)
+    for k, v in attrs.items():
+        setattr(obj, k, v)
+    return obj
+
+
+# ── GH #6876 regression: IntelligentAgent._get_llm_analysis ─────────────────
+
+
+class TestIntelligentAgentGetLLMAnalysis:
+    """_get_llm_analysis() must use chat(), not generate_response()."""
+
+    @pytest.mark.asyncio
+    async def test_uses_chat_not_generate_response(self):
+        spec, mod = _load_module(
+            str(_BACKEND_ROOT / "intelligence" / "intelligent_agent.py"),
+            "intelligent_agent_under_test",
+        )
+        if mod is None or not isinstance(mod, type(importlib.util)):
+            pytest.skip(f"intelligent_agent dep chain unavailable: {mod}")
+
+        llm = _ChatOnlyLLM(content="Analysis result from chat()")
+        agent = _bypass_init(mod.IntelligentAgent, llm_interface=llm, state=MagicMock())
+
+        result = await agent._get_llm_analysis("list running processes")
+
+        assert llm.chat_calls, "_get_llm_analysis() must call llm_interface.chat()"
+        assert result == "Analysis result from chat()", (
+            f"Expected content from chat(), got: {result!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_chat_receives_messages_list(self):
+        spec, mod = _load_module(
+            str(_BACKEND_ROOT / "intelligence" / "intelligent_agent.py"),
+            "intelligent_agent_under_test_2",
+        )
+        if mod is None or not isinstance(mod, type(importlib.util)):
+            pytest.skip(f"intelligent_agent dep chain unavailable: {mod}")
+
+        llm = _ChatOnlyLLM()
+        agent = _bypass_init(mod.IntelligentAgent, llm_interface=llm, state=MagicMock())
+
+        await agent._get_llm_analysis("test goal")
+
+        assert len(llm.chat_calls) == 1
+        call = llm.chat_calls[0]
+        assert isinstance(call["messages"], list), "chat() must receive a messages list"
+        assert any(m.get("role") for m in call["messages"]), (
+            "Each message in the list must have a 'role' key"
+        )
+
+
+# ── GH #6876 regression: StreamingCommandExecutor commentary methods ──────────
+
+
+class TestStreamingExecutorCommentaryMethods:
+    """Commentary methods must use chat(), not generate_response()."""
+
+    @pytest.fixture(autouse=True)
+    def _load_executor_module(self):
+        spec, mod = _load_module(
+            str(_BACKEND_ROOT / "intelligence" / "streaming_executor.py"),
+            "streaming_executor_under_test",
+        )
+        if mod is None or not isinstance(mod, type(importlib.util)):
+            pytest.skip(f"streaming_executor dep chain unavailable: {mod}")
+        self._mod = mod
+
+    def _make_executor(self, content="Commentary text"):
+        llm = _ChatOnlyLLM(content=content)
+        validator = MagicMock()
+        validator.is_command_safe.return_value = True
+        executor = _bypass_init(
+            self._mod.StreamingCommandExecutor,
+            llm_interface=llm,
+            command_validator=validator,
+            active_processes={},
+            _max_processes=10,
+        )
+        return executor, llm
+
+    @pytest.mark.asyncio
+    async def test_progress_commentary_uses_chat(self):
+        """_provide_progress_commentary must call chat(), not generate_response()."""
+        executor, llm = self._make_executor("Progress update via chat()")
+
+        chunks = []
+        async for chunk in executor._provide_progress_commentary(
+            recent_output="Installing package...", user_goal="install numpy"
+        ):
+            chunks.append(chunk)
+
+        assert llm.chat_calls, (
+            "_provide_progress_commentary() must call llm_interface.chat() "
+            "(GH #6876 regression: was calling nonexistent generate_response())"
+        )
+
+    @pytest.mark.asyncio
+    async def test_completion_commentary_uses_chat(self):
+        """_provide_completion_commentary must call chat(), not generate_response()."""
+        executor, llm = self._make_executor("Completion summary via chat()")
+
+        chunks = []
+        async for chunk in executor._provide_completion_commentary(
+            command="pip install numpy", user_goal="install numpy", execution_time=1.5
+        ):
+            chunks.append(chunk)
+
+        assert llm.chat_calls, (
+            "_provide_completion_commentary() must call llm_interface.chat() "
+            "(GH #6876 regression: was calling nonexistent generate_response())"
+        )
+
+    @pytest.mark.asyncio
+    async def test_progress_commentary_skips_empty_output(self):
+        """Empty output must produce no chunks — guards against spurious LLM calls."""
+        executor, llm = self._make_executor()
+
+        chunks = []
+        async for chunk in executor._provide_progress_commentary(
+            recent_output="   ", user_goal="install numpy"
+        ):
+            chunks.append(chunk)
+
+        assert not chunks, "Empty output must not produce any commentary chunks."
+        assert not llm.chat_calls, "Empty output must not trigger an LLM call."
+
+    @pytest.mark.asyncio
+    async def test_commentary_returns_skip_gracefully(self):
+        """When LLM returns 'SKIP', no chunk should be yielded."""
+        executor, llm = self._make_executor(content="SKIP")
+
+        chunks = []
+        async for chunk in executor._provide_progress_commentary(
+            recent_output="boring log line", user_goal="run tests"
+        ):
+            chunks.append(chunk)
+
+        assert not chunks, "LLM SKIP response must produce no commentary chunks."

--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
@@ -205,14 +205,14 @@ const fetchEntityName = async (id: string, type: 'user' | 'group'): Promise<stri
       response = await apiService.getGroupById(id)
     }
 
-    // Extract name from response
+    // Extract name from response — apiService returns parsed JSON directly (no .data envelope)
     let displayName = id
-    if (response && response.data) {
+    if (response) {
       if (type === 'user') {
-        const userData = response.data as { display_name?: string; email?: string; username?: string }
+        const userData = response as unknown as { display_name?: string; email?: string; username?: string }
         displayName = userData.display_name || userData.email || userData.username || id
       } else {
-        const groupData = response.data as { name?: string }
+        const groupData = response as unknown as { name?: string }
         displayName = groupData.name || id
       }
     }

--- a/autobot-frontend/src/composables/useErrorHandler.ts
+++ b/autobot-frontend/src/composables/useErrorHandler.ts
@@ -21,8 +21,8 @@
  *
  * // Basic async operation wrapper
  * const { execute, loading, error } = useAsyncHandler(async () => {
- *   const response = await apiClient.get<any>('/data')
- *   return response.data
+ *   // apiClient.get() returns parsed JSON directly — no .data envelope
+ *   return await apiClient.get<any>('/data')
  * })
  *
  * // Execute operation

--- a/autobot-slm-backend/ansible/roles/redis/templates/redis-stack.conf.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/redis-stack.conf.j2
@@ -3,8 +3,36 @@
 
 # Network
 bind 0.0.0.0
+{% if redis_tls_enabled | default(false) | bool and redis_tls_disable_plain_port | default(false) | bool %}
+port 0
+{% else %}
 port {{ redis_port }}
+{% endif %}
 protected-mode no
+
+# TLS Configuration (Issue #725: mTLS support)
+# #6701: TLS lines are gated on a per-file stat (registered by tasks/main.yml)
+# in addition to redis_tls_enabled. Without the stat guard, deployments where
+# distribute-tls-certs.yml hasn't run (or the cert was rotated out) crash
+# redis-server at boot with "Cannot read CA certificate". Mirror of the
+# #6677 backend.env.j2 pattern.
+{# #7272: stat names migrated from redis_tls_* to canonical tls_* #}
+{# (registered by _shared/tasks/stat_tls_certs.yml) #}
+{% if redis_tls_enabled | default(false) | bool
+      and (tls_server_cert.stat.exists | default(false))
+      and (tls_server_key.stat.exists | default(false))
+      and (tls_ca_cert.stat.exists | default(false)) %}
+tls-port {{ redis_tls_port }}
+tls-cert-file {{ redis_tls_cert_dir }}/server-cert.pem
+tls-key-file {{ redis_tls_cert_dir }}/server-key.pem
+tls-ca-cert-file {{ redis_tls_cert_dir }}/ca-cert.pem
+tls-auth-clients {{ redis_tls_auth_clients | default('optional') }}
+{% else %}
+# TLS intentionally unset (#6701): one or more of server-cert.pem,
+# server-key.pem, ca-cert.pem is missing at deploy time. Run
+# distribute-tls-certs.yml to provision and re-deploy this role to
+# pick them up. Plain-port redis remains available for non-TLS clients.
+{% endif %}
 tcp-backlog 511
 timeout {{ redis_timeout }}
 tcp-keepalive {{ redis_tcp_keepalive }}


### PR DESCRIPTION
## Summary

- Reserves `auto`, `auto-fast`, `auto-quality` model names in `openai_compat.py` via `_AUTO_MODEL_NAMES` frozenset
- `model == "auto"`: routes through `TieredModelRouter` complexity scoring to select simple or complex tier
- `model == "auto-fast"`: forces simple tier without scoring
- `model == "auto-quality"`: forces complex tier without scoring
- Response `model` field always reflects the concrete resolved model name (never `"auto"`)
- `GET /v1/models` now lists all three auto aliases
- All other model names pass through existing provider resolution unchanged (no regression)

## Test plan

- [ ] `curl -d '{"model":"auto",...}' /v1/chat/completions` returns 200 with real model name in `.model`
- [ ] `curl -d '{"model":"auto-fast",...}'` returns simple-tier model
- [ ] `curl -d '{"model":"auto-quality",...}'` returns complex-tier model
- [ ] `GET /v1/models` includes `auto`, `auto-fast`, `auto-quality` entries
- [ ] Unknown model names still resolve via existing provider fallback (no new 422s)

Closes mrveiss/AutoBot-AI#6592

🤖 Generated with [Claude Code](https://claude.com/claude-code)