### PR TITLE
fix(ansible/redis): wire TLS variables into redis-stack.conf.j2 (#6955)

### DIFF
--- a/autobot-slm-backend/ansible/roles/redis/templates/redis-stack.conf.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/redis-stack.conf.j2
@@ -3,11 +3,39 @@
 
 # Network
 bind 0.0.0.0
+{% if redis_tls_enabled | default(false) | bool and redis_tls_disable_plain_port | default(false) | bool %}
+port 0
+{% else %}
 port {{ redis_port }}
+{% endif %}
 protected-mode no
 tcp-backlog 511
 timeout {{ redis_timeout }}
 tcp-keepalive {{ redis_tcp_keepalive }}
+
+# TLS Configuration (Issue #725: mTLS support, #6955: wire TLS vars into template)
+# Mirrors the #6677 (roles/backend) / #6701 (roles/redis/redis.conf.j2) stat-and-
+# conditional pattern. TLS directives only emit when redis_tls_enabled is true
+# AND all three certs exist on the target host (registered by
+# _shared/tasks/stat_tls_certs.yml in roles/redis/tasks/main.yml). Without the
+# stat guard, deployments where distribute-tls-certs.yml hasn't run crash
+# redis-stack-server at boot with "Cannot read CA certificate". When TLS is
+# disabled (default), this block emits nothing -- no regression vs. pre-#6955.
+{% if redis_tls_enabled | default(false) | bool
+      and (tls_server_cert.stat.exists | default(false))
+      and (tls_server_key.stat.exists | default(false))
+      and (tls_ca_cert.stat.exists | default(false)) %}
+tls-port {{ redis_tls_port }}
+tls-cert-file {{ redis_tls_cert_dir }}/server-cert.pem
+tls-key-file {{ redis_tls_cert_dir }}/server-key.pem
+tls-ca-cert-file {{ redis_tls_cert_dir }}/ca-cert.pem
+tls-auth-clients {{ redis_tls_auth_clients | default('optional') }}
+{% elif redis_tls_enabled | default(false) | bool %}
+# TLS intentionally unset (#6955): one or more of server-cert.pem,
+# server-key.pem, ca-cert.pem is missing at deploy time. Run
+# distribute-tls-certs.yml to provision and re-deploy this role to
+# pick them up. Plain-port redis-stack remains available for non-TLS clients.
+{% endif %}
 
 # General
 daemonize no


### PR DESCRIPTION
## Summary

- `redis-stack.conf.j2` (the actually-deployed template) had **zero TLS lines** — `AUTOBOT_REDIS_TLS_ENABLED=true` was silently ignored, leaving SLM Redis plaintext on the network
- Wires in all five TLS variables (`redis_tls_enabled`, `redis_tls_port`, `redis_tls_cert_dir`, `redis_tls_auth_clients`, `redis_tls_disable_plain_port`) following the existing `#6677` / `#6701` stat-and-conditional pattern
- The stat task (`_shared/tasks/stat_tls_certs.yml`) was **already called** in `tasks/main.yml`; this PR just consumes its registered facts in the template

## Acceptance Criteria

- [x] `redis-stack.conf.j2` honors `redis_tls_enabled`, `redis_tls_port`, `redis_tls_cert_dir`, `redis_tls_auth_clients`, `redis_tls_disable_plain_port`
- [x] `tls-ca-cert-file` gated behind stat-task check (`tls_ca_cert.stat.exists | default(false)`)
- [x] Same for `tls-cert-file` and `tls-key-file`
- [x] When TLS disabled (default), rendered config is unchanged — **zero regression** (verified by offline render)
- [x] When TLS enabled + certs missing → explanatory comment emitted, plain port stays available (safe fallback, not a crash)

## Verification

Offline Jinja2 render across 5 scenarios (all passing):

```
AC4 PASS: TLS disabled → no TLS directives, plain port intact.
AC1+AC2+AC3 PASS: all five TLS directives emitted; plain port preserved.
AC2 PASS: missing cert → no TLS directives + explanatory comment; plain port intact.
AC1 PASS: redis_tls_disable_plain_port=True → 'port 0' + tls-port present.
STRING-BOOL PASS: string 'true'/'false' env vars coerce correctly through | bool.

==== ALL ACCEPTANCE CRITERIA PASS ====
```

## Files Changed

- `autobot-slm-backend/ansible/roles/redis/templates/redis-stack.conf.j2` — +28 lines

## Related

- Closes #6955
- Related: #725 (original mTLS), #6677 (stat pattern source), #6701 (redis.conf.j2 precedent), #7272 (shared stat helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)