### PR TITLE
fix(frontend): fix response.data envelope bug in ShareKnowledgeDialog (#7502)

### DIFF
--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
@@ -205,14 +205,14 @@ const fetchEntityName = async (id: string, type: 'user' | 'group'): Promise<stri
       response = await apiService.getGroupById(id)
     }
 
-    // Extract name from response
+    // Extract name from response — apiService returns parsed JSON directly (no .data envelope)
     let displayName = id
-    if (response && response.data) {
+    if (response) {
       if (type === 'user') {
-        const userData = response.data as { display_name?: string; email?: string; username?: string }
+        const userData = response as unknown as { display_name?: string; email?: string; username?: string }
         displayName = userData.display_name || userData.email || userData.username || id
       } else {
-        const groupData = response.data as { name?: string }
+        const groupData = response as unknown as { name?: string }
         displayName = groupData.name || id
       }
     }

--- a/autobot-frontend/src/composables/useErrorHandler.ts
+++ b/autobot-frontend/src/composables/useErrorHandler.ts
@@ -21,8 +21,8 @@
  *
  * // Basic async operation wrapper
  * const { execute, loading, error } = useAsyncHandler(async () => {
- *   const response = await apiClient.get<any>('/data')
- *   return response.data
+ *   // apiClient.get() returns parsed JSON directly — no .data envelope
+ *   return await apiClient.get<any>('/data')
  * })
  *
  * // Execute operation


### PR DESCRIPTION
## Summary

- Audited all 145 `response.data` call-sites in `autobot-frontend/src/` across 7 `.ts` and 7 `.vue` files
- **1 confirmed bug**: `ShareKnowledgeDialog.vue` was accessing `.response.data` on flat `UserResponse`/`TeamResponse` objects (confirmed via OpenAPI schema), causing the share dialog to silently show user IDs instead of display names
- Fixed by removing the `.data` envelope access — `apiService.getUserById()` / `getGroupById()` use `apiClient.get()` which returns parsed JSON directly with no wrapper
- Also corrected misleading JSDoc example in `useErrorHandler.ts` that showed `response.data` from `apiClient.get()`

## Audit Classification

All other `response.data` usages are **correct** — they use clients with explicit wrappers:
- `ChatRepository.ts` — uses axios (`AxiosResponse.data`) ✓
- `KnowledgeRepository.ts` / `SystemRepository.ts` — extend `ApiRepository` returning `ApiResponse<T>` with `.data` ✓
- `useWorkflowBuilder.ts` — `WorkflowBuilderApiClient` wraps in `{success, data}` ✓
- `SettingsPanel.vue` — uses axios directly ✓
- `ScreenCaptureViewer.vue`, `VideoProcessor.vue`, `VisionAnalysisModal.vue` — use `VisionMultimodalApiClient` returning `{success, data}` ✓
- `FeatureFlagsSettingsPanel.vue` — `FeatureFlagsApiClient` returns raw backend JSON; guards `response.success` confirm backend uses DataResponse shape ✓
- `TerminalModals.vue:330` — error handler with optional chaining `error?.response?.data?.detail` (safe) ✓

## Test Plan
- [ ] Open knowledge base share dialog → entity names should display correctly (not raw IDs)
- [ ] Verify no TypeScript regressions: `npx vue-tsc --noEmit -p tsconfig.app.json` (93 pre-existing errors unchanged)

Closes #7502

🤖 Generated with [Claude Code](https://claude.ai/claude-code)