### PR TITLE
fix(media/image): patch _vision_processor_checked, not nonexistent _VISION_PROCESSOR_AVAILABLE (#6844)

### DIFF
--- a/autobot-backend/media/image/pipeline.py
+++ b/autobot-backend/media/image/pipeline.py
@@ -154,7 +154,7 @@ class ImagePipeline(BasePipeline):
             input_id=media_input.media_id,
             modality_type=ModalityType.IMAGE,
             data=pil_image,
-            intent=ProcessingIntent.ANALYSIS,
+            intent=ProcessingIntent.VISUAL_QA,
         )
         try:
             vp_result = await vp.process(mm_input)

--- a/autobot-backend/media/image/pipeline_test.py
+++ b/autobot-backend/media/image/pipeline_test.py
@@ -139,7 +139,7 @@ class TestImagePipelinePilOnly:
         media_input = _make_input(img_bytes)
 
         with (
-            patch("media.image.pipeline._VISION_PROCESSOR_AVAILABLE", False),
+            patch("media.image.pipeline._vision_processor_checked", True),
             patch("media.image.pipeline._vision_processor", None),
         ):
             result = await pipe._process_image(media_input)
@@ -180,9 +180,9 @@ class TestImagePipelineVisionProcessor:
 
         with (
             patch("media.image.pipeline._PIL_AVAILABLE", True),
-            patch("media.image.pipeline._VISION_PROCESSOR_AVAILABLE", True),
+            patch("media.image.pipeline._vision_processor_checked", True),
             patch("media.image.pipeline._vision_processor", mock_vp),
-            patch("media.image.pipeline.MultiModalInput", return_value=mock_mm_input),
+            patch("multimodal_processor.models.MultiModalInput", return_value=mock_mm_input),
         ):
             result = await pipe._process_image(media_input)
 
@@ -207,9 +207,9 @@ class TestImagePipelineVisionProcessor:
 
         with (
             patch("media.image.pipeline._PIL_AVAILABLE", True),
-            patch("media.image.pipeline._VISION_PROCESSOR_AVAILABLE", True),
+            patch("media.image.pipeline._vision_processor_checked", True),
             patch("media.image.pipeline._vision_processor", mock_vp),
-            patch("media.image.pipeline.MultiModalInput", return_value=MagicMock()),
+            patch("multimodal_processor.models.MultiModalInput", return_value=MagicMock()),
         ):
             result = await pipe._process_image(media_input)
 
@@ -232,7 +232,7 @@ class TestImagePipelineAsync:
         media_input = _make_input(img_bytes)
 
         with (
-            patch("media.image.pipeline._VISION_PROCESSOR_AVAILABLE", False),
+            patch("media.image.pipeline._vision_processor_checked", True),
             patch("media.image.pipeline._vision_processor", None),
         ):
             result = await pipe._process_impl(media_input)


### PR DESCRIPTION
## Summary

- `pipeline_test.py` patched `_VISION_PROCESSOR_AVAILABLE` which no longer exists in `pipeline.py` — the lazy-loader (`_get_vision_processor`) replaced it. Patches silently had no effect.
- Fix: replace with `_vision_processor_checked=True` to short-circuit the lazy loader and make `_get_vision_processor()` return the patched `_vision_processor` value.
- Fix: `MultiModalInput` patch target was `media.image.pipeline.MultiModalInput` (not in module namespace — locally imported) → moved to `multimodal_processor.models.MultiModalInput` (the actual source).
- Fix: pre-existing production bug exposed by now-meaningful tests: `ProcessingIntent.ANALYSIS` does not exist in `multimodal_processor.types.ProcessingIntent`; replaced with `ProcessingIntent.VISUAL_QA`.

## Test Plan
- [x] All 12 `media/image/pipeline_test.py` tests pass (was: 10 pass, 2 fail with `AttributeError: ANALYSIS` after patch correction)
- [x] Verified `_vision_processor_checked=True` correctly short-circuits `_get_vision_processor()` in both VP-available and VP-unavailable paths
- [x] Black formatting clean

Closes #6844

🤖 Generated with Claude Code