### PR TITLE
fix(ansible): add cache_valid_time to apt update_cache tasks (#6719)

### DIFF
--- a/autobot-slm-backend/ansible/apply-system-updates.yml
+++ b/autobot-slm-backend/ansible/apply-system-updates.yml
@@ -116,6 +116,7 @@
       ansible.builtin.apt:
         upgrade: safe
         update_cache: true
+        cache_valid_time: 3600
         force_apt_get: true
         dpkg_options: 'force-confold,force-confdef'
       register: security_update_result
@@ -128,6 +129,7 @@
       ansible.builtin.apt:
         upgrade: dist
         update_cache: true
+        cache_valid_time: 3600
         force_apt_get: true
         dpkg_options: 'force-confold,force-confdef'
         autoremove: true
@@ -143,6 +145,7 @@
         name: "{{ specific_packages.split(',') if specific_packages is string else specific_packages }}"
         state: latest
         update_cache: true
+        cache_valid_time: 3600
         force_apt_get: true
       register: specific_update_result
       when:

--- a/autobot-slm-backend/ansible/playbooks/deploy-base.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-base.yml
@@ -94,6 +94,7 @@
 
         state: present
         update_cache: true
+        cache_valid_time: 3600
       retries: 3
       delay: 10
 

--- a/autobot-slm-backend/ansible/playbooks/deploy-database.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-database.yml
@@ -54,6 +54,7 @@
           - "python3-redis"
         state: present
         update_cache: true
+        cache_valid_time: 3600
       retries: 3
       delay: 10
 

--- a/autobot-slm-backend/ansible/playbooks/deploy-hybrid-docker.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-hybrid-docker.yml
@@ -27,6 +27,7 @@
               - software-properties-common
             state: present
             update_cache: yes
+            cache_valid_time: 3600
 
         - name: Add Docker GPG key
           apt_key:

--- a/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
@@ -24,6 +24,7 @@
           - supervisor
         state: present
         update_cache: yes
+        cache_valid_time: 3600
 
     - name: Create autobot service user
       user:

--- a/autobot-slm-backend/ansible/playbooks/deploy-nginx-proxy.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-nginx-proxy.yml
@@ -36,6 +36,7 @@
         name: nginx
         state: present
         update_cache: true
+        cache_valid_time: 3600
 
     # -------------------------------------------------------
     # 2. Deploy vhost config (but don't start nginx yet)

--- a/autobot-slm-backend/ansible/playbooks/enroll-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-node.yml
@@ -237,6 +237,7 @@
                 name: nodejs
                 state: present
                 update_cache: yes
+                cache_valid_time: 3600
 
         # Redis-specific setup
         - name: "Setup Redis Stack"

--- a/autobot-slm-backend/ansible/playbooks/setup-vm-names-and-lvm.yml
+++ b/autobot-slm-backend/ansible/playbooks/setup-vm-names-and-lvm.yml
@@ -136,6 +136,7 @@
     - name: Update system packages (since we're setting up VMs)
       apt:
         update_cache: yes
+        cache_valid_time: 3600
         upgrade: dist
         autoremove: yes
         autoclean: yes
@@ -170,6 +171,7 @@
           - ntp
         state: present
         update_cache: yes
+        cache_valid_time: 3600
 
     - name: Configure NTP for time synchronization
       service:

--- a/autobot-slm-backend/ansible/site.yml
+++ b/autobot-slm-backend/ansible/site.yml
@@ -9,6 +9,7 @@
     - name: Update system packages
       apt:
         update_cache: yes
+        cache_valid_time: 3600
         upgrade: dist
       tags: ['system', 'update']
 


### PR DESCRIPTION
## Summary

Adds `cache_valid_time: 3600` to 12 Ansible tasks using `update_cache: true`, making deploys resilient to transient PPA failures. When apt cache is fresh (updated within the last hour), Ansible skips the update, reducing deploy failures from flaky third-party repositories.

## Changes

Modified 9 Ansible files across 12 `apt` module tasks:

- **site.yml**: Update system packages pre-task
- **deploy-base.yml**: Install essential packages
- **deploy-database.yml**: Install Redis Stack
- **deploy-hybrid-docker.yml**: Install Docker dependencies
- **deploy-native-services.yml**: Install common packages
- **deploy-nginx-proxy.yml**: Install nginx
- **enroll-node.yml**: Install Node.js
- **setup-vm-names-and-lvm.yml**: System package updates + essential packages
- **apply-system-updates.yml**: Apply security/all/specific updates (3 tasks)

## Design Notes

- Intentionally left unchanged:
  - Tasks after `apt_repository` operations without `update_cache: true` (need forced refresh for new repos)
  - System-update playbooks with `cache_valid_time: 0` (require forced updates by design)
  - `dependency_patching/update-system.yml` (already has `cache_valid_time: 300`)

## Testing

- Verified all changes with grep search confirming 12 taskshave `cache_valid_time: 3600`
- No breaking changes to playbook behavior

Closes mrveiss/AutoBot-AI#6719