### PR TITLE
ci(code-quality): fix isort import ordering on 7 backend files (#7522)

### DIFF
--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -46,9 +46,9 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.time_utils import utc_timestamp
 from constants.threshold_constants import TimingConstants
 from dependencies import get_config, get_knowledge_base
+from exceptions import InternalError, SubprocessError
 from monitoring.prometheus_metrics import get_metrics_manager
 from services.ai_stack_client import AIStackError, get_ai_stack_client
-from exceptions import InternalError, SubprocessError
 from utils.response_helpers import create_success_response, handle_ai_stack_error
 
 router = APIRouter()

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -50,13 +50,13 @@ from constants.threshold_constants import TimingConstants
 # Import dependencies and utilities - Using available dependencies
 from dependencies import get_config, get_knowledge_base
 
+# Import shared exception classes (Issue #292 - Eliminate duplicate code)
+from exceptions import get_exceptions_lazy
+
 # CRITICAL SECURITY FIX: Import session ownership validation
 from security.session_ownership import validate_session_ownership
 from services.ai_stack_client import AIStackError, get_ai_stack_client
 from type_defs.common import STREAMING_MESSAGE_TYPES, Metadata
-
-# Import shared exception classes (Issue #292 - Eliminate duplicate code)
-from exceptions import get_exceptions_lazy
 
 # Import reusable chat utilities - Phase 1 Utility Extraction
 from utils.chat_utils import (

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -37,15 +37,15 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 # Import session lifecycle hooks (Issue #4260)
 from chat_workflow.session_handler import _emit_session_create, _emit_session_destroy
 
+# Import shared exception classes (Issue #292 - Eliminate duplicate code)
+from exceptions import get_exceptions_lazy
+
 # CRITICAL SECURITY FIX: Import session ownership validation
 from security.session_ownership import validate_session_ownership
 
 # Issue #6559: Wire audit_record into session create/delete/export endpoints
 from services.audit import AuditAction, audit_record
 from type_defs.common import Metadata
-
-# Import shared exception classes (Issue #292 - Eliminate duplicate code)
-from exceptions import get_exceptions_lazy
 
 # Import reusable chat utilities
 from utils.chat_utils import (

--- a/autobot-backend/api/conversation_export.py
+++ b/autobot-backend/api/conversation_export.py
@@ -24,13 +24,13 @@ from api.schemas_agent import ConversationImportRequest, ConversationImportRespo
 from api.schemas_common import DataResponse
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from exceptions import get_exceptions_lazy
 from services.conversation_export import (
     export_all_conversations_json,
     export_conversation_json,
     export_conversation_markdown,
     import_conversation,
 )
-from exceptions import get_exceptions_lazy
 from utils.chat_utils import get_chat_history_manager, validate_chat_session_id
 
 logger = logging.getLogger(__name__)

--- a/autobot-backend/services/playwright_service.py
+++ b/autobot-backend/services/playwright_service.py
@@ -16,8 +16,8 @@ import aiohttp
 
 from autobot_shared.http_client import get_http_client
 from constants.network_constants import NetworkConstants, ServiceURLs
-from type_defs.common import Metadata
 from exceptions import ServiceUnavailableError
+from type_defs.common import Metadata
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/tests/security/test_cross_service_auth_parity.py
+++ b/autobot-backend/tests/security/test_cross_service_auth_parity.py
@@ -34,12 +34,14 @@ class TestSharedPermissionEnumIsCanonical:
 
     def test_auth_rbac_re_exports_match_shared(self):
         """auth_rbac.py must re-export the identical objects, not local copies."""
-        import sys
         import os
+        import sys
 
         sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
         try:
-            from auth_rbac import Permission as RbacPerm, Role as RbacRole, ROLE_PERMISSIONS as RbacRP
+            from auth_rbac import ROLE_PERMISSIONS as RbacRP
+            from auth_rbac import Permission as RbacPerm
+            from auth_rbac import Role as RbacRole
 
             assert RbacPerm is Permission, "auth_rbac.Permission must be the same object as shared Permission"
             assert RbacRole is Role, "auth_rbac.Role must be the same object as shared Role"

--- a/autobot-backend/tests/test_exceptions_canonical.py
+++ b/autobot-backend/tests/test_exceptions_canonical.py
@@ -14,7 +14,6 @@ import pytest
 import exceptions as exc
 import utils.chat_exceptions as chat_exc
 
-
 # ---------------------------------------------------------------------------
 # Canonical module exports
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Automated isort run to fix import ordering issues introduced by recent refactoring commits.

Acceptance criteria:
- [x] isort --check-only exits 0
- [ ] code-quality CI check passes

Closes #7522