### PR TITLE
ci: Docker Smoke Test — buildx layer cache + 15-min health wait (closes #7034)

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   smoke-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code
@@ -27,16 +27,51 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
 
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Create .env from .env.example
         run: cp .env.example .env
 
+      - name: Build images with layer cache
+        run: |
+          docker buildx build \
+            --cache-from type=local,src=/tmp/.buildx-cache \
+            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --file docker/backend/Dockerfile \
+            --tag autobot/backend:latest \
+            --load \
+            .
+          docker buildx build \
+            --cache-from type=local,src=/tmp/.buildx-cache \
+            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --file docker/slm/Dockerfile \
+            --tag autobot/slm:latest \
+            --load \
+            .
+          docker buildx build \
+            --cache-from type=local,src=/tmp/.buildx-cache \
+            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --file docker/frontend/Dockerfile \
+            --tag autobot/frontend:latest \
+            --load \
+            .
+          # Rotate cache so next run gets the freshest layers
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
       - name: Start services with Docker Compose
-        run: docker compose --env-file docker/.env.docker up -d --build
+        run: docker compose --env-file docker/.env.docker up -d
 
       - name: Wait for services to be healthy
         run: |
           echo "Waiting for services to start..."
-          max_attempts=45
+          max_attempts=90
           attempt=0
 
           while [ $attempt -lt $max_attempts ]; do
@@ -66,7 +101,7 @@ jobs:
             sleep 10
           done
 
-          echo "Services failed to become healthy within 7.5 minutes (450s)"
+          echo "Services failed to become healthy within 15 minutes (900s)"
           echo ""
           echo "=== Docker Compose Logs ==="
           docker compose --env-file docker/.env.docker logs


### PR DESCRIPTION
## Summary

Fixes #7034 — Docker Smoke Test services not healthy within 7.5-minute timeout.

**Root cause:** On cold github-hosted runners, building images from scratch takes ~12 min (confirmed from run logs for PR #7023). The 7.5-min `Wait for services` loop starts only after build completes, leaving zero margin for service startup. At run 25389773914, the `autobot-frontend` container showed `Up Less than a second (health: starting)` the instant the wait-loop hit attempt 1.

**Changes:**

- **`actions/cache@v4` for `/tmp/.buildx-cache`** — persists Docker BuildKit layer cache across runs using a `runner.os`/`sha`-keyed restore chain
- **Explicit `docker buildx build` per service** — replaces `docker compose up --build` with individual buildx invocations that specify `--cache-from`/`--cache-to type=local`; images are loaded into the daemon before `docker compose up -d` (no `--build`)
- **Cache rotation** — writes to a `-new` dir and renames on completion so stale entries don't accumulate indefinitely
- **Health-wait `max_attempts` 45 → 90** (7.5 min → 15 min) — safety net for cache-miss / cold-runner scenarios
- **`timeout-minutes` 30 → 45** — headroom for the wider health window

**Expected outcome:**
- Cache hit: build ~2–3 min, services healthy well within 15-min window
- Cache miss (first run / Dockerfile change): 15-min window covers cold build + startup within 45-min job cap

## Test plan

- [ ] CI smoke-test passes on this PR (first run = cache miss, seeds the cache)
- [ ] A follow-up PR using the same base images completes within ~10 min (cache hit)
- [ ] No `service not healthy` errors in either run

🤖 Generated with [Claude Code](https://claude.com/claude-code)