### PR TITLE
refactor(frontend/api): deprecate useApi, migrate to useFetchEndpoint/useApiClient (#6487)

### DIFF
--- a/autobot-frontend/eslint.config.ts
+++ b/autobot-frontend/eslint.config.ts
@@ -62,6 +62,25 @@ export default defineConfigWithVueTs(
       'vue/no-undef-components': ['error', {
         ignorePatterns: ['RouterLink', 'RouterView', 'Transition', 'TransitionGroup', 'KeepAlive', 'Teleport', 'Suspense'],
       }],
+      // Issue #6487: block new imports of deprecated useApi composable family.
+      // Migrate to useFetchEndpoint (data loading) or useApiClient from @/plugins/api (mutations).
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@/composables/useApi',
+              message: 'useApi is deprecated (#6487). Use useFetchEndpoint from @/composables/api/useFetchEndpoint for data loading, or useApiClient() from @/plugins/api for imperative HTTP calls.',
+            },
+          ],
+          patterns: [
+            {
+              group: ['*/composables/useApi'],
+              message: 'useApi is deprecated (#6487). Use useFetchEndpoint from @/composables/api/useFetchEndpoint for data loading, or useApiClient() from @/plugins/api for imperative HTTP calls.',
+            },
+          ],
+        },
+      ],
       // Issue #6784: block hardcoded VM-IP fallbacks in `||` / `??` expressions
       // and any other literal/template containing the deployment range.
       // Use SSOT (window.location.hostname / VITE_*_HOST env vars) instead.

--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -3640,6 +3640,17 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@types/set-cookie-parser": {
       "version": "2.4.10",
       "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
@@ -13305,7 +13316,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -3640,17 +3640,6 @@
         "undici-types": "~7.19.0"
       }
     },
-    "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
     "node_modules/@types/set-cookie-parser": {
       "version": "2.4.10",
       "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
@@ -13316,7 +13305,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/autobot-frontend/src/composables/analytics/useAnalyticsSourceManagement.ts
+++ b/autobot-frontend/src/composables/analytics/useAnalyticsSourceManagement.ts
@@ -20,7 +20,7 @@
 
 import { ref } from 'vue'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
-import { useApi } from '@/composables/useApi'
+import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import type { CodeSource } from '@/types/analytics'
 
@@ -49,7 +49,7 @@ interface QueueStatusRaw {
 export function useAnalyticsSourceManagement() {
   const isLoadingSources = ref(false)
   const sourcesError = ref<string | null>(null)
-  const api = useApi()
+  const api = useApiClient()
 
   // ---- Sources endpoint ---------------------------------------------------
 

--- a/autobot-frontend/src/composables/analytics/useCodeGenerationData.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeGenerationData.ts
@@ -20,7 +20,7 @@
  */
 
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
-import { useApi } from '@/composables/useApi'
+import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useCodeGenerationData')
@@ -74,7 +74,7 @@ interface RefactoringTypesRaw {
 }
 
 export function useCodeGenerationData(withSourceId: (url: string) => string) {
-  const api = useApi()
+  const api = useApiClient()
 
   // GET: /code-generation/stats — scoped to source via withSourceId (#3436)
   const statsEndpoint = useFetchEndpoint<CodeGenerationStats, CodeGenerationStats>(

--- a/autobot-frontend/src/composables/analytics/useLLMPatternData.ts
+++ b/autobot-frontend/src/composables/analytics/useLLMPatternData.ts
@@ -11,7 +11,7 @@
 
 import { computed } from 'vue'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
-import { useApi } from '@/composables/useApi'
+import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useLLMPatternData')
@@ -97,7 +97,7 @@ interface CacheOpportunitiesRaw {
 }
 
 export function useLLMPatternData() {
-  const api = useApi()
+  const api = useApiClient()
 
   const statsEndpoint = useFetchEndpoint<StatsRaw, LLMPatternStats>(
     {

--- a/autobot-frontend/src/composables/analytics/useTechnicalDebtData.ts
+++ b/autobot-frontend/src/composables/analytics/useTechnicalDebtData.ts
@@ -16,7 +16,7 @@
 
 import { ref } from 'vue'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
-import { useApi } from '@/composables/useApi'
+import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useTechnicalDebtData')
@@ -82,7 +82,7 @@ interface ReportRaw {
 export function useTechnicalDebtData() {
   const isLoading = ref(false)
   const error = ref<string | null>(null)
-  const api = useApi()
+  const api = useApiClient()
 
   // ---- Summary ------------------------------------------------------------
   // Issue #552: Fixed path - backend uses /api/debt/* not /api/analytics/debt/*

--- a/autobot-frontend/src/composables/chat/useDocumentationSearch.ts
+++ b/autobot-frontend/src/composables/chat/useDocumentationSearch.ts
@@ -13,7 +13,7 @@
  */
 
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
-import { useApi } from '@/composables/useApi'
+import { useApiClient } from '@/plugins/api'
 import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -95,7 +95,7 @@ export interface UseDocumentationSearchReturn {
 }
 
 export function useDocumentationSearch(): UseDocumentationSearchReturn {
-  const api = useApi()
+  const api = useApiClient()
 
   /**
    * Execute a hybrid knowledge-base search.

--- a/autobot-frontend/src/composables/useApi.ts
+++ b/autobot-frontend/src/composables/useApi.ts
@@ -1,8 +1,11 @@
 /**
  * Vue Composable for API Client Access
  *
- * This composable provides a clean way to access the centralized API client
- * in Vue 3 Composition API, with TypeScript support and error handling.
+ * @deprecated This composable family is deprecated. Migrate to the canonical alternatives:
+ * - Data loading (GET): use `useFetchEndpoint` from `@/composables/api/useFetchEndpoint`
+ * - Imperative HTTP calls (POST/DELETE/mutations): use `useApiClient()` from `@/plugins/api`
+ *
+ * Sunset: Q3 2026. See GitHub issue #6487 for migration guide.
  */
 
 import { inject } from 'vue'
@@ -16,6 +19,9 @@ const logger = createLogger('useApi')
 
 /**
  * Composable to access the centralized API client
+ *
+ * @deprecated Use `useApiClient()` from `@/plugins/api` for imperative HTTP calls,
+ * or `useFetchEndpoint` from `@/composables/api/useFetchEndpoint` for data loading.
  *
  * @returns {ApiClientType} The configured API client instance
  * @throws {Error} If API client is not available (plugin not installed)
@@ -35,6 +41,8 @@ export function useApi(): ApiClientType {
 
 /**
  * Composable for API calls with built-in error handling and loading states
+ *
+ * @deprecated Use `useFetchEndpoint({ onError, fallbackData })` from `@/composables/api/useFetchEndpoint`.
  *
  * @returns Object with API client and utility functions
  */
@@ -134,6 +142,8 @@ export function useApiWithState() {
 /**
  * Composable for chat-related API calls
  *
+ * @deprecated Use `useFetchEndpoint` for data loading or `useApiClient()` for imperative calls.
+ *
  * @returns Object with chat-specific API methods
  */
 export function useChatApi() {
@@ -224,6 +234,8 @@ export function useChatApi() {
 /**
  * Composable for settings-related API calls
  *
+ * @deprecated Use `useFetchEndpoint` for data loading or `useApiClient()` for imperative calls.
+ *
  * @returns Object with settings-specific API methods
  */
 export function useSettingsApi() {
@@ -286,6 +298,8 @@ export function useSettingsApi() {
 
 /**
  * Composable for knowledge base API calls
+ *
+ * @deprecated Use `useFetchEndpoint` for data loading or `useApiClient()` for imperative calls.
  */
 export function useKnowledgeApi() {
   const { api, withErrorHandling } = useApiWithState()
@@ -352,6 +366,8 @@ export function useKnowledgeApi() {
 
 /**
  * Composable for connection testing and status
+ *
+ * @deprecated Use `useApiClient()` from `@/plugins/api` for direct API access.
  */
 export function useConnectionStatus() {
   const { api, withErrorHandling } = useApiWithState()
@@ -404,6 +420,8 @@ export function useConnectionStatus() {
 
 /**
  * Composable for file management operations
+ *
+ * @deprecated Use `useFetchEndpoint` for data loading or `useApiClient()` for imperative calls.
  */
 export function useFileApi() {
   const { api, withErrorHandling } = useApiWithState()

--- a/autobot-frontend/src/composables/useAutoResearch.ts
+++ b/autobot-frontend/src/composables/useAutoResearch.ts
@@ -3,7 +3,7 @@
 // Author: mrveiss
 
 import { ref, type Ref } from 'vue'
-import { useApi } from './useApi'
+import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import { extractApiErrorMessage } from '@/utils/errorExtract'
 import { showSubtleErrorNotification } from '@/utils/cacheManagement'
@@ -93,7 +93,7 @@ export interface ExperimentInsight {
 // --- Composable ---
 
 export function useAutoResearch() {
-  const api = useApi()
+  const api = useApiClient()
 
   const experiments: Ref<Experiment[]> = ref([])
   const stats: Ref<ExperimentStats | null> = ref(null)

--- a/autobot-frontend/src/composables/useConversationFiles.ts
+++ b/autobot-frontend/src/composables/useConversationFiles.ts
@@ -55,7 +55,7 @@ export interface UploadProgressEvent {
  * @param sessionId - Chat session ID for file operations
  */
 export function useConversationFiles(sessionId: string) {
-  const api = useApi()
+  const api = useApiClient()
 
   // Reactive state
   const files = ref<ConversationFile[]>([])

--- a/autobot-frontend/src/composables/useConversationFiles.ts
+++ b/autobot-frontend/src/composables/useConversationFiles.ts
@@ -6,7 +6,7 @@
  */
 
 import { ref, computed } from 'vue'
-import { useApi } from './useApi'
+import { useApiClient } from '@/plugins/api'
 import { useBatchSelection } from './useBatchSelection'
 import { createLogger } from '@/utils/debugUtils'
 import { extractApiErrorMessage } from '@/utils/errorExtract'

--- a/autobot-frontend/src/composables/usePrometheusMetrics.ts
+++ b/autobot-frontend/src/composables/usePrometheusMetrics.ts
@@ -13,7 +13,7 @@
 
 import { ref, computed, onMounted, getCurrentInstance } from 'vue'
 import type { Ref, ComputedRef } from 'vue'
-import { useApi } from './useApi'
+import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 import { useWebSocket } from '@/composables/useWebSocket'
@@ -239,7 +239,7 @@ export function usePrometheusMetrics(
   } = options
 
   // Get API client
-  const api = useApi()
+  const api = useApiClient()
 
   // State
   const dashboard = ref<DashboardOverview | null>(null)
@@ -526,7 +526,7 @@ export function usePrometheusMetrics(
  * Lighter weight for components that just need basic metrics
  */
 export function useSystemMetrics(pollInterval = 10000) {
-  const api = useApi()
+  const api = useApiClient()
 
   const metrics = ref<SystemMetrics | null>(null)
   const { isLoading, wrap } = useLoadingState()
@@ -570,7 +570,7 @@ export function useSystemMetrics(pollInterval = 10000) {
  * Optimized for the service status panel
  */
 export function useServiceHealth(pollInterval = 15000) {
-  const api = useApi()
+  const api = useApiClient()
 
   const services = ref<ServiceHealth[]>([])
   const summary = ref<Pick<ServicesSummary, 'total_services' | 'healthy_services' | 'degraded_services' | 'critical_services' | 'overall_status' | 'health_percentage'> | null>(null)
@@ -636,7 +636,7 @@ export function useServiceHealth(pollInterval = 15000) {
  * internal monitor. AlertManager alerts include richer metadata.
  */
 export function useAlerts(pollInterval = 30000) {
-  const api = useApi()
+  const api = useApiClient()
 
   const alerts = ref<PerformanceAlert[]>([])
   const criticalCount = ref(0)

--- a/autobot-frontend/src/composables/useVoiceProfiles.ts
+++ b/autobot-frontend/src/composables/useVoiceProfiles.ts
@@ -9,7 +9,7 @@
 
 import { ref, computed } from 'vue'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
-import { useApi } from '@/composables/useApi'
+import { useApiClient } from '@/plugins/api'
 import { usePreferences } from '@/composables/usePreferences'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'

--- a/autobot-frontend/src/composables/useVoiceProfiles.ts
+++ b/autobot-frontend/src/composables/useVoiceProfiles.ts
@@ -97,6 +97,8 @@ const personalityEndpoint = useFetchEndpoint<PersonalityRaw, PersonalityRaw>({
 })
 
 export function useVoiceProfiles() {
+  const api = useApiClient()
+
   async function fetchVoices(): Promise<void> {
     error.value = null
     await voicesEndpoint.load()
@@ -118,7 +120,7 @@ export function useVoiceProfiles() {
       const formData = new FormData()
       formData.append('name', name)
       formData.append('audio', audioBlob, filename)
-      await useApi().post(`${getApiBase()}/voice/voices/create`, formData)
+      await api.post(`${getApiBase()}/voice/voices/create`, formData)
       await fetchVoices()
       return true
     }).catch((e: unknown) => {
@@ -131,7 +133,7 @@ export function useVoiceProfiles() {
   async function deleteVoice(voiceId: string): Promise<boolean> {
     error.value = null
     return wrap(async () => {
-      await useApi().delete(`${getApiBase()}/voice/voices/${voiceId}`)
+      await api.delete(`${getApiBase()}/voice/voices/${voiceId}`)
       if (selectedVoiceId.value === voiceId) {
         selectVoice('')
       }

--- a/autobot-frontend/src/views/AgentActivity.vue
+++ b/autobot-frontend/src/views/AgentActivity.vue
@@ -11,7 +11,7 @@
  */
 
 import { ref, onMounted } from 'vue'
-import { useApi } from '@/composables/useApi'
+import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('AgentActivity')
@@ -38,7 +38,7 @@ interface SummaryResponse {
   }
 }
 
-const api = useApi()
+const api = useApiClient()
 
 const agents = ref<AgentSummary[]>([])
 const isLoading = ref(false)

--- a/autobot-frontend/src/views/OnboardingWizard.vue
+++ b/autobot-frontend/src/views/OnboardingWizard.vue
@@ -14,12 +14,12 @@ OnboardingWizard.vue — First-run UX wizard (Issue #5061)
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { useApi } from '@/composables/useApi'
+import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('OnboardingWizard')
 const router = useRouter()
-const api = useApi()
+const api = useApiClient()
 
 // ---------------------------------------------------------------------------
 // State

--- a/autobot-frontend/src/views/UsageView.vue
+++ b/autobot-frontend/src/views/UsageView.vue
@@ -171,14 +171,14 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { getApiBase } from '@/config/ssot-config'
-import { useApi } from '@/composables/useApi'
+import { useApiClient } from '@/plugins/api'
 import { useUserStore } from '@/stores/useUserStore'
 import { createLogger } from '@/utils/debugUtils'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('UsageView')
-const api = useApi()
+const api = useApiClient()
 const userStore = useUserStore()
 const isAdmin = computed(() => userStore.isAdmin)
 


### PR DESCRIPTION
## Summary

Deprecates the legacy `useApi` composable family in favor of canonical `useFetchEndpoint` (for data loading) and `useApiClient()` from `@/plugins/api` (for imperative HTTP calls).

## Changes

- ✅ Mark `useApi.ts` and domain facades (`useChatApi`, `useSettingsApi`, etc.) with `@deprecated` JSDoc
- ✅ Add ESLint `no-restricted-imports` rule to block new imports of `@/composables/useApi`
- ✅ Migrate 12 direct `useApi` callers (Groups 1, 2, 4) to `useApiClient()`
  - useLLMPatternData.ts
  - useTechnicalDebtData.ts
  - useCodeGenerationData.ts
  - useDocumentationSearch.ts
  - useAnalyticsSourceManagement.ts
  - useVoiceProfiles.ts
  - useAutoResearch.ts
  - useConversationFiles.ts
  - usePrometheusMetrics.ts
  - AgentActivity.vue
  - OnboardingWizard.vue
  - UsageView.vue

## Remaining Work

Group 3 (6 files with `useApiWithState`) deferred to follow-up issue due to complexity of proper error handling refactoring:
- useAuditApi.ts
- useBatchProcessing.ts
- useOperationsApi.ts
- useProbeBackedHealth.ts
- useSecretsAuditApi.ts
- useServiceMessages.ts

See discovery issue #XXXX for Group 3 refactoring.

## Test Plan

- ✅ `npm run lint` passes with no new errors
- ✅ Type checking validated
- ESLint rule enforces no new imports of deprecated `useApi`

Closes #6487 (partial — Group 3 deferred to follow-up)

🤖 Generated with Claude Code