### PR TITLE
feat(llm-keys): virtual LLM API keys with per-key budgets (#6590)

### DIFF
--- a/autobot-backend/api/llm_keys.py
+++ b/autobot-backend/api/llm_keys.py
@@ -1,0 +1,149 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Admin-only virtual LLM API key management endpoints (#6590).
+
+Routes (all require admin permission):
+  POST /llm-keys/issue   — create a new virtual key
+  POST /llm-keys/revoke  — revoke a key by key_id
+  POST /llm-keys/rotate  — rotate a key (old hash stays valid for grace period)
+  GET  /llm-keys/list    — list keys with current-month spend
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
+
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from auth_middleware import check_admin_permission
+from services.llm_api_key_service import get_llm_api_key_service
+
+router = APIRouter(tags=["llm-keys"])
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+
+
+class IssueKeyRequest(BaseModel):
+    team_id: str
+    label: str = ""
+    monthly_budget_usd: float = 0.0
+    allowed_models: List[str] = []
+    expires_at: Optional[float] = None
+
+
+class IssueKeyResponse(BaseModel):
+    key_id: str
+    raw_key: str  # shown exactly once — caller must store it
+    team_id: str
+    label: str
+    monthly_budget_usd: float
+    allowed_models: List[str]
+    expires_at: Optional[float]
+
+
+class RevokeKeyRequest(BaseModel):
+    key_id: str
+
+
+class RotateKeyRequest(BaseModel):
+    key_id: str
+
+
+class RotateKeyResponse(BaseModel):
+    key_id: str
+    new_raw_key: str  # shown exactly once
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/issue", response_model=IssueKeyResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="issue_llm_key",
+    error_code_prefix="LLM_KEYS",
+)
+async def issue_key(
+    body: IssueKeyRequest,
+    _user: Any = Depends(check_admin_permission),
+) -> IssueKeyResponse:
+    """Issue a new virtual LLM API key."""
+    svc = get_llm_api_key_service()
+    record, raw_key = await svc.issue_key(
+        team_id=body.team_id,
+        label=body.label,
+        monthly_budget_usd=body.monthly_budget_usd,
+        allowed_models=body.allowed_models,
+        expires_at=body.expires_at,
+    )
+    return IssueKeyResponse(
+        key_id=record.key_id,
+        raw_key=raw_key,
+        team_id=record.team_id,
+        label=record.label,
+        monthly_budget_usd=record.monthly_budget_usd,
+        allowed_models=record.allowed_models,
+        expires_at=record.expires_at,
+    )
+
+
+@router.post("/revoke")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="revoke_llm_key",
+    error_code_prefix="LLM_KEYS",
+)
+async def revoke_key(
+    body: RevokeKeyRequest,
+    _user: Any = Depends(check_admin_permission),
+) -> Dict[str, Any]:
+    """Revoke a virtual LLM API key."""
+    svc = get_llm_api_key_service()
+    found = await svc.revoke_key(body.key_id)
+    if not found:
+        raise HTTPException(status_code=404, detail="Key not found")
+    return {"ok": True, "key_id": body.key_id}
+
+
+@router.post("/rotate", response_model=RotateKeyResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="rotate_llm_key",
+    error_code_prefix="LLM_KEYS",
+)
+async def rotate_key(
+    body: RotateKeyRequest,
+    _user: Any = Depends(check_admin_permission),
+) -> RotateKeyResponse:
+    """Rotate a virtual LLM API key. Old key stays valid for grace period."""
+    svc = get_llm_api_key_service()
+    result = await svc.rotate_key(body.key_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Key not found or revoked")
+    record, new_raw = result
+    return RotateKeyResponse(key_id=record.key_id, new_raw_key=new_raw)
+
+
+@router.get("/list")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_llm_keys",
+    error_code_prefix="LLM_KEYS",
+)
+async def list_keys(
+    team_id: Optional[str] = Query(None),
+    _user: Any = Depends(check_admin_permission),
+) -> Dict[str, Any]:
+    """List virtual LLM API keys with current-month spend."""
+    svc = get_llm_api_key_service()
+    keys = await svc.list_keys(team_id=team_id)
+    return {"keys": keys}

--- a/autobot-backend/api/openai_compat.py
+++ b/autobot-backend/api/openai_compat.py
@@ -21,7 +21,7 @@ import inspect
 import json
 import logging
 import time
-from typing import Any, AsyncIterator, Dict, List
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
 from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, Request
@@ -40,6 +40,7 @@ from api.schemas_code import (
     OAIUsage,
 )
 from auth_middleware import get_current_user
+from services.llm_api_key_service import LLMApiKeyRecord, get_llm_api_key_service
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from llm_interface_pkg.models import LLMRequest
 from llm_interface_pkg.tiered_routing.tier_router import get_tiered_router
@@ -103,6 +104,32 @@ def _get_user(request: Request) -> Dict[str, Any]:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 
+def _extract_bearer(request: Request) -> Optional[str]:
+    """Return the raw Bearer token string, or None if absent/malformed."""
+    header = request.headers.get("authorization", "")
+    if header.lower().startswith("bearer "):
+        return header[7:].strip()
+    return None
+
+
+async def _resolve_auth(request: Request) -> Tuple[Optional[Dict[str, Any]], Optional[LLMApiKeyRecord]]:
+    """Dual-auth: accept either a platform JWT or a virtual sk-... API key.
+
+    Returns (user_dict, api_key_record). Exactly one of them will be non-None.
+    Raises HTTPException 401 if neither form of auth succeeds.
+    """
+    bearer = _extract_bearer(request)
+    if bearer and bearer.startswith("sk-"):
+        svc = get_llm_api_key_service()
+        record = await svc.authenticate_key(bearer)
+        if record is None:
+            raise HTTPException(status_code=401, detail="Invalid or revoked API key")
+        return None, record
+    # Fall back to platform JWT
+    user = _get_user(request)
+    return user, None
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -162,6 +189,7 @@ async def _stream_generator(
     *,
     include_usage: bool = False,
     prompt_text: str = "",
+    api_key_record: Optional[LLMApiKeyRecord] = None,
 ) -> AsyncIterator[str]:
     """Yield SSE lines for a streaming completion."""
     created = int(time.time())
@@ -242,6 +270,14 @@ async def _stream_generator(
 
     yield "data: [DONE]\n\n"
 
+    # Record per-key spend and publish usage event after stream completes (#6590)
+    if api_key_record is not None:
+        svc = get_llm_api_key_service()
+        await svc.record_spend(api_key_record, cost_usd)
+        await svc.publish_usage_event(
+            api_key_record, model_name, prompt_tokens, completion_tokens, cost_usd
+        )
+
 
 # ---------------------------------------------------------------------------
 # Endpoints
@@ -260,11 +296,31 @@ async def chat_completions(
 ) -> Any:
     """OpenAI-compatible chat completions endpoint (#4447).
 
-    Accepts Bearer token auth, delegates to ProviderRegistry, returns
-    OpenAI-format response (streaming or non-streaming).
+    Accepts Bearer token auth (platform JWT or virtual sk-... key), delegates
+    to ProviderRegistry, returns OpenAI-format response (streaming or non-streaming).
+    Virtual keys enforce per-key monthly budget and model whitelist (#6590).
     """
-    _get_user(request)
+    _user, api_key_record = await _resolve_auth(request)
     await _oai_limiter.check_or_429(_remote_addr(request))
+
+    # Virtual key enforcement: model whitelist + budget (#6590)
+    if api_key_record is not None:
+        from services.llm_api_key_service import LLMApiKeyService
+
+        if body.model not in _AUTO_MODEL_NAMES and body.model != "autobot-default":
+            if not LLMApiKeyService.model_allowed(api_key_record, body.model):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Model not permitted for this API key",
+                    headers={"x-llm-key-allowed-models": ",".join(api_key_record.allowed_models)},
+                )
+        allowed, remaining = await get_llm_api_key_service().check_budget(api_key_record)
+        if not allowed:
+            raise HTTPException(
+                status_code=429,
+                detail="Monthly budget exhausted",
+                headers={"x-llm-budget-remaining": "0"},
+            )
 
     # Resolve auto-* model aliases to concrete model names via tiered routing (#6592)
     if body.model in _AUTO_MODEL_NAMES:
@@ -305,6 +361,7 @@ async def chat_completions(
                 resolved_model,
                 include_usage=include_usage,
                 prompt_text=prompt_text,
+                api_key_record=api_key_record,
             ),
             media_type="text/event-stream",
             headers={
@@ -355,6 +412,19 @@ async def chat_completions(
     # Extract cost from hidden params and add as header
     response_cost = llm_response.hidden_params.get("response_cost", 0)
     headers = {"x-llm-cost": str(response_cost)} if response_cost > 0 else {}
+
+    # Record per-key spend and publish usage event (#6590)
+    if api_key_record is not None:
+        svc = get_llm_api_key_service()
+        await svc.record_spend(api_key_record, cost_usd)
+        await svc.publish_usage_event(
+            api_key_record,
+            resolved_model,
+            usage.prompt_tokens,
+            usage.completion_tokens,
+            cost_usd,
+        )
+
     return JSONResponse(
         content=response.model_dump(),
         headers=headers,
@@ -372,7 +442,7 @@ async def list_models(request: Request) -> OAIModelListResponse:
 
     Returns all models available across registered providers.
     """
-    _get_user(request)
+    await _resolve_auth(request)
 
     registry = get_provider_registry()
     created = int(time.time())

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1143,6 +1143,24 @@ async def _init_voice_interface(app: FastAPI) -> None:
         app.state.voice_interface = None
 
 
+async def _init_llm_key_rotation_scheduler(app: FastAPI) -> None:
+    """Start LLM API key expiry rotation scheduler (issue #6590).
+
+    NON-CRITICAL: key expiry rotation not required for request handling.
+    """
+    logger.info("[100%%] LLM Key Rotation: Initializing...")
+    try:
+        from services.llm_key_rotation_scheduler import get_llm_key_rotation_scheduler
+
+        scheduler = get_llm_key_rotation_scheduler()
+        await scheduler.start()
+        app.state.llm_key_rotation_scheduler = scheduler
+        logger.info("[100%%] LLM Key Rotation: Scheduler started")
+    except Exception as e:
+        logger.warning("LLM key rotation scheduler initialization failed (non-critical): %s", e)
+        app.state.llm_key_rotation_scheduler = None
+
+
 async def _init_backup_scheduler(app: FastAPI) -> None:
     """Start the knowledge-base backup scheduler (issue #3294).
 
@@ -1380,6 +1398,7 @@ async def initialize_background_services(app: FastAPI):
         await _init_web_researcher(app)
         await _init_plugin_manager(app)
         await _init_backup_scheduler(app)
+        await _init_llm_key_rotation_scheduler(app)
         await _start_autonomous_loop(app)
         await _start_community_clustering_loop(app)
 
@@ -1457,6 +1476,11 @@ async def cleanup_services(app: FastAPI):
         if hasattr(app.state, "backup_scheduler") and app.state.backup_scheduler:
             await app.state.backup_scheduler.stop()
             logger.info("✅ Backup scheduler stopped")
+
+        # Issue #6590: Stop LLM key rotation scheduler
+        if hasattr(app.state, "llm_key_rotation_scheduler") and app.state.llm_key_rotation_scheduler:
+            await app.state.llm_key_rotation_scheduler.stop()
+            logger.info("✅ LLM key rotation scheduler stopped")
 
         # Issue #4946: Cancel community clustering background task
         task = getattr(app.state, "community_cluster_task", None)

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -410,6 +410,13 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["admin", "feature-flags"],
         "feature_flags",
     ),
+    # Issue #6590: Virtual LLM API keys with per-key budgets
+    (
+        "api.llm_keys",
+        "/llm-keys",
+        ["llm-keys", "admin", "security"],
+        "llm_keys",
+    ),
     # Issue #4203: External tool integrations consolidated into integration_routers.py
     # Skills repo management and governance MUST be registered before the base skills
     # router so their static path prefixes take precedence over skills' /{name} param.

--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -1,6 +1,7 @@
 -e ../autobot_shared
 
 # Core
+apscheduler>=3.10.4             # Issue #6590: hourly LLM key rotation job
 fastapi>=0.136.1                # SECURITY UPDATE - requires starlette >=0.52.1
 uvicorn>=0.46.0
 websockets>=16.0           # Issue #3098: required for WebSocket protocol support (desktop_streaming_manager, slm_client)

--- a/autobot-backend/services/llm_api_key_service.py
+++ b/autobot-backend/services/llm_api_key_service.py
@@ -1,0 +1,328 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Virtual LLM API key service (#6590).
+
+Stores key metadata in Redis MAIN database:
+  llm:apikey:{key_id}         → Hash  (key metadata)
+  llm:apikeys:all             → Set   (all key_ids)
+  llm:apikeys:team:{team_id}  → Set   (per-team index)
+  llm:spend:key:{key_id}:{YYYY-MM} → String float counter
+  llm:usage:stream            → Redis Stream (audit events)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import secrets
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from autobot_shared.redis_client import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+# Rotation grace period: after a key is rotated the old hash remains valid for
+# this many seconds so in-flight requests finish cleanly.
+import os
+
+_ROTATION_GRACE_SECS = int(os.environ.get("AUTOBOT_LLM_KEY_ROTATION_GRACE_SECS", "86400"))
+
+_KEY_TTL_STREAM_SECS = 7 * 24 * 3600  # usage stream events retained 7 days
+
+
+@dataclass
+class LLMApiKeyRecord:
+    key_id: str
+    key_hash: str  # SHA-256 hex of the raw bearer token
+    team_id: str
+    label: str
+    monthly_budget_usd: float  # 0.0 = unlimited
+    allowed_models: List[str]  # empty list = all models allowed
+    created_at: float  # Unix timestamp
+    expires_at: Optional[float]  # None = no expiry
+    rotated_at: Optional[float]  # set when a rotation is pending
+    prev_key_hash: Optional[str]  # old hash kept valid during grace period
+    revoked: bool
+
+    def to_redis_hash(self) -> Dict[str, str]:
+        return {
+            "key_id": self.key_id,
+            "key_hash": self.key_hash,
+            "team_id": self.team_id,
+            "label": self.label,
+            "monthly_budget_usd": str(self.monthly_budget_usd),
+            "allowed_models": ",".join(self.allowed_models),
+            "created_at": str(self.created_at),
+            "expires_at": str(self.expires_at) if self.expires_at is not None else "",
+            "rotated_at": str(self.rotated_at) if self.rotated_at is not None else "",
+            "prev_key_hash": self.prev_key_hash or "",
+            "revoked": "1" if self.revoked else "0",
+        }
+
+    @classmethod
+    def from_redis_hash(cls, data: Dict[str, str]) -> "LLMApiKeyRecord":
+        return cls(
+            key_id=data["key_id"],
+            key_hash=data["key_hash"],
+            team_id=data.get("team_id", ""),
+            label=data.get("label", ""),
+            monthly_budget_usd=float(data.get("monthly_budget_usd", "0")),
+            allowed_models=[m for m in data.get("allowed_models", "").split(",") if m],
+            created_at=float(data.get("created_at", "0")),
+            expires_at=float(data["expires_at"]) if data.get("expires_at") else None,
+            rotated_at=float(data["rotated_at"]) if data.get("rotated_at") else None,
+            prev_key_hash=data.get("prev_key_hash") or None,
+            revoked=data.get("revoked", "0") == "1",
+        )
+
+
+def _generate_raw_key(key_id: str) -> str:
+    """Return a new raw bearer token: sk-{key_id[:8]}-{32 hex chars}."""
+    return f"sk-{key_id[:8]}-{secrets.token_hex(16)}"
+
+
+def _hash_raw_key(raw_key: str) -> str:
+    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+
+
+def _parse_key_id_from_bearer(bearer: str) -> Optional[str]:
+    """Extract the 8-char key_id prefix from sk-XXXXXXXX-... format."""
+    if not bearer.startswith("sk-"):
+        return None
+    parts = bearer.split("-")
+    # Format: ["sk", "<8hex>", "<32hex>"]
+    if len(parts) != 3 or len(parts[1]) != 8:
+        return None
+    return parts[1]
+
+
+def _spend_key(key_id: str) -> str:
+    month = datetime.now(timezone.utc).strftime("%Y-%m")
+    return f"llm:spend:key:{key_id}:{month}"
+
+
+class LLMApiKeyService:
+    """Manages virtual LLM API keys backed by Redis MAIN database."""
+
+    def __init__(self) -> None:
+        self._redis = get_redis_client()
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    async def issue_key(
+        self,
+        team_id: str,
+        label: str,
+        monthly_budget_usd: float = 0.0,
+        allowed_models: Optional[List[str]] = None,
+        expires_at: Optional[float] = None,
+    ) -> tuple[LLMApiKeyRecord, str]:
+        """Create a new key. Returns (record, raw_key). raw_key shown once."""
+        key_id = secrets.token_hex(4)  # 8 hex chars
+        raw_key = _generate_raw_key(key_id)
+        key_hash = _hash_raw_key(raw_key)
+        now = time.time()
+        record = LLMApiKeyRecord(
+            key_id=key_id,
+            key_hash=key_hash,
+            team_id=team_id,
+            label=label,
+            monthly_budget_usd=monthly_budget_usd,
+            allowed_models=allowed_models or [],
+            created_at=now,
+            expires_at=expires_at,
+            rotated_at=None,
+            prev_key_hash=None,
+            revoked=False,
+        )
+        pipe = self._redis.pipeline()
+        pipe.hset(f"llm:apikey:{key_id}", mapping=record.to_redis_hash())
+        pipe.sadd("llm:apikeys:all", key_id)
+        pipe.sadd(f"llm:apikeys:team:{team_id}", key_id)
+        await pipe.execute()
+        logger.info("Issued LLM API key %s for team %s label=%r", key_id, team_id, label)
+        return record, raw_key
+
+    async def revoke_key(self, key_id: str) -> bool:
+        """Mark a key as revoked. Returns True if found."""
+        redis_key = f"llm:apikey:{key_id}"
+        exists = await self._redis.exists(redis_key)
+        if not exists:
+            return False
+        await self._redis.hset(redis_key, "revoked", "1")
+        logger.info("Revoked LLM API key %s", key_id)
+        return True
+
+    async def rotate_key(self, key_id: str) -> Optional[tuple[LLMApiKeyRecord, str]]:
+        """Issue a new raw key for key_id, keeping old hash valid for grace period."""
+        redis_key = f"llm:apikey:{key_id}"
+        data = await self._redis.hgetall(redis_key)
+        if not data:
+            return None
+        record = LLMApiKeyRecord.from_redis_hash(data)
+        if record.revoked:
+            return None
+
+        new_raw = _generate_raw_key(key_id)
+        new_hash = _hash_raw_key(new_raw)
+        record.prev_key_hash = record.key_hash
+        record.key_hash = new_hash
+        record.rotated_at = time.time()
+        await self._redis.hset(redis_key, mapping=record.to_redis_hash())
+        logger.info("Rotated LLM API key %s", key_id)
+        return record, new_raw
+
+    async def list_keys(self, team_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """List keys with current month spend."""
+        if team_id:
+            key_ids = list(await self._redis.smembers(f"llm:apikeys:team:{team_id}"))
+        else:
+            key_ids = list(await self._redis.smembers("llm:apikeys:all"))
+
+        result = []
+        for kid in key_ids:
+            kid_str = kid if isinstance(kid, str) else kid.decode()
+            data = await self._redis.hgetall(f"llm:apikey:{kid_str}")
+            if not data:
+                continue
+            record = LLMApiKeyRecord.from_redis_hash(data)
+            spend_raw = await self._redis.get(_spend_key(kid_str))
+            spend = float(spend_raw) if spend_raw else 0.0
+            result.append({
+                "key_id": record.key_id,
+                "key_prefix": f"sk-{record.key_id[:8]}-...",
+                "team_id": record.team_id,
+                "label": record.label,
+                "monthly_budget_usd": record.monthly_budget_usd,
+                "spend_usd_this_month": spend,
+                "allowed_models": record.allowed_models,
+                "created_at": record.created_at,
+                "expires_at": record.expires_at,
+                "revoked": record.revoked,
+            })
+        return result
+
+    # ------------------------------------------------------------------
+    # Authentication & enforcement
+    # ------------------------------------------------------------------
+
+    async def authenticate_key(self, raw_key: str) -> Optional[LLMApiKeyRecord]:
+        """Validate a raw bearer token. Returns record if valid, else None."""
+        key_id = _parse_key_id_from_bearer(raw_key)
+        if not key_id:
+            return None
+        data = await self._redis.hgetall(f"llm:apikey:{key_id}")
+        if not data:
+            return None
+        record = LLMApiKeyRecord.from_redis_hash(data)
+        if record.revoked:
+            return None
+        # Constant-time comparison against current hash
+        candidate = _hash_raw_key(raw_key)
+        if secrets.compare_digest(candidate, record.key_hash):
+            return record
+        # Also accept old hash during grace period
+        if (
+            record.prev_key_hash
+            and record.rotated_at
+            and (time.time() - record.rotated_at) < _ROTATION_GRACE_SECS
+            and secrets.compare_digest(candidate, record.prev_key_hash)
+        ):
+            return record
+        return None
+
+    async def check_budget(self, record: LLMApiKeyRecord) -> tuple[bool, float]:
+        """Return (allowed, remaining_usd). remaining=-1 means unlimited."""
+        if record.monthly_budget_usd <= 0:
+            return True, -1.0
+        spend_raw = await self._redis.get(_spend_key(record.key_id))
+        spend = float(spend_raw) if spend_raw else 0.0
+        remaining = record.monthly_budget_usd - spend
+        return remaining > 0, max(remaining, 0.0)
+
+    async def record_spend(self, record: LLMApiKeyRecord, cost_usd: float) -> None:
+        """Increment per-key monthly spend counter."""
+        if cost_usd <= 0:
+            return
+        await self._redis.incrbyfloat(_spend_key(record.key_id), cost_usd)
+
+    @staticmethod
+    def model_allowed(record: LLMApiKeyRecord, model: str) -> bool:
+        """Check if model is permitted by the key's allowlist."""
+        if not record.allowed_models:
+            return True
+        for pattern in record.allowed_models:
+            if pattern == "*":
+                return True
+            if model == pattern:
+                return True
+            if pattern.endswith("*") and model.startswith(pattern[:-1]):
+                return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Usage events
+    # ------------------------------------------------------------------
+
+    async def publish_usage_event(
+        self,
+        record: LLMApiKeyRecord,
+        model: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        cost_usd: float,
+    ) -> None:
+        """Publish a usage event to llm:usage:stream. Errors are swallowed."""
+        try:
+            event: Dict[str, str] = {
+                "key_id": record.key_id,
+                "team_id": record.team_id,
+                "model": model,
+                "prompt_tokens": str(prompt_tokens),
+                "completion_tokens": str(completion_tokens),
+                "cost_usd": str(cost_usd),
+                "ts": str(time.time()),
+            }
+            await self._redis.xadd("llm:usage:stream", event, maxlen=10000, approximate=True)
+        except Exception as exc:
+            logger.warning("Failed to publish LLM usage event: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Rotation job
+    # ------------------------------------------------------------------
+
+    async def rotate_expired_keys(self) -> int:
+        """Revoke keys whose expires_at has passed. Returns count revoked."""
+        now = time.time()
+        key_ids = await self._redis.smembers("llm:apikeys:all")
+        revoked_count = 0
+        for kid in key_ids:
+            kid_str = kid if isinstance(kid, str) else kid.decode()
+            data = await self._redis.hgetall(f"llm:apikey:{kid_str}")
+            if not data:
+                continue
+            record = LLMApiKeyRecord.from_redis_hash(data)
+            if record.revoked:
+                continue
+            if record.expires_at and record.expires_at < now:
+                await self._redis.hset(f"llm:apikey:{kid_str}", "revoked", "1")
+                revoked_count += 1
+                logger.info("Auto-revoked expired LLM API key %s", kid_str)
+        return revoked_count
+
+
+_service_instance: Optional[LLMApiKeyService] = None
+
+
+def get_llm_api_key_service() -> LLMApiKeyService:
+    global _service_instance
+    if _service_instance is None:
+        _service_instance = LLMApiKeyService()
+    return _service_instance

--- a/autobot-backend/services/llm_key_rotation_scheduler.py
+++ b/autobot-backend/services/llm_key_rotation_scheduler.py
@@ -1,0 +1,66 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Background scheduler for LLM API key expiry rotation (#6590).
+
+Runs hourly (configurable via AUTOBOT_LLM_KEY_ROTATION_INTERVAL_MINUTES)
+and auto-revokes keys whose expires_at has passed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from services.llm_api_key_service import get_llm_api_key_service
+
+logger = logging.getLogger(__name__)
+
+_ROTATION_INTERVAL_MINUTES = int(
+    os.environ.get("AUTOBOT_LLM_KEY_ROTATION_INTERVAL_MINUTES", "60")
+)
+
+
+class LLMKeyRotationScheduler:
+    def __init__(self) -> None:
+        self._scheduler = AsyncIOScheduler()
+
+    async def start(self) -> None:
+        self._scheduler.add_job(
+            self._run_rotation,
+            "interval",
+            minutes=_ROTATION_INTERVAL_MINUTES,
+            id="llm_key_rotation",
+            replace_existing=True,
+        )
+        self._scheduler.start()
+        logger.info(
+            "LLM key rotation scheduler started (interval=%dm)", _ROTATION_INTERVAL_MINUTES
+        )
+
+    async def stop(self) -> None:
+        if self._scheduler.running:
+            self._scheduler.shutdown(wait=False)
+            logger.info("LLM key rotation scheduler stopped")
+
+    async def _run_rotation(self) -> None:
+        try:
+            svc = get_llm_api_key_service()
+            count = await svc.rotate_expired_keys()
+            if count:
+                logger.info("LLM key rotation: revoked %d expired key(s)", count)
+        except Exception as exc:
+            logger.error("LLM key rotation job failed: %s", exc)
+
+
+_scheduler_instance: LLMKeyRotationScheduler | None = None
+
+
+def get_llm_key_rotation_scheduler() -> LLMKeyRotationScheduler:
+    global _scheduler_instance
+    if _scheduler_instance is None:
+        _scheduler_instance = LLMKeyRotationScheduler()
+    return _scheduler_instance

--- a/autobot-backend/tests/services/test_llm_api_key_service.py
+++ b/autobot-backend/tests/services/test_llm_api_key_service.py
@@ -1,0 +1,266 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for LLMApiKeyService (#6590)."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.llm_api_key_service import (
+    LLMApiKeyRecord,
+    LLMApiKeyService,
+    _hash_raw_key,
+    _parse_key_id_from_bearer,
+)
+
+
+def _make_record(**kwargs) -> LLMApiKeyRecord:
+    defaults = {
+        "key_id": "abcd1234",
+        "key_hash": "deadbeef" * 8,
+        "team_id": "team-a",
+        "label": "test",
+        "monthly_budget_usd": 10.0,
+        "allowed_models": [],
+        "created_at": time.time(),
+        "expires_at": None,
+        "rotated_at": None,
+        "prev_key_hash": None,
+        "revoked": False,
+    }
+    defaults.update(kwargs)
+    return LLMApiKeyRecord(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_key_id_from_bearer_valid():
+    assert _parse_key_id_from_bearer("sk-abcd1234-" + "a" * 32) == "abcd1234"
+
+
+def test_parse_key_id_from_bearer_invalid():
+    assert _parse_key_id_from_bearer("Bearer not-a-key") is None
+    assert _parse_key_id_from_bearer("sk-short") is None
+    assert _parse_key_id_from_bearer("sk-toolong12-rest") is None
+
+
+def test_hash_determinism():
+    raw = "sk-abcd1234-" + "b" * 32
+    assert _hash_raw_key(raw) == _hash_raw_key(raw)
+    assert _hash_raw_key(raw) == hashlib.sha256(raw.encode()).hexdigest()
+
+
+def test_key_format():
+    from services.llm_api_key_service import _generate_raw_key
+
+    key = _generate_raw_key("abcd1234")
+    assert key.startswith("sk-abcd1234-")
+    assert len(key) == len("sk-abcd1234-") + 32
+
+
+# ---------------------------------------------------------------------------
+# model_allowed
+# ---------------------------------------------------------------------------
+
+
+def test_model_allowed_empty_list():
+    rec = _make_record(allowed_models=[])
+    assert LLMApiKeyService.model_allowed(rec, "gpt-4") is True
+
+
+def test_model_allowed_exact():
+    rec = _make_record(allowed_models=["gpt-4"])
+    assert LLMApiKeyService.model_allowed(rec, "gpt-4") is True
+    assert LLMApiKeyService.model_allowed(rec, "gpt-3.5") is False
+
+
+def test_model_allowed_wildcard():
+    rec = _make_record(allowed_models=["*"])
+    assert LLMApiKeyService.model_allowed(rec, "anything") is True
+
+
+def test_model_allowed_prefix():
+    rec = _make_record(allowed_models=["gpt-4*"])
+    assert LLMApiKeyService.model_allowed(rec, "gpt-4-turbo") is True
+    assert LLMApiKeyService.model_allowed(rec, "gpt-3") is False
+
+
+# ---------------------------------------------------------------------------
+# issue_key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_issue_key():
+    mock_redis = AsyncMock()
+    mock_pipe = AsyncMock()
+    mock_redis.pipeline.return_value.__aenter__ = AsyncMock(return_value=mock_pipe)
+    mock_redis.pipeline.return_value.__aexit__ = AsyncMock(return_value=False)
+    mock_pipe.execute = AsyncMock(return_value=[True, True, True])
+
+    svc = LLMApiKeyService.__new__(LLMApiKeyService)
+    svc._redis = mock_redis
+
+    # pipeline() is used as a context manager in issue_key — but actually it's
+    # called synchronously; use the non-context-manager approach
+    mock_pipe2 = MagicMock()
+    mock_pipe2.execute = AsyncMock(return_value=[1, 1, 1])
+    mock_redis.pipeline.return_value = mock_pipe2
+
+    record, raw_key = await svc.issue_key(
+        team_id="t1", label="test", monthly_budget_usd=5.0, allowed_models=["gpt-4"]
+    )
+    assert raw_key.startswith("sk-")
+    assert record.team_id == "t1"
+    assert record.monthly_budget_usd == 5.0
+    assert not record.revoked
+
+
+# ---------------------------------------------------------------------------
+# revoke_key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revoke_key_found():
+    mock_redis = AsyncMock()
+    mock_redis.exists = AsyncMock(return_value=1)
+    mock_redis.hset = AsyncMock()
+
+    svc = LLMApiKeyService.__new__(LLMApiKeyService)
+    svc._redis = mock_redis
+
+    result = await svc.revoke_key("abcd1234")
+    assert result is True
+    mock_redis.hset.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_revoke_key_not_found():
+    mock_redis = AsyncMock()
+    mock_redis.exists = AsyncMock(return_value=0)
+
+    svc = LLMApiKeyService.__new__(LLMApiKeyService)
+    svc._redis = mock_redis
+
+    result = await svc.revoke_key("missing")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# check_budget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_budget_unlimited():
+    rec = _make_record(monthly_budget_usd=0.0)
+    svc = LLMApiKeyService.__new__(LLMApiKeyService)
+    svc._redis = AsyncMock()
+
+    allowed, remaining = await svc.check_budget(rec)
+    assert allowed is True
+    assert remaining == -1.0
+
+
+@pytest.mark.asyncio
+async def test_check_budget_within():
+    rec = _make_record(monthly_budget_usd=10.0)
+    svc = LLMApiKeyService.__new__(LLMApiKeyService)
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value="3.0")
+    svc._redis = mock_redis
+
+    allowed, remaining = await svc.check_budget(rec)
+    assert allowed is True
+    assert abs(remaining - 7.0) < 0.001
+
+
+@pytest.mark.asyncio
+async def test_check_budget_exceeded():
+    rec = _make_record(monthly_budget_usd=5.0)
+    svc = LLMApiKeyService.__new__(LLMApiKeyService)
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value="6.0")
+    svc._redis = mock_redis
+
+    allowed, remaining = await svc.check_budget(rec)
+    assert allowed is False
+    assert remaining == 0.0
+
+
+# ---------------------------------------------------------------------------
+# authenticate_key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_authenticate_key_valid():
+    from services.llm_api_key_service import _generate_raw_key
+
+    raw = _generate_raw_key("abcd1234")
+    key_hash = _hash_raw_key(raw)
+    rec = _make_record(key_id="abcd1234", key_hash=key_hash)
+
+    svc = LLMApiKeyService.__new__(LLMApiKeyService)
+    mock_redis = AsyncMock()
+    mock_redis.hgetall = AsyncMock(return_value=rec.to_redis_hash())
+    svc._redis = mock_redis
+
+    result = await svc.authenticate_key(raw)
+    assert result is not None
+    assert result.key_id == "abcd1234"
+
+
+@pytest.mark.asyncio
+async def test_authenticate_key_wrong_hash():
+    svc = LLMApiKeyService.__new__(LLMApiKeyService)
+    rec = _make_record(key_id="abcd1234", key_hash="wronghash" * 7 + "wronghas")
+    mock_redis = AsyncMock()
+    mock_redis.hgetall = AsyncMock(return_value=rec.to_redis_hash())
+    svc._redis = mock_redis
+
+    result = await svc.authenticate_key("sk-abcd1234-" + "z" * 32)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_authenticate_key_revoked():
+    from services.llm_api_key_service import _generate_raw_key
+
+    raw = _generate_raw_key("abcd1234")
+    key_hash = _hash_raw_key(raw)
+    rec = _make_record(key_id="abcd1234", key_hash=key_hash, revoked=True)
+
+    svc = LLMApiKeyService.__new__(LLMApiKeyService)
+    mock_redis = AsyncMock()
+    mock_redis.hgetall = AsyncMock(return_value=rec.to_redis_hash())
+    svc._redis = mock_redis
+
+    result = await svc.authenticate_key(raw)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# publish_usage_event — Redis error swallowed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_usage_event_swallows_error():
+    svc = LLMApiKeyService.__new__(LLMApiKeyService)
+    mock_redis = AsyncMock()
+    mock_redis.xadd = AsyncMock(side_effect=Exception("Redis down"))
+    svc._redis = mock_redis
+
+    rec = _make_record()
+    # Should not raise
+    await svc.publish_usage_event(rec, "gpt-4", 100, 50, 0.01)

--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -48,4 +48,6 @@ export const navItems: NavItem[] = [
   // Issue #4465: Usage moved under /analytics/usage tab
   // Issue #1440: AutoResearch experiment dashboard (admin-only)
   { to: '/experiments', labelKey: 'nav.experiments', adminOnly: true, icon: 'M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z' },
+  // Issue #6590: Virtual LLM API keys admin view (admin-only)
+  { to: '/admin/llm-keys', labelKey: 'nav.llmApiKeys', adminOnly: true, icon: 'M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z', iconRule: 'evenodd' },
 ];

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -17,6 +17,7 @@
     "clear": "Clear",
     "reset": "Reset",
     "copy": "Copy",
+    "saving": "Saving...",
     "share": "Share",
     "export": "Export",
     "import": "Import",
@@ -6659,6 +6660,42 @@
       "unknown": "Unknown"
     }
   },
+  "llmKeys": {
+    "title": "LLM API Keys",
+    "issueKey": "Issue Key",
+    "revoke": "Revoke",
+    "rotate": "Rotate",
+    "unlimited": "Unlimited",
+    "empty": "No API keys found.",
+    "rawKeyWarning": "Copy this key now — it will not be shown again.",
+    "col": {
+      "prefix": "Key Prefix",
+      "team": "Team",
+      "label": "Label",
+      "budget": "Monthly Budget",
+      "spend": "Spend (MTD)",
+      "models": "Allowed Models",
+      "status": "Status",
+      "expires": "Expires"
+    },
+    "status": {
+      "active": "Active",
+      "revoked": "Revoked"
+    },
+    "form": {
+      "teamId": "Team ID",
+      "label": "Label",
+      "budget": "Monthly Budget (USD)",
+      "budgetHint": "Set to 0 for unlimited.",
+      "models": "Allowed Models (JSON array)",
+      "modelsHint": "E.g. [\"gpt-4\", \"claude-*\"]. Leave blank to allow all.",
+      "expiresAt": "Expires At (optional)"
+    },
+    "revokeConfirm": {
+      "title": "Revoke API Key",
+      "body": "Are you sure you want to revoke key {id}? This cannot be undone."
+    }
+  },
   "featureFlags": {
     "accessMetrics": {
       "title": "Access Control Metrics",
@@ -7069,6 +7106,7 @@
     "agentRegistry": "Agents",
     "agentActivity": "Agent Activity",
     "experiments": "Experiments",
+    "llmApiKeys": "LLM API Keys",
     "slmAdmin": "SLM Admin",
     "slmAdminTitle": "Open SLM Admin Panel",
     "profileSettings": "Profile Settings",

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -686,6 +686,18 @@ export const routes: RouteRecordRaw[] = [
       requiresAuth: true,
     },
   },
+  // Issue #6590: Virtual LLM API Keys admin view
+  {
+    path: '/admin/llm-keys',
+    name: 'llm-api-keys',
+    component: () => import('@/views/LLMApiKeysView.vue'),
+    meta: {
+      title: 'LLM API Keys',
+      description: 'Manage virtual LLM API keys with per-key budgets',
+      requiresAuth: true,
+      admin: true,
+    },
+  },
   // Issue #1801: Admin User Management
   {
     path: '/admin/users',

--- a/autobot-frontend/src/views/LLMApiKeysView.vue
+++ b/autobot-frontend/src/views/LLMApiKeysView.vue
@@ -1,0 +1,299 @@
+<template>
+  <div class="p-6 max-w-7xl mx-auto">
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+        {{ t('llmKeys.title') }}
+      </h1>
+      <button
+        class="btn-primary flex items-center gap-2"
+        @click="showIssueModal = true"
+      >
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+        </svg>
+        {{ t('llmKeys.issueKey') }}
+      </button>
+    </div>
+
+    <!-- New raw key banner -->
+    <div
+      v-if="newRawKey"
+      class="mb-4 p-4 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-300 dark:border-yellow-700 rounded-lg"
+    >
+      <p class="text-sm font-semibold text-yellow-800 dark:text-yellow-200 mb-1">
+        {{ t('llmKeys.rawKeyWarning') }}
+      </p>
+      <div class="flex items-center gap-2">
+        <code class="flex-1 text-sm font-mono bg-white dark:bg-gray-800 px-2 py-1 rounded border">{{ newRawKey }}</code>
+        <button class="btn-secondary text-xs" @click="copyRawKey">{{ t('common.copy') }}</button>
+      </div>
+      <button class="mt-2 text-xs text-yellow-600 underline" @click="newRawKey = ''">{{ t('common.dismiss') }}</button>
+    </div>
+
+    <!-- Keys table -->
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead class="bg-gray-50 dark:bg-gray-700 text-gray-500 dark:text-gray-400 uppercase text-xs">
+          <tr>
+            <th class="px-4 py-3 text-left">{{ t('llmKeys.col.prefix') }}</th>
+            <th class="px-4 py-3 text-left">{{ t('llmKeys.col.team') }}</th>
+            <th class="px-4 py-3 text-left">{{ t('llmKeys.col.label') }}</th>
+            <th class="px-4 py-3 text-right">{{ t('llmKeys.col.budget') }}</th>
+            <th class="px-4 py-3 text-right">{{ t('llmKeys.col.spend') }}</th>
+            <th class="px-4 py-3 text-left">{{ t('llmKeys.col.models') }}</th>
+            <th class="px-4 py-3 text-left">{{ t('llmKeys.col.status') }}</th>
+            <th class="px-4 py-3 text-left">{{ t('llmKeys.col.expires') }}</th>
+            <th class="px-4 py-3 text-left">{{ t('common.actions') }}</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+          <tr v-if="loading">
+            <td colspan="9" class="px-4 py-8 text-center text-gray-400">{{ t('common.loading') }}</td>
+          </tr>
+          <tr v-else-if="keys.length === 0">
+            <td colspan="9" class="px-4 py-8 text-center text-gray-400">{{ t('llmKeys.empty') }}</td>
+          </tr>
+          <tr
+            v-for="key in keys"
+            :key="key.key_id"
+            class="hover:bg-gray-50 dark:hover:bg-gray-750"
+          >
+            <td class="px-4 py-3 font-mono text-xs">{{ key.key_prefix }}</td>
+            <td class="px-4 py-3">{{ key.team_id }}</td>
+            <td class="px-4 py-3 text-gray-600 dark:text-gray-300">{{ key.label || '—' }}</td>
+            <td class="px-4 py-3 text-right">
+              {{ key.monthly_budget_usd > 0 ? '$' + key.monthly_budget_usd.toFixed(2) : t('llmKeys.unlimited') }}
+            </td>
+            <td class="px-4 py-3 text-right">
+              <span :class="spendClass(key)">
+                ${{ key.spend_usd_this_month.toFixed(4) }}
+              </span>
+            </td>
+            <td class="px-4 py-3 text-xs">
+              {{ key.allowed_models.length ? key.allowed_models.join(', ') : '*' }}
+            </td>
+            <td class="px-4 py-3">
+              <span
+                :class="key.revoked
+                  ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                  : 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'"
+                class="px-2 py-0.5 rounded-full text-xs font-medium"
+              >
+                {{ key.revoked ? t('llmKeys.status.revoked') : t('llmKeys.status.active') }}
+              </span>
+            </td>
+            <td class="px-4 py-3 text-xs text-gray-500">
+              {{ key.expires_at ? new Date(key.expires_at * 1000).toLocaleDateString() : '—' }}
+            </td>
+            <td class="px-4 py-3">
+              <div class="flex gap-2">
+                <button
+                  v-if="!key.revoked"
+                  class="text-xs text-blue-600 hover:underline"
+                  @click="handleRotate(key.key_id)"
+                >
+                  {{ t('llmKeys.rotate') }}
+                </button>
+                <button
+                  v-if="!key.revoked"
+                  class="text-xs text-red-600 hover:underline"
+                  @click="confirmRevoke(key.key_id)"
+                >
+                  {{ t('llmKeys.revoke') }}
+                </button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Issue Key Modal -->
+    <div v-if="showIssueModal" class="modal-overlay" @click.self="showIssueModal = false">
+      <div class="modal-content w-full max-w-lg">
+        <h2 class="text-lg font-semibold mb-4">{{ t('llmKeys.issueKey') }}</h2>
+        <form @submit.prevent="handleIssue">
+          <div class="space-y-4">
+            <div>
+              <label class="form-label">{{ t('llmKeys.form.teamId') }} *</label>
+              <input v-model="form.team_id" class="form-input" required />
+            </div>
+            <div>
+              <label class="form-label">{{ t('llmKeys.form.label') }}</label>
+              <input v-model="form.label" class="form-input" />
+            </div>
+            <div>
+              <label class="form-label">{{ t('llmKeys.form.budget') }}</label>
+              <input v-model.number="form.monthly_budget_usd" type="number" step="0.01" min="0" class="form-input" />
+              <p class="text-xs text-gray-500 mt-1">{{ t('llmKeys.form.budgetHint') }}</p>
+            </div>
+            <div>
+              <label class="form-label">{{ t('llmKeys.form.models') }}</label>
+              <input v-model="form.allowed_models_raw" class="form-input" placeholder='["gpt-4", "claude-*"]' />
+              <p class="text-xs text-gray-500 mt-1">{{ t('llmKeys.form.modelsHint') }}</p>
+            </div>
+            <div>
+              <label class="form-label">{{ t('llmKeys.form.expiresAt') }}</label>
+              <input v-model="form.expires_at_str" type="date" class="form-input" />
+            </div>
+          </div>
+          <div class="flex justify-end gap-3 mt-6">
+            <button type="button" class="btn-secondary" @click="showIssueModal = false">
+              {{ t('common.cancel') }}
+            </button>
+            <button type="submit" class="btn-primary" :disabled="issuing">
+              {{ issuing ? t('common.saving') : t('llmKeys.issueKey') }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <!-- Revoke Confirmation Modal -->
+    <div v-if="revokeKeyId" class="modal-overlay" @click.self="revokeKeyId = ''">
+      <div class="modal-content w-full max-w-sm">
+        <h2 class="text-lg font-semibold mb-2">{{ t('llmKeys.revokeConfirm.title') }}</h2>
+        <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          {{ t('llmKeys.revokeConfirm.body', { id: revokeKeyId }) }}
+        </p>
+        <div class="flex justify-end gap-3">
+          <button class="btn-secondary" @click="revokeKeyId = ''">{{ t('common.cancel') }}</button>
+          <button class="btn-danger" @click="handleRevoke">{{ t('llmKeys.revoke') }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { getBackendUrl } from '@/config/ssot-config'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { createLogger } from '@/utils/logger'
+
+const { t } = useI18n()
+const logger = createLogger('LLMApiKeysView')
+
+interface KeyRow {
+  key_id: string
+  key_prefix: string
+  team_id: string
+  label: string
+  monthly_budget_usd: number
+  spend_usd_this_month: number
+  allowed_models: string[]
+  revoked: boolean
+  expires_at: number | null
+}
+
+const keys = ref<KeyRow[]>([])
+const loading = ref(false)
+const showIssueModal = ref(false)
+const issuing = ref(false)
+const newRawKey = ref('')
+const revokeKeyId = ref('')
+
+const form = reactive({
+  team_id: '',
+  label: '',
+  monthly_budget_usd: 0,
+  allowed_models_raw: '',
+  expires_at_str: '',
+})
+
+function spendClass(key: KeyRow): string {
+  if (key.monthly_budget_usd <= 0) return 'text-gray-700 dark:text-gray-300'
+  const ratio = key.spend_usd_this_month / key.monthly_budget_usd
+  if (ratio >= 0.9) return 'text-red-600 font-semibold'
+  if (ratio >= 0.7) return 'text-yellow-600 font-semibold'
+  return 'text-green-600'
+}
+
+async function loadKeys(): Promise<void> {
+  loading.value = true
+  try {
+    const data = await fetchWithAuth(getBackendUrl() + '/api/llm-keys/list')
+    keys.value = (data as { keys: KeyRow[] }).keys ?? []
+  } catch (err) {
+    logger.error('Failed to load LLM API keys', err)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleIssue(): Promise<void> {
+  issuing.value = true
+  try {
+    let allowed_models: string[] = []
+    if (form.allowed_models_raw.trim()) {
+      allowed_models = JSON.parse(form.allowed_models_raw)
+    }
+    const expires_at = form.expires_at_str
+      ? new Date(form.expires_at_str).getTime() / 1000
+      : null
+
+    const result = await fetchWithAuth(getBackendUrl() + '/api/llm-keys/issue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        team_id: form.team_id,
+        label: form.label,
+        monthly_budget_usd: form.monthly_budget_usd,
+        allowed_models,
+        expires_at,
+      }),
+    })
+    newRawKey.value = (result as { raw_key: string }).raw_key
+    showIssueModal.value = false
+    Object.assign(form, { team_id: '', label: '', monthly_budget_usd: 0, allowed_models_raw: '', expires_at_str: '' })
+    await loadKeys()
+  } catch (err) {
+    logger.error('Failed to issue LLM API key', err)
+  } finally {
+    issuing.value = false
+  }
+}
+
+function confirmRevoke(keyId: string): void {
+  revokeKeyId.value = keyId
+}
+
+async function handleRevoke(): Promise<void> {
+  try {
+    await fetchWithAuth(getBackendUrl() + '/api/llm-keys/revoke', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key_id: revokeKeyId.value }),
+    })
+    revokeKeyId.value = ''
+    await loadKeys()
+  } catch (err) {
+    logger.error('Failed to revoke LLM API key', err)
+  }
+}
+
+async function handleRotate(keyId: string): Promise<void> {
+  try {
+    const result = await fetchWithAuth(getBackendUrl() + '/api/llm-keys/rotate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key_id: keyId }),
+    })
+    newRawKey.value = (result as { new_raw_key: string }).new_raw_key
+    await loadKeys()
+  } catch (err) {
+    logger.error('Failed to rotate LLM API key', err)
+  }
+}
+
+async function copyRawKey(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(newRawKey.value)
+  } catch {
+    // clipboard unavailable
+  }
+}
+
+onMounted(loadKeys)
+</script>


### PR DESCRIPTION
## Summary

- **`LLMApiKeyService`** — Redis MAIN-backed virtual keys: `issue_key`, `revoke_key`, `rotate_key`, `list_keys`, `authenticate_key`, `check_budget`, `record_spend`, `publish_usage_event`, `rotate_expired_keys`. SHA-256 hash storage, `secrets.compare_digest` for constant-time comparison, rotation grace period (env `AUTOBOT_LLM_KEY_ROTATION_GRACE_SECS`, default 86400s), per-key monthly spend via `INCRBYFLOAT`, usage audit events to Redis Stream `llm:usage:stream`.
- **`/api/llm-keys` router** (`api/llm_keys.py`) — admin-only CRUD: `POST /issue`, `POST /revoke`, `POST /rotate`, `GET /list?team_id=`. Raw key shown once in response.
- **`openai_compat.py`** — dual-auth path: `sk-...` virtual keys OR platform JWT. Model whitelist returns 403 + `x-llm-key-allowed-models` header. Budget enforcement returns 429 + `x-llm-budget-remaining: 0` header. Spend + usage event recording on both streaming and non-streaming paths.
- **`LLMKeyRotationScheduler`** — APScheduler `AsyncIOScheduler` hourly job auto-revokes expired keys. Interval via `AUTOBOT_LLM_KEY_ROTATION_INTERVAL_MINUTES` (default 60). Wired into `lifespan.py` Phase 2.
- **`LLMApiKeysView.vue`** — admin UI: table with spend color-coding (green/yellow/red), issue modal, revoke confirmation modal, rotate button with new-key copy banner.
- Router entry `/admin/llm-keys`, nav item (adminOnly), i18n keys.
- Unit tests: 15 cases covering key format, model_allowed (exact/wildcard/prefix/empty), issue, revoke, budget (unlimited/within/exceeded), authenticate (valid/wrong/revoked), publish_usage_event error swallowing.

## Test plan

- [ ] `python3 -m py_compile` passes on all backend files
- [ ] Unit tests: `pytest autobot-backend/tests/services/test_llm_api_key_service.py`
- [ ] POST `/api/llm-keys/issue` returns `raw_key` once
- [ ] `Bearer sk-...` auth accepted by `/v1/chat/completions` (200)
- [ ] Budget exceeded → 429 + `x-llm-budget-remaining: 0`
- [ ] Model not in allowlist → 403 + `x-llm-key-allowed-models` header
- [ ] Platform JWT still works (no regression)
- [ ] Admin nav shows "LLM API Keys" entry at `/admin/llm-keys`

Closes #6590

🤖 Generated with [Claude Code](https://claude.com/claude-code)