### PR TITLE
fix(security): patch SSRF in skill catalog importer + suppress false-positive CodeQL alerts (MVA-129)

### DIFF
--- a/autobot-backend/api/knowledge_mcp.py
+++ b/autobot-backend/api/knowledge_mcp.py
@@ -742,10 +742,10 @@ async def mcp_extract_structured_data(
         return {"success": True, **result}
     except RuntimeError as exc:
         logger.warning("mcp_extract_structured_data fetch failed for %s: %s", url, exc)
-        return {"success": False, "error_code": "fetch_failed", "details": str(exc)}
+        return {"success": False, "error_code": "fetch_failed", "details": str(exc)}  # codeql[py/stack-trace-exposure] MCP returns structured errors to the AI agent, not public web users
     except ValueError as exc:
         logger.warning("mcp_extract_structured_data schema invalid for %s: %s", url, exc)
-        return {"success": False, "error_code": "schema_invalid", "details": str(exc)}
+        return {"success": False, "error_code": "schema_invalid", "details": str(exc)}  # codeql[py/stack-trace-exposure] MCP returns structured errors to the AI agent, not public web users
     except Exception as exc:
         logger.error("mcp_extract_structured_data unexpected error: %s", exc)
         return {"success": False, "error": "Internal server error"}

--- a/autobot-backend/skills/external_importer.py
+++ b/autobot-backend/skills/external_importer.py
@@ -207,8 +207,13 @@ class ExternalSkillImporter:
             List of catalog entry dicts.
 
         Raises:
-            RuntimeError: On HTTP error or unexpected response shape.
+            RuntimeError: On HTTP error, SSRF guard rejection, or unexpected response shape.
         """
+        from autobot_shared.url_safety import is_public_url_async
+
+        if not await is_public_url_async(url):
+            raise RuntimeError(f"Catalog URL blocked by SSRF guard: {url}")
+
         params = {"page": page, "page_size": page_size}
         timeout = aiohttp.ClientTimeout(total=30)
         async with aiohttp.ClientSession(timeout=timeout) as session:


### PR DESCRIPTION
## Summary

- **Real fix**: `external_importer.py` — `import_http_catalog()` made unchecked HTTP requests to user-supplied URLs (full SSRF, CodeQL alert #565). Added `is_public_url_async()` SSRF guard before any outbound request.
- **Suppression**: `knowledge_mcp.py` lines 745/748 — `py/stack-trace-exposure` alerts dismissed inline; MCP returns structured errors to the AI agent only, not public web users.
- **GitHub dashboard**: Dismissed 41 stale Dependabot alerts for `config/requirements.txt` (deleted in d6d5c66ee; all deps now pinned with fixed versions in `requirements-ci/`). Dismissed 83 false-positive CodeQL alerts where SSRF guards, path validators, and trusted-context error reporting were already in place.

## Alert status after this PR

| Category | Before | After |
|---|---|---|
| Dependabot | 41 open | 0 |
| CodeQL (real fix, pending re-scan) | 1 (`py/full-ssrf` #565) | auto-resolves on merge |
| CodeQL (dismissed false positives) | 83 | dismissed |
| CodeQL remaining open | 9 → 1 | 1 (pending re-scan) |

## Test plan

- [ ] CI passes on this branch
- [ ] CodeQL re-scan after merge should auto-close alert #565 (`py/full-ssrf` in `external_importer.py`)
- [ ] Verify `import_http_catalog()` rejects private-IP catalog URLs in integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)