### PR TITLE
fix(security): suppress CodeQL py/full-ssrf false positive in fetch_safe_url (#6533)

### DIFF
--- a/autobot_shared/security/ssrf_guard.py
+++ b/autobot_shared/security/ssrf_guard.py
@@ -161,7 +161,7 @@ async def fetch_safe_url(
         connector=connector,
         headers=headers or {},
     ) as session:
-        async with session.get(url, allow_redirects=False) as response:
+        async with session.get(url, allow_redirects=False) as response:  # codeql[py/full-ssrf] SSRF mitigated: scheme validated, host resolved to public IP via resolve_safe_ip(), connector uses pinned resolver defeating DNS-rebind, redirects disabled (#6533)
             status = response.status
             content_type = response.headers.get("Content-Type", "")
             body = await response.content.read(max_bytes + 1)


### PR DESCRIPTION
## Summary

- Adds `# codeql[py/full-ssrf]` suppression comment at `ssrf_guard.py:164` (`session.get()` call)
- CodeQL alert #572 fired post-merge of PR #7594 — static analysis sees the user URL flowing to an HTTP request without recognising the pinned aiohttp resolver as SSRF mitigation
- This is a confirmed false positive: all SSRF vectors are blocked by the surrounding code

## Why this is a false positive

The `fetch_safe_url()` function already mitigates SSRF at every layer:
1. **Scheme validation** — only `http`/`https` permitted
2. **DNS → public IP** — `resolve_safe_ip()` rejects loopback, RFC1918, link-local (169.254.0.0/16), IPv6 ULA (fc00::/7), multicast
3. **Pinned resolver** — `safe_aiohttp_resolver()` returns a custom `AbstractResolver` that supplies the pre-resolved public IP directly; the aiohttp connector never calls DNS again, defeating DNS-rebind TOCTOU
4. **`allow_redirects=False`** — prevents redirect-chain escapes to internal addresses

CodeQL does not model custom aiohttp resolvers, so it cannot see that step 3 prevents the URL from ever reaching a non-public host at connection time.

## Test plan

- [ ] CI CodeQL scan no longer reports alert #572
- [ ] All existing SSRF guard tests continue to pass (`autobot_shared/security/ssrf_guard_test.py`)

Closes CodeQL alert #572 (py/full-ssrf on `autobot_shared/security/ssrf_guard.py:164`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)