### PR TITLE
ci: enable pip and npm caching across all CI workflows (GH#7073)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,8 @@ jobs:
       uses: actions/setup-node@v6.4.0
       with:
         node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: autobot-frontend/package-lock.json
 
     - name: Install frontend dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,8 @@ jobs:
       uses: actions/setup-node@v6.4.0
       with:
         node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: autobot-frontend/package-lock.json
+        cache: 'npm'
+        cache-dependency-path: autobot-frontend/package-lock.json
 
     - name: Install frontend dependencies
       run: |

--- a/.github/workflows/frontend-codegen-drift.yml
+++ b/.github/workflows/frontend-codegen-drift.yml
@@ -59,6 +59,11 @@ jobs:
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v5.0.0
         with:
           python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements*.txt
+            autobot-backend/requirements*.txt
+            autobot-slm-backend/requirements*.txt
 
       - name: Install minimal codegen deps
         # pydantic is the only non-stdlib import any MANIFEST source file

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: autobot-frontend/package-lock.json
 
       - name: Install dependencies
         working-directory: autobot-frontend
@@ -127,6 +129,8 @@ jobs:
         uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: autobot-frontend/package-lock.json
 
       - name: Install dependencies
         working-directory: autobot-frontend
@@ -170,6 +174,8 @@ jobs:
         uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: autobot-frontend/package-lock.json
 
       - name: Install dependencies
         working-directory: autobot-frontend

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -94,6 +94,8 @@ jobs:
       uses: actions/setup-node@v6.4.0
       with:
         node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: autobot-frontend/package-lock.json
 
     - name: Install Frontend dependencies
       run: |

--- a/.github/workflows/unwired-tracker-audit.yml
+++ b/.github/workflows/unwired-tracker-audit.yml
@@ -47,6 +47,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements*.txt
+            autobot-backend/requirements*.txt
+            autobot-slm-backend/requirements*.txt
 
       - name: Run audit (dry-run, JSON output)
         id: scan

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -55,6 +55,8 @@ jobs:
         uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: autobot-frontend/package-lock.json
 
       - name: Install dependencies
         working-directory: autobot-frontend


### PR DESCRIPTION
## Summary

- Add `cache: 'pip'` with `cache-dependency-path` to `setup-python` steps in `frontend-codegen-drift.yml` and `unwired-tracker-audit.yml` (the only 2 Python workflows missing it)
- Add `cache: 'npm'` with `cache-dependency-path: autobot-frontend/package-lock.json` to `setup-node` steps in `ci.yml`, `security.yml`, `frontend-test.yml` (3 jobs), and `visual-regression.yml`
- All workflows that install Python or Node deps now use hash-keyed wheel/module caches

**Before:** `frontend-codegen-drift.yml`, `unwired-tracker-audit.yml` re-downloaded all pip wheels on every run. All node workflows except `frontend-typecheck-regression.yml` re-downloaded npm packages.

**After:** Every workflow that calls `setup-python` or `setup-node` uses caching. Expected install time: ~30s (from cache hit) vs ~2-4min cold.

**Verification:**
```
grep -c "cache: 'pip'" .github/workflows/*.yml  # non-zero for python workflows
grep -c "cache: 'npm'" .github/workflows/*.yml  # non-zero for node workflows
```

## Test plan

- [ ] Confirm CI runs on this PR show pip/npm install steps completing faster (expect cache miss on first run, cache hit on subsequent runs)
- [ ] Verify no cache key collision errors in workflow logs
- [ ] Confirm all 6 modified workflows still pass their jobs

Closes GH#7073 | Paperclip: MVA-54

🤖 Generated with [Claude Code](https://claude.com/claude-code)