### PR TITLE
fix(ci): remove 2 remaining F401 unused imports blocking code-quality (MVA-137)

### DIFF
--- a/autobot-backend/api/llm_keys.py
+++ b/autobot-backend/api/llm_keys.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling

--- a/autobot_shared/datetime_utils.py
+++ b/autobot_shared/datetime_utils.py
@@ -8,7 +8,7 @@ See #7436 (GitHub) and MVA-48 (Paperclip) for the migration plan.
 
 from datetime import datetime, timezone
 
-from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
+from autobot_shared.time_utils import now_utc, utc_timestamp
 
 # Canonical aliases matching MVA-48 naming convention
 datetime_now = now_utc


### PR DESCRIPTION
## Summary

- **llm_keys.py**: drop `Request` from `fastapi` import — only Pydantic models named `*Request*` are used in this file, not FastAPI's `Request` class
- **datetime_utils.py**: drop `parse_utc_iso` from `time_utils` import — only `now_utc` and `utc_timestamp` are aliased; `parse_utc_iso` was re-exported by mistake

## Verification

```
$ flake8 --select=F401,F811,F841 autobot-backend/ autobot-slm-backend/ autobot_shared/
0
```

Zero F401/F811/F841 errors on Dev_new_gui after this patch.

## Context

The bulk of the 35 flake8 regressions were already cleared by prior PRs (#7596 isort fixes, and partial cherry-picks from issue-7522). These two were the final stragglers introduced by recent merges (llm-keys #7617, datetime_utils in auth dedupe #7601).

Closes #7522
Relates to MVA-137

🤖 Generated with [Claude Code](https://claude.com/claude-code)