### PR TITLE
fix(dedup): consolidate slack_approval_integration.CircuitState into shared analyzer module (MVA-139)

### DIFF
--- a/autobot-backend/services/slack_approval_integration.py
+++ b/autobot-backend/services/slack_approval_integration.py
@@ -23,9 +23,9 @@ Usage::
 import json
 import logging
 import time
-from enum import Enum
 from typing import Any, Dict, Optional
 
+from agents.agent_orchestration.types import CircuitState
 from autobot_shared.redis_client import get_redis_client
 
 logger = logging.getLogger(__name__)
@@ -36,14 +36,6 @@ _APPROVAL_THREAD_PREFIX = "approval_thread"
 _CHANNEL_MAPPING_PREFIX = "slack_channel_mapping"
 _APPROVAL_CIRCUIT_BREAKER_PREFIX = "approval_redis_circuit"
 _APPROVAL_TTL_SECONDS = 86400  # 24 hours
-
-
-class CircuitState(str, Enum):
-    """Circuit breaker states for Redis failures."""
-
-    CLOSED = "closed"  # Normal operation
-    OPEN = "open"  # Failures detected, skip Redis ops
-    HALF_OPEN = "half_open"  # Testing if Redis recovered
 
 
 class SlackApprovalManager:


### PR DESCRIPTION
## Summary

- Removes the 3rd duplicate `CircuitState` class definition from `services/slack_approval_integration.py`
- Replaces it with an import from the canonical shared module: `agents.agent_orchestration.types`
- PR #7520 previously deduplicated two copies into `agents/agent_orchestration/types.py`; this completes the consolidation by catching the missed instance in `slack_approval_integration`

## Changes

`autobot-backend/services/slack_approval_integration.py`:
- Removed local `class CircuitState(str, Enum)` (CLOSED/OPEN/HALF_OPEN)
- Removed `from enum import Enum` (no longer needed)
- Added `from agents.agent_orchestration.types import CircuitState`

## Acceptance Criteria

- [x] No duplicate `CircuitState` definitions in `services/slack_approval_integration.py`
- [x] `slack_approval_integration` imports from shared `agents.agent_orchestration.types` module
- [x] All `CircuitState` usages in `SlackApprovalManager` (state checks, transitions, logging) remain functionally identical

Closes GH#7615

🤖 Generated with [Claude Code](https://claude.com/claude-code)