### PR TITLE
fix(openai-compat): streaming cost SSE chunk now a valid ChatCompletionChunk (MVA-138)

### DIFF
--- a/autobot-backend/api/llm_keys.py
+++ b/autobot-backend/api/llm_keys.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling

--- a/autobot-backend/api/openai_compat.py
+++ b/autobot-backend/api/openai_compat.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import json
 import logging
 import time
 from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
@@ -243,10 +242,14 @@ async def _stream_generator(
     )
     yield f"data: {final_chunk.model_dump_json()}\n\n"
 
-    # Usage chunk (OpenAI spec: emit only when stream_options.include_usage=true)
     prompt_tokens = _estimate_tokens(prompt_text)
     completion_tokens = _estimate_tokens("".join(completion_text_parts))
+    tracker = get_cost_tracker()
+    cost_usd = tracker.calculate_cost(model_name, prompt_tokens, completion_tokens)
 
+    # Usage chunk (OpenAI spec: emit only when stream_options.include_usage=true)
+    # Cost is embedded here when available; a standalone cost chunk is emitted
+    # when include_usage is false so clients get cost info in a valid chunk (#7610).
     if include_usage:
         usage_chunk = ChatCompletionChunk(
             id=completion_id,
@@ -257,16 +260,19 @@ async def _stream_generator(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
                 total_tokens=prompt_tokens + completion_tokens,
+                cost_usd=cost_usd if cost_usd > 0 else None,
             ),
         )
-        yield f"data: {usage_chunk.model_dump_json()}\n\n"
-
-    # Cost chunk - emit in final SSE event (estimated from streaming tokens)
-    tracker = get_cost_tracker()
-    cost_usd = tracker.calculate_cost(model_name, prompt_tokens, completion_tokens)
-    if cost_usd > 0:
-        cost_chunk = {"cost": cost_usd}
-        yield f"data: {json.dumps(cost_chunk)}\n\n"
+        yield f"data: {usage_chunk.model_dump_json(exclude_none=True)}\n\n"
+    elif cost_usd > 0:
+        cost_chunk = ChatCompletionChunk(
+            id=completion_id,
+            created=created,
+            model=model_name,
+            choices=[],
+            usage=OAIUsage(cost_usd=cost_usd),
+        )
+        yield f"data: {cost_chunk.model_dump_json(exclude_none=True)}\n\n"
 
     yield "data: [DONE]\n\n"
 

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -1745,6 +1745,7 @@ class OAIUsage(BaseModel):
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    cost_usd: Optional[float] = None
 
 
 class ChatCompletionResponse(BaseModel):

--- a/autobot-backend/api/test_openai_compat.py
+++ b/autobot-backend/api/test_openai_compat.py
@@ -59,7 +59,7 @@ def _make_mock_registry(content: str = "Hello from AutoBot", models: list = None
         yield "Hello "
         yield "from AutoBot"
 
-    mock_provider.stream_completion = MagicMock(side_effect=lambda r: _fake_stream(r))
+    mock_provider.stream_completion = _fake_stream
     mock_provider.list_models = AsyncMock(return_value=models)
 
     mock_registry = MagicMock()
@@ -167,15 +167,22 @@ async def test_chat_completions_streaming_returns_sse_done():
         assert "choices" in chunk
 
 
-def _stream_post(payload):
+def _stream_post(payload, *, mock_tracker=None):
     """Helper that issues the streaming POST and returns decoded SSE text."""
+    import contextlib
+
     mock_registry = _make_mock_registry()
 
     async def _run():
-        with (
+        patches = [
             patch("api.openai_compat.get_provider_registry", return_value=mock_registry),
             patch("api.openai_compat._get_user", return_value=_SYNTHETIC_USER),
-        ):
+        ]
+        if mock_tracker is not None:
+            patches.append(patch("api.openai_compat.get_cost_tracker", return_value=mock_tracker))
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
                 async with client.stream("POST", "/v1/chat/completions", json=payload) as response:
                     assert response.status_code == 200
@@ -243,3 +250,57 @@ async def test_streaming_omits_usage_when_stream_options_absent():
     )()
     chunks = _parse_sse_chunks(text)
     assert all(c.get("usage") is None for c in chunks)
+
+
+@pytest.mark.asyncio
+async def test_streaming_cost_chunk_is_valid_chat_completion_chunk():
+    """Cost SSE chunk must be a valid ChatCompletionChunk, not a bare dict (#7610)."""
+    mock_tracker = MagicMock()
+    mock_tracker.calculate_cost = MagicMock(return_value=0.00123)
+
+    text = await _stream_post(
+        {
+            "model": "autobot-model-1",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "stream": True,
+        },
+        mock_tracker=mock_tracker,
+    )()
+
+    assert "data: [DONE]" in text
+    chunks = _parse_sse_chunks(text)
+    # Every chunk must have the required ChatCompletionChunk fields
+    for chunk in chunks:
+        assert chunk.get("object") == "chat.completion.chunk", f"Invalid chunk: {chunk}"
+        assert "choices" in chunk, f"Missing 'choices' in chunk: {chunk}"
+        assert "id" in chunk, f"Missing 'id' in chunk: {chunk}"
+        assert "model" in chunk, f"Missing 'model' in chunk: {chunk}"
+    # The cost chunk (choices=[]) must carry cost_usd in usage
+    cost_chunks = [c for c in chunks if c.get("usage") and c["usage"].get("cost_usd") is not None]
+    assert len(cost_chunks) == 1, "Expected exactly one chunk with cost_usd in usage"
+    assert cost_chunks[0]["usage"]["cost_usd"] == pytest.approx(0.00123)
+
+
+@pytest.mark.asyncio
+async def test_streaming_cost_embedded_in_usage_chunk_when_include_usage_true():
+    """When include_usage=true and cost>0, cost_usd must appear in the usage chunk (#7610)."""
+    mock_tracker = MagicMock()
+    mock_tracker.calculate_cost = MagicMock(return_value=0.005)
+
+    text = await _stream_post(
+        {
+            "model": "autobot-model-1",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        },
+        mock_tracker=mock_tracker,
+    )()
+
+    chunks = _parse_sse_chunks(text)
+    usage_chunks = [c for c in chunks if c.get("usage") is not None]
+    assert len(usage_chunks) == 1, "Expected exactly one chunk with usage"
+    usage = usage_chunks[0]["usage"]
+    assert usage["prompt_tokens"] >= 1
+    assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+    assert usage.get("cost_usd") == pytest.approx(0.005)

--- a/autobot_shared/datetime_utils.py
+++ b/autobot_shared/datetime_utils.py
@@ -8,7 +8,7 @@ See #7436 (GitHub) and MVA-48 (Paperclip) for the migration plan.
 
 from datetime import datetime, timezone
 
-from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
+from autobot_shared.time_utils import now_utc, utc_timestamp
 
 # Canonical aliases matching MVA-48 naming convention
 datetime_now = now_utc


### PR DESCRIPTION
## Summary

- The cost SSE chunk on `/v1/chat/completions` was emitting a bare `{"cost": ...}` dict — not a valid `ChatCompletionChunk`, breaking clients that parse all `data:` lines against the OpenAI schema (GH#7610, MVA-138)
- Added `cost_usd: Optional[float]` to `OAIUsage` so cost rides in the standard `usage` field
- When `include_usage=true`: cost is embedded in the existing usage chunk (one chunk, no extra event)
- When `include_usage=false`: cost emitted as a valid `ChatCompletionChunk` with `choices=[]` and `usage.cost_usd` set; `exclude_none=True` keeps the wire format clean
- Fixed pre-existing mock bug where `stream_completion = MagicMock(...)` failed `inspect.isasyncgenfunction` guard added in #5132; replaced with the async gen function directly
- All 8 existing + 2 new tests pass

## Test plan

- [x] `test_chat_completions_streaming_returns_sse_done` — all chunks have `object=chat.completion.chunk` + `choices`
- [x] `test_streaming_emits_usage_when_include_usage_true` — one usage chunk, is last before `[DONE]`, has token counts
- [x] `test_streaming_omits_usage_when_include_usage_false` — no usage chunks (cost=0 in tests)
- [x] `test_streaming_cost_chunk_is_valid_chat_completion_chunk` (new) — mocked cost>0, verifies every chunk is valid ChatCompletionChunk
- [x] `test_streaming_cost_embedded_in_usage_chunk_when_include_usage_true` (new) — mocked cost>0 + include_usage, verifies cost_usd in usage chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)