### PR TITLE
fix(dedup): correct CircuitState import to circuit_breaker — canonical source (MVA-139 follow-up)

### DIFF
--- a/autobot-backend/services/slack_approval_integration.py
+++ b/autobot-backend/services/slack_approval_integration.py
@@ -25,7 +25,7 @@ import logging
 import time
 from typing import Any, Dict, Optional
 
-from agents.agent_orchestration.types import CircuitState
+from circuit_breaker import CircuitState
 from autobot_shared.redis_client import get_redis_client
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

Follow-up to PR #7631 (MVA-139). Code review (MVA-141) correctly identified that `circuit_breaker.CircuitState` is the canonical shared definition established by the dedup sprint (PR #7520), not `agents.agent_orchestration.types.CircuitState`.

Evidence: `npu_integration.py` already imports `from circuit_breaker import CircuitState` after round-3 dedup.

## Change

`autobot-backend/services/slack_approval_integration.py`:
- `from agents.agent_orchestration.types import CircuitState` → `from circuit_breaker import CircuitState`

No behavior change — both enums have identical values (CLOSED/OPEN/HALF_OPEN).

Fixes GH#7615

🤖 Generated with [Claude Code](https://claude.com/claude-code)