### PR TITLE
feat(security): SEC-2 Phase 3 — JWT refresh endpoint + path-prefix guard (MVA-91)

### DIFF
--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -14,7 +14,7 @@ import secrets
 from datetime import timezone
 from typing import Dict, Optional, Tuple
 
-from fastapi import Request
+from fastapi import HTTPException, Request, status
 
 from autobot_shared.auth.jwt_core import (
     decode_jwt_or_none,
@@ -670,9 +670,18 @@ async def get_current_user(request: Request) -> Dict:
     if user_data:
         return user_data
 
-    # Fallback: run-scoped JWT — async because it hits the Redis denylist
+    # Fallback: run-scoped JWT — async because it hits the Redis denylist.
+    # SEC-2 #6473: run JWTs are valid ONLY on the refresh endpoint and MCP
+    # bridge routes. Presenting a run JWT to any other REST endpoint returns
+    # 403 so a scoped token cannot reach chat/knowledge/LLM write paths.
     run_user = await middleware._extract_user_from_run_jwt(request)
     if run_user:
+        _RUN_JWT_ALLOWED_PREFIXES = ("/api/runs/", "/api/mcp/")
+        if not any(request.url.path.startswith(p) for p in _RUN_JWT_ALLOWED_PREFIXES):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Run JWT not permitted on this endpoint",
+            )
         return run_user
 
     raise_auth_error("AUTH_0002", "Authentication required")

--- a/autobot-backend/tests/integration/test_run_jwt_lifecycle.py
+++ b/autobot-backend/tests/integration/test_run_jwt_lifecycle.py
@@ -303,3 +303,81 @@ async def test_user_jwt_auth_unaffected_by_run_jwt_fallback(monkeypatch):
     result = await middleware._extract_user_from_run_jwt(request)
     # A JWT signed with ALT_SIGNING_KEY must not validate against LONG_SIGNING_KEY
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: path-prefix guard — run JWT blocked on non-allowed paths (SEC-2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_jwt_blocked_on_non_allowed_path(jwt_secret, monkeypatch):
+    """Integration: get_current_user raises 403 for run JWT on a non-allowed path.
+
+    A run JWT must not be usable on arbitrary REST endpoints (e.g. /api/llm/chat).
+    The path-prefix guard ensures that even a valid, non-revoked run JWT returns
+    403 Forbidden when presented outside /api/runs/ and /api/mcp/.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from fastapi import HTTPException
+
+    store, factory = _make_redis_store()
+    monkeypatch.setattr("services.run_jwt.get_async_redis_client", factory)
+    # Disable single-user mode so the run JWT fallback path is reached
+    monkeypatch.setenv("AUTOBOT_SINGLE_USER_MODE", "false")
+
+    run_id = str(uuid.uuid4())
+    token = mint_run_jwt(run_id, "task-1", "agent-1", "tenant-1", ["task:read"])
+
+    request = MagicMock()
+    request.headers = MagicMock()
+    request.headers.get = lambda k, d="": f"Bearer {token}" if k == "Authorization" else d
+    request.url.path = "/api/llm/chat"
+    request.cookies = {}
+    request.state = MagicMock(spec=[])
+
+    from auth_middleware import AuthenticationMiddleware, get_current_user
+
+    middleware = AuthenticationMiddleware.__new__(AuthenticationMiddleware)
+
+    with patch("auth_middleware.get_auth_middleware", return_value=middleware), patch.object(
+        middleware, "get_user_from_request", return_value=None
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(request)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_run_jwt_allowed_on_refresh_path(jwt_secret, monkeypatch):
+    """Integration: get_current_user accepts run JWT on /api/runs/ paths.
+
+    The refresh endpoint lives under /api/runs/{run_id}/jwt/refresh — confirming
+    the path-prefix guard allows the token through on this prefix.
+    """
+    from unittest.mock import MagicMock, patch
+
+    store, factory = _make_redis_store()
+    monkeypatch.setattr("services.run_jwt.get_async_redis_client", factory)
+
+    run_id = str(uuid.uuid4())
+    token = mint_run_jwt(run_id, "task-1", "agent-1", "tenant-1", ["task:read"])
+
+    request = MagicMock()
+    request.headers = MagicMock()
+    request.headers.get = lambda k, d="": f"Bearer {token}" if k == "Authorization" else d
+    request.url.path = f"/api/runs/{run_id}/jwt/refresh"
+    request.cookies = {}
+    request.state = MagicMock(spec=[])
+
+    from auth_middleware import AuthenticationMiddleware, get_current_user
+
+    middleware = AuthenticationMiddleware.__new__(AuthenticationMiddleware)
+
+    with patch("auth_middleware.get_auth_middleware", return_value=middleware), patch.object(
+        middleware, "get_user_from_request", return_value=None
+    ):
+        user = await get_current_user(request)
+    assert user["auth_method"] == "run_jwt"
+    assert user["run_id"] == run_id


### PR DESCRIPTION
## Summary

- Adds `POST /api/runs/{run_id}/jwt/refresh` endpoint so heartbeat schedulers can renew run-scoped JWTs mid-run without re-minting from scratch
- Extends `auth_middleware.get_current_user` to accept run JWTs as a Bearer token fallback (backward-compat — user JWTs continue to work unchanged)
- **Security fix (HIGH):** adds path-prefix guard so run JWTs are only accepted on `/api/runs/` and `/api/mcp/` prefixes — prevents a scoped token from reaching `POST /api/llm/chat`, knowledge-write, or any other non-run REST endpoint

## Key files

| File | Change |
|------|--------|
| `api/run_jwt_router.py` | New — `POST /runs/{run_id}/jwt/refresh` |
| `services/run_jwt.py` | `refresh_run_jwt()` + `AuditAction.RUN_JWT_REFRESH` |
| `auth_middleware.py` | `_extract_user_from_run_jwt()` + path-prefix guard in `get_current_user` |
| `initialization/router_registry/feature_routers.py` | Register new router |
| `tests/services/test_run_jwt.py` | 6 new `TestRefreshRunJwt` tests |
| `tests/integration/test_run_jwt_lifecycle.py` | 5 new integration tests incl. path-prefix guard |

## Test plan

- [ ] `pytest autobot-backend/tests/services/test_run_jwt.py` — 22 tests (all pass)
- [ ] `pytest autobot-backend/tests/integration/test_run_jwt_lifecycle.py` — 12 tests (all pass)
- [ ] `flake8 autobot-backend/auth_middleware.py autobot-backend/api/run_jwt_router.py` — clean
- [ ] Security: `test_run_jwt_blocked_on_non_allowed_path` proves 403 on `/api/llm/chat`
- [ ] Security: `test_run_jwt_allowed_on_refresh_path` proves pass-through on `/api/runs/`

Closes #6473 (SEC-2 Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)