### PR TITLE
fix(knowledge): replace undefined validated_url with request.url (MVA-176)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -1011,7 +1011,7 @@ async def add_url_to_knowledge(
 
     url_metadata: dict = {
         "title": title,
-        "source": validated_url,
+        "source": request.url,
         "category": request.category,
         "tags": request.tags,
         "type": "url",


### PR DESCRIPTION
## Summary

- **Root cause:** Commit `04c698a82` refactored SSRF validation into `fetch_safe_url`, removing the `validate_url()` call that produced `validated_url`. The `url_metadata` dict's `"source"` field was not updated to match, leaving an F821 undefined-name at `knowledge.py:1014`.
- **Fix:** Replace `validated_url` with `request.url` — the URL has already been SSRF-validated inside `_fetch_and_extract_url` via `fetch_safe_url`; storing the original request URL as the source is semantically correct.
- **Impact:** One-line change; no behaviour change beyond fixing the NameError that would have been raised at runtime.

## Verification

```
flake8 autobot-backend/api/knowledge.py --select=F821
# exit 0, no output
```

Closes MVA-176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)