### PR TITLE
fix(auth): mint new JWT before revoking old in refresh_run_jwt (MVA-170)

### DIFF
--- a/autobot-backend/api/autobot_mcp_router_test.py
+++ b/autobot-backend/api/autobot_mcp_router_test.py
@@ -64,9 +64,9 @@ def test_error_code_maps_to_correct_http_status(error_code: int, expected_status
             json=_json_rpc_body(),
             headers={"Authorization": "Bearer test-token"},
         )
-    assert response.status_code == expected_status, (
-        f"error code {error_code} should map to HTTP {expected_status}, got {response.status_code}"
-    )
+    assert (
+        response.status_code == expected_status
+    ), f"error code {error_code} should map to HTTP {expected_status}, got {response.status_code}"
 
 
 def test_successful_tool_call_returns_200() -> None:

--- a/autobot-backend/api/openai_compat_test.py
+++ b/autobot-backend/api/openai_compat_test.py
@@ -41,7 +41,9 @@ class TestGetUserAsync:
         fake_user = {"id": "u1", "email": "test@example.com"}
 
         async def run():
-            with patch("api.openai_compat.get_current_user", new_callable=AsyncMock, return_value=fake_user) as mock_gcu:
+            with patch(
+                "api.openai_compat.get_current_user", new_callable=AsyncMock, return_value=fake_user
+            ) as mock_gcu:
                 result = await openai_compat._get_user(fake_request)
                 mock_gcu.assert_awaited_once_with(fake_request)
                 assert result == fake_user
@@ -52,7 +54,11 @@ class TestGetUserAsync:
         fake_request = MagicMock()
 
         async def run():
-            with patch("api.openai_compat.get_current_user", new_callable=AsyncMock, side_effect=HTTPException(status_code=401, detail="Unauthorized")):
+            with patch(
+                "api.openai_compat.get_current_user",
+                new_callable=AsyncMock,
+                side_effect=HTTPException(status_code=401, detail="Unauthorized"),
+            ):
                 with pytest.raises(HTTPException) as exc_info:
                     await openai_compat._get_user(fake_request)
                 assert exc_info.value.status_code == 401
@@ -63,7 +69,11 @@ class TestGetUserAsync:
         fake_request = MagicMock()
 
         async def run():
-            with patch("api.openai_compat.get_current_user", new_callable=AsyncMock, side_effect=RuntimeError("jwt decode failed")):
+            with patch(
+                "api.openai_compat.get_current_user",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("jwt decode failed"),
+            ):
                 with pytest.raises(HTTPException) as exc_info:
                     await openai_compat._get_user(fake_request)
                 assert exc_info.value.status_code == 401

--- a/autobot-backend/services/run_jwt.py
+++ b/autobot-backend/services/run_jwt.py
@@ -364,9 +364,11 @@ async def refresh_run_jwt(token: str, run_id: str) -> str:
     tenant_id = str(claims.get("tenant_id", ""))
     old_jti = str(claims.get("jti", ""))
 
-    await revoke_run_jwt_async(token, agent_id=agent_id)
-
+    # Mint first so the agent retains a valid token if minting fails.
+    # Only revoke the old token after the new one is in hand.
     new_token = mint_run_jwt(run_id, task_id, agent_id, tenant_id, scope)
+
+    await revoke_run_jwt_async(token, agent_id=agent_id)
 
     audit_record(
         user_id=agent_id,

--- a/autobot-backend/tests/integration/test_run_jwt_lifecycle.py
+++ b/autobot-backend/tests/integration/test_run_jwt_lifecycle.py
@@ -341,8 +341,9 @@ async def test_run_jwt_blocked_on_non_allowed_path(jwt_secret, monkeypatch):
 
     middleware = AuthenticationMiddleware.__new__(AuthenticationMiddleware)
 
-    with patch("auth_middleware.get_auth_middleware", return_value=middleware), patch.object(
-        middleware, "get_user_from_request", return_value=None
+    with (
+        patch("auth_middleware.get_auth_middleware", return_value=middleware),
+        patch.object(middleware, "get_user_from_request", return_value=None),
     ):
         with pytest.raises(HTTPException) as exc_info:
             await get_current_user(request)
@@ -375,8 +376,9 @@ async def test_run_jwt_allowed_on_refresh_path(jwt_secret, monkeypatch):
 
     middleware = AuthenticationMiddleware.__new__(AuthenticationMiddleware)
 
-    with patch("auth_middleware.get_auth_middleware", return_value=middleware), patch.object(
-        middleware, "get_user_from_request", return_value=None
+    with (
+        patch("auth_middleware.get_auth_middleware", return_value=middleware),
+        patch.object(middleware, "get_user_from_request", return_value=None),
     ):
         user = await get_current_user(request)
     assert user["auth_method"] == "run_jwt"

--- a/autobot-backend/tests/services/test_run_jwt.py
+++ b/autobot-backend/tests/services/test_run_jwt.py
@@ -341,6 +341,26 @@ class TestRefreshRunJwt:
             with pytest.raises(JWTDecodeError, match="revoked"):
                 await refresh_run_jwt(token, _RUN_ID)
 
+    @pytest.mark.asyncio
+    async def test_old_token_survives_mint_failure(self, _no_audit):
+        """Regression: MVA-170 — old token must remain valid when minting fails.
+
+        If mint_run_jwt raises (e.g. bad scope or secret misconfiguration),
+        refresh_run_jwt must not have revoked the original token yet.  The
+        agent must be able to continue using the old token.
+        """
+        store, client = _make_store()
+        with patch("services.run_jwt.get_async_redis_client", side_effect=client):
+            token = mint_run_jwt(_RUN_ID, _TASK_ID, _AGENT_ID, _TENANT_ID, _SCOPE)
+
+            with patch("services.run_jwt.mint_run_jwt", side_effect=RuntimeError("mint failure")):
+                with pytest.raises(RuntimeError, match="mint failure"):
+                    await refresh_run_jwt(token, _RUN_ID)
+
+            # Old token must still be valid — revoke must not have run
+            claims = await validate_run_jwt(token)
+            assert claims["run_id"] == _RUN_ID
+
 
 # ---------------------------------------------------------------------------
 # VALID_SCOPES completeness check


### PR DESCRIPTION
## Summary

- **Bug:** `refresh_run_jwt()` was revoking the existing token _before_ minting a replacement. If `mint_run_jwt()` raised for any reason (signing secret misconfiguration, invalid scope, etc.) the agent was permanently locked out with no valid token.
- **Fix:** Mint the new token first; revoke the old one only after the new token is successfully in hand. This matches the standard rotate-then-retire safety contract.
- **Regression test:** `test_old_token_survives_mint_failure` patches `mint_run_jwt` to raise, then asserts the original token remains valid — proving the revoke is never reached on mint failure.

Closes #7658 (MVA-170)

## Files changed

- `autobot-backend/services/run_jwt.py` — swap mint/revoke order in `refresh_run_jwt`
- `autobot-backend/tests/services/test_run_jwt.py` — add `test_old_token_survives_mint_failure`

## Test plan

- [ ] `pytest autobot-backend/tests/services/test_run_jwt.py -v` — all tests pass, including the new regression test
- [ ] `pytest autobot-backend/tests/integration/test_run_jwt_lifecycle.py -v` — all integration lifecycle tests pass
- [ ] Verify no other callers of `refresh_run_jwt` are affected (single call site: `api/run_jwt_router.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)