### PR TITLE
fix(knowledge): replace undefined validated_url with request.url (F821)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -1011,7 +1011,7 @@ async def add_url_to_knowledge(
 
     url_metadata: dict = {
         "title": title,
-        "source": validated_url,
+        "source": request.url,
         "category": request.category,
         "tags": request.tags,
         "type": "url",


### PR DESCRIPTION
## Summary

- Fixes pre-existing `F821 undefined name 'validated_url'` in `autobot-backend/api/knowledge.py:1014`
- This error was left as a stale reference when SSRF validation was refactored into `_fetch_and_extract_url` via `fetch_safe_url` (#6533)
- Was blocking all PRs via the `code-quality` flake8 CI check

## Root Cause

`validated_url` was previously a local variable produced by inline SSRF validation. When that logic was extracted into `_fetch_and_extract_url`, the assignment was removed but the reference was missed. The correct value is `request.url` (the URL that was passed to and validated by `_fetch_and_extract_url`).

## Test plan

- [x] `python3 -m flake8 autobot-backend/api/knowledge.py --select=F821` → no output
- [x] `python3 -m py_compile autobot-backend/api/knowledge.py` → clean
- [ ] CI `code-quality` check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)