### PR TITLE
fix(mcp): map JSON-RPC -32003 scope-denied to HTTP 403 in FastAPI router (MVA-171)

### DIFF
--- a/autobot-backend/api/autobot_mcp_router.py
+++ b/autobot-backend/api/autobot_mcp_router.py
@@ -71,6 +71,8 @@ async def mcp_tool_call(request: Request) -> JSONResponse:
         code = response["error"].get("code", -32000)
         if code == -32001:
             status = 401
+        elif code == -32003:
+            status = 403
         elif code == -32029:
             status = 429
 

--- a/autobot-backend/api/autobot_mcp_router_test.py
+++ b/autobot-backend/api/autobot_mcp_router_test.py
@@ -1,0 +1,94 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for the FastAPI MCP router HTTP status-code mapping.
+
+Covers the translation of JSON-RPC error codes to HTTP status codes so that
+HTTP clients receive proper 4xx responses instead of opaque 200 OK payloads.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fastapi import FastAPI
+from api.autobot_mcp_router import router
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+app = FastAPI()
+app.include_router(router, prefix="/api")
+
+client = TestClient(app)
+
+
+def _json_rpc_body(method: str = "tools/call", name: str = "kb.search") -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": {"name": name, "arguments": {}},
+    }
+
+
+def _mock_response(error_code: int, message: str = "error") -> dict:
+    return {"jsonrpc": "2.0", "id": 1, "error": {"code": error_code, "message": message}}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error_code, expected_status",
+    [
+        (-32001, 401),  # invalid / expired token
+        (-32003, 403),  # scope denied — regression guard for GH#7659
+        (-32029, 429),  # rate limited
+        (-32000, 200),  # generic server error — stays 200
+        (-32602, 200),  # invalid params — stays 200
+    ],
+)
+def test_error_code_maps_to_correct_http_status(error_code: int, expected_status: int) -> None:
+    mock_resp = _mock_response(error_code)
+    with patch("api.autobot_mcp_router.AutoBotMCPServer") as mock_cls:
+        instance = mock_cls.return_value
+        instance.handle_request = AsyncMock(return_value=mock_resp)
+        response = client.post(
+            "/api/mcp/tool",
+            json=_json_rpc_body(),
+            headers={"Authorization": "Bearer test-token"},
+        )
+    assert response.status_code == expected_status, (
+        f"error code {error_code} should map to HTTP {expected_status}, got {response.status_code}"
+    )
+
+
+def test_successful_tool_call_returns_200() -> None:
+    mock_resp = {"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": "ok"}]}}
+    with patch("api.autobot_mcp_router.AutoBotMCPServer") as mock_cls:
+        instance = mock_cls.return_value
+        instance.handle_request = AsyncMock(return_value=mock_resp)
+        response = client.post(
+            "/api/mcp/tool",
+            json=_json_rpc_body(),
+            headers={"Authorization": "Bearer valid-token"},
+        )
+    assert response.status_code == 200
+    assert response.json()["result"]["content"][0]["text"] == "ok"
+
+
+def test_malformed_json_returns_400() -> None:
+    response = client.post(
+        "/api/mcp/tool",
+        content=b"not json",
+        headers={"Authorization": "Bearer token", "Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["code"] == -32700


### PR DESCRIPTION
## Description

Post-merge regression from SEC-2 JWT PR (#7646). The FastAPI MCP router (`api/autobot_mcp_router.py`) was missing the `-32003 → HTTP 403` mapping that the aiohttp transport (`mcp/autobot_server.py` lines 660–661) already had. HTTP clients that sent a run JWT with insufficient scope received an opaque `200 OK` with a JSON-RPC error payload instead of a proper `403 Forbidden`.

**Root cause:** The `elif code == -32003: status = 403` branch was never added to the FastAPI router when the scope-denied error code was introduced.

**Fix:** One `elif` added to the status-code mapping in `mcp_tool_call()`.

## Related Issue

Closes #7659 (MVA-171)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- Added `autobot-backend/api/autobot_mcp_router_test.py` with a parametrised test covering all four error-code → HTTP status mappings (`-32001 → 401`, `-32003 → 403`, `-32029 → 429`, generic error → `200`), plus happy-path and malformed-JSON cases.
- The new `-32003 → 403` case would have failed before this fix.

## Checklist

- [x] I have tested this locally
- [x] I have updated relevant documentation
- [x] No new warnings are generated
- [x] Code follows the project style