### PR TITLE
fix(frontend): fix 4 vue-tsc errors in LLMApiKeysView — restore baseline to 93 (MVA-177, GH#7653)

### DIFF
--- a/.github/workflows/frontend-typecheck-regression.yml
+++ b/.github/workflows/frontend-typecheck-regression.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Run vue-tsc and check error count
         working-directory: autobot-frontend
         env:
-          BASELINE: 97
+          BASELINE: 93
         run: |
           set +e
           # Use a pipeline-safe pattern so vue-tsc's exit code doesn't break the count

--- a/autobot-frontend/src/views/LLMApiKeysView.vue
+++ b/autobot-frontend/src/views/LLMApiKeysView.vue
@@ -170,7 +170,7 @@ import { onMounted, reactive, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { getBackendUrl } from '@/config/ssot-config'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import { createLogger } from '@/utils/logger'
+import { createLogger } from '@/utils/debugUtils'
 
 const { t } = useI18n()
 const logger = createLogger('LLMApiKeysView')
@@ -213,8 +213,9 @@ function spendClass(key: KeyRow): string {
 async function loadKeys(): Promise<void> {
   loading.value = true
   try {
-    const data = await fetchWithAuth(getBackendUrl() + '/api/llm-keys/list')
-    keys.value = (data as { keys: KeyRow[] }).keys ?? []
+    const resp = await fetchWithAuth(getBackendUrl() + '/api/llm-keys/list')
+    const data = (await resp.json()) as { keys: KeyRow[] }
+    keys.value = data.keys ?? []
   } catch (err) {
     logger.error('Failed to load LLM API keys', err)
   } finally {
@@ -233,7 +234,7 @@ async function handleIssue(): Promise<void> {
       ? new Date(form.expires_at_str).getTime() / 1000
       : null
 
-    const result = await fetchWithAuth(getBackendUrl() + '/api/llm-keys/issue', {
+    const issueResp = await fetchWithAuth(getBackendUrl() + '/api/llm-keys/issue', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -244,7 +245,8 @@ async function handleIssue(): Promise<void> {
         expires_at,
       }),
     })
-    newRawKey.value = (result as { raw_key: string }).raw_key
+    const issueResult = (await issueResp.json()) as { raw_key: string }
+    newRawKey.value = issueResult.raw_key
     showIssueModal.value = false
     Object.assign(form, { team_id: '', label: '', monthly_budget_usd: 0, allowed_models_raw: '', expires_at_str: '' })
     await loadKeys()
@@ -275,12 +277,13 @@ async function handleRevoke(): Promise<void> {
 
 async function handleRotate(keyId: string): Promise<void> {
   try {
-    const result = await fetchWithAuth(getBackendUrl() + '/api/llm-keys/rotate', {
+    const rotateResp = await fetchWithAuth(getBackendUrl() + '/api/llm-keys/rotate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ key_id: keyId }),
     })
-    newRawKey.value = (result as { new_raw_key: string }).new_raw_key
+    const rotateResult = (await rotateResp.json()) as { new_raw_key: string }
+    newRawKey.value = rotateResult.new_raw_key
     await loadKeys()
   } catch (err) {
     logger.error('Failed to rotate LLM API key', err)


### PR DESCRIPTION
## Summary

- Fixed 4 vue-tsc errors introduced by `e3ba64e0c` (feat(llm-keys): virtual LLM API keys, #7617)
- All errors were in `LLMApiKeysView.vue`, introduced in `e3ba64e0c` (feat(llm-keys): virtual LLM API keys, #7617)
- Restored `BASELINE` in CI workflow from 97 → 93

## Errors fixed

| File | Error | Fix |
|------|-------|-----|
| `LLMApiKeysView.vue:173` | TS2307 `Cannot find module '@/utils/logger'` | Changed to correct module `@/utils/debugUtils` |
| `LLMApiKeysView.vue:217` | TS2352 `Response` → `{ keys: KeyRow[] }` cast | Added `await resp.json()` before cast |
| `LLMApiKeysView.vue:247` | TS2352 `Response` → `{ raw_key: string }` cast | Added `await issueResp.json()` before cast |
| `LLMApiKeysView.vue:283` | TS2352 `Response` → `{ new_raw_key: string }` cast | Added `await rotateResp.json()` before cast |

The `fetchWithAuth` utility returns `Promise<Response>` (native fetch Response), not parsed JSON. The original code cast the Response object directly without calling `.json()` — a type error **and** a runtime bug (keys would never load, rotated keys would never appear).

## Verification

```
npx vue-tsc --noEmit -p tsconfig.app.json 2>&1 | grep -cE "error TS"
# → 93
```

Closes #7653
Closes MVA-177