### PR TITLE
tech-debt(backend/redis): enforce kb.redis() factory — noqa cleanup for scanner false-positives (#7439)

### DIFF
--- a/autobot-backend/code_intelligence/redis_optimizer.py
+++ b/autobot-backend/code_intelligence/redis_optimizer.py
@@ -794,7 +794,7 @@ class RedisOptimizer:
                     file_path=file_path,
                     line_start=line_number,
                     line_end=line_number,
-                    description="Direct redis.Redis() instantiation - violates canonical pattern",
+                    description="Direct redis.Redis() instantiation - violates canonical pattern",  # noqa: redis
                     suggestion=(
                         "Use get_redis_client() from autobot_shared.redis_client." " Provides pooling and monitoring."
                     ),

--- a/autobot-backend/utils/redis_immediate_test.py
+++ b/autobot-backend/utils/redis_immediate_test.py
@@ -60,7 +60,7 @@ def _create_redis_client_for_test(host: str, port: int, db: int) -> redis.Redis:
 
     Issue #620.
     """
-    return redis.Redis(
+    return redis.Redis(  # noqa: redis — diagnostic connectivity probe, not a production client (Issue #620)
         host=host,
         port=port,
         db=db,


### PR DESCRIPTION
## Summary

Closes out GH#7439 / MVA-199. The bulk of the 325-callsite cleanup was completed by earlier work (the `get_redis_client()` canonical factory, the `no-kb-aioredis-access` pre-commit hook, and the `pre-commit-no-direct-redis` CI gate). This PR suppresses the two remaining scanner false-positives in production `autobot-backend` code so future commits to these files are not incorrectly blocked.

**Changes:**

- `autobot-backend/code_intelligence/redis_optimizer.py` — adds `# noqa: redis` to a string *literal* containing the text `"redis.Redis()"` (the optimizer's own violation description). The pre-commit tokenizer marks the line as code because the surrounding `description=` keyword arg has NAME/OP tokens, causing a false positive that would block any future commit to this file.
- `autobot-backend/utils/redis_immediate_test.py` — adds `# noqa: redis` at the call site (Issue #620 diagnostic probe). Already documented in the function docstring; suppression now also explicit at the line level, matching the pattern used in service_discovery.py.

**Intentional exceptions already annotated (unchanged by this PR):**

| File | Reason |
|------|--------|
| `autobot_shared/redis_management/connection_manager.py` | Factory implementation — legitimate direct instantiation with `connection_pool=` |
| `autobot-backend/utils/service_discovery.py` | Health-check probe to arbitrary endpoints; `# noqa: redis` |
| `autobot-backend/utils/distributed_service_discovery.py` | Same — `# noqa: redis` |
| `autobot-infrastructure/shared/scripts/**` | Standalone migration/analysis scripts excluded from hook policy (`^autobot-infrastructure/`) |
| `autobot-slm-backend/ansible/inventory/dynamic/generate_inventory.py` | Ansible dynamic inventory; explicit Issue #1086 comment |

**Post-PR scanner result:** 0 violations in `autobot-backend` production files.

**CI gate:** `pre-commit-no-direct-redis` + `no-kb-aioredis-access` hooks already block new violations on every PR.

## Test plan

- [x] Run tokenizer-based scanner over `autobot-backend/**/*.py` (excl. test files) → 0 violations
- [x] `pre-commit-no-direct-redis` hook passes (hook excludes `_test.py` suffix; `redis_optimizer.py` line now suppressed)
- CI will verify no regressions on the two touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)