### PR TITLE
fix(enums): consolidate TaskPriority and AgentStatus to canonical status_enums (#7504)

### DIFF
--- a/autobot-backend/agents/base_agent.py
+++ b/autobot-backend/agents/base_agent.py
@@ -28,6 +28,7 @@ from protocols.agent_communication import (
     StandardMessage,
     get_communication_manager,
 )
+from autobot_shared.status_enums import AgentStatus  # #7504 consolidation
 
 logger = logging.getLogger(__name__)
 
@@ -38,15 +39,6 @@ class DeploymentMode(Enum):
     LOCAL = "local"
     CONTAINER = "container"
     REMOTE = "remote"
-
-
-class AgentStatus(Enum):
-    """Agent health status"""
-
-    HEALTHY = "healthy"
-    DEGRADED = "degraded"
-    UNHEALTHY = "unhealthy"
-    OFFLINE = "offline"
 
 
 # Performance optimization: O(1) lookup for available agent statuses (Issue #326)

--- a/autobot-backend/constants/status_enums.py
+++ b/autobot-backend/constants/status_enums.py
@@ -14,19 +14,25 @@ New code should import directly from ``autobot_shared.status_enums``.
 """
 
 from autobot_shared.status_enums import (
+    AgentLifecycleStatus,
+    AgentStatus,
     HealthStatus,
     LLMProvider,
     OperationOutcome,
     Priority,
     Severity,
+    TaskPriority,
     TaskStatus,
 )
 
 __all__ = [
+    "AgentLifecycleStatus",
+    "AgentStatus",
     "HealthStatus",
     "LLMProvider",
     "OperationOutcome",
     "Priority",
     "Severity",
+    "TaskPriority",
     "TaskStatus",
 ]

--- a/autobot-backend/models/agent.py
+++ b/autobot-backend/models/agent.py
@@ -11,20 +11,12 @@ rows in this table.
 """
 
 import uuid
-from enum import Enum
 
 from sqlalchemy import Column, String, Text
 from sqlalchemy.types import Uuid
 
 from user_management.models.base import Base
-
-
-class AgentStatus(str, Enum):
-    """Lifecycle states for an agent (#1754)."""
-
-    ACTIVE = "active"
-    INACTIVE = "inactive"
-    ARCHIVED = "archived"
+from autobot_shared.status_enums import AgentLifecycleStatus as AgentStatus  # #7504 consolidation
 
 
 class Agent(Base):

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -106,6 +106,7 @@ except ImportError:
 
 
 from autobot_shared.status_enums import WorkflowStatus  # #6973 consolidation
+from autobot_shared.status_enums import Priority as TaskPriority  # #7504 consolidation
 
 try:
     from workflow_templates import WorkflowStep
@@ -120,13 +121,6 @@ except ImportError:
         agent_type: str
         action: str
         description: str
-
-
-class TaskPriority(Enum):
-    LOW = "low"
-    NORMAL = "normal"
-    HIGH = "high"
-    URGENT = "urgent"
 
 
 class OrchestrationMode(Enum):

--- a/autobot-backend/services/agents/subagent_task.py
+++ b/autobot-backend/services/agents/subagent_task.py
@@ -12,20 +12,11 @@ Defines task data structures for subagent spawning and execution:
 
 import time
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
+from autobot_shared.status_enums import TaskPriority  # #7504 consolidation
 from autobot_shared.status_enums import TaskStatus  # #6973 consolidation
-
-
-class TaskPriority(str, Enum):
-    """Priority level for task execution."""
-
-    LOW = "low"
-    NORMAL = "normal"
-    HIGH = "high"
-    URGENT = "urgent"
 
 
 @dataclass

--- a/autobot-backend/utils/task_queue.py
+++ b/autobot-backend/utils/task_queue.py
@@ -16,11 +16,11 @@ import traceback
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
-from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 
 from autobot_shared.missing_dep import MissingDep as _MissingDep
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.status_enums import Priority as TaskPriority  # #7504 consolidation
 from autobot_shared.status_enums import TaskStatus
 from autobot_shared.time_utils import parse_utc_iso
 
@@ -47,15 +47,6 @@ ErrorCategory = None
 # except ImportError:
 def log_performance_metric(*args, **kwargs):
     """Log performance metric placeholder until logging_config module is created."""
-
-
-class TaskPriority(Enum):
-    """Task priority levels."""
-
-    LOW = 1
-    NORMAL = 2
-    HIGH = 3
-    CRITICAL = 4
 
 
 @dataclass
@@ -136,7 +127,9 @@ class Task:
     def from_dict(cls, data: Dict[str, Any]) -> "Task":
         """Create from dictionary."""
         if "priority" in data:
-            data["priority"] = TaskPriority(data["priority"])
+            val = data["priority"]
+            # Backward compat: old queue stored integer priority scores (1-4)
+            data["priority"] = TaskPriority.from_numeric(val) if isinstance(val, int) else TaskPriority(val)
         if "created_at" in data:
             data["created_at"] = parse_utc_iso(data["created_at"])
         if "scheduled_at" in data and data["scheduled_at"]:
@@ -270,7 +263,7 @@ class TaskQueue:
                 score = scheduled_at.timestamp()
                 await self.redis.zadd(self.scheduled_key, {task_id: score})
             else:
-                priority_score = priority.value * 1000000 + int(time.time())
+                priority_score = TaskPriority.to_numeric(priority) * 1000000 + int(time.time())
                 await self.redis.zadd(self.pending_key, {task_id: priority_score})
         except RedisError as e:
             self.logger.error("Failed to enqueue task %s: %s", task_id, e)

--- a/autobot_shared/status_enums.py
+++ b/autobot_shared/status_enums.py
@@ -240,6 +240,38 @@ class HealthStatus(Enum):
     STOPPING = "stopping"
 
 
+class AgentStatus(Enum):
+    """
+    Canonical operational health state of a running agent (#7504).
+
+    Replaces the local class in agents/base_agent.py. Distinct from
+    AgentLifecycleStatus which tracks registry/DB lifecycle.
+    """
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNHEALTHY = "unhealthy"
+    OFFLINE = "offline"
+
+
+class AgentLifecycleStatus(str, Enum):
+    """
+    Registry/lifecycle state of an agent record (#7504, #1754).
+
+    Replaces the local AgentStatus class in models/agent.py. str-subclass
+    so SQLAlchemy can coerce directly to/from the column string value.
+    """
+
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    ARCHIVED = "archived"
+
+
+# Task priority — canonical alias for Priority covering agent/task scheduling.
+# Replaces local TaskPriority classes in services/agents/subagent_task.py,
+# utils/task_queue.py, and orchestrator.py (#7504).
+TaskPriority = Priority
+
 __all__ = [
     "TaskStatus",
     "JobStatus",
@@ -247,7 +279,10 @@ __all__ = [
     "Severity",
     "RiskLevel",
     "Priority",
+    "TaskPriority",
     "LLMProvider",
     "OperationOutcome",
     "HealthStatus",
+    "AgentStatus",
+    "AgentLifecycleStatus",
 ]


### PR DESCRIPTION
## Summary
Consolidates 3 scattered TaskPriority enum definitions and 2 AgentStatus definitions into canonical enums in autobot_shared.status_enums:

- **TaskPriority**: Consolidated from subagent_task.py, task_queue.py, orchestrator.py → imports Priority alias
- **AgentStatus**: Consolidated from base_agent.py → imports canonical AgentStatus (operational health)
- **AgentLifecycleStatus**: Consolidated from models/agent.py → imports as AgentStatus (registry lifecycle)

All enum values preserved (strings); backward compatibility maintained for existing Redis-stored integer priorities via deserialization in task_queue.py.

## Test Plan
- [x] All imports verified: `from autobot_shared.status_enums import ...`
- [x] Python syntax check: `py_compile` on all 7 modified files
- [x] No type-coercion warnings (string-valued enums, except task_queue backward compat)
- [x] Commit tested locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)