### PR TITLE
perf(skill-router): prepared-runtime-facts pattern for skill router + LLM gateway (#7370)

### DIFF
--- a/autobot-backend/llm_interface_pkg/provider_registry.py
+++ b/autobot-backend/llm_interface_pkg/provider_registry.py
@@ -33,6 +33,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 from llm_interface_pkg.models import LLMRequest
+from prepared_facts import ProviderRuntimeFact
 
 from .base_provider import BaseProvider
 
@@ -70,6 +71,7 @@ class ProviderRegistry:
         self._health_cache: Dict[str, tuple[bool, float]] = {}
         self._health_lock = asyncio.Lock()
         self._initialized = False
+        self._provider_facts: Dict[str, ProviderRuntimeFact] = {}
 
     # ------------------------------------------------------------------
     # Registration
@@ -88,6 +90,7 @@ class ProviderRegistry:
         if name in self._providers:
             logger.warning("Replacing existing provider: %s", name)
         self._providers[name] = provider
+        self._provider_facts[name] = ProviderRuntimeFact.build_at_startup(name, provider)
         logger.info("Registered provider: %s", name)
 
     def unregister(self, name: str) -> None:
@@ -95,6 +98,7 @@ class ProviderRegistry:
         if name in self._providers:
             del self._providers[name]
             self._health_cache.pop(name, None)
+            self._provider_facts.pop(name, None)
             logger.info("Unregistered provider: %s", name)
 
     def set_fallback_chain(self, chain: List[str]) -> None:
@@ -290,6 +294,10 @@ class ProviderRegistry:
         instead of accessing the private attribute directly.
         """
         return self._providers.get(name)
+
+    def get_provider_facts(self) -> Dict[str, ProviderRuntimeFact]:
+        """Return a snapshot of pre-computed provider capability facts (#7370)."""
+        return dict(self._provider_facts)
 
     def list_providers(self) -> List[Dict[str, object]]:
         """Return a serialisable summary of registered providers."""

--- a/autobot-backend/prepared_facts.py
+++ b/autobot-backend/prepared_facts.py
@@ -12,12 +12,12 @@ Facts:
   SkillRoutingIndex  — compiled index of all skill facts; rebuilt on registry change
   ProviderRuntimeFact — per-provider capabilities precomputed at registration
 """
+
 from __future__ import annotations
 
 import re
 from dataclasses import dataclass
 from typing import Any, Dict, FrozenSet, List, Optional, Sequence, Tuple
-
 
 # ---------------------------------------------------------------------------
 # Internal tokenizer — same regex as skill_router._tokenize but returns a
@@ -129,9 +129,7 @@ class SkillRoutingIndex:
         frozen token sets — no regex is executed for individual skills.
         """
         task_tokens = _tok(task_text)
-        scored: List[Tuple[SkillTokenFact, float]] = [
-            (f, f.score(task_tokens)) for f in self._facts
-        ]
+        scored: List[Tuple[SkillTokenFact, float]] = [(f, f.score(task_tokens)) for f in self._facts]
         scored.sort(key=lambda x: x[1], reverse=True)
         result = []
         for fact, score in scored[:top_k]:
@@ -175,11 +173,7 @@ class ProviderRuntimeFact:
     def build_at_startup(cls, name: str, provider: Any) -> "ProviderRuntimeFact":
         """Build a fact for a provider instance."""
         settings: Dict[str, Any] = getattr(provider, "settings", {}) or {}
-        auth_configured = bool(
-            settings.get("api_key")
-            or settings.get("api_token")
-            or settings.get("base_url")
-        )
+        auth_configured = bool(settings.get("api_key") or settings.get("api_token") or settings.get("base_url"))
         is_local = name in {"ollama", "vllm"}
         return cls(name=name, auth_configured=auth_configured, is_local=is_local)
 

--- a/autobot-backend/prepared_facts.py
+++ b/autobot-backend/prepared_facts.py
@@ -1,0 +1,195 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Runtime-facts pattern for AutoBot hot paths (GH#7370).
+
+Each dataclass represents a set of facts computed once at startup and
+consumed directly in hot paths, eliminating per-request rediscovery.
+
+Facts:
+  SkillTokenFact     — pre-tokenized fields for a single registered skill
+  SkillRoutingIndex  — compiled index of all skill facts; rebuilt on registry change
+  ProviderRuntimeFact — per-provider capabilities precomputed at registration
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, FrozenSet, List, Optional, Sequence, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Internal tokenizer — same regex as skill_router._tokenize but returns a
+# frozenset so facts can be frozen.  Kept here to avoid a circular import
+# between prepared_facts and skills.builtin.skill_router.
+# ---------------------------------------------------------------------------
+
+
+def _tok(text: str) -> FrozenSet[str]:
+    return frozenset(t for t in re.split(r"[\W_]+", text.lower()) if t)
+
+
+# ---------------------------------------------------------------------------
+# Skill-routing facts
+# ---------------------------------------------------------------------------
+
+_W_NAME = 3.0
+_W_TAGS = 3.0
+_W_TOOLS = 2.0
+_W_DESC = 1.0
+
+
+@dataclass(frozen=True)
+class SkillTokenFact:
+    """Pre-tokenized fields for a single registered skill.
+
+    Built once at registration time; all token sets are frozen so the
+    dataclass itself is immutable and safe to share across workers.
+    """
+
+    name: str
+    name_tokens: FrozenSet[str]
+    tag_tokens: FrozenSet[str]
+    tool_tokens: FrozenSet[str]
+    desc_tokens: FrozenSet[str]
+
+    @classmethod
+    def build_at_startup(
+        cls,
+        name: str,
+        tags: Sequence[str],
+        tools: Sequence[str],
+        description: str,
+    ) -> "SkillTokenFact":
+        """Build a fact from skill manifest fields."""
+        tag_t: set = set()
+        for tag in tags:
+            tag_t.update(_tok(tag))
+        tool_t: set = set()
+        for tool in tools:
+            tool_t.update(_tok(tool))
+        return cls(
+            name=name,
+            name_tokens=_tok(name),
+            tag_tokens=frozenset(tag_t),
+            tool_tokens=frozenset(tool_t),
+            desc_tokens=_tok(description),
+        )
+
+    def score(self, task_tokens: FrozenSet[str]) -> float:
+        """Score this skill against a pre-tokenized task description."""
+        return (
+            len(task_tokens & self.name_tokens) * _W_NAME
+            + len(task_tokens & self.tag_tokens) * _W_TAGS
+            + len(task_tokens & self.tool_tokens) * _W_TOOLS
+            + len(task_tokens & self.desc_tokens) * _W_DESC
+        )
+
+
+class SkillRoutingIndex:
+    """Compiled index of pre-tokenized skill facts plus a skills snapshot.
+
+    Rebuilt once when the registry changes (register / unregister).
+    Per-message lookup is O(n_skills) with no regex work; only the task
+    text is tokenized at request time.
+    """
+
+    def __init__(
+        self,
+        facts: List[SkillTokenFact],
+        skill_map: Dict[str, Dict[str, Any]],
+    ) -> None:
+        self._facts = facts
+        self._skill_map = skill_map
+
+    @classmethod
+    def build_at_startup(cls, skills: Sequence[Dict[str, Any]]) -> "SkillRoutingIndex":
+        """Build the index from the list returned by registry.list_skills()."""
+        facts = [
+            SkillTokenFact.build_at_startup(
+                name=s["name"],
+                tags=s.get("tags", []),
+                tools=s.get("tools", []),
+                description=s.get("description", ""),
+            )
+            for s in skills
+        ]
+        skill_map = {s["name"]: s for s in skills}
+        return cls(facts, skill_map)
+
+    def score_candidates(
+        self,
+        task_text: str,
+        top_k: int = 5,
+    ) -> List[Dict[str, Any]]:
+        """Return top-k skill dicts (with 'score' field) sorted by score desc.
+
+        task_text is tokenized once here; all per-skill work uses pre-built
+        frozen token sets — no regex is executed for individual skills.
+        """
+        task_tokens = _tok(task_text)
+        scored: List[Tuple[SkillTokenFact, float]] = [
+            (f, f.score(task_tokens)) for f in self._facts
+        ]
+        scored.sort(key=lambda x: x[1], reverse=True)
+        result = []
+        for fact, score in scored[:top_k]:
+            if score <= 0:
+                break
+            skill_data = self._skill_map.get(fact.name, {})
+            result.append(
+                {
+                    "name": fact.name,
+                    "description": skill_data.get("description", ""),
+                    "tags": skill_data.get("tags", []),
+                    "tools": skill_data.get("tools", []),
+                    "score": score,
+                }
+            )
+        return result
+
+    def __len__(self) -> int:
+        return len(self._facts)
+
+
+# ---------------------------------------------------------------------------
+# Provider runtime facts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProviderRuntimeFact:
+    """Precomputed per-provider capabilities, built once at registration.
+
+    Avoids repeated introspection of provider objects in the hot path.
+    auth_configured signals whether credentials were present at startup;
+    is_local marks providers that run in-process with no external API cost.
+    """
+
+    name: str
+    auth_configured: bool
+    is_local: bool
+
+    @classmethod
+    def build_at_startup(cls, name: str, provider: Any) -> "ProviderRuntimeFact":
+        """Build a fact for a provider instance."""
+        settings: Dict[str, Any] = getattr(provider, "settings", {}) or {}
+        auth_configured = bool(
+            settings.get("api_key")
+            or settings.get("api_token")
+            or settings.get("base_url")
+        )
+        is_local = name in {"ollama", "vllm"}
+        return cls(name=name, auth_configured=auth_configured, is_local=is_local)
+
+
+# ---------------------------------------------------------------------------
+# Public re-exports
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "SkillTokenFact",
+    "SkillRoutingIndex",
+    "ProviderRuntimeFact",
+]

--- a/autobot-backend/prepared_facts.py
+++ b/autobot-backend/prepared_facts.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, FrozenSet, List, Optional, Sequence, Tuple
+from typing import Any, Dict, FrozenSet, List, Sequence, Tuple
 
 # ---------------------------------------------------------------------------
 # Internal tokenizer — same regex as skill_router._tokenize but returns a

--- a/autobot-backend/prepared_facts_test.py
+++ b/autobot-backend/prepared_facts_test.py
@@ -9,7 +9,6 @@ import pytest
 
 from prepared_facts import ProviderRuntimeFact, SkillRoutingIndex, SkillTokenFact
 
-
 # ---------------------------------------------------------------------------
 # SkillTokenFact
 # ---------------------------------------------------------------------------

--- a/autobot-backend/prepared_facts_test.py
+++ b/autobot-backend/prepared_facts_test.py
@@ -1,0 +1,256 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for the prepared-runtime-facts module (GH#7370)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from prepared_facts import ProviderRuntimeFact, SkillRoutingIndex, SkillTokenFact
+
+
+# ---------------------------------------------------------------------------
+# SkillTokenFact
+# ---------------------------------------------------------------------------
+
+
+def test_skill_token_fact_build_tokenizes_name():
+    fact = SkillTokenFact.build_at_startup(
+        name="pdf-analyzer",
+        tags=[],
+        tools=[],
+        description="",
+    )
+    assert "pdf" in fact.name_tokens
+    assert "analyzer" in fact.name_tokens
+
+
+def test_skill_token_fact_build_tokenizes_tags():
+    fact = SkillTokenFact.build_at_startup(
+        name="x",
+        tags=["document", "pdf-analysis"],
+        tools=[],
+        description="",
+    )
+    assert "document" in fact.tag_tokens
+    assert "pdf" in fact.tag_tokens
+    assert "analysis" in fact.tag_tokens
+
+
+def test_skill_token_fact_build_tokenizes_tools():
+    fact = SkillTokenFact.build_at_startup(
+        name="x",
+        tags=[],
+        tools=["analyze_document", "extract_text"],
+        description="",
+    )
+    assert "analyze" in fact.tool_tokens
+    assert "document" in fact.tool_tokens
+    assert "extract" in fact.tool_tokens
+    assert "text" in fact.tool_tokens
+
+
+def test_skill_token_fact_build_tokenizes_description():
+    fact = SkillTokenFact.build_at_startup(
+        name="x",
+        tags=[],
+        tools=[],
+        description="Converts audio to text transcription",
+    )
+    assert "audio" in fact.desc_tokens
+    assert "transcription" in fact.desc_tokens
+
+
+def test_skill_token_fact_score_name_weight():
+    fact = SkillTokenFact.build_at_startup(
+        name="pdf-tool",
+        tags=[],
+        tools=[],
+        description="",
+    )
+    # name match only → _W_NAME = 3.0
+    assert fact.score(frozenset({"pdf"})) == 3.0
+
+
+def test_skill_token_fact_score_tag_weight():
+    fact = SkillTokenFact.build_at_startup(
+        name="unrelated",
+        tags=["pdf"],
+        tools=[],
+        description="",
+    )
+    # tag match only → _W_TAGS = 3.0
+    assert fact.score(frozenset({"pdf"})) == 3.0
+
+
+def test_skill_token_fact_score_tool_weight():
+    fact = SkillTokenFact.build_at_startup(
+        name="unrelated",
+        tags=[],
+        tools=["pdf_reader"],
+        description="",
+    )
+    # tool match → _W_TOOLS = 2.0
+    assert fact.score(frozenset({"pdf"})) == 2.0
+
+
+def test_skill_token_fact_score_desc_weight():
+    fact = SkillTokenFact.build_at_startup(
+        name="unrelated",
+        tags=[],
+        tools=[],
+        description="handles pdf documents",
+    )
+    # description match → _W_DESC = 1.0
+    assert fact.score(frozenset({"pdf"})) == 1.0
+
+
+def test_skill_token_fact_score_zero_no_overlap():
+    fact = SkillTokenFact.build_at_startup(
+        name="calendar-tool",
+        tags=["calendar"],
+        tools=["create_event"],
+        description="manage calendar events",
+    )
+    assert fact.score(frozenset({"browser", "scrape"})) == 0.0
+
+
+def test_skill_token_fact_is_frozen():
+    fact = SkillTokenFact.build_at_startup("test", [], [], "")
+    with pytest.raises(Exception):
+        fact.name = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# SkillRoutingIndex
+# ---------------------------------------------------------------------------
+
+_SKILLS = [
+    {
+        "name": "pdf-analyzer",
+        "description": "Analyze PDF documents",
+        "tags": ["pdf", "document"],
+        "tools": ["analyze_pdf"],
+    },
+    {
+        "name": "browser-automation",
+        "description": "Automate web browsing",
+        "tags": ["browser", "web"],
+        "tools": ["browse"],
+    },
+    {
+        "name": "calendar-integration",
+        "description": "Manage calendar events",
+        "tags": ["calendar", "events"],
+        "tools": ["create_event"],
+    },
+]
+
+
+def test_routing_index_len():
+    index = SkillRoutingIndex.build_at_startup(_SKILLS)
+    assert len(index) == 3
+
+
+def test_routing_index_score_candidates_returns_top_k():
+    index = SkillRoutingIndex.build_at_startup(_SKILLS)
+    results = index.score_candidates("analyze this pdf document", top_k=2)
+    assert len(results) <= 2
+
+
+def test_routing_index_score_candidates_correct_winner():
+    index = SkillRoutingIndex.build_at_startup(_SKILLS)
+    results = index.score_candidates("analyze pdf document", top_k=5)
+    assert results[0]["name"] == "pdf-analyzer"
+
+
+def test_routing_index_score_candidates_excludes_zero_scores():
+    index = SkillRoutingIndex.build_at_startup(_SKILLS)
+    results = index.score_candidates("completely unrelated xyz query", top_k=5)
+    assert results == []
+
+
+def test_routing_index_score_candidates_result_shape():
+    index = SkillRoutingIndex.build_at_startup(_SKILLS)
+    results = index.score_candidates("pdf", top_k=5)
+    assert len(results) >= 1
+    row = results[0]
+    assert "name" in row
+    assert "description" in row
+    assert "tags" in row
+    assert "tools" in row
+    assert "score" in row
+    assert isinstance(row["score"], float)
+
+
+def test_routing_index_score_candidates_sorted_desc():
+    index = SkillRoutingIndex.build_at_startup(_SKILLS)
+    results = index.score_candidates("pdf browser", top_k=5)
+    scores = [r["score"] for r in results]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_routing_index_empty_registry():
+    index = SkillRoutingIndex.build_at_startup([])
+    assert len(index) == 0
+    assert index.score_candidates("anything", top_k=5) == []
+
+
+# ---------------------------------------------------------------------------
+# ProviderRuntimeFact
+# ---------------------------------------------------------------------------
+
+
+def _provider_with(**settings):
+    p = MagicMock()
+    p.settings = settings
+    return p
+
+
+def test_provider_fact_auth_configured_via_api_key():
+    fact = ProviderRuntimeFact.build_at_startup("openai", _provider_with(api_key="val"))
+    assert fact.auth_configured is True
+
+
+def test_provider_fact_auth_configured_via_api_token():
+    fact = ProviderRuntimeFact.build_at_startup("hf", _provider_with(api_token="val"))
+    assert fact.auth_configured is True
+
+
+def test_provider_fact_auth_configured_via_base_url():
+    fact = ProviderRuntimeFact.build_at_startup("ollama", _provider_with(base_url="http://localhost:11434"))
+    assert fact.auth_configured is True
+
+
+def test_provider_fact_auth_not_configured():
+    fact = ProviderRuntimeFact.build_at_startup("unknown", _provider_with())
+    assert fact.auth_configured is False
+
+
+def test_provider_fact_is_local_ollama():
+    fact = ProviderRuntimeFact.build_at_startup("ollama", _provider_with(base_url="http://localhost:11434"))
+    assert fact.is_local is True
+
+
+def test_provider_fact_is_local_vllm():
+    fact = ProviderRuntimeFact.build_at_startup("vllm", _provider_with(base_url="http://localhost:8000"))
+    assert fact.is_local is True
+
+
+def test_provider_fact_is_not_local_openai():
+    fact = ProviderRuntimeFact.build_at_startup("openai", _provider_with(api_key="val"))
+    assert fact.is_local is False
+
+
+def test_provider_fact_no_settings_attribute():
+    provider = MagicMock(spec=[])  # no .settings
+    fact = ProviderRuntimeFact.build_at_startup("minimal", provider)
+    assert fact.auth_configured is False
+    assert fact.is_local is False
+
+
+def test_provider_fact_is_frozen():
+    fact = ProviderRuntimeFact.build_at_startup("openai", _provider_with(api_key="x"))
+    with pytest.raises(Exception):
+        fact.name = "mutated"  # type: ignore[misc]

--- a/autobot-backend/skills/builtin/skill_router.py
+++ b/autobot-backend/skills/builtin/skill_router.py
@@ -170,8 +170,18 @@ class SkillRouterSkill(BaseSkill):
         return await self._enable_and_respond(winner, reason, method, candidates, registry, dry_run)
 
     def _build_candidates(self, task: str, registry: Any) -> List[Dict[str, Any]]:
-        """Score all registered skills and return top-K candidates."""
+        """Score all registered skills and return top-K candidates.
+
+        Uses the pre-built SkillRoutingIndex when available (no per-request
+        regex — only the task text is tokenized at call time).  Falls back to
+        per-request tokenization when the index is not yet built (e.g. during
+        the very first register() call).
+        """
         top_k: int = self._config.get("top_k", 5)
+        index = registry.get_routing_index() if hasattr(registry, "get_routing_index") else None
+        if index is not None:
+            return index.score_candidates(task, top_k)
+        # Fallback: per-request tokenization (index not yet built)
         task_tokens = _tokenize(task)
         scored = [
             {

--- a/autobot-backend/skills/builtin/skill_router_test.py
+++ b/autobot-backend/skills/builtin/skill_router_test.py
@@ -159,6 +159,7 @@ async def test_find_skill_enables_best_match_via_llm():
     mock_llm_response.error = None
 
     mock_registry = MagicMock()
+    mock_registry.get_routing_index.return_value = None
     mock_registry.list_skills.return_value = [
         _make_skill_dict(
             "document-analysis",
@@ -195,6 +196,7 @@ async def test_find_skill_enables_best_match_via_llm():
 async def test_find_skill_falls_back_to_keyword_on_llm_error():
     """If LLM fails, use the top keyword-scored skill."""
     mock_registry = MagicMock()
+    mock_registry.get_routing_index.return_value = None
     mock_registry.list_skills.return_value = [
         _make_skill_dict(
             "document-analysis",
@@ -232,6 +234,7 @@ async def test_find_skill_dry_run_does_not_enable():
     mock_llm_response.error = None
 
     mock_registry = MagicMock()
+    mock_registry.get_routing_index.return_value = None
     mock_registry.list_skills.return_value = [
         _make_skill_dict(
             "document-analysis",
@@ -271,6 +274,7 @@ async def test_find_skill_requires_task_param():
 async def test_find_skill_no_skills_registered():
     """find_skill returns error when registry is empty and no build-skill available."""
     mock_registry = MagicMock()
+    mock_registry.get_routing_index.return_value = None
     mock_registry.list_skills.return_value = []
     mock_registry.get.return_value = None  # autonomous-skill-development not found
 
@@ -295,6 +299,7 @@ async def test_find_skill_no_match_delegates_to_autonomous():
         }
     )
     mock_registry = MagicMock()
+    mock_registry.get_routing_index.return_value = None
     mock_registry.list_skills.return_value = [
         _make_skill_dict(
             "calendar-integration",
@@ -342,6 +347,7 @@ async def test_find_skill_no_match_uses_research_context():
     mock_build_skill = MagicMock()
     mock_build_skill.execute = AsyncMock(return_value={"success": True, "state": "pending_approval"})
     mock_registry = MagicMock()
+    mock_registry.get_routing_index.return_value = None
     mock_registry.list_skills.return_value = []
     mock_registry.get.side_effect = lambda name: (mock_researcher if name == "skill-researcher" else mock_build_skill)
 
@@ -362,6 +368,7 @@ async def test_find_skill_no_match_uses_research_context():
 async def test_find_skill_no_match_dry_run_skips_build():
     """dry_run=True with no matching skill returns info without triggering build."""
     mock_registry = MagicMock()
+    mock_registry.get_routing_index.return_value = None
     mock_registry.list_skills.return_value = []
 
     with patch("skills.builtin.skill_router.get_skill_registry", return_value=mock_registry):

--- a/autobot-backend/skills/registry.py
+++ b/autobot-backend/skills/registry.py
@@ -15,6 +15,7 @@ import threading
 from typing import Any, Dict, List, Optional, Set, Type
 
 from autobot_shared.singleton_factory import lazy_singleton
+from prepared_facts import SkillRoutingIndex
 from skills.base_skill import BaseSkill, SkillHealth, SkillManifest, SkillStatus
 from skills.dependency_resolver import check_missing_dependencies, resolve_dependencies
 
@@ -31,6 +32,7 @@ class SkillRegistry:
         self._skills: Dict[str, BaseSkill] = {}
         self._skill_classes: Dict[str, Type[BaseSkill]] = {}
         self._lock = threading.Lock()
+        self._routing_index: Optional[SkillRoutingIndex] = None
 
     def register(self, skill_class: Type[BaseSkill]) -> None:
         """Register a skill class and create its instance.
@@ -53,6 +55,23 @@ class SkillRegistry:
         # BlockedPlanResumer subscriber. Fire-and-forget; never raises if
         # Redis is unavailable (logged at debug).
         self._publish_skill_promoted(name, manifest.tools)
+        self._rebuild_routing_index()
+
+    def _rebuild_routing_index(self) -> None:
+        """Rebuild the pre-tokenized skill routing index from current registry state.
+
+        Called after every register() and unregister() so hot-path lookups are
+        always O(1) dict access into a frozen snapshot — no per-request regex.
+        """
+        try:
+            self._routing_index = SkillRoutingIndex.build_at_startup(self.list_skills())
+        except Exception as exc:
+            logger.warning("Failed to rebuild routing index: %s", exc)
+            self._routing_index = None
+
+    def get_routing_index(self) -> Optional[SkillRoutingIndex]:
+        """Return the current pre-built skill routing index, or None if not built."""
+        return self._routing_index
 
     @staticmethod
     def _publish_skill_promoted(name: str, tools: List[str]) -> None:
@@ -100,7 +119,8 @@ class SkillRegistry:
             del self._skills[name]
             del self._skill_classes[name]
             logger.info("Unregistered skill: %s", name)
-            return True
+        self._rebuild_routing_index()
+        return True
 
     def get(self, name: str) -> Optional[BaseSkill]:
         """Get a skill instance by name."""

--- a/autobot-backend/skills/registry.py
+++ b/autobot-backend/skills/registry.py
@@ -62,9 +62,13 @@ class SkillRegistry:
 
         Called after every register() and unregister() so hot-path lookups are
         always O(1) dict access into a frozen snapshot — no per-request regex.
+        Acquires the lock only to snapshot the skill list; index construction
+        runs outside the lock so tokenization work does not block concurrents.
         """
+        with self._lock:
+            skill_list = self.list_skills()
         try:
-            self._routing_index = SkillRoutingIndex.build_at_startup(self.list_skills())
+            self._routing_index = SkillRoutingIndex.build_at_startup(skill_list)
         except Exception as exc:
             logger.warning("Failed to rebuild routing index: %s", exc)
             self._routing_index = None


### PR DESCRIPTION
## Summary

- Adds `prepared_facts.py` with three typed, frozen dataclasses built once at registration time: `SkillTokenFact` (pre-tokenized frozensets per skill), `SkillRoutingIndex` (compiled lookup over all skills), and `ProviderRuntimeFact` (per-provider auth/locality flags)
- `SkillRegistry` rebuilds the `SkillRoutingIndex` on every `register()` and `unregister()` call and exposes it via `get_routing_index()`; `SkillRouterSkill._build_candidates()` consumes it, falling back to per-request tokenization only during startup or if the index is unavailable
- `ProviderRegistry` stores a `ProviderRuntimeFact` for each provider at registration and exposes them via `get_provider_facts()`

## Test plan

- [ ] `python3 -m pytest autobot-backend/prepared_facts_test.py` → 26 new tests all pass
- [ ] `python3 -m pytest autobot-backend/skills/builtin/skill_router_test.py` → 15 existing tests all pass (7 updated for `get_routing_index` mock)
- [ ] No change to external LLM API contract or skill routing behavior

Closes #7370

🤖 Generated with [Claude Code](https://claude.com/claude-code)