### PR TITLE
docs(ci): record code-quality as required check on Dev_new_gui (MVA-283)

### DIFF
--- a/docs/deployment/CI_PIPELINE_SETUP.md
+++ b/docs/deployment/CI_PIPELINE_SETUP.md
@@ -57,6 +57,11 @@ The pipeline uses these GitHub repository secrets:
 - `CODECOV_TOKEN`: For coverage reporting (optional)
 
 ### Branch Protection
+
+**`Dev_new_gui` required status checks (enforced):**
+- `smoke-test` — startup import smoke test
+- `code-quality` — Black, isort, flake8, bandit, autoflake, mypy, and custom regression guards
+
 Recommended branch protection rules for `main`:
 - Require status checks to pass
 - Require branches to be up to date


### PR DESCRIPTION
## Summary

- Adds a `Dev_new_gui` required status checks section to `CI_PIPELINE_SETUP.md` documenting both `smoke-test` and `code-quality` as enforced gates.
- The branch protection rule itself was applied via GitHub API (not via this PR) as part of [MVA-283](/MVA/issues/MVA-283).

## Test plan

- [x] `code-quality` confirmed passing on Dev_new_gui HEAD before rule was applied
- [x] Branch protection rule updated via GitHub API: both `smoke-test` and `code-quality` are now required
- [x] Doc update only — no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)