### PR TITLE
fix(ansible): write SLM_AUTH_TOKEN to autobot-backend.env — stops WS 403 storm (#7689)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -53,6 +53,8 @@ backend_cors_origins: "*"
 # Internal API key shared with SLM backend for proxy authentication (#1779, #3512).
 # REQUIRED for personality and voice proxies — set via Ansible Vault or inventory.
 autobot_internal_api_key: ""
+# SLM WebSocket auth bearer value — populated from /etc/autobot/slm-secrets.env at deploy time (#7689).
+backend_slm_auth_tok: ""
 
 # LLM Configuration (Issue #858)
 backend_llm_provider: "ollama"  # Default LLM provider for all agents

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -95,6 +95,25 @@
     tls_cert_dir: /etc/autobot/certs
   tags: ['backend', 'config']
 
+# #7689: Read SLM_AUTH_TOKEN from /etc/autobot/slm-secrets.env on the target
+# host and expose it as backend_slm_auth_tok for the backend.env.j2 template.
+# The secrets file is written by the slm_manager role; on single-host deploys
+# it is already present before this role runs.
+- name: "Backend | Read SLM_AUTH_TOKEN from slm-secrets.env (#7689)"
+  ansible.builtin.shell:
+    cmd: >-
+      grep -oP '^SLM_AUTH_TOKEN=\K.*'
+      /etc/autobot/slm-secrets.env 2>/dev/null || true
+  register: _backend_slm_auth_tok
+  changed_when: false
+  failed_when: false
+  tags: ['backend', 'config']
+
+- name: "Backend | Set slm auth fact for env template (#7689)"
+  ansible.builtin.set_fact:
+    backend_slm_auth_tok: "{{ _backend_slm_auth_tok.stdout | default('') | trim }}"
+  tags: ['backend', 'config']
+
 - name: "Backend | Deploy /etc/autobot/autobot-backend.env"
   ansible.builtin.template:
     src: backend.env.j2

--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -40,6 +40,9 @@ SERVICE_AUTH_RATE_LIMIT_WINDOW={{ service_auth_rate_limit_window | default(300) 
 SERVICE_AUTH_RATE_LIMIT_MAX_FAILURES={{ service_auth_rate_limit_max_failures | default(10) }}
 
 # SLM connection (Issue #1048: route through nginx, not direct port)
+# #7689: Bearer token for backend → SLM WebSocket authentication.
+# Read from /etc/autobot/slm-secrets.env by the backend role at deploy time.
+SLM_AUTH_TOKEN={{ backend_slm_auth_tok | default('') }}
 AUTOBOT_SLM_TLS_ENABLED=true
 {% if tls_ca_cert.stat.exists | default(false) %}
 # CA cert for SLM self-signed cert — deployed by enable-tls.yml / distribute-tls-certs.yml.

--- a/autobot-slm-backend/ansible/roles/slm_manager/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/defaults/main.yml
@@ -68,6 +68,8 @@ slm_frontend_build: true
 slm_secret_key: ""
 slm_encryption_key: ""
 slm_admin_password: ""
+# Service token for autobot-backend → SLM WebSocket auth (#7689)
+slm_auth_token: ""
 
 # ==========================================================
 # Main Backend Proxy (#1791)

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -317,6 +317,8 @@
       {{ slm_admin_password
          if (slm_admin_password | default('') | length > 0)
          else lookup('password', '/dev/null length=24 chars=ascii_letters,digits') }}
+    slm_auth_token: >-
+      {{ lookup('password', '/dev/null length=48 chars=ascii_letters,digits') }}
   when: not slm_secrets_stat.stat.exists
   no_log: true
   tags: ['slm', 'secrets']
@@ -329,6 +331,33 @@
     group: "{{ slm_group }}"
     mode: "0600"
   when: not slm_secrets_stat.stat.exists
+  no_log: true
+  tags: ['slm', 'secrets']
+
+# #7689: On existing installations the secrets file already exists and the
+# template task above is skipped. Idempotently add SLM_AUTH_TOKEN when absent.
+- name: "SLM | Check if SLM_AUTH_TOKEN present in secrets file (#7689)"
+  ansible.builtin.shell:
+    cmd: >-
+      grep -q '^SLM_AUTH_TOKEN='
+      {{ slm_credentials_dir }}/{{ slm_credentials_file }}
+  register: _slm_auth_tok_check
+  changed_when: false
+  failed_when: false
+  when: slm_secrets_stat.stat.exists
+  no_log: true
+  tags: ['slm', 'secrets']
+
+- name: "SLM | Add SLM_AUTH_TOKEN to existing secrets file (#7689)"
+  ansible.builtin.lineinfile:
+    path: "{{ slm_credentials_dir }}/{{ slm_credentials_file }}"
+    regexp: "^SLM_AUTH_TOKEN="
+    line: >-
+      SLM_AUTH_TOKEN={{ lookup('password', '/dev/null length=48 chars=ascii_letters,digits') }}
+    create: false
+  when:
+    - slm_secrets_stat.stat.exists
+    - _slm_auth_tok_check.rc != 0
   no_log: true
   tags: ['slm', 'secrets']
 

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/slm-secrets.env.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/slm-secrets.env.j2
@@ -9,6 +9,8 @@
 SLM_SECRET_KEY={{ slm_secret_key }}
 SLM_ENCRYPTION_KEY={{ slm_encryption_key }}
 SLM_ADMIN_PASSWORD={{ slm_admin_password }}
+# Bearer token for autobot-backend → SLM WebSocket authentication (#7689)
+SLM_AUTH_TOKEN={{ slm_auth_token }}
 
 # Internal API key shared with main backend for proxy authentication (#1779)
 # Must be set to a non-empty secret in inventory/vault; defaults to "" (disabled)


### PR DESCRIPTION
## Summary

Fixes the root cause of 4400+ WebSocket 403 errors/day (GH#7689 / MVA-312).

**Root cause chain:**
`SLM_AUTH_TOKEN` unset in `/etc/autobot/autobot-backend.env` → `SLMClient(auth_token=None)` → no `Authorization` header on WS connection → `SERVICE_AUTH_ENFORCEMENT_MODE=true` on SLM → HTTP 403 → 60s reconnect loop → 4400+ 403s/day.

**Changes:**
- `slm_manager/defaults/main.yml` — add `slm_auth_token: ""` (auto-generated when empty)
- `slm_manager/tasks/main.yml` — generate `slm_auth_token` on fresh installs; idempotent `lineinfile` to inject `SLM_AUTH_TOKEN` into existing `slm-secrets.env` on upgrade (handles already-deployed machines)
- `slm_manager/templates/slm-secrets.env.j2` — persist `SLM_AUTH_TOKEN` so it survives redeployments
- `backend/tasks/main.yml` — `shell` + `set_fact` to read the token from `/etc/autobot/slm-secrets.env` on the target host before the env template renders; fails-safe to empty string if file absent
- `backend/templates/backend.env.j2` — emit `SLM_AUTH_TOKEN=` line in the SLM connection section
- `backend/defaults/main.yml` — document `backend_slm_auth_tok` default

## Test plan

- [ ] Fresh deploy: `slm_manager` role generates `SLM_AUTH_TOKEN` and writes to `slm-secrets.env`; `backend` role reads it and writes to `autobot-backend.env`; `SLMClient` connects with `Authorization: Bearer <token>`; WS 403 errors stop
- [ ] Upgrade deploy (existing `slm-secrets.env`): lineinfile idempotently adds `SLM_AUTH_TOKEN` only when absent; subsequent backend deploy picks it up
- [ ] Re-run deploy: lineinfile skips (token already present); `autobot-backend.env` unchanged → no spurious restart
- [ ] Confirm WS 403 error rate drops to 0 after next Ansible playbook run + service restart

Closes #7689

🤖 Generated with [Claude Code](https://claude.com/claude-code)