### PR TITLE
docs(agent-patterns): replace PR-wait polling with Monitor/ScheduleWakeup guidance (MVA-315)

### DIFF
--- a/docs/developer/skills/batch-implement.md
+++ b/docs/developer/skills/batch-implement.md
@@ -322,6 +322,20 @@ python -m black --check $(git diff origin/Dev_new_gui...$PR_BRANCH --name-only |
 
 ---
 
+# Phase 2.5: Anti-Polling Rule (PR Wait)
+
+**batch-implement is a self-contained session**: you review and merge your own PRs in the same run. Do **not** create PRs and then exit, leaving the batch issue `in_progress` for the next heartbeat to re-check.
+
+If the batch session must exit before all PRs are merged (e.g. budget limit, rate limit after 3× retries):
+- Update the batch issue to `in_review`, not `in_progress`.
+- Post ONE comment listing which PRs are open: "Batch paused — PRs #N, #M await merge."
+- Use `ScheduleWakeup` with `delaySeconds: 900` for a single deferred re-check.
+- Do **not** spin with repeated identical "PRs still open" comments on every heartbeat.
+
+This avoids the polling anti-pattern: an agent re-running every 2–5 min posting "PR open, awaiting merge" 11 times in 1h (GH#7623 / MVA-315).
+
+---
+
 # Phase 3: Merge Each PR
 
 Merge immediately after review passes. Do not let PRs sit overnight.


### PR DESCRIPTION
## Summary

- Adds explicit anti-polling guidance to three files that govern agent heartbeat behavior
- No runtime code changed — all behavioral/documentation changes to skills and agent instructions

## Changes

1. **`docs/developer/skills/batch-implement.md`** — new Phase 2.5 "Anti-Polling Rule": batch sessions that can't complete must exit to `in_review` + `ScheduleWakeup(900s)`, not spin with identical "awaiting merge" comments
2. **`~/.claude/skills/implement/SKILL.md`** — new Step 6.5: after PR creation when review required → one comment → `in_review` → `ScheduleWakeup(900s)` → stop
3. **`AGENTS.md`** (FoundingEngineer instructions) — new "PR-Wait Anti-Pattern (PROHIBITED)" section with three correct patterns: self-merge / reviewer path / blocked-by path

## Root Cause

The anti-pattern (GH#7623) was purely behavioral: SecurityEngineer ran 11 heartbeats/hour checking "is PR #7622 merged?" instead of using passive-wait patterns. No polling code existed in the codebase — the fix is guidance in the skill and agent instructions.

## Test plan

- [x] `AGENTS.md` reviewed — prohibits busy-wait, documents three correct alternatives
- [x] `batch-implement.md` reviewed — Phase 2.5 rule present
- [x] `implement/SKILL.md` reviewed — Step 6.5 passive-wait pattern present
- [x] No runtime code changed — no test suite needed

Closes GH#7623

🤖 Generated with [Claude Code](https://claude.com/claude-code)