### PR TITLE
fix(a11y): aria-label remediation - BaseButton contract + P1-P4 patches (MVA-317)

### DIFF
--- a/autobot-frontend/src/components/base/BaseButton.vue
+++ b/autobot-frontend/src/components/base/BaseButton.vue
@@ -4,6 +4,7 @@
     :class="buttonClasses"
     :disabled="disabled || loading"
     :type="htmlType"
+    :aria-label="ariaLabel || undefined"
     @click="handleClick"
     @touchstart="handleTouchStart"
     @touchend="handleTouchEnd"
@@ -20,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, onMounted, useSlots, Comment } from 'vue'
 
 interface Props {
   variant?: 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info' | 'light' | 'dark' | 'outline-solid' | 'ghost' | 'link'
@@ -30,6 +31,7 @@ interface Props {
   block?: boolean
   rounded?: boolean
   label?: string
+  ariaLabel?: string
   htmlType?: 'button' | 'submit' | 'reset'
   tag?: string
   to?: string | object
@@ -51,6 +53,22 @@ const props = withDefaults(defineProps<Props>(), {
   touchFeedback: true,
   hapticFeedback: true
 })
+
+const slots = useSlots()
+
+if (import.meta.env.DEV) {
+  onMounted(() => {
+    const hasVisibleText = !!props.label || !!slots.default?.()?.some(
+      (vnode: any) => vnode.type !== Comment && vnode.children
+    )
+    if (!hasVisibleText && !props.ariaLabel) {
+      console.warn(
+        '[BaseButton] Icon-only button rendered without ariaLabel prop. ' +
+        'This is a WCAG 4.1.2 failure. Add :ariaLabel="$t(\'common.actionName\')" to the button.'
+      )
+    }
+  })
+}
 
 const emit = defineEmits<{
   click: [event: MouseEvent]

--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -116,21 +116,21 @@
         </div>
         <div ref="cytoscapeContainer" class="cytoscape-container"></div>
         <div class="network-controls">
-          <button @click="zoomIn" :title="$t('charts.callGraph.controls.zoomIn')">
+          <button @click="zoomIn" :title="$t('charts.callGraph.controls.zoomIn')" :aria-label="$t('common.zoomIn')">
             <i class="fas fa-plus"></i>
           </button>
           <span class="zoom-level">{{ Math.round(zoomLevel * 100) }}%</span>
-          <button @click="zoomOut" :title="$t('charts.callGraph.controls.zoomOut')">
+          <button @click="zoomOut" :title="$t('charts.callGraph.controls.zoomOut')" :aria-label="$t('common.zoomOut')">
             <i class="fas fa-minus"></i>
           </button>
-          <button @click="fitGraph" :title="$t('charts.callGraph.controls.fitToView')">
+          <button @click="fitGraph" :title="$t('charts.callGraph.controls.fitToView')" :aria-label="$t('common.fitToView')">
             <i class="fas fa-expand"></i>
           </button>
-          <button @click="toggleLayout" :title="$t('charts.callGraph.controls.toggleLayout')">
+          <button @click="toggleLayout" :title="$t('charts.callGraph.controls.toggleLayout')" :aria-label="$t('common.toggleLayout')">
             <i class="fas fa-th"></i>
           </button>
           <span class="control-separator">|</span>
-          <button @click="toggleFullscreen" :title="isFullscreen ? $t('charts.callGraph.controls.exitFullscreen') : $t('charts.callGraph.controls.fullscreen')">
+          <button @click="toggleFullscreen" :title="isFullscreen ? $t('charts.callGraph.controls.exitFullscreen') : $t('charts.callGraph.controls.fullscreen')" :aria-label="isFullscreen ? $t('common.exitFullscreen') : $t('common.fullscreen')">
             <i :class="isFullscreen ? 'fas fa-compress' : 'fas fa-expand-arrows-alt'"></i>
           </button>
         </div>
@@ -140,7 +140,7 @@
           <div class="detail-header">
             <span v-if="selectedNodeInfo.isAsync" class="async-badge">async</span>
             <span class="detail-name">{{ selectedNodeInfo.name }}</span>
-            <button class="close-btn" @click="selectedNodeInfo = null" :title="$t('charts.callGraph.controls.close')">
+            <button class="close-btn" @click="selectedNodeInfo = null" :title="$t('charts.callGraph.controls.close')" :aria-label="$t('common.close')">
               <i class="fas fa-times"></i>
             </button>
           </div>
@@ -266,17 +266,17 @@
         </div>
         <div ref="clusterContainer" class="cluster-container"></div>
         <div class="network-controls cluster-controls">
-          <button @click="zoomInCluster" :title="$t('charts.callGraph.controls.zoomIn')">
+          <button @click="zoomInCluster" :title="$t('charts.callGraph.controls.zoomIn')" :aria-label="$t('common.zoomIn')">
             <i class="fas fa-plus"></i>
           </button>
           <span class="zoom-level">{{ Math.round(clusterZoomLevel * 100) }}%</span>
-          <button @click="zoomOutCluster" :title="$t('charts.callGraph.controls.zoomOut')">
+          <button @click="zoomOutCluster" :title="$t('charts.callGraph.controls.zoomOut')" :aria-label="$t('common.zoomOut')">
             <i class="fas fa-minus"></i>
           </button>
-          <button @click="fitClusterGraph" :title="$t('charts.callGraph.controls.fitToView')">
+          <button @click="fitClusterGraph" :title="$t('charts.callGraph.controls.fitToView')" :aria-label="$t('common.fitToView')">
             <i class="fas fa-expand"></i>
           </button>
-          <button @click="toggleClusterLayout" :title="$t('charts.callGraph.controls.toggleLayout')">
+          <button @click="toggleClusterLayout" :title="$t('charts.callGraph.controls.toggleLayout')" :aria-label="$t('common.toggleLayout')">
             <i class="fas fa-th"></i>
           </button>
         </div>

--- a/autobot-frontend/src/components/charts/ImportTreeChart.vue
+++ b/autobot-frontend/src/components/charts/ImportTreeChart.vue
@@ -89,21 +89,21 @@
           </div>
           <div ref="cytoscapeContainer" class="cytoscape-container"></div>
           <div class="network-controls">
-            <button @click="zoomIn" :title="$t('charts.importTree.controls.zoomIn')">
+            <button @click="zoomIn" :title="$t('charts.importTree.controls.zoomIn')" :aria-label="$t('common.zoomIn')">
               <i class="fas fa-plus"></i>
             </button>
             <span class="zoom-level">{{ Math.round(zoomLevel * 100) }}%</span>
-            <button @click="zoomOut" :title="$t('charts.importTree.controls.zoomOut')">
+            <button @click="zoomOut" :title="$t('charts.importTree.controls.zoomOut')" :aria-label="$t('common.zoomOut')">
               <i class="fas fa-minus"></i>
             </button>
-            <button @click="fitGraph" :title="$t('charts.importTree.controls.fitToView')">
+            <button @click="fitGraph" :title="$t('charts.importTree.controls.fitToView')" :aria-label="$t('common.fitToView')">
               <i class="fas fa-expand"></i>
             </button>
-            <button @click="toggleLayout" :title="$t('charts.importTree.controls.toggleLayout')">
+            <button @click="toggleLayout" :title="$t('charts.importTree.controls.toggleLayout')" :aria-label="$t('common.toggleLayout')">
               <i class="fas fa-th"></i>
             </button>
             <span class="control-separator">|</span>
-            <button @click="toggleFullscreen" :title="isFullscreen ? $t('charts.importTree.controls.exitFullscreen') : $t('charts.importTree.controls.fullscreen')">
+            <button @click="toggleFullscreen" :title="isFullscreen ? $t('charts.importTree.controls.exitFullscreen') : $t('charts.importTree.controls.fullscreen')" :aria-label="isFullscreen ? $t('common.exitFullscreen') : $t('common.fullscreen')">
               <i :class="isFullscreen ? 'fas fa-compress' : 'fas fa-expand-arrows-alt'"></i>
             </button>
           </div>
@@ -113,7 +113,7 @@
             <div class="detail-header">
               <span class="detail-icon">{{ getFileIcon(selectedNode.path) }}</span>
               <span class="detail-name">{{ selectedNode.shortName }}</span>
-              <button class="close-btn" @click="selectedNode = null" :title="$t('charts.importTree.controls.close')">
+              <button class="close-btn" @click="selectedNode = null" :title="$t('charts.importTree.controls.close')" :aria-label="$t('common.close')">
                 <i class="fas fa-times"></i>
               </button>
             </div>

--- a/autobot-frontend/src/components/chat/ChatFilePanel.vue
+++ b/autobot-frontend/src/components/chat/ChatFilePanel.vue
@@ -7,13 +7,13 @@
         <h3 class="text-sm font-semibold text-autobot-text-primary">{{ $t('chat.filePanel.title') }}</h3>
       </div>
       <div class="flex items-center gap-1">
-        <button @click="showCreateDialog = true" class="action-btn" :title="$t('chat.filePanel.newFile')">
+        <button @click="showCreateDialog = true" class="action-btn" :title="$t('chat.filePanel.newFile')" :aria-label="$t('chat.filePanel.newFile')">
           <i class="fas fa-plus text-xs"></i>
         </button>
-        <button @click="viewMode = viewMode === 'list' ? 'grid' : 'list'" class="action-btn" :title="viewMode === 'list' ? $t('chat.filePanel.gridView') : $t('chat.filePanel.listView')">
+        <button @click="viewMode = viewMode === 'list' ? 'grid' : 'list'" class="action-btn" :title="viewMode === 'list' ? $t('chat.filePanel.gridView') : $t('chat.filePanel.listView')" :aria-label="viewMode === 'list' ? $t('chat.filePanel.gridView') : $t('chat.filePanel.listView')">
           <i :class="viewMode === 'list' ? 'fas fa-th' : 'fas fa-list'" class="text-xs"></i>
         </button>
-        <button @click="$emit('close')" class="action-btn" :title="$t('chat.filePanel.closePanel')">
+        <button @click="$emit('close')" class="action-btn" :title="$t('chat.filePanel.closePanel')" :aria-label="$t('chat.filePanel.closePanel')">
           <i class="fas fa-times text-xs"></i>
         </button>
       </div>
@@ -114,6 +114,7 @@
         <button
           @click="clearError"
           class="text-red-400 hover:text-red-600 transition-colors shrink-0"
+          :aria-label="$t('common.dismiss')"
         >
           <i class="fas fa-times text-xs"></i>
         </button>
@@ -199,6 +200,7 @@
               @click="handlePreview(file.file_id)"
               class="action-btn"
               :title="$t('chat.filePanel.preview')"
+              :aria-label="$t('chat.filePanel.preview')"
             >
               <i class="fas fa-eye text-xs"></i>
             </button>
@@ -207,6 +209,7 @@
               @click="startEdit(file.file_id, file.filename)"
               class="action-btn"
               :title="$t('common.edit')"
+              :aria-label="$t('common.edit')"
             >
               <i class="fas fa-edit text-xs"></i>
             </button>
@@ -214,6 +217,7 @@
               @click="handleDownload(file.file_id, file.filename)"
               class="action-btn"
               :title="$t('chat.filePanel.download')"
+              :aria-label="$t('common.download')"
             >
               <i class="fas fa-download text-xs"></i>
             </button>
@@ -221,6 +225,7 @@
               @click="handleDelete(file.file_id, file.filename)"
               class="action-btn text-red-400 hover:text-red-600"
               :title="$t('common.delete')"
+              :aria-label="$t('common.delete')"
             >
               <i class="fas fa-trash text-xs"></i>
             </button>
@@ -284,7 +289,7 @@
         <div class="bg-autobot-bg-card rounded-lg shadow-xl w-[480px] max-h-[80vh] flex flex-col p-4">
           <div class="flex items-center justify-between mb-3">
             <h4 class="text-sm font-semibold text-autobot-text-primary truncate">{{ editingFileName }}</h4>
-            <button @click="editingFileId = null" class="action-btn"><i class="fas fa-times text-xs"></i></button>
+            <button @click="editingFileId = null" class="action-btn" :aria-label="$t('common.close')"><i class="fas fa-times text-xs"></i></button>
           </div>
           <textarea
             v-model="editingContent"

--- a/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
+++ b/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
@@ -18,44 +18,44 @@
       <div class="flex items-center space-x-2">
         <!-- Browser Controls -->
         <div class="flex items-center space-x-1">
-          <button @click="refreshBrowser" class="browser-btn" :disabled="isRefreshing" :title="$t('desktop.popoutBrowser.refresh')">
+          <button @click="refreshBrowser" class="browser-btn" :disabled="isRefreshing" :title="$t('desktop.popoutBrowser.refresh')" :aria-label="$t('desktop.popoutBrowser.refresh')">
             <i class="fas fa-sync-alt" :class="{ 'fa-spin': isRefreshing }"></i>
           </button>
 
-          <button @click="navigateHome" class="browser-btn" :title="$t('desktop.popoutBrowser.home')">
+          <button @click="navigateHome" class="browser-btn" :title="$t('desktop.popoutBrowser.home')" :aria-label="$t('desktop.popoutBrowser.home')">
             <i class="fas fa-home"></i>
           </button>
 
-          <button @click="showDevTools = !showDevTools" class="browser-btn" :title="$t('desktop.popoutBrowser.devTools')">
+          <button @click="showDevTools = !showDevTools" class="browser-btn" :title="$t('desktop.popoutBrowser.devTools')" :aria-label="$t('desktop.popoutBrowser.devTools')">
             <i class="fas fa-code"></i>
           </button>
 
-          <button @click="openVncPopout" class="browser-btn" style="color: var(--color-primary)" :title="$t('desktop.popoutBrowser.openVnc')">
+          <button @click="openVncPopout" class="browser-btn" style="color: var(--color-primary)" :title="$t('desktop.popoutBrowser.openVnc')" :aria-label="$t('desktop.popoutBrowser.openVnc')">
             <i class="fas fa-desktop"></i>
           </button>
         </div>
 
         <!-- Playwright Automation Controls -->
         <div class="border-l border-autobot-border pl-2 flex items-center space-x-1">
-          <button @click="showPlaywrightPanel = !showPlaywrightPanel" class="browser-btn" :title="$t('desktop.popoutBrowser.playwrightAutomation')">
+          <button @click="showPlaywrightPanel = !showPlaywrightPanel" class="browser-btn" :title="$t('desktop.popoutBrowser.playwrightAutomation')" :aria-label="$t('desktop.popoutBrowser.playwrightAutomation')">
             <i class="fas fa-robot" :style="showPlaywrightPanel ? 'color: var(--color-primary)' : ''"></i>
           </button>
 
-          <button @click="runFrontendTest" class="browser-btn" :disabled="isTestingFrontend" :title="$t('desktop.popoutBrowser.testFrontend')">
+          <button @click="runFrontendTest" class="browser-btn" :disabled="isTestingFrontend" :title="$t('desktop.popoutBrowser.testFrontend')" :aria-label="$t('desktop.popoutBrowser.testFrontend')">
             <i class="fas fa-vials" :class="{ 'fa-spin': isTestingFrontend }"></i>
           </button>
 
-          <button @click="performWebSearch" class="browser-btn" :disabled="isSearching" :title="$t('desktop.popoutBrowser.webSearch')">
+          <button @click="performWebSearch" class="browser-btn" :disabled="isSearching" :title="$t('desktop.popoutBrowser.webSearch')" :aria-label="$t('desktop.popoutBrowser.webSearch')">
             <i class="fas fa-search" :class="{ 'fa-spin': isSearching }"></i>
           </button>
 
-          <button @click="sendTestMessage" class="browser-btn" :disabled="isSendingMessage" :title="$t('desktop.popoutBrowser.testMessage')">
+          <button @click="sendTestMessage" class="browser-btn" :disabled="isSendingMessage" :title="$t('desktop.popoutBrowser.testMessage')" :aria-label="$t('desktop.popoutBrowser.testMessage')">
             <i class="fas fa-paper-plane" :class="{ 'fa-spin': isSendingMessage }"></i>
           </button>
         </div>
 
         <div class="border-l border-autobot-border pl-2">
-          <button @click="$emit('close')" class="browser-btn text-red-600" :title="$t('desktop.popoutBrowser.close')">
+          <button @click="$emit('close')" class="browser-btn text-red-600" :title="$t('desktop.popoutBrowser.close')" :aria-label="$t('desktop.popoutBrowser.close')">
             <i class="fas fa-times"></i>
           </button>
         </div>
@@ -64,10 +64,10 @@
 
     <!-- Address Bar -->
     <div class="address-bar bg-autobot-bg-secondary border-b border-autobot-border p-3 flex items-center space-x-3">
-      <button @click="goBack" :disabled="!canGoBack || isGoingBack" class="nav-btn" :title="$t('desktop.popoutBrowser.back')">
+      <button @click="goBack" :disabled="!canGoBack || isGoingBack" class="nav-btn" :title="$t('desktop.popoutBrowser.back')" :aria-label="$t('desktop.popoutBrowser.back')">
         <i class="fas fa-arrow-left" :class="{ 'fa-pulse': isGoingBack }"></i>
       </button>
-      <button @click="goForward" :disabled="!canGoForward || isGoingForward" class="nav-btn" :title="$t('desktop.popoutBrowser.forward')">
+      <button @click="goForward" :disabled="!canGoForward || isGoingForward" class="nav-btn" :title="$t('desktop.popoutBrowser.forward')" :aria-label="$t('desktop.popoutBrowser.forward')">
         <i class="fas fa-arrow-right" :class="{ 'fa-pulse': isGoingForward }"></i>
       </button>
       <div class="flex-1 flex items-center bg-autobot-bg-tertiary rounded-lg px-3 py-2" :class="{ 'opacity-50': isNavigating }">
@@ -312,7 +312,7 @@
       <div v-if="showDevTools" class="absolute bottom-0 left-0 right-0 h-1/3 bg-gray-900 border-t border-gray-600">
         <div class="flex items-center justify-between bg-gray-800 p-2 text-white text-sm">
           <span>{{ $t('desktop.popoutBrowser.developerConsole') }}</span>
-          <button @click="showDevTools = false" class="text-gray-400 hover:text-white">
+          <button @click="showDevTools = false" class="text-gray-400 hover:text-white" :aria-label="$t('common.close')">
             <i class="fas fa-times"></i>
           </button>
         </div>

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -26,17 +26,17 @@
           </div>
         </div>
         <div class="toolbar-divider"></div>
-        <button class="tool-btn" @click="clearCanvas" :title="$t('workflow.canvas.clear')">
+        <button class="tool-btn" @click="clearCanvas" :title="$t('workflow.canvas.clear')" :aria-label="$t('workflow.canvas.clear')">
           <i class="fas fa-trash-alt"></i>
         </button>
-        <button class="tool-btn" @click="autoLayout" :title="$t('workflow.canvas.autoLayout')">
+        <button class="tool-btn" @click="autoLayout" :title="$t('workflow.canvas.autoLayout')" :aria-label="$t('workflow.canvas.autoLayout')">
           <i class="fas fa-magic"></i>
         </button>
       </div>
       <div class="toolbar-right">
-        <button class="tool-btn" @click="zoomIn"><i class="fas fa-search-plus"></i></button>
-        <button class="tool-btn" @click="zoomOut"><i class="fas fa-search-minus"></i></button>
-        <button class="tool-btn" @click="resetZoom"><i class="fas fa-compress-arrows-alt"></i></button>
+        <button class="tool-btn" @click="zoomIn" :aria-label="$t('common.zoomIn')"><i class="fas fa-search-plus"></i></button>
+        <button class="tool-btn" @click="zoomOut" :aria-label="$t('common.zoomOut')"><i class="fas fa-search-minus"></i></button>
+        <button class="tool-btn" @click="resetZoom" :aria-label="$t('common.fitToView')"><i class="fas fa-compress-arrows-alt"></i></button>
         <div class="toolbar-divider"></div>
         <button class="tool-btn primary" @click="saveWorkflow" :disabled="nodes.length === 0">
           <i class="fas fa-save"></i> {{ $t('workflow.canvas.save') }}
@@ -66,7 +66,7 @@
           <div class="node-header">
             <i :class="nodeIcons[node.type]"></i>
             <span>{{ nodeLabels[node.type] }}</span>
-            <button class="delete-btn" @click.stop="deleteNode(node.id)"><i class="fas fa-times"></i></button>
+            <button class="delete-btn" @click.stop="deleteNode(node.id)" :aria-label="$t('common.delete')"><i class="fas fa-times"></i></button>
           </div>
           <div class="node-body">
             <template v-if="node.type === 'step'">

--- a/autobot-frontend/src/components/workflow/WorkflowHistory.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowHistory.vue
@@ -48,10 +48,10 @@
           <div class="stat skipped" v-if="getSkippedCount(wf) > 0"><span>{{ getSkippedCount(wf) }}</span> {{ $t('workflow.history.skipped') }}</div>
         </div>
         <div class="item-actions">
-          <button class="btn-icon" @click.stop="$emit('view-workflow', wf.workflow_id)" :title="$t('workflow.history.viewDetails')">
+          <button class="btn-icon" @click.stop="$emit('view-workflow', wf.workflow_id)" :title="$t('workflow.history.viewDetails')" :aria-label="$t('workflow.history.viewDetails')">
             <i class="fas fa-eye"></i>
           </button>
-          <button class="btn-icon" @click.stop="$emit('re-run', wf.workflow_id)" :title="$t('workflow.history.reRun')">
+          <button class="btn-icon" @click.stop="$emit('re-run', wf.workflow_id)" :title="$t('workflow.history.reRun')" :aria-label="$t('workflow.history.reRun')">
             <i class="fas fa-redo"></i>
           </button>
         </div>
@@ -60,9 +60,9 @@
 
     <!-- Pagination -->
     <div v-if="totalPages > 1" class="pagination">
-      <button :disabled="currentPage === 1" @click="currentPage--"><i class="fas fa-chevron-left"></i></button>
+      <button :disabled="currentPage === 1" @click="currentPage--" :aria-label="$t('common.previous')"><i class="fas fa-chevron-left"></i></button>
       <span>{{ $t('workflow.history.pageOf', { current: currentPage, total: totalPages }) }}</span>
-      <button :disabled="currentPage === totalPages" @click="currentPage++"><i class="fas fa-chevron-right"></i></button>
+      <button :disabled="currentPage === totalPages" @click="currentPage++" :aria-label="$t('common.next')"><i class="fas fa-chevron-right"></i></button>
     </div>
   </div>
 </template>

--- a/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
@@ -45,8 +45,8 @@
           </div>
         </div>
         <div class="template-actions">
-          <button class="btn-icon" @click.stop="openPreview(template)" :title="$t('workflow.templates.preview')"><i class="fas fa-eye"></i></button>
-          <button class="btn-run" @click.stop="$emit('run-template', template)" :title="$t('workflow.templates.runNow')"><i class="fas fa-play"></i></button>
+          <button class="btn-icon" @click.stop="openPreview(template)" :title="$t('workflow.templates.preview')" :aria-label="$t('workflow.templates.preview')"><i class="fas fa-eye"></i></button>
+          <button class="btn-run" @click.stop="$emit('run-template', template)" :title="$t('workflow.templates.runNow')" :aria-label="$t('workflow.templates.runNow')"><i class="fas fa-play"></i></button>
         </div>
       </div>
     </div>
@@ -56,7 +56,7 @@
       <div v-if="previewTemplate" class="preview-panel">
         <div class="preview-header">
           <h3>{{ previewTemplate.name }}</h3>
-          <button @click="previewTemplate = null"><i class="fas fa-times"></i></button>
+          <button @click="previewTemplate = null" :aria-label="$t('common.close')"><i class="fas fa-times"></i></button>
         </div>
         <div class="preview-body">
           <p class="preview-desc">{{ previewTemplate.description }}</p>

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -84,7 +84,22 @@
     "page": "Page",
     "previous": "Previous",
     "optional": "optional",
-    "remove": "Remove"
+    "remove": "Remove",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "fitToView": "Fit to view",
+    "toggleLayout": "Toggle layout",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "copyToClipboard": "Copy to clipboard",
+    "sortAscending": "Sort ascending",
+    "sortDescending": "Sort descending",
+    "moreOptions": "More options",
+    "exportJson": "Export as JSON",
+    "exportCsv": "Export as CSV",
+    "download": "Download"
   },
   "chat": {
     "sendMessage": "Send a message...",


### PR DESCRIPTION
## Summary

- **BaseButton**: adds `ariaLabel?: string` prop wired to `:aria-label` on root element; adds dev-mode `onMounted` warning when icon-only button renders without the prop (WCAG 4.1.2 regression guard)
- **en.json**: 15 new `common.*` i18n keys: `zoomIn`, `zoomOut`, `fitToView`, `toggleLayout`, `fullscreen`, `exitFullscreen`, `expand`, `collapse`, `copyToClipboard`, `sortAscending`, `sortDescending`, `moreOptions`, `exportJson`, `exportCsv`, `download`
- **P1 — PopoutChromiumBrowser**: all 11 icon-only buttons with `:title`-only now also have `:aria-label` using existing `desktop.popoutBrowser.*` keys; dev-tools close button patched with `common.close`
- **P2 — Charts**: `ImportTreeChart` and `FunctionCallGraph` chart controls (zoom in/out, fit to view, toggle layout, fullscreen/exit, close node panel) wired to new `common.*` keys; cluster view in FunctionCallGraph also patched
- **P3 — Workflow**: `WorkflowCanvas` toolbar (zoom, clear, auto-layout, per-node delete), `WorkflowHistory` (view details, re-run, previous/next pagination), `WorkflowTemplateGallery` (preview, run-template, close preview)
- **P4 — ChatFilePanel**: header buttons (new file, toggle view, close panel), error dismiss, file action row (preview, edit, download, delete), edit dialog close

Closes MVA-317. Implements [MVA-188 spec](https://github.com/mrveiss/AutoBot-AI/issues/MVA-188).

## Test plan

- [ ] Open PopoutChromiumBrowser — all toolbar buttons should have accessible names visible in browser DevTools (Elements > Accessibility tree)
- [ ] Open ImportTreeChart or FunctionCallGraph network view — zoom/fit/layout/fullscreen buttons have aria-label in accessibility tree
- [ ] Open WorkflowCanvas — toolbar zoom/clear/auto-layout buttons and node delete buttons have aria-label
- [ ] Open ChatFilePanel — header and file action buttons have aria-label
- [ ] Open browser devtools console in dev mode with a `<BaseButton>` that has no `ariaLabel` and no visible text — should see WCAG warning
- [ ] Buttons with visible text labels (e.g. "Save", "Add Step") should NOT have redundant aria-label
- [ ] Run axe DevTools on patched components — zero 4.1.2 violations on patched buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)