### PR TITLE
a11y(chat): aria-label audit & remediation — VisualBrowserPanel.vue (MVA-322)

### DIFF
--- a/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
+++ b/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
@@ -209,13 +209,13 @@ onMounted(() => {
       <div class="address-row">
         <!-- Back / Forward / Reload -->
         <div class="nav-controls">
-          <button @click="goBack" :disabled="!isConnected || loading" class="nav-btn" :title="$t('chat.visualBrowser.back')">
+          <button @click="goBack" :disabled="!isConnected || loading" class="nav-btn" :title="$t('chat.visualBrowser.back')" :aria-label="$t('common.back')">
             <i class="fas fa-arrow-left"></i>
           </button>
-          <button @click="goForward" :disabled="!isConnected || loading" class="nav-btn" :title="$t('chat.visualBrowser.forward')">
+          <button @click="goForward" :disabled="!isConnected || loading" class="nav-btn" :title="$t('chat.visualBrowser.forward')" :aria-label="$t('common.forward')">
             <i class="fas fa-arrow-right"></i>
           </button>
-          <button @click="reload" :disabled="!isConnected || loading" class="nav-btn" :title="$t('chat.visualBrowser.reload')">
+          <button @click="reload" :disabled="!isConnected || loading" class="nav-btn" :title="$t('chat.visualBrowser.reload')" :aria-label="$t('common.refresh')">
             <i class="fas fa-redo" :class="{ 'fa-spin': loading }"></i>
           </button>
         </div>
@@ -233,13 +233,13 @@ onMounted(() => {
         </div>
 
         <!-- Go button -->
-        <button @click="navigate" :disabled="loading" class="go-btn">
+        <button @click="navigate" :disabled="loading" class="go-btn" :aria-label="$t('common.search')">
           <i class="fas fa-search" v-if="!loading"></i>
           <i class="fas fa-spinner fa-spin" v-else></i>
         </button>
 
         <!-- Screenshot button -->
-        <button @click="captureScreenshot" :disabled="!isConnected || loading" class="nav-btn screenshot-btn" :title="$t('chat.visualBrowser.refreshScreenshot')">
+        <button @click="captureScreenshot" :disabled="!isConnected || loading" class="nav-btn screenshot-btn" :title="$t('chat.visualBrowser.refreshScreenshot')" :aria-label="$t('chat.visualBrowser.refreshScreenshot')">
           <i class="fas fa-camera"></i>
         </button>
 
@@ -249,6 +249,7 @@ onMounted(() => {
           class="nav-btn automation-toggle-btn"
           :class="{ 'automation-active': showAutomation }"
           :title="$t('chat.visualBrowser.toggleAutomation')"
+          :aria-label="$t('chat.visualBrowser.toggleAutomation')"
         >
           <i class="fas fa-robot"></i>
         </button>
@@ -259,7 +260,7 @@ onMounted(() => {
     <div v-if="error" class="error-banner">
       <i class="fas fa-exclamation-triangle"></i>
       <span>{{ error }}</span>
-      <button @click="error = null" class="error-dismiss"><i class="fas fa-times"></i></button>
+      <button @click="error = null" class="error-dismiss" :aria-label="$t('common.dismiss')"><i class="fas fa-times"></i></button>
     </div>
 
     <!-- Content Area (viewport + optional automation panel) (#1242) -->

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -9,6 +9,7 @@
     "dismiss": "Dismiss",
     "confirm": "Confirm",
     "back": "Back",
+    "forward": "Forward",
     "next": "Next",
     "loading": "Loading...",
     "error": "Error",


### PR DESCRIPTION
## Summary

Resolves [MVA-322](/MVA/issues/MVA-322) — full WCAG 4.1.2 aria-label audit for `VisualBrowserPanel.vue`.

### Buttons patched (7 icon-only controls)

| Button | `aria-label` key | English |
|--------|-----------------|---------|
| Back | `common.back` | "Back" |
| Forward | `common.forward` | "Forward" |
| Reload | `common.refresh` | "Refresh" |
| Go / Navigate | `common.search` | "Search" |
| Refresh Screenshot | `chat.visualBrowser.refreshScreenshot` | "Refresh Screenshot" |
| Toggle Automation | `chat.visualBrowser.toggleAutomation` | "Toggle GUI Automation Panel" |
| Error Dismiss | `common.dismiss` | "Dismiss" |

### i18n changes

- Added `common.forward: "Forward"` to `en.json` — the MVA-188 spec lists this as Existing, but it was missing from the file.

### Not changed

- The "Capture Screenshot" button (viewport empty state) has visible text — accessible name already present, no `aria-label` needed.
- All `:title` attributes retained for sighted keyboard users (per MVA-188 spec: keep `:title` alongside `:aria-label`, don't remove).

## Test plan

- [ ] Open browser dev tools → Accessibility tree: confirm all 7 buttons show their accessible name
- [ ] `axe-core` scan on VisualBrowserPanel: zero WCAG 4.1.2 violations
- [ ] TypeScript: no new errors introduced (`vue-tsc --noEmit -p tsconfig.app.json`)
- [ ] i18n: `common.forward` resolves correctly in the UI

## Parent

Child of [MVA-321](/MVA/issues/MVA-321) · Spec: [MVA-188](/MVA/issues/MVA-188#document-spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)