### PR TITLE
fix(a11y): aria-label remediation for 10 zero-accessibility icon-only buttons (MVA-332)

### DIFF
--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -132,7 +132,13 @@
         <div class="screenshot-content" @click.stop>
           <div class="screenshot-header">
             <h3 class="text-lg font-semibold text-autobot-text-primary">{{ $t('desktop.interface.screenshotTitle') }}</h3>
-            <button @click="showScreenshotModal = false" class="close-btn">×</button>
+            <button
+              @click="showScreenshotModal = false"
+              class="close-btn"
+              :aria-label="$t('common.close')"
+              :title="$t('common.close')"
+              type="button"
+            >×</button>
           </div>
           <div class="screenshot-body">
             <img v-if="screenshotData" :src="screenshotData" :alt="$t('desktop.interface.screenshotAlt')" class="screenshot-image" loading="lazy" />
@@ -153,7 +159,13 @@
         <div class="type-dialog-content" @click.stop>
           <div class="type-dialog-header">
             <h3 class="text-lg font-semibold text-autobot-text-primary">{{ $t('desktop.interface.typeTextTitle') }}</h3>
-            <button @click="showTypeDialog = false" class="close-btn">×</button>
+            <button
+              @click="showTypeDialog = false"
+              class="close-btn"
+              :aria-label="$t('common.close')"
+              :title="$t('common.close')"
+              type="button"
+            >×</button>
           </div>
           <div class="type-dialog-body">
             <textarea

--- a/autobot-frontend/src/components/knowledge/TreeNodeComponent.vue
+++ b/autobot-frontend/src/components/knowledge/TreeNodeComponent.vue
@@ -30,7 +30,13 @@
       <span v-else class="expand-spacer"></span>
 
       <!-- Node icon -->
-      <button class="node-icon-btn" @click.stop="$emit('select', node)" type="button">
+      <button
+        class="node-icon-btn"
+        @click.stop="$emit('select', node)"
+        type="button"
+        :aria-label="node.name"
+        :title="node.name"
+      >
         <i :class="['node-icon', nodeIcon]"></i>
       </button>
 

--- a/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
+++ b/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
@@ -5,7 +5,14 @@
         <i class="fas fa-users-cog"></i>
         {{ $t('workflow.agentObservability.title') }}
       </h3>
-      <button class="btn-refresh-sm" @click="$emit('refresh')" :disabled="loading">
+      <button
+        class="btn-refresh-sm"
+        @click="$emit('refresh')"
+        :disabled="loading"
+        :aria-label="$t('common.refresh')"
+        :title="$t('common.refresh')"
+        type="button"
+      >
         <i class="fas fa-sync-alt" :class="{ 'fa-spin': loading }"></i>
       </button>
     </div>

--- a/autobot-frontend/src/components/workflow/WorkflowRunner.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowRunner.vue
@@ -4,7 +4,14 @@
     <div class="runner-sidebar">
       <div class="sidebar-header">
         <h4><i class="fas fa-tasks"></i> {{ $t('workflow.runner.activeWorkflows') }}</h4>
-        <button class="btn-refresh" @click="$emit('refresh')" :disabled="loading">
+        <button
+          class="btn-refresh"
+          @click="$emit('refresh')"
+          :disabled="loading"
+          :aria-label="$t('common.refresh')"
+          :title="$t('common.refresh')"
+          type="button"
+        >
           <i class="fas fa-sync-alt" :class="{ 'fa-spin': loading }"></i>
         </button>
       </div>

--- a/autobot-frontend/src/views/AdminUsersView.vue
+++ b/autobot-frontend/src/views/AdminUsersView.vue
@@ -138,7 +138,13 @@
       <div class="modal">
         <div class="modal-header">
           <h3>Add User</h3>
-          <button class="btn-close" @click="showCreateModal = false"><Icon name="times" /></button>
+          <button
+            class="btn-close"
+            @click="showCreateModal = false"
+            :aria-label="$t('common.close')"
+            :title="$t('common.close')"
+            type="button"
+          ><Icon name="times" /></button>
         </div>
         <form class="modal-body" @submit.prevent="createUser">
           <div class="form-group">

--- a/autobot-frontend/src/views/CustomDashboard.vue
+++ b/autobot-frontend/src/views/CustomDashboard.vue
@@ -124,7 +124,13 @@
       <div class="modal-content">
         <div class="modal-header">
           <h4><Icon name="cog" class="modal-icon" /> {{ $t('views.customDashboard.configureWidget') }}</h4>
-          <button @click="showConfigModal = false" class="close-btn">
+          <button
+            @click="showConfigModal = false"
+            class="close-btn"
+            :aria-label="$t('common.close')"
+            :title="$t('common.close')"
+            type="button"
+          >
             <Icon name="times" />
           </button>
         </div>
@@ -172,7 +178,13 @@
       <div class="modal-content">
         <div class="modal-header">
           <h4><Icon name="plus-circle" class="modal-icon" /> {{ $t('views.customDashboard.createDashboard') }}</h4>
-          <button @click="showNewDashboardModal = false" class="close-btn">
+          <button
+            @click="showNewDashboardModal = false"
+            class="close-btn"
+            :aria-label="$t('common.close')"
+            :title="$t('common.close')"
+            type="button"
+          >
             <Icon name="times" />
           </button>
         </div>
@@ -203,7 +215,13 @@
       <div class="modal-content wide">
         <div class="modal-header">
           <h4><Icon name="plus-circle" class="modal-icon" /> {{ $t('views.customDashboard.addWidgetTitle') }}</h4>
-          <button @click="showAddWidgetModal = false" class="close-btn">
+          <button
+            @click="showAddWidgetModal = false"
+            class="close-btn"
+            :aria-label="$t('common.close')"
+            :title="$t('common.close')"
+            type="button"
+          >
             <Icon name="times" />
           </button>
         </div>

--- a/autobot-frontend/src/views/WorkflowBuilderView.vue
+++ b/autobot-frontend/src/views/WorkflowBuilderView.vue
@@ -588,7 +588,14 @@
           <div class="agents-container">
             <div class="agents-header">
               <h3><Icon name="users-cog" /> {{ $t('workflow.views.agentCapabilities') }}</h3>
-              <button @click="loadAgentCapabilities" class="btn-refresh-sm" :disabled="loadingCapabilities">
+              <button
+                @click="loadAgentCapabilities"
+                class="btn-refresh-sm"
+                :disabled="loadingCapabilities"
+                :aria-label="$t('common.refresh')"
+                :title="$t('common.refresh')"
+                type="button"
+              >
                 <Icon name="sync-alt" :spin="loadingCapabilities" />
               </button>
             </div>


### PR DESCRIPTION
## Summary

Fixes all 10 Severity-1 buttons that had **no accessibility attributes whatsoever** — screen readers received zero context for these icon-only controls.

- `WorkflowBuilderView.vue` — `btn-refresh-sm` refresh button (`:aria-label="$t('common.refresh')"`)
- `CustomDashboard.vue` — 3× `close-btn` (config modal, new-dashboard modal, add-widget modal; `:aria-label="$t('common.close')"`)
- `AdminUsersView.vue` — `btn-close` close create-user modal (`:aria-label="$t('common.close')"`)
- `DesktopInterface.vue` — 2× `close-btn` (screenshot modal, type dialog; `:aria-label="$t('common.close')"`)
- `TreeNodeComponent.vue` — `node-icon-btn` select-node button (`:aria-label="node.name"` — dynamic, most descriptive label)
- `WorkflowRunner.vue` — `btn-refresh` (`:aria-label="$t('common.refresh')"`)
- `AgentObservabilityPanel.vue` — `btn-refresh-sm` (`:aria-label="$t('common.refresh')"`)

Both `common.close` and `common.refresh` already existed in the i18n locale files — no new keys were needed.

## Test plan

- [ ] Each of the 10 buttons now surfaces a meaningful label to VoiceOver / NVDA
- [ ] `WorkflowBuilderView` agents section: hover the refresh button — tooltip shows "Refresh"
- [ ] `CustomDashboard` modals: hover the × close button in each modal — tooltip shows "Close"
- [ ] `AdminUsersView` create-user modal: hover the × close button — tooltip shows "Close"
- [ ] `DesktopInterface` screenshot + type-text modals: hover × — tooltip shows "Close"
- [ ] `TreeNodeComponent`: inspect node icon button aria-label in DevTools — equals `node.name`
- [ ] `WorkflowRunner` sidebar: hover the refresh button — tooltip shows "Refresh"
- [ ] `AgentObservabilityPanel` header: hover the refresh button — tooltip shows "Refresh"
- [ ] No visual regressions in any of the above components

Closes MVA-332

🤖 Generated with [Claude Code](https://claude.com/claude-code)