### PR TITLE
fix(a11y): aria-label for 10 Severity-2 icon-only buttons (MVA-335)

### DIFF
--- a/autobot-frontend/src/components/file-browser/FileTreeView.vue
+++ b/autobot-frontend/src/components/file-browser/FileTreeView.vue
@@ -3,10 +3,10 @@
     <div class="tree-header">
       <h3><i class="fas fa-folder-tree"></i> {{ $t('fileBrowser.treeView.title') }}</h3>
       <div class="tree-controls">
-        <button @click="$emit('expand-all')" :title="$t('fileBrowser.treeView.expandAll')">
+        <button @click="$emit('expand-all')" :title="$t('fileBrowser.treeView.expandAll')" :aria-label="$t('fileBrowser.treeView.expandAll')">
           <i class="fas fa-expand-alt"></i>
         </button>
-        <button @click="$emit('collapse-all')" :title="$t('fileBrowser.treeView.collapseAll')">
+        <button @click="$emit('collapse-all')" :title="$t('fileBrowser.treeView.collapseAll')" :aria-label="$t('fileBrowser.treeView.collapseAll')">
           <i class="fas fa-compress-alt"></i>
         </button>
       </div>

--- a/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
@@ -228,6 +228,7 @@
                 @click="viewEntry(entry)"
                 class="icon-btn"
                 :title="$t('knowledge.entries.viewBtn')"
+                :aria-label="$t('knowledge.entries.viewBtn')"
               >
                 <i class="fas fa-eye"></i>
               </BaseButton>
@@ -237,6 +238,7 @@
                 @click="editEntry(entry)"
                 class="icon-btn"
                 :title="$t('knowledge.entries.editBtn')"
+                :aria-label="$t('knowledge.entries.editBtn')"
               >
                 <i class="fas fa-edit"></i>
               </BaseButton>
@@ -246,6 +248,7 @@
                 @click="deleteEntry(entry)"
                 class="icon-btn danger"
                 :title="$t('knowledge.entries.deleteBtn')"
+                :aria-label="$t('knowledge.entries.deleteBtn')"
               >
                 <i class="fas fa-trash"></i>
               </BaseButton>

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -107,10 +107,10 @@
           <span class="subtitle">{{ t('security.secretsManager.credentialCount', { count: filteredSecrets.length }, filteredSecrets.length) }}</span>
         </div>
         <div class="header-actions">
-          <button @click="loadSecrets" class="btn-icon" :disabled="loading" :title="t('security.secretsManager.refresh')">
+          <button @click="loadSecrets" class="btn-icon" :disabled="loading" :title="t('security.secretsManager.refresh')" :aria-label="t('security.secretsManager.refresh')">
             <i class="fas fa-sync-alt" :class="{ 'fa-spin': loading }"></i>
           </button>
-          <button @click="toggleView" class="btn-icon" :title="viewMode === 'grid' ? t('security.secretsManager.listView') : t('security.secretsManager.gridView')">
+          <button @click="toggleView" class="btn-icon" :title="viewMode === 'grid' ? t('security.secretsManager.listView') : t('security.secretsManager.gridView')" :aria-label="viewMode === 'grid' ? t('security.secretsManager.listView') : t('security.secretsManager.gridView')">
             <i :class="viewMode === 'grid' ? 'fas fa-list' : 'fas fa-th'"></i>
           </button>
         </div>

--- a/autobot-frontend/src/components/terminal/Terminal.vue
+++ b/autobot-frontend/src/components/terminal/Terminal.vue
@@ -18,15 +18,15 @@
       <div class="flex items-center space-x-2">
         <!-- Terminal Controls -->
         <div class="flex items-center space-x-1">
-          <button @click="toggleConnection" :class="connectionButtonClass" :disabled="isConnecting" class="terminal-btn" :title="connectionButtonText">
+          <button @click="toggleConnection" :class="connectionButtonClass" :disabled="isConnecting" class="terminal-btn" :title="connectionButtonText" :aria-label="connectionButtonText">
             <i :class="connectionIconClass"></i>
           </button>
 
-          <button @click="clearTerminal" class="terminal-btn" :title="$t('terminal.terminal.clearTerminal')">
+          <button @click="clearTerminal" class="terminal-btn" :title="$t('terminal.terminal.clearTerminal')" :aria-label="$t('terminal.terminal.clearTerminal')">
             <i class="fas fa-trash"></i>
           </button>
 
-          <button @click="copyTerminalOutput" class="terminal-btn" :title="$t('terminal.terminal.copyOutput')">
+          <button @click="copyTerminalOutput" class="terminal-btn" :title="$t('terminal.terminal.copyOutput')" :aria-label="$t('terminal.terminal.copyOutput')">
             <i class="fas fa-copy"></i>
           </button>
         </div>


### PR DESCRIPTION
## Summary

- Adds `:aria-label` to all 10 Severity-2 icon-only buttons identified in [MVA-335](/MVA/issues/MVA-335), mirroring the existing `:title` binding in each case
- Components fixed: `KnowledgeEntries.vue` (3), `SecretsManager.vue` (2), `FileTreeView.vue` (2), `Terminal.vue` (3)
- No logic changes — pure attribute addition

## Test plan

- [ ] Screen-reader announces button labels in Knowledge Entries (View/Edit/Delete)
- [ ] Screen-reader announces Refresh and List/Grid-view buttons in Secrets Manager
- [ ] Screen-reader announces Expand All / Collapse All in File Tree
- [ ] Screen-reader announces Connect/Disconnect, Clear, Copy buttons in Terminal
- [ ] No visual regressions in any of the four components

🤖 Generated with [Claude Code](https://claude.com/claude-code)