### PR TITLE
fix(a11y): aria-label remediation - Severity-2 views and charts (MVA-333)

### DIFF
--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -116,21 +116,21 @@
         </div>
         <div ref="cytoscapeContainer" class="cytoscape-container"></div>
         <div class="network-controls">
-          <button @click="zoomIn" :title="$t('charts.callGraph.controls.zoomIn')" :aria-label="$t('common.zoomIn')">
+          <button @click="zoomIn" :title="$t('charts.callGraph.controls.zoomIn')" :aria-label="$t('charts.callGraph.controls.zoomIn')">
             <i class="fas fa-plus"></i>
           </button>
           <span class="zoom-level">{{ Math.round(zoomLevel * 100) }}%</span>
-          <button @click="zoomOut" :title="$t('charts.callGraph.controls.zoomOut')" :aria-label="$t('common.zoomOut')">
+          <button @click="zoomOut" :title="$t('charts.callGraph.controls.zoomOut')" :aria-label="$t('charts.callGraph.controls.zoomOut')">
             <i class="fas fa-minus"></i>
           </button>
-          <button @click="fitGraph" :title="$t('charts.callGraph.controls.fitToView')" :aria-label="$t('common.fitToView')">
+          <button @click="fitGraph" :title="$t('charts.callGraph.controls.fitToView')" :aria-label="$t('charts.callGraph.controls.fitToView')">
             <i class="fas fa-expand"></i>
           </button>
-          <button @click="toggleLayout" :title="$t('charts.callGraph.controls.toggleLayout')" :aria-label="$t('common.toggleLayout')">
+          <button @click="toggleLayout" :title="$t('charts.callGraph.controls.toggleLayout')" :aria-label="$t('charts.callGraph.controls.toggleLayout')">
             <i class="fas fa-th"></i>
           </button>
           <span class="control-separator">|</span>
-          <button @click="toggleFullscreen" :title="isFullscreen ? $t('charts.callGraph.controls.exitFullscreen') : $t('charts.callGraph.controls.fullscreen')" :aria-label="isFullscreen ? $t('common.exitFullscreen') : $t('common.fullscreen')">
+          <button @click="toggleFullscreen" :title="isFullscreen ? $t('charts.callGraph.controls.exitFullscreen') : $t('charts.callGraph.controls.fullscreen')" :aria-label="isFullscreen ? $t('charts.callGraph.controls.exitFullscreen') : $t('charts.callGraph.controls.fullscreen')">
             <i :class="isFullscreen ? 'fas fa-compress' : 'fas fa-expand-arrows-alt'"></i>
           </button>
         </div>
@@ -140,7 +140,7 @@
           <div class="detail-header">
             <span v-if="selectedNodeInfo.isAsync" class="async-badge">async</span>
             <span class="detail-name">{{ selectedNodeInfo.name }}</span>
-            <button class="close-btn" @click="selectedNodeInfo = null" :title="$t('charts.callGraph.controls.close')" :aria-label="$t('common.close')">
+            <button class="close-btn" @click="selectedNodeInfo = null" :title="$t('charts.callGraph.controls.close')" :aria-label="$t('charts.callGraph.controls.close')">
               <i class="fas fa-times"></i>
             </button>
           </div>
@@ -266,17 +266,17 @@
         </div>
         <div ref="clusterContainer" class="cluster-container"></div>
         <div class="network-controls cluster-controls">
-          <button @click="zoomInCluster" :title="$t('charts.callGraph.controls.zoomIn')" :aria-label="$t('common.zoomIn')">
+          <button @click="zoomInCluster" :title="$t('charts.callGraph.controls.zoomIn')" :aria-label="$t('charts.callGraph.controls.zoomIn')">
             <i class="fas fa-plus"></i>
           </button>
           <span class="zoom-level">{{ Math.round(clusterZoomLevel * 100) }}%</span>
-          <button @click="zoomOutCluster" :title="$t('charts.callGraph.controls.zoomOut')" :aria-label="$t('common.zoomOut')">
+          <button @click="zoomOutCluster" :title="$t('charts.callGraph.controls.zoomOut')" :aria-label="$t('charts.callGraph.controls.zoomOut')">
             <i class="fas fa-minus"></i>
           </button>
-          <button @click="fitClusterGraph" :title="$t('charts.callGraph.controls.fitToView')" :aria-label="$t('common.fitToView')">
+          <button @click="fitClusterGraph" :title="$t('charts.callGraph.controls.fitToView')" :aria-label="$t('charts.callGraph.controls.fitToView')">
             <i class="fas fa-expand"></i>
           </button>
-          <button @click="toggleClusterLayout" :title="$t('charts.callGraph.controls.toggleLayout')" :aria-label="$t('common.toggleLayout')">
+          <button @click="toggleClusterLayout" :title="$t('charts.callGraph.controls.toggleLayout')" :aria-label="$t('charts.callGraph.controls.toggleLayout')">
             <i class="fas fa-th"></i>
           </button>
         </div>

--- a/autobot-frontend/src/components/charts/ImportTreeChart.vue
+++ b/autobot-frontend/src/components/charts/ImportTreeChart.vue
@@ -89,21 +89,21 @@
           </div>
           <div ref="cytoscapeContainer" class="cytoscape-container"></div>
           <div class="network-controls">
-            <button @click="zoomIn" :title="$t('charts.importTree.controls.zoomIn')" :aria-label="$t('common.zoomIn')">
+            <button @click="zoomIn" :title="$t('charts.importTree.controls.zoomIn')" :aria-label="$t('charts.importTree.controls.zoomIn')">
               <i class="fas fa-plus"></i>
             </button>
             <span class="zoom-level">{{ Math.round(zoomLevel * 100) }}%</span>
-            <button @click="zoomOut" :title="$t('charts.importTree.controls.zoomOut')" :aria-label="$t('common.zoomOut')">
+            <button @click="zoomOut" :title="$t('charts.importTree.controls.zoomOut')" :aria-label="$t('charts.importTree.controls.zoomOut')">
               <i class="fas fa-minus"></i>
             </button>
-            <button @click="fitGraph" :title="$t('charts.importTree.controls.fitToView')" :aria-label="$t('common.fitToView')">
+            <button @click="fitGraph" :title="$t('charts.importTree.controls.fitToView')" :aria-label="$t('charts.importTree.controls.fitToView')">
               <i class="fas fa-expand"></i>
             </button>
-            <button @click="toggleLayout" :title="$t('charts.importTree.controls.toggleLayout')" :aria-label="$t('common.toggleLayout')">
+            <button @click="toggleLayout" :title="$t('charts.importTree.controls.toggleLayout')" :aria-label="$t('charts.importTree.controls.toggleLayout')">
               <i class="fas fa-th"></i>
             </button>
             <span class="control-separator">|</span>
-            <button @click="toggleFullscreen" :title="isFullscreen ? $t('charts.importTree.controls.exitFullscreen') : $t('charts.importTree.controls.fullscreen')" :aria-label="isFullscreen ? $t('common.exitFullscreen') : $t('common.fullscreen')">
+            <button @click="toggleFullscreen" :title="isFullscreen ? $t('charts.importTree.controls.exitFullscreen') : $t('charts.importTree.controls.fullscreen')" :aria-label="isFullscreen ? $t('charts.importTree.controls.exitFullscreen') : $t('charts.importTree.controls.fullscreen')">
               <i :class="isFullscreen ? 'fas fa-compress' : 'fas fa-expand-arrows-alt'"></i>
             </button>
           </div>
@@ -113,7 +113,7 @@
             <div class="detail-header">
               <span class="detail-icon">{{ getFileIcon(selectedNode.path) }}</span>
               <span class="detail-name">{{ selectedNode.shortName }}</span>
-              <button class="close-btn" @click="selectedNode = null" :title="$t('charts.importTree.controls.close')" :aria-label="$t('common.close')">
+              <button class="close-btn" @click="selectedNode = null" :title="$t('charts.importTree.controls.close')" :aria-label="$t('charts.importTree.controls.close')">
                 <i class="fas fa-times"></i>
               </button>
             </div>

--- a/autobot-frontend/src/views/CustomDashboard.vue
+++ b/autobot-frontend/src/views/CustomDashboard.vue
@@ -29,7 +29,7 @@
               {{ dash.name }}
             </option>
           </select>
-          <button @click="createNewDashboard" class="icon-btn" :title="$t('views.customDashboard.createNewDashboard')">
+          <button @click="createNewDashboard" class="icon-btn" :title="$t('views.customDashboard.createNewDashboard')" :aria-label="$t('views.customDashboard.createNewDashboard')">
             <Icon name="plus" />
           </button>
         </div>
@@ -79,16 +79,16 @@
             {{ widget.title }}
           </h3>
           <div class="widget-actions" v-if="isEditMode">
-            <button @click="configureWidget(widget)" :title="$t('views.customDashboard.configure')">
+            <button @click="configureWidget(widget)" :title="$t('views.customDashboard.configure')" :aria-label="$t('views.customDashboard.configure')">
               <Icon name="cog" />
             </button>
-            <button @click="resizeWidget(widget, 'expand')" :title="$t('views.customDashboard.expand')">
+            <button @click="resizeWidget(widget, 'expand')" :title="$t('views.customDashboard.expand')" :aria-label="$t('views.customDashboard.expand')">
               <Icon name="expand-alt" />
             </button>
-            <button @click="resizeWidget(widget, 'shrink')" :title="$t('views.customDashboard.shrink')">
+            <button @click="resizeWidget(widget, 'shrink')" :title="$t('views.customDashboard.shrink')" :aria-label="$t('views.customDashboard.shrink')">
               <Icon name="compress-alt" />
             </button>
-            <button @click="removeWidget(widget.id)" class="remove-btn" :title="$t('views.customDashboard.remove')">
+            <button @click="removeWidget(widget.id)" class="remove-btn" :title="$t('views.customDashboard.remove')" :aria-label="$t('views.customDashboard.remove')">
               <Icon name="times" />
             </button>
           </div>

--- a/autobot-frontend/src/views/MarketplaceView.vue
+++ b/autobot-frontend/src/views/MarketplaceView.vue
@@ -7,7 +7,7 @@
           <h1 class="page-title">{{ $t('views.marketplace.title') }}</h1>
           <p class="page-subtitle">{{ $t('views.marketplace.subtitle') }}</p>
         </div>
-        <button class="btn-refresh" :disabled="loading" @click="load" :title="$t('views.marketplace.refresh')">
+        <button class="btn-refresh" :disabled="loading" @click="load" :title="$t('views.marketplace.refresh')" :aria-label="$t('views.marketplace.refresh')">
           <svg
             class="refresh-icon"
             :class="{ spinning: loading }"

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -7,7 +7,7 @@
           <h1 class="page-title">{{ $t('views.plugins.title') }}</h1>
           <p class="page-subtitle">{{ $t('views.plugins.subtitle') }}</p>
         </div>
-        <button v-if="!isMarketplaceActive" class="btn-refresh" :disabled="loading" @click="refresh" :title="$t('views.plugins.refresh')">
+        <button v-if="!isMarketplaceActive" class="btn-refresh" :disabled="loading" @click="refresh" :title="$t('views.plugins.refresh')" :aria-label="$t('views.plugins.refresh')">
           <svg
             class="refresh-icon"
             :class="{ spinning: loading }"


### PR DESCRIPTION
## Summary

Fixed all 14 icon-only buttons across 5 Vue files per MVA-333 acceptance criteria.

**Newly added `:aria-label` (7 buttons):**
- `views/CustomDashboard.vue`: createNewDashboard, configure, expand, shrink, remove buttons
- `views/MarketplaceView.vue`: refresh button  
- `views/PluginsView.vue`: refresh button

**Key alignment (common.* → charts.* specific keys):**
- `components/charts/ImportTreeChart.vue`: Updated 6 buttons (zoomIn, zoomOut, fitToView, toggleLayout, toggleFullscreen, close) to use `charts.importTree.controls.*` keys instead of `common.*` keys
- `components/charts/FunctionCallGraph.vue`: Updated all controls to use `charts.callGraph.controls.*` keys instead of `common.*` keys

## Test plan

- [x] All 14+ buttons have `:aria-label` mirroring `:title` binding
- [x] All i18n keys exist in en.json
- [x] No syntax errors in Vue templates
- [x] Git diff reviewed — only aria-label attributes changed