### PR TITLE
feat(design-tokens): add canonical Size and Intent types (MVA-346)

### DIFF
--- a/autobot-frontend/src/design-tokens/tokens.ts
+++ b/autobot-frontend/src/design-tokens/tokens.ts
@@ -1,0 +1,5 @@
+export const size = ["xs", "sm", "md", "lg", "xl"] as const;
+export type Size = typeof size[number];
+
+export const intent = ["error", "warning", "success", "info"] as const;
+export type Intent = typeof intent[number];


### PR DESCRIPTION
## Summary

- Creates `autobot-frontend/src/design-tokens/tokens.ts` as the single source of truth for canonical size and semantic color vocabularies
- Exports `size` and `intent` const arrays and their union types `Size` and `Intent`
- No component files modified — this is Phase 0, establishing types before the codemod runs

## Acceptance criteria

- [x] File `src/design-tokens/tokens.ts` exists and exports `Size` and `Intent` union types
- [x] TypeScript compiles without errors (verified with `tsc --noEmit --strict --target ES2020 --module ESNext --moduleResolution bundler`)
- [x] No component files modified in this phase

## Test plan

- [ ] Run `cd autobot-frontend && vue-tsc --noEmit` to verify full project type-check passes
- [ ] Confirm no Vue/TS component files changed in this PR (only `src/design-tokens/tokens.ts` added)

Related: MVA-346 (parent: MVA-192)

🤖 Generated with [Claude Code](https://claude.com/claude-code)