### PR TITLE
fix(ci): align artifact action versions to v4 in security.yml (GH#7712)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -110,7 +110,7 @@ jobs:
         npm audit --audit-level=moderate || true
 
     - name: Upload Security Reports
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: dependency-security-reports
@@ -228,7 +228,7 @@ jobs:
         fi
 
     - name: Upload SAST Reports
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: sast-security-reports
@@ -302,7 +302,7 @@ jobs:
 
     steps:
     - name: Download all security reports
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@v4
 
     - name: Generate Security Summary
       run: |
@@ -335,7 +335,7 @@ jobs:
         echo "3. Address any SAST findings in critical code paths" >> security-summary.md
 
     - name: Upload Security Summary
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         name: security-summary
         path: security-summary.md


### PR DESCRIPTION
## Summary

Fixes GH#7712 — version mismatch between `upload-artifact` and `download-artifact` actions in `.github/workflows/security.yml`.

- `upload-artifact@v7` → `upload-artifact@v4` (3 occurrences: dependency-security, static-analysis, security-summary jobs)
- `download-artifact@v8` → `download-artifact@v4` (1 occurrence: security-summary job)

Note: GH#7711 (setup-node YAML indentation) was already fixed in commit `bf0b62cab` (MVA-350) and GH#7711 is closed.

## Test plan
- [x] YAML validates with `python3 -c "import yaml; yaml.safe_load(open(...))"` — passes
- [x] All artifact action versions aligned to v4 (verified via grep)
- [x] Diff reviewed — only version strings changed, no structural modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)