### PR TITLE
feat(toast): reduce max stack 5→3 with Tier C eviction protection (MVA-347)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useToast.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useToast.test.ts
@@ -1,12 +1,13 @@
 /**
  * useToast Composable Tests
  *
- * Covers acceptance criteria from issue #3283:
+ * Covers acceptance criteria from issue #3283 and MVA-347:
  * - Global availability via provide/inject
  * - success / error / warning / info variants
  * - Auto-dismiss after configurable timeout (default 4s for success, persistent for errors)
- * - Maximum 5 toasts stacked; older ones evicted
- * - Manual dismiss
+ * - Maximum 3 toasts stacked; oldest Tier A/B evicted (Miller's Law)
+ * - Tier C (persistent error) toasts never auto-evicted; excess queued
+ * - Manual dismiss promotes queued toasts
  *
  * @author mrveiss
  * @copyright 2025 mrveiss
@@ -173,26 +174,107 @@ describe('useToast — acceptance criteria #3283', () => {
   })
 
   // -------------------------------------------------------------------------
-  // 5. Maximum 5 toasts stacked
+  // 5. Maximum 3 toasts stacked with Tier C eviction protection (MVA-347)
   // -------------------------------------------------------------------------
-  describe('maximum stack size', () => {
-    it('MAX_TOASTS constant is 5', () => {
-      expect(MAX_TOASTS).toBe(5)
+  describe('maximum stack size and Tier C eviction protection', () => {
+    it('MAX_TOASTS constant is 3', () => {
+      expect(MAX_TOASTS).toBe(3)
     })
 
-    it('does not exceed 5 toasts; oldest is evicted when a 6th is added', () => {
+    it('does not exceed 3 toasts; oldest Tier A/B is evicted when a 4th is added', () => {
       const { showToast, toasts } = withSetup(() => useToast())
-      for (let i = 1; i <= 5; i++) {
-        showToast(`toast ${i}`, 'info', 0)
-      }
-      expect(toasts.value).toHaveLength(5)
+      showToast('toast 1', 'info', 0)
+      showToast('toast 2', 'success', 0)
+      showToast('toast 3', 'warning', 0)
+      expect(toasts.value).toHaveLength(3)
       expect(toasts.value[0].message).toBe('toast 1')
 
-      // Add a 6th — toast 1 should be evicted
-      showToast('toast 6', 'info', 0)
-      expect(toasts.value).toHaveLength(5)
+      // Add a 4th — toast 1 (oldest, Tier A/B) should be evicted
+      showToast('toast 4', 'info', 0)
+      expect(toasts.value).toHaveLength(3)
       expect(toasts.value.some((t) => t.message === 'toast 1')).toBe(false)
-      expect(toasts.value[toasts.value.length - 1].message).toBe('toast 6')
+      expect(toasts.value[toasts.value.length - 1].message).toBe('toast 4')
+    })
+
+    it('evicts oldest non-Tier-C when stack has mixed Tier A/B and Tier C toasts', () => {
+      const { showToast, toasts } = withSetup(() => useToast())
+      // Tier C (persistent error) first
+      showToast('error 1', 'error')
+      // Then two Tier A/B
+      showToast('info 1', 'info', 0)
+      showToast('info 2', 'info', 0)
+      expect(toasts.value).toHaveLength(3)
+
+      // 4th toast — should evict 'info 1' (oldest non-Tier-C), NOT 'error 1'
+      showToast('warning 1', 'warning', 0)
+      expect(toasts.value).toHaveLength(3)
+      expect(toasts.value.some((t) => t.message === 'error 1')).toBe(true)
+      expect(toasts.value.some((t) => t.message === 'info 1')).toBe(false)
+      expect(toasts.value.some((t) => t.message === 'warning 1')).toBe(true)
+    })
+
+    it('queues a new toast (not shown) when all 3 visible slots are Tier C', () => {
+      const { showToast, toasts } = withSetup(() => useToast())
+      showToast('error 1', 'error')
+      showToast('error 2', 'error')
+      showToast('error 3', 'error')
+      expect(toasts.value).toHaveLength(3)
+
+      // 4th toast cannot evict any Tier C — should be queued, not visible
+      showToast('info queued', 'info', 0)
+      expect(toasts.value).toHaveLength(3)
+      expect(toasts.value.some((t) => t.message === 'info queued')).toBe(false)
+    })
+
+    it('promotes queued toast when user dismisses a Tier C', async () => {
+      const { showToast, removeToast, toasts } = withSetup(() => useToast())
+      const id1 = showToast('error 1', 'error')
+      showToast('error 2', 'error')
+      showToast('error 3', 'error')
+
+      // Queue a non-Tier-C toast
+      showToast('info queued', 'info', 0)
+      expect(toasts.value.some((t) => t.message === 'info queued')).toBe(false)
+
+      // Dismiss one Tier C — queued toast should become visible
+      removeToast(id1)
+      await nextTick()
+      expect(toasts.value).toHaveLength(3)
+      expect(toasts.value.some((t) => t.message === 'info queued')).toBe(true)
+    })
+
+    it('clearAllToasts also clears the pending queue', async () => {
+      const { showToast, clearAllToasts, removeToast, toasts } = withSetup(() => useToast())
+      const id1 = showToast('error 1', 'error')
+      showToast('error 2', 'error')
+      showToast('error 3', 'error')
+
+      // Queue a toast
+      showToast('queued info', 'info', 0)
+
+      // Clear everything — pending queue must also be cleared
+      clearAllToasts()
+      expect(toasts.value).toHaveLength(0)
+
+      // Simulate dismissing (no-op after clear) — queued toast must NOT reappear
+      removeToast(id1)
+      await nextTick()
+      expect(toasts.value).toHaveLength(0)
+    })
+
+    it('error toast with non-zero duration is NOT Tier C and can be evicted', () => {
+      const { showToast, toasts } = withSetup(() => useToast())
+      // Custom-duration error (Tier A/B, not Tier C)
+      showToast('timed error', 'error', 2000)
+      showToast('info 1', 'info', 0)
+      showToast('info 2', 'info', 0)
+      expect(toasts.value).toHaveLength(3)
+
+      // 4th toast: 'timed error' is the oldest and NOT Tier C — evict it
+      showToast('info 3', 'info', 0)
+      expect(toasts.value).toHaveLength(3)
+      expect(toasts.value.some((t) => t.message === 'timed error')).toBe(false)
+      expect(toasts.value.some((t) => t.message === 'info 3')).toBe(true)
     })
   })
 

--- a/autobot-frontend/src/composables/useToast.ts
+++ b/autobot-frontend/src/composables/useToast.ts
@@ -47,8 +47,12 @@ export interface UseToastReturn {
   clearAllToasts: () => void
 }
 
-/** Maximum number of toasts displayed simultaneously (oldest evicted first). */
-export const MAX_TOASTS = 5
+/**
+ * Maximum number of toasts displayed simultaneously (Miller's Law — MVA-347).
+ * Oldest Tier A/B toast is evicted when the stack is full.
+ * Tier C (persistent error) toasts are never auto-evicted.
+ */
+export const MAX_TOASTS = 3
 
 /**
  * Default auto-dismiss durations per toast type (ms).
@@ -64,6 +68,12 @@ export const TOAST_DURATIONS: Record<ToastType, number> = {
 /** Injection key for provide/inject usage. */
 export const TOAST_INJECT_KEY: InjectionKey<UseToastReturn> = Symbol('useToast')
 
+/**
+ * Returns true for Tier C toasts: persistent errors that must never be
+ * auto-evicted to make room for lower-priority notifications.
+ */
+const isTierC = (t: Toast): boolean => t.type === 'error' && t.duration === 0
+
 // ============================================================
 // Module-level singleton state (shared across all instances
 // that do NOT use the provide/inject path).
@@ -72,10 +82,28 @@ const _toasts = ref<Toast[]>([])
 let _nextId = 1
 
 function _buildApi(toasts: Ref<Toast[]>, idCounter: { value: number }): UseToastReturn {
+  // Toasts waiting for a visible slot; shown in FIFO order when a slot opens.
+  const pendingQueue: Toast[] = []
+
   const removeToast = (id: number): void => {
+    // Remove from visible stack.
     const index = toasts.value.findIndex((t) => t.id === id)
     if (index > -1) {
       toasts.value.splice(index, 1)
+      // Promote next queued toast now that a slot opened.
+      if (pendingQueue.length > 0) {
+        const next = pendingQueue.shift()!
+        toasts.value.push(next)
+        if (next.duration > 0) {
+          setTimeout(() => removeToast(next.id), next.duration)
+        }
+      }
+      return
+    }
+    // Also handle removal of a still-queued toast.
+    const queueIndex = pendingQueue.findIndex((t) => t.id === id)
+    if (queueIndex > -1) {
+      pendingQueue.splice(queueIndex, 1)
     }
   }
 
@@ -88,9 +116,16 @@ function _buildApi(toasts: Ref<Toast[]>, idCounter: { value: number }): UseToast
     const id = idCounter.value++
     const toast: Toast = { id, message, type, duration: resolvedDuration }
 
-    // Enforce maximum stack size — evict the oldest toast when full.
     if (toasts.value.length >= MAX_TOASTS) {
-      toasts.value.splice(0, toasts.value.length - MAX_TOASTS + 1)
+      // Evict the oldest non-Tier-C toast to make room.
+      const evictIndex = toasts.value.findIndex((t) => !isTierC(t))
+      if (evictIndex !== -1) {
+        toasts.value.splice(evictIndex, 1)
+      } else {
+        // All visible slots are Tier C — queue until the user dismisses one.
+        pendingQueue.push(toast)
+        return id
+      }
     }
 
     toasts.value.push(toast)
@@ -106,6 +141,7 @@ function _buildApi(toasts: Ref<Toast[]>, idCounter: { value: number }): UseToast
 
   const clearAllToasts = (): void => {
     toasts.value.splice(0)
+    pendingQueue.splice(0)
   }
 
   return { toasts, showToast, removeToast, clearAllToasts }


### PR DESCRIPTION
## Summary

- Reduces `MAX_TOASTS` from 5 → 3 (Miller's Law, per [MVA-347](/MVA/issues/MVA-347) spec §4.1)
- Adds `isTierC()` predicate: `type === 'error' && duration === 0` — persistent errors are never auto-evicted
- Tier-aware eviction: when stack is full, evict the oldest **non-Tier-C** toast; if all 3 slots are Tier C, the new toast enters `pendingQueue` (FIFO)
- `removeToast()` now promotes the next queued toast when a visible slot opens
- `clearAllToasts()` drains both the visible stack and the pending queue

## Files changed

- `autobot-frontend/src/composables/useToast.ts` — core logic change
- `autobot-frontend/src/composables/__tests__/useToast.test.ts` — updated + 6 new tests

## Test evidence

```
Tests  26 passed (26)
```

All 6 new acceptance-criteria tests pass:
- ✅ MAX_TOASTS constant is 3
- ✅ Oldest Tier A/B evicted when 4th added
- ✅ Mixed stack evicts oldest non-Tier-C (not the error)
- ✅ All-Tier-C stack queues new toast, not shown
- ✅ Dismissing Tier C promotes queued toast
- ✅ clearAllToasts drains pending queue (queued toast doesn't reappear)
- ✅ Custom-duration error (non-Tier-C) CAN be evicted

🤖 Generated with [Claude Code](https://claude.ai/claude-code)