### PR TITLE
fix(ci): standardize artifact versions + fix Phase 3 cleanup exit (#7712, #7537)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -110,7 +110,7 @@ jobs:
         npm audit --audit-level=moderate || true
 
     - name: Upload Security Reports
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: dependency-security-reports
@@ -228,7 +228,7 @@ jobs:
         fi
 
     - name: Upload SAST Reports
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: sast-security-reports
@@ -302,7 +302,7 @@ jobs:
 
     steps:
     - name: Download all security reports
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@v4
 
     - name: Generate Security Summary
       run: |
@@ -335,7 +335,7 @@ jobs:
         echo "3. Address any SAST findings in critical code paths" >> security-summary.md
 
     - name: Upload Security Summary
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         name: security-summary
         path: security-summary.md

--- a/scripts/cleanup-worktrees.sh
+++ b/scripts/cleanup-worktrees.sh
@@ -174,7 +174,7 @@ local_branches=$(git -C "$REPO_ROOT" branch | sed 's/^[* +]*//' | grep -v "${BAS
 if [ -n "$local_branches" ]; then
     while IFS= read -r branch; do
         [ -z "$branch" ] && continue
-        issue_number=$(echo "$branch" | grep -oP '\d{4,}' | head -1)
+        issue_number=$(echo "$branch" | grep -oP '\d{4,}' | head -1) || true
         [ -z "$issue_number" ] && continue
 
         issue_state=$(gh issue view "$issue_number" --json state --jq '.state' 2>/dev/null) || true
@@ -204,7 +204,7 @@ remote_branches=$(git -C "$REPO_ROOT" branch -r | sed 's|^ *origin/||' \
 if [ -n "$remote_branches" ]; then
     while IFS= read -r branch; do
         [ -z "$branch" ] && continue
-        issue_number=$(echo "$branch" | grep -oP '\d{4,}' | head -1)
+        issue_number=$(echo "$branch" | grep -oP '\d{4,}' | head -1) || true
         [ -z "$issue_number" ] && continue
 
         issue_state=$(gh issue view "$issue_number" --json state --jq '.state' 2>/dev/null) || true


### PR DESCRIPTION
## Summary

- **#7712**: Normalize `upload-artifact@v7` → `@v4` and `download-artifact@v8` → `@v4` in `security.yml`. v7/v8 don't exist as published versions for these actions — all other workflows use @v4.
- **#7537**: Fix `cleanup-worktrees.sh` Phase 3 aborting with exit code 1 under `set -euo pipefail`. Root cause: `grep -oP` returns exit 1 when no 4-digit match is found in a branch name, and `set -e` aborts before the `[ -z ]` guard runs. Fix: add `|| true` to both `issue_number=$(...)` assignments in local and remote branch loops.

## Test plan
- [ ] Verify security.yml CI runs without action version errors
- [ ] Run `scripts/cleanup-worktrees.sh --dry-run` with branches that have no issue numbers — should skip cleanly, not exit 1
- [ ] Confirm branch-cleanup.yml scheduled run completes Phase 3 successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)