### PR TITLE
fix(analyzer): _detect_data_clumps KeyError + LSP description (#7518, #7519)

### DIFF
--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -1003,11 +1003,13 @@ class AntiPatternDetector:
         # Report param groups that appear multiple times
         for params, methods in param_groups.items():
             if len(methods) >= 3:  # Appears in 3+ methods
+                _cls_name = methods[0].split(".")[0] if methods else ""
+                _cls = next((v for v in self.classes.values() if v.name == _cls_name), None)
                 issues.append(
                     AntiPatternInstance(
                         pattern_type=AntiPatternType.DATA_CLUMP,
                         severity=Severity.MEDIUM if len(methods) > 5 else Severity.LOW,
-                        file_path=(self.classes[methods[0].split(".")[0]].file_path if methods else ""),
+                        file_path=(_cls.file_path if _cls else ""),
                         line_number=1,
                         entity_name=", ".join(params),
                         description=(f"Parameter group ({', '.join(params)}) appears in {len(methods)} methods"),
@@ -1254,8 +1256,8 @@ class AntiPatternDetector:
                             line_number=child_method.lineno,
                             entity_name=f"{child.name}.{child_method.name}",
                             description=(
-                                f"Override of {parent.name}.{child_method.name} accepts "
-                                f"{child_total_positional} positional args but the parent "
+                                f"Override of {parent.name}.{child_method.name} drops required positional params: "
+                                f"accepts {child_total_positional} positional args but the parent "
                                 f"requires {parent_required}. A factory call like "
                                 "``cls(arg1, arg2)`` against the parent contract will "
                                 "crash with TypeError on this subclass."


### PR DESCRIPTION
## Summary

- **#7518**: Fix `KeyError` in `_detect_data_clumps` when looking up a class by bare name (e.g. `"EnhancedSecurityLayer"`) in `self.classes` which is keyed by full module path. Replace direct dict lookup with name-based search via `next()` over `self.classes.values()`.
- **#7519**: Fix `test_lsp_signature_incompatible_required_param_dropped` returning 0 findings. The description in `_detect_lsp_violations` was rewritten but the test filter still searched for `"drops required positional params"`. Added the phrase to the description so detection output matches the test assertion.

## Test plan
- [ ] `python3 -m pytest autobot-backend/code_analysis/src/anti_pattern_detector_lsp_test.py::test_lsp_signature_incompatible_required_param_dropped` — must pass
- [ ] `AntiPatternDetector.analyze("autobot-backend", ...)` completes without KeyError on any real codebase run
- [ ] `analyze_cross_file_only()` continues to work (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)