### PR TITLE
ci(hooks,actions): complete lib/_common.sh migration + composite setup-python action (GH#7086, GH#7203)

### DIFF
--- a/.github/actions/setup-python-ci/action.yml
+++ b/.github/actions/setup-python-ci/action.yml
@@ -1,0 +1,71 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Composite action: Setup Python + install CI dependencies (GH#7086)
+#
+# Encapsulates the repeated "setup Python + pip bootstrap + install deps"
+# pattern shared across ci.yml, code-quality.yml, and other workflows.
+# Eliminates ~15 lines of duplicated YAML per job.
+#
+# Usage:
+#   - uses: ./.github/actions/setup-python-ci
+#     with:
+#       python-version: '3.12'
+#       requirements-file: 'requirements-ci.txt'
+#       extra-packages: 'pytest pytest-asyncio mypy'
+
+name: Setup Python CI
+description: 'Set up Python with pip caching, upgrade pip/setuptools/wheel, and install project dependencies.'
+
+inputs:
+  python-version:
+    description: 'Python version to install (e.g. "3.12")'
+    required: false
+    default: '3.12'
+  requirements-file:
+    description: 'Path to requirements file to install (relative to repo root). Empty to skip.'
+    required: false
+    default: ''
+  extra-packages:
+    description: 'Space-separated list of additional pip packages to install after requirements-file.'
+    required: false
+    default: ''
+
+outputs:
+  python-version:
+    description: 'The resolved Python version that was installed.'
+    value: ${{ steps.setup.outputs.python-version }}
+  cache-key:
+    description: 'The pip cache key used (for documentation and debugging).'
+    value: ${{ steps.cache-key.outputs.value }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      id: setup
+      uses: actions/setup-python@1d6f8c11a0e30b87a6af51d0d78681a80e55c65a  # v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: 'pip'
+
+    - name: Compute cache key
+      id: cache-key
+      shell: bash
+      run: |
+        echo "value=python-${{ inputs.python-version }}-pip-${{ hashFiles('**/requirements*.txt', 'pyproject.toml') }}" >> "$GITHUB_OUTPUT"
+
+    - name: Upgrade pip, setuptools, wheel
+      shell: bash
+      run: python -m pip install --upgrade pip setuptools wheel
+
+    - name: Install requirements file
+      if: inputs.requirements-file != ''
+      shell: bash
+      run: python -m pip install -r ${{ inputs.requirements-file }} --prefer-binary
+
+    - name: Install extra packages
+      if: inputs.extra-packages != ''
+      shell: bash
+      run: python -m pip install ${{ inputs.extra-packages }}

--- a/autobot-infrastructure/shared/scripts/hooks/post-commit-doc-sync
+++ b/autobot-infrastructure/shared/scripts/hooks/post-commit-doc-sync
@@ -11,11 +11,9 @@
 
 set -e
 
-# Colors for output
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m' # No Color
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/_common.sh
+source "$SCRIPT_DIR/lib/_common.sh"
 
 # Get the project root directory
 PROJECT_ROOT="$(git rev-parse --show-toplevel)"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-branch-guard
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-branch-guard
@@ -25,11 +25,9 @@
 
 set -uo pipefail
 
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/_common.sh
+source "$SCRIPT_DIR/lib/_common.sh"
 
 GIT_DIR_PATH=$(git rev-parse --git-dir 2>/dev/null)
 if [ -z "$GIT_DIR_PATH" ]; then

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-detect-mass-deletions
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-detect-mass-deletions
@@ -22,11 +22,9 @@
 
 set -uo pipefail
 
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/_common.sh
+source "$SCRIPT_DIR/lib/_common.sh"
 
 # Threshold: alert if >50 files are staged for deletion
 # (anything >50 is almost certainly a stash bug, not intended cleanup)

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-function-length
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-function-length
@@ -18,16 +18,11 @@
 
 set -uo pipefail
 
-# Colors (matching existing hooks pattern)
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-GREEN='\033[0;32m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
-
-# Get script directory for Python script location
+# Get script directory for Python script location (also used by lib/_common.sh source)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/_common.sh
+source "$SCRIPT_DIR/lib/_common.sh"
+
 PYTHON_SCRIPT="${SCRIPT_DIR}/function_length_checker.py"
 
 # Find Python interpreter
@@ -46,10 +41,10 @@ find_python() {
     fi
 }
 
-# Get staged Python files (excluding tests, __init__, temp directories, migrations)
-get_staged_files() {
-    git diff --cached --name-only --diff-filter=ACM 2>/dev/null | \
-        grep -E '\.py$' | \
+# Get staged Python files (excluding tests, __init__, temp directories, migrations).
+# Named get_staged_python_files to avoid shadowing _common.sh's get_staged_files.
+get_staged_python_files() {
+    get_staged_files '\.py$' | \
         grep -v -E '(__pycache__|node_modules|\.venv|venv|archive|temp)' | \
         grep -v -E '(test_|_test\.py|tests/)' | \
         grep -v -E '__init__\.py$' | \
@@ -76,7 +71,7 @@ main() {
     fi
 
     local files
-    files=$(get_staged_files)
+    files=$(get_staged_python_files)
 
     if [[ -z "$files" ]]; then
         echo -e "${GREEN}No Python files staged for commit.${NC}"

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-target-branch-guard
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-target-branch-guard
@@ -30,11 +30,9 @@
 
 set -uo pipefail
 
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/_common.sh
+source "$SCRIPT_DIR/lib/_common.sh"
 
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
 

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-warn-untracked
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-warn-untracked
@@ -28,10 +28,9 @@
 
 set -uo pipefail
 
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/_common.sh
+source "$SCRIPT_DIR/lib/_common.sh"
 
 SOURCE_PATTERN='\.py$|\.ts$|\.vue$|\.js$'
 

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-worktree-branch-guard
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-worktree-branch-guard
@@ -25,11 +25,9 @@
 
 set -uo pipefail
 
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/_common.sh
+source "$SCRIPT_DIR/lib/_common.sh"
 
 main() {
     current_branch=$(git branch --show-current 2>/dev/null)


### PR DESCRIPTION
## Summary

- **GH#7203**: Migrate remaining 7 hooks to `lib/_common.sh` — all 14 shell hooks now source the shared library instead of duplicating ANSI color vars inline
- **GH#7086**: Create `.github/actions/setup-python-ci` composite action encapsulating the repeated "setup Python + pip bootstrap + install deps" pattern across CI workflows
- **GH#7105**: Already merged to `Dev_new_gui` (`a7e0c8892`) — closing via this PR only

### Hooks migrated in this PR (7)
| Hook | Change |
|------|--------|
| `pre-commit-branch-guard` | Replace 5 inline color vars with `source lib/_common.sh` |
| `pre-commit-detect-mass-deletions` | Replace 5 inline color vars |
| `pre-commit-function-length` | Replace 6 inline color vars; rename local `get_staged_files` → `get_staged_python_files` to avoid shadowing the shared helper |
| `pre-commit-target-branch-guard` | Replace 5 inline color vars |
| `pre-commit-warn-untracked` | Replace 4 inline color vars |
| `pre-commit-worktree-branch-guard` | Replace 5 inline color vars |
| `post-commit-doc-sync` | Replace 4 inline color vars |

Previously migrated (already in Dev_new_gui): `pre-commit-hardcoded-values`, `pre-commit-no-direct-redis`, `pre-commit-no-new-health-route`, `pre-commit-no-new-workflow-step`, `pre-commit-no-print-console`, `pre-commit-no-new-status-enum`, `pre-commit-no-tag-pinned-action` = 7 hooks.

Total after this PR: **14/14 shell hooks** use `lib/_common.sh`.

### Composite action (GH#7086)
`.github/actions/setup-python-ci/action.yml` — composite action with inputs:
- `python-version` (default: `3.12`)
- `requirements-file` (optional, e.g. `requirements-ci.txt`)
- `extra-packages` (optional, space-separated)

Outputs `python-version` and `cache-key` used for the run.

## Test plan
- [x] `bash -n` syntax check passes on all 7 migrated hooks
- [x] All hooks now report `MIGRATED` when grepped for `_common.sh`
- [x] Composite action YAML is valid (name/description/inputs/outputs/runs present)
- [x] `pre-commit-function-length` uses `get_staged_python_files` (not the shadowed name)
- [x] GH#7105 mypy already in Dev_new_gui — no CI regression expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)