### PR TITLE
chore(docs): enforce PR template with Thinking Path + Model Used CI check (#6474)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,33 @@
-## Description
-A clear description of the changes made.
+## Thinking Path
+<!-- Required: Trace the reasoning from problem context to this change. What problem are we solving? Why this approach over alternatives? -->
 
-## Related Issue
-Closes #123 (if applicable)
 
-## Type of Change
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (change that would cause existing functionality to not work as expected)
-- [ ] Documentation update
+## What Changed
+<!-- Required: Bullet list of concrete changes made. Be specific — file names, function names, config keys. -->
 
-## Testing
-How was this tested?
+-
+
+## Verification
+<!-- Required: How a reviewer can confirm this works. Include commands to run, endpoints to hit, or UI steps to follow. -->
+
+
+## Risks
+<!-- What could go wrong; edge cases not covered; rollback plan if needed. Write "None identified" if applicable. -->
+
+
+## Model Used
+<!-- Required: The AI model that produced or assisted with this change. Format: "Provider ModelID". Write "None — human-authored" if no AI was used. -->
+<!-- Examples: "Claude Sonnet 4.6 (claude-sonnet-4-6)", "None — human-authored" -->
+
+
+## Issue Link
+<!-- Closes #N or related #N -->
+Closes #
 
 ## Checklist
-- [ ] I have tested this locally
-- [ ] I have updated relevant documentation
-- [ ] No new warnings are generated
-- [ ] Code follows the project style
+- [ ] Code follows AutoBot patterns from `CLAUDE.md`
+- [ ] Tests added or updated (or N/A with reason)
+- [ ] Documentation updated if behavior changed
+- [ ] Pre-commit hooks pass (`git commit` runs them automatically)
+- [ ] PR targets `Dev_new_gui` (not `main`)
+- [ ] No secrets or credentials in the diff

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,65 @@
+# PR Template Compliance Check
+#
+# Validates that required sections in the PR template are filled in.
+# Fails if any required section contains only the placeholder comment or is empty.
+# See: https://github.com/mrveiss/AutoBot-AI/issues/6474
+
+name: PR Template Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [Dev_new_gui, main]
+
+jobs:
+  check-template:
+    name: Validate PR template sections
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+
+    steps:
+    - name: Check required sections
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        # Fetch PR body via CLI (avoids direct expression injection)
+        PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body' 2>/dev/null || echo "")
+
+        FAILED=0
+
+        check_section() {
+          local section_header="$1"
+          local section_name="$2"
+
+          # Extract content between this section header and the next ## header
+          content=$(echo "$PR_BODY" \
+            | awk "/^## ${section_header}/{found=1; next} found && /^## /{exit} found{print}" \
+            | sed 's/<!--[^>]*-->//g' \
+            | sed '/^[[:space:]]*$/d')
+
+          if [ -z "$content" ]; then
+            echo "::error::Required section '${section_name}' is empty. Please fill it in before merging."
+            FAILED=$((FAILED + 1))
+          else
+            echo "::notice::Section '${section_name}': OK"
+          fi
+        }
+
+        check_section "Thinking Path" "Thinking Path"
+        check_section "What Changed" "What Changed"
+        check_section "Verification" "Verification"
+        check_section "Model Used" "Model Used"
+
+        if [ "$FAILED" -gt 0 ]; then
+          echo ""
+          echo "::error::${FAILED} required PR template section(s) are empty."
+          echo "Please update the PR description using the template sections."
+          exit 1
+        fi
+
+        echo "All required PR template sections are filled in."


### PR DESCRIPTION
## Thinking Path
Implementing #6474 — PR template enforcement. AutoBot PRs lack a structured template, making AI model auditability and reasoning traceability impossible. The fix is a 7-section PR template + CI enforcement workflow.

## What Changed
- `.github/PULL_REQUEST_TEMPLATE.md`: upgraded from 4-section minimal template to 7-section structured format (Thinking Path, What Changed, Verification, Risks, Model Used, Issue Link, Checklist)
- `.github/workflows/pr-template-check.yml`: new CI workflow that validates Thinking Path, What Changed, Verification, and Model Used sections are non-empty using GitHub CLI (avoids expression injection)

## Verification
1. Open a PR with empty required sections → CI check should fail with annotations
2. Open a PR with all sections filled → CI check passes
3. Human-authored PRs: write "None — human-authored" in Model Used → passes

## Risks
- Existing open PRs may fail this check if they don't fill in the new sections — authors will need to update descriptions

## Model Used
Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link
Closes #6474

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (N/A — CI workflow is the validation)
- [x] Documentation updated if behavior changed
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)