### PR TITLE
refactor(frontend/security): add Storybook stories for 3 security components (#6864)

### DIFF
--- a/autobot-frontend/src/components/security/SecretsManager.stories.ts
+++ b/autobot-frontend/src/components/security/SecretsManager.stories.ts
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import SecretsManager from './SecretsManager.vue';
+
+const meta = {
+  title: 'Components/Security/SecretsManager',
+  component: SecretsManager,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof SecretsManager>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  render: () => ({
+    components: { SecretsManager },
+    template: '<SecretsManager />',
+  }),
+};
+
+export const FullWidth: Story = {
+  render: () => ({
+    components: { SecretsManager },
+    template: `
+      <div style="width: 100%; min-height: 600px;">
+        <SecretsManager />
+      </div>
+    `,
+  }),
+};
+
+export const InPanel: Story = {
+  render: () => ({
+    components: { SecretsManager },
+    template: `
+      <div style="max-width: 1200px; border: 1px solid #e5e7eb; border-radius: 8px; overflow: hidden;">
+        <SecretsManager />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.stories.ts
+++ b/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.stories.ts
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import ThreatIntelligenceDashboard from './ThreatIntelligenceDashboard.vue';
+
+const meta = {
+  title: 'Components/Security/ThreatIntelligenceDashboard',
+  component: ThreatIntelligenceDashboard,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof ThreatIntelligenceDashboard>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  render: () => ({
+    components: { ThreatIntelligenceDashboard },
+    template: '<ThreatIntelligenceDashboard />',
+  }),
+};
+
+export const InPanel: Story = {
+  render: () => ({
+    components: { ThreatIntelligenceDashboard },
+    template: `
+      <div style="max-width: 1200px; padding: 1rem;">
+        <ThreatIntelligenceDashboard />
+      </div>
+    `,
+  }),
+};
+
+export const Compact: Story = {
+  render: () => ({
+    components: { ThreatIntelligenceDashboard },
+    template: `
+      <div style="max-width: 800px; padding: 1rem;">
+        <ThreatIntelligenceDashboard />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/security/ThreatIntelligenceSettings.stories.ts
+++ b/autobot-frontend/src/components/security/ThreatIntelligenceSettings.stories.ts
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import ThreatIntelligenceSettings from './ThreatIntelligenceSettings.vue';
+
+const meta = {
+  title: 'Components/Security/ThreatIntelligenceSettings',
+  component: ThreatIntelligenceSettings,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof ThreatIntelligenceSettings>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  render: () => ({
+    components: { ThreatIntelligenceSettings },
+    template: '<ThreatIntelligenceSettings />',
+  }),
+};
+
+export const InSettingsPanel: Story = {
+  render: () => ({
+    components: { ThreatIntelligenceSettings },
+    template: `
+      <div style="max-width: 900px; padding: 1.5rem; background: #f9fafb; border-radius: 8px;">
+        <ThreatIntelligenceSettings />
+      </div>
+    `,
+  }),
+};
+
+export const Narrow: Story = {
+  render: () => ({
+    components: { ThreatIntelligenceSettings },
+    template: `
+      <div style="max-width: 600px;">
+        <ThreatIntelligenceSettings />
+      </div>
+    `,
+  }),
+};


### PR DESCRIPTION
## Thinking Path

#6864 requires Storybook stories for all 3 Vue components in `autobot-frontend/src/components/security/`. These components are stateful — they manage secrets, threat intelligence status, and API key configuration internally via composables. The render-only pattern (used in `PreferencesPanel.stories.ts`) is the right fit: mount the component as-is, show it in different layout contexts (full-width, panel, compact), let Storybook's autodocs capture the component structure.

## What Changed

- `autobot-frontend/src/components/security/SecretsManager.stories.ts`: Default, FullWidth, InPanel
- `autobot-frontend/src/components/security/ThreatIntelligenceDashboard.stories.ts`: Default, InPanel, Compact
- `autobot-frontend/src/components/security/ThreatIntelligenceSettings.stories.ts`: Default, InSettingsPanel, Narrow

All three follow the `as Meta<typeof Component>` + `StoryObj<any>` pattern (per #7273 feedback) with `tags: ['autodocs']` and title prefix `Components/Security/`.

## Verification

```bash
cd autobot-frontend
npm run build-storybook  # should succeed
# Or: npm run storybook → navigate to Components/Security/
```

## Risks

None identified — stories are read-only Storybook scaffolding, no production code changes.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Closes #6864

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (N/A — Storybook stories are visual tests)
- [x] Documentation updated if behavior changed (N/A)
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff