### PR TITLE
fix(toast): canonical durations in chat notify() wrapper (MVA-351)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -441,7 +441,7 @@ function closeVoicePanel(): void {
 // Toast notifications
 const { showToast } = useToast()
 const notify = (message: string, type: 'info' | 'success' | 'warning' | 'error' = 'info') => {
-  showToast(message, type, type === 'error' ? 5000 : 3000)
+  showToast(message, type, type === 'error' ? 0 : type === 'warning' ? 6000 : 4000)
 }
 
 // Issue #4414: multi-model compare panel toggle


### PR DESCRIPTION
## Summary

- Fixes \`notify()\` wrapper in \`ChatInterface.vue\` to use canonical toast durations per [MVA-189](/MVA/issues/MVA-189) spec Section 5
- Errors now persistent (\`duration: 0\`) instead of auto-dismissing at 5 s
- Warnings dismiss at 6 000 ms; success/info dismiss at 4 000 ms

## Thinking Path

1. Found \`notify()\` wrapper at \`ChatInterface.vue:443-444\`
2. Confirmed all 10 call sites are transient (not view-contextual chat message errors)
3. Verified \`useToast\`'s \`TOAST_DURATIONS\` already uses canonical values — the explicit ternary aligns with the spec's suggested change
4. Applied one-line fix; no type impact

## What Changed

\`\`\`typescript
// Before
showToast(message, type, type === 'error' ? 5000 : 3000)

// After (canonical)
showToast(message, type, type === 'error' ? 0 : type === 'warning' ? 6000 : 4000)
\`\`\`

All 10 \`notify()\` call sites in \`ChatInterface.vue\` are transient notifications (tool approval, overseer events, feedback submission, init failure) — none are view-contextual chat message errors, so no migration to BaseAlert was needed.

## Verification

- ✅ Chat error notifications persist until dismissed (not 5 s auto-dismiss)
- ✅ Chat success/info notifications dismiss at 4 000 ms
- ✅ Chat warning notifications dismiss at 6 000 ms
- ✅ No new TS errors (one-line change, no type impact)
- Smoke-test passes (CI)

## Model Used

claude-sonnet-4-6

## Changelog fragment

- [ ] N/A — internal bug fix aligned to existing canonical spec, no user-visible API change

🤖 Generated with [Claude Code](https://claude.com/claude-code)