### PR TITLE
refactor(pydantic): migrate v1→v2 patterns in 6 files (#7442)

### DIFF
--- a/autobot-backend/code_intelligence/pattern_analysis/refactoring_generator.py
+++ b/autobot-backend/code_intelligence/pattern_analysis/refactoring_generator.py
@@ -455,14 +455,15 @@ class ErrorHandler:
             RefactoringSuggestion or None
         """
         code_template = """
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 
 class ValidatedInput(BaseModel):
     \"\"\"Validated input model using Pydantic.\"\"\"
 
     field: str
 
-    @validator('field')
+    @field_validator('field')
+    @classmethod
     def validate_field(cls, v):
         # Add validation logic here
         return v

--- a/autobot-backend/knowledge/activity_types.py
+++ b/autobot-backend/knowledge/activity_types.py
@@ -18,7 +18,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from autobot_shared.time_utils import now_utc
 
@@ -51,8 +51,8 @@ class TerminalActivity(BaseModel):
     )
     timestamp: datetime = Field(default_factory=now_utc)
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "user_id": "550e8400-e29b-41d4-a716-446655440000",
                 "session_id": "chat_abc123",
@@ -64,6 +64,7 @@ class TerminalActivity(BaseModel):
                 "metadata": {"shell": "bash", "duration_ms": 1250},
             }
         }
+    )
 
 
 class FileActivity(BaseModel):
@@ -94,8 +95,8 @@ class FileActivity(BaseModel):
     )
     timestamp: datetime = Field(default_factory=now_utc)
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "user_id": "550e8400-e29b-41d4-a716-446655440000",
                 "session_id": "chat_abc123",
@@ -106,6 +107,7 @@ class FileActivity(BaseModel):
                 "metadata": {"permissions": "0644", "encoding": "utf-8"},
             }
         }
+    )
 
 
 class BrowserActivity(BaseModel):
@@ -139,8 +141,8 @@ class BrowserActivity(BaseModel):
     )
     timestamp: datetime = Field(default_factory=now_utc)
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "user_id": "550e8400-e29b-41d4-a716-446655440000",
                 "session_id": "chat_abc123",
@@ -151,6 +153,7 @@ class BrowserActivity(BaseModel):
                 "metadata": {"status_code": 200, "redirect_url": "/dashboard"},
             }
         }
+    )
 
 
 class DesktopActivity(BaseModel):
@@ -181,8 +184,8 @@ class DesktopActivity(BaseModel):
     )
     timestamp: datetime = Field(default_factory=now_utc)
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "user_id": "550e8400-e29b-41d4-a716-446655440000",
                 "session_id": "chat_abc123",
@@ -192,6 +195,7 @@ class DesktopActivity(BaseModel):
                 "metadata": {"app": "code", "ocr_text": "Save File"},
             }
         }
+    )
 
 
 class SecretUsage(BaseModel):
@@ -228,8 +232,8 @@ class SecretUsage(BaseModel):
     )
     timestamp: datetime = Field(default_factory=now_utc)
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "secret_id": "660e8400-e29b-41d4-a716-446655440001",
                 "user_id": "550e8400-e29b-41d4-a716-446655440000",
@@ -240,3 +244,4 @@ class SecretUsage(BaseModel):
                 "metadata": {"ip": "192.168.1.10", "location": "office"},
             }
         }
+    )

--- a/autobot-backend/models/npu_models.py
+++ b/autobot-backend/models/npu_models.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from autobot_shared.time_utils import now_utc
 from constants.network_constants import NetworkConstants
@@ -60,14 +60,16 @@ class NPUWorkerConfig(BaseModel):
     weight: int = Field(default=1, ge=1, le=100, description="Worker weight for weighted load balancing")
     max_concurrent_tasks: int = Field(default=4, ge=1, description="Maximum concurrent tasks")
 
-    @validator("url")
+    @field_validator("url")
+    @classmethod
     def validate_url(cls, v):
         """Validate URL format"""
         if not v.startswith(_VALID_URL_SCHEMES):  # Issue #380
             raise ValueError("URL must start with http:// or https://")
         return v.rstrip("/")
 
-    @validator("id")
+    @field_validator("id")
+    @classmethod
     def validate_id(cls, v):
         """Validate worker ID format"""
         if not v or len(v.strip()) == 0:
@@ -77,8 +79,8 @@ class NPUWorkerConfig(BaseModel):
             raise ValueError("Worker ID must contain only alphanumeric characters, hyphens, and underscores")
         return v
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "id": "npu-worker-1",
                 "name": "Primary NPU Worker",
@@ -90,6 +92,7 @@ class NPUWorkerConfig(BaseModel):
                 "max_concurrent_tasks": 4,
             }
         }
+    )
 
 
 class NPUWorkerStatus(BaseModel):
@@ -104,8 +107,8 @@ class NPUWorkerStatus(BaseModel):
     last_heartbeat: Optional[datetime] = Field(default=None, description="Last successful heartbeat timestamp")
     error_message: Optional[str] = Field(default=None, description="Latest error message if status is ERROR")
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "id": "npu-worker-1",
                 "status": "online",
@@ -117,6 +120,7 @@ class NPUWorkerStatus(BaseModel):
                 "error_message": None,
             }
         }
+    )
 
 
 class NPUWorkerMetrics(BaseModel):
@@ -130,8 +134,8 @@ class NPUWorkerMetrics(BaseModel):
     last_error_time: Optional[datetime] = Field(default=None, description="Timestamp of last error")
     metrics_timestamp: datetime = Field(default_factory=now_utc, description="Metrics collection timestamp")
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "id": "npu-worker-1",
                 "avg_response_time_ms": 245.8,
@@ -142,6 +146,7 @@ class NPUWorkerMetrics(BaseModel):
                 "metrics_timestamp": "2025-10-04T12:34:56Z",
             }
         }
+    )
 
 
 class LoadBalancingConfig(BaseModel):
@@ -169,8 +174,8 @@ class LoadBalancingConfig(BaseModel):
         description="Cooldown period before retrying failed workers (10-600 seconds)",
     )
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "strategy": "least-loaded",
                 "health_check_interval": 30,
@@ -179,6 +184,7 @@ class LoadBalancingConfig(BaseModel):
                 "retry_cooldown_seconds": 60,
             }
         }
+    )
 
 
 class NPUWorkerDetails(BaseModel):
@@ -214,15 +220,15 @@ class NPUWorkerDetails(BaseModel):
             "current_load": self.status.current_load,
             "max_capacity": self.config.max_concurrent_tasks,
             "uptime": f"{int(self.status.uptime_seconds)}s",
-            "performance_metrics": self.metrics.dict() if self.metrics else {},
+            "performance_metrics": self.metrics.model_dump() if self.metrics else {},
             "priority": self.config.priority,
             "weight": self.config.weight,
             "last_heartbeat": (self.status.last_heartbeat.isoformat() + "Z" if self.status.last_heartbeat else ""),
             "created_at": "",  # Not tracked in current model
         }
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "config": {
                     "id": "npu-worker-1",
@@ -255,6 +261,7 @@ class NPUWorkerDetails(BaseModel):
                 },
             }
         }
+    )
 
 
 class WorkerHeartbeat(BaseModel):
@@ -275,8 +282,8 @@ class WorkerHeartbeat(BaseModel):
     loaded_models: list = Field(default_factory=list, description="List of loaded model names")
     metrics: Optional[Dict[str, Any]] = Field(default=None, description="Performance metrics")
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "worker_id": "windows_npu_worker_abc123",
                 "status": "online",
@@ -291,6 +298,7 @@ class WorkerHeartbeat(BaseModel):
                 "metrics": {"avg_response_time_ms": 25.5, "cache_hit_rate": 85.2},
             }
         }
+    )
 
 
 class WorkerTestResult(BaseModel):
@@ -303,8 +311,8 @@ class WorkerTestResult(BaseModel):
     error_message: Optional[str] = Field(default=None, description="Error message if test failed")
     health_data: Optional[Dict] = Field(default=None, description="Health check response data")
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "worker_id": "npu-worker-1",
                 "success": True,
@@ -318,3 +326,4 @@ class WorkerTestResult(BaseModel):
                 },
             }
         }
+    )

--- a/autobot-backend/user_management/schemas/user.py
+++ b/autobot-backend/user_management/schemas/user.py
@@ -12,19 +12,18 @@ import uuid
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
 
 
 class RoleResponse(BaseModel):
     """Role information in responses."""
 
+    model_config = ConfigDict(from_attributes=True)
+
     id: uuid.UUID
     name: str
     description: Optional[str] = None
     is_system: bool = False
-
-    class Config:
-        from_attributes = True
 
 
 class UserCreate(BaseModel):
@@ -96,6 +95,8 @@ class UserUpdate(BaseModel):
 class UserResponse(BaseModel):
     """Response model for a single user."""
 
+    model_config = ConfigDict(from_attributes=True)
+
     id: uuid.UUID
     email: str
     username: str
@@ -112,9 +113,6 @@ class UserResponse(BaseModel):
     last_login_at: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime
-
-    class Config:
-        from_attributes = True
 
 
 class UserListResponse(BaseModel):

--- a/autobot-backend/utils/api_responses.py
+++ b/autobot-backend/utils/api_responses.py
@@ -74,7 +74,7 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException, status
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from autobot_shared.time_utils import utc_timestamp
 
@@ -98,8 +98,8 @@ class StandardResponse(BaseModel):
         description="Response timestamp (ISO 8601)",
     )
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "success": True,
                 "message": "Operation completed successfully",
@@ -107,6 +107,7 @@ class StandardResponse(BaseModel):
                 "timestamp": "2025-01-09T10:00:00.000000",
             }
         }
+    )
 
 
 class ErrorResponse(BaseModel):
@@ -125,8 +126,8 @@ class ErrorResponse(BaseModel):
         description="Error timestamp (ISO 8601)",
     )
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "success": False,
                 "error": "Resource not found",
@@ -135,6 +136,7 @@ class ErrorResponse(BaseModel):
                 "timestamp": "2025-01-09T10:00:00.000000",
             }
         }
+    )
 
 
 class PaginatedResponse(BaseModel):

--- a/autobot-backend/utils/validators.py
+++ b/autobot-backend/utils/validators.py
@@ -39,7 +39,8 @@ from utils.validators import (
 class MyModel(BaseModel):
     username: str
 
-    @validator("username")
+    @field_validator("username")
+    @classmethod
     def validate_username(cls, v):
         v = sanitize_string(v)  # Strip and lowercase
         validate_non_empty_string(v, "Username")


### PR DESCRIPTION
## Summary

Completes remaining Pydantic v1→v2 migration (GH#7442) for 6 backend files:

- **`models/npu_models.py`**: `@validator` → `@field_validator` + `@classmethod`; 7× `class Config: json_schema_extra` → `model_config = ConfigDict(...)`; `.dict()` → `.model_dump()`
- **`knowledge/activity_types.py`**: 5× `class Config: json_schema_extra` → `model_config = ConfigDict(...)`
- **`utils/api_responses.py`**: 2× `class Config: json_schema_extra` → `model_config = ConfigDict(...)`
- **`user_management/schemas/user.py`**: 2× `class Config: from_attributes = True` → `model_config = ConfigDict(from_attributes=True)`
- **`code_intelligence/pattern_analysis/refactoring_generator.py`**: Update code template string to v2 `@field_validator` + `@classmethod`
- **`utils/validators.py`**: Update docstring example to v2 `@field_validator` syntax

**Not changed** (confirmed non-Pydantic `class Config:` patterns):
- `autobot_memory_graph/core.py` — standalone configuration class
- `config/compat.py` — backward compatibility wrapper
- `code_analysis/src/frontend_analyzer.py` — ImportError fallback object

## Test plan

- [x] All 6 changed files pass `python3 -m py_compile`
- [x] `StandardResponse`, `ErrorResponse`, `TerminalActivity`, `RoleResponse`, `UserCreate` all instantiate correctly with v2 semantics
- [x] Final pattern sweep: 0 remaining `class Config:` inner classes, `@validator`, or `orm_mode` in Pydantic models
- [x] Pre-existing test suite failure (`AgentThresholds` import error in `ssot_constants.py`) confirmed unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)