### PR TITLE
deprecate(orchestrator): add DeprecationWarning to process_user_request (closes GH#7423)

### DIFF
--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -22,6 +22,7 @@ import asyncio
 import json
 import time
 import uuid
+import warnings
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -452,9 +453,17 @@ class Orchestrator:
     ) -> Dict[str, Any]:
         """Process user request. Issue #281, #620, #5058.
 
+        .. deprecated::
+            No live callers exist. Call execute_enhanced_workflow directly (GH#7423).
+
         SIMPLE mode: direct LLM call (fast path, no workflow planning).
         All other modes: delegate to execute_enhanced_workflow (unified path).
         """
+        warnings.warn(
+            "process_user_request is deprecated and has no live callers — use execute_enhanced_workflow directly. (GH#7423)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         start_time = time.time()
         task_id = str(uuid.uuid4())
         logger.info("Processing user request %s: %s...", task_id, user_message[:100])


### PR DESCRIPTION
## Thinking Path

> GH#7423 documents that process_user_request in orchestrator.py has zero live callers — execute_enhanced_workflow is the actual entry point (confirmed by SeniorCodeArchitect audit on MVA-378). Rather than deleting the function (a larger behavioural change), the minimal safe fix is a DeprecationWarning so any future mistaken call-site surfaces during development. The RST deprecated docstring directive follows Python convention.

## What Changed

- autobot-backend/orchestrator.py: added import warnings to imports block
- autobot-backend/orchestrator.py: added warnings.warn(..., DeprecationWarning, stacklevel=2) at top of process_user_request body
- autobot-backend/orchestrator.py: prepended .. deprecated:: RST directive to docstring referencing GH#7423

## Verification

python3 -m py_compile autobot-backend/orchestrator.py (no syntax errors)
grep -r process_user_request autobot-backend autobot_shared --include="*.py" | grep -v "def process_user_request" (zero live callers unchanged)
CI: startup-import-smoke, code-quality, smoke-test failures are pre-existing on Dev_new_gui base (canvas.py, schemas_canvas.py unrelated to this PR).

## Risks

None — zero live callers. Warning only fires if a new caller is introduced, which is intended.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Closes #7423

## Checklist
- [x] Code follows AutoBot patterns from CLAUDE.md
- [x] Tests added or updated (N/A — deprecation warning, no logic change)
- [x] Documentation updated (docstring updated)
- [x] Pre-commit hooks pass
- [x] PR targets Dev_new_gui
- [x] No secrets or credentials in the diff