### PR TITLE
feat(frontend/a11y): SLM canonical alignment + icon-only button aria-label audit (GH#7449, GH#7391)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -246,6 +246,7 @@
               <button
                 @click="showSystemStatus = false"
                 class="rounded-md text-autobot-text-muted hover:text-autobot-text-primary focus:outline-none focus:ring-2 focus:ring-autobot-primary"
+                :aria-label="$t('common.close')"
               >
                 <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
@@ -122,7 +122,7 @@
         <div class="panel">
           <div class="panel-header">
             <h3>{{ $t('analytics.llmPatterns.optimizationRecommendations') }}</h3>
-            <button class="refresh-btn" @click="fetchRecommendations">
+            <button class="refresh-btn" @click="fetchRecommendations" :aria-label="$t('common.refresh')">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
               </svg>

--- a/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
@@ -424,7 +424,7 @@ onUnmounted(() => {
               d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
           </svg>
           <span>{{ errorMsg }}</span>
-          <button class="error-dismiss" @click="errorMsg = null">
+          <button class="error-dismiss" @click="errorMsg = null" :aria-label="$t('common.dismiss')">
             <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>

--- a/autobot-frontend/src/views/AgentRegistryView.vue
+++ b/autobot-frontend/src/views/AgentRegistryView.vue
@@ -384,6 +384,7 @@ onMounted(async () => {
             <button
               @click="closeDetailModal"
               class="text-secondary hover:text-primary"
+              :aria-label="$t('common.close')"
             >
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/autobot-slm-frontend/src/App.vue
+++ b/autobot-slm-frontend/src/App.vue
@@ -14,12 +14,16 @@ import { onMounted, watch, computed } from 'vue'
 import { RouterView, useRoute } from 'vue-router'
 import Sidebar from '@/components/common/Sidebar.vue'
 import SkipLink from '@/components/common/SkipLink.vue'
+import ToastContainer from '@/components/common/ToastContainer.vue'
 import UpdateNotification from '@/components/UpdateNotification.vue'
 import { useFleetStore } from '@/stores/fleet'
 import { useAuthStore } from '@/stores/auth'
 import { useSlmWebSocket } from '@/composables/useSlmWebSocket'
 import { useHighContrast, useDarkMode } from '@/composables/useAccessibility'
 import { ensureTimezone } from '@/composables/useTimezone'
+import { provideToast } from '@/composables/useToast'
+
+provideToast()
 
 const route = useRoute()
 const fleetStore = useFleetStore()
@@ -78,6 +82,8 @@ onMounted(async () => {
 <template>
   <!-- Issue #754: Skip link for keyboard navigation -->
   <SkipLink />
+  <!-- Canonical toast notification container (GH#7449) -->
+  <ToastContainer />
 
   <!-- Login page - no sidebar -->
   <template v-if="isLoginPage">

--- a/autobot-slm-frontend/src/components/DeploymentWizard.vue
+++ b/autobot-slm-frontend/src/components/DeploymentWizard.vue
@@ -231,6 +231,7 @@ function getCategoryIcon(category: string): string {
         <button
           @click="$emit('close')"
           class="text-gray-400 hover:text-gray-600 transition-colors"
+          aria-label="Close"
         >
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/autobot-slm-frontend/src/components/InfrastructureWizard.vue
+++ b/autobot-slm-frontend/src/components/InfrastructureWizard.vue
@@ -301,6 +301,7 @@ function getStatusColor(status: string): string {
           @click="$emit('close')"
           class="text-gray-400 hover:text-gray-600 transition-colors"
           :disabled="currentExecution?.status === 'running'"
+          aria-label="Close"
         >
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/autobot-slm-frontend/src/components/RedisServicePanel.vue
+++ b/autobot-slm-frontend/src/components/RedisServicePanel.vue
@@ -203,6 +203,7 @@ onUnmounted(() => {
         :disabled="isLoading || isActionInProgress"
         class="p-1.5 text-gray-400 hover:text-gray-600 disabled:opacity-40 transition-colors"
         title="Refresh status"
+        aria-label="Refresh status"
       >
         <svg :class="['w-4 h-4', isLoading ? 'animate-spin' : '']" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -214,7 +215,7 @@ onUnmounted(() => {
     <!-- Success / Error banners -->
     <div v-if="successMessage" class="px-4 py-2 bg-green-50 border-b border-green-100 text-sm text-green-700 flex items-center justify-between">
       <span>{{ successMessage }}</span>
-      <button @click="successMessage = null" class="text-green-500 hover:text-green-700">
+      <button @click="successMessage = null" class="text-green-500 hover:text-green-700" aria-label="Dismiss">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>
@@ -222,7 +223,7 @@ onUnmounted(() => {
     </div>
     <div v-if="errorMessage" class="px-4 py-2 bg-red-50 border-b border-red-100 text-sm text-red-700 flex items-center justify-between">
       <span>{{ errorMessage }}</span>
-      <button @click="errorMessage = null" class="text-red-500 hover:text-red-700">
+      <button @click="errorMessage = null" class="text-red-500 hover:text-red-700" aria-label="Dismiss">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>

--- a/autobot-slm-frontend/src/components/common/ToastContainer.vue
+++ b/autobot-slm-frontend/src/components/common/ToastContainer.vue
@@ -1,0 +1,199 @@
+<template>
+  <Teleport to="body">
+    <div
+      class="toast-container"
+      role="region"
+      aria-label="Notifications"
+      aria-live="polite"
+    >
+      <TransitionGroup name="toast">
+        <div
+          v-for="toast in toasts"
+          :key="toast.id"
+          :class="['toast', `toast-${toast.type}`]"
+          role="alert"
+          :aria-atomic="true"
+        >
+          <div class="toast-icon">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="getIconPath(toast.type)" />
+            </svg>
+          </div>
+          <div class="toast-content">
+            <span class="toast-message">{{ toast.message }}</span>
+          </div>
+          <button
+            class="toast-close"
+            @click="removeToast(toast.id)"
+            aria-label="Dismiss notification"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </TransitionGroup>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import { useToast } from '@/composables/useToast'
+
+const { toasts, removeToast } = useToast()
+
+const getIconPath = (type: string): string => {
+  switch (type) {
+    case 'success':
+      return 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z'
+    case 'error':
+      return 'M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z'
+    case 'warning':
+      return 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z'
+    default:
+      return 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+  }
+}
+</script>
+
+<style scoped>
+.toast-container {
+  position: fixed;
+  top: 80px;
+  right: 20px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 400px;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  pointer-events: auto;
+  min-width: 300px;
+  max-width: 400px;
+  background: white;
+}
+
+.toast-info {
+  border-left: 4px solid #3b82f6;
+  border: 1px solid #93c5fd;
+  border-left: 4px solid #3b82f6;
+}
+
+.toast-success {
+  border: 1px solid #86efac;
+  border-left: 4px solid #22c55e;
+}
+
+.toast-warning {
+  border: 1px solid #fcd34d;
+  border-left: 4px solid #f59e0b;
+}
+
+.toast-error {
+  border: 1px solid #fca5a5;
+  border-left: 4px solid #ef4444;
+}
+
+.toast-icon {
+  flex-shrink: 0;
+}
+
+.toast-info .toast-icon { color: #3b82f6; }
+.toast-success .toast-icon { color: #22c55e; }
+.toast-warning .toast-icon { color: #f59e0b; }
+.toast-error .toast-icon { color: #ef4444; }
+
+.toast-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.toast-message {
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  word-break: break-word;
+  color: #111827;
+}
+
+.toast-close {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: #6b7280;
+  min-width: 32px;
+  min-height: 32px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, color 0.15s;
+}
+
+.toast-close:hover {
+  background: #f3f4f6;
+  color: #111827;
+}
+
+.toast-close:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+.toast-enter-active {
+  animation: slideIn 0.3s ease-out;
+}
+
+.toast-leave-active {
+  animation: slideOut 0.2s ease-in;
+}
+
+.toast-move {
+  transition: transform 0.3s ease-in-out;
+}
+
+@keyframes slideIn {
+  from { opacity: 0; transform: translateX(100%); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes slideOut {
+  from { opacity: 1; transform: translateX(0); }
+  to { opacity: 0; transform: translateX(100%); }
+}
+
+@media (max-width: 480px) {
+  .toast-container {
+    left: 12px;
+    right: 12px;
+    top: 70px;
+    max-width: none;
+  }
+  .toast { min-width: unset; max-width: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast-enter-active,
+  .toast-leave-active {
+    animation: none;
+    transition: opacity 0.15s ease-in-out;
+  }
+  .toast-enter-from,
+  .toast-leave-to { opacity: 0; }
+  .toast-move { transition: none; }
+}
+</style>

--- a/autobot-slm-frontend/src/components/fleet/FleetToolsTab.vue
+++ b/autobot-slm-frontend/src/components/fleet/FleetToolsTab.vue
@@ -248,6 +248,7 @@ async function runShellCommand(): Promise<void> {
         <button
           @click="closeTool"
           class="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+          aria-label="Close tool panel"
         >
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/autobot-slm-frontend/src/components/fleet/NPUDetailsPanel.vue
+++ b/autobot-slm-frontend/src/components/fleet/NPUDetailsPanel.vue
@@ -166,6 +166,7 @@ onMounted(async () => {
           <button
             @click="emit('close')"
             class="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            aria-label="Close"
           >
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/autobot-slm-frontend/src/components/fleet/NPUWorkerMonitor.vue
+++ b/autobot-slm-frontend/src/components/fleet/NPUWorkerMonitor.vue
@@ -210,7 +210,7 @@ onUnmounted(() => {
             </div>
           </div>
         </div>
-        <button @click="refresh" :disabled="loading" class="p-2 text-gray-400 hover:text-gray-600 transition-colors" title="Refresh now">
+        <button @click="refresh" :disabled="loading" class="p-2 text-gray-400 hover:text-gray-600 transition-colors" title="Refresh now" aria-label="Refresh now">
           <svg :class="['w-5 h-5', loading ? 'animate-spin' : '']" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
           </svg>

--- a/autobot-slm-frontend/src/components/fleet/NodeServicesPanel.vue
+++ b/autobot-slm-frontend/src/components/fleet/NodeServicesPanel.vue
@@ -348,6 +348,7 @@ onUnmounted(() => {
       <button
         @click="emit('close')"
         class="text-gray-400 hover:text-gray-600 transition-colors"
+        aria-label="Close"
       >
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -358,7 +359,7 @@ onUnmounted(() => {
     <!-- Error Banner -->
     <div v-if="errorMessage" class="px-4 py-2 bg-red-50 border-b border-red-100 text-sm text-red-700 flex items-center justify-between">
       <span>{{ errorMessage }}</span>
-      <button @click="errorMessage = null" class="text-red-500 hover:text-red-700">
+      <button @click="errorMessage = null" class="text-red-500 hover:text-red-700" aria-label="Dismiss error">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>
@@ -607,6 +608,7 @@ onUnmounted(() => {
             <button
               @click="closeLogsModal"
               class="text-gray-400 hover:text-gray-600 transition-colors"
+              aria-label="Close"
             >
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/autobot-slm-frontend/src/composables/useToast.ts
+++ b/autobot-slm-frontend/src/composables/useToast.ts
@@ -1,0 +1,92 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import { ref, inject, provide, type Ref, type InjectionKey } from 'vue'
+
+export type ToastType = 'info' | 'success' | 'warning' | 'error'
+
+export interface Toast {
+  id: number
+  message: string
+  type: ToastType
+  duration: number
+}
+
+export interface UseToastReturn {
+  toasts: Ref<Toast[]>
+  showToast: (message: string, type?: ToastType, duration?: number) => number
+  removeToast: (id: number) => void
+  clearAllToasts: () => void
+}
+
+export const MAX_TOASTS = 5
+
+export const TOAST_DURATIONS: Record<ToastType, number> = {
+  success: 4000,
+  info: 4000,
+  warning: 6000,
+  error: 0,
+}
+
+export const TOAST_INJECT_KEY: InjectionKey<UseToastReturn> = Symbol('useToast')
+
+const _toasts = ref<Toast[]>([])
+let _nextId = 1
+
+function _buildApi(toasts: Ref<Toast[]>, idCounter: { value: number }): UseToastReturn {
+  const removeToast = (id: number): void => {
+    const index = toasts.value.findIndex((t) => t.id === id)
+    if (index > -1) {
+      toasts.value.splice(index, 1)
+    }
+  }
+
+  const showToast = (
+    message: string,
+    type: ToastType = 'info',
+    duration?: number,
+  ): number => {
+    const resolvedDuration = duration !== undefined ? duration : TOAST_DURATIONS[type]
+    const id = idCounter.value++
+    const toast: Toast = { id, message, type, duration: resolvedDuration }
+
+    if (toasts.value.length >= MAX_TOASTS) {
+      toasts.value.splice(0, toasts.value.length - MAX_TOASTS + 1)
+    }
+
+    toasts.value.push(toast)
+
+    if (resolvedDuration > 0) {
+      setTimeout(() => {
+        removeToast(id)
+      }, resolvedDuration)
+    }
+
+    return id
+  }
+
+  const clearAllToasts = (): void => {
+    toasts.value.splice(0)
+  }
+
+  return { toasts, showToast, removeToast, clearAllToasts }
+}
+
+const _idCounter = { value: _nextId }
+const _singletonApi = _buildApi(_toasts, _idCounter)
+
+Object.defineProperty(_idCounter, 'value', {
+  get: () => _nextId,
+  set: (v: number) => { _nextId = v },
+})
+
+export function provideToast(): UseToastReturn {
+  provide(TOAST_INJECT_KEY, _singletonApi)
+  return _singletonApi
+}
+
+export function useToast(): UseToastReturn {
+  const injected = inject(TOAST_INJECT_KEY, null)
+  return injected ?? _singletonApi
+}

--- a/autobot-slm-frontend/src/router/index.ts
+++ b/autobot-slm-frontend/src/router/index.ts
@@ -23,14 +23,14 @@ const router = createRouter({
       path: '/login',
       name: 'login',
       component: () => import('@/views/LoginView.vue'),
-      meta: { title: 'Login', public: true }
+      meta: { title: 'Login', requiresAuth: false }
     },
     {
       // Issue #576: SSO callback handler for OAuth2/SAML redirects
       path: '/sso-callback',
       name: 'sso-callback',
       component: () => import('@/views/SSOCallbackView.vue'),
-      meta: { title: 'SSO Login', public: true },
+      meta: { title: 'SSO Login', requiresAuth: false },
     },
     {
       // Issue #1294: Setup wizard — guided first-run fleet configuration
@@ -470,8 +470,8 @@ const router = createRouter({
 router.beforeEach(async (to, _from) => {
   const authStore = useAuthStore()
 
-  // Public routes don't need auth
-  if (to.meta.public) {
+  // Public routes don't need auth (requiresAuth: false)
+  if (to.meta.requiresAuth === false) {
     // If already authenticated, redirect to home
     if (authStore.isAuthenticated && to.name === 'login') {
       return { name: 'fleet' }

--- a/autobot-slm-frontend/src/types/router.d.ts
+++ b/autobot-slm-frontend/src/types/router.d.ts
@@ -1,0 +1,23 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import 'vue-router'
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    /** Route title for document.title and breadcrumbs */
+    title?: string
+
+    /** Whether auth is required (false = public route, default = true) */
+    requiresAuth?: boolean
+
+    /** Parent route name for breadcrumb hierarchy */
+    parent?: string
+
+    /** Whether route requires admin role */
+    admin?: boolean
+  }
+}
+
+export {}

--- a/autobot-slm-frontend/src/views/BackupsView.vue
+++ b/autobot-slm-frontend/src/views/BackupsView.vue
@@ -14,7 +14,10 @@ import { useRoute, useRouter } from 'vue-router'
 import { useSlmApi } from '@/composables/useSlmApi'
 import { useFleetStore } from '@/stores/fleet'
 import { formatDateTime } from '@/composables/useTimezone'
+import { useToast } from '@/composables/useToast'
 import type { Backup, BackupRequest, Replication, ReplicationRequest } from '@/types/slm'
+
+const { showToast } = useToast()
 
 const api = useSlmApi()
 const fleetStore = useFleetStore()
@@ -107,7 +110,7 @@ async function handleRestore(backupId: string): Promise<void> {
     await api.restoreBackup(backupId)
     await fetchBackups()
   } catch (e) {
-    alert(`Restore failed: ${e instanceof Error ? e.message : 'Unknown error'}`)
+    showToast(`Restore failed: ${e instanceof Error ? e.message : 'Unknown error'}`, 'error')
   }
 }
 
@@ -127,7 +130,7 @@ async function fetchReplications(): Promise<void> {
 async function handleCreateReplication(): Promise<void> {
   if (!newReplication.value.source_node_id || !newReplication.value.target_node_id) return
   if (newReplication.value.source_node_id === newReplication.value.target_node_id) {
-    alert('Source and target nodes must be different')
+    showToast('Source and target nodes must be different', 'error')
     return
   }
 
@@ -155,7 +158,7 @@ async function handlePromoteReplica(replicationId: string): Promise<void> {
     await api.promoteReplica(replicationId)
     await fetchReplications()
   } catch (e) {
-    alert(`Promote failed: ${e instanceof Error ? e.message : 'Unknown error'}`)
+    showToast(`Promote failed: ${e instanceof Error ? e.message : 'Unknown error'}`, 'error')
   }
 }
 

--- a/autobot-slm-frontend/src/views/DeploymentsView.vue
+++ b/autobot-slm-frontend/src/views/DeploymentsView.vue
@@ -1518,7 +1518,7 @@ function getNodeHostname(nodeId: string): string {
                   {{ selectedDeployment.status.replaceAll('_', ' ') }}
                 </span>
               </div>
-              <button @click="closeDetails" class="text-gray-400 hover:text-gray-600">
+              <button @click="closeDetails" class="text-gray-400 hover:text-gray-600" aria-label="Close">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>
@@ -1622,7 +1622,7 @@ function getNodeHostname(nodeId: string): string {
                   {{ selectedBgDeployment.status.replaceAll('_', ' ') }}
                 </span>
               </div>
-              <button @click="closeBgDetails" class="text-gray-400 hover:text-gray-600">
+              <button @click="closeBgDetails" class="text-gray-400 hover:text-gray-600" aria-label="Close">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>

--- a/autobot-slm-frontend/src/views/MaintenanceView.vue
+++ b/autobot-slm-frontend/src/views/MaintenanceView.vue
@@ -678,6 +678,7 @@ function getNodeName(nodeId: string | null): string {
               <button
                 @click="closeScheduleDialog"
                 class="text-gray-400 hover:text-gray-600"
+                aria-label="Close"
               >
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/autobot-slm-frontend/src/views/ReplicationView.vue
+++ b/autobot-slm-frontend/src/views/ReplicationView.vue
@@ -14,6 +14,7 @@ import { useSlmApi } from '@/composables/useSlmApi'
 import { useSlmWebSocket } from '@/composables/useSlmWebSocket'
 import { useFleetStore } from '@/stores/fleet'
 import { formatDateTime as formatDateTimeTz } from '@/composables/useTimezone'
+import { useToast } from '@/composables/useToast'
 import { createLogger } from '@/utils/debugUtils'
 import type { Replication, ReplicationRequest } from '@/types/slm'
 
@@ -21,6 +22,7 @@ const logger = createLogger('ReplicationView')
 const api = useSlmApi()
 const ws = useSlmWebSocket()
 const fleetStore = useFleetStore()
+const { showToast } = useToast()
 
 // State
 const replications = ref<Replication[]>([])
@@ -112,7 +114,7 @@ async function handleCreateReplication(): Promise<void> {
     await fetchReplications()
   } catch (err) {
     logger.error('Failed to start replication:', err)
-    alert('Failed to start replication')
+    showToast('Failed to start replication', 'error')
   } finally {
     isCreating.value = false
   }
@@ -128,7 +130,7 @@ async function handlePromote(replicationId: string): Promise<void> {
     await fetchReplications()
   } catch (err) {
     logger.error('Failed to promote replica:', err)
-    alert('Failed to promote replica')
+    showToast('Failed to promote replica', 'error')
   }
 }
 
@@ -142,7 +144,7 @@ async function handleStop(replicationId: string): Promise<void> {
     await fetchReplications()
   } catch (err) {
     logger.error('Failed to stop replication:', err)
-    alert('Failed to stop replication')
+    showToast('Failed to stop replication', 'error')
   }
 }
 
@@ -574,7 +576,7 @@ function getNodeHostname(nodeId: string): string {
                   {{ selectedReplication.status }}
                 </span>
               </div>
-              <button @click="closeDetails" class="text-gray-400 hover:text-gray-600">
+              <button @click="closeDetails" class="text-gray-400 hover:text-gray-600" aria-label="Close">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>

--- a/autobot-slm-frontend/src/views/ServicesView.vue
+++ b/autobot-slm-frontend/src/views/ServicesView.vue
@@ -542,7 +542,7 @@ onUnmounted(() => {
       class="mb-4 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700 flex items-center justify-between"
     >
       <span>{{ errorMessage }}</span>
-      <button @click="errorMessage = null" class="text-red-500 hover:text-red-700">
+      <button @click="errorMessage = null" class="text-red-500 hover:text-red-700" aria-label="Dismiss error">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>

--- a/autobot-slm-frontend/src/views/monitoring/ErrorMonitor.vue
+++ b/autobot-slm-frontend/src/views/monitoring/ErrorMonitor.vue
@@ -527,7 +527,7 @@ onUnmounted(() => {
           class="p-4 border-b border-gray-200 flex items-center justify-between"
         >
           <h3 class="text-lg font-semibold text-gray-900">{{ $t('monitoring.errorMonitor.errorDetails') }}</h3>
-          <button @click="closeDetail" class="text-gray-400 hover:text-gray-600">
+          <button @click="closeDetail" class="text-gray-400 hover:text-gray-600" aria-label="Close">
             <svg
               class="w-5 h-5"
               fill="none"

--- a/autobot-slm-frontend/src/views/settings/admin/CacheSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/CacheSettings.vue
@@ -205,7 +205,7 @@ onMounted(async () => {
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
       {{ error }}
-      <button @click="error = null" class="ml-auto text-red-500 hover:text-red-700">
+      <button @click="error = null" class="ml-auto text-red-500 hover:text-red-700" aria-label="Dismiss error">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>

--- a/autobot-slm-frontend/src/views/settings/admin/LLMSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/LLMSettings.vue
@@ -204,7 +204,7 @@ onMounted(fetchConfig)
           d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
       {{ error }}
-      <button class="ml-auto text-red-500 hover:text-red-700" @click="error = null">
+      <button class="ml-auto text-red-500 hover:text-red-700" @click="error = null" aria-label="Dismiss error">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>
@@ -235,7 +235,7 @@ onMounted(fetchConfig)
       <span v-if="testResult.latency_ms" class="text-sm opacity-75">
         ({{ testResult.latency_ms }}ms)
       </span>
-      <button class="ml-auto opacity-60 hover:opacity-100" @click="testResult = null">
+      <button class="ml-auto opacity-60 hover:opacity-100" @click="testResult = null" aria-label="Dismiss">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>

--- a/autobot-slm-frontend/src/views/settings/admin/LogForwardingSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/LogForwardingSettings.vue
@@ -282,7 +282,7 @@ onMounted(async () => {
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
       {{ error }}
-      <button @click="error = null" class="ml-auto text-red-500 hover:text-red-700">
+      <button @click="error = null" class="ml-auto text-red-500 hover:text-red-700" aria-label="Dismiss error">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>
@@ -511,7 +511,7 @@ onMounted(async () => {
           <h3 class="text-lg font-semibold text-gray-900">
             {{ editingDestination ? 'Edit Destination' : 'Add Destination' }}
           </h3>
-          <button @click="closeModal" class="text-gray-400 hover:text-gray-600">
+          <button @click="closeModal" class="text-gray-400 hover:text-gray-600" aria-label="Close">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>

--- a/autobot-slm-frontend/src/views/settings/admin/NPUWorkersSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/NPUWorkersSettings.vue
@@ -279,7 +279,7 @@ onUnmounted(() => {
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
       {{ error }}
-      <button @click="error = null" class="ml-auto text-red-500 hover:text-red-700">
+      <button @click="error = null" class="ml-auto text-red-500 hover:text-red-700" aria-label="Dismiss error">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>
@@ -395,6 +395,7 @@ onUnmounted(() => {
           @click="fetchWorkers"
           :disabled="loading"
           class="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-sm"
+          aria-label="Refresh workers"
         >
           <svg :class="['w-5 h-5', loading && 'animate-spin']" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -671,7 +672,7 @@ onUnmounted(() => {
       <div class="relative bg-white rounded-lg shadow-xl w-full max-w-lg p-6">
         <div class="flex items-center justify-between mb-4">
           <h3 class="text-lg font-semibold text-gray-900">{{ selectedWorkerMetrics.hostname }} Metrics</h3>
-          <button @click="showMetrics = false" class="text-gray-400 hover:text-gray-600">
+          <button @click="showMetrics = false" class="text-gray-400 hover:text-gray-600" aria-label="Close">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>

--- a/autobot-slm-frontend/src/views/settings/admin/PromptsSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/PromptsSettings.vue
@@ -169,7 +169,7 @@ onMounted(() => {
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
       {{ error }}
-      <button @click="error = null" class="ml-auto text-red-500 hover:text-red-700">
+      <button @click="error = null" class="ml-auto text-red-500 hover:text-red-700" aria-label="Dismiss error">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>

--- a/autobot-slm-frontend/src/views/settings/admin/SecretsSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/SecretsSettings.vue
@@ -149,7 +149,7 @@ onMounted(fetchSecrets)
         />
       </svg>
       {{ error }}
-      <button class="ml-auto text-red-500 hover:text-red-700" @click="error = null">
+      <button class="ml-auto text-red-500 hover:text-red-700" @click="error = null" aria-label="Dismiss error">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>

--- a/autobot-slm-frontend/src/views/settings/admin/UserManagementSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/UserManagementSettings.vue
@@ -542,7 +542,7 @@ watch(() => authStore.user, (newUser: typeof authStore.user) => {
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
       {{ error }}
-      <button @click="error = null" class="ml-auto text-red-500 hover:text-red-700">
+      <button @click="error = null" class="ml-auto text-red-500 hover:text-red-700" aria-label="Dismiss error">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>

--- a/autobot-slm-frontend/src/views/tools/admin/BatchTool.vue
+++ b/autobot-slm-frontend/src/views/tools/admin/BatchTool.vue
@@ -463,7 +463,7 @@ onUnmounted(() => {
       <div class="bg-white rounded-lg shadow-xl max-w-lg w-full mx-4 p-6">
         <div class="flex items-center justify-between mb-6">
           <h3 class="text-lg font-semibold text-gray-900">{{ $t('tools.admin.batchTool.createBatchJob') }}</h3>
-          <button @click="showCreateModal = false" class="text-gray-400 hover:text-gray-600">
+          <button @click="showCreateModal = false" class="text-gray-400 hover:text-gray-600" aria-label="Close">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>

--- a/autobot-slm-frontend/src/views/tools/admin/TerminalTool.vue
+++ b/autobot-slm-frontend/src/views/tools/admin/TerminalTool.vue
@@ -217,6 +217,7 @@ onMounted(() => {
             @click="addTab"
             class="p-1.5 text-gray-600 hover:text-gray-800 hover:bg-gray-200 rounded-sm transition-colors"
             title="New Tab"
+            aria-label="Add terminal tab"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
@@ -241,6 +242,7 @@ onMounted(() => {
             @click="clearTerminal"
             class="p-1.5 text-gray-600 hover:text-gray-800 hover:bg-gray-200 rounded-sm transition-colors"
             title="Clear Terminal"
+            aria-label="Clear terminal"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -279,6 +281,7 @@ onMounted(() => {
             v-if="tabs.length > 1"
             @click.stop="closeTab(tab.id)"
             class="ml-1 text-gray-500 hover:text-red-600"
+            :aria-label="`Close tab ${tab.id}`"
           >
             <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />


### PR DESCRIPTION
## Summary

- **GH#7449** — SLM frontend aligned with main frontend conventions: canonical `useToast` composable + `ToastContainer`, `alert()` replaced with `showToast()`, router meta aligned to `requiresAuth` pattern, `types/router.d.ts` added, TS6.0 deprecation fixed
- **GH#7391** — Icon-only button a11y audit: 31 SLM buttons + 4 main frontend buttons fixed with `aria-label` per WCAG 4.1.2

## Changes

### GH#7449 — SLM canonical alignment
- `autobot-slm-frontend/src/composables/useToast.ts` — canonical toast composable (matches main frontend)
- `autobot-slm-frontend/src/components/common/ToastContainer.vue` — global toast renderer, wired in `App.vue`
- `BackupsView.vue`, `ReplicationView.vue` — 6 `alert()` calls replaced with `showToast('...', 'error')`
- `router/index.ts` — `public: true` → `requiresAuth: false`; guard updated to match
- `types/router.d.ts` — typed `RouteMeta` (title, requiresAuth, parent, admin)
- `tsconfig.json` — `ignoreDeprecations: "6.0"` for TS6 baseUrl warning

### GH#7391 — Icon-only button a11y
- **SLM frontend (31 buttons, 18 files)**: close buttons (`aria-label="Close"`), error-dismiss buttons (`aria-label="Dismiss error"`), action buttons (refresh, add-tab, clear-terminal)
- **Main frontend (4 buttons)**: `App.vue` system-status close, `AgentRegistryView` agent-detail close, `KnowledgeResearchPanel` error-dismiss, `LLMPatternDashboard` refresh

## Test plan
- [ ] SLM frontend: toast appears on BackupsView restore error / ReplicationView start-replication error (replaces `alert()`)
- [ ] SLM login page still accessible (requiresAuth: false guard works)
- [ ] Screen reader audit: icon-only buttons announce correctly via aria-label
- [ ] Main frontend: no regression on close/dismiss/refresh buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)