### PR TITLE
fix(nginx): re-include security headers in /slm/index.html + document orchestration boundary (#7737, #7379)

### DIFF
--- a/autobot-backend/enhanced_orchestration/__init__.py
+++ b/autobot-backend/enhanced_orchestration/__init__.py
@@ -2,7 +2,18 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Enhanced Orchestration Package — re-exports only.
+Multi-Agent Coordination  (#7379 boundary)
+
+BOUNDARY: this package owns multi-agent coordination — strategy selection,
+agent routing, Redis pub/sub collaboration, and subagent dispatch.
+Use it when you need to COORDINATE multiple agents across a run.
+
+The sibling `orchestration/` package owns single-workflow execution primitives
+(DAG/graph execution, error handling, variable piping, causal recovery).
+New single-workflow primitives go there; new multi-agent coordination goes here.
+
+`AgentCapability` is defined canonically in `orchestration/types.py`; this
+package re-exports it for backwards compatibility (see import below).
 
 Issue #381: Extracted from enhanced_multi_agent_orchestrator.py god class refactoring.
 Issue #4048: EnhancedMultiAgentOrchestrator inlined here from orchestrator.py.
@@ -10,13 +21,15 @@ Issue #5040: EnhancedMultiAgentOrchestrator merged into the single Orchestrator 
              This package now re-exports types and sub-components only.
 
 Sub-modules:
-- types.py: Enums and dataclasses (AgentCapability, ExecutionStrategy, AgentTask, etc.)
+- types.py: Enums and dataclasses (ExecutionStrategy, AgentTask, AgentPerformance, etc.)
 - execution_strategies.py: Strategy implementations (sequential, parallel, pipeline, etc.)
-- workflow_planning.py: Workflow planning, building, and utilities
+- workflow_planning.py: Multi-agent strategy planning (StrategyPlanner)
+- workflow_runner.py: Multi-agent workflow execution engine (WorkflowRunner)
 - success_criteria.py: Structured success criteria evaluation
 - collaboration_coordinator.py: Redis pub/sub collaboration layer (#6393)
 - agent_router.py: Agent selection, resolution, capability coverage (#6393/#6392)
 - subagent_dispatcher.py: Autonomous subagent spawning for parallel workstreams (#6822)
+- blocked_plan_resumer.py: Recovery for stalled multi-agent plans
 """
 
 from orchestration.types import AgentCapability  # canonical definition (#6192)

--- a/autobot-backend/orchestration/__init__.py
+++ b/autobot-backend/orchestration/__init__.py
@@ -2,21 +2,35 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Orchestration Package
+Workflow Execution Primitives  (#7379 boundary)
+
+BOUNDARY: this package owns single-workflow execution building blocks.
+Use it when you need to BUILD or RUN a single workflow.
+
+The sibling `enhanced_orchestration/` package owns multi-agent coordination
+(strategy selection, agent routing, Redis pub/sub collaboration, subagent
+dispatch). New multi-agent features go there; new single-workflow primitives
+go here.
 
 Issue #381: Extracted from enhanced_orchestrator.py god class refactoring.
 Provides agent orchestration, workflow planning, and auto-documentation.
 
 This package contains:
-- types: Enums and dataclasses for orchestration
+- types: Enums and dataclasses for workflow plans, steps, and agents
 - agent_registry: Agent registration and management
-- workflow_planner: Workflow step planning and estimation
-- workflow_executor: Workflow execution with agent coordination
+- workflow_planner: Map capability requirements to available agents
+- workflow_executor: Execute a single workflow step by step
 - workflow_documentation: Auto-documentation and knowledge extraction
 - dag_executor: DAG-based execution with condition/branch routing (#2140)
-- error_handler: Step-level error handling and workflow checkpointing (#2154)
-- execution_modes: Dry-run validation and step-by-step debug mode (#2148)
+- graph_runner: Unified graph model (AutoBotGraph, GraphRunner) (#3228)
+- error_handler: Step-level error handling and checkpointing (#2154)
+- execution_modes: Dry-run validation and debug mode (#2148)
 - sub_workflow: Sub-workflow composition — workflows as reusable building blocks (#2143)
+- variable_resolver: Cross-step variable piping (#2141)
+- causal_executor / causal_error_recovery / causal_validator: Causal DAG
+  execution with automated error recovery (#5058)
+- workflow_memory: Per-run memory scoped to a workflow execution
+- performance_tracker: Timing and cost metrics for workflow runs (#5058)
 """
 
 from .agent_registry import AgentRegistry, get_default_agents

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2
@@ -370,7 +370,9 @@ server {
         try_files $uri $uri/ /slm/index.html;
 
         # Prevent index.html from being cached so new deployments are picked up
+        # #7737: child location replaces server-level add_header — re-include snippet
         location ~* /slm/index\.html$ {
+            include /etc/nginx/snippets/autobot-security-headers-strict.conf;
             add_header Cache-Control "no-cache, no-store, must-revalidate" always;
             add_header Pragma "no-cache" always;
         }


### PR DESCRIPTION
## Thinking Path

GH#7737: nginx child `location` blocks replace **all** parent `add_header` directives (not just for the matching path). The `/slm/index.html` sub-location had only `Cache-Control` and `Pragma` — CSP, X-Frame-Options, X-Content-Type-Options, etc. were silently absent. Fix: `include` the existing strict-headers snippet inside the child block, matching the pattern already used in the `/` and `/grafana/` locations.

GH#7379: Audited every module across both directories. The apparent "overlap" (same-named files) is at different abstraction levels — `workflow_planner` maps capabilities to agents while `workflow_planning` picks multi-agent strategies; `workflow_executor` runs a single workflow while `workflow_runner` coordinates multiple agents. The boundary is already respected in practice; only documentation was missing. Decision: split principled with `BOUNDARY:` docstrings in both `__init__.py` files, no migration needed.

## What Changed

- `autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2`: added `include /etc/nginx/snippets/autobot-security-headers-strict.conf;` as first directive inside the `location ~* /slm/index\.html$` block
- `autobot-backend/orchestration/__init__.py`: replaced vague module list with `BOUNDARY:` docstring — this package owns single-workflow execution primitives (DAG, graph runner, error handling, causal recovery, variable piping, memory)
- `autobot-backend/enhanced_orchestration/__init__.py`: added matching `BOUNDARY:` docstring — this package owns multi-agent coordination (strategy selection, agent routing, Redis pub/sub collaboration, subagent dispatch)

Closes #7737
Closes #7379

## Verification

- `python3 -m py_compile autobot-backend/orchestration/__init__.py autobot-backend/enhanced_orchestration/__init__.py` → `Syntax OK`
- nginx change is template-only (Ansible deploys); pattern identical to the `/` location block at line 386 which already carries the include + `always` headers
- No callers changed — docstring-only update to both `__init__.py` files

## Model Used

claude-sonnet-4-6