### PR TITLE
feat(frontend): useNotificationBus wire-in + GH#7741 + GH#7434 already resolved

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
+++ b/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
@@ -212,13 +212,13 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 // @ts-ignore - Component may not have type declarations
 import BaseButton from '@/components/base/BaseButton.vue'
-import { useToast } from '@/composables/useToast'
+import { useNotificationBus } from '@/composables/useNotificationBus'
 import { useCodeEvolutionData } from '@/composables/analytics/useCodeEvolutionData'
 import type { TimelinePoint, TrendData, PatternPoint } from '@/composables/analytics/useCodeEvolutionData'
 
 const { t } = useI18n()
 
-const { showToast } = useToast()
+const { showToast } = useNotificationBus()
 const { fetchTimeline: apiFetchTimeline, fetchTrends: apiFetchTrends, fetchPatterns: apiFetchPatterns, fetchExport: apiFetchExport } = useCodeEvolutionData()
 
 // State

--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -350,7 +350,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { useToast } from '@/composables/useToast'
+import { useNotificationBus } from '@/composables/useNotificationBus'
 import { useGroupingMemo, useAggregationMemo } from '@/composables/useComputedMemo'
 import api from '@/services/api'
 import { createLogger } from '@/utils/debugUtils'
@@ -415,7 +415,7 @@ interface Pattern {
 }
 
 // State
-const { showToast } = useToast()
+const { showToast } = useNotificationBus()
 const loading = ref(false)
 const hasAnalyzed = ref(false)
 const selectedPath = ref('')

--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -446,7 +446,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import PatternAnalysis from '@/components/analytics/PatternAnalysis.vue'
-import { useToast } from '@/composables/useToast'
+import { useNotificationBus } from '@/composables/useNotificationBus'
 import { getCssVar } from '@/composables/useCssVars'
 import { useCodebaseExport, type SectionType } from '@/composables/analytics/useCodebaseExport'
 import type { ScanDefinition } from '@/composables/useAnalyticsScanRunner'
@@ -500,7 +500,7 @@ const isEvolutionTabActive = computed(() => route.path.endsWith('/evolution'))
 const isCodeGenerationTabActive = computed(() => route.path.includes('/code-generation'))
 
 // Toast notifications
-const { showToast } = useToast()
+const { showToast } = useNotificationBus()
 
 // Notification helper
 const notify = (message: string, type: 'info' | 'success' | 'warning' | 'error' = 'info') => {

--- a/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
@@ -354,7 +354,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useToast } from '@/composables/useToast'
+import { useNotificationBus } from '@/composables/useNotificationBus'
 import api from '@/services/api'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
@@ -414,7 +414,7 @@ interface Hotspot {
 }
 
 // State
-const { showToast } = useToast()
+const { showToast } = useNotificationBus()
 const loading = ref(false)
 const selectedPath = ref('')
 const lastResult = ref<AnalysisResult | null>(null)

--- a/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
@@ -294,7 +294,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useToast } from '@/composables/useToast'
+import { useNotificationBus } from '@/composables/useNotificationBus'
 import { useExpansion } from '@/composables/useExpansion'
 import api from '@/services/api'
 import { createLogger } from '@/utils/debugUtils'
@@ -362,7 +362,7 @@ interface Summary {
 }
 
 // State
-const { showToast } = useToast()
+const { showToast } = useNotificationBus()
 const installing = ref(false)
 const checking = ref(false)
 const hookStatus = ref<HookStatus>({ installed: false })

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -280,7 +280,7 @@ import { useVoiceConversation } from '@/composables/useVoiceConversation'
 import { useChatStore } from '@/stores/useChatStore'
 import { useChatController } from '@/models/controllers'
 import { useAppStore } from '@/stores/useAppStore'
-import { useToast } from '@/composables/useToast'
+import { useNotificationBus } from '@/composables/useNotificationBus'
 import { usePreferences } from '@/composables/usePreferences'
 import { useOverseerAgent } from '@/composables/useOverseerAgent'
 import ApiClient from '@/utils/ApiClient'
@@ -439,7 +439,7 @@ function closeVoicePanel(): void {
 }
 
 // Toast notifications
-const { showToast } = useToast()
+const { showToast } = useNotificationBus()
 const notify = (message: string, type: 'info' | 'success' | 'warning' | 'error' = 'info') => {
   showToast(message, type, type === 'error' ? 0 : type === 'warning' ? 6000 : 4000)
 }

--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -329,7 +329,7 @@ import EmptyState from '@/components/ui/EmptyState.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import BaseModal from '@/components/ui/BaseModal.vue'
 import { createLogger } from '@/utils/debugUtils'
-import { useToast } from '@/composables/useToast'
+import { useNotificationBus } from '@/composables/useNotificationBus'
 
 const logger = createLogger('ChatSidebar')
 
@@ -436,7 +436,7 @@ const showShareDialog = ref(false)
 const shareTargetSessionId = ref<string | null>(null)
 
 // Toast for notifications (Issue #547)
-const { showToast } = useToast()
+const { showToast } = useNotificationBus()
 
 // Display settings configuration (UI labels)
 const displaySettingsConfig = computed(() => [

--- a/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
@@ -256,7 +256,7 @@
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useToast } from '@/composables/useToast';
+import { useNotificationBus } from '@/composables/useNotificationBus';
 import { useBatchSelection } from '@/composables/useBatchSelection';
 import { apiService } from '@/services/api';
 import { getApiBase } from '@/config/ssot-config';
@@ -289,7 +289,7 @@ const props = defineProps({
 const emit = defineEmits(['close', 'decisions-applied', 'chat-compiled']);
 
 // Composables
-const { showToast } = useToast();
+const { showToast } = useNotificationBus();
 
 // Reactive data
 const pendingItems = ref([]);

--- a/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.vue
@@ -78,7 +78,7 @@ Issue #4273: Wire orphaned components EnforcementModeSelector, FlagChangeHistory
 import { ref, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { createLogger } from '@/utils/debugUtils';
-import { useToast } from '@/composables/useToast';
+import { useNotificationBus } from '@/composables/useNotificationBus';
 import featureFlagsApiClient, {
   type EnforcementMode,
   type FeatureFlagsStatus,
@@ -92,7 +92,7 @@ import LoadingSpinner from '@/components/ui/LoadingSpinner.vue';
 
 const logger = createLogger('FeatureFlagsSettingsPanel');
 const { t } = useI18n();
-const { showToast } = useToast();
+const { showToast } = useNotificationBus();
 
 // State
 const loading = ref(false);

--- a/autobot-frontend/src/components/settings/SettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/SettingsPanel.vue
@@ -77,7 +77,7 @@ const { t } = useI18n()
 
 // Import error handling composables
 import { useAsyncHandler } from '@/composables/useErrorHandler'
-import { useToast } from '@/composables/useToast'
+import { useNotificationBus } from '@/composables/useNotificationBus'
 
 // Import sub-components
 import ErrorBoundary from '../common/ErrorBoundary.vue'
@@ -140,7 +140,7 @@ const cacheActivity = ref<CacheActivityItem[]>([])
 const cacheStats = ref<CacheStats | null>(null)
 
 // Toast notifications
-const { showToast } = useToast()
+const { showToast } = useNotificationBus()
 
 // Notification helper for useAsyncHandler
 const notify = (message: string, type: 'success' | 'error' | 'info') => {

--- a/autobot-frontend/src/components/vision/GUIAutomationControls.vue
+++ b/autobot-frontend/src/components/vision/GUIAutomationControls.vue
@@ -161,7 +161,7 @@
 import { ref, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { createLogger } from '@/utils/debugUtils';
-import { useToast } from '@/composables/useToast';
+import { useNotificationBus } from '@/composables/useNotificationBus';
 import {
   visionMultimodalApiClient,
   type AutomationOpportunity,
@@ -171,7 +171,7 @@ import {
 
 const { t } = useI18n();
 const logger = createLogger('GUIAutomationControls');
-const { showToast } = useToast();
+const { showToast } = useNotificationBus();
 
 // Props
 const props = defineProps<{

--- a/autobot-frontend/src/components/vision/MediaGallery.vue
+++ b/autobot-frontend/src/components/vision/MediaGallery.vue
@@ -176,12 +176,12 @@
 <script setup lang="ts">
 import { ref, computed, onUnmounted } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useToast } from '@/composables/useToast';
+import { useNotificationBus } from '@/composables/useNotificationBus';
 import { useThumbnailWorker } from '@/composables/useThumbnailWorker';
 import type { GalleryItem } from '@/utils/VisionMultimodalApiClient';
 
 const { t } = useI18n();
-const { showToast } = useToast();
+const { showToast } = useNotificationBus();
 const { revokeBlobUrl } = useThumbnailWorker();
 
 // Props

--- a/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
+++ b/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
@@ -202,7 +202,7 @@
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { createLogger } from '@/utils/debugUtils';
-import { useToast } from '@/composables/useToast';
+import { useNotificationBus } from '@/composables/useNotificationBus';
 import { usePollingJob } from '@/composables/usePollingJob';
 import {
   visionMultimodalApiClient,
@@ -213,7 +213,7 @@ import {
 
 const { t } = useI18n();
 const logger = createLogger('ScreenCaptureViewer');
-const { showToast } = useToast();
+const { showToast } = useNotificationBus();
 
 // Emits
 const emit = defineEmits<{

--- a/autobot-frontend/src/components/vision/VideoProcessor.vue
+++ b/autobot-frontend/src/components/vision/VideoProcessor.vue
@@ -194,7 +194,7 @@
 import { ref, computed, onUnmounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { createLogger } from '@/utils/debugUtils';
-import { useToast } from '@/composables/useToast';
+import { useNotificationBus } from '@/composables/useNotificationBus';
 import { useThumbnailWorker } from '@/composables/useThumbnailWorker';
 import {
   visionMultimodalApiClient,
@@ -209,7 +209,7 @@ interface FrameResult extends MultiModalResponse {
 
 const { t } = useI18n();
 const logger = createLogger('VideoProcessor');
-const { showToast } = useToast();
+const { showToast } = useNotificationBus();
 const { generateThumbnail, isSupported: isWorkerSupported } = useThumbnailWorker();
 
 // Emits

--- a/autobot-frontend/src/composables/useCommandApproval.ts
+++ b/autobot-frontend/src/composables/useCommandApproval.ts
@@ -19,7 +19,7 @@ import { ref } from 'vue'
 import appConfig from '@/config/AppConfig.js'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import apiClient from '@/utils/ApiClient'
-import { useToast } from '@/composables/useToast'
+import { useNotificationBus } from '@/composables/useNotificationBus'
 import { createLogger } from '@/utils/debugUtils'
 import { useChatStore } from '@/stores/useChatStore'
 import { usePermissionStore } from '@/stores/usePermissionStore'
@@ -54,7 +54,7 @@ export interface ApprovalResponse {
 }
 
 export function useCommandApproval() {
-  const { showToast } = useToast()
+  const { showToast } = useNotificationBus()
   const chatStore = useChatStore()
   const permissionStore = usePermissionStore()
 

--- a/autobot-frontend/src/composables/useNotificationBus.ts
+++ b/autobot-frontend/src/composables/useNotificationBus.ts
@@ -1,0 +1,35 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Canonical notification bus composable.
+ *
+ * Provides typed convenience methods for component-level notifications.
+ * All components should import this instead of useToast directly.
+ * The underlying transport is useToast; notificationBridge wraps this for
+ * non-Vue (class/utility) callers.
+ *
+ * Usage:
+ * ```typescript
+ * const { success, error, warning, info, showToast } = useNotificationBus()
+ * success('Saved')
+ * error('Upload failed')
+ * showToast('Custom duration', 'info', 2000)
+ * ```
+ */
+
+import { useToast } from '@/composables/useToast'
+export type { ToastType } from '@/composables/useToast'
+
+export function useNotificationBus() {
+  const { showToast } = useToast()
+
+  return {
+    showToast,
+    success: (message: string, duration?: number) => showToast(message, 'success', duration),
+    error: (message: string, duration?: number) => showToast(message, 'error', duration),
+    warning: (message: string, duration?: number) => showToast(message, 'warning', duration),
+    info: (message: string, duration?: number) => showToast(message, 'info', duration),
+  }
+}

--- a/autobot-frontend/src/views/SettingsView.vue
+++ b/autobot-frontend/src/views/SettingsView.vue
@@ -240,12 +240,12 @@ import Icon from '@/components/ui/Icon.vue'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
-import { useToast } from '@/composables/useToast'
+import { useNotificationBus } from '@/composables/useNotificationBus'
 import apiClient from '@/utils/ApiClient'
 
 const logger = createLogger('SettingsView')
 const { t } = useI18n()
-const { showToast } = useToast()
+const { showToast } = useNotificationBus()
 
 logger.debug('Settings view initialized')
 

--- a/autobot-frontend/src/views/WorkflowBuilderView.vue
+++ b/autobot-frontend/src/views/WorkflowBuilderView.vue
@@ -657,7 +657,7 @@ import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { createLogger } from '@/utils/debugUtils';
-import { useToast } from '@/composables/useToast';
+import { useNotificationBus } from '@/composables/useNotificationBus';
 import {
   useWorkflowBuilder,
   type WorkflowNode,
@@ -691,7 +691,7 @@ const route = useRoute();
 
 /** True when a child route (e.g. /automation/browser-automation) is active (#2368) */
 const isChildRoute = computed(() => route.matched.length > 1);
-const { showToast } = useToast();
+const { showToast } = useNotificationBus();
 
 // Section Types
 type SectionType =


### PR DESCRIPTION
## Summary

- **GH#7741**: Create canonical `useNotificationBus` composable and wire it into all 17 components that previously imported `useToast` directly
- **GH#7434**: Already resolved in commit `9ff5b36` (Storybook `waitFor({state:visible})` → `waitForFunction(sb-show-main)`)

## Thinking Path

GH#7741 calls for a canonical notification composable (`useNotificationBus`) to be created and wired into consuming components. The existing `useToast` composable is the underlying transport; `useNotificationBus` wraps it with typed convenience methods (`success`/`error`/`warning`/`info`) while preserving a `showToast` passthrough for callers that need custom duration. The migration is a mechanical import swap in 17 files — no call-site changes needed since `showToast` remains the same function. `ToastContainer.vue` and `notificationBridge.ts` are excluded: they are the rendering layer and non-Vue bridge respectively.

GH#7434 (Storybook `#storybook-root waitFor timeout`) was already fixed in commit `9ff5b36` as part of GH#7410 by replacing `root.waitFor({state:'visible'})` with `waitForFunction(() => document.body.classList.contains('sb-show-main'))`.

## What Changed

- **New**: `autobot-frontend/src/composables/useNotificationBus.ts` — canonical composable wrapping `useToast`, exposing `success`/`error`/`warning`/`info` convenience methods and `showToast` passthrough
- **Modified (17 files)**: Import changed from `useToast` → `useNotificationBus`, instantiation from `useToast()` → `useNotificationBus()`:
  - `src/views/SettingsView.vue`
  - `src/views/WorkflowBuilderView.vue`
  - `src/composables/useCommandApproval.ts`
  - `src/components/settings/FeatureFlagsSettingsPanel.vue`
  - `src/components/settings/SettingsPanel.vue`
  - `src/components/knowledge/KnowledgePersistenceDialog.vue`
  - `src/components/analytics/PerformanceAnalysisDashboard.vue`
  - `src/components/analytics/CodeReviewDashboard.vue`
  - `src/components/analytics/PrecommitHookDashboard.vue`
  - `src/components/analytics/CodebaseAnalytics.vue`
  - `src/components/analytics/CodeEvolutionTimeline.vue`
  - `src/components/chat/ChatSidebar.vue`
  - `src/components/chat/ChatInterface.vue`
  - `src/components/vision/GUIAutomationControls.vue`
  - `src/components/vision/VideoProcessor.vue`
  - `src/components/vision/MediaGallery.vue`
  - `src/components/vision/ScreenCaptureViewer.vue`

## Verification

- `vue-tsc --noEmit -p tsconfig.app.json`: 87 pre-existing errors, **0 new errors** introduced
- `grep -r "import { useToast }"` on non-rendering files: only `useNotificationBus.ts` itself remains (correct)
- 18 files reference `useNotificationBus` (composable definition + 17 consumers)
- GH#7434 fix confirmed: `storybook-stories.spec.ts` line 69-72 uses `waitForFunction(sb-show-main)` — not the old `waitFor({state:visible})`

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Test plan

- [ ] `vue-tsc --noEmit` passes with no new errors (verified locally)
- [ ] No remaining direct `useToast` imports in non-rendering component files
- [ ] Storybook visual regression CI passes (GH#7434 fix already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)