### PR TITLE
ci(hardening): pipefail + concurrency + actionlint (GH#7071, GH#7074, GH#7083)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,19 @@
+name: actionlint
+
+on:
+  push:
+    branches: [main, Dev_new_gui]
+    paths: [".github/workflows/**"]
+  pull_request:
+    paths: [".github/workflows/**"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca  # v1.7.12

--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -16,6 +16,10 @@ on:
     types: [closed]
     branches: [Dev_new_gui]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   notify-issues:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/autoresearch-image.yml
+++ b/.github/workflows/autoresearch-image.yml
@@ -10,6 +10,10 @@ on:
       - Dev_new_gui
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -26,6 +26,10 @@ on:
         type: boolean
         default: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/branch-health-report.yml
+++ b/.github/workflows/branch-health-report.yml
@@ -19,6 +19,10 @@ on:
     - cron: '0 5 1 * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   generate-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,6 +15,10 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -129,7 +129,9 @@ jobs:
       # currently scores ~22% against stale criteria; gating on it would
       # block every merge for reasons unrelated to the change under review.
       continue-on-error: true
+      shell: bash
       run: |
+        set -euo pipefail
         echo "Checking phase validation gate..."
 
         # Extract overall maturity from results
@@ -238,7 +240,9 @@ jobs:
     - name: Integration readiness check
       # Non-blocking until #7496 — same reason as Phase Validation Gate.
       continue-on-error: true
+      shell: bash
       run: |
+        set -euo pipefail
         echo "Checking integration readiness..."
 
         # Check if validation results indicate system is ready for integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale-branches-warning.yml
+++ b/.github/workflows/stale-branches-warning.yml
@@ -18,6 +18,10 @@ on:
     - cron: '0 3 * * 1'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   detect-stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -16,6 +16,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/unwired-tracker-audit.yml
+++ b/.github/workflows/unwired-tracker-audit.yml
@@ -55,7 +55,9 @@ jobs:
 
       - name: Run audit (dry-run, JSON output)
         id: scan
+        shell: bash
         run: |
+          set -euo pipefail
           python3 pipeline-scripts/audit-unwired-trackers.py --json > findings.json || true
           count=$(jq 'length' findings.json)
           echo "count=${count}" >> "$GITHUB_OUTPUT"
@@ -82,9 +84,11 @@ jobs:
 
       - name: Summary
         if: always()
+        shell: bash
         env:
           FINDING_COUNT: ${{ steps.scan.outputs.count }}
         run: |
+          set -euo pipefail
           {
             echo "### Unwired Tracker Audit"
             echo ""

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -375,6 +375,12 @@ repos:
         stages: [pre-commit]
         description: "Blocks new ad-hoc *Status(Enum) declarations outside autobot_shared/status_enums.py; lifecycle-shaped enums must use canonical TaskStatus/JobStatus/WorkflowStatus aliases"
 
+  # Lint GitHub Actions workflow files with actionlint (Issue #7083)
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
   # No tag-pinned 3rd-party GitHub Actions (Issue #7120, preventive for #7091)
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary

CI hardening batch closing 3 issues:

- **GH#7071** — `set -euo pipefail` added to 4 unguarded piped `run:` blocks across 2 workflows
- **GH#7074** — `concurrency:` blocks added to all 9 identified workflows
- **GH#7083** — `actionlint` integrated as both a CI workflow and pre-commit hook

## Changes

### GH#7071 — pipefail (4 blocks, 2 files)

`unwired-tracker-audit.yml`:
- **Run audit (dry-run, JSON output)** — `jq | head -50` now guarded
- **Summary** — `jq | head -50` now guarded

`phase_validation.yml`:
- **Phase Validation Gate** — `bc -l` pipe now guarded (continue-on-error:true preserved)
- **Integration readiness check** — `bc -l` pipe now guarded (continue-on-error:true preserved)

### GH#7074 — concurrency (9 workflows)

| Workflow | Trigger | cancel-in-progress |
|---|---|---|
| `auto-close-issues.yml` | pull_request | `true` (per-PR slot) |
| `issue-triage.yml` | issues | `true` (per-issue slot) |
| `autoresearch-image.yml` | push (path-filtered) | `true` (newer push supersedes) |
| `branch-health-report.yml` | schedule | `false` (must run to completion) |
| `dependabot-auto-merge.yml` | schedule | `false` (must run to completion) |
| `sync-main-to-dev.yml` | workflow_dispatch | `false` (manual release, never cancel) |
| `stale-branches-warning.yml` | schedule | `false` (must run to completion) |
| `branch-cleanup.yml` | schedule | `false` (must run to completion) |
| `release.yml` | push to main | `false` (release must complete) |

### GH#7083 — actionlint

- `.github/workflows/actionlint.yml` — SHA-pinned `rhysd/actionlint@914e7df` (v1.7.12), triggers on `push`/`pull_request` for `.github/workflows/**`
- `.pre-commit-config.yaml` — `rhysd/actionlint` hook at `rev: v1.7.12`

## Test plan

- [ ] CI passes on this PR (actionlint itself validates all modified workflows)
- [ ] No new lint/CI errors from the concurrency blocks
- [ ] `set -euo pipefail` blocks verified by inspecting diffs

Closes GH#7071, GH#7074, GH#7083

🤖 Generated with [Claude Code](https://claude.com/claude-code)