### PR TITLE
fix(npu-worker): correct root() return type Dict[str,str] → Dict[str,Any] (MVA-342)

### DIFF
--- a/autobot-slm-backend/ansible/roles/npu-worker/templates/npu-worker.py.j2
+++ b/autobot-slm-backend/ansible/roles/npu-worker/templates/npu-worker.py.j2
@@ -87,7 +87,7 @@ async def health_check() -> JSONResponse:
 
 
 @app.get("/")
-async def root() -> Dict[str, str]:
+async def root() -> Dict[str, Any]:
     """Root endpoint."""
     return {
         "service": "AutoBot NPU Worker",


### PR DESCRIPTION
## Thinking Path

`root()` in `npu-worker.py.j2` has `endpoints: list[str]` in its return dict but was typed as `Dict[str, str]`. FastAPI/Pydantic validates the response against the annotation, so it rejected the `list` value with `string_type` error. `Dict[str, Any]` is the correct annotation for a heterogeneous response dict. `Any` was already imported.

## What Changed

- `autobot-slm-backend/ansible/roles/npu-worker/templates/npu-worker.py.j2` line 90: `Dict[str, str]` → `Dict[str, Any]`

## Verification

Deploy NPU worker via Ansible playbook and run:
```bash
curl http://localhost:8081/
```
Expected: 200 JSON response with no `ResponseValidationError` in `/var/log/autobot/npu-worker-error.log`.

## Risks

None identified — annotation-only change, no runtime logic modified.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Closes MVA-342

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason) — N/A: Jinja2 template, no unit test
- [x] Documentation updated if behavior changed — N/A: annotation fix
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff