### PR TITLE
fix(chromadb): canonical provenance keys in DocIndexerService + create_collection injection (GH#7761, GH#7762)

### DIFF
--- a/autobot-backend/knowledge/backends/async_chromadb_adapter.py
+++ b/autobot-backend/knowledge/backends/async_chromadb_adapter.py
@@ -201,10 +201,15 @@ class AsyncChromaDBClient(AsyncBaseClient):
         metadata: Optional[Metadata] = None,
         embedding_function: Optional[Any] = None,
     ) -> AsyncBaseCollection:
+        from datetime import datetime, timezone
+
+        provenance: dict = {"created_at": datetime.now(timezone.utc).isoformat()}
+        if metadata:
+            provenance.update(metadata)
         try:
             raw_col = await self._raw.create_collection(
                 name=name,
-                metadata=metadata,
+                metadata=provenance,
                 embedding_function=embedding_function,
             )
         except Exception as exc:

--- a/autobot-backend/knowledge/backends/chromadb_adapter.py
+++ b/autobot-backend/knowledge/backends/chromadb_adapter.py
@@ -210,9 +210,12 @@ class ChromaDBClient(BaseClient):
         metadata: Optional[Metadata] = None,
         embedding_function: Optional[Any] = None,
     ) -> BaseCollection:
-        kwargs: dict = {"name": name}
-        if metadata is not None:
-            kwargs["metadata"] = metadata
+        from datetime import datetime, timezone
+
+        provenance: dict = {"created_at": datetime.now(timezone.utc).isoformat()}
+        if metadata:
+            provenance.update(metadata)
+        kwargs: dict = {"name": name, "metadata": provenance}
         if embedding_function is not None:
             kwargs["embedding_function"] = embedding_function
         try:

--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -672,6 +672,10 @@ class DocIndexerService:
 
             from llama_index.embeddings.ollama import OllamaEmbedding
 
+            from autobot_shared.embedding_provenance import (
+                EmbeddingProvenance,
+                provenance_to_metadata,
+            )
             from knowledge.backends import get_default_client
 
             chromadb_path = self._root_dir / "data" / "chromadb"
@@ -703,13 +707,14 @@ class DocIndexerService:
             }
             embed_dim = _KNOWN_DIMS.get(embed_model_name)
 
+            provenance_meta = (
+                provenance_to_metadata(EmbeddingProvenance(embed_model_name, embed_dim))
+                if embed_dim is not None
+                else {}
+            )
             self._collection = self._client.get_or_create_collection(
                 name=self.COLLECTION_NAME,
-                metadata={
-                    "hnsw:space": "cosine",
-                    "embedding_model": embed_model_name,
-                    **({"embedding_dim": embed_dim} if embed_dim is not None else {}),
-                },
+                metadata={"hnsw:space": "cosine", **provenance_meta},
             )
 
             self._embed_model = OllamaEmbedding(model_name=embed_model_name, base_url=ollama_url)


### PR DESCRIPTION
## Summary

- **GH#7761**: Fix `doc_indexer.py` to use `provenance_to_metadata(EmbeddingProvenance(...))` instead of bare `embedding_model`/`embedding_dim` keys, so the mismatch guard in `async_chromadb_client.py` actually fires for DocIndexerService collections
- **GH#7762**: Apply `created_at` provenance injection to `create_collection()` in both `chromadb_adapter.py` and `async_chromadb_adapter.py`, matching what `get_or_create_collection()` already does — closes the 4 code paths that used `create_collection` directly without any provenance metadata

## Changes

| File | Change |
|------|--------|
| `autobot-backend/services/knowledge/doc_indexer.py` | Replace bare dict keys with `provenance_to_metadata(EmbeddingProvenance(...))`, skip provenance for unknown models (embed_dim is None) |
| `autobot-backend/knowledge/backends/chromadb_adapter.py` | Add `created_at` provenance injection to `create_collection()` |
| `autobot-backend/knowledge/backends/async_chromadb_adapter.py` | Add `created_at` provenance injection to `create_collection()` |

## Root Cause

PR #7756 tagged ChromaDB collections with provenance metadata but:
1. Used bare `embedding_model`/`embedding_dim` keys that the guard (`provenance_from_metadata()`) doesn't recognise — it reads `autobot.embedding_provenance.*` keys (GH#7761)
2. Left `create_collection()` as a plain pass-through with no provenance injection while `get_or_create_collection()` had it (GH#7762)

## Test Plan

- [ ] `doc_indexer.py` `initialize()` now tags collection with `autobot.embedding_provenance.model_name` and `autobot.embedding_provenance.dim` keys
- [ ] `create_collection()` in both adapters injects `created_at` matching `get_or_create_collection()` behaviour
- [ ] Unknown embedding models (embed_dim is None) correctly skip provenance tagging — consistent with opt-in design from PR #7429
- [ ] Syntax check passes on all 3 modified files
- [ ] No call-site breakage (no symbols removed)

Closes #7761
Closes #7762

🤖 Generated with [Claude Code](https://claude.com/claude-code)