### PR TITLE
fix(celery): import knowledge_tasks and memory_tasks in tasks/__init__.py (MVA-341)

### DIFF
--- a/autobot-backend/tasks/__init__.py
+++ b/autobot-backend/tasks/__init__.py
@@ -10,10 +10,39 @@ Note: Deployment tasks removed - now managed by SLM server (#729)
 System tasks (RBAC, updates) maintained as stubs for backward compatibility.
 """
 
+from .knowledge_tasks import (
+    cleanup_generated_files,
+    cleanup_orphan_documents,
+    full_man_page_index,
+    prune_sync_queue_done,
+    reindex_knowledge_base,
+    refresh_system_knowledge,
+    scan_man_page_changes,
+)
+from .memory_tasks import (
+    compact_snapshot_task,
+    extract_facts_task,
+    update_graph_task,
+    write_verbatim_task,
+)
 from .system_tasks import check_available_updates, initialize_rbac, run_system_update
 
 __all__ = [
+    # system tasks
     "initialize_rbac",
     "run_system_update",
     "check_available_updates",
+    # knowledge tasks
+    "refresh_system_knowledge",
+    "reindex_knowledge_base",
+    "scan_man_page_changes",
+    "full_man_page_index",
+    "cleanup_orphan_documents",
+    "cleanup_generated_files",
+    "prune_sync_queue_done",
+    # memory tasks
+    "write_verbatim_task",
+    "extract_facts_task",
+    "update_graph_task",
+    "compact_snapshot_task",
 ]


### PR DESCRIPTION
## Thinking Path

Celery workers build their task registry by executing `@celery_app.task` decorators at import time. `tasks/__init__.py` only imported `system_tasks`, so the 7 tasks in `knowledge_tasks.py` and 4 tasks in `memory_tasks.py` were never decorated, leaving them absent from every worker's `celery.app.tasks` dict. Beat sent `tasks.prune_sync_queue_done` on schedule; every worker responded with `KeyError` because it had no record of that task name.

Fix: explicitly import all task functions from both modules. Their `@celery_app.task` decorators fire at import time, registering them in the worker registry before Beat fires.

## What Changed

- `autobot-backend/tasks/__init__.py`: added imports from `.knowledge_tasks` (7 tasks) and `.memory_tasks` (4 tasks); added all 14 task names to `__all__`

## Verification

After deployment:
```bash
# On any celery worker node
celery -A celery_app inspect registered | grep prune_sync_queue_done
# Expected: tasks.prune_sync_queue_done appears in output

# After the next Beat fire interval, confirm no new KeyError in:
tail /var/log/autobot/celery-error.log | grep prune_sync_queue_done
```

## Risks

None — import-only change. The `@celery_app.task` decorators were already correct; they just weren't triggered at worker startup.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Closes MVA-341

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated — N/A: fix is an import, verified by existing task module tests
- [x] Documentation updated if behavior changed — N/A
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff