### PR TITLE
ci: add cache-dependency-path to Python/Node setup + no-literal-ttl-seconds pre-commit hook (GH#7073, GH#7080)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       with:
         python-version: '3.12'
         cache: 'pip'
+        cache-dependency-path: |
+          requirements*.txt
+          autobot-backend/requirements*.txt
 
     - name: Install Python dependencies
       run: |
@@ -242,6 +245,9 @@ jobs:
       with:
         python-version: '3.12'
         cache: 'pip'
+        cache-dependency-path: |
+          requirements*.txt
+          autobot-backend/requirements*.txt
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -45,6 +45,9 @@ jobs:
       with:
         python-version: '3.12'
         cache: 'pip'
+        cache-dependency-path: |
+          requirements*.txt
+          autobot-backend/requirements*.txt
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -47,6 +47,9 @@ jobs:
       with:
         python-version: '3.12'
         cache: 'pip'
+        cache-dependency-path: |
+          requirements*.txt
+          autobot-backend/requirements*.txt
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -67,6 +67,9 @@ jobs:
       with:
         python-version: '3.12'
         cache: 'pip'
+        cache-dependency-path: |
+          requirements*.txt
+          autobot-backend/requirements*.txt
 
     - name: Install Python dependencies
       run: |
@@ -141,6 +144,9 @@ jobs:
       with:
         python-version: '3.12'
         cache: 'pip'
+        cache-dependency-path: |
+          requirements*.txt
+          autobot-backend/requirements*.txt
 
     - name: Install SAST tools
       run: |

--- a/.github/workflows/startup-import-smoke.yml
+++ b/.github/workflows/startup-import-smoke.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          cache-dependency-path: |
+            requirements*.txt
+            autobot-backend/requirements*.txt
 
       - name: Install backend dependencies
         # #6947: pipefail required so pip install failures surface (was masked by `| tail -5`).

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -74,6 +74,8 @@ jobs:
         uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: autobot-frontend/package-lock.json
 
       - name: Install dependencies
         working-directory: autobot-frontend

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,6 +113,24 @@ repos:
         stages: [pre-commit]
         description: "patch('src.…') silently no-ops — autobot-backend has no src/ package"
 
+  # AutoBot custom: regression-prevention for #6743 (chat-session TTL drift).
+  # The root cause was a literal `3600` in setex() with no env-var knob.
+  # This hook blocks any new literal integer/float in the TTL position of
+  # Redis calls (setex, expire, pexpire) and Cache.set(ttl=N).
+  # Use named constants from autobot_shared.ssot_constants (TTL_1_HOUR, etc.).
+  # Allowlist: autobot-backend/constants/ttl_constants.py and
+  # autobot_shared/ssot_constants.py (where the constants live).
+  - repo: local
+    hooks:
+      - id: no-literal-ttl-seconds
+        name: Ban literal TTL seconds in Redis calls (#6743 / #7080)
+        entry: pipeline-scripts/check_no_literal_ttl_seconds.py
+        language: python
+        files: \.py$
+        exclude: ^(autobot-backend/constants/ttl_constants\.py|autobot_shared/ssot_constants.*\.py)$
+        stages: [pre-commit]
+        description: "Use TTL_* named constants from autobot_shared.ssot_constants instead of literal ints in setex/expire/pexpire/Cache.set(ttl=)"
+
   # AutoBot custom: regression-prevention for #7150 git safe.directory migration.
   # When code_source/ is owned by `autobot` (cloned by install.sh) and the
   # Ansible playbook runs as root via sudo, git 2.35+ aborts read-only

--- a/autobot-backend/api/ide_integration.py
+++ b/autobot-backend/api/ide_integration.py
@@ -56,6 +56,7 @@ from api.schemas_code import (
 from api.system_health import ComponentHealth, register_health_probe
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.ssot_constants import TTL_10_SECONDS
 from autobot_shared.singleton_factory import lazy_optional_singleton, lazy_singleton
 from models.completion_context import CompletionContext
 from services.context_analyzer import ContextAnalyzer
@@ -744,7 +745,7 @@ class IDEIntegrationEngine:
         completions = self._rank_completions(completions, context)
         completions = completions[: request.max_completions]
 
-        _get_redis_client().setex(cache_key, 10, json.dumps([c.model_dump() for c in completions]))
+        _get_redis_client().setex(cache_key, TTL_10_SECONDS, json.dumps([c.model_dump() for c in completions]))
         elapsed_ms = (_time.time() - start_time) * 1000
         return CompletionResponse(
             completions=completions,

--- a/autobot-backend/code_analysis/src/architectural_pattern_analyzer.py
+++ b/autobot-backend/code_analysis/src/architectural_pattern_analyzer.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List
 from autobot_shared.logging_manager import get_logger
 
 from autobot_shared.async_compat import run_or_schedule
+from autobot_shared.ssot_constants import TTL_1_HOUR
 
 # Issue #394: Import from architectural_analysis package
 from .architectural_analysis import (
@@ -177,7 +178,7 @@ class ArchitecturalPatternAnalyzer:
             try:
                 key = self.ARCHITECTURE_KEY
                 value = json.dumps(results, default=str)
-                await self.redis_client.setex(key, 3600, value)
+                await self.redis_client.setex(key, TTL_1_HOUR, value)
             except Exception as e:
                 logger.warning(f"Failed to cache results: {e}")
 

--- a/autobot-backend/code_analysis/src/code_quality_dashboard.py
+++ b/autobot-backend/code_analysis/src/code_quality_dashboard.py
@@ -22,6 +22,7 @@ from security_analyzer import SecurityAnalyzer
 from testing_coverage_analyzer import TestingCoverageAnalyzer
 
 from autobot_shared.async_compat import run_or_schedule
+from autobot_shared.ssot_constants import TTL_1_HOUR
 from constants.ttl_constants import TTL_30_DAYS
 
 logger = get_logger(__name__)
@@ -726,7 +727,7 @@ class CodeQualityDashboard:
         await self._ensure_redis()
         if self.redis_client:
             try:
-                await self.redis_client.setex(self.DASHBOARD_KEY, 3600, json.dumps(report, default=str))  # 1 hour
+                await self.redis_client.setex(self.DASHBOARD_KEY, TTL_1_HOUR, json.dumps(report, default=str))  # 1 hour
             except Exception as e:
                 logger.warning(f"Failed to cache dashboard report: {e}")
 

--- a/autobot-backend/code_analysis/src/env_analyzer.py
+++ b/autobot-backend/code_analysis/src/env_analyzer.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.ssot_config import QUALITY_MODEL
+from autobot_shared.ssot_constants import TTL_1_HOUR
 
 # Issue #542: Handle imports for both standalone execution and backend import
 # When imported from backend, project root is in sys.path
@@ -1240,7 +1241,7 @@ class EnvironmentAnalyzer:
             try:
                 key = self.RECOMMENDATIONS_KEY
                 value = json.dumps(results, default=str)
-                await self.redis_client.setex(key, 3600, value)  # 1 hour TTL
+                await self.redis_client.setex(key, TTL_1_HOUR, value)  # 1 hour TTL
             except Exception as e:
                 logger.warning(f"Failed to cache results: {e}")
 

--- a/autobot-backend/code_analysis/src/frontend_analyzer.py
+++ b/autobot-backend/code_analysis/src/frontend_analyzer.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional
 from autobot_shared.logging_manager import get_logger
 
 from autobot_shared.async_compat import run_or_schedule
+from autobot_shared.ssot_constants import TTL_1_HOUR
 
 # Add AutoBot root to path for imports
 autobot_root = Path(__file__).parent.parent.parent
@@ -801,7 +802,7 @@ class FrontendAnalyzer:
         await self._ensure_redis()
         if self.redis_client:
             try:
-                await self.redis_client.setex(self.FRONTEND_KEY, 3600, json.dumps(results, default=str))
+                await self.redis_client.setex(self.FRONTEND_KEY, TTL_1_HOUR, json.dumps(results, default=str))
             except Exception as e:
                 logger.warning(f"Failed to cache results: {e}")
 

--- a/autobot-backend/code_analysis/src/patch_generator.py
+++ b/autobot-backend/code_analysis/src/patch_generator.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List
 from autobot_shared.logging_manager import get_logger
 
 from autobot_shared.async_compat import run_or_schedule
+from autobot_shared.ssot_constants import TTL_1_HOUR
 
 logger = get_logger(__name__)
 
@@ -594,7 +595,7 @@ class AutomatedFixGenerator:
         await self._ensure_redis()
         if self.redis_client:
             try:
-                await self.redis_client.setex(self.FIXES_KEY, 3600, json.dumps(results, default=str))  # 1 hour
+                await self.redis_client.setex(self.FIXES_KEY, TTL_1_HOUR, json.dumps(results, default=str))  # 1 hour
             except Exception as e:
                 logger.warning(f"Failed to cache fixes: {e}")
 

--- a/autobot-backend/code_analysis/src/security_analyzer.py
+++ b/autobot-backend/code_analysis/src/security_analyzer.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional
 from autobot_shared.logging_manager import get_logger
 
 from autobot_shared.async_compat import run_or_schedule
+from autobot_shared.ssot_constants import TTL_1_HOUR
 
 logger = get_logger(__name__)
 
@@ -806,7 +807,7 @@ class SecurityAnalyzer:
             try:
                 key = self.SECURITY_KEY
                 value = json.dumps(results, default=str)
-                await self.redis_client.setex(key, 3600, value)
+                await self.redis_client.setex(key, TTL_1_HOUR, value)
             except Exception as e:
                 logger.warning(f"Failed to cache results: {e}")
 

--- a/autobot-backend/code_analysis/src/testing_coverage_analyzer.py
+++ b/autobot-backend/code_analysis/src/testing_coverage_analyzer.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional
 from autobot_shared.logging_manager import get_logger
 
 from autobot_shared.async_compat import run_or_schedule
+from autobot_shared.ssot_constants import TTL_1_HOUR
 
 logger = get_logger(__name__)
 
@@ -808,7 +809,7 @@ class TestingCoverageAnalyzer:
             try:
                 key = self.COVERAGE_KEY
                 value = json.dumps(results, default=str)
-                await self.redis_client.setex(key, 3600, value)
+                await self.redis_client.setex(key, TTL_1_HOUR, value)
             except Exception as e:
                 logger.warning(f"Failed to cache results: {e}")
 

--- a/autobot-backend/code_intelligence/cross_language_patterns/detector.py
+++ b/autobot-backend/code_intelligence/cross_language_patterns/detector.py
@@ -23,6 +23,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_constants import TTL_1_HOUR
 
 from autobot_shared.redis_mixin import AsyncRedisClientLockedMixin
 
@@ -1038,7 +1039,7 @@ class CrossLanguagePatternDetector(AsyncRedisClientLockedMixin):
             cache_key = f"cross_lang_analysis:{analysis.analysis_id}"
             cache_data = json.dumps(analysis.to_dict(), default=str)
 
-            await redis.setex(cache_key, 3600, cache_data)  # 1 hour TTL
+            await redis.setex(cache_key, TTL_1_HOUR, cache_data)  # 1 hour TTL
             logger.info("Cached analysis results: %s", cache_key)
         except Exception as e:
             logger.warning("Failed to cache results: %s", e)

--- a/autobot-backend/constants/ttl_constants.py
+++ b/autobot-backend/constants/ttl_constants.py
@@ -9,6 +9,7 @@ MIGRATION (Issue #GH7440):
 """
 
 from autobot_shared.ssot_constants import (  # noqa: F401,F403
+    TTL_10_SECONDS,
     TTL_5_MINUTES,
     TTL_1_HOUR,
     TTL_24_HOURS,

--- a/autobot-backend/security/session_ownership.py
+++ b/autobot-backend/security/session_ownership.py
@@ -17,6 +17,7 @@ FEATURE FLAG SUPPORT:
 import logging
 from typing import Dict, Optional
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_constants import TTL_30_DAYS
 
 from fastapi import HTTPException, Request
 
@@ -96,7 +97,7 @@ class SessionOwnershipValidator:
             # Add to user's session set
             user_sessions_key = self._get_user_sessions_key(username)
             await self.redis.sadd(user_sessions_key, session_id)
-            await self.redis.expire(user_sessions_key, 2592000)  # 30 days
+            await self.redis.expire(user_sessions_key, TTL_30_DAYS)  # 30 days
 
             # Issue #684: Store org/team indices
             if org_id:
@@ -117,13 +118,13 @@ class SessionOwnershipValidator:
         """Store session in organization's session set (#684)."""
         org_key = self._get_org_sessions_key(org_id)
         await self.redis.sadd(org_key, session_id)
-        await self.redis.expire(org_key, 2592000)  # 30 days
+        await self.redis.expire(org_key, TTL_30_DAYS)  # 30 days
 
     async def _store_team_session_index(self, session_id: str, team_id: str) -> None:
         """Store session in team's session set (#684)."""
         team_key = self._get_team_sessions_key(team_id)
         await self.redis.sadd(team_key, session_id)
-        await self.redis.expire(team_key, 2592000)  # 30 days
+        await self.redis.expire(team_key, TTL_30_DAYS)  # 30 days
 
     async def _store_session_context(self, session_id: str, org_id: str | None, team_id: str | None) -> None:
         """Store org/team context for a session (#684)."""
@@ -618,9 +619,9 @@ class SessionOwnershipValidator:
                 await self.redis.sadd(shared_key, user_id)
                 user_key = self._get_user_shared_sessions_key(user_id)
                 await self.redis.sadd(user_key, session_id)
-                await self.redis.expire(user_key, 2592000)  # 30 days
+                await self.redis.expire(user_key, TTL_30_DAYS)  # 30 days
 
-            await self.redis.expire(shared_key, 2592000)  # 30 days
+            await self.redis.expire(shared_key, TTL_30_DAYS)  # 30 days
             logger.info(
                 "Session %s... shared by %s with %d users",
                 session_id[:8],

--- a/autobot-backend/services/context_analyzer.py
+++ b/autobot-backend/services/context_analyzer.py
@@ -14,6 +14,7 @@ import uuid
 from typing import Optional
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.ssot_constants import TTL_1_HOUR
 from models.completion_context import CompletionContext
 from services.dependency_tracker import DependencyTracker
 from services.semantic_analyzer import SemanticAnalyzer
@@ -284,7 +285,7 @@ class ContextAnalyzer:
         try:
             self.redis_client.setex(
                 f"completion_context:{context.context_id}",
-                3600,
+                TTL_1_HOUR,
                 json.dumps(context.to_dict()),
             )
         except Exception as e:

--- a/autobot-backend/services/fast_document_scanner.py
+++ b/autobot-backend/services/fast_document_scanner.py
@@ -17,6 +17,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_constants import TTL_7_DAYS
 
 from services.man_page_parser import ManPageContent, ManPageParser
 
@@ -205,7 +206,7 @@ class FastDocumentScanner:
             },
         )
         # Expire after 7 days
-        self.redis.expire(cache_key, 604800)
+        self.redis.expire(cache_key, TTL_7_DAYS)
 
     def _check_file_changes(
         self,
@@ -303,7 +304,7 @@ class FastDocumentScanner:
         if commands_to_check:
             self.redis.delete(cache_key)
             self.redis.sadd(cache_key, *commands_to_check)
-            self.redis.expire(cache_key, 604800)  # 7 days
+            self.redis.expire(cache_key, TTL_7_DAYS)  # 7 days
 
         return changes
 

--- a/autobot-backend/services/memory/redis_provider.py
+++ b/autobot-backend/services/memory/redis_provider.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.redis_management.types import DATABASE_MAPPING
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_constants import TTL_24_HOURS
 
 logger = get_logger(__name__)
 
@@ -66,7 +67,7 @@ class RedisMemoryProvider:
                 "entity_updates": turn.get("entity_updates", []),
                 "relation_updates": turn.get("relation_updates", []),
             }
-            await self.redis.setex(cache_key, 86400, json.dumps(cache_data, default=str))
+            await self.redis.setex(cache_key, TTL_24_HOURS, json.dumps(cache_data, default=str))
             logger.debug(f"Cached turn data for {conversation_id}")
         except Exception as e:
             logger.error(f"Error syncing to Redis: {e}")
@@ -110,7 +111,7 @@ class RedisMemoryProvider:
             entity = await self.get_entity(entity_id)
             if entity:
                 entity.update(updates)
-                await self.redis.setex(cache_key, 86400, json.dumps(entity, default=str))
+                await self.redis.setex(cache_key, TTL_24_HOURS, json.dumps(entity, default=str))
         except Exception as e:
             logger.error(f"Error updating entity in Redis: {e}")
 

--- a/autobot-backend/utils/advanced_cache_manager.py
+++ b/autobot-backend/utils/advanced_cache_manager.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Dict, List, Optional
 from autobot_shared.logging_manager import get_logger
 
 from autobot_shared.redis_client import get_async_redis_client, get_redis_client
+from autobot_shared.ssot_constants import TTL_24_HOURS
 from constants.ttl_constants import TTL_1_HOUR, TTL_5_MINUTES
 
 logger = get_logger(__name__)
@@ -473,7 +474,7 @@ class AdvancedCacheManager:
                 pipe.hincrby(stats_key, "misses", 1)
 
             pipe.hset(stats_key, "last_access", current_time)
-            pipe.expire(stats_key, 86400)  # Stats expire after 24 hours
+            pipe.expire(stats_key, TTL_24_HOURS)  # Stats expire after 24 hours
 
             await pipe.execute()
 

--- a/autobot-backend/utils/hardware_metrics.py
+++ b/autobot-backend/utils/hardware_metrics.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from functools import wraps
 from typing import Any, Dict, List, Optional
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_constants import TTL_1_HOUR
 
 import aiohttp
 import psutil
@@ -1464,7 +1465,7 @@ def _store_performance_in_redis(
                 ): time.time()
             },
         )
-        phase9_monitor.redis_client.expire(key, 3600)  # 1 hour retention
+        phase9_monitor.redis_client.expire(key, TTL_1_HOUR)  # 1 hour retention
     except Exception:
         logger.debug("Suppressed exception in try block", exc_info=True)
 

--- a/autobot-backend/utils/performance_monitoring/decorator.py
+++ b/autobot-backend/utils/performance_monitoring/decorator.py
@@ -15,6 +15,7 @@ import logging
 import time
 from functools import wraps
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_constants import TTL_1_HOUR
 
 logger = get_logger(__name__)
 
@@ -53,7 +54,7 @@ def _store_performance_in_redis(
                 ): time.time()
             },
         )
-        _redis_client.expire(key, 3600)  # 1 hour retention
+        _redis_client.expire(key, TTL_1_HOUR)  # 1 hour retention
     except Exception:
         logger.debug("Suppressed exception in try block", exc_info=True)
 

--- a/autobot-backend/utils/performance_monitoring/monitor.py
+++ b/autobot-backend/utils/performance_monitoring/monitor.py
@@ -18,6 +18,7 @@ import time
 from dataclasses import asdict
 from typing import Any, Callable, Dict, List
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_constants import TTL_1_HOUR
 
 # Issue #469: Import Prometheus metrics manager
 from monitoring.prometheus_metrics import get_metrics_manager
@@ -451,7 +452,7 @@ class PerformanceMonitor:
                 key = "performance_alerts"
                 for alert in alerts:
                     self.redis_client.zadd(key, {json.dumps(alert): time.time()})
-                self.redis_client.expire(key, 3600)
+                self.redis_client.expire(key, TTL_1_HOUR)
 
             await asyncio.to_thread(_store_alerts)
         except Exception as e:

--- a/autobot_shared/ssot_constants.py
+++ b/autobot_shared/ssot_constants.py
@@ -608,6 +608,7 @@ class ProtocolDefaults:
 # TTL CONSTANTS
 # ============================================================================
 
+TTL_10_SECONDS = 10
 TTL_5_MINUTES = 300
 TTL_1_HOUR = 3_600
 TTL_24_HOURS = 86_400

--- a/pipeline-scripts/check_no_literal_ttl_seconds.py
+++ b/pipeline-scripts/check_no_literal_ttl_seconds.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Pre-commit hook: ban literal integer seconds in Redis TTL positions.
+
+Checks Python AST for calls to setex, expire, pexpire (and Cache.set ttl=N)
+where the TTL argument is a literal integer or float rather than a named constant.
+
+Allowlist: autobot-backend/constants/ttl_constants.py and
+autobot_shared/ssot_constants.py — these define the named TTL values.
+
+Closes GH#7080. Prevents recurrence of the #6743 chat-session TTL drift bug.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+# Files that are allowed to contain literal TTL values (the constants themselves).
+ALLOWLISTED_PATHS = {
+    "autobot-backend/constants/ttl_constants.py",
+    "autobot_shared/ssot_constants.py",
+    "autobot_shared/ssot_constants/ttl.py",
+}
+
+# Redis client method names whose second positional argument (index 1) is a TTL.
+# setex(key, ttl, value) — index 1
+# expire(key, ttl) — index 1
+# pexpire(key, ttl_ms) — index 1 (milliseconds, but still block literals)
+TTL_METHODS_INDEX_1 = {"setex", "expire", "pexpire"}
+
+# Cache.set(key, value, ttl=N) — keyword argument
+CACHE_SET_TTL_KWARG = "ttl"
+
+
+def _is_literal_number(node: ast.expr) -> bool:
+    """Return True if node is a literal int or float (not a name reference)."""
+    return isinstance(node, ast.Constant) and isinstance(node.value, (int, float))
+
+
+def check_file(path: Path) -> list[str]:
+    """Return list of violation messages for a single file."""
+    violations = []
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return violations
+
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return violations
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+
+        func = node.func
+
+        # Match obj.method(...) calls
+        if isinstance(func, ast.Attribute):
+            method_name = func.attr.lower()
+
+            if method_name in TTL_METHODS_INDEX_1:
+                # setex(key, ttl, value): ttl is args[1]
+                if len(node.args) >= 2 and _is_literal_number(node.args[1]):
+                    violations.append(
+                        f"{path}:{node.lineno}: literal TTL {node.args[1].value!r} "
+                        f"in .{func.attr}() — use a named constant from "
+                        f"autobot_shared.ssot_constants (e.g. TTL_1_HOUR)"
+                    )
+
+            elif method_name == "set":
+                # Cache.set(key, value, ttl=N) — keyword arg
+                for kw in node.keywords:
+                    if kw.arg == CACHE_SET_TTL_KWARG and _is_literal_number(kw.value):
+                        violations.append(
+                            f"{path}:{node.lineno}: literal ttl={kw.value.value!r} "
+                            f"in .set() — use a named constant from "
+                            f"autobot_shared.ssot_constants (e.g. TTL_1_HOUR)"
+                        )
+
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    all_violations: list[str] = []
+
+    for arg in argv:
+        path = Path(arg)
+        if path.suffix != ".py":
+            continue
+
+        # Normalize path for allowlist check (strip leading ./ or worktree prefix)
+        normalized = str(path).lstrip("./")
+        if any(normalized.endswith(al) or al in normalized for al in ALLOWLISTED_PATHS):
+            continue
+
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print("no-literal-ttl-seconds: literal TTL values found (use named constants):\n")
+        for v in all_violations:
+            print(f"  {v}")
+        print(
+            "\nFix: replace the literal with the appropriate constant from "
+            "autobot_shared.ssot_constants:\n"
+            "  from autobot_shared.ssot_constants import TTL_1_HOUR\n"
+            "  redis.setex(key, TTL_1_HOUR, value)"
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

- **GH#7073** — Adds `cache-dependency-path` to all `setup-python@v5` calls in `ci.yml`, `code-quality.yml`, `phase_validation.yml`, `security.yml`, and `startup-import-smoke.yml`. Also adds npm cache + `cache-dependency-path` to `visual-regression.yml` (the one Node workflow missing it). Cache keys now derive from requirements file hashes, ensuring invalidation on dependency changes.

- **GH#7080** — Adds `pipeline-scripts/check_no_literal_ttl_seconds.py`: an AST-based pre-commit hook that blocks literal integer/float TTL arguments in Redis `setex`/`expire`/`pexpire` calls and `Cache.set(ttl=N)`. Adds `TTL_10_SECONDS = 10` to `autobot_shared.ssot_constants` and migrates all 23 pre-existing violations across 15 files to use `TTL_*` named constants, preventing recurrence of the #6743 class of TTL drift bugs.

## Changes

### GH#7073 — CI pip/npm cache dependency paths
- `ci.yml` — 2 Python blocks + already-correct Node block
- `code-quality.yml`, `phase_validation.yml`, `startup-import-smoke.yml` — 1 Python block each
- `security.yml` — 2 Python blocks (dependency-audit + SAST jobs)
- `visual-regression.yml` — Node cache + `cache-dependency-path` added

### GH#7080 — no-literal-ttl-seconds pre-commit hook
- New: `pipeline-scripts/check_no_literal_ttl_seconds.py` (AST-based, allowlist for constants files)
- New hook entry in `.pre-commit-config.yaml`
- `TTL_10_SECONDS = 10` added to `autobot_shared/ssot_constants.py` and re-exported from `autobot-backend/constants/ttl_constants.py`
- 23 violations migrated across: `ide_integration.py`, `session_ownership.py`, `context_analyzer.py`, `fast_document_scanner.py`, `redis_provider.py`, `advanced_cache_manager.py`, `hardware_metrics.py`, `performance_monitoring/decorator.py`, `performance_monitoring/monitor.py`, `cross_language_patterns/detector.py`, and 7 `code_analysis/src/` files

## Test plan

- [ ] Run `python3 pipeline-scripts/check_no_literal_ttl_seconds.py $(find autobot-backend -name "*.py" | grep -v __pycache__ | grep -v "_test|/tests/")` — exits 0
- [ ] Inject a literal `setex(key, 3600, val)` — hook exits 1 with clear message
- [ ] All affected CI workflows pass on this branch (no setup-python/node regressions)
- [ ] `grep -r "cache-dependency-path" .github/workflows/*.yml` confirms presence in all Python workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)