### PR TITLE
fix(config,chromadb,constants): circular import + provenance + ssot_constants (GH#7765, GH#7762, GH#7750)

### DIFF
--- a/autobot-backend/config/__init__.py
+++ b/autobot-backend/config/__init__.py
@@ -34,9 +34,12 @@ Note: Uses lazy imports via __getattr__ to avoid circular import with NetworkCon
 import logging
 from autobot_shared.ssot_config import config
 from typing import TYPE_CHECKING
-from autobot_shared.logging_manager import get_logger
 
-logger = get_logger(__name__)
+# Use stdlib logging here to avoid circular import:
+# constants → network_constants → autobot_shared/network_constants → config.registry →
+# config/__init__ → get_logger → logging_manager → from config import config_manager (incomplete)
+# GH#7765
+logger = logging.getLogger(__name__)
 
 # Type hints for IDE support without runtime import
 if TYPE_CHECKING:

--- a/autobot-backend/config/registry.py
+++ b/autobot-backend/config/registry.py
@@ -16,7 +16,6 @@ ARCHITECTURE:
 
 USAGE:
     from config.registry import ConfigRegistry
-from autobot_shared.logging_manager import get_logger
 
     # Get single value with fallback
     redis_host = ConfigRegistry.get("redis.host")  # SSOT default via registry_defaults
@@ -34,7 +33,9 @@ import threading
 import time
 from typing import Any, Dict, Optional
 
-logger = get_logger(__name__)
+# stdlib logging avoids circular import: network_constants → config.registry → get_logger
+# → logging_manager → from config import config_manager (partially initialized) GH#7765
+logger = logging.getLogger(__name__)
 
 # Redis key prefix for all config values
 REDIS_CONFIG_PREFIX = "autobot:config:"

--- a/autobot-backend/knowledge/backends/async_chromadb_adapter.py
+++ b/autobot-backend/knowledge/backends/async_chromadb_adapter.py
@@ -201,10 +201,15 @@ class AsyncChromaDBClient(AsyncBaseClient):
         metadata: Optional[Metadata] = None,
         embedding_function: Optional[Any] = None,
     ) -> AsyncBaseCollection:
+        from datetime import datetime, timezone
+
+        provenance: dict = {"created_at": datetime.now(timezone.utc).isoformat()}
+        if metadata:
+            provenance.update(metadata)
         try:
             raw_col = await self._raw.create_collection(
                 name=name,
-                metadata=metadata,
+                metadata=provenance,
                 embedding_function=embedding_function,
             )
         except Exception as exc:

--- a/autobot-backend/knowledge/backends/chromadb_adapter.py
+++ b/autobot-backend/knowledge/backends/chromadb_adapter.py
@@ -210,9 +210,12 @@ class ChromaDBClient(BaseClient):
         metadata: Optional[Metadata] = None,
         embedding_function: Optional[Any] = None,
     ) -> BaseCollection:
-        kwargs: dict = {"name": name}
-        if metadata is not None:
-            kwargs["metadata"] = metadata
+        from datetime import datetime, timezone
+
+        provenance: dict = {"created_at": datetime.now(timezone.utc).isoformat()}
+        if metadata:
+            provenance.update(metadata)
+        kwargs: dict = {"name": name, "metadata": provenance}
         if embedding_function is not None:
             kwargs["embedding_function"] = embedding_function
         try:

--- a/autobot_shared/ssot_constants.py
+++ b/autobot_shared/ssot_constants.py
@@ -157,12 +157,60 @@ FALLBACK_GOOGLE_MODEL = GOOGLE_GEMINI_PRO
 
 @dataclass(frozen=True)
 class ModelConfig:
-    """Model configuration settings"""
+    """Model configuration settings — generation parameters and limits."""
 
     DEFAULT_CONTEXT_LENGTH: int = 8192
     MAX_CONTEXT_LENGTH: int = 32768
+    MAX_HISTORY_TOKENS: int = 3000
+
+    # RAG context-length optimization (by complexity score)
+    RAG_CONTEXT_HIGH_COMPLEXITY: int = 3000
+    RAG_CONTEXT_MEDIUM_COMPLEXITY: int = 2500
+    RAG_CONTEXT_LOW_COMPLEXITY: int = 2000
+
+    # RAG chunk-count optimization
+    RAG_CHUNKS_HIGH_COMPLEXITY: int = 8
+    RAG_CHUNKS_MEDIUM_COMPLEXITY: int = 6
+    RAG_CHUNKS_LOW_COMPLEXITY: int = 5
+
+    # Model-size thresholds (MB)
+    MODEL_SIZE_LIGHTWEIGHT_THRESHOLD_MB: int = 1000
+    MODEL_SIZE_MODERATE_THRESHOLD_MB: int = 3000
+
+    # Generation parameters
     DEFAULT_TEMPERATURE: float = 0.7
     DEFAULT_TOP_P: float = 0.9
+    DEFAULT_TOP_K: int = 40
+    DEFAULT_REPEAT_PENALTY: float = 1.1
+    DEFAULT_MAX_TOKENS: int = 2048
+    DEFAULT_NUM_CTX: int = 4096
+    CHAT_NUM_CTX: int = 8192
+
+    # Timeouts (seconds)
+    DEFAULT_TIMEOUT: int = 120
+    LONG_GENERATION_TIMEOUT: int = 120
+
+    # Retry settings
+    MAX_RETRIES: int = 3
+    RETRY_DELAY: int = 2
+
+    # Performance settings
+    DEFAULT_CONNECTION_POOL_SIZE: int = 20
+    DEFAULT_MAX_CONCURRENT_REQUESTS: int = 8
+    DEFAULT_CACHE_TTL: int = 300  # TTL_5_MINUTES — hardcoded to avoid forward-ref
+    DEFAULT_MAX_CHUNKS: int = 1000
+
+    # RAG search settings
+    RAG_DEFAULT_MAX_RESULTS: int = 5
+    RAG_MAX_RESULTS_PER_STAGE: int = 20
+    RAG_HYBRID_WEIGHT_SEMANTIC: float = 0.7
+    RAG_HYBRID_WEIGHT_KEYWORD: float = 0.3
+    RAG_DIVERSITY_THRESHOLD: float = 0.85
+    RAG_DEFAULT_CONTEXT_LENGTH: int = 2000
+    RAG_MAX_CONTEXT_LENGTH: int = 5000
+
+    # MMR diversity scoring (0.0 = pure relevance, 1.0 = pure diversity)
+    RAG_MMR_LAMBDA: float = 0.0
 
 
 class ModelConstants:
@@ -190,6 +238,131 @@ class ModelConstants:
     PROVIDER_LM_STUDIO: str = "lm_studio"
 
     CURRENT_PROVIDER: str = "ollama"
+
+    @staticmethod
+    def get_ollama_url() -> str:
+        """Get Ollama service URL (lazy import to avoid circular imports)."""
+        from config.registry import ConfigRegistry  # noqa: PLC0415
+        from constants.network_constants import NetworkConstants  # noqa: PLC0415
+
+        host = ConfigRegistry.get("vm.ollama", NetworkConstants.AI_STACK_VM_IP)
+        port = ConfigRegistry.get("port.ollama", str(NetworkConstants.OLLAMA_PORT))
+        return f"http://{host}:{port}"
+
+    @staticmethod
+    def get_lm_studio_url() -> str:
+        """Get LM Studio service URL."""
+        from autobot_shared.ssot_config import config as _cfg  # noqa: PLC0415
+
+        return _cfg.llm.lmstudio_host
+
+
+# ============================================================================
+# MODEL PRICING (GH#7750: missing from original GH#7440 migration)
+# ============================================================================
+
+MODEL_PRICING_PER_1M_TOKENS: Dict[str, Dict[str, float]] = {
+    ANTHROPIC_CLAUDE_OPUS4: {"input": 15.00, "output": 75.00},
+    ANTHROPIC_CLAUDE_HAIKU4_5: {"input": 0.80, "output": 4.00},
+    ANTHROPIC_CLAUDE_SONNET4: {"input": 3.00, "output": 15.00},
+    ANTHROPIC_CLAUDE35_SONNET: {"input": 3.00, "output": 15.00},
+    ANTHROPIC_CLAUDE35_HAIKU: {"input": 0.80, "output": 4.00},
+    ANTHROPIC_CLAUDE3_OPUS_DATED: {"input": 15.00, "output": 75.00},
+    ANTHROPIC_CLAUDE3_SONNET_DATED: {"input": 3.00, "output": 15.00},
+    ANTHROPIC_CLAUDE3_HAIKU_DATED: {"input": 0.25, "output": 1.25},
+    OPENAI_GPT41: {"input": 2.00, "output": 8.00},
+    OPENAI_GPT41_MINI: {"input": 0.40, "output": 1.60},
+    OPENAI_GPT41_NANO: {"input": 0.10, "output": 0.40},
+    OPENAI_GPT4O: {"input": 2.50, "output": 10.00},
+    OPENAI_GPT4O_MINI: {"input": 0.15, "output": 0.60},
+    OPENAI_GPT4_TURBO: {"input": 10.00, "output": 30.00},
+    OPENAI_GPT4: {"input": 30.00, "output": 60.00},
+    OPENAI_GPT35_TURBO: {"input": 0.50, "output": 1.50},
+    OPENAI_O1: {"input": 15.00, "output": 60.00},
+    OPENAI_O1_MINI: {"input": 3.00, "output": 12.00},
+    OPENAI_O3: {"input": 2.00, "output": 8.00},
+    OPENAI_O3_MINI: {"input": 1.10, "output": 4.40},
+    OPENAI_O4_MINI: {"input": 1.10, "output": 4.40},
+    GOOGLE_GEMINI25_PRO: {"input": 1.25, "output": 10.00},
+    GOOGLE_GEMINI25_FLASH: {"input": 0.15, "output": 0.60},
+    GOOGLE_GEMINI20_FLASH: {"input": 0.10, "output": 0.40},
+    GOOGLE_GEMINI15_PRO: {"input": 1.25, "output": 5.00},
+    GOOGLE_GEMINI15_FLASH: {"input": 0.075, "output": 0.30},
+    DEEPSEEK_V3: {"input": 0.27, "output": 1.10},
+    DEEPSEEK_R1_API: {"input": 0.55, "output": 2.19},
+    LOCAL_LLAMA3: {"input": 0.0, "output": 0.0},
+    LOCAL_LLAMA31: {"input": 0.0, "output": 0.0},
+    LOCAL_LLAMA32: {"input": 0.0, "output": 0.0},
+    LOCAL_LLAMA33: {"input": 0.0, "output": 0.0},
+    LOCAL_MISTRAL: {"input": 0.0, "output": 0.0},
+    LOCAL_MIXTRAL: {"input": 0.0, "output": 0.0},
+    LOCAL_CODELLAMA: {"input": 0.0, "output": 0.0},
+    LOCAL_QWEN25: {"input": 0.0, "output": 0.0},
+    LOCAL_QWEN3: {"input": 0.0, "output": 0.0},
+    LOCAL_DEEPSEEK_CODER: {"input": 0.0, "output": 0.0},
+    LOCAL_DEEPSEEK_R1: {"input": 0.0, "output": 0.0},
+    LOCAL_PHI3: {"input": 0.0, "output": 0.0},
+    LOCAL_PHI4: {"input": 0.0, "output": 0.0},
+    LOCAL_GEMMA2: {"input": 0.0, "output": 0.0},
+    LOCAL_GEMMA3: {"input": 0.0, "output": 0.0},
+}
+
+MODEL_PRICING_PER_1K_TOKENS: Dict[str, Dict[str, float]] = {
+    OPENAI_GPT4: {"prompt": 0.03, "completion": 0.06},
+    OPENAI_GPT4_TURBO: {"prompt": 0.01, "completion": 0.03},
+    OPENAI_GPT4O: {"prompt": 0.005, "completion": 0.015},
+    OPENAI_GPT35_TURBO: {"prompt": 0.0015, "completion": 0.002},
+    ANTHROPIC_CLAUDE3_OPUS: {"prompt": 0.015, "completion": 0.075},
+    ANTHROPIC_CLAUDE3_SONNET: {"prompt": 0.003, "completion": 0.015},
+    ANTHROPIC_CLAUDE3_HAIKU: {"prompt": 0.00025, "completion": 0.00125},
+    ANTHROPIC_CLAUDE_SONNET4_SHORT: {"prompt": 0.003, "completion": 0.015},
+    "ollama": {"prompt": 0.0, "completion": 0.0},
+    "default": {"prompt": 0.001, "completion": 0.002},
+}
+
+MODEL_COSTS_PER_1M_TOKENS: Dict[str, Dict[str, float]] = {
+    ANTHROPIC_CLAUDE3_OPUS: {"input": 15.00, "output": 75.00},
+    ANTHROPIC_CLAUDE3_SONNET: {"input": 3.00, "output": 15.00},
+    ANTHROPIC_CLAUDE3_HAIKU: {"input": 0.25, "output": 1.25},
+    ANTHROPIC_CLAUDE_SONNET4_SHORT: {"input": 3.00, "output": 15.00},
+    OPENAI_GPT4O: {"input": 2.50, "output": 10.00},
+    OPENAI_GPT4O_MINI: {"input": 0.15, "output": 0.60},
+    OPENAI_GPT4_TURBO: {"input": 10.00, "output": 30.00},
+    OPENAI_GPT35_TURBO: {"input": 0.50, "output": 1.50},
+    GOOGLE_GEMINI15_PRO: {"input": 1.25, "output": 5.00},
+    GOOGLE_GEMINI15_FLASH: {"input": 0.075, "output": 0.30},
+    LOCAL_LLAMA3: {"input": 0.0, "output": 0.0},
+    LOCAL_MISTRAL: {"input": 0.0, "output": 0.0},
+    LOCAL_CODELLAMA: {"input": 0.0, "output": 0.0},
+}
+
+# Singleton instances (backward compat with constants.model_constants imports)
+model_constants = ModelConstants()
+model_config = ModelConfig()
+
+
+@lru_cache(maxsize=8)
+def get_default_model(provider: Optional[str] = None) -> str:
+    """Get the default model for a specific provider or the system default."""
+    if provider == ModelConstants.PROVIDER_OLLAMA:
+        return ModelConstants.DEFAULT_OLLAMA_MODEL
+    elif provider == ModelConstants.PROVIDER_OPENAI:
+        return ModelConstants.DEFAULT_OPENAI_MODEL
+    elif provider == ModelConstants.PROVIDER_ANTHROPIC:
+        return ModelConstants.DEFAULT_ANTHROPIC_MODEL
+    elif provider == ModelConstants.PROVIDER_GOOGLE:
+        return ModelConstants.DEFAULT_GOOGLE_MODEL
+    return ModelConstants.DEFAULT_OLLAMA_MODEL
+
+
+@lru_cache(maxsize=8)
+def get_model_endpoint(provider: str) -> str:
+    """Get the endpoint URL for a specific provider."""
+    if provider == ModelConstants.PROVIDER_OLLAMA:
+        return ModelConstants.get_ollama_url()
+    elif provider == ModelConstants.PROVIDER_LM_STUDIO:
+        return ModelConstants.get_lm_studio_url()
+    raise ValueError(f"Unknown provider: {provider}")
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

All three original issues (GH#7440, GH#7441, GH#7442) were already closed. Picked the next 3 open backend issues per the batch instructions.

### GH#7765 — Break circular import preventing enhanced_orchestration tests
- `config/__init__.py`: replaced `get_logger()` with `logging.getLogger()` at module level. The `get_logger` call triggered `logging_manager → from config import config_manager` on a partially-initialized module, causing `ImportError` for all tests importing `constants`.
- `config/registry.py`: same fix; also removed a misplaced import that had drifted into the docstring.

### GH#7762 — Add provenance metadata to `create_collection` in ChromaDB adapters
- `chromadb_adapter.py` and `async_chromadb_adapter.py`: `create_collection` now injects `{"created_at": <iso8601>}` merged with caller-supplied metadata, matching `get_or_create_collection`. Fixes 4 production code paths that bypass provenance tagging.

### GH#7750 — Complete GH#7440 migration: missing items in ssot_constants.py
- Expanded `ModelConfig` from a 4-field stub to the full 30-field dataclass.
- Added `get_ollama_url()` / `get_lm_studio_url()` static methods to `ModelConstants`.
- Added `MODEL_PRICING_PER_1M_TOKENS`, `MODEL_PRICING_PER_1K_TOKENS`, `MODEL_COSTS_PER_1M_TOKENS` dicts.
- Added `model_constants`/`model_config` singletons and `get_default_model()`/`get_model_endpoint()` helpers — all required by the `constants/model_constants.py` re-export shim.

## Test plan
- [x] `from constants.threshold_constants import AgentThresholds` — passes (circular import fixed)
- [x] `from constants.model_constants import MODEL_PRICING_PER_1M_TOKENS, model_constants, get_default_model` — passes (missing constants added)
- [x] `ChromaDBClient.create_collection` applies same provenance dict as `get_or_create_collection`
- [x] `InMemoryClient.create_collection` still raises `ValueError` on duplicate (contract preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)