### PR TITLE
fix(backend): add startup warning when SLM_AUTH_TOKEN is unset (GH#7713)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -926,6 +926,11 @@ async def _init_slm_client():
 
         slm_url = config.slm_url or get_config().slm_url
         slm_token = config.slm_auth_token
+        if not slm_token:
+            logger.warning(
+                "SLM_AUTH_TOKEN is unset — SLM WebSocket will connect without auth header. "
+                "Set SERVICE_AUTH_ENFORCEMENT_MODE=false or configure the token to avoid 403 errors."
+            )
 
         await init_slm_client(slm_url, slm_token)
         logger.info("✅ [ 89%] SLM Client: Connected to SLM server at %s", slm_url)


### PR DESCRIPTION
## Summary

- Adds a `logger.warning()` in `_init_slm_client()` when `SLM_AUTH_TOKEN` is empty/unset, so missing-token issues surface immediately in startup logs rather than surfacing only as a silent 403 at runtime.

## Changes

- `autobot-backend/initialization/lifespan.py`: check `slm_token` after reading from config; emit warning if falsy.

## Test plan

- [ ] Start backend without `SLM_AUTH_TOKEN` set — confirm warning appears in startup logs
- [ ] Start backend with `SLM_AUTH_TOKEN` set — confirm no warning emitted

Closes #7713

🤖 Generated with [Claude Code](https://claude.com/claude-code)