### PR TITLE
fix(slm-frontend): reconcile FleetCert type — remove local interface and unsafe cast (GH#7767)

### DIFF
--- a/autobot-slm-frontend/src/types/api-responses.ts
+++ b/autobot-slm-frontend/src/types/api-responses.ts
@@ -638,11 +638,18 @@ export interface SecurityPolicyListResponse {
 // =============================================================================
 
 export interface FleetCert {
+  cert_id: string
   node_id: string
-  hostname: string
-  certificate: string
-  expiry: string
+  serial_number: string | null
+  subject: string | null
+  issuer: string | null
+  not_before: string | null
+  not_after: string | null
+  fingerprint: string | null
   status: string
+  days_until_expiry: number | null
+  created_at: string
+  updated_at: string
 }
 
 // =============================================================================

--- a/autobot-slm-frontend/src/views/SecurityView.vue
+++ b/autobot-slm-frontend/src/views/SecurityView.vue
@@ -17,7 +17,7 @@
 import { ref, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useSlmApi } from '@/composables/useSlmApi'
-import type { TLSEndpointResponse } from '@/types/api-responses'
+import type { TLSEndpointResponse, FleetCert } from '@/types/api-responses'
 import { createLogger } from '@/utils/debugUtils'
 import { formatRelativeTime } from '@/utils/dateUtils'
 import config from '@/config/ssot-config'
@@ -41,19 +41,6 @@ type SecurityPolicy = SecurityPolicyResponse
 type SecurityOverview = SecurityOverviewResponse
 type ThreatSummary = ThreatSummaryType
 
-
-interface FleetCert {
-  cert_id: string
-  node_id: string
-  subject: string | null
-  issuer: string | null
-  serial_number: string | null
-  fingerprint: string | null
-  not_before: string | null
-  not_after: string | null
-  status: string
-  days_until_expiry: number | null
-}
 
 // Active tab — route-based
 type SecurityTab = 'overview' | 'tls-settings' | 'certificates' | 'audit' | 'threats' | 'policies'
@@ -231,7 +218,7 @@ async function fetchFleetCerts() {
   fleetCertsLoading.value = true
   try {
     const data = await slmApi.getFleetCerts()
-    fleetCerts.value = data as unknown as FleetCert[]
+    fleetCerts.value = data
   } catch (err) {
     logger.error('Failed to fetch fleet cert expiry:', err)
   } finally {


### PR DESCRIPTION
## Summary

- Updates `api-responses.ts` `FleetCert` to match what the backend `CertificateResponse` actually returns (PKI fields: `cert_id`, `subject`, `issuer`, `serial_number`, `fingerprint`, `not_before`, `not_after`, `days_until_expiry`).
- Removes the duplicate local `FleetCert` interface from `SecurityView.vue`.
- Drops the `as unknown as FleetCert[]` stopgap cast — types now align without coercion.

## Root cause

`api-responses.ts` defined `FleetCert` with a stale schema (`node_id`, `hostname`, `certificate`, `expiry`, `status`) that did not match the backend `CertificateResponse`. `SecurityView.vue` worked around this with a local re-definition and an unsafe cast. The backend schema is authoritative; the shared type now reflects it.

## Changes

- `autobot-slm-frontend/src/types/api-responses.ts`: update `FleetCert` to PKI schema
- `autobot-slm-frontend/src/views/SecurityView.vue`: remove local `FleetCert` interface, import from `api-responses`, remove `as unknown as` cast

## Test plan

- [ ] `SecurityView` certificates tab renders cert list without TS errors
- [ ] `getFleetCerts()` return type aligns with `FleetCert[]` — no unsafe cast needed

Closes #7767

🤖 Generated with [Claude Code](https://claude.com/claude-code)