### PR TITLE
audit(ansible): standardize become: yes→true across all playbooks (#7454)

### DIFF
--- a/autobot-slm-backend/ansible/deploy-access-control.yml
+++ b/autobot-slm-backend/ansible/deploy-access-control.yml
@@ -22,8 +22,8 @@
 
 - name: Deploy access control
   hosts: slm_server
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   roles:
     - role: access_control

--- a/autobot-slm-backend/ansible/deploy-agent-config.yml
+++ b/autobot-slm-backend/ansible/deploy-agent-config.yml
@@ -22,8 +22,8 @@
 
 - name: Deploy agent configuration
   hosts: slm_nodes
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   roles:
     - role: agent_config

--- a/autobot-slm-backend/ansible/deploy-centralized-logging.yml
+++ b/autobot-slm-backend/ansible/deploy-centralized-logging.yml
@@ -11,7 +11,7 @@
 
 - name: Deploy Loki on main server
   hosts: backend
-  become: yes
+  become: true
   tags:
     - loki
     - logging
@@ -20,7 +20,7 @@
 
 - name: Deploy Promtail on all nodes
   hosts: autobot
-  become: yes
+  become: true
   tags:
     - promtail
     - logging

--- a/autobot-slm-backend/ansible/deploy-distributed-setup.yml
+++ b/autobot-slm-backend/ansible/deploy-distributed-setup.yml
@@ -23,8 +23,8 @@
 
 - name: Setup distributed architecture
   hosts: slm_server
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   roles:
     - role: distributed_setup

--- a/autobot-slm-backend/ansible/deploy-dns.yml
+++ b/autobot-slm-backend/ansible/deploy-dns.yml
@@ -21,8 +21,8 @@
 
 - name: Deploy DNS configuration
   hosts: all
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   roles:
     - role: dns

--- a/autobot-slm-backend/ansible/deploy-slm-agent.yml
+++ b/autobot-slm-backend/ansible/deploy-slm-agent.yml
@@ -11,8 +11,8 @@
 ---
 - name: Deploy SLM Agent to Managed Nodes
   hosts: slm_nodes
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   pre_tasks:
     - name: "Pre-check | Verify connectivity"
@@ -23,8 +23,8 @@
       user:
         name: autobot
         state: present
-        system: yes
-        create_home: yes
+        system: true
+        create_home: true
         shell: /bin/bash
       tags: ['setup']
 

--- a/autobot-slm-backend/ansible/inventory/localhost.yml
+++ b/autobot-slm-backend/ansible/inventory/localhost.yml
@@ -8,7 +8,7 @@ all:
     localhost:
       ansible_connection: local
       ansible_user: "{{ ansible_user_id }}"
-      ansible_become: yes
+      ansible_become: true
       ansible_become_method: sudo
 
   children:

--- a/autobot-slm-backend/ansible/inventory/production.yml
+++ b/autobot-slm-backend/ansible/inventory/production.yml
@@ -8,7 +8,7 @@ all:
     # Issue #700: SSH key authentication (no plaintext passwords)
     ansible_user: autobot
     ansible_ssh_private_key_file: /etc/autobot/ssh/autobot_key
-    ansible_become: yes
+    ansible_become: true
     # Become password from vault (only needed if passwordless sudo not configured)
     # To use: ansible-playbook ... --ask-vault-pass
     # ansible_become_password: "{{ vault_become_password_autobot }}"
@@ -92,7 +92,7 @@ all:
           ansible_connection: local    # This is the local WSL machine
           ansible_host: 127.0.0.1      # Local connection
           network_address: "{{ lookup('env', 'AUTOBOT_BACKEND_HOST') | default('127.0.0.1', true) }}"  # IP used by other VMs to reach this host
-          ansible_become: no           # Issue #700: Disable become for local host by default
+          ansible_become: false           # Issue #700: Disable become for local host by default
           # Enable become when needed with: --extra-vars "ansible_become=yes"
           # Or use: --ask-become-pass for operations requiring sudo
           vm_id: "autobot-wsl-machine"

--- a/autobot-slm-backend/ansible/playbooks/deploy-backend-env.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-backend-env.yml
@@ -53,7 +53,7 @@
         src: "{{ backend_install_dir }}/../autobot_shared"
         dest: "{{ backend_code_dir }}/autobot_shared"
         state: link
-        force: yes
+        force: true
         owner: "{{ backend_user }}"
         group: "{{ backend_group }}"
 

--- a/autobot-slm-backend/ansible/playbooks/deploy-backend-local.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-backend-local.yml
@@ -17,8 +17,8 @@
 - name: Deploy Backend Services to Main Machine
   hosts: localhost
   connection: local
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   vars:
     # Backend configuration

--- a/autobot-slm-backend/ansible/playbooks/deploy-backend-remote.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-backend-remote.yml
@@ -16,11 +16,11 @@
 
 - name: Deploy Backend Services to Main Machine (Remote)
   hosts: autobot-host
-  gather_facts: yes
+  gather_facts: true
 
   vars:
     # Override inventory setting for deployment
-    ansible_become: yes
+    ansible_become: true
     # Backend configuration
     backend_user: autobot
     backend_group: autobot

--- a/autobot-slm-backend/ansible/playbooks/deploy-development-services.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-development-services.yml
@@ -4,18 +4,18 @@
 
 - name: Deploy Development Frontend on VM1
   hosts: frontend
-  become: yes
+  become: true
 
   tasks:
     - name: Stop any existing services
       systemd:
         name: "{{ item }}"
         state: stopped
-        enabled: no
+        enabled: false
       loop:
         - autobot-frontend-dev
         - nginx
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Install Node.js 20 for development
       block:
@@ -35,7 +35,7 @@
               - nodejs
               - npm
             state: present
-            update_cache: yes
+            update_cache: true
 
     - name: Copy frontend source files from deployment directory
       copy:
@@ -100,16 +100,16 @@
           [Install]
           WantedBy=multi-user.target
         dest: /etc/systemd/system/autobot-frontend-dev.service
-        backup: yes
+        backup: true
 
     - name: Reload systemd daemon
       systemd:
-        daemon_reload: yes
+        daemon_reload: true
 
     - name: Enable and start development frontend service
       systemd:
         name: autobot-frontend-dev
-        enabled: yes
+        enabled: true
         state: started
 
     - name: Configure firewall for development frontend
@@ -146,14 +146,14 @@
 
 - name: Verify development services are running
   hosts: backend
-  become: yes
+  become: true
 
   tasks:
     - name: Ensure autobot-backend service is running
       systemd:
         name: autobot-backend
         state: started
-        enabled: yes
+        enabled: true
 
 # Display final status
 - name: Development Setup Complete

--- a/autobot-slm-backend/ansible/playbooks/deploy-hybrid-docker.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-hybrid-docker.yml
@@ -5,8 +5,8 @@
 
 - name: Deploy Docker Containers to VMs
   hosts: all
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   vars:
     docker_compose_version: "2.29.1"
@@ -26,7 +26,7 @@
               - lsb-release
               - software-properties-common
             state: present
-            update_cache: yes
+            update_cache: true
             cache_valid_time: 3600
 
         - name: Add Docker GPG key
@@ -47,19 +47,19 @@
               - containerd.io
               - docker-compose-plugin
             state: present
-            update_cache: yes
+            update_cache: true
 
         - name: Add autobot user to docker group
           user:
             name: autobot
             groups: docker
-            append: yes
+            append: true
 
         - name: Start and enable Docker
           systemd:
             name: docker
             state: started
-            enabled: yes
+            enabled: true
 
         - name: Install Docker Compose
           get_url:
@@ -108,7 +108,7 @@
 # Deploy Redis Stack on VM3 (Database VM)
 - name: Deploy Redis Stack
   hosts: database
-  become: yes
+  become: true
   vars:
     container_name: autobot-redis
 
@@ -178,7 +178,7 @@
 # Deploy Frontend on VM1
 - name: Deploy Frontend
   hosts: frontend
-  become: yes
+  become: true
   vars:
     container_name: autobot-frontend
 
@@ -232,8 +232,8 @@
       synchronize:
         src: ${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/
         dest: /tmp/autobot/
-        delete: no
-        recursive: yes
+        delete: false
+        recursive: true
       delegate_to: localhost
 
     - name: Build and start Frontend
@@ -241,7 +241,7 @@
         project_src: "{{ autobot_dir }}/compose"
         files:
           - frontend-docker-compose.yml
-        build: yes
+        build: true
         state: present
       become_user: autobot
 
@@ -256,7 +256,7 @@
 # Deploy AI Stack and NPU Worker on VM4
 - name: Deploy AI Stack and NPU Worker
   hosts: aiml
-  become: yes
+  become: true
   vars:
     ai_container: autobot-ai-stack
     npu_container: autobot-npu-worker
@@ -354,8 +354,8 @@
       synchronize:
         src: ${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/
         dest: /tmp/autobot/
-        delete: no
-        recursive: yes
+        delete: false
+        recursive: true
       delegate_to: localhost
 
     - name: Build and start AI Stack and NPU Worker
@@ -363,7 +363,7 @@
         project_src: "{{ autobot_dir }}/compose"
         files:
           - aiml-docker-compose.yml
-        build: yes
+        build: true
         state: present
       become_user: autobot
 
@@ -397,7 +397,7 @@
 # Deploy Browser Service on VM5
 - name: Deploy Browser Service
   hosts: browser
-  become: yes
+  become: true
   vars:
     container_name: autobot-browser
 
@@ -473,7 +473,7 @@
 # Final validation and configuration
 - name: Validate All Services
   hosts: all
-  become: yes
+  become: true
 
   tasks:
     - name: Check Docker container status

--- a/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
@@ -4,8 +4,8 @@
 
 - name: Prepare All VMs
   hosts: all
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   tasks:
     - name: Install common packages
@@ -23,16 +23,16 @@
           - nginx
           - supervisor
         state: present
-        update_cache: yes
+        update_cache: true
         cache_valid_time: 3600
 
     - name: Create autobot service user
       user:
         name: autobot-service
-        system: yes
+        system: true
         shell: /bin/bash
         home: /opt/autobot
-        create_home: yes
+        create_home: true
 
     - name: Create service directories
       file:
@@ -51,7 +51,7 @@
 # Deploy Redis Stack natively on VM3 (Database VM)
 - name: Deploy Redis Stack Natively
   hosts: database
-  become: yes
+  become: true
 
   tasks:
     - name: Install Redis Stack from repository
@@ -71,7 +71,7 @@
             name:
               - redis-stack-server
             state: present
-            update_cache: yes
+            update_cache: true
 
     - name: Configure Redis Stack
       copy:
@@ -102,7 +102,7 @@
           logfile /var/log/redis/redis-server.log
           loglevel notice
         dest: /etc/redis/redis.conf
-        backup: yes
+        backup: true
 
     - name: Create Redis log directory
       file:
@@ -115,9 +115,9 @@
     - name: Configure Redis Stack systemd service
       systemd:
         name: redis-stack-server
-        enabled: yes
+        enabled: true
         state: restarted
-        daemon_reload: yes
+        daemon_reload: true
 
     - name: Install and configure RedisInsight
       block:
@@ -153,10 +153,10 @@
         - name: Start RedisInsight
           systemd:
             name: redisinsight
-            enabled: yes
+            enabled: true
             state: started
-            daemon_reload: yes
-      ignore_errors: yes
+            daemon_reload: true
+      ignore_errors: true
 
     - name: Configure firewall for Redis
       ufw:
@@ -179,7 +179,7 @@
 # Deploy Frontend natively on VM1
 - name: Deploy Frontend Natively
   hosts: frontend
-  become: yes
+  become: true
 
   tasks:
     - name: Install Node.js 20
@@ -198,7 +198,7 @@
           apt:
             name: nodejs
             state: present
-            update_cache: yes
+            update_cache: true
 
     - name: Copy frontend source files from deployment directory
       copy:
@@ -210,7 +210,7 @@
         path: /opt/autobot/src
         owner: autobot-service
         group: autobot-service
-        recurse: yes
+        recurse: true
 
     - name: Install frontend dependencies
       shell: |
@@ -278,7 +278,7 @@
               gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
           }
         dest: /etc/nginx/sites-available/autobot-frontend
-        backup: yes
+        backup: true
 
     - name: Enable nginx site
       file:
@@ -313,7 +313,7 @@
 # Deploy NPU Worker natively on VM2 with hardware acceleration
 - name: Deploy NPU Worker Service Natively
   hosts: npu
-  become: yes
+  become: true
 
   tasks:
     - name: Install Python dependencies for NPU Worker
@@ -345,10 +345,10 @@
       synchronize:
         src: ${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/
         dest: /opt/autobot/src/
-        delete: no
-        recursive: yes
-        owner: no
-        group: no
+        delete: false
+        recursive: true
+        owner: false
+        group: false
       delegate_to: localhost
 
     - name: Set ownership of source code for NPU Worker
@@ -356,7 +356,7 @@
         path: /opt/autobot/src
         owner: autobot-service
         group: autobot-service
-        recurse: yes
+        recurse: true
 
     - name: Create Python virtual environment for NPU Worker
       shell: python3.11 -m venv /opt/autobot/venv
@@ -446,16 +446,16 @@
           [Install]
           WantedBy=multi-user.target
         dest: /etc/systemd/system/autobot-npu-worker.service
-        backup: yes
+        backup: true
 
     - name: Reload systemd daemon for NPU Worker
       systemd:
-        daemon_reload: yes
+        daemon_reload: true
 
     - name: Enable and start NPU Worker service
       systemd:
         name: autobot-npu-worker
-        enabled: yes
+        enabled: true
         state: started
 
     - name: Configure firewall for NPU Worker
@@ -468,7 +468,7 @@
 # Deploy AI Stack natively on VM4
 - name: Deploy AI Services Natively
   hosts: aiml
-  become: yes
+  become: true
 
   tasks:
     - name: Install Python dependencies for AI services
@@ -489,10 +489,10 @@
       synchronize:
         src: ${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/
         dest: /opt/autobot/src/
-        delete: no
-        recursive: yes
-        owner: no
-        group: no
+        delete: false
+        recursive: true
+        owner: false
+        group: false
       delegate_to: localhost
 
     - name: Set ownership of source code
@@ -500,7 +500,7 @@
         path: /opt/autobot/src
         owner: autobot-service
         group: autobot-service
-        recurse: yes
+        recurse: true
 
     - name: Create Python virtual environment
       shell: |
@@ -558,9 +558,9 @@
         - name: Start Ollama service
           systemd:
             name: ollama
-            enabled: yes
+            enabled: true
             state: started
-            daemon_reload: yes
+            daemon_reload: true
 
         - name: Pull required Ollama models (6-tier mapping, #2553)
           shell: |
@@ -632,9 +632,9 @@
     - name: Start AI services
       systemd:
         name: "{{ item }}"
-        enabled: yes
+        enabled: true
         state: started
-        daemon_reload: yes
+        daemon_reload: true
       loop:
         - autobot-ai-stack
         - autobot-npu-worker
@@ -653,7 +653,7 @@
 # Deploy Browser Service natively on VM5
 - name: Deploy Browser Service Natively
   hosts: browser
-  become: yes
+  become: true
 
   tasks:
     - name: Install desktop environment and browsers
@@ -680,10 +680,10 @@
       synchronize:
         src: ${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/
         dest: /opt/autobot/src/
-        delete: no
-        recursive: yes
-        owner: no
-        group: no
+        delete: false
+        recursive: true
+        owner: false
+        group: false
       delegate_to: localhost
 
     - name: Set ownership of source code
@@ -691,7 +691,7 @@
         path: /opt/autobot/src
         owner: autobot-service
         group: autobot-service
-        recurse: yes
+        recurse: true
 
     - name: Create Playwright service
       copy:
@@ -737,9 +737,9 @@
     - name: Start browser services
       systemd:
         name: "{{ item }}"
-        enabled: yes
+        enabled: true
         state: started
-        daemon_reload: yes
+        daemon_reload: true
       loop:
         - autobot-browser
         - vnc-server
@@ -757,13 +757,13 @@
 # Final validation
 - name: Validate All Services
   hosts: all
-  become: yes
+  become: true
 
   tasks:
     - name: Check systemd services status
       shell: systemctl status {{ item }}
       register: service_status
-      ignore_errors: yes
+      ignore_errors: true
       loop: "{{ services[inventory_hostname_short] | default([]) }}"
       vars:
         services:
@@ -797,7 +797,7 @@
             - { url: 'http://localhost:8081/health', name: 'NPU Worker', expected_status: [200, 404] }
           'autobot-browser':
             - { url: 'http://localhost:3000/health', name: 'Browser Service', expected_status: [200, 404] }
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Display deployment summary
       debug:

--- a/autobot-slm-backend/ansible/playbooks/deploy-slm-agent.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-slm-agent.yml
@@ -17,7 +17,7 @@
 
 - name: Deploy SLM Agent to managed nodes
   hosts: slm_nodes
-  become: yes
+  become: true
 
   pre_tasks:
     - name: Ensure Python is available

--- a/autobot-slm-backend/ansible/playbooks/deploy-time-sync.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-time-sync.yml
@@ -4,8 +4,8 @@
 
 - name: "Deploy Time Synchronization Across AutoBot Infrastructure"
   hosts: production_vms
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   vars:
     # Override time_sync configuration if needed

--- a/autobot-slm-backend/ansible/playbooks/deploy_role.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy_role.yml
@@ -4,8 +4,8 @@
 
 - name: "Deploy AutoBot Role"
   hosts: "{{ target_host | default('all') }}"
-  gather_facts: yes
-  become: yes
+  gather_facts: true
+  become: true
 
   vars:
     deploy_timestamp: "{{ ansible_facts['date_time'].iso8601 }}"

--- a/autobot-slm-backend/ansible/playbooks/diagnose-backend-crash.yml
+++ b/autobot-slm-backend/ansible/playbooks/diagnose-backend-crash.yml
@@ -8,8 +8,8 @@
 
 - name: Diagnose Backend Crash-Loop
   hosts: autobot-backend
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   vars:
     backend_install_dir: /opt/autobot
@@ -217,7 +217,7 @@
       systemd:
         name: autobot-backend
         state: stopped
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Wait for service to stop
       pause:
@@ -241,7 +241,7 @@
       systemd:
         name: autobot-backend
         state: started
-      ignore_errors: yes
+      ignore_errors: true
 
     # ============================================================
     # Phase 7: Collect All Diagnostics
@@ -251,7 +251,7 @@
       fetch:
         src: "{{ diagnostic_output_dir }}/{{ item }}"
         dest: "/tmp/backend-diagnostics-{{ ansible_facts['date_time'].iso8601_basic_short }}/"
-        flat: no
+        flat: false
       loop:
         - 01-service-status.txt
         - 02-service-config.txt

--- a/autobot-slm-backend/ansible/playbooks/enroll-local.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-local.yml
@@ -35,9 +35,9 @@
         name: "{{ emergency_admin_user }}"
         comment: "Emergency Admin User (fallback access)"
         shell: /bin/bash
-        create_home: yes
+        create_home: true
         groups: sudo
-        append: yes
+        append: true
         password: "{{ emergency_admin_password_hash }}"
         state: present
 
@@ -66,10 +66,10 @@
         name: "{{ autobot_user }}"
         group: "{{ autobot_group }}"
         groups: "sudo"
-        append: yes
+        append: true
         shell: /bin/bash
         home: "{{ autobot_home }}"
-        create_home: yes
+        create_home: true
         state: present
 
     - name: Fix home directory ownership

--- a/autobot-slm-backend/ansible/playbooks/enroll-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-node.yml
@@ -23,8 +23,8 @@
 
 - name: "AutoBot Node Enrollment"
   hosts: "{{ target_host | default('all') }}"
-  gather_facts: yes
-  become: yes
+  gather_facts: true
+  become: true
 
   vars:
     enrollment_timestamp: "{{ ansible_facts['date_time'].iso8601 }}"
@@ -111,7 +111,7 @@
       block:
         - name: "Update apt cache"
           apt:
-            update_cache: yes
+            update_cache: true
             cache_valid_time: 3600
 
         - name: "Install base packages"
@@ -140,9 +140,9 @@
             groups: sudo
             shell: /bin/bash
             home: "{{ autobot_home }}"
-            create_home: yes
+            create_home: true
             state: present
-          ignore_errors: yes  # User may already exist
+          ignore_errors: true  # User may already exist
 
         - name: "Create AutoBot directories"
           file:
@@ -163,16 +163,16 @@
             user: "{{ autobot_user }}"
             state: present
             key: "{{ lookup('file', '/etc/autobot/ssh/autobot_key.pub') }}"
-          ignore_errors: yes  # Key may not exist during initial enrollment
+          ignore_errors: true  # Key may not exist during initial enrollment
 
         - name: "Create emergency admin user"
           user:
             name: "{{ emergency_admin_user }}"
             comment: "Emergency Admin User (fallback access)"
             shell: /bin/bash
-            create_home: yes
+            create_home: true
             groups: sudo
-            append: yes
+            append: true
             password: "{{ emergency_admin_password_hash }}"
             state: present
           when: vault_emergency_admin_password_hash is defined
@@ -236,7 +236,7 @@
               apt:
                 name: nodejs
                 state: present
-                update_cache: yes
+                update_cache: true
                 cache_valid_time: 3600
 
         # Redis-specific setup
@@ -254,7 +254,7 @@
               apt:
                 name: redis-stack-server
                 state: present
-                update_cache: yes
+                update_cache: true
 
         # NPU Worker setup
         - name: "Setup NPU Worker"
@@ -375,7 +375,7 @@
             direction: incoming
 
       tags: ['firewall']
-      ignore_errors: yes  # Firewall may be managed externally
+      ignore_errors: true  # Firewall may be managed externally
 
     # ===========================================
     # Phase 4: Service Registration

--- a/autobot-slm-backend/ansible/playbooks/fix-backend-clean-restart.yml
+++ b/autobot-slm-backend/ansible/playbooks/fix-backend-clean-restart.yml
@@ -7,8 +7,8 @@
 
 - name: Clean Restart Backend Service
   hosts: autobot-backend
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   vars:
     backend_code_dir: /opt/autobot/autobot-user-backend
@@ -89,7 +89,7 @@
 
     - name: Reload systemd daemon
       systemd:
-        daemon_reload: yes
+        daemon_reload: true
 
     - name: Display current service configuration
       command: cat /etc/systemd/system/autobot-backend.service
@@ -107,7 +107,7 @@
       systemd:
         name: autobot-backend
         state: started
-        enabled: yes
+        enabled: true
 
     - name: Wait 10 seconds for initialization
       pause:

--- a/autobot-slm-backend/ansible/playbooks/fix-backend-environment.yml
+++ b/autobot-slm-backend/ansible/playbooks/fix-backend-environment.yml
@@ -7,8 +7,8 @@
 
 - name: Fix Backend Environment Configuration
   hosts: autobot-backend
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   vars:
     backend_install_dir: /opt/autobot
@@ -150,7 +150,7 @@
   handlers:
     - name: reload systemd
       systemd:
-        daemon_reload: yes
+        daemon_reload: true
 
   post_tasks:
     - name: Restart backend service

--- a/autobot-slm-backend/ansible/playbooks/fix-backend-symlink.yml
+++ b/autobot-slm-backend/ansible/playbooks/fix-backend-symlink.yml
@@ -12,8 +12,8 @@
 
 - name: Fix Backend Symlink Configuration
   hosts: autobot-backend
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   vars:
     backend_code_dir: /opt/autobot/autobot-user-backend

--- a/autobot-slm-backend/ansible/playbooks/manage_services.yml
+++ b/autobot-slm-backend/ansible/playbooks/manage_services.yml
@@ -4,8 +4,8 @@
 
 - name: "Manage AutoBot Services"
   hosts: "{{ target_host | default('all') }}"
-  gather_facts: yes
-  become: yes
+  gather_facts: true
+  become: true
 
   vars:
     service_action: "{{ action | default('status') }}"
@@ -47,7 +47,7 @@
         - autobot-frontend
       when: is_frontend | bool
       register: frontend_service_result
-      ignore_errors: yes
+      ignore_errors: true
       tags: ['frontend']
 
     - name: "Manage Redis Service"
@@ -57,7 +57,7 @@
         enabled: "{{ true if service_action == 'enable' else false if service_action == 'disable' else omit }}"
       when: is_database | bool
       register: redis_service_result
-      ignore_errors: yes
+      ignore_errors: true
       tags: ['redis']
 
     - name: "Manage NPU Worker Service"
@@ -67,7 +67,7 @@
         enabled: "{{ true if service_action == 'enable' else false if service_action == 'disable' else omit }}"
       when: is_npu | bool
       register: npu_service_result
-      ignore_errors: yes
+      ignore_errors: true
       tags: ['npu_worker']
 
     - name: "Manage AI Stack Service"
@@ -80,7 +80,7 @@
         - autobot-ai-stack
       when: is_ai_stack | bool
       register: ai_service_result
-      ignore_errors: yes
+      ignore_errors: true
       tags: ['ai_stack']
 
     - name: "Manage SLM Backend Service"
@@ -93,7 +93,7 @@
         - nginx
       when: is_slm | bool
       register: slm_service_result
-      ignore_errors: yes
+      ignore_errors: true
       tags: ['slm']
 
     - name: "Manage Browser Services"
@@ -106,7 +106,7 @@
         - autobot-playwright
       when: is_browser | bool
       register: browser_service_result
-      ignore_errors: yes
+      ignore_errors: true
       tags: ['browser']
 
   post_tasks:
@@ -116,7 +116,7 @@
       register: service_status
       loop: "{{ services | default([]) }}"
       when: service_action == 'status'
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: "Display service management summary"
       debug:

--- a/autobot-slm-backend/ansible/playbooks/patch-dependencies.yml
+++ b/autobot-slm-backend/ansible/playbooks/patch-dependencies.yml
@@ -24,7 +24,7 @@
 
 - name: "AutoBot Dependency Patching - Pre-flight Checks"
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: Display patching information
       ansible.builtin.debug:
@@ -55,7 +55,7 @@
 # Phase 1: Update Database (Redis) - No Python venv, but included for completeness
 - name: "Phase 1: Database Updates"
   hosts: database
-  become: yes
+  become: true
   serial: 1
   max_fail_percentage: 0
   roles:
@@ -67,7 +67,7 @@
 # Phase 2: Update Backend Services
 - name: "Phase 2: Backend Updates"
   hosts: backend
-  become: yes
+  become: true
   serial: 1
   max_fail_percentage: 0
   roles:
@@ -79,7 +79,7 @@
 # Phase 3: Update AI/ML Stack
 - name: "Phase 3: AI/ML Stack Updates"
   hosts: aiml
-  become: yes
+  become: true
   serial: 1
   max_fail_percentage: 0
   roles:
@@ -91,7 +91,7 @@
 # Phase 4: Update NPU Workers
 - name: "Phase 4: NPU Worker Updates"
   hosts: npu
-  become: yes
+  become: true
   serial: 1
   max_fail_percentage: 0
   roles:
@@ -103,7 +103,7 @@
 # Phase 5: Update Frontend (Node.js, not Python)
 - name: "Phase 5: Frontend Updates"
   hosts: frontend
-  become: yes
+  become: true
   serial: 1
   max_fail_percentage: 0
   roles:
@@ -115,7 +115,7 @@
 # Final: Summary and verification
 - name: "Post-Patching Summary"
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: Display completion summary
       ansible.builtin.debug:

--- a/autobot-slm-backend/ansible/playbooks/patch-system-packages.yml
+++ b/autobot-slm-backend/ansible/playbooks/patch-system-packages.yml
@@ -23,7 +23,7 @@
 
 - name: "AutoBot System Package Patching - Pre-flight"
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: Display patching info
       ansible.builtin.debug:
@@ -60,7 +60,7 @@
 # Phase 1: Database VMs (Redis Stack) - most critical, update first
 - name: "Phase 1: Database VMs (Redis)"
   hosts: database
-  become: yes
+  become: true
   serial: 1
   max_fail_percentage: 0
   tasks:
@@ -75,7 +75,7 @@
 # Phase 2: Backend VMs - depends on database
 - name: "Phase 2: Backend VMs"
   hosts: backend
-  become: yes
+  become: true
   serial: 1
   max_fail_percentage: 0
   tasks:
@@ -90,7 +90,7 @@
 # Phase 3: AI/ML Stack VMs - depends on backend
 - name: "Phase 3: AI/ML Stack VMs"
   hosts: aiml
-  become: yes
+  become: true
   serial: 1
   max_fail_percentage: 0
   tasks:
@@ -105,7 +105,7 @@
 # Phase 4: NPU Worker VMs - depends on AI stack
 - name: "Phase 4: NPU Worker VMs"
   hosts: npu
-  become: yes
+  become: true
   serial: 1
   max_fail_percentage: 0
   tasks:
@@ -120,7 +120,7 @@
 # Phase 5: Frontend VMs - depends on backend API
 - name: "Phase 5: Frontend VMs"
   hosts: frontend
-  become: yes
+  become: true
   serial: 1
   max_fail_percentage: 0
   tasks:
@@ -135,7 +135,7 @@
 # Phase 6: Browser VMs - isolated, can update last
 - name: "Phase 6: Browser VMs"
   hosts: browser
-  become: yes
+  become: true
   serial: 1
   max_fail_percentage: 0
   tasks:
@@ -150,7 +150,7 @@
 # Summary
 - name: "Post-Update Summary"
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: Display completion summary
       ansible.builtin.debug:

--- a/autobot-slm-backend/ansible/playbooks/pre-deployment-validation.yml
+++ b/autobot-slm-backend/ansible/playbooks/pre-deployment-validation.yml
@@ -22,7 +22,7 @@
 
 - name: "Pre-Deployment Validation"
   hosts: all
-  gather_facts: yes
+  gather_facts: true
 
   vars:
     # Minimum disk space required (in GB)
@@ -213,7 +213,7 @@
               Install with: sudo apt-get install -y {{ item }}
             success_msg: "Package {{ item }} found"
           loop: "{{ required_packages.common }}"
-          ignore_errors: yes
+          ignore_errors: true
 
       tags: [packages, validation, always]
 
@@ -237,7 +237,7 @@
               Install with: sudo apt-get install -y {{ item }}
             success_msg: "Package {{ item }} found for role {{ host_role }}"
           loop: "{{ required_packages[host_role] | default([]) }}"
-          ignore_errors: yes
+          ignore_errors: true
 
       tags: [packages, validation]
 
@@ -273,7 +273,7 @@
                 success_msg: "Port {{ item.port }} ({{ item.name }}) available"
               loop: "{{ ports_to_check }}"
               when: inventory_hostname == item.host
-              ignore_errors: yes
+              ignore_errors: true
 
       tags: [ports, validation]
 
@@ -288,7 +288,7 @@
             nslookup github.com 2>&1 | grep -c "Name:"
           register: dns_test
           changed_when: false
-          ignore_errors: yes
+          ignore_errors: true
 
         - name: Validate DNS working
           assert:
@@ -299,19 +299,19 @@
               Cannot resolve github.com.
               Check /etc/resolv.conf and network settings.
             success_msg: "DNS resolution working"
-          ignore_errors: yes
+          ignore_errors: true
 
         - name: Test external network connectivity
           shell: |
             timeout 5 curl -s -o /dev/null -w "%{http_code}" https://github.com || echo "999"
           register: connectivity_test
           changed_when: false
-          ignore_errors: yes
+          ignore_errors: true
 
         - name: Display connectivity status
           debug:
             msg: "External connectivity test (HTTP {{ connectivity_test.stdout }})"
-          ignore_errors: yes
+          ignore_errors: true
 
       tags: [network, validation]
 
@@ -330,7 +330,7 @@
             path: "{{ item.path }}"
           register: config_stat_results
           loop: "{{ required_config_files[host_role_config] | default([]) }}"
-          ignore_errors: yes
+          ignore_errors: true
 
         - name: Validate config files permissions
           assert:
@@ -344,7 +344,7 @@
             success_msg: "Config file {{ item.item.path }} found"
           loop: "{{ config_stat_results.results }}"
           when: item is not skipped
-          ignore_errors: yes
+          ignore_errors: true
 
       tags: [config, validation]
 
@@ -367,7 +367,7 @@
             executable: /bin/bash
           register: pip_check
           changed_when: false
-          ignore_errors: yes
+          ignore_errors: true
           when: venv_stat.stat.exists
 
         - name: Alert if venv missing (will be created during deploy)
@@ -397,7 +397,7 @@
             npm audit --audit-level=moderate 2>&1
           register: npm_audit_result
           changed_when: false
-          ignore_errors: yes
+          ignore_errors: true
           when: package_json_stat.stat.exists
 
         - name: Display npm audit results
@@ -415,7 +415,7 @@
               Review and fix before deployment
             success_msg: "npm audit clean - no vulnerabilities found"
           when: package_json_stat.stat.exists
-          ignore_errors: yes
+          ignore_errors: true
 
         - name: Alert if package.json missing (will be deployed)
           debug:
@@ -437,13 +437,13 @@
           getent:
             database: passwd
             key: autobot
-          ignore_errors: yes
+          ignore_errors: true
 
         - name: Check /etc/autobot directory permissions
           stat:
             path: "/etc/autobot"
           register: autobot_dir_stat
-          ignore_errors: yes
+          ignore_errors: true
 
         - name: Validate /etc/autobot ownership
           assert:
@@ -457,7 +457,7 @@
               Fix with: sudo chown -R root:autobot /etc/autobot
             success_msg: "/etc/autobot ownership correct (root:autobot)"
           when: autobot_dir_stat.stat.exists
-          ignore_errors: yes
+          ignore_errors: true
 
       tags: [permissions, validation]
 
@@ -519,7 +519,7 @@
         dest: "/tmp/validation-{{ inventory_hostname }}-{{ ansible_facts['date_time'].date }}.checkpoint"
         mode: '0644'
       changed_when: false
-      ignore_errors: yes
+      ignore_errors: true
       tags: [validation, always]
 
     - name: Alert on validation failures

--- a/autobot-slm-backend/ansible/playbooks/pre-flight-code-sync.yml
+++ b/autobot-slm-backend/ansible/playbooks/pre-flight-code-sync.yml
@@ -67,9 +67,9 @@
         repo: "{{ github_repo }}"
         dest: "{{ git_repo_root }}"
         version: "{{ deploy_ref }}"
-        update: yes
-        force: yes
-      ignore_errors: yes
+        update: true
+        force: true
+      ignore_errors: true
       register: github_sync
       tags: [always]
 

--- a/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
@@ -107,9 +107,9 @@
         repo: "{{ github_repo }}"
         dest: "{{ git_repo_root }}"
         version: "{{ deploy_ref }}"
-        update: yes
-        force: yes
-      ignore_errors: yes
+        update: true
+        force: true
+      ignore_errors: true
       register: github_sync
       tags: [always]
 

--- a/autobot-slm-backend/ansible/playbooks/provision_host.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision_host.yml
@@ -15,8 +15,8 @@
 # Provision the host with required roles
 - name: "Provision AutoBot Host"
   hosts: "{{ target_host | default('all') }}"
-  gather_facts: yes
-  become: yes
+  gather_facts: true
+  become: true
 
   vars:
     provision_timestamp: "{{ ansible_facts['date_time'].iso8601 }}"

--- a/autobot-slm-backend/ansible/playbooks/recover_host.yml
+++ b/autobot-slm-backend/ansible/playbooks/recover_host.yml
@@ -4,8 +4,8 @@
 
 - name: "Recover AutoBot Host"
   hosts: "{{ target_host }}"
-  gather_facts: yes
-  become: yes
+  gather_facts: true
+  become: true
 
   vars:
     recovery_timestamp: "{{ ansible_facts['date_time'].iso8601 }}"
@@ -56,7 +56,7 @@
               - /etc/nginx/sites-available/autobot-*
             dest: "/var/backups/autobot-recovery/config-{{ recovery_timestamp }}.tar.gz"
             format: gz
-          ignore_errors: yes
+          ignore_errors: true
 
         - name: "Display backup location"
           debug:
@@ -77,7 +77,7 @@
         - ollama
         - autobot-vnc
         - autobot-playwright
-      ignore_errors: yes
+      ignore_errors: true
       tags: ['stop_services']
 
     - name: "Clean existing installation"
@@ -88,12 +88,12 @@
         - /home/autobot/autobot-vue
         - /home/autobot/backend
         - /etc/systemd/system/autobot-*.service
-      ignore_errors: yes
+      ignore_errors: true
       tags: ['cleanup']
 
     - name: "Reload systemd"
       systemd:
-        daemon_reload: yes
+        daemon_reload: true
       tags: ['cleanup']
 
   roles:

--- a/autobot-slm-backend/ansible/playbooks/rollback-dependencies.yml
+++ b/autobot-slm-backend/ansible/playbooks/rollback-dependencies.yml
@@ -17,7 +17,7 @@
 
 - name: "AutoBot Dependency Rollback - Pre-flight"
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: Display rollback warning
       ansible.builtin.debug:
@@ -42,7 +42,7 @@
 
 - name: "Rollback NPU Worker Services"
   hosts: npu
-  become: yes
+  become: true
   serial: 1
   vars:
     # Use most recent backup if not specified
@@ -57,7 +57,7 @@
 
 - name: "Rollback AI/ML Stack Services"
   hosts: aiml
-  become: yes
+  become: true
   serial: 1
   vars:
     latest_backup: "{{ lookup('pipe', 'ls -t ' ~ backup_base_path | default('/opt/autobot/backups') ~ '/venv-*.tar.gz 2>/dev/null | head -1') | default(omit) }}"
@@ -71,7 +71,7 @@
 
 - name: "Rollback Backend Services"
   hosts: backend
-  become: yes
+  become: true
   serial: 1
   vars:
     latest_backup: "{{ lookup('pipe', 'ls -t ' ~ backup_base_path | default('/opt/autobot/backups') ~ '/venv-*.tar.gz 2>/dev/null | head -1') | default(omit) }}"
@@ -85,7 +85,7 @@
 
 - name: "Post-Rollback Summary"
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: Display completion summary
       ansible.builtin.debug:

--- a/autobot-slm-backend/ansible/playbooks/rollback-system-packages.yml
+++ b/autobot-slm-backend/ansible/playbooks/rollback-system-packages.yml
@@ -17,7 +17,7 @@
 
 - name: "AutoBot System Rollback - Pre-flight"
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: Display rollback warning
       ansible.builtin.debug:
@@ -50,7 +50,7 @@
 # Rollback in reverse order of updates (most dependent first)
 - name: "Rollback Browser Services"
   hosts: browser
-  become: yes
+  become: true
   serial: 1
   tasks:
     - name: Include system rollback tasks
@@ -62,7 +62,7 @@
 
 - name: "Rollback Frontend Services"
   hosts: frontend
-  become: yes
+  become: true
   serial: 1
   tasks:
     - name: Include system rollback tasks
@@ -74,7 +74,7 @@
 
 - name: "Rollback NPU Worker Services"
   hosts: npu
-  become: yes
+  become: true
   serial: 1
   tasks:
     - name: Include system rollback tasks
@@ -86,7 +86,7 @@
 
 - name: "Rollback AI/ML Stack Services"
   hosts: aiml
-  become: yes
+  become: true
   serial: 1
   tasks:
     - name: Include system rollback tasks
@@ -98,7 +98,7 @@
 
 - name: "Rollback Backend Services"
   hosts: backend
-  become: yes
+  become: true
   serial: 1
   tasks:
     - name: Include system rollback tasks
@@ -110,7 +110,7 @@
 
 - name: "Rollback Database Services"
   hosts: database
-  become: yes
+  become: true
   serial: 1
   tasks:
     - name: Include system rollback tasks
@@ -122,7 +122,7 @@
 
 - name: "Post-Rollback Summary"
   hosts: localhost
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: Display completion summary
       ansible.builtin.debug:

--- a/autobot-slm-backend/ansible/playbooks/setup-passwordless-sudo.yml
+++ b/autobot-slm-backend/ansible/playbooks/setup-passwordless-sudo.yml
@@ -21,8 +21,8 @@
 ---
 - name: Configure Passwordless Sudo for AutoBot
   hosts: all
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   vars:
     sudoers_file: "/etc/sudoers.d/autobot-nopasswd"

--- a/autobot-slm-backend/ansible/playbooks/setup-vm-names-and-lvm.yml
+++ b/autobot-slm-backend/ansible/playbooks/setup-vm-names-and-lvm.yml
@@ -5,8 +5,8 @@
 
 - name: Setup VM Names and Expand LVM Storage
   hosts: all
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   vars:
     # LVM configuration
@@ -35,7 +35,7 @@
         path: /etc/hosts
         regexp: '^127\.0\.1\.1'
         line: "127.0.1.1 {{ vm_hostname }}.{{ autobot_domain | default('local') }} {{ vm_hostname }}"
-        backup: yes
+        backup: true
 
     - name: Update /etc/hosts with all AutoBot VMs
       blockinfile:
@@ -48,7 +48,7 @@
           {% endif %}
           {% endfor %}
         marker: "# {mark} AUTOBOT VM BLOCK"
-        backup: yes
+        backup: true
 
     - name: Check current LVM setup
       shell: |
@@ -61,7 +61,7 @@
         echo "=== Filesystem Usage ==="
         df -h /
       register: lvm_info
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Display current LVM configuration
       debug:
@@ -71,7 +71,7 @@
     - name: Get available disk space
       shell: vgs --noheadings --units g -o vg_free {{ volume_group }}
       register: vg_free_space
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Check if LVM expansion is needed
       set_fact:
@@ -96,18 +96,18 @@
         # Refresh volume group
         vgchange -a y {{ volume_group }}
       when: vm_resources is defined and expansion_needed | default(false) | bool
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Extend logical volume to use available space
       lvol:
         vg: "{{ volume_group }}"
         lv: "{{ logical_volume }}"
         size: "+100%FREE"
-        resizefs: yes
-        force: yes
+        resizefs: true
+        force: true
       when: vm_resources is defined and expansion_needed | default(false) | bool
       register: lv_extend_result
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Alternative LVM extension method (if first method fails)
       shell: |
@@ -119,7 +119,7 @@
         - expansion_needed | bool
         - lv_extend_result is failed
       register: manual_extend
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Verify disk expansion results
       shell: |
@@ -135,11 +135,11 @@
 
     - name: Update system packages (since we're setting up VMs)
       apt:
-        update_cache: yes
+        update_cache: true
         cache_valid_time: 3600
         upgrade: dist
-        autoremove: yes
-        autoclean: yes
+        autoremove: true
+        autoclean: true
       register: package_update
       retries: 3
       delay: 10
@@ -170,14 +170,14 @@
           - rsync
           - ntp
         state: present
-        update_cache: yes
+        update_cache: true
         cache_valid_time: 3600
 
     - name: Configure NTP for time synchronization
       service:
         name: systemd-timesyncd
         state: started
-        enabled: yes
+        enabled: true
 
     - name: Create autobot application directory structure
       file:

--- a/autobot-slm-backend/ansible/playbooks/slm-service-control.yml
+++ b/autobot-slm-backend/ansible/playbooks/slm-service-control.yml
@@ -5,8 +5,8 @@
 
 - name: "SLM Service Control"
   hosts: target
-  gather_facts: no
-  become: yes
+  gather_facts: false
+  become: true
 
   vars:
     service_name: "{{ service | mandatory }}"

--- a/autobot-slm-backend/ansible/playbooks/slm-service-logs.yml
+++ b/autobot-slm-backend/ansible/playbooks/slm-service-logs.yml
@@ -5,8 +5,8 @@
 
 - name: "SLM Get Service Logs"
   hosts: target
-  gather_facts: no
-  become: yes
+  gather_facts: false
+  become: true
 
   vars:
     service_name: "{{ service | mandatory }}"

--- a/autobot-slm-backend/ansible/playbooks/sync-user-backend.yml
+++ b/autobot-slm-backend/ansible/playbooks/sync-user-backend.yml
@@ -5,7 +5,7 @@
 
 - name: Sync User Backend Code
   hosts: autobot-host
-  gather_facts: no
+  gather_facts: false
   vars:
     local_autobot_root: "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"
     backend_user: "autobot"
@@ -17,8 +17,8 @@
       ansible.builtin.systemd:
         name: autobot-backend
         state: stopped
-      become: yes
-      ignore_errors: yes  # Service might not be running
+      become: true
+      ignore_errors: true  # Service might not be running
 
     - name: Clean up problematic symlinks
       ansible.builtin.file:
@@ -27,8 +27,8 @@
       loop:
         - autobot_shared
         - backend
-      become: yes
-      ignore_errors: yes
+      become: true
+      ignore_errors: true
 
     - name: Sync code using direct sudo rsync
       ansible.builtin.shell: |
@@ -58,17 +58,17 @@
         path: "{{ item }}"
         owner: "{{ backend_user }}"
         group: "{{ backend_user }}"
-        recurse: yes
+        recurse: true
       loop:
         - "{{ backend_install_dir }}/autobot-backend"
         - "{{ backend_install_dir }}/autobot_shared"
-      become: yes
+      become: true
 
     - name: Start backend service
       ansible.builtin.systemd:
         name: autobot-backend
         state: started
-      become: yes
+      become: true
 
     - name: Wait for backend to initialize
       ansible.builtin.pause:
@@ -79,7 +79,7 @@
         url: "http://{{ backend_host }}:8001/api/health"
         timeout: 5
       register: health_check
-      ignore_errors: yes
+      ignore_errors: true
       retries: 5
       delay: 3
       until: health_check.status == 200

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -55,7 +55,7 @@
         repo: "{{ github_repo }}"
         dest: "{{ git_repo_root }}"
         version: "{{ deploy_ref }}"
-        force: yes
+        force: true
         depth: 1
 
     - name: "[PRE-FLIGHT] Get current git branch"

--- a/autobot-slm-backend/ansible/roles/access_control/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/access_control/handlers/main.yml
@@ -6,7 +6,7 @@
 
 - name: reload systemd
   systemd:
-    daemon_reload: yes
+    daemon_reload: true
 
 - name: restart access-monitor
   systemd:

--- a/autobot-slm-backend/ansible/roles/access_control/tasks/monitoring.yml
+++ b/autobot-slm-backend/ansible/roles/access_control/tasks/monitoring.yml
@@ -32,9 +32,9 @@
 - name: Enable and start monitoring timer
   systemd:
     name: autobot-access-monitor.timer
-    enabled: yes
+    enabled: true
     state: started
-    daemon_reload: yes
+    daemon_reload: true
 
 - name: Display monitoring status
   debug:

--- a/autobot-slm-backend/ansible/roles/agent_config/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/handlers/main.yml
@@ -8,5 +8,5 @@
   systemd:
     name: autobot-agent
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
   when: create_systemd_service

--- a/autobot-slm-backend/ansible/roles/agent_config/tasks/config.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/tasks/config.yml
@@ -54,7 +54,7 @@
   lineinfile:
     path: "/home/{{ service_user }}/.bashrc"
     line: "export {{ item.key }}={{ item.value }}"
-    create: yes
+    create: true
     owner: "{{ service_user }}"
     group: "{{ service_group }}"
   loop: "{{ env_vars | dict2items }}"

--- a/autobot-slm-backend/ansible/roles/agent_config/tasks/ollama.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/tasks/ollama.yml
@@ -27,7 +27,7 @@
   systemd:
     name: ollama
     state: started
-    enabled: yes
+    enabled: true
 
 - name: Pull Ollama models
   command: "ollama pull {{ item }}"

--- a/autobot-slm-backend/ansible/roles/agent_config/tasks/openvino.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/tasks/openvino.yml
@@ -49,7 +49,7 @@
   user:
     name: "{{ service_user }}"
     groups: render
-    append: yes
+    append: true
 
 - name: Set up OpenVINO environment in venv
   pip:

--- a/autobot-slm-backend/ansible/roles/agent_config/tasks/service.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/tasks/service.yml
@@ -15,12 +15,12 @@
 
 - name: Reload systemd daemon
   systemd:
-    daemon_reload: yes
+    daemon_reload: true
 
 - name: Enable autobot-agent service
   systemd:
     name: autobot-agent
-    enabled: yes
+    enabled: true
 
 # (#2872) Removed failed_when: false — service start failures must
 # surface so deployment reports the real state.

--- a/autobot-slm-backend/ansible/roles/backend_services/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend_services/tasks/main.yml
@@ -5,7 +5,7 @@
     name: autobot
     home: /opt/autobot
     shell: /bin/bash
-    system: yes
+    system: true
 
 - name: Create AutoBot directories
   file:
@@ -65,6 +65,6 @@
 - name: Enable and start backend services
   systemd:
     name: autobot-backend
-    enabled: yes
+    enabled: true
     state: started
-    daemon_reload: yes
+    daemon_reload: true

--- a/autobot-slm-backend/ansible/roles/browser/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/browser/handlers/main.yml
@@ -5,7 +5,7 @@
   systemd:
     name: autobot-vnc
     state: restarted
-  become: yes
+  become: true
   # (#2872) Intentional: VNC service may not be deployed on all browser
   # nodes (install_vnc flag).  Handler is notified from tasks that are
   # conditionally included, so it must tolerate the unit being absent.
@@ -15,17 +15,17 @@
   systemd:
     name: autobot-playwright
     state: restarted
-  become: yes
+  become: true
   # (#2872) Intentional: Playwright service may not be deployed yet when
   # the handler fires during initial provisioning.
   failed_when: false
 
 - name: reload systemd
   systemd:
-    daemon_reload: yes
-  become: yes
+    daemon_reload: true
+  become: true
 
 - name: reload firewall
   ufw:
     state: reloaded
-  become: yes
+  become: true

--- a/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
@@ -60,7 +60,7 @@
     owner: "{{ browser_user }}"
     group: "{{ browser_group }}"
     mode: '0755'
-  become: yes
+  become: true
   tags: ['browser', 'deploy']
 
 - name: "Browser | Sync browser worker code from code_source"
@@ -90,7 +90,7 @@
       - x11vnc
       - xvfb
     state: present
-  become: yes
+  become: true
   when:
     - install_vnc | default(false)
     - node_roles is not defined or 'vnc' in node_roles
@@ -124,7 +124,7 @@
              if ansible_facts['distribution_release'] == 'noble'
              else ['libasound2', 'libatk1.0-0']) }}
     state: present
-  become: yes
+  become: true
   tags: ['browser', 'packages']
 
 - name: "Browser | Install Playwright and FastAPI dependencies via pip"
@@ -136,7 +136,7 @@
       - fastapi
     state: present
     executable: pip3
-  become: yes
+  become: true
   environment:
     PIP_DEFAULT_TIMEOUT: "120"
   timeout: 300  # Issue #2835: prevent indefinite hang on dependency resolution
@@ -154,7 +154,7 @@
   npm:
     path: /opt/autobot/autobot-browser-worker
     state: present
-  become: yes
+  become: true
   when: _browser_worker_dir.stat.exists | default(false)
   tags: ['browser', 'packages']
 
@@ -169,7 +169,7 @@
     owner: root
     group: root
     mode: "0755"
-  become: yes
+  become: true
   tags: ['browser', 'packages']
 
 # Guard: skip the ~2-minute install when Chromium is already present. (#4855, #4662)
@@ -179,7 +179,7 @@
   ansible.builtin.find:
     paths: /var/lib/autobot/playwright-browsers
     patterns: "chrome"
-    recurse: yes
+    recurse: true
     file_type: file
   register: _chromium_binary
   tags: ['browser', 'packages']
@@ -188,7 +188,7 @@
   ansible.builtin.command:
     cmd: node_modules/.bin/playwright install chromium
     chdir: /opt/autobot/autobot-browser-worker
-  become: yes
+  become: true
   environment:
     PLAYWRIGHT_BROWSERS_PATH: /var/lib/autobot/playwright-browsers
   changed_when: true
@@ -201,9 +201,9 @@
   ansible.builtin.find:
     paths: /var/lib/autobot/playwright-browsers
     file_type: directory
-    recurse: yes
+    recurse: true
   register: _pb_dirs
-  become: yes
+  become: true
   when: _browser_worker_dir.stat.exists | default(false)
   tags: ['browser', 'packages']
 
@@ -213,7 +213,7 @@
     state: directory
     mode: "0755"
   loop: "{{ _pb_dirs.files | default([]) }}"
-  become: yes
+  become: true
   when: _browser_worker_dir.stat.exists | default(false)
   tags: ['browser', 'packages']
 
@@ -221,9 +221,9 @@
   ansible.builtin.find:
     paths: /var/lib/autobot/playwright-browsers
     file_type: file
-    recurse: yes
+    recurse: true
   register: _pb_files
-  become: yes
+  become: true
   when: _browser_worker_dir.stat.exists | default(false)
   tags: ['browser', 'packages']
 
@@ -233,7 +233,7 @@
     state: file
     mode: "0644"
   loop: "{{ _pb_files.files | default([]) }}"
-  become: yes
+  become: true
   when: _browser_worker_dir.stat.exists | default(false)
   tags: ['browser', 'packages']
 
@@ -244,7 +244,7 @@
     owner: autobot
     group: autobot
     mode: '0700'
-  become: yes
+  become: true
   when:
     - install_vnc | default(false)
     - node_roles is not defined or 'vnc' in node_roles
@@ -254,7 +254,7 @@
   stat:
     path: /etc/autobot/vnc-secrets.env
   register: browser_vnc_secrets_stat
-  become: yes
+  become: true
   when:
     - install_vnc | default(false)
     - node_roles is not defined or 'vnc' in node_roles
@@ -268,7 +268,7 @@
     chown root:autobot /etc/autobot/vnc-secrets.env
   args:
     creates: /etc/autobot/vnc-secrets.env
-  become: yes
+  become: true
   when:
     - install_vnc | default(false)
     - node_roles is not defined or 'vnc' in node_roles
@@ -281,7 +281,7 @@
     | cut -d= -f2
   register: browser_vnc_password
   changed_when: false
-  become: yes
+  become: true
   when:
     - install_vnc | default(false)
     - node_roles is not defined or 'vnc' in node_roles
@@ -293,7 +293,7 @@
       > /home/autobot/.vnc/passwd
     chmod 0600 /home/autobot/.vnc/passwd
     chown autobot:autobot /home/autobot/.vnc/passwd
-  become: yes
+  become: true
   when:
     - install_vnc | default(false)
     - node_roles is not defined or 'vnc' in node_roles
@@ -305,7 +305,7 @@
     src: vnc.service.j2
     dest: /etc/systemd/system/autobot-vnc.service
     mode: '0644'
-  become: yes
+  become: true
   when:
     - install_vnc | default(false)
     - node_roles is not defined or 'vnc' in node_roles
@@ -319,7 +319,7 @@
     src: playwright.service.j2
     dest: /etc/systemd/system/autobot-playwright.service
     mode: '0644'
-  become: yes
+  become: true
   notify:
     - reload systemd
     - restart playwright
@@ -332,7 +332,7 @@
     proto: tcp
     from_ip: "{{ network_subnet }}"
     comment: "VNC Server"
-  become: yes
+  become: true
   when:
     - install_vnc | default(false)
     - node_roles is not defined or 'vnc' in node_roles
@@ -346,7 +346,7 @@
     proto: tcp
     from_ip: "{{ network_subnet }}"
     delete: true
-  become: yes
+  become: true
   loop: "{{ playwright_ports_legacy | default([]) }}"
   when: item | int != playwright_port | int
   ignore_errors: true
@@ -359,16 +359,16 @@
     proto: tcp
     from_ip: "{{ network_subnet }}"
     comment: "Playwright API"
-  become: yes
+  become: true
   notify: reload firewall
   tags: ['browser', 'firewall']
 
 - name: "Browser | Enable VNC service"
   systemd:
     name: autobot-vnc
-    enabled: yes
-    daemon_reload: yes
-  become: yes
+    enabled: true
+    daemon_reload: true
+  become: true
   when:
     - install_vnc | default(false)
     - node_roles is not defined or 'vnc' in node_roles
@@ -377,9 +377,9 @@
 - name: "Browser | Enable Playwright service"
   systemd:
     name: autobot-playwright
-    enabled: yes
-    daemon_reload: yes
-  become: yes
+    enabled: true
+    daemon_reload: true
+  become: true
   tags: ['browser', 'service']
 
 - name: "Browser | Display configuration summary"

--- a/autobot-slm-backend/ansible/roles/centralized_logging/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/centralized_logging/handlers/main.yml
@@ -6,7 +6,7 @@
 
 - name: reload systemd
   systemd:
-    daemon_reload: yes
+    daemon_reload: true
 
 - name: restart loki
   systemd:

--- a/autobot-slm-backend/ansible/roles/centralized_logging/tasks/loki.yml
+++ b/autobot-slm-backend/ansible/roles/centralized_logging/tasks/loki.yml
@@ -26,7 +26,7 @@
   unarchive:
     src: "/tmp/loki-linux-amd64.zip"
     dest: "/tmp/"
-    remote_src: yes
+    remote_src: true
   when: not loki_binary.stat.exists
 
 - name: Install Loki binary
@@ -34,7 +34,7 @@
     src: "/tmp/loki-linux-amd64"
     dest: "{{ loki_binary_path }}"
     mode: '0755'
-    remote_src: yes
+    remote_src: true
   when: not loki_binary.stat.exists
   notify: restart loki
 
@@ -72,9 +72,9 @@
 - name: Enable and start Loki service
   systemd:
     name: loki
-    enabled: yes
+    enabled: true
     state: started
-    daemon_reload: yes
+    daemon_reload: true
 
 - name: Wait for Loki to be ready
   uri:

--- a/autobot-slm-backend/ansible/roles/centralized_logging/tasks/monitoring.yml
+++ b/autobot-slm-backend/ansible/roles/centralized_logging/tasks/monitoring.yml
@@ -27,7 +27,7 @@
 - name: Enable log monitoring timer
   systemd:
     name: autobot-log-monitor.timer
-    enabled: yes
+    enabled: true
     state: started
-    daemon_reload: yes
+    daemon_reload: true
   when: enable_alerting

--- a/autobot-slm-backend/ansible/roles/centralized_logging/tasks/promtail.yml
+++ b/autobot-slm-backend/ansible/roles/centralized_logging/tasks/promtail.yml
@@ -26,7 +26,7 @@
   unarchive:
     src: "/tmp/promtail-linux-amd64.zip"
     dest: "/tmp/"
-    remote_src: yes
+    remote_src: true
   when: not promtail_binary.stat.exists
 
 - name: Install Promtail binary
@@ -34,7 +34,7 @@
     src: "/tmp/promtail-linux-amd64"
     dest: "{{ promtail_binary_path }}"
     mode: '0755'
-    remote_src: yes
+    remote_src: true
   when: not promtail_binary.stat.exists
   notify: restart promtail
 
@@ -71,9 +71,9 @@
 - name: Enable and start Promtail service
   systemd:
     name: promtail
-    enabled: yes
+    enabled: true
     state: started
-    daemon_reload: yes
+    daemon_reload: true
 
 - name: Cleanup temporary files
   file:

--- a/autobot-slm-backend/ansible/roles/common/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/handlers/main.yml
@@ -4,10 +4,10 @@
 - name: reload firewall
   ufw:
     state: reloaded
-  become: yes
+  become: true
 
 - name: restart ssh
   systemd:
     name: sshd
     state: restarted
-  become: yes
+  become: true

--- a/autobot-slm-backend/ansible/roles/common/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/tasks/main.yml
@@ -39,7 +39,7 @@
       - iputils-ping
       - dnsutils
     state: present
-  become: yes
+  become: true
   tags: ['common', 'packages']
 
 - name: "Common | Create autobot user"
@@ -48,9 +48,9 @@
     comment: "AutoBot Service User"
     home: /home/autobot
     shell: /bin/bash
-    create_home: yes
+    create_home: true
     state: present
-  become: yes
+  become: true
   tags: ['common', 'users']
 
 - name: "Common | Create emergency admin user"
@@ -58,12 +58,12 @@
     name: "{{ emergency_admin_user }}"
     comment: "Emergency Admin User (fallback access)"
     shell: /bin/bash
-    create_home: yes
+    create_home: true
     groups: sudo
-    append: yes
+    append: true
     password: "{{ emergency_admin_password_hash }}"
     state: present
-  become: yes
+  become: true
   when: emergency_admin_password_hash is defined
   tags: ['common', 'users', 'emergency']
 
@@ -75,7 +75,7 @@
     group: root
     mode: '0440'
     validate: 'visudo -cf %s'
-  become: yes
+  become: true
   when: emergency_admin_password_hash is defined
   tags: ['common', 'users', 'emergency']
 
@@ -92,7 +92,7 @@
     - /opt/autobot/data
     - /opt/autobot/config
     - /opt/autobot/scripts
-  become: yes
+  become: true
   tags: ['common', 'directories']
 
 # Issue #2828: Use shared key path so any user in the autobot group can
@@ -102,7 +102,7 @@
     user: autobot
     key: "{{ lookup('file', '/etc/autobot/ssh/autobot_key.pub') }}"
     state: present
-  become: yes
+  become: true
   when: lookup('file', '/etc/autobot/ssh/autobot_key.pub', errors='ignore') is not none
   tags: ['common', 'ssh']
 
@@ -111,17 +111,17 @@
     - name: "Common | Disable UFW temporarily"
       ufw:
         state: disabled
-      become: yes
+      become: true
 
     - name: "Common | Reset UFW rules to defaults"
       command: ufw --force reset
-      become: yes
+      become: true
       changed_when: true
 
     - name: "Common | Re-enable UFW"
       ufw:
         state: enabled
-      become: yes
+      become: true
   when: ufw_reset_rules | default(false) | bool
   tags: ['common', 'firewall', 'firewall-reset']
 
@@ -134,7 +134,7 @@
     - { direction: 'incoming', policy: "{{ ufw_default_incoming_policy }}" }
     - { direction: 'outgoing', policy: "{{ ufw_default_outgoing_policy }}" }
     - { direction: 'routed', policy: "{{ ufw_default_routed_policy }}" }
-  become: yes
+  become: true
   tags: ['common', 'firewall']
 
 - name: "Common | Allow all localhost traffic (#2722)"
@@ -143,7 +143,7 @@
     from_ip: 127.0.0.1
     to_ip: 127.0.0.1
     comment: "Allow localhost"
-  become: yes
+  become: true
   tags: ['common', 'firewall']
 
 - name: "Common | Merge base and role-specific firewall rules (#894)"
@@ -160,7 +160,7 @@
     to_ip: "{{ item.dest | default('any') }}"
     comment: "{{ item.comment | default('AutoBot rule') }}"
   loop: "{{ merged_firewall_rules }}"
-  become: yes
+  become: true
   notify: reload firewall
   when: merged_firewall_rules | length > 0
   tags: ['common', 'firewall']
@@ -168,20 +168,20 @@
 - name: "Common | Configure firewall - Set logging level (#887)"
   ufw:
     logging: "{{ ufw_logging }}"
-  become: yes
+  become: true
   tags: ['common', 'firewall']
 
 - name: "Common | Enable firewall"
   ufw:
     state: enabled
-  become: yes
+  become: true
   when: ufw_enabled | bool
   tags: ['common', 'firewall']
 
 - name: "Common | Set hostname"
   hostname:
     name: "{{ inventory_hostname }}"
-  become: yes
+  become: true
   when:
     - inventory_hostname is defined
     - inventory_hostname != '00-SLM-Manager'
@@ -193,7 +193,7 @@
     line: "{{ ansible_facts['default_ipv4'].address }} {{ inventory_hostname }} {{ inventory_hostname_short }}"
     regexp: "^{{ ansible_facts['default_ipv4'].address }}"
     state: present
-  become: yes
+  become: true
   when:
     - ansible_facts['default_ipv4'].address is defined
     - inventory_hostname != '00-SLM-Manager'
@@ -206,7 +206,7 @@
     owner: root
     group: root
     mode: '0644'
-  become: yes
+  become: true
   when: dns_servers is defined
   tags: ['common', 'dns']
 
@@ -227,7 +227,7 @@
       - wheel
     state: latest
     executable: pip3
-  become: yes
+  become: true
   environment:
     PIP_DEFAULT_TIMEOUT: "120"
   timeout: 120  # Issue #2835: prevent indefinite hang on network issues
@@ -241,7 +241,7 @@
     owner: autobot
     group: autobot
     mode: '0755'
-  become: yes
+  become: true
   tags: ['common', 'logging']
 
 - name: "Common | Display configuration summary"

--- a/autobot-slm-backend/ansible/roles/dependency_patching/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/dependency_patching/handlers/main.yml
@@ -9,28 +9,28 @@
   ansible.builtin.systemd:
     name: autobot-backend
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
   listen: "restart autobot services"
 
 - name: Restart AI stack service
   ansible.builtin.systemd:
     name: autobot-aistack
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
   listen: "restart autobot services"
 
 - name: Restart NPU worker service
   ansible.builtin.systemd:
     name: autobot-npu
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
   listen: "restart autobot services"
 
 - name: Restart frontend service
   ansible.builtin.systemd:
     name: autobot-frontend
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
   listen: "restart autobot services"
 
 - name: Restart Redis service
@@ -41,5 +41,5 @@
 
 - name: Reload systemd
   ansible.builtin.systemd:
-    daemon_reload: yes
+    daemon_reload: true
   listen: "reload systemd"

--- a/autobot-slm-backend/ansible/roles/dependency_patching/tasks/post-update.yml
+++ b/autobot-slm-backend/ansible/roles/dependency_patching/tasks/post-update.yml
@@ -13,7 +13,7 @@
   ansible.builtin.systemd:
     name: "{{ current_service.service_name }}"
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
   when:
     - restart_service_after_update
     - current_service.service_name is defined

--- a/autobot-slm-backend/ansible/roles/dependency_patching/tasks/rollback-system.yml
+++ b/autobot-slm-backend/ansible/roles/dependency_patching/tasks/rollback-system.yml
@@ -75,7 +75,7 @@
 
 - name: Reload systemd daemon first
   ansible.builtin.systemd:
-    daemon_reload: yes
+    daemon_reload: true
 
 - name: Check if service unit file exists
   ansible.builtin.stat:

--- a/autobot-slm-backend/ansible/roles/dependency_patching/tasks/rollback.yml
+++ b/autobot-slm-backend/ansible/roles/dependency_patching/tasks/rollback.yml
@@ -55,7 +55,7 @@
   ansible.builtin.unarchive:
     src: "{{ latest_backup }}"
     dest: "{{ temp_restore_dir.path }}"
-    remote_src: yes
+    remote_src: true
   when:
     - backup_exists.stat.exists | default(false)
     - temp_restore_dir.path is defined
@@ -105,7 +105,7 @@
   ansible.builtin.systemd:
     name: "{{ current_service.service_name }}"
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
   when:
     - current_service.service_name is defined
     - venv_restored.changed | default(false)

--- a/autobot-slm-backend/ansible/roles/dependency_patching/tasks/update-system.yml
+++ b/autobot-slm-backend/ansible/roles/dependency_patching/tasks/update-system.yml
@@ -56,7 +56,7 @@
       ansible.builtin.copy:
         src: /etc/apt/sources.list
         dest: "{{ backup_base_path }}/system/sources.list-{{ ansible_facts['date_time'].iso8601_basic }}"
-        remote_src: yes
+        remote_src: true
       when: backup_enabled
 
     - name: Record pre-update state
@@ -88,7 +88,7 @@
 
     - name: Update apt cache
       ansible.builtin.apt:
-        update_cache: yes
+        update_cache: true
         cache_valid_time: 300
       register: apt_cache_result
       retries: 3
@@ -111,8 +111,8 @@
     - name: Perform full system update
       ansible.builtin.apt:
         upgrade: safe
-        autoremove: yes
-        autoclean: yes
+        autoremove: true
+        autoclean: true
       when: not (security_only | default(false))
       register: full_update_result
       timeout: "{{ system_update_timeout }}"
@@ -150,7 +150,7 @@
       ansible.builtin.systemd:
         name: "{{ current_service.service_name }}"
         state: started
-        daemon_reload: yes
+        daemon_reload: true
       when:
         - current_service.service_name is defined
         - restart_service_after_update

--- a/autobot-slm-backend/ansible/roles/distributed_setup/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/distributed_setup/handlers/main.yml
@@ -6,7 +6,7 @@
 
 - name: reload systemd
   systemd:
-    daemon_reload: yes
+    daemon_reload: true
 
 - name: restart autobot-coordinator
   systemd:

--- a/autobot-slm-backend/ansible/roles/distributed_setup/tasks/config.yml
+++ b/autobot-slm-backend/ansible/roles/distributed_setup/tasks/config.yml
@@ -49,7 +49,7 @@
   lineinfile:
     path: "{{ config_dir }}/autobot.env"
     line: "AUTOBOT_DEPLOYMENT_MODE=distributed"
-    create: yes
+    create: true
     owner: "{{ service_user }}"
     group: "{{ service_group }}"
     mode: '0640'

--- a/autobot-slm-backend/ansible/roles/distributed_setup/tasks/health_monitoring.yml
+++ b/autobot-slm-backend/ansible/roles/distributed_setup/tasks/health_monitoring.yml
@@ -29,9 +29,9 @@
 - name: Enable and start health monitoring timer
   systemd:
     name: autobot-health-monitor.timer
-    enabled: yes
+    enabled: true
     state: started
-    daemon_reload: yes
+    daemon_reload: true
   when: create_systemd_services
 
 - name: Create health check status directory

--- a/autobot-slm-backend/ansible/roles/distributed_setup/tasks/redis_cli.yml
+++ b/autobot-slm-backend/ansible/roles/distributed_setup/tasks/redis_cli.yml
@@ -34,7 +34,7 @@
       unarchive:
         src: "/tmp/redis-{{ redis_cli_version }}.tar.gz"
         dest: /tmp
-        remote_src: yes
+        remote_src: true
 
     - name: Compile redis-cli
       command: make redis-cli
@@ -52,7 +52,7 @@
         src: "/tmp/redis-{{ redis_cli_version }}/src/redis-cli"
         dest: "{{ ansible_facts['env'].HOME }}/.local/bin/redis-cli"
         mode: '0755'
-        remote_src: yes
+        remote_src: true
 
     - name: Add local bin to PATH in bashrc
       lineinfile:
@@ -61,7 +61,7 @@
         # with the dict-key quotes from ansible_facts['env'].
         line: 'export PATH="{{ ansible_facts.env.HOME }}/.local/bin:$PATH"'
         state: present
-        create: yes
+        create: true
 
   when: (redis_cli_check.rc != 0 and redis_cli_build_from_source) or (redis_tools_install is defined and redis_tools_install.failed)
 

--- a/autobot-slm-backend/ansible/roles/distributed_setup/tasks/service_scripts.yml
+++ b/autobot-slm-backend/ansible/roles/distributed_setup/tasks/service_scripts.yml
@@ -56,6 +56,6 @@
 - name: Enable coordinator service
   systemd:
     name: autobot-coordinator
-    enabled: yes
-    daemon_reload: yes
+    enabled: true
+    daemon_reload: true
   when: create_systemd_services and inventory_hostname == groups['slm_server'][0]

--- a/autobot-slm-backend/ansible/roles/dns/tasks/dnsmasq.yml
+++ b/autobot-slm-backend/ansible/roles/dns/tasks/dnsmasq.yml
@@ -21,7 +21,7 @@
 - name: Enable dnsmasq service
   systemd:
     name: dnsmasq
-    enabled: yes
+    enabled: true
     state: started
 
 - name: Configure resolv.conf to use dnsmasq

--- a/autobot-slm-backend/ansible/roles/dns/tasks/etc_hosts.yml
+++ b/autobot-slm-backend/ansible/roles/dns/tasks/etc_hosts.yml
@@ -28,7 +28,7 @@
       {{ entry.ip }}    {{ entry.hostnames | join(' ') }}
       {% endfor %}
     state: present
-    create: yes
+    create: true
     mode: '0644'
 
 - name: Verify /etc/hosts entries

--- a/autobot-slm-backend/ansible/roles/dns/tasks/systemd_resolved.yml
+++ b/autobot-slm-backend/ansible/roles/dns/tasks/systemd_resolved.yml
@@ -25,7 +25,7 @@
 - name: Enable systemd-resolved
   systemd:
     name: systemd-resolved
-    enabled: yes
+    enabled: true
     state: started
   when: resolved_check.rc == 0
 
@@ -34,7 +34,7 @@
     src: /run/systemd/resolve/stub-resolv.conf
     dest: /etc/resolv.conf
     state: link
-    force: yes
+    force: true
   when: resolved_check.rc == 0
 
 - name: Verify systemd-resolved status

--- a/autobot-slm-backend/ansible/roles/frontend/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/handlers/main.yml
@@ -5,17 +5,17 @@
   systemd:
     name: nginx
     state: reloaded
-  become: yes
+  become: true
 
 - name: test nginx config
   command: nginx -t
-  become: yes
+  become: true
 
 - name: restart frontend
   systemd:
     name: autobot-frontend
     state: restarted
-  become: yes
+  become: true
   # (#2872) Intentional: autobot-frontend service may not exist on hosts
   # that serve only the static build via nginx (no dev server).  Handler
   # is notified from tasks that conditionally deploy the unit file.
@@ -23,10 +23,10 @@
 
 - name: reload systemd
   systemd:
-    daemon_reload: yes
-  become: yes
+    daemon_reload: true
+  become: true
 
 - name: reload firewall
   ufw:
     state: reloaded
-  become: yes
+  become: true

--- a/autobot-slm-backend/ansible/roles/frontend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/tasks/main.yml
@@ -63,7 +63,7 @@
     owner: "{{ frontend_user }}"
     group: "{{ frontend_group }}"
     mode: '0755'
-  become: yes
+  become: true
   tags: ['frontend', 'directories']
 
 - name: "Frontend | Sync frontend code from code_source"
@@ -93,7 +93,7 @@
     owner: root
     group: root
     mode: '0755'
-  become: yes
+  become: true
   tags: ['frontend', 'tls']
 
 - name: "Frontend | Check existing TLS certificate"
@@ -110,7 +110,7 @@
     -keyout {{ frontend_tls_key }}
     -out {{ frontend_tls_cert }}
     -subj "/CN={{ ansible_host | default('127.0.0.1') }}/O=AutoBot/C=US"
-  become: yes
+  become: true
   when: not _tls_cert.stat.exists
   notify: restart nginx
   tags: ['frontend', 'tls']
@@ -121,7 +121,7 @@
     owner: root
     group: root
     mode: '0644'
-  become: yes
+  become: true
   when: not _tls_cert.stat.exists
   tags: ['frontend', 'tls']
 
@@ -135,7 +135,7 @@
   ansible.builtin.command:
     cmd: npm install --legacy-peer-deps
     chdir: "{{ frontend_install_dir }}/autobot-frontend"
-  become: yes
+  become: true
   become_user: "{{ frontend_user }}"
   environment:
     CYPRESS_INSTALL_BINARY: "0"
@@ -148,7 +148,7 @@
   ansible.builtin.command:
     cmd: npm install esbuild --legacy-peer-deps
     chdir: "{{ frontend_install_dir }}/autobot-frontend"
-  become: yes
+  become: true
   become_user: "{{ frontend_user }}"
   when: package_json_path.stat.exists
   changed_when: true
@@ -158,7 +158,7 @@
   command: npx vite build
   args:
     chdir: "{{ frontend_install_dir }}/autobot-frontend"
-  become: yes
+  become: true
   become_user: "{{ frontend_user }}"
   when: package_json_path.stat.exists
   tags: ['frontend', 'build']
@@ -169,8 +169,8 @@
     src: nginx-frontend.conf.j2
     dest: /etc/nginx/sites-available/autobot-frontend
     mode: '0644'
-    backup: yes
-  become: yes
+    backup: true
+  become: true
   notify:
     - test nginx config
     - restart nginx
@@ -182,7 +182,7 @@
     src: /etc/nginx/sites-available/autobot-frontend
     dest: /etc/nginx/sites-enabled/autobot-frontend
     state: link
-  become: yes
+  become: true
   notify: restart nginx
   when: not (slm_colocated_frontend | default(false) | bool)
   tags: ['frontend', 'nginx']
@@ -191,7 +191,7 @@
   file:
     path: /etc/nginx/sites-enabled/autobot-frontend
     state: absent
-  become: yes
+  become: true
   notify: restart nginx
   when: slm_colocated_frontend | default(false) | bool
   tags: ['frontend', 'nginx']
@@ -200,7 +200,7 @@
   file:
     path: /etc/nginx/sites-enabled/default
     state: absent
-  become: yes
+  become: true
   notify: restart nginx
   tags: ['frontend', 'nginx']
 
@@ -210,7 +210,7 @@
     port: "{{ nginx_http_port }}"
     proto: tcp
     comment: "HTTP (redirects to HTTPS)"
-  become: yes
+  become: true
   notify: reload firewall
   tags: ['frontend', 'firewall']
 
@@ -220,17 +220,17 @@
     port: "{{ frontend_port }}"
     proto: tcp
     comment: "HTTPS"
-  become: yes
+  become: true
   notify: reload firewall
   tags: ['frontend', 'firewall']
 
 - name: "Frontend | Enable and start nginx"
   systemd:
     name: nginx
-    enabled: yes
+    enabled: true
     state: started
-    daemon_reload: yes
-  become: yes
+    daemon_reload: true
+  become: true
   tags: ['frontend', 'service']
 
 - name: "Frontend | Check if legacy Vite dev server service exists"
@@ -243,8 +243,8 @@
   systemd:
     name: autobot-frontend
     state: stopped
-    enabled: no
-  become: yes
+    enabled: false
+  become: true
   when: _legacy_frontend_service.stat.exists
   tags: ['frontend', 'cleanup']
 

--- a/autobot-slm-backend/ansible/roles/llm/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/llm/tasks/main.yml
@@ -163,7 +163,7 @@
     cmd: "ollama pull {{ item }}"
   loop: "{{ _llm_models_to_pull }}"
   when: llm_pull_models | default(true)
-  become: yes
+  become: true
   register: _model_pull
   changed_when: "'pulling' in (_model_pull.stderr | default(''))"
   failed_when: _model_pull.rc != 0

--- a/autobot-slm-backend/ansible/roles/postgresql/tasks/install.yml
+++ b/autobot-slm-backend/ansible/roles/postgresql/tasks/install.yml
@@ -124,7 +124,7 @@
     login_port: "{{ postgresql_port }}"
     login_user: "{{ postgresql_user | default('postgres') }}"
     query: "SELECT 1"
-  become: yes
+  become: true
   become_user: postgres
   retries: 60
   delay: 5

--- a/autobot-slm-backend/ansible/roles/redis/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/handlers/main.yml
@@ -5,25 +5,25 @@
   systemd:
     name: redis-stack-server
     state: restarted
-  become: yes
+  become: true
 
 - name: reload systemd
   systemd:
-    daemon_reload: yes
-  become: yes
+    daemon_reload: true
+  become: true
 
 - name: reload firewall
   ufw:
     state: reloaded
-  become: yes
+  become: true
 
 - name: Reload systemd
   ansible.builtin.systemd:
     daemon_reload: true
-  become: yes
+  become: true
 
 - name: Restart redis_exporter
   ansible.builtin.systemd:
     name: redis_exporter
     state: restarted
-  become: yes
+  become: true

--- a/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
@@ -15,7 +15,7 @@
   apt_key:
     url: https://packages.redis.io/gpg
     state: present
-  become: yes
+  become: true
   when: _redis_installed.rc != 0
   tags: ['redis', 'packages']
 
@@ -61,7 +61,7 @@
     name:
       - redis-stack-server
     state: present
-  become: yes
+  become: true
   when: _redis_installed.rc != 0
   tags: ['redis', 'packages']
 
@@ -70,7 +70,7 @@
     name: redis
     system: true
     state: present
-  become: yes
+  become: true
   tags: ['redis', 'packages']
 
 - name: "Redis | Create redis system user"
@@ -82,7 +82,7 @@
     home: /var/lib/redis-stack
     create_home: false
     state: present
-  become: yes
+  become: true
   tags: ['redis', 'packages']
 
 # Issue #3396: Add autobot to the redis group as defense-in-depth so that
@@ -92,8 +92,8 @@
   user:
     name: autobot
     groups: redis
-    append: yes
-  become: yes
+    append: true
+  become: true
   tags: ['redis', 'ownership']
 
 # Issue #3396: Ownership is set to autobot:autobot (not redis:redis) so the
@@ -110,7 +110,7 @@
     owner: autobot
     group: autobot
     mode: '0750'
-  become: yes
+  become: true
   tags: ['redis', 'ownership']
 
 - name: "Redis | Enforce autobot:autobot ownership on Redis data files (recursive)"
@@ -119,8 +119,8 @@
     state: directory
     owner: autobot
     group: autobot
-    recurse: yes
-  become: yes
+    recurse: true
+  become: true
   tags: ['redis', 'ownership']
 
 - name: "Redis | Set vm.overcommit_memory for background saves"
@@ -130,7 +130,7 @@
     state: present
     sysctl_set: true
     reload: true
-  become: yes
+  become: true
   tags: ['redis', 'configuration']
 
 # #6701 + #7272: Stat each TLS cert before rendering redis.conf so the
@@ -152,8 +152,8 @@
     owner: autobot
     group: autobot
     mode: '0640'
-    backup: yes
-  become: yes
+    backup: true
+  become: true
   notify: restart redis-stack
   tags: ['redis', 'configuration']
 
@@ -164,7 +164,7 @@
     proto: tcp
     from_ip: "{{ network_subnet }}"
     comment: "Redis Stack"
-  become: yes
+  become: true
   notify: reload firewall
   tags: ['redis', 'firewall']
 
@@ -175,7 +175,7 @@
     proto: tcp
     from_ip: "{{ network_subnet }}"
     comment: "RedisInsight"
-  become: yes
+  become: true
   notify: reload firewall
   tags: ['redis', 'firewall']
 
@@ -186,14 +186,14 @@
   ansible.builtin.stat:
     path: /etc/systemd/system/redis-stack-server.service
   register: _redis_service_file
-  become: yes
+  become: true
   tags: ['redis', 'systemd']
 
 - name: "Redis | Restore missing dpkg conffile (--force-confmiss)"
   ansible.builtin.shell: >
     apt-get -o Dpkg::Options::="--force-confmiss"
     install --reinstall redis-stack-server -y
-  become: yes
+  become: true
   when: not _redis_service_file.stat.exists
   tags: ['redis', 'systemd']
 
@@ -202,7 +202,7 @@
     path: /etc/systemd/system/redis-stack-server.service.d
     state: directory
     mode: '0755'
-  become: yes
+  become: true
   tags: ['redis', 'systemd']
 
 - name: "Redis | Configure systemd service override"
@@ -210,7 +210,7 @@
     src: redis-stack-override.conf.j2
     dest: /etc/systemd/system/redis-stack-server.service.d/override.conf
     mode: '0644'
-  become: yes
+  become: true
   notify:
     - reload systemd
     - restart redis-stack
@@ -219,10 +219,10 @@
 - name: "Redis | Enable and start Redis Stack"
   systemd:
     name: redis-stack-server
-    enabled: yes
+    enabled: true
     state: started
-    daemon_reload: yes
-  become: yes
+    daemon_reload: true
+  become: true
   tags: ['redis', 'service']
 
 - name: "Redis | Wait for Redis to be ready (retry-based)"
@@ -246,7 +246,7 @@
     owner: autobot
     group: autobot
     mode: '0755'
-  become: yes
+  become: true
   tags: ['redis', 'backup']
 
 - name: "Redis | Create backup script"
@@ -256,7 +256,7 @@
     mode: '0755'
     owner: root
     group: root
-  become: yes
+  become: true
   tags: ['redis', 'backup']
 
 - name: "Redis | Schedule daily backups"
@@ -266,7 +266,7 @@
     hour: "2"
     minute: "0"
     user: root
-  become: yes
+  become: true
   tags: ['redis', 'backup']
 
 # Prometheus exporter - scrape target for SLM monitoring

--- a/autobot-slm-backend/ansible/roles/redis/tasks/redis_exporter.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/redis_exporter.yml
@@ -14,7 +14,7 @@
     system: true
     shell: /usr/sbin/nologin
     create_home: false
-  become: yes
+  become: true
   tags: ['redis', 'redis_exporter']
 
 - name: "Redis Exporter | Check if binary exists"
@@ -30,7 +30,7 @@
     owner: redis_exporter
     group: redis_exporter
     mode: "0755"
-  become: yes
+  become: true
   tags: ['redis', 'redis_exporter']
 
 - name: "Redis Exporter | Download archive"
@@ -39,7 +39,7 @@
     dest: "/tmp/redis_exporter-v{{ redis_exporter_version }}.tar.gz"
     mode: "0644"
   when: not _redis_exporter_binary.stat.exists
-  become: yes
+  become: true
   tags: ['redis', 'redis_exporter']
 
 - name: "Redis Exporter | Extract binary"
@@ -52,7 +52,7 @@
     owner: redis_exporter
     group: redis_exporter
   when: not _redis_exporter_binary.stat.exists
-  become: yes
+  become: true
   tags: ['redis', 'redis_exporter']
 
 - name: "Redis Exporter | Deploy systemd service"
@@ -62,7 +62,7 @@
     owner: root
     group: root
     mode: "0644"
-  become: yes
+  become: true
   notify:
     - Reload systemd
     - Restart redis_exporter
@@ -74,7 +74,7 @@
     state: started
     enabled: true
     daemon_reload: true
-  become: yes
+  become: true
   tags: ['redis', 'redis_exporter']
 
 - name: "Redis Exporter | Check if UFW is installed"
@@ -92,6 +92,6 @@
     port: "{{ redis_exporter_port | string }}"
     proto: tcp
     comment: "Redis Exporter (Prometheus scrape from SLM)"
-  become: yes
+  become: true
   when: _ufw_check.rc == 0
   tags: ['redis', 'redis_exporter', 'firewall']

--- a/autobot-slm-backend/ansible/roles/slm_agent/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/handlers/main.yml
@@ -6,29 +6,29 @@
 
 - name: Reload systemd
   systemd:
-    daemon_reload: yes
-  become: yes
+    daemon_reload: true
+  become: true
 
 - name: Restart SLM agent
   systemd:
     name: slm-agent
     state: restarted
-  become: yes
+  become: true
 
 - name: Stop SLM agent
   systemd:
     name: slm-agent
     state: stopped
-  become: yes
+  become: true
 
 - name: Start SLM agent
   systemd:
     name: slm-agent
     state: started
-  become: yes
+  become: true
 
 - name: Restart node_exporter
   ansible.builtin.systemd:
     name: node_exporter
     state: restarted
-  become: yes
+  become: true

--- a/autobot-slm-backend/ansible/roles/slm_agent/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/tasks/clean.yml
@@ -35,12 +35,12 @@
     path: "{{ slm_agent_dir }}"
     state: absent
   when: slm_agent_dir_stat.stat.exists and slm_agent_dir_stat.stat.islnk
-  become: yes
+  become: true
   tags: ['clean']
 
 - name: "SLM Agent | Clean: pre-#1129 flat install at /opt/slm-agent"
   ansible.builtin.file:
     path: /opt/slm-agent
     state: absent
-  become: yes
+  become: true
   tags: ['clean']

--- a/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
@@ -37,7 +37,7 @@
   # (#2872) Intentional: legacy service may already be stopped/disabled;
   # this is cleanup of a previous service name (#917).
   failed_when: false
-  become: yes
+  become: true
   tags: ['slm_agent', 'cleanup']
 
 - name: "SLM Agent | Remove legacy autobot-agent.service unit file"
@@ -45,7 +45,7 @@
     path: /etc/systemd/system/autobot-agent.service
     state: absent
   when: legacy_agent_unit.stat.exists
-  become: yes
+  become: true
   notify: Reload systemd
   tags: ['slm_agent', 'cleanup']
 
@@ -61,7 +61,7 @@
     - "{{ slm_agent_dir }}/slm"
     - "{{ slm_agent_dir }}/slm/agent"
     - "{{ slm_agent_data_dir }}"
-  become: yes
+  become: true
   tags: ['slm_agent', 'directories']
 
 # Issue #741: Version tracking - Get git commit and deploy version.json
@@ -91,7 +91,7 @@
     owner: "{{ slm_agent_user }}"
     group: "{{ slm_agent_group }}"
     mode: '0644'
-  become: yes
+  become: true
   tags: ['slm_agent', 'version']
 
 - name: "SLM Agent | Install Python dependencies"
@@ -100,7 +100,7 @@
     state: present
     executable: pip3
     extra_args: "--break-system-packages"
-  become: yes
+  become: true
   environment:
     PIP_DEFAULT_TIMEOUT: "120"
   timeout: 300  # Issue #2835: prevent indefinite hang on dependency resolution
@@ -117,7 +117,7 @@
     owner: "{{ slm_agent_user }}"
     group: "{{ slm_agent_group }}"
     mode: '0644'
-  become: yes
+  become: true
   notify: Restart SLM agent
   tags: ['slm_agent', 'deploy']
 
@@ -128,7 +128,7 @@
     owner: "{{ slm_agent_user }}"
     group: "{{ slm_agent_group }}"
     mode: '0644'
-  become: yes
+  become: true
   notify: Restart SLM agent
   tags: ['slm_agent', 'deploy']
 
@@ -139,7 +139,7 @@
     owner: "{{ slm_agent_user }}"
     group: "{{ slm_agent_group }}"
     mode: '0644'
-  become: yes
+  become: true
   notify: Restart SLM agent
   tags: ['slm_agent', 'deploy']
 
@@ -150,7 +150,7 @@
     owner: "{{ slm_agent_user }}"
     group: "{{ slm_agent_group }}"
     mode: '0644'
-  become: yes
+  become: true
   notify: Restart SLM agent
   tags: ['slm_agent', 'deploy']
 
@@ -162,7 +162,7 @@
     owner: "{{ slm_agent_user }}"
     group: "{{ slm_agent_group }}"
     mode: '0644'
-  become: yes
+  become: true
   notify: Restart SLM agent
   tags: ['slm_agent', 'deploy']
 
@@ -174,7 +174,7 @@
     owner: "{{ slm_agent_user }}"
     group: "{{ slm_agent_group }}"
     mode: '0644'
-  become: yes
+  become: true
   notify: Restart SLM agent
   tags: ['slm_agent', 'deploy']
 
@@ -185,7 +185,7 @@
     owner: "{{ slm_agent_user }}"
     group: "{{ slm_agent_group }}"
     mode: '0644'
-  become: yes
+  become: true
   notify: Restart SLM agent
   tags: ['slm_agent', 'deploy']
 
@@ -196,7 +196,7 @@
     owner: "{{ slm_agent_user }}"
     group: "{{ slm_agent_group }}"
     mode: '0640'
-  become: yes
+  become: true
   notify: Restart SLM agent
   tags: ['slm_agent', 'config']
 
@@ -208,7 +208,7 @@
     owner: "{{ slm_agent_user }}"
     group: "{{ slm_agent_group }}"
     mode: '0644'
-  become: yes
+  become: true
   tags: ['slm_agent', 'deploy', 'role-meta']
 
 - name: "SLM Agent | Deploy systemd service unit"
@@ -218,7 +218,7 @@
     owner: root
     group: root
     mode: '0644'
-  become: yes
+  become: true
   notify:
     - Reload systemd
     - Restart SLM agent
@@ -231,17 +231,17 @@
     port: "{{ slm_agent_api_port | default('8444') }}"
     proto: tcp
     comment: "SLM Agent API"
-  become: yes
+  become: true
   when: slm_agent_api_port is defined
   tags: ['slm_agent', 'firewall']
 
 - name: "SLM Agent | Enable and start service"
   systemd:
     name: slm-agent
-    enabled: yes
+    enabled: true
     state: started
-    daemon_reload: yes
-  become: yes
+    daemon_reload: true
+  become: true
   tags: ['slm_agent', 'service']
 
 - name: "SLM Agent | Wait for agent to start"
@@ -253,7 +253,7 @@
   systemd:
     name: slm-agent
   register: slm_agent_status
-  become: yes
+  become: true
   tags: ['slm_agent', 'verify']
 
 # General fleet monitoring - node_exporter on every managed node (#945)

--- a/autobot-slm-backend/ansible/roles/slm_agent/tasks/node_exporter.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/tasks/node_exporter.yml
@@ -15,7 +15,7 @@
     system: true
     shell: /usr/sbin/nologin
     create_home: false
-  become: yes
+  become: true
   tags: ['slm_agent', 'node_exporter']
 
 - name: "Node Exporter | Check if binary exists"
@@ -31,7 +31,7 @@
     owner: node_exporter
     group: node_exporter
     mode: "0755"
-  become: yes
+  become: true
   tags: ['slm_agent', 'node_exporter']
 
 - name: "Node Exporter | Download archive"
@@ -40,7 +40,7 @@
     dest: "/tmp/node_exporter-{{ node_exporter_version }}.tar.gz"
     mode: "0644"
   when: not _node_exporter_binary.stat.exists
-  become: yes
+  become: true
   tags: ['slm_agent', 'node_exporter']
 
 - name: "Node Exporter | Extract binary"
@@ -53,7 +53,7 @@
     owner: node_exporter
     group: node_exporter
   when: not _node_exporter_binary.stat.exists
-  become: yes
+  become: true
   tags: ['slm_agent', 'node_exporter']
 
 - name: "Node Exporter | Deploy systemd service"
@@ -63,7 +63,7 @@
     owner: root
     group: root
     mode: "0644"
-  become: yes
+  become: true
   notify:
     - Reload systemd
     - Restart node_exporter
@@ -75,7 +75,7 @@
     state: started
     enabled: true
     daemon_reload: true
-  become: yes
+  become: true
   tags: ['slm_agent', 'node_exporter']
 
 # ── Hardware-specific textfile collector remediation (#1147) ──────────────────
@@ -123,7 +123,7 @@
     name: prometheus-node-exporter-ipmitool-sensor
     masked: true
     daemon_reload: true
-  become: yes
+  become: true
   when: not _ne_ipmi_device.stat.exists
   # (#2872) Intentional: collector unit may not exist (binary install)
   failed_when: false
@@ -134,7 +134,7 @@
     name: prometheus-node-exporter-mellanox-hca-temp
     masked: true
     daemon_reload: true
-  become: yes
+  become: true
   when: _ne_infiniband_devices.files | default([]) | length == 0
   # (#2872) Intentional: collector unit may not exist (binary install)
   failed_when: false
@@ -145,7 +145,7 @@
     name: prometheus-node-exporter-nvme
     masked: true
     daemon_reload: true
-  become: yes
+  become: true
   when: _ne_nvme_devices.files | length == 0
   # (#2872) Intentional: collector unit may not exist (binary install)
   failed_when: false
@@ -156,7 +156,7 @@
     name: prometheus-node-exporter-smartmon
     masked: true
     daemon_reload: true
-  become: yes
+  become: true
   when: _ne_smartctl.rc != 0
   # (#2872) Intentional: collector unit may not exist (binary install)
   failed_when: false
@@ -179,6 +179,6 @@
     port: "{{ node_exporter_port | string }}"
     proto: tcp
     comment: "Node Exporter (Prometheus scrape from SLM)"
-  become: yes
+  become: true
   when: _ufw_check.rc == 0
   tags: ['slm_agent', 'node_exporter', 'firewall']

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -521,7 +521,7 @@
     path: /etc/nginx/snippets
     state: directory
     mode: "0755"
-  become: yes
+  become: true
   tags: ['slm', 'nginx']
 
 - name: "SLM | Deploy strict security-headers nginx snippet (#6842)"
@@ -529,7 +529,7 @@
     src: autobot-security-headers-strict.conf.j2
     dest: /etc/nginx/snippets/autobot-security-headers-strict.conf
     mode: "0644"
-  become: yes
+  become: true
   notify:
     - test nginx config
     - reload nginx
@@ -540,7 +540,7 @@
     src: autobot-security-headers-iframe-host.conf.j2
     dest: /etc/nginx/snippets/autobot-security-headers-iframe-host.conf
     mode: "0644"
-  become: yes
+  become: true
   notify:
     - test nginx config
     - reload nginx
@@ -561,14 +561,14 @@
   ansible.builtin.stat:
     path: /etc/nginx/sites-enabled/{{ slm_nginx_config }}
   register: nginx_sites_enabled_stat
-  become: yes
+  become: true
   tags: ['slm', 'nginx']
 
 - name: "SLM | Remove standalone sites-enabled file if not a symlink (#1122)"
   ansible.builtin.file:
     path: /etc/nginx/sites-enabled/{{ slm_nginx_config }}
     state: absent
-  become: yes
+  become: true
   when:
     - nginx_sites_enabled_stat.stat.exists
     - not nginx_sites_enabled_stat.stat.islnk
@@ -579,7 +579,7 @@
     src: /etc/nginx/sites-available/{{ slm_nginx_config }}
     dest: /etc/nginx/sites-enabled/{{ slm_nginx_config }}
     state: link
-  become: yes
+  become: true
   notify: reload nginx
   tags: ['slm', 'nginx']
 

--- a/autobot-slm-backend/ansible/roles/time_sync/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/time_sync/handlers/main.yml
@@ -5,14 +5,14 @@
   systemd:
     name: systemd-timesyncd
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
   tags: ['time_sync', 'handlers']
 
 - name: restart chrony
   systemd:
     name: chrony
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
   tags: ['time_sync', 'handlers']
 
 - name: restart rsyslog
@@ -35,5 +35,5 @@
 
 - name: reload systemd
   systemd:
-    daemon_reload: yes
+    daemon_reload: true
   tags: ['time_sync', 'handlers']

--- a/autobot-slm-backend/ansible/roles/time_sync/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/time_sync/tasks/main.yml
@@ -79,20 +79,20 @@
       systemd:
         name: systemd-timesyncd
         state: stopped
-        enabled: no
+        enabled: false
 
     - name: "Time Sync | Configure chrony"
       template:
         src: chrony.conf.j2
         dest: "/etc/chrony/chrony.conf"
-        backup: yes
+        backup: true
       notify: restart chrony
 
     - name: "Time Sync | Enable and start chrony"
       systemd:
         name: chrony
         state: started
-        enabled: yes
+        enabled: true
 
   when: time_sync.ntp.use_chrony | default(false)
   tags: ['time_sync', 'chrony']
@@ -103,7 +103,7 @@
       systemd:
         name: chrony
         state: stopped
-        enabled: no
+        enabled: false
       # (#2872) Intentional: chrony may not be installed; this is a
       # cleanup task when switching from chrony to systemd-timesyncd.
       failed_when: false
@@ -112,14 +112,14 @@
       template:
         src: timesyncd.conf.j2
         dest: "/etc/systemd/timesyncd.conf"
-        backup: yes
+        backup: true
       notify: restart systemd-timesyncd
 
     - name: "Time Sync | Enable and start systemd-timesyncd"
       systemd:
         name: systemd-timesyncd
         state: started
-        enabled: yes
+        enabled: true
 
   when: not (time_sync.ntp.use_chrony | default(false))
   tags: ['time_sync', 'systemd-timesyncd']
@@ -203,7 +203,7 @@
   systemd:
     name: cron
     state: started
-    enabled: yes
+    enabled: true
   tags: ['time_sync', 'monitoring']
 
 - name: "Time Sync | Add cron job for time sync monitoring"

--- a/autobot-slm-backend/ansible/service_management.yml
+++ b/autobot-slm-backend/ansible/service_management.yml
@@ -2,7 +2,7 @@
 # AutoBot Service Management Playbook
 - name: Manage AutoBot Services
   hosts: "{{ target | default('autobot_cluster') }}"
-  become: yes
+  become: true
   vars:
     action: "{{ service_action | default('status') }}"  # start, stop, restart, status
 
@@ -11,7 +11,7 @@
       systemd:
         name: "autobot-{{ item.name }}"
         state: "{{ action }}"
-        enabled: yes
+        enabled: true
       loop: "{{ services }}"
       when: services is defined
 
@@ -39,7 +39,7 @@
         timeout: 10
       loop: "{{ services }}"
       register: health_checks
-      ignore_errors: yes
+      ignore_errors: true
       when: item.port is defined
 
     - name: Report health status

--- a/autobot-slm-backend/ansible/site.yml
+++ b/autobot-slm-backend/ansible/site.yml
@@ -2,13 +2,13 @@
 # AutoBot Main Deployment Playbook
 - name: Deploy AutoBot Infrastructure
   hosts: all
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   pre_tasks:
     - name: Update system packages
       apt:
-        update_cache: yes
+        update_cache: true
         cache_valid_time: 3600
         upgrade: dist
       tags: ['system', 'update']
@@ -39,7 +39,7 @@
 # Frontend VMs
 - name: Deploy Frontend Services
   hosts: frontend
-  become: yes
+  become: true
   roles:
     - nodejs
     - nginx
@@ -49,7 +49,7 @@
 # Backend VMs
 - name: Deploy Backend Services
   hosts: backend
-  become: yes
+  become: true
   roles:
     - python
     - fastapi_app
@@ -59,7 +59,7 @@
 # AI Stack VMs
 - name: Deploy AI Services
   hosts: ai_stack
-  become: yes
+  become: true
   roles:
     - python
     - cuda_drivers
@@ -70,7 +70,7 @@
 # NPU Worker VMs
 - name: Deploy NPU Services
   hosts: npu_workers
-  become: yes
+  become: true
   roles:
     - python
     - intel_npu
@@ -80,7 +80,7 @@
 # Database VMs
 - name: Deploy Database Services
   hosts: database
-  become: yes
+  become: true
   roles:
     - redis_stack
     - data_backup
@@ -89,7 +89,7 @@
 # Final configuration
 - name: Configure Service Communication
   hosts: autobot_cluster
-  become: yes
+  become: true
   tasks:
     - name: Generate service discovery configuration
       template:

--- a/autobot-slm-backend/ansible/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/update-all-nodes.yml
@@ -63,8 +63,8 @@
         repo: "{{ github_repo }}"
         dest: "{{ git_repo_root }}"
         version: "{{ deploy_ref }}"
-        update: yes
-      ignore_errors: yes
+        update: true
+      ignore_errors: true
       register: github_sync
       tags: [always]
 


### PR DESCRIPTION
## Summary

Standardizes all YAML boolean values in `autobot-slm-backend/ansible/` from deprecated `yes`/`no` to canonical YAML 1.2 `true`/`false` form, as recommended by ansible-lint and the YAML 1.2 spec.

- 85 files updated, 471 replacements
- Covers: `become`, `ansible_become`, `gather_facts`, `changed_when`, `failed_when`, `ignore_errors`, module boolean params (`enabled`, `daemon_reload`, `update_cache`, `remote_src`, etc.)
- String literals (e.g. `: no cert at ...` in log messages) were not modified
- All 284 YAML files validated with `yaml.safe_load_all` — zero parse errors

## Closes

Closes #7454

## Testing

All modified YAML files validated with Python `yaml.safe_load_all`. No functional changes — purely a canonicalization of existing values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)