### PR TITLE
docs(ansible): mark redis.conf.j2 as non-deployed reference template (#7257)

### DIFF
--- a/autobot-slm-backend/ansible/roles/redis/templates/redis.conf.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/redis.conf.j2
@@ -1,3 +1,25 @@
+{#
+  NOTE: This template is NOT currently deployed by any Ansible task.
+  It is retained as a reference / future wiring point.
+
+  Actual deployed Redis configurations (as of issues #6701 / #7257):
+    1. roles/redis/templates/redis-stack.conf.j2
+         → deployed by roles/redis/tasks/main.yml (task "Redis | Configure Redis Stack")
+         → dest: /etc/redis-stack.conf
+    2. playbooks/deploy-native-services.yml (~line 103, literal copy: block)
+         → dest: /etc/redis/redis.conf
+         → writes a minimal inline config directly; does NOT use this template.
+
+  To activate this template instead of the literal copy: block:
+    - Replace the copy: task in deploy-native-services.yml with a template: task:
+        template:
+          src: ../roles/redis/templates/redis.conf.j2
+          dest: /etc/redis/redis.conf
+    - Ensure all required vars (redis_bind, redis_port, etc.) are set for the
+      target host group.
+
+  References: #6701 (TLS wiring), #7257 (discovery: template is unreferenced)
+#}
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss


### PR DESCRIPTION
## Summary

Adds a Jinja2 comment header to `roles/redis/templates/redis.conf.j2` documenting that it is not currently deployed by any Ansible task, and explains the actual deployed config paths.

**Why:** The template has existed since the project's early days but no task references it via `template:` or `src:`. The actual deployed Redis configs are:
1. `redis-stack.conf.j2` → deployed by `roles/redis/tasks/main.yml` to `/etc/redis-stack.conf`  
2. A literal `copy:` block in `deploy-native-services.yml` → `/etc/redis/redis.conf`

This resolves the "Decision recorded" acceptance criterion by choosing the **document** option (lower-risk than wiring in, better than deleting a working template).

## Verification

`redis-stack.conf.j2` confirmed referenced in two places:
- `roles/redis/tasks/main.yml:150` (dest `/etc/redis-stack.conf`)
- `playbooks/deploy-database.yml:123` (dest `{{ redis_config_dir }}/redis-stack.conf`)

Only `redis.conf.j2` was orphaned.

## Closes

Closes #7257

🤖 Generated with [Claude Code](https://claude.com/claude-code)