### PR TITLE
chore(deps): Phase D batch 4 — remove ast-tools + OTel floor fix + Dependabot grouping (#6959, #6960, #6961)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     labels:
       - "dependencies"
       - "backend"
+    groups:
+      opentelemetry:
+        patterns:
+          - "opentelemetry-*"
     ignore:
       - dependency-name: "numpy"
         update-types: ["version-update:semver-major"]
@@ -34,6 +38,10 @@ updates:
     labels:
       - "dependencies"
       - "backend"
+    groups:
+      opentelemetry:
+        patterns:
+          - "opentelemetry-*"
     ignore:
       - dependency-name: "pydantic"
         update-types: ["version-update:semver-major"]
@@ -74,6 +82,13 @@ updates:
     labels:
       - "dependencies"
       - "frontend"
+    groups:
+      frontend-core:
+        patterns:
+          - "vue"
+          - "vite"
+          - "@vitejs/*"
+          - "typescript"
     ignore:
       - dependency-name: "vue"
         update-types: ["version-update:semver-major"]
@@ -315,6 +330,10 @@ updates:
       - "dependencies"
       - "backend"
       - "devops"
+    groups:
+      opentelemetry:
+        patterns:
+          - "opentelemetry-*"
     ignore:
       - dependency-name: "fastapi"
         update-types: ["version-update:semver-major"]

--- a/autobot-backend/code_analysis/requirements.txt
+++ b/autobot-backend/code_analysis/requirements.txt
@@ -8,9 +8,6 @@ numpy>=2.4.4,<3.0.0
 scikit-learn>=1.5.0
 pandas>=3.0.2
 
-# Code Analysis
-ast-tools>=0.1.8
-
 # Vector Database for Embeddings
 chromadb>=1.5.9
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ opentelemetry-proto==1.41.1
 opentelemetry-instrumentation-fastapi>=0.62b1
 opentelemetry-propagator-b3==1.41.1
 # Issue #697: Additional instrumentation for comprehensive tracing
-opentelemetry-instrumentation-redis>=0.61b0
+opentelemetry-instrumentation-redis>=0.62b1
 opentelemetry-instrumentation-aiohttp-client>=0.62b1
 
 # FAISS - Vector Similarity Search (Issue #387, #856)


### PR DESCRIPTION
## Thinking Path

Three dependency hygiene issues identified in Phase D batch 4:
- `ast-tools` pulled in via `code_analysis/requirements.txt` but zero usage found across the entire backend codebase
- OTel floor inconsistency: root `requirements.txt` had `>=0.61b0` while `autobot_shared/pyproject.toml` and all other instrumentation entries used `>=0.62b1` (matching `opentelemetry-sdk==1.41.1`)
- Dependabot grouping missing for OTel and frontend-core packages, causing noisy one-at-a-time update PRs

## What Changed

- **GH#6959**: Removed `ast-tools>=0.1.8` from `autobot-backend/code_analysis/requirements.txt` — zero references in codebase
- **GH#6960**: Bumped OTel floor `opentelemetry-instrumentation-redis` from `>=0.61b0` → `>=0.62b1` in root `requirements.txt`
- **GH#6961**: Added `groups.opentelemetry` to 3 pip entries and `groups.frontend-core` to npm entry in `.github/dependabot.yml`

## Verification

- `python3 -c 'import code_analysis'` passes after ast-tools removal
- OTel floor diff verified — `0.62b1` matches sdk==1.41.1 and all other instrumentation pins
- Dependabot YAML valid per v2 spec groups syntax

## Risks

Low — no runtime code changed. Only dependency metadata and Dependabot config updated. ast-tools removal cannot break anything since zero imports existed.

## Model Used

claude-sonnet-4-6

## Checklist

- [x] No runtime code changed
- [x] Import smoke test passes after ast-tools removal
- [x] OTel version floor consistent across all entries
- [x] Dependabot YAML syntax valid
- [x] No backwards-compatibility concerns

---

## Summary

Closes three dependency hygiene issues from Phase D batch 4.

### GH#6959 — Remove unused `ast-tools` dependency
- `grep -r 'ast_tools\|ast-tools' autobot-backend/ --include='*.py'` returns zero results
- Removed `ast-tools>=0.1.8` from `autobot-backend/code_analysis/requirements.txt`
- Verified: `python3 -c 'import code_analysis'` passes without errors

### GH#6960 — Fix OTel instrumentation version floor inconsistency
- Root `requirements.txt` had `opentelemetry-instrumentation-redis>=0.61b0` while all other instrumentation pins used `>=0.62b1` (matching `opentelemetry-sdk==1.41.1`)
- `autobot_shared/pyproject.toml` already had `opentelemetry-instrumentation-redis>=0.62b1` — root `requirements.txt` was the only outlier
- Bumped floor: `0.61b0` → `0.62b1`

### GH#6961 — Add Dependabot grouping config for OTel + frontend-core
- Added `groups.opentelemetry` (pattern: `opentelemetry-*`) to:
  - `/autobot-backend` pip entry
  - `/autobot_shared` pip entry
  - `/` (root) pip entry
- Added `groups.frontend-core` (patterns: `vue`, `vite`, `@vitejs/*`, `typescript`) to `/autobot-frontend` npm entry
- Groups batch related updates into a single PR, reducing noise

## Test plan

- [x] `python3 -c 'import code_analysis'` passes after ast-tools removal
- [x] OTel floor diff verified: `0.61b0` → `0.62b1` matches sdk==1.41.1 and all other instrumentation pins
- [x] Dependabot YAML is valid — groups syntax follows Dependabot v2 spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)