### PR TITLE
refactor(schemas): consolidate duplicate lowercase-id regex + rename FailsafeLLMResponse (GH#6958, GH#6978, GH#6977)

### DIFF
--- a/autobot-backend/agents/llm_failsafe_agent.py
+++ b/autobot-backend/agents/llm_failsafe_agent.py
@@ -40,7 +40,7 @@ class LLMTier(Enum):
 
 
 @dataclass
-class LLMResponse:
+class FailsafeLLMResponse:
     """Standardized LLM response format"""
 
     content: str
@@ -407,7 +407,7 @@ class LLMFailsafeAgent(StandardizedAgent):
 
         return messages
 
-    async def get_response(self, prompt: str, context: Optional[Dict[str, Any]] = None) -> LLMResponse:
+    async def get_response(self, prompt: str, context: Optional[Dict[str, Any]] = None) -> FailsafeLLMResponse:
         """
         Get a response using the most appropriate available tier.
 
@@ -416,7 +416,7 @@ class LLMFailsafeAgent(StandardizedAgent):
             context: Optional context information
 
         Returns:
-            LLMResponse with content and metadata
+            FailsafeLLMResponse with content and metadata
         """
         start_time = time.time()
 
@@ -462,14 +462,14 @@ class LLMFailsafeAgent(StandardizedAgent):
         confidence: float = 0.9,
         warnings: list = None,
         extra_metadata: dict = None,
-    ) -> LLMResponse:
-        """Build LLMResponse object (Issue #398: extracted)."""
+    ) -> FailsafeLLMResponse:
+        """Build FailsafeLLMResponse object (Issue #398: extracted)."""
         response_time = time.time() - start_time
         self._update_tier_stats(tier, response_time, success=True)
         metadata = {"context": context}
         if extra_metadata:
             metadata.update(extra_metadata)
-        return LLMResponse(
+        return FailsafeLLMResponse(
             content=response,
             tier_used=tier,
             model_used=model,
@@ -480,7 +480,7 @@ class LLMFailsafeAgent(StandardizedAgent):
             metadata=metadata,
         )
 
-    async def _try_primary_llm(self, prompt: str, context: Optional[Dict[str, Any]], start_time: float) -> LLMResponse:
+    async def _try_primary_llm(self, prompt: str, context: Optional[Dict[str, Any]], start_time: float) -> FailsafeLLMResponse:
         """Try primary LLM communication (Issue #398: refactored)."""
         self.tier_stats[LLMTier.PRIMARY]["requests"] += 1
         try:
@@ -510,7 +510,7 @@ class LLMFailsafeAgent(StandardizedAgent):
 
     async def _try_secondary_llm(
         self, prompt: str, context: Optional[Dict[str, Any]], start_time: float
-    ) -> LLMResponse:
+    ) -> FailsafeLLMResponse:
         """Try secondary LLM communication (Issue #398: refactored)."""
         self.tier_stats[LLMTier.SECONDARY]["requests"] += 1
         try:
@@ -551,7 +551,7 @@ class LLMFailsafeAgent(StandardizedAgent):
             # Fall back to basic
             return await self._try_basic_response(prompt, context, start_time)
 
-    def _match_pattern_response(self, prompt: str, context: Any, start_time: float) -> Optional[LLMResponse]:
+    def _match_pattern_response(self, prompt: str, context: Any, start_time: float) -> Optional[FailsafeLLMResponse]:
         """Match pattern and return response (Issue #398: extracted)."""
         import re
 
@@ -573,7 +573,7 @@ class LLMFailsafeAgent(StandardizedAgent):
 
     async def _try_basic_response(
         self, prompt: str, context: Optional[Dict[str, Any]], start_time: float
-    ) -> LLMResponse:
+    ) -> FailsafeLLMResponse:
         """Generate rule-based response (Issue #398: refactored)."""
         self.tier_stats[LLMTier.BASIC]["requests"] += 1
         try:
@@ -616,7 +616,7 @@ class LLMFailsafeAgent(StandardizedAgent):
 
     async def _try_emergency_response(
         self, prompt: str, context: Optional[Dict[str, Any]], start_time: float
-    ) -> LLMResponse:
+    ) -> FailsafeLLMResponse:
         """Generate emergency static response"""
         self.tier_stats[LLMTier.EMERGENCY]["requests"] += 1
 
@@ -628,7 +628,7 @@ class LLMFailsafeAgent(StandardizedAgent):
             response_time = time.time() - start_time
             self._update_tier_stats(LLMTier.EMERGENCY, response_time, success=True)
 
-            return LLMResponse(
+            return FailsafeLLMResponse(
                 content=response,
                 tier_used=LLMTier.EMERGENCY,
                 model_used="emergency_static_responses",
@@ -643,7 +643,7 @@ class LLMFailsafeAgent(StandardizedAgent):
             self.logger.critical("Emergency response tier failed: %s", e)
             return self._create_emergency_response(prompt, start_time, f"Emergency tier failure: {e}")
 
-    def _create_emergency_response(self, prompt: str, start_time: float, error_msg: str) -> LLMResponse:
+    def _create_emergency_response(self, prompt: str, start_time: float, error_msg: str) -> FailsafeLLMResponse:
         """Create absolute last resort response"""
         # Create a more user-friendly emergency response
         user_message = (
@@ -658,7 +658,7 @@ class LLMFailsafeAgent(StandardizedAgent):
                 "My AI models are currently unavailable. I'm working to restore service. " "Please try again shortly."
             )
 
-        return LLMResponse(
+        return FailsafeLLMResponse(
             content=user_message,
             tier_used=LLMTier.EMERGENCY,
             model_used="emergency_fallback",
@@ -736,7 +736,7 @@ class LLMFailsafeAgent(StandardizedAgent):
             },
         }
 
-    async def _test_tier(self, tier: LLMTier, test_prompt: str) -> LLMResponse:
+    async def _test_tier(self, tier: LLMTier, test_prompt: str) -> FailsafeLLMResponse:
         """Test a specific tier (Issue #334 - extracted helper)."""
         tier_handlers = {
             LLMTier.PRIMARY: self._try_primary_llm,
@@ -786,7 +786,7 @@ def get_llm_failsafe() -> "LLMFailsafeAgent":
     return _llm_failsafe
 
 
-async def get_robust_llm_response(prompt: str, context: Optional[Dict[str, Any]] = None) -> LLMResponse:
+async def get_robust_llm_response(prompt: str, context: Optional[Dict[str, Any]] = None) -> FailsafeLLMResponse:
     """
     Convenience function to get a robust LLM response with automatic failover.
 
@@ -795,7 +795,7 @@ async def get_robust_llm_response(prompt: str, context: Optional[Dict[str, Any]]
         context: Optional context information
 
     Returns:
-        LLMResponse with guaranteed content (even if degraded)
+        FailsafeLLMResponse with guaranteed content (even if degraded)
     """
     return await get_llm_failsafe().get_response(prompt, context)
 

--- a/autobot-backend/api/knowledge_tags.py
+++ b/autobot-backend/api/knowledge_tags.py
@@ -26,7 +26,6 @@ Endpoints:
 Related Issues: #77 (Tags), #185 (Split), #209 (Knowledge split), #409 (Tag CRUD), #410 (Tag Styling)
 """
 
-import re
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
@@ -53,6 +52,7 @@ from api.schemas_knowledge import (
     RenameTagRequest,
     SearchByTagsRequest,
     UpdateTagStyleRequest,
+    _LOWERCASE_TAG_RE,
 )
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -62,14 +62,6 @@ from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
 
-
-# Issue #380: Pre-compiled regex for tag-name + prefix validation.
-# #6672: was r"^[a-z0-9_-]*$" — the `*` quantifier accepted empty/whitespace
-# input (after .strip()) as a "valid" tag name across 7 endpoints, letting
-# blank tags slip past the create/update/delete/get/relations callsites.
-# The `+` quantifier matches schemas_knowledge.py:_LOWERCASE_TAG_RE which is
-# the canonical tag validator (used by TagValidator + 9 other field validators).
-_TAG_PREFIX_RE = re.compile(r"^[a-z0-9_-]+$")
 
 # Create router for tag management endpoints
 router = APIRouter(tags=["knowledge-tags"])
@@ -335,7 +327,7 @@ async def list_all_tags(
     # Validate prefix if provided
     if prefix:
         prefix = prefix.lower().strip()
-        if not _TAG_PREFIX_RE.match(prefix):
+        if not _LOWERCASE_TAG_RE.match(prefix):
             raise HTTPException(
                 status_code=400,
                 detail="Invalid prefix format: only lowercase alphanumeric allowed",
@@ -435,7 +427,7 @@ async def rename_tag(
     """
     # Validate tag format
     tag_name = tag_name.lower().strip()
-    if not _TAG_PREFIX_RE.match(tag_name):
+    if not _LOWERCASE_TAG_RE.match(tag_name):
         raise HTTPException(
             status_code=400,
             detail="Invalid tag format: only lowercase alphanumeric, hyphens, underscores",
@@ -492,7 +484,7 @@ async def delete_tag_globally(
     """
     # Validate tag format
     tag_name = tag_name.lower().strip()
-    if not _TAG_PREFIX_RE.match(tag_name):
+    if not _LOWERCASE_TAG_RE.match(tag_name):
         raise HTTPException(
             status_code=400,
             detail="Invalid tag format: only lowercase alphanumeric, hyphens, underscores",
@@ -614,7 +606,7 @@ async def get_facts_by_tag(
     """
     # Validate tag format
     tag_name = tag_name.lower().strip()
-    if not _TAG_PREFIX_RE.match(tag_name):
+    if not _LOWERCASE_TAG_RE.match(tag_name):
         raise HTTPException(
             status_code=400,
             detail="Invalid tag format: only lowercase alphanumeric, hyphens, underscores",
@@ -678,7 +670,7 @@ async def get_tag_info(
     """
     # Validate tag format
     tag_name = tag_name.lower().strip()
-    if not _TAG_PREFIX_RE.match(tag_name):
+    if not _LOWERCASE_TAG_RE.match(tag_name):
         raise HTTPException(
             status_code=400,
             detail="Invalid tag format: only lowercase alphanumeric, hyphens, underscores",
@@ -738,7 +730,7 @@ async def update_tag_style(
     """
     # Validate tag format
     tag_name = tag_name.lower().strip()
-    if not _TAG_PREFIX_RE.match(tag_name):
+    if not _LOWERCASE_TAG_RE.match(tag_name):
         raise HTTPException(
             status_code=400,
             detail="Invalid tag format: only lowercase alphanumeric, hyphens, underscores",
@@ -806,7 +798,7 @@ async def get_tag_style(
     """
     # Validate tag format
     tag_name = tag_name.lower().strip()
-    if not _TAG_PREFIX_RE.match(tag_name):
+    if not _LOWERCASE_TAG_RE.match(tag_name):
         raise HTTPException(
             status_code=400,
             detail="Invalid tag format: only lowercase alphanumeric, hyphens, underscores",
@@ -867,7 +859,7 @@ async def delete_tag_style(
     """
     # Validate tag format
     tag_name = tag_name.lower().strip()
-    if not _TAG_PREFIX_RE.match(tag_name):
+    if not _LOWERCASE_TAG_RE.match(tag_name):
         raise HTTPException(
             status_code=400,
             detail="Invalid tag format: only lowercase alphanumeric, hyphens, underscores",

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -1783,7 +1783,6 @@ class UpdateTagStyleRequest(BaseModel):
 # ===== CATEGORY MANAGEMENT MODELS (Issue #411) =====
 
 # Issue #411: Pre-compiled regex for category name validation
-_CATEGORY_NAME_RE = re.compile(r"^[a-z0-9_-]+$")
 _CATEGORY_PATH_RE = re.compile(r"^[a-z0-9_/-]+$")
 
 
@@ -1826,7 +1825,7 @@ class CreateCategoryRequest(BaseModel):
     def validate_name(cls, v):
         """Validate category name format."""
         v = v.lower().strip().replace(" ", "-")
-        if not _CATEGORY_NAME_RE.match(v):
+        if not _LOWERCASE_TAG_RE.match(v):
             raise ValueError("Invalid category name: only lowercase alphanumeric, " "hyphens, underscores allowed")
         if contains_path_traversal(v):
             raise ValueError("Invalid characters in category name")
@@ -1890,7 +1889,7 @@ class UpdateCategoryRequest(BaseModel):
         """Validate category name format if provided."""
         if v is not None:
             v = v.lower().strip().replace(" ", "-")
-            if not _CATEGORY_NAME_RE.match(v):
+            if not _LOWERCASE_TAG_RE.match(v):
                 raise ValueError("Invalid category name: only lowercase alphanumeric, " "hyphens, underscores allowed")
         return v
 


### PR DESCRIPTION
## Thinking Path

Phase B batch 13 addresses three naming/consolidation issues:
- `agents/llm_failsafe_agent.py` defined a local `LLMResponse` dataclass whose fields (`tier_used`, `model_used`, `confidence`, `success`, `warnings`) are entirely different from the canonical `llm_interface_pkg.models.LLMResponse` (`model`, `provider`, `tokens_used`). Renaming eliminates import ambiguity without touching any external callsites.
- `schemas_knowledge.py:_CATEGORY_NAME_RE` was identical to `_LOWERCASE_TAG_RE` (same pattern `^[a-z0-9_-]+$`) — 2 callsites updated to use the canonical version.
- `knowledge_tags.py:_TAG_PREFIX_RE` was another copy of the same pattern, defined locally with an `import re` that can now be removed — 8 callsites updated to import from `schemas_knowledge`.

## What Changed

- **GH#6958**: `LLMResponse` → `FailsafeLLMResponse` in `llm_failsafe_agent.py` (class + all internal uses, public `get_robust_llm_response` return type)
- **GH#6978**: Removed `_CATEGORY_NAME_RE` from `schemas_knowledge.py`; 2 callsites now use `_LOWERCASE_TAG_RE`
- **GH#6977**: Removed `_TAG_PREFIX_RE` + `import re` from `knowledge_tags.py`; imports `_LOWERCASE_TAG_RE` from `api.schemas_knowledge`; 8 callsites updated

## Verification

- `python3 -m py_compile` passes on all 3 changed files
- No external callers import `LLMResponse` from `llm_failsafe_agent` — only `get_robust_llm_response` and `LLMFailsafeAgent` are used externally
- Zero remaining `_TAG_PREFIX_RE` or `_CATEGORY_NAME_RE` references in codebase

## Risks

Low — rename is internal to module; no public-facing API change. `_LOWERCASE_TAG_RE` export from `schemas_knowledge` crosses the module boundary with a leading underscore (convention: private), but Python does not enforce this at import time and this is the established consolidation pattern for the batch.

## Model Used

claude-sonnet-4-6

## Checklist

- [x] py_compile passes on all 3 changed files
- [x] No external LLMResponse import from llm_failsafe_agent
- [x] Zero _TAG_PREFIX_RE references remain
- [x] Zero _CATEGORY_NAME_RE references remain
- [x] import re removed from knowledge_tags.py

---

## Summary

Phase B batch 13 — three backend consolidation issues resolved in one commit.

### GH#6958 — ChatMessage + LLMResponse dedup
- `agents/llm_failsafe_agent.py:LLMResponse` renamed to `FailsafeLLMResponse` — its fields (`tier_used`, `model_used`, `confidence`, `success`, `warnings`) are completely different from the canonical `llm_interface_pkg.models.LLMResponse` (`model`, `provider`, `tokens_used`, etc.). Renaming eliminates the naming clash without breaking any external callers (the two importers only use `get_robust_llm_response` and `LLMFailsafeAgent`).
- `api/schemas_chat.py:ChatMessage` is a Pydantic API model (with `session_id`, validation) vs `llm_interface_pkg.models.ChatMessage` is an internal LLM dataclass — architecturally distinct, no merge needed.

### GH#6978 — 4 near-identical lowercase-id regex consolidated
- `_CATEGORY_NAME_RE = re.compile(r"^[a-z0-9_-]+$")` in `schemas_knowledge.py:1786` was identical to `_LOWERCASE_TAG_RE` — removed; 2 callsites updated to use `_LOWERCASE_TAG_RE`.
- `_BOARD_ID_RE = re.compile(r"^[a-z0-9_-]{1,100}$")` has a length constraint — intentionally kept.

### GH#6977 — 8 knowledge_tags.py callsites wired to canonical
- `knowledge_tags.py` was defining `_TAG_PREFIX_RE = re.compile(r"^[a-z0-9_-]+$")` locally (identical to `_LOWERCASE_TAG_RE`).
- Now imports `_LOWERCASE_TAG_RE` from `api.schemas_knowledge`; removes local `_TAG_PREFIX_RE` and unused `import re`.
- All 8 `_TAG_PREFIX_RE.match(...)` callsites updated to `_LOWERCASE_TAG_RE.match(...)`.

## Test plan
- [ ] `python3 -m py_compile autobot-backend/api/schemas_knowledge.py` — passes
- [ ] `python3 -m py_compile autobot-backend/api/knowledge_tags.py` — passes
- [ ] `python3 -m py_compile autobot-backend/agents/llm_failsafe_agent.py` — passes
- [ ] No `_TAG_PREFIX_RE` references remain (`grep -r _TAG_PREFIX_RE autobot-backend/`)
- [ ] No `_CATEGORY_NAME_RE` references remain (`grep -r _CATEGORY_NAME_RE autobot-backend/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)