### PR TITLE
refactor(frontend): Phase C batch 5 — i18n audit + Storybook DRY + size/variant enums

### DIFF
--- a/autobot-frontend/.storybook/preview.ts
+++ b/autobot-frontend/.storybook/preview.ts
@@ -2,6 +2,7 @@ import type { Preview } from '@storybook/vue3';
 import '../src/assets/main.css';
 
 const preview: Preview = {
+  tags: ['autodocs'],
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {

--- a/autobot-frontend/src/components/auth/LoginForm.stories.ts
+++ b/autobot-frontend/src/components/auth/LoginForm.stories.ts
@@ -4,7 +4,6 @@ import LoginForm from './LoginForm.vue';
 const meta = {
   title: 'Components/Auth/LoginForm',
   component: LoginForm,
-  tags: ['autodocs'],
 } as Meta<typeof LoginForm>;
 
 export default meta;

--- a/autobot-frontend/src/components/base/BaseBadge.stories.ts
+++ b/autobot-frontend/src/components/base/BaseBadge.stories.ts
@@ -4,7 +4,6 @@ import BaseBadge from './BaseBadge.vue';
 const meta = {
   title: 'Components/Base/BaseBadge',
   component: BaseBadge,
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'select',

--- a/autobot-frontend/src/components/base/BaseBadge.vue
+++ b/autobot-frontend/src/components/base/BaseBadge.vue
@@ -19,10 +19,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import type { BadgeVariant } from '@/types/component-props'
 
 interface Props {
   label?: string
-  variant?: 'default' | 'primary' | 'success' | 'warning' | 'error' | 'info'
+  variant?: BadgeVariant
   size?: 'xs' | 'sm' | 'md' | 'lg'
   rounded?: boolean
   outline?: boolean

--- a/autobot-frontend/src/components/base/BaseButton.stories.ts
+++ b/autobot-frontend/src/components/base/BaseButton.stories.ts
@@ -4,7 +4,6 @@ import BaseButton from './BaseButton.vue';
 const meta = {
   title: 'Components/Base/BaseButton',
   component: BaseButton,
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'select',

--- a/autobot-frontend/src/components/base/BaseButton.vue
+++ b/autobot-frontend/src/components/base/BaseButton.vue
@@ -22,10 +22,11 @@
 
 <script setup lang="ts">
 import { computed, ref, onMounted, useSlots, Comment } from 'vue'
+import type { ButtonVariant, ComponentSize } from '@/types/component-props'
 
 interface Props {
-  variant?: 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info' | 'light' | 'dark' | 'outline-solid' | 'ghost' | 'link'
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  variant?: ButtonVariant
+  size?: ComponentSize
   disabled?: boolean
   loading?: boolean
   block?: boolean

--- a/autobot-frontend/src/components/base/BaseCard.stories.ts
+++ b/autobot-frontend/src/components/base/BaseCard.stories.ts
@@ -4,7 +4,6 @@ import BaseCard from './BaseCard.vue';
 const meta = {
   title: 'Components/Base/BaseCard',
   component: BaseCard,
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'select',

--- a/autobot-frontend/src/components/base/BaseInput.stories.ts
+++ b/autobot-frontend/src/components/base/BaseInput.stories.ts
@@ -4,7 +4,6 @@ import BaseInput from './BaseInput.vue';
 const meta = {
   title: 'Components/Base/BaseInput',
   component: BaseInput,
-  tags: ['autodocs'],
   argTypes: {
     modelValue: {
       control: 'text',

--- a/autobot-frontend/src/components/base/BasePanel.stories.ts
+++ b/autobot-frontend/src/components/base/BasePanel.stories.ts
@@ -4,7 +4,6 @@ import BasePanel from './BasePanel.vue';
 const meta = {
   title: 'Components/Base/BasePanel',
   component: BasePanel,
-  tags: ['autodocs'],
   argTypes: {
     title: {
       control: 'text',

--- a/autobot-frontend/src/components/base/BaseTable.stories.ts
+++ b/autobot-frontend/src/components/base/BaseTable.stories.ts
@@ -4,7 +4,6 @@ import BaseTable from './BaseTable.vue';
 const meta = {
   title: 'Components/Base/BaseTable',
   component: BaseTable,
-  tags: ['autodocs'],
   argTypes: {
     columns: {
       description: 'Table column definitions',

--- a/autobot-frontend/src/components/chat/ChatHeader.stories.ts
+++ b/autobot-frontend/src/components/chat/ChatHeader.stories.ts
@@ -4,7 +4,6 @@ import ChatHeader from './ChatHeader.vue';
 const meta = {
   title: 'Components/Chat/ChatHeader',
   component: ChatHeader,
-  tags: ['autodocs'],
   argTypes: {
     currentSessionTitle: {
       control: 'text',

--- a/autobot-frontend/src/components/common/ErrorBoundary.stories.ts
+++ b/autobot-frontend/src/components/common/ErrorBoundary.stories.ts
@@ -4,7 +4,6 @@ import ErrorBoundary from './ErrorBoundary.vue';
 const meta = {
   title: 'Components/Common/ErrorBoundary',
   component: ErrorBoundary,
-  tags: ['autodocs'],
   argTypes: {
     title: {
       control: 'text',

--- a/autobot-frontend/src/components/common/PermissionDenied.stories.ts
+++ b/autobot-frontend/src/components/common/PermissionDenied.stories.ts
@@ -4,7 +4,6 @@ import PermissionDenied from './PermissionDenied.vue';
 const meta = {
   title: 'Components/Common/PermissionDenied',
   component: PermissionDenied,
-  tags: ['autodocs'],
 } as Meta<typeof PermissionDenied>;
 
 export default meta;

--- a/autobot-frontend/src/components/knowledge/WebResearchPanel.stories.ts
+++ b/autobot-frontend/src/components/knowledge/WebResearchPanel.stories.ts
@@ -9,7 +9,6 @@ import WebResearchPanel from './WebResearchPanel.vue'
 const meta = {
   title: 'Components/Knowledge/WebResearchPanel',
   component: WebResearchPanel,
-  tags: ['autodocs'],
   parameters: {
     docs: {
       description: {

--- a/autobot-frontend/src/components/layout/LanguageSwitcher.stories.ts
+++ b/autobot-frontend/src/components/layout/LanguageSwitcher.stories.ts
@@ -4,7 +4,6 @@ import LanguageSwitcher from './LanguageSwitcher.vue';
 const meta = {
   title: 'Components/Layout/LanguageSwitcher',
   component: LanguageSwitcher,
-  tags: ['autodocs'],
   parameters: {
     layout: 'centered',
     docs: {

--- a/autobot-frontend/src/components/layout/NavOverflowMenu.stories.ts
+++ b/autobot-frontend/src/components/layout/NavOverflowMenu.stories.ts
@@ -42,7 +42,6 @@ const sampleItems: NavItem[] = [
 const meta = {
   title: 'Components/Layout/NavOverflowMenu',
   component: NavOverflowMenu,
-  tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',
     docs: {

--- a/autobot-frontend/src/components/security/SecretsManager.stories.ts
+++ b/autobot-frontend/src/components/security/SecretsManager.stories.ts
@@ -4,7 +4,6 @@ import SecretsManager from './SecretsManager.vue';
 const meta = {
   title: 'Components/Security/SecretsManager',
   component: SecretsManager,
-  tags: ['autodocs'],
   argTypes: {},
 } as Meta<typeof SecretsManager>;
 

--- a/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.stories.ts
+++ b/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.stories.ts
@@ -4,7 +4,6 @@ import ThreatIntelligenceDashboard from './ThreatIntelligenceDashboard.vue';
 const meta = {
   title: 'Components/Security/ThreatIntelligenceDashboard',
   component: ThreatIntelligenceDashboard,
-  tags: ['autodocs'],
   argTypes: {},
 } as Meta<typeof ThreatIntelligenceDashboard>;
 

--- a/autobot-frontend/src/components/security/ThreatIntelligenceSettings.stories.ts
+++ b/autobot-frontend/src/components/security/ThreatIntelligenceSettings.stories.ts
@@ -4,7 +4,6 @@ import ThreatIntelligenceSettings from './ThreatIntelligenceSettings.vue';
 const meta = {
   title: 'Components/Security/ThreatIntelligenceSettings',
   component: ThreatIntelligenceSettings,
-  tags: ['autodocs'],
   argTypes: {},
 } as Meta<typeof ThreatIntelligenceSettings>;
 

--- a/autobot-frontend/src/components/ui/BaseAlert.stories.ts
+++ b/autobot-frontend/src/components/ui/BaseAlert.stories.ts
@@ -4,7 +4,6 @@ import BaseAlert from './BaseAlert.vue';
 const meta = {
   title: 'Components/UI/BaseAlert',
   component: BaseAlert,
-  tags: ['autodocs'],
   argTypes: {
     type: {
       control: 'select',

--- a/autobot-frontend/src/components/ui/BaseModal.stories.ts
+++ b/autobot-frontend/src/components/ui/BaseModal.stories.ts
@@ -4,7 +4,6 @@ import BaseModal from './BaseModal.vue';
 const meta = {
   title: 'Components/UI/BaseModal',
   component: BaseModal,
-  tags: ['autodocs'],
   argTypes: {
     modelValue: {
       control: 'boolean',

--- a/autobot-frontend/src/components/ui/CommandPermissionDialog.stories.ts
+++ b/autobot-frontend/src/components/ui/CommandPermissionDialog.stories.ts
@@ -4,7 +4,6 @@ import CommandPermissionDialog from './CommandPermissionDialog.vue';
 const meta = {
   title: 'Components/UI/CommandPermissionDialog',
   component: CommandPermissionDialog,
-  tags: ['autodocs'],
   argTypes: {
     show: {
       control: 'boolean',

--- a/autobot-frontend/src/components/ui/ConfirmDialog.stories.ts
+++ b/autobot-frontend/src/components/ui/ConfirmDialog.stories.ts
@@ -4,7 +4,6 @@ import ConfirmDialog from './ConfirmDialog.vue';
 const meta = {
   title: 'Components/UI/ConfirmDialog',
   component: ConfirmDialog,
-  tags: ['autodocs'],
   argTypes: {},
 } as Meta<typeof ConfirmDialog>;
 

--- a/autobot-frontend/src/components/ui/DarkModeToggle.stories.ts
+++ b/autobot-frontend/src/components/ui/DarkModeToggle.stories.ts
@@ -4,7 +4,6 @@ import DarkModeToggle from './DarkModeToggle.vue';
 const meta = {
   title: 'Components/UI/DarkModeToggle',
   component: DarkModeToggle,
-  tags: ['autodocs'],
   argTypes: {},
 } as Meta<typeof DarkModeToggle>;
 

--- a/autobot-frontend/src/components/ui/DataTable.stories.ts
+++ b/autobot-frontend/src/components/ui/DataTable.stories.ts
@@ -4,7 +4,6 @@ import DataTable from './DataTable.vue';
 const meta = {
   title: 'Components/UI/DataTable',
   component: DataTable,
-  tags: ['autodocs'],
   argTypes: {
     columns: {
       control: 'object',

--- a/autobot-frontend/src/components/ui/EmptyState.stories.ts
+++ b/autobot-frontend/src/components/ui/EmptyState.stories.ts
@@ -8,7 +8,6 @@ import EmptyState from './EmptyState.vue';
 const meta = {
   title: 'Components/UI/EmptyState',
   component: EmptyState,
-  tags: ['autodocs'],
   argTypes: {
     icon: {
       control: 'text',

--- a/autobot-frontend/src/components/ui/HostSelectionDialog.stories.ts
+++ b/autobot-frontend/src/components/ui/HostSelectionDialog.stories.ts
@@ -4,7 +4,6 @@ import HostSelectionDialog from './HostSelectionDialog.vue';
 const meta = {
   title: 'Components/UI/HostSelectionDialog',
   component: HostSelectionDialog,
-  tags: ['autodocs'],
   argTypes: {
     show: {
       control: 'boolean',

--- a/autobot-frontend/src/components/ui/HostSelector.stories.ts
+++ b/autobot-frontend/src/components/ui/HostSelector.stories.ts
@@ -4,7 +4,6 @@ import HostSelector from './HostSelector.vue';
 const meta = {
   title: 'Components/UI/HostSelector',
   component: HostSelector,
-  tags: ['autodocs'],
   argTypes: {
     chatId: {
       control: 'text',

--- a/autobot-frontend/src/components/ui/Icon.stories.ts
+++ b/autobot-frontend/src/components/ui/Icon.stories.ts
@@ -4,7 +4,6 @@ import Icon from './Icon.vue';
 const meta = {
   title: 'Components/UI/Icon',
   component: Icon,
-  tags: ['autodocs'],
   argTypes: {
     name: {
       control: 'select',

--- a/autobot-frontend/src/components/ui/Icon.vue
+++ b/autobot-frontend/src/components/ui/Icon.vue
@@ -208,9 +208,11 @@ const ICONS = {
 
 export type IconName = keyof typeof ICONS
 
+import type { ComponentSize } from '@/types/component-props'
+
 interface IconProps {
   name: IconName
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  size?: ComponentSize
   spin?: boolean
   strokeWidth?: number
   filled?: boolean

--- a/autobot-frontend/src/components/ui/LoadingSpinner.stories.ts
+++ b/autobot-frontend/src/components/ui/LoadingSpinner.stories.ts
@@ -4,7 +4,6 @@ import LoadingSpinner from './LoadingSpinner.vue';
 const meta = {
   title: 'Components/UI/LoadingSpinner',
   component: LoadingSpinner,
-  tags: ['autodocs'],
   argTypes: {
     size: {
       control: 'select',

--- a/autobot-frontend/src/components/ui/LoadingSpinner.vue
+++ b/autobot-frontend/src/components/ui/LoadingSpinner.vue
@@ -44,12 +44,13 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import type { ComponentSize } from '@/types/component-props'
 
 const { t } = useI18n()
 
 interface Props {
   variant?: 'circle' | 'dots' | 'pulse' | 'bars'
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  size?: ComponentSize
   color?: string
   label?: string
   labelPosition?: 'bottom' | 'right'

--- a/autobot-frontend/src/components/ui/MessageStatus.stories.ts
+++ b/autobot-frontend/src/components/ui/MessageStatus.stories.ts
@@ -4,7 +4,6 @@ import MessageStatus from './MessageStatus.vue';
 const meta = {
   title: 'Components/UI/MessageStatus',
   component: MessageStatus,
-  tags: ['autodocs'],
   argTypes: {
     status: {
       control: 'select',

--- a/autobot-frontend/src/components/ui/OfflineBanner.stories.ts
+++ b/autobot-frontend/src/components/ui/OfflineBanner.stories.ts
@@ -4,7 +4,6 @@ import OfflineBanner from './OfflineBanner.vue';
 const meta = {
   title: 'Components/UI/OfflineBanner',
   component: OfflineBanner,
-  tags: ['autodocs'],
   argTypes: {},
 } as Meta<typeof OfflineBanner>;
 

--- a/autobot-frontend/src/components/ui/PreferencesPanel.stories.ts
+++ b/autobot-frontend/src/components/ui/PreferencesPanel.stories.ts
@@ -4,7 +4,6 @@ import PreferencesPanel from './PreferencesPanel.vue';
 const meta = {
   title: 'Components/UI/PreferencesPanel',
   component: PreferencesPanel,
-  tags: ['autodocs'],
   argTypes: {},
 } as Meta<typeof PreferencesPanel>;
 

--- a/autobot-frontend/src/components/ui/ProgressBar.stories.ts
+++ b/autobot-frontend/src/components/ui/ProgressBar.stories.ts
@@ -4,7 +4,6 @@ import ProgressBar from './ProgressBar.vue';
 const meta = {
   title: 'Components/UI/ProgressBar',
   component: ProgressBar,
-  tags: ['autodocs'],
   argTypes: {
     progress: {
       control: { type: 'range', min: 0, max: 100, step: 1 },

--- a/autobot-frontend/src/components/ui/SkeletonLoader.stories.ts
+++ b/autobot-frontend/src/components/ui/SkeletonLoader.stories.ts
@@ -4,7 +4,6 @@ import SkeletonLoader from './SkeletonLoader.vue';
 const meta = {
   title: 'Components/UI/SkeletonLoader',
   component: SkeletonLoader,
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'select',

--- a/autobot-frontend/src/components/ui/StableLoadingState.stories.ts
+++ b/autobot-frontend/src/components/ui/StableLoadingState.stories.ts
@@ -4,7 +4,6 @@ import StableLoadingState from './StableLoadingState.vue';
 const meta = {
   title: 'Components/UI/StableLoadingState',
   component: StableLoadingState,
-  tags: ['autodocs'],
   argTypes: {
     isLoading: {
       control: 'boolean',

--- a/autobot-frontend/src/components/ui/StatusBadge.stories.ts
+++ b/autobot-frontend/src/components/ui/StatusBadge.stories.ts
@@ -4,7 +4,6 @@ import StatusBadge from './StatusBadge.vue';
 const meta = {
   title: 'Components/UI/StatusBadge',
   component: StatusBadge,
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'select',

--- a/autobot-frontend/src/components/ui/SystemStatusNotification.stories.ts
+++ b/autobot-frontend/src/components/ui/SystemStatusNotification.stories.ts
@@ -4,7 +4,6 @@ import SystemStatusNotification from './SystemStatusNotification.vue';
 const meta = {
   title: 'Components/UI/SystemStatusNotification',
   component: SystemStatusNotification,
-  tags: ['autodocs'],
   argTypes: {
     visible: {
       control: 'boolean',

--- a/autobot-frontend/src/components/ui/ThemeToggle.stories.ts
+++ b/autobot-frontend/src/components/ui/ThemeToggle.stories.ts
@@ -4,7 +4,6 @@ import ThemeToggle from './ThemeToggle.vue';
 const meta = {
   title: 'Components/UI/ThemeToggle',
   component: ThemeToggle,
-  tags: ['autodocs'],
   argTypes: {
     mode: {
       control: 'select',

--- a/autobot-frontend/src/components/ui/ToastContainer.stories.ts
+++ b/autobot-frontend/src/components/ui/ToastContainer.stories.ts
@@ -4,7 +4,6 @@ import ToastContainer from './ToastContainer.vue';
 const meta = {
   title: 'Components/UI/ToastContainer',
   component: ToastContainer,
-  tags: ['autodocs'],
   argTypes: {},
 } as Meta<typeof ToastContainer>;
 

--- a/autobot-frontend/src/components/ui/TouchFriendlyButton.stories.ts
+++ b/autobot-frontend/src/components/ui/TouchFriendlyButton.stories.ts
@@ -4,7 +4,6 @@ import TouchFriendlyButton from './TouchFriendlyButton.vue';
 const meta = {
   title: 'Components/UI/TouchFriendlyButton',
   component: TouchFriendlyButton,
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'select',

--- a/autobot-frontend/src/components/ui/TouchFriendlyButton.vue
+++ b/autobot-frontend/src/components/ui/TouchFriendlyButton.vue
@@ -27,10 +27,11 @@
 <script setup lang="ts">
 import { computed, ref, nextTick } from 'vue'
 import LoadingSpinner from './LoadingSpinner.vue'
+import type { ComponentSize } from '@/types/component-props'
 
 interface Props {
   variant?: 'primary' | 'secondary' | 'outline-solid' | 'ghost' | 'danger'
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  size?: ComponentSize
   loading?: boolean
   disabled?: boolean
   loadingVariant?: 'circle' | 'dots' | 'pulse'

--- a/autobot-frontend/src/components/ui/UnifiedLoadingView.stories.ts
+++ b/autobot-frontend/src/components/ui/UnifiedLoadingView.stories.ts
@@ -4,7 +4,6 @@ import UnifiedLoadingView from './UnifiedLoadingView.vue';
 const meta = {
   title: 'Components/UI/UnifiedLoadingView',
   component: UnifiedLoadingView,
-  tags: ['autodocs'],
   argTypes: {
     isLoading: {
       control: 'boolean',

--- a/autobot-frontend/src/stories/DesignTokens.stories.ts
+++ b/autobot-frontend/src/stories/DesignTokens.stories.ts
@@ -13,7 +13,6 @@ import {
 
 const meta = {
   title: 'Design System/Design Tokens',
-  tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',
     docs: {

--- a/autobot-frontend/src/stories/IconLibrary.stories.ts
+++ b/autobot-frontend/src/stories/IconLibrary.stories.ts
@@ -175,7 +175,6 @@ const ALL_ICON_NAMES: string[] = ICON_GROUPS.flatMap((g) => g.names);
 
 const meta = {
   title: 'Design System/Icon Library',
-  tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',
     docs: {

--- a/autobot-frontend/src/stories/Welcome.stories.ts
+++ b/autobot-frontend/src/stories/Welcome.stories.ts
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from '@storybook/vue3';
 
 const meta = {
   title: 'Introduction/Welcome',
-  tags: ['autodocs'],
   parameters: {
     layout: 'centered',
   },

--- a/autobot-frontend/src/types/component-props.ts
+++ b/autobot-frontend/src/types/component-props.ts
@@ -1,0 +1,17 @@
+// Canonical shared prop types for UI components
+export type { Size as ComponentSize } from '@/design-tokens/tokens'
+
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'danger'
+  | 'warning'
+  | 'info'
+  | 'light'
+  | 'dark'
+  | 'outline-solid'
+  | 'ghost'
+  | 'link'
+
+export type BadgeVariant = 'default' | 'primary' | 'success' | 'warning' | 'error' | 'info'


### PR DESCRIPTION
## Thinking Path

Phase C batch 5 closes three frontend hygiene issues:
- GH#6979: i18n audit — purely defensive, to confirm no duplicate JSON keys exist before further locale work. Result: clean.
- GH#6936: Storybook has `tags: ['autodocs']` duplicated in every story file, while `main.js` already has `docs.autodocs: 'tag'`. Moving the tag to `preview.ts` makes it a single global SSOT — 42 per-story copies become noise.
- GH#6939: `BaseButton`, `BaseBadge`, `LoadingSpinner`, `Icon`, `TouchFriendlyButton` all inline literal union types for `variant` and `size`. Creating shared `component-props.ts` consolidates them and enables type-level enforcement when new variants are added.

## What Changed

- **GH#6979**: No file changes — audit confirmed 0 duplicate i18n keys
- **GH#6936**: Added `tags: ['autodocs']` to `preview.ts`; removed the redundant line from 42 story files
- **GH#6939**: Created `src/types/component-props.ts` with `ComponentSize` (re-export from design-tokens), `ButtonVariant` (11-option union), `BadgeVariant` (6-option union); updated 5 components to import from shared types

## Verification

- `vue-tsc --noEmit -p tsconfig.app.json` — no new errors introduced
- `node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/en.json','utf8'))"` — passes
- 42 story files confirmed updated (git diff count matches)

## Risks

Low. Autodocs behavior is identical — global tag in preview.ts is the documented pattern. Type aliases are compile-time only; no runtime impact. i18n audit is a no-op change.

## Model Used

claude-sonnet-4-6

## Checklist

- [x] vue-tsc passes with no new errors
- [x] i18n JSON validates
- [x] Storybook autodocs behavior unchanged (tag moved to global, not removed)
- [x] 42 story files updated (per-story tag removed)
- [x] 5 components use shared types from component-props.ts
- [x] component-props.ts created with all 3 types

---

## Summary

Closes GH#6979, GH#6936, GH#6939 — three frontend hygiene issues from Phase C batch 5.

### GH#6979 — i18n key audit (no-op)
- Audited `autobot-frontend/src/i18n/locales/en.json` and all locale files using Python `json.loads(…, object_pairs_hook=…)` to detect true duplicates (same key in same object)
- **Result: 0 duplicates found** — JSON is clean, 484 top-level keys parse correctly
- `node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/en.json','utf8'))"` passes

### GH#6936 — Storybook DRY: global autodocs tag
- Added `tags: ['autodocs']` to global `preview.ts` (single source of truth)
- Removed the now-redundant `tags: ['autodocs']` line from all **42 story files**
- `main.js` `docs.autodocs: 'tag'` unchanged — still reads the global tag correctly
- Net change: 1 line added (preview.ts), 42 lines removed (stories)

### GH#6939 — Shared size/variant enum types
- Created `src/types/component-props.ts` with:
  - `ComponentSize` (re-export of `Size` from `@/design-tokens/tokens`)
  - `ButtonVariant` (canonical 11-option union for BaseButton)
  - `BadgeVariant` (canonical 6-option union for BaseBadge)
- Updated 5 components to import from shared types instead of inline literals:
  - `BaseButton.vue` — `ButtonVariant + ComponentSize`
  - `BaseBadge.vue` — `BadgeVariant`
  - `LoadingSpinner.vue` — `ComponentSize`
  - `Icon.vue` — `ComponentSize`
  - `TouchFriendlyButton.vue` — `ComponentSize`
- `vue-tsc --noEmit -p tsconfig.app.json`: no new errors introduced

## Test plan

- [ ] Storybook builds with autodocs on all stories (global tag propagates)
- [ ] Type check passes: `npm run type-check`
- [ ] i18n JSON validates: `node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/en.json','utf8'))"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)