### PR TITLE
monitor(ci): alert on stale self-hosted runner state (closes #7045)

### DIFF
--- a/.github/workflows/self-hosted-runner-health.yml
+++ b/.github/workflows/self-hosted-runner-health.yml
@@ -1,0 +1,26 @@
+name: self-hosted-runner-health
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe runner state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          state=$(gh api repos/${{ github.repository }}/actions/runners --jq '.runners[] | select(.name == "MV-Stealth-VM")')
+          status=$(echo "$state" | jq -r '.status')
+          busy=$(echo "$state" | jq -r '.busy')
+          if [ "$status" != "online" ] || [ "$busy" = "true" ]; then
+            in_progress=$(gh api repos/${{ github.repository }}/actions/runs --paginate --jq '[.workflow_runs[] | select(.status == "in_progress")] | length')
+            if [ "$in_progress" = "0" ] && [ "$busy" = "true" ]; then
+              echo "::error::Runner desynced: status=$status busy=$busy with 0 in_progress jobs"
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
## Summary

Adds scheduled workflow to monitor the self-hosted runner (MV-Stealth-VM) for desync conditions.

## Changes
- New workflow: `.github/workflows/self-hosted-runner-health.yml`
- Runs every 30 min on ubuntu-latest
- Probes runner state via GitHub API
- Alerts on desync: `busy=true` with no in-progress jobs
- Includes `workflow_dispatch` for manual testing

## Testing
Workflow will execute on next 30-min boundary; can trigger manually via workflow_dispatch.

Closes #7045