### PR TITLE
fix(rbac): close pubsub before reconnect; use pipeline for bulk cache clear

### DIFF
--- a/autobot-backend/user_management/middleware/rbac_middleware.py
+++ b/autobot-backend/user_management/middleware/rbac_middleware.py
@@ -64,13 +64,18 @@ async def _run_invalidation_listener() -> None:
             return
         except Exception:
             logger.exception("RBAC invalidation listener: reconnecting in 5s")
+            try:
+                await pubsub.unsubscribe(_PUBSUB_CHANNEL)
+                await pubsub.aclose()
+            except Exception:
+                pass
             await asyncio.sleep(5)
 
 
 async def _ensure_listener_started() -> None:
     global _listener_task
     if _listener_task is None or _listener_task.done():
-        _listener_task = asyncio.ensure_future(_run_invalidation_listener())
+        _listener_task = asyncio.create_task(_run_invalidation_listener())
 
 
 class RBACMiddleware:
@@ -231,8 +236,10 @@ class RBACMiddleware:
             if user_id:
                 await redis.delete(f"{_REDIS_KEY_PREFIX}{user_id}")
             else:
+                pipeline = redis.pipeline()
                 async for key in redis.scan_iter(f"{_REDIS_KEY_PREFIX}*"):
-                    await redis.delete(key)
+                    pipeline.delete(key)
+                await pipeline.execute()
             payload = json.dumps({"user_id": str(user_id)} if user_id else {})
             await redis.publish(_PUBSUB_CHANNEL, payload)
             logger.debug("RBAC cache invalidated for user=%s", user_id)

--- a/autobot-slm-backend/user_management/middleware/rbac_middleware.py
+++ b/autobot-slm-backend/user_management/middleware/rbac_middleware.py
@@ -63,13 +63,18 @@ async def _run_invalidation_listener() -> None:
             return
         except Exception:
             logger.exception("RBAC invalidation listener: reconnecting in 5s")
+            try:
+                await pubsub.unsubscribe(_PUBSUB_CHANNEL)
+                await pubsub.aclose()
+            except Exception:
+                pass
             await asyncio.sleep(5)
 
 
 async def _ensure_listener_started() -> None:
     global _listener_task
     if _listener_task is None or _listener_task.done():
-        _listener_task = asyncio.ensure_future(_run_invalidation_listener())
+        _listener_task = asyncio.create_task(_run_invalidation_listener())
 
 
 class RBACMiddleware:
@@ -230,8 +235,10 @@ class RBACMiddleware:
             if user_id:
                 await redis.delete(f"{_REDIS_KEY_PREFIX}{user_id}")
             else:
+                pipeline = redis.pipeline()
                 async for key in redis.scan_iter(f"{_REDIS_KEY_PREFIX}*"):
-                    await redis.delete(key)
+                    pipeline.delete(key)
+                await pipeline.execute()
             payload = json.dumps({"user_id": str(user_id)} if user_id else {})
             await redis.publish(_PUBSUB_CHANNEL, payload)
             logger.debug("RBAC cache invalidated for user=%s", user_id)


### PR DESCRIPTION
## Summary

RBAC security hardening fixes for two open issues found during MVA-123 code review:

- **GH#7608** — `_run_invalidation_listener()` did not call `pubsub.unsubscribe()` / `pubsub.aclose()` before the 5s reconnect sleep, leaking Redis pub/sub connections on transient failures. Added cleanup in the `except Exception` handler (wrapped in its own try/except so a missing `pubsub` binding is silently ignored).
- **GH#7607** — `clear_cache()` issued N individual `redis.delete()` calls when clearing all keys. Replaced with a pipeline: queue all deletes, then `pipeline.execute()` in one round-trip.
- **GH#7606** (bonus, same file) — replaced deprecated `asyncio.ensure_future` with `asyncio.create_task` in `_ensure_listener_started()`.

All three changes applied to both `autobot-backend` and `autobot-slm-backend`.

## Test plan

- [ ] Verify RBAC invalidation listener reconnects cleanly after Redis blip (no leaked connections)
- [ ] Verify bulk-clear path flushes all `rbac:perm:*` keys in a single pipeline round-trip
- [ ] Existing RBAC permission-check flow unaffected

Closes #7608
Closes #7607

🤖 Generated with [Claude Code](https://claude.com/claude-code)