### PR TITLE
feat(api/analytics): wire-in EngagementMetricsResponse — backend endpoint + frontend composable (#7111)

### DIFF
--- a/autobot-backend/api/analytics.py
+++ b/autobot-backend/api/analytics.py
@@ -389,6 +389,7 @@ from api import (
     analytics_behavior,
     analytics_code,
     analytics_cost,
+    analytics_engagement,
     analytics_export,
 )
 
@@ -398,6 +399,7 @@ router.include_router(analytics_code.router)
 # Include Issue #59 sub-routers (Advanced Analytics & BI)
 router.include_router(analytics_cost.router)
 router.include_router(analytics_agents.router)
+router.include_router(analytics_engagement.router)
 router.include_router(analytics_export.router)
 router.include_router(analytics_behavior.router)
 

--- a/autobot-backend/api/analytics_engagement.py
+++ b/autobot-backend/api/analytics_engagement.py
@@ -1,0 +1,88 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Engagement Metrics Analytics API
+
+Provides endpoints for tracking user engagement metrics across features.
+"""
+
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+from api.schemas_analytics import EngagementMetricsResponse
+from api.schemas_common import DataResponse
+from autobot_shared.error_boundaries import with_error_handling
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_redis_client
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/engagement-metrics", tags=["engagement", "analytics"])
+
+
+@router.get("", response_model=DataResponse[EngagementMetricsResponse])
+@with_error_handling
+async def get_engagement_metrics():
+    """Get engagement metrics for all features."""
+    redis = get_redis_client()
+
+    try:
+        # Retrieve engagement metrics from Redis
+        # Format: engagement:feature:<feature_name> -> {count, last_accessed}
+        engagement_data = {}
+
+        if redis:
+            # Scan for all engagement keys
+            cursor = 0
+            feature_counts = {}
+
+            while True:
+                cursor, keys = redis.scan(cursor, match="engagement:feature:*", count=100)
+
+                for key in keys:
+                    feature_name = key.decode().replace("engagement:feature:", "")
+                    count = redis.get(f"engagement:feature:{feature_name}:count")
+                    if count:
+                        feature_counts[feature_name] = int(count)
+
+                if cursor == 0:
+                    break
+
+        # Calculate feature popularity
+        sorted_features = sorted(feature_counts.items(), key=lambda x: x[1], reverse=True)
+        feature_popularity = [{"feature": f, "count": c} for f, c in sorted_features[:10]]
+        most_popular = sorted_features[0][0] if sorted_features else None
+
+        # Build response
+        response = EngagementMetricsResponse(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            metrics={
+                "total_features_tracked": len(feature_counts),
+                "total_interactions": sum(feature_counts.values()),
+                "average_interactions_per_feature": (
+                    sum(feature_counts.values()) // len(feature_counts)
+                    if feature_counts
+                    else 0
+                ),
+            },
+            feature_popularity=feature_popularity,
+            most_popular_feature=most_popular,
+        )
+
+        return DataResponse(data=response)
+
+    except Exception as e:
+        logger.error(f"Error retrieving engagement metrics: {e}")
+        # Return empty response on error
+        return DataResponse(
+            data=EngagementMetricsResponse(
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                metrics={},
+                feature_popularity=[],
+                most_popular_feature=None,
+            )
+        )

--- a/autobot-frontend/src/composables/analytics/useEngagementMetrics.ts
+++ b/autobot-frontend/src/composables/analytics/useEngagementMetrics.ts
@@ -1,0 +1,47 @@
+import { ref, computed } from 'vue'
+import { useApi } from '@/composables/useApi'
+
+export interface EngagementMetrics {
+  timestamp: string
+  metrics: Record<string, any>
+  feature_popularity: Array<{ feature: string; count: number }>
+  most_popular_feature: string | null
+}
+
+export function useEngagementMetrics() {
+  const api = useApi()
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const data = ref<EngagementMetrics | null>(null)
+
+  const fetch = async () => {
+    loading.value = true
+    error.value = null
+
+    try {
+      const response = await api.get('/analytics/engagement-metrics')
+      data.value = response.data
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to load engagement metrics'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const totalInteractions = computed(() => {
+    return data.value?.metrics?.total_interactions ?? 0
+  })
+
+  const avgInteractionsPerFeature = computed(() => {
+    return data.value?.metrics?.average_interactions_per_feature ?? 0
+  })
+
+  return {
+    loading,
+    error,
+    data,
+    fetch,
+    totalInteractions,
+    avgInteractionsPerFeature
+  }
+}


### PR DESCRIPTION
Wires in EngagementMetricsResponse endpoint per #7111.

## Changes
- Created `analytics_engagement.py` with GET /api/analytics/engagement-metrics endpoint
- Returns EngagementMetricsResponse with feature popularity and engagement tracking
- Registered router in analytics.py
- Created frontend composable `useEngagementMetrics.ts` for consuming the endpoint

## Acceptance Criteria Met
- ✅ Backend endpoint created and registered
- ✅ Returns EngagementMetricsResponse per schema
- ✅ Frontend composable provided for view integration
- ✅ Data source: Redis engagement keys with fallback to empty response on error