### PR TITLE
refactor(llm): Phase B batch 14 — UnifiedLLMInterface + MockLLMInterface + AgentProfile overlap (#6942, #6943, #6931)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/types.py
+++ b/autobot-backend/agents/agent_orchestration/types.py
@@ -145,7 +145,11 @@ class AgentType(Enum):
 
 @dataclass
 class AgentCapabilityDescriptor:
-    """Describes an agent's capabilities and constraints."""
+    """Static capability descriptor for an agent *type* (model_size, strengths, limitations).
+
+    Distinct from ``orchestration.types.AgentProfile``, which tracks runtime
+    state of a specific agent instance (workload, success rate, availability).
+    """
 
     agent_type: AgentType
     model_size: str

--- a/autobot-backend/llm_multi_provider.py
+++ b/autobot-backend/llm_multi_provider.py
@@ -201,9 +201,11 @@ class UnifiedLLMInterface:
     """
     Backward-compatible facade over the plugin-per-provider registry.
 
-    New code should call ``get_provider_registry()`` directly.  This class
-    exists solely to avoid breaking call sites that still instantiate
-    ``UnifiedLLMInterface()``.
+    **Deprecated** — new code should use ``LLMService`` from
+    ``services.llm_service`` (the canonical post-#3185 entry point).
+    This class exists solely to avoid breaking call sites that still
+    instantiate ``UnifiedLLMInterface()``; it is not the canonical
+    interface and should not be imported in new code.
     """
 
     def __init__(self) -> None:

--- a/autobot-backend/orchestration/types.py
+++ b/autobot-backend/orchestration/types.py
@@ -64,7 +64,11 @@ class DocumentationType(Enum):
 
 @dataclass
 class AgentProfile:
-    """Enhanced agent profile with capabilities and performance metrics."""
+    """Runtime state for a specific agent instance (workload, success rate, availability).
+
+    Distinct from ``AgentCapabilityDescriptor`` (agents.agent_orchestration.types),
+    which is a static per-type descriptor (model_size, strengths, limitations).
+    """
 
     agent_id: str
     agent_type: str

--- a/autobot-backend/services/nl_database_service.py
+++ b/autobot-backend/services/nl_database_service.py
@@ -526,13 +526,15 @@ class NLDatabaseService:
             Extracted SQL string
         """
         try:
-            from llm_multi_provider import UnifiedLLMInterface
+            from services.llm_service import LLMService
 
             if self._llm is None:
-                self._llm = UnifiedLLMInterface()
-                await self._llm.initialize()
+                self._llm = LLMService()
 
-            response = await self._llm.generate_response(prompt, llm_type="task")
+            llm_response = await self._llm.chat(
+                [{"role": "user", "content": prompt}], llm_type="task"
+            )
+            response = llm_response.content
             return _extract_sql_from_response(response)
         except Exception as exc:
             logger.error("LLM SQL generation failed: %s", exc)

--- a/autobot-backend/tests/fixtures/mocks.py
+++ b/autobot-backend/tests/fixtures/mocks.py
@@ -7,8 +7,8 @@ Mock fixtures for AutoBot backend testing (canonical location for #6994).
 Provides mock implementations of core components for tests and the
 `__main__` demo blocks under `intelligence/`:
 
-- MockLLMInterface  - Legacy mock matching the deleted LLMInterface surface
-                      (kept per "never delete code — wire it in" policy).
+- MockLLMInterface  - Mock for UnifiedLLMInterface (llm_multi_provider); covers
+                      both chat_completion() and legacy generate_response().
 - MockLLMService    - Mock matching the LLMService surface that replaced
                       LLMInterface in #3185. Returns LLMResponse-shaped
                       objects via `.chat(...)` so demos exercising
@@ -25,11 +25,13 @@ from typing import Any, Dict, List, Optional
 
 
 class MockLLMInterface:
-    """Legacy mock LLM interface for testing agent workflows.
+    """Mock for ``UnifiedLLMInterface`` (``llm_multi_provider.UnifiedLLMInterface``).
 
-    Predates the #3185 LLMInterface retirement. Kept for any test that
-    still depends on the `generate_response()` surface. New code should
-    prefer `MockLLMService`.
+    Covers the full surface of ``UnifiedLLMInterface``: both the primary
+    ``chat_completion()`` method and the legacy ``generate_response()`` shim.
+    New test code should prefer ``MockLLMService`` (which mocks the canonical
+    ``LLMService.chat()`` surface); this class is retained for tests that
+    still exercise ``UnifiedLLMInterface`` directly.
     """
 
     def __init__(self, responses: Optional[Dict[str, str]] = None):
@@ -37,14 +39,10 @@ class MockLLMInterface:
         self._call_count = 0
         self._call_history: list = []
 
-    async def generate_response(self, prompt: str, **kwargs) -> str:
-        self._call_count += 1
-        self._call_history.append({"prompt": prompt, "kwargs": kwargs})
-
+    def _pick_response(self, prompt: str) -> str:
         for keyword, response in self._custom_responses.items():
             if keyword.lower() in prompt.lower():
                 return response
-
         prompt_lower = prompt.lower()
         if "progress" in prompt_lower:
             return "Processing data..."
@@ -53,6 +51,26 @@ class MockLLMInterface:
         if "command" in prompt_lower:
             return "COMMAND: echo 'This is a test response'\nEXPLANATION: Testing the system"
         return "Command executing..."
+
+    async def chat_completion(
+        self,
+        messages: List[Dict[str, Any]],
+        **kwargs: Any,
+    ) -> Any:
+        """Mock primary method matching ``UnifiedLLMInterface.chat_completion``."""
+        prompt = messages[-1].get("content", "") if messages else ""
+        self._call_count += 1
+        self._call_history.append({"prompt": prompt, "kwargs": kwargs})
+        return make_llm_response(content=self._pick_response(prompt))
+
+    async def generate_response(self, prompt: str, **kwargs: Any) -> str:
+        """Legacy shim matching ``UnifiedLLMInterface.generate_response``."""
+        self._call_count += 1
+        self._call_history.append({"prompt": prompt, "kwargs": kwargs})
+        return self._pick_response(prompt)
+
+    async def initialize(self) -> None:
+        """No-op — matches ``UnifiedLLMInterface.initialize``."""
 
     @property
     def call_count(self) -> int:


### PR DESCRIPTION
## Summary

Closes #6942, #6943, #6931 — LLM consolidation (Phase B batch 14).

- **GH#6942** — `UnifiedLLMInterface` in `llm_multi_provider.py` marked deprecated in favour of canonical `LLMService`; `nl_database_service._generate_sql_with_llm_prompt` migrated to `LLMService.chat()`.
- **GH#6943** — `MockLLMInterface` updated to mock the full `UnifiedLLMInterface` surface: adds `chat_completion()`, `initialize()` stubs; fixes module-level docstring; legacy `generate_response()` retained for backward compat.
- **GH#6931** — `AgentProfile` (runtime state of an agent instance) and `AgentCapabilityDescriptor` (static capabilities of an agent type) are **not duplicates** — confirmed by field-level analysis. Cross-reference docstrings added to both classes to document the distinction.

## Thinking Path

- **#6942**: `UnifiedLLMInterface` is a legacy facade per the #3185 LLM consolidation; callers should use `LLMService` instead. `nl_database_service` was still using `UnifiedLLMInterface()` + `generate_response()` — migrated to `LLMService.chat()` which returns `LLMResponse`; extracted `.content` to preserve the `str` return contract downstream. Marked the facade class deprecated rather than deleting (per "never delete code" policy).
- **#6943**: `MockLLMInterface` docstring was stale ("Legacy mock matching the deleted LLMInterface") — wrong class. Refactored to match the actual `UnifiedLLMInterface` surface: extracted `_pick_response()` helper, added `chat_completion()` as primary method, `generate_response()` now delegates to `_pick_response`, `initialize()` added as no-op. Legacy callers unaffected.
- **#6931**: Field-level diff of `AgentProfile` vs `AgentCapabilityDescriptor` shows they serve orthogonal concerns (runtime workload/availability vs static type capabilities). No consolidation needed; cross-reference docstrings prevent future confusion.

## What Changed

| File | Change |
|---|---|
| `autobot-backend/llm_multi_provider.py` | `UnifiedLLMInterface` docstring updated to **Deprecated** with redirect to `LLMService` |
| `autobot-backend/services/nl_database_service.py` | `_generate_sql_with_llm_prompt`: removed `UnifiedLLMInterface` import, migrated to `LLMService.chat()`, extract `.content` from `LLMResponse` |
| `autobot-backend/tests/fixtures/mocks.py` | `MockLLMInterface`: add `chat_completion()`, `initialize()`, extract `_pick_response()`; fix module docstring; `generate_response()` retained |
| `autobot-backend/orchestration/types.py` | `AgentProfile` docstring cross-references `AgentCapabilityDescriptor` with path |
| `autobot-backend/agents/agent_orchestration/types.py` | `AgentCapabilityDescriptor` docstring cross-references `AgentProfile` with path |

## Verification

- [x] All 5 changed files pass `python3 -m py_compile`
- [x] `nl_database_service.py` no longer imports `UnifiedLLMInterface` — confirmed by grep
- [x] `MockLLMInterface.chat_completion()` added — backward-compat with existing test callers (legacy `generate_response` retained)
- [x] No circular imports introduced (`llm_service.py` imports from `llm_interface_pkg`, not `llm_multi_provider`)
- [x] `AgentProfile` and `AgentCapabilityDescriptor` field sets confirmed orthogonal — no consolidation needed for #6931

## Risks

- **Low**: `nl_database_service` LLM migration — `LLMService.chat()` returns `LLMResponse`; we extract `.content` (str). If `LLMService` ever returns a non-content response the exception is caught and logged (existing `try/except`).
- **None**: `UnifiedLLMInterface` deprecation is documentation-only; no code paths removed.
- **None**: `MockLLMInterface` refactor is test-only; `generate_response()` preserved for backward compat.
- **None**: Docstring cross-references are documentation-only.

## Model Used

claude-sonnet-4-6 (Phase B batch implementation agent)

## Checklist

- [x] Changes are scoped to the linked issues only
- [x] No new imports of `UnifiedLLMInterface` added
- [x] `MockLLMInterface` backward-compatible (legacy `generate_response` retained)
- [x] All modified Python files compile cleanly
- [x] No magic numbers or hardcoded values introduced
- [x] No TODO/FIXME comments left in code
- [x] Changelog: N/A — internal refactor (docstrings + deprecation notice + test mock update)

## Changes

- Migrate `nl_database_service` from `UnifiedLLMInterface` to `LLMService.chat()`
- Deprecate `UnifiedLLMInterface` (redirect to `LLMService` in docstring)
- Expand `MockLLMInterface` to cover full `UnifiedLLMInterface` surface
- Cross-reference `AgentProfile` ↔ `AgentCapabilityDescriptor` docstrings

## Test plan

- [x] All 5 changed files pass `python3 -m py_compile`
- [x] `nl_database_service.py` no longer imports `UnifiedLLMInterface`
- [x] `MockLLMInterface.chat_completion()` added — backward-compat with existing test callers
- [x] No circular imports introduced (`llm_service.py` imports from `llm_interface_pkg`, not `llm_multi_provider`)

## Changelog fragment

- [ ] N/A — internal refactor: deprecation notices + test mock update + docstring cross-references; no user-visible behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)