### PR TITLE
ci: route code-quality and frontend-test to self-hosted runner (MVA-454)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   code-quality:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -30,7 +30,7 @@ jobs:
   # Job 1: Unit and Integration Tests
   unit-tests:
     name: Unit & Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
       - name: Checkout code
@@ -119,7 +119,7 @@ jobs:
   # Job 2: Security Scanning
   security-scan:
     name: Security Scan
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
       - name: Checkout code
@@ -163,7 +163,7 @@ jobs:
   # Job 3: Build Test
   build-test:
     name: Build Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: unit-tests
 
     steps:
@@ -201,7 +201,7 @@ jobs:
   # Job 4: Test Summary and Reporting
   test-summary:
     name: Test Summary
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: [unit-tests, security-scan, build-test]
     if: always()
 

--- a/autobot-backend/agents/llm_failsafe_agent.py
+++ b/autobot-backend/agents/llm_failsafe_agent.py
@@ -480,7 +480,9 @@ class LLMFailsafeAgent(StandardizedAgent):
             metadata=metadata,
         )
 
-    async def _try_primary_llm(self, prompt: str, context: Optional[Dict[str, Any]], start_time: float) -> FailsafeLLMResponse:
+    async def _try_primary_llm(
+        self, prompt: str, context: Optional[Dict[str, Any]], start_time: float
+    ) -> FailsafeLLMResponse:
         """Try primary LLM communication (Issue #398: refactored)."""
         self.tier_stats[LLMTier.PRIMARY]["requests"] += 1
         try:

--- a/autobot-backend/api/analytics_engagement.py
+++ b/autobot-backend/api/analytics_engagement.py
@@ -64,9 +64,7 @@ async def get_engagement_metrics():
                 "total_features_tracked": len(feature_counts),
                 "total_interactions": sum(feature_counts.values()),
                 "average_interactions_per_feature": (
-                    sum(feature_counts.values()) // len(feature_counts)
-                    if feature_counts
-                    else 0
+                    sum(feature_counts.values()) // len(feature_counts) if feature_counts else 0
                 ),
             },
             feature_popularity=feature_popularity,

--- a/autobot-backend/api/sandbox_files.py
+++ b/autobot-backend/api/sandbox_files.py
@@ -118,9 +118,7 @@ async def view_file(request: Request, file_path: str):
     operation="sandbox_rename_file",
     error_code_prefix="SANDBOX_FILES",
 )
-async def rename_file_or_directory(
-    request: Request, path: str = Form(...), new_name: str = Form(...)
-):
+async def rename_file_or_directory(request: Request, path: str = Form(...), new_name: str = Form(...)):
     """Rename a file or directory within the sandbox."""
     _check_permission(request, "upload")
 
@@ -135,9 +133,7 @@ async def rename_file_or_directory(
     target_path = source_path.parent / new_name
 
     if await run_in_file_executor(target_path.exists):
-        raise HTTPException(
-            status_code=409, detail="A file or directory with that name already exists"
-        )
+        raise HTTPException(status_code=409, detail="A file or directory with that name already exists")
 
     await run_in_file_executor(source_path.rename, target_path)
 
@@ -268,9 +264,7 @@ async def get_directory_tree(request: Request, path: str = ""):
     def build_tree(directory: Path) -> list:
         try:
             items = []
-            for item in sorted(
-                directory.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())
-            ):
+            for item in sorted(directory.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())):
                 try:
                     rel = str(item.relative_to(SANDBOX_FILES_ROOT))
                     entry: dict = {

--- a/autobot-backend/services/nl_database_service.py
+++ b/autobot-backend/services/nl_database_service.py
@@ -531,9 +531,7 @@ class NLDatabaseService:
             if self._llm is None:
                 self._llm = LLMService()
 
-            llm_response = await self._llm.chat(
-                [{"role": "user", "content": prompt}], llm_type="task"
-            )
+            llm_response = await self._llm.chat([{"role": "user", "content": prompt}], llm_type="task")
             response = llm_response.content
             return _extract_sql_from_response(response)
         except Exception as exc:

--- a/autobot-backend/tests/test_sunset_legacy_health.py
+++ b/autobot-backend/tests/test_sunset_legacy_health.py
@@ -152,9 +152,7 @@ def test_legacy_hit_increments_counter():
     with patch.object(mw, "autobot_legacy_health_hits_total", mock_counter):
         client.get("/api/redis/health", headers={"User-Agent": "prometheus/2.x"})
 
-    mock_counter.labels.assert_called_once_with(
-        path="/api/redis/health", user_agent="prometheus/2.x"
-    )
+    mock_counter.labels.assert_called_once_with(path="/api/redis/health", user_agent="prometheus/2.x")
     mock_labels.inc.assert_called_once()
 
 

--- a/autobot-backend/utils/behavioral_grep.py
+++ b/autobot-backend/utils/behavioral_grep.py
@@ -170,11 +170,7 @@ def behavioral_grep(
     for dirpath, dirnames, filenames in os.walk(root):
         # Prune excluded directories in-place to prevent os.walk from descending.
         dirnames[:] = [
-            d
-            for d in dirnames
-            if not _matches_any(
-                os.path.relpath(os.path.join(dirpath, d), root), exclude_globs
-            )
+            d for d in dirnames if not _matches_any(os.path.relpath(os.path.join(dirpath, d), root), exclude_globs)
         ]
 
         for filename in filenames:
@@ -243,8 +239,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="behavioral_grep",
         description=(
-            "Behavioral-grep audit utility. "
-            "Finds all sites implementing a behavior pattern across a directory tree."
+            "Behavioral-grep audit utility. " "Finds all sites implementing a behavior pattern across a directory tree."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
@@ -310,12 +305,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     include_globs = args.include_globs if args.include_globs else ["*.py"]
-    exclude_globs = args.exclude_globs if args.exclude_globs else [
-        "*/__pycache__/*",
-        "*.pyc",
-        "*/.git/*",
-        "*/node_modules/*",
-    ]
+    exclude_globs = (
+        args.exclude_globs
+        if args.exclude_globs
+        else [
+            "*/__pycache__/*",
+            "*.pyc",
+            "*/.git/*",
+            "*/node_modules/*",
+        ]
+    )
 
     label = args.before_label or args.after_label  # CLI provides one at a time
 

--- a/autobot_shared/db_session.py
+++ b/autobot_shared/db_session.py
@@ -8,6 +8,7 @@ rollback-on-error, and guaranteed close semantics in one place.
 
 Async callers use db_session_context() from user_management.database.
 """
+
 from contextlib import contextmanager
 from typing import Callable, Generator
 

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -107,8 +107,7 @@ class PluginLoader:
             missing_required, missing_optional = self._check_required_env(manifest)
             if missing_required:
                 raise PluginLoadError(
-                    f"Cannot load plugin '{manifest.name}': "
-                    f"required env vars not set: {missing_required}"
+                    f"Cannot load plugin '{manifest.name}': " f"required env vars not set: {missing_required}"
                 )
             if missing_optional:
                 logger.info(

--- a/autobot_shared/plugin_sdk/manifest_contract_test.py
+++ b/autobot_shared/plugin_sdk/manifest_contract_test.py
@@ -11,7 +11,6 @@ import pytest
 from plugin_sdk.manifest_contract import ManifestContract
 from plugin_sdk.unified_registry import UnifiedRegistry, get_unified_registry
 
-
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------

--- a/autobot_shared/plugin_sdk/plugin_sdk_test.py
+++ b/autobot_shared/plugin_sdk/plugin_sdk_test.py
@@ -750,10 +750,7 @@ async def test_load_plugin_raises_plugin_load_error_when_required_env_missing(mo
         if missing_required:
             from plugin_sdk.base import PluginLoadError as _PLE
 
-            raise _PLE(
-                f"Cannot load plugin '{manifest.name}': "
-                f"required env vars not set: {missing_required}"
-            )
+            raise _PLE(f"Cannot load plugin '{manifest.name}': " f"required env vars not set: {missing_required}")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Routes `code-quality` (required merge check) to `[self-hosted, Linux, X64]` — MV-Stealth-VM is online and idle while ubuntu-latest queue backs up to 101+ jobs
- Routes `frontend-test` to self-hosted (the workflow header comment already states this intent but wasn't implemented)
- `docker-smoke-test` stays on `ubuntu-latest`: ports 80/443/6379/5432/11434 are all occupied on the self-hosted host

## Root cause

MV-Stealth-VM runner is **online** and healthy (systemd service active since 08:54 UTC, listening for jobs, not busy). The problem is that no workflows target it — all use `ubuntu-latest`. Batch PR creation from SCA phases filled the ubuntu-latest queue (101 queued, 20 in-progress). This PR fixes the critical merge-blocking check (`code-quality`) to bypass the queue.

## Test plan

- [ ] Verify `code-quality` job picks up on MV-Stealth-VM (check Actions tab → job runner name)
- [ ] Verify `frontend-test` jobs pick up on MV-Stealth-VM
- [ ] Confirm `code-quality` check passes and shows `green` on this PR
- [ ] After merge, open a test PR against Dev_new_gui touching a `.py` file and confirm code-quality runs on self-hosted

Closes MVA-454

🤖 Generated with [Claude Code](https://claude.com/claude-code)