### PR TITLE
observability(health): complete #6919 — user_agent label + INFO log + tests + docs

### DIFF
--- a/autobot-backend/middleware/sunset_legacy_health.py
+++ b/autobot-backend/middleware/sunset_legacy_health.py
@@ -21,16 +21,14 @@ prior notice.
 
 Issue #6919: Logging and Prometheus metering added so external audits can
 identify which scrapers are still calling deprecated endpoints.  Each hit
-is logged at WARNING level (deprecated API surface being called) and
-increments a ``autobot_legacy_health_hits_total`` counter labelled by
-``path``.  This allows Prometheus queries such as
-``topk(10, autobot_legacy_health_hits_total)`` to surface active scrapers
-during the sunset window.
+is logged at INFO level and increments
+``autobot_legacy_health_hits_total{path, user_agent}`` so operators can
+query ``sum by (path, user_agent) (autobot_legacy_health_hits_total)``
+to identify the caller and the targeted endpoint.
 """
 
 from __future__ import annotations
 
-from prometheus_client import Counter
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
@@ -54,13 +52,30 @@ _CANONICAL_PATHS = frozenset(
     }
 )
 
-# Issue #6919: Prometheus counter — one time-series per deprecated path so
-# Prometheus / Grafana can show which endpoints are still being scraped.
-_LEGACY_HEALTH_HITS = Counter(
-    "autobot_legacy_health_hits_total",
-    "Number of requests to deprecated /api/<module>/health endpoints (Issue #6919)",
-    ["path"],
-)
+
+class _NoopCounter:
+    """Fallback counter used when prometheus_client is unavailable."""
+
+    def labels(self, **_kwargs: object) -> "_NoopCounter":
+        return self
+
+    def inc(self, _amount: int = 1) -> None:
+        return None
+
+
+try:  # pragma: no cover - exercised in environments with the dep
+    from prometheus_client import Counter as _PromCounter
+
+    autobot_legacy_health_hits_total: _NoopCounter | _PromCounter = _PromCounter(
+        "autobot_legacy_health_hits_total",
+        (
+            "Count of requests to deprecated /api/<module>/health endpoints "
+            "during grace period (#6919). Query over 14 days before deletion."
+        ),
+        ("path", "user_agent"),
+    )
+except Exception:  # pragma: no cover - defensive fallback
+    autobot_legacy_health_hits_total = _NoopCounter()
 
 
 def _is_legacy_module_health(path: str) -> bool:
@@ -77,12 +92,7 @@ def _is_legacy_module_health(path: str) -> bool:
 
 
 class SunsetLegacyHealthMiddleware(BaseHTTPMiddleware):
-    """Add ``Sunset`` / ``Deprecation`` / ``Link`` headers to legacy /health responses.
-
-    Issue #6919: Also logs each hit at WARNING level and increments a
-    per-path Prometheus counter so external audits can identify remaining
-    scrapers during the sunset window.
-    """
+    """Add ``Sunset`` / ``Deprecation`` / ``Link`` headers to legacy /health responses."""
 
     async def dispatch(self, request: Request, call_next) -> Response:
         response = await call_next(request)
@@ -91,15 +101,8 @@ class SunsetLegacyHealthMiddleware(BaseHTTPMiddleware):
             response.headers["Sunset"] = SUNSET_DATE_HTTP
             response.headers["Deprecation"] = "true"
             response.headers["Link"] = '</api/system/health>; rel="successor-version"'
-
             client_ip = get_client_ip(request) or "unknown"
-            logger.warning(
-                "Deprecated legacy health endpoint called — migrate to /api/system/health "
-                "(sunset: %s). path=%s client_ip=%s",
-                SUNSET_DATE_HTTP,
-                path,
-                client_ip,
-            )
-            _LEGACY_HEALTH_HITS.labels(path=path).inc()
-
+            ua = request.headers.get("user-agent", "unknown")[:120]
+            logger.info("Legacy health hit: %s from %s (%s)", path, client_ip, ua)
+            autobot_legacy_health_hits_total.labels(path=path, user_agent=ua).inc()
         return response

--- a/autobot-backend/tests/test_sunset_legacy_health.py
+++ b/autobot-backend/tests/test_sunset_legacy_health.py
@@ -4,7 +4,13 @@
 """Issue #6902: SunsetLegacyHealthMiddleware adds Sunset/Deprecation headers
 to legacy /api/<module>/health routes — but NOT to the canonical aggregator
 at /api/system/health.
+
+Issue #6919: middleware also emits an INFO log and increments
+autobot_legacy_health_hits_total{path, user_agent} on every legacy hit.
 """
+
+import logging
+from unittest.mock import MagicMock, patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -113,3 +119,79 @@ def test_is_legacy_excludes_non_api_prefix():
     assert _is_legacy_module_health("/health") is False
     assert _is_legacy_module_health("/redis/health") is False
     assert _is_legacy_module_health("/static/health") is False
+
+
+# --- Telemetry signals (#6919) -----------------------------------------------
+
+
+def test_legacy_hit_emits_info_log(caplog):
+    client = _build_app()
+    with caplog.at_level(logging.INFO, logger="middleware.sunset_legacy_health"):
+        client.get("/api/redis/health")
+    legacy_records = [r for r in caplog.records if "Legacy health hit" in r.message]
+    assert len(legacy_records) == 1
+    assert "/api/redis/health" in legacy_records[0].message
+
+
+def test_canonical_path_does_not_emit_info_log(caplog):
+    client = _build_app()
+    with caplog.at_level(logging.INFO, logger="middleware.sunset_legacy_health"):
+        client.get("/api/system/health")
+    legacy_records = [r for r in caplog.records if "Legacy health hit" in r.message]
+    assert len(legacy_records) == 0
+
+
+def test_legacy_hit_increments_counter():
+    import middleware.sunset_legacy_health as mw
+
+    mock_counter = MagicMock()
+    mock_labels = MagicMock()
+    mock_counter.labels.return_value = mock_labels
+
+    client = _build_app()
+    with patch.object(mw, "autobot_legacy_health_hits_total", mock_counter):
+        client.get("/api/redis/health", headers={"User-Agent": "prometheus/2.x"})
+
+    mock_counter.labels.assert_called_once_with(
+        path="/api/redis/health", user_agent="prometheus/2.x"
+    )
+    mock_labels.inc.assert_called_once()
+
+
+def test_canonical_path_does_not_increment_counter():
+    import middleware.sunset_legacy_health as mw
+
+    mock_counter = MagicMock()
+    client = _build_app()
+    with patch.object(mw, "autobot_legacy_health_hits_total", mock_counter):
+        client.get("/api/system/health")
+
+    mock_counter.labels.assert_not_called()
+
+
+def test_user_agent_truncated_to_120_chars():
+    import middleware.sunset_legacy_health as mw
+
+    mock_counter = MagicMock()
+    mock_counter.labels.return_value = MagicMock()
+
+    client = _build_app()
+    with patch.object(mw, "autobot_legacy_health_hits_total", mock_counter):
+        client.get("/api/redis/health", headers={"User-Agent": "A" * 200})
+
+    call_kwargs = mock_counter.labels.call_args.kwargs
+    assert len(call_kwargs["user_agent"]) == 120
+
+
+def test_missing_user_agent_defaults_to_unknown():
+    import middleware.sunset_legacy_health as mw
+
+    mock_counter = MagicMock()
+    mock_counter.labels.return_value = MagicMock()
+
+    client = _build_app()
+    with patch.object(mw, "autobot_legacy_health_hits_total", mock_counter):
+        client.get("/api/redis/health", headers={})
+
+    call_kwargs = mock_counter.labels.call_args.kwargs
+    assert call_kwargs["user_agent"] == "unknown"

--- a/docs/api/health.md
+++ b/docs/api/health.md
@@ -193,16 +193,27 @@ dashboards) should treat the `Sunset` header as a signal to migrate to
 
 Before the route-deletion PR can run:
 
-1. **Deployment configs** — grep Ansible playbooks, k8s manifests, and
+1. **Empirical traffic check** — query the Prometheus counter added by #6919
+   over a 14-day window and assert zero hits per path before deletion.
+   ```promql
+   # Must return 0 for every legacy path before deletion is safe
+   sum by (path, user_agent) (increase(autobot_legacy_health_hits_total[14d]))
+   ```
+   This converts the audit from a "static config grep" to an empirical
+   traffic check; any unknown scraper that survived the config search will
+   show up here. The counter is registered in
+   `autobot-backend/middleware/sunset_legacy_health.py` with labels
+   `{path, user_agent}` so operators can identify the caller by user-agent.
+2. **Deployment configs** — grep Ansible playbooks, k8s manifests, and
    Prometheus job specs for `/api/<module>/health` paths. Confirm zero
    live scrapers remain.
    ```bash
    grep -rn "/api/[a-z_-]\+/health" autobot-infrastructure/ \
      k8s/ prometheus/ monitoring/ 2>/dev/null
    ```
-2. **Server-side access logs** — sample 7 days of nginx/uvicorn logs and
+3. **Server-side access logs** — sample 7 days of nginx/uvicorn logs and
    confirm zero hits on per-module `/health` paths from external IPs.
-3. **Frontend callers** — these three callers still consume rich
+4. **Frontend callers** — these three callers still consume rich
    per-module response shapes (active_jobs, redis_connected, etc.) that
    the canonical aggregator's `ComponentHealth.data` does not expose.
    Either enrich the relevant probes' `data` payload, or accept that the
@@ -210,12 +221,12 @@ Before the route-deletion PR can run:
    - `useBatchProcessing.ts:263` → `/api/batch-jobs/health`
    - `useOperationsApi.ts:117` → `/api/long-running/health`
    - `usePrometheusMetrics.ts:368/583` → `/api/monitoring/services/health`
-4. **`Sunset:` header live for at least one release** — the middleware
+5. **`Sunset:` header live for at least one release** — the middleware
    shipped with PR #6912 (commit landed on `Dev_new_gui` at 2026-05-04).
-5. **Pre-commit hook becomes hard-line** — drop the `# noqa: health-route`
+6. **Pre-commit hook becomes hard-line** — drop the `# noqa: health-route`
    suppression escape hatch from the production code path.
 
-When all five gates clear, the route-deletion PR can:
+When all six gates clear, the route-deletion PR can:
 
 - Delete the 38 `@router.get("/health")` definitions across `autobot-backend/api/`
 - Delete the now-orphaned `*HealthResponse` Pydantic schemas


### PR DESCRIPTION
## Summary

Completes the #6919 acceptance criteria left unmet in PR #7807:

- **`user_agent` label added** to `autobot_legacy_health_hits_total` counter — issue spec explicitly requires `{path, user_agent}` so operators can identify the calling scraper, not just the path
- **Log level changed** `WARNING` → `INFO` per issue acceptance criteria (AC2)
- **`_NoopCounter` fallback** added so the module imports safely without `prometheus_client` (matches canonical `knowledge/metrics.py` pattern; avoids `ImportError` in minimal deployments)
- **6 unit tests** added (AC3): INFO log fires on legacy path + suppressed on canonical; counter fires with correct labels + suppressed on canonical; user_agent truncation to 120 chars; missing UA defaults to "unknown"
- **`docs/api/health.md`** pre-deletion audit checklist updated (AC4): PromQL empirical traffic check (`sum by (path, user_agent) (increase(autobot_legacy_health_hits_total[14d]))`) added as gate 1 before route deletion

Closes #6919

## Test plan

- [x] 6 new telemetry tests in `tests/test_sunset_legacy_health.py` covering all AC3 criteria
- [x] Existing header tests unchanged
- [x] `py_compile` passes on modified files