### PR TITLE
fix(security-ci): upload-artifact/download-artifact version mismatch (#7712)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -110,7 +110,7 @@ jobs:
         npm audit --audit-level=moderate || true
 
     - name: Upload Security Reports
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: dependency-security-reports
@@ -228,7 +228,7 @@ jobs:
         fi
 
     - name: Upload SAST Reports
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: sast-security-reports
@@ -302,7 +302,7 @@ jobs:
 
     steps:
     - name: Download all security reports
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@v4
 
     - name: Generate Security Summary
       run: |
@@ -335,7 +335,7 @@ jobs:
         echo "3. Address any SAST findings in critical code paths" >> security-summary.md
 
     - name: Upload Security Summary
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         name: security-summary
         path: security-summary.md


### PR DESCRIPTION
## Summary

- Aligned all `upload-artifact` calls from `@v7` to `@v4` (3 occurrences: lines 113, 231, 338 in `.github/workflows/security.yml`)
- Aligned `download-artifact` call from `@v8` to `@v4` (1 occurrence: line 305)

The major version mismatch caused the `security-summary` job to silently download nothing — artifacts uploaded by `@v7` are not visible to `@v8`'s download step — producing an empty (and misleading) security summary report.

## Root Cause

Post-merge review of PR #7708 (MVA-207) identified that the newly added semgrep/cosign steps introduced `upload-artifact@v7` while the existing `security-summary` job used `download-artifact@v8`. GitHub Actions artifact storage is keyed per major version, so cross-major uploads/downloads silently produce empty results rather than failing.

## Test Plan

- [ ] Verify `.github/workflows/security.yml` has all four artifact actions at `@v4`
- [ ] Confirm security-summary job produces non-empty output in next CI run on Dev_new_gui
- [ ] No regressions in other workflow jobs

Fixes: GH#7712 / MVA-352

🤖 Generated with [Claude Code](https://claude.com/claude-code)