### PR TITLE
fix(canvas): declare bleach and weasyprint as explicit deps (MVA-362 security)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -69,6 +69,10 @@ praw>=7.8.1             # Reddit OAuth API for CommunityGrowthSkill
 spacy>=3.8.13                  # Issue #2025: NLP entity extraction
 scikit-learn>=1.8.0           # Issue #2027: RAPTOR clustering
 
+# Live Canvas export (MVA-359)
+bleach>=6.0.0           # HTML sanitization for canvas HTML/PDF export (XSS prevention — security-critical)
+weasyprint>=60.0        # HTML→PDF rendering for canvas PDF export
+
 # Media processing pipelines (Issue #932)
 aiohttp>=3.13.4         # Async HTTP client - SECURITY UPDATE
 beautifulsoup4>=4.14.3  # HTML parsing for link pipeline


### PR DESCRIPTION
## Summary

Security finding from MVA-362 review: `bleach` (HTML sanitizer) and `weasyprint` (PDF renderer) were used in the canvas export path via soft `try: import ... except ImportError` fallbacks, but were not declared in `requirements.txt`.

- Without `bleach` in requirements, production installs fall back to bare `html.escape()` for XSS sanitization. While that fallback is technically adequate, the security intent is to use `bleach` and this should not be load-bearing on an undeclared optional dep.
- Without `weasyprint` in requirements, PDF export returns HTTP 501 in production rather than actually generating PDFs.

Both are now declared as hard dependencies under a `# Live Canvas export (MVA-359)` section.

## Related issues

- Security review: [MVA-362](/MVA/issues/MVA-362) (this is a required fix from that review)
- Canvas implementation: [MVA-359](/MVA/issues/MVA-359)

🤖 Generated with [Claude Code](https://claude.com/claude-code)