### PR TITLE
wire-in(batch1): mountAllPlugins, datetime_utils, fact_extractor (#7793 #7797 #7804)

### DIFF
--- a/autobot-backend/knowledge/connectors/base.py
+++ b/autobot-backend/knowledge/connectors/base.py
@@ -14,6 +14,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import List, Optional
 
+from autobot_shared.datetime_utils import datetime_now
 from autobot_shared.logging_manager import get_logger
 from knowledge.connectors.models import (
     ChangeInfo,
@@ -110,9 +111,7 @@ class AbstractConnector(ABC):
         Returns:
             SyncResult with counts and any per-source errors.
         """
-        from datetime import datetime as _dt
-
-        started_at = _dt.utcnow()
+        started_at = datetime_now()
         result = SyncResult(
             connector_id=self.config.connector_id,
             started_at=started_at,
@@ -140,7 +139,7 @@ class AbstractConnector(ABC):
             result.errors.append(str(exc))
             result.status = "failed"
         finally:
-            result.completed_at = _dt.utcnow()
+            result.completed_at = datetime_now()
 
         return result
 

--- a/autobot-backend/knowledge/pipeline/cognifiers/__init__.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/__init__.py
@@ -10,6 +10,7 @@ Issue #759: Knowledge Pipeline Foundation - Extract, Cognify, Load (ECL).
 from knowledge.pipeline.cognifiers.context_generator import ContextGeneratorCognifier
 from knowledge.pipeline.cognifiers.entity_extractor import EntityExtractor
 from knowledge.pipeline.cognifiers.event_extractor import EventExtractor
+from knowledge.pipeline.cognifiers.fact_extractor import FactExtractor
 from knowledge.pipeline.cognifiers.recursive_summarizer import RecursiveSummarizer
 from knowledge.pipeline.cognifiers.relationship_extractor import RelationshipExtractor
 from knowledge.pipeline.cognifiers.summarizer import HierarchicalSummarizer
@@ -18,6 +19,7 @@ __all__ = [
     "ContextGeneratorCognifier",
     "EntityExtractor",
     "EventExtractor",
+    "FactExtractor",
     "HierarchicalSummarizer",
     "RecursiveSummarizer",
     "RelationshipExtractor",

--- a/autobot-frontend/src/main.ts
+++ b/autobot-frontend/src/main.ts
@@ -44,6 +44,7 @@ import i18n from './i18n'
 import rumPlugin from './plugins/rum'
 import errorHandlerPlugin from './plugins/errorHandler'
 import ApiPlugin from './plugins/api'
+import { mountAllPlugins } from '@/plugins/registry'
 
 // Import global services
 import './services/GlobalWebSocketService'
@@ -86,6 +87,9 @@ app.use(router)
 app.use(rumPlugin, { router })
 app.use(errorHandlerPlugin)
 app.use(ApiPlugin)
+
+// Register plugin UI components from the plugin mount registry (#6972 / #7793)
+mountAllPlugins(app)
 
 // Global error handler for uncaught errors
 app.config.errorHandler = (err, _instance, info) => {


### PR DESCRIPTION
## Summary

Three wire-in fixes from MVA-463 tech-debt campaign (MVA-467 batch 1).

- **#7793** `autobot-frontend/src/main.ts`: Import and call `mountAllPlugins(app)` from `@/plugins/registry` after `ApiPlugin` setup. Registry is currently empty; this is a no-op until first plugin UI ships. Pre-wired so future plugins auto-register without touching main.ts again.

- **#7797** `knowledge/connectors/base.py`: Replace inline `_dt.utcnow()` (deprecated pattern) with `datetime_now()` from `autobot_shared.datetime_utils`. Creates the first production caller for `datetime_utils` module. Also removes the lazy `from datetime import datetime as _dt` local import.

- **#7804** `knowledge/pipeline/cognifiers/__init__.py`: Import `FactExtractor` from `fact_extractor` module to trigger its `@TaskRegistry.register_cognifier("extract_facts")` decorator. All other cognifiers are already imported here; `fact_extractor` was the only one missing.

## Test plan

- [ ] TypeScript compiles with no new errors (`npm run type-check`)
- [ ] `python3 -m py_compile autobot-backend/knowledge/connectors/base.py` passes
- [ ] `python3 -m py_compile autobot-backend/knowledge/pipeline/cognifiers/__init__.py` passes
- [ ] `TaskRegistry._cognifiers` includes `"extract_facts"` after importing `knowledge.pipeline.cognifiers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)