### PR TITLE
wire-in(batch2): alert_cooldown and workflow_versioning (#7799 #7801)

### DIFF
--- a/autobot-backend/services/workflow_automation/manager.py
+++ b/autobot-backend/services/workflow_automation/manager.py
@@ -14,6 +14,7 @@ from autobot_shared.logging_manager import get_logger
 from orchestrator import Orchestrator
 from orchestrator import get_orchestrator_sync as get_orchestrator
 from services.notification_service import NotificationService
+from services.workflow_versioning import WorkflowVersionStore
 from type_defs.common import Metadata
 
 from .controller import WorkflowController
@@ -143,6 +144,17 @@ class WorkflowAutomationManager:
         )
 
         self.active_workflows[workflow_id] = workflow
+
+        # Snapshot initial state for rollback/audit (#2145)
+        try:
+            version_store = WorkflowVersionStore()
+            await version_store.save_version(
+                workflow_id,
+                workflow.to_status_dict() if hasattr(workflow, "to_status_dict") else {"name": name},
+                notes="initial version",
+            )
+        except Exception:
+            logger.warning("workflow_versioning: could not snapshot workflow %s", workflow_id)
 
         logger.info("Created automated workflow %s: %s", workflow_id, name)
         return workflow_id

--- a/autobot-backend/utils/monitoring_alerts.py
+++ b/autobot-backend/utils/monitoring_alerts.py
@@ -13,11 +13,28 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
+from autobot_shared.alert_cooldown import AlertCooldownManager, AlertTier
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from constants.threshold_constants import TimingConstants
 from constants.ttl_constants import TTL_7_DAYS
 
 logger = get_logger(__name__)
+
+_get_alert_cooldown = lazy_singleton(AlertCooldownManager)
+
+_SEVERITY_TO_TIER = {
+    "critical": AlertTier.FLASH,
+    "high": AlertTier.PRIORITY,
+    "medium": AlertTier.PRIORITY,
+    "low": AlertTier.ROUTINE,
+}
+
+
+def _severity_to_tier(severity) -> AlertTier:
+    """Map AlertSeverity to AlertTier for cooldown checks (#1948)."""
+    key = severity.value if hasattr(severity, "value") else str(severity)
+    return _SEVERITY_TO_TIER.get(key, AlertTier.ROUTINE)
 
 
 class AlertSeverity(Enum):
@@ -687,16 +704,27 @@ class MonitoringAlertsManager:
 
     async def _send_alert_notifications(self, alert: Alert):
         """Send alert to all enabled notification channels"""
+        tier = _severity_to_tier(alert.severity)
+        cooldown = _get_alert_cooldown()
+        if not cooldown.should_send(alert.message, tier):
+            logger.debug("Alert suppressed by cooldown: %s (tier=%s)", alert.rule_name, tier)
+            return
+
+        sent_any = False
         for channel_name, channel in self.notification_channels.items():
             if channel.enabled:
                 try:
                     success = await channel.send_alert(alert)
                     if success:
+                        sent_any = True
                         logger.debug(f"Alert sent via {channel_name}")
                     else:
                         logger.warning(f"Failed to send alert via {channel_name}")
                 except Exception as e:
                     logger.error(f"Error sending alert via {channel_name}: {e}")
+
+        if sent_any:
+            cooldown.record_sent(alert.message, tier)
 
     async def _send_recovery_notifications(self, alert: Alert):
         """Send recovery notification to all enabled notification channels"""


### PR DESCRIPTION
## Summary

Two wire-in fixes from MVA-463 tech-debt campaign (MVA-467 batch 2).

- **#7799** `utils/monitoring_alerts.py`: Wire `AlertCooldownManager` (from `autobot_shared.alert_cooldown`) into `_send_alert_notifications`. Maps `AlertSeverity` → `AlertTier` (CRITICAL→FLASH, HIGH/MEDIUM→PRIORITY, LOW→ROUTINE). Checks `should_send()` before dispatching to prevent notification fatigue; records `record_sent()` after at least one channel succeeds. Uses `lazy_singleton` for the manager instance.

- **#7801** `services/workflow_automation/manager.py`: Wire `WorkflowVersionStore` (from `services.workflow_versioning`) into `create_automated_workflow`. Saves initial version snapshot after writing to `active_workflows`. Wrapped in try/except so version failures are logged at WARNING and never block workflow creation.

## Test plan

- [ ] `python3 -m py_compile autobot-backend/utils/monitoring_alerts.py` passes
- [ ] `python3 -m py_compile autobot-backend/services/workflow_automation/manager.py` passes
- [ ] Alert suppression: duplicate alerts within cooldown window are suppressed (logged at debug)
- [ ] Workflow creation succeeds even if Redis is unavailable (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)