### PR TITLE
refactor(frontend/agents): add Storybook stories for AgentSettingsPanel and HeartbeatPanel (#6865)

### DIFF
--- a/autobot-frontend/src/components/agents/AgentSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/agents/AgentSettingsPanel.stories.ts
@@ -1,0 +1,56 @@
+import type { Meta } from '@storybook/vue3';
+import AgentSettingsPanel from './AgentSettingsPanel.vue';
+
+const meta = {
+  title: 'Components/Agents/AgentSettingsPanel',
+  component: AgentSettingsPanel,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Runtime agent configuration panel. Self-contained — fetches and persists settings ' +
+          'via ApiClient (/api/settings). Requires a running AutoBot backend to load or save data. ' +
+          'In Storybook the panel renders immediately with its built-in defaults when the API call ' +
+          'fails (the loading spinner resolves to the form).',
+      },
+    },
+  },
+} as Meta<typeof AgentSettingsPanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Story = { render?: () => unknown; decorators?: unknown[]; parameters?: unknown };
+
+/** Default view — panel loads with built-in defaults (API call fails gracefully in Storybook). */
+export const Default: Story = {
+  render: () => ({
+    components: { AgentSettingsPanel },
+    template: '<AgentSettingsPanel />',
+  }),
+};
+
+/** Panel in a constrained-width container, matching typical settings tab usage. */
+export const NarrowContainer: Story = {
+  render: () => ({
+    components: { AgentSettingsPanel },
+    template: `
+      <div style="max-width: 600px; padding: 1rem;">
+        <AgentSettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+/** Panel in a full-width layout, matching the desktop settings page. */
+export const WideContainer: Story = {
+  render: () => ({
+    components: { AgentSettingsPanel },
+    template: `
+      <div style="max-width: 1200px; padding: 1.5rem;">
+        <AgentSettingsPanel />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/agents/HeartbeatPanel.stories.ts
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.stories.ts
@@ -1,0 +1,57 @@
+import type { Meta } from '@storybook/vue3';
+import HeartbeatPanel from './HeartbeatPanel.vue';
+
+const meta = {
+  title: 'Components/Agents/HeartbeatPanel',
+  component: HeartbeatPanel,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Heartbeat monitoring panel for a single agent. Self-contained — enter an agent ID ' +
+          'and click Load to fetch config, run history, and wakeup queue from the AutoBot backend ' +
+          '(/api/heartbeat). Subscribes to live heartbeat_run_started / heartbeat_run_completed ' +
+          'events via SSE. Requires a running AutoBot backend; in Storybook the panel renders in ' +
+          'its empty/idle state until an agent ID is supplied.',
+      },
+    },
+  },
+} as Meta<typeof HeartbeatPanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Story = { render?: () => unknown; decorators?: unknown[]; parameters?: unknown };
+
+/** Default idle state — panel is empty, waiting for an agent ID to be entered. */
+export const Default: Story = {
+  render: () => ({
+    components: { HeartbeatPanel },
+    template: '<HeartbeatPanel />',
+  }),
+};
+
+/** Panel inside a realistic page-content container with padding and dark background. */
+export const InPageContext: Story = {
+  render: () => ({
+    components: { HeartbeatPanel },
+    template: `
+      <div style="background: #0f172a; padding: 1.5rem; min-height: 400px;">
+        <HeartbeatPanel />
+      </div>
+    `,
+  }),
+};
+
+/** Panel in a narrow column — tests responsive layout of header and config grid. */
+export const NarrowColumn: Story = {
+  render: () => ({
+    components: { HeartbeatPanel },
+    template: `
+      <div style="max-width: 480px; background: #0f172a; padding: 1rem;">
+        <HeartbeatPanel />
+      </div>
+    `,
+  }),
+};


### PR DESCRIPTION
## Summary

Adds Storybook stories for the 2 components in `autobot-frontend/src/components/agents/`.

- `AgentSettingsPanel.stories.ts` — 3 stories: Default, NarrowContainer, WideContainer (render-only, self-contained with API)
- `HeartbeatPanel.stories.ts` — 3 stories: Default, NarrowColumn, InPageContext (render-only, self-contained with API)

Both components have no props and self-fetch data, so stories use render functions per the #7273 pattern.

Closes #6865. Part of #4201 Phase 2 Storybook stories campaign.