### PR TITLE
refactor(frontend/browser): add Storybook stories for BrowserSessionManager and InteractiveScreenshot (#6867)

### DIFF
--- a/autobot-frontend/src/components/browser/BrowserSessionManager.stories.ts
+++ b/autobot-frontend/src/components/browser/BrowserSessionManager.stories.ts
@@ -1,0 +1,43 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import type { Meta, StoryObj } from '@storybook/vue3';
+import BrowserSessionManager from './BrowserSessionManager.vue';
+
+const meta = {
+  title: 'Components/Browser/BrowserSessionManager',
+  component: BrowserSessionManager,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof BrowserSessionManager>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+/**
+ * BrowserSessionManager is a self-contained component that fetches live
+ * browser session data from the AutoBot backend via useBrowserAutomation().
+ * It has no props — all state is managed internally.
+ *
+ * In a real environment (172.16.168.21 with backend at 172.16.168.20:8001)
+ * the component renders a full session dashboard with stats cards,
+ * sortable session cards, and a create-session modal.
+ */
+export const Default: Story = {
+  render: () => ({
+    template: `
+      <div style="padding: 20px; background: #f5f5f5; border-radius: 8px; font-family: sans-serif;">
+        <p style="margin: 0 0 8px; font-weight: 600; color: #374151;">
+          BrowserSessionManager
+        </p>
+        <p style="margin: 0; color: #6b7280; font-size: 14px;">
+          Requires backend API connection (172.16.168.20:8001).
+          Renders session stats, sortable session cards, pause/resume/delete actions,
+          and a create-session modal when connected.
+        </p>
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/browser/InteractiveScreenshot.stories.ts
+++ b/autobot-frontend/src/components/browser/InteractiveScreenshot.stories.ts
@@ -1,0 +1,128 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import type { Meta, StoryObj } from '@storybook/vue3';
+import InteractiveScreenshot from './InteractiveScreenshot.vue';
+
+// 1x1 transparent PNG for story demonstrations
+const SAMPLE_SCREENSHOT =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+const SAMPLE_REGIONS = [
+  {
+    selector: '#main-nav',
+    rect: { x: 0, y: 0, width: 200, height: 50 },
+    label: 'Navigation',
+  },
+  {
+    selector: '.hero-section',
+    rect: { x: 0, y: 50, width: 1280, height: 400 },
+    label: 'Hero',
+  },
+];
+
+const meta = {
+  title: 'Components/Browser/InteractiveScreenshot',
+  component: InteractiveScreenshot,
+  tags: ['autodocs'],
+  argTypes: {
+    screenshot: {
+      control: 'text',
+      description: 'Base64-encoded PNG screenshot data (without data URI prefix)',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading overlay over the screenshot',
+    },
+    interactive: {
+      control: 'boolean',
+      description: 'Allow click/scroll/type interaction with the screenshot',
+    },
+    viewportWidth: {
+      control: { type: 'number', min: 320, max: 3840, step: 10 },
+      description: 'Width of the remote viewport in pixels',
+    },
+    viewportHeight: {
+      control: { type: 'number', min: 240, max: 2160, step: 10 },
+      description: 'Height of the remote viewport in pixels',
+    },
+    regions: {
+      control: 'object',
+      description: 'Array of PageRegion objects for region-marking mode',
+    },
+    markRegionsMode: {
+      control: 'boolean',
+      description: 'Activate region-marking overlay (requires regions + screenshot)',
+    },
+  },
+} as Meta<typeof InteractiveScreenshot>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+/** No screenshot loaded — shows placeholder message */
+export const Empty: Story = {
+  args: {
+    screenshot: null,
+    loading: false,
+    interactive: true,
+    viewportWidth: 1280,
+    viewportHeight: 720,
+    regions: [],
+    markRegionsMode: false,
+  },
+};
+
+/** Screenshot is loading — spinner overlay shown on existing image */
+export const Loading: Story = {
+  args: {
+    screenshot: SAMPLE_SCREENSHOT,
+    loading: true,
+    interactive: true,
+    viewportWidth: 1280,
+    viewportHeight: 720,
+    regions: [],
+    markRegionsMode: false,
+  },
+};
+
+/** Screenshot loaded and interactive — crosshair cursor, scroll/type toolbar visible */
+export const WithScreenshot: Story = {
+  args: {
+    screenshot: SAMPLE_SCREENSHOT,
+    loading: false,
+    interactive: true,
+    viewportWidth: 1280,
+    viewportHeight: 720,
+    regions: [],
+    markRegionsMode: false,
+  },
+};
+
+/** Screenshot loaded but read-only — toolbar hidden, normal cursor */
+export const ReadOnly: Story = {
+  args: {
+    screenshot: SAMPLE_SCREENSHOT,
+    loading: false,
+    interactive: false,
+    viewportWidth: 1280,
+    viewportHeight: 720,
+    regions: [],
+    markRegionsMode: false,
+  },
+};
+
+/** Region-marking mode active with sample page regions (#5136) */
+export const WithRegions: Story = {
+  args: {
+    screenshot: SAMPLE_SCREENSHOT,
+    loading: false,
+    interactive: true,
+    viewportWidth: 1280,
+    viewportHeight: 720,
+    regions: SAMPLE_REGIONS,
+    markRegionsMode: true,
+  },
+};


### PR DESCRIPTION
## Summary

Adds Storybook stories for the 2 components in `autobot-frontend/src/components/browser/`.

- `InteractiveScreenshot.stories.ts` — 5 stories: Empty, Loading, WithScreenshot, ReadOnly, WithRegions
- `BrowserSessionManager.stories.ts` — 1 placeholder story (component has no props, requires live backend)

InteractiveScreenshot has full prop coverage via argTypes controls. BrowserSessionManager uses render placeholder since it's self-contained and fetches from the API.

Closes #6867. Part of #4201 Phase 2 Storybook stories campaign.