### PR TITLE
fix(slm-frontend): align MonitoringError with RecentError API shape, remove stopgap cast (#7768)

### DIFF
--- a/autobot-slm-frontend/src/views/monitoring/admin/AdminMonitoringView.vue
+++ b/autobot-slm-frontend/src/views/monitoring/admin/AdminMonitoringView.vue
@@ -58,9 +58,9 @@ const errorStats = ref<ErrorStats | null>(null)
 interface MonitoringError {
   id: string
   level: string
-  component: string
   message: string
   timestamp: string
+  resolved: boolean
 }
 
 const recentErrors = ref<MonitoringError[]>([])
@@ -136,7 +136,7 @@ async function loadErrorStats(): Promise<void> {
 async function loadRecentErrors(): Promise<void> {
   try {
     const data = await api.getRecentErrors(10)
-    recentErrors.value = (data.errors || []) as unknown as MonitoringError[]
+    recentErrors.value = data.errors || []
   } catch (e) {
     logger.error('Failed to load recent errors:', e)
   }
@@ -381,7 +381,6 @@ onUnmounted(() => {
                     <span :class="['px-2 py-0.5 text-xs font-medium rounded-sm', getErrorLevelClass(err.level)]">
                       {{ err.level }}
                     </span>
-                    <span class="text-xs text-gray-500">{{ err.component }}</span>
                   </div>
                   <p class="text-sm text-gray-900 font-medium">{{ err.message }}</p>
                   <p class="text-xs text-gray-500 mt-1">{{ formatDate(err.timestamp) }}</p>


### PR DESCRIPTION
## Summary

- Aligned the local `MonitoringError` interface in `AdminMonitoringView.vue` with the actual `RecentError` API shape
- Removed the `as unknown as MonitoringError[]` stopgap cast — assignment is now direct with correct types
- Removed `<span>{{ err.component }}</span>` from the template — this field doesn't exist in the API response and was rendering `undefined` at runtime

## Root Cause

`AdminMonitoringView.vue` had `MonitoringError.component: string` but `useAutobotApi.getRecentErrors()` returns `{ id, level, message, timestamp, resolved }` — no `component` field. The stopgap `as unknown as MonitoringError[]` cast was masking the type error.

## Files Changed

- `autobot-slm-frontend/src/views/monitoring/admin/AdminMonitoringView.vue`

## Test plan

- [ ] `npx vue-tsc --noEmit` passes (no new type errors) ✅
- [ ] No `as unknown as MonitoringError[]` cast remains
- [ ] Template no longer renders `err.component` (which would be `undefined`)

Closes #7768

🤖 Generated with [Claude Code](https://claude.com/claude-code)