### PR TITLE
test(celery): regression test for task registration to prevent repeat of unregistered-task bug (#7766)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -121,6 +121,62 @@ except ImportError:
     _schedules_stub.crontab = _StubCrontab
     sys.modules["celery.schedules"] = _schedules_stub
 
+# celery_app stub — issue #7766.  The production celery_app.py pulls in the
+# full Redis / config dependency chain which causes a circular import in the
+# test environment.  We inject a lightweight in-process Celery app so that
+# ``from celery_app import celery_app`` in task modules succeeds and the
+# ``@celery_app.task`` decorators register tasks on a real (but isolated) app.
+#
+# Strategy: use the real celery package if it is installed (it is in the dev
+# venv — see the ``try`` block above); otherwise use the stub _StubCelery.
+# Either way the resulting object must support .task() as a decorator and must
+# maintain a .tasks dict so that test_task_registration.py can introspect it.
+if "celery_app" not in sys.modules:
+    _celery_app_mod = types.ModuleType("celery_app")
+    try:
+        import celery as _cel_pkg  # noqa: F401
+        _test_app = _cel_pkg.Celery(
+            "test_autobot", broker="memory://", backend="cache+memory://"
+        )
+    except (ImportError, Exception):
+        # Fall back to the stub Celery that is already in sys.modules["celery"]
+        _StubCeleryClass = sys.modules["celery"].Celery
+        _test_app = _StubCeleryClass("test_autobot")
+    _celery_app_mod.celery_app = _test_app  # type: ignore[attr-defined]
+    sys.modules["celery_app"] = _celery_app_mod
+
+# autobot_shared.redis_management stubs — the real package tries to open
+# sockets at import time; tests must not do that.
+for _redis_sub in [
+    "autobot_shared.redis_management",
+    "autobot_shared.redis_management.types",
+    "autobot_shared.redis_management.connection_manager",
+]:
+    if _redis_sub not in sys.modules:
+        _redis_stub = types.ModuleType(_redis_sub)
+        _redis_stub.__path__ = []
+        _redis_stub.__package__ = _redis_sub.rpartition(".")[0]
+        _redis_stub.DATABASE_MAPPING = {  # type: ignore[attr-defined]
+            "celery_broker": 0,
+            "celery_results": 1,
+        }
+        _redis_stub.__getattr__ = lambda attr: MagicMock()  # type: ignore[attr-defined]
+        sys.modules[_redis_sub] = _redis_stub
+
+# autobot_shared.logging_manager.get_logger stub — issue #7766.
+# get_logger() tries to open a log file which requires the config/Redis stack
+# and hangs in the test environment.  Patch it to return a stdlib logger so
+# that task modules that call ``logger = get_logger(__name__)`` at module load
+# time proceed instantly.
+try:
+    import logging as _stdlib_logging
+    import autobot_shared.logging_manager as _lm_mod
+    if not getattr(_lm_mod, "_get_logger_patched_for_tests", False):
+        _lm_mod.get_logger = lambda name, *_a, **_k: _stdlib_logging.getLogger(name)
+        _lm_mod._get_logger_patched_for_tests = True  # type: ignore[attr-defined]
+except Exception:
+    pass
+
 # Package stubs for SQLAlchemy and alembic sub-packages (need __path__ so
 # dotted sub-module imports like ``sqlalchemy.dialects.postgresql`` resolve).
 _PKG_STUBS = [

--- a/autobot-backend/tasks/conftest.py
+++ b/autobot-backend/tasks/conftest.py
@@ -1,0 +1,79 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+tasks/ directory conftest — stubs heavy infrastructure so that task modules
+can be imported in the dev/CI environment without a live Redis stack.
+
+Issue #7766: Added to support the task-registration regression test.
+Previously the tasks package could not be imported in tests at all because
+``celery_app.py`` pulls in the full config/Redis dependency chain.
+
+Approach
+--------
+Pytest loads directory-level conftest.py files before importing any test
+modules in that directory.  By injecting stubs into ``sys.modules`` here we
+prevent the real ``celery_app`` module (and its Redis/config chain) from being
+executed, while still allowing the ``@celery_app.task`` decorators to run and
+register tasks on a lightweight in-process Celery app.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import celery as _real_celery
+
+# ---------------------------------------------------------------------------
+# 1. Build a lightweight in-process Celery app for the test session.
+#    All task decorators will register against this app.
+# ---------------------------------------------------------------------------
+
+_test_celery_app = _real_celery.Celery(
+    "test_autobot",
+    broker="memory://",
+    backend="cache+memory://",
+)
+
+# ---------------------------------------------------------------------------
+# 2. Inject it as the ``celery_app`` module so that
+#    ``from celery_app import celery_app``  inside task files gets our instance.
+# ---------------------------------------------------------------------------
+
+_celery_app_mod = types.ModuleType("celery_app")
+_celery_app_mod.celery_app = _test_celery_app  # type: ignore[attr-defined]
+sys.modules.setdefault("celery_app", _celery_app_mod)
+
+# ---------------------------------------------------------------------------
+# 3. Stub autobot_shared sub-packages that are imported at module level in
+#    knowledge_tasks.py / memory_tasks.py / system_tasks.py.
+#    The top-level conftest.py already stubs the root ``autobot_shared``
+#    package — here we only add the specific sub-modules.
+# ---------------------------------------------------------------------------
+
+
+def _ensure_stub(name: str) -> types.ModuleType:
+    """Return existing module or create+register a MagicMock stub."""
+    if name in sys.modules:
+        return sys.modules[name]
+    mod = types.ModuleType(name)
+    mod.__path__ = []  # mark as package
+    mod.__package__ = name.rpartition(".")[0] or name
+    _m = MagicMock()
+    mod.__getattr__ = lambda attr: _m  # type: ignore[attr-defined]
+    sys.modules[name] = mod
+    return mod
+
+
+_logging_stub = _ensure_stub("autobot_shared.logging_manager")
+_logging_stub.get_logger = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
+
+_async_compat_stub = _ensure_stub("autobot_shared.async_compat")
+_async_compat_stub.run_or_schedule = MagicMock()  # type: ignore[attr-defined]
+
+# type_defs.common is imported by knowledge_tasks.py
+_type_defs = _ensure_stub("type_defs")
+_type_defs_common = _ensure_stub("type_defs.common")
+_type_defs_common.Metadata = dict  # type: ignore[attr-defined]

--- a/autobot-backend/tasks/test_task_registration.py
+++ b/autobot-backend/tasks/test_task_registration.py
@@ -1,0 +1,79 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Regression test for Celery task registration (Issue #7766).
+
+Background
+----------
+While fixing MVA-341 (KeyError on ``tasks.prune_sync_queue_done``), it was
+discovered that ALL tasks in ``knowledge_tasks.py`` and ``memory_tasks.py``
+were unregistered because their imports were missing from ``tasks/__init__.py``.
+The fix added the missing imports, but without a regression guard the same
+mistake can silently reappear.
+
+What this test does
+-------------------
+After the tasks package is imported, every task that the application expects
+to dispatch or schedule must be present in the Celery task registry.
+
+The infrastructure stubs (celery_app, redis, logging) are set up in
+``conftest.py`` and the tasks-directory ``conftest.py`` so that no live
+Redis / config stack is needed.
+
+Failure mode
+------------
+If a developer moves a task to a new file and forgets to add the
+corresponding import to ``tasks/__init__.py``, the missing task will
+silently be unavailable on production workers.  This test makes that
+failure loud and immediate.
+"""
+
+from __future__ import annotations
+
+import sys
+
+# ---------------------------------------------------------------------------
+# Expected task names — update this list whenever a task is added or renamed.
+# ---------------------------------------------------------------------------
+
+EXPECTED_TASKS: list[str] = [
+    # knowledge_tasks.py  (registered as "tasks.*")
+    "tasks.cleanup_orphan_documents",
+    "tasks.cleanup_generated_files",
+    "tasks.refresh_system_knowledge",
+    "tasks.reindex_knowledge_base",
+    "tasks.scan_man_page_changes",
+    "tasks.full_man_page_index",
+    "tasks.prune_sync_queue_done",
+    # memory_tasks.py  (registered as "memory.*")
+    "memory.write_verbatim",
+    "memory.extract_facts",
+    "memory.update_graph",
+    "memory.compact_snapshot",
+]
+
+
+def test_all_expected_tasks_registered():
+    """Every name in EXPECTED_TASKS must appear in the Celery task registry.
+
+    The ``celery_app`` module injected by ``conftest.py`` holds the
+    lightweight in-process app that the task decorators registered against
+    when the tasks package was imported during test collection.
+    """
+    # Retrieve the Celery app instance that conftest.py injected.
+    celery_app_mod = sys.modules.get("celery_app")
+    assert celery_app_mod is not None, (
+        "celery_app module not found in sys.modules — "
+        "check that conftest.py injected the stub correctly."
+    )
+    app = celery_app_mod.celery_app
+    registered = set(app.tasks.keys())
+
+    missing = [name for name in EXPECTED_TASKS if name not in registered]
+    assert not missing, (
+        f"The following tasks are NOT registered in Celery and will be "
+        f"unavailable on workers: {missing!r}\n"
+        f"Fix: ensure the task module is imported in tasks/__init__.py "
+        f"(or listed in celery_app.autodiscover_tasks)."
+    )


### PR DESCRIPTION
## Summary

- Added `autobot-backend/tasks/test_task_registration.py` — regression guard asserting all 11 expected Celery tasks are present in the registry after import
- Added `autobot-backend/conftest.py` stubs (lightweight in-process Celery app, `autobot_shared.redis_management` stubs, `logging_manager` patch) so the test runs without a live Redis/config stack
- Added `autobot-backend/tasks/conftest.py` documenting the stub strategy

## Background

MVA-341 fixed a `KeyError` on `tasks.prune_sync_queue_done` by adding missing imports to `tasks/__init__.py`. Without a regression guard, the same omission can silently reappear. This test makes it loud and immediate.

## Verification

Confirmed `tasks/__init__.py` already has all required imports (MVA-341 fix was in place). No production code changes needed.

## Test plan

- [ ] `pytest tasks/test_task_registration.py -xvs` passes in the dev environment ✅ (1 passed in 0.07s per agent run)
- [ ] Test fails if any task name is removed from `tasks/__init__.py` imports

Closes #7766

🤖 Generated with [Claude Code](https://claude.com/claude-code)