### PR TITLE
refactor(frontend/audit): add Storybook stories for 4 audit components (#6858)

### DIFF
--- a/autobot-frontend/src/components/audit/AuditFilters.stories.ts
+++ b/autobot-frontend/src/components/audit/AuditFilters.stories.ts
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import AuditFilters from './AuditFilters.vue';
+
+const defaultFilter = {
+  dateRange: 'today' as const,
+  startDate: null,
+  endDate: null,
+  operation: null,
+  result: null,
+  userId: null,
+  sessionId: null,
+  vmName: null,
+  limit: 100,
+};
+
+const sampleOperationCategories = {
+  Authentication: ['user_login', 'user_logout', 'token_refresh'],
+  'VM Operations': ['vm_start', 'vm_stop', 'vm_snapshot', 'vm_delete'],
+  'File System': ['file_read', 'file_write', 'file_delete'],
+  Network: ['connection_open', 'connection_close', 'firewall_rule_add'],
+};
+
+const meta = {
+  title: 'Components/Audit/AuditFilters',
+  component: AuditFilters,
+  tags: ['autodocs'],
+  argTypes: {
+    filter: {
+      control: 'object',
+      description: 'Current filter state (AuditFilter)',
+    },
+    operationCategories: {
+      control: 'object',
+      description: 'Grouped operation names for the operation dropdown',
+    },
+    'onUpdate:filter': { action: 'update:filter' },
+    onApply: { action: 'apply' },
+    onReset: { action: 'reset' },
+  },
+} as Meta<typeof AuditFilters>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    filter: { ...defaultFilter },
+    operationCategories: sampleOperationCategories,
+  },
+};
+
+export const WithActiveFilters: Story = {
+  args: {
+    filter: {
+      ...defaultFilter,
+      operation: 'user_login',
+      result: 'denied',
+      userId: 'alice',
+    },
+    operationCategories: sampleOperationCategories,
+  },
+};
+
+export const CustomDateRange: Story = {
+  args: {
+    filter: {
+      ...defaultFilter,
+      dateRange: 'custom',
+      startDate: '2026-05-01T00:00',
+      endDate: '2026-05-15T23:59',
+    },
+    operationCategories: sampleOperationCategories,
+  },
+};
+
+export const WeekRange: Story = {
+  args: {
+    filter: {
+      ...defaultFilter,
+      dateRange: 'week',
+    },
+    operationCategories: sampleOperationCategories,
+  },
+};
+
+export const HighLimitWithSessionFilter: Story = {
+  args: {
+    filter: {
+      ...defaultFilter,
+      limit: 500,
+      sessionId: 'abc12345',
+      vmName: 'vm-worker-01',
+    },
+    operationCategories: sampleOperationCategories,
+  },
+};

--- a/autobot-frontend/src/components/audit/AuditLogTable.stories.ts
+++ b/autobot-frontend/src/components/audit/AuditLogTable.stories.ts
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import AuditLogTable from './AuditLogTable.vue';
+
+const makeEntry = (
+  id: string,
+  operation: string,
+  result: 'success' | 'denied' | 'failed' | 'error',
+  overrides: Record<string, unknown> = {}
+) => ({
+  id,
+  timestamp: new Date(Date.now() - Math.random() * 3600000).toISOString(),
+  operation,
+  result,
+  user_id: 'alice',
+  session_id: `sess-${id}`,
+  vm_name: 'vm-worker-01',
+  vm_source: 'proxmox',
+  ip_address: '192.168.1.10',
+  error_message: null,
+  details: {},
+  ...overrides,
+});
+
+const sampleEntries = [
+  makeEntry('1', 'user_login', 'success'),
+  makeEntry('2', 'file_read', 'success', { user_id: 'bob', vm_name: 'vm-dev-02' }),
+  makeEntry('3', 'vm_snapshot', 'denied', { error_message: 'Permission denied for snapshot on protected VM' }),
+  makeEntry('4', 'token_refresh', 'failed', { error_message: 'Token expired' }),
+  makeEntry('5', 'connection_open', 'error', { error_message: 'Network unreachable' }),
+  makeEntry('6', 'user_logout', 'success', { session_id: null, user_id: null }),
+];
+
+const meta = {
+  title: 'Components/Audit/AuditLogTable',
+  component: AuditLogTable,
+  tags: ['autodocs'],
+  argTypes: {
+    entries: {
+      control: 'object',
+      description: 'Array of AuditEntry objects to display',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Shows a loading overlay when true',
+    },
+    hasMore: {
+      control: 'boolean',
+      description: 'Enables the Next Page button and shows "more available" indicator',
+    },
+    currentPage: {
+      control: 'number',
+      description: 'Current pagination page number',
+    },
+    onRefresh: { action: 'refresh' },
+    onExport: { action: 'export' },
+    'onEntry-select': { action: 'entry-select' },
+    'onUser-click': { action: 'user-click' },
+    'onSession-click': { action: 'session-click' },
+    'onNext-page': { action: 'next-page' },
+    'onPrev-page': { action: 'prev-page' },
+  },
+} as Meta<typeof AuditLogTable>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    entries: sampleEntries,
+    loading: false,
+    hasMore: false,
+    currentPage: 1,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    entries: [],
+    loading: true,
+    hasMore: false,
+    currentPage: 1,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    entries: [],
+    loading: false,
+    hasMore: false,
+    currentPage: 1,
+  },
+};
+
+export const WithPagination: Story = {
+  args: {
+    entries: sampleEntries,
+    loading: false,
+    hasMore: true,
+    currentPage: 3,
+  },
+};
+
+export const MixedResults: Story = {
+  args: {
+    entries: [
+      makeEntry('a', 'vm_start', 'success'),
+      makeEntry('b', 'vm_delete', 'denied', { error_message: 'Unauthorized VM deletion attempt' }),
+      makeEntry('c', 'firewall_rule_add', 'failed', { user_id: null, session_id: null, vm_name: null }),
+      makeEntry('d', 'file_write', 'error', {
+        details: { file: '/etc/passwd', size_bytes: 4096 },
+        error_message: 'Disk quota exceeded',
+      }),
+    ],
+    loading: false,
+    hasMore: false,
+    currentPage: 1,
+  },
+};

--- a/autobot-frontend/src/components/audit/AuditStatistics.stories.ts
+++ b/autobot-frontend/src/components/audit/AuditStatistics.stories.ts
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import AuditStatistics from './AuditStatistics.vue';
+
+const fullStatistics = {
+  total_entries: 12340,
+  success_count: 11200,
+  denied_count: 820,
+  failed_count: 240,
+  error_count: 80,
+  success_rate: 90.8,
+  top_operations: [
+    { operation: 'user_login', count: 4200 },
+    { operation: 'file_read', count: 3100 },
+    { operation: 'vm_start', count: 2200 },
+    { operation: 'token_refresh', count: 1800 },
+    { operation: 'connection_open', count: 1040 },
+  ],
+  top_users: [
+    { user_id: 'alice', count: 5400 },
+    { user_id: 'bob', count: 3200 },
+    { user_id: 'carol', count: 2100 },
+    { user_id: 'dave', count: 1100 },
+    { user_id: 'eve', count: 540 },
+  ],
+};
+
+const meta = {
+  title: 'Components/Audit/AuditStatistics',
+  component: AuditStatistics,
+  tags: ['autodocs'],
+  argTypes: {
+    statistics: {
+      control: 'object',
+      description: 'AuditStatistics data object, or null when unavailable',
+    },
+    vmInfo: {
+      control: 'object',
+      description: 'Optional VM name/source info to display in the VM card',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Shows a loading overlay when true',
+    },
+    'onUser-click': { action: 'user-click' },
+  },
+} as Meta<typeof AuditStatistics>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    statistics: fullStatistics,
+    vmInfo: null,
+    loading: false,
+  },
+};
+
+export const WithVmInfo: Story = {
+  args: {
+    statistics: fullStatistics,
+    vmInfo: { vm_name: 'vm-worker-01', vm_source: 'proxmox' },
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    statistics: null,
+    vmInfo: null,
+    loading: true,
+  },
+};
+
+export const NoData: Story = {
+  args: {
+    statistics: null,
+    vmInfo: null,
+    loading: false,
+  },
+};
+
+export const LowSuccessRate: Story = {
+  args: {
+    statistics: {
+      ...fullStatistics,
+      success_count: 600,
+      denied_count: 5200,
+      failed_count: 4200,
+      error_count: 2340,
+      success_rate: 48.7,
+    },
+    vmInfo: { vm_name: 'vm-prod-03', vm_source: 'proxmox' },
+    loading: false,
+  },
+};
+
+export const HighThroughput: Story = {
+  args: {
+    statistics: {
+      ...fullStatistics,
+      total_entries: 2500000,
+      success_count: 2450000,
+      denied_count: 35000,
+      failed_count: 10000,
+      error_count: 5000,
+      success_rate: 98.0,
+    },
+    vmInfo: null,
+    loading: false,
+  },
+};

--- a/autobot-frontend/src/components/audit/AuditTimeline.stories.ts
+++ b/autobot-frontend/src/components/audit/AuditTimeline.stories.ts
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import AuditTimeline from './AuditTimeline.vue';
+
+const makeEntry = (
+  id: string,
+  operation: string,
+  result: 'success' | 'denied' | 'failed' | 'error',
+  overrides: Record<string, unknown> = {}
+) => ({
+  id,
+  timestamp: new Date(Date.now() - parseInt(id) * 300000).toISOString(),
+  operation,
+  result,
+  user_id: 'alice',
+  session_id: 'sess-abc12345',
+  vm_name: 'vm-worker-01',
+  vm_source: 'proxmox',
+  ip_address: '192.168.1.10',
+  error_message: null,
+  details: {},
+  ...overrides,
+});
+
+const sessionEntries = [
+  makeEntry('1', 'user_login', 'success'),
+  makeEntry('2', 'file_read', 'success', { details: { path: '/home/alice/config.yaml' } }),
+  makeEntry('3', 'vm_start', 'success', { user_id: 'bob' }),
+  makeEntry('4', 'vm_snapshot', 'denied', { error_message: 'Permission denied: snapshot on protected VM' }),
+  makeEntry('5', 'user_logout', 'success'),
+];
+
+const userEntries = [
+  makeEntry('1', 'user_login', 'success', { session_id: 'sess-aaa11111' }),
+  makeEntry('2', 'token_refresh', 'success', { session_id: 'sess-aaa11111' }),
+  makeEntry('3', 'file_write', 'failed', {
+    session_id: 'sess-bbb22222',
+    error_message: 'Disk quota exceeded',
+  }),
+  makeEntry('4', 'connection_open', 'error', {
+    session_id: 'sess-ccc33333',
+    error_message: 'Network unreachable',
+    ip_address: '10.0.0.5',
+  }),
+];
+
+const meta = {
+  title: 'Components/Audit/AuditTimeline',
+  component: AuditTimeline,
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'select',
+      options: ['session', 'user'],
+      description: 'Whether this timeline shows a session trail or user activity',
+    },
+    entityId: {
+      control: 'text',
+      description: 'The session ID or user ID being displayed',
+    },
+    entries: {
+      control: 'object',
+      description: 'Array of AuditEntry objects shown in the timeline',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Shows a loading spinner instead of entries when true',
+    },
+    onClose: { action: 'close' },
+    onRefresh: { action: 'refresh' },
+  },
+} as Meta<typeof AuditTimeline>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const SessionTimeline: Story = {
+  args: {
+    type: 'session',
+    entityId: 'sess-abc12345',
+    entries: sessionEntries,
+    loading: false,
+  },
+};
+
+export const UserTimeline: Story = {
+  args: {
+    type: 'user',
+    entityId: 'alice',
+    entries: userEntries,
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    type: 'session',
+    entityId: 'sess-xyz99999',
+    entries: [],
+    loading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    type: 'user',
+    entityId: 'nobody',
+    entries: [],
+    loading: false,
+  },
+};
+
+export const WithErrors: Story = {
+  args: {
+    type: 'session',
+    entityId: 'sess-err00001',
+    entries: [
+      makeEntry('1', 'user_login', 'success'),
+      makeEntry('2', 'vm_delete', 'denied', { error_message: 'Unauthorized: VM is protected' }),
+      makeEntry('3', 'firewall_rule_add', 'error', {
+        error_message: 'Internal error: firewall daemon unreachable',
+        details: { rule: 'DENY tcp 0.0.0.0/0 22', attempt: 3 },
+      }),
+      makeEntry('4', 'user_logout', 'failed', { error_message: 'Session already expired' }),
+    ],
+    loading: false,
+  },
+};


### PR DESCRIPTION
## Summary

Adds Storybook stories for 4 components in `autobot-frontend/src/components/audit/`.

- `AuditFilters.stories.ts` — 5 stories: Default, WithActiveFilters, CustomDateRange, WeekRange, HighLimitWithSessionFilter
- `AuditLogTable.stories.ts` — 5 stories: Default, Loading, Empty, WithPagination, MixedResults
- `AuditStatistics.stories.ts` — 6 stories: Default, WithVmInfo, Loading, NoData, LowSuccessRate, HighThroughput
- `AuditTimeline.stories.ts` — 5 stories: SessionTimeline, UserTimeline, Loading, Empty, WithErrors

Closes #6858. Part of #4201 Phase 2 Storybook stories campaign.