### PR TITLE
refactor(frontend/plugins): add Storybook stories for MarketplaceSourcesModal and PluginInstallModal (#6868)

### DIFF
--- a/autobot-frontend/src/components/plugins/MarketplaceSourcesModal.stories.ts
+++ b/autobot-frontend/src/components/plugins/MarketplaceSourcesModal.stories.ts
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import MarketplaceSourcesModal from './MarketplaceSourcesModal.vue';
+
+const meta = {
+  title: 'Components/Plugins/MarketplaceSourcesModal',
+  component: MarketplaceSourcesModal,
+  argTypes: {
+    open: {
+      control: 'boolean',
+      description: 'Controls whether the modal is visible',
+    },
+  },
+} as Meta<typeof MarketplaceSourcesModal>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Open: Story = {
+  args: {
+    open: true,
+  },
+  render: (args: any) => ({
+    components: { MarketplaceSourcesModal },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div style="position: relative; width: 100%; height: 600px;">
+        <p class="mb-4 text-sm text-gray-500">
+          MarketplaceSourcesModal manages the list of marketplace plugin sources.
+          It allows adding new sources (name + URL) and removing custom ones.
+          Built-in sources are read-only and display a badge.
+        </p>
+        <MarketplaceSourcesModal :open="args.open" @close="args.open = false" @updated="() => {}" />
+      </div>
+    `,
+  }),
+};
+
+export const Closed: Story = {
+  args: {
+    open: false,
+  },
+  render: (args: any) => ({
+    components: { MarketplaceSourcesModal },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div>
+        <p class="mb-4 text-sm text-gray-500">
+          When <code>open</code> is false the modal is hidden — nothing is rendered to the DOM.
+        </p>
+        <MarketplaceSourcesModal :open="args.open" @close="args.open = false" @updated="() => {}" />
+        <p class="mt-4 text-sm text-gray-400">Modal is hidden in this state.</p>
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/plugins/PluginInstallModal.stories.ts
+++ b/autobot-frontend/src/components/plugins/PluginInstallModal.stories.ts
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import PluginInstallModal from './PluginInstallModal.vue';
+
+const meta = {
+  title: 'Components/Plugins/PluginInstallModal',
+  component: PluginInstallModal,
+  argTypes: {
+    open: {
+      control: 'boolean',
+      description: 'Controls whether the modal is visible',
+    },
+  },
+} as Meta<typeof PluginInstallModal>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const OpenZipTab: Story = {
+  name: 'Open — ZIP tab',
+  args: {
+    open: true,
+  },
+  render: (args: any) => ({
+    components: { PluginInstallModal },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div style="position: relative; width: 100%; height: 600px;">
+        <p class="mb-4 text-sm text-gray-500">
+          PluginInstallModal opens on the ZIP tab by default.
+          Users can pick a .zip archive from their filesystem to install a plugin.
+        </p>
+        <PluginInstallModal :open="args.open" @close="args.open = false" @installed="() => {}" />
+      </div>
+    `,
+  }),
+};
+
+export const OpenGitTab: Story = {
+  name: 'Open — Git tab',
+  args: {
+    open: true,
+  },
+  render: (args: any) => ({
+    components: { PluginInstallModal },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div style="position: relative; width: 100%; height: 600px;">
+        <p class="mb-4 text-sm text-gray-500">
+          The Git tab lets users install a plugin directly from a Git repository URL
+          with an optional branch/tag/commit ref.
+        </p>
+        <!--
+          The modal initialises activeTab to 'zip' on open.
+          To pre-select 'git' in Storybook, click the Git tab after the modal mounts.
+        -->
+        <PluginInstallModal :open="args.open" @close="args.open = false" @installed="() => {}" />
+      </div>
+    `,
+  }),
+};
+
+export const Closed: Story = {
+  args: {
+    open: false,
+  },
+  render: (args: any) => ({
+    components: { PluginInstallModal },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div>
+        <p class="mb-4 text-sm text-gray-500">
+          When <code>open</code> is false the modal is hidden — nothing is rendered to the DOM.
+        </p>
+        <PluginInstallModal :open="args.open" @close="args.open = false" @installed="() => {}" />
+        <p class="mt-4 text-sm text-gray-400">Modal is hidden in this state.</p>
+      </div>
+    `,
+  }),
+};


### PR DESCRIPTION
## Summary

Adds Storybook stories for 2 components in `autobot-frontend/src/components/plugins/`.

- `MarketplaceSourcesModal.stories.ts` — 2 stories: Open, Closed
- `PluginInstallModal.stories.ts` — 3 stories: Open (ZIP tab), Open (Git tab), Closed

Both modals use a single `open: boolean` prop. Stories follow the `StoryObj<any>` pattern per #7273.

Closes #6868. Part of #4201 Phase 2 Storybook stories campaign.