### PR TITLE
refactor(frontend/secrets): add Storybook stories for 3 secrets components (#6863)

### DIFF
--- a/autobot-frontend/src/components/secrets/SecretAuditLog.stories.ts
+++ b/autobot-frontend/src/components/secrets/SecretAuditLog.stories.ts
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import SecretAuditLog from './SecretAuditLog.vue';
+
+const meta = {
+  title: 'Components/Secrets/SecretAuditLog',
+  component: SecretAuditLog,
+  tags: ['autodocs'],
+  argTypes: {
+    secretId: {
+      control: 'text',
+      description: 'Filter audit log entries by a specific secret ID',
+    },
+  },
+} as Meta<typeof SecretAuditLog>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  render: () => ({
+    components: { SecretAuditLog },
+    template: `
+      <div style="height: 500px; width: 700px; background: #1f2937;">
+        <SecretAuditLog />
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Default audit log showing all secret operations. Fetches real data from the backend on mount.',
+      },
+    },
+  },
+};
+
+export const FilteredBySecret: Story = {
+  render: () => ({
+    components: { SecretAuditLog },
+    template: `
+      <div style="height: 500px; width: 700px; background: #1f2937;">
+        <SecretAuditLog secret-id="secret_abc123" />
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Audit log scoped to a single secret ID — only entries for that secret are displayed.',
+      },
+    },
+  },
+};
+
+export const CompactContainer: Story = {
+  render: () => ({
+    components: { SecretAuditLog },
+    template: `
+      <div style="height: 300px; width: 400px; background: #1f2937;">
+        <SecretAuditLog />
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Audit log in a compact container, demonstrating the flex layout adapts to smaller heights.',
+      },
+    },
+  },
+};

--- a/autobot-frontend/src/components/secrets/SecretVault.stories.ts
+++ b/autobot-frontend/src/components/secrets/SecretVault.stories.ts
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import SecretVault from './SecretVault.vue';
+
+const meta = {
+  title: 'Components/Secrets/SecretVault',
+  component: SecretVault,
+  tags: ['autodocs'],
+  argTypes: {
+    scope: {
+      control: 'select',
+      options: ['session', 'user', 'all'],
+      description: 'Filters which secrets are displayed: session-scoped, user/global, or all accessible secrets.',
+    },
+  },
+} as Meta<typeof SecretVault>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const AllSecrets: Story = {
+  render: () => ({
+    components: { SecretVault },
+    template: `
+      <div style="height: 600px; width: 480px; background: #1f2937;">
+        <SecretVault />
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Vault with no scope restriction — shows all accessible secrets. Fetches from backend on mount.',
+      },
+    },
+  },
+};
+
+export const SessionScope: Story = {
+  render: () => ({
+    components: { SecretVault },
+    template: `
+      <div style="height: 600px; width: 480px; background: #1f2937;">
+        <SecretVault scope="session" />
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Vault filtered to session-scoped and chat-scoped secrets only.',
+      },
+    },
+  },
+};
+
+export const UserScope: Story = {
+  render: () => ({
+    components: { SecretVault },
+    template: `
+      <div style="height: 600px; width: 480px; background: #1f2937;">
+        <SecretVault scope="user" />
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Vault filtered to user-scoped and global secrets only.',
+      },
+    },
+  },
+};

--- a/autobot-frontend/src/components/secrets/ShareSecretDialog.stories.ts
+++ b/autobot-frontend/src/components/secrets/ShareSecretDialog.stories.ts
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { ref } from 'vue';
+import ShareSecretDialog from './ShareSecretDialog.vue';
+
+const meta = {
+  title: 'Components/Secrets/ShareSecretDialog',
+  component: ShareSecretDialog,
+  tags: ['autodocs'],
+  argTypes: {
+    modelValue: {
+      control: 'boolean',
+      description: 'Controls dialog open/close state (v-model)',
+    },
+    secretId: {
+      control: 'text',
+      description: 'ID of the secret being shared',
+    },
+    secretName: {
+      control: 'text',
+      description: 'Display name of the secret',
+    },
+    secretType: {
+      control: 'text',
+      description: 'Type of the secret (e.g. api_key, password, ssh_key)',
+    },
+  },
+} as Meta<typeof ShareSecretDialog>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Open: Story = {
+  render: () => ({
+    components: { ShareSecretDialog },
+    setup() {
+      const open = ref(true);
+      return { open };
+    },
+    template: `
+      <div style="min-height: 400px; background: #1f2937; position: relative;">
+        <ShareSecretDialog
+          v-model="open"
+          secret-id="secret_abc123"
+          secret-name="Production API Key"
+          secret-type="api_key"
+        />
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Dialog in the open state, ready for participant selection and expiry configuration.',
+      },
+    },
+  },
+};
+
+export const Closed: Story = {
+  render: () => ({
+    components: { ShareSecretDialog },
+    setup() {
+      const open = ref(false);
+      return { open };
+    },
+    template: `
+      <div style="min-height: 200px; background: #1f2937; display: flex; align-items: center; justify-content: center;">
+        <p style="color: #9ca3af; font-size: 14px;">Dialog is closed — toggle modelValue to open it.</p>
+        <ShareSecretDialog
+          v-model="open"
+          secret-id="secret_abc123"
+          secret-name="Production API Key"
+          secret-type="api_key"
+        />
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Dialog in the closed state. The component renders nothing visible; backdrop and panel are hidden.',
+      },
+    },
+  },
+};
+
+export const OpenWithPasswordSecret: Story = {
+  render: () => ({
+    components: { ShareSecretDialog },
+    setup() {
+      const open = ref(true);
+      return { open };
+    },
+    template: `
+      <div style="min-height: 400px; background: #1f2937; position: relative;">
+        <ShareSecretDialog
+          v-model="open"
+          secret-id="secret_def456"
+          secret-name="Database Root Password"
+          secret-type="password"
+        />
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Dialog open for a password-type secret, showing how the secretType label renders differently.',
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Adds Storybook stories for 3 components in `autobot-frontend/src/components/secrets/`.

- `SecretAuditLog.stories.ts` — 3 stories: Default, FilteredBySecret, CompactContainer
- `SecretVault.stories.ts` — 3 stories: AllSecrets, SessionScope, UserScope
- `ShareSecretDialog.stories.ts` — 3 stories: Open, Closed, OpenWithPasswordSecret

Note: The `secrets/` dir matches a gitignore pattern for K8s secrets. Story files use `git add -f` to match the treatment of the existing `.vue` files in that directory.

Closes #6863. Part of #4201 Phase 2 Storybook stories campaign.