### PR TITLE
refactor(frontend/vision): add Storybook stories for 4 vision components (#6859)

### DIFF
--- a/autobot-frontend/src/components/vision/GUIAutomationControls.stories.ts
+++ b/autobot-frontend/src/components/vision/GUIAutomationControls.stories.ts
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import GUIAutomationControls from './GUIAutomationControls.vue';
+
+const meta = {
+  title: 'Components/Vision/GUIAutomationControls',
+  component: GUIAutomationControls,
+  tags: ['autodocs'],
+  argTypes: {
+    opportunities: {
+      control: 'object',
+      description: 'List of automation opportunities to display',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Whether the component is loading/analyzing',
+    },
+  },
+} as Meta<typeof GUIAutomationControls>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+const sampleOpportunities = [
+  {
+    element_id: 'btn-submit-001',
+    element_type: 'button',
+    action: 'Click Submit',
+    description: 'Submit form button is available and ready to be clicked.',
+    confidence: 0.92,
+  },
+  {
+    element_id: 'input-search-002',
+    element_type: 'input',
+    action: 'Type in Search',
+    description: 'Search input field is focused and ready for text entry.',
+    confidence: 0.78,
+  },
+  {
+    element_id: 'dropdown-menu-003',
+    element_type: 'dropdown',
+    action: 'Open Dropdown',
+    description: 'Dropdown menu can be expanded to reveal options.',
+    confidence: 0.55,
+  },
+];
+
+export const Default: Story = {
+  args: {
+    opportunities: sampleOpportunities,
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    opportunities: [],
+    loading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    opportunities: [],
+    loading: false,
+  },
+};
+
+export const HighConfidenceOnly: Story = {
+  args: {
+    opportunities: [
+      {
+        element_id: 'btn-ok-001',
+        element_type: 'button',
+        action: 'Click OK',
+        description: 'OK button detected with very high confidence.',
+        confidence: 0.97,
+      },
+      {
+        element_id: 'link-nav-002',
+        element_type: 'link',
+        action: 'Follow Navigation Link',
+        description: 'Navigation link is clearly visible and clickable.',
+        confidence: 0.89,
+      },
+    ],
+    loading: false,
+  },
+};
+
+export const MixedConfidence: Story = {
+  args: {
+    opportunities: [
+      {
+        element_id: 'btn-primary-001',
+        element_type: 'button',
+        action: 'Submit',
+        description: 'Primary action button.',
+        confidence: 0.95,
+      },
+      {
+        element_id: 'checkbox-terms-002',
+        element_type: 'checkbox',
+        action: 'Toggle Checkbox',
+        description: 'Terms and conditions checkbox.',
+        confidence: 0.62,
+      },
+      {
+        element_id: 'icon-close-003',
+        element_type: 'icon',
+        action: 'Close Modal',
+        description: 'Close icon for dismissing the modal dialog.',
+        confidence: 0.38,
+      },
+    ],
+    loading: false,
+  },
+};

--- a/autobot-frontend/src/components/vision/MediaGallery.stories.ts
+++ b/autobot-frontend/src/components/vision/MediaGallery.stories.ts
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import MediaGallery from './MediaGallery.vue';
+
+const meta = {
+  title: 'Components/Vision/MediaGallery',
+  component: MediaGallery,
+  tags: ['autodocs'],
+  argTypes: {
+    items: {
+      control: 'object',
+      description: 'Array of gallery items (images, videos, screen captures)',
+    },
+  },
+} as Meta<typeof MediaGallery>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+const now = Date.now();
+
+const imageItems = [
+  {
+    id: 'img-001',
+    type: 'image',
+    filename: 'screenshot_dashboard.png',
+    thumbnail: '',
+    timestamp: now - 60000,
+    analysisResult: {
+      confidence: 0.91,
+      processing_time: 1.23,
+      device_used: 'npu',
+    },
+  },
+  {
+    id: 'img-002',
+    type: 'image',
+    filename: 'capture_analysis_report.jpg',
+    thumbnail: '',
+    timestamp: now - 120000,
+    analysisResult: {
+      confidence: 0.85,
+      processing_time: 0.98,
+      device_used: 'cpu',
+    },
+  },
+];
+
+const videoItems = [
+  {
+    id: 'vid-001',
+    type: 'video',
+    filename: 'screen_recording_session.mp4',
+    thumbnail: '',
+    timestamp: now - 300000,
+    analysisResult: {
+      frames_processed: 12,
+      confidence: 0.88,
+      processing_time: 14.5,
+      device_used: 'npu',
+    },
+  },
+];
+
+const screenItems = [
+  {
+    id: 'scr-001',
+    type: 'screen',
+    filename: 'auto_capture_20260516_143022.png',
+    thumbnail: '',
+    timestamp: now - 30000,
+    analysisResult: {
+      confidence: 0.93,
+      processing_time: 0.75,
+      device_used: 'npu',
+    },
+  },
+];
+
+export const Default: Story = {
+  args: {
+    items: [...imageItems, ...videoItems, ...screenItems],
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    items: [],
+  },
+};
+
+export const ImagesOnly: Story = {
+  args: {
+    items: imageItems,
+  },
+};
+
+export const VideosOnly: Story = {
+  args: {
+    items: videoItems,
+  },
+};
+
+export const MixedMediaTypes: Story = {
+  args: {
+    items: [
+      ...imageItems,
+      ...videoItems,
+      ...screenItems,
+      {
+        id: 'scr-002',
+        type: 'screen',
+        filename: 'auto_capture_20260516_150000.png',
+        thumbnail: '',
+        timestamp: now - 600000,
+        analysisResult: null,
+      },
+    ],
+  },
+};

--- a/autobot-frontend/src/components/vision/ScreenCaptureViewer.stories.ts
+++ b/autobot-frontend/src/components/vision/ScreenCaptureViewer.stories.ts
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import ScreenCaptureViewer from './ScreenCaptureViewer.vue';
+
+const meta = {
+  title: 'Components/Vision/ScreenCaptureViewer',
+  component: ScreenCaptureViewer,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof ScreenCaptureViewer>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+const sampleAnalysisResult = {
+  confidence_score: 0.87,
+  timestamp: Math.floor(Date.now() / 1000),
+  ui_elements: [
+    {
+      element_id: 'el-btn-001',
+      element_type: 'button',
+      confidence: 0.94,
+      text_content: 'Submit',
+      bbox: { x: 100, y: 200, width: 120, height: 40 },
+      center_point: [160, 220],
+      possible_interactions: ['click'],
+    },
+    {
+      element_id: 'el-input-002',
+      element_type: 'input',
+      confidence: 0.89,
+      text_content: 'Search...',
+      bbox: { x: 50, y: 100, width: 300, height: 36 },
+      center_point: [200, 118],
+      possible_interactions: ['click', 'type'],
+    },
+    {
+      element_id: 'el-link-003',
+      element_type: 'link',
+      confidence: 0.72,
+      text_content: 'Learn more',
+      bbox: { x: 400, y: 350, width: 90, height: 20 },
+      center_point: [445, 360],
+      possible_interactions: ['click'],
+    },
+    {
+      element_id: 'el-menu-004',
+      element_type: 'menu',
+      confidence: 0.45,
+      text_content: null,
+      bbox: { x: 0, y: 0, width: 200, height: 600 },
+      center_point: [100, 300],
+      possible_interactions: ['click', 'hover'],
+    },
+  ],
+  text_regions: [
+    { text: 'Welcome to AutoBot Dashboard' },
+    { text: 'System Status: Online' },
+    { text: 'Last updated: just now' },
+  ],
+  layout_structure: {
+    type: 'application_window',
+    regions: ['header', 'sidebar', 'main_content', 'footer'],
+  },
+};
+
+export const Default: Story = {
+  args: {},
+  render: () => ({
+    components: { ScreenCaptureViewer },
+    template: `<div style="height: 600px;"><ScreenCaptureViewer /></div>`,
+  }),
+};
+
+export const WithAnalysisResult: Story = {
+  render: () => ({
+    components: { ScreenCaptureViewer },
+    setup() {
+      return { sampleAnalysisResult };
+    },
+    template: `
+      <div style="height: 600px;">
+        <ScreenCaptureViewer />
+      </div>
+    `,
+  }),
+};
+
+export const EmptyState: Story = {
+  render: () => ({
+    components: { ScreenCaptureViewer },
+    template: `
+      <div style="height: 500px;">
+        <ScreenCaptureViewer />
+      </div>
+    `,
+  }),
+};
+
+export const CompactView: Story = {
+  render: () => ({
+    components: { ScreenCaptureViewer },
+    template: `
+      <div style="height: 400px; width: 600px;">
+        <ScreenCaptureViewer />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/vision/VideoProcessor.stories.ts
+++ b/autobot-frontend/src/components/vision/VideoProcessor.stories.ts
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import VideoProcessor from './VideoProcessor.vue';
+
+const meta = {
+  title: 'Components/Vision/VideoProcessor',
+  component: VideoProcessor,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof VideoProcessor>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  render: () => ({
+    components: { VideoProcessor },
+    template: `<VideoProcessor />`,
+  }),
+};
+
+export const DropZoneIdle: Story = {
+  render: () => ({
+    components: { VideoProcessor },
+    template: `
+      <div style="max-width: 800px;">
+        <VideoProcessor />
+      </div>
+    `,
+  }),
+};
+
+export const WithFrameResults: Story = {
+  render: () => ({
+    components: { VideoProcessor },
+    template: `
+      <div style="max-width: 800px; padding: 16px;">
+        <VideoProcessor @analysis-complete="onComplete" @add-to-gallery="onGallery" />
+      </div>
+    `,
+    methods: {
+      onComplete(result: unknown) {
+        // eslint-disable-next-line no-console
+        console.log('Analysis complete:', result);
+      },
+      onGallery(item: unknown) {
+        // eslint-disable-next-line no-console
+        console.log('Add to gallery:', item);
+      },
+    },
+  }),
+};
+
+export const NarrowLayout: Story = {
+  render: () => ({
+    components: { VideoProcessor },
+    template: `
+      <div style="max-width: 480px;">
+        <VideoProcessor />
+      </div>
+    `,
+  }),
+};
+
+export const WideLayout: Story = {
+  render: () => ({
+    components: { VideoProcessor },
+    template: `
+      <div style="max-width: 1200px;">
+        <VideoProcessor />
+      </div>
+    `,
+  }),
+};


### PR DESCRIPTION
Adds stories for GUIAutomationControls (5 stories), MediaGallery (5), ScreenCaptureViewer (4), VideoProcessor (5). Self-contained components use render functions. Closes #6859. Part of #4201 Phase 2.