### PR TITLE
refactor(frontend/feature-flags): add Storybook stories for 4 feature-flag components (#6861)

### DIFF
--- a/autobot-frontend/src/components/feature-flags/AccessMetrics.stories.ts
+++ b/autobot-frontend/src/components/feature-flags/AccessMetrics.stories.ts
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import AccessMetrics from './AccessMetrics.vue';
+
+const meta = {
+  title: 'Components/FeatureFlags/AccessMetrics',
+  component: AccessMetrics,
+  tags: ['autodocs'],
+  argTypes: {
+    metrics: {
+      control: 'object',
+      description: 'ViolationStatistics object or null',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state',
+    },
+    compact: {
+      control: 'boolean',
+      description: 'Compact display mode (summary cards only, no breakdowns)',
+    },
+  },
+} as Meta<typeof AccessMetrics>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+const sampleMetrics = {
+  total_violations: 47,
+  period_days: 7,
+  daily_change_percent: 12.5,
+  by_endpoint: {
+    '/api/admin/users': 18,
+    '/api/settings/global': 14,
+    '/api/agent/config': 9,
+    '/api/knowledge/delete': 6,
+  },
+  by_user: {
+    'alice@example.com': 22,
+    'bob@example.com': 15,
+    'charlie@example.com': 10,
+  },
+  by_day: {
+    '2026-05-10': 5,
+    '2026-05-11': 8,
+    '2026-05-12': 4,
+    '2026-05-13': 11,
+    '2026-05-14': 7,
+    '2026-05-15': 9,
+    '2026-05-16': 3,
+  },
+  recent_violations: [
+    {
+      id: 'v1',
+      timestamp: Math.floor(Date.now() / 1000) - 300,
+      username: 'alice@example.com',
+      endpoint: '/api/admin/users',
+      actual_owner: 'admin',
+    },
+    {
+      id: 'v2',
+      timestamp: Math.floor(Date.now() / 1000) - 900,
+      username: 'bob@example.com',
+      endpoint: '/api/settings/global',
+      actual_owner: 'superadmin',
+    },
+    {
+      id: 'v3',
+      timestamp: Math.floor(Date.now() / 1000) - 3600,
+      username: 'charlie@example.com',
+      endpoint: '/api/agent/config',
+      actual_owner: 'admin',
+    },
+  ],
+};
+
+export const WithData: Story = {
+  args: {
+    metrics: sampleMetrics,
+    loading: false,
+    compact: false,
+  },
+};
+
+export const CompactMode: Story = {
+  args: {
+    metrics: sampleMetrics,
+    loading: false,
+    compact: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    metrics: null,
+    loading: true,
+    compact: false,
+  },
+};
+
+export const NoViolations: Story = {
+  args: {
+    metrics: {
+      total_violations: 0,
+      period_days: 7,
+      daily_change_percent: -100,
+      by_endpoint: {},
+      by_user: {},
+      by_day: {},
+      recent_violations: [],
+    },
+    loading: false,
+    compact: false,
+  },
+};
+
+export const TrendDown: Story = {
+  args: {
+    metrics: {
+      ...sampleMetrics,
+      daily_change_percent: -25.3,
+    },
+    loading: false,
+    compact: false,
+  },
+};

--- a/autobot-frontend/src/components/feature-flags/EndpointEnforcement.stories.ts
+++ b/autobot-frontend/src/components/feature-flags/EndpointEnforcement.stories.ts
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import EndpointEnforcement from './EndpointEnforcement.vue';
+
+const meta = {
+  title: 'Components/FeatureFlags/EndpointEnforcement',
+  component: EndpointEnforcement,
+  tags: ['autodocs'],
+  argTypes: {
+    overrides: {
+      control: 'object',
+      description: 'Map of endpoint path to EnforcementMode override',
+    },
+    globalMode: {
+      control: 'select',
+      options: ['disabled', 'log_only', 'enforced'],
+      description: 'The global default enforcement mode',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading/saving state',
+    },
+  },
+} as Meta<typeof EndpointEnforcement>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const WithOverrides: Story = {
+  args: {
+    overrides: {
+      '/api/admin/users': 'enforced',
+      '/api/settings/global': 'log_only',
+      '/api/debug/dump': 'disabled',
+    },
+    globalMode: 'log_only',
+    loading: false,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    overrides: {},
+    globalMode: 'log_only',
+    loading: false,
+  },
+};
+
+export const GlobalEnforced: Story = {
+  args: {
+    overrides: {
+      '/api/public/health': 'disabled',
+    },
+    globalMode: 'enforced',
+    loading: false,
+  },
+};
+
+export const GlobalDisabled: Story = {
+  args: {
+    overrides: {
+      '/api/admin/users': 'enforced',
+      '/api/payments/process': 'enforced',
+    },
+    globalMode: 'disabled',
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    overrides: {
+      '/api/admin/users': 'enforced',
+    },
+    globalMode: 'log_only',
+    loading: true,
+  },
+};

--- a/autobot-frontend/src/components/feature-flags/EnforcementModeSelector.stories.ts
+++ b/autobot-frontend/src/components/feature-flags/EnforcementModeSelector.stories.ts
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import EnforcementModeSelector from './EnforcementModeSelector.vue';
+
+const meta = {
+  title: 'Components/FeatureFlags/EnforcementModeSelector',
+  component: EnforcementModeSelector,
+  tags: ['autodocs'],
+  argTypes: {
+    currentMode: {
+      control: 'select',
+      options: ['disabled', 'log_only', 'enforced'],
+      description: 'Currently active enforcement mode',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show pending/updating state on the selected mode option',
+    },
+  },
+} as Meta<typeof EnforcementModeSelector>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Disabled: Story = {
+  args: {
+    currentMode: 'disabled',
+    loading: false,
+  },
+};
+
+export const LogOnly: Story = {
+  args: {
+    currentMode: 'log_only',
+    loading: false,
+  },
+};
+
+export const Enforced: Story = {
+  args: {
+    currentMode: 'enforced',
+    loading: false,
+  },
+};
+
+export const Updating: Story = {
+  args: {
+    currentMode: 'log_only',
+    loading: true,
+  },
+};
+
+export const Interactive: Story = {
+  render: () => ({
+    components: { EnforcementModeSelector },
+    data() {
+      return { mode: 'disabled' as 'disabled' | 'log_only' | 'enforced', busy: false };
+    },
+    methods: {
+      onUpdate(newMode: 'disabled' | 'log_only' | 'enforced') {
+        this.busy = true;
+        setTimeout(() => {
+          this.mode = newMode;
+          this.busy = false;
+        }, 800);
+      },
+    },
+    template: `
+      <EnforcementModeSelector
+        :current-mode="mode"
+        :loading="busy"
+        @update:mode="onUpdate"
+      />
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/feature-flags/FlagChangeHistory.stories.ts
+++ b/autobot-frontend/src/components/feature-flags/FlagChangeHistory.stories.ts
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import FlagChangeHistory from './FlagChangeHistory.vue';
+
+const meta = {
+  title: 'Components/FeatureFlags/FlagChangeHistory',
+  component: FlagChangeHistory,
+  tags: ['autodocs'],
+  argTypes: {
+    history: {
+      control: 'object',
+      description: 'Array of HistoryEntry objects (timestamp, mode, changed_by)',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state when history is not yet fetched',
+    },
+  },
+} as Meta<typeof FlagChangeHistory>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+const now = new Date();
+const hoursAgo = (h: number) => new Date(now.getTime() - h * 3600 * 1000).toISOString();
+
+export const WithHistory: Story = {
+  args: {
+    history: [
+      { timestamp: hoursAgo(1), mode: 'enforced', changed_by: 'alice@example.com' },
+      { timestamp: hoursAgo(6), mode: 'log_only', changed_by: 'bob@example.com' },
+      { timestamp: hoursAgo(24), mode: 'disabled', changed_by: 'system' },
+      { timestamp: hoursAgo(72), mode: 'log_only', changed_by: 'charlie@example.com' },
+    ],
+    loading: false,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    history: [],
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    history: [],
+    loading: true,
+  },
+};
+
+export const SingleEntry: Story = {
+  args: {
+    history: [
+      { timestamp: hoursAgo(2), mode: 'enforced', changed_by: 'admin@example.com' },
+    ],
+    loading: false,
+  },
+};
+
+export const LongHistory: Story = {
+  args: {
+    history: [
+      { timestamp: hoursAgo(0.5), mode: 'enforced', changed_by: 'alice@example.com' },
+      { timestamp: hoursAgo(3), mode: 'log_only', changed_by: 'alice@example.com' },
+      { timestamp: hoursAgo(8), mode: 'enforced', changed_by: 'bob@example.com' },
+      { timestamp: hoursAgo(15), mode: 'disabled', changed_by: 'system' },
+      { timestamp: hoursAgo(30), mode: 'log_only', changed_by: 'charlie@example.com' },
+      { timestamp: hoursAgo(48), mode: 'disabled', changed_by: 'alice@example.com' },
+      { timestamp: hoursAgo(96), mode: 'log_only', changed_by: 'system' },
+    ],
+    loading: false,
+  },
+};


### PR DESCRIPTION
Adds stories for AccessMetrics (5 stories), EndpointEnforcement (5), EnforcementModeSelector (5), FlagChangeHistory (5). Closes #6861. Part of #4201 Phase 2.