### PR TITLE
refactor(frontend/desktop): add Storybook stories for 4 desktop components (#6860)

### DIFF
--- a/autobot-frontend/src/components/desktop/ConnectionSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/desktop/ConnectionSettingsPanel.stories.ts
@@ -1,0 +1,89 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import type { Meta } from '@storybook/vue3';
+import ConnectionSettingsPanel from './ConnectionSettingsPanel.vue';
+
+const meta = {
+  title: 'Components/Desktop/ConnectionSettingsPanel',
+  component: ConnectionSettingsPanel,
+  tags: ['autodocs'],
+  argTypes: {},
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Displays VNC connection settings including quality presets, auto-reconnect ' +
+          'configuration, and live connection metrics. All data is fetched via ' +
+          'useVncConnection and polled every 10 seconds.',
+      },
+    },
+  },
+} as Meta<typeof ConnectionSettingsPanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = import('@storybook/vue3').StoryObj<any>;
+
+/**
+ * Default state: the component mounts, loads settings and begins metrics polling.
+ * In Storybook the composable will return its initial values (settings = null → loading state).
+ */
+export const Default: Story = {
+  render: () => ({
+    components: { ConnectionSettingsPanel },
+    template: `<div style="width:320px"><ConnectionSettingsPanel /></div>`,
+  }),
+};
+
+/**
+ * Shows what the panel looks like while settings are still being fetched
+ * (mocked by rendering the component in an isolated container where the
+ * composable returns its initial null state).
+ */
+export const LoadingState: Story = {
+  render: () => ({
+    components: { ConnectionSettingsPanel },
+    template: `
+      <div style="width:320px">
+        <p class="text-xs text-gray-400 mb-2">Loading state (composable returns null on first render)</p>
+        <ConnectionSettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+/**
+ * Demonstrates the panel at a narrow sidebar width.
+ */
+export const NarrowSidebar: Story = {
+  render: () => ({
+    components: { ConnectionSettingsPanel },
+    template: `<div style="width:240px"><ConnectionSettingsPanel /></div>`,
+  }),
+};
+
+/**
+ * Demonstrates the panel at a wider layout (e.g. a settings drawer).
+ */
+export const WideLayout: Story = {
+  render: () => ({
+    components: { ConnectionSettingsPanel },
+    template: `<div style="width:480px"><ConnectionSettingsPanel /></div>`,
+  }),
+};
+
+/**
+ * Shows the panel inside a dark-themed wrapper that mirrors the sidebar context.
+ */
+export const DarkSidebar: Story = {
+  render: () => ({
+    components: { ConnectionSettingsPanel },
+    template: `
+      <div style="width:320px;background:#1a1a2e;padding:16px;border-radius:8px">
+        <ConnectionSettingsPanel />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/desktop/DesktopContextPanel.stories.ts
+++ b/autobot-frontend/src/components/desktop/DesktopContextPanel.stories.ts
@@ -1,0 +1,86 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import type { Meta } from '@storybook/vue3';
+import DesktopContextPanel from './DesktopContextPanel.vue';
+
+const meta = {
+  title: 'Components/Desktop/DesktopContextPanel',
+  component: DesktopContextPanel,
+  tags: ['autodocs'],
+  argTypes: {},
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Displays live desktop context information: system metrics (CPU, memory, uptime), ' +
+          'desktop state (resolution, active window, window count), and top running processes. ' +
+          'Data is polled from /vnc/desktop/context every 5 seconds with a manual refresh button.',
+      },
+    },
+  },
+} as Meta<typeof DesktopContextPanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = import('@storybook/vue3').StoryObj<any>;
+
+/**
+ * Default render — composable starts with context = null so the loading skeleton is shown.
+ */
+export const Default: Story = {
+  render: () => ({
+    components: { DesktopContextPanel },
+    template: `<div style="width:320px"><DesktopContextPanel /></div>`,
+  }),
+};
+
+/**
+ * Narrow sidebar width, mirroring how the panel appears in the desktop slide-out.
+ */
+export const NarrowSidebar: Story = {
+  render: () => ({
+    components: { DesktopContextPanel },
+    template: `<div style="width:240px"><DesktopContextPanel /></div>`,
+  }),
+};
+
+/**
+ * Wider layout — useful for full-page settings or inspection dashboards.
+ */
+export const WideLayout: Story = {
+  render: () => ({
+    components: { DesktopContextPanel },
+    template: `<div style="width:480px"><DesktopContextPanel /></div>`,
+  }),
+};
+
+/**
+ * Two panels side-by-side to verify they lay out independently.
+ */
+export const SideBySide: Story = {
+  render: () => ({
+    components: { DesktopContextPanel },
+    template: `
+      <div style="display:flex;gap:16px">
+        <div style="width:300px"><DesktopContextPanel /></div>
+        <div style="width:300px"><DesktopContextPanel /></div>
+      </div>
+    `,
+  }),
+};
+
+/**
+ * Dark background — matches the desktop overlay context.
+ */
+export const DarkBackground: Story = {
+  render: () => ({
+    components: { DesktopContextPanel },
+    template: `
+      <div style="width:320px;background:#111827;padding:16px;border-radius:8px">
+        <DesktopContextPanel />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/desktop/DesktopInterface.stories.ts
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.stories.ts
@@ -1,0 +1,116 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import type { Meta } from '@storybook/vue3';
+import DesktopInterface from './DesktopInterface.vue';
+import type { SelectorHost } from '@/composables/useHostSelector';
+
+const meta = {
+  title: 'Components/Desktop/DesktopInterface',
+  component: DesktopInterface,
+  tags: ['autodocs'],
+  argTypes: {
+    host: {
+      control: 'object',
+      description:
+        'Optional SelectorHost record. When provided the VNC URL is derived directly ' +
+        'from host.host + host.vnc_port instead of loading from AppConfig.',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Full-featured desktop streaming interface wrapping an iframe VNC session. ' +
+          'Includes connection controls (fullscreen, reconnect, open in new window), ' +
+          'desktop action toolbar (screenshot, type text, Ctrl+Alt+Del, clipboard paste), ' +
+          'and an optional collapsible DesktopContextPanel overlay.',
+      },
+    },
+    layout: 'fullscreen',
+  },
+} as Meta<typeof DesktopInterface>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = import('@storybook/vue3').StoryObj<any>;
+
+/**
+ * Default — no host prop; the component attempts to load the VNC URL from AppConfig.
+ * In Storybook (no backend), it will land in the error/config-failure state showing the
+ * error UI and Reconnect button.
+ */
+export const Default: Story = {
+  args: {
+    host: null,
+  },
+  render: (args: any) => ({
+    components: { DesktopInterface },
+    setup() { return { args } },
+    template: `<div style="height:600px"><DesktopInterface v-bind="args" /></div>`,
+  }),
+};
+
+/**
+ * With a host record injected — the component derives the VNC URL directly without
+ * hitting AppConfig. The iframe will load (or show an error if the host is unreachable).
+ * Replace host values with a real VM host when testing against a live environment.
+ */
+export const WithHostProp: Story = {
+  args: {
+    host: {
+      host: 'desktop-vm.local',
+      vnc_port: 6080,
+      label: 'Frontend VM',
+    } satisfies Partial<SelectorHost>,
+  },
+  render: (args: any) => ({
+    components: { DesktopInterface },
+    setup() { return { args } },
+    template: `<div style="height:600px"><DesktopInterface v-bind="args" /></div>`,
+  }),
+};
+
+/**
+ * Compact height — shows how the layout adapts in a split-pane or panel context.
+ */
+export const CompactHeight: Story = {
+  args: { host: null },
+  render: (args: any) => ({
+    components: { DesktopInterface },
+    setup() { return { args } },
+    template: `<div style="height:360px"><DesktopInterface v-bind="args" /></div>`,
+  }),
+};
+
+/**
+ * Tall layout — full page display.
+ */
+export const TallLayout: Story = {
+  args: { host: null },
+  render: (args: any) => ({
+    components: { DesktopInterface },
+    setup() { return { args } },
+    template: `<div style="height:900px"><DesktopInterface v-bind="args" /></div>`,
+  }),
+};
+
+/**
+ * Custom VM host — demonstrates changing the target VM at runtime.
+ * Replace host/port with actual values when using against a live environment.
+ */
+export const CustomVmHost: Story = {
+  args: {
+    host: {
+      host: 'worker-vm.local',
+      vnc_port: 6081,
+      label: 'Worker VM',
+    } satisfies Partial<SelectorHost>,
+  },
+  render: (args: any) => ({
+    components: { DesktopInterface },
+    setup() { return { args } },
+    template: `<div style="height:600px"><DesktopInterface v-bind="args" /></div>`,
+  }),
+};

--- a/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.stories.ts
+++ b/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.stories.ts
@@ -1,0 +1,136 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import type { Meta } from '@storybook/vue3';
+import PopoutChromiumBrowser from './PopoutChromiumBrowser.vue';
+
+const meta = {
+  title: 'Components/Desktop/PopoutChromiumBrowser',
+  component: PopoutChromiumBrowser,
+  tags: ['autodocs'],
+  argTypes: {
+    sessionId: {
+      control: 'text',
+      description:
+        'Browser session identifier. Pass "manual-browser" to show the launch-session ' +
+        'empty state; any other non-empty value triggers Playwright session initialization.',
+    },
+    initialUrl: {
+      control: 'text',
+      description: 'Starting URL loaded into the address bar on mount.',
+    },
+    canResize: {
+      control: 'boolean',
+      description: 'Enables ResizeObserver for responsive layout adjustments.',
+    },
+    autoPopout: {
+      control: 'boolean',
+      description: 'When true the browser pops out of the panel automatically on mount.',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Headed Chromium browser panel backed by Playwright automation. Renders a VNC ' +
+          'iframe for live browser display, an address bar with navigation controls, a ' +
+          'Playwright automation panel (web search, frontend tests, test messages), and a ' +
+          'developer tools console overlay.',
+      },
+    },
+    layout: 'fullscreen',
+  },
+} as Meta<typeof PopoutChromiumBrowser>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = import('@storybook/vue3').StoryObj<any>;
+
+/**
+ * Manual browser mode — sessionId = "manual-browser" shows the empty state with a
+ * "Launch Session" button and no VNC iframe.
+ */
+export const ManualBrowserMode: Story = {
+  args: {
+    sessionId: 'manual-browser',
+    initialUrl: 'about:blank',
+    canResize: true,
+    autoPopout: false,
+  },
+  render: (args: any) => ({
+    components: { PopoutChromiumBrowser },
+    setup() { return { args } },
+    template: `<div style="height:600px"><PopoutChromiumBrowser v-bind="args" @close="() => {}" /></div>`,
+  }),
+};
+
+/**
+ * Active session — triggers Playwright connection flow. In Storybook (no backend) the
+ * component will reach the error state showing the retry button.
+ */
+export const ActiveSession: Story = {
+  args: {
+    sessionId: 'session-abc12345',
+    initialUrl: 'https://example.com',
+    canResize: true,
+    autoPopout: false,
+  },
+  render: (args: any) => ({
+    components: { PopoutChromiumBrowser },
+    setup() { return { args } },
+    template: `<div style="height:600px"><PopoutChromiumBrowser v-bind="args" @close="() => {}" /></div>`,
+  }),
+};
+
+/**
+ * HTTPS secure URL — the lock icon in the address bar should be visible.
+ */
+export const SecureUrl: Story = {
+  args: {
+    sessionId: 'session-secure',
+    initialUrl: 'https://anthropic.com',
+    canResize: true,
+    autoPopout: false,
+  },
+  render: (args: any) => ({
+    components: { PopoutChromiumBrowser },
+    setup() { return { args } },
+    template: `<div style="height:600px"><PopoutChromiumBrowser v-bind="args" @close="() => {}" /></div>`,
+  }),
+};
+
+/**
+ * Non-resizable variant — ResizeObserver is disabled; layout is fixed.
+ */
+export const NonResizable: Story = {
+  args: {
+    sessionId: 'session-fixed',
+    initialUrl: 'about:blank',
+    canResize: false,
+    autoPopout: false,
+  },
+  render: (args: any) => ({
+    components: { PopoutChromiumBrowser },
+    setup() { return { args } },
+    template: `<div style="height:500px;width:800px"><PopoutChromiumBrowser v-bind="args" @close="() => {}" /></div>`,
+  }),
+};
+
+/**
+ * Compact embedding — demonstrates the browser at a smaller container size used in
+ * split-pane research layouts.
+ */
+export const CompactEmbedded: Story = {
+  args: {
+    sessionId: 'manual-browser',
+    initialUrl: 'about:blank',
+    canResize: false,
+    autoPopout: false,
+  },
+  render: (args: any) => ({
+    components: { PopoutChromiumBrowser },
+    setup() { return { args } },
+    template: `<div style="height:400px;width:640px"><PopoutChromiumBrowser v-bind="args" @close="() => {}" /></div>`,
+  }),
+};


### PR DESCRIPTION
Adds stories for ConnectionSettingsPanel (5 stories), DesktopContextPanel (5), DesktopInterface (5 with host prop), PopoutChromiumBrowser (5 with all props). Closes #6860. Part of #4201 Phase 2.