### PR TITLE
refactor(frontend/visualizations): add Storybook stories for 5 visualization components (#6857)

### DIFF
--- a/autobot-frontend/src/components/visualizations/AgentActivityVisualization.stories.ts
+++ b/autobot-frontend/src/components/visualizations/AgentActivityVisualization.stories.ts
@@ -1,0 +1,62 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import type { Meta, StoryObj } from '@storybook/vue3'
+import AgentActivityVisualization from './AgentActivityVisualization.vue'
+
+const meta = {
+  title: 'Components/Visualizations/AgentActivityVisualization',
+  component: AgentActivityVisualization,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Override the default panel title',
+    },
+    refreshInterval: {
+      control: 'number',
+      description: 'Polling interval in milliseconds (0 = disabled)',
+    },
+  },
+} as Meta<typeof AgentActivityVisualization>
+
+export default meta
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>
+
+export const Default: Story = {
+  args: {
+    refreshInterval: 0,
+  },
+}
+
+export const WithCustomTitle: Story = {
+  args: {
+    title: 'Production Agent Fleet',
+    refreshInterval: 0,
+  },
+}
+
+export const LivePolling: Story = {
+  args: {
+    title: 'Live Agent Activity',
+    refreshInterval: 5000,
+  },
+}
+
+export const GridView: Story = {
+  name: 'Grid View (Default)',
+  args: {
+    title: 'Agent Grid',
+    refreshInterval: 0,
+  },
+}
+
+export const NoAutoRefresh: Story = {
+  name: 'Static — No Auto Refresh',
+  args: {
+    title: 'Static Agent View',
+    refreshInterval: 0,
+  },
+}

--- a/autobot-frontend/src/components/visualizations/ResourceHeatmap.stories.ts
+++ b/autobot-frontend/src/components/visualizations/ResourceHeatmap.stories.ts
@@ -1,0 +1,80 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import type { Meta, StoryObj } from '@storybook/vue3'
+import ResourceHeatmap from './ResourceHeatmap.vue'
+
+const meta = {
+  title: 'Components/Visualizations/ResourceHeatmap',
+  component: ResourceHeatmap,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Override the default panel title',
+    },
+    height: {
+      control: 'number',
+      description: 'Chart height in pixels',
+    },
+    refreshInterval: {
+      control: 'number',
+      description: 'Polling interval in milliseconds (0 = disabled)',
+    },
+    machine: {
+      control: 'select',
+      options: ['all', 'main-vm', 'frontend-vm', 'browser-vm'],
+      description: 'Filter metrics to a specific machine or show all',
+    },
+  },
+} as Meta<typeof ResourceHeatmap>
+
+export default meta
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>
+
+export const Default: Story = {
+  args: {
+    height: 350,
+    refreshInterval: 0,
+    machine: 'all',
+  },
+}
+
+export const WithCustomTitle: Story = {
+  args: {
+    title: 'CPU Usage Heatmap',
+    height: 350,
+    refreshInterval: 0,
+    machine: 'all',
+  },
+}
+
+export const TallChart: Story = {
+  name: 'Tall Chart (500px)',
+  args: {
+    height: 500,
+    refreshInterval: 0,
+    machine: 'all',
+  },
+}
+
+export const SingleMachine: Story = {
+  name: 'Single Machine Filter',
+  args: {
+    title: 'Main VM Resources',
+    height: 350,
+    refreshInterval: 0,
+    machine: 'main-vm',
+  },
+}
+
+export const LivePolling: Story = {
+  args: {
+    title: 'Live Resource Heatmap',
+    height: 350,
+    refreshInterval: 60000,
+    machine: 'all',
+  },
+}

--- a/autobot-frontend/src/components/visualizations/ServiceMessageTimeline.stories.ts
+++ b/autobot-frontend/src/components/visualizations/ServiceMessageTimeline.stories.ts
@@ -1,0 +1,73 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import type { Meta, StoryObj } from '@storybook/vue3'
+import ServiceMessageTimeline from './ServiceMessageTimeline.vue'
+
+const meta = {
+  title: 'Components/Visualizations/ServiceMessageTimeline',
+  component: ServiceMessageTimeline,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof ServiceMessageTimeline>
+
+export default meta
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>
+
+export const Default: Story = {
+  name: 'Default (All Messages)',
+  args: {},
+}
+
+export const FilteredBySender: Story = {
+  name: 'Filtered by Sender',
+  render: () => ({
+    components: { ServiceMessageTimeline },
+    template: `
+      <div style="height: 500px; background: var(--bg-primary, #1a1a2e); border-radius: 8px; overflow: hidden;">
+        <ServiceMessageTimeline />
+      </div>
+    `,
+  }),
+}
+
+export const Compact: Story = {
+  name: 'Compact Container',
+  render: () => ({
+    components: { ServiceMessageTimeline },
+    template: `
+      <div style="height: 300px; background: var(--bg-primary, #1a1a2e); border-radius: 8px; overflow: hidden;">
+        <ServiceMessageTimeline />
+      </div>
+    `,
+  }),
+}
+
+export const FullHeight: Story = {
+  name: 'Full Height Container',
+  render: () => ({
+    components: { ServiceMessageTimeline },
+    template: `
+      <div style="height: 700px; background: var(--bg-primary, #1a1a2e); border-radius: 8px; overflow: hidden;">
+        <ServiceMessageTimeline />
+      </div>
+    `,
+  }),
+}
+
+export const InPanel: Story = {
+  name: 'Inside Dashboard Panel',
+  render: () => ({
+    components: { ServiceMessageTimeline },
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 12px; padding: 16px; background: #0f172a; min-height: 500px;">
+        <h2 style="color: #e0e0ff; font-size: 14px; margin: 0;">Service Message Audit Trail</h2>
+        <div style="flex: 1; background: var(--bg-primary, #1a1a2e); border-radius: 8px; overflow: hidden; min-height: 440px;">
+          <ServiceMessageTimeline />
+        </div>
+      </div>
+    `,
+  }),
+}

--- a/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.stories.ts
+++ b/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.stories.ts
@@ -1,0 +1,75 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import type { Meta, StoryObj } from '@storybook/vue3'
+import SystemArchitectureDiagram from './SystemArchitectureDiagram.vue'
+
+const meta = {
+  title: 'Components/Visualizations/SystemArchitectureDiagram',
+  component: SystemArchitectureDiagram,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Override the default diagram title',
+    },
+    height: {
+      control: 'number',
+      description: 'Diagram canvas height in pixels',
+    },
+    autoRefresh: {
+      control: 'boolean',
+      description: 'Automatically refresh service health at the given interval',
+    },
+    refreshInterval: {
+      control: 'number',
+      description: 'Health refresh interval in milliseconds',
+    },
+  },
+} as Meta<typeof SystemArchitectureDiagram>
+
+export default meta
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>
+
+export const Default: Story = {
+  args: {
+    height: 600,
+    autoRefresh: false,
+  },
+}
+
+export const WithCustomTitle: Story = {
+  args: {
+    title: 'AutoBot Production Architecture',
+    height: 600,
+    autoRefresh: false,
+  },
+}
+
+export const Compact: Story = {
+  name: 'Compact (400px)',
+  args: {
+    height: 400,
+    autoRefresh: false,
+  },
+}
+
+export const WithAutoRefresh: Story = {
+  name: 'Auto-Refresh Enabled',
+  args: {
+    title: 'Live Architecture',
+    height: 600,
+    autoRefresh: true,
+    refreshInterval: 30000,
+  },
+}
+
+export const Tall: Story = {
+  name: 'Tall Canvas (800px)',
+  args: {
+    height: 800,
+    autoRefresh: false,
+  },
+}

--- a/autobot-frontend/src/components/visualizations/WorkflowVisualization.stories.ts
+++ b/autobot-frontend/src/components/visualizations/WorkflowVisualization.stories.ts
@@ -1,0 +1,129 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import type { Meta, StoryObj } from '@storybook/vue3'
+import WorkflowVisualization from './WorkflowVisualization.vue'
+
+const meta = {
+  title: 'Components/Visualizations/WorkflowVisualization',
+  component: WorkflowVisualization,
+  tags: ['autodocs'],
+  argTypes: {
+    layoutMode: {
+      control: 'select',
+      options: ['horizontal', 'vertical'],
+      description: 'Initial node layout direction',
+    },
+    workflow: {
+      control: 'object',
+      description: 'Workflow data (nodes + connections). Omit to use built-in sample data.',
+    },
+  },
+} as Meta<typeof WorkflowVisualization>
+
+export default meta
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>
+
+export const SampleData: Story = {
+  name: 'Sample Data (No Props)',
+  args: {
+    layoutMode: 'horizontal',
+  },
+}
+
+export const HorizontalLayout: Story = {
+  args: {
+    layoutMode: 'horizontal',
+  },
+}
+
+export const VerticalLayout: Story = {
+  args: {
+    layoutMode: 'vertical',
+  },
+}
+
+const completedWorkflow = {
+  id: 'wf-demo-001',
+  name: 'Data Pipeline — Completed',
+  status: 'completed' as const,
+  nodes: [
+    { id: 'start', name: 'Start', type: 'start' as const, status: 'completed' as const, x: 100, y: 150 },
+    { id: 'fetch', name: 'Fetch Data', type: 'action' as const, status: 'completed' as const, x: 280, y: 150, duration: 2300 },
+    { id: 'validate', name: 'Validate', type: 'decision' as const, status: 'completed' as const, x: 460, y: 150, duration: 310 },
+    { id: 'transform', name: 'Transform', type: 'task' as const, status: 'completed' as const, x: 640, y: 80, duration: 5100 },
+    { id: 'store', name: 'Store Result', type: 'action' as const, status: 'completed' as const, x: 820, y: 150, duration: 780 },
+    { id: 'end', name: 'End', type: 'end' as const, status: 'completed' as const, x: 1000, y: 150 },
+  ],
+  connections: [
+    { from: 'start', to: 'fetch', status: 'success' as const },
+    { from: 'fetch', to: 'validate', status: 'success' as const },
+    { from: 'validate', to: 'transform', status: 'success' as const, label: 'valid' },
+    { from: 'transform', to: 'store', status: 'success' as const },
+    { from: 'store', to: 'end', status: 'success' as const },
+  ],
+}
+
+export const CompletedWorkflow: Story = {
+  name: 'Completed Workflow',
+  args: {
+    workflow: completedWorkflow,
+    layoutMode: 'horizontal',
+  },
+}
+
+const runningWorkflow = {
+  id: 'wf-demo-002',
+  name: 'Model Training — Running',
+  status: 'running' as const,
+  nodes: [
+    { id: 'start', name: 'Start', type: 'start' as const, status: 'completed' as const, x: 100, y: 150 },
+    { id: 'prep', name: 'Prepare Data', type: 'action' as const, status: 'completed' as const, x: 280, y: 150, duration: 4500 },
+    { id: 'train', name: 'Train Model', type: 'task' as const, status: 'running' as const, x: 460, y: 150 },
+    { id: 'eval', name: 'Evaluate', type: 'action' as const, status: 'pending' as const, x: 640, y: 150 },
+    { id: 'end', name: 'End', type: 'end' as const, status: 'pending' as const, x: 820, y: 150 },
+  ],
+  connections: [
+    { from: 'start', to: 'prep', status: 'success' as const },
+    { from: 'prep', to: 'train', status: 'active' as const },
+    { from: 'train', to: 'eval' },
+    { from: 'eval', to: 'end' },
+  ],
+}
+
+export const RunningWorkflow: Story = {
+  name: 'Running Workflow',
+  args: {
+    workflow: runningWorkflow,
+    layoutMode: 'horizontal',
+  },
+}
+
+const failedWorkflow = {
+  id: 'wf-demo-003',
+  name: 'Deployment Pipeline — Failed',
+  status: 'failed' as const,
+  nodes: [
+    { id: 'start', name: 'Start', type: 'start' as const, status: 'completed' as const, x: 100, y: 150 },
+    { id: 'build', name: 'Build Image', type: 'action' as const, status: 'completed' as const, x: 280, y: 150, duration: 18000 },
+    { id: 'test', name: 'Run Tests', type: 'task' as const, status: 'failed' as const, x: 460, y: 150, duration: 3200, error: 'Test suite failed: 3 assertions failed in auth module' },
+    { id: 'deploy', name: 'Deploy', type: 'action' as const, status: 'skipped' as const, x: 640, y: 150 },
+    { id: 'end', name: 'End', type: 'end' as const, status: 'pending' as const, x: 820, y: 150 },
+  ],
+  connections: [
+    { from: 'start', to: 'build', status: 'success' as const },
+    { from: 'build', to: 'test', status: 'success' as const },
+    { from: 'test', to: 'deploy', status: 'error' as const },
+    { from: 'deploy', to: 'end' },
+  ],
+}
+
+export const FailedWorkflow: Story = {
+  name: 'Failed Workflow',
+  args: {
+    workflow: failedWorkflow,
+    layoutMode: 'horizontal',
+  },
+}


### PR DESCRIPTION
Adds stories for AgentActivityVisualization (5), ResourceHeatmap (5), ServiceMessageTimeline (5), SystemArchitectureDiagram (5), WorkflowVisualization (7). Closes #6857. Part of #4201 Phase 2.