### PR TITLE
refactor(frontend/manpage): add Storybook stories for 6 manpage components (#6855)

### DIFF
--- a/autobot-frontend/src/components/manpage/IntegrationActionsPanel.stories.ts
+++ b/autobot-frontend/src/components/manpage/IntegrationActionsPanel.stories.ts
@@ -1,0 +1,78 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+import type { Meta, StoryObj } from '@storybook/vue3';
+import IntegrationActionsPanel from './IntegrationActionsPanel.vue';
+
+const meta = {
+  title: 'Components/ManPage/IntegrationActionsPanel',
+  component: IntegrationActionsPanel,
+  tags: ['autodocs'],
+  argTypes: {
+    loading: {
+      control: 'object',
+      description: 'Loading state for each action button',
+    },
+    canInitialize: {
+      control: 'boolean',
+      description: 'Whether the initialize action is available',
+    },
+    canIntegrate: {
+      control: 'boolean',
+      description: 'Whether the integrate action is available',
+    },
+    hasIntegration: {
+      control: 'boolean',
+      description: 'Whether an integration exists (enables test search)',
+    },
+  },
+} as Meta<typeof IntegrationActionsPanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    loading: { initialize: false, integrate: false, search: false },
+    canInitialize: true,
+    canIntegrate: true,
+    hasIntegration: true,
+  },
+};
+
+export const AllDisabled: Story = {
+  args: {
+    loading: { initialize: false, integrate: false, search: false },
+    canInitialize: false,
+    canIntegrate: false,
+    hasIntegration: false,
+  },
+};
+
+export const InitializeLoading: Story = {
+  args: {
+    loading: { initialize: true, integrate: false, search: false },
+    canInitialize: true,
+    canIntegrate: true,
+    hasIntegration: false,
+  },
+};
+
+export const IntegrateLoading: Story = {
+  args: {
+    loading: { initialize: false, integrate: true, search: false },
+    canInitialize: true,
+    canIntegrate: true,
+    hasIntegration: true,
+  },
+};
+
+export const SearchLoading: Story = {
+  args: {
+    loading: { initialize: false, integrate: false, search: true },
+    canInitialize: true,
+    canIntegrate: true,
+    hasIntegration: true,
+  },
+};

--- a/autobot-frontend/src/components/manpage/IntegrationStatusPanel.stories.ts
+++ b/autobot-frontend/src/components/manpage/IntegrationStatusPanel.stories.ts
@@ -1,0 +1,75 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+import type { Meta, StoryObj } from '@storybook/vue3';
+import IntegrationStatusPanel from './IntegrationStatusPanel.vue';
+
+const meta = {
+  title: 'Components/ManPage/IntegrationStatusPanel',
+  component: IntegrationStatusPanel,
+  tags: ['autodocs'],
+  argTypes: {
+    status: {
+      control: 'object',
+      description: 'Integration status object',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading spinner',
+    },
+  },
+} as Meta<typeof IntegrationStatusPanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const NotIntegrated: Story = {
+  args: {
+    status: { status: 'not_integrated' },
+    loading: false,
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    status: { status: 'error', message: 'Connection to knowledge base failed.' },
+    loading: false,
+  },
+};
+
+export const Integrated: Story = {
+  args: {
+    status: {
+      status: 'integrated',
+      successful: 142,
+      processed: 150,
+      current_man_page_files: 142,
+      total_available_tools: 98,
+      integration_date: '2025-05-10T14:30:00Z',
+      available_commands: ['ls', 'grep', 'awk', 'sed', 'curl', 'ssh', 'git', 'docker'],
+    },
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    status: null,
+    loading: true,
+  },
+};
+
+export const IntegratedNoCommands: Story = {
+  args: {
+    status: {
+      status: 'integrated',
+      successful: 10,
+      processed: 10,
+      current_man_page_files: 10,
+      total_available_tools: 5,
+      integration_date: '2025-05-01T08:00:00Z',
+    },
+    loading: false,
+  },
+};

--- a/autobot-frontend/src/components/manpage/MachineProfilePanel.stories.ts
+++ b/autobot-frontend/src/components/manpage/MachineProfilePanel.stories.ts
@@ -1,0 +1,81 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+import type { Meta, StoryObj } from '@storybook/vue3';
+import MachineProfilePanel from './MachineProfilePanel.vue';
+
+const meta = {
+  title: 'Components/ManPage/MachineProfilePanel',
+  component: MachineProfilePanel,
+  tags: ['autodocs'],
+  argTypes: {
+    profile: {
+      control: 'object',
+      description: 'Machine profile data object',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading spinner',
+    },
+  },
+} as Meta<typeof MachineProfilePanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const LinuxProfile: Story = {
+  args: {
+    profile: {
+      machine_id: 'autobot-node-01',
+      os_type: 'linux',
+      distro: 'Ubuntu 22.04 LTS',
+      package_manager: 'apt',
+      available_tools: ['curl', 'wget', 'git', 'docker', 'python3', 'pip3'],
+      architecture: 'x86_64',
+    },
+    loading: false,
+  },
+};
+
+export const WindowsProfile: Story = {
+  args: {
+    profile: {
+      machine_id: 'autobot-win-01',
+      os_type: 'windows',
+      distro: 'N/A',
+      package_manager: 'winget',
+      available_tools: ['powershell', 'git'],
+      architecture: 'x86_64',
+    },
+    loading: false,
+  },
+};
+
+export const MacOSProfile: Story = {
+  args: {
+    profile: {
+      machine_id: 'autobot-mac-01',
+      os_type: 'macos',
+      distro: 'Ventura 13.5',
+      package_manager: 'brew',
+      available_tools: ['curl', 'git', 'python3'],
+      architecture: 'arm64',
+    },
+    loading: false,
+  },
+};
+
+export const NoData: Story = {
+  args: {
+    profile: null,
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    profile: null,
+    loading: true,
+  },
+};

--- a/autobot-frontend/src/components/manpage/ManPageManager.stories.ts
+++ b/autobot-frontend/src/components/manpage/ManPageManager.stories.ts
@@ -1,0 +1,41 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+import type { Meta, StoryObj } from '@storybook/vue3';
+import ManPageManager from './ManPageManager.vue';
+
+const meta = {
+  title: 'Components/ManPage/ManPageManager',
+  component: ManPageManager,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof ManPageManager>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+// ManPageManager is self-contained: it fetches its own data via composables on mount.
+// Stories render the shell; real data requires a live backend.
+
+export const Default: Story = {
+  render: () => ({
+    components: { ManPageManager },
+    template: '<ManPageManager />',
+  }),
+};
+
+export const WithStubSetup: Story = {
+  name: 'Default (stub note)',
+  render: () => ({
+    components: { ManPageManager },
+    template: `
+      <div>
+        <p style="color: var(--color-warning, #f39c12); margin-bottom: 8px; font-size: 0.85rem;">
+          Note: ManPageManager fetches live data on mount. Connect to a running backend to see populated state.
+        </p>
+        <ManPageManager />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/manpage/ManPageSearchPanel.stories.ts
+++ b/autobot-frontend/src/components/manpage/ManPageSearchPanel.stories.ts
@@ -1,0 +1,109 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+import type { Meta, StoryObj } from '@storybook/vue3';
+import ManPageSearchPanel from './ManPageSearchPanel.vue';
+
+const meta = {
+  title: 'Components/ManPage/ManPageSearchPanel',
+  component: ManPageSearchPanel,
+  tags: ['autodocs'],
+  argTypes: {
+    show: {
+      control: 'boolean',
+      description: 'Whether the panel is visible',
+    },
+    query: {
+      control: 'text',
+      description: 'Current search query (v-model)',
+    },
+    lastQuery: {
+      control: 'text',
+      description: 'Last executed search query (shown in results heading)',
+    },
+    results: {
+      control: 'object',
+      description: 'Array of search results, or null before first search',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Disable search button while loading',
+    },
+  },
+} as Meta<typeof ManPageSearchPanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Hidden: Story = {
+  args: {
+    show: false,
+    query: '',
+    lastQuery: '',
+    results: null,
+    loading: false,
+  },
+};
+
+export const EmptyQuery: Story = {
+  args: {
+    show: true,
+    query: '',
+    lastQuery: '',
+    results: null,
+    loading: false,
+  },
+};
+
+export const WithResults: Story = {
+  args: {
+    show: true,
+    query: 'network interface',
+    lastQuery: 'network interface',
+    results: [
+      {
+        command: 'ip',
+        purpose: 'Show and manipulate routing, network devices, interfaces and tunnels.',
+        relevance_score: 0.92,
+        source: 'man8',
+        machine_id: 'autobot-node-01',
+      },
+      {
+        command: 'ifconfig',
+        purpose: 'Configure a network interface.',
+        relevance_score: 0.85,
+        source: 'man8',
+        machine_id: 'autobot-node-01',
+      },
+      {
+        command: 'netstat',
+        purpose: 'Print network connections, routing tables, interface statistics.',
+        relevance_score: 0.78,
+        source: 'man8',
+        machine_id: 'autobot-node-01',
+      },
+    ],
+    loading: false,
+  },
+};
+
+export const NoResults: Story = {
+  args: {
+    show: true,
+    query: 'xyzzy_unknown',
+    lastQuery: 'xyzzy_unknown',
+    results: [],
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    show: true,
+    query: 'file permissions',
+    lastQuery: 'file permissions',
+    results: null,
+    loading: true,
+  },
+};

--- a/autobot-frontend/src/components/manpage/ProgressTrackingPanel.stories.ts
+++ b/autobot-frontend/src/components/manpage/ProgressTrackingPanel.stories.ts
@@ -1,0 +1,118 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+import type { Meta, StoryObj } from '@storybook/vue3';
+import ProgressTrackingPanel from './ProgressTrackingPanel.vue';
+
+const meta = {
+  title: 'Components/ManPage/ProgressTrackingPanel',
+  component: ProgressTrackingPanel,
+  tags: ['autodocs'],
+  argTypes: {
+    show: {
+      control: 'boolean',
+      description: 'Whether the panel is visible',
+    },
+    state: {
+      control: 'object',
+      description: 'Progress state object',
+    },
+    websocketConnected: {
+      control: 'boolean',
+      description: 'WebSocket connection status',
+    },
+  },
+} as Meta<typeof ProgressTrackingPanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Hidden: Story = {
+  args: {
+    show: false,
+    state: {
+      currentTask: '',
+      taskDetail: '',
+      overallProgress: 0,
+      taskProgress: 0,
+      status: 'waiting',
+      messages: [],
+    },
+    websocketConnected: false,
+  },
+};
+
+export const Waiting: Story = {
+  args: {
+    show: true,
+    state: {
+      currentTask: '',
+      taskDetail: '',
+      overallProgress: 0,
+      taskProgress: 0,
+      status: 'waiting',
+      messages: [],
+    },
+    websocketConnected: true,
+  },
+};
+
+export const Running: Story = {
+  args: {
+    show: true,
+    state: {
+      currentTask: 'Integrating man pages',
+      taskDetail: 'Processing section 8 commands',
+      overallProgress: 55,
+      taskProgress: 72,
+      status: 'running',
+      messages: [
+        { text: 'Starting integration...', type: 'info', timestamp: Date.now() - 30000 },
+        { text: 'Profile detected: Ubuntu 22.04', type: 'success', timestamp: Date.now() - 20000 },
+        { text: 'Processing section 1 commands (42 found)', type: 'info', timestamp: Date.now() - 10000 },
+        { text: 'Processing section 8 commands (67 found)', type: 'info', timestamp: Date.now() - 2000 },
+      ],
+    },
+    websocketConnected: true,
+  },
+};
+
+export const Completed: Story = {
+  args: {
+    show: true,
+    state: {
+      currentTask: 'Integration complete',
+      taskDetail: 'All man pages processed successfully',
+      overallProgress: 100,
+      taskProgress: 100,
+      status: 'success',
+      messages: [
+        { text: 'Starting integration...', type: 'info', timestamp: Date.now() - 60000 },
+        { text: 'Profile detected: Ubuntu 22.04', type: 'success', timestamp: Date.now() - 50000 },
+        { text: 'Processed 142 man pages', type: 'success', timestamp: Date.now() - 10000 },
+        { text: 'Integration complete!', type: 'success', timestamp: Date.now() - 1000 },
+      ],
+    },
+    websocketConnected: true,
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    show: true,
+    state: {
+      currentTask: 'Integration Failed',
+      taskDetail: 'Backend connection lost',
+      overallProgress: 30,
+      taskProgress: 0,
+      status: 'error',
+      messages: [
+        { text: 'Starting integration...', type: 'info', timestamp: Date.now() - 20000 },
+        { text: 'Profile detected: Ubuntu 22.04', type: 'success', timestamp: Date.now() - 15000 },
+        { text: 'Error: Backend connection lost', type: 'error', timestamp: Date.now() - 5000 },
+      ],
+    },
+    websocketConnected: false,
+  },
+};


### PR DESCRIPTION
Adds stories for IntegrationActionsPanel (5), IntegrationStatusPanel (5), MachineProfilePanel (5), ManPageManager (2), ManPageSearchPanel (5), ProgressTrackingPanel (5). Closes #6855. Part of #4201 Phase 2.