### PR TITLE
refactor(frontend/settings): add Storybook stories for 6 settings components (#6853)

### DIFF
--- a/autobot-frontend/src/components/settings/ApiKeySetupWizard.stories.ts
+++ b/autobot-frontend/src/components/settings/ApiKeySetupWizard.stories.ts
@@ -1,0 +1,65 @@
+import type { Meta } from '@storybook/vue3';
+import ApiKeySetupWizard from './ApiKeySetupWizard.vue';
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const meta = {
+  title: 'Components/Settings/ApiKeySetupWizard',
+  component: ApiKeySetupWizard,
+  tags: ['autodocs'],
+  argTypes: {
+    modelValue: {
+      control: 'boolean',
+      description: 'Controls the visibility of the wizard modal (v-model)',
+    },
+  },
+} as Meta<typeof ApiKeySetupWizard>;
+
+export default meta;
+
+export const Open: Story = {
+  args: {
+    modelValue: true,
+  },
+};
+
+export const Closed: Story = {
+  args: {
+    modelValue: false,
+  },
+};
+
+export const StepOne: Story = {
+  name: 'Step 1 – Role Selection',
+  args: {
+    modelValue: true,
+  },
+};
+
+export const WithRolesSelected: Story = {
+  name: 'With Roles Pre-selected (render)',
+  render: () => ({
+    components: { ApiKeySetupWizard },
+    data() {
+      return { open: true };
+    },
+    template: `<ApiKeySetupWizard v-model="open" />`,
+  }),
+};
+
+export const ClosedState: Story = {
+  name: 'Modal Hidden',
+  render: () => ({
+    components: { ApiKeySetupWizard },
+    data() {
+      return { open: false };
+    },
+    template: `
+      <div>
+        <p style="color:#aaa">Modal is closed — modelValue=false</p>
+        <ApiKeySetupWizard v-model="open" />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.stories.ts
@@ -1,0 +1,61 @@
+import type { Meta } from '@storybook/vue3';
+import FeatureFlagsSettingsPanel from './FeatureFlagsSettingsPanel.vue';
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const meta = {
+  title: 'Components/Settings/FeatureFlagsSettingsPanel',
+  component: FeatureFlagsSettingsPanel,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof FeatureFlagsSettingsPanel>;
+
+export default meta;
+
+// The panel fetches its own data on mount; stories render the full
+// lifecycle with the network calls hitting the real backend (or MSW mocks).
+
+export const Default: Story = {
+  name: 'Default (fetches on mount)',
+  render: () => ({
+    components: { FeatureFlagsSettingsPanel },
+    template: `<FeatureFlagsSettingsPanel />`,
+  }),
+};
+
+export const LoadingState: Story = {
+  name: 'Loading State (render)',
+  render: () => ({
+    components: { FeatureFlagsSettingsPanel },
+    template: `
+      <div style="max-width:800px">
+        <FeatureFlagsSettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+export const InContainer: Story = {
+  name: 'Inside Settings Container',
+  render: () => ({
+    components: { FeatureFlagsSettingsPanel },
+    template: `
+      <div style="padding:24px;background:var(--bg-primary,#0f0f23);min-height:400px">
+        <FeatureFlagsSettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+export const NarrowViewport: Story = {
+  name: 'Narrow Viewport',
+  render: () => ({
+    components: { FeatureFlagsSettingsPanel },
+    template: `
+      <div style="max-width:480px;padding:16px">
+        <FeatureFlagsSettingsPanel />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/settings/LanguageSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/settings/LanguageSettingsPanel.stories.ts
@@ -1,0 +1,64 @@
+import type { Meta } from '@storybook/vue3';
+import LanguageSettingsPanel from './LanguageSettingsPanel.vue';
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const meta = {
+  title: 'Components/Settings/LanguageSettingsPanel',
+  component: LanguageSettingsPanel,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof LanguageSettingsPanel>;
+
+export default meta;
+
+// LanguageSettingsPanel has no external props; it reads from usePreferences /
+// useAvailableLanguages composables on mount.
+
+export const Default: Story = {
+  name: 'Default',
+  render: () => ({
+    components: { LanguageSettingsPanel },
+    template: `<LanguageSettingsPanel />`,
+  }),
+};
+
+export const InCard: Story = {
+  name: 'In Settings Card',
+  render: () => ({
+    components: { LanguageSettingsPanel },
+    template: `
+      <div style="max-width:560px;padding:24px;background:var(--bg-primary,#0f0f23)">
+        <LanguageSettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+export const SuccessStatus: Story = {
+  name: 'After Successful Change (render)',
+  render: () => ({
+    components: { LanguageSettingsPanel },
+    template: `
+      <div style="max-width:560px">
+        <p style="color:#94a3b8;margin-bottom:12px;font-size:14px">
+          Select a language from the dropdown to see the success status message.
+        </p>
+        <LanguageSettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+export const NarrowViewport: Story = {
+  name: 'Narrow Viewport (mobile)',
+  render: () => ({
+    components: { LanguageSettingsPanel },
+    template: `
+      <div style="max-width:360px">
+        <LanguageSettingsPanel />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/settings/SettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/settings/SettingsPanel.stories.ts
@@ -1,0 +1,80 @@
+import type { Meta } from '@storybook/vue3';
+import SettingsPanel from './SettingsPanel.vue';
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const meta = {
+  title: 'Components/Settings/SettingsPanel',
+  component: SettingsPanel,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof SettingsPanel>;
+
+export default meta;
+
+// SettingsPanel is a data-container that fetches settings from the backend
+// on mount and uses router-view for sub-routes. Stories render the shell
+// with the default empty state visible until the async load resolves.
+
+export const Default: Story = {
+  name: 'Default (loading then offline)',
+  render: () => ({
+    components: { SettingsPanel },
+    template: `<SettingsPanel style="height:600px" />`,
+  }),
+};
+
+export const InFullWidthLayout: Story = {
+  name: 'Full-Width Layout',
+  render: () => ({
+    components: { SettingsPanel },
+    template: `
+      <div style="width:100%;height:700px;background:var(--bg-primary,#0f0f23)">
+        <SettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+export const OfflineState: Story = {
+  name: 'Offline / Backend Unreachable',
+  render: () => ({
+    components: { SettingsPanel },
+    template: `
+      <div style="max-width:1024px;height:600px">
+        <p style="color:#94a3b8;font-size:13px;margin-bottom:8px">
+          When the backend is unreachable, the panel shows an offline banner.
+        </p>
+        <SettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+export const NarrowSidebar: Story = {
+  name: 'Narrow (480px) Sidebar Mode',
+  render: () => ({
+    components: { SettingsPanel },
+    template: `
+      <div style="max-width:480px;height:600px;overflow:hidden">
+        <SettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+export const WithUnsavedChangesContext: Story = {
+  name: 'With Unsaved Changes Banner (context)',
+  render: () => ({
+    components: { SettingsPanel },
+    template: `
+      <div style="height:600px">
+        <p style="color:#f59e0b;font-size:13px;margin-bottom:8px">
+          Change a setting to trigger the save/discard action bar at the bottom.
+        </p>
+        <SettingsPanel />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/settings/VoiceSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/settings/VoiceSettingsPanel.stories.ts
@@ -1,0 +1,79 @@
+import type { Meta } from '@storybook/vue3';
+import VoiceSettingsPanel from './VoiceSettingsPanel.vue';
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const meta = {
+  title: 'Components/Settings/VoiceSettingsPanel',
+  component: VoiceSettingsPanel,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof VoiceSettingsPanel>;
+
+export default meta;
+
+// VoiceSettingsPanel has no external props; it fetches voice profiles via
+// useVoiceProfiles composable on mount.
+
+export const Default: Story = {
+  name: 'Default (fetches voices on mount)',
+  render: () => ({
+    components: { VoiceSettingsPanel },
+    template: `<VoiceSettingsPanel />`,
+  }),
+};
+
+export const InCard: Story = {
+  name: 'In Settings Card',
+  render: () => ({
+    components: { VoiceSettingsPanel },
+    template: `
+      <div style="max-width:520px;padding:20px;background:var(--bg-secondary,#1a1a2e);border-radius:8px">
+        <VoiceSettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+export const WithAddDialogHint: Story = {
+  name: 'Add Voice Dialog Hint',
+  render: () => ({
+    components: { VoiceSettingsPanel },
+    template: `
+      <div style="max-width:520px;padding:20px">
+        <p style="color:#94a3b8;font-size:13px;margin-bottom:12px">
+          Click "Add Voice Profile" to open the voice creation dialog.
+        </p>
+        <VoiceSettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+export const NarrowViewport: Story = {
+  name: 'Narrow Viewport (mobile)',
+  render: () => ({
+    components: { VoiceSettingsPanel },
+    template: `
+      <div style="max-width:360px;padding:12px">
+        <VoiceSettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+export const LoadingState: Story = {
+  name: 'Loading State (render)',
+  render: () => ({
+    components: { VoiceSettingsPanel },
+    template: `
+      <div style="max-width:520px">
+        <p style="color:#94a3b8;font-size:13px;margin-bottom:8px">
+          Loading spinner visible before voices are fetched.
+        </p>
+        <VoiceSettingsPanel />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/settings/WebResearchSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/settings/WebResearchSettingsPanel.stories.ts
@@ -1,0 +1,80 @@
+import type { Meta } from '@storybook/vue3';
+import WebResearchSettingsPanel from './WebResearchSettingsPanel.vue';
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const meta = {
+  title: 'Components/Settings/WebResearchSettingsPanel',
+  component: WebResearchSettingsPanel,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof WebResearchSettingsPanel>;
+
+export default meta;
+
+// WebResearchSettingsPanel has no external props; all state is managed by
+// useWebResearchStore (Pinia). Stories render the full form at its default
+// store state.
+
+export const Default: Story = {
+  name: 'Default',
+  render: () => ({
+    components: { WebResearchSettingsPanel },
+    template: `<WebResearchSettingsPanel />`,
+  }),
+};
+
+export const InCard: Story = {
+  name: 'In Settings Card',
+  render: () => ({
+    components: { WebResearchSettingsPanel },
+    template: `
+      <div style="max-width:680px;padding:24px;background:var(--bg-primary,#0f0f23)">
+        <WebResearchSettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+export const EnabledState: Story = {
+  name: 'Enabled – Research Active',
+  render: () => ({
+    components: { WebResearchSettingsPanel },
+    template: `
+      <div style="max-width:680px">
+        <p style="color:#94a3b8;font-size:13px;margin-bottom:12px">
+          Toggle the "Enable Web Research" switch to see the active state.
+        </p>
+        <WebResearchSettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+export const NarrowViewport: Story = {
+  name: 'Narrow Viewport (mobile)',
+  render: () => ({
+    components: { WebResearchSettingsPanel },
+    template: `
+      <div style="max-width:400px">
+        <WebResearchSettingsPanel />
+      </div>
+    `,
+  }),
+};
+
+export const ResetInteraction: Story = {
+  name: 'Reset Button Interaction',
+  render: () => ({
+    components: { WebResearchSettingsPanel },
+    template: `
+      <div style="max-width:680px">
+        <p style="color:#94a3b8;font-size:13px;margin-bottom:12px">
+          Modify any field then click Reset to revert all settings to defaults.
+        </p>
+        <WebResearchSettingsPanel />
+      </div>
+    `,
+  }),
+};


### PR DESCRIPTION
Adds stories for ApiKeySetupWizard (5), FeatureFlagsSettingsPanel (4), LanguageSettingsPanel (4), SettingsPanel (5), VoiceSettingsPanel (5), WebResearchSettingsPanel (5). Closes #6853. Part of #4201 Phase 2.