### PR TITLE
chore(tools): rename audit-unwired-trackers.py to audit_unwired_trackers.py (#7009)

### DIFF
--- a/.github/workflows/unwired-tracker-audit.yml
+++ b/.github/workflows/unwired-tracker-audit.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 pipeline-scripts/audit-unwired-trackers.py --json > findings.json || true
+          python3 pipeline-scripts/audit_unwired_trackers.py --json > findings.json || true
           count=$(jq 'length' findings.json)
           echo "count=${count}" >> "$GITHUB_OUTPUT"
           jq -r '"\(.file)\t#\(.tracker)"' findings.json | head -50
@@ -79,7 +79,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAX_ISSUES: ${{ github.event.inputs.max_issues || '10' }}
         run: |
-          python3 pipeline-scripts/audit-unwired-trackers.py \
+          python3 pipeline-scripts/audit_unwired_trackers.py \
             --file-issues --max-issues "$MAX_ISSUES"
 
       - name: Summary

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -662,7 +662,7 @@ class DatabaseMCPStatusResponse(BaseModel):
 # class ≥1 production caller, surface a ``useSandboxFiles`` composable.
 #
 # Until #7409 lands, these classes are intentionally caller-less. The
-# closure-gate audit (``audit-unwired-trackers.py``) will keep flagging
+# closure-gate audit (``audit_unwired_trackers.py``) will keep flagging
 # them; that's expected — the cure is implementing #7409, not deleting.
 # ---------------------------------------------------------------------------
 

--- a/pipeline-scripts/audit_unwired_trackers.py
+++ b/pipeline-scripts/audit_unwired_trackers.py
@@ -9,10 +9,10 @@ features whose tracker was closed prematurely — code complete, integration
 skipped — the pattern surfaced by the orchestration audit (#4048 → #6836).
 
 Usage:
-    pipeline-scripts/audit-unwired-trackers.py [--json]
+    pipeline-scripts/audit_unwired_trackers.py [--json]
         Print findings to stdout (human-readable or JSON).
 
-    pipeline-scripts/audit-unwired-trackers.py --file-issues
+    pipeline-scripts/audit_unwired_trackers.py --file-issues
         File a GitHub discovery issue for each finding (deduped against
         existing open issues by tracker number).
 
@@ -443,7 +443,7 @@ def file_discovery_issue(finding: Finding) -> Optional[int]:
     )
     body = f"""## Discovered by
 
-`pipeline-scripts/audit-unwired-trackers.py` — automated tracker cross-reference (#6836 process gate).
+`pipeline-scripts/audit_unwired_trackers.py` — automated tracker cross-reference (#6836 process gate).
 
 ## Finding
 

--- a/pipeline-scripts/test_audit_unwired_trackers.py
+++ b/pipeline-scripts/test_audit_unwired_trackers.py
@@ -2,7 +2,7 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Unit tests for pipeline-scripts/audit-unwired-trackers.py (#6929).
+"""Unit tests for pipeline-scripts/audit_unwired_trackers.py (#6929).
 
 Covers the surfaces flagged in #6927 (SCAN_DIRS gap), #6928 (regex gap),
 and #6929 (no tests). The script is the Tier-3 cron defense for the
@@ -12,7 +12,6 @@ dedup paths erode the entire defense, so these tests pin the contract.
 
 from __future__ import annotations
 
-import importlib.util
 import json
 import sys
 from pathlib import Path
@@ -21,13 +20,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# The script's filename has a hyphen, so we have to load it via importlib.
-_SCRIPT_PATH = Path(__file__).parent / "audit-unwired-trackers.py"
-_SPEC = importlib.util.spec_from_file_location("audit_unwired_trackers", _SCRIPT_PATH)
-assert _SPEC is not None and _SPEC.loader is not None
-audit = importlib.util.module_from_spec(_SPEC)
-sys.modules["audit_unwired_trackers"] = audit
-_SPEC.loader.exec_module(audit)
+import audit_unwired_trackers as audit
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Renames `pipeline-scripts/audit-unwired-trackers.py` → `pipeline-scripts/audit_unwired_trackers.py` (hyphen → underscore) so the module is importable as a standard Python package
- Updates `.github/workflows/unwired-tracker-audit.yml` (2 invocation lines)
- Updates `pipeline-scripts/test_audit_unwired_trackers.py`: drops importlib gymnastics, uses plain `import audit_unwired_trackers as audit`
- Updates docstring self-references in the renamed script (lines 12, 15, 446)
- Updates comment reference in `autobot-backend/api/schemas_code.py:665`

Closes #7009

## Acceptance Criteria

- [x] File renamed; workflow runs against new path
- [x] Test file uses plain `import` — no importlib gymnastics
- [x] All references updated (`grep -rn "audit-unwired-trackers"` returns 0)

## Test plan

- [ ] Verify `grep -rn "audit-unwired-trackers"` returns 0 after merge
- [ ] Confirm CI workflow passes on Dev_new_gui

🤖 Generated with [Claude Code](https://claude.com/claude-code)