### PR TITLE
refactor(frontend/file-browser): add Storybook stories for 7 file-browser components (#6852)

### DIFF
--- a/autobot-frontend/src/components/file-browser/FileBrowser.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FileBrowser.stories.ts
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import FileBrowser from './FileBrowser.vue';
+
+const meta = {
+  title: 'Components/FileBrowser/FileBrowser',
+  component: FileBrowser,
+  tags: ['autodocs'],
+  argTypes: {
+    chatContext: {
+      control: 'boolean',
+      description: 'When true, logs file activity to the session activity logger',
+    },
+  },
+} as Meta<typeof FileBrowser>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    chatContext: false,
+  },
+};
+
+export const ChatContext: Story = {
+  args: {
+    chatContext: true,
+  },
+};
+
+export const Standalone: Story = {
+  render: () => ({
+    components: { FileBrowser },
+    template: `
+      <div style="height: 600px; width: 100%;">
+        <FileBrowser :chat-context="false" />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/file-browser/FileBrowserHeader.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FileBrowserHeader.stories.ts
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import FileBrowserHeader from './FileBrowserHeader.vue';
+
+const meta = {
+  title: 'Components/FileBrowser/FileBrowserHeader',
+  component: FileBrowserHeader,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Optional title override; falls back to i18n key fileBrowser.header.title',
+    },
+    viewMode: {
+      control: 'select',
+      options: ['tree', 'list'],
+      description: 'Current view mode (tree or list)',
+    },
+    currentPath: {
+      control: 'text',
+      description: 'Current filesystem path shown in the path navigation',
+    },
+    onUpload: { action: 'upload' },
+    onNewFolder: { action: 'new-folder' },
+    onNavigateToPath: { action: 'navigate-to-path' },
+  },
+} as Meta<typeof FileBrowserHeader>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    viewMode: 'tree',
+    currentPath: '/',
+  },
+};
+
+export const WithTitle: Story = {
+  args: {
+    title: 'My Files',
+    viewMode: 'tree',
+    currentPath: '/',
+  },
+};
+
+export const ListMode: Story = {
+  args: {
+    viewMode: 'list',
+    currentPath: '/documents',
+  },
+};
+
+export const NestedPath: Story = {
+  args: {
+    viewMode: 'tree',
+    currentPath: '/home/user/projects/autobot',
+  },
+};
+
+export const TreeMode: Story = {
+  args: {
+    title: 'File Browser',
+    viewMode: 'tree',
+    currentPath: '/var/log',
+  },
+};

--- a/autobot-frontend/src/components/file-browser/FileListTable.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FileListTable.stories.ts
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import FileListTable from './FileListTable.vue';
+
+const sampleFiles = [
+  { name: 'documents', path: '/documents', is_dir: true, last_modified: '2026-05-01T10:00:00Z' },
+  { name: 'images', path: '/images', is_dir: true, last_modified: '2026-05-10T08:30:00Z' },
+  { name: 'report.pdf', path: '/report.pdf', is_dir: false, size: 204800, last_modified: '2026-05-12T14:22:00Z' },
+  { name: 'config.json', path: '/config.json', is_dir: false, size: 1024, last_modified: '2026-04-30T09:15:00Z' },
+  { name: 'main.ts', path: '/main.ts', is_dir: false, size: 3512, last_modified: '2026-05-15T17:45:00Z' },
+];
+
+const meta = {
+  title: 'Components/FileBrowser/FileListTable',
+  component: FileListTable,
+  tags: ['autodocs'],
+  argTypes: {
+    files: {
+      control: 'object',
+      description: 'Array of FileItem objects to display in the table',
+    },
+    sortField: {
+      control: 'select',
+      options: ['name', 'type', 'size', 'modified'],
+      description: 'Field currently used for sorting',
+    },
+    sortOrder: {
+      control: 'select',
+      options: ['asc', 'desc'],
+      description: 'Sort direction',
+    },
+    currentPath: {
+      control: 'text',
+      description: 'Current directory path',
+    },
+    onSort: { action: 'sort' },
+    onNavigate: { action: 'navigate' },
+    onViewFile: { action: 'view-file' },
+    onRenameFile: { action: 'rename-file' },
+    onDeleteFile: { action: 'delete-file' },
+  },
+} as Meta<typeof FileListTable>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    files: sampleFiles,
+    sortField: 'name',
+    sortOrder: 'asc',
+    currentPath: '/',
+  },
+};
+
+export const SortedBySize: Story = {
+  args: {
+    files: sampleFiles,
+    sortField: 'size',
+    sortOrder: 'desc',
+    currentPath: '/',
+  },
+};
+
+export const SortedByModified: Story = {
+  args: {
+    files: sampleFiles,
+    sortField: 'modified',
+    sortOrder: 'asc',
+    currentPath: '/documents',
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    files: [],
+    sortField: 'name',
+    sortOrder: 'asc',
+    currentPath: '/empty-folder',
+  },
+};
+
+export const FilesOnly: Story = {
+  args: {
+    files: [
+      { name: 'archive.zip', path: '/archive.zip', is_dir: false, size: 1048576, last_modified: '2026-05-01T00:00:00Z' },
+      { name: 'photo.png', path: '/photo.png', is_dir: false, size: 524288, last_modified: '2026-05-08T12:00:00Z' },
+      { name: 'notes.txt', path: '/notes.txt', is_dir: false, size: 256, last_modified: '2026-05-14T18:00:00Z' },
+    ],
+    sortField: 'name',
+    sortOrder: 'asc',
+    currentPath: '/',
+  },
+};

--- a/autobot-frontend/src/components/file-browser/FilePathNavigation.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FilePathNavigation.stories.ts
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import FilePathNavigation from './FilePathNavigation.vue';
+
+const meta = {
+  title: 'Components/FileBrowser/FilePathNavigation',
+  component: FilePathNavigation,
+  tags: ['autodocs'],
+  argTypes: {
+    currentPath: {
+      control: 'text',
+      description: 'Current filesystem path displayed as breadcrumb segments',
+    },
+    onNavigateToPath: { action: 'navigate-to-path' },
+  },
+} as Meta<typeof FilePathNavigation>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Root: Story = {
+  args: {
+    currentPath: '/',
+  },
+};
+
+export const SingleLevel: Story = {
+  args: {
+    currentPath: '/documents',
+  },
+};
+
+export const DeepPath: Story = {
+  args: {
+    currentPath: '/home/user/projects/autobot/src',
+  },
+};
+
+export const LogPath: Story = {
+  args: {
+    currentPath: '/var/log/autobot',
+  },
+};
+
+export const LongPath: Story = {
+  args: {
+    currentPath: '/opt/autobot/autobot-frontend/src/components/file-browser',
+  },
+};

--- a/autobot-frontend/src/components/file-browser/FilePreview.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FilePreview.stories.ts
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import FilePreview from './FilePreview.vue';
+
+const meta = {
+  title: 'Components/FileBrowser/FilePreview',
+  component: FilePreview,
+  tags: ['autodocs'],
+  argTypes: {
+    showPreview: {
+      control: 'boolean',
+      description: 'Controls modal visibility',
+    },
+    previewFile: {
+      control: 'object',
+      description: 'FilePreviewData object with name, type, and optional url/content/size',
+    },
+    onClose: { action: 'close' },
+    onDownload: { action: 'download' },
+  },
+} as Meta<typeof FilePreview>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Hidden: Story = {
+  args: {
+    showPreview: false,
+    previewFile: null,
+  },
+};
+
+export const TextFile: Story = {
+  args: {
+    showPreview: true,
+    previewFile: {
+      name: 'readme.txt',
+      type: 'text',
+      content: 'This is a plain text file.\nIt has multiple lines.\nLine three here.',
+    },
+  },
+};
+
+export const JsonFile: Story = {
+  args: {
+    showPreview: true,
+    previewFile: {
+      name: 'config.json',
+      type: 'json',
+      content: '{"name":"autobot","version":"1.0.0","debug":false}',
+    },
+  },
+};
+
+export const ImageFile: Story = {
+  args: {
+    showPreview: true,
+    previewFile: {
+      name: 'logo.png',
+      type: 'image',
+      url: 'https://via.placeholder.com/400x300',
+    },
+  },
+};
+
+export const UnknownFile: Story = {
+  args: {
+    showPreview: true,
+    previewFile: {
+      name: 'archive.tar.gz',
+      type: 'archive',
+      fileType: 'GZ Archive',
+      size: 2097152,
+      url: '/files/archive.tar.gz',
+    },
+  },
+};

--- a/autobot-frontend/src/components/file-browser/FileTreeView.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FileTreeView.stories.ts
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import FileTreeView from './FileTreeView.vue';
+
+const flatTree = [
+  { name: 'home', path: '/home', is_dir: true, level: 0, expanded: true },
+  { name: 'user', path: '/home/user', is_dir: true, level: 1, expanded: true },
+  { name: 'documents', path: '/home/user/documents', is_dir: true, level: 2, expanded: false },
+  { name: 'notes.txt', path: '/home/user/notes.txt', is_dir: false, level: 2 },
+  { name: 'projects', path: '/home/user/projects', is_dir: true, level: 2, expanded: true },
+  { name: 'autobot', path: '/home/user/projects/autobot', is_dir: true, level: 3, expanded: false },
+];
+
+const meta = {
+  title: 'Components/FileBrowser/FileTreeView',
+  component: FileTreeView,
+  tags: ['autodocs'],
+  argTypes: {
+    directoryTree: {
+      control: 'object',
+      description: 'Flat array of TreeItem nodes representing the directory structure',
+    },
+    selectedPath: {
+      control: 'text',
+      description: 'Path of the currently selected tree node',
+    },
+    onToggleNode: { action: 'toggle-node' },
+    onExpandAll: { action: 'expand-all' },
+    onCollapseAll: { action: 'collapse-all' },
+  },
+} as Meta<typeof FileTreeView>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    directoryTree: flatTree,
+    selectedPath: '/home/user',
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    directoryTree: [],
+    selectedPath: '',
+  },
+};
+
+export const SingleLevel: Story = {
+  args: {
+    directoryTree: [
+      { name: 'documents', path: '/documents', is_dir: true, level: 0, expanded: false },
+      { name: 'images', path: '/images', is_dir: true, level: 0, expanded: false },
+      { name: 'logs', path: '/logs', is_dir: true, level: 0, expanded: false },
+    ],
+    selectedPath: '/documents',
+  },
+};
+
+export const DeepSelection: Story = {
+  args: {
+    directoryTree: flatTree,
+    selectedPath: '/home/user/projects/autobot',
+  },
+};
+
+export const AllExpanded: Story = {
+  args: {
+    directoryTree: flatTree.map(node => ({ ...node, expanded: true })),
+    selectedPath: '/home/user/documents',
+  },
+};

--- a/autobot-frontend/src/components/file-browser/FileUpload.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FileUpload.stories.ts
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import FileUpload from './FileUpload.vue';
+
+const meta = {
+  title: 'Components/FileBrowser/FileUpload',
+  component: FileUpload,
+  tags: ['autodocs'],
+  argTypes: {
+    onFilesSelected: { action: 'files-selected' },
+  },
+} as Meta<typeof FileUpload>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {};
+
+export const InlineUsage: Story = {
+  render: () => ({
+    components: { FileUpload },
+    template: `
+      <div style="padding: 16px; background: #f9f9f9; border-radius: 8px;">
+        <p style="margin-bottom: 8px; font-size: 14px; color: #666;">Inline file upload:</p>
+        <FileUpload @files-selected="onFilesSelected" />
+      </div>
+    `,
+    methods: {
+      onFilesSelected(files: FileList) {
+        console.log('Files selected:', Array.from(files).map(f => f.name));
+      },
+    },
+  }),
+};
+
+export const FullWidth: Story = {
+  render: () => ({
+    components: { FileUpload },
+    template: `
+      <div style="width: 100%; max-width: 600px;">
+        <FileUpload @files-selected="() => {}" />
+      </div>
+    `,
+  }),
+};
+
+export const Compact: Story = {
+  render: () => ({
+    components: { FileUpload },
+    template: `
+      <div style="width: 300px;">
+        <FileUpload @files-selected="() => {}" />
+      </div>
+    `,
+  }),
+};


### PR DESCRIPTION
Adds stories for FileBrowser (3), FileBrowserHeader (5), FileListTable (5), FilePathNavigation (5), FilePreview (5), FileTreeView (5), FileUpload (4). Closes #6852. Part of #4201 Phase 2.