### PR TITLE
infra(gitignore): exclude .claude/scheduled_tasks.lock (#6980)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -444,6 +444,7 @@ ansible/inventory/group_vars/vault.yml
 .claude/agents-optimized/
 .claude/.optimization_cache.json
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Git worktrees for isolated development
 .worktrees/


### PR DESCRIPTION
## Summary

- Adds `.claude/scheduled_tasks.lock` to `.gitignore` next to existing `.claude/` entries (line 446)
- Prevents `git status` noise and `gh pr create` warnings about uncommitted lock files during scheduled-task sessions

Closes #6980

## Acceptance Criteria

- [x] `.claude/scheduled_tasks.lock` excluded from git tracking
- [x] Placed adjacent to existing `.claude/` gitignore entries for consistency
- [x] Does not affect existing tracked `.claude/` content (agents, hooks, settings.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)