### PR TITLE
refactor(frontend/charts): add Storybook stories for 11 chart components (#6850)

### DIFF
--- a/autobot-frontend/src/components/charts/BaseChart.stories.ts
+++ b/autobot-frontend/src/components/charts/BaseChart.stories.ts
@@ -1,0 +1,124 @@
+import type { Meta } from '@storybook/vue3';
+import BaseChart from './BaseChart.vue';
+
+const meta = {
+  title: 'Components/Charts/BaseChart',
+  component: BaseChart,
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'select',
+      options: ['line', 'area', 'bar', 'pie', 'donut', 'radialBar', 'scatter', 'bubble', 'heatmap', 'treemap', 'polarArea', 'radar'],
+      description: 'ApexCharts chart type',
+    },
+    height: {
+      control: 'text',
+      description: 'Chart height (number or CSS string)',
+    },
+    width: {
+      control: 'text',
+      description: 'Chart width (number or CSS string)',
+    },
+    title: {
+      control: 'text',
+      description: 'Chart title',
+    },
+    subtitle: {
+      control: 'text',
+      description: 'Chart subtitle',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+  },
+} as Meta<typeof BaseChart>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+export const BarChart: Story = {
+  args: {
+    type: 'bar',
+    height: 350,
+    title: 'Monthly Metrics',
+    subtitle: 'Commits per month',
+    series: [
+      {
+        name: 'Commits',
+        data: [44, 55, 57, 56, 61, 58, 63, 60, 66],
+      },
+    ],
+    options: {
+      xaxis: {
+        categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep'],
+      },
+    },
+  },
+};
+
+export const LineChart: Story = {
+  args: {
+    type: 'line',
+    height: 350,
+    title: 'Code Quality Score',
+    subtitle: 'Over time',
+    series: [
+      { name: 'Maintainability', data: [70, 74, 78, 75, 80, 83, 85] },
+      { name: 'Complexity', data: [60, 58, 62, 65, 67, 70, 72] },
+    ],
+    options: {
+      xaxis: {
+        categories: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+      },
+    },
+  },
+};
+
+export const DonutChart: Story = {
+  args: {
+    type: 'donut',
+    height: 350,
+    title: 'Issue Distribution',
+    subtitle: 'By severity',
+    series: [44, 55, 13, 43],
+    options: {
+      labels: ['Critical', 'High', 'Medium', 'Low'],
+    },
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    type: 'bar',
+    height: 350,
+    title: 'Loading Chart',
+    series: [],
+    loading: true,
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    type: 'bar',
+    height: 350,
+    title: 'Error Chart',
+    series: [],
+    error: 'Failed to load chart data. Please try again.',
+  },
+};
+
+export const NoDataState: Story = {
+  args: {
+    type: 'bar',
+    height: 350,
+    title: 'Empty Chart',
+    series: [],
+  },
+};

--- a/autobot-frontend/src/components/charts/DependencyTreemap.stories.ts
+++ b/autobot-frontend/src/components/charts/DependencyTreemap.stories.ts
@@ -1,0 +1,88 @@
+import type { Meta } from '@storybook/vue3';
+import DependencyTreemap from './DependencyTreemap.vue';
+
+const meta = {
+  title: 'Components/Charts/DependencyTreemap',
+  component: DependencyTreemap,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Chart title (overrides i18n default)',
+    },
+    subtitle: {
+      control: 'text',
+      description: 'Chart subtitle (overrides i18n default)',
+    },
+    height: {
+      control: 'number',
+      description: 'Chart height in pixels',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+  },
+} as Meta<typeof DependencyTreemap>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const sampleData = [
+  { package: 'fastapi', usage_count: 87 },
+  { package: 'pydantic', usage_count: 64 },
+  { package: 'sqlalchemy', usage_count: 52 },
+  { package: 'redis', usage_count: 45 },
+  { package: 'httpx', usage_count: 38 },
+  { package: 'celery', usage_count: 29 },
+  { package: 'pytest', usage_count: 23 },
+  { package: 'numpy', usage_count: 18 },
+  { package: 'boto3', usage_count: 14 },
+  { package: 'jwt', usage_count: 11 },
+];
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+    height: 400,
+  },
+};
+
+export const WithCustomTitle: Story = {
+  args: {
+    data: sampleData,
+    title: 'Python Package Usage',
+    subtitle: 'Top external dependencies by import count',
+    height: 400,
+  },
+};
+
+export const SmallDataset: Story = {
+  args: {
+    data: sampleData.slice(0, 4),
+    title: 'Top 4 Dependencies',
+    height: 300,
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    data: [],
+    loading: true,
+    height: 400,
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    data: [],
+    error: 'Failed to load dependency data.',
+    height: 400,
+  },
+};

--- a/autobot-frontend/src/components/charts/EvolutionTimelineChart.stories.ts
+++ b/autobot-frontend/src/components/charts/EvolutionTimelineChart.stories.ts
@@ -1,0 +1,102 @@
+import type { Meta } from '@storybook/vue3';
+import EvolutionTimelineChart from './EvolutionTimelineChart.vue';
+
+const meta = {
+  title: 'Components/Charts/EvolutionTimelineChart',
+  component: EvolutionTimelineChart,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Chart title (overrides i18n default)',
+    },
+    subtitle: {
+      control: 'text',
+      description: 'Chart subtitle (overrides i18n default)',
+    },
+    height: {
+      control: 'number',
+      description: 'Chart height in pixels',
+    },
+    metrics: {
+      control: 'object',
+      description: 'Metrics to display from timeline data',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+  },
+} as Meta<typeof EvolutionTimelineChart>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+function makeDays(count: number) {
+  const now = Date.now();
+  return Array.from({ length: count }, (_, i) => {
+    const d = new Date(now - (count - 1 - i) * 86400000);
+    return d.toISOString();
+  });
+}
+
+const timestamps = makeDays(14);
+
+const sampleData = timestamps.map((timestamp, i) => ({
+  timestamp,
+  overall_score: 60 + i * 1.5 + Math.sin(i) * 3,
+  maintainability: 55 + i * 1.2 + Math.cos(i) * 4,
+  complexity: 70 - i * 0.8 + Math.sin(i * 0.7) * 2,
+}));
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+    height: 400,
+  },
+};
+
+export const WithCustomTitle: Story = {
+  args: {
+    data: sampleData,
+    title: 'Code Health Over 2 Weeks',
+    subtitle: 'Overall score, maintainability and complexity',
+    height: 400,
+  },
+};
+
+export const AllMetrics: Story = {
+  args: {
+    data: sampleData.map((d, i) => ({
+      ...d,
+      testability: 50 + i * 1.8,
+      security: 80 - i * 0.5,
+      performance: 65 + i,
+    })),
+    metrics: ['overall_score', 'maintainability', 'complexity', 'testability', 'security', 'performance'],
+    height: 450,
+    title: 'All Quality Metrics',
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    data: [],
+    loading: true,
+    height: 400,
+  },
+};
+
+export const EmptyData: Story = {
+  args: {
+    data: [],
+    title: 'No Evolution Data',
+    height: 400,
+  },
+};

--- a/autobot-frontend/src/components/charts/FunctionCallGraph.stories.ts
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.stories.ts
@@ -1,0 +1,136 @@
+import type { Meta } from '@storybook/vue3';
+import FunctionCallGraph from './FunctionCallGraph.vue';
+
+const meta = {
+  title: 'Components/Charts/FunctionCallGraph',
+  component: FunctionCallGraph,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Chart title',
+    },
+    subtitle: {
+      control: 'text',
+      description: 'Chart subtitle',
+    },
+    height: {
+      control: 'number',
+      description: 'Graph container height in pixels',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+  },
+} as Meta<typeof FunctionCallGraph>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const sampleData = {
+  nodes: [
+    { id: 'app.main', name: 'main', full_name: 'app.main', module: 'app', file: 'app/main.py', line: 1, is_async: false },
+    { id: 'app.startup', name: 'startup', full_name: 'app.startup', module: 'app', file: 'app/main.py', line: 15, is_async: true },
+    { id: 'db.connect', name: 'connect', full_name: 'db.connect', module: 'db', file: 'db/client.py', line: 8, is_async: true },
+    { id: 'db.query', name: 'query', full_name: 'db.query', module: 'db', file: 'db/client.py', line: 42, is_async: true },
+    { id: 'api.router', name: 'router', full_name: 'api.router', module: 'api', file: 'api/routes.py', line: 5, is_async: false },
+    { id: 'api.handler', name: 'handler', full_name: 'api.handler', module: 'api', file: 'api/routes.py', line: 20, is_async: true },
+  ],
+  edges: [
+    { from: 'app.main', to: 'app.startup', resolved: true, count: 1 },
+    { from: 'app.startup', to: 'db.connect', resolved: true, count: 1 },
+    { from: 'app.startup', to: 'api.router', resolved: true, count: 1 },
+    { from: 'api.router', to: 'api.handler', resolved: true, count: 3 },
+    { from: 'api.handler', to: 'db.query', resolved: true, count: 5 },
+  ],
+};
+
+const sampleSummary = {
+  total_functions: 6,
+  connected_functions: 6,
+  orphaned_functions: 0,
+  total_call_relationships: 5,
+  resolved_calls: 5,
+  unresolved_calls: 0,
+  top_callers: [
+    { function: 'api.handler', calls: 5 },
+    { function: 'app.startup', calls: 2 },
+  ],
+  most_called: [
+    { function: 'db.query', calls: 5 },
+    { function: 'api.handler', calls: 3 },
+  ],
+};
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+    summary: sampleSummary,
+    orphanedFunctions: [],
+    title: 'Function Call Graph',
+    subtitle: 'Application call relationships',
+    height: 600,
+  },
+};
+
+export const WithOrphanedFunctions: Story = {
+  args: {
+    data: sampleData,
+    summary: { ...sampleSummary, orphaned_functions: 2 },
+    orphanedFunctions: [
+      {
+        id: 'utils.helper',
+        name: 'helper',
+        full_name: 'utils.helper',
+        module: 'utils',
+        class: null,
+        file: 'utils/helpers.py',
+        line: 12,
+        is_async: false,
+      },
+      {
+        id: 'utils.unused',
+        name: 'unused',
+        full_name: 'utils.unused',
+        module: 'utils',
+        class: null,
+        file: 'utils/helpers.py',
+        line: 30,
+        is_async: false,
+      },
+    ],
+    title: 'Function Call Graph (with Orphans)',
+    height: 600,
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    data: { nodes: [], edges: [] },
+    loading: true,
+    height: 600,
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    data: { nodes: [], edges: [] },
+    error: 'Failed to load call graph data.',
+    height: 600,
+  },
+};
+
+export const NoData: Story = {
+  args: {
+    data: { nodes: [], edges: [] },
+    title: 'Empty Call Graph',
+    height: 600,
+  },
+};

--- a/autobot-frontend/src/components/charts/ImportTreeChart.stories.ts
+++ b/autobot-frontend/src/components/charts/ImportTreeChart.stories.ts
@@ -1,0 +1,115 @@
+import type { Meta } from '@storybook/vue3';
+import ImportTreeChart from './ImportTreeChart.vue';
+
+const meta = {
+  title: 'Components/Charts/ImportTreeChart',
+  component: ImportTreeChart,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Chart title',
+    },
+    subtitle: {
+      control: 'text',
+      description: 'Chart subtitle',
+    },
+    height: {
+      control: 'number',
+      description: 'Container height in pixels',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+  },
+} as Meta<typeof ImportTreeChart>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const sampleData = [
+  {
+    path: 'src/app/main.py',
+    imports: [
+      { module: 'fastapi', is_external: true },
+      { module: 'src.db.client', file: 'src/db/client.py', is_external: false },
+      { module: 'src.api.routes', file: 'src/api/routes.py', is_external: false },
+    ],
+    imported_by: [],
+  },
+  {
+    path: 'src/db/client.py',
+    imports: [
+      { module: 'sqlalchemy', is_external: true },
+      { module: 'redis', is_external: true },
+    ],
+    imported_by: [
+      { file: 'src/app/main.py', module: 'src.db.client' },
+      { file: 'src/api/routes.py', module: 'src.db.client' },
+    ],
+  },
+  {
+    path: 'src/api/routes.py',
+    imports: [
+      { module: 'fastapi', is_external: true },
+      { module: 'src.db.client', file: 'src/db/client.py', is_external: false },
+    ],
+    imported_by: [
+      { file: 'src/app/main.py', module: 'src.api.routes' },
+    ],
+  },
+  {
+    path: 'src/utils/helpers.py',
+    imports: [
+      { module: 'typing', is_external: true },
+    ],
+    imported_by: [],
+  },
+];
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+    height: 600,
+  },
+};
+
+export const WithCustomTitle: Story = {
+  args: {
+    data: sampleData,
+    title: 'Module Import Relationships',
+    subtitle: 'Visualizing dependencies between source files',
+    height: 600,
+  },
+};
+
+export const SmallProject: Story = {
+  args: {
+    data: sampleData.slice(0, 2),
+    title: 'Simple Import Tree',
+    height: 500,
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    data: [],
+    loading: true,
+    height: 600,
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    data: [],
+    error: 'Failed to load import tree data.',
+    height: 600,
+  },
+};

--- a/autobot-frontend/src/components/charts/ModuleImportsChart.stories.ts
+++ b/autobot-frontend/src/components/charts/ModuleImportsChart.stories.ts
@@ -1,0 +1,91 @@
+import type { Meta } from '@storybook/vue3';
+import ModuleImportsChart from './ModuleImportsChart.vue';
+
+const meta = {
+  title: 'Components/Charts/ModuleImportsChart',
+  component: ModuleImportsChart,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Chart title (overrides i18n default)',
+    },
+    subtitle: {
+      control: 'text',
+      description: 'Chart subtitle (overrides i18n default)',
+    },
+    height: {
+      control: 'number',
+      description: 'Chart height in pixels',
+    },
+    maxModules: {
+      control: 'number',
+      description: 'Maximum number of modules to display',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+  },
+} as Meta<typeof ModuleImportsChart>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const sampleData = [
+  { path: 'src/services/auth.py', name: 'auth', package: 'services', import_count: 42, functions: 12, classes: 3 },
+  { path: 'src/db/client.py', name: 'client', package: 'db', import_count: 38, functions: 8, classes: 2 },
+  { path: 'src/utils/helpers.py', name: 'helpers', package: 'utils', import_count: 31, functions: 20, classes: 0 },
+  { path: 'src/api/middleware.py', name: 'middleware', package: 'api', import_count: 27, functions: 6, classes: 4 },
+  { path: 'src/models/user.py', name: 'user', package: 'models', import_count: 24, functions: 5, classes: 1 },
+  { path: 'src/config/settings.py', name: 'settings', package: 'config', import_count: 19, functions: 2, classes: 1 },
+  { path: 'src/tasks/worker.py', name: 'worker', package: 'tasks', import_count: 15, functions: 9, classes: 2 },
+  { path: 'src/cache/redis_cache.py', name: 'redis_cache', package: 'cache', import_count: 12, functions: 7, classes: 1 },
+];
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+    height: 400,
+  },
+};
+
+export const WithCustomTitle: Story = {
+  args: {
+    data: sampleData,
+    title: 'Most Imported Modules',
+    subtitle: 'Top modules by import count across the codebase',
+    height: 400,
+  },
+};
+
+export const LimitedModules: Story = {
+  args: {
+    data: sampleData,
+    maxModules: 5,
+    title: 'Top 5 Modules',
+    height: 300,
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    data: [],
+    loading: true,
+    height: 400,
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    data: [],
+    error: 'Failed to load module import data.',
+    height: 400,
+  },
+};

--- a/autobot-frontend/src/components/charts/PatternEvolutionChart.stories.ts
+++ b/autobot-frontend/src/components/charts/PatternEvolutionChart.stories.ts
@@ -1,0 +1,105 @@
+import type { Meta } from '@storybook/vue3';
+import PatternEvolutionChart from './PatternEvolutionChart.vue';
+
+const meta = {
+  title: 'Components/Charts/PatternEvolutionChart',
+  component: PatternEvolutionChart,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Chart title (overrides i18n default)',
+    },
+    subtitle: {
+      control: 'text',
+      description: 'Chart subtitle (overrides i18n default)',
+    },
+    height: {
+      control: 'number',
+      description: 'Chart height in pixels',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+  },
+} as Meta<typeof PatternEvolutionChart>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+function makeDays(count: number) {
+  const now = Date.now();
+  return Array.from({ length: count }, (_, i) => {
+    const d = new Date(now - (count - 1 - i) * 86400000);
+    return d.toISOString();
+  });
+}
+
+const timestamps = makeDays(10);
+
+const sampleData = {
+  race_condition: timestamps.map((timestamp, i) => ({
+    timestamp,
+    count: Math.max(0, 8 - i + Math.round(Math.sin(i) * 2)),
+    pattern_type: 'race_condition',
+  })),
+  global_state: timestamps.map((timestamp, i) => ({
+    timestamp,
+    count: Math.max(0, 12 - i * 0.5 + Math.round(Math.cos(i) * 1)),
+    pattern_type: 'global_state',
+  })),
+  long_method: timestamps.map((timestamp, i) => ({
+    timestamp,
+    count: Math.max(0, 6 - i * 0.3),
+    pattern_type: 'long_method',
+  })),
+};
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+    height: 400,
+  },
+};
+
+export const WithCustomTitle: Story = {
+  args: {
+    data: sampleData,
+    title: 'Anti-Pattern Trends',
+    subtitle: 'Pattern occurrences over the last 10 days',
+    height: 400,
+  },
+};
+
+export const SinglePattern: Story = {
+  args: {
+    data: {
+      race_condition: sampleData.race_condition,
+    },
+    title: 'Race Condition Trend',
+    height: 350,
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    data: {},
+    loading: true,
+    height: 400,
+  },
+};
+
+export const EmptyData: Story = {
+  args: {
+    data: {},
+    title: 'No Pattern Data',
+    height: 400,
+  },
+};

--- a/autobot-frontend/src/components/charts/ProblemTypesChart.stories.ts
+++ b/autobot-frontend/src/components/charts/ProblemTypesChart.stories.ts
@@ -1,0 +1,89 @@
+import type { Meta } from '@storybook/vue3';
+import ProblemTypesChart from './ProblemTypesChart.vue';
+
+const meta = {
+  title: 'Components/Charts/ProblemTypesChart',
+  component: ProblemTypesChart,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Chart title (overrides i18n default)',
+    },
+    subtitle: {
+      control: 'text',
+      description: 'Chart subtitle',
+    },
+    height: {
+      control: 'number',
+      description: 'Chart height in pixels',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+  },
+} as Meta<typeof ProblemTypesChart>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const sampleData = [
+  { type: 'security', count: 23 },
+  { type: 'race_condition', count: 18 },
+  { type: 'performance', count: 42 },
+  { type: 'style', count: 67 },
+  { type: 'complexity', count: 31 },
+  { type: 'documentation', count: 15 },
+];
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+    height: 350,
+  },
+};
+
+export const WithCustomTitle: Story = {
+  args: {
+    data: sampleData,
+    title: 'Problem Type Breakdown',
+    subtitle: 'Distribution of detected issues by category',
+    height: 350,
+  },
+};
+
+export const NameValueFormat: Story = {
+  args: {
+    data: [
+      { name: 'Error', value: 12 },
+      { name: 'Warning', value: 45 },
+      { name: 'Info', value: 89 },
+      { name: 'Hint', value: 24 },
+    ],
+    title: 'Issues by Severity Level',
+    height: 350,
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    data: [],
+    loading: true,
+    height: 350,
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    data: [],
+    error: 'Failed to load problem type data.',
+    height: 350,
+  },
+};

--- a/autobot-frontend/src/components/charts/RaceConditionsDonut.stories.ts
+++ b/autobot-frontend/src/components/charts/RaceConditionsDonut.stories.ts
@@ -1,0 +1,87 @@
+import type { Meta } from '@storybook/vue3';
+import RaceConditionsDonut from './RaceConditionsDonut.vue';
+
+const meta = {
+  title: 'Components/Charts/RaceConditionsDonut',
+  component: RaceConditionsDonut,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Chart title (overrides i18n default)',
+    },
+    subtitle: {
+      control: 'text',
+      description: 'Chart subtitle',
+    },
+    height: {
+      control: 'number',
+      description: 'Chart height in pixels',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+  },
+} as Meta<typeof RaceConditionsDonut>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const sampleData = [
+  { category: 'thread_unsafe_singleton', count: 7 },
+  { category: 'unprotected_global_state', count: 12 },
+  { category: 'async_shared_state', count: 9 },
+  { category: 'file_write_without_lock', count: 4 },
+  { category: 'read_modify_write', count: 6 },
+];
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+    height: 350,
+  },
+};
+
+export const WithCustomTitle: Story = {
+  args: {
+    data: sampleData,
+    title: 'Race Condition Breakdown',
+    subtitle: 'Detected concurrency issues by category',
+    height: 350,
+  },
+};
+
+export const NameValueFormat: Story = {
+  args: {
+    data: [
+      { name: 'thread_unsafe_singleton', value: 5 },
+      { name: 'async_global_modification', value: 8 },
+      { name: 'unprotected_mutating_method', value: 3 },
+    ],
+    title: 'Race Conditions (name/value format)',
+    height: 350,
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    data: [],
+    loading: true,
+    height: 350,
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    data: [],
+    error: 'Failed to load race condition data.',
+    height: 350,
+  },
+};

--- a/autobot-frontend/src/components/charts/SeverityBarChart.stories.ts
+++ b/autobot-frontend/src/components/charts/SeverityBarChart.stories.ts
@@ -1,0 +1,90 @@
+import type { Meta } from '@storybook/vue3';
+import SeverityBarChart from './SeverityBarChart.vue';
+
+const meta = {
+  title: 'Components/Charts/SeverityBarChart',
+  component: SeverityBarChart,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Chart title (overrides i18n default)',
+    },
+    subtitle: {
+      control: 'text',
+      description: 'Chart subtitle',
+    },
+    height: {
+      control: 'number',
+      description: 'Chart height in pixels',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+  },
+} as Meta<typeof SeverityBarChart>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const sampleData = [
+  { severity: 'critical', count: 5 },
+  { severity: 'high', count: 18 },
+  { severity: 'medium', count: 43 },
+  { severity: 'low', count: 87 },
+  { severity: 'info', count: 124 },
+];
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+    height: 300,
+  },
+};
+
+export const WithCustomTitle: Story = {
+  args: {
+    data: sampleData,
+    title: 'Issues by Severity',
+    subtitle: 'Count of detected problems per severity level',
+    height: 300,
+  },
+};
+
+export const NameValueFormat: Story = {
+  args: {
+    data: [
+      { name: 'error', value: 8 },
+      { name: 'warning', value: 34 },
+      { name: 'hint', value: 61 },
+    ],
+    title: 'Severity Levels (name/value format)',
+    height: 250,
+  },
+};
+
+export const HighSeverityOnly: Story = {
+  args: {
+    data: [
+      { severity: 'critical', count: 3 },
+      { severity: 'high', count: 9 },
+    ],
+    title: 'High Severity Issues',
+    height: 200,
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    data: [],
+    loading: true,
+    height: 300,
+  },
+};

--- a/autobot-frontend/src/components/charts/TopFilesChart.stories.ts
+++ b/autobot-frontend/src/components/charts/TopFilesChart.stories.ts
@@ -1,0 +1,97 @@
+import type { Meta } from '@storybook/vue3';
+import TopFilesChart from './TopFilesChart.vue';
+
+const meta = {
+  title: 'Components/Charts/TopFilesChart',
+  component: TopFilesChart,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Chart title (overrides i18n default)',
+    },
+    subtitle: {
+      control: 'text',
+      description: 'Chart subtitle',
+    },
+    height: {
+      control: 'number',
+      description: 'Chart height in pixels',
+    },
+    maxFiles: {
+      control: 'number',
+      description: 'Maximum number of files to display',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message to display',
+    },
+  },
+} as Meta<typeof TopFilesChart>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3';
+type Story = StoryObj<any>;
+
+const sampleData = [
+  { file: 'src/services/auth_service.py', count: 47 },
+  { file: 'src/api/v1/endpoints/users.py', count: 38 },
+  { file: 'src/db/repositories/user_repo.py', count: 31 },
+  { file: 'src/utils/validation.py', count: 28 },
+  { file: 'src/models/domain/user.py', count: 24 },
+  { file: 'src/api/middleware/auth.py', count: 19 },
+  { file: 'src/tasks/email_worker.py', count: 16 },
+  { file: 'src/config/settings.py', count: 13 },
+  { file: 'src/cache/session_cache.py', count: 11 },
+  { file: 'src/utils/crypto.py', count: 9 },
+];
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+    height: 400,
+  },
+};
+
+export const WithCustomTitle: Story = {
+  args: {
+    data: sampleData,
+    title: 'Files with Most Issues',
+    subtitle: 'Top files ranked by problem count',
+    height: 400,
+  },
+};
+
+export const LimitedFiles: Story = {
+  args: {
+    data: sampleData,
+    maxFiles: 5,
+    title: 'Top 5 Problematic Files',
+    height: 300,
+  },
+};
+
+export const NameValueFormat: Story = {
+  args: {
+    data: [
+      { name: 'main.py', value: 55 },
+      { name: 'utils.py', value: 42 },
+      { name: 'models.py', value: 30 },
+    ],
+    title: 'Files (name/value format)',
+    height: 250,
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    data: [],
+    loading: true,
+    height: 400,
+  },
+};


### PR DESCRIPTION
Adds stories for BaseChart (6), DependencyTreemap (5), EvolutionTimelineChart (5), FunctionCallGraph (5), ImportTreeChart (5), ModuleImportsChart (5), PatternEvolutionChart (5), ProblemTypesChart (5), RaceConditionsDonut (5), SeverityBarChart (5), TopFilesChart (5). Closes #6850. Part of #4201 Phase 2.