### PR TITLE
refactor(frontend/workflow): add Storybook stories for 11 workflow components (#6851)

### DIFF
--- a/autobot-frontend/src/components/workflow/AgentObservabilityPanel.stories.ts
+++ b/autobot-frontend/src/components/workflow/AgentObservabilityPanel.stories.ts
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import AgentObservabilityPanel from './AgentObservabilityPanel.vue';
+
+const meta = {
+  title: 'Components/Workflow/AgentObservabilityPanel',
+  component: AgentObservabilityPanel,
+  tags: ['autodocs'],
+  argTypes: {
+    agentPerformance: {
+      control: 'object',
+      description: 'Record of agent performance data keyed by agent identifier',
+    },
+    agentCapabilities: {
+      control: 'object',
+      description: 'Record of agent capability data keyed by agent identifier',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Whether data is being loaded',
+    },
+  },
+} as Meta<typeof AgentObservabilityPanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+const samplePerformance = {
+  coordinator: {
+    agent_name: 'Coordinator Agent',
+    total_tasks: 42,
+    successful_tasks: 39,
+    failed_tasks: 3,
+    average_duration: 12.5,
+    reliability_score: 0.93,
+  },
+  researcher: {
+    agent_name: 'Research Agent',
+    total_tasks: 28,
+    successful_tasks: 22,
+    failed_tasks: 6,
+    average_duration: 45.2,
+    reliability_score: 0.79,
+  },
+  executor: {
+    agent_name: 'Executor Agent',
+    total_tasks: 15,
+    successful_tasks: 8,
+    failed_tasks: 7,
+    average_duration: 8.1,
+    reliability_score: 0.53,
+  },
+};
+
+const sampleCapabilities = {
+  coordinator: {
+    agent: 'Coordinator Agent',
+    capabilities: ['task-routing', 'priority-management', 'agent-coordination'],
+    performance: { total_tasks: 42, reliability: 0.93 },
+  },
+  researcher: {
+    agent: 'Research Agent',
+    capabilities: ['web-search', 'document-analysis', 'summarization', 'fact-checking', 'citation'],
+    performance: { total_tasks: 28, reliability: 0.79 },
+  },
+  executor: {
+    agent: 'Executor Agent',
+    capabilities: ['shell-commands', 'file-operations'],
+    performance: { total_tasks: 15, reliability: 0.53 },
+  },
+};
+
+export const Default: Story = {
+  args: {
+    agentPerformance: samplePerformance,
+    agentCapabilities: sampleCapabilities,
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    agentPerformance: {},
+    agentCapabilities: {},
+    loading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    agentPerformance: {},
+    agentCapabilities: {},
+    loading: false,
+  },
+};
+
+export const SingleAgent: Story = {
+  args: {
+    agentPerformance: {
+      coordinator: samplePerformance.coordinator,
+    },
+    agentCapabilities: {
+      coordinator: sampleCapabilities.coordinator,
+    },
+    loading: false,
+  },
+};
+
+export const HighReliabilityAgents: Story = {
+  args: {
+    agentPerformance: {
+      alpha: {
+        agent_name: 'Alpha Agent',
+        total_tasks: 100,
+        successful_tasks: 98,
+        failed_tasks: 2,
+        average_duration: 3.2,
+        reliability_score: 0.98,
+      },
+      beta: {
+        agent_name: 'Beta Agent',
+        total_tasks: 80,
+        successful_tasks: 76,
+        failed_tasks: 4,
+        average_duration: 5.6,
+        reliability_score: 0.95,
+      },
+    },
+    agentCapabilities: {
+      alpha: { agent: 'Alpha Agent', capabilities: ['fast-execution', 'retries'], performance: { total_tasks: 100, reliability: 0.98 } },
+      beta: { agent: 'Beta Agent', capabilities: ['analysis', 'reporting'], performance: { total_tasks: 80, reliability: 0.95 } },
+    },
+    loading: false,
+  },
+};

--- a/autobot-frontend/src/components/workflow/NotificationConfigModal.stories.ts
+++ b/autobot-frontend/src/components/workflow/NotificationConfigModal.stories.ts
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import NotificationConfigModal from './NotificationConfigModal.vue';
+
+const meta = {
+  title: 'Components/Workflow/NotificationConfigModal',
+  component: NotificationConfigModal,
+  tags: ['autodocs'],
+  argTypes: {
+    visible: {
+      control: 'boolean',
+      description: 'Whether the modal is visible',
+    },
+    workflowId: {
+      control: 'text',
+      description: 'ID of the workflow to configure notifications for',
+    },
+  },
+} as Meta<typeof NotificationConfigModal>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Visible: Story = {
+  args: {
+    visible: true,
+    workflowId: 'wf-abc123',
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    visible: false,
+    workflowId: 'wf-abc123',
+  },
+};
+
+export const DifferentWorkflow: Story = {
+  args: {
+    visible: true,
+    workflowId: 'wf-xyz789',
+  },
+};

--- a/autobot-frontend/src/components/workflow/OrchestrationVisualizer.stories.ts
+++ b/autobot-frontend/src/components/workflow/OrchestrationVisualizer.stories.ts
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import OrchestrationVisualizer from './OrchestrationVisualizer.vue';
+
+const meta = {
+  title: 'Components/Workflow/OrchestrationVisualizer',
+  component: OrchestrationVisualizer,
+  tags: ['autodocs'],
+  argTypes: {
+    status: {
+      control: 'object',
+      description: 'Orchestration system status object',
+    },
+    strategies: {
+      control: 'object',
+      description: 'Available execution strategies keyed by strategy name',
+    },
+    currentWorkflow: {
+      control: 'object',
+      description: 'Currently active workflow, or null if none',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Whether strategies are loading',
+    },
+  },
+} as Meta<typeof OrchestrationVisualizer>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+const sampleStatus = {
+  status: 'operational',
+  active_workflows: 3,
+  total_agents: 8,
+  max_parallel_tasks: 5,
+  capabilities: {
+    agent_coordination: true,
+    performance_tracking: true,
+    automatic_failover: true,
+    resource_optimization: false,
+  },
+};
+
+const sampleStrategies = {
+  sequential: {
+    name: 'Sequential',
+    description: 'Execute tasks one at a time in order.',
+    best_for: 'Dependent tasks with strict ordering',
+  },
+  parallel: {
+    name: 'Parallel',
+    description: 'Execute independent tasks simultaneously.',
+    best_for: 'Independent tasks with no dependencies',
+  },
+  pipeline: {
+    name: 'Pipeline',
+    description: 'Stream results from one stage to the next.',
+    best_for: 'Data processing workflows',
+  },
+  collaborative: {
+    name: 'Collaborative',
+    description: 'Multiple agents cooperate on a single task.',
+    best_for: 'Complex tasks requiring diverse expertise',
+  },
+};
+
+const sampleWorkflow = {
+  workflow_id: 'wf-001',
+  name: 'Deploy Backend Service',
+  description: 'Full CI/CD deployment pipeline',
+  automation_mode: 'full_auto',
+  current_step: 2,
+  total_steps: 5,
+  is_paused: false,
+  is_cancelled: false,
+  completed_at: null,
+  phase: 'executing',
+  steps: [
+    { step_id: 's1', status: 'completed', description: 'Run unit tests', command: 'pytest', risk_level: 'low', requires_confirmation: false },
+    { step_id: 's2', status: 'completed', description: 'Build Docker image', command: 'docker build', risk_level: 'low', requires_confirmation: false },
+    { step_id: 's3', status: 'executing', description: 'Push to registry', command: 'docker push', risk_level: 'medium', requires_confirmation: false },
+    { step_id: 's4', status: 'pending', description: 'Deploy to staging', command: 'kubectl apply', risk_level: 'high', requires_confirmation: true },
+    { step_id: 's5', status: 'pending', description: 'Run smoke tests', command: 'pytest smoke/', risk_level: 'low', requires_confirmation: false },
+  ],
+};
+
+export const Operational: Story = {
+  args: {
+    status: sampleStatus,
+    strategies: sampleStrategies,
+    currentWorkflow: sampleWorkflow,
+    loading: false,
+  },
+};
+
+export const NoActiveWorkflow: Story = {
+  args: {
+    status: sampleStatus,
+    strategies: sampleStrategies,
+    currentWorkflow: null,
+    loading: false,
+  },
+};
+
+export const LoadingStrategies: Story = {
+  args: {
+    status: sampleStatus,
+    strategies: {},
+    currentWorkflow: null,
+    loading: true,
+  },
+};
+
+export const DegradedStatus: Story = {
+  args: {
+    status: {
+      status: 'degraded',
+      active_workflows: 1,
+      total_agents: 3,
+      max_parallel_tasks: 2,
+      capabilities: {
+        agent_coordination: true,
+        performance_tracking: false,
+        automatic_failover: false,
+        resource_optimization: false,
+      },
+    },
+    strategies: sampleStrategies,
+    currentWorkflow: null,
+    loading: false,
+  },
+};
+
+export const CompletedWorkflow: Story = {
+  args: {
+    status: sampleStatus,
+    strategies: sampleStrategies,
+    currentWorkflow: {
+      ...sampleWorkflow,
+      current_step: 4,
+      completed_at: new Date().toISOString(),
+      steps: sampleWorkflow.steps.map(s => ({ ...s, status: 'completed' })),
+    },
+    loading: false,
+  },
+};

--- a/autobot-frontend/src/components/workflow/PhaseProgressionIndicator.stories.ts
+++ b/autobot-frontend/src/components/workflow/PhaseProgressionIndicator.stories.ts
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import PhaseProgressionIndicator from './PhaseProgressionIndicator.vue';
+
+const meta = {
+  title: 'Components/Workflow/PhaseProgressionIndicator',
+  component: PhaseProgressionIndicator,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof PhaseProgressionIndicator>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+// PhaseProgressionIndicator fetches its own data on demand via the
+// /api/validation-dashboard/report endpoint. Stories render the idle
+// (ready) state; clicking the "Load Data" button triggers the fetch.
+
+export const ReadyState: Story = {
+  render: () => ({
+    components: { PhaseProgressionIndicator },
+    template: '<PhaseProgressionIndicator />',
+  }),
+};
+
+export const ContainerWidth: Story = {
+  render: () => ({
+    components: { PhaseProgressionIndicator },
+    template: `
+      <div style="max-width: 800px; margin: 0 auto;">
+        <PhaseProgressionIndicator />
+      </div>
+    `,
+  }),
+};
+
+export const NarrowViewport: Story = {
+  render: () => ({
+    components: { PhaseProgressionIndicator },
+    template: '<PhaseProgressionIndicator />',
+  }),
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+  },
+};

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.stories.ts
@@ -1,0 +1,142 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import WorkflowCanvas from './WorkflowCanvas.vue';
+
+const meta = {
+  title: 'Components/Workflow/WorkflowCanvas',
+  component: WorkflowCanvas,
+  tags: ['autodocs'],
+  argTypes: {
+    nodes: {
+      control: 'object',
+      description: 'Array of workflow nodes on the canvas',
+    },
+    selectedNodeId: {
+      control: 'text',
+      description: 'ID of the currently selected node, or null',
+    },
+  },
+} as Meta<typeof WorkflowCanvas>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Empty: Story = {
+  args: {
+    nodes: [],
+    selectedNodeId: null,
+  },
+};
+
+export const WithStepNodes: Story = {
+  args: {
+    nodes: [
+      {
+        id: 'node_1',
+        type: 'step',
+        position: { x: 100, y: 100 },
+        data: {
+          description: 'Install dependencies',
+          command: 'npm install',
+          risk_level: 'low',
+          requires_confirmation: false,
+          estimated_duration: 30,
+        },
+        connections: ['node_2'],
+      },
+      {
+        id: 'node_2',
+        type: 'step',
+        position: { x: 400, y: 100 },
+        data: {
+          description: 'Run tests',
+          command: 'npm test',
+          risk_level: 'low',
+          requires_confirmation: false,
+          estimated_duration: 60,
+        },
+        connections: ['node_3'],
+      },
+      {
+        id: 'node_3',
+        type: 'step',
+        position: { x: 700, y: 100 },
+        data: {
+          description: 'Deploy to production',
+          command: 'npm run deploy',
+          risk_level: 'high',
+          requires_confirmation: true,
+          estimated_duration: 120,
+        },
+        connections: [],
+      },
+    ],
+    selectedNodeId: 'node_2',
+  },
+};
+
+export const WithConditionNode: Story = {
+  args: {
+    nodes: [
+      {
+        id: 'node_start',
+        type: 'step',
+        position: { x: 80, y: 120 },
+        data: { description: 'Check environment', command: 'env check', risk_level: 'low', requires_confirmation: false, estimated_duration: 5 },
+        connections: ['node_cond'],
+      },
+      {
+        id: 'node_cond',
+        type: 'condition',
+        position: { x: 360, y: 120 },
+        data: { condition: 'ENV == production' },
+        connections: [],
+      },
+    ],
+    selectedNodeId: null,
+  },
+};
+
+export const WithVisionNodes: Story = {
+  args: {
+    nodes: [
+      {
+        id: 'vis_1',
+        type: 'vision-capture',
+        position: { x: 80, y: 80 },
+        data: { target: 'vnc', include_ocr: true, include_elements: true, include_layout: true },
+        connections: ['vis_2'],
+      },
+      {
+        id: 'vis_2',
+        type: 'vision-find-element',
+        position: { x: 360, y: 80 },
+        data: { target: 'vnc', element_type: 'button', text_match: 'Submit', confidence_threshold: 0.8 },
+        connections: ['vis_3'],
+      },
+      {
+        id: 'vis_3',
+        type: 'vision-click',
+        position: { x: 640, y: 80 },
+        data: { target: 'vnc', element_ref: '', click_type: 'single' },
+        connections: [],
+      },
+    ],
+    selectedNodeId: 'vis_1',
+  },
+};
+
+export const SelectedNode: Story = {
+  args: {
+    nodes: [
+      {
+        id: 'sel_1',
+        type: 'step',
+        position: { x: 100, y: 150 },
+        data: { description: 'Selected step', command: 'echo hello', risk_level: 'medium', requires_confirmation: true, estimated_duration: 10 },
+        connections: [],
+      },
+    ],
+    selectedNodeId: 'sel_1',
+  },
+};

--- a/autobot-frontend/src/components/workflow/WorkflowHistory.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowHistory.stories.ts
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import WorkflowHistory from './WorkflowHistory.vue';
+
+const meta = {
+  title: 'Components/Workflow/WorkflowHistory',
+  component: WorkflowHistory,
+  tags: ['autodocs'],
+  argTypes: {
+    workflows: {
+      control: 'object',
+      description: 'Active (finished) workflows to display in history',
+    },
+    completedWorkflows: {
+      control: 'object',
+      description: 'Persisted completed workflows (merged with workflows, deduplicated)',
+    },
+  },
+} as Meta<typeof WorkflowHistory>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+const makeSteps = (statuses: string[]) =>
+  statuses.map((status, i) => ({
+    step_id: `step_${i}`,
+    status,
+    description: `Step ${i + 1}`,
+    command: `cmd_${i}`,
+    risk_level: 'low',
+    requires_confirmation: false,
+  }));
+
+const sampleWorkflows = [
+  {
+    workflow_id: 'wf-001',
+    name: 'Deploy Backend v2.4',
+    description: 'Full deployment pipeline for backend service version 2.4',
+    automation_mode: 'full_auto',
+    total_steps: 5,
+    current_step: 4,
+    steps: makeSteps(['completed', 'completed', 'completed', 'completed', 'completed']),
+    created_at: new Date(Date.now() - 3_600_000).toISOString(),
+    started_at: new Date(Date.now() - 3_500_000).toISOString(),
+    completed_at: new Date(Date.now() - 3_000_000).toISOString(),
+    is_paused: false,
+    is_cancelled: false,
+    phase: 'complete',
+  },
+  {
+    workflow_id: 'wf-002',
+    name: 'Security Audit',
+    description: 'Run automated security scanning on all services',
+    automation_mode: 'supervised',
+    total_steps: 4,
+    current_step: 2,
+    steps: makeSteps(['completed', 'completed', 'failed', 'pending']),
+    created_at: new Date(Date.now() - 7_200_000).toISOString(),
+    started_at: new Date(Date.now() - 7_100_000).toISOString(),
+    completed_at: new Date(Date.now() - 6_000_000).toISOString(),
+    is_paused: false,
+    is_cancelled: false,
+    phase: 'complete',
+  },
+  {
+    workflow_id: 'wf-003',
+    name: 'Database Migration',
+    description: 'Migrate schema to v3 with data backfill',
+    automation_mode: 'manual',
+    total_steps: 6,
+    current_step: 3,
+    steps: makeSteps(['completed', 'completed', 'completed', 'pending', 'pending', 'pending']),
+    created_at: new Date(Date.now() - 86_400_000).toISOString(),
+    started_at: new Date(Date.now() - 86_300_000).toISOString(),
+    completed_at: null,
+    is_paused: false,
+    is_cancelled: true,
+    phase: 'executing',
+  },
+];
+
+export const WithHistory: Story = {
+  args: {
+    workflows: sampleWorkflows,
+    completedWorkflows: [],
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    workflows: [],
+    completedWorkflows: [],
+  },
+};
+
+export const MixedSources: Story = {
+  args: {
+    workflows: [sampleWorkflows[0]],
+    completedWorkflows: [sampleWorkflows[1], sampleWorkflows[2]],
+  },
+};
+
+export const SingleEntry: Story = {
+  args: {
+    workflows: [sampleWorkflows[0]],
+    completedWorkflows: [],
+  },
+};
+
+export const LargeHistory: Story = {
+  args: {
+    workflows: Array.from({ length: 15 }, (_, i) => ({
+      workflow_id: `wf-bulk-${i}`,
+      name: `Workflow ${i + 1}`,
+      description: `Automated task batch ${i + 1}`,
+      automation_mode: 'full_auto',
+      total_steps: 3,
+      current_step: 2,
+      steps: makeSteps(['completed', 'completed', 'completed']),
+      created_at: new Date(Date.now() - i * 3_600_000).toISOString(),
+      started_at: new Date(Date.now() - i * 3_600_000 + 60_000).toISOString(),
+      completed_at: new Date(Date.now() - i * 3_600_000 + 600_000).toISOString(),
+      is_paused: false,
+      is_cancelled: false,
+      phase: 'complete',
+    })),
+    completedWorkflows: [],
+  },
+};

--- a/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.stories.ts
@@ -1,0 +1,155 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import WorkflowLiveDashboard from './WorkflowLiveDashboard.vue';
+
+const meta = {
+  title: 'Components/Workflow/WorkflowLiveDashboard',
+  component: WorkflowLiveDashboard,
+  tags: ['autodocs'],
+  argTypes: {
+    activeWorkflows: {
+      control: 'object',
+      description: 'Array of currently active workflow objects',
+    },
+    agentPerformance: {
+      control: 'object',
+      description: 'Record of agent performance data keyed by agent name',
+    },
+    agentCapabilities: {
+      control: 'object',
+      description: 'Record of agent capability data keyed by agent name',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Whether active workflows are loading',
+    },
+    loadingCapabilities: {
+      control: 'boolean',
+      description: 'Whether agent capabilities are loading',
+    },
+  },
+} as Meta<typeof WorkflowLiveDashboard>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+const makeSteps = (statuses: string[]) =>
+  statuses.map((status, i) => ({
+    step_id: `step_${i}`,
+    status,
+    description: `Step ${i + 1}`,
+    command: `cmd_${i}`,
+    risk_level: 'low',
+    requires_confirmation: false,
+  }));
+
+const runningWorkflow = {
+  workflow_id: 'wf-live-001',
+  name: 'CI/CD Pipeline',
+  description: 'Continuous integration and deployment',
+  automation_mode: 'full_auto',
+  current_step: 2,
+  total_steps: 6,
+  steps: makeSteps(['completed', 'completed', 'executing', 'pending', 'pending', 'pending']),
+  created_at: new Date(Date.now() - 900_000).toISOString(),
+  started_at: new Date(Date.now() - 850_000).toISOString(),
+  completed_at: null,
+  is_paused: false,
+  is_cancelled: false,
+  automation_mode_label: 'Full Auto',
+  phase: 'executing',
+  active_service: 'autobot-backend',
+};
+
+const pausedWorkflow = {
+  workflow_id: 'wf-live-002',
+  name: 'Database Backup',
+  description: 'Nightly database backup routine',
+  automation_mode: 'supervised',
+  current_step: 1,
+  total_steps: 4,
+  steps: makeSteps(['completed', 'paused', 'pending', 'pending']),
+  created_at: new Date(Date.now() - 1_800_000).toISOString(),
+  started_at: new Date(Date.now() - 1_750_000).toISOString(),
+  completed_at: null,
+  is_paused: true,
+  is_cancelled: false,
+  phase: 'executing',
+  active_service: null,
+};
+
+const agentPerf = {
+  coordinator: {
+    agent_name: 'Coordinator',
+    total_tasks: 20,
+    successful_tasks: 19,
+    failed_tasks: 1,
+    average_duration: 8.4,
+    reliability_score: 0.95,
+  },
+};
+
+const agentCaps = {
+  coordinator: {
+    agent: 'Coordinator',
+    capabilities: ['routing', 'scheduling'],
+    performance: { total_tasks: 20, reliability: 0.95 },
+  },
+};
+
+export const WithActiveWorkflows: Story = {
+  args: {
+    activeWorkflows: [runningWorkflow, pausedWorkflow],
+    agentPerformance: agentPerf,
+    agentCapabilities: agentCaps,
+    loading: false,
+    loadingCapabilities: false,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    activeWorkflows: [],
+    agentPerformance: {},
+    agentCapabilities: {},
+    loading: false,
+    loadingCapabilities: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    activeWorkflows: [],
+    agentPerformance: {},
+    agentCapabilities: {},
+    loading: true,
+    loadingCapabilities: true,
+  },
+};
+
+export const SingleRunning: Story = {
+  args: {
+    activeWorkflows: [runningWorkflow],
+    agentPerformance: agentPerf,
+    agentCapabilities: agentCaps,
+    loading: false,
+    loadingCapabilities: false,
+  },
+};
+
+export const WithFailedStep: Story = {
+  args: {
+    activeWorkflows: [
+      {
+        ...runningWorkflow,
+        workflow_id: 'wf-live-fail',
+        name: 'Failing Pipeline',
+        steps: makeSteps(['completed', 'failed', 'pending', 'pending', 'pending', 'pending']),
+      },
+    ],
+    agentPerformance: agentPerf,
+    agentCapabilities: agentCaps,
+    loading: false,
+    loadingCapabilities: false,
+  },
+};

--- a/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.stories.ts
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import WorkflowNotificationConfig from './WorkflowNotificationConfig.vue';
+
+const meta = {
+  title: 'Components/Workflow/WorkflowNotificationConfig',
+  component: WorkflowNotificationConfig,
+  tags: ['autodocs'],
+  argTypes: {
+    workflows: {
+      control: 'object',
+      description: 'List of workflow summaries available for selection',
+    },
+  },
+} as Meta<typeof WorkflowNotificationConfig>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+const sampleWorkflows = [
+  { workflow_id: 'wf-aaa111', name: 'Backend Deployment' },
+  { workflow_id: 'wf-bbb222', name: 'Database Migration' },
+  { workflow_id: 'wf-ccc333', name: 'Security Scan' },
+  { workflow_id: 'wf-ddd444', name: 'Nightly Backup' },
+];
+
+export const WithWorkflows: Story = {
+  args: {
+    workflows: sampleWorkflows,
+  },
+};
+
+export const NoWorkflows: Story = {
+  args: {
+    workflows: [],
+  },
+};
+
+export const SingleWorkflow: Story = {
+  args: {
+    workflows: [sampleWorkflows[0]],
+  },
+};
+
+export const ManyWorkflows: Story = {
+  args: {
+    workflows: Array.from({ length: 12 }, (_, i) => ({
+      workflow_id: `wf-bulk-${i}`,
+      name: `Workflow ${i + 1} — ${['Deploy', 'Backup', 'Scan', 'Migrate'][i % 4]}`,
+    })),
+  },
+};

--- a/autobot-frontend/src/components/workflow/WorkflowProgressWidget.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowProgressWidget.stories.ts
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import WorkflowProgressWidget from './WorkflowProgressWidget.vue';
+
+const meta = {
+  title: 'Components/Workflow/WorkflowProgressWidget',
+  component: WorkflowProgressWidget,
+  tags: ['autodocs'],
+  argTypes: {
+    workflowId: {
+      control: 'text',
+      description: 'ID of the workflow to track; triggers data polling when set',
+    },
+  },
+} as Meta<typeof WorkflowProgressWidget>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+// WorkflowProgressWidget fetches its own data via the API using the workflowId prop.
+// Stories show the idle state (no workflowId) and the loading state (workflowId set).
+
+export const NoWorkflow: Story = {
+  args: {
+    workflowId: undefined,
+  },
+};
+
+export const WithWorkflowId: Story = {
+  args: {
+    workflowId: 'wf-demo-001',
+  },
+};
+
+export const AlternateWorkflow: Story = {
+  args: {
+    workflowId: 'wf-demo-002',
+  },
+};
+
+export const ContainerContext: Story = {
+  render: () => ({
+    components: { WorkflowProgressWidget },
+    template: `
+      <div style="position: relative; height: 300px; background: #1e293b; border-radius: 8px; padding: 16px;">
+        <p style="color: #94a3b8; font-size: 14px;">Page content area</p>
+        <WorkflowProgressWidget workflow-id="wf-demo-003" />
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/workflow/WorkflowRunner.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowRunner.stories.ts
@@ -1,0 +1,127 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import WorkflowRunner from './WorkflowRunner.vue';
+
+const meta = {
+  title: 'Components/Workflow/WorkflowRunner',
+  component: WorkflowRunner,
+  tags: ['autodocs'],
+  argTypes: {
+    workflows: {
+      control: 'object',
+      description: 'List of active workflows shown in the sidebar',
+    },
+    currentWorkflow: {
+      control: 'object',
+      description: 'Currently selected workflow shown in the detail panel, or null',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Whether the workflow list is refreshing',
+    },
+  },
+} as Meta<typeof WorkflowRunner>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+const makeSteps = (statuses: string[]) =>
+  statuses.map((status, i) => ({
+    step_id: `s${i}`,
+    status,
+    description: `Step ${i + 1}: ${['Build', 'Test', 'Deploy', 'Verify', 'Notify'][i] ?? 'Task'}`,
+    command: `cmd_step_${i}`,
+    risk_level: i === 2 ? 'high' : 'low',
+    requires_confirmation: i === 2,
+    started_at: status === 'completed' ? new Date(Date.now() - (5 - i) * 60_000).toISOString() : undefined,
+    completed_at: status === 'completed' ? new Date(Date.now() - (4 - i) * 60_000).toISOString() : undefined,
+    execution_result: status === 'completed' ? { exit_code: 0, output: 'OK' } : undefined,
+  }));
+
+const activeWorkflow = {
+  workflow_id: 'wf-runner-001',
+  name: 'Deploy Backend v2.5',
+  description: 'Production deployment of backend service version 2.5.0',
+  automation_mode: 'supervised',
+  current_step: 2,
+  total_steps: 5,
+  steps: makeSteps(['completed', 'completed', 'executing', 'pending', 'pending']),
+  created_at: new Date(Date.now() - 600_000).toISOString(),
+  started_at: new Date(Date.now() - 580_000).toISOString(),
+  completed_at: null,
+  is_paused: false,
+  is_cancelled: false,
+  phase: 'executing',
+  active_service: 'autobot-backend',
+};
+
+const pausedWorkflow = {
+  ...activeWorkflow,
+  workflow_id: 'wf-runner-002',
+  name: 'Security Scan',
+  current_step: 1,
+  steps: makeSteps(['completed', 'paused', 'pending', 'pending', 'pending']),
+  is_paused: true,
+};
+
+export const NoSelection: Story = {
+  args: {
+    workflows: [activeWorkflow, pausedWorkflow],
+    currentWorkflow: null,
+    loading: false,
+  },
+};
+
+export const WithSelectedWorkflow: Story = {
+  args: {
+    workflows: [activeWorkflow, pausedWorkflow],
+    currentWorkflow: activeWorkflow,
+    loading: false,
+  },
+};
+
+export const PausedWorkflow: Story = {
+  args: {
+    workflows: [pausedWorkflow],
+    currentWorkflow: pausedWorkflow,
+    loading: false,
+  },
+};
+
+export const EmptyList: Story = {
+  args: {
+    workflows: [],
+    currentWorkflow: null,
+    loading: false,
+  },
+};
+
+export const LoadingRefresh: Story = {
+  args: {
+    workflows: [activeWorkflow],
+    currentWorkflow: activeWorkflow,
+    loading: true,
+  },
+};
+
+export const WithApprovalPending: Story = {
+  args: {
+    workflows: [
+      {
+        ...activeWorkflow,
+        workflow_id: 'wf-runner-approval',
+        name: 'High-Risk Deploy',
+        current_step: 2,
+        steps: makeSteps(['completed', 'completed', 'waiting_approval', 'pending', 'pending']),
+      },
+    ],
+    currentWorkflow: {
+      ...activeWorkflow,
+      workflow_id: 'wf-runner-approval',
+      name: 'High-Risk Deploy',
+      current_step: 2,
+      steps: makeSteps(['completed', 'completed', 'waiting_approval', 'pending', 'pending']),
+    },
+    loading: false,
+  },
+};

--- a/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.stories.ts
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import WorkflowTemplateGallery from './WorkflowTemplateGallery.vue';
+
+const meta = {
+  title: 'Components/Workflow/WorkflowTemplateGallery',
+  component: WorkflowTemplateGallery,
+  tags: ['autodocs'],
+  argTypes: {
+    templates: {
+      control: 'object',
+      description: 'Array of workflow templates (used when useApi is false)',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Whether templates are loading (used when useApi is false)',
+    },
+    useApi: {
+      control: 'boolean',
+      description: 'When true, fetches templates from the API; when false, uses the templates prop',
+    },
+  },
+} as Meta<typeof WorkflowTemplateGallery>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+const makeTemplate = (
+  id: string,
+  name: string,
+  description: string,
+  category: string,
+  icon: string,
+  stepCount = 4,
+) => ({
+  id,
+  name,
+  description,
+  category,
+  icon,
+  estimated_duration_minutes: stepCount * 5,
+  agents_involved: ['coordinator', 'executor'],
+  steps: Array.from({ length: stepCount }, (_, i) => ({
+    task_id: `${id}-step-${i}`,
+    agent_type: 'executor',
+    action: 'run',
+    command: `step_cmd_${i}`,
+    description: `Step ${i + 1}`,
+    requires_approval: i === stepCount - 1,
+    dependencies: i > 0 ? [`${id}-step-${i - 1}`] : [],
+    inputs: {},
+    estimated_duration_seconds: 60,
+    prompt: null,
+    tools_allowed: null,
+    tools_denied: [],
+  })),
+});
+
+const sampleTemplates = [
+  makeTemplate('tpl-001', 'Deploy Backend Service', 'Full CI/CD pipeline for backend deployment', 'Development', 'fas fa-code', 5),
+  makeTemplate('tpl-002', 'Security Vulnerability Scan', 'Automated CVE scanning across all services', 'Security', 'fas fa-shield-alt', 3),
+  makeTemplate('tpl-003', 'Database Backup', 'Scheduled backup with integrity verification', 'Backup', 'fas fa-database', 4),
+  makeTemplate('tpl-004', 'System Health Report', 'Aggregate system metrics and generate report', 'System', 'fas fa-cog', 6),
+  makeTemplate('tpl-005', 'Log Analysis', 'Parse and summarise application logs', 'Analysis', 'fas fa-chart-bar', 3),
+  makeTemplate('tpl-006', 'Community Sync', 'Sync contributions from external repositories', 'Community', 'fas fa-users', 2),
+];
+
+export const StaticTemplates: Story = {
+  args: {
+    templates: sampleTemplates,
+    loading: false,
+    useApi: false,
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    templates: [],
+    loading: true,
+    useApi: false,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    templates: [],
+    loading: false,
+    useApi: false,
+  },
+};
+
+export const ApiMode: Story = {
+  args: {
+    templates: [],
+    loading: false,
+    useApi: true,
+  },
+};
+
+export const SingleTemplate: Story = {
+  args: {
+    templates: [sampleTemplates[0]],
+    loading: false,
+    useApi: false,
+  },
+};


### PR DESCRIPTION
Adds stories for AgentObservabilityPanel (5), NotificationConfigModal (3), OrchestrationVisualizer (5), PhaseProgressionIndicator (3), WorkflowCanvas (5), WorkflowHistory (5), WorkflowLiveDashboard (5), WorkflowNotificationConfig (4), WorkflowProgressWidget (4), WorkflowRunner (6), WorkflowTemplateGallery (5). Closes #6851. Part of #4201 Phase 2.