### PR TITLE
fix(a11y): convert KnowledgePromptEditor prompt-item divs to button elements (#7720)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
@@ -298,16 +298,18 @@ onBeforeUnmount(() => {
                 <span class="count">{{ categoryPrompts.length }}</span>
               </div>
               <div class="category-prompts">
-                <div
+                <button
                   v-for="prompt in categoryPrompts"
                   :key="prompt.id"
                   class="prompt-item"
                   :class="{ selected: selectedPrompt?.id === prompt.id }"
+                  type="button"
+                  :aria-pressed="selectedPrompt?.id === prompt.id"
                   @click="selectPrompt(prompt)"
                 >
                   <span class="prompt-name">{{ prompt.name }}</span>
                   <span v-if="prompt.description" class="prompt-desc">{{ prompt.description }}</span>
-                </div>
+                </button>
               </div>
             </div>
           </template>
@@ -607,8 +609,13 @@ onBeforeUnmount(() => {
 }
 
 .prompt-item {
+  display: block;
+  width: 100%;
   padding: var(--spacing-2-5) var(--spacing-3);
+  border: none;
   border-radius: var(--radius-md);
+  background: transparent;
+  text-align: left;
   cursor: pointer;
   transition: all var(--duration-150);
 }


### PR DESCRIPTION
## Summary

- Converts clickable `<div class="prompt-item">` elements to semantic `<button>` elements in KnowledgePromptEditor prompt sidebar
- Adds `type="button"` (prevents accidental form submission) and `aria-pressed` state attribute
- Resets button browser defaults in CSS: `border: none`, `background: transparent`, `text-align: left`, `display: block`, `width: 100%`

Fixes WCAG 4.1.2 (Name, Role, Value) — screen readers now correctly expose prompt items as interactive buttons, not generic containers.

## Test plan

- [ ] Prompt items in KnowledgePromptEditor sidebar are accessible via keyboard (Tab focus, Enter/Space selection)
- [ ] Screen reader announces items as "button" with pressed state
- [ ] Visual appearance unchanged (hover, selected styles still apply)
- [ ] No layout regression — buttons fill full sidebar width

Closes #7720

🤖 Generated with [Claude Code](https://claude.com/claude-code)