### PR TITLE
ci(phase-validation): re-enable blocking gate now that PHASE_CRITERIA is fixed (closes #7496)

### DIFF
--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -126,12 +126,6 @@ jobs:
         python3 autobot-infrastructure/shared/scripts/validation_dashboard_generator.py --ci-mode > validation_dashboard.html || echo "Dashboard generation failed"
 
     - name: Phase Validation Gate
-      # Non-blocking until #7496 rewrites the legacy PHASE_CRITERIA paths
-      # (`src/`, `backend/`, `main.py`, …) to match the current
-      # `autobot-backend/` / `autobot-frontend/` reorganisation. The gate
-      # currently scores ~22% against stale criteria; gating on it would
-      # block every merge for reasons unrelated to the change under review.
-      continue-on-error: true
       shell: bash
       run: |
         set -euo pipefail
@@ -241,8 +235,6 @@ jobs:
         name: phase-validation-reports
 
     - name: Integration readiness check
-      # Non-blocking until #7496 — same reason as Phase Validation Gate.
-      continue-on-error: true
       shell: bash
       run: |
         set -euo pipefail


### PR DESCRIPTION
## Summary

- Removes the two `continue-on-error: true` guards added in #7475 while PHASE_CRITERIA referenced stale pre-reorganisation paths (`src/`, `backend/`, etc.)
- The criteria were already updated in a prior commit to reference the current layout (`autobot-backend/`, `autobot_shared/`, etc.) — all 10 phases score 100% in `--ci-mode`
- The Phase Validation Gate and Integration readiness check now block again as designed

## What was already done before this PR
- PR #7475 fixed the `overall_maturity` key bug and the `autobot_shared` import error, and added `continue-on-error: true` as a stopgap
- The PHASE_CRITERIA rewrite (criteria paths + Redis coroutine fix) landed as part of that same body of work

## Test plan
- [ ] Phase Validation Integration workflow passes on Dev_new_gui push after merge
- [ ] `--ci-mode` validation locally scores ≥60% (verified: 100% with updated criteria)
- [ ] No other workflow changes needed

Closes #7496

🤖 Generated with [Claude Code](https://claude.com/claude-code)