### PR TITLE
refactor(backend): migrate hand-rolled singletons to lazy_singleton (#7445)

### DIFF
--- a/autobot-backend/agents/audio_processing_agent.py
+++ b/autobot-backend/agents/audio_processing_agent.py
@@ -10,10 +10,10 @@ Handles audio content analysis, transcription processing, and audio metadata
 interpretation using LLM capabilities.
 """
 
-import threading
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import (
     get_agent_endpoint_explicit,
     get_agent_model_explicit,
@@ -164,15 +164,5 @@ class AudioProcessingAgent(StandardizedAgent):
         return str(response)
 
 
-_audio_processing_agent_instance = None
-_audio_processing_agent_lock = threading.Lock()
-
-
-def get_audio_processing_agent() -> AudioProcessingAgent:
-    """Get the singleton Audio Processing Agent instance (thread-safe)."""
-    global _audio_processing_agent_instance
-    if _audio_processing_agent_instance is None:
-        with _audio_processing_agent_lock:
-            if _audio_processing_agent_instance is None:
-                _audio_processing_agent_instance = AudioProcessingAgent()
-    return _audio_processing_agent_instance
+get_audio_processing_agent = lazy_singleton(AudioProcessingAgent)
+"""Get the singleton Audio Processing Agent instance (thread-safe)."""

--- a/autobot-backend/agents/chat_agent.py
+++ b/autobot-backend/agents/chat_agent.py
@@ -11,6 +11,7 @@ Focuses on quick, natural interactions without complex reasoning.
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import (
     get_agent_endpoint_explicit,
     get_agent_model_explicit,
@@ -361,19 +362,5 @@ For complex technical tasks, analysis, or system commands, you should "
         return len(message.split()) <= 10
 
 
-# Singleton instance (thread-safe)
-import threading
-
-_chat_agent_instance = None
-_chat_agent_lock = threading.Lock()
-
-
-def get_chat_agent() -> ChatAgent:
-    """Get the singleton Chat Agent instance (thread-safe)."""
-    global _chat_agent_instance
-    if _chat_agent_instance is None:
-        with _chat_agent_lock:
-            # Double-check after acquiring lock
-            if _chat_agent_instance is None:
-                _chat_agent_instance = ChatAgent()
-    return _chat_agent_instance
+get_chat_agent = lazy_singleton(ChatAgent)
+"""Get the singleton Chat Agent instance (thread-safe)."""

--- a/autobot-backend/agents/code_generation_agent.py
+++ b/autobot-backend/agents/code_generation_agent.py
@@ -10,10 +10,10 @@ Handles code generation from natural language descriptions, code explanation,
 and multi-language programming support.
 """
 
-import threading
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import (
     get_agent_endpoint_explicit,
     get_agent_model_explicit,
@@ -157,15 +157,5 @@ class CodeGenerationAgent(StandardizedAgent):
         return str(response)
 
 
-_code_generation_agent_instance = None
-_code_generation_agent_lock = threading.Lock()
-
-
-def get_code_generation_agent() -> CodeGenerationAgent:
-    """Get the singleton Code Generation Agent instance (thread-safe)."""
-    global _code_generation_agent_instance
-    if _code_generation_agent_instance is None:
-        with _code_generation_agent_lock:
-            if _code_generation_agent_instance is None:
-                _code_generation_agent_instance = CodeGenerationAgent()
-    return _code_generation_agent_instance
+get_code_generation_agent = lazy_singleton(CodeGenerationAgent)
+"""Get the singleton Code Generation Agent instance (thread-safe)."""

--- a/autobot-backend/agents/data_analysis_agent.py
+++ b/autobot-backend/agents/data_analysis_agent.py
@@ -10,10 +10,10 @@ Handles data analysis tasks using LLM to identify patterns, compute statistics,
 and provide insights from structured and unstructured data.
 """
 
-import threading
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import (
     get_agent_endpoint_explicit,
     get_agent_model_explicit,
@@ -166,15 +166,5 @@ class DataAnalysisAgent(StandardizedAgent):
         return str(response)
 
 
-_data_analysis_agent_instance = None
-_data_analysis_agent_lock = threading.Lock()
-
-
-def get_data_analysis_agent() -> DataAnalysisAgent:
-    """Get the singleton Data Analysis Agent instance (thread-safe)."""
-    global _data_analysis_agent_instance
-    if _data_analysis_agent_instance is None:
-        with _data_analysis_agent_lock:
-            if _data_analysis_agent_instance is None:
-                _data_analysis_agent_instance = DataAnalysisAgent()
-    return _data_analysis_agent_instance
+get_data_analysis_agent = lazy_singleton(DataAnalysisAgent)
+"""Get the singleton Data Analysis Agent instance (thread-safe)."""

--- a/autobot-backend/agents/knowledge_retrieval_agent.py
+++ b/autobot-backend/agents/knowledge_retrieval_agent.py
@@ -12,6 +12,7 @@ import time
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import (
     get_agent_endpoint_explicit,
     get_agent_model_explicit,
@@ -599,19 +600,5 @@ If the information is not in the provided text, respond with "Information not fo
         return False
 
 
-# Singleton instance (thread-safe)
-import threading
-
-_knowledge_retrieval_agent_instance = None
-_knowledge_retrieval_agent_lock = threading.Lock()
-
-
-def get_knowledge_retrieval_agent() -> KnowledgeRetrievalAgent:
-    """Get the singleton Knowledge Retrieval Agent instance (thread-safe)."""
-    global _knowledge_retrieval_agent_instance
-    if _knowledge_retrieval_agent_instance is None:
-        with _knowledge_retrieval_agent_lock:
-            # Double-check after acquiring lock
-            if _knowledge_retrieval_agent_instance is None:
-                _knowledge_retrieval_agent_instance = KnowledgeRetrievalAgent()
-    return _knowledge_retrieval_agent_instance
+get_knowledge_retrieval_agent = lazy_singleton(KnowledgeRetrievalAgent)
+"""Get the singleton Knowledge Retrieval Agent instance (thread-safe)."""

--- a/autobot-backend/agents/rag_agent.py
+++ b/autobot-backend/agents/rag_agent.py
@@ -12,6 +12,7 @@ import json
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import (
     get_agent_endpoint_explicit,
     get_agent_model_explicit,
@@ -594,19 +595,5 @@ Focus on creating 2-4 reformulated queries that would retrieve different but rel
         return any(pattern in message_lower for pattern in rag_patterns)
 
 
-# Singleton instance (thread-safe)
-import threading
-
-_rag_agent_instance = None
-_rag_agent_lock = threading.Lock()
-
-
-def get_rag_agent() -> RAGAgent:
-    """Get the singleton RAG Agent instance (thread-safe)."""
-    global _rag_agent_instance
-    if _rag_agent_instance is None:
-        with _rag_agent_lock:
-            # Double-check after acquiring lock
-            if _rag_agent_instance is None:
-                _rag_agent_instance = RAGAgent()
-    return _rag_agent_instance
+get_rag_agent = lazy_singleton(RAGAgent)
+"""Get the singleton RAG Agent instance (thread-safe)."""

--- a/autobot-backend/agents/sentiment_analysis_agent.py
+++ b/autobot-backend/agents/sentiment_analysis_agent.py
@@ -10,10 +10,10 @@ Handles sentiment analysis (positive/negative/neutral) and fine-grained
 emotion classification from text input.
 """
 
-import threading
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import (
     get_agent_endpoint_explicit,
     get_agent_model_explicit,
@@ -188,15 +188,5 @@ class SentimentAnalysisAgent(StandardizedAgent):
         return str(response)
 
 
-_sentiment_analysis_agent_instance = None
-_sentiment_analysis_agent_lock = threading.Lock()
-
-
-def get_sentiment_analysis_agent() -> SentimentAnalysisAgent:
-    """Get the singleton Sentiment Analysis Agent instance (thread-safe)."""
-    global _sentiment_analysis_agent_instance
-    if _sentiment_analysis_agent_instance is None:
-        with _sentiment_analysis_agent_lock:
-            if _sentiment_analysis_agent_instance is None:
-                _sentiment_analysis_agent_instance = SentimentAnalysisAgent()
-    return _sentiment_analysis_agent_instance
+get_sentiment_analysis_agent = lazy_singleton(SentimentAnalysisAgent)
+"""Get the singleton Sentiment Analysis Agent instance (thread-safe)."""

--- a/autobot-backend/agents/summarization_agent.py
+++ b/autobot-backend/agents/summarization_agent.py
@@ -10,10 +10,10 @@ Handles text summarization with configurable length, key point extraction,
 and structured summary generation.
 """
 
-import threading
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import (
     get_agent_endpoint_explicit,
     get_agent_model_explicit,
@@ -160,15 +160,5 @@ class SummarizationAgent(StandardizedAgent):
         return str(response)
 
 
-_summarization_agent_instance = None
-_summarization_agent_lock = threading.Lock()
-
-
-def get_summarization_agent() -> SummarizationAgent:
-    """Get the singleton Summarization Agent instance (thread-safe)."""
-    global _summarization_agent_instance
-    if _summarization_agent_instance is None:
-        with _summarization_agent_lock:
-            if _summarization_agent_instance is None:
-                _summarization_agent_instance = SummarizationAgent()
-    return _summarization_agent_instance
+get_summarization_agent = lazy_singleton(SummarizationAgent)
+"""Get the singleton Summarization Agent instance (thread-safe)."""

--- a/autobot-backend/agents/translation_agent.py
+++ b/autobot-backend/agents/translation_agent.py
@@ -10,10 +10,10 @@ Handles text translation between languages with context-aware processing
 and automatic language detection.
 """
 
-import threading
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import (
     get_agent_endpoint_explicit,
     get_agent_model_explicit,
@@ -162,15 +162,5 @@ class TranslationAgent(StandardizedAgent):
         return str(response)
 
 
-_translation_agent_instance = None
-_translation_agent_lock = threading.Lock()
-
-
-def get_translation_agent() -> TranslationAgent:
-    """Get the singleton Translation Agent instance (thread-safe)."""
-    global _translation_agent_instance
-    if _translation_agent_instance is None:
-        with _translation_agent_lock:
-            if _translation_agent_instance is None:
-                _translation_agent_instance = TranslationAgent()
-    return _translation_agent_instance
+get_translation_agent = lazy_singleton(TranslationAgent)
+"""Get the singleton Translation Agent instance (thread-safe)."""

--- a/autobot-backend/services/documentation_watcher.py
+++ b/autobot-backend/services/documentation_watcher.py
@@ -25,6 +25,7 @@ from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 
 logger = get_logger(__name__)
 
@@ -94,8 +95,6 @@ class DocumentationWatcherService:
     Issue #165: Provides real-time sync between docs/ changes and the knowledge base.
     """
 
-    _instance: "DocumentationWatcherService" | None = None
-
     def __init__(self) -> None:
         """Initialize the documentation watcher service."""
         self._observer: Observer | None = None
@@ -111,13 +110,6 @@ class DocumentationWatcherService:
             "last_change": None,
             "errors": 0,
         }
-
-    @classmethod
-    def get_instance(cls) -> "DocumentationWatcherService":
-        """Get or create singleton instance."""
-        if cls._instance is None:
-            cls._instance = cls()
-        return cls._instance
 
     async def start(self) -> bool:
         """
@@ -403,9 +395,8 @@ class DocumentationWatcherService:
 
 
 # Convenience functions
-def get_documentation_watcher() -> DocumentationWatcherService:
-    """Get the documentation watcher singleton instance."""
-    return DocumentationWatcherService.get_instance()
+get_documentation_watcher = lazy_singleton(DocumentationWatcherService)
+"""Get the documentation watcher singleton instance."""
 
 
 async def start_documentation_watcher() -> bool:

--- a/autobot-backend/services/nl_database_service.py
+++ b/autobot-backend/services/nl_database_service.py
@@ -28,6 +28,7 @@ from uuid import uuid4
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config
 from autobot_shared.time_utils import utc_timestamp
 
@@ -276,8 +277,6 @@ class NLDatabaseService:
     databases. Enforces read-only access and logs all queries for audit.
     """
 
-    _instance: "NLDatabaseService" | None = None
-
     def __init__(self) -> None:
         """Initialize the NLDatabaseService."""
         self._vanna: Any | None = None
@@ -286,13 +285,6 @@ class NLDatabaseService:
         self._local_schema: str = ""
         self._vanna_available = False
         self._initialized = False
-
-    @classmethod
-    def get_instance(cls) -> "NLDatabaseService":
-        """Get or create singleton instance."""
-        if cls._instance is None:
-            cls._instance = cls()
-        return cls._instance
 
     async def initialize(self) -> None:
         """Initialize Vanna.ai and train on local schema."""
@@ -773,6 +765,5 @@ class NLDatabaseService:
             logger.warning("Failed to save query history: %s", exc)
 
 
-def get_nl_database_service() -> NLDatabaseService:
-    """Get the singleton NLDatabaseService instance."""
-    return NLDatabaseService.get_instance()
+get_nl_database_service = lazy_singleton(NLDatabaseService)
+"""Get the singleton NLDatabaseService instance."""

--- a/autobot-backend/utils/error_catalog.py
+++ b/autobot-backend/utils/error_catalog.py
@@ -16,6 +16,7 @@ import yaml
 
 from autobot_shared.error_boundaries import ErrorCategory
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from constants.path_constants import PATH
 
 logger = get_logger(__name__)
@@ -419,27 +420,19 @@ class ErrorCatalog:
     Singleton error catalog loader with caching and validation
 
     Usage:
-        catalog = ErrorCatalog.get_instance()
+        catalog = get_error_catalog_instance()
         error = catalog.get_error("KB_0001")
         if error:
             logger.info("%s - Retry: %s", error.message, error.retry)
     """
 
-    _instance: "ErrorCatalog" | None = None
     _initialized: bool = False
 
     def __init__(self):
-        """Initialize error catalog (use get_instance() instead)"""
+        """Initialize error catalog (use get_error_catalog_instance() instead)"""
         self._catalog: Dict[str, ErrorDefinition] = {}
         self._raw_data: dict | None = None
         self._catalog_path: Path | None = None
-
-    @classmethod
-    def get_instance(cls) -> "ErrorCatalog":
-        """Get singleton instance of error catalog"""
-        if cls._instance is None:
-            cls._instance = cls()
-        return cls._instance
 
     def _resolve_catalog_path(self) -> Path | None:
         """Find error_messages.yaml searching backend static dir then infrastructure.
@@ -647,6 +640,10 @@ class ErrorCatalog:
         return self.load_catalog(self._catalog_path)
 
 
+get_error_catalog_instance = lazy_singleton(ErrorCatalog)
+"""Get the singleton ErrorCatalog instance (thread-safe)."""
+
+
 # Convenience functions for direct access
 def get_error(error_code: str) -> ErrorDefinition | None:
     """
@@ -663,7 +660,7 @@ def get_error(error_code: str) -> ErrorDefinition | None:
         if error:
             logger.info("%s - Status: %s", error.message, error.status_code)
     """
-    catalog = ErrorCatalog.get_instance()
+    catalog = get_error_catalog_instance()
     return catalog.get_error(error_code)
 
 
@@ -681,7 +678,7 @@ def get_error_message(error_code: str, default: str = "Unknown error") -> str:
     Example:
         message = get_error_message("LLM_0001", "LLM service unavailable")
     """
-    catalog = ErrorCatalog.get_instance()
+    catalog = get_error_catalog_instance()
     return catalog.get_error_message(error_code, default)
 
 
@@ -699,10 +696,10 @@ def validate_error_code(error_code: str) -> bool:
         if validate_error_code("AUTH_0001"):
             logger.info("Valid error code")
     """
-    catalog = ErrorCatalog.get_instance()
+    catalog = get_error_catalog_instance()
     return catalog.validate_code(error_code)
 
 
 # Pre-load catalog on module import
-_catalog_instance = ErrorCatalog.get_instance()
+_catalog_instance = get_error_catalog_instance()
 _catalog_instance.load_catalog()


### PR DESCRIPTION
Migrates 12 of 62 hand-rolled singleton patterns to the canonical `lazy_singleton()` helper.

## Changed files
- `agents/chat_agent.py`
- `agents/rag_agent.py`
- `agents/knowledge_retrieval_agent.py`
- `agents/data_analysis_agent.py`
- `agents/translation_agent.py`
- `agents/sentiment_analysis_agent.py`
- `agents/code_generation_agent.py`
- `agents/audio_processing_agent.py`
- `agents/summarization_agent.py`
- `services/documentation_watcher.py`
- `services/nl_database_service.py`
- `utils/error_catalog.py`

## Skipped (50 complex patterns)
Patterns with async post-construction `await initialize()`, `reset()`/`force_reinit` hooks, `__new__`-based singletons with shared class-level state, or cleanup callbacks were left unchanged: `orchestrator`, `advanced_rag_optimizer`, `knowledge_sync_service`, `agent_client`, `intelligent_agent` (reload endpoint), `anti_pattern` (importlib factory), `external_provider_factory`, `gateway`, `tracing_service`, `http_client`, `plugin_sdk/{base,unified_registry,hooks}`, `redis/connection_manager`, `cache/coordinator`, `llm/adapters/registry`, `knowledge_base_factory`, `code_intelligence/{file_cache,ast_cache}`, `claude_api_integration`.

Closes #7445