### PR TITLE
fix(frontend): correct getUserById/getGroupById return types (GH#7541)

### DIFF
--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
@@ -198,21 +198,15 @@ const fetchEntityName = async (id: string, type: 'user' | 'group'): Promise<stri
   }
 
   try {
-    let response
-    if (type === 'user') {
-      response = await apiService.getUserById(id)
-    } else {
-      response = await apiService.getGroupById(id)
-    }
-
-    // Extract name from response — apiService returns parsed JSON directly (no .data envelope)
     let displayName = id
-    if (response) {
-      if (type === 'user') {
-        const userData = response as unknown as { display_name?: string; email?: string; username?: string }
+    if (type === 'user') {
+      const userData = await apiService.getUserById(id)
+      if (userData) {
         displayName = userData.display_name || userData.email || userData.username || id
-      } else {
-        const groupData = response as unknown as { name?: string }
+      }
+    } else {
+      const groupData = await apiService.getGroupById(id)
+      if (groupData) {
         displayName = groupData.name || id
       }
     }

--- a/autobot-frontend/src/services/api.ts
+++ b/autobot-frontend/src/services/api.ts
@@ -5,6 +5,7 @@ import type {
   ChatSession,
   WorkflowApproval
 } from '@/types/api'
+import type { UserResponse, TeamResponse } from '@/types/api-contract'
 import apiClient from '@/utils/ApiClient'
 import type { RequestOptions } from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
@@ -261,11 +262,11 @@ class ApiService {
   }
 
   // User Management API
-  async getUserById(userId: string): Promise<ApiResponse> {
+  async getUserById(userId: string): Promise<UserResponse> {
     return this.get(`${getApiBase()}/user-management/users/${userId}`)
   }
 
-  async getGroupById(groupId: string): Promise<ApiResponse> {
+  async getGroupById(groupId: string): Promise<TeamResponse> {
     return this.get(`${getApiBase()}/user-management/teams/${groupId}`)
   }
 }

--- a/autobot-frontend/src/types/api-contract.ts
+++ b/autobot-frontend/src/types/api-contract.ts
@@ -526,3 +526,11 @@ export type McpHealthResponse = components['schemas']['McpHealthResponse']
 
 /** `POST /rag-feedback` response. */
 export type RagFeedbackResponse = components['schemas']['RagFeedbackResponse']
+
+// --- user-management schemas (GH#7541) ----------------------------------------
+
+/** `GET /user-management/users/{user_id}` response. */
+export type UserResponse = components['schemas']['UserResponse']
+
+/** `GET /user-management/teams/{team_id}` response. */
+export type TeamResponse = components['schemas']['TeamResponse']


### PR DESCRIPTION
## Summary

- `getUserById` and `getGroupById` in `apiService` were declared as returning `Promise<ApiResponse>` but actually return flat `UserResponse`/`TeamResponse` objects — `apiClient.get()` returns parsed JSON directly with no envelope (GH#7541)
- Added `UserResponse` and `TeamResponse` type aliases to `api-contract.ts` following the established SSOT pattern
- Changed return type annotations in `api.ts` to `Promise<UserResponse>` / `Promise<TeamResponse>`
- Removed `as unknown as` casts in `ShareKnowledgeDialog.vue` — now accesses typed fields directly

## Test plan

- [x] TypeScript compiles without new errors in changed files
- [x] `ShareKnowledgeDialog.vue` call sites access `userData.display_name`, `.email`, `.username` and `groupData.name` without casts — all fields confirmed present in generated `UserResponse`/`TeamResponse` types
- [x] No functional behaviour change — runtime path is identical, only types corrected

Closes #7541

🤖 Generated with [Claude Code](https://claude.com/claude-code)