### PR TITLE
refactor(frontend/analytics): add Storybook stories for 32 components (#6847)

### DIFF
--- a/autobot-frontend/src/components/analytics/AddSourceModal.stories.ts
+++ b/autobot-frontend/src/components/analytics/AddSourceModal.stories.ts
@@ -1,0 +1,61 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import AddSourceModal from './AddSourceModal.vue';
+
+const meta = {
+  title: 'Components/Analytics/AddSourceModal',
+  component: AddSourceModal,
+  tags: ['autodocs'],
+  argTypes: {
+    visible: { control: 'boolean' },
+    source: { control: 'object' },
+  },
+} as Meta<typeof AddSourceModal>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    visible: true,
+    source: null,
+  },
+};
+
+export const EditMode: Story = {
+  args: {
+    visible: true,
+    source: {
+      id: 'src-001',
+      name: 'AutoBot Backend',
+      source_type: 'github',
+      repo: 'mrveiss/AutoBot-AI',
+      branch: 'Dev_new_gui',
+      access: 'private',
+      status: 'ready',
+    },
+  },
+};
+
+export const LocalPathMode: Story = {
+  args: {
+    visible: true,
+    source: {
+      id: 'src-002',
+      name: 'Local Project',
+      source_type: 'local',
+      clone_path: '/opt/autobot',
+      branch: 'main',
+      access: 'shared',
+      status: 'configured',
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    visible: false,
+    source: null,
+  },
+};

--- a/autobot-frontend/src/components/analytics/AdvancedAnalytics.stories.ts
+++ b/autobot-frontend/src/components/analytics/AdvancedAnalytics.stories.ts
@@ -1,0 +1,36 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import AdvancedAnalytics from './AdvancedAnalytics.vue';
+
+const meta = {
+  title: 'Components/Analytics/AdvancedAnalytics',
+  component: AdvancedAnalytics,
+  tags: ['autodocs'],
+} as Meta<typeof AdvancedAnalytics>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Loading: Story = {
+  render: () => ({
+    template: '<AdvancedAnalytics />',
+    components: { AdvancedAnalytics },
+  }),
+};
+
+export const CostTab: Story = {
+  args: {},
+};
+
+export const AgentsTab: Story = {
+  args: {},
+};
+
+export const ExportTab: Story = {
+  args: {},
+};

--- a/autobot-frontend/src/components/analytics/AgentCostPanel.stories.ts
+++ b/autobot-frontend/src/components/analytics/AgentCostPanel.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import AgentCostPanel from './AgentCostPanel.vue';
+
+const meta = {
+  title: 'Components/Analytics/AgentCostPanel',
+  component: AgentCostPanel,
+  tags: ['autodocs'],
+} as Meta<typeof AgentCostPanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const WithData: Story = {
+  args: {},
+  render: () => ({
+    template: '<AgentCostPanel />',
+    components: { AgentCostPanel },
+  }),
+};
+
+export const Empty: Story = {
+  args: {},
+};
+
+export const WithBudgetExceeded: Story = {
+  args: {},
+};

--- a/autobot-frontend/src/components/analytics/AnalyticsHeader.stories.ts
+++ b/autobot-frontend/src/components/analytics/AnalyticsHeader.stories.ts
@@ -1,0 +1,93 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import AnalyticsHeader from './AnalyticsHeader.vue';
+
+const meta = {
+  title: 'Components/Analytics/AnalyticsHeader',
+  component: AnalyticsHeader,
+  tags: ['autodocs'],
+  argTypes: {
+    rootPath: { control: 'text' },
+    analyzing: { control: 'boolean' },
+    currentJobId: { control: 'text' },
+    analyzingCodeSmells: { control: 'boolean' },
+    exportingReport: { control: 'boolean' },
+    clearingCache: { control: 'boolean' },
+    sources: { control: 'object' },
+    selectedSource: { control: 'object' },
+  },
+} as Meta<typeof AnalyticsHeader>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    rootPath: '/opt/autobot',
+    analyzing: false,
+    currentJobId: null,
+    analyzingCodeSmells: false,
+    exportingReport: false,
+    clearingCache: false,
+    sources: [],
+    selectedSource: null,
+  },
+};
+
+export const Analyzing: Story = {
+  args: {
+    rootPath: '/opt/autobot',
+    analyzing: true,
+    currentJobId: 'job-abc12345',
+    analyzingCodeSmells: false,
+    exportingReport: false,
+    clearingCache: false,
+    sources: [],
+    selectedSource: null,
+  },
+};
+
+export const WithSourceSelected: Story = {
+  args: {
+    rootPath: '',
+    analyzing: false,
+    currentJobId: null,
+    analyzingCodeSmells: false,
+    exportingReport: false,
+    clearingCache: false,
+    sources: [
+      {
+        id: 'src-001',
+        name: 'AutoBot Backend',
+        source_type: 'github',
+        repo: 'mrveiss/AutoBot-AI',
+        branch: 'Dev_new_gui',
+        access: 'private',
+        status: 'ready',
+      },
+    ],
+    selectedSource: {
+      id: 'src-001',
+      name: 'AutoBot Backend',
+      source_type: 'github',
+      repo: 'mrveiss/AutoBot-AI',
+      branch: 'Dev_new_gui',
+      access: 'private',
+      status: 'ready',
+    },
+  },
+};
+
+export const AnalyzingCodeSmells: Story = {
+  args: {
+    rootPath: '/opt/autobot',
+    analyzing: false,
+    currentJobId: null,
+    analyzingCodeSmells: true,
+    exportingReport: false,
+    clearingCache: false,
+    sources: [],
+    selectedSource: null,
+  },
+};

--- a/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.stories.ts
+++ b/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.stories.ts
@@ -1,0 +1,75 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import AnalyticsHeaderControls from './AnalyticsHeaderControls.vue';
+
+const meta = {
+  title: 'Components/Analytics/AnalyticsHeaderControls',
+  component: AnalyticsHeaderControls,
+  tags: ['autodocs'],
+  argTypes: {
+    analyzing: { control: 'boolean' },
+    rootPath: { control: 'text' },
+    selectedSource: { control: 'object' },
+    scanRunnerRunning: { control: 'boolean' },
+    loadingApiEndpoints: { control: 'boolean' },
+    analyzingCodeSmells: { control: 'boolean' },
+    exportingReport: { control: 'boolean' },
+    clearingCache: { control: 'boolean' },
+  },
+} as Meta<typeof AnalyticsHeaderControls>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    analyzing: false,
+    rootPath: '/opt/autobot',
+    selectedSource: null,
+    scanRunnerRunning: false,
+    loadingApiEndpoints: false,
+    analyzingCodeSmells: false,
+    exportingReport: false,
+    clearingCache: false,
+  },
+};
+
+export const Analyzing: Story = {
+  args: {
+    analyzing: true,
+    rootPath: '/opt/autobot',
+    selectedSource: null,
+    scanRunnerRunning: false,
+    loadingApiEndpoints: false,
+    analyzingCodeSmells: false,
+    exportingReport: false,
+    clearingCache: false,
+  },
+};
+
+export const ScanRunnerRunning: Story = {
+  args: {
+    analyzing: false,
+    rootPath: '/opt/autobot',
+    selectedSource: null,
+    scanRunnerRunning: true,
+    loadingApiEndpoints: false,
+    analyzingCodeSmells: false,
+    exportingReport: false,
+    clearingCache: false,
+  },
+};
+
+export const AllOperationsActive: Story = {
+  args: {
+    analyzing: false,
+    rootPath: '/opt/autobot',
+    selectedSource: null,
+    scanRunnerRunning: true,
+    loadingApiEndpoints: true,
+    analyzingCodeSmells: true,
+    exportingReport: false,
+    clearingCache: false,
+  },
+};

--- a/autobot-frontend/src/components/analytics/AnalyticsProgressSection.stories.ts
+++ b/autobot-frontend/src/components/analytics/AnalyticsProgressSection.stories.ts
@@ -1,0 +1,114 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import AnalyticsProgressSection from './AnalyticsProgressSection.vue';
+
+const mockScanRunner = {
+  running: { value: false },
+  results: { value: [] },
+  completedCount: { value: 0 },
+  totalCount: { value: 0 },
+  progress: { value: 0 },
+};
+
+const mockScanRunnerActive = {
+  running: { value: true },
+  results: {
+    value: [
+      { id: '1', label: 'Declarations', status: 'completed', durationMs: 120 },
+      { id: '2', label: 'Duplicates', status: 'running', durationMs: null },
+      { id: '3', label: 'Hardcodes', status: 'pending', durationMs: null },
+    ],
+  },
+  completedCount: { value: 1 },
+  totalCount: { value: 3 },
+  progress: { value: 33 },
+};
+
+const meta = {
+  title: 'Components/Analytics/AnalyticsProgressSection',
+  component: AnalyticsProgressSection,
+  tags: ['autodocs'],
+  argTypes: {
+    analyzing: { control: 'boolean' },
+    analyzingCodeSmells: { control: 'boolean' },
+    progressStatus: { control: 'text' },
+    progressPercent: { control: { type: 'range', min: 0, max: 100 } },
+    currentJobId: { control: 'text' },
+  },
+} as Meta<typeof AnalyticsProgressSection>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    analyzing: true,
+    analyzingCodeSmells: false,
+    progressStatus: 'Scanning files...',
+    progressPercent: 45,
+    currentJobId: 'job-abc12345',
+    jobPhases: {
+      phase_list: [
+        { id: 'parse', name: 'Parse Files', status: 'completed' },
+        { id: 'index', name: 'Index Content', status: 'running' },
+        { id: 'store', name: 'Store Results', status: 'pending' },
+      ],
+    },
+    jobBatches: { total_batches: 10, completed_batches: 4 },
+    jobStats: {
+      files_scanned: 120,
+      problems_found: 8,
+      functions_found: 340,
+      classes_found: 45,
+      items_stored: 1200,
+    },
+    scanRunner: mockScanRunner,
+    codeSmellsProgressTitle: 'Analyzing code smells...',
+  },
+};
+
+export const CodeSmellsOnly: Story = {
+  args: {
+    analyzing: false,
+    analyzingCodeSmells: true,
+    progressStatus: 'Detecting anti-patterns...',
+    progressPercent: 0,
+    currentJobId: null,
+    jobPhases: null,
+    jobBatches: null,
+    jobStats: null,
+    scanRunner: mockScanRunner,
+    codeSmellsProgressTitle: 'Code Smell Analysis',
+  },
+};
+
+export const ScanRunnerActive: Story = {
+  args: {
+    analyzing: false,
+    analyzingCodeSmells: false,
+    progressStatus: 'Ready',
+    progressPercent: 0,
+    currentJobId: null,
+    jobPhases: null,
+    jobBatches: null,
+    jobStats: null,
+    scanRunner: mockScanRunnerActive,
+    codeSmellsProgressTitle: '',
+  },
+};
+
+export const Completed: Story = {
+  args: {
+    analyzing: false,
+    analyzingCodeSmells: false,
+    progressStatus: 'Indexing completed successfully',
+    progressPercent: 100,
+    currentJobId: null,
+    jobPhases: null,
+    jobBatches: null,
+    jobStats: null,
+    scanRunner: mockScanRunner,
+    codeSmellsProgressTitle: '',
+  },
+};

--- a/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import CodeEvolutionTimeline from './CodeEvolutionTimeline.vue';
+
+const meta = {
+  title: 'Components/Analytics/CodeEvolutionTimeline',
+  component: CodeEvolutionTimeline,
+  tags: ['autodocs'],
+} as Meta<typeof CodeEvolutionTimeline>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Loading: Story = {
+  args: {},
+  render: () => ({
+    template: '<CodeEvolutionTimeline />',
+    components: { CodeEvolutionTimeline },
+  }),
+};
+
+export const DailyGranularity: Story = {
+  args: {},
+};
+
+export const WeeklyGranularity: Story = {
+  args: {},
+};

--- a/autobot-frontend/src/components/analytics/CodeGenerationDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodeGenerationDashboard.stories.ts
@@ -1,0 +1,29 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import CodeGenerationDashboard from './CodeGenerationDashboard.vue';
+
+const meta = {
+  title: 'Components/Analytics/CodeGenerationDashboard',
+  component: CodeGenerationDashboard,
+  tags: ['autodocs'],
+} as Meta<typeof CodeGenerationDashboard>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const GenerateMode: Story = {
+  args: {},
+};
+
+export const RefactorMode: Story = {
+  args: {},
+};
+
+export const Loading: Story = {
+  args: {},
+};

--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import CodeQualityDashboard from './CodeQualityDashboard.vue';
+
+const meta = {
+  title: 'Components/Analytics/CodeQualityDashboard',
+  component: CodeQualityDashboard,
+  tags: ['autodocs'],
+} as Meta<typeof CodeQualityDashboard>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Loading: Story = {
+  args: {},
+};
+
+export const Connected: Story = {
+  args: {},
+  render: () => ({
+    template: '<CodeQualityDashboard />',
+    components: { CodeQualityDashboard },
+  }),
+};
+
+export const NoData: Story = {
+  args: {},
+};

--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import CodeReviewDashboard from './CodeReviewDashboard.vue';
+
+const meta = {
+  title: 'Components/Analytics/CodeReviewDashboard',
+  component: CodeReviewDashboard,
+  tags: ['autodocs'],
+} as Meta<typeof CodeReviewDashboard>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Loading: Story = {
+  args: {},
+};
+
+export const WithResults: Story = {
+  args: {},
+  render: () => ({
+    template: '<CodeReviewDashboard />',
+    components: { CodeReviewDashboard },
+  }),
+};
+
+export const Empty: Story = {
+  args: {},
+};

--- a/autobot-frontend/src/components/analytics/CodeSmellsSection.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodeSmellsSection.stories.ts
@@ -1,0 +1,72 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import CodeSmellsSection from './CodeSmellsSection.vue';
+
+const sampleSmells = [
+  {
+    severity: 'high',
+    description: 'Function is too long (150 lines)',
+    file_path: 'autobot-backend/chat/handler.py',
+    line_number: 42,
+    suggestion: 'Extract into smaller functions',
+    smell_type: 'long_function',
+  },
+  {
+    severity: 'medium',
+    description: 'God class with 25 methods',
+    file_path: 'autobot-backend/agents/manager.py',
+    line_number: 10,
+    suggestion: 'Split into focused classes',
+    smell_type: 'god_class',
+  },
+  {
+    severity: 'low',
+    description: 'Magic number used directly',
+    file_path: 'autobot-backend/config.py',
+    line_number: 88,
+    suggestion: 'Use named constant',
+    smell_type: 'magic_number',
+  },
+];
+
+const meta = {
+  title: 'Components/Analytics/CodeSmellsSection',
+  component: CodeSmellsSection,
+  tags: ['autodocs'],
+  argTypes: {
+    smells: { control: 'object' },
+    codeHealthScore: { control: 'object' },
+  },
+} as Meta<typeof CodeSmellsSection>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    smells: sampleSmells,
+    codeHealthScore: { grade: 'B', health_score: 78 },
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    smells: [],
+    codeHealthScore: null,
+  },
+};
+
+export const HighScore: Story = {
+  args: {
+    smells: sampleSmells.slice(0, 1),
+    codeHealthScore: { grade: 'A', health_score: 92 },
+  },
+};
+
+export const LowScore: Story = {
+  args: {
+    smells: [...sampleSmells, ...sampleSmells, ...sampleSmells],
+    codeHealthScore: { grade: 'D', health_score: 38 },
+  },
+};

--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import CodebaseAnalytics from './CodebaseAnalytics.vue';
+
+const meta = {
+  title: 'Components/Analytics/CodebaseAnalytics',
+  component: CodebaseAnalytics,
+  tags: ['autodocs'],
+} as Meta<typeof CodebaseAnalytics>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Analyzing: Story = {
+  args: {},
+};
+
+export const WithResults: Story = {
+  args: {},
+  render: () => ({
+    template: '<CodebaseAnalytics />',
+    components: { CodebaseAnalytics },
+  }),
+};
+
+export const Empty: Story = {
+  args: {},
+};

--- a/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import CodebaseAnalyticsLanding from './CodebaseAnalyticsLanding.vue';
+
+const meta = {
+  title: 'Components/Analytics/CodebaseAnalyticsLanding',
+  component: CodebaseAnalyticsLanding,
+  tags: ['autodocs'],
+} as Meta<typeof CodebaseAnalyticsLanding>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Loading: Story = {
+  args: {},
+  render: () => ({
+    template: '<CodebaseAnalyticsLanding />',
+    components: { CodebaseAnalyticsLanding },
+  }),
+};
+
+export const WithProjects: Story = {
+  args: {},
+};
+
+export const Empty: Story = {
+  args: {},
+};

--- a/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.stories.ts
@@ -1,0 +1,103 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import CodebaseDependenciesPanel from './CodebaseDependenciesPanel.vue';
+
+const sampleDependencyData = {
+  nodes: [
+    { id: 'mod_a', name: 'module_a', type: 'module' },
+    { id: 'mod_b', name: 'module_b', type: 'module' },
+    { id: 'mod_c', name: 'module_c', type: 'module' },
+  ],
+  edges: [
+    { source: 'mod_a', target: 'mod_b', type: 'import' },
+    { source: 'mod_b', target: 'mod_c', type: 'import' },
+  ],
+  summary: {
+    total_modules: 3,
+    total_import_relationships: 2,
+    external_dependency_count: 5,
+    circular_dependency_count: 0,
+  },
+};
+
+const meta = {
+  title: 'Components/Analytics/CodebaseDependenciesPanel',
+  component: CodebaseDependenciesPanel,
+  tags: ['autodocs'],
+  argTypes: {
+    dependencyLoading: { control: 'boolean' },
+    dependencyError: { control: 'text' },
+    importTreeLoading: { control: 'boolean' },
+    importTreeError: { control: 'text' },
+    callGraphLoading: { control: 'boolean' },
+    callGraphError: { control: 'text' },
+  },
+} as Meta<typeof CodebaseDependenciesPanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    dependencyData: sampleDependencyData,
+    dependencyLoading: false,
+    dependencyError: '',
+    importTreeData: [],
+    importTreeLoading: false,
+    importTreeError: '',
+    callGraphData: { nodes: [], edges: [] },
+    callGraphSummary: null,
+    callGraphOrphaned: [],
+    callGraphLoading: false,
+    callGraphError: '',
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    dependencyData: null,
+    dependencyLoading: true,
+    dependencyError: '',
+    importTreeData: [],
+    importTreeLoading: true,
+    importTreeError: '',
+    callGraphData: { nodes: [], edges: [] },
+    callGraphSummary: null,
+    callGraphOrphaned: [],
+    callGraphLoading: true,
+    callGraphError: '',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    dependencyData: null,
+    dependencyLoading: false,
+    dependencyError: 'Failed to load dependency graph',
+    importTreeData: [],
+    importTreeLoading: false,
+    importTreeError: 'Failed to load import tree',
+    callGraphData: { nodes: [], edges: [] },
+    callGraphSummary: null,
+    callGraphOrphaned: [],
+    callGraphLoading: false,
+    callGraphError: '',
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    dependencyData: null,
+    dependencyLoading: false,
+    dependencyError: '',
+    importTreeData: [],
+    importTreeLoading: false,
+    importTreeError: '',
+    callGraphData: { nodes: [], edges: [] },
+    callGraphSummary: null,
+    callGraphOrphaned: [],
+    callGraphLoading: false,
+    callGraphError: '',
+  },
+};

--- a/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.stories.ts
@@ -1,0 +1,80 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import CodebaseOverviewPanel from './CodebaseOverviewPanel.vue';
+
+const meta = {
+  title: 'Components/Analytics/CodebaseOverviewPanel',
+  component: CodebaseOverviewPanel,
+  tags: ['autodocs'],
+  argTypes: {
+    realTimeEnabled: { control: 'boolean' },
+    systemOverview: { control: 'object' },
+    communicationPatterns: { control: 'object' },
+    codeQuality: { control: 'object' },
+    performanceMetrics: { control: 'object' },
+  },
+} as Meta<typeof CodebaseOverviewPanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    systemOverview: {
+      api_requests_per_minute: 42,
+      average_response_time: 180,
+      active_connections: 7,
+      system_health: 'Healthy',
+    },
+    communicationPatterns: {
+      websocket_connections: 3,
+      api_call_frequency: 12,
+      data_transfer_rate: 24.5,
+      unique_endpoints: 18,
+    },
+    codeQuality: {
+      overall_score: 84,
+      test_coverage: 67,
+      code_duplicates: 12,
+      technical_debt: 8,
+    },
+    performanceMetrics: {
+      efficiency_score: 91,
+      memory_usage: 512,
+      cpu_usage: 23,
+      load_time: 340,
+    },
+    realTimeEnabled: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    systemOverview: null,
+    communicationPatterns: null,
+    codeQuality: null,
+    performanceMetrics: null,
+    realTimeEnabled: false,
+  },
+};
+
+export const StaticData: Story = {
+  args: {
+    systemOverview: {
+      api_requests_per_minute: 0,
+      average_response_time: 0,
+      active_connections: 0,
+      system_health: 'Unknown',
+    },
+    communicationPatterns: null,
+    codeQuality: {
+      overall_score: 55,
+      test_coverage: 30,
+      code_duplicates: 45,
+      technical_debt: 40,
+    },
+    performanceMetrics: null,
+    realTimeEnabled: false,
+  },
+};

--- a/autobot-frontend/src/components/analytics/CodebaseSecurityPanel.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodebaseSecurityPanel.stories.ts
@@ -1,0 +1,104 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import CodebaseSecurityPanel from './CodebaseSecurityPanel.vue';
+
+const meta = {
+  title: 'Components/Analytics/CodebaseSecurityPanel',
+  component: CodebaseSecurityPanel,
+  tags: ['autodocs'],
+  argTypes: {
+    securityFindings: { control: 'object' },
+    performanceFindings: { control: 'object' },
+    redisFindings: { control: 'object' },
+    findingsLoading: { control: 'boolean' },
+    analysisLoading: { control: 'boolean' },
+    totalFindings: { control: 'number' },
+  },
+} as Meta<typeof CodebaseSecurityPanel>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    securityFindings: [
+      {
+        id: 'sec-001',
+        file_path: 'autobot-backend/api/routes.py',
+        line_number: 42,
+        severity: 'high',
+        pattern_name: 'SQL Injection Risk',
+        description: 'Unsanitized user input used in query',
+        suggestion: 'Use parameterized queries',
+      },
+    ],
+    performanceFindings: [],
+    redisFindings: [],
+    findingsLoading: false,
+    analysisLoading: false,
+    totalFindings: 1,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    securityFindings: [],
+    performanceFindings: [],
+    redisFindings: [],
+    findingsLoading: true,
+    analysisLoading: true,
+    totalFindings: 0,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    securityFindings: [],
+    performanceFindings: [],
+    redisFindings: [],
+    findingsLoading: false,
+    analysisLoading: false,
+    totalFindings: 0,
+  },
+};
+
+export const MultipleFindings: Story = {
+  args: {
+    securityFindings: [
+      {
+        id: 'sec-001',
+        file_path: 'autobot-backend/api/routes.py',
+        line_number: 42,
+        severity: 'critical',
+        pattern_name: 'Hardcoded Secret',
+        description: 'API key hardcoded in source',
+        suggestion: 'Move to environment variable',
+      },
+      {
+        id: 'sec-002',
+        file_path: 'autobot-backend/auth/handler.py',
+        line_number: 15,
+        severity: 'high',
+        pattern_name: 'Weak Hash',
+        description: 'MD5 used for password hashing',
+        suggestion: 'Use bcrypt or argon2',
+      },
+    ],
+    performanceFindings: [
+      {
+        id: 'perf-001',
+        file_path: 'autobot-backend/db/queries.py',
+        line_number: 88,
+        severity: 'medium',
+        pattern_name: 'N+1 Query',
+        description: 'Database query in loop',
+        suggestion: 'Use batch query',
+      },
+    ],
+    redisFindings: [],
+    findingsLoading: false,
+    analysisLoading: false,
+    totalFindings: 3,
+  },
+};

--- a/autobot-frontend/src/components/analytics/ConversationFlowDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/ConversationFlowDashboard.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import ConversationFlowDashboard from './ConversationFlowDashboard.vue';
+
+const meta = {
+  title: 'Components/Analytics/ConversationFlowDashboard',
+  component: ConversationFlowDashboard,
+  tags: ['autodocs'],
+} as Meta<typeof ConversationFlowDashboard>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Loading: Story = {
+  args: {},
+};
+
+export const WithData: Story = {
+  args: {},
+  render: () => ({
+    template: '<ConversationFlowDashboard />',
+    components: { ConversationFlowDashboard },
+  }),
+};
+
+export const Last7Days: Story = {
+  args: {},
+};

--- a/autobot-frontend/src/components/analytics/DeclarationsSection.stories.ts
+++ b/autobot-frontend/src/components/analytics/DeclarationsSection.stories.ts
@@ -1,0 +1,82 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import DeclarationsSection from './DeclarationsSection.vue';
+
+const sampleDeclarations = [
+  {
+    name: 'get_redis_client',
+    file_path: 'autobot-backend/utils/redis.py',
+    line_number: 12,
+    is_exported: true,
+    declaration_type: 'function',
+  },
+  {
+    name: 'ChatController',
+    file_path: 'autobot-frontend/src/controllers/ChatController.ts',
+    line_number: 5,
+    is_exported: true,
+    declaration_type: 'class',
+  },
+  {
+    name: 'API_BASE_URL',
+    file_path: 'autobot-frontend/src/config/ssot-config.ts',
+    line_number: 3,
+    is_exported: true,
+    declaration_type: 'variable',
+  },
+  {
+    name: 'MessageType',
+    file_path: 'autobot-backend/schemas/common.py',
+    line_number: 22,
+    is_exported: false,
+    declaration_type: 'type',
+  },
+];
+
+const meta = {
+  title: 'Components/Analytics/DeclarationsSection',
+  component: DeclarationsSection,
+  tags: ['autodocs'],
+  argTypes: {
+    declarations: { control: 'object' },
+    loading: { control: 'boolean' },
+  },
+} as Meta<typeof DeclarationsSection>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    declarations: sampleDeclarations,
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    declarations: [],
+    loading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    declarations: [],
+    loading: false,
+  },
+};
+
+export const LargeDataset: Story = {
+  args: {
+    declarations: Array.from({ length: 50 }, (_, i) => ({
+      name: `function_${i}`,
+      file_path: `module_${i % 5}/file.py`,
+      line_number: (i + 1) * 10,
+      is_exported: i % 3 === 0,
+      declaration_type: ['function', 'class', 'variable', 'type'][i % 4],
+    })),
+    loading: false,
+  },
+};

--- a/autobot-frontend/src/components/analytics/DuplicatesSection.stories.ts
+++ b/autobot-frontend/src/components/analytics/DuplicatesSection.stories.ts
@@ -1,0 +1,66 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import DuplicatesSection from './DuplicatesSection.vue';
+
+const sampleDuplicates = [
+  {
+    similarity: 95,
+    lines: 42,
+    file1: 'autobot-backend/agents/agent_a.py',
+    file2: 'autobot-backend/agents/agent_b.py',
+  },
+  {
+    similarity: 82,
+    lines: 18,
+    file1: 'autobot-frontend/src/utils/format.ts',
+    file2: 'autobot-frontend/src/utils/helpers.ts',
+  },
+  {
+    similarity: 68,
+    lines: 9,
+    file1: 'autobot-backend/api/routes_v1.py',
+    file2: 'autobot-backend/api/routes_v2.py',
+  },
+];
+
+const meta = {
+  title: 'Components/Analytics/DuplicatesSection',
+  component: DuplicatesSection,
+  tags: ['autodocs'],
+  argTypes: {
+    duplicates: { control: 'object' },
+    loading: { control: 'boolean' },
+  },
+} as Meta<typeof DuplicatesSection>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    duplicates: sampleDuplicates,
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    duplicates: [],
+    loading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    duplicates: [],
+    loading: false,
+  },
+};
+
+export const HighSimilarity: Story = {
+  args: {
+    duplicates: sampleDuplicates.filter(d => d.similarity >= 90),
+    loading: false,
+  },
+};

--- a/autobot-frontend/src/components/analytics/EnhancedAnalyticsGrid.stories.ts
+++ b/autobot-frontend/src/components/analytics/EnhancedAnalyticsGrid.stories.ts
@@ -1,0 +1,74 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import EnhancedAnalyticsGrid from './EnhancedAnalyticsGrid.vue';
+
+const meta = {
+  title: 'Components/Analytics/EnhancedAnalyticsGrid',
+  component: EnhancedAnalyticsGrid,
+  tags: ['autodocs'],
+  argTypes: {
+    realTimeEnabled: { control: 'boolean' },
+    systemOverview: { control: 'object' },
+    communicationPatterns: { control: 'object' },
+    codeQuality: { control: 'object' },
+    performanceMetrics: { control: 'object' },
+  },
+} as Meta<typeof EnhancedAnalyticsGrid>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    systemOverview: {
+      api_requests_per_minute: 35,
+      average_response_time: 150,
+      active_connections: 5,
+      system_health: 'Healthy',
+    },
+    communicationPatterns: {
+      websocket_connections: 2,
+      api_call_frequency: 8,
+      data_transfer_rate: 18.3,
+    },
+    codeQuality: {
+      overall_score: 79,
+      test_coverage: 58,
+      code_duplicates: 22,
+      technical_debt: 12,
+    },
+    performanceMetrics: {
+      efficiency_score: 85,
+      memory_usage: 480,
+      cpu_usage: 18,
+      load_time: 290,
+    },
+    realTimeEnabled: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    systemOverview: null,
+    communicationPatterns: null,
+    codeQuality: null,
+    performanceMetrics: null,
+    realTimeEnabled: false,
+  },
+};
+
+export const StaticMode: Story = {
+  args: {
+    systemOverview: {
+      api_requests_per_minute: 0,
+      average_response_time: 0,
+      active_connections: 0,
+      system_health: 'Degraded',
+    },
+    communicationPatterns: null,
+    codeQuality: null,
+    performanceMetrics: null,
+    realTimeEnabled: false,
+  },
+};

--- a/autobot-frontend/src/components/analytics/HardcodesSection.stories.ts
+++ b/autobot-frontend/src/components/analytics/HardcodesSection.stories.ts
@@ -1,0 +1,75 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import HardcodesSection from './HardcodesSection.vue';
+
+const sampleHardcodes = [
+  {
+    type: 'url',
+    file: 'autobot-backend/config.py',
+    line: 14,
+    value: 'http://localhost:8001',
+    variable_name: 'BACKEND_URL',
+    severity: 'high',
+    suggested_env_var: 'AUTOBOT_BACKEND_URL',
+  },
+  {
+    type: 'port',
+    file: 'autobot-backend/main.py',
+    line: 55,
+    value: '8080',
+    variable_name: null,
+    severity: 'medium',
+    suggested_env_var: 'AUTOBOT_PORT',
+  },
+  {
+    type: 'magic_number',
+    file: 'autobot-backend/cache.py',
+    line: 30,
+    value: '3600',
+    variable_name: 'ttl',
+    severity: 'low',
+    suggested_env_var: 'CACHE_TTL_SECONDS',
+  },
+];
+
+const meta = {
+  title: 'Components/Analytics/HardcodesSection',
+  component: HardcodesSection,
+  tags: ['autodocs'],
+  argTypes: {
+    hardcodes: { control: 'object' },
+    loading: { control: 'boolean' },
+  },
+} as Meta<typeof HardcodesSection>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    hardcodes: sampleHardcodes,
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    hardcodes: [],
+    loading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    hardcodes: [],
+    loading: false,
+  },
+};
+
+export const HighSeverityOnly: Story = {
+  args: {
+    hardcodes: sampleHardcodes.filter(h => h.severity === 'high'),
+    loading: false,
+  },
+};

--- a/autobot-frontend/src/components/analytics/HealthScoreGauge.stories.ts
+++ b/autobot-frontend/src/components/analytics/HealthScoreGauge.stories.ts
@@ -1,0 +1,62 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import HealthScoreGauge from './HealthScoreGauge.vue';
+
+const meta = {
+  title: 'Components/Analytics/HealthScoreGauge',
+  component: HealthScoreGauge,
+  tags: ['autodocs'],
+  argTypes: {
+    score: { control: { type: 'range', min: 0, max: 100 } },
+    grade: { control: 'text' },
+    label: { control: 'text' },
+    statusMessage: { control: 'text' },
+  },
+} as Meta<typeof HealthScoreGauge>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    score: 85,
+    grade: 'B',
+    label: 'Code Health',
+    statusMessage: 'Good overall quality',
+  },
+};
+
+export const Excellent: Story = {
+  args: {
+    score: 95,
+    grade: 'A',
+    label: 'Code Health',
+    statusMessage: 'Excellent quality',
+  },
+};
+
+export const Poor: Story = {
+  args: {
+    score: 35,
+    grade: 'F',
+    label: 'Code Health',
+    statusMessage: 'Needs significant improvement',
+  },
+};
+
+export const Average: Story = {
+  args: {
+    score: 65,
+    grade: 'C',
+    label: 'Code Health',
+  },
+};
+
+export const NoMessage: Story = {
+  args: {
+    score: 78,
+    grade: 'B',
+    label: 'Overall Score',
+  },
+};

--- a/autobot-frontend/src/components/analytics/IndexingProgress.stories.ts
+++ b/autobot-frontend/src/components/analytics/IndexingProgress.stories.ts
@@ -1,0 +1,89 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import IndexingProgress from './IndexingProgress.vue';
+
+const meta = {
+  title: 'Components/Analytics/IndexingProgress',
+  component: IndexingProgress,
+  tags: ['autodocs'],
+  argTypes: {
+    analyzing: { control: 'boolean' },
+    analyzingCodeSmells: { control: 'boolean' },
+    progressPercent: { control: { type: 'range', min: 0, max: 100 } },
+    progressStatus: { control: 'text' },
+    currentJobId: { control: 'text' },
+    codeSmellsProgressTitle: { control: 'text' },
+  },
+} as Meta<typeof IndexingProgress>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    analyzing: true,
+    currentJobId: 'job-abc12345',
+    progressPercent: 55,
+    progressStatus: 'Indexing Python files...',
+    jobPhases: {
+      phase_list: [
+        { id: 'parse', name: 'Parse', status: 'completed' },
+        { id: 'index', name: 'Index', status: 'running' },
+        { id: 'store', name: 'Store', status: 'pending' },
+      ],
+    },
+    jobBatches: { total_batches: 8, completed_batches: 4 },
+    jobStats: {
+      files_scanned: 88,
+      problems_found: 5,
+      functions_found: 220,
+      classes_found: 30,
+      items_stored: 880,
+    },
+    analyzingCodeSmells: false,
+    codeSmellsProgressTitle: '',
+  },
+};
+
+export const CodeSmellsAnalysis: Story = {
+  args: {
+    analyzing: false,
+    currentJobId: null,
+    progressPercent: 0,
+    progressStatus: '',
+    jobPhases: null,
+    jobBatches: null,
+    jobStats: null,
+    analyzingCodeSmells: true,
+    codeSmellsProgressTitle: 'Analyzing anti-patterns...',
+  },
+};
+
+export const NoBatches: Story = {
+  args: {
+    analyzing: true,
+    currentJobId: 'job-xyz98765',
+    progressPercent: 20,
+    progressStatus: 'Starting scan...',
+    jobPhases: null,
+    jobBatches: null,
+    jobStats: null,
+    analyzingCodeSmells: false,
+    codeSmellsProgressTitle: '',
+  },
+};
+
+export const Idle: Story = {
+  args: {
+    analyzing: false,
+    currentJobId: null,
+    progressPercent: 0,
+    progressStatus: '',
+    jobPhases: null,
+    jobBatches: null,
+    jobStats: null,
+    analyzingCodeSmells: false,
+    codeSmellsProgressTitle: '',
+  },
+};

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import LLMPatternDashboard from './LLMPatternDashboard.vue';
+
+const meta = {
+  title: 'Components/Analytics/LLMPatternDashboard',
+  component: LLMPatternDashboard,
+  tags: ['autodocs'],
+} as Meta<typeof LLMPatternDashboard>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Loading: Story = {
+  args: {},
+};
+
+export const WithData: Story = {
+  args: {},
+  render: () => ({
+    template: '<LLMPatternDashboard />',
+    components: { LLMPatternDashboard },
+  }),
+};
+
+export const Empty: Story = {
+  args: {},
+};

--- a/autobot-frontend/src/components/analytics/LogPatternDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/LogPatternDashboard.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import LogPatternDashboard from './LogPatternDashboard.vue';
+
+const meta = {
+  title: 'Components/Analytics/LogPatternDashboard',
+  component: LogPatternDashboard,
+  tags: ['autodocs'],
+} as Meta<typeof LogPatternDashboard>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Analyzing: Story = {
+  args: {},
+};
+
+export const WithPatterns: Story = {
+  args: {},
+  render: () => ({
+    template: '<LogPatternDashboard />',
+    components: { LogPatternDashboard },
+  }),
+};
+
+export const Last24Hours: Story = {
+  args: {},
+};

--- a/autobot-frontend/src/components/analytics/PatternAnalysis.stories.ts
+++ b/autobot-frontend/src/components/analytics/PatternAnalysis.stories.ts
@@ -1,0 +1,45 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import PatternAnalysis from './PatternAnalysis.vue';
+
+const meta = {
+  title: 'Components/Analytics/PatternAnalysis',
+  component: PatternAnalysis,
+  tags: ['autodocs'],
+  argTypes: {
+    rootPath: { control: 'text' },
+    autoLoad: { control: 'boolean' },
+  },
+} as Meta<typeof PatternAnalysis>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    rootPath: '/opt/autobot',
+    autoLoad: false,
+  },
+};
+
+export const AutoLoad: Story = {
+  args: {
+    rootPath: '/opt/autobot',
+    autoLoad: true,
+  },
+};
+
+export const NoPath: Story = {
+  args: {
+    rootPath: '',
+    autoLoad: false,
+  },
+};
+
+export const LongPath: Story = {
+  args: {
+    rootPath: '/home/user/projects/very-long-project-name/autobot-ai',
+    autoLoad: false,
+  },
+};

--- a/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import PerformanceAnalysisDashboard from './PerformanceAnalysisDashboard.vue';
+
+const meta = {
+  title: 'Components/Analytics/PerformanceAnalysisDashboard',
+  component: PerformanceAnalysisDashboard,
+  tags: ['autodocs'],
+} as Meta<typeof PerformanceAnalysisDashboard>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Loading: Story = {
+  args: {},
+};
+
+export const WithResults: Story = {
+  args: {},
+  render: () => ({
+    template: '<PerformanceAnalysisDashboard />',
+    components: { PerformanceAnalysisDashboard },
+  }),
+};
+
+export const Empty: Story = {
+  args: {},
+};

--- a/autobot-frontend/src/components/analytics/PrecommitHookDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/PrecommitHookDashboard.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import PrecommitHookDashboard from './PrecommitHookDashboard.vue';
+
+const meta = {
+  title: 'Components/Analytics/PrecommitHookDashboard',
+  component: PrecommitHookDashboard,
+  tags: ['autodocs'],
+} as Meta<typeof PrecommitHookDashboard>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const HooksInstalled: Story = {
+  args: {},
+  render: () => ({
+    template: '<PrecommitHookDashboard />',
+    components: { PrecommitHookDashboard },
+  }),
+};
+
+export const HooksNotInstalled: Story = {
+  args: {},
+};
+
+export const CheckFailed: Story = {
+  args: {},
+};

--- a/autobot-frontend/src/components/analytics/ProblemsReportSection.stories.ts
+++ b/autobot-frontend/src/components/analytics/ProblemsReportSection.stories.ts
@@ -1,0 +1,82 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import ProblemsReportSection from './ProblemsReportSection.vue';
+
+const sampleProblems = [
+  {
+    severity: 'critical',
+    description: 'Unhandled exception in request handler',
+    file_path: 'autobot-backend/api/chat.py',
+    line_number: 88,
+    suggestion: 'Add proper error handling',
+    type: 'exception',
+  },
+  {
+    severity: 'high',
+    message: 'Blocking synchronous call in async context',
+    file_path: 'autobot-backend/agents/base.py',
+    line_number: 42,
+    suggestion: 'Use asyncio.run_in_executor',
+    problem_type: 'async_violation',
+  },
+  {
+    severity: 'medium',
+    description: 'Missing type annotation',
+    file_path: 'autobot-backend/utils/helpers.py',
+    line: 15,
+    suggestion: 'Add return type annotation',
+    category: 'typing',
+  },
+  {
+    severity: 'low',
+    description: 'Unused import',
+    file_path: 'autobot-frontend/src/views/Dashboard.vue',
+    line_number: 3,
+    suggestion: 'Remove unused import',
+    type: 'import',
+  },
+];
+
+const meta = {
+  title: 'Components/Analytics/ProblemsReportSection',
+  component: ProblemsReportSection,
+  tags: ['autodocs'],
+  argTypes: {
+    problems: { control: 'object' },
+  },
+} as Meta<typeof ProblemsReportSection>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    problems: sampleProblems,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    problems: [],
+  },
+};
+
+export const CriticalOnly: Story = {
+  args: {
+    problems: sampleProblems.filter(p => p.severity === 'critical'),
+  },
+};
+
+export const LargeDataset: Story = {
+  args: {
+    problems: Array.from({ length: 40 }, (_, i) => ({
+      severity: ['critical', 'high', 'medium', 'low'][i % 4],
+      description: `Problem description ${i + 1}`,
+      file_path: `module_${i % 5}/file_${i}.py`,
+      line_number: (i + 1) * 5,
+      suggestion: 'Fix this issue',
+      type: ['exception', 'async_violation', 'typing', 'import'][i % 4],
+    })),
+  },
+};

--- a/autobot-frontend/src/components/analytics/ShareSourceModal.stories.ts
+++ b/autobot-frontend/src/components/analytics/ShareSourceModal.stories.ts
@@ -1,0 +1,62 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import ShareSourceModal from './ShareSourceModal.vue';
+
+const sampleSource = {
+  id: 'src-001',
+  name: 'AutoBot Backend',
+  source_type: 'github' as const,
+  repo: 'mrveiss/AutoBot-AI',
+  branch: 'Dev_new_gui',
+  access: 'private' as const,
+  status: 'ready' as const,
+};
+
+const meta = {
+  title: 'Components/Analytics/ShareSourceModal',
+  component: ShareSourceModal,
+  tags: ['autodocs'],
+  argTypes: {
+    visible: { control: 'boolean' },
+    source: { control: 'object' },
+  },
+} as Meta<typeof ShareSourceModal>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    visible: true,
+    source: sampleSource,
+  },
+};
+
+export const LocalSource: Story = {
+  args: {
+    visible: true,
+    source: {
+      id: 'src-002',
+      name: 'Local Dev',
+      source_type: 'local',
+      clone_path: '/opt/autobot',
+      access: 'shared',
+      status: 'configured',
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    visible: false,
+    source: sampleSource,
+  },
+};
+
+export const NoSource: Story = {
+  args: {
+    visible: true,
+    source: null,
+  },
+};

--- a/autobot-frontend/src/components/analytics/SourceManager.stories.ts
+++ b/autobot-frontend/src/components/analytics/SourceManager.stories.ts
@@ -1,0 +1,45 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import SourceManager from './SourceManager.vue';
+
+const meta = {
+  title: 'Components/Analytics/SourceManager',
+  component: SourceManager,
+  tags: ['autodocs'],
+  argTypes: {
+    visible: { control: 'boolean' },
+    selectedSourceId: { control: 'text' },
+  },
+} as Meta<typeof SourceManager>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {
+    visible: true,
+    selectedSourceId: null,
+  },
+};
+
+export const WithSelection: Story = {
+  args: {
+    visible: true,
+    selectedSourceId: 'src-001',
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    visible: false,
+    selectedSourceId: null,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    visible: true,
+    selectedSourceId: null,
+  },
+};

--- a/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.stories.ts
@@ -1,0 +1,37 @@
+import type { Meta } from '@storybook/vue3';
+import type { StoryObj } from '@storybook/vue3';
+import TechnicalDebtDashboard from './TechnicalDebtDashboard.vue';
+
+const meta = {
+  title: 'Components/Analytics/TechnicalDebtDashboard',
+  component: TechnicalDebtDashboard,
+  tags: ['autodocs'],
+} as Meta<typeof TechnicalDebtDashboard>;
+
+export default meta;
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Loading: Story = {
+  args: {},
+};
+
+export const WithDebtData: Story = {
+  args: {},
+  render: () => ({
+    template: '<TechnicalDebtDashboard />',
+    components: { TechnicalDebtDashboard },
+  }),
+};
+
+export const HighDebt: Story = {
+  args: {},
+};
+
+export const LowDebt: Story = {
+  args: {},
+};


### PR DESCRIPTION
## Summary

Adds Storybook stories for all 32 components in `autobot-frontend/src/components/analytics/`:

**Props-driven components** (with full argTypes + state variants):
AddSourceModal, AnalyticsHeader, AnalyticsHeaderControls, AnalyticsProgressSection, CodebaseOverviewPanel, CodebaseDependenciesPanel, CodebaseSecurityPanel, CodeSmellsSection, DeclarationsSection, DuplicatesSection, EnhancedAnalyticsGrid, HardcodesSection, HealthScoreGauge, IndexingProgress, PatternAnalysis, ProblemsReportSection, ShareSourceModal, SourceManager

**Container/dashboard components** (Default + state variant stories with args:{}):
AdvancedAnalytics, AgentCostPanel, CodebaseAnalytics, CodebaseAnalyticsLanding, CodeEvolutionTimeline, CodeGenerationDashboard, CodeQualityDashboard, CodeReviewDashboard, ConversationFlowDashboard, LLMPatternDashboard, LogPatternDashboard, PerformanceAnalysisDashboard, PrecommitHookDashboard, TechnicalDebtDashboard

## Pattern
All files follow `'Components/Analytics/ComponentName'` title, `tags:['autodocs']`, `StoryObj<any>` per #7273.

## Test plan
- [ ] `npm run build-storybook` passes with no errors
- [ ] Stories render under `Components/Analytics/*`

Closes #6847

🤖 Generated with [Claude Code](https://claude.com/claude-code)