### PR TITLE
tech-debt(naming): clarify plugin vs extension vs skill terminology (#7426)

### DIFF
--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -19,9 +19,9 @@ from autobot_shared.ssot_config import config as _ssot_config
 from constants.api_constants import PATH_OLLAMA_GENERATE
 from constants.model_constants import ModelConstants
 from dependencies import get_config
-from extensions.base import HookContext
-from extensions.hooks import HookPoint
-from extensions.manager import get_extension_manager
+from middleware.base import HookContext
+from middleware.hooks import HookPoint
+from middleware.manager import get_extension_manager
 from prompt_manager import get_language_instruction, get_prompt, resolve_language
 
 from .models import WorkflowSession

--- a/autobot-backend/chat_workflow/session_handler.py
+++ b/autobot-backend/chat_workflow/session_handler.py
@@ -15,9 +15,9 @@ from autobot_shared.error_boundaries import error_boundary
 from autobot_shared.logging_manager import get_logger
 from conversation_context import ConversationContext, ConversationContextAnalyzer
 from conversation_safety import ConversationSafetyGuards, SafetyCheckResult
-from extensions.base import HookContext
-from extensions.hooks import HookPoint
-from extensions.manager import get_extension_manager
+from middleware.base import HookContext
+from middleware.hooks import HookPoint
+from middleware.manager import get_extension_manager
 from intent_classifier import ConversationIntent, IntentClassification, IntentClassifier
 
 from .models import WorkflowSession

--- a/autobot-backend/extensions/__init__.py
+++ b/autobot-backend/extensions/__init__.py
@@ -2,63 +2,30 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Extension Hooks System.
+Re-export shim for backwards compatibility (#7426).
 
-Issue #658: Implements Agent Zero's extension pattern with 24 lifecycle
-hook points for modular customization of agent behavior.
+The extensions package has been renamed to middleware to clarify that
+these are lifecycle hooks (middleware), not loadable plugins.
 
-Issue #4202: Introduces HookInvoker for centralized, extensible hook
-invocation strategy with declarative configuration modes.
+This shim re-exports all public APIs from middleware/ so existing code
+continues to work. Remove this shim after one release cycle.
 
-This package provides:
-- HookPoint enum with 24 lifecycle points
-- Extension base class for creating extensions
-- ExtensionManager for registration and invocation
-- HookInvoker for centralized, configurable hook invocation
-- Built-in extensions (logging, secret_masking)
-
-Usage (HookInvoker pattern - Issue #4202):
-    from extensions import (
-        HookPoint,
-        Extension,
-        HookContext,
-        HookInvoker,
-        get_extension_manager,
-    )
-
-    # Get invoker
-    manager = get_extension_manager()
-    invoker = HookInvoker(manager)
-
-    # Invoke with strategy
-    ctx = HookContext(session_id="sess-123", message="Hello")
-    results = await invoker.invoke(HookPoint.BEFORE_MESSAGE_PROCESS, ctx)
-
-    # Register custom extension
-    class MyExtension(Extension):
-        name = "my_extension"
-
-        async def on_before_tool_execute(self, ctx: HookContext):
-            # Custom logic
-            pass
-
-    manager.register(MyExtension())
-
-Legacy usage (direct manager):
-    manager = get_extension_manager()
-    await manager.invoke_hook(HookPoint.BEFORE_MESSAGE_PROCESS, ctx)
+New code should import from middleware instead:
+    from middleware import Extension, HookPoint, get_extension_manager
 """
 
-from extensions.base import Extension, HookContext
-from extensions.hook_invoker import (
+# Re-export everything from middleware for backwards compat
+from middleware import (
+    Extension,
+    ExtensionManager,
+    HOOK_METADATA,
+    HookContext,
     HookInvocationConfig,
     HookInvoker,
+    HookPoint,
     InvocationMode,
-)
-from extensions.hooks import HOOK_METADATA, HookPoint, get_hook_metadata
-from extensions.manager import (
-    ExtensionManager,
     get_extension_manager,
+    get_hook_metadata,
     reset_extension_manager,
 )
 

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -356,12 +356,12 @@ async def _init_builtin_extensions(app: FastAPI) -> None:
     Non-critical: a failure logs a warning but does not block startup.
     """
     try:
-        from extensions.builtin import (
+        from middleware.builtin import (
             LoggingExtension,
             PermissionEnforcementExtension,
             SecretMaskingExtension,
         )
-        from extensions.manager import ExtensionManager
+        from middleware.manager import ExtensionManager
 
         manager = getattr(app.state, "extension_manager", None)
         if manager is None:
@@ -1598,7 +1598,7 @@ def create_lifespan_manager():
         logger.info("🧵 Bounded thread pool configured (max %d workers)", MAX_WORKER_THREADS)
 
         # Register the running event loop for sync-endpoint audit scheduling (#1568)
-        from middleware.audit_middleware import set_main_event_loop
+        from autobot_backend.audit_middleware import set_main_event_loop
 
         set_main_event_loop(asyncio.get_running_loop())
 

--- a/autobot-backend/middleware/base.py
+++ b/autobot-backend/middleware/base.py
@@ -1,0 +1,554 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Base Extension class for the extension hooks system.
+
+Issue #658: Implements Agent Zero's extension pattern where extensions
+can hook into 22 lifecycle points to modify agent behavior.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.plugin_sdk.extension_manifest import ExtensionManifest
+from middleware.hooks import HookPoint
+
+logger = get_logger(__name__)
+
+# Re-export so callers that do `from middleware.base import ExtensionManifest` still work.
+__all__ = ["ExtensionManifest", "Extension", "HookContext"]
+
+
+@dataclass
+class HookContext:
+    """
+    Context passed to all hook invocations.
+
+    This dataclass carries all relevant information about the current
+    operation and provides methods for extensions to read/modify data.
+
+    Attributes:
+        session_id: Current chat session ID
+        message: Original user message
+        agent_id: ID of the current agent (for hierarchical agents)
+        data: Shared data dictionary for extensions to communicate
+
+    Usage:
+        # Read data set by previous extension
+        prompt = ctx.get("prompt", "")
+
+        # Modify data for subsequent extensions
+        ctx.set("prompt", modified_prompt)
+
+        # Store multiple values
+        ctx.merge({"key1": "value1", "key2": "value2"})
+    """
+
+    session_id: str = ""
+    message: str = ""
+    agent_id: str | None = None
+    data: Dict[str, Any] = field(default_factory=dict)
+
+    def set(self, key: str, value: Any) -> None:
+        """
+        Set a value in the context data.
+
+        Args:
+            key: Data key
+            value: Data value
+        """
+        self.data[key] = value
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """
+        Get a value from the context data.
+
+        Args:
+            key: Data key
+            default: Default value if key not found
+
+        Returns:
+            The value or default
+        """
+        return self.data.get(key, default)
+
+    def merge(self, updates: Dict[str, Any]) -> None:
+        """
+        Merge multiple values into context data.
+
+        Args:
+            updates: Dictionary of key-value pairs to merge
+        """
+        self.data.update(updates)
+
+    def has(self, key: str) -> bool:
+        """
+        Check if a key exists in context data.
+
+        Args:
+            key: Data key
+
+        Returns:
+            True if key exists
+        """
+        return key in self.data
+
+    def remove(self, key: str) -> Any | None:
+        """
+        Remove and return a value from context data.
+
+        Args:
+            key: Data key
+
+        Returns:
+            The removed value or None
+        """
+        return self.data.pop(key, None)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert context to dictionary for serialization."""
+        return {
+            "session_id": self.session_id,
+            "message": self.message,
+            "agent_id": self.agent_id,
+            "data": self.data,
+        }
+
+
+class Extension:
+    """
+    Base class for extensions.
+
+    Issue #658: Extensions can hook into 22 lifecycle points to modify
+    agent behavior without changing core code. Override hook methods
+    as needed in subclasses.
+
+    Attributes:
+        name: Unique extension name for identification
+        priority: Execution order (lower = runs first, default 100)
+        enabled: Whether extension is active
+
+    Usage:
+        class MyExtension(Extension):
+            name = "my_extension"
+            priority = 50  # Run before default (100)
+
+            async def on_before_tool_execute(self, ctx: HookContext) -> bool | None:
+                # Return False to cancel tool execution
+                if ctx.get("tool_name") == "dangerous_tool":
+                    return False
+                return None  # Continue normally
+    """
+
+    name: str = "base"
+    version: str = "0.0.0"
+    description: str = ""
+    priority: int = 100
+    enabled: bool = True
+
+    @property
+    def manifest(self) -> "ExtensionManifest":
+        """Return an ExtensionManifest derived from this extension's class attributes."""
+        return ExtensionManifest(
+            name=self.name,
+            version=self.version,
+            description=self.description,
+        )
+
+    async def on_hook(
+        self,
+        hook: HookPoint,
+        context: HookContext,
+    ) -> Any | None:
+        """
+        Dispatch to specific hook method.
+
+        This method is called by ExtensionManager and routes to the
+        appropriate on_<hook_name> method.
+
+        Args:
+            hook: The hook point being invoked
+            context: Hook context with relevant data
+
+        Returns:
+            Result from the specific hook method or None
+        """
+        if not self.enabled:
+            return None
+
+        # Convert hook name to method name: BEFORE_MESSAGE_PROCESS -> on_before_message_process
+        method_name = f"on_{hook.name.lower()}"
+        method = getattr(self, method_name, None)
+
+        if method and callable(method):
+            try:
+                return await method(context)
+            except Exception as e:
+                logger.error(
+                    "[Issue #658] Extension %s error on %s: %s",
+                    self.name,
+                    hook.name,
+                    str(e),
+                )
+                # Don't re-raise - extension errors shouldn't crash the system
+                return None
+
+        return None
+
+    # ========== Message Preparation Hooks ==========
+
+    async def on_before_message_process(self, ctx: HookContext) -> None | None:
+        """
+        Called at the start of message handling.
+
+        Use to preprocess the message or initialize extension state.
+
+        Args:
+            ctx: Hook context with message
+
+        Returns:
+            None (modify ctx.data directly)
+        """
+
+    async def on_before_prompt_build(self, ctx: HookContext) -> None:
+        """
+        Called before building the prompt.
+
+        Use to prepare context or validate inputs before prompt construction.
+
+        Args:
+            ctx: Hook context with context information
+
+        Returns:
+            None (modify ctx.data directly)
+        """
+
+    async def on_after_prompt_build(self, ctx: HookContext) -> str | None:
+        """
+        Called after prompt is built and before being sent to the LLM.
+
+        Use to modify or append to the prompt.
+
+        Args:
+            ctx: Hook context with prompt in data["prompt"]
+
+        Returns:
+            Modified prompt string or None to keep unchanged
+        """
+
+    # ========== LLM Interaction Hooks ==========
+
+    async def on_before_llm_call(self, ctx: HookContext) -> bool | None:
+        """
+        Called before calling the LLM.
+
+        Use to modify prompt, change model, or cancel the call.
+
+        Args:
+            ctx: Hook context with prompt and model in data
+
+        Returns:
+            False to cancel LLM call, None to continue
+        """
+
+    async def on_during_llm_streaming(self, ctx: HookContext) -> str | None:
+        """
+        Called for each streaming chunk from LLM.
+
+        Use to modify or filter streaming content.
+
+        Args:
+            ctx: Hook context with chunk in data["chunk"]
+
+        Returns:
+            Modified chunk or None to keep unchanged
+        """
+
+    async def on_after_llm_response(self, ctx: HookContext) -> str | None:
+        """
+        Called after full response is received.
+
+        Use to post-process the complete LLM response.
+
+        Args:
+            ctx: Hook context with response in data["response"]
+
+        Returns:
+            Modified response or None to keep unchanged
+        """
+
+    # ========== Tool Execution Hooks ==========
+
+    async def on_before_tool_parse(self, ctx: HookContext) -> str | None:
+        """
+        Called before parsing tool calls from response.
+
+        Use to modify response before tool parsing.
+
+        Args:
+            ctx: Hook context with response in data["response"]
+
+        Returns:
+            Modified response or None to keep unchanged
+        """
+
+    async def on_before_tool_execute(self, ctx: HookContext) -> bool | None:
+        """
+        Called before each tool execution.
+
+        Use to validate, modify, or cancel tool execution.
+
+        Args:
+            ctx: Hook context with tool_call in data
+
+        Returns:
+            False to cancel execution, None to continue
+        """
+
+    async def on_after_tool_execute(self, ctx: HookContext) -> Any | None:
+        """
+        Called after tool execution completes.
+
+        Use to post-process tool results.
+
+        Args:
+            ctx: Hook context with result in data["result"]
+
+        Returns:
+            Modified result or None to keep unchanged
+        """
+
+    async def on_tool_error(self, ctx: HookContext) -> Any | None:
+        """
+        Called when a tool throws an error.
+
+        Use to convert errors to RepairableException or handle.
+
+        Args:
+            ctx: Hook context with error in data["error"]
+
+        Returns:
+            RepairableException or None to use default handling
+        """
+
+    # ========== Continuation Loop Hooks ==========
+
+    async def on_before_continuation(self, ctx: HookContext) -> bool | None:
+        """
+        Called before LLM continuation iteration.
+
+        Use to modify context or stop the continuation loop.
+
+        Args:
+            ctx: Hook context with iteration info
+
+        Returns:
+            False to stop loop, None to continue
+        """
+
+    async def on_after_continuation(self, ctx: HookContext) -> None | None:
+        """
+        Called after each continuation iteration.
+
+        Use for logging or state updates.
+
+        Args:
+            ctx: Hook context with iteration results
+
+        Returns:
+            None
+        """
+
+    async def on_loop_complete(self, ctx: HookContext) -> None | None:
+        """
+        Called when message loop completes.
+
+        Use for cleanup or final processing.
+
+        Args:
+            ctx: Hook context with final_response
+
+        Returns:
+            None
+        """
+
+    # ========== Error Handling Hooks ==========
+
+    async def on_repairable_error(self, ctx: HookContext) -> str | None:
+        """
+        Called when a repairable error occurs.
+
+        Use to modify suggestion or add context.
+
+        Args:
+            ctx: Hook context with error and suggestion
+
+        Returns:
+            Modified suggestion or None to keep unchanged
+        """
+
+    async def on_critical_error(self, ctx: HookContext) -> None | None:
+        """
+        Called when a critical error occurs.
+
+        Use for logging or alerting only.
+
+        Args:
+            ctx: Hook context with error
+
+        Returns:
+            None (logging only)
+        """
+
+    # ========== Response Hooks ==========
+
+    async def on_before_response_send(self, ctx: HookContext) -> str | None:
+        """
+        Called before sending response via WebSocket.
+
+        Use to modify or filter outgoing responses.
+
+        Args:
+            ctx: Hook context with response in data
+
+        Returns:
+            Modified response or None to keep unchanged
+        """
+
+    async def on_after_response_send(self, ctx: HookContext) -> None | None:
+        """
+        Called after response is sent.
+
+        Use for logging or metrics only.
+
+        Args:
+            ctx: Hook context
+
+        Returns:
+            None (logging only)
+        """
+
+    # ========== Session Lifecycle Hooks ==========
+
+    async def on_session_create(self, ctx: HookContext) -> None | None:
+        """
+        Called when a new session is created.
+
+        Use to initialize session-specific state.
+
+        Args:
+            ctx: Hook context with session info
+
+        Returns:
+            None
+        """
+
+    async def on_session_destroy(self, ctx: HookContext) -> None | None:
+        """
+        Called when a session is destroyed.
+
+        Use for cleanup only.
+
+        Args:
+            ctx: Hook context with session info
+
+        Returns:
+            None (cleanup only)
+        """
+
+    # ========== Knowledge Integration Hooks ==========
+
+    async def on_before_rag_query(self, ctx: HookContext) -> str | None:
+        """
+        Called before querying knowledge base.
+
+        Use to modify the query or add filters.
+
+        Args:
+            ctx: Hook context with query in data
+
+        Returns:
+            Modified query or None to keep unchanged
+        """
+
+    async def on_after_rag_results(self, ctx: HookContext) -> List[Dict[str, Any]] | None:
+        """
+        Called after RAG results are retrieved.
+
+        Use to filter, rank, or modify results.
+
+        Args:
+            ctx: Hook context with results and citations
+
+        Returns:
+            Modified results or None to keep unchanged
+        """
+
+    # ========== Approval Flow Hooks ==========
+
+    async def on_approval_required(self, ctx: HookContext) -> bool | None:
+        """
+        Called when tool requires user approval.
+
+        Use to auto-approve or modify approval request.
+
+        Args:
+            ctx: Hook context with tool_call and message
+
+        Returns:
+            True to auto-approve, None for normal flow
+        """
+
+    async def on_approval_received(self, ctx: HookContext) -> None | None:
+        """
+        Called when user approval is received.
+
+        Use for logging or analytics.
+
+        Args:
+            ctx: Hook context with approval info
+
+        Returns:
+            None (logging only)
+        """
+
+    # ========== Prompt Pipeline Hooks (Issue #3405) ==========
+
+    async def on_system_prompt_ready(self, ctx: HookContext) -> str | None:
+        """
+        Called after the system prompt is built.
+
+        Receives the assembled system prompt in ctx.data["system_prompt"] and
+        ctx.data["session"] for session metadata.  Return a non-None str to
+        replace the system prompt; return None to leave it unchanged.
+
+        Args:
+            ctx: Hook context with data["system_prompt"] and data["session"]
+
+        Returns:
+            Modified system prompt str or None to keep unchanged
+        """
+
+    async def on_full_prompt_ready(self, ctx: HookContext) -> str | None:
+        """
+        Called after the full prompt (system + knowledge + conversation) is built.
+
+        Receives the full prompt in ctx.data["prompt"], LLM parameters in
+        ctx.data["llm_params"], and request context in ctx.data["context"].
+        Return a non-None str to replace the full prompt; return None to keep it
+        unchanged.
+
+        Args:
+            ctx: Hook context with data["prompt"], data["llm_params"],
+                 data["context"]
+
+        Returns:
+            Modified full prompt str or None to keep unchanged
+        """
+
+    # ========== Utility Methods ==========
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(name='{self.name}', priority={self.priority})"

--- a/autobot-backend/middleware/builtin/__init__.py
+++ b/autobot-backend/middleware/builtin/__init__.py
@@ -1,0 +1,21 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Built-in extensions for the extension hooks system.
+
+Issue #658: Provides default extensions that demonstrate the
+extension system and provide useful functionality.
+
+Issue #3009: Adds PermissionEnforcementExtension for per-operation RBAC.
+"""
+
+from middleware.builtin.logging_extension import LoggingExtension
+from middleware.builtin.permission_enforcement import PermissionEnforcementExtension
+from middleware.builtin.secret_masking import SecretMaskingExtension
+
+__all__ = [
+    "LoggingExtension",
+    "PermissionEnforcementExtension",
+    "SecretMaskingExtension",
+]

--- a/autobot-backend/middleware/builtin/logging_extension.py
+++ b/autobot-backend/middleware/builtin/logging_extension.py
@@ -1,0 +1,267 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Logging Extension for debugging and monitoring.
+
+Issue #658: Built-in extension that logs all hook invocations
+for debugging and monitoring purposes.
+"""
+
+import logging
+import time
+from autobot_shared.logging_manager import get_logger
+from middleware.base import Extension, HookContext
+
+logger = get_logger(__name__)
+
+
+class LoggingExtension(Extension):
+    """
+    Extension that logs hook invocations.
+
+    Issue #658: This built-in extension provides visibility into
+    the agent lifecycle by logging key events. Useful for debugging
+    and monitoring.
+
+    Attributes:
+        name: "logging"
+        priority: 1 (runs first to capture all events)
+        log_level: Logging level for messages (default INFO)
+        include_data: Whether to log context data (default False)
+
+    Usage:
+        manager.register(LoggingExtension())
+
+        # Or with custom settings
+        ext = LoggingExtension()
+        ext.log_level = logging.DEBUG
+        ext.include_data = True
+        manager.register(ext)
+    """
+
+    name = "logging"
+    priority = 1  # Run first to capture all events
+
+    def __init__(self):
+        """Initialize logging extension."""
+        self.log_level = logging.INFO
+        self.include_data = False
+        self._session_start_times: dict = {}
+
+    async def on_before_message_process(self, ctx: HookContext) -> None | None:
+        """Log message processing start."""
+        message_preview = ctx.message[:100] if ctx.message else "(empty)"
+        if len(ctx.message) > 100:
+            message_preview += "..."
+
+        logger.log(
+            self.log_level,
+            "[%s] Processing message: %s",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+            message_preview,
+        )
+
+        # Track timing
+        self._session_start_times[ctx.session_id] = time.time()
+
+        if self.include_data:
+            logger.debug("[%s] Context data: %s", ctx.session_id[:8], ctx.data)
+
+        return None
+
+    async def on_after_prompt_build(self, ctx: HookContext) -> str | None:
+        """Log prompt building."""
+        prompt = ctx.get("prompt", "")
+        logger.log(
+            self.log_level,
+            "[%s] Prompt built: %d chars",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+            len(prompt),
+        )
+        return None  # Don't modify prompt
+
+    async def on_before_llm_call(self, ctx: HookContext) -> bool | None:
+        """Log LLM call start."""
+        model = ctx.get("model", "unknown")
+        logger.log(
+            self.log_level,
+            "[%s] Calling LLM: model=%s",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+            model,
+        )
+        return None  # Don't cancel
+
+    async def on_after_llm_response(self, ctx: HookContext) -> str | None:
+        """Log LLM response received."""
+        response = ctx.get("response", "")
+        logger.log(
+            self.log_level,
+            "[%s] LLM response: %d chars",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+            len(response),
+        )
+        return None  # Don't modify response
+
+    async def on_before_tool_execute(self, ctx: HookContext) -> bool | None:
+        """Log tool execution start."""
+        tool_name = ctx.get("tool_name", "unknown")
+        logger.log(
+            self.log_level,
+            "[%s] Executing tool: %s",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+            tool_name,
+        )
+
+        if self.include_data:
+            params = ctx.get("tool_params", {})
+            logger.debug("[%s] Tool params: %s", ctx.session_id[:8], params)
+
+        return None  # Don't cancel
+
+    async def on_after_tool_execute(self, ctx: HookContext) -> None | None:
+        """Log tool execution complete."""
+        tool_name = ctx.get("tool_name", "unknown")
+        success = ctx.get("success", True)
+        execution_time = ctx.get("execution_time", 0)
+
+        status = "SUCCESS" if success else "FAILED"
+        logger.log(
+            self.log_level,
+            "[%s] Tool %s: %s (%.2fs)",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+            tool_name,
+            status,
+            execution_time,
+        )
+        return None
+
+    async def on_tool_error(self, ctx: HookContext) -> None | None:
+        """Log tool errors."""
+        tool_name = ctx.get("tool_name", "unknown")
+        error = ctx.get("error", "unknown error")
+
+        logger.error(
+            "[%s] Tool %s error: %s",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+            tool_name,
+            str(error),
+        )
+        return None
+
+    async def on_repairable_error(self, ctx: HookContext) -> str | None:
+        """Log repairable errors."""
+        error = ctx.get("error", "")
+        suggestion = ctx.get("suggestion", "")
+
+        logger.warning(
+            "[%s] Repairable error: %s (suggestion: %s)",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+            str(error),
+            suggestion,
+        )
+        return None  # Don't modify suggestion
+
+    async def on_critical_error(self, ctx: HookContext) -> None | None:
+        """Log critical errors."""
+        error = ctx.get("error", "")
+
+        logger.error(
+            "[%s] CRITICAL ERROR: %s",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+            str(error),
+        )
+        return None
+
+    async def on_loop_complete(self, ctx: HookContext) -> None | None:
+        """Log message loop completion with timing."""
+        session_id = ctx.session_id or "no-session"
+        start_time = self._session_start_times.pop(session_id, None)
+
+        if start_time:
+            elapsed = time.time() - start_time
+            logger.log(
+                self.log_level,
+                "[%s] Message loop completed in %.2fs",
+                session_id[:8],
+                elapsed,
+            )
+        else:
+            logger.log(
+                self.log_level,
+                "[%s] Message loop completed",
+                session_id[:8],
+            )
+
+        return None
+
+    async def on_session_create(self, ctx: HookContext) -> None | None:
+        """Log session creation."""
+        logger.log(
+            self.log_level,
+            "[%s] Session created",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+        )
+        return None
+
+    async def on_session_destroy(self, ctx: HookContext) -> None | None:
+        """Log session destruction."""
+        logger.log(
+            self.log_level,
+            "[%s] Session destroyed",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+        )
+
+        # Cleanup timing data
+        if ctx.session_id in self._session_start_times:
+            del self._session_start_times[ctx.session_id]
+
+        return None
+
+    async def on_before_rag_query(self, ctx: HookContext) -> str | None:
+        """Log RAG query."""
+        query = ctx.get("query", "")
+        logger.log(
+            self.log_level,
+            "[%s] RAG query: %s",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+            query[:100] if query else "(empty)",
+        )
+        return None
+
+    async def on_after_rag_results(self, ctx: HookContext) -> None | None:
+        """Log RAG results."""
+        results = ctx.get("results", [])
+        logger.log(
+            self.log_level,
+            "[%s] RAG returned %d results",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+            len(results) if isinstance(results, list) else 0,
+        )
+        return None
+
+    async def on_approval_required(self, ctx: HookContext) -> bool | None:
+        """Log approval requests."""
+        tool_name = ctx.get("tool_name", "unknown")
+        logger.log(
+            self.log_level,
+            "[%s] Approval required for: %s",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+            tool_name,
+        )
+        return None  # Don't auto-approve
+
+    async def on_approval_received(self, ctx: HookContext) -> None | None:
+        """Log approval received."""
+        tool_name = ctx.get("tool_name", "unknown")
+        approved = ctx.get("approved", False)
+
+        status = "APPROVED" if approved else "DENIED"
+        logger.log(
+            self.log_level,
+            "[%s] Approval %s: %s",
+            ctx.session_id[:8] if ctx.session_id else "no-session",
+            status,
+            tool_name,
+        )
+        return None

--- a/autobot-backend/middleware/builtin/permission_enforcement.py
+++ b/autobot-backend/middleware/builtin/permission_enforcement.py
@@ -1,0 +1,131 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Permission Enforcement Extension — issue #3009.
+
+Built-in extension that checks tool permission levels against user roles
+before allowing tool execution. Wires into the BEFORE_TOOL_EXECUTE hook.
+
+Legacy tools that do not set ``tool_permission`` on HookContext are allowed
+through unchanged so that existing callers are not broken.
+"""
+
+from autobot_shared.logging_manager import get_logger
+from middleware.base import Extension, HookContext
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Role / permission maps
+# ---------------------------------------------------------------------------
+
+# Role hierarchy — higher index = more privilege.
+# Roles not in this map default to 0 (public / unauthenticated level).
+_ROLE_LEVELS: dict[str, int] = {
+    "public": 0,
+    "readonly": 1,
+    "user": 2,
+    "editor": 3,
+    "analyst": 3,
+    "operator": 4,
+    "admin": 5,
+    "system": 5,
+}
+
+# Minimum role level required for each tool permission tier.
+_PERMISSION_MIN_LEVEL: dict[str, int] = {
+    "public": 0,
+    "authenticated": 2,  # requires at least "user" level
+    "operator": 4,
+    "admin": 5,
+}
+
+
+def _role_satisfies(user_role: str | None, tool_permission: str) -> bool:
+    """Return True if *user_role* meets the *tool_permission* requirement.
+
+    Args:
+        user_role: User's role string (e.g. ``"user"``, ``"admin"``).
+                   ``None`` represents an unauthenticated caller.
+        tool_permission: Required permission tier (e.g. ``"public"``, ``"admin"``).
+
+    Returns:
+        True when the caller has sufficient privilege.
+    """
+    if tool_permission == "public":
+        return True
+
+    if user_role is None:
+        # Unauthenticated — only public tools are permitted
+        return False
+
+    user_level = _ROLE_LEVELS.get(user_role.lower(), 0)
+    required_level = _PERMISSION_MIN_LEVEL.get(tool_permission.lower(), 5)
+    return user_level >= required_level
+
+
+class PermissionEnforcementExtension(Extension):
+    """Enforces per-operation tool permission levels before execution.
+
+    Reads ``tool_permission`` and ``user_role`` from HookContext.data and
+    raises ``PermissionError`` when the caller lacks sufficient privilege.
+
+    Legacy tools that do not set ``tool_permission`` on HookContext are
+    allowed through without any check (backward compatibility).
+
+    Priority 0 ensures this extension runs before all others so that a
+    permission denial short-circuits the entire tool-execution chain.
+
+    Usage::
+
+        ext = PermissionEnforcementExtension()
+        # Register with ExtensionManager so it fires on BEFORE_TOOL_EXECUTE
+        manager.register(ext)
+    """
+
+    name = "permission_enforcement"
+    priority = 0  # Runs first — before any other extension
+
+    async def on_before_tool_execute(self, ctx: HookContext) -> bool | None:
+        """Check caller permission before tool execution.
+
+        Args:
+            ctx: Hook context.  Reads:
+                 - ``ctx.data["tool_permission"]``: required permission tier
+                   (``"public"``, ``"authenticated"``, ``"operator"``,
+                   ``"admin"``).  If absent the tool is treated as legacy and
+                   allowed through.
+                 - ``ctx.data["user_role"]``: caller's role string.
+                   If absent the caller is treated as unauthenticated.
+
+        Returns:
+            None when the check passes (execution continues normally).
+
+        Raises:
+            PermissionError: When the caller lacks the required permission.
+        """
+        tool_permission = ctx.get("tool_permission")
+        if tool_permission is None:
+            # Legacy tool — no permission schema declared; allow through
+            return None
+
+        user_role = ctx.get("user_role")
+
+        if not _role_satisfies(user_role, tool_permission):
+            logger.warning(
+                "Permission denied: tool requires '%s', user has role '%s' " "(session=%s)",
+                tool_permission,
+                user_role,
+                ctx.session_id,
+            )
+            raise PermissionError(f"Tool requires '{tool_permission}' permission, " f"user has role '{user_role}'")
+
+        logger.debug(
+            "Permission granted: tool_permission='%s' user_role='%s' session=%s",
+            tool_permission,
+            user_role,
+            ctx.session_id,
+        )
+        return None  # Allow execution

--- a/autobot-backend/middleware/builtin/secret_masking.py
+++ b/autobot-backend/middleware/builtin/secret_masking.py
@@ -1,0 +1,314 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Secret Masking Extension for security.
+
+Issue #658: Built-in extension that masks sensitive information
+in responses before they are displayed to users.
+"""
+
+import re
+from typing import Any, Dict, List
+
+from autobot_shared.logging_manager import get_logger
+from middleware.base import Extension, HookContext
+
+logger = get_logger(__name__)
+
+
+class SecretMaskingExtension(Extension):
+    """
+    Extension that masks secrets in responses.
+
+    Issue #658: This built-in extension provides security by masking
+    sensitive information (API keys, passwords, tokens) before responses
+    are sent to users.
+
+    Attributes:
+        name: "secret_masking"
+        priority: 90 (runs near the end, before response is sent)
+        patterns: List of regex patterns to detect secrets
+        mask_char: Character used for masking (default '*')
+        show_chars: Number of characters to show at start/end
+
+    Usage:
+        manager.register(SecretMaskingExtension())
+
+        # Or with custom patterns
+        ext = SecretMaskingExtension()
+        ext.add_pattern(r'my-custom-secret-\\w+', 'Custom Secret')
+        manager.register(ext)
+    """
+
+    name = "secret_masking"
+    priority = 90  # Run near the end, before logging
+
+    # Default patterns for common secrets
+    DEFAULT_PATTERNS: List[Dict[str, Any]] = [
+        {
+            "name": "API Key (generic)",
+            "pattern": r"(?i)(api[_-]?key|apikey)\s*[:=]\s*['\"]?([a-zA-Z0-9_-]{20,})['\"]?",
+            "group": 2,
+        },
+        {
+            "name": "AWS Access Key",
+            "pattern": r"AKIA[0-9A-Z]{16}",
+            "group": 0,
+        },
+        {
+            "name": "AWS Secret Key",
+            "pattern": (
+                r"(?i)(aws[_-]?secret[_-]?access[_-]?key|secret[_-]?key)" r"\s*[:=]\s*['\"]?([a-zA-Z0-9/+=]{40})['\"]?"
+            ),
+            "group": 2,
+        },
+        {
+            "name": "Bearer Token",
+            "pattern": r"(?i)bearer\s+([a-zA-Z0-9_-]{20,})",
+            "group": 1,
+        },
+        {
+            "name": "Password (generic)",
+            "pattern": r"(?i)(password|passwd|pwd)\s*[:=]\s*['\"]?([^\s'\"]{8,})['\"]?",
+            "group": 2,
+        },
+        {
+            "name": "Private Key Header",
+            "pattern": r"-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----",
+            "group": 0,
+        },
+        {
+            "name": "GitHub Token",
+            "pattern": r"gh[pousr]_[A-Za-z0-9_]{36,}",
+            "group": 0,
+        },
+        {
+            "name": "Slack Token",
+            "pattern": r"xox[baprs]-[0-9A-Za-z-]{10,}",
+            "group": 0,
+        },
+        {
+            "name": "JWT Token",
+            "pattern": r"eyJ[a-zA-Z0-9_-]*\.eyJ[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]*",
+            "group": 0,
+        },
+        {
+            "name": "Generic Secret",
+            "pattern": r"(?i)(secret|token|credential)\s*[:=]\s*['\"]?([a-zA-Z0-9_-]{16,})['\"]?",
+            "group": 2,
+        },
+        {
+            "name": "OpenAI API Key",
+            "pattern": r"sk-[a-zA-Z0-9]{48}",
+            "group": 0,
+        },
+        {
+            "name": "Anthropic API Key",
+            "pattern": r"sk-ant-[a-zA-Z0-9-]{32,}",
+            "group": 0,
+        },
+    ]
+
+    def __init__(self):
+        """Initialize secret masking extension."""
+        self.patterns: List[Dict[str, Any]] = []
+        self.compiled_patterns: List[tuple] = []
+        self.mask_char = "*"
+        self.show_chars = 4  # Show first/last N chars
+        self.mask_count = 0  # Track number of masks applied
+
+        # Load default patterns
+        for pattern_config in self.DEFAULT_PATTERNS:
+            self.add_pattern(
+                pattern_config["pattern"],
+                pattern_config["name"],
+                pattern_config.get("group", 0),
+            )
+
+    def add_pattern(
+        self,
+        pattern: str,
+        name: str,
+        group: int = 0,
+    ) -> bool:
+        """
+        Add a pattern to detect secrets.
+
+        Args:
+            pattern: Regex pattern string
+            name: Human-readable name for logging
+            group: Regex group to mask (0 = whole match)
+
+        Returns:
+            True if pattern added successfully
+        """
+        try:
+            compiled = re.compile(pattern)
+            self.patterns.append(
+                {
+                    "name": name,
+                    "pattern": pattern,
+                    "group": group,
+                }
+            )
+            self.compiled_patterns.append((compiled, name, group))
+            return True
+        except re.error as e:
+            logger.error(
+                "[Issue #658] Invalid regex pattern '%s': %s",
+                name,
+                str(e),
+            )
+            return False
+
+    # CodeQL: false positive — this method intentionally handles secrets to mask them
+    def mask_secret(self, secret: str) -> str:
+        """
+        Mask a secret string.
+
+        Shows first and last N characters with masked middle.
+
+        Args:
+            secret: The secret to mask
+
+        Returns:
+            Masked string
+        """
+        if len(secret) <= self.show_chars * 2:
+            # Too short to show any chars - mask entirely
+            return self.mask_char * len(secret)
+
+        start = secret[: self.show_chars]
+        end = secret[-self.show_chars :]
+        middle_len = len(secret) - (self.show_chars * 2)
+
+        return f"{start}{self.mask_char * middle_len}{end}"
+
+    def mask_secrets(self, text: str) -> str:
+        """
+        Mask all detected secrets in text.
+
+        Args:
+            text: Text potentially containing secrets
+
+        Returns:
+            Text with secrets masked
+        """
+        masked_text = text
+        masks_applied = 0
+
+        for compiled_pattern, name, group in self.compiled_patterns:
+            try:
+                matches = list(compiled_pattern.finditer(masked_text))
+                # Process in reverse to maintain correct positions
+                for match in reversed(matches):
+                    if group == 0:
+                        # CodeQL: false positive — extracting secret to mask it
+                        secret = match.group(0)  # noqa: S105
+                        start, end = match.start(), match.end()
+                    else:
+                        try:
+                            secret = match.group(group)
+                            start = match.start(group)
+                            end = match.end(group)
+                        except IndexError:
+                            continue
+
+                    masked = self.mask_secret(secret)
+                    masked_text = masked_text[:start] + masked + masked_text[end:]
+                    masks_applied += 1
+
+                    logger.debug(
+                        "[Issue #658] Masked %s pattern",
+                        name,
+                    )
+            except Exception as e:
+                logger.error(
+                    "[Issue #658] Error applying pattern '%s': %s",
+                    name,
+                    str(e),
+                )
+
+        if masks_applied > 0:
+            self.mask_count += masks_applied
+            logger.info(
+                "[Issue #658] Masked %d secret(s) in response",
+                masks_applied,
+            )
+
+        return masked_text
+
+    async def on_before_response_send(self, ctx: HookContext) -> str | None:
+        """
+        Mask secrets before sending response.
+
+        Args:
+            ctx: Hook context with response in data
+
+        Returns:
+            Masked response or None if no changes
+        """
+        response = ctx.get("response", "")
+        if not response:
+            return None
+
+        masked = self.mask_secrets(response)
+        if masked != response:
+            ctx.set("response", masked)
+            return masked
+
+        return None
+
+    async def on_after_llm_response(self, ctx: HookContext) -> str | None:
+        """
+        Mask secrets in LLM responses.
+
+        Args:
+            ctx: Hook context with response in data
+
+        Returns:
+            Masked response or None if no changes
+        """
+        response = ctx.get("response", "")
+        if not response:
+            return None
+
+        masked = self.mask_secrets(response)
+        if masked != response:
+            return masked
+
+        return None
+
+    async def on_after_tool_execute(self, ctx: HookContext) -> str | None:
+        """
+        Mask secrets in tool results.
+
+        Args:
+            ctx: Hook context with result in data
+
+        Returns:
+            Masked result or None if no changes
+        """
+        result = ctx.get("result", "")
+        if not result or not isinstance(result, str):
+            return None
+
+        masked = self.mask_secrets(result)
+        if masked != result:
+            return masked
+
+        return None
+
+    def get_statistics(self) -> Dict[str, Any]:
+        """
+        Get statistics about secret masking.
+
+        Returns:
+            Dictionary with masking stats
+        """
+        return {
+            "pattern_count": len(self.patterns),
+            "total_masks_applied": self.mask_count,
+            "patterns": [p["name"] for p in self.patterns],
+        }

--- a/autobot-backend/middleware/extension_manifest.py
+++ b/autobot-backend/middleware/extension_manifest.py
@@ -1,0 +1,8 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Re-export ExtensionManifest from canonical location in autobot_shared."""
+
+from autobot_shared.plugin_sdk.extension_manifest import ExtensionManifest
+
+__all__ = ["ExtensionManifest"]

--- a/autobot-backend/middleware/hook_invoker.py
+++ b/autobot-backend/middleware/hook_invoker.py
@@ -1,0 +1,358 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Centralized hook invocation strategy for extensibility.
+
+Issue #4202: Redesigns hook invocation to eliminate boilerplate and
+improve extensibility through a unified invocation strategy.
+
+This module provides:
+- HookInvoker: Central coordinator for all hook invocations
+- Hook configuration with declarative patterns (transform, cancel, collect)
+- Consistent error handling and logging across all hook points
+"""
+
+from enum import Enum
+from typing import Any, Dict, List
+
+from autobot_shared.logging_manager import get_logger
+from middleware.base import HookContext
+from middleware.hooks import HookPoint
+from middleware.manager import ExtensionManager
+
+logger = get_logger(__name__)
+
+
+class InvocationMode(Enum):
+    """
+    Strategy for how a hook should be invoked.
+
+    COLLECT: Invoke all extensions, collect all non-None results (default)
+    TRANSFORM: Invoke all extensions with transform semantics on a specific key
+    UNTIL_HANDLED: Stop at first truthy result (one-winner pattern)
+    CANCELLABLE: Stop if any extension returns False (veto pattern)
+    """
+
+    COLLECT = "collect"
+    TRANSFORM = "transform"
+    UNTIL_HANDLED = "until_handled"
+    CANCELLABLE = "cancellable"
+
+
+class HookInvocationConfig:
+    """Configuration for how a specific hook should be invoked."""
+
+    def __init__(
+        self,
+        mode: InvocationMode = InvocationMode.COLLECT,
+        transform_key: str | None = None,
+        expected_type: type | None = None,
+    ):
+        """
+        Initialize hook invocation configuration.
+
+        Args:
+            mode: How the hook should be invoked
+            transform_key: For TRANSFORM mode, which context key to transform
+            expected_type: For TRANSFORM mode, validate result type (e.g., str)
+        """
+        self.mode = mode
+        self.transform_key = transform_key
+        self.expected_type = expected_type
+
+    def validate(self) -> None:
+        """Validate configuration consistency."""
+        if self.mode == InvocationMode.TRANSFORM:
+            if not self.transform_key:
+                raise ValueError("TRANSFORM mode requires transform_key")
+
+
+class HookInvoker:
+    """
+    Centralized hook invocation coordinator.
+
+    Issue #4202: Eliminates repetitive _emit_* wrapper functions by
+    providing a unified invocation interface with configurable strategies.
+
+    Usage:
+        invoker = HookInvoker(extension_manager)
+
+        # Collect all results
+        results = await invoker.invoke(
+            HookPoint.BEFORE_MESSAGE_PROCESS,
+            ctx
+        )
+
+        # Transform a specific context value
+        modified_prompt = await invoker.invoke(
+            HookPoint.AFTER_PROMPT_BUILD,
+            ctx,
+            config=HookInvocationConfig(
+                mode=InvocationMode.TRANSFORM,
+                transform_key="prompt",
+                expected_type=str
+            )
+        )
+
+        # Stop at first handler (veto pattern)
+        should_proceed = await invoker.invoke(
+            HookPoint.BEFORE_LLM_CALL,
+            ctx,
+            config=HookInvocationConfig(mode=InvocationMode.CANCELLABLE)
+        )
+    """
+
+    def __init__(self, manager: ExtensionManager):
+        """
+        Initialize HookInvoker.
+
+        Args:
+            manager: ExtensionManager instance for invoking extensions
+        """
+        self.manager = manager
+        self._configs: Dict[HookPoint, HookInvocationConfig] = {}
+        self._register_default_configs()
+
+    def _register_default_configs(self) -> None:
+        """Register default invocation configurations for all hooks."""
+        # Message preparation hooks
+        self._configs[HookPoint.BEFORE_MESSAGE_PROCESS] = HookInvocationConfig(mode=InvocationMode.COLLECT)
+        self._configs[HookPoint.BEFORE_PROMPT_BUILD] = HookInvocationConfig(mode=InvocationMode.COLLECT)
+        self._configs[HookPoint.AFTER_PROMPT_BUILD] = HookInvocationConfig(
+            mode=InvocationMode.TRANSFORM,
+            transform_key="prompt",
+            expected_type=str,
+        )
+
+        # LLM interaction hooks
+        self._configs[HookPoint.BEFORE_LLM_CALL] = HookInvocationConfig(mode=InvocationMode.CANCELLABLE)
+        self._configs[HookPoint.DURING_LLM_STREAMING] = HookInvocationConfig(mode=InvocationMode.COLLECT)
+        self._configs[HookPoint.AFTER_LLM_RESPONSE] = HookInvocationConfig(
+            mode=InvocationMode.TRANSFORM,
+            transform_key="response",
+            expected_type=str,
+        )
+
+        # Tool execution hooks
+        self._configs[HookPoint.BEFORE_TOOL_PARSE] = HookInvocationConfig(
+            mode=InvocationMode.TRANSFORM,
+            transform_key="llm_response",
+            expected_type=str,
+        )
+        self._configs[HookPoint.BEFORE_TOOL_EXECUTE] = HookInvocationConfig(mode=InvocationMode.CANCELLABLE)
+        self._configs[HookPoint.AFTER_TOOL_EXECUTE] = HookInvocationConfig(
+            mode=InvocationMode.TRANSFORM,
+            transform_key="tool_result",
+        )
+        self._configs[HookPoint.TOOL_ERROR] = HookInvocationConfig(mode=InvocationMode.COLLECT)
+
+        # Continuation loop hooks
+        self._configs[HookPoint.BEFORE_CONTINUATION] = HookInvocationConfig(mode=InvocationMode.CANCELLABLE)
+        self._configs[HookPoint.AFTER_CONTINUATION] = HookInvocationConfig(
+            mode=InvocationMode.TRANSFORM,
+            transform_key="response",
+            expected_type=str,
+        )
+        self._configs[HookPoint.LOOP_COMPLETE] = HookInvocationConfig(
+            mode=InvocationMode.TRANSFORM,
+            transform_key="final_response",
+            expected_type=str,
+        )
+
+        # Error handling hooks
+        self._configs[HookPoint.REPAIRABLE_ERROR] = HookInvocationConfig(mode=InvocationMode.COLLECT)
+        self._configs[HookPoint.CRITICAL_ERROR] = HookInvocationConfig(mode=InvocationMode.COLLECT)
+
+        # Response hooks
+        self._configs[HookPoint.BEFORE_RESPONSE_SEND] = HookInvocationConfig(
+            mode=InvocationMode.TRANSFORM,
+            transform_key="response",
+        )
+        self._configs[HookPoint.AFTER_RESPONSE_SEND] = HookInvocationConfig(mode=InvocationMode.COLLECT)
+
+        # Session lifecycle hooks
+        self._configs[HookPoint.SESSION_CREATE] = HookInvocationConfig(mode=InvocationMode.COLLECT)
+        self._configs[HookPoint.SESSION_DESTROY] = HookInvocationConfig(mode=InvocationMode.COLLECT)
+
+        # Knowledge integration hooks
+        self._configs[HookPoint.BEFORE_RAG_QUERY] = HookInvocationConfig(
+            mode=InvocationMode.TRANSFORM,
+            transform_key="query",
+            expected_type=str,
+        )
+        self._configs[HookPoint.AFTER_RAG_RESULTS] = HookInvocationConfig(
+            mode=InvocationMode.TRANSFORM,
+            transform_key="results",
+        )
+
+        # Approval flow hooks
+        self._configs[HookPoint.APPROVAL_REQUIRED] = HookInvocationConfig(mode=InvocationMode.UNTIL_HANDLED)
+        self._configs[HookPoint.APPROVAL_RECEIVED] = HookInvocationConfig(mode=InvocationMode.COLLECT)
+
+        # Prompt pipeline hooks (Issue #3405)
+        self._configs[HookPoint.SYSTEM_PROMPT_READY] = HookInvocationConfig(
+            mode=InvocationMode.TRANSFORM,
+            transform_key="system_prompt",
+            expected_type=str,
+        )
+        self._configs[HookPoint.FULL_PROMPT_READY] = HookInvocationConfig(
+            mode=InvocationMode.TRANSFORM,
+            transform_key="prompt",
+            expected_type=str,
+        )
+
+    def register_config(self, hook: HookPoint, config: HookInvocationConfig) -> None:
+        """
+        Register or override a hook's invocation configuration.
+
+        Args:
+            hook: The hook point to configure
+            config: Configuration specifying how to invoke it
+        """
+        config.validate()
+        self._configs[hook] = config
+        logger.debug(
+            "[Issue #4202] Registered %s config for %s",
+            config.mode.value,
+            hook.name,
+        )
+
+    async def invoke(
+        self,
+        hook: HookPoint,
+        context: HookContext,
+        config: HookInvocationConfig | None = None,
+    ) -> Any:
+        """
+        Invoke a hook using its registered strategy.
+
+        Args:
+            hook: The hook point to invoke
+            context: Hook context with data to pass to extensions
+            config: Optional override configuration (uses registered if None)
+
+        Returns:
+            Result based on invocation mode:
+            - COLLECT: List of non-None results
+            - TRANSFORM: Transformed value (or original if no transform)
+            - UNTIL_HANDLED: First truthy result or None
+            - CANCELLABLE: True if should proceed, False if vetoed
+        """
+        cfg = config or self._configs.get(hook)
+        if not cfg:
+            # Fallback to default COLLECT strategy
+            cfg = HookInvocationConfig(mode=InvocationMode.COLLECT)
+
+        try:
+            if cfg.mode == InvocationMode.COLLECT:
+                return await self._invoke_collect(hook, context)
+            elif cfg.mode == InvocationMode.TRANSFORM:
+                return await self._invoke_transform(hook, context, cfg.transform_key, cfg.expected_type)
+            elif cfg.mode == InvocationMode.UNTIL_HANDLED:
+                return await self._invoke_until_handled(hook, context)
+            elif cfg.mode == InvocationMode.CANCELLABLE:
+                return await self._invoke_cancellable(hook, context)
+            else:
+                # Default to COLLECT
+                return await self._invoke_collect(hook, context)
+        except Exception as e:
+            logger.error(
+                "[Issue #4202] Failed to invoke %s: %s",
+                hook.name,
+                str(e),
+                exc_info=True,
+            )
+            raise
+
+    async def _invoke_collect(self, hook: HookPoint, context: HookContext) -> List[Any]:
+        """
+        Collect all non-None results from middleware.
+
+        Args:
+            hook: The hook point to invoke
+            context: Hook context
+
+        Returns:
+            List of non-None results
+        """
+        return await self.manager.invoke_hook(hook, context)
+
+    async def _invoke_transform(
+        self,
+        hook: HookPoint,
+        context: HookContext,
+        key: str,
+        expected_type: type | None,
+    ) -> Any:
+        """
+        Transform a context value through all extensions.
+
+        Args:
+            hook: The hook point to invoke
+            context: Hook context
+            key: Context key to transform
+            expected_type: Expected type of result (for validation)
+
+        Returns:
+            Transformed value or original if unchanged
+        """
+        result = await self.manager.invoke_with_transform(hook, context, key)
+
+        # Validate type if expected
+        if expected_type and result is not None:
+            if not isinstance(result, expected_type):
+                logger.warning(
+                    "[Issue #4202] %s returned %s, expected %s",
+                    hook.name,
+                    type(result).__name__,
+                    expected_type.__name__,
+                )
+        return result
+
+    async def _invoke_until_handled(self, hook: HookPoint, context: HookContext) -> Any | None:
+        """
+        Invoke until one extension handles (returns truthy value).
+
+        Args:
+            hook: The hook point to invoke
+            context: Hook context
+
+        Returns:
+            First truthy result or None
+        """
+        return await self.manager.invoke_until_handled(hook, context)
+
+    async def _invoke_cancellable(self, hook: HookPoint, context: HookContext) -> bool:
+        """
+        Invoke with veto semantics - False cancels operation.
+
+        Args:
+            hook: The hook point to invoke
+            context: Hook context
+
+        Returns:
+            True if should proceed, False if vetoed
+        """
+        return await self.manager.invoke_cancellable(hook, context)
+
+    def get_config(self, hook: HookPoint) -> HookInvocationConfig | None:
+        """
+        Get the registered configuration for a hook.
+
+        Args:
+            hook: The hook point
+
+        Returns:
+            Configuration or None if using default
+        """
+        return self._configs.get(hook)
+
+    def list_hooks(self) -> List[tuple]:
+        """
+        List all configured hooks with their modes.
+
+        Returns:
+            List of (hook_name, mode) tuples
+        """
+        return [(hook.name, cfg.mode.value) for hook, cfg in self._configs.items()]

--- a/autobot-backend/middleware/hooks.py
+++ b/autobot-backend/middleware/hooks.py
@@ -1,0 +1,232 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Extension hook point definitions.
+
+Issue #658: Defines 22 lifecycle hook points for the extension system,
+implementing Agent Zero's pattern for modular customization.
+"""
+
+from enum import Enum, auto
+
+
+class HookPoint(Enum):
+    """
+    All extension hook points in the agent lifecycle.
+
+    Hook points are organized into logical groups:
+    - Message preparation (BEFORE_MESSAGE_PROCESS, BEFORE_PROMPT_BUILD, AFTER_PROMPT_BUILD)
+    - LLM interaction (BEFORE_LLM_CALL, DURING_LLM_STREAMING, etc.)
+    - Tool execution (BEFORE_TOOL_PARSE, BEFORE_TOOL_EXECUTE, etc.)
+    - Continuation loop (BEFORE_CONTINUATION, AFTER_CONTINUATION, etc.)
+    - Error handling (REPAIRABLE_ERROR, CRITICAL_ERROR)
+    - Response (BEFORE_RESPONSE_SEND, AFTER_RESPONSE_SEND)
+    - Session lifecycle (SESSION_CREATE, SESSION_DESTROY)
+    - Knowledge integration (BEFORE_RAG_QUERY, AFTER_RAG_RESULTS)
+    - Approval flow (APPROVAL_REQUIRED, APPROVAL_RECEIVED)
+
+    Usage:
+        from middleware.hooks import HookPoint
+
+        # Invoke hook at specific point
+        await extension_manager.invoke_hook(
+            HookPoint.BEFORE_TOOL_EXECUTE,
+            context
+        )
+    """
+
+    # Message preparation
+    BEFORE_MESSAGE_PROCESS = auto()
+    BEFORE_PROMPT_BUILD = auto()
+    AFTER_PROMPT_BUILD = auto()
+
+    # LLM interaction
+    BEFORE_LLM_CALL = auto()
+    DURING_LLM_STREAMING = auto()
+    AFTER_LLM_RESPONSE = auto()
+
+    # Tool execution
+    BEFORE_TOOL_PARSE = auto()
+    BEFORE_TOOL_EXECUTE = auto()
+    AFTER_TOOL_EXECUTE = auto()
+    TOOL_ERROR = auto()  # Method: on_tool_error
+
+    # Continuation loop
+    BEFORE_CONTINUATION = auto()
+    AFTER_CONTINUATION = auto()
+    LOOP_COMPLETE = auto()  # Method: on_loop_complete
+
+    # Error handling
+    REPAIRABLE_ERROR = auto()  # Method: on_repairable_error
+    CRITICAL_ERROR = auto()  # Method: on_critical_error
+
+    # Response
+    BEFORE_RESPONSE_SEND = auto()
+    AFTER_RESPONSE_SEND = auto()
+
+    # Session lifecycle
+    SESSION_CREATE = auto()  # Method: on_session_create
+    SESSION_DESTROY = auto()  # Method: on_session_destroy
+
+    # Knowledge integration
+    BEFORE_RAG_QUERY = auto()
+    AFTER_RAG_RESULTS = auto()
+
+    # Approval flow
+    APPROVAL_REQUIRED = auto()  # Method: on_approval_required
+    APPROVAL_RECEIVED = auto()  # Method: on_approval_received
+
+    # Prompt pipeline — Issue #3405
+    SYSTEM_PROMPT_READY = auto()  # Method: on_system_prompt_ready
+    FULL_PROMPT_READY = auto()  # Method: on_full_prompt_ready
+
+
+# Hook metadata for documentation and validation
+HOOK_METADATA = {
+    HookPoint.BEFORE_MESSAGE_PROCESS: {
+        "description": "Called at the start of message handling",
+        "can_modify": ["message", "context"],
+        "return_type": "None",
+    },
+    HookPoint.BEFORE_PROMPT_BUILD: {
+        "description": "Called before building the prompt",
+        "can_modify": ["context"],
+        "return_type": "None",
+    },
+    HookPoint.AFTER_PROMPT_BUILD: {
+        "description": "Called after prompt is built and before being sent to LLM",
+        "can_modify": ["prompt"],
+        "return_type": "Modified prompt string or None",
+    },
+    HookPoint.BEFORE_LLM_CALL: {
+        "description": "Called before calling the LLM",
+        "can_modify": ["prompt", "model"],
+        "return_type": "False to cancel, None to continue",
+    },
+    HookPoint.DURING_LLM_STREAMING: {
+        "description": "Called for each streaming chunk from LLM",
+        "can_modify": ["chunk"],
+        "return_type": "Modified chunk or None",
+    },
+    HookPoint.AFTER_LLM_RESPONSE: {
+        "description": "Called after full response is received",
+        "can_modify": ["response"],
+        "return_type": "Modified response or None",
+    },
+    HookPoint.BEFORE_TOOL_PARSE: {
+        "description": "Called before parsing tool calls from response",
+        "can_modify": ["response"],
+        "return_type": "Modified response or None",
+    },
+    HookPoint.BEFORE_TOOL_EXECUTE: {
+        "description": "Called before each tool execution",
+        "can_modify": ["tool_call"],
+        "return_type": "False to cancel, None to continue",
+    },
+    HookPoint.AFTER_TOOL_EXECUTE: {
+        "description": "Called after tool execution completes",
+        "can_modify": ["result"],
+        "return_type": "Modified result or None",
+    },
+    HookPoint.TOOL_ERROR: {
+        "description": "Called when a tool throws an error",
+        "can_modify": ["error"],
+        "return_type": "RepairableException or re-raise",
+    },
+    HookPoint.BEFORE_CONTINUATION: {
+        "description": "Called before LLM continuation iteration",
+        "can_modify": ["prompt", "context"],
+        "return_type": "False to stop loop, None to continue",
+    },
+    HookPoint.AFTER_CONTINUATION: {
+        "description": "Called after each continuation iteration",
+        "can_modify": ["response"],
+        "return_type": "None",
+    },
+    HookPoint.LOOP_COMPLETE: {
+        "description": "Called when message loop completes",
+        "can_modify": ["final_response"],
+        "return_type": "None",
+    },
+    HookPoint.REPAIRABLE_ERROR: {
+        "description": "Called when a repairable error occurs",
+        "can_modify": ["error", "suggestion"],
+        "return_type": "Modified suggestion or None",
+    },
+    HookPoint.CRITICAL_ERROR: {
+        "description": "Called when a critical error occurs",
+        "can_modify": ["error"],
+        "return_type": "None (logging only)",
+    },
+    HookPoint.BEFORE_RESPONSE_SEND: {
+        "description": "Called before sending response via WebSocket",
+        "can_modify": ["response"],
+        "return_type": "Modified response or None",
+    },
+    HookPoint.AFTER_RESPONSE_SEND: {
+        "description": "Called after response is sent",
+        "can_modify": [],
+        "return_type": "None (logging only)",
+    },
+    HookPoint.SESSION_CREATE: {
+        "description": "Called when a new session is created",
+        "can_modify": ["session"],
+        "return_type": "None",
+    },
+    HookPoint.SESSION_DESTROY: {
+        "description": "Called when a session is destroyed",
+        "can_modify": [],
+        "return_type": "None (cleanup only)",
+    },
+    HookPoint.BEFORE_RAG_QUERY: {
+        "description": "Called before querying knowledge base",
+        "can_modify": ["query"],
+        "return_type": "Modified query or None",
+    },
+    HookPoint.AFTER_RAG_RESULTS: {
+        "description": "Called after RAG results are retrieved",
+        "can_modify": ["results", "citations"],
+        "return_type": "Modified results or None",
+    },
+    HookPoint.APPROVAL_REQUIRED: {
+        "description": "Called when tool requires user approval",
+        "can_modify": ["tool_call", "message"],
+        "return_type": "True to auto-approve, None for normal flow",
+    },
+    HookPoint.APPROVAL_RECEIVED: {
+        "description": "Called when user approval is received",
+        "can_modify": [],
+        "return_type": "None (logging only)",
+    },
+    HookPoint.SYSTEM_PROMPT_READY: {
+        "description": "Called after the system prompt is built; return a str to replace it",
+        "can_modify": ["system_prompt"],
+        "return_type": "Modified system prompt str or None",
+    },
+    HookPoint.FULL_PROMPT_READY: {
+        "description": "Called after the full prompt is assembled; return a str to replace it",
+        "can_modify": ["prompt"],
+        "return_type": "Modified full prompt str or None",
+    },
+}
+
+
+def get_hook_metadata(hook: HookPoint) -> dict:
+    """
+    Get metadata for a hook point.
+
+    Args:
+        hook: The hook point
+
+    Returns:
+        Dictionary with description, can_modify, and return_type
+    """
+    return HOOK_METADATA.get(
+        hook,
+        {
+            "description": "Unknown hook",
+            "can_modify": [],
+            "return_type": "None",
+        },
+    )

--- a/autobot-backend/middleware/manager.py
+++ b/autobot-backend/middleware/manager.py
@@ -1,0 +1,404 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Extension Manager for registration and invocation.
+
+Issue #658: Manages the lifecycle of extensions and coordinates
+hook invocations across all registered extensions.
+"""
+
+import threading
+from typing import Any, Dict, List, Type
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.plugin_sdk.unified_registry import get_unified_registry
+from middleware.base import Extension, HookContext
+from middleware.hooks import HookPoint
+
+logger = get_logger(__name__)
+
+
+class ExtensionManager:
+    """
+    Manages extension registration and hook invocation.
+
+    Issue #658: Central coordinator for the extension system. Extensions
+    are sorted by priority and invoked in order at each hook point.
+
+    Usage:
+        manager = ExtensionManager()
+
+        # Register extensions
+        manager.register(LoggingExtension())
+        manager.register(SecretMaskingExtension())
+
+        # Or load from a list
+        manager.load_extensions([LoggingExtension, SecretMaskingExtension])
+
+        # Invoke hooks
+        ctx = HookContext(session_id="sess-123", message="Hello")
+        results = await manager.invoke_hook(HookPoint.BEFORE_MESSAGE_PROCESS, ctx)
+
+        # Or invoke until one extension handles
+        result = await manager.invoke_until_handled(
+            HookPoint.APPROVAL_REQUIRED,
+            ctx
+        )
+    """
+
+    def __init__(self):
+        """Initialize extension manager."""
+        self.extensions: List[Extension] = []
+        self._extension_map: Dict[str, Extension] = {}
+
+        logger.info("[Issue #658] ExtensionManager initialized")
+
+    def register(self, extension: Extension) -> bool:
+        """
+        Register an extension.
+
+        Extensions are sorted by priority (lower = runs first).
+
+        Args:
+            extension: Extension instance to register
+
+        Returns:
+            True if registered, False if duplicate name
+        """
+        if extension.name in self._extension_map:
+            logger.warning(
+                "[Issue #658] Extension '%s' already registered, skipping",
+                extension.name,
+            )
+            return False
+
+        self.extensions.append(extension)
+        self._extension_map[extension.name] = extension
+
+        # Sort by priority
+        self.extensions.sort(key=lambda e: e.priority)
+
+        get_unified_registry().register(extension.manifest)
+
+        logger.info(
+            "[Issue #658] Registered extension '%s' (priority=%d)",
+            extension.name,
+            extension.priority,
+        )
+        return True
+
+    def unregister(self, name: str) -> bool:
+        """
+        Unregister an extension by name.
+
+        Args:
+            name: Extension name to unregister
+
+        Returns:
+            True if unregistered, False if not found
+        """
+        if name not in self._extension_map:
+            return False
+
+        extension = self._extension_map.pop(name)
+        self.extensions.remove(extension)
+        get_unified_registry().unregister(name)
+
+        logger.info("[Issue #658] Unregistered extension '%s'", name)
+        return True
+
+    def get_extension(self, name: str) -> Extension | None:
+        """
+        Get an extension by name.
+
+        Args:
+            name: Extension name
+
+        Returns:
+            Extension instance or None
+        """
+        return self._extension_map.get(name)
+
+    def enable_extension(self, name: str) -> bool:
+        """
+        Enable an extension by name.
+
+        Args:
+            name: Extension name
+
+        Returns:
+            True if enabled, False if not found
+        """
+        extension = self._extension_map.get(name)
+        if extension:
+            extension.enabled = True
+            logger.info("[Issue #658] Enabled extension '%s'", name)
+            return True
+        return False
+
+    def disable_extension(self, name: str) -> bool:
+        """
+        Disable an extension by name.
+
+        Args:
+            name: Extension name
+
+        Returns:
+            True if disabled, False if not found
+        """
+        extension = self._extension_map.get(name)
+        if extension:
+            extension.enabled = False
+            logger.info("[Issue #658] Disabled extension '%s'", name)
+            return True
+        return False
+
+    def load_extensions(
+        self,
+        extension_classes: List[Type[Extension]],
+    ) -> int:
+        """
+        Load multiple extensions from class list.
+
+        Args:
+            extension_classes: List of Extension subclasses
+
+        Returns:
+            Number of successfully registered extensions
+        """
+        count = 0
+        for cls in extension_classes:
+            try:
+                extension = cls()
+                if self.register(extension):
+                    count += 1
+            except Exception as e:
+                logger.error(
+                    "[Issue #658] Failed to instantiate extension %s: %s",
+                    cls.__name__,
+                    str(e),
+                )
+        return count
+
+    async def invoke_hook(
+        self,
+        hook: HookPoint,
+        context: HookContext,
+    ) -> List[Any]:
+        """
+        Invoke all extensions for a hook point.
+
+        Each extension's hook method is called in priority order.
+        Results are collected and returned.
+
+        Args:
+            hook: The hook point to invoke
+            context: Hook context with relevant data
+
+        Returns:
+            List of non-None results from extensions
+        """
+        results = []
+
+        for extension in self.extensions:
+            if not extension.enabled:
+                continue
+
+            try:
+                result = await extension.on_hook(hook, context)
+                if result is not None:
+                    results.append(result)
+            except Exception as e:
+                logger.error(
+                    "[Issue #658] Extension %s failed on %s: %s",
+                    extension.name,
+                    hook.name,
+                    str(e),
+                )
+                # Continue with other extensions - don't let one failure stop all
+
+        return results
+
+    async def invoke_until_handled(
+        self,
+        hook: HookPoint,
+        context: HookContext,
+    ) -> Any | None:
+        """
+        Invoke extensions until one returns a truthy value.
+
+        Useful for hooks where only one extension should handle
+        (e.g., auto-approval).
+
+        Args:
+            hook: The hook point to invoke
+            context: Hook context with relevant data
+
+        Returns:
+            First truthy result or None if no handler
+        """
+        for extension in self.extensions:
+            if not extension.enabled:
+                continue
+
+            try:
+                result = await extension.on_hook(hook, context)
+                if result:
+                    logger.debug(
+                        "[Issue #658] Hook %s handled by extension '%s'",
+                        hook.name,
+                        extension.name,
+                    )
+                    return result
+            except Exception as e:
+                logger.error(
+                    "[Issue #658] Extension %s failed on %s: %s",
+                    extension.name,
+                    hook.name,
+                    str(e),
+                )
+
+        return None
+
+    async def invoke_with_transform(
+        self,
+        hook: HookPoint,
+        context: HookContext,
+        key: str,
+    ) -> Any:
+        """
+        Invoke hook and apply transformations to a specific value.
+
+        Each extension can modify the value at `key` in context.
+        Final transformed value is returned.
+
+        Args:
+            hook: The hook point to invoke
+            context: Hook context with data[key] to transform
+            key: The data key to transform
+
+        Returns:
+            Final transformed value
+        """
+        original_value = context.get(key)
+
+        for extension in self.extensions:
+            if not extension.enabled:
+                continue
+
+            try:
+                result = await extension.on_hook(hook, context)
+                if result is not None:
+                    # Extension returned a modified value
+                    context.set(key, result)
+            except Exception as e:
+                logger.error(
+                    "[Issue #658] Extension %s failed on %s: %s",
+                    extension.name,
+                    hook.name,
+                    str(e),
+                )
+
+        return context.get(key, original_value)
+
+    async def invoke_cancellable(
+        self,
+        hook: HookPoint,
+        context: HookContext,
+    ) -> bool:
+        """
+        Invoke hook that can be cancelled by returning False.
+
+        If any extension returns False, the operation is cancelled.
+
+        Args:
+            hook: The hook point to invoke
+            context: Hook context with relevant data
+
+        Returns:
+            True if operation should proceed, False if cancelled
+        """
+        for extension in self.extensions:
+            if not extension.enabled:
+                continue
+
+            try:
+                result = await extension.on_hook(hook, context)
+                if result is False:  # Explicit False check
+                    logger.info(
+                        "[Issue #658] Operation cancelled by extension '%s' at %s",
+                        extension.name,
+                        hook.name,
+                    )
+                    return False
+            except Exception as e:
+                logger.error(
+                    "[Issue #658] Extension %s failed on %s: %s",
+                    extension.name,
+                    hook.name,
+                    str(e),
+                )
+
+        return True
+
+    def get_statistics(self) -> Dict[str, Any]:
+        """
+        Get statistics about registered extensions.
+
+        Returns:
+            Dictionary with extension counts and details
+        """
+        enabled_count = sum(1 for e in self.extensions if e.enabled)
+        disabled_count = len(self.extensions) - enabled_count
+
+        return {
+            "total_extensions": len(self.extensions),
+            "enabled_count": enabled_count,
+            "disabled_count": disabled_count,
+            "extensions": [
+                {
+                    "name": e.name,
+                    "priority": e.priority,
+                    "enabled": e.enabled,
+                }
+                for e in self.extensions
+            ],
+        }
+
+    def list_extensions(self) -> List[str]:
+        """
+        List all registered extension names.
+
+        Returns:
+            List of extension names in priority order
+        """
+        return [e.name for e in self.extensions]
+
+
+# Singleton instance for global access (Issue #662: thread-safe)
+_global_manager: ExtensionManager | None = None
+_global_manager_lock = threading.Lock()
+
+
+def get_extension_manager() -> ExtensionManager:
+    """
+    Get the global extension manager instance (thread-safe).
+
+    Returns:
+        Global ExtensionManager singleton
+    """
+    global _global_manager
+    if _global_manager is None:
+        with _global_manager_lock:
+            # Double-check after acquiring lock
+            if _global_manager is None:
+                _global_manager = ExtensionManager()
+    return _global_manager
+
+
+def reset_extension_manager() -> None:
+    """Reset the global extension manager (for testing)."""
+    global _global_manager
+    with _global_manager_lock:
+        _global_manager = None

--- a/docs/developer/plugin-vs-extension-vs-skill.md
+++ b/docs/developer/plugin-vs-extension-vs-skill.md
@@ -1,0 +1,148 @@
+# Plugin vs Extension vs Skill — Terminology and Architecture
+
+**Issue:** [#7426](https://github.com/mrveiss/AutoBot-AI/issues/7426)
+**Status:** Resolved (renames + terminology canonical)
+
+---
+
+## Executive Summary
+
+AutoBot has three plugin-like subsystems, each with a distinct purpose and API:
+
+| Layer | Package | Purpose | API |
+|---|---|---|---|
+| **Middleware** | `autobot-backend/middleware/` | Lifecycle hooks at 24 pipeline points | Extends `Extension` base class |
+| **Skills** | `autobot-backend/skills/` | User-facing capabilities (calendar, code-review, web-fetch…) | Service classes with methods |
+| **Plugins** | `plugins/core-plugins/` | Standalone packages with manifests | Load via `autobot_shared/plugin_sdk/` |
+
+These terms were historically conflated. **Middleware** was called "extensions" because the base class was `Extension`. New code should use "middleware" exclusively.
+
+---
+
+## Terms Defined
+
+### Middleware (renamed from "extensions")
+
+**Location:** `autobot-backend/middleware/builtin/`
+
+**Purpose:** Implement before/after hooks at defined lifecycle points in message processing.
+
+**API:** Subclass `Extension` and override hook handlers:
+```python
+from middleware import Extension, HookPoint, HookContext
+
+class LoggingMiddleware(Extension):
+    name = "logging_middleware"
+    
+    async def on_before_message_process(self, ctx: HookContext):
+        # Log before processing
+        pass
+```
+
+**Lifecycle points (HookPoint enum):** 24 points including:
+- `BEFORE_MESSAGE_PROCESS` / `AFTER_MESSAGE_PROCESS`
+- `BEFORE_TOOL_EXECUTE` / `AFTER_TOOL_EXECUTE`
+- `APPROVAL_REQUIRED`
+- And 20 others
+
+**Invocation:** Central `ExtensionManager` (misnomer — will be renamed to `MiddlewareManager` in v2).
+
+---
+
+### Skill
+
+**Location:** `autobot-backend/skills/builtin/`
+
+**Purpose:** User-facing capabilities (available to agents as commands).
+
+**API:** Standalone Python class or async function with a schema:
+```python
+class WebFetchSkill:
+    """Fetch content from a URL."""
+    
+    async def execute(self, url: str, timeout: int = 30) -> str:
+        # Implement skill logic
+        pass
+```
+
+**Invocation:** Agent requests skill by name; `SkillManager` routes and executes.
+
+**Examples:** `calendar_integration`, `code_review`, `web_fetch`, `github_search`
+
+---
+
+### Plugin (core-plugins)
+
+**Location:** `plugins/core-plugins/`
+
+**Purpose:** Standalone packages that extend AutoBot via manifest-driven loading.
+
+**API:** Package with `plugin.json` manifest + Python/JavaScript code:
+```json
+{
+  "id": "hello-plugin",
+  "name": "Hello World Plugin",
+  "version": "1.0.0",
+  "entryPoint": "main.py",
+  "hooks": ["BEFORE_MESSAGE_PROCESS"]
+}
+```
+
+**Invocation:** `autobot_shared/plugin_sdk/loader.py` loads at startup.
+
+**Examples:** `hello-plugin`, `logger-plugin`, `telemetry-prompt-middleware`
+
+---
+
+## Migration (Issue #7426)
+
+### Renames Executed
+
+1. **Backend:** `autobot-backend/extensions/` → `autobot-backend/middleware/`
+   - All `from extensions.` imports → `from middleware.`
+   - Base class still `Extension` (v2: rename to `Middleware`)
+   - Re-export shim in `extensions/__init__.py` for one release cycle
+
+2. **Frontend:** `autobot-frontend/src/plugins/` (unchanged for now)
+   - These are Vue plugin utilities, not part of the plugin system
+   - Future: rename to `vue-plugins/` or inline into `main.ts` (filed separately)
+
+### Call-Site Updates
+
+External callers updated:
+- `autobot-backend/chat_workflow/session_handler.py`
+- `autobot-backend/chat_workflow/llm_handler.py`
+- `autobot-backend/initialization/lifespan.py`
+
+Test files work via backwards-compat re-export shim.
+
+### Deprecation Timeline
+
+**v1 (now):**
+- Middleware code in `autobot-backend/middleware/`
+- Extensions package is a re-export shim pointing to middleware
+- Importing from `extensions` still works (triggers deprecation warning in v2)
+
+**v2 (next release):**
+- Remove `extensions/__init__.py` shim
+- Rename `Extension` class → `Middleware`
+- Rename `ExtensionManager` → `MiddlewareManager`
+
+---
+
+## Acceptance Criteria
+
+- [x] Terminology decision document created (this file)
+- [x] Directory renamed: `extensions/` → `middleware/`
+- [x] Re-export shim in `extensions/__init__.py` for backwards compat
+- [x] External call sites updated
+- [x] CLAUDE.md references updated (if any)
+
+---
+
+## Related
+
+- [#7372](https://github.com/mrveiss/AutoBot-AI/issues/7372) — import boundary enforcement
+- [#658](https://github.com/mrveiss/AutoBot-AI/issues/658) — extension manager origin
+- [#730](https://github.com/mrveiss/AutoBot-AI/issues/730) — plugin SDK origin
+- [#3185](https://github.com/mrveiss/AutoBot-AI/issues/3185) — LLM consolidation


### PR DESCRIPTION
Clarify overlapping terminology between Middleware (lifecycle hooks), Skills (user-facing capabilities), and Plugins (standalone packages). Migrate extensions/ → middleware/ with backward-compatibility re-export shim for one-release deprecation.

**Changes:**
- New: `autobot-backend/middleware/` directory with all extension files (imports updated to `from middleware.`)
- Modified: `autobot-backend/extensions/__init__.py` — re-export shim from middleware
- Modified: 3 call sites (session_handler, llm_handler, lifespan) to use `from middleware.`
- New: `docs/developer/plugin-vs-extension-vs-skill.md` — terminology decision document

**Acceptance Criteria Met:**
- ✅ Terminology clearly defined and documented
- ✅ Migration completed with backward-compat shim
- ✅ Core call sites updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)