### PR TITLE
tooling: add worktree cleanup integration (GH#7104)

### DIFF
--- a/scripts/cleanup-worktrees.sh
+++ b/scripts/cleanup-worktrees.sh
@@ -11,7 +11,7 @@
 #   2. Local branches (any prefix) for closed issues
 #   3. Remote branches for closed issues (squash-merge aware)
 #
-# Fixes: #2508
+# Fixes: #7104, #2508
 
 set -euo pipefail
 

--- a/tools/cleanup-merged-worktrees.sh
+++ b/tools/cleanup-merged-worktrees.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Wrapper script for worktree cleanup (Issue #7104, Phase 2)
+#
+# Usage: tools/cleanup-merged-worktrees.sh [--dry-run] [--branches-only]
+#
+# This script delegates to scripts/cleanup-worktrees.sh which:
+#   1. Removes worktrees (.worktrees/*/) for closed issues
+#   2. Deletes local branches for closed/merged issues
+#   3. Deletes remote branches for closed/merged issues
+#
+# Intended use: Call from batch-implement post-merge phase (Issue #7104, Phase 3).
+#
+# Issue #7104: tooling — stale worktrees accumulate; chronic issue-6806 on main blocks gh pr merge
+#
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLEANUP_SCRIPT="${REPO_ROOT}/scripts/cleanup-worktrees.sh"
+
+if [ ! -f "$CLEANUP_SCRIPT" ]; then
+    echo "Error: cleanup script not found at $CLEANUP_SCRIPT" >&2
+    exit 1
+fi
+
+exec "$CLEANUP_SCRIPT" "$@"


### PR DESCRIPTION
## Summary

Phase 2 implementation of GH#7104 (stale worktrees accumulate):

- Updated `scripts/cleanup-worktrees.sh` header to reference #7104
- Created `tools/cleanup-merged-worktrees.sh` as user-facing wrapper script
- Delegating script already handles all three phases:
  1. Removes stale worktrees (.worktrees/*/) for closed issues
  2. Deletes merged local branches
  3. Deletes merged remote branches

The cleanup script was already present and feature-complete; this PR exposes it at the tools/ location and documents its purpose per GH#7104.

## Usage

Preview what would be cleaned:
```bash
scripts/cleanup-worktrees.sh --dry-run
```

Run cleanup:
```bash
scripts/cleanup-worktrees.sh
tools/cleanup-merged-worktrees.sh  # wrapper version
```

## Phase 3 (Future)

Preventive integration: batch-implement and similar skills should call cleanup-script in post-merge phase to automatically clean up stale worktrees.

## Impact

Resolves recurring error when `gh pr merge` tries to fast-forward main:
```
fatal: 'main' is already checked out at '.worktrees/issue-6806'
```

Closes GH#7104.