### PR TITLE
test(ci): run audit-unwired-trackers tests before cron audit (#6929)

### DIFF
--- a/.github/workflows/unwired-tracker-audit.yml
+++ b/.github/workflows/unwired-tracker-audit.yml
@@ -53,6 +53,12 @@ jobs:
             autobot-backend/requirements*.txt
             autobot-slm-backend/requirements*.txt
 
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Test audit script (#6929)
+        run: pytest pipeline-scripts/test_audit_unwired_trackers.py -v
+
       - name: Run audit (dry-run, JSON output)
         id: scan
         shell: bash


### PR DESCRIPTION
## Summary

- Adds `pytest pipeline-scripts/test_audit_unwired_trackers.py` step to `.github/workflows/unwired-tracker-audit.yml`, running before the audit step
- The 76-test suite (512 lines) already exists in the repo — it covers regex shapes, `is_test_path`, scan boundaries, dedup, and end-to-end fixtures
- Test failure breaks the workflow fail-fast before the audit runs

## Problem solved

`pipeline-scripts/audit_unwired_trackers.py` is the Tier-3 cron defense for the #6836 closure-gate process. It had 387 LOC and zero automated tests. Silent regressions in the regex, scan, or dedup paths would surface as "no findings" rather than a clear test failure.

## Acceptance criteria

- [x] Test file exists with ≥6 test cases per function — 76 tests total ✅
- [x] Tests pass on clean checkout ✅
- [x] Tests run in the cron workflow before the audit step ✅

## Test plan

- `pytest pipeline-scripts/test_audit_unwired_trackers.py`: 76 passed ✅
- YAML syntax check: ✅
- Closes #6929

🤖 Generated with [Claude Code](https://claude.com/claude-code)