### PR TITLE
[MVA-477] canvas.py: _user_id() raises HTTP 401 on missing JWT fields

### DIFF
--- a/autobot-backend/api/canvas.py
+++ b/autobot-backend/api/canvas.py
@@ -76,7 +76,10 @@ _EXPORT_CONTENT_TYPES: dict[str, str] = {
 
 def _user_id(current_user: dict) -> str:
     """Extract stable user identifier from JWT dict."""
-    return current_user.get("user_id") or current_user.get("id") or current_user.get("username", "")
+    uid = current_user.get("user_id") or current_user.get("id") or current_user.get("username")
+    if not uid:
+        raise HTTPException(status_code=401, detail="Cannot identify user from token")
+    return uid
 
 
 def _log_metric(event: str, **kw) -> None:

--- a/autobot-backend/tests/api/test_canvas.py
+++ b/autobot-backend/tests/api/test_canvas.py
@@ -365,6 +365,66 @@ class TestTransitionCell:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# _user_id() extraction and validation
+# ---------------------------------------------------------------------------
+
+
+class TestUserIdExtraction:
+    def test_user_id_from_user_id_field(self):
+        from api.canvas import _user_id
+
+        uid = _user_id({"user_id": "user-alice"})
+        assert uid == "user-alice"
+
+    def test_user_id_from_id_field(self):
+        from api.canvas import _user_id
+
+        uid = _user_id({"id": "user-bob"})
+        assert uid == "user-bob"
+
+    def test_user_id_from_username_field(self):
+        from api.canvas import _user_id
+
+        uid = _user_id({"username": "charlie"})
+        assert uid == "charlie"
+
+    def test_user_id_prefers_user_id_over_id(self):
+        from api.canvas import _user_id
+
+        uid = _user_id({"user_id": "alice-id", "id": "bob-id"})
+        assert uid == "alice-id"
+
+    def test_user_id_prefers_id_over_username(self):
+        from api.canvas import _user_id
+
+        uid = _user_id({"id": "bob-id", "username": "charlie"})
+        assert uid == "bob-id"
+
+    def test_user_id_raises_401_when_all_fields_missing(self):
+        from api.canvas import _user_id
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            _user_id({})
+        assert exc_info.value.status_code == 401
+        assert "Cannot identify user from token" in exc_info.value.detail
+
+    def test_user_id_raises_401_when_all_fields_empty(self):
+        from api.canvas import _user_id
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            _user_id({"user_id": "", "id": "", "username": ""})
+        assert exc_info.value.status_code == 401
+        assert "Cannot identify user from token" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Export helpers (pure functions — no DB, no auth)
+# ---------------------------------------------------------------------------
+
+
 class TestExportHelpers:
     def test_md_export(self):
         from api.canvas import _export_md


### PR DESCRIPTION
## Summary

Security hardening from [MVA-362](/MVA/issues/MVA-362) finding F-2 (should-fix, non-blocking).

**Problem:** `_user_id()` in `canvas.py` returned an empty string when JWT dict contained none of `user_id`, `id`, or `username`. A canvas created under that empty-string user_id would be accessible to any other user whose JWT also lacked those fields.

**Fix:** Raise `HTTPException(401, "Cannot identify user from token")` when all three fields are absent, hardening the API against this defensive programming gap.

**Tests:** Added comprehensive unit tests for `_user_id()` validation covering all extraction paths and the new error case.

## Files Changed
- `autobot-backend/api/canvas.py` — raise 401 on missing JWT fields
- `autobot-backend/tests/api/test_canvas.py` — 7 new unit tests

## Test Plan
- Unit tests pass locally (7 tests for `_user_id()`)
- CI integration tests verify no regressions on existing canvas endpoints
- 401 error is properly returned on missing JWT fields