### PR TITLE
chore(api): remove _get_llm_interface() compat wrapper (#6944)

### DIFF
--- a/autobot-backend/api/llm.py
+++ b/autobot-backend/api/llm.py
@@ -24,6 +24,7 @@ from config.manager import get_config_manager
 # Import unified configuration system - NO HARDCODED VALUES
 from constants.model_constants import ModelConstants
 from services.config_service import ConfigService
+from services.llm_service import get_llm_service
 
 # Import caching utilities from unified cache manager (P4 Cache Consolidation)
 from utils.advanced_cache_manager import cache_response
@@ -38,18 +39,6 @@ logger = get_logger(__name__)
 # Performance optimization: O(1) lookup for embedding model detection (Issue #326)
 EMBEDDING_MODEL_PATTERNS = {"embed", "nomic", "all-minilm", "sentence"}
 TEXT_MODEL_SIZE_INDICATORS = {"small", "large", "medium"}
-
-
-def _get_llm_interface():
-    """Return the LLMService singleton (#3185).
-
-    Name retained for backwards compatibility — callers below access
-    ``_tier_router`` which LLMService exposes alongside the public
-    ``tier_router`` property.
-    """
-    from services.llm_service import get_llm_service
-
-    return get_llm_service()
 
 
 @router.get("/config", response_model=LLMConfigResponse)
@@ -823,7 +812,7 @@ async def get_tiered_routing_metrics(
         - fallback_count: Times simple tier failed and escalated
     """
     try:
-        llm_interface = _get_llm_interface()
+        llm_interface = get_llm_service()
 
         if not hasattr(llm_interface, "_tier_router") or not llm_interface._tier_router:
             return JSONResponse(
@@ -876,7 +865,7 @@ async def get_tiered_routing_config(
         - logging: Logging configuration
     """
     try:
-        llm_interface = _get_llm_interface()
+        llm_interface = get_llm_service()
 
         if not hasattr(llm_interface, "_tier_router") or not llm_interface._tier_router:
             return JSONResponse(
@@ -1004,7 +993,7 @@ async def update_tiered_routing_config(
         Updated configuration and confirmation message
     """
     try:
-        llm_interface = _get_llm_interface()
+        llm_interface = get_llm_service()
         tier_router = _get_tier_router(llm_interface)
         _apply_tiered_routing_updates(tier_router, config_data)
         logger.info("Tiered routing configuration updated: %s", config_data)
@@ -1042,7 +1031,7 @@ async def reset_tiered_routing_metrics(
         Confirmation of metrics reset
     """
     try:
-        llm_interface = _get_llm_interface()
+        llm_interface = get_llm_service()
 
         if not hasattr(llm_interface, "_tier_router") or not llm_interface._tier_router:
             raise HTTPException(

--- a/autobot-backend/api/llm_providers.py
+++ b/autobot-backend/api/llm_providers.py
@@ -22,18 +22,6 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-def _get_llm_interface():
-    """Return the LLMService singleton (#3185).
-
-    Name retained for backwards compatibility — LLMService exposes
-    ``provider_routing`` and ``is_provider_healthy`` matching the
-    LLMInterface surface this module previously used.
-    """
-    from services.llm_service import get_llm_service
-
-    return get_llm_service()
-
-
 @router.post("/switch", response_model=DataResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -93,7 +81,7 @@ async def test_llm_provider(
     current_user: dict = Depends(get_current_user),
 ):
     """Test a specific LLM provider connection."""
-    llm = _get_llm_interface()
+    llm = get_llm_service()
     if provider_name not in llm.provider_routing:
         raise HTTPException(
             status_code=404,


### PR DESCRIPTION
## Summary
Inline `get_llm_service()` at all call sites (4 in `api/llm.py`, 1 in `api/llm_providers.py`) and delete the `_get_llm_interface()` wrapper function.

Function was retained for backwards compatibility during #3185 migration but is now safe to remove — all external callers use `get_llm_service()` directly.

## Acceptance Criteria
- [x] `_get_llm_interface()` removed from both files
- [x] All call sites use `get_llm_service()` directly
- [x] `grep -n '_get_llm_interface' autobot-backend/api/llm.py autobot-backend/api/llm_providers.py` returns nothing

🤖 Generated with Claude Code