### PR TITLE
fix(nginx/slm): add /openapi.json /docs /redoc to standalone-mode block (#6843)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2
@@ -275,6 +275,30 @@ server {
         proxy_set_header Host $host;
     }
 
+    # FastAPI OpenAPI docs (#6843 — without these, the SPA fallback serves
+    # index.html for /openapi.json /docs /redoc instead of the spec).
+    # Use `=` for /openapi.json (exact match) so it can't shadow real routes;
+    # `^~` for /docs and /redoc so prefix match takes priority over the SPA
+    # catch-all.
+    location = /openapi.json {
+        proxy_pass http://{{ slm_backend_host }}:{{ slm_backend_port }};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location ^~ /docs {
+        proxy_pass http://{{ slm_backend_host }}:{{ slm_backend_port }};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location ^~ /redoc {
+        proxy_pass http://{{ slm_backend_host }}:{{ slm_backend_port }};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
 {% endif %}
 
     # Grafana Live WebSocket (must be before the general /grafana/ block)


### PR DESCRIPTION
## Summary

- Standalone-mode nginx block in `autobot-slm.conf.j2` was missing the `/openapi.json`, `/docs`, and `/redoc` location blocks
- Without them nginx served the SPA `index.html` fallback for those paths instead of the FastAPI OpenAPI spec
- Added three location blocks matching the co-located block's pattern, proxying to `http://{{ slm_backend_host }}:{{ slm_backend_port }}`

## Changes

- `autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2`: 24 lines added inside the `{% else %}` (standalone) branch, after `location /api/health`

## Test plan

- [ ] Deploy SLM in standalone mode (no `slm_colocated_frontend`)
- [ ] Browse `/openapi.json` — should return the FastAPI OpenAPI spec JSON
- [ ] Browse `/docs` — should load the Swagger UI
- [ ] Browse `/redoc` — should load the ReDoc UI

Closes #6843

🤖 Generated with [Claude Code](https://claude.com/claude-code)