### PR TITLE
fix(ansible): add ansible_host fallback to ansible_default_ipv4.address callsites (#6840)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/configure-redis-service-management.yml
+++ b/autobot-slm-backend/ansible/playbooks/configure-redis-service-management.yml
@@ -17,7 +17,7 @@
       debug:
         msg:
           - "🔧 Configuring Redis Service Management"
-          - "Host: {{ inventory_hostname }} ({{ ansible_facts['default_ipv4'].address }})"
+          - "Host: {{ inventory_hostname }} ({{ ansible_facts['default_ipv4'].address | default(ansible_host) }})"
           - "User: {{ autobot_user }}"
           - "Service: {{ redis_service_name }}"
           - "Sudoers file: {{ sudoers_file }}"

--- a/autobot-slm-backend/ansible/playbooks/data-migration.yml
+++ b/autobot-slm-backend/ansible/playbooks/data-migration.yml
@@ -377,7 +377,7 @@
 
   tasks:
     - name: Check migrated data on database VM
-      command: redis-cli -h {{ ansible_facts['default_ipv4'].address }} -p 6379 info keyspace
+      command: redis-cli -h {{ ansible_facts['default_ipv4'].address | default(ansible_host) }} -p 6379 info keyspace
       register: redis_keyspace
       changed_when: false
       when: inventory_hostname in groups['database']

--- a/autobot-slm-backend/ansible/playbooks/decommission-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/decommission-node.yml
@@ -123,7 +123,7 @@
             dest: "{{ decommission_backup_path }}/manifest.yml"
             content: |
               hostname: {{ ansible_facts['hostname'] }}
-              ip_address: {{ ansible_facts['default_ipv4'].address }}
+              ip_address: {{ ansible_facts['default_ipv4'].address | default(ansible_host) }}
               timestamp: {{ ansible_facts['date_time'].iso8601 }}
               directories: {{ _existing_dirs | to_json }}
             mode: '0640'
@@ -404,7 +404,7 @@
           ========================================
           Node decommission COMPLETE: {{ ansible_facts['hostname'] }}
           ========================================
-          - IP: {{ ansible_facts['default_ipv4'].address }}
+          - IP: {{ ansible_facts['default_ipv4'].address | default(ansible_host) }}
           - Services: stopped and removed
           - Systemd units: removed
           - Application code: /opt/autobot removed

--- a/autobot-slm-backend/ansible/playbooks/deploy-base.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-base.yml
@@ -18,7 +18,7 @@
       debug:
         msg:
           - "Configuring VM: {{ inventory_hostname }}"
-          - "IP Address: {{ ansible_facts['default_ipv4'].address }}"
+          - "IP Address: {{ ansible_facts['default_ipv4'].address | default(ansible_host) }}"
           - "OS: {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }}"
           - "Role: {{ group_names | join(', ') }}"
           - "Resources: {{ hostvars[inventory_hostname]['vm_resources'] | default('Default') }}"
@@ -248,8 +248,8 @@
     - name: Update /etc/hosts with VM information
       lineinfile:
         path: /etc/hosts
-        regexp: "^{{ hostvars[item]['ansible_default_ipv4']['address'] }}"
-        line: "{{ hostvars[item]['ansible_default_ipv4']['address'] }} {{ item }} {{ item }}.{{ network.domain }}"
+        regexp: "^{{ hostvars[item]['ansible_default_ipv4']['address'] | default(hostvars[item]['ansible_host']) }}"
+        line: "{{ hostvars[item]['ansible_default_ipv4']['address'] | default(hostvars[item]['ansible_host']) }} {{ item }} {{ item }}.{{ network.domain }}"
         state: present
       loop: "{{ groups['all'] }}"
       when: hostvars[item]['ansible_default_ipv4']['address'] is defined

--- a/autobot-slm-backend/ansible/playbooks/deploy-database.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-database.yml
@@ -20,7 +20,7 @@
       debug:
         msg:
           - "🗄️  Deploying Database Infrastructure"
-          - "VM: {{ inventory_hostname }} ({{ ansible_facts['default_ipv4'].address }})"
+          - "VM: {{ inventory_hostname }} ({{ ansible_facts['default_ipv4'].address | default(ansible_host) }})"
           - "Services: Redis Stack {{ redis.version }}, Model Storage"
           - "Memory Allocation: {{ redis.memory.maxmemory }}"
           - "Persistence: RDB + AOF enabled"
@@ -425,7 +425,7 @@
           - "📊 Memory Limit: {{ redis.memory.maxmemory }}"
           - "🗂️  Databases: {{ database_schema.databases | length }} configured"
           - "📁 Model Storage: {{ model_storage.directories.base_dir }}"
-          - "🔧 RedisInsight: {{ redis_insight.enabled | ternary('http://' + ansible_facts['default_ipv4'].address + ':8002', 'Disabled') }}"
+          - "🔧 RedisInsight: {{ redis_insight.enabled | ternary('http://' + (ansible_facts['default_ipv4'].address | default(ansible_host)) + ':8002', 'Disabled') }}"
           - "💾 Backup: {{ backup.enabled | ternary('Scheduled', 'Manual only') }}"
 
     - name: Create database deployment marker

--- a/autobot-slm-backend/ansible/playbooks/deploy-hybrid-docker.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-hybrid-docker.yml
@@ -161,7 +161,7 @@
     - name: Wait for Redis to be ready
       wait_for:
         port: 6379
-        host: "{{ ansible_facts['default_ipv4'].address }}"
+        host: "{{ ansible_facts['default_ipv4'].address | default(ansible_host) }}"
         delay: 5
         timeout: 60
 
@@ -248,7 +248,7 @@
     - name: Wait for Frontend to be ready
       wait_for:
         port: 5173
-        host: "{{ ansible_facts['default_ipv4'].address }}"
+        host: "{{ ansible_facts['default_ipv4'].address | default(ansible_host) }}"
         delay: 10
         timeout: 120
 
@@ -385,7 +385,7 @@
     - name: Wait for services to be ready
       wait_for:
         port: "{{ item }}"
-        host: "{{ ansible_facts['default_ipv4'].address }}"
+        host: "{{ ansible_facts['default_ipv4'].address | default(ansible_host) }}"
         delay: 10
         timeout: 120
       loop:
@@ -465,7 +465,7 @@
     - name: Wait for Browser service to be ready
       wait_for:
         port: 3000
-        host: "{{ ansible_facts['default_ipv4'].address }}"
+        host: "{{ ansible_facts['default_ipv4'].address | default(ansible_host) }}"
         delay: 10
         timeout: 120
 
@@ -507,7 +507,7 @@
     - name: Create service summary
       set_fact:
         service_summary: |
-          VM: {{ ansible_facts['hostname'] }} ({{ ansible_facts['default_ipv4'].address }})
+          VM: {{ ansible_facts['hostname'] }} ({{ ansible_facts['default_ipv4'].address | default(ansible_host) }})
           Services: {{ docker_status.stdout_lines | length - 1 }} containers running
           Status: Deployment complete
 

--- a/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
@@ -802,6 +802,6 @@
     - name: Display deployment summary
       debug:
         msg: |
-          VM: {{ ansible_facts['hostname'] }} ({{ ansible_facts['default_ipv4'].address }})
+          VM: {{ ansible_facts['hostname'] }} ({{ ansible_facts['default_ipv4'].address | default(ansible_host) }})
           Services deployed natively (no containers)
           Status: Ready for production use

--- a/autobot-slm-backend/ansible/playbooks/health-check.yml
+++ b/autobot-slm-backend/ansible/playbooks/health-check.yml
@@ -28,7 +28,7 @@
       debug:
         msg:
           - "AutoBot Health Check Starting"
-          - "VM: {{ inventory_hostname }} ({{ ansible_facts['default_ipv4'].address }})"
+          - "VM: {{ inventory_hostname }} ({{ ansible_facts['default_ipv4'].address | default(ansible_host) }})"
           - "Role: {{ group_names | join(', ') }}"
           - "OS: {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }}"
       tags: always
@@ -82,7 +82,7 @@
     # ==========================================
 
     - name: Test internal network connectivity
-      command: ping -c 3 {{ hostvars[item]['ansible_default_ipv4']['address'] }}
+      command: ping -c 3 {{ hostvars[item]['ansible_default_ipv4']['address'] | default(hostvars[item]['ansible_host']) }}
       loop: "{{ groups['all'] }}"
       when: item != inventory_hostname
       register: network_tests

--- a/autobot-slm-backend/ansible/playbooks/remove-role.yml
+++ b/autobot-slm-backend/ansible/playbooks/remove-role.yml
@@ -104,7 +104,7 @@
             content: |
               role: {{ role_name }}
               hostname: {{ ansible_facts['hostname'] }}
-              ip_address: {{ ansible_facts['default_ipv4'].address }}
+              ip_address: {{ ansible_facts['default_ipv4'].address | default(ansible_host) }}
               timestamp: {{ ansible_facts['date_time'].iso8601 }}
               directories: {{ _existing_dirs | to_json }}
             mode: '0640'
@@ -189,7 +189,7 @@
       ansible.builtin.debug:
         msg: |
           Role removal complete: {{ role_name }}
-          - Host: {{ ansible_facts['hostname'] }} ({{ ansible_facts['default_ipv4'].address }})
+          - Host: {{ ansible_facts['hostname'] }} ({{ ansible_facts['default_ipv4'].address | default(ansible_host) }})
           - Service: {{ 'stopped and removed' if _service_file.stat.exists else 'not present' }}
           - Service file: {{ 'skipped (dpkg conffile)' if (_dpkg_check.stdout_lines | default([]) | last | default('')) == 'dpkg_owned' else 'removed' }}
           - Disk cleanup: {{ '/opt/autobot/' + role_target_dir + ' removed' if (role_target_dir is defined and role_target_dir | length > 0) else 'skipped (no target dir)' }}

--- a/autobot-slm-backend/ansible/roles/common/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/tasks/main.yml
@@ -190,8 +190,8 @@
 - name: "Common | Update /etc/hosts"
   lineinfile:
     path: /etc/hosts
-    line: "{{ ansible_facts['default_ipv4'].address }} {{ inventory_hostname }} {{ inventory_hostname_short }}"
-    regexp: "^{{ ansible_facts['default_ipv4'].address }}"
+    line: "{{ ansible_facts['default_ipv4'].address | default(ansible_host) }} {{ inventory_hostname }} {{ inventory_hostname_short }}"
+    regexp: "^{{ ansible_facts['default_ipv4'].address | default(ansible_host) }}"
     state: present
   become: true
   when:

--- a/autobot-slm-backend/ansible/roles/distributed_setup/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/distributed_setup/defaults/main.yml
@@ -17,7 +17,7 @@ backup_dir: "{{ project_root }}/backups"
 
 # Distributed architecture configuration (from SSOT)
 distributed_mode: true
-coordinator_host: "{{ ansible_facts['default_ipv4'].address }}"
+coordinator_host: "{{ ansible_facts['default_ipv4'].address | default(ansible_host) | default('') }}"
 
 # Fleet nodes (derived from inventory)
 fleet_nodes: []  # Populated dynamically from slm_nodes group

--- a/autobot-slm-backend/ansible/roles/frontend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/tasks/main.yml
@@ -253,7 +253,7 @@
     msg:
       - "=== Frontend Configuration Complete ==="
       - "Node.js: {{ node_version.stdout }}"
-      - "Frontend URL: https://{{ ansible_facts['default_ipv4'].address }}"
+      - "Frontend URL: https://{{ ansible_facts['default_ipv4'].address | default(ansible_host) }}"
       - "TLS: Enabled ({{ frontend_tls_cert }})"
       - "API Proxy: {{ backend_host | default(ansible_host) }}:{{ backend_port | default(8443) }}"
       - "Nginx: Enabled (production build)"

--- a/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
@@ -278,7 +278,7 @@
   debug:
     msg:
       - "=== Redis Stack Configuration Complete ==="
-      - "Redis Host: {{ ansible_facts['default_ipv4'].address }}"
+      - "Redis Host: {{ ansible_facts['default_ipv4'].address | default(ansible_host) }}"
       - "Redis Port: {{ redis_port }}"
       - "RedisInsight Port: {{ redis_insight_port }}"
       - "Memory Limit: {{ redis_memory_limit }}"

--- a/autobot-slm-backend/ansible/roles/redis/templates/redis-backup.sh.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/redis-backup.sh.j2
@@ -15,11 +15,11 @@ echo "[$(date)] Starting Redis Stack backup..."
 mkdir -p "$BACKUP_DIR"
 
 # Trigger Redis save
-redis-cli -h {{ ansible_facts['default_ipv4'].address }} -p {{ redis_port }} BGSAVE
+redis-cli -h {{ ansible_facts['default_ipv4'].address | default(ansible_host) }} -p {{ redis_port }} BGSAVE
 
 # Wait for save to complete
 sleep 5
-while redis-cli -h {{ ansible_facts['default_ipv4'].address }} -p {{ redis_port }} LASTSAVE | grep -q "$(date +%s)"; do
+while redis-cli -h {{ ansible_facts['default_ipv4'].address | default(ansible_host) }} -p {{ redis_port }} LASTSAVE | grep -q "$(date +%s)"; do
     echo "Waiting for BGSAVE to complete..."
     sleep 2
 done

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/slm-secrets.env.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/slm-secrets.env.j2
@@ -23,4 +23,4 @@ AUTOBOT_BACKEND_HOST={{ main_host | default(infrastructure.hosts.backend if infr
 # Issue #2758: set external_url to this node's actual routable IP so that
 # self-detection logic (e.g. _is_local_node) works correctly.
 # ansible_facts['default_ipv4'].address is the primary non-loopback interface IP.
-SLM_EXTERNAL_URL=https://{{ ansible_facts['default_ipv4'].address }}
+SLM_EXTERNAL_URL=https://{{ ansible_facts['default_ipv4'].address | default(ansible_host) }}

--- a/autobot-slm-backend/ansible/roles/time_sync/templates/chrony.conf.j2
+++ b/autobot-slm-backend/ansible/roles/time_sync/templates/chrony.conf.j2
@@ -31,7 +31,7 @@ rtcsync
 #minsources 2
 
 # Allow NTP client access from local network.
-{% if ansible_facts['default_ipv4'].network is defined %}
+{% if ansible_facts['default_ipv4'] is defined and ansible_facts['default_ipv4'].network is defined %}
 allow {{ ansible_facts['default_ipv4'].network }}/{{ ansible_facts['default_ipv4'].netmask }}
 {% endif %}
 


### PR DESCRIPTION
## Summary

- `ansible_facts['default_ipv4']` is unreliable on WSL2 (may be undefined when no default route exists) and multi-NIC hosts (wrong interface selected)
- Audited all ~20 callsites; added `| default(ansible_host)` fallbacks so playbooks degrade gracefully instead of crashing with an undefined-variable error
- Connection-critical uses fall back to the inventory `ansible_host`; display-only uses keep `| default('N/A')` where already present

## Changes (16 files)

**Roles:**
- `roles/common/tasks/main.yml` — `lineinfile` line/regexp targets use `| default(ansible_host)`
- `roles/time_sync/templates/chrony.conf.j2` — outer `{% if %}` guard now checks `is defined`
- `roles/distributed_setup/defaults/main.yml` — `coordinator_host` double fallback
- `roles/slm_manager/templates/slm-secrets.env.j2` — `SLM_EXTERNAL_URL` fallback
- `roles/frontend/tasks/main.yml` — display line fallback
- `roles/redis/tasks/main.yml` — display line fallback
- `roles/redis/templates/redis-backup.sh.j2` — both `redis-cli -h` lines

**Playbooks:**
- `deploy-base.yml`, `deploy-database.yml`, `deploy-hybrid-docker.yml`, `deploy-native-services.yml`
- `configure-redis-service-management.yml`, `data-migration.yml`, `decommission-node.yml`
- `health-check.yml`, `remove-role.yml`

## Test plan

- [ ] Run any playbook on a WSL2 host — no `ansible_default_ipv4 is undefined` errors
- [ ] Run any playbook on a multi-NIC host — uses correct `ansible_host` IP when default_ipv4 doesn't match

Closes #6840

🤖 Generated with [Claude Code](https://claude.com/claude-code)