### PR TITLE
fix(slm-client): pass auth token as query param to stop /api/ws/events reconnect spam (#6839)

### DIFF
--- a/autobot-backend/services/slm_client.py
+++ b/autobot-backend/services/slm_client.py
@@ -561,8 +561,14 @@ class SLMClient:
         """Connect to WebSocket and listen for events."""
         ws_url = self.slm_url.replace("http://", "ws://").replace("https://", "wss://")
         ws_url = f"{ws_url}/api/ws/events"
+        # SLM backend authenticates via ?token= query param, not Authorization header (#6839)
+        if self.auth_token:
+            ws_url = f"{ws_url}?token={self.auth_token}"
+        else:
+            logger.debug("No auth token configured; skipping WebSocket connection to SLM")
+            return
 
-        logger.info("Connecting to WebSocket at %s", ws_url)
+        logger.info("Connecting to WebSocket at %s", ws_url.split("?")[0])  # don't log token
 
         try:
             # Accept self-signed certs for wss:// connections (#1048, #6654)
@@ -570,7 +576,6 @@ class SLMClient:
             async with websockets.connect(
                 ws_url,
                 ssl=ws_ssl,
-                additional_headers=({"Authorization": f"Bearer {self.auth_token}"} if self.auth_token else {}),
             ) as websocket:
                 self._ws_connected = True
                 self._reconnect_delay = 1.0  # Reset backoff on successful connect


### PR DESCRIPTION
## Summary

- `slm_client.py` was sending the auth token as an `Authorization` header to the SLM WebSocket endpoint
- The SLM backend's `_authenticate_websocket_token()` only reads `?token=` query parameter
- This caused auth to always fail: Starlette sends HTTP 101 (upgrade) before sending the close frame, so `websockets.connect()` entered the `async with` block and reset `_reconnect_delay` to 1 s on every attempt
- The result: a permanent ~1-second reconnect loop generating **568+ log entries per 5 min**

## Root cause

```python
# Before — token in header, server ignores it
async with websockets.connect(ws_url, additional_headers={"Authorization": f"Bearer {token}"}) as ws:
    self._reconnect_delay = 1.0  # ← reset every time, even on auth failure
```

Server always closes with 4001 → backoff never grows beyond 1 s.

## Fix

```python
# After — token in query param (matches server expectation)
if self.auth_token:
    ws_url = f"{ws_url}?token={self.auth_token}"
else:
    logger.debug("No auth token configured; skipping WebSocket connection to SLM")
    return
```

- Token appended as `?token=` query param matching `websocket.query_params.get("token")`
- No token → return early (no connection attempt, no reconnect loop)
- Log message uses `ws_url.split("?")[0]` so token is never written to logs

## Changes

- `autobot-backend/services/slm_client.py`: 7 insertions, 2 deletions in `_ws_connect_and_listen`

## Test plan

- [ ] Set `SLM_AUTH_TOKEN` and verify WebSocket connects and stays connected
- [ ] Without `SLM_AUTH_TOKEN`, confirm only a single debug log (no reconnect loop)
- [ ] Check log volume — should not see repeated "Connecting to WebSocket" entries

Closes #6839

🤖 Generated with [Claude Code](https://claude.com/claude-code)