### PR TITLE
refactor(frontend): swap space-x-* with gap-* for flex containers (#6841)

### DIFF
--- a/autobot-frontend/src/components/browser/BrowserSessionManager.vue
+++ b/autobot-frontend/src/components/browser/BrowserSessionManager.vue
@@ -2,7 +2,7 @@
   <div class="session-manager">
     <!-- Header -->
     <div class="manager-header">
-      <div class="flex items-center space-x-3">
+      <div class="flex items-center gap-3">
         <i class="fas fa-window-restore text-green-600 text-xl"></i>
         <div>
           <h3 class="text-lg font-semibold text-autobot-text-primary">{{ $t('browser.sessionManager.title') }}</h3>
@@ -10,7 +10,7 @@
         </div>
       </div>
 
-      <div class="flex items-center space-x-2">
+      <div class="flex items-center gap-2">
         <BaseButton
           variant="primary"
           size="sm"
@@ -91,7 +91,7 @@
         >
           <!-- Session Header -->
           <div class="session-header">
-            <div class="flex items-center space-x-3 flex-1">
+            <div class="flex items-center gap-3 flex-1">
               <div class="session-icon" :class="getSessionIconClass(session.status)">
                 <i :class="getSessionIcon(session.status)"></i>
               </div>
@@ -101,7 +101,7 @@
               </div>
             </div>
 
-            <div class="flex items-center space-x-2">
+            <div class="flex items-center gap-2">
               <StatusBadge :variant="getStatusVariant(session.status)" size="small">
                 {{ session.status.toUpperCase() }}
               </StatusBadge>

--- a/autobot-frontend/src/components/chat/ChatBrowser.vue
+++ b/autobot-frontend/src/components/chat/ChatBrowser.vue
@@ -298,7 +298,7 @@ onUnmounted(async () => {
 }
 
 .session-badge {
-  @apply flex items-center space-x-1 px-2 py-1 rounded-full text-xs;
+  @apply flex items-center gap-1 px-2 py-1 rounded-full text-xs;
 }
 
 .browser-body {

--- a/autobot-frontend/src/components/chat/ChatBrowser.vue
+++ b/autobot-frontend/src/components/chat/ChatBrowser.vue
@@ -2,14 +2,14 @@
   <div class="chat-browser-container">
     <!-- Browser Header with Session Info -->
     <div class="browser-header">
-      <div class="flex items-center space-x-3">
-        <div class="flex space-x-1">
+      <div class="flex items-center gap-3">
+        <div class="flex gap-1">
           <div class="w-3 h-3 bg-red-500 rounded-full"></div>
           <div class="w-3 h-3 bg-yellow-500 rounded-full"></div>
           <div class="w-3 h-3 bg-green-500 rounded-full"></div>
         </div>
 
-        <div class="flex items-center space-x-2 text-sm">
+        <div class="flex items-center gap-2 text-sm">
           <i class="fas fa-globe" :class="iconClass"></i>
           <span class="font-medium">{{ $t('chat.browser.title') }}</span>
 
@@ -25,9 +25,9 @@
         </div>
       </div>
 
-      <div class="flex items-center space-x-2">
+      <div class="flex items-center gap-2">
         <!-- Connection Status -->
-        <div class="flex items-center space-x-1">
+        <div class="flex items-center gap-1">
           <div
             class="w-2 h-2 rounded-full"
             :class="connectionStatusClass"

--- a/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
+++ b/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
@@ -2,22 +2,22 @@
   <div class="chromium-browser-container">
     <!-- Browser Header -->
     <div class="browser-header bg-autobot-bg-tertiary border-b border-autobot-border p-2 flex items-center justify-between">
-      <div class="flex items-center space-x-3">
-        <div class="flex space-x-1">
+      <div class="flex items-center gap-3">
+        <div class="flex gap-1">
           <div class="w-3 h-3 bg-red-500 rounded-full"></div>
           <div class="w-3 h-3 bg-yellow-500 rounded-full"></div>
           <div class="w-3 h-3 bg-green-500 rounded-full"></div>
         </div>
-        <div class="flex items-center space-x-2 text-sm">
+        <div class="flex items-center gap-2 text-sm">
           <i class="fab fa-chrome" style="color: var(--color-primary)"></i>
           <span class="font-medium">{{ $t('desktop.popoutBrowser.title') }}</span>
           <span v-if="sessionId" class="text-xs text-autobot-text-muted">{{ $t('desktop.popoutBrowser.sessionLabel', { id: sessionId.slice(0, 8) }) }}</span>
         </div>
       </div>
 
-      <div class="flex items-center space-x-2">
+      <div class="flex items-center gap-2">
         <!-- Browser Controls -->
-        <div class="flex items-center space-x-1">
+        <div class="flex items-center gap-1">
           <button @click="refreshBrowser" class="browser-btn" :disabled="isRefreshing" :title="$t('desktop.popoutBrowser.refresh')" :aria-label="$t('desktop.popoutBrowser.refresh')">
             <i class="fas fa-sync-alt" :class="{ 'fa-spin': isRefreshing }"></i>
           </button>
@@ -36,7 +36,7 @@
         </div>
 
         <!-- Playwright Automation Controls -->
-        <div class="border-l border-autobot-border pl-2 flex items-center space-x-1">
+        <div class="border-l border-autobot-border pl-2 flex items-center gap-1">
           <button @click="showPlaywrightPanel = !showPlaywrightPanel" class="browser-btn" :title="$t('desktop.popoutBrowser.playwrightAutomation')" :aria-label="$t('desktop.popoutBrowser.playwrightAutomation')">
             <i class="fas fa-robot" :style="showPlaywrightPanel ? 'color: var(--color-primary)' : ''"></i>
           </button>
@@ -63,7 +63,7 @@
     </div>
 
     <!-- Address Bar -->
-    <div class="address-bar bg-autobot-bg-secondary border-b border-autobot-border p-3 flex items-center space-x-3">
+    <div class="address-bar bg-autobot-bg-secondary border-b border-autobot-border p-3 flex items-center gap-3">
       <button @click="goBack" :disabled="!canGoBack || isGoingBack" class="nav-btn" :title="$t('desktop.popoutBrowser.back')" :aria-label="$t('desktop.popoutBrowser.back')">
         <i class="fas fa-arrow-left" :class="{ 'fa-pulse': isGoingBack }"></i>
       </button>
@@ -90,7 +90,7 @@
     <!-- Playwright Automation Panel -->
     <div v-if="showPlaywrightPanel" class="automation-panel border-b p-4" style="background: var(--color-info-bg); border-color: rgba(59,130,246,0.2)">
       <div class="flex items-center justify-between mb-4">
-        <div class="flex items-center space-x-2">
+        <div class="flex items-center gap-2">
           <i class="fas fa-robot" style="color: var(--color-info)"></i>
           <span class="font-medium text-autobot-text-primary">{{ $t('desktop.popoutBrowser.browserAutomation') }}</span>
           <span class="text-sm px-2 py-1 rounded" style="background: var(--color-info-bg); color: var(--color-info)">{{ playwrightStatus }}</span>
@@ -107,7 +107,7 @@
       <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
         <!-- Web Search -->
         <div class="automation-card">
-          <div class="flex items-center space-x-2 mb-2">
+          <div class="flex items-center gap-2 mb-2">
             <i class="fas fa-search text-green-500"></i>
             <span class="text-sm font-medium">{{ $t('desktop.popoutBrowser.webSearch') }}</span>
           </div>
@@ -127,7 +127,7 @@
 
         <!-- Frontend Testing -->
         <div class="automation-card">
-          <div class="flex items-center space-x-2 mb-2">
+          <div class="flex items-center gap-2 mb-2">
             <i class="fas fa-vials" style="color: var(--color-info)"></i>
             <span class="text-sm font-medium">{{ $t('desktop.popoutBrowser.frontendTest') }}</span>
           </div>
@@ -139,7 +139,7 @@
 
         <!-- Automation Results -->
         <div class="automation-card">
-          <div class="flex items-center space-x-2 mb-2">
+          <div class="flex items-center gap-2 mb-2">
             <i class="fas fa-chart-bar text-purple-500"></i>
             <span class="text-sm font-medium">{{ $t('desktop.popoutBrowser.results') }}</span>
           </div>
@@ -232,7 +232,7 @@
               <StatusBadge variant="success" size="small">{{ $t('desktop.popoutBrowser.connected') }}</StatusBadge>
             </div>
             <div class="text-xs text-autobot-text-secondary">
-              <div class="flex items-center space-x-2">
+              <div class="flex items-center gap-2">
                 <i class="fas fa-link" style="color: var(--color-info)"></i>
                 <span class="text-sm" style="color: var(--text-link)">{{ currentUrl }}</span>
               </div>
@@ -244,7 +244,7 @@
             <h4 class="text-sm font-medium text-autobot-text-primary mb-3">{{ $t('desktop.popoutBrowser.recentResults') }}</h4>
 
             <div v-if="automationResults.lastSearch" class="mb-3 p-3 rounded" style="background: var(--color-info-bg)">
-              <div class="flex items-center space-x-2 mb-1">
+              <div class="flex items-center gap-2 mb-1">
                 <i class="fas fa-search" style="color: var(--color-info)"></i>
                 <span class="text-sm font-medium">{{ $t('desktop.popoutBrowser.webSearch') }}</span>
               </div>
@@ -252,7 +252,7 @@
             </div>
 
             <div v-if="automationResults.lastTest" class="p-3 rounded" style="background: var(--color-success-bg)">
-              <div class="flex items-center space-x-2 mb-1">
+              <div class="flex items-center gap-2 mb-1">
                 <i class="fas fa-vials text-green-500"></i>
                 <span class="text-sm font-medium">{{ $t('desktop.popoutBrowser.frontendTest') }}</span>
               </div>
@@ -332,7 +332,7 @@
             <h3 class="text-lg font-semibold">{{ $t('desktop.popoutBrowser.interactionRequired') }}</h3>
           </div>
           <p class="text-autobot-text-primary mb-4">{{ interactionMessage }}</p>
-          <div class="flex space-x-3">
+          <div class="flex gap-3">
             <BaseButton variant="primary" @click="handleInteraction('wait')">
               <i class="fas fa-clock mr-1"></i>
               {{ $t('desktop.popoutBrowser.waitAndMonitor') }}

--- a/autobot-frontend/src/components/layout/NavOverflowMenu.vue
+++ b/autobot-frontend/src/components/layout/NavOverflowMenu.vue
@@ -5,7 +5,7 @@
       aria-haspopup="menu"
       :aria-label="$t('nav.moreItems')"
       :class="[
-        'px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 flex items-center space-x-1',
+        'px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 flex items-center gap-1',
         hasActiveItem
           ? 'bg-autobot-primary text-white'
           : 'text-autobot-text-primary hover:bg-autobot-bg-tertiary'
@@ -43,7 +43,7 @@
           role="menuitem"
           active-class=""
           exact-active-class="text-autobot-primary"
-          class="flex items-center space-x-2 px-3 py-2 text-sm transition-colors duration-150 hover:bg-autobot-bg-tertiary text-autobot-text-primary"
+          class="flex items-center gap-2 px-3 py-2 text-sm transition-colors duration-150 hover:bg-autobot-bg-tertiary text-autobot-text-primary"
           @click="close"
         >
           <svg

--- a/autobot-frontend/src/components/services/RedisServiceControl.vue
+++ b/autobot-frontend/src/components/services/RedisServiceControl.vue
@@ -2,7 +2,7 @@
   <div class="redis-service-control bg-autobot-bg-card rounded-lg shadow-md overflow-hidden" data-testid="redis-service-container">
     <!-- Service Header -->
     <div class="flex items-center justify-between px-6 py-4 border-b bg-linear-to-r from-red-50 to-red-100" data-testid="redis-service-header">
-      <div class="flex items-center space-x-3">
+      <div class="flex items-center gap-3">
         <i class="fas fa-database text-2xl text-red-600"></i>
         <div>
           <h3 class="text-lg font-semibold text-autobot-text-primary" data-testid="redis-service-title">{{ $t('redis.title') }}</h3>
@@ -11,7 +11,7 @@
       </div>
 
       <!-- Status Badge -->
-      <div class="flex items-center space-x-3" data-testid="redis-service-status-area">
+      <div class="flex items-center gap-3" data-testid="redis-service-status-area">
         <span class="text-xs text-autobot-text-muted" data-testid="redis-service-last-check">
           {{ $t('redis.lastCheck') }} {{ formatLastCheck(serviceStatus.last_check) }}
         </span>
@@ -53,12 +53,12 @@
     <!-- Control Buttons -->
     <div class="px-6 py-4 border-b" data-testid="redis-service-controls">
       <div class="flex items-center justify-between">
-        <div class="flex space-x-3">
+        <div class="flex gap-3">
           <BaseButton
             variant="success"
             @click="handleStartService"
             :disabled="serviceStatus.status === 'running' || loading"
-            class="flex items-center space-x-2 px-4 py-2"
+            class="flex items-center gap-2 px-4 py-2"
             data-testid="redis-service-start-btn"
           >
             <i class="fas fa-play"></i>
@@ -69,7 +69,7 @@
             variant="warning"
             @click="handleRestartService"
             :disabled="serviceStatus.status !== 'running' || loading"
-            class="flex items-center space-x-2 px-4 py-2"
+            class="flex items-center gap-2 px-4 py-2"
             data-testid="redis-service-restart-btn"
           >
             <i class="fas fa-sync"></i>
@@ -80,7 +80,7 @@
             variant="danger"
             @click="handleStopService"
             :disabled="serviceStatus.status !== 'running' || loading"
-            class="flex items-center space-x-2 px-4 py-2"
+            class="flex items-center gap-2 px-4 py-2"
             data-testid="redis-service-stop-btn"
           >
             <i class="fas fa-stop"></i>
@@ -92,7 +92,7 @@
           variant="secondary"
           @click="refreshStatus"
           :loading="loading"
-          class="flex items-center space-x-2 px-4 py-2"
+          class="flex items-center gap-2 px-4 py-2"
           data-testid="redis-service-refresh-btn"
         >
           <i class="fas fa-sync-alt"></i>

--- a/autobot-frontend/src/components/terminal/Terminal.vue
+++ b/autobot-frontend/src/components/terminal/Terminal.vue
@@ -2,22 +2,22 @@
   <div class="terminal-container">
     <!-- Terminal Header (matching browser/desktop style) -->
     <div class="terminal-header bg-autobot-bg-secondary border-b border-autobot-border p-2 flex items-center justify-between">
-      <div class="flex items-center space-x-3">
-        <div class="flex space-x-1">
+      <div class="flex items-center gap-3">
+        <div class="flex gap-1">
           <div class="w-3 h-3 bg-red-500 rounded-full"></div>
           <div class="w-3 h-3 bg-yellow-500 rounded-full"></div>
           <div class="w-3 h-3 bg-green-500 rounded-full"></div>
         </div>
-        <div class="flex items-center space-x-2 text-sm">
+        <div class="flex items-center gap-2 text-sm">
           <i class="fas fa-terminal text-green-600"></i>
           <span class="font-medium">{{ props.chatSessionId ? $t('terminal.terminal.chatTerminal') : $t('terminal.terminal.systemTerminal') }}</span>
           <span class="text-xs text-autobot-text-muted">{{ props.chatSessionId ? $t('terminal.terminal.chatSession') : $t('terminal.terminal.independentTool') }}</span>
         </div>
       </div>
 
-      <div class="flex items-center space-x-2">
+      <div class="flex items-center gap-2">
         <!-- Terminal Controls -->
-        <div class="flex items-center space-x-1">
+        <div class="flex items-center gap-1">
           <button @click="toggleConnection" :class="connectionButtonClass" :disabled="isConnecting" class="terminal-btn" :title="connectionButtonText" :aria-label="connectionButtonText">
             <i :class="connectionIconClass"></i>
           </button>


### PR DESCRIPTION
## Summary

Audited and fixed all 38 space-x-N callsites in autobot-frontend/src/{views,components}. Swapped to gap-N for flex containers. Caught and fixed missed @apply space-x-1 in ChatBrowser.vue .session-badge CSS rule.

-space-x-2 in PresenceIndicator intentionally kept (avatar overlap pattern; no gap equivalent).

Related: GH #7899 filed for App.vue callsites outside original audit scope.

## Test plan

- [ ] Visual regression check on tabs, nav, service controls, browsers
- [ ] Responsive layout verified (flex containers at breakpoints)
- [ ] No layout shifts or color changes in space-x-dependent components