### PR TITLE
refactor(voice): migrate VoiceConversationOverlay to useVoiceOutput for wsConnected (GH #6825)

### DIFF
--- a/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
@@ -58,9 +58,9 @@
                 class="voice-overlay__ws-indicator"
                 :class="{
                   'voice-overlay__ws-indicator--connected':
-                    voiceConversation.wsConnected.value,
+                    wsConnected.value,
                 }"
-                :title="voiceConversation.wsConnected.value
+                :title="wsConnected.value
                   ? $t('chat.voice.connected') : $t('chat.voice.disconnected')"
               ></div>
 
@@ -247,6 +247,7 @@ import {
 } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useVoiceConversation } from '@/composables/useVoiceConversation'
+import { useVoiceOutput } from '@/composables/useVoiceOutput'
 
 const emit = defineEmits<{
   (e: 'close'): void
@@ -254,6 +255,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const voiceConversation = useVoiceConversation()
+const { wsConnected } = useVoiceOutput()
 const overlayRef = ref<HTMLElement | null>(null)
 const conversationRef = ref<HTMLElement | null>(null)
 

--- a/autobot-frontend/src/composables/useVoiceConversation.ts
+++ b/autobot-frontend/src/composables/useVoiceConversation.ts
@@ -697,7 +697,7 @@ function _handleVadSpeechEnd(audio: Float32Array): void {
 // ─── Main composable ────────────────────────────────────
 
 export function useVoiceConversation() {
-  const { isSpeaking, unlockAudio, stopSpeaking, wsConnected } = useVoiceOutput()
+  const { isSpeaking, unlockAudio, stopSpeaking } = useVoiceOutput()
 
   const isListening = computed(() => state.value === 'listening')
   const isProcessing = computed(() => state.value === 'processing')
@@ -847,7 +847,6 @@ export function useVoiceConversation() {
     bubbles,
     isActive,
     errorMessage,
-    wsConnected,
     audioLevel,
     silenceThreshold,
     micAccessAvailable,


### PR DESCRIPTION
## Summary

Cleans up the architectural boundary established by #6788: `wsConnected` belongs to `useVoiceOutput` (the WS owner), not `useVoiceConversation`. The re-export was a smell indicating readers might think the wrong composable owns WS state.

- `VoiceConversationOverlay.vue` now imports `useVoiceOutput` directly and reads `wsConnected` from it
- Remove `wsConnected` from `useVoiceConversation`'s return object (it still imports it internally for the full-duplex speak path)

## Changes

- `autobot-frontend/src/components/chat/VoiceConversationOverlay.vue` — import `useVoiceOutput`, destructure `wsConnected` directly
- `autobot-frontend/src/composables/useVoiceConversation.ts` — remove `wsConnected` re-export from return object

## Test Plan

- [ ] TS check passes (zero errors)
- [ ] `VoiceConversationOverlay.vue` reads `wsConnected` from `useVoiceOutput` directly
- [ ] `useVoiceConversation` no longer re-exports `wsConnected`
- [ ] Internal `voiceWsConnected` usage in speak path unaffected

Closes #6825