### PR TITLE
feat(voice): env_int_clamped helper + AUTOBOT_TTS_MAX_CHUNK_CHARS env-var (GH #6824)

### DIFF
--- a/autobot-backend/api/voice_stream.py
+++ b/autobot-backend/api/voice_stream.py
@@ -33,6 +33,7 @@ from collections import deque
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
 
+from autobot_shared.env_utils import env_int_clamped
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
@@ -41,8 +42,8 @@ from services.tts_client import get_tts_client
 logger = get_logger(__name__)
 router = APIRouter()
 
-# Maximum TTS text length per chunk (characters)
-_MAX_TTS_CHUNK_CHARS = 200
+# Maximum TTS text length per chunk (characters). Override via AUTOBOT_TTS_MAX_CHUNK_CHARS.
+_MAX_TTS_CHUNK_CHARS = env_int_clamped("AUTOBOT_TTS_MAX_CHUNK_CHARS", 200, 50, 1000)
 
 
 def _split_text_for_tts(text: str) -> list[str]:
@@ -98,13 +99,7 @@ async def _cancel_pending_task(task: "asyncio.Task | None") -> None:
 # typical jitter without piling backlog. Override with AUTOBOT_TTS_PIPELINE_DEPTH
 # (clamped to 1..8 to prevent ops typos OOMing the worker).
 def _resolve_tts_pipeline_depth() -> int:
-    raw = config.tts_pipeline_depth
-    try:
-        value = int(raw)
-    except ValueError:
-        logger.warning("Invalid AUTOBOT_TTS_PIPELINE_DEPTH=%r; using 2", raw)
-        return 2
-    return max(1, min(8, value))
+    return env_int_clamped("AUTOBOT_TTS_PIPELINE_DEPTH", 2, 1, 8)
 
 
 _TTS_PIPELINE_DEPTH = _resolve_tts_pipeline_depth()

--- a/autobot_shared/env_utils.py
+++ b/autobot_shared/env_utils.py
@@ -1,0 +1,36 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+"""Environment variable helpers shared across AutoBot services."""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def env_int_clamped(
+    name: str,
+    default: int,
+    min_v: int | None = None,
+    max_v: int | None = None,
+) -> int:
+    """Read an integer environment variable with optional min/max clamping.
+
+    Falls back to *default* (with a warning) if the env var is set but not a
+    valid integer.  Returns *default* silently when the var is absent.
+    Clamps to [min_v, max_v] when either bound is provided.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        value = default
+    else:
+        try:
+            value = int(raw)
+        except ValueError:
+            logger.warning("Invalid %s=%r; using %d", name, raw, default)
+            value = default
+    if min_v is not None:
+        value = max(min_v, value)
+    if max_v is not None:
+        value = min(max_v, value)
+    return value

--- a/autobot_shared/env_utils_test.py
+++ b/autobot_shared/env_utils_test.py
@@ -1,0 +1,72 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+import os
+
+from autobot_shared.env_utils import env_int_clamped
+
+_VAR = "TEST_ENV_INT_CLAMPED_XYZ"
+
+
+def _clean():
+    os.environ.pop(_VAR, None)
+
+
+def test_default_when_missing():
+    _clean()
+    assert env_int_clamped(_VAR, 5) == 5
+
+
+def test_reads_env_var():
+    os.environ[_VAR] = "10"
+    try:
+        assert env_int_clamped(_VAR, 5) == 10
+    finally:
+        _clean()
+
+
+def test_clamps_min():
+    os.environ[_VAR] = "0"
+    try:
+        assert env_int_clamped(_VAR, 5, min_v=1) == 1
+    finally:
+        _clean()
+
+
+def test_clamps_max():
+    os.environ[_VAR] = "100"
+    try:
+        assert env_int_clamped(_VAR, 5, max_v=10) == 10
+    finally:
+        _clean()
+
+
+def test_invalid_falls_back_to_default():
+    os.environ[_VAR] = "notanint"
+    try:
+        assert env_int_clamped(_VAR, 5) == 5
+    finally:
+        _clean()
+
+
+def test_no_bounds():
+    os.environ[_VAR] = "999"
+    try:
+        assert env_int_clamped(_VAR, 1) == 999
+    finally:
+        _clean()
+
+
+def test_clamps_both_bounds():
+    os.environ[_VAR] = "15"
+    try:
+        assert env_int_clamped(_VAR, 5, min_v=1, max_v=10) == 10
+    finally:
+        _clean()
+
+
+def test_negative_value_allowed_without_bounds():
+    os.environ[_VAR] = "-3"
+    try:
+        assert env_int_clamped(_VAR, 0) == -3
+    finally:
+        _clean()


### PR DESCRIPTION
## Summary

Phase 1 of #6824: makes `_MAX_TTS_CHUNK_CHARS` ops-configurable without redeploy, and DRYs up the env-int-with-clamp pattern used by `_resolve_tts_pipeline_depth`.

- Add `autobot_shared/env_utils.py` with `env_int_clamped(name, default, min_v, max_v)` — shared helper for clamped integer env vars
- Rewrite `_resolve_tts_pipeline_depth()` as a one-liner via the helper
- Make `_MAX_TTS_CHUNK_CHARS` read from `AUTOBOT_TTS_MAX_CHUNK_CHARS` (default 200, clamp 50–1000)
- 8 unit tests covering default, reads, min/max clamp, both bounds, no bounds, invalid value fallback

## Changes

- `autobot_shared/env_utils.py` — new module
- `autobot_shared/env_utils_test.py` — 8 unit tests (all passing)
- `autobot-backend/api/voice_stream.py` — `_MAX_TTS_CHUNK_CHARS` and `_resolve_tts_pipeline_depth` use `env_int_clamped`

## Test Plan

- [ ] `python -m pytest autobot_shared/env_utils_test.py -v` — 8 tests pass
- [ ] `AUTOBOT_TTS_MAX_CHUNK_CHARS=500` changes chunk splitting boundary at runtime
- [ ] Invalid env var value logs a warning and falls back to default

Closes #6824