### PR TITLE
impl(frontend): promote runtimeHttpProto to top-level export (#6809)

### DIFF
--- a/autobot-frontend/src/config/__tests__/ssot-config.spec.ts
+++ b/autobot-frontend/src/config/__tests__/ssot-config.spec.ts
@@ -17,8 +17,8 @@
  * Author: mrveiss
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { reloadConfig } from '../ssot-config';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { reloadConfig, runtimeHttpProto } from '../ssot-config';
 
 // Note: In a real test environment, we would need to mock import.meta.env
 // For now, these tests validate the TypeScript structure and default values
@@ -500,6 +500,31 @@ describe('SSOT Config runtimeHttpProto() — protocol detection', () => {
       if (result.startsWith('/')) return;
       expect(result).toMatch(/^http:\/\//);
     });
+  });
+});
+
+// =============================================================================
+// Issue #6809: runtimeHttpProto() direct unit tests
+// =============================================================================
+
+describe('runtimeHttpProto', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns "https" when window.location.protocol is "https:"', () => {
+    vi.stubGlobal('window', { location: { protocol: 'https:', host: 'example.com' } });
+    expect(runtimeHttpProto()).toBe('https');
+  });
+
+  it('returns "http" when window.location.protocol is "http:"', () => {
+    vi.stubGlobal('window', { location: { protocol: 'http:', host: 'example.com' } });
+    expect(runtimeHttpProto()).toBe('http');
+  });
+
+  it('falls back to VITE_HTTP_PROTOCOL env var in SSR (no window)', () => {
+    vi.stubGlobal('window', undefined);
+    expect(runtimeHttpProto()).toBe('http'); // default from getEnv fallback
   });
 });
 

--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -333,6 +333,23 @@ function getEnvBoolean(key: string, defaultValue: boolean): boolean {
 }
 
 // =============================================================================
+// Runtime Protocol Helper
+// =============================================================================
+
+/**
+ * Detect the HTTP protocol at runtime from window.location.
+ * Falls back to VITE_HTTP_PROTOCOL for SSR / non-browser contexts.
+ * Exported so callers outside ssot-config can reuse the same detection logic
+ * without importing the full config singleton.
+ */
+export function runtimeHttpProto(): string {
+  if (typeof window !== 'undefined' && window.location?.protocol) {
+    return window.location.protocol === 'https:' ? 'https' : 'http';
+  }
+  return getEnv('VITE_HTTP_PROTOCOL', 'http');
+}
+
+// =============================================================================
 // Configuration Builder
 // =============================================================================
 
@@ -423,19 +440,6 @@ function buildConfig(): AutoBotConfig {
   const debug = getEnvBoolean('VITE_DEBUG', false);
   const httpProtocol = getEnv('VITE_HTTP_PROTOCOL', 'http');
 
-  // #6795: derive protocol at runtime from window.location to avoid the
-  // mixed-content trap that previously hit websocketUrl (#6642). The
-  // build-time VITE_HTTP_PROTOCOL stays as fallback for SSR / non-browser
-  // contexts where window is undefined. All browser-facing URL builders
-  // below use this helper so behaviour is consistent regardless of how the
-  // env var is set at build time.
-  const runtimeHttpProto = (): string => {
-    if (typeof window !== 'undefined' && window.location?.protocol) {
-      return window.location.protocol === 'https:' ? 'https' : 'http';
-    }
-    return httpProtocol;
-  };
-
   // Build the config object with computed URL getters
   const configObj: AutoBotConfig = {
     vm,
@@ -470,17 +474,7 @@ function buildConfig(): AutoBotConfig {
     },
 
     get websocketUrl(): string {
-      // #6642: detect protocol from window.location at runtime, not from
-      // build-time VITE_HTTP_PROTOCOL. The env var defaults to 'http' and
-      // produced ws:// URLs that browsers blocked as mixed-content when the
-      // page itself was served over HTTPS. Mirror the runtime detection that
-      // getBackendWsUrl() already uses so behaviour stays correct regardless
-      // of the build-time env.
-      const isHttps =
-        typeof window !== 'undefined'
-          ? window.location.protocol === 'https:'
-          : httpProtocol === 'https';
-      if (isHttps) {
+      if (runtimeHttpProto() === 'https') {
         const host =
           typeof window !== 'undefined' ? window.location.host : vm.main;
         return `wss://${host}/api/ws`;


### PR DESCRIPTION
## Summary

- Extracts `runtimeHttpProto()` from a closure inside `buildConfig()` to a named, exported module-level function in `ssot-config.ts`
- Removes the inner closure (same name, same logic — call sites in `buildConfig()` now resolve to the module-level export)
- Fixes `websocketUrl` getter: replaces 19-line inline duplicate protocol detection with a single `runtimeHttpProto()` call
- Adds 3 Vitest unit tests: HTTPS detection, HTTP fallback, SSR (no window)

## Test plan

- [x] `npm run test -- src/config/__tests__/ssot-config.spec.ts` → 25/25 passed
- [x] `vue-tsc --noEmit -p tsconfig.app.json` → zero errors in `ssot-config.ts` (pre-existing errors elsewhere unchanged)
- [x] No `any` introduced; canonical naming and `@/` imports preserved

Closes GH#6809

🤖 Generated with [Claude Code](https://claude.com/claude-code)