### PR TITLE
feat(backend): centralize background scheduler registry (GH#6594)

### DIFF
--- a/autobot-backend/api/admin_schedulers.py
+++ b/autobot-backend/api/admin_schedulers.py
@@ -1,0 +1,39 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Admin API: background scheduler registry endpoint (GH#6594).
+
+Endpoint:
+    GET /api/admin/schedulers
+
+Access: admin role required.
+"""
+
+from dataclasses import asdict
+
+from fastapi import APIRouter, Depends, Request
+
+from auth_middleware import get_auth_middleware
+from services.scheduler_registry import REGISTRY
+from utils.catalog_http_exceptions import raise_auth_error
+
+router = APIRouter(prefix="/admin", tags=["admin", "schedulers"])
+
+
+def _require_admin(request: Request) -> bool:
+    """Dependency: reject non-admin callers."""
+    user_data = get_auth_middleware().get_user_from_request(request)
+    if not user_data:
+        raise_auth_error("AUTH_0002", "Authentication required")
+    if user_data.get("role") != "admin":
+        raise_auth_error("AUTH_0003", "Admin permission required")
+    return True
+
+
+@router.get("/schedulers")
+async def list_schedulers(_admin: bool = Depends(_require_admin)) -> dict:
+    """Return all registered background schedulers with their runtime metadata."""
+    return {
+        "count": len(REGISTRY),
+        "schedulers": [asdict(job) for job in REGISTRY],
+    }

--- a/autobot-backend/api/admin_schedulers.py
+++ b/autobot-backend/api/admin_schedulers.py
@@ -17,7 +17,7 @@ from auth_middleware import get_auth_middleware
 from services.scheduler_registry import REGISTRY
 from utils.catalog_http_exceptions import raise_auth_error
 
-router = APIRouter(prefix="/admin", tags=["admin", "schedulers"])
+router = APIRouter(prefix="/admin")
 
 
 def _require_admin(request: Request) -> bool:

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -12,6 +12,7 @@ and are imported at module level to fail fast if missing.
 # Core router imports - these are required for basic functionality
 from api.adapters import router as adapters_router  # Issue #1403
 from api.admin_event_logs import router as admin_event_logs_router  # Issue #4461
+from api.admin_schedulers import router as admin_schedulers_router  # GH#6594
 from api.agent import router as agent_router
 from api.agent_config import router as agent_config_router
 from api.agent_org import router as agent_org_router  # #1405
@@ -95,6 +96,7 @@ def _get_system_routers() -> list:
     """Get system and settings routers (Issue #560: extracted, #1281: audit, #4461: event-logs)."""
     return [
         (admin_event_logs_router, "", ["admin", "compliance"], "admin_event_logs"),  # Issue #4461
+        (admin_schedulers_router, "", ["admin", "schedulers"], "admin_schedulers"),  # GH#6594
         (audit_router, "", ["audit"], "audit"),
         (auth_router, "/auth", ["auth"], "auth"),
         (service_messages_router, "", ["service-messages"], "service_messages"),

--- a/autobot-backend/services/scheduler_registry.py
+++ b/autobot-backend/services/scheduler_registry.py
@@ -1,0 +1,130 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Canonical registry of all background schedulers in the backend (GH#6594).
+
+This is the single source of truth for what scheduled jobs exist, how often
+they run, which file owns them, and which runtime model they use.
+
+New schedulers MUST be added here before shipping; tests/services/test_scheduler_registry.py
+enforces this automatically at CI time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class ScheduledJob:
+    name: str
+    interval_seconds: int | str
+    owner_file: str
+    runtime: Literal["asyncio_per_worker", "celery_beat", "leader_elected", "apscheduler"]
+    description: str
+
+
+REGISTRY: list[ScheduledJob] = [
+    ScheduledJob(
+        name="WorkflowScheduler",
+        interval_seconds=10,
+        owner_file="workflow_scheduler.py",
+        runtime="asyncio_per_worker",
+        description=(
+            "Polls for pending scheduled workflows and dispatches them when due. "
+            "Tick interval is WorkflowConfig.SCHEDULER_CHECK_INTERVAL_S (10 s)."
+        ),
+    ),
+    ScheduledJob(
+        name="HeartbeatScheduler",
+        interval_seconds="config:db_min_10s",
+        owner_file="services/heartbeat_scheduler.py",
+        runtime="asyncio_per_worker",
+        description=(
+            "Fires agent heartbeat runs on per-agent intervals persisted in the DB; "
+            "minimum enforced floor is 10 s."
+        ),
+    ),
+    ScheduledJob(
+        name="ConnectorScheduler",
+        interval_seconds="dynamic",
+        owner_file="knowledge/connectors/scheduler.py",
+        runtime="leader_elected",
+        description=(
+            "Triggers knowledge connector syncs. Interval is per-connector and "
+            "resolved dynamically from connector configuration."
+        ),
+    ),
+    ScheduledJob(
+        name="MeshBrainScheduler",
+        interval_seconds="300/86400/604800/realtime",
+        owner_file="services/mesh_brain/scheduler.py",
+        runtime="asyncio_per_worker",
+        description=(
+            "Runs four sub-tasks: edge_sync (300 s), node_promoter (24 h), "
+            "edge_discoverer (24 h), mesh_pruner (7 d), edge_learner (realtime Redis consumer). "
+            "NOTE: not initialized in lifespan.py — currently inert."
+        ),
+    ),
+    ScheduledJob(
+        name="SkillHealthScheduler",
+        interval_seconds=300,
+        owner_file="services/skill_management/skill_health_scheduler.py",
+        runtime="asyncio_per_worker",
+        description=(
+            "Checks skill health every 300 s. "
+            "NOTE: not initialized in lifespan.py — currently inert."
+        ),
+    ),
+    ScheduledJob(
+        name="LLMKeyRotationScheduler",
+        interval_seconds="config:AUTOBOT_LLM_KEY_ROTATION_INTERVAL_MINUTES",
+        owner_file="services/llm_key_rotation_scheduler.py",
+        runtime="apscheduler",
+        description=(
+            "Auto-revokes expired LLM API keys. Interval (in minutes) comes from "
+            "the AUTOBOT_LLM_KEY_ROTATION_INTERVAL_MINUTES environment variable."
+        ),
+    ),
+    ScheduledJob(
+        name="BackupScheduler",
+        interval_seconds="unknown",
+        owner_file="backup/scheduler.py",
+        runtime="asyncio_per_worker",
+        description=(
+            "Database backup scheduler referenced in lifespan.py. "
+            "WARNING: owner_file is missing from the repository. See discovery issue filed for GH#6594."
+        ),
+    ),
+    ScheduledJob(
+        name="CeleryBeat:cleanup_orphans",
+        interval_seconds="config:SSOT_CRON",
+        owner_file="celery_app.py",
+        runtime="celery_beat",
+        description=(
+            "Removes orphaned knowledge base entries. Schedule from "
+            "ssot_config.knowledge_orphan_cleanup_schedule (crontab)."
+        ),
+    ),
+    ScheduledJob(
+        name="CeleryBeat:cleanup_generated",
+        interval_seconds="config:SSOT_CRON",
+        owner_file="celery_app.py",
+        runtime="celery_beat",
+        description=(
+            "Removes generated knowledge files. Schedule from "
+            "ssot_config.knowledge_generated_files_cleanup_schedule (crontab)."
+        ),
+    ),
+    ScheduledJob(
+        name="CeleryBeat:prune_sync_queue",
+        interval_seconds="config:SSOT_CRON",
+        owner_file="celery_app.py",
+        runtime="celery_beat",
+        description=(
+            "Prunes completed entries from the knowledge sync queue. Schedule from "
+            "ssot_config.knowledge_sync_queue_prune_schedule (crontab)."
+        ),
+    ),
+]

--- a/autobot-backend/tests/services/test_scheduler_registry.py
+++ b/autobot-backend/tests/services/test_scheduler_registry.py
@@ -1,0 +1,103 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Enforcement test: every *scheduler*.py in the backend must be in REGISTRY (GH#6594).
+
+This test discovers all scheduler files on disk and asserts each is referenced
+by at least one entry in REGISTRY.owner_file, preventing silent scheduler additions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import scheduler_registry directly to avoid services/__init__.py pulling in
+# ai_stack_client (which transitively imports autobot_shared modules that require
+# Python 3.11+ when using the | union syntax without 'from __future__ import annotations').
+_REGISTRY_PATH = Path(__file__).parent.parent.parent / "services" / "scheduler_registry.py"
+_spec = importlib.util.spec_from_file_location("services.scheduler_registry", _REGISTRY_PATH)
+_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+sys.modules["services.scheduler_registry"] = _mod  # register before exec so @dataclass resolves
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+REGISTRY = _mod.REGISTRY
+ScheduledJob = _mod.ScheduledJob
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BACKEND_ROOT = Path(__file__).parent.parent.parent
+
+
+def _discover_scheduler_files() -> list[str]:
+    """Return background scheduler implementation paths relative to the backend root.
+
+    Excludes __pycache__, test files (test_*.py and *_test.py), api/ endpoint
+    modules, and the registry file itself — only actual scheduler implementations.
+    """
+    return [
+        str(p.relative_to(_BACKEND_ROOT))
+        for p in _BACKEND_ROOT.rglob("*scheduler*.py")
+        if "__pycache__" not in str(p)
+        and not p.name.startswith("test_")
+        and not p.name.endswith("_test.py")
+        and "autobot-backend/api/" not in str(p).replace("\\", "/")
+        and p.resolve() != _REGISTRY_PATH.resolve()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Registry shape tests
+# ---------------------------------------------------------------------------
+
+
+def test_registry_is_nonempty() -> None:
+    assert len(REGISTRY) > 0, "REGISTRY must contain at least one entry"
+
+
+def test_registry_entries_are_scheduled_jobs() -> None:
+    for job in REGISTRY:
+        assert isinstance(job, ScheduledJob), f"REGISTRY entry is not a ScheduledJob: {job!r}"
+
+
+def test_registry_names_are_unique() -> None:
+    names = [job.name for job in REGISTRY]
+    duplicates = [n for n in names if names.count(n) > 1]
+    assert not duplicates, f"Duplicate names in REGISTRY: {set(duplicates)}"
+
+
+def test_registry_runtimes_are_valid() -> None:
+    valid = {"asyncio_per_worker", "celery_beat", "leader_elected", "apscheduler"}
+    for job in REGISTRY:
+        assert job.runtime in valid, (
+            f"REGISTRY entry '{job.name}' has unknown runtime '{job.runtime}'. "
+            f"Valid values: {valid}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Enforcement test: all scheduler files must be registered
+# ---------------------------------------------------------------------------
+
+
+def test_all_scheduler_files_registered() -> None:
+    """Every *scheduler*.py on disk must appear in REGISTRY.owner_file.
+
+    If this test fails, add the new scheduler file to
+    autobot-backend/services/scheduler_registry.py before merging.
+    """
+    registered_owner_files = {job.owner_file for job in REGISTRY}
+    discovered = _discover_scheduler_files()
+
+    unregistered = [f for f in discovered if f not in registered_owner_files]
+
+    assert not unregistered, (
+        "The following scheduler files are NOT registered in "
+        "services/scheduler_registry.REGISTRY:\n"
+        + "\n".join(f"  - {f}" for f in sorted(unregistered))
+        + "\n\nAdd an entry for each file to autobot-backend/services/scheduler_registry.py."
+    )

--- a/docs/developer/HEARTBEAT_SYSTEM.md
+++ b/docs/developer/HEARTBEAT_SYSTEM.md
@@ -3,6 +3,11 @@
 > Issue #1407. Backend: `autobot-backend/services/heartbeat_scheduler.py` and
 > `autobot-backend/api/heartbeat.py`. Frontend: `autobot-frontend/src/components/agents/HeartbeatPanel.vue`.
 
+> **All background schedulers** (including HeartbeatScheduler) are enumerated in
+> `autobot-backend/services/scheduler_registry.py` — the canonical source of truth for
+> runtime model, tick interval, and owner file. The full list is also available at runtime via
+> `GET /api/admin/schedulers`. See GH#6594.
+
 ---
 
 ## What HeartbeatPanel Does


### PR DESCRIPTION
## Summary

- **`services/scheduler_registry.py`** — new canonical registry of all 10 background scheduler entries (8 schedulers; Celery Beat split into 3 named jobs). Each entry carries `name`, `interval_seconds`, `owner_file`, `runtime`, and `description`.
- **`api/admin_schedulers.py`** — new `GET /api/admin/schedulers` endpoint, admin-gated, returns the full registry as JSON.
- **`initialization/router_registry/core_routers.py`** — registers the new admin schedulers router.
- **`tests/services/test_scheduler_registry.py`** — enforcement test that discovers all `*scheduler*.py` files on disk and asserts each appears in `REGISTRY.owner_file`. Prevents silent scheduler additions at CI time. (5/5 pass)
- **`docs/developer/HEARTBEAT_SYSTEM.md`** — callout block added pointing at `scheduler_registry.py` and `/api/admin/schedulers` as the canonical background-job reference.

`BackupScheduler` is noted in the registry with `owner_file="backup/scheduler.py"` and a `FILE MISSING` warning; a discovery issue was filed for that separately.

## Test plan

- [x] `pytest tests/services/test_scheduler_registry.py` — 5/5 passed locally
- [x] `GET /api/admin/schedulers` requires admin role (same `_require_admin` dependency used by `admin_event_logs`)
- [x] Registry covers all 8 schedulers from the GH#6594 audit, expanded to 10 entries for Celery Beat sub-jobs
- [x] New scheduler files added in the future will cause `test_all_scheduler_files_registered` to fail until they're added to the registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)