### PR TITLE
feat(system-health): probe-name SSOT — KnownProbes enum + frontend constants (#6917)

### DIFF
--- a/autobot-backend/api/batch_jobs.py
+++ b/autobot-backend/api/batch_jobs.py
@@ -38,7 +38,7 @@ from api.schemas_workflows import (
     BatchTemplate,
     BatchTemplateDeleteResponse,
 )
-from api.system_health import ComponentHealth, register_health_probe
+from api.system_health import ComponentHealth, KnownProbes, register_health_probe
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -573,7 +573,7 @@ async def delete_batch_schedule(
 # =============================================================================
 
 
-@register_health_probe("batch_jobs")
+@register_health_probe(KnownProbes.BATCH_JOBS)
 async def probe_batch_jobs(
     request: Request | None = None,
 ) -> ComponentHealth:

--- a/autobot-backend/api/error_resilience.py
+++ b/autobot-backend/api/error_resilience.py
@@ -18,7 +18,7 @@ from api.schemas_workflows import (
     ErrorBudgetResetResponse,
     ErrorBudgetStatusResponse,
 )
-from api.system_health import ComponentHealth, register_health_probe
+from api.system_health import ComponentHealth, KnownProbes, register_health_probe
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from services.resilience.circuit_breaker_manager import (
@@ -32,7 +32,7 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/api/resilience", tags=["resilience"])
 
 
-@register_health_probe("error_resilience")
+@register_health_probe(KnownProbes.ERROR_RESILIENCE)
 async def probe_error_resilience(
     request: Request | None = None,
 ) -> ComponentHealth:

--- a/autobot-backend/api/intelligent_agent.py
+++ b/autobot-backend/api/intelligent_agent.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends, HTTPException, Request, WebSocket, WebSocketDisconnect
 
-from api.system_health import ComponentHealth, register_health_probe
+from api.system_health import ComponentHealth, KnownProbes, register_health_probe
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.logging_manager import get_logger
 
@@ -200,7 +200,7 @@ async def get_system_info(
     )
 
 
-@register_health_probe("intelligent_agent")
+@register_health_probe(KnownProbes.INTELLIGENT_AGENT)
 async def probe_intelligent_agent(
     request: Request | None = None,
 ) -> ComponentHealth:

--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -50,7 +50,7 @@ from api.schemas_knowledge import (
     DocsBrowseRequest,
     OrgKnowledgeConfigPayload,
 )
-from api.system_health import ComponentHealth, register_health_probe
+from api.system_health import ComponentHealth, KnownProbes, register_health_probe
 from auth_middleware import check_admin_permission, get_auth_middleware, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -1462,7 +1462,7 @@ async def upload_audio_file(
 # Includes: /search, /enhanced_search, /rag_search, /similarity_search
 
 
-@register_health_probe("knowledge")
+@register_health_probe(KnownProbes.KNOWLEDGE)
 async def probe_knowledge(
     request: Request | None = None,
 ) -> ComponentHealth:

--- a/autobot-backend/api/long_running_operations.py
+++ b/autobot-backend/api/long_running_operations.py
@@ -45,7 +45,7 @@ from api.schemas_workflows import (
     SecurityScanRequest,
     TestSuiteRequest,
 )
-from api.system_health import ComponentHealth, register_health_probe
+from api.system_health import ComponentHealth, KnownProbes, register_health_probe
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.security.path_validator import validate_path
@@ -543,7 +543,7 @@ async def websocket_progress_updates(websocket: WebSocket, operation_id: str):
             operation_integration_manager.websocket_connections[operation_id].remove(websocket)
 
 
-@register_health_probe("long_running")
+@register_health_probe(KnownProbes.LONG_RUNNING)
 async def probe_long_running(
     request: Request | None = None,
 ) -> ComponentHealth:

--- a/autobot-backend/api/system_health.py
+++ b/autobot-backend/api/system_health.py
@@ -18,6 +18,7 @@ aggregator.
 from __future__ import annotations
 
 import asyncio
+import enum
 import time
 from datetime import datetime, timezone
 from typing import Awaitable, Callable, Literal
@@ -28,6 +29,26 @@ from pydantic import BaseModel
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
+
+
+class KnownProbes(str, enum.Enum):
+    """Canonical probe-name constants — single source of truth.
+
+    Issue #6917: both backend probes and frontend callers previously
+    hardcoded probe name strings independently. Using this enum at
+    registration time makes a typo an immediate ImportError/AttributeError
+    rather than a silent runtime fallback.
+
+    Frontend code should import these values via the OpenAPI schema or
+    reference this file's docstring when adding a new frontend caller.
+    """
+
+    BATCH_JOBS = "batch_jobs"
+    LONG_RUNNING = "long_running"
+    KNOWLEDGE = "knowledge"
+    ERROR_RESILIENCE = "error_resilience"
+    INTELLIGENT_AGENT = "intelligent_agent"
+
 
 # Per-probe timeout. Probes slower than this become ``status="down"`` so a slow
 # component cannot hold the aggregator hostage.

--- a/autobot-backend/docs/api/health.md
+++ b/autobot-backend/docs/api/health.md
@@ -1,0 +1,97 @@
+# System Health API
+
+## Overview
+
+`/api/system/health` aggregates every registered probe into a single
+`SystemHealth` response (worst-of-components rollup).  The implementation lives
+in `api/system_health.py`.
+
+---
+
+## Probe-name SSOT — design decision (Issue #6917)
+
+### Problem
+
+Before this change, probe name strings were hardcoded independently in two
+places:
+
+- **Backend** — `@register_health_probe("batch_jobs")` in e.g. `api/batch_jobs.py`
+- **Frontend** — callers that matched on `probes[name="batch_jobs"]` in the
+  health response
+
+A one-character typo on either side produced a silent runtime fallback (the
+frontend fell back to "unknown" status) rather than an immediate error.
+
+### Options considered
+
+| Option | Description | Verdict |
+|--------|-------------|---------|
+| A | Generate a TypeScript const file from Python at build time | Too much tooling; overkill for the current scale |
+| B | Document the strings in a shared README and rely on code review | Low friction but still allows divergence |
+| **C** | Add a `KnownProbes` (`str, enum.Enum`) in the backend; use it at registration time | **Chosen** — zero new tooling, immediate import-time error on typo |
+
+### Chosen approach — Option C
+
+`KnownProbes` is defined in `api/system_health.py` immediately after the
+logger setup:
+
+```python
+class KnownProbes(str, enum.Enum):
+    BATCH_JOBS       = "batch_jobs"
+    LONG_RUNNING     = "long_running"
+    KNOWLEDGE        = "knowledge"
+    ERROR_RESILIENCE = "error_resilience"
+    INTELLIGENT_AGENT = "intelligent_agent"
+```
+
+Because `KnownProbes` inherits from `str`, every member *is* the string value.
+Passing `KnownProbes.BATCH_JOBS` to `register_health_probe(name: str)` works
+without a cast, and the registered key in `_PROBES` is the plain string
+`"batch_jobs"` — no change to the HTTP response shape.
+
+---
+
+## Adding a new probe
+
+1. Add a member to `KnownProbes` in `api/system_health.py`:
+
+   ```python
+   MY_NEW_PROBE = "my_new_probe"
+   ```
+
+2. In the probe module, import and use it:
+
+   ```python
+   from api.system_health import ComponentHealth, KnownProbes, register_health_probe
+
+   @register_health_probe(KnownProbes.MY_NEW_PROBE)
+   async def probe_my_new_probe(request=None) -> ComponentHealth:
+       ...
+   ```
+
+3. The name automatically appears in the OpenAPI schema under
+   `/api/system/health` → `components[].name`.  Frontend callers should derive
+   the expected probe names from the OpenAPI schema rather than hardcoding
+   strings.
+
+---
+
+## Frontend guidance
+
+Frontend code **must not** hardcode probe name strings.  Instead:
+
+1. Reference the OpenAPI schema exported at `/openapi.json` — the
+   `ComponentHealth.name` field documents the possible values.
+2. When adding a new frontend caller, verify the probe name against
+   `KnownProbes` in `api/system_health.py` (this file) before shipping.
+
+---
+
+## Probe timeout and error handling
+
+Every probe runs under a `_PROBE_TIMEOUT_S = 2.0` second deadline enforced by
+`asyncio.wait_for`.  A probe that times out or raises is recorded as
+`status="down"` — it cannot crash the aggregator.
+
+Probes **must** be `async def`.  The registry rejects sync probes at
+registration time with a `TypeError` (see Issue #6918).

--- a/autobot-frontend/src/composables/useBatchProcessing.ts
+++ b/autobot-frontend/src/composables/useBatchProcessing.ts
@@ -32,6 +32,7 @@ import type {
 import { isTerminalStatus } from '@/types/batch-processing'
 import { getApiBase } from '@/config/ssot-config'
 import { useProbeBackedHealth } from '@/composables/useProbeBackedHealth'
+import { PROBE_NAMES } from '@/types/probe-names'
 
 const logger = createLogger('useBatchProcessing')
 
@@ -185,7 +186,7 @@ export function useBatchProcessingApi() {
      * the fallback values match the prior behaviour.
      */
     getHealth: useProbeBackedHealth<BatchHealthResponse>({
-      probeName: 'batch_jobs',
+      probeName: PROBE_NAMES.BATCH_JOBS,
       buildHealthy: (probe, data) => ({
         status: 'healthy',
         active_jobs: 0,

--- a/autobot-frontend/src/types/probe-names.ts
+++ b/autobot-frontend/src/types/probe-names.ts
@@ -1,0 +1,24 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * Frontend probe-name constants — single source of truth (Issue #6917).
+ *
+ * These values mirror `KnownProbes` in `autobot-backend/api/system_health.py`.
+ * When adding a new probe, update BOTH files and keep the string values in sync.
+ *
+ * Usage:
+ *   import { PROBE_NAMES } from '@/types/probe-names'
+ *   probeName: PROBE_NAMES.BATCH_JOBS
+ */
+
+export const PROBE_NAMES = {
+  BATCH_JOBS: 'batch_jobs',
+  LONG_RUNNING: 'long_running',
+  KNOWLEDGE: 'knowledge',
+  ERROR_RESILIENCE: 'error_resilience',
+  INTELLIGENT_AGENT: 'intelligent_agent',
+} as const
+
+export type ProbeName = (typeof PROBE_NAMES)[keyof typeof PROBE_NAMES]


### PR DESCRIPTION
## Summary

- Adds `KnownProbes(str, enum.Enum)` in `autobot-backend/api/system_health.py` as the single source of truth for probe name strings
- 5 backend probes updated to use `KnownProbes.*` at registration time — typos now surface as `AttributeError` at import time rather than silent runtime fallbacks
- Adds `autobot-frontend/src/types/probe-names.ts` mirroring the backend enum for frontend callers
- Updates `useBatchProcessing.ts` to use `PROBE_NAMES.BATCH_JOBS` (first frontend caller on the SSOT)
- Records the decision (Option C chosen over A/B) in `autobot-backend/docs/api/health.md`

## Behavioral grep audit

Not an extraction PR — no behavior duplication to migrate. This is a refactor of the registration call sites; the registered string values are unchanged, so the HTTP response shape is identical.

```bash
# Before: hardcoded literals at registration sites
$ grep -rn 'register_health_probe("' autobot-backend/api/ --include="*.py"
# 5 hits

# After: all 5 replaced with KnownProbes members
$ grep -rn 'register_health_probe("' autobot-backend/api/ --include="*.py"
# 0 hits
$ grep -rn 'register_health_probe(KnownProbes\.' autobot-backend/api/ --include="*.py"
# 5 hits
```

## Acceptance criteria

- [x] Decision recorded in `docs/api/health.md`
- [x] Implementation matches Option C (backend `str, enum.Enum`)
- [x] At least one backend probe uses the SSOT — 5 probes updated
- [x] At least one frontend caller uses the SSOT — `useBatchProcessing.ts` uses `PROBE_NAMES.BATCH_JOBS`

## Test plan

- [ ] `python -m py_compile autobot-backend/api/system_health.py` passes
- [ ] `python -m py_compile autobot-backend/api/batch_jobs.py` passes
- [ ] All 5 probe modules import `KnownProbes` without `ImportError`
- [ ] `KnownProbes.BATCH_JOBS == "batch_jobs"` (str enum equality preserved)
- [ ] OpenAPI schema unchanged — probe name values in response are the same strings

Closes #6917

🤖 Generated with [Claude Code](https://claude.com/claude-code)