### PR TITLE
refactor(frontend): deduplicate *HealthResponse interfaces and probe-status mapping (#6920)

### DIFF
--- a/autobot-frontend/src/composables/useBatchProcessing.ts
+++ b/autobot-frontend/src/composables/useBatchProcessing.ts
@@ -31,7 +31,7 @@ import type {
 } from '@/types/batch-processing'
 import { isTerminalStatus } from '@/types/batch-processing'
 import { getApiBase } from '@/config/ssot-config'
-import { useProbeBackedHealth } from '@/composables/useProbeBackedHealth'
+import { useProbeBackedHealth, probeStatusToLegacy } from '@/composables/useProbeBackedHealth'
 import { PROBE_NAMES } from '@/types/probe-names'
 
 const logger = createLogger('useBatchProcessing')
@@ -188,14 +188,14 @@ export function useBatchProcessingApi() {
     getHealth: useProbeBackedHealth<BatchHealthResponse>({
       probeName: PROBE_NAMES.BATCH_JOBS,
       buildHealthy: (probe, data) => ({
-        status: 'healthy',
+        status: probeStatusToLegacy(probe.status),
         active_jobs: 0,
         total_jobs: 0,
         redis_connected: Boolean(data.redis_connected),
         message: probe.detail,
       }),
       buildUnavailable: (message) => ({
-        status: 'unavailable',
+        status: 'unavailable' as const,
         active_jobs: 0,
         total_jobs: 0,
         redis_connected: false,

--- a/autobot-frontend/src/composables/useOperationsApi.ts
+++ b/autobot-frontend/src/composables/useOperationsApi.ts
@@ -24,7 +24,7 @@ import type {
 } from '@/types/operations'
 import { isTerminalStatus } from '@/types/operations'
 import { getApiBase } from '@/config/ssot-config'
-import { useProbeBackedHealth } from '@/composables/useProbeBackedHealth'
+import { useProbeBackedHealth, probeStatusToLegacy } from '@/composables/useProbeBackedHealth'
 
 const logger = createLogger('useOperationsApi')
 
@@ -89,7 +89,7 @@ export function useOperationsApi() {
     getHealth: useProbeBackedHealth<OperationsHealthResponse>({
       probeName: 'long_running',
       buildHealthy: (probe, data) => ({
-        status: 'healthy',
+        status: probeStatusToLegacy(probe.status),
         active_operations: Number(data.active_operations ?? 0),
         total_operations: Number(data.total_operations ?? 0),
         redis_connected: Boolean(data.redis_connected),
@@ -97,7 +97,7 @@ export function useOperationsApi() {
         message: probe.detail,
       }),
       buildUnavailable: (message) => ({
-        status: 'unavailable',
+        status: 'unavailable' as const,
         active_operations: 0,
         total_operations: 0,
         redis_connected: false,

--- a/autobot-frontend/src/composables/useProbeBackedHealth.ts
+++ b/autobot-frontend/src/composables/useProbeBackedHealth.ts
@@ -37,8 +37,21 @@ import { findProbeByName, type ProbeResponse } from '@/composables/useHealthProb
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
+import type { LegacyHealthStatus } from '@/types/health'
 
 const logger = createLogger('useProbeBackedHealth')
+
+/**
+ * Maps a backend probe status string to the legacy per-module health vocab.
+ * Mirrors the backend's `_PROBE_TO_LEGACY` dict so the two sides stay in sync.
+ *
+ * @example
+ * probeStatusToLegacy('ok')          // → 'healthy'
+ * probeStatusToLegacy('degraded')    // → 'unavailable'
+ */
+export function probeStatusToLegacy(status: ProbeResponse['status']): LegacyHealthStatus {
+  return status === 'ok' ? 'healthy' : 'unavailable'
+}
 
 export interface ProbeBackedHealthOptions<R> {
   /** Probe name to look up in `/api/system/health` payload (e.g. `'batch_jobs'`). */

--- a/autobot-frontend/src/types/batch-processing.ts
+++ b/autobot-frontend/src/types/batch-processing.ts
@@ -7,6 +7,8 @@
  * Issue #584 - Batch Processing Manager
  */
 
+import type { BaseModuleHealthResponse } from './health'
+
 /**
  * Batch job status enum
  */
@@ -112,12 +114,9 @@ export interface BatchSchedulesListResponse {
 /**
  * Batch service health check response
  */
-export interface BatchHealthResponse {
-  status: 'healthy' | 'unavailable' | 'error'
+export interface BatchHealthResponse extends BaseModuleHealthResponse {
   active_jobs: number
   total_jobs: number
-  redis_connected: boolean
-  message?: string
 }
 
 /**

--- a/autobot-frontend/src/types/health.ts
+++ b/autobot-frontend/src/types/health.ts
@@ -1,0 +1,24 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * Shared health-response types (#6920 — deduplicate *HealthResponse interfaces).
+ */
+
+/**
+ * Vocabulary used by legacy per-module health endpoints and the
+ * probe-backed health helpers. Mirrors the backend's `_PROBE_TO_LEGACY`
+ * dict values so the two sides stay in sync.
+ */
+export type LegacyHealthStatus = 'healthy' | 'unavailable' | 'error'
+
+/**
+ * Fields shared by every per-module health response. Module-specific
+ * interfaces must extend this type rather than redeclaring these fields.
+ */
+export interface BaseModuleHealthResponse {
+  status: LegacyHealthStatus
+  redis_connected: boolean
+  message?: string
+}

--- a/autobot-frontend/src/types/operations.ts
+++ b/autobot-frontend/src/types/operations.ts
@@ -7,6 +7,8 @@
  * Issue #591 - Long-Running Operations Tracker
  */
 
+import type { BaseModuleHealthResponse } from './health'
+
 /**
  * Operation status enum matching backend OperationStatus
  */
@@ -73,13 +75,10 @@ export interface OperationsListResponse {
 /**
  * Operation health check response
  */
-export interface OperationsHealthResponse {
-  status: 'healthy' | 'unavailable' | 'error'
+export interface OperationsHealthResponse extends BaseModuleHealthResponse {
   active_operations: number
   total_operations: number
-  redis_connected: boolean
   background_processor_running: boolean
-  message?: string
 }
 
 /**


### PR DESCRIPTION
## Summary

- Introduces `LegacyHealthStatus` type and `BaseModuleHealthResponse` interface in `autobot-frontend/src/types/health.ts`
- `BatchHealthResponse` and `OperationsHealthResponse` now extend `BaseModuleHealthResponse` — removes 3 duplicated fields per interface
- Adds `probeStatusToLegacy()` helper in `useProbeBackedHealth.ts` — single place to translate probe `ok/degraded/down` → legacy `healthy/unavailable`
- Both `useBatchProcessing.ts` and `useOperationsApi.ts` updated to use the helper instead of hardcoded `'healthy'`

## Behavioral grep audit

Pattern being unified: hardcoded `status: 'healthy'` in probe-backed health builders.

```bash
# Before: inline status mapping in two composables
$ grep -n "status: 'healthy'" autobot-frontend/src/composables/useBatchProcessing.ts autobot-frontend/src/composables/useOperationsApi.ts
useBatchProcessing.ts:191:        status: 'healthy',
useOperationsApi.ts:92:          status: 'healthy',
# 2 hits

# After: both use probeStatusToLegacy()
$ grep -n "status: 'healthy'" autobot-frontend/src/composables/useBatchProcessing.ts autobot-frontend/src/composables/useOperationsApi.ts
# 0 hits

$ grep -n "probeStatusToLegacy" autobot-frontend/src/composables/useBatchProcessing.ts autobot-frontend/src/composables/useOperationsApi.ts
# 2 hits — both callers migrated
```

## Acceptance criteria

- [x] `BaseModuleHealthResponse` interface introduced in `types/health.ts`
- [x] `BatchHealthResponse` extends `BaseModuleHealthResponse`
- [x] `OperationsHealthResponse` extends `BaseModuleHealthResponse`
- [x] `probeStatusToLegacy` helper used by both `getHealth()` callers
- [x] No new module-health response interface defined without extending the base

## Test plan

- [ ] `npx vue-tsc --noEmit -p tsconfig.app.json` error count ≤ baseline (no new errors introduced)
- [ ] `npx vitest run src/composables/__tests__/useProbeBackedHealth.test.ts` passes
- [ ] Batch processing health endpoint still returns `{ status: 'healthy' }` when probe is `ok`
- [ ] Operations health endpoint still returns `{ status: 'unavailable' }` when probe is `degraded` or `down`

Closes #6920

🤖 Generated with [Claude Code](https://claude.com/claude-code)