### PR TITLE
[6808] fix(lint): remove unused Optional import from feature_routers.py

### DIFF
--- a/autobot-backend/initialization/endpoints.py
+++ b/autobot-backend/initialization/endpoints.py
@@ -174,22 +174,26 @@ def register_root_endpoints(app: FastAPI) -> None:
     @app.get("/api/health/feature-routers")
     @with_error_handling(category=ErrorCategory.SYSTEM)
     async def feature_routers_health():
-        """Surface feature-router load status (#6797).
+        """Cross-worker feature-router load status (#6797, #6808).
 
         Returns the structured load-results registry populated by
         ``load_feature_routers()``. Until this endpoint existed, the
         graceful-fallback pattern from #281 silently dropped failed routers
         (boot succeeded with /api/* endpoints absent — see #6583, #6664-6667).
-        SLM dashboards and operators can now poll this endpoint to detect
-        partial-boot state without scraping logs.
+
+        #6808: results are now aggregated across all uvicorn workers via Redis
+        so a poll is not subject to per-worker sampling variance. Divergent
+        worker states (one worker missing a router) are visible with
+        worker-PID provenance in the ``workers`` field.
         """
         from initialization.router_registry.feature_routers import (
             FEATURE_ROUTER_CONFIGS,
-            get_feature_router_load_results,
+            get_cross_worker_load_results,
         )
 
-        results = get_feature_router_load_results()
-        loaded_count = sum(1 for r in results if r["loaded"])
+        cross = get_cross_worker_load_results()
+        aggregated = cross["aggregated"]
+        loaded_count = sum(1 for r in aggregated if r["loaded"])
         expected = len(FEATURE_ROUTER_CONFIGS)
         return {
             "timestamp": datetime.now(tz=timezone.utc).isoformat(),
@@ -197,7 +201,10 @@ def register_root_endpoints(app: FastAPI) -> None:
             "loaded": loaded_count,
             "failed": expected - loaded_count,
             "all_loaded": loaded_count == expected,
-            "routers": results,
+            "worker_count": cross["worker_count"],
+            "redis_available": cross["redis_available"],
+            "routers": aggregated,
+            "workers": cross["workers"],
         }
 
     @app.get("/api/version")

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -15,7 +15,7 @@ data-driven configuration pattern for improved maintainability.
 import importlib
 import json
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -13,7 +13,9 @@ data-driven configuration pattern for improved maintainability.
 """
 
 import importlib
-from typing import Any, Dict, List, Tuple
+import json
+import os
+from typing import Any, Dict, List, Optional, Tuple
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
@@ -25,6 +27,103 @@ logger = get_logger(__name__)
 # scraping logs. Each entry: {"name": str, "module": str, "loaded": bool,
 # "error": str | None}.
 _LOAD_RESULTS: List[Dict[str, Any]] = []
+
+# #6808: Redis key prefix and TTL for cross-worker aggregation.
+# Each uvicorn worker publishes its results under its PID so the health
+# endpoint can show a unified view regardless of which worker handles the poll.
+_REDIS_KEY_PREFIX = "autobot:feature_routers:"
+_REDIS_TTL_SECONDS = 600  # 10 min — survives rolling restarts
+
+
+def _publish_load_results_to_redis(results: List[Dict[str, Any]]) -> None:
+    """Best-effort: publish this worker's load results to Redis (#6808).
+
+    Uses the PID as the worker discriminator so the health endpoint can
+    aggregate across all workers with ``KEYS autobot:feature_routers:*``.
+    Never raises — Redis unavailability must not block startup.
+    """
+    try:
+        from autobot_shared.redis_client import get_redis_client
+
+        redis = get_redis_client(database="main")
+        if redis is None:
+            return
+        key = f"{_REDIS_KEY_PREFIX}{os.getpid()}"
+        redis.set(key, json.dumps(results), ex=_REDIS_TTL_SECONDS)
+    except Exception:
+        logger.debug("Could not publish feature-router results to Redis (#6808)", exc_info=True)
+
+
+def get_cross_worker_load_results() -> Dict[str, Any]:
+    """Aggregate load results from all uvicorn workers via Redis (#6808).
+
+    Returns a dict with:
+      - ``workers``: mapping of PID → per-worker result list
+      - ``aggregated``: union of all workers' results (by router name)
+      - ``worker_count``: number of live workers seen
+      - ``redis_available``: whether aggregation succeeded
+
+    Falls back to the local ``_LOAD_RESULTS`` when Redis is unavailable.
+    """
+    try:
+        from autobot_shared.redis_client import get_redis_client
+
+        redis = get_redis_client(database="main")
+        if redis is None:
+            raise RuntimeError("Redis client unavailable")
+
+        # Scan for all worker keys (KEYS is fine here — small keyspace, admin op)
+        keys = redis.keys(f"{_REDIS_KEY_PREFIX}*")
+        workers: Dict[str, List[Dict[str, Any]]] = {}
+        for key in keys:
+            pid = key.decode() if isinstance(key, bytes) else key
+            pid = pid.removeprefix(_REDIS_KEY_PREFIX)
+            raw = redis.get(f"{_REDIS_KEY_PREFIX}{pid}")
+            if raw:
+                workers[pid] = json.loads(raw)
+
+        if not workers:
+            # No Redis data yet — fall back to local (boot race window)
+            return {
+                "workers": {str(os.getpid()): _LOAD_RESULTS},
+                "aggregated": _LOAD_RESULTS,
+                "worker_count": 1,
+                "redis_available": True,
+                "note": "local-only: no other worker keys found in Redis yet",
+            }
+
+        # Build union: for each router name, collect all worker statuses
+        by_name: Dict[str, Dict[str, Any]] = {}
+        for pid, results in workers.items():
+            for entry in results:
+                name = entry["name"]
+                if name not in by_name:
+                    by_name[name] = dict(entry)
+                    by_name[name]["worker_statuses"] = {}
+                by_name[name]["worker_statuses"][pid] = {
+                    "loaded": entry["loaded"],
+                    "error": entry["error"],
+                }
+                # Mark as failed if any worker failed to load this router
+                if not entry["loaded"]:
+                    by_name[name]["loaded"] = False
+                    by_name[name]["error"] = entry["error"]
+
+        aggregated = sorted(by_name.values(), key=lambda r: r["name"])
+        return {
+            "workers": workers,
+            "aggregated": aggregated,
+            "worker_count": len(workers),
+            "redis_available": True,
+        }
+    except Exception:
+        logger.debug("Redis aggregation failed, falling back to local results (#6808)", exc_info=True)
+        return {
+            "workers": {str(os.getpid()): _LOAD_RESULTS},
+            "aggregated": _LOAD_RESULTS,
+            "worker_count": 1,
+            "redis_available": False,
+        }
 
 
 # Issue #281: Router configurations as data instead of repetitive code blocks
@@ -651,4 +750,7 @@ def load_feature_routers() -> List[Tuple]:
             )
     else:
         logger.info("📊 Loaded %s/%s feature routers", loaded, expected)
+    # #6808: publish this worker's results to Redis so the health endpoint can
+    # aggregate across all workers instead of returning a per-worker snapshot.
+    _publish_load_results_to_redis(_LOAD_RESULTS)
     return optional_routers


### PR DESCRIPTION
## Summary

Work from worktree `.worktrees/issue-6808` — 2 unmerged commit(s) on branch `issue-6808`.

Resolves #6808

## Commits
- 5da59ba1c fix(lint): remove unused Optional import from feature_routers.py
- d71e42065 observability(backend): aggregate _LOAD_RESULTS across workers via Redis (#6808)

## Note
This PR was created by the MVA-588 worktree audit to preserve and submit unmerged work.