### PR TITLE
[7053] tech-debt(ansible): canonicalize role names to autobot-X form (#7053)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -262,6 +262,22 @@ repos:
         stages: [pre-commit]
         description: "Block requests.* and Path.read_text/write_text inside async def bodies (#7444)"
 
+  # AutoBot custom: regression-prevention for #7053 Ansible role-name drift.
+  # Short-form role names ('backend', 'frontend', etc.) in node_roles checks
+  # are deprecated; canonical form is 'autobot-X'. New gates must use the
+  # role_X_active shared facts or the canonical 'autobot-X' form directly.
+  # Allowlist: group_vars/all.yml and vars/role_active_facts.yml (OR-chains
+  # maintained for backward compat with existing hosts).
+  - repo: local
+    hooks:
+      - id: canonical-role-names
+        name: Enforce canonical Ansible role names (#7053)
+        entry: tools/lint/check_canonical_role_names.py
+        language: python
+        files: \.(yml|yaml)$
+        stages: [pre-commit]
+        description: "Flags 'short-form' in node_roles checks; use role_X_active shared facts or 'autobot-X' canonical form (#7053)"
+
   # AutoBot custom: regression-prevention for #7372 plugin/extension boundary.
   # Extensions (lifecycle hooks), skills (user-facing capabilities), and
   # core-plugins must import ONLY from autobot_shared/ (the public SDK).

--- a/autobot-slm-backend/ansible/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/inventory/group_vars/all.yml
@@ -237,7 +237,36 @@ repositories:
     repo: "deb https://apt.repos.intel.com/openvino/2024 {{ ansible_facts['distribution_release'] }} main"
 
 # ==========================================
-# SHARED ROLE-ACTIVE FACTS (#7031)
+# CANONICAL ROLE NAMES (#7053)
+# ==========================================
+# All node_roles entries MUST use the canonical form below.
+# Short-form aliases (e.g. 'backend') are DEPRECATED; new gates and
+# inventory entries must use the canonical 'autobot-X' prefix.
+#
+# Canonical names:
+#   autobot-backend         (deploys /opt/autobot/autobot-backend/)
+#   autobot-frontend        (deploys /opt/autobot/autobot-frontend/)
+#   autobot-ai-stack        (deploys /opt/autobot/autobot-ai-stack/)
+#   autobot-npu-worker      (deploys /opt/autobot/autobot-npu-worker/)
+#   autobot-browser-worker  (deploys /opt/autobot/autobot-browser-worker/)
+#   autobot-tts-worker      (deploys /opt/autobot/autobot-tts-worker/)
+#   vnc                     (VNC/display — no autobot- prefix by convention)
+#   llm                     (LLM runtime — no autobot- prefix by convention)
+#   redis                   (Redis service — no autobot- prefix by convention)
+#
+# Short-form → canonical mapping (for reference only; authoritative copy
+# is also in tools/lint/check_canonical_role_names.py):
+_role_aliases:
+  backend: autobot-backend
+  frontend: autobot-frontend
+  ai-stack: autobot-ai-stack
+  npu-worker: autobot-npu-worker
+  browser: autobot-browser-worker
+  browser-service: autobot-browser-worker
+  tts-worker: autobot-tts-worker
+
+# ==========================================
+# SHARED ROLE-ACTIVE FACTS (#7031, #7053)
 # ==========================================
 # Per-host booleans answering "is role X deployed on this host?".
 # Used by both:
@@ -246,9 +275,13 @@ repositories:
 #
 # Single source of truth — keeps provision and cleanup decisions in sync.
 # Each fact mirrors the union of role checks the provision gate uses:
-#   1. Short role name in node_roles (e.g. 'backend')
-#   2. autobot-prefixed role name in node_roles (e.g. 'autobot-backend')
+#   1. Short role name in node_roles (e.g. 'backend')     ← DEPRECATED (#7053)
+#   2. autobot-prefixed role name in node_roles (e.g. 'autobot-backend') ← CANONICAL
 #   3. Inventory group membership (e.g. groups['main'], groups['backend'])
+#
+# The OR-chain below (short + canonical forms) is kept for backward
+# compatibility with any hosts still configured with the short form.
+# New inventory entries MUST use the canonical form (see _role_aliases above).
 #
 # History: prior to #7031, cleanup gates used only check (1), missing
 # (2) and (3). Co-located/single-host installs (where install.sh writes

--- a/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
+++ b/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
@@ -1,4 +1,4 @@
-# #7050/#7051 shared role-active facts — DUPLICATE of inventory/group_vars/all.yml.
+# #7050/#7051/#7053 shared role-active facts — DUPLICATE of inventory/group_vars/all.yml.
 #
 # WHY DUPLICATED:
 # When SLM triggers provision-fleet-roles.yml from a node-add or wizard flow,
@@ -16,6 +16,15 @@
 # DRY trade-off: kept identical to group_vars/all.yml definitions. If they
 # diverge, the CI test playbook (#7068) won't catch it — that test loads
 # group_vars directly. TODO follow-up: single source of truth via include.
+#
+# CANONICAL ROLE NAMES (#7053):
+# The short-form names in the OR-chains below (e.g. 'backend', 'frontend')
+# are DEPRECATED. Canonical form is 'autobot-X' (e.g. 'autobot-backend').
+# The OR-chain is retained for backward compatibility only. New node_roles
+# inventory entries MUST use canonical form. See also:
+#   - inventory/group_vars/all.yml (_role_aliases dict + CANONICAL ROLE NAMES section)
+#   - tools/lint/check_canonical_role_names.py (pre-commit enforcement)
+#   - docs/developer/ANSIBLE_ROLE_NAMES.md (full reference)
 ---
 role_backend_active: >-
   {{ ('backend' in (node_roles | default([]))) or

--- a/docs/developer/ANSIBLE_ROLE_NAMES.md
+++ b/docs/developer/ANSIBLE_ROLE_NAMES.md
@@ -1,0 +1,106 @@
+# Ansible Role Name Conventions (#7053)
+
+## Canonical Role Names
+
+All `node_roles` inventory entries **must** use the canonical form below.
+Short-form aliases (e.g. `backend`) are **deprecated** as of #7053.
+
+| Canonical name            | Deploys / manages                              |
+|---------------------------|------------------------------------------------|
+| `autobot-backend`         | `/opt/autobot/autobot-backend/`                |
+| `autobot-frontend`        | `/opt/autobot/autobot-frontend/`               |
+| `autobot-ai-stack`        | `/opt/autobot/autobot-ai-stack/`               |
+| `autobot-npu-worker`      | `/opt/autobot/autobot-npu-worker/`             |
+| `autobot-browser-worker`  | `/opt/autobot/autobot-browser-worker/`         |
+| `autobot-tts-worker`      | `/opt/autobot/autobot-tts-worker/`             |
+| `vnc`                     | VNC/display — no `autobot-` prefix by convention |
+| `llm`                     | LLM runtime — no `autobot-` prefix by convention |
+| `redis`                   | Redis service — no `autobot-` prefix by convention |
+
+## Deprecated Short-Form Aliases
+
+These short forms were previously used interchangeably with the canonical
+names. They are now deprecated and must not appear in new inventory entries
+or gate conditions.
+
+| Deprecated alias  | Canonical replacement       |
+|-------------------|-----------------------------|
+| `backend`         | `autobot-backend`           |
+| `frontend`        | `autobot-frontend`          |
+| `ai-stack`        | `autobot-ai-stack`          |
+| `npu-worker`      | `autobot-npu-worker`        |
+| `browser`         | `autobot-browser-worker`    |
+| `browser-service` | `autobot-browser-worker`    |
+| `tts-worker`      | `autobot-tts-worker`        |
+
+## Why the Dual Forms Existed
+
+Prior to #7053, `install.sh` and the fleet-seeding playbook used different
+conventions: `install.sh` wrote `node_roles: [autobot-backend, vnc]` (prefixed)
+while some older inventory files and gates checked for bare `backend` or
+`frontend`. The `role_X_active` shared facts (introduced in #7031) bridged
+this gap with OR-chains that accept both forms. The backward-compat OR-chains
+remain in place; only new code must use the canonical prefix.
+
+## Shared Role-Active Facts
+
+New gate conditions must use the `role_X_active` boolean facts rather than
+raw `node_roles` string checks. These facts are defined in two places (kept
+in sync for temp-inventory compatibility — see #7050 / #7051):
+
+- `autobot-slm-backend/ansible/inventory/group_vars/all.yml`
+  (loaded automatically for static inventories)
+- `autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml`
+  (loaded explicitly via `vars_files:` for temp inventories)
+
+Available facts:
+
+| Fact                    | True when…                                           |
+|-------------------------|------------------------------------------------------|
+| `role_backend_active`   | host carries `autobot-backend` (or legacy `backend`) |
+| `role_frontend_active`  | host carries `autobot-frontend` (or legacy `frontend`) |
+| `role_ai_stack_active`  | host carries `autobot-ai-stack` (or legacy `ai-stack`) |
+| `role_npu_worker_active`| host carries `autobot-npu-worker` (or legacy `npu-worker`) |
+| `role_browser_active`   | host carries `autobot-browser-worker` (or legacy `browser`/`browser-service`) |
+| `role_tts_worker_active`| host carries `autobot-tts-worker` (or legacy `tts-worker`) |
+| `role_slm_active`       | host is the SLM manager node (by hostname or group)  |
+| `role_redis_active`     | host carries `redis` (or group membership)           |
+| `role_vnc_active`       | host carries `vnc` (or group membership)             |
+| `role_llm_active`       | host carries `llm` (or group membership)             |
+
+## Pre-Commit Enforcement
+
+`tools/lint/check_canonical_role_names.py` (registered in `.pre-commit-config.yaml`)
+blocks new gate conditions that check short-form role names directly in
+`node_roles`:
+
+```yaml
+# BLOCKED — use role_backend_active instead:
+when: "'backend' in node_roles"
+
+# ALLOWED — canonical form in node_roles:
+when: "'autobot-backend' in node_roles"
+
+# PREFERRED — use the shared fact:
+when: role_backend_active
+```
+
+Files in the backward-compat allowlist (`group_vars/all.yml`,
+`vars/role_active_facts.yml`) are excluded from this check because they
+must maintain the OR-chains for existing hosts.
+
+## Adding a New Role
+
+When adding a new role, update **all** of the following:
+
+1. Choose a canonical name: `autobot-<service-name>` (or a bare name if
+   the role has no `autobot-` equivalent by convention, like `vnc`/`llm`).
+2. Add the canonical name to the table in this document.
+3. Add a `role_<name>_active` fact to **both**:
+   - `inventory/group_vars/all.yml` (under SHARED ROLE-ACTIVE FACTS)
+   - `playbooks/vars/role_active_facts.yml`
+4. If the role has a deprecated short-form alias, add it to the
+   `_role_aliases` dict in `group_vars/all.yml` and to
+   `DEPRECATED_SHORT_FORMS` in `tools/lint/check_canonical_role_names.py`.
+5. Add the role to `seed-fleet-nodes.yml` `node_role_map` using the
+   canonical name.

--- a/tools/lint/check_canonical_role_names.py
+++ b/tools/lint/check_canonical_role_names.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Regression-prevention check for #7053 Ansible role-name canonicalization.
+
+Blocks new gate conditions that check short-form role names directly against
+``node_roles``.  The canonical form is ``autobot-X`` (e.g. ``autobot-backend``);
+short forms like ``'backend' in node_roles`` are deprecated.
+
+Preferred pattern for new gates:
+    when: role_backend_active          # use the shared fact (best)
+    when: "'autobot-backend' in ..."   # canonical direct check (acceptable)
+
+Blocked patterns:
+    when: "'backend' in node_roles"    # short form — DEPRECATED (#7053)
+    when: "'frontend' in node_roles"
+    # ... etc. for all deprecated aliases
+
+Allowlist: group_vars/all.yml and vars/role_active_facts.yml must maintain
+the OR-chains for backward compat with existing hosts — those files are
+excluded from this check.
+
+Exit code:
+  0 — clean
+  1 — banned patterns found (commit blocked)
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Deprecated short-form role names and their canonical replacements (#7053).
+# Update this dict when adding new roles — see docs/developer/ANSIBLE_ROLE_NAMES.md.
+DEPRECATED_SHORT_FORMS: Dict[str, str] = {
+    "backend": "autobot-backend",
+    "frontend": "autobot-frontend",
+    "ai-stack": "autobot-ai-stack",
+    "npu-worker": "autobot-npu-worker",
+    "browser": "autobot-browser-worker",
+    "browser-service": "autobot-browser-worker",
+    "tts-worker": "autobot-tts-worker",
+}
+
+# Files allowed to use the deprecated short forms (backward-compat OR-chains).
+ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # The facts themselves must check both forms for backward compat.
+        "autobot-slm-backend/ansible/inventory/group_vars/all.yml",
+        "autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml",
+        # This file and its test.
+        "tools/lint/check_canonical_role_names.py",
+        "tools/lint/check_canonical_role_names_test.py",
+    }
+)
+
+# Matches: 'short-name' in node_roles  (various quote styles)
+# Captures: the role name (group 1).
+# Examples matched:
+#   'backend' in node_roles
+#   "frontend" in node_roles
+#   ('ai-stack' in node_roles)
+# Not matched (canonical):
+#   'autobot-backend' in node_roles
+_ROLE_PAT = re.compile(
+    r"""['"](""" + "|".join(re.escape(k) for k in DEPRECATED_SHORT_FORMS) + r""")['"]\s+in\s+node_roles"""
+)
+
+
+def iter_yaml_files(root: Path) -> Iterable[Path]:
+    """Yield .yml/.yaml files under root, skipping vendored/cached dirs."""
+    skip_dirs = {".git", "__pycache__", "node_modules", ".worktrees", "venv", ".venv"}
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix not in {".yml", ".yaml"}:
+            continue
+        if any(part in skip_dirs for part in path.parts):
+            continue
+        yield path
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def find_violations(path: Path) -> List[Tuple[int, str, str, str]]:
+    """Return (lineno, deprecated_name, canonical_name, snippet) tuples."""
+    rel = _rel(path)
+    if rel in ALLOWLIST:
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    violations: List[Tuple[int, str, str, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        # Skip comment lines (Ansible YAML comment = leading #).
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        for match in _ROLE_PAT.finditer(line):
+            deprecated = match.group(1)
+            canonical = DEPRECATED_SHORT_FORMS[deprecated]
+            violations.append((lineno, deprecated, canonical, line.strip()[:120]))
+    return violations
+
+
+def main(paths: List[str]) -> int:
+    if paths:
+        targets = [Path(p) for p in paths]
+        files = [p for p in targets if p.is_file() and p.suffix in {".yml", ".yaml"}]
+    else:
+        # Scan the whole Ansible tree if invoked with no args (manual run).
+        files = list(iter_yaml_files(REPO_ROOT / "autobot-slm-backend" / "ansible"))
+
+    found = False
+    for path in files:
+        for lineno, deprecated, canonical, snippet in find_violations(path):
+            rel = _rel(path)
+            print(
+                f"{rel}:{lineno}: deprecated role name '{deprecated}' in node_roles (#7053)\n"
+                f"  Use canonical form '{canonical}' or the shared fact "
+                f"role_{deprecated.replace('-', '_')}_active\n"
+                f"  {snippet}",
+                file=sys.stderr,
+            )
+            found = True
+
+    if found:
+        print(
+            "\n--- BLOCKED ---\n"
+            "Short-form role names in node_roles checks are deprecated (#7053).\n"
+            "Options:\n"
+            "  1. Use the shared boolean fact:  when: role_X_active\n"
+            "  2. Use the canonical form:       when: \"'autobot-X' in node_roles\"\n"
+            "See docs/developer/ANSIBLE_ROLE_NAMES.md for the full canonical name table.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Work from worktree `.worktrees/issue-7053` — 1 unmerged commit(s) on branch `fix-7053-ansible-role-canonical`.

Resolves #7053

## Commits
- 98632b7c5 tech-debt(ansible): canonicalize role names to autobot-X form (#7053)

## Note
This PR was created by the MVA-588 worktree audit to preserve and submit unmerged work.