### PR TITLE
preserve(#6844): fix(media/image): patch _vision_processor_checked instead of nonexistent _VISION_PROCESSOR_AVAILABLE (#6844)

### DIFF
--- a/autobot-backend/media/image/pipeline.py
+++ b/autobot-backend/media/image/pipeline.py
@@ -154,7 +154,7 @@ class ImagePipeline(BasePipeline):
             input_id=media_input.media_id,
             modality_type=ModalityType.IMAGE,
             data=pil_image,
-            intent=ProcessingIntent.ANALYSIS,
+            intent=ProcessingIntent.VISUAL_QA,
         )
         try:
             vp_result = await vp.process(mm_input)

--- a/autobot-backend/media/image/pipeline_test.py
+++ b/autobot-backend/media/image/pipeline_test.py
@@ -139,7 +139,7 @@ class TestImagePipelinePilOnly:
         media_input = _make_input(img_bytes)
 
         with (
-            patch("media.image.pipeline._VISION_PROCESSOR_AVAILABLE", False),
+            patch("media.image.pipeline._vision_processor_checked", True),
             patch("media.image.pipeline._vision_processor", None),
         ):
             result = await pipe._process_image(media_input)
@@ -180,9 +180,9 @@ class TestImagePipelineVisionProcessor:
 
         with (
             patch("media.image.pipeline._PIL_AVAILABLE", True),
-            patch("media.image.pipeline._VISION_PROCESSOR_AVAILABLE", True),
+            patch("media.image.pipeline._vision_processor_checked", True),
             patch("media.image.pipeline._vision_processor", mock_vp),
-            patch("media.image.pipeline.MultiModalInput", return_value=mock_mm_input),
+            patch("multimodal_processor.models.MultiModalInput", return_value=mock_mm_input),
         ):
             result = await pipe._process_image(media_input)
 
@@ -207,9 +207,9 @@ class TestImagePipelineVisionProcessor:
 
         with (
             patch("media.image.pipeline._PIL_AVAILABLE", True),
-            patch("media.image.pipeline._VISION_PROCESSOR_AVAILABLE", True),
+            patch("media.image.pipeline._vision_processor_checked", True),
             patch("media.image.pipeline._vision_processor", mock_vp),
-            patch("media.image.pipeline.MultiModalInput", return_value=MagicMock()),
+            patch("multimodal_processor.models.MultiModalInput", return_value=MagicMock()),
         ):
             result = await pipe._process_image(media_input)
 
@@ -232,7 +232,7 @@ class TestImagePipelineAsync:
         media_input = _make_input(img_bytes)
 
         with (
-            patch("media.image.pipeline._VISION_PROCESSOR_AVAILABLE", False),
+            patch("media.image.pipeline._vision_processor_checked", True),
             patch("media.image.pipeline._vision_processor", None),
         ):
             result = await pipe._process_impl(media_input)


### PR DESCRIPTION
## Summary

**Preservation PR** — issue #6844 is already **closed**, but work was never submitted as a PR.

This PR preserves the unmerged work from worktree `.worktrees/issue-6844` (branch `fix/mva-106-pipeline-test-patch`, 1 commit(s)).

> ⚠️ Issue #6844 was closed. This PR is for code preservation. Review if the work should be merged or discarded.

## Commits
- 488ac013a fix(media/image): patch _vision_processor_checked instead of nonexistent _VISION_PROCESSOR_AVAILABLE (#6844)

## Note
Created by MVA-588 worktree audit.