### PR TITLE
preserve(#7202): fix(test): repoint 7 mock paths from nonexistent utils.redis_client to canonical (#7202)

### DIFF
--- a/autobot-backend/config/config_migration_integration_test.py
+++ b/autobot-backend/config/config_migration_integration_test.py
@@ -74,14 +74,15 @@ class TestConfigurationMigration:
         test_config.set("redis.port", 9999)
         test_config.set("redis.password", "test-password")
 
-        # Mock the global config manager used by redis_client
-        with patch("utils.redis_client.config_manager", test_config):
-            # The redis client should now use centralized config
-            # Note: We can't easily test get_redis_client() without Redis running
-            # But we can test that config values are accessible
-            assert test_config.get("redis.host") == "test-redis-host"
-            assert test_config.get("redis.port") == 9999
-            assert test_config.get("redis.password") == "test-password"
+        # The redis client patch target `utils.redis_client.config_manager`
+        # never existed (canonical module is autobot_shared.redis_client, and
+        # `config_manager` was never a module-level attribute there). The
+        # original `with patch(...)` wrapper raised ModuleNotFoundError; the
+        # assertions below don't depend on the patch — they just verify
+        # ConfigManager.get/set round-trip. Wrapper removed; behavior preserved.
+        assert test_config.get("redis.host") == "test-redis-host"
+        assert test_config.get("redis.port") == 9999
+        assert test_config.get("redis.password") == "test-password"
 
     def test_secrets_service_config_migration(self):
         """Test that secrets service uses centralized configuration"""

--- a/autobot-backend/monitoring/redis_prometheus_metrics_test.py
+++ b/autobot-backend/monitoring/redis_prometheus_metrics_test.py
@@ -21,7 +21,7 @@ def pool_manager():
 @pytest.fixture
 def mock_metrics():
     """Mock the Prometheus metrics manager"""
-    with patch("utils.redis_client.get_metrics_manager") as mock_get:
+    with patch("autobot_shared.monitoring.prometheus_metrics.get_metrics_manager") as mock_get:
         mock_manager = MagicMock()
         mock_get.return_value = mock_manager
         yield mock_manager
@@ -91,7 +91,7 @@ class TestRedisPrometheusIntegration:
 
     def test_prometheus_failure_does_not_affect_redis(self, pool_manager):
         """Test that Prometheus recording failure doesn't break Redis operations"""
-        with patch("utils.redis_client.get_metrics_manager") as mock_get:
+        with patch("autobot_shared.monitoring.prometheus_metrics.get_metrics_manager") as mock_get:
             # Make prometheus throw an exception
             mock_get.side_effect = Exception("Prometheus unavailable")
 

--- a/autobot-backend/utils/redis_thread_safety_test.py
+++ b/autobot-backend/utils/redis_thread_safety_test.py
@@ -126,7 +126,7 @@ class TestIdleCleanupThreadSafety:
 
         # Mock time to make connection appear idle (>300s)
         _old_time = datetime.now()
-        with patch("utils.redis_client.datetime") as mock_datetime:
+        with patch("autobot_shared.redis_management.connection_manager.datetime") as mock_datetime:
             # First call: get current time for idle check
             # Second call: return time 400s in the future
             mock_datetime.now.side_effect = [
@@ -179,7 +179,7 @@ class TestIdleCleanupThreadSafety:
         manager._max_idle_time_seconds = 300  # 5 minutes
 
         # Mock current time to be 10 minutes after old_time
-        with patch("utils.redis_client.datetime") as mock_datetime:
+        with patch("autobot_shared.redis_management.connection_manager.datetime") as mock_datetime:
             mock_datetime.now.return_value = datetime(2025, 1, 1, 12, 10, 0)
 
             # Run cleanup
@@ -225,7 +225,7 @@ class TestIdleCleanupThreadSafety:
         manager._max_idle_time_seconds = 300
 
         # Mock current time
-        with patch("utils.redis_client.datetime") as mock_datetime:
+        with patch("autobot_shared.redis_management.connection_manager.datetime") as mock_datetime:
             mock_datetime.now.return_value = datetime(2025, 1, 1, 12, 10, 0)
 
             # Run cleanup - should not raise exception
@@ -389,7 +389,7 @@ class TestRaceConditionPrevention:
         async def run_cleanup():
             """Run cleanup once"""
             nonlocal cleanup_done
-            with patch("utils.redis_client.datetime") as mock_datetime:
+            with patch("autobot_shared.redis_management.connection_manager.datetime") as mock_datetime:
                 mock_datetime.now.return_value = datetime(2025, 1, 1, 12, 10, 0)
                 await manager.cleanup_idle_connections()
             cleanup_done = True


### PR DESCRIPTION
Preservation PR — issue #7202 is closed but work was never submitted. Branch: `issue-7202`, 1 commit(s). Created by MVA-588 worktree audit.