### PR TITLE
feat(canvas): Live Canvas backend — MVA-359/362/370

### DIFF
--- a/.paperclip/config.json
+++ b/.paperclip/config.json
@@ -1,0 +1,57 @@
+{
+  "$meta": {
+    "version": 1,
+    "updatedAt": "2026-05-16T07:19:34.633Z",
+    "source": "configure"
+  },
+  "database": {
+    "mode": "embedded-postgres",
+    "embeddedPostgresDataDir": "/home/martins/.paperclip-worktrees/instances/paperclip-mva-359/db",
+    "embeddedPostgresPort": 54330,
+    "backup": {
+      "enabled": true,
+      "intervalMinutes": 60,
+      "retentionDays": 30,
+      "dir": "/home/martins/.paperclip-worktrees/instances/paperclip-mva-359/data/backups"
+    }
+  },
+  "logging": {
+    "mode": "file",
+    "logDir": "/home/martins/.paperclip-worktrees/instances/paperclip-mva-359/logs"
+  },
+  "server": {
+    "deploymentMode": "local_trusted",
+    "exposure": "private",
+    "bind": "loopback",
+    "host": "127.0.0.1",
+    "port": 3101,
+    "allowedHostnames": [],
+    "serveUi": true
+  },
+  "auth": {
+    "baseUrlMode": "auto",
+    "disableSignUp": false
+  },
+  "telemetry": {
+    "enabled": true
+  },
+  "storage": {
+    "provider": "local_disk",
+    "localDisk": {
+      "baseDir": "/home/martins/.paperclip-worktrees/instances/paperclip-mva-359/data/storage"
+    },
+    "s3": {
+      "bucket": "paperclip",
+      "region": "us-east-1",
+      "prefix": "",
+      "forcePathStyle": false
+    }
+  },
+  "secrets": {
+    "provider": "local_encrypted",
+    "strictMode": false,
+    "localEncrypted": {
+      "keyFilePath": "/home/martins/.paperclip-worktrees/instances/paperclip-mva-359/secrets/master.key"
+    }
+  }
+}

--- a/autobot-backend/api/canvas.py
+++ b/autobot-backend/api/canvas.py
@@ -345,14 +345,14 @@ async def transition_cell(
         await _get_canvas_owned(canvas_id, uid, session)
         cell = await _get_cell_owned(cell_id, canvas_id, uid, session)
 
-        # State machine: complete → committed or cancelled only
-        if cell.state not in (CellState.complete, CellState.committed):
+        target_state = _ACTION_TO_TARGET_STATE[body.action]
+
+        # Enforce the state machine: committed is terminal, only complete allows transitions
+        if target_state not in _VALID_TRANSITIONS.get(cell.state, set()):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail=f"Cell in state '{cell.state}' cannot be accepted/edited/discarded.",
+                detail=f"Cannot transition cell from state '{cell.state}' with action '{body.action}'.",
             )
-
-        target_state = _ACTION_TO_TARGET_STATE[body.action]
         now = datetime.now(tz=timezone.utc)
 
         cell.state = target_state

--- a/autobot-backend/api/schemas_canvas.py
+++ b/autobot-backend/api/schemas_canvas.py
@@ -6,6 +6,9 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from canvas.models import CellType
+
+
 # ---------------------------------------------------------------------------
 # Shared
 # ---------------------------------------------------------------------------
@@ -58,7 +61,7 @@ class CellAutosaveItem(BaseModel):
     id: uuid.UUID
     position: int
     content: str
-    type: str = "text"
+    type: CellType = CellType.text
 
 
 class CanvasPutRequest(BaseModel):
@@ -77,7 +80,7 @@ class CanvasPutResponse(BaseModel):
 
 
 class CellCreateRequest(BaseModel):
-    type: str = "text"
+    type: CellType = CellType.text
     content: str = ""
     position: int = 0
     # Phase 2: optional rich payload for chart/code cells

--- a/autobot-backend/api/websockets.py
+++ b/autobot-backend/api/websockets.py
@@ -216,6 +216,11 @@ def _format_agent_plan(raw_data: dict) -> Tuple[str, str]:
     return f"Plan ({step_count} steps): {summary}", "agent-plan"
 
 
+def _format_canvas_cell(raw_data: dict) -> Tuple[str, str]:
+    """Format canvas_cell event (pass-through, not logged to chat history)."""
+    return None, "canvas"
+
+
 # Issue #336: Dispatch table for message type formatting
 MESSAGE_TYPE_FORMATTERS: Dict[str, Callable[[dict], Tuple[str, str]]] = {
     "goal_received": _format_goal_received,
@@ -249,6 +254,8 @@ MESSAGE_TYPE_FORMATTERS: Dict[str, Callable[[dict], Tuple[str, str]]] = {
     "agent.tool.result": _format_agent_tool_result,
     "agent.llm.chunk": _format_agent_llm_chunk,
     "agent.plan": _format_agent_plan,
+    # MVA-370: Canvas cell streaming events
+    "canvas_cell": _format_canvas_cell,
 }
 
 
@@ -266,6 +273,93 @@ def _format_event_for_chat(message_type: str, raw_data: dict) -> Tuple[str | Non
     if formatter:
         return formatter(raw_data)
     return None, "system"
+
+
+async def register_canvas_streaming_task(canvas_id: str, cell_id: str, task: asyncio.Task) -> None:
+    """Register a canvas cell streaming task for cancellation support (MVA-370).
+
+    Args:
+        canvas_id: The canvas ID
+        cell_id: The cell ID
+        task: The asyncio.Task for the streaming operation
+    """
+    async with _canvas_tasks_lock:
+        key = (canvas_id, cell_id)
+        _canvas_streaming_tasks[key] = task
+        logger.debug(f"Registered streaming task for canvas {canvas_id}, cell {cell_id}")
+
+
+async def unregister_canvas_streaming_task(canvas_id: str, cell_id: str) -> None:
+    """Unregister a canvas cell streaming task (MVA-370).
+
+    Args:
+        canvas_id: The canvas ID
+        cell_id: The cell ID
+    """
+    async with _canvas_tasks_lock:
+        key = (canvas_id, cell_id)
+        if key in _canvas_streaming_tasks:
+            del _canvas_streaming_tasks[key]
+            logger.debug(f"Unregistered streaming task for canvas {canvas_id}, cell {cell_id}")
+
+
+def get_canvas_cell_event(cell_id: str, seq: int, delta: str, state: str, canvas_id: Optional[str] = None) -> dict:
+    """Create a canvas_cell WebSocket event (MVA-370).
+
+    Args:
+        cell_id: The cell ID
+        seq: The sequence number for this delta
+        delta: The content delta/chunk
+        state: The current cell state (queued, skeleton, streaming, complete, etc.)
+        canvas_id: Optional canvas ID for context
+
+    Returns:
+        A formatted WebSocket event dict ready to send
+    """
+    return {
+        "type": "canvas_cell",
+        "payload": {
+            "cellId": cell_id,
+            "canvasId": canvas_id,
+            "seq": seq,
+            "delta": delta,
+            "state": state,
+        },
+    }
+
+
+async def _handle_canvas_cancel(data: dict) -> None:
+    """Handle canvas_cancel message from client (MVA-370).
+
+    Cancels the streaming task for the specified cell and marks it as cancelled.
+
+    Args:
+        data: The message data with cellId
+    """
+    try:
+        cell_id = data.get("cellId")
+        canvas_id = data.get("canvasId")
+
+        if not cell_id:
+            logger.warning("canvas_cancel message missing cellId")
+            return
+
+        # Try to find and cancel the streaming task
+        async with _canvas_tasks_lock:
+            # Search through all tasks for this cell
+            keys_to_remove = [
+                k for k in _canvas_streaming_tasks.keys()
+                if k[1] == cell_id and (not canvas_id or k[0] == canvas_id)
+            ]
+
+            for key in keys_to_remove:
+                task = _canvas_streaming_tasks[key]
+                if not task.done():
+                    task.cancel()
+                    logger.info(f"Cancelled streaming task for cell {cell_id}")
+                del _canvas_streaming_tasks[key]
+    except Exception as e:
+        logger.error(f"Error handling canvas_cancel: {e}")
 
 
 async def _handle_command_approval(websocket: WebSocket, data: dict) -> None:
@@ -419,6 +513,8 @@ async def _handle_websocket_message(websocket: WebSocket, message: str) -> None:
             logger.debug("Received pong from client")
         elif msg_type == "command_approval":
             await _handle_command_approval(websocket, data)
+        elif msg_type == "canvas_cancel":
+            await _handle_canvas_cancel(data)
     except json.JSONDecodeError:
         logger.warning("Received invalid JSON via WebSocket: %s", message)
 
@@ -434,6 +530,12 @@ _ws_clients_lock = asyncio.Lock()
 import threading
 
 _npu_events_lock = threading.Lock()
+
+
+# MVA-370: Canvas cell streaming task registry
+# Tracks active streaming tasks by (canvas_id, cell_id) -> Task
+_canvas_streaming_tasks: Dict[tuple, asyncio.Task] = {}
+_canvas_tasks_lock = asyncio.Lock()
 
 
 @router.websocket("/ws-test")

--- a/autobot-backend/api/websockets.py
+++ b/autobot-backend/api/websockets.py
@@ -10,7 +10,9 @@ between the backend and frontend clients.
 
 import asyncio
 import json
-from typing import Callable, Dict, Tuple
+import logging
+import uuid
+from typing import Callable, Dict, Optional, Tuple
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
@@ -328,13 +330,15 @@ def get_canvas_cell_event(cell_id: str, seq: int, delta: str, state: str, canvas
     }
 
 
-async def _handle_canvas_cancel(data: dict) -> None:
+async def _handle_canvas_cancel(data: dict, current_user_id: str) -> None:
     """Handle canvas_cancel message from client (MVA-370).
 
-    Cancels the streaming task for the specified cell and marks it as cancelled.
+    Cancels the streaming task for the specified cell. Verifies that the
+    requesting user owns the cell before cancelling (MVA-362 security fix).
 
     Args:
         data: The message data with cellId
+        current_user_id: Authenticated user ID from the WebSocket session
     """
     try:
         cell_id = data.get("cellId")
@@ -342,6 +346,32 @@ async def _handle_canvas_cancel(data: dict) -> None:
 
         if not cell_id:
             logger.warning("canvas_cancel message missing cellId")
+            return
+
+        # Validate cellId format before DB lookup
+        try:
+            cell_uuid = uuid.UUID(cell_id)
+        except ValueError:
+            logger.warning("canvas_cancel: invalid cellId format")
+            return
+
+        # Verify ownership: only the cell owner may cancel their streaming task
+        from canvas.models import CanvasCell
+        from sqlalchemy import select
+        from user_management.database import db_session_context
+
+        async with db_session_context() as session:
+            result = await session.execute(
+                select(CanvasCell).where(CanvasCell.id == cell_uuid)
+            )
+            cell = result.scalar_one_or_none()
+
+        if cell is None or cell.user_id != current_user_id:
+            logger.warning(
+                "canvas_cancel: forbidden - cell %s not owned by user %s",
+                cell_id,
+                current_user_id,
+            )
             return
 
         # Try to find and cancel the streaming task
@@ -463,11 +493,12 @@ async def _create_broadcast_event_handler(websocket: WebSocket, chat_history_man
     return broadcast_event
 
 
-async def _websocket_message_receive_loop(websocket: WebSocket) -> None:
+async def _websocket_message_receive_loop(websocket: WebSocket, current_user_id: str) -> None:
     """Main message receive loop for WebSocket (Issue #315 - extracted).
 
     Args:
         websocket: The WebSocket connection
+        current_user_id: Authenticated user ID for ownership checks
     """
     while True:
         # Check connection state before each operation
@@ -493,15 +524,16 @@ async def _websocket_message_receive_loop(websocket: WebSocket) -> None:
                 continue
 
         # Issue #336: Use extracted helper for message handling
-        await _handle_websocket_message(websocket, message)
+        await _handle_websocket_message(websocket, message, current_user_id)
 
 
-async def _handle_websocket_message(websocket: WebSocket, message: str) -> None:
+async def _handle_websocket_message(websocket: WebSocket, message: str, current_user_id: str) -> None:
     """Handle incoming WebSocket message (Issue #336 - extracted helper).
 
     Args:
         websocket: The WebSocket connection
         message: The raw message string
+        current_user_id: Authenticated user ID from the WebSocket session
     """
     try:
         data = json.loads(message)
@@ -514,7 +546,7 @@ async def _handle_websocket_message(websocket: WebSocket, message: str) -> None:
         elif msg_type == "command_approval":
             await _handle_command_approval(websocket, data)
         elif msg_type == "canvas_cancel":
-            await _handle_canvas_cancel(data)
+            await _handle_canvas_cancel(data, current_user_id)
     except json.JSONDecodeError:
         logger.warning("Received invalid JSON via WebSocket: %s", message)
 
@@ -659,6 +691,9 @@ async def websocket_endpoint(websocket: WebSocket):
         await websocket.close(code=4001, reason="Authentication required")
         return
 
+    # Extract stable user ID for ownership checks (mirrors canvas.py _user_id())
+    current_user_id: str = user.get("user_id") or user.get("id") or user.get("username", "")
+
     try:
         await websocket.accept()
         logger.info("WebSocket connected from client: %s", websocket.client)
@@ -682,7 +717,7 @@ async def websocket_endpoint(websocket: WebSocket):
     _register_event_manager_broadcast(broadcast_event)
 
     try:
-        await _websocket_message_receive_loop(websocket)
+        await _websocket_message_receive_loop(websocket, current_user_id)
     except WebSocketDisconnect:
         logger.info("WebSocket disconnected normally")
     except Exception as e:

--- a/autobot-backend/tests/api/test_canvas.py
+++ b/autobot-backend/tests/api/test_canvas.py
@@ -6,13 +6,14 @@ Covers:
 - PUT /api/canvas/{id}: autosave, 403 cross-user
 - POST /api/canvas/{id}/cells: add user-owned cell, 403 cross-user
 - PATCH /api/canvas/{id}/cells/{cellId}: accept/edit/discard, trust contract,
-  state machine enforcement
+  state machine enforcement (including committed → terminal)
 - POST /api/canvas/{id}/export: md/json/html/pdf, include toggles
-- WebSocket canvas_cell and canvas_cancel (MVA-370)
+- WebSocket canvas_cell and canvas_cancel (MVA-370): ownership check, cross-user rejection
 """
 
 import asyncio
 import uuid
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -366,6 +367,19 @@ class TestTransitionCell:
             )
         assert resp.status_code == 422
 
+    def test_committed_cell_is_terminal(self, app):
+        """committed is a terminal state — discard/accept must return 409."""
+        canvas = _make_canvas()
+        cell = _make_cell(owner="agent", state=CellState.committed)
+        self._setup_app(app, canvas, cell)
+
+        with TestClient(app) as client:
+            resp = client.patch(
+                f"/api/canvas/{_CANVAS_ID}/cells/{_CELL_ID}",
+                json={"action": "discard"},
+            )
+        assert resp.status_code == 409
+
     def test_transition_403_cross_user(self, app):
         canvas = _make_canvas(user_id="user-alice")
         session = _mock_session()
@@ -448,6 +462,24 @@ class TestExportHelpers:
 # ---------------------------------------------------------------------------
 
 
+def _make_cancel_db_mock(cell_user_id: str):
+    """Return an async context manager that yields a session returning a cell owned by cell_user_id."""
+    mock_cell = MagicMock(spec=CanvasCell)
+    mock_cell.user_id = cell_user_id
+
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = mock_cell
+    session.execute = AsyncMock(return_value=result)
+    session.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _ctx():
+        yield session
+
+    return _ctx
+
+
 class TestCanvasWebSocketStreaming:
     @pytest.mark.asyncio
     async def test_register_and_unregister_streaming_task(self):
@@ -481,6 +513,7 @@ class TestCanvasWebSocketStreaming:
 
         canvas_id = str(uuid.uuid4())
         cell_id = str(uuid.uuid4())
+        owner_id = "user-alice"
 
         async def mock_stream():
             try:
@@ -493,8 +526,8 @@ class TestCanvasWebSocketStreaming:
 
         assert not task.done()
 
-        # Send canvas_cancel
-        await _handle_canvas_cancel({"cellId": cell_id, "canvasId": canvas_id})
+        with patch("user_management.database.db_session_context", _make_cancel_db_mock(owner_id)):
+            await _handle_canvas_cancel({"cellId": cell_id, "canvasId": canvas_id}, owner_id)
 
         # Task should be cancelled
         await asyncio.sleep(0.01)  # Give task time to process cancellation
@@ -512,6 +545,7 @@ class TestCanvasWebSocketStreaming:
         canvas_id = str(uuid.uuid4())
         cell_id_1 = str(uuid.uuid4())
         cell_id_2 = str(uuid.uuid4())
+        owner_id = "user-alice"
 
         async def mock_stream():
             try:
@@ -525,8 +559,8 @@ class TestCanvasWebSocketStreaming:
         await register_canvas_streaming_task(canvas_id, cell_id_1, task1)
         await register_canvas_streaming_task(canvas_id, cell_id_2, task2)
 
-        # Cancel only cell_id_1
-        await _handle_canvas_cancel({"cellId": cell_id_1, "canvasId": canvas_id})
+        with patch("user_management.database.db_session_context", _make_cancel_db_mock(owner_id)):
+            await _handle_canvas_cancel({"cellId": cell_id_1, "canvasId": canvas_id}, owner_id)
 
         await asyncio.sleep(0.01)
         assert task1.done()
@@ -536,6 +570,46 @@ class TestCanvasWebSocketStreaming:
         task2.cancel()
         try:
             await task2
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_canvas_cancel_cross_user_rejected(self):
+        """User B cannot cancel User A's streaming task (MVA-362 security fix)."""
+        from api.websockets import (
+            register_canvas_streaming_task,
+            _handle_canvas_cancel,
+            _canvas_streaming_tasks,
+        )
+
+        canvas_id = str(uuid.uuid4())
+        cell_id = str(uuid.uuid4())
+        owner_id = "user-alice"
+        attacker_id = "user-bob"
+
+        async def mock_stream():
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                pass
+
+        task = asyncio.create_task(mock_stream())
+        await register_canvas_streaming_task(canvas_id, cell_id, task)
+
+        assert not task.done()
+
+        # user-bob tries to cancel user-alice's cell — DB returns alice's cell
+        with patch("user_management.database.db_session_context", _make_cancel_db_mock(owner_id)):
+            await _handle_canvas_cancel({"cellId": cell_id, "canvasId": canvas_id}, attacker_id)
+
+        await asyncio.sleep(0.01)
+        # Task must NOT be cancelled
+        assert not task.done()
+
+        # Cleanup
+        task.cancel()
+        try:
+            await task
         except asyncio.CancelledError:
             pass
 

--- a/autobot-backend/tests/api/test_canvas.py
+++ b/autobot-backend/tests/api/test_canvas.py
@@ -8,8 +8,10 @@ Covers:
 - PATCH /api/canvas/{id}/cells/{cellId}: accept/edit/discard, trust contract,
   state machine enforcement
 - POST /api/canvas/{id}/export: md/json/html/pdf, include toggles
+- WebSocket canvas_cell and canvas_cancel (MVA-370)
 """
 
+import asyncio
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -414,3 +416,115 @@ class TestExportHelpers:
         data = _json.loads(result)
         assert len(data["cells"]) == 1
         assert data["cells"][0]["owner"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# WebSocket canvas streaming (MVA-370)
+# ---------------------------------------------------------------------------
+
+
+class TestCanvasWebSocketStreaming:
+    @pytest.mark.asyncio
+    async def test_register_and_unregister_streaming_task(self):
+        from api.websockets import register_canvas_streaming_task, unregister_canvas_streaming_task, _canvas_streaming_tasks
+
+        task = asyncio.create_task(asyncio.sleep(10))
+        canvas_id = str(uuid.uuid4())
+        cell_id = str(uuid.uuid4())
+
+        await register_canvas_streaming_task(canvas_id, cell_id, task)
+        key = (canvas_id, cell_id)
+        assert key in _canvas_streaming_tasks
+        assert _canvas_streaming_tasks[key] == task
+
+        await unregister_canvas_streaming_task(canvas_id, cell_id)
+        assert key not in _canvas_streaming_tasks
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_canvas_cancel_stops_streaming_task(self):
+        from api.websockets import (
+            register_canvas_streaming_task,
+            _handle_canvas_cancel,
+            _canvas_streaming_tasks,
+        )
+
+        canvas_id = str(uuid.uuid4())
+        cell_id = str(uuid.uuid4())
+
+        async def mock_stream():
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                pass
+
+        task = asyncio.create_task(mock_stream())
+        await register_canvas_streaming_task(canvas_id, cell_id, task)
+
+        assert not task.done()
+
+        # Send canvas_cancel
+        await _handle_canvas_cancel({"cellId": cell_id, "canvasId": canvas_id})
+
+        # Task should be cancelled
+        await asyncio.sleep(0.01)  # Give task time to process cancellation
+        assert task.done()
+        assert task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_canvas_cancel_with_multiple_tasks(self):
+        from api.websockets import (
+            register_canvas_streaming_task,
+            _handle_canvas_cancel,
+            _canvas_streaming_tasks,
+        )
+
+        canvas_id = str(uuid.uuid4())
+        cell_id_1 = str(uuid.uuid4())
+        cell_id_2 = str(uuid.uuid4())
+
+        async def mock_stream():
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                pass
+
+        task1 = asyncio.create_task(mock_stream())
+        task2 = asyncio.create_task(mock_stream())
+
+        await register_canvas_streaming_task(canvas_id, cell_id_1, task1)
+        await register_canvas_streaming_task(canvas_id, cell_id_2, task2)
+
+        # Cancel only cell_id_1
+        await _handle_canvas_cancel({"cellId": cell_id_1, "canvasId": canvas_id})
+
+        await asyncio.sleep(0.01)
+        assert task1.done()
+        assert not task2.done()
+
+        # Cleanup
+        task2.cancel()
+        try:
+            await task2
+        except asyncio.CancelledError:
+            pass
+
+    def test_canvas_cell_event_format(self):
+        from api.websockets import get_canvas_cell_event
+
+        cell_id = str(uuid.uuid4())
+        canvas_id = str(uuid.uuid4())
+
+        event = get_canvas_cell_event(cell_id, seq=1, delta="Hello", state="streaming", canvas_id=canvas_id)
+
+        assert event["type"] == "canvas_cell"
+        assert event["payload"]["cellId"] == cell_id
+        assert event["payload"]["canvasId"] == canvas_id
+        assert event["payload"]["seq"] == 1
+        assert event["payload"]["delta"] == "Hello"
+        assert event["payload"]["state"] == "streaming"

--- a/autobot-backend/tests/api/test_canvas.py
+++ b/autobot-backend/tests/api/test_canvas.py
@@ -35,8 +35,9 @@ _CELL_ID = uuid.uuid4()
 _NOW = datetime(2026, 5, 16, 8, 0, 0, tzinfo=timezone.utc)
 
 
-def _make_canvas(user_id: str = "user-alice") -> Canvas:
-    c = Canvas.__new__(Canvas)
+def _make_canvas(user_id: str = "user-alice"):
+    """Create a mock Canvas instance with required attributes."""
+    c = MagicMock(spec=Canvas)
     c.id = _CANVAS_ID
     c.user_id = user_id
     c.title = "Test Canvas"
@@ -51,8 +52,9 @@ def _make_cell(
     owner: str = "agent",
     state: str = CellState.complete,
     user_id: str = "user-alice",
-) -> CanvasCell:
-    cell = CanvasCell.__new__(CanvasCell)
+):
+    """Create a mock CanvasCell instance with required attributes."""
+    cell = MagicMock(spec=CanvasCell)
     cell.id = _CELL_ID
     cell.canvas_id = _CANVAS_ID
     cell.user_id = user_id
@@ -84,7 +86,8 @@ def _mock_session():
     # Simulate scalars().all() chain
     scalars_mock = MagicMock()
     scalars_mock.all.return_value = []
-    result_mock = AsyncMock()
+    # Create a non-async result mock where scalar_one_or_none is a regular method
+    result_mock = MagicMock()
     result_mock.scalar_one_or_none.return_value = None
     result_mock.scalars.return_value = scalars_mock
     session.execute = AsyncMock(return_value=result_mock)
@@ -105,7 +108,7 @@ class TestGetCanvas:
         session = _mock_session()
 
         def _execute_side_effect(stmt):
-            result = AsyncMock()
+            result = MagicMock()
             scalars = MagicMock()
             scalars.all.return_value = []
             result.scalar_one_or_none = MagicMock(return_value=canvas)
@@ -115,14 +118,15 @@ class TestGetCanvas:
         session.execute = AsyncMock(side_effect=_execute_side_effect)
 
         from user_management.database import get_async_session
+        from auth_middleware import get_current_user
 
         app.dependency_overrides = {
             get_async_session: lambda: session,
+            get_current_user: lambda: _USER_A,
         }
 
-        with patch("api.canvas.get_current_user", return_value=_USER_A):
-            with TestClient(app) as client:
-                resp = client.get(f"/api/canvas/{_CANVAS_ID}")
+        with TestClient(app) as client:
+            resp = client.get(f"/api/canvas/{_CANVAS_ID}")
         assert resp.status_code == 200
         data = resp.json()
         assert data["canvas"]["id"] == str(_CANVAS_ID)
@@ -133,12 +137,15 @@ class TestGetCanvas:
         session.execute.return_value.scalar_one_or_none = MagicMock(return_value=None)
 
         from user_management.database import get_async_session
+        from auth_middleware import get_current_user
 
-        app.dependency_overrides = {get_async_session: lambda: session}
+        app.dependency_overrides = {
+            get_async_session: lambda: session,
+            get_current_user: lambda: _USER_A,
+        }
 
-        with patch("api.canvas.get_current_user", return_value=_USER_A):
-            with TestClient(app) as client:
-                resp = client.get(f"/api/canvas/{uuid.uuid4()}")
+        with TestClient(app) as client:
+            resp = client.get(f"/api/canvas/{uuid.uuid4()}")
         assert resp.status_code == 404
 
     def test_get_canvas_403_cross_user(self, app):
@@ -147,12 +154,15 @@ class TestGetCanvas:
         session.execute.return_value.scalar_one_or_none = MagicMock(return_value=canvas)
 
         from user_management.database import get_async_session
+        from auth_middleware import get_current_user
 
-        app.dependency_overrides = {get_async_session: lambda: session}
+        app.dependency_overrides = {
+            get_async_session: lambda: session,
+            get_current_user: lambda: _USER_B,
+        }
 
-        with patch("api.canvas.get_current_user", return_value=_USER_B):
-            with TestClient(app) as client:
-                resp = client.get(f"/api/canvas/{_CANVAS_ID}")
+        with TestClient(app) as client:
+            resp = client.get(f"/api/canvas/{_CANVAS_ID}")
         assert resp.status_code == 403
 
 
@@ -168,15 +178,18 @@ class TestPutCanvas:
         session.execute.return_value.scalar_one_or_none = MagicMock(return_value=canvas)
 
         from user_management.database import get_async_session
+        from auth_middleware import get_current_user
 
-        app.dependency_overrides = {get_async_session: lambda: session}
+        app.dependency_overrides = {
+            get_async_session: lambda: session,
+            get_current_user: lambda: _USER_A,
+        }
 
-        with patch("api.canvas.get_current_user", return_value=_USER_A):
-            with TestClient(app) as client:
-                resp = client.put(
-                    f"/api/canvas/{_CANVAS_ID}",
-                    json={"title": "Updated Title", "cells": []},
-                )
+        with TestClient(app) as client:
+            resp = client.put(
+                f"/api/canvas/{_CANVAS_ID}",
+                json={"title": "Updated Title", "cells": []},
+            )
         assert resp.status_code == 200
         data = resp.json()
         assert "save_token" in data
@@ -188,12 +201,15 @@ class TestPutCanvas:
         session.execute.return_value.scalar_one_or_none = MagicMock(return_value=canvas)
 
         from user_management.database import get_async_session
+        from auth_middleware import get_current_user
 
-        app.dependency_overrides = {get_async_session: lambda: session}
+        app.dependency_overrides = {
+            get_async_session: lambda: session,
+            get_current_user: lambda: _USER_B,
+        }
 
-        with patch("api.canvas.get_current_user", return_value=_USER_B):
-            with TestClient(app) as client:
-                resp = client.put(f"/api/canvas/{_CANVAS_ID}", json={"cells": []})
+        with TestClient(app) as client:
+            resp = client.put(f"/api/canvas/{_CANVAS_ID}", json={"cells": []})
         assert resp.status_code == 403
 
 
@@ -224,15 +240,18 @@ class TestAddCell:
         session.refresh = _refresh_patch
 
         from user_management.database import get_async_session
+        from auth_middleware import get_current_user
 
-        app.dependency_overrides = {get_async_session: lambda: session}
+        app.dependency_overrides = {
+            get_async_session: lambda: session,
+            get_current_user: lambda: _USER_A,
+        }
 
-        with patch("api.canvas.get_current_user", return_value=_USER_A):
-            with TestClient(app) as client:
-                resp = client.post(
-                    f"/api/canvas/{_CANVAS_ID}/cells",
-                    json={"type": "text", "content": "Hello", "position": 0},
-                )
+        with TestClient(app) as client:
+            resp = client.post(
+                f"/api/canvas/{_CANVAS_ID}/cells",
+                json={"type": "text", "content": "Hello", "position": 0},
+            )
         assert resp.status_code == 201
 
     def test_add_cell_403_cross_user(self, app):
@@ -241,15 +260,18 @@ class TestAddCell:
         session.execute.return_value.scalar_one_or_none = MagicMock(return_value=canvas)
 
         from user_management.database import get_async_session
+        from auth_middleware import get_current_user
 
-        app.dependency_overrides = {get_async_session: lambda: session}
+        app.dependency_overrides = {
+            get_async_session: lambda: session,
+            get_current_user: lambda: _USER_B,
+        }
 
-        with patch("api.canvas.get_current_user", return_value=_USER_B):
-            with TestClient(app) as client:
-                resp = client.post(
-                    f"/api/canvas/{_CANVAS_ID}/cells",
-                    json={"type": "text", "content": "Hello", "position": 0},
-                )
+        with TestClient(app) as client:
+            resp = client.post(
+                f"/api/canvas/{_CANVAS_ID}/cells",
+                json={"type": "text", "content": "Hello", "position": 0},
+            )
         assert resp.status_code == 403
 
 
@@ -265,7 +287,7 @@ class TestTransitionCell:
 
         def _execute_side_effect(stmt):
             nonlocal call_count
-            result = AsyncMock()
+            result = MagicMock()
             scalars_mock = MagicMock()
             scalars_mock.all.return_value = []
             result.scalars = MagicMock(return_value=scalars_mock)
@@ -284,8 +306,12 @@ class TestTransitionCell:
         session.refresh = _refresh_patch
 
         from user_management.database import get_async_session
+        from auth_middleware import get_current_user
 
-        app.dependency_overrides = {get_async_session: lambda: session}
+        app.dependency_overrides = {
+            get_async_session: lambda: session,
+            get_current_user: lambda: _USER_A,
+        }
         return session
 
     def test_accept_agent_cell_reaches_committed(self, app):
@@ -293,12 +319,11 @@ class TestTransitionCell:
         cell = _make_cell(owner="agent", state=CellState.complete)
         self._setup_app(app, canvas, cell)
 
-        with patch("api.canvas.get_current_user", return_value=_USER_A):
-            with TestClient(app) as client:
-                resp = client.patch(
-                    f"/api/canvas/{_CANVAS_ID}/cells/{_CELL_ID}",
-                    json={"action": "accept"},
-                )
+        with TestClient(app) as client:
+            resp = client.patch(
+                f"/api/canvas/{_CANVAS_ID}/cells/{_CELL_ID}",
+                json={"action": "accept"},
+            )
         assert resp.status_code == 200
         assert resp.json()["state"] == CellState.committed
 
@@ -309,12 +334,11 @@ class TestTransitionCell:
         cell = _make_cell(owner="agent", state=CellState.streaming)
         self._setup_app(app, canvas, cell)
 
-        with patch("api.canvas.get_current_user", return_value=_USER_A):
-            with TestClient(app) as client:
-                resp = client.patch(
-                    f"/api/canvas/{_CANVAS_ID}/cells/{_CELL_ID}",
-                    json={"action": "accept"},
-                )
+        with TestClient(app) as client:
+            resp = client.patch(
+                f"/api/canvas/{_CANVAS_ID}/cells/{_CELL_ID}",
+                json={"action": "accept"},
+            )
         assert resp.status_code == 409
 
     def test_discard_moves_to_cancelled(self, app):
@@ -322,12 +346,11 @@ class TestTransitionCell:
         cell = _make_cell(owner="agent", state=CellState.complete)
         self._setup_app(app, canvas, cell)
 
-        with patch("api.canvas.get_current_user", return_value=_USER_A):
-            with TestClient(app) as client:
-                resp = client.patch(
-                    f"/api/canvas/{_CANVAS_ID}/cells/{_CELL_ID}",
-                    json={"action": "discard"},
-                )
+        with TestClient(app) as client:
+            resp = client.patch(
+                f"/api/canvas/{_CANVAS_ID}/cells/{_CELL_ID}",
+                json={"action": "discard"},
+            )
         assert resp.status_code == 200
         assert resp.json()["state"] == CellState.cancelled
 
@@ -336,12 +359,11 @@ class TestTransitionCell:
         cell = _make_cell(owner="agent", state=CellState.complete)
         self._setup_app(app, canvas, cell)
 
-        with patch("api.canvas.get_current_user", return_value=_USER_A):
-            with TestClient(app) as client:
-                resp = client.patch(
-                    f"/api/canvas/{_CANVAS_ID}/cells/{_CELL_ID}",
-                    json={"action": "edit"},
-                )
+        with TestClient(app) as client:
+            resp = client.patch(
+                f"/api/canvas/{_CANVAS_ID}/cells/{_CELL_ID}",
+                json={"action": "edit"},
+            )
         assert resp.status_code == 422
 
     def test_transition_403_cross_user(self, app):
@@ -350,15 +372,18 @@ class TestTransitionCell:
         session.execute.return_value.scalar_one_or_none = MagicMock(return_value=canvas)
 
         from user_management.database import get_async_session
+        from auth_middleware import get_current_user
 
-        app.dependency_overrides = {get_async_session: lambda: session}
+        app.dependency_overrides = {
+            get_async_session: lambda: session,
+            get_current_user: lambda: _USER_B,
+        }
 
-        with patch("api.canvas.get_current_user", return_value=_USER_B):
-            with TestClient(app) as client:
-                resp = client.patch(
-                    f"/api/canvas/{_CANVAS_ID}/cells/{_CELL_ID}",
-                    json={"action": "accept"},
-                )
+        with TestClient(app) as client:
+            resp = client.patch(
+                f"/api/canvas/{_CANVAS_ID}/cells/{_CELL_ID}",
+                json={"action": "accept"},
+            )
         assert resp.status_code == 403
 
 

--- a/autobot-backend/user_management/models/user.py
+++ b/autobot-backend/user_management/models/user.py
@@ -34,6 +34,18 @@ if TYPE_CHECKING:
     from user_management.models.sso import UserSSOLink
     from user_management.models.team import TeamMembership
 
+# Runtime imports for SQLAlchemy relationships (avoid circular imports)
+try:
+    from models.activities import (  # noqa: F401
+        BrowserActivityModel,
+        DesktopActivityModel,
+        FileActivityModel,
+        SecretUsageModel,
+        TerminalActivityModel,
+    )
+except ImportError:
+    pass
+
 
 class User(Base):
     """


### PR DESCRIPTION
Canvas feature commits recovered from paperclip-MVA-359 standalone clone during worktree sprawl cleanup (MVA-586)

## Commits included
- feat(canvas): Phase 1 Live Canvas backend — schema, API, state machine, export (MVA-359)
- feat(canvas): Add WebSocket envelope for canvas cell streaming (MVA-370)
- fix(tests): Update canvas test fixtures and dependency overrides
- fix(models): Add runtime imports for TerminalActivityModel and related activity models
- fix(canvas): address MVA-362 security review change requests