### PR TITLE
fix(toast): use canonical durations in chat notify() wrapper (MVA-351)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -441,7 +441,7 @@ function closeVoicePanel(): void {
 // Toast notifications
 const { showToast } = useToast()
 const notify = (message: string, type: 'info' | 'success' | 'warning' | 'error' = 'info') => {
-  showToast(message, type, type === 'error' ? 5000 : 3000)
+  showToast(message, type, type === 'error' ? 0 : type === 'warning' ? 6000 : 4000)
 }
 
 // Issue #4414: multi-model compare panel toggle


### PR DESCRIPTION
## Summary

- Fixes `notify()` wrapper in `ChatInterface.vue` to use canonical toast durations
- Error notifications: `5000ms` → `0` (persistent, dismiss-only)
- Warning notifications: `3000ms` → `6000ms`
- Success/Info notifications: `3000ms` → `4000ms`

## Changes

`autobot-frontend/src/components/chat/ChatInterface.vue`: 1 line change

## Related

- Paperclip issue: MVA-351 (done)
- Part of toast canonical duration standardization (MVA-189)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)