### PR TITLE
feat(a11y): BaseAlert compact size variant + document role=alert (MVA-349)

### DIFF
--- a/autobot-frontend/src/components/ui/BaseAlert.stories.ts
+++ b/autobot-frontend/src/components/ui/BaseAlert.stories.ts
@@ -5,22 +5,27 @@ const meta = {
   title: 'Components/UI/BaseAlert',
   component: BaseAlert,
   argTypes: {
-    type: {
+    variant: {
       control: 'select',
-      options: ['success', 'error', 'warning', 'info'],
-      description: 'Alert type',
+      options: ['success', 'info', 'warning', 'error', 'critical'],
+      description: 'Alert variant',
+    },
+    size: {
+      control: 'select',
+      options: ['default', 'compact'],
+      description: 'Size variant — compact hides the title and uses reduced padding (for inline field errors)',
     },
     title: {
       control: 'text',
-      description: 'Alert title',
+      description: 'Alert title (hidden in compact size)',
     },
     message: {
       control: 'text',
       description: 'Alert message',
     },
-    closable: {
+    dismissible: {
       control: 'boolean',
-      description: 'Show close button',
+      description: 'Show dismiss button',
     },
     icon: {
       control: 'boolean',
@@ -35,7 +40,7 @@ type Story = StoryObj<any>;
 
 export const Success: Story = {
   args: {
-    type: 'success',
+    variant: 'success',
     title: 'Success',
     message: 'Operation completed successfully',
   },
@@ -43,7 +48,7 @@ export const Success: Story = {
 
 export const Error: Story = {
   args: {
-    type: 'error',
+    variant: 'error',
     title: 'Error',
     message: 'An error occurred while processing your request',
   },
@@ -51,7 +56,7 @@ export const Error: Story = {
 
 export const Warning: Story = {
   args: {
-    type: 'warning',
+    variant: 'warning',
     title: 'Warning',
     message: 'Please review this information before proceeding',
   },
@@ -59,7 +64,7 @@ export const Warning: Story = {
 
 export const Info: Story = {
   args: {
-    type: 'info',
+    variant: 'info',
     title: 'Information',
     message: 'Here is some important information for you',
   },
@@ -67,20 +72,52 @@ export const Info: Story = {
 
 export const Closable: Story = {
   args: {
-    type: 'info',
+    variant: 'info',
     title: 'Closable Alert',
     message: 'This alert can be dismissed by clicking the close button',
-    closable: true,
+    dismissible: true,
   },
 };
 
 export const NoIcon: Story = {
   args: {
-    type: 'success',
+    variant: 'success',
     title: 'Success',
     message: 'Operation completed without displaying an icon',
     icon: false,
   },
+};
+
+/** Compact size — intended for inline field-level errors below form inputs */
+export const CompactError: Story = {
+  args: {
+    variant: 'error',
+    size: 'compact',
+    message: 'This field is required',
+  },
+};
+
+export const CompactWarning: Story = {
+  args: {
+    variant: 'warning',
+    size: 'compact',
+    message: 'Value exceeds recommended limit',
+  },
+};
+
+/** All compact variants side by side */
+export const CompactAllVariants: Story = {
+  render: () => ({
+    components: { BaseAlert },
+    template: `
+      <div class="space-y-2">
+        <BaseAlert variant="error" size="compact" message="Email address is required" />
+        <BaseAlert variant="warning" size="compact" message="Password must be at least 8 characters" />
+        <BaseAlert variant="info" size="compact" message="Username is already taken" />
+        <BaseAlert variant="success" size="compact" message="Field validated successfully" />
+      </div>
+    `,
+  }),
 };
 
 export const AllTypes: Story = {
@@ -88,10 +125,10 @@ export const AllTypes: Story = {
     components: { BaseAlert },
     template: `
       <div class="space-y-4">
-        <BaseAlert type="success" title="Success" message="This is a success alert message" closable />
-        <BaseAlert type="error" title="Error" message="This is an error alert message" closable />
-        <BaseAlert type="warning" title="Warning" message="This is a warning alert message" closable />
-        <BaseAlert type="info" title="Information" message="This is an info alert message" closable />
+        <BaseAlert variant="success" title="Success" message="This is a success alert message" dismissible />
+        <BaseAlert variant="error" title="Error" message="This is an error alert message" dismissible />
+        <BaseAlert variant="warning" title="Warning" message="This is a warning alert message" dismissible />
+        <BaseAlert variant="info" title="Information" message="This is an info alert message" dismissible />
       </div>
     `,
   }),

--- a/autobot-frontend/src/components/ui/BaseAlert.vue
+++ b/autobot-frontend/src/components/ui/BaseAlert.vue
@@ -8,13 +8,14 @@
     <!-- Icon -->
     <div v-if="showIcon" class="alert-icon">
       <slot name="icon">
-        <component :is="defaultIcon" class="h-5 w-5" />
+        <component :is="defaultIcon" :class="iconSizeClass" />
       </slot>
     </div>
 
     <!-- Content -->
     <div class="alert-content">
-      <div v-if="title" class="alert-title">{{ title }}</div>
+      <!-- title is suppressed in compact size -->
+      <div v-if="title && size !== 'compact'" class="alert-title">{{ title }}</div>
       <div class="alert-message">
         <slot>{{ message }}</slot>
       </div>
@@ -48,6 +49,7 @@ import {
 
 export interface BaseAlertProps {
   variant?: 'success' | 'info' | 'warning' | 'error' | 'critical'
+  size?: 'default' | 'compact'
   title?: string
   message?: string
   icon?: boolean
@@ -58,6 +60,7 @@ export interface BaseAlertProps {
 
 const props = withDefaults(defineProps<BaseAlertProps>(), {
   variant: 'info',
+  size: 'default',
   message: '',
   icon: true,
   dismissible: false,
@@ -75,6 +78,8 @@ const dismissed = ref(false)
 
 const showIcon = computed(() => props.icon !== false)
 
+// role="alert" is a static attribute on the root element.
+// Screen readers announce on DOM insertion (mount). No JS re-trigger needed.
 const defaultIcon = computed(() => {
   switch (props.variant) {
     case 'success':
@@ -90,10 +95,16 @@ const defaultIcon = computed(() => {
   }
 })
 
+// compact: 16px (h-4 w-4); default: 20px (h-5 w-5)
+const iconSizeClass = computed(() => (props.size === 'compact' ? 'h-4 w-4' : 'h-5 w-5'))
+
 const alertClasses = computed(() => {
   const classes = [`alert-${props.variant}`]
   if (props.bordered) {
     classes.push('alert-bordered')
+  }
+  if (props.size === 'compact') {
+    classes.push('alert-compact')
   }
   return classes
 })
@@ -126,9 +137,24 @@ onMounted(() => {
   transition: all var(--duration-200) var(--ease-out);
 }
 
+/* compact size: single-line layout, reduced padding (--spacing-2), smaller icon (16px) */
+.alert-compact {
+  align-items: center;
+  padding: var(--spacing-2);
+  gap: var(--spacing-2);
+}
+
+.alert-compact .alert-message {
+  line-height: 1.25rem;
+}
+
 .alert-icon {
   flex-shrink: 0;
   margin-top: var(--spacing-0-5);
+}
+
+.alert-compact .alert-icon {
+  margin-top: 0;
 }
 
 .alert-content {


### PR DESCRIPTION
## Summary

- Adds compact size variant to `BaseAlert` component for dense UI contexts
- Documents `role=alert` for screen reader accessibility compliance (MVA-349)

## Preservation PR

This branch was preserved from a worktree audit (MVA-588). The commit applies cleanly onto current `Dev_new_gui`.

## Changes

- `autobot-frontend/src/components/ui/BaseAlert.vue` — compact size variant
- `autobot-frontend/src/components/ui/BaseAlert.stories.ts` — story updates