### PR TITLE
feat(canvas): MSW mock layer for Live Canvas API (MVA-399)

### DIFF
--- a/autobot-frontend/src/test/mocks/canvas.fixtures.ts
+++ b/autobot-frontend/src/test/mocks/canvas.fixtures.ts
@@ -1,0 +1,178 @@
+// Typed fixture factories for Live Canvas API — MVA-399
+// Shapes match the frozen contract at MVA-359#document-api-contract
+
+export type CellType = 'text' | 'code' | 'chart' | 'image'
+export type CellState =
+  | 'queued'
+  | 'skeleton'
+  | 'streaming'
+  | 'complete'
+  | 'committed'
+  | 'error'
+  | 'cancelled'
+export type CellOwner = 'agent' | 'user'
+export type ExportFormat = 'md' | 'json' | 'html' | 'pdf'
+export type UndoEventType =
+  | 'cell_add'
+  | 'cell_edit'
+  | 'cell_delete'
+  | 'cell_accept'
+  | 'cell_discard'
+export type CellAction = 'accept' | 'edit' | 'discard'
+
+export interface CanvasFixture {
+  id: string
+  user_id: string
+  title: string
+  created_at: string
+  updated_at: string
+  save_token: string
+  undo_cursor: number
+}
+
+export interface CanvasCellFixture {
+  id: string
+  canvas_id: string
+  user_id: string
+  position: number
+  type: CellType
+  content: string
+  state: CellState
+  owner: CellOwner
+  version: number
+  locked_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface CanvasUndoEventFixture {
+  id: string
+  canvas_id: string
+  seq: number
+  event_type: UndoEventType
+  payload: Record<string, unknown>
+  created_at: string
+}
+
+export interface CanvasGetResponse {
+  canvas: Omit<CanvasFixture, 'user_id'>
+  cells: Omit<CanvasCellFixture, 'canvas_id' | 'user_id' | 'created_at' | 'updated_at'>[]
+}
+
+export interface CanvasAutosaveResponse {
+  save_token: string
+  saved_at: string
+}
+
+export interface CanvasCellTransitionResponse {
+  id: string
+  state: CellState
+  version: number
+  content: string
+  updated_at: string
+}
+
+export interface CanvasWsEnvelope {
+  type: 'canvas_cell'
+  cellId: string
+  seq: number
+  delta: string | null
+  state: CellState
+}
+
+export interface CanvasCancelMessage {
+  type: 'canvas_cancel'
+  cellId: string
+}
+
+let _seq = 0
+const iso = () => new Date().toISOString()
+const uuid = () => crypto.randomUUID()
+
+export const makeCanvas = (overrides: Partial<CanvasFixture> = {}): CanvasFixture => ({
+  id: uuid(),
+  user_id: 'user-test-001',
+  title: 'Test Canvas',
+  created_at: iso(),
+  updated_at: iso(),
+  save_token: uuid(),
+  undo_cursor: 0,
+  ...overrides,
+})
+
+export const makeCanvasCell = (
+  overrides: Partial<CanvasCellFixture> = {},
+): CanvasCellFixture => ({
+  id: uuid(),
+  canvas_id: 'canvas-test-001',
+  user_id: 'user-test-001',
+  position: 0,
+  type: 'text',
+  content: 'Test cell content',
+  state: 'committed',
+  owner: 'user',
+  version: 1,
+  locked_by: null,
+  created_at: iso(),
+  updated_at: iso(),
+  ...overrides,
+})
+
+export const makeAgentCell = (overrides: Partial<CanvasCellFixture> = {}): CanvasCellFixture =>
+  makeCanvasCell({
+    owner: 'agent',
+    state: 'complete',
+    content: 'Agent-generated content awaiting review',
+    ...overrides,
+  })
+
+export const makeCanvasGetResponse = (
+  canvas?: Partial<CanvasFixture>,
+  cells?: Partial<CanvasCellFixture>[],
+): CanvasGetResponse => {
+  const c = makeCanvas(canvas)
+  return {
+    canvas: {
+      id: c.id,
+      title: c.title,
+      created_at: c.created_at,
+      updated_at: c.updated_at,
+      save_token: c.save_token,
+      undo_cursor: c.undo_cursor,
+    },
+    cells: (cells ?? [{}]).map((overrides, i) => {
+      const cell = makeCanvasCell({ canvas_id: c.id, position: i, ...overrides })
+      return {
+        id: cell.id,
+        position: cell.position,
+        type: cell.type,
+        content: cell.content,
+        state: cell.state,
+        owner: cell.owner,
+        version: cell.version,
+        locked_by: cell.locked_by,
+      }
+    }),
+  }
+}
+
+export const makeAutosaveResponse = (): CanvasAutosaveResponse => ({
+  save_token: uuid(),
+  saved_at: iso(),
+})
+
+export const makeWsEnvelope = (
+  cellId: string,
+  overrides: Partial<Omit<CanvasWsEnvelope, 'type' | 'cellId'>> = {},
+): CanvasWsEnvelope => ({
+  type: 'canvas_cell',
+  cellId,
+  seq: ++_seq,
+  delta: 'streaming chunk',
+  state: 'streaming',
+  ...overrides,
+})
+
+export const resetFixtureSeq = () => {
+  _seq = 0
+}

--- a/autobot-frontend/src/test/mocks/canvas.handlers.ts
+++ b/autobot-frontend/src/test/mocks/canvas.handlers.ts
@@ -1,0 +1,173 @@
+// MSW handlers for Live Canvas API — MVA-399
+// Frozen contract: MVA-359#document-api-contract
+// All 5 REST endpoints + error variants
+
+import { http, HttpResponse } from 'msw'
+import { ServiceURLs } from '@/constants/network'
+import {
+  makeCanvasGetResponse,
+  makeCanvasCell,
+  makeAutosaveResponse,
+  type CellAction,
+  type CellState,
+  type ExportFormat,
+} from './canvas.fixtures'
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || ServiceURLs.BACKEND_LOCAL
+
+// State-machine: which target state results from each action
+const TRANSITION_MAP: Record<CellAction, CellState> = {
+  accept: 'committed',
+  edit: 'committed',
+  discard: 'cancelled',
+}
+
+// States that allow accept/edit/discard (agent cells must be complete first)
+const TRANSITIONABLE_STATES: CellState[] = ['complete', 'committed']
+
+export const canvasHandlers = [
+  // GET /api/canvas/{id}
+  http.get(`${API_BASE}/api/canvas/:id`, ({ params }) => {
+    const id = params.id as string
+    const agentCell = makeCanvasCell({
+      canvas_id: id,
+      owner: 'agent',
+      state: 'complete',
+      content: 'Agent draft awaiting review',
+      position: 1,
+    })
+    const userCell = makeCanvasCell({
+      canvas_id: id,
+      owner: 'user',
+      state: 'committed',
+      content: 'User cell',
+      position: 0,
+    })
+    const response = makeCanvasGetResponse({ id }, [
+      { ...userCell },
+      { ...agentCell },
+    ])
+    return HttpResponse.json(response)
+  }),
+
+  // PUT /api/canvas/{id} — autosave
+  http.put(`${API_BASE}/api/canvas/:id`, async ({ request }) => {
+    await request.json() // consume body; optimistic — ignore content in mock
+    return HttpResponse.json(makeAutosaveResponse())
+  }),
+
+  // POST /api/canvas/{id}/cells — add user-owned cell
+  http.post(`${API_BASE}/api/canvas/:id/cells`, async ({ request, params }) => {
+    const body = await request.json() as { type?: string; content?: string; position?: number }
+    const cell = makeCanvasCell({
+      canvas_id: params.id as string,
+      owner: 'user',
+      state: 'committed',
+      type: (body.type as 'text' | 'code' | 'chart' | 'image') ?? 'text',
+      content: body.content ?? '',
+      position: body.position ?? 0,
+    })
+    return HttpResponse.json(
+      {
+        id: cell.id,
+        canvas_id: cell.canvas_id,
+        position: cell.position,
+        type: cell.type,
+        content: cell.content,
+        state: cell.state,
+        owner: cell.owner,
+        version: cell.version,
+        locked_by: cell.locked_by,
+        created_at: cell.created_at,
+      },
+      { status: 201 },
+    )
+  }),
+
+  // PATCH /api/canvas/{id}/cells/{cellId} — accept | edit | discard
+  http.patch(`${API_BASE}/api/canvas/:id/cells/:cellId`, async ({ request, params }) => {
+    const body = await request.json() as { action: CellAction; content?: string }
+    const { action, content } = body
+
+    const targetState = TRANSITION_MAP[action]
+    if (!targetState) {
+      return HttpResponse.json(
+        { detail: 'Cell not in a state that allows this action' },
+        { status: 409 },
+      )
+    }
+
+    return HttpResponse.json({
+      id: params.cellId as string,
+      state: targetState,
+      version: 2,
+      content: action === 'edit' ? (content ?? '') : 'Agent draft awaiting review',
+      updated_at: new Date().toISOString(),
+    })
+  }),
+
+  // POST /api/canvas/{id}/export
+  http.post(`${API_BASE}/api/canvas/:id/export`, async ({ request }) => {
+    const body = await request.json() as { format: ExportFormat; include?: Record<string, boolean> }
+    const format = body.format ?? 'md'
+
+    const contentTypeMap: Record<ExportFormat, string> = {
+      md: 'text/markdown; charset=utf-8',
+      json: 'application/json',
+      html: 'text/html; charset=utf-8',
+      pdf: 'application/pdf',
+    }
+
+    const mockExportBody: Record<ExportFormat, string> = {
+      md: '# Canvas Export\n\nMock markdown export.',
+      json: JSON.stringify({ canvas: 'mock', cells: [] }),
+      html: '<!DOCTYPE html><html><body><h1>Canvas Export</h1></body></html>',
+      pdf: '%PDF-1.4 mock',
+    }
+
+    return new HttpResponse(mockExportBody[format], {
+      status: 200,
+      headers: { 'Content-Type': contentTypeMap[format] },
+    })
+  }),
+]
+
+// Error scenario handlers for canvas endpoints
+export const canvasErrorHandlers = [
+  http.get(`${API_BASE}/api/canvas/:id`, () =>
+    HttpResponse.json({ detail: 'Forbidden' }, { status: 403 }),
+  ),
+
+  http.put(`${API_BASE}/api/canvas/:id`, () =>
+    HttpResponse.json({ detail: 'Forbidden' }, { status: 403 }),
+  ),
+
+  http.post(`${API_BASE}/api/canvas/:id/cells`, () =>
+    HttpResponse.json({ detail: 'Forbidden' }, { status: 403 }),
+  ),
+
+  http.patch(`${API_BASE}/api/canvas/:id/cells/:cellId`, () =>
+    HttpResponse.json({ detail: 'Cell not in a state that allows this action' }, { status: 409 }),
+  ),
+
+  http.post(`${API_BASE}/api/canvas/:id/export`, () =>
+    HttpResponse.json({ detail: 'Internal server error' }, { status: 500 }),
+  ),
+]
+
+// Handler that returns 404 for a canvas that doesn't exist
+export const canvasNotFoundHandlers = [
+  http.get(`${API_BASE}/api/canvas/:id`, () =>
+    HttpResponse.json({ detail: 'Canvas not found' }, { status: 404 }),
+  ),
+]
+
+// Simulate cell state in transition conflict (409) on PATCH
+export const canvasInvalidTransitionHandlers = [
+  http.patch(`${API_BASE}/api/canvas/:id/cells/:cellId`, () =>
+    HttpResponse.json(
+      { detail: 'Cell not in a state that allows this action' },
+      { status: 409 },
+    ),
+  ),
+]

--- a/autobot-frontend/src/test/mocks/websocket-mock.ts
+++ b/autobot-frontend/src/test/mocks/websocket-mock.ts
@@ -103,6 +103,9 @@ export const WebSocketMessageType = {
   TERMINAL_CONNECTED: 'terminal_connected',
   TERMINAL_DISCONNECTED: 'terminal_disconnected',
   SYSTEM_STATUS: 'system_status',
+  // Live Canvas envelope types (MVA-359 frozen contract)
+  CANVAS_CELL: 'canvas_cell',
+  CANVAS_CANCEL: 'canvas_cancel',
   ERROR: 'error',
 } as const
 
@@ -193,6 +196,41 @@ export class WebSocketTestUtil {
     if (ws) {
       ws.simulateError(error)
     }
+  }
+
+  // Canvas cell streaming helpers (MVA-359 WS envelope)
+  simulateCanvasCellDelta(
+    cellId: string,
+    delta: string,
+    seq: number,
+    state: 'skeleton' | 'streaming' | 'complete' | 'error' | 'cancelled' = 'streaming',
+  ) {
+    this.simulateMessage(WebSocketMessageType.CANVAS_CELL, { cellId, seq, delta, state })
+  }
+
+  simulateCanvasCellComplete(cellId: string, seq: number) {
+    this.simulateMessage(WebSocketMessageType.CANVAS_CELL, {
+      cellId,
+      seq,
+      delta: null,
+      state: 'complete',
+    })
+  }
+
+  simulateCanvasCellError(cellId: string, seq: number) {
+    this.simulateMessage(WebSocketMessageType.CANVAS_CELL, {
+      cellId,
+      seq,
+      delta: null,
+      state: 'error',
+    })
+  }
+
+  expectCanvasCancelSent(cellId: string) {
+    const ws = this.getConnection()
+    expect(ws?.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: WebSocketMessageType.CANVAS_CANCEL, cellId }),
+    )
   }
 
   simulateClose(code = 1000, reason = '') {


### PR DESCRIPTION
## Summary

- Implements MSW (Mock Service Worker) mock layer for the Live Canvas API (MVA-399)
- Adds `canvas.fixtures.ts` and `canvas.handlers.ts` for test isolation

## Preservation PR

Preserved from worktree audit (MVA-588). Commit rebased onto current `Dev_new_gui`.