### PR TITLE
feat(browser): wire snapshot-with-regions to PopoutChromiumBrowser (#6446)

### DIFF
--- a/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
+++ b/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
@@ -85,6 +85,17 @@
       <div class="text-xs text-autobot-text-muted">
         {{ Math.round(zoomLevel) }}% | {{ pageLoadTime }}ms
       </div>
+      <!-- Region-marking toggle (#5136 / #6446) -->
+      <button
+        @click="toggleRegionMarking"
+        :disabled="isSnapshotLoading || !sessionId || sessionId === 'manual-browser'"
+        class="nav-btn"
+        :class="{ 'text-color-primary': markRegionsMode }"
+        :title="markRegionsMode ? $t('desktop.popoutBrowser.exitRegionMode') : $t('desktop.popoutBrowser.markRegions')"
+        :aria-label="markRegionsMode ? $t('desktop.popoutBrowser.exitRegionMode') : $t('desktop.popoutBrowser.markRegions')"
+      >
+        <i class="fas" :class="isSnapshotLoading ? 'fa-spinner fa-spin' : 'fa-vector-square'"></i>
+      </button>
     </div>
 
     <!-- Playwright Automation Panel -->
@@ -215,12 +226,23 @@
         <!-- VNC iframe for live browser display with headed Playwright -->
         <!-- Using v-if instead of v-show to prevent iframe from loading at all -->
         <iframe
-          v-if="vncUrl && (browserStatus === 'connected' || browserStatus === 'ready')"
+          v-if="vncUrl && (browserStatus === 'connected' || browserStatus === 'ready') && !markRegionsMode"
           ref="vncIframe"
           :src="vncUrl"
           class="w-full h-full border-none"
           allow="clipboard-read; clipboard-write"
         ></iframe>
+
+        <!-- Region-marking overlay (#5136 / #6446): replaces VNC when active -->
+        <div v-if="markRegionsMode && regionSnapshot" class="absolute inset-0 z-20 bg-autobot-bg-primary">
+          <InteractiveScreenshot
+            :screenshot="regionSnapshot"
+            :regions="pageRegions"
+            :mark-regions-mode="true"
+            :interactive="false"
+            @regions-selected="handleRegionsSelected"
+          />
+        </div>
       </div>
 
       <!-- Playwright Automation Status Panel -->
@@ -357,7 +379,8 @@ import type { Ref } from 'vue'
 import type { AutomationResults, SearchData, TestData, MessageData } from '@/types/browser'
 import appConfig from '@/config/AppConfig.js'
 import { useBrowserSessionData } from '@/composables/desktop/useBrowserSessionData'
-import type { PlaywrightNavigationResponse } from '@/composables/desktop/useBrowserSessionData'
+import type { PlaywrightNavigationResponse, PageRegion, SnapshotWithRegionsResult } from '@/composables/desktop/useBrowserSessionData'
+import InteractiveScreenshot from '@/components/browser/InteractiveScreenshot.vue'
 import UnifiedLoadingView from '@/components/ui/UnifiedLoadingView.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import StatusBadge from '@/components/ui/StatusBadge.vue'
@@ -382,7 +405,8 @@ export default {
     UnifiedLoadingView,
     EmptyState,
     StatusBadge,
-    BaseButton
+    BaseButton,
+    InteractiveScreenshot,
   },
   props: {
     sessionId: {
@@ -452,6 +476,12 @@ export default {
     const vncIframe: Ref<HTMLIFrameElement | null> = ref(null)
     const webview: Ref<any | null> = ref(null)
     const remoteIframe: Ref<HTMLIFrameElement | null> = ref(null)
+
+    // Region-marking state (#5136 / #6446) — snapshot-with-regions wire-in
+    const markRegionsMode = ref(false)
+    const pageRegions = ref<PageRegion[]>([])
+    const regionSnapshot = ref<string | null>(null)
+    const isSnapshotLoading = ref(false)
 
     // Computed styles with responsive sizing
     const browserContentStyle = computed(() => ({
@@ -799,6 +829,35 @@ export default {
       interactionMessage.value = ''
     }
 
+    // Region-marking toggle (#5136 / #6446)
+    const toggleRegionMarking = async (): Promise<void> => {
+      if (markRegionsMode.value) {
+        markRegionsMode.value = false
+        pageRegions.value = []
+        regionSnapshot.value = null
+        return
+      }
+      isSnapshotLoading.value = true
+      try {
+        const result: SnapshotWithRegionsResult = await browserApi.snapshotWithRegions(props.sessionId)
+        regionSnapshot.value = result.screenshot
+        pageRegions.value = result.regions
+        markRegionsMode.value = true
+        logger.info(`Region snapshot: ${result.regions.length} regions detected`)
+      } catch (e) {
+        logger.warn('Region snapshot failed:', e)
+        addConsoleLog('warn', `Region snapshot failed: ${e instanceof Error ? e.message : String(e)}`)
+      } finally {
+        isSnapshotLoading.value = false
+      }
+    }
+
+    const handleRegionsSelected = (selected: Array<{ selector: string; xpath: string; label: string }>): void => {
+      logger.info(`Regions selected: ${selected.length}`)
+      emit('interact', { action: 'regions_selected', sessionId: props.sessionId, regions: selected })
+      markRegionsMode.value = false
+    }
+
     // Utility functions
     const getLogColor = (level: string): string => {
       switch (level) {
@@ -948,6 +1007,14 @@ export default {
       hideInteractionOverlay,
       addConsoleLog,
       getLogColor,
+
+      // Region-marking (#5136 / #6446)
+      markRegionsMode,
+      pageRegions,
+      regionSnapshot,
+      isSnapshotLoading,
+      toggleRegionMarking,
+      handleRegionsSelected,
 
       // UnifiedLoadingView event handlers
       handlePlaywrightConnected,

--- a/autobot-frontend/src/composables/desktop/useBrowserSessionData.ts
+++ b/autobot-frontend/src/composables/desktop/useBrowserSessionData.ts
@@ -32,6 +32,28 @@ export interface BrowserSessionResponse {
   [key: string]: unknown
 }
 
+export interface RegionRect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+/** DOM region returned by POST /playwright/snapshot-with-regions (#5136). */
+export interface PageRegion {
+  selector: string
+  xpath: string
+  rect: RegionRect
+  textPreview: string
+  role: string
+}
+
+export interface SnapshotWithRegionsResult {
+  screenshot: string
+  regions: PageRegion[]
+  viewport: Record<string, unknown>
+}
+
 // ===== Composable =====
 
 export function useBrowserSessionData() {
@@ -144,6 +166,40 @@ export function useBrowserSessionData() {
     })
   }
 
+  /**
+   * Take a screenshot of a research browser session and return detected DOM regions.
+   *
+   * Calls POST /playwright/snapshot-with-regions (#5136 / #6446). Returns a
+   * base64 PNG screenshot together with a list of interactive DOM regions so
+   * the caller can display an overlay for scraping-template creation.
+   *
+   * The backend wraps the response in DataResponse[SnapshotWithRegionsResponse],
+   * so the parsed JSON shape is { data: { screenshot, regions, viewport } }.
+   * Backend sends `text_preview` (snake_case) — mapped here to `textPreview`.
+   */
+  async function snapshotWithRegions(
+    sessionId: string,
+    goal = ''
+  ): Promise<SnapshotWithRegionsResult> {
+    const envelope = await apiClient.post<any>(
+      `${getApiBase()}/playwright/snapshot-with-regions`,
+      { session_id: sessionId, goal }
+    ) as { data: Record<string, unknown> }
+    const payload = envelope?.data ?? (envelope as unknown as Record<string, unknown>)
+    const rawRegions = (payload.regions as Array<Record<string, unknown>>) ?? []
+    return {
+      screenshot: (payload.screenshot as string) ?? '',
+      regions: rawRegions.map(r => ({
+        selector: (r.selector as string) ?? '',
+        xpath: (r.xpath as string) ?? '',
+        rect: (r.rect as RegionRect) ?? { x: 0, y: 0, w: 0, h: 0 },
+        textPreview: (r.text_preview as string) ?? '',
+        role: (r.role as string) ?? '',
+      })),
+      viewport: (payload.viewport as Record<string, unknown>) ?? {},
+    }
+  }
+
   return {
     fetchSession,
     fetchPlaywrightHealth,
@@ -153,6 +209,7 @@ export function useBrowserSessionData() {
     reloadPage,
     webSearch,
     runFrontendTests,
-    sendTestMessage
+    sendTestMessage,
+    snapshotWithRegions,
   }
 }


### PR DESCRIPTION
## Summary

- **#6446**: Wires the `POST /playwright/snapshot-with-regions` endpoint to the frontend. Previously had zero callers.
- Adds `snapshotWithRegions(sessionId, goal?)` to `useBrowserSessionData` composable with proper types
- Adds a "Mark Regions" toggle button to `PopoutChromiumBrowser.vue` toolbar
- When toggled ON: calls the backend, stores screenshot + regions, shows `InteractiveScreenshot` overlay over VNC view
- When `regionsSelected` fires, emits `interact` event with selected region data and exits regions mode

## Wire-in architecture note

`PopoutChromiumBrowser.vue` is the correct wire-in target because:
- It has `props.sessionId` (research browser session ID)
- Already uses `useBrowserSessionData` as `browserApi`
- The `snapshot-with-regions` endpoint requires a research browser session (not the worker)
- `VisualBrowserPanel` and `KnowledgeResearchPanel` use the playwright worker (no session ID)

## Test plan

- [ ] Open a research browser session via `PopoutChromiumBrowser`
- [ ] Verify "Mark Regions" button appears in toolbar (fa-vector-square icon)
- [ ] Click button → loading spinner shows → `POST /api/playwright/snapshot-with-regions` fires
- [ ] Screenshot + region overlay appears, replacing VNC iframe
- [ ] Click a region → popup label appears, save → `regionsSelected` emit fires
- [ ] Click "Mark Regions" again → exits regions mode, VNC resumes
- [ ] Button disabled when `sessionId === 'manual-browser'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)