### PR TITLE
fix(ansible): wrap SLM health check in block/rescue so diagnostics run on failure (#7919)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -673,37 +673,42 @@
   when: _slm_pre_health_active.stdout | default('') not in ['active', 'activating']
   tags: ['slm', 'service']
 
-- name: "SLM | Wait for backend to be healthy (retry-based)"
-  ansible.builtin.uri:
-    url: "http://{{ slm_backend_host }}:{{ slm_backend_port }}/api/health"
-    method: GET
-    status_code: 200
-    timeout: 10
-  register: _slm_health
-  retries: 120
-  delay: 5
-  until: _slm_health is succeeded
-  tags: ['slm', 'service']
+# block/rescue ensures diagnostic tasks run even when the health check fails (#7919).
+# Without this, Ansible halts the play on failure and the log tasks are never reached.
+- block:
+    - name: "SLM | Wait for backend to be healthy (retry-based)"
+      ansible.builtin.uri:
+        url: "http://{{ slm_backend_host }}:{{ slm_backend_port }}/api/health"
+        method: GET
+        status_code: 200
+        timeout: 10
+      register: _slm_health
+      retries: 120
+      delay: 5
+      until: _slm_health is succeeded
+      tags: ['slm', 'service']
 
-# Emit service logs when health check fails to surface the actual error.
-# Runs when _slm_health was registered (task attempted) but did not succeed.
-- name: "SLM | Collect backend logs on health check failure"
-  ansible.builtin.shell:
-    cmd: >-
-      journalctl -u {{ slm_backend_service }} -n 100 --no-pager 2>&1 ||
-      tail -100 {{ slm_log_dir }}/slm-backend.log 2>/dev/null ||
-      echo "No logs available yet"
-  register: _slm_backend_log_output
-  changed_when: false
-  failed_when: false
-  when: _slm_health is defined and _slm_health is failed
-  tags: ['slm', 'service', 'debug']
+  rescue:
+    - name: "SLM | Collect backend logs on health check failure"
+      ansible.builtin.shell:
+        cmd: >-
+          journalctl -u {{ slm_backend_service }} -n 100 --no-pager 2>&1 ||
+          tail -100 {{ slm_log_dir }}/slm-backend.log 2>/dev/null ||
+          echo "No logs available yet"
+      register: _slm_backend_log_output
+      changed_when: false
+      failed_when: false
+      tags: ['slm', 'service', 'debug']
 
-- name: "SLM | Display backend logs on health check failure"
-  ansible.builtin.debug:
-    msg: "{{ _slm_backend_log_output.stdout_lines | default([]) }}"
-  when: _slm_health is defined and _slm_health is failed
-  tags: ['slm', 'service', 'debug']
+    - name: "SLM | Display backend logs on health check failure"
+      ansible.builtin.debug:
+        msg: "{{ _slm_backend_log_output.stdout_lines | default([]) }}"
+      tags: ['slm', 'service', 'debug']
+
+    - name: "SLM | Fail with diagnostic context"
+      ansible.builtin.fail:
+        msg: "SLM backend health check failed after {{ 120 * 5 }}s. See logs above."
+      tags: ['slm', 'service']
 
 - name: "SLM | Export admin password for downstream plays"
   ansible.builtin.shell:


### PR DESCRIPTION
## Summary

Fixes GH #7919 — the diagnostic log-collection tasks added in PR #7918 had a dead `when` condition.

**Root cause:** Ansible halts the play when `uri` retries are exhausted (task is marked `failed`, no `ignore_errors`). Tasks that follow with `when: _slm_health is defined and _slm_health is failed` are **never reached** — the play stopped already.

**Fix:** Wrap the health check and the diagnostic tasks in a `block/rescue` structure. The `rescue` branch runs unconditionally when `block` fails, so log collection and display now execute when the health check times out. The rescue closes with an explicit `fail` task to preserve play-failure semantics with a human-readable message.

**Removes** the two standalone diagnostic tasks that had the unreachable `when` condition.

## Test plan
- [ ] Healthy deploy: block succeeds, rescue never runs, behavior unchanged
- [ ] Failed health check: rescue runs, journalctl/log output appears in Ansible output, play fails with `"SLM backend health check failed after 600s. See logs above."`

🤖 Generated with [Claude Code](https://claude.com/claude-code)