### PR TITLE
fix(nginx): add CSP header to frontend HTML and SPA fallback locations (#6814)

### DIFF
--- a/autobot-slm-backend/ansible/roles/frontend/templates/nginx-frontend.conf.j2
+++ b/autobot-slm-backend/ansible/roles/frontend/templates/nginx-frontend.conf.j2
@@ -76,6 +76,7 @@ server {
         add_header Referrer-Policy strict-origin-when-cross-origin;
         add_header Cross-Origin-Opener-Policy "same-origin";
         add_header Cross-Origin-Embedder-Policy "credentialless";
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' wss://$host; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
 
         try_files $uri =404;
     }
@@ -116,6 +117,7 @@ server {
         add_header Referrer-Policy strict-origin-when-cross-origin;
         add_header Cross-Origin-Opener-Policy "same-origin";
         add_header Cross-Origin-Embedder-Policy "credentialless";
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' wss://$host; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
     }
 
     # Issue #1099: Extended timeouts for heavy analytics/code-intelligence


### PR DESCRIPTION
## Summary

- Adds `Content-Security-Policy` header to `location ~* \.html$` and `location /` blocks in `nginx-frontend.conf.j2`
- Root cause: nginx child `location` blocks with any `add_header` directive lose parent-level headers — CSP must be repeated inline in each child block
- The `/api/*` location already had CSP; frontend SPA routes and HTML files were missing it (issue #6814)

## Changes

- `autobot-slm-backend/ansible/roles/frontend/templates/nginx-frontend.conf.j2`: Added `Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' wss://$host; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;` to both the HTML location block and the SPA fallback `/` block.

## Test plan

- [ ] Deploy nginx config; verify `curl -I https://<host>/` and `curl -I https://<host>/login` include `Content-Security-Policy` header
- [ ] Verify existing CSP on `/api/*` unchanged
- [ ] Verify no regression in existing security headers (X-Frame-Options, X-Content-Type-Options, etc.)

Closes #6814

🤖 Generated with [Claude Code](https://claude.com/claude-code)