### PR TITLE
feat(tls): canonical SSL context factory in autobot_shared/tls.py (#6702)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -10,7 +10,6 @@ with real-time event streaming and task routing.
 Issue #725: Added mTLS support for Redis connections.
 """
 
-import ssl
 import urllib.parse
 from pathlib import Path
 
@@ -41,24 +40,24 @@ _broker_ssl_options = None
 _backend_ssl_options = None
 
 if _redis_tls_enabled:
-    # Check for explicit cert paths first (set by SLM enable-tls playbook)
-    _ca_cert = config.tls_ca_path
-    _client_cert = config.tls_cert_path
-    _client_key = config.tls_key_path
+    # #6702: resolve cert paths (explicit env vars first, legacy cert_dir fallback)
+    from autobot_shared.tls import get_internal_tls_context
+
+    _ca_cert = ssot_config.misc.tls_ca_path
+    _client_cert = ssot_config.misc.tls_cert_path
+    _client_key = ssot_config.misc.tls_key_path
 
     # Fallback to legacy cert_dir pattern for backwards compatibility
     if not _ca_cert or not _client_cert or not _client_key:
         _project_root = Path(__file__).parent.parent
-        _cert_dir = config.tls_cert_dir
+        _cert_dir = ssot_config.tls.cert_dir
         _ca_cert = str(_project_root / _cert_dir / "ca" / "ca-cert.pem")
         _client_cert = str(_project_root / _cert_dir / "main-host" / "server-cert.pem")
         _client_key = str(_project_root / _cert_dir / "main-host" / "server-key.pem")
 
-    # Create SSL context for mTLS
-    _ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-    _ssl_context.load_verify_locations(_ca_cert)
-    _ssl_context.load_cert_chain(_client_cert, _client_key)
-
+    _ssl_context = get_internal_tls_context(
+        ca_path=_ca_cert, client_cert=_client_cert, client_key=_client_key
+    )
     _broker_ssl_options = {"ssl": _ssl_context}
     _backend_ssl_options = {"ssl": _ssl_context}
 

--- a/autobot-backend/orchestration/dag_executor.py
+++ b/autobot-backend/orchestration/dag_executor.py
@@ -592,12 +592,10 @@ class DAGExecutor:
 
 
 def _build_slm_ssl_context() -> ssl.SSLContext:
-    """Create SSL context for SLM HTTP calls (mirrors slm_client pattern)."""
-    ctx = ssl.create_default_context()
-    if config.skip_tls_verify.lower() == "true":
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
-    return ctx
+    """Create SSL context for SLM HTTP calls (#6702: delegates to shared tls.py)."""
+    from autobot_shared.tls import get_internal_tls_context
+
+    return get_internal_tls_context()
 
 
 async def _execute_on_node(

--- a/autobot-backend/services/notification_service.py
+++ b/autobot-backend/services/notification_service.py
@@ -30,7 +30,6 @@ from autobot_shared.logging_manager import get_logger
 
 import json
 import smtplib
-import ssl
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -424,7 +423,9 @@ class NotificationService:
 
         try:
             if use_tls:
-                context = ssl.create_default_context()
+                from autobot_shared.tls import get_internal_tls_context
+
+                context = get_internal_tls_context()  # #6702: canonical SSL context
                 with smtplib.SMTP(smtp_host, smtp_port, timeout=10) as server:
                     server.ehlo()
                     server.starttls(context=context)

--- a/autobot-backend/services/slm_client.py
+++ b/autobot-backend/services/slm_client.py
@@ -23,7 +23,6 @@ Related to Issue #760 Phase 2.
 
 import asyncio
 import os
-import ssl
 import time
 from dataclasses import dataclass
 from typing import Callable, Dict
@@ -137,83 +136,14 @@ class ServiceDiscoveryCache:
         logger.debug("Cleared service discovery cache")
 
 
-_LOOPBACK_HOSTS: frozenset = frozenset({"127.0.0.1", "localhost", "::1", "ip6-localhost"})
-
-# Emit the loopback-permissive warning once per process to avoid log spam.
-_loopback_permissive_warned: bool = False
-
-
-def _is_loopback_target(target_url: str | None) -> bool:
-    """Return True iff target_url's host resolves to a loopback address.
-
-    Loopback targets cannot be MITM'd (no off-host network path), so trusting
-    a self-signed cert here is safe even when no project CA is bundled.
-    """
-    if not target_url:
-        return False
-    try:
-        from urllib.parse import urlparse
-
-        host = (urlparse(target_url).hostname or "").lower()
-    except Exception:
-        return False
-    return host in _LOOPBACK_HOSTS
-
-
-def _create_permissive_ssl_context(target_url: str | None = None):
-    """Create SSL context for internal SLM communication (#1048, #2852, #4664, #6654).
-
-    Trust hierarchy (first match wins):
-    1. AUTOBOT_TLS_CA_PATH env var → load that CA cert (production mTLS)
-    2. AUTOBOT_SKIP_TLS_VERIFY=true → disable verification (dev/test only)
-    3. AutoBot project CA fallback (certs/ca/ca-cert.pem) → load if present
-    4. Loopback target with no CA configured → CERT_NONE (single-host self-signed
-       installs, #6654: no MITM possible when SLM is on the same host)
-    5. System trust store → default Python SSL behaviour (strict)
-
-    Set AUTOBOT_SKIP_TLS_VERIFY=true ONLY in dev/test environments — never in
-    production. For non-loopback production deploys, configure AUTOBOT_TLS_CA_PATH.
-    """
-    ctx = ssl.create_default_context()
-
-    # 1. Explicit CA path from env (production deployment)
-    ca_path = config.tls_ca_path
-    if ca_path and os.path.isfile(ca_path):
-        ctx.load_verify_locations(ca_path)
-        return ctx
-
-    # 2. Dev/test override — skip verification entirely
-    if config.skip_tls_verify.lower() == "true":
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
-        return ctx
-
-    # 3. AutoBot project CA fallback (covers single-host installs with self-signed certs)
-    _project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    _cert_dir = config.tls_cert_dir
-    _fallback_ca = os.path.join(_project_root, _cert_dir, "ca", "ca-cert.pem")
-    if os.path.isfile(_fallback_ca):
-        ctx.load_verify_locations(_fallback_ca)
-        return ctx
-
-    # 4. Loopback target — accept self-signed certs. No MITM is possible because
-    #    the connection never leaves the host. Single-host installs typically have
-    #    no project CA bundled and would otherwise crash on every connect (#6654).
-    if _is_loopback_target(target_url):
-        global _loopback_permissive_warned
-        if not _loopback_permissive_warned:
-            logger.warning(
-                "TLS verification disabled for loopback target %s — no CA configured "
-                "(set AUTOBOT_TLS_CA_PATH for strict verification, #6654)",
-                target_url,
-            )
-            _loopback_permissive_warned = True
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
-        return ctx
-
-    # 5. Strict by default (system trust store).
-    return ctx
+# #6702: SSL context creation moved to autobot_shared/tls.py — single canonical
+# implementation shared across slm_client, dag_executor, celery_app, and
+# notification_service. Re-exported here for one-cycle backward compatibility.
+from autobot_shared.tls import (
+    _LOOPBACK_HOSTS,
+    _is_loopback_target,
+    get_internal_tls_context as _create_permissive_ssl_context,
+)
 
 
 class ServiceNotConfiguredError(Exception):

--- a/autobot_shared/tls.py
+++ b/autobot_shared/tls.py
@@ -1,0 +1,115 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Canonical SSL/TLS context factory for internal service-to-service connections.
+
+Issue #6702: consolidates 4+ duplicate ssl.create_default_context() call sites
+(slm_client.py, dag_executor.py, celery_app.py, notification_service.py) into
+one function with a documented trust hierarchy.
+"""
+
+import os
+import ssl
+from typing import Optional
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+# Hosts treated as loopback for TLS trust decisions (#6654).
+_LOOPBACK_HOSTS: frozenset = frozenset({"127.0.0.1", "localhost", "::1", "ip6-localhost"})
+
+_loopback_permissive_warned: bool = False
+
+
+def _is_loopback_target(target_url: Optional[str]) -> bool:
+    """Return True when target_url resolves to a loopback address."""
+    if not target_url:
+        return False
+    try:
+        from urllib.parse import urlparse
+
+        host = (urlparse(target_url).hostname or "").lower()
+    except Exception:
+        return False
+    return host in _LOOPBACK_HOSTS
+
+
+def get_internal_tls_context(
+    target_url: Optional[str] = None,
+    ca_path: Optional[str] = None,
+    client_cert: Optional[str] = None,
+    client_key: Optional[str] = None,
+) -> ssl.SSLContext:
+    """Create SSL context for internal service-to-service TLS (#6702).
+
+    Trust hierarchy (first match wins):
+    1. Explicit ``ca_path`` argument — mTLS callers that resolve the cert path
+       themselves (e.g. celery_app with Redis mTLS).
+    2. ``AUTOBOT_TLS_CA_PATH`` env var — production deployments with a shared CA.
+    3. ``AUTOBOT_SKIP_TLS_VERIFY=true`` — development / CI only; never production.
+    4. Project CA fallback at ``<project_root>/<AUTOBOT_TLS_CERT_DIR>/ca/ca-cert.pem``
+       (single-host installs using the self-signed project CA).
+    5. Loopback target with no CA configured — ``CERT_NONE`` (no MITM risk when
+       the service is on the same host; logs a one-time warning; #6654).
+    6. System trust store — default Python SSL strict behaviour.
+
+    When ``client_cert`` and ``client_key`` are provided, mutual TLS (mTLS) is
+    enabled: the client certificate is loaded for authentication in addition to
+    the normal server verification.
+
+    Set ``AUTOBOT_SKIP_TLS_VERIFY=true`` ONLY in dev/test environments.
+    For non-loopback production deployments configure ``AUTOBOT_TLS_CA_PATH``.
+    """
+    ctx = ssl.create_default_context()
+
+    # 1. Explicit CA path (mTLS callers resolve the path before calling)
+    if ca_path and os.path.isfile(ca_path):
+        ctx.load_verify_locations(ca_path)
+        if client_cert and client_key:
+            ctx.load_cert_chain(client_cert, client_key)
+        return ctx
+
+    # 2. AUTOBOT_TLS_CA_PATH env var (production deployment)
+    env_ca_path = os.environ.get("AUTOBOT_TLS_CA_PATH", "")
+    if env_ca_path and os.path.isfile(env_ca_path):
+        ctx.load_verify_locations(env_ca_path)
+        if client_cert and client_key:
+            ctx.load_cert_chain(client_cert, client_key)
+        return ctx
+
+    # 3. Dev/test override — skip verification entirely
+    if os.environ.get("AUTOBOT_SKIP_TLS_VERIFY", "").lower() == "true":
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+
+    # 4. AutoBot project CA fallback (single-host installs with self-signed certs)
+    _project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    _cert_dir = os.environ.get("AUTOBOT_TLS_CERT_DIR", "certs")
+    _fallback_ca = os.path.join(_project_root, _cert_dir, "ca", "ca-cert.pem")
+    if os.path.isfile(_fallback_ca):
+        ctx.load_verify_locations(_fallback_ca)
+        if client_cert and client_key:
+            ctx.load_cert_chain(client_cert, client_key)
+        return ctx
+
+    # 5. Loopback target — accept self-signed certs (no MITM possible, #6654)
+    if _is_loopback_target(target_url):
+        global _loopback_permissive_warned
+        if not _loopback_permissive_warned:
+            logger.warning(
+                "TLS verification disabled for loopback target %s — no CA configured "
+                "(set AUTOBOT_TLS_CA_PATH for strict verification, #6654)",
+                target_url,
+            )
+            _loopback_permissive_warned = True
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+
+    # 6. Strict by default (system trust store)
+    if client_cert and client_key:
+        ctx.load_cert_chain(client_cert, client_key)
+    return ctx

--- a/autobot_shared/tls_test.py
+++ b/autobot_shared/tls_test.py
@@ -1,0 +1,174 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for autobot_shared.tls — canonical SSL context factory (#6702).
+
+Lifted from services/slm_client_test.py::TestCreatePermissiveSslContext and
+adapted to test get_internal_tls_context directly.
+"""
+
+import os
+import ssl
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from autobot_shared.tls import _is_loopback_target, get_internal_tls_context
+
+
+class TestGetInternalTlsContext:
+    """Tests for get_internal_tls_context trust hierarchy."""
+
+    def test_returns_ssl_context(self) -> None:
+        """Default call returns an ssl.SSLContext."""
+        ctx = get_internal_tls_context()
+        assert isinstance(ctx, ssl.SSLContext)
+
+    def test_verification_enabled_by_default(self) -> None:
+        """Without any env vars, verification is not disabled."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            ctx = get_internal_tls_context()
+        assert ctx.verify_mode != ssl.CERT_NONE
+
+    def test_skip_tls_verify_disables_verification(self) -> None:
+        """AUTOBOT_SKIP_TLS_VERIFY=true disables cert verification."""
+        with patch.dict(os.environ, {"AUTOBOT_SKIP_TLS_VERIFY": "true"}, clear=False):
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            ctx = get_internal_tls_context()
+        assert ctx.verify_mode == ssl.CERT_NONE
+        assert ctx.check_hostname is False
+
+    def test_skip_tls_verify_case_insensitive(self) -> None:
+        """AUTOBOT_SKIP_TLS_VERIFY=TRUE (upper-case) also disables verification."""
+        with patch.dict(os.environ, {"AUTOBOT_SKIP_TLS_VERIFY": "TRUE"}, clear=False):
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            ctx = get_internal_tls_context()
+        assert ctx.verify_mode == ssl.CERT_NONE
+
+    def test_explicit_ca_path_loads_ca(self) -> None:
+        """AUTOBOT_TLS_CA_PATH pointing to a valid CA cert is loaded."""
+        import subprocess
+
+        with tempfile.NamedTemporaryFile(suffix=".pem", delete=False) as f:
+            ca_path = f.name
+
+        try:
+            result = subprocess.run(
+                [
+                    "openssl",
+                    "req",
+                    "-x509",
+                    "-newkey",
+                    "rsa:2048",
+                    "-keyout",
+                    "/dev/null",
+                    "-out",
+                    ca_path,
+                    "-days",
+                    "1",
+                    "-nodes",
+                    "-subj",
+                    "/CN=TestCA",
+                ],
+                capture_output=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                pytest.skip("openssl not available")
+
+            with patch.dict(os.environ, {"AUTOBOT_TLS_CA_PATH": ca_path}, clear=False):
+                os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+                ctx = get_internal_tls_context()
+
+            assert ctx.verify_mode != ssl.CERT_NONE
+        finally:
+            os.unlink(ca_path)
+
+    def test_explicit_ca_path_argument_takes_precedence(self) -> None:
+        """Explicit ca_path= argument bypasses the env-var chain."""
+        import subprocess
+
+        with tempfile.NamedTemporaryFile(suffix=".pem", delete=False) as f:
+            ca_path = f.name
+
+        try:
+            result = subprocess.run(
+                ["openssl", "req", "-x509", "-newkey", "rsa:2048", "-keyout", "/dev/null",
+                 "-out", ca_path, "-days", "1", "-nodes", "-subj", "/CN=TestCA"],
+                capture_output=True, timeout=10,
+            )
+            if result.returncode != 0:
+                pytest.skip("openssl not available")
+
+            # Even with SKIP_TLS_VERIFY set, explicit ca_path wins
+            with patch.dict(os.environ, {"AUTOBOT_SKIP_TLS_VERIFY": "true"}, clear=False):
+                ctx = get_internal_tls_context(ca_path=ca_path)
+
+            assert ctx.verify_mode != ssl.CERT_NONE
+        finally:
+            os.unlink(ca_path)
+
+    def test_nonexistent_ca_path_falls_through(self) -> None:
+        """A missing AUTOBOT_TLS_CA_PATH file does not crash — falls through."""
+        with patch.dict(
+            os.environ, {"AUTOBOT_TLS_CA_PATH": "/nonexistent/ca.pem"}, clear=False
+        ):
+            os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+            ctx = get_internal_tls_context()
+        assert isinstance(ctx, ssl.SSLContext)
+
+    def test_loopback_target_uses_cert_none_when_no_ca_configured(self) -> None:
+        """Loopback target with no CA → CERT_NONE (#6654)."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            for url in (
+                "https://127.0.0.1:8000",
+                "https://localhost:8000",
+                "wss://127.0.0.1:8000/api/ws/events",
+            ):
+                ctx = get_internal_tls_context(url)
+                assert ctx.verify_mode == ssl.CERT_NONE, f"loopback URL {url} should disable verify"
+                assert ctx.check_hostname is False
+
+    def test_non_loopback_target_remains_strict_when_no_ca_configured(self) -> None:
+        """Non-loopback target with no CA → strict (production safety, #6654)."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            ctx = get_internal_tls_context("https://10.0.0.5:8000")
+        assert ctx.verify_mode != ssl.CERT_NONE
+
+    def test_no_target_url_remains_strict(self) -> None:
+        """No URL passed → strict (preserves original strict-by-default contract)."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            ctx = get_internal_tls_context()
+        assert ctx.verify_mode != ssl.CERT_NONE
+
+
+class TestIsLoopbackTarget:
+    """Tests for the loopback host detection helper."""
+
+    def test_localhost(self) -> None:
+        assert _is_loopback_target("https://localhost:8000") is True
+
+    def test_127(self) -> None:
+        assert _is_loopback_target("https://127.0.0.1:8000") is True
+
+    def test_ipv6_loopback(self) -> None:
+        assert _is_loopback_target("https://[::1]:8000") is True
+
+    def test_non_loopback(self) -> None:
+        assert _is_loopback_target("https://10.0.0.5:8000") is False
+
+    def test_none_url(self) -> None:
+        assert _is_loopback_target(None) is False
+
+    def test_empty_string(self) -> None:
+        assert _is_loopback_target("") is False


### PR DESCRIPTION
## Summary

- Consolidates 4+ duplicate `ssl.SSLContext` builders into one canonical `get_internal_tls_context()` in `autobot_shared/tls.py`
- Fixes a latent `AttributeError` bug where `config.tls_ca_path` / `config.skip_tls_verify` were accessed via ConfigManager proxy but only exist under `config.misc.tls_ca_path` — new module reads `os.environ` directly
- 15 unit tests for the new factory and loopback-detection helper

## Trust Hierarchy

1. Explicit `ca_path=` argument (mTLS callers like Celery Redis)
2. `AUTOBOT_TLS_CA_PATH` env var (production CA)
3. `AUTOBOT_SKIP_TLS_VERIFY=true` (dev/test permissive mode)
4. Project CA fallback at `<root>/<AUTOBOT_TLS_CERT_DIR>/ca/ca-cert.pem`
5. Loopback target → `CERT_NONE` (fixes #6654 regression — no CA configured for localhost)
6. System trust store — strict by default

## Files Changed

- `autobot_shared/tls.py` — new canonical module
- `autobot_shared/tls_test.py` — 15 unit tests
- `autobot-backend/services/slm_client.py` — removed local duplicate; re-exports canonical for one-cycle backward compat
- `autobot-backend/orchestration/dag_executor.py` — `_build_slm_ssl_context()` now delegates to shared factory
- `autobot-backend/celery_app.py` — mTLS Redis context uses canonical factory + fixes `ssot_config.misc.tls_ca_path` access
- `autobot-backend/services/notification_service.py` — SMTP TLS uses canonical factory

## Test plan

- [ ] `python -m pytest autobot_shared/tls_test.py -v` — all 15 tests pass
- [ ] `python -c 'from autobot_shared.tls import get_internal_tls_context'` — import OK
- [ ] `python -c 'from autobot-backend.services.slm_client import _create_permissive_ssl_context'` — backward compat re-export OK
- [ ] Celery worker starts with Redis TLS enabled (smoke test)

Closes #6702

🤖 Generated with [Claude Code](https://claude.com/claude-code)