### PR TITLE
refactor(backend): complete optional_import migration for 5 modules (#7895)

### DIFF
--- a/autobot-backend/api/codebase_analytics/analyzers.py
+++ b/autobot-backend/api/codebase_analytics/analyzers.py
@@ -16,6 +16,7 @@ from typing import Dict, List, Set, Tuple
 import aiofiles
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.missing_dep import optional_import
 from constants.network_constants import NetworkConstants
 from services.llm_service import get_llm_service
 from type_defs.common import Metadata
@@ -26,23 +27,18 @@ logger = get_logger(__name__)
 # Issue #662: Thread-safe locks for analyzer singletons
 _analyzers_lock = threading.Lock()
 
-try:
-    from code_intelligence.anti_pattern_detector import AntiPatternDetector
-    from code_intelligence.bug_predictor import BugPredictor
-    from code_intelligence.performance_analyzer import PerformanceAnalyzer
-
-    _anti_pattern_detector: AntiPatternDetector | None = None
-    _performance_analyzer: PerformanceAnalyzer | None = None
-    _bug_predictor: BugPredictor | None = None
-    _analyzers_available = True
-except ImportError as e:
-    from autobot_shared.missing_dep import MissingDep as _MissingDep
-
-    logger.warning("Code intelligence analyzers not available: %s", e)
-    _analyzers_available = False
-    _anti_pattern_detector = _MissingDep("AntiPatternDetector", e)  # type: ignore[assignment]
-    _performance_analyzer = _MissingDep("PerformanceAnalyzer", e)  # type: ignore[assignment]
-    _bug_predictor = _MissingDep("BugPredictor", e)  # type: ignore[assignment]
+_apd = optional_import("code_intelligence.anti_pattern_detector", ["AntiPatternDetector"])
+_bp = optional_import("code_intelligence.bug_predictor", ["BugPredictor"])
+_pa = optional_import("code_intelligence.performance_analyzer", ["PerformanceAnalyzer"])
+AntiPatternDetector = _apd["AntiPatternDetector"]  # type: ignore[assignment]
+BugPredictor = _bp["BugPredictor"]  # type: ignore[assignment]
+PerformanceAnalyzer = _pa["PerformanceAnalyzer"]  # type: ignore[assignment]
+_analyzers_available = bool(AntiPatternDetector)
+if not _analyzers_available:
+    logger.warning("Code intelligence analyzers not available: %s", AntiPatternDetector)
+_anti_pattern_detector = None if _analyzers_available else AntiPatternDetector  # type: ignore[assignment]
+_performance_analyzer = None if _analyzers_available else PerformanceAnalyzer  # type: ignore[assignment]
+_bug_predictor = None if _analyzers_available else BugPredictor  # type: ignore[assignment]
 
 
 # =============================================================================

--- a/autobot-backend/api/long_running_operations.py
+++ b/autobot-backend/api/long_running_operations.py
@@ -56,33 +56,29 @@ from constants.threshold_constants import TimingConstants
 sys.path.append(str(PATH.PROJECT_ROOT))
 
 # Import our long-running operations framework
-try:
-    from utils.long_running_operations_framework import OperationStatus, OperationType
-    from utils.operation_timeout_integration import (
-        CreateOperationRequest,
-        OperationMigrator,
-        operation_integration_manager,
-    )
+from autobot_shared.missing_dep import optional_import
 
-    _OPERATIONS_AVAILABLE = True
-except ImportError as _e:
-    from autobot_shared.missing_dep import MissingDep as _MissingDep
-
-    logging.warning(f"Long-running operations framework not available: {_e}")
-    OperationStatus = _MissingDep("OperationStatus", _e)  # type: ignore[assignment]
-    OperationType = _MissingDep("OperationType", _e)  # type: ignore[assignment]
-    CreateOperationRequest = _MissingDep("CreateOperationRequest", _e)  # type: ignore[assignment]
-    OperationMigrator = _MissingDep("OperationMigrator", _e)  # type: ignore[assignment]
-    operation_integration_manager = _MissingDep("operation_integration_manager", _e)  # type: ignore[assignment]
-    _OPERATIONS_AVAILABLE = False
+_lro = optional_import("utils.long_running_operations_framework", ["OperationStatus", "OperationType"])
+_lro_int = optional_import(
+    "utils.operation_timeout_integration",
+    ["CreateOperationRequest", "OperationMigrator", "operation_integration_manager"],
+)
+OperationStatus = _lro["OperationStatus"]  # type: ignore[assignment]
+OperationType = _lro["OperationType"]  # type: ignore[assignment]
+CreateOperationRequest = _lro_int["CreateOperationRequest"]  # type: ignore[assignment]
+OperationMigrator = _lro_int["OperationMigrator"]  # type: ignore[assignment]
+operation_integration_manager = _lro_int["operation_integration_manager"]  # type: ignore[assignment]
+_OPERATIONS_AVAILABLE = bool(OperationStatus)
+if not _OPERATIONS_AVAILABLE:
+    logging.warning("Long-running operations framework not available: %s", OperationStatus)
 
 logger = get_logger(__name__)
 router = APIRouter(tags=["long-running-operations"])
 
 # Performance optimization: O(1) lookup for failed operation statuses (Issue #326)
-try:
+if _OPERATIONS_AVAILABLE:
     FAILED_OPERATION_STATUSES = {OperationStatus.FAILED, OperationStatus.TIMEOUT}
-except ImportError:
+else:
     FAILED_OPERATION_STATUSES = set()
 
 

--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -13,21 +13,18 @@ from fastapi.responses import JSONResponse
 from api.schemas_workflows import AgentRecommendationRequest, WorkflowRequest
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.missing_dep import optional_import
 
-try:
-    from orchestrator import create_and_execute_workflow, get_orchestrator_sync
-
-    # Issue #5040: Single Orchestrator conductor; provides all multi-agent
-    # workflow methods (create_workflow_plan, execute_workflow,
-    # get_performance_report, get_agent_recommendations, etc.).
-    orchestrator = get_orchestrator_sync()
+# Issue #5040: Single Orchestrator conductor; provides all multi-agent workflow
+# methods (create_workflow_plan, execute_workflow, get_performance_report, etc.).
+_orch = optional_import("orchestrator", ["create_and_execute_workflow", "get_orchestrator_sync"])
+create_and_execute_workflow = _orch["create_and_execute_workflow"]  # type: ignore[assignment]
+if _orch["get_orchestrator_sync"]:
+    orchestrator = _orch["get_orchestrator_sync"]()  # type: ignore[assignment]
     _ORCHESTRATOR_AVAILABLE = True
-except ImportError as _e:
-    from autobot_shared.missing_dep import MissingDep as _MissingDep
-
+else:
+    orchestrator = _orch["get_orchestrator_sync"]  # MissingDep stub  # type: ignore[assignment]
     _ORCHESTRATOR_AVAILABLE = False
-    create_and_execute_workflow = _MissingDep("create_and_execute_workflow", _e)  # type: ignore[assignment]
-    orchestrator = _MissingDep("orchestrator", _e)  # type: ignore[assignment]
     get_logger(__name__).warning("orchestrator module not available")
 
 from api.schemas_common import DataResponse

--- a/autobot-backend/training/__init__.py
+++ b/autobot-backend/training/__init__.py
@@ -8,7 +8,7 @@ ML model training infrastructure for code completion.
 """
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.missing_dep import MissingDep as _MissingDep
+from autobot_shared.missing_dep import MissingDep as _MissingDep, optional_import
 
 logger = get_logger(__name__)
 
@@ -21,16 +21,14 @@ __all__ = [
     "CompletionEvaluator",
 ]
 
+# optional_import handles ImportError; RuntimeError (e.g. from torch CUDA init on import)
+# is caught separately so all six symbols get MissingDep stubs in either case.
 try:
-    from training.completion_model import CompletionModel
-    from training.completion_trainer import CompletionTrainer
-    from training.data_loader import PatternDataset, Tokenizer, create_dataloaders
-    from training.evaluator import CompletionEvaluator
-except (ImportError, RuntimeError) as e:
-    logger.warning("ML training dependencies unavailable: %s", e)
-    CompletionModel = _MissingDep("CompletionModel", e)  # type: ignore[assignment]
-    CompletionTrainer = _MissingDep("CompletionTrainer", e)  # type: ignore[assignment]
-    PatternDataset = _MissingDep("PatternDataset", e)  # type: ignore[assignment]
-    Tokenizer = _MissingDep("Tokenizer", e)  # type: ignore[assignment]
-    create_dataloaders = _MissingDep("create_dataloaders", e)  # type: ignore[assignment]
-    CompletionEvaluator = _MissingDep("CompletionEvaluator", e)  # type: ignore[assignment]
+    globals().update(optional_import("training.completion_model", ["CompletionModel"]))
+    globals().update(optional_import("training.completion_trainer", ["CompletionTrainer"]))
+    globals().update(optional_import("training.data_loader", ["PatternDataset", "Tokenizer", "create_dataloaders"]))
+    globals().update(optional_import("training.evaluator", ["CompletionEvaluator"]))
+except RuntimeError as _e:
+    logger.warning("ML training dependencies unavailable: %s", _e)
+    for _name in ["CompletionModel", "CompletionTrainer", "PatternDataset", "Tokenizer", "create_dataloaders", "CompletionEvaluator"]:
+        globals()[_name] = _MissingDep(_name, _e)

--- a/autobot-backend/utils/gpu_vector_search.py
+++ b/autobot-backend/utils/gpu_vector_search.py
@@ -31,6 +31,10 @@ from autobot_shared.missing_dep import MissingDep as _MissingDep
 from knowledge.backends import BaseClient, BaseCollection
 from utils.async_initializable import AsyncInitializable
 
+# FAISS and ChromaDB are imported as whole-module objects (faiss.IndexFlatL2(),
+# faiss.StandardGpuResources(), etc.) so optional_import() — which extracts
+# individual symbols — cannot replace these blocks without refactoring all
+# 15+ call sites.  MissingDep is applied at the module level below instead.
 # FAISS import with graceful fallback
 try:
     import faiss


### PR DESCRIPTION
## Summary

Completes the optional_import migration (#6691 Phase 2) for the 5 remaining multi-symbol optional-import sites identified in GH#7895.

- **training/__init__.py** (6 symbols): 4 sub-module calls via `globals().update(optional_import(...))`; RuntimeError (e.g. torch CUDA init) still caught in a wrapping try/except since `optional_import` only catches ImportError
- **api/orchestration.py** (2 symbols): `optional_import("orchestrator", [...])` with a bool guard to call `get_orchestrator_sync()` only when the module loaded
- **api/long_running_operations.py** (5 symbols): two `optional_import` calls (one per source module); `_OPERATIONS_AVAILABLE` derived from `bool(OperationStatus)`; secondary try/except replaced with if/else
- **api/codebase_analytics/analyzers.py** (3 symbols): three one-symbol `optional_import` calls; `_analyzers_available` flag and instance vars updated accordingly
- **utils/gpu_vector_search.py**: faiss/chromadb are whole-module objects used via `faiss.XYZ()` throughout (15+ call sites) with a GPU `hasattr` check that `optional_import` would break for CPU-only installs — retained MissingDep pattern with an explanatory comment

## Test plan

- [x] `python -m py_compile` passes on all 5 modified files
- [x] No removed or renamed functions — call-site impact is zero
- [x] `optional_import` is already in `autobot_shared/missing_dep.py` — no new dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)