### PR TITLE
fix: debug discoveries #6769 (ChromaDB missing), #6770 (circuit-breaker total_calls=0), #6771 (i18n 59 missing keys)

### DIFF
--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -347,15 +347,16 @@ ws_manager = MonitoringWebSocketManager()
 
 
 def _resolve_service_urls() -> tuple:
-    """Helper for get_services_health. Ref: #1088.
+    """Helper for get_services_health. Ref: #1088, #6769.
 
-    Resolve health-check URLs for NPU worker, browser, and Ollama from the
-    config manager, falling back to known static addresses on any error.
+    Resolve health-check URLs for NPU worker, browser, Ollama, and ChromaDB
+    from the config manager, falling back to known static addresses on any error.
     """
     try:
         npu_url = f"http://{_ssot.vm.npu}:{_ssot.port.npu}/health"
         browser_url = f"http://{_ssot.vm.browser}:{_ssot.port.browser}/health"
         ollama_url = f"http://{_ssot.vm.ollama}:{_ssot.port.ollama}/api/version"
+        chromadb_url = f"http://{_ssot.vm.aistack}:{_ssot.port.aistack}/api/v2/heartbeat"
     except Exception:
         # Issue #1229: Use ConfigRegistry (defaults from SSOT via registry_defaults)
         npu_host = ConfigRegistry.get("vm.npu")
@@ -364,10 +365,13 @@ def _resolve_service_urls() -> tuple:
         browser_port = ConfigRegistry.get("port.browser")
         ollama_host = ConfigRegistry.get("vm.llm")
         ollama_port = ConfigRegistry.get("port.ollama")
+        chromadb_host = ConfigRegistry.get("vm.aistack")
+        chromadb_port = ConfigRegistry.get("port.aistack")
         npu_url = f"http://{npu_host}:{npu_port}/health"
         browser_url = f"http://{browser_host}:{browser_port}/health"
         ollama_url = f"http://{ollama_host}:{ollama_port}/api/version"
-    return npu_url, browser_url, ollama_url
+        chromadb_url = f"http://{chromadb_host}:{chromadb_port}/api/v2/heartbeat"
+    return npu_url, browser_url, ollama_url, chromadb_url
 
 
 def _safe_result(res, default=("offline", "Error")):
@@ -390,7 +394,7 @@ def _to_service_entry(name: str, host: str, port: int, status: str, msg: str) ->
 
 
 def _build_service_list(results: list) -> list:
-    """Helper for get_services_health. Ref: #1088.
+    """Helper for get_services_health. Ref: #1088, #6769.
 
     Unpack asyncio.gather results into a ServicesSummary-compatible list.
     Each entry is a dict with name, host, port, status, response_time_ms,
@@ -400,6 +404,7 @@ def _build_service_list(results: list) -> list:
     npu_s, npu_m = _safe_result(results[1])
     ollama_s, ollama_m = _safe_result(results[2])
     browser_s, browser_m = _safe_result(results[3])
+    chromadb_s, chromadb_m = _safe_result(results[4])
 
     # Issue #1229/#2671: Use ConfigRegistry (defaults from SSOT via registry_defaults)
     return [
@@ -437,6 +442,13 @@ def _build_service_list(results: list) -> list:
             int(ConfigRegistry.get("port.browser")),
             browser_s,
             browser_m,
+        ),
+        _to_service_entry(
+            "ChromaDB",
+            ConfigRegistry.get("vm.aistack"),
+            int(ConfigRegistry.get("port.aistack")),
+            chromadb_s,
+            chromadb_m,
         ),
     ]
 
@@ -485,13 +497,14 @@ async def get_services_health():
     """
     from api.service_monitor import _check_http_health, _check_redis_health
 
-    npu_url, browser_url, ollama_url = _resolve_service_urls()
+    npu_url, browser_url, ollama_url, chromadb_url = _resolve_service_urls()
 
     results = await asyncio.gather(
         _check_redis_health(),
         _check_http_health(npu_url),
         _check_http_health(ollama_url),
         _check_http_health(browser_url),
+        _check_http_health(chromadb_url),
         return_exceptions=True,
     )
 

--- a/autobot-backend/llm_shared/providers/ollama_provider.py
+++ b/autobot-backend/llm_shared/providers/ollama_provider.py
@@ -90,6 +90,8 @@ class OllamaProvider(BaseProvider):
             if chat_template:
                 # Issue #4525: when a chat_template is set, render messages to a
                 # prompt string and POST to /api/generate directly.
+                # Issue #6770: route through the shared "ollama_service" circuit breaker
+                # so total_calls is incremented (same breaker as the delegate path).
                 base_url = self._resolve_base_url()
                 model = request.model_name or self._get_setting("default_model", "")
                 raw_messages = [
@@ -110,18 +112,25 @@ class OllamaProvider(BaseProvider):
                 if request.max_tokens:
                     payload["options"]["num_predict"] = request.max_tokens
 
-                http_client = get_http_client()
-                timeout = aiohttp.ClientTimeout(total=None, connect=5.0, sock_read=None)
-                async with await http_client.post(
-                    f"{base_url}{PATH_OLLAMA_GENERATE}",
-                    headers={"Content-Type": "application/json"},
-                    json=payload,
-                    timeout=timeout,
-                ) as resp:
-                    if resp.status != 200:
-                        body = await resp.text()
-                        raise RuntimeError(f"Ollama generate returned HTTP {resp.status}: {body}")
-                    data = await resp.json()
+                from circuit_breaker import get_circuit_breaker_manager
+
+                cb = get_circuit_breaker_manager().get_circuit_breaker("ollama_service")
+
+                async def _generate() -> Dict[str, Any]:
+                    http_client = get_http_client()
+                    timeout = aiohttp.ClientTimeout(total=None, connect=5.0, sock_read=None)
+                    async with await http_client.post(
+                        f"{base_url}{PATH_OLLAMA_GENERATE}",
+                        headers={"Content-Type": "application/json"},
+                        json=payload,
+                        timeout=timeout,
+                    ) as resp:
+                        if resp.status != 200:
+                            body = await resp.text()
+                            raise RuntimeError(f"Ollama generate returned HTTP {resp.status}: {body}")
+                        return await resp.json()
+
+                data = await cb.call_async(_generate)
                 content = data.get("response", "")
                 usage = {
                     "prompt_tokens": data.get("prompt_eval_count", 0),

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -2274,7 +2274,20 @@
       "subtitle": "Subtitle",
       "title": "Title",
       "traditionalDesc": "Traditional desc",
-      "traditionalSearch": "Traditional search"
+      "traditionalSearch": "Traditional search",
+      "accessPlatform": "Platform",
+      "accessPublic": "Public",
+      "accessSystem": "System",
+      "accessUser": "User",
+      "clickToView": "Click to view full document",
+      "close": "Close",
+      "copyContent": "Copy Content",
+      "defaultDocTitle": "Untitled Document",
+      "foundResults": "Found {count} results for \"{query}\"",
+      "loadingDocument": "Loading document content...",
+      "matchScore": "{value}% match",
+      "noContent": "No content available",
+      "rerankScore": "{value}% rerank"
     },
     "upload": {
       "tagsPlaceholder": "Enter tags separated by commas...",
@@ -2323,7 +2336,14 @@
       "visShared": "Vis shared",
       "visSystem": "Vis system",
       "visibility": "Visibility",
-      "visibilityHint": "Visibility hint"
+      "visibilityHint": "Visibility hint",
+      "errorAddText": "Failed to add text to knowledge base",
+      "errorFileTooLarge": "File \"{name}\" exceeds the maximum size limit",
+      "errorImportUrl": "Failed to import URL content",
+      "errorUnsupportedFormat": "File \"{name}\" has an unsupported format",
+      "errorUploadFiles": "Failed to upload files",
+      "successTextAdded": "Text added to knowledge base successfully",
+      "successUrlImported": "URL content imported successfully"
     },
     "documents": "Documents",
     "categories": {
@@ -3245,7 +3265,8 @@
       "vectorFramework": "Vector framework",
       "vectorIndexHealth": "Vector index health",
       "vectorNotGenerated": "Vector not generated",
-      "vectorizedForRag": "Vectorized for rag"
+      "vectorizedForRag": "Vectorized for rag",
+      "confirmOptimize": "This will optimize the database. Continue?"
     },
     "summaries": {
       "search": {
@@ -3376,7 +3397,11 @@
       "decisionsApplied": "{count} decision(s) applied successfully",
       "compiledSuccess": "Chat compiled successfully",
       "failedToLoad": "Failed to load knowledge items",
-      "decisionsApplyFailed": "Failed to apply decisions"
+      "decisionsApplyFailed": "Failed to apply decisions",
+      "compileFailed": "Failed to compile conversation",
+      "suggestionAddToKb": "Suggested: Add to Knowledge Base",
+      "suggestionDelete": "Suggested: Delete",
+      "suggestionKeepTemporary": "Suggested: Keep Temporarily"
     },
     "systemKnowledge": {
       "vectorizeTooltip": "Generate vector embeddings for all knowledge base entries to enable semantic search",
@@ -3409,7 +3434,14 @@
       "success": "Success",
       "targetHost": "Target host",
       "totalFacts": "Total facts",
-      "vectorizing": "Vectorizing"
+      "vectorizing": "Vectorizing",
+      "confirmIndexDocs": "Do you want to force reindex existing documents?",
+      "confirmInitialize": "This will initialize system knowledge for the selected host. This may take several minutes. Continue?",
+      "confirmRefreshManPages": "This will refresh man pages for the selected host. Continue?",
+      "confirmReindex": "This will reindex all documents for the selected host. Continue?",
+      "confirmVectorize": "This will vectorize {totalFacts} facts. Currently {totalVectors} vectors exist, {needsVectorization} need vectorization. Continue?",
+      "vectorizeComplete": "Vectorize Facts (✓ {vectors} vectors from {facts} facts)",
+      "vectorizePending": "Vectorize Facts ({pending} pending)"
     },
     "vectorization": {
       "actionVectorize": "Vectorize",
@@ -3428,7 +3460,15 @@
       "noDocuments": "No documents",
       "progressTitle": "Progress title",
       "retryFailed": "Retry failed",
-      "total": "Total"
+      "total": "Total",
+      "statusFailed": "Failed",
+      "statusPending": "Pending",
+      "statusUnknown": "Unknown",
+      "statusVectorized": "Vectorized",
+      "tooltipFailed": "Vectorization failed for this document",
+      "tooltipPending": "Document is pending vectorization",
+      "tooltipUnknown": "Vectorization status unknown",
+      "tooltipVectorized": "Document has been vectorized and is searchable via RAG"
     },
     "batchSelection": {
       "selected": "{count} selected",
@@ -3468,7 +3508,15 @@
       "warnings": "Warnings"
     },
     "manager": {
-      "errorFallback": "Error fallback"
+      "errorFallback": "Error fallback",
+      "tabAdvanced": "Advanced",
+      "tabCategories": "Categories",
+      "tabManage": "Manage",
+      "tabPromptEditor": "Prompts",
+      "tabSearch": "Search",
+      "tabStatistics": "Statistics",
+      "tabSystemDocs": "System Docs",
+      "tabUpload": "Upload"
     },
     "memoryOrphan": {
       "activeSessions": "Active sessions",
@@ -3633,7 +3681,8 @@
       "user": "User",
       "write": "Write",
       "searchError": "Search failed",
-      "searchUnavailable": "Search unavailable"
+      "searchUnavailable": "Search unavailable",
+      "unsavedConfirm": "You have unsaved changes. Are you sure you want to close?"
     },
     "systemDocs": {
       "copied": "Copied",
@@ -3649,7 +3698,13 @@
       "selectDocument": "Select document",
       "subtitle": "Subtitle",
       "title": "Title",
-      "words": "Words"
+      "words": "Words",
+      "errorCopy": "Failed to copy to clipboard",
+      "errorExport": "Failed to export document",
+      "errorExportAll": "Failed to export all documents",
+      "errorLoadCategories": "Failed to load documentation categories",
+      "errorLoadContent": "Failed to load document content",
+      "errorLoadDocs": "Failed to load documents"
     },
     "treeNode": {
       "itemsCount": "Items count",
@@ -3678,7 +3733,11 @@
       "selectAll": "Select all",
       "selectedCount": "Selected count",
       "title": "Title",
-      "untitled": "Untitled"
+      "untitled": "Untitled",
+      "typeConnector": "Connector",
+      "typeResearch": "Web Research",
+      "typeUpload": "Manual Upload",
+      "typeUrl": "URL Fetch"
     },
     "webResearch": {
       "title": "Web Research",


### PR DESCRIPTION
## Summary

- **#6769** `api/monitoring.py`: ChromaDB was missing from `_build_service_list`, so `/api/services/version` reported `services_count: 5` while the fleet has 6 members. Added ChromaDB health check (`/api/v2/heartbeat`) to `_resolve_service_urls`, the `asyncio.gather` call, and the service list — count now matches the 6-service fleet.
- **#6770** `llm_shared/providers/ollama_provider.py`: The `chat_template` code path in `OllamaProvider.chat_completion` called `http_client.post()` directly, bypassing the `"ollama_service"` circuit breaker entirely. `total_calls` stayed at 0 because this is the primary code path for local Ollama models. Extracted the HTTP call into a `_generate()` closure and routed it through `cb.call_async`, sharing the same circuit breaker as the delegate path.
- **#6771** `autobot-frontend/src/i18n/locales/en.json`: 59 `knowledge.*` translation keys existed only as flat top-level JSON strings (e.g. `"knowledge.manager.tabSearch": "Search"`). vue-i18n v9+ path-resolver cannot find flat keys — it traverses nested objects. Added all 59 to their proper nested paths under `knowledge.manager`, `knowledge.search`, `knowledge.upload`, `knowledge.persistence`, `knowledge.systemDocs`, `knowledge.systemKnowledge`, `knowledge.vectorization`, `knowledge.verification`, and `knowledge.share`.

## Test plan

- [ ] `python3 -m py_compile autobot-backend/api/monitoring.py` — syntax clean
- [ ] `python3 -m py_compile autobot-backend/llm_shared/providers/ollama_provider.py` — syntax clean
- [ ] `python3 -c "import json; d=json.load(open('...en.json')); assert d['knowledge']['manager']['tabSearch']=='Search'"` — key resolvable via path
- [ ] After deploy: `GET /api/services/version` → `services_count: 6`
- [ ] After deploy + chat: `GET /api/health/circuit-breakers` → `ollama_service.total_calls > 0`
- [ ] In app: `/knowledge` manage tab labels render as text, not raw key strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)