### PR TITLE
fix(code-analysis): threshold tuning, problem-dict helper, consolidation fixes (#6780, #6759, #6757)

### DIFF
--- a/autobot-backend/api/codebase_analytics/analyzers.py
+++ b/autobot-backend/api/codebase_analytics/analyzers.py
@@ -947,14 +947,16 @@ def _run_anti_pattern_analysis(file_path: str) -> List[Dict]:
                 if _anti_pattern_detector is None:
                     _anti_pattern_detector = AntiPatternDetector()
         result = _anti_pattern_detector.analyze_file(file_path)
-        for pattern in result.get("patterns", []):
+        # #6757: key is "anti_patterns" (list of dicts from .to_dict()); not
+        # "patterns" (old wrong key) and not AntiPatternResult objects.
+        for pattern in result.get("anti_patterns", []):
             problems.append(
                 {
-                    "type": f"code_smell_{pattern.pattern_type.value}",
-                    "severity": pattern.severity.value,
-                    "line": pattern.line_number,
-                    "description": pattern.description,
-                    "suggestion": pattern.suggestion,
+                    "type": f"code_smell_{pattern['pattern_type']}",
+                    "severity": pattern["severity"],
+                    "line": pattern.get("line_number", 0),
+                    "description": pattern.get("description", ""),
+                    "suggestion": pattern.get("suggestion", ""),
                 }
             )
     except Exception as e:

--- a/autobot-backend/api/codebase_analytics/chromadb_storage.py
+++ b/autobot-backend/api/codebase_analytics/chromadb_storage.py
@@ -239,6 +239,32 @@ async def _generate_batch_embeddings_fallback(
     return all_embeddings
 
 
+def make_problem_dict(
+    problem_type: str,
+    severity: str,
+    file_path: str,
+    line: int,
+    description: str,
+    suggestion: str,
+    file_category: str = FILE_CATEGORY_CODE,
+) -> Dict:
+    """Canonical factory for the problem-dict schema (#6759).
+
+    Single source of truth for the keys read by ``_prepare_problem_document``
+    and written by cross-file analysis converters.  If the schema gains a new
+    field, add it here and update the reader below.
+    """
+    return {
+        "type": problem_type,
+        "severity": severity,
+        "file_path": file_path,
+        "file_category": file_category,
+        "line": line,
+        "description": description,
+        "suggestion": suggestion,
+    }
+
+
 def _prepare_problem_document(problem: Dict, problem_idx: int, source_id: str | None = None) -> tuple:
     """
     Prepare a problem document for ChromaDB storage.

--- a/autobot-backend/api/codebase_analytics/cross_file_analysis.py
+++ b/autobot-backend/api/codebase_analytics/cross_file_analysis.py
@@ -25,30 +25,30 @@ from typing import Any, Dict, List  # noqa: F401  (List used in pub API)
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
 
+from .chromadb_storage import make_problem_dict
+
 logger = get_logger(__name__)
 
 
 def _antipattern_to_problem(ap: Any, file_category: str = "code") -> Dict[str, Any]:
-    """Map an ``AntiPatternInstance`` to the dict shape persisted by
-    ``_store_problems_batch_to_chromadb`` in chromadb_storage.py:251-287.
+    """Map an ``AntiPatternInstance`` to the canonical problem dict (#6759).
 
-    The persistence layer reads the keys ``type``, ``severity``, ``file_path``,
-    ``line``, ``description``, ``suggestion`` — others are ignored.  We prefix
-    the type with ``code_smell_`` to match the convention from
-    ``analyzers.py::_run_anti_pattern_analysis`` so the dashboard's existing
-    grouping picks the new findings up automatically.
+    Uses ``make_problem_dict`` from ``chromadb_storage`` as the single source
+    of truth for the schema, so adding a new persistence field only requires
+    updating that factory.  We prefix the type with ``code_smell_`` to match
+    the convention from ``analyzers.py::_run_anti_pattern_analysis``.
     """
     pattern_type = ap.pattern_type.value if hasattr(ap, "pattern_type") else "unknown"
     severity = ap.severity.value if hasattr(ap, "severity") else "medium"
-    return {
-        "type": f"code_smell_{pattern_type}",
-        "severity": severity,
-        "file_path": getattr(ap, "file_path", ""),
-        "file_category": file_category,
-        "line": getattr(ap, "line_number", 0),
-        "description": getattr(ap, "description", ""),
-        "suggestion": getattr(ap, "suggestion", ""),
-    }
+    return make_problem_dict(
+        problem_type=f"code_smell_{pattern_type}",
+        severity=severity,
+        file_path=getattr(ap, "file_path", ""),
+        line=getattr(ap, "line_number", 0),
+        description=getattr(ap, "description", ""),
+        suggestion=getattr(ap, "suggestion", ""),
+        file_category=file_category,
+    )
 
 
 async def _persist_to_chromadb(

--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -1399,7 +1399,13 @@ class AntiPatternDetector:
             "NamedTuple",
         }
     )
-    _SHAPE_MIN_METHODS = 5
+    # #6780: lowered from 5 → 2 so small identical-shape boilerplate clusters
+    # are detected.  Classes with fewer than _SHAPE_MIN_METHODS_STRICT methods
+    # use a strict Jaccard threshold of 1.0 (exact match) to avoid false
+    # positives for FastAPI endpoint classes that share a few method names by
+    # design.  The relaxed threshold applies only above _SHAPE_MIN_METHODS_STRICT.
+    _SHAPE_MIN_METHODS = 2
+    _SHAPE_MIN_METHODS_STRICT = 5
     _SHAPE_JACCARD_THRESHOLD = 0.7
     # #6755 round 3: bumped from 0.7 to 0.85 to suppress priority-scale
     # FPs. Enums like ``SandboxSecurityLevel`` (high/low/medium),
@@ -1613,8 +1619,15 @@ class AntiPatternDetector:
                 # intended relationship, not a duplicate.
                 if self._is_protocol_impl_pair(cls_a, cls_b):
                     continue
+                # #6780: small classes (below strict threshold) require exact
+                # match (Jaccard=1.0) to suppress FastAPI-handler false positives.
+                threshold = (
+                    self._SHAPE_JACCARD_THRESHOLD
+                    if max(len(names_a), len(names_b)) >= self._SHAPE_MIN_METHODS_STRICT
+                    else 1.0
+                )
                 similarity = self._jaccard(names_a, names_b)
-                if similarity < self._SHAPE_JACCARD_THRESHOLD:
+                if similarity < threshold:
                     continue
                 shared = sorted(names_a & names_b)
                 pair_key = tuple(sorted([full_a, full_b]))
@@ -1940,6 +1953,61 @@ class AntiPatternDetector:
             except Exception as e:
                 logger.warning(f"Failed to retrieve cached results: {e}")
         return None
+
+    def analyze_file(self, file_path: str) -> Dict[str, Any]:
+        """Per-file analysis compatibility shim (#6757).
+
+        Runs the per-file detectors (god_class, feature_envy, long_method,
+        long_parameter_list, lazy_class) on a single file without the
+        cross-file rules that require a whole-codebase index.
+
+        Returns a dict compatible with the legacy ``code_intelligence``
+        per-file analyzer shape expected by callers in ``analyzers.py`` and
+        ``code_evolution_miner.py``.
+        """
+        import asyncio
+
+        async def _inner() -> List[AntiPatternInstance]:
+            clear_ast_cache()
+            detector = AntiPatternDetector()
+            module_info = await detector._parse_file(file_path)
+            if not module_info:
+                return []
+            detector.modules = {module_info.name: module_info}
+            detector.classes = {
+                f"{module_info.name}.{cls.name}": cls for cls in module_info.classes
+            }
+            detector.all_defined_names = {cls.name for cls in module_info.classes}
+            detector.all_defined_names.update(module_info.functions)
+
+            patterns: List[AntiPatternInstance] = []
+            patterns.extend(await detector._detect_god_classes())
+            patterns.extend(await detector._detect_feature_envy())
+            patterns.extend(await detector._detect_long_methods())
+            patterns.extend(await detector._detect_long_parameter_lists())
+            patterns.extend(await detector._detect_lazy_classes())
+            return patterns
+
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                patterns = loop.run_until_complete(_inner())
+            finally:
+                loop.close()
+        except Exception as exc:
+            logger.error("analyze_file error for %s: %s", file_path, exc)
+            patterns = []
+
+        summary: Dict[str, int] = {}
+        for p in patterns:
+            k = p.pattern_type.value
+            summary[k] = summary.get(k, 0) + 1
+
+        return {
+            "file_path": file_path,
+            "anti_patterns": [p.to_dict() for p in patterns],
+            "summary": summary,
+        }
 
 
 # Convenience function for CLI usage

--- a/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
@@ -321,8 +321,12 @@ async def test_duplicate_class_shape_skips_pydantic_models(fixture_root):
 
 
 @pytest.mark.asyncio
-async def test_duplicate_class_shape_below_method_threshold_skipped(fixture_root):
-    """Classes with fewer than the method threshold must NOT be flagged."""
+async def test_duplicate_class_shape_small_identical_flagged(fixture_root):
+    """#6780: small classes with IDENTICAL method sets (Jaccard=1.0) ARE flagged.
+
+    The threshold was lowered from 5 → 2.  The guard for false positives is
+    the strict-Jaccard rule: small classes need exact match, not just ≥0.7.
+    """
     apd = _load_detector_module()
     _write_module(
         fixture_root,
@@ -345,7 +349,40 @@ async def test_duplicate_class_shape_below_method_threshold_skipped(fixture_root
         exclude_patterns=["__pycache__"],
     )
     dup_shape = [ap for ap in report.anti_patterns if ap.pattern_type.value == "duplicate_class_shape"]
-    assert not dup_shape, "small classes (< _SHAPE_MIN_METHODS) should be skipped"
+    assert dup_shape, "small classes with identical method sets should be flagged (#6780)"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_class_shape_small_partial_overlap_skipped(fixture_root):
+    """#6780: small classes with partial method overlap are NOT flagged.
+
+    Below _SHAPE_MIN_METHODS_STRICT (5) the threshold is 1.0 (exact match).
+    A class pair sharing 1 of 2 methods (Jaccard=0.33) must NOT produce a
+    finding — this guards against FastAPI endpoint false positives.
+    """
+    apd = _load_detector_module()
+    _write_module(
+        fixture_root,
+        "partial",
+        """
+        class EndpointA:
+            def list(self): pass
+            def create(self): pass
+
+        class EndpointB:
+            def list(self): pass
+            def delete(self): pass
+        """,
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+    dup_shape = [ap for ap in report.anti_patterns if ap.pattern_type.value == "duplicate_class_shape"]
+    assert not dup_shape, "small classes with partial overlap should NOT be flagged (strict threshold)"
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/code_intelligence/anti_pattern_detector.py
+++ b/autobot-backend/code_intelligence/anti_pattern_detector.py
@@ -26,6 +26,18 @@ New facade: ~100 lines (92% reduction)
 # Backward compatibility: Expose commonly used regex patterns
 import re
 
+# #6757: canonical AntiPatternDetector lives in code_analysis.src.
+# Expose it here so that all callers of this facade get the unified class
+# that has both per-file (analyze_file) and cross-file (analyze,
+# analyze_cross_file_only) support.  Fall back to the package-local class
+# if code_analysis is unavailable (e.g., isolated test environments).
+try:
+    from code_analysis.src.anti_pattern_detector import (
+        AntiPatternDetector,  # noqa: F401  (re-exported below)
+    )
+except ImportError:
+    from .anti_pattern_detection import AntiPatternDetector  # type: ignore[assignment]
+
 # Re-export all public API from the package for backward compatibility
 from .anti_pattern_detection import (  # Types and enums; Data models; Severity utilities; Detectors; Main analyzer
     ALLOWED_MAGIC_NUMBERS,
@@ -34,7 +46,6 @@ from .anti_pattern_detection import (  # Types and enums; Data models; Severity 
     DEFAULT_IGNORE_PATTERNS,
     SNAKE_CASE_RE,
     AnalysisReport,
-    AntiPatternDetector,
     AntiPatternResult,
     AntiPatternSeverity,
     AntiPatternType,

--- a/autobot-backend/code_intelligence/code_evolution_miner.py
+++ b/autobot-backend/code_intelligence/code_evolution_miner.py
@@ -415,21 +415,19 @@ class CodeEvolutionMiner:
 
                 # Analyze file for anti-patterns
                 try:
-                    with open(file_path, encoding="utf-8") as f:
-                        code = f.read()
-
-                    # Use anti-pattern detector
-                    results = self.anti_pattern_detector.analyze_code(code, str(file_path))
+                    # #6757: analyze_code() never existed; use analyze_file()
+                    # which returns {"anti_patterns": [dict, ...], ...}.
+                    result_dict = self.anti_pattern_detector.analyze_file(str(file_path))
 
                     # Track each detected pattern
-                    for result in results.patterns:
+                    for ap in result_dict.get("anti_patterns", []):
                         occurrence = PatternOccurrence(
-                            pattern_type=result.type.value,
+                            pattern_type=ap.get("pattern_type", "unknown"),
                             file_path=str(item),
-                            line_number=result.line_number,
+                            line_number=ap.get("line_number", 0),
                             commit_hash=commit["hash"],
                             timestamp=commit["timestamp"],
-                            severity=result.severity.value,
+                            severity=ap.get("severity", "low"),
                         )
                         self.tracker.track_pattern(occurrence)
 


### PR DESCRIPTION
## Summary

Three related code-analysis fixes in one PR:

**#6780 — DUPLICATE_CLASS_SHAPE threshold tuning**
- `_SHAPE_MIN_METHODS` lowered from 5 → 2 so small identical-shape boilerplate clusters can be detected
- Classes below `_SHAPE_MIN_METHODS_STRICT` (5) require Jaccard=1.0 (exact match) to suppress FastAPI endpoint false positives
- Replaced test `below_method_threshold_skipped` with two precise tests: `small_identical_flagged` + `small_partial_overlap_skipped`
- All 12 consolidation tests pass

**#6759 — Extract problem-dict helper**
- Added `make_problem_dict()` factory to `chromadb_storage.py` — single source of truth for the problem persistence schema
- `cross_file_analysis.py::_antipattern_to_problem()` now calls the factory, eliminating the lock-step update risk when the schema gains a new field

**#6757 — Partial consolidation (two broken callers fixed)**
- Added `analyze_file()` shim to `code_analysis/src/AntiPatternDetector` — now supports both per-file and cross-file analysis
- Made `code_intelligence/anti_pattern_detector.py` facade import canonical class from `code_analysis/src` (falls back to package if unavailable)
- Fixed `analyzers.py`: wrong dict key `"patterns"` → `"anti_patterns"` + object-attribute access → dict-key access (was a silent no-op)
- Fixed `code_evolution_miner.py`: non-existent `analyze_code()` → `analyze_file()` + proper dict access (was crashing)

Note: Full #6757 consolidation (one canonical enum + delete dead module) is tracked in the remaining acceptance criteria — the per-file and cross-file enum types are fundamentally different domains requiring a separate focused PR.

## Test plan
- [x] All 12 `anti_pattern_detector_consolidation_test.py` tests pass
- [x] Python syntax clean on all 7 modified files (`py_compile`)
- [x] New tests: `test_duplicate_class_shape_small_identical_flagged`, `test_duplicate_class_shape_small_partial_overlap_skipped`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)