### PR TITLE
fix(slm-backend): revert Mapped[X|None] PEP 604 codemod + fix ChromaDB health URL (#8266 #8265)

### DIFF
--- a/autobot-backend/user_management/models/api_key.py
+++ b/autobot-backend/user_management/models/api_key.py
@@ -9,7 +9,7 @@ Long-lived API keys for programmatic access.
 
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import JSONB
@@ -141,7 +141,7 @@ class APIKey(Base):
         foreign_keys=[user_id],
     )
 
-    team: Mapped["Team" | None] = relationship(
+    team: Mapped[Optional["Team"]] = relationship(
         "Team",
         back_populates="api_keys",
     )

--- a/autobot-backend/user_management/models/role.py
+++ b/autobot-backend/user_management/models/role.py
@@ -8,7 +8,7 @@ Implements database-driven RBAC (Role-Based Access Control).
 """
 
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, ForeignKey, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -133,7 +133,7 @@ class Role(Base):
     )
 
     # Relationships
-    organization: Mapped["Organization" | None] = relationship(
+    organization: Mapped[Optional["Organization"]] = relationship(
         "Organization",
         back_populates="roles",
     )

--- a/autobot-backend/user_management/models/sso.py
+++ b/autobot-backend/user_management/models/sso.py
@@ -12,7 +12,7 @@ Supports multiple SSO providers:
 import uuid
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
@@ -130,7 +130,7 @@ class SSOProvider(Base):
     )
 
     # Relationships
-    organization: Mapped["Organization" | None] = relationship(
+    organization: Mapped[Optional["Organization"]] = relationship(
         "Organization",
         back_populates="sso_providers",
     )

--- a/autobot-backend/user_management/models/user.py
+++ b/autobot-backend/user_management/models/user.py
@@ -9,7 +9,7 @@ Core user model with authentication, profile, and tenant association.
 
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import JSONB
@@ -168,7 +168,7 @@ class User(Base):
     )
 
     # Relationships
-    organization: Mapped["Organization" | None] = relationship(
+    organization: Mapped[Optional["Organization"]] = relationship(
         "Organization",
         back_populates="users",
     )
@@ -199,7 +199,7 @@ class User(Base):
         cascade="all, delete-orphan",
     )
 
-    mfa: Mapped["UserMFA" | None] = relationship(
+    mfa: Mapped[Optional["UserMFA"]] = relationship(
         "UserMFA",
         back_populates="user",
         uselist=False,

--- a/autobot-slm-backend/ansible/setup-ai-stack.yml
+++ b/autobot-slm-backend/ansible/setup-ai-stack.yml
@@ -71,8 +71,8 @@
 
     - name: Check ChromaDB health
       uri:
-        url: "http://{{ ansible_host }}:{{ chromadb_port }}/api/v1/heartbeat"
-        status_code: [200, 404]
+        url: "http://{{ ansible_host }}:{{ chromadb_port }}/api/v2/heartbeat"
+        status_code: [200]
         timeout: 5
       register: chromadb_check
       failed_when: false

--- a/autobot-slm-backend/user_management/models/api_key.py
+++ b/autobot-slm-backend/user_management/models/api_key.py
@@ -9,7 +9,7 @@ Long-lived API keys for programmatic access.
 
 import uuid
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import JSONB, UUID
@@ -139,7 +139,7 @@ class APIKey(Base, TimestampMixin):
         foreign_keys=[user_id],
     )
 
-    team: Mapped["Team" | None] = relationship(
+    team: Mapped[Optional["Team"]] = relationship(
         "Team",
         back_populates="api_keys",
     )

--- a/autobot-slm-backend/user_management/models/role.py
+++ b/autobot-slm-backend/user_management/models/role.py
@@ -8,7 +8,7 @@ Implements database-driven RBAC (Role-Based Access Control).
 """
 
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import UUID
@@ -133,7 +133,7 @@ class Role(Base, TimestampMixin):
     )
 
     # Relationships
-    organization: Mapped["Organization" | None] = relationship(
+    organization: Mapped[Optional["Organization"]] = relationship(
         "Organization",
         back_populates="roles",
     )

--- a/autobot-slm-backend/user_management/models/sso.py
+++ b/autobot-slm-backend/user_management/models/sso.py
@@ -12,7 +12,7 @@ Supports multiple SSO providers:
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID
@@ -127,7 +127,7 @@ class SSOProvider(Base, TimestampMixin):
     )
 
     # Relationships
-    organization: Mapped["Organization" | None] = relationship(
+    organization: Mapped[Optional["Organization"]] = relationship(
         "Organization",
         back_populates="sso_providers",
     )

--- a/autobot-slm-backend/user_management/models/user.py
+++ b/autobot-slm-backend/user_management/models/user.py
@@ -9,7 +9,7 @@ Core user model with authentication, profile, and tenant association.
 
 import uuid
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
@@ -147,7 +147,7 @@ class User(Base, TimestampMixin):
     )
 
     # Relationships
-    organization: Mapped["Organization" | None] = relationship(
+    organization: Mapped[Optional["Organization"]] = relationship(
         "Organization",
         back_populates="users",
     )
@@ -178,7 +178,7 @@ class User(Base, TimestampMixin):
         cascade="all, delete-orphan",
     )
 
-    mfa: Mapped["UserMFA" | None] = relationship(
+    mfa: Mapped[Optional["UserMFA"]] = relationship(
         "UserMFA",
         back_populates="user",
         uselist=False,


### PR DESCRIPTION
## Summary

Fixes two production emergencies:

### #8266 — SLM crash-loop (CRITICAL)

**Root cause:** Commit `f67fd54a2` (PEP 604 codemod #7443) converted `Mapped[Optional["X"]]` to `Mapped["X" | None]` in SQLAlchemy relationship annotations. At runtime `"X"` is a Python `str`, so `str | None` raises `TypeError: unsupported operand type(s) for |: 'str' and 'NoneType'` — crashing SLM on every startup (783+ restarts).

**Fix:** Added `Optional` to `typing` imports; reverted 5 relationship annotations in `autobot-slm-backend` + 5 in `autobot-backend` (companion tree hit by same codemod).

### #8265 — ChromaDB health check URL

**Fix:** Updated `/api/v1/heartbeat` → `/api/v2/heartbeat` (v1 returns 410 on chromadb≥0.4).

## Thinking Path

1. Identified crash traceback: `Mapped["Team" | None]` evaluates `"Team" | None` at class-parse time → `str | None` → `TypeError` on Python <3.10
2. Grepped for all `Mapped[".*" | None]` patterns in both `autobot-slm-backend` and `autobot-backend` models
3. Fix: add `Optional` to typing import + convert annotation to `Mapped[Optional["X"]]` (SQLAlchemy-compatible form)
4. For ChromaDB: health check URL was `/api/v1/heartbeat` which returns 410 on chromadb≥0.4; updated to `/api/v2/heartbeat`
5. Code review caught that `autobot-backend` had the identical pattern — added second commit to fix both trees

## What Changed

- `autobot-slm-backend/user_management/models/api_key.py` — `Optional` import + `Mapped[Optional["Team"]]`
- `autobot-slm-backend/user_management/models/user.py` — `Optional` import + `Mapped[Optional["Organization"]]`, `Mapped[Optional["UserMFA"]]`
- `autobot-slm-backend/user_management/models/role.py` — `Optional` import + `Mapped[Optional["Organization"]]`
- `autobot-slm-backend/user_management/models/sso.py` — `Optional` import + `Mapped[Optional["Organization"]]`
- `autobot-backend/user_management/models/api_key.py` — same as SLM counterpart
- `autobot-backend/user_management/models/user.py` — same as SLM counterpart
- `autobot-backend/user_management/models/role.py` — same as SLM counterpart
- `autobot-backend/user_management/models/sso.py` — same as SLM counterpart
- `autobot-slm-backend/ansible/setup-ai-stack.yml` — health check URL v1→v2

## Verification

- `python3 -c "import ast; ast.parse(open(f).read())"` passes on all 8 changed model files
- `grep -rn "Mapped[\".*\" | None]"` returns no matches in either model tree after fix
- All 5 SLM annotations confirmed `Mapped[Optional["X"]]` in place; all 5 backend annotations same
- `Optional` import present in all 4 SLM model files and all 4 backend model files

## Model Used

Claude Sonnet 4.6

## Test plan

- [ ] SLM backend starts without TypeError after Ansible deploy
- [ ] `systemctl status autobot-chromadb` shows active after `setup-ai-stack.yml` runs
- [ ] `/api/v2/heartbeat` health check returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)