### PR TITLE
refactor(async): wakeup coalescing + scheduler docs (#6472, #6505, #6507)

### DIFF
--- a/autobot-backend/api/heartbeat.py
+++ b/autobot-backend/api/heartbeat.py
@@ -306,4 +306,5 @@ def _wakeup_to_response(req: AgentWakeupRequest) -> WakeupRequestResponse:
         consumed=req.consumed_at is not None,
         consumed_at=(req.consumed_at.isoformat() if req.consumed_at else None),
         created_at=(req.created_at.isoformat() if req.created_at else None),
+        merged_count=req.merged_count if req.merged_count is not None else 0,
     )

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -2347,6 +2347,7 @@ class WakeupRequestResponse(BaseModel):
     consumed: bool
     consumed_at: str | None
     created_at: str | None
+    merged_count: int = 0
 
 
 class RunEventResponse(BaseModel):

--- a/autobot-backend/migrations/versions/20260522_021_heartbeat_wakeup_merged_count.py
+++ b/autobot-backend/migrations/versions/20260522_021_heartbeat_wakeup_merged_count.py
@@ -1,0 +1,31 @@
+"""Add merged_count to agent_wakeup_requests for wakeup coalescing observability.
+
+Revision ID: 20260522_021
+Revises: 20260516_020
+Create Date: 2026-05-22 00:00:00.000000
+
+GH#6472: Pre-insert dedup in HeartbeatScheduler.wakeup() coalesces repeated
+wakeup signals for the same (agent_id, task_id) into one row.  This column
+tracks how many extra signals were merged, enabling tuning visibility.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260522_021"
+down_revision: Union[str, None] = "20260516_020"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_wakeup_requests",
+        sa.Column("merged_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_wakeup_requests", "merged_count")

--- a/autobot-backend/models/heartbeat.py
+++ b/autobot-backend/models/heartbeat.py
@@ -162,6 +162,7 @@ class AgentWakeupRequest(Base):
     reason = Column(String(255), nullable=True)
     consumed_at = Column(DateTime, nullable=True)
     consumed_by_run_id = Column(Uuid(as_uuid=True), nullable=True)
+    merged_count = Column(Integer, nullable=False, default=0)
 
     runtime_state = relationship("AgentRuntimeState", back_populates="wakeup_requests")
 

--- a/autobot-backend/services/heartbeat_scheduler.py
+++ b/autobot-backend/services/heartbeat_scheduler.py
@@ -16,7 +16,7 @@ import asyncio
 import uuid
 from typing import Any, Dict, Tuple
 
-from sqlalchemy import select, update
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from autobot_shared.logging_manager import get_logger

--- a/autobot-backend/services/heartbeat_scheduler.py
+++ b/autobot-backend/services/heartbeat_scheduler.py
@@ -16,7 +16,7 @@ import asyncio
 import uuid
 from typing import Any, Dict, Tuple
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from autobot_shared.logging_manager import get_logger
@@ -106,8 +106,43 @@ class HeartbeatScheduler:
         priority: int = 0,
         reason: str | None = None,
     ) -> str:
-        """Queue an event-driven wakeup request. Returns the request UUID (#1407)."""
+        """Queue an event-driven wakeup request. Returns the request UUID (#1407).
+
+        Deduplicates by (agent_id, task_id) for un-consumed requests (#6472).
+        When a matching un-consumed row exists: merges contexts (incoming wins
+        on conflict), takes max priority, increments merged_count, and returns
+        the existing request id.  If task_id is absent from context no
+        coalescing is attempted.
+        """
+        task_id: str | None = (context or {}).get("task_id")
+
         async with self._session_factory() as session:
+            if task_id is not None:
+                existing_result = await session.execute(
+                    select(AgentWakeupRequest)
+                    .where(
+                        AgentWakeupRequest.agent_id == agent_id,
+                        AgentWakeupRequest.consumed_at.is_(None),
+                        AgentWakeupRequest.context["task_id"].astext == task_id,
+                    )
+                    .with_for_update()
+                    .limit(1)
+                )
+                existing = existing_result.scalar_one_or_none()
+                if existing is not None:
+                    existing.context = {**(existing.context or {}), **(context or {})}
+                    existing.priority = max(existing.priority, priority)
+                    existing.merged_count = existing.merged_count + 1
+                    await session.commit()
+                    req_id = str(existing.id)
+                    logger.debug(
+                        "Wakeup coalesced for agent=%s task_id=%s (merged_count=%d)",
+                        agent_id,
+                        task_id,
+                        existing.merged_count,
+                    )
+                    return req_id
+
             state = await _get_or_create_state(session, agent_id)
             req = AgentWakeupRequest(
                 id=uuid.uuid4(),
@@ -120,6 +155,7 @@ class HeartbeatScheduler:
             session.add(req)
             await session.commit()
             req_id = str(req.id)
+
         logger.info("Wakeup request %s queued for agent %s", req_id, agent_id)
         if agent_id not in self._tasks and self._running:
             asyncio.create_task(

--- a/autobot-backend/tests/unit/test_heartbeat_coalescing.py
+++ b/autobot-backend/tests/unit/test_heartbeat_coalescing.py
@@ -1,0 +1,256 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""
+Unit tests for heartbeat wakeup coalescing (#6472).
+
+Verifies that HeartbeatScheduler.wakeup() deduplicates by (agent_id, task_id)
+for un-consumed requests: multiple calls for the same task_id produce exactly
+one row, with merged context, max priority, and incremented merged_count.
+
+Uses importlib to load only the scheduler module (not the whole services
+package), plus lightweight stubs for ORM/infrastructure deps.
+
+The sqlalchemy `select` call is patched to a chainable MagicMock so the
+query-builder code doesn't need a real mapped class — only session.execute()
+is inspected by the tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Stubs + direct-file module loading
+# ---------------------------------------------------------------------------
+
+def _make_stub(name: str, **attrs: Any) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_scheduler() -> types.ModuleType:
+    """Load heartbeat_scheduler.py directly, bypassing services/__init__.py."""
+    # Fake ORM base so models.heartbeat loads without the full user_management chain
+    _make_stub("user_management")
+    _make_stub("user_management.models")
+    _make_stub("user_management.models.base", Base=type("Base", (), {}))
+
+    # Minimal autobot_shared stubs
+    _make_stub("autobot_shared")
+    _make_stub("autobot_shared.logging_manager", get_logger=MagicMock(return_value=MagicMock()))
+    _make_stub("autobot_shared.time_utils", now_utc=MagicMock())
+
+    # events / live event manager
+    _make_stub("events")
+    _make_stub(
+        "events.event_types",
+        HEARTBEAT_RUN_COMPLETED="heartbeat_run_completed",
+        HEARTBEAT_RUN_STARTED="heartbeat_run_started",
+    )
+    _make_stub("live_event_manager", publish_live_event=AsyncMock())
+
+    # models.heartbeat — loaded directly so Column/JSONB work; we swap Base
+    backend_root = Path(__file__).parents[3] / "autobot-backend"
+    hb_spec = importlib.util.spec_from_file_location(
+        "models.heartbeat", backend_root / "models" / "heartbeat.py"
+    )
+    assert hb_spec and hb_spec.loader
+    hb_mod = importlib.util.module_from_spec(hb_spec)
+    sys.modules["models"] = types.ModuleType("models")
+    sys.modules["models.heartbeat"] = hb_mod
+    hb_spec.loader.exec_module(hb_mod)  # type: ignore[union-attr]
+
+    # models.agent
+    _make_stub("models.agent", Agent=MagicMock())
+
+    # services.run_jwt
+    _make_stub("services")
+    _make_stub(
+        "services.run_jwt",
+        get_run_jwt_scopes=MagicMock(),
+        mint_run_jwt=AsyncMock(),
+        revoke_run_jwt_async=AsyncMock(),
+    )
+
+    # Load the scheduler
+    sched_spec = importlib.util.spec_from_file_location(
+        "services.heartbeat_scheduler", backend_root / "services" / "heartbeat_scheduler.py"
+    )
+    assert sched_spec and sched_spec.loader
+    sched_mod = importlib.util.module_from_spec(sched_spec)
+    sys.modules["services.heartbeat_scheduler"] = sched_mod
+    sched_spec.loader.exec_module(sched_mod)  # type: ignore[union-attr]
+    return sched_mod
+
+
+_mod = _load_scheduler()
+HeartbeatScheduler = _mod.HeartbeatScheduler
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_req(agent_id: str, task_id: str, priority: int = 0, merged: int = 0) -> MagicMock:
+    req = MagicMock()
+    req.id = uuid.uuid4()
+    req.agent_id = agent_id
+    req.context = {"task_id": task_id}
+    req.priority = priority
+    req.merged_count = merged
+    req.consumed_at = None
+    return req
+
+
+def _make_state(agent_id: str) -> MagicMock:
+    state = MagicMock()
+    state.id = uuid.uuid4()
+    state.agent_id = agent_id
+    return state
+
+
+def _session_returning(scalar: Any) -> AsyncMock:
+    """Async session whose execute().scalar_one_or_none() returns `scalar`."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _chainable_select() -> MagicMock:
+    """Return a MagicMock that returns itself on every attribute/call chain."""
+    m = MagicMock()
+    m.where.return_value = m
+    m.with_for_update.return_value = m
+    m.limit.return_value = m
+    m.__getitem__.return_value = m
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# Patch `select` in the scheduler module so query-builder code doesn't
+# attempt to use the real SQLAlchemy mapped class metadata.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_coalescing_without_task_id() -> None:
+    """Wakeup without task_id in context always inserts a new row."""
+    scheduler = HeartbeatScheduler.__new__(HeartbeatScheduler)
+    scheduler._running = False
+    scheduler._tasks = {}
+    state = _make_state("agent-1")
+    inserted: list[Any] = []
+
+    def make_session() -> AsyncMock:
+        s = _session_returning(None)
+        s.add = lambda row: inserted.append(row)
+        return s
+
+    scheduler._session_factory = MagicMock(side_effect=make_session)
+    fake_req = MagicMock()
+    fake_req.id = uuid.uuid4()
+
+    with patch.object(_mod, "select", return_value=_chainable_select()), \
+         patch.object(_mod, "AgentWakeupRequest", return_value=fake_req), \
+         patch.object(_mod, "_get_or_create_state", AsyncMock(return_value=state)):
+        id1 = await scheduler.wakeup("agent-1", context={"foo": "bar"}, priority=1)
+        fake_req.id = uuid.uuid4()  # different id for second call
+        id2 = await scheduler.wakeup("agent-1", context={"foo": "baz"}, priority=2)
+
+    assert id1 != id2
+    assert len(inserted) == 2
+
+
+@pytest.mark.asyncio
+async def test_coalesce_on_same_task_id() -> None:
+    """Five wakeups for same task_id → 1 row inserted, merged_count=4."""
+    scheduler = HeartbeatScheduler.__new__(HeartbeatScheduler)
+    scheduler._running = False
+    scheduler._tasks = {}
+
+    agent_id = "agent-coalesce"
+    task_id = "task-abc"
+    existing_req = _make_req(agent_id, task_id, priority=0, merged=0)
+    state = _make_state(agent_id)
+    inserted: list[Any] = []
+    call_num = [0]
+
+    def make_session() -> AsyncMock:
+        call_num[0] += 1
+        if call_num[0] == 1:
+            s = _session_returning(None)
+            s.add = lambda row: inserted.append(row)
+            return s
+        return _session_returning(existing_req)
+
+    scheduler._session_factory = MagicMock(side_effect=make_session)
+    new_row = MagicMock()
+    new_row.id = uuid.uuid4()
+
+    with patch.object(_mod, "select", return_value=_chainable_select()), \
+         patch.object(_mod, "AgentWakeupRequest", return_value=new_row), \
+         patch.object(_mod, "_get_or_create_state", AsyncMock(return_value=state)):
+        await scheduler.wakeup(agent_id, context={"task_id": task_id}, priority=0)
+        for i in range(4):
+            ret_id = await scheduler.wakeup(agent_id, context={"task_id": task_id}, priority=i)
+            assert ret_id == str(existing_req.id)
+
+    assert len(inserted) == 1
+    assert existing_req.merged_count == 4
+
+
+@pytest.mark.asyncio
+async def test_coalesce_takes_max_priority() -> None:
+    """Coalescing takes the max priority across all wakeups."""
+    scheduler = HeartbeatScheduler.__new__(HeartbeatScheduler)
+    scheduler._running = False
+    scheduler._tasks = {}
+
+    existing_req = _make_req("agent-p", "task-p", priority=3, merged=0)
+    scheduler._session_factory = MagicMock(return_value=_session_returning(existing_req))
+
+    with patch.object(_mod, "select", return_value=_chainable_select()), \
+         patch.object(_mod, "_get_or_create_state", AsyncMock()):
+        await scheduler.wakeup("agent-p", context={"task_id": "task-p"}, priority=10)
+
+    assert existing_req.priority == 10
+
+
+@pytest.mark.asyncio
+async def test_coalesce_merges_context() -> None:
+    """Coalescing merges context dicts; incoming keys win on conflict."""
+    scheduler = HeartbeatScheduler.__new__(HeartbeatScheduler)
+    scheduler._running = False
+    scheduler._tasks = {}
+
+    existing_req = _make_req("agent-c", "task-c")
+    existing_req.context = {"task_id": "task-c", "a": "old", "b": "keep"}
+    scheduler._session_factory = MagicMock(return_value=_session_returning(existing_req))
+
+    with patch.object(_mod, "select", return_value=_chainable_select()), \
+         patch.object(_mod, "_get_or_create_state", AsyncMock()):
+        await scheduler.wakeup("agent-c", context={"task_id": "task-c", "a": "new", "c": "added"}, priority=0)
+
+    assert existing_req.context["a"] == "new"
+    assert existing_req.context["b"] == "keep"
+    assert existing_req.context["c"] == "added"

--- a/autobot-backend/utils/task_queue.py
+++ b/autobot-backend/utils/task_queue.py
@@ -6,6 +6,15 @@ Robust task queue system for AutoBot with Redis backend.
 
 This module provides a comprehensive task queue implementation with
 priority handling, retry logic, and distributed task execution.
+
+Architecture note — #6505 carve-out (#6468):
+  The Phase 1 async-consolidation plan (GH#6505) migrates most task-queue
+  work onto Celery.  This module is explicitly retained as a carve-out
+  because the NPU worker manager (initialization/lifespan.py) needs atomic
+  Redis Streams claim semantics (SETNX-based exclusive ownership per
+  GH#6468) that Celery does not expose.  Do NOT migrate or delete this
+  file until GH#6468 is resolved.  See docs/architecture/async-work.md
+  for the decision tree.
 """
 
 import asyncio

--- a/docs/architecture/async-work.md
+++ b/docs/architecture/async-work.md
@@ -2,11 +2,13 @@
 
 > Tracks the consolidation effort under umbrella issue [#6495](https://github.com/mrveiss/AutoBot-AI/issues/6495). This document is updated as each phase lands.
 >
-> - **Phase 1 — Task queues** ([#6505](https://github.com/mrveiss/AutoBot-AI/issues/6505)): _pending_
+> - **Phase 1 — Task queues** ([#6505](https://github.com/mrveiss/AutoBot-AI/issues/6505)): _pending_ — background_task_manager migration to Celery; task_queue.py retained as [#6468](https://github.com/mrveiss/AutoBot-AI/issues/6468) carve-out
 > - **Phase 2 — Progress trackers** ([#6506](https://github.com/mrveiss/AutoBot-AI/issues/6506)): **landed**
-> - **Phase 3 — Periodic schedulers** ([#6507](https://github.com/mrveiss/AutoBot-AI/issues/6507)): partially landed
->   - Beat deployment ([#6555](https://github.com/mrveiss/AutoBot-AI/issues/6555)): **landed (this PR)**
->   - ConnectorScheduler multi-worker fix ([#6556](https://github.com/mrveiss/AutoBot-AI/issues/6556)): **landed**
+> - **Phase 3 — Periodic schedulers** ([#6507](https://github.com/mrveiss/AutoBot-AI/issues/6507)): **landed**
+>   - Beat deployment ([#6555](https://github.com/mrveiss/AutoBot-AI/issues/6555)): landed
+>   - ConnectorScheduler multi-worker fix ([#6556](https://github.com/mrveiss/AutoBot-AI/issues/6556)): landed
+>   - cron_scheduler.py dead stub: deleted
+> - **Wakeup coalescing** ([#6472](https://github.com/mrveiss/AutoBot-AI/issues/6472)): **landed** — dedup by (agent_id, task_id), merged_count observability column
 
 The async-work stack covers three sub-domains: **queue work → execute → report progress → schedule next**. Historically each had two or three parallel implementations; #6495 consolidates them onto one canonical primitive per sub-domain.
 
@@ -151,6 +153,37 @@ All four workers call `begin_leader_election()` at startup
 
 - `services/scheduling/cron_scheduler.py` — 44 LOC stub with no execution loop,
   zero callers. Deleted in [#6507](https://github.com/mrveiss/AutoBot-AI/issues/6507).
+
+## Wakeup coalescing ([#6472](https://github.com/mrveiss/AutoBot-AI/issues/6472))
+
+### Problem
+
+Without deduplication, N simultaneous wakeup signals for the same
+`(agent_id, task_id)` — e.g., `@-mention + assignment + cron` firing within
+the same second — insert N rows and trigger N redundant agent runs, burning N×
+tokens for the same effective work.
+
+### Solution
+
+`HeartbeatScheduler.wakeup()` checks for an existing un-consumed row with the
+same `(agent_id, task_id)` before inserting. When found:
+
+1. Context is merged (incoming keys win on conflict).
+2. Priority is updated to `max(existing, incoming)`.
+3. `merged_count` is incremented (observability column; default 0 on clean rows).
+4. The existing row id is returned — no new row is inserted.
+
+Coalescing is skipped when `context` is absent or does not contain `task_id`,
+so non-task wakeups (interval ticks, manual triggers) are unaffected.
+
+The `FOR UPDATE` lock on the existing row prevents a TOCTOU race where two
+concurrent calls both see "no existing row" and both insert.
+
+### Schema
+
+`agent_wakeup_requests.merged_count INTEGER NOT NULL DEFAULT 0` — migration
+`20260522_021`. Read this column in Grafana or the `/heartbeat/{agent_id}/wakeup`
+API response to tune coalescing thresholds.
 
 ## Cross-cutting
 


### PR DESCRIPTION
## Summary

Refactors for the async/scheduler consolidation phase (#6472, #6505, #6507).

Closes #6472 — Heartbeat wakeup coalescing
Partially closes #6507 — Scheduler docs update  
Partially closes #6505 — task_queue.py carve-out documented

## Thinking Path

1. Read all three issues; #6507 is largely done (cron_scheduler.py already deleted, ConnectorScheduler upgraded with leader election in MVA-160/#6556); #6505 is >5pt and needs a split; #6472 is the bounded implementable change.
2. For #6472: the wakeup() method in heartbeat_scheduler.py does a plain INSERT with no dedup — N wakeup signals for same (agent_id, task_id) → N rows → N redundant agent runs. Fix: check for un-consumed row with matching task_id before inserting; merge context + max priority + increment merged_count.
3. Added merged_count column with server_default=0 (additive-only migration 021). Exposed in WakeupRequestResponse. Used WITH FOR UPDATE locking in the SQLAlchemy query to prevent TOCTOU.
4. For #6505: task_queue.py needs to stay because lifespan.py wires NPU worker manager through it using Redis Streams atomic claims (#6468). Added carve-out docstring.
5. For #6507: docs/architecture/async-work.md already documents the 3-scheduler decision tree (Celery Beat for static cron, ConnectorScheduler for dynamic per-entity, heartbeat for event-driven). Updated status lines and added wakeup coalescing section.
6. Unit tests use importlib direct-file loading + select patching to avoid the full ORM import chain (which has a pre-existing Python 3.10 compat issue in user_management models, filed as #8271 — separately fixed in #8269).

## What Changed

- `autobot-backend/services/heartbeat_scheduler.py` — coalescing logic in `wakeup()`: check existing un-consumed row by `(agent_id, task_id)`, merge if found, else insert
- `autobot-backend/models/heartbeat.py` — `merged_count INTEGER NOT NULL DEFAULT 0` column on `AgentWakeupRequest`
- `autobot-backend/api/schemas_system.py` — `merged_count: int = 0` in `WakeupRequestResponse`
- `autobot-backend/api/heartbeat.py` — map `merged_count` in `_wakeup_to_response()`
- `autobot-backend/migrations/versions/20260522_021_heartbeat_wakeup_merged_count.py` — additive migration
- `autobot-backend/tests/unit/test_heartbeat_coalescing.py` — 4 unit tests covering no-coalesce-without-task-id, 5-wakeups→1-row (merged_count=4), max-priority, context-merge
- `autobot-backend/utils/task_queue.py` — carve-out docstring explaining why this file is NOT migrated to Celery in Phase 1 (#6468 atomic claim dependency)
- `docs/architecture/async-work.md` — Phase 3 marked landed; wakeup coalescing section added

## Verification

- `pytest autobot-backend/tests/unit/test_heartbeat_coalescing.py` → 4/4 passed
- `python3 -m py_compile` on all 7 modified `.py` files → no errors
- `flake8` on all modified `.py` files → 0 E/F errors
- No removed functions; additive-only: new column (nullable via server_default), new schema field (default=0), new conditional branch in wakeup()
- No callers of removed/renamed symbols

## Model Used

Claude Sonnet 4.6

## Test plan

- [x] `pytest autobot-backend/tests/unit/test_heartbeat_coalescing.py` — 4/4 passed
- [x] Pre-merge syntax/import/lint gates pass for my 7 changed files
- [ ] After Ansible deploy: rapid-fire wakeup bursts for same task_id produce 1 row; `merged_count > 0` visible in `/heartbeat/{agent_id}/wakeup` API

## Changelog fragment

- [ ] N/A (internal refactor — no user-visible behavior change for single wakeups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)