### PR TITLE
fix(install): add asyncpg connect timeout + Python import smoke test (MVA-514)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -631,6 +631,42 @@
 # ==========================================================
 # (#2872) Removed ignore_errors — service start failures must surface.
 # If the service fails to start, deployment should report the real state.
+
+# Smoke test: verify Python can import the app before starting the service (MVA-514).
+# Catches import errors immediately — the full traceback appears inline in Ansible output
+# and is saved to slm-startup-smoke.log for reference.
+# Sources the deployed env files so PYTHONPATH and secrets match the live service.
+- name: "SLM | Smoke-test Python import before service start (MVA-514)"
+  ansible.builtin.shell:
+    cmd: >-
+      set -a ;
+      test -f {{ postgresql_credentials_dir }}/{{ postgresql_credentials_file }} &&
+        . {{ postgresql_credentials_dir }}/{{ postgresql_credentials_file }} || true ;
+      test -f {{ slm_credentials_dir }}/{{ slm_credentials_file }} &&
+        . {{ slm_credentials_dir }}/{{ slm_credentials_file }} || true ;
+      set +a ;
+      PYTHONPATH="{{ slm_backend_dir }}:{{ slm_shared_dir }}:{{ slm_base_dir }}"
+      {{ slm_backend_dir }}/venv/bin/python3 -c "import main" 2>&1
+      | tee -a {{ slm_log_dir }}/slm-startup-smoke.log
+  args:
+    chdir: "{{ slm_backend_dir }}"
+    executable: /bin/bash
+  register: _slm_import_check
+  become: true
+  become_user: "{{ slm_user }}"
+  changed_when: false
+  failed_when: false
+  tags: ['slm', 'service']
+
+- name: "SLM | Fail immediately on Python import error (MVA-514)"
+  ansible.builtin.fail:
+    msg: >-
+      SLM backend Python import failed — see error above and in
+      {{ slm_log_dir }}/slm-startup-smoke.log.
+      Last output: {{ _slm_import_check.stdout_lines | default([]) | last(20) }}
+  when: _slm_import_check.rc | default(0) != 0
+  tags: ['slm', 'service']
+
 - name: "SLM | Start backend service"
   ansible.builtin.systemd:
     name: "{{ slm_backend_service }}"
@@ -700,14 +736,28 @@
       failed_when: false
       tags: ['slm', 'service', 'debug']
 
-    - name: "SLM | Display backend logs on health check failure"
+    - name: "SLM | Write backend crash log to file for easier access (MVA-514)"
+      ansible.builtin.copy:
+        content: "{{ _slm_backend_log_output.stdout | default('(empty)') }}"
+        dest: "{{ slm_log_dir }}/slm-health-check-failure.log"
+        owner: "{{ slm_user }}"
+        group: "{{ slm_group }}"
+        mode: '0640'
+      changed_when: false
+      failed_when: false
+      tags: ['slm', 'service', 'debug']
+
+    - name: "SLM | Display last 30 lines of backend log on failure"
       ansible.builtin.debug:
-        msg: "{{ _slm_backend_log_output.stdout_lines | default([]) }}"
+        msg: "{{ _slm_backend_log_output.stdout_lines | default([]) | last(30) }}"
       tags: ['slm', 'service', 'debug']
 
     - name: "SLM | Fail with diagnostic context"
       ansible.builtin.fail:
-        msg: "SLM backend health check failed after {{ 120 * 5 }}s. See logs above."
+        msg: >-
+          SLM backend health check failed after {{ 120 * 5 }}s.
+          Full crash log: {{ slm_log_dir }}/slm-health-check-failure.log
+          Import smoke log: {{ slm_log_dir }}/slm-startup-smoke.log
       tags: ['slm', 'service']
 
 - name: "SLM | Export admin password for downstream plays"

--- a/autobot-slm-backend/services/database.py
+++ b/autobot-slm-backend/services/database.py
@@ -44,6 +44,7 @@ class DatabaseService:
             max_overflow=settings.db_pool_max_overflow,
             pool_recycle=settings.db_pool_recycle,
             pool_pre_ping=True,  # Verify connections before use
+            connect_args={"timeout": 10},  # Prevent indefinite hang on DB unavailable (#7689)
         )
 
         self.session_factory = async_sessionmaker(

--- a/autobot-slm-backend/user_management/database.py
+++ b/autobot-slm-backend/user_management/database.py
@@ -86,6 +86,7 @@ def get_slm_engine() -> AsyncEngine:
                     pool_recycle=pool["pool_recycle"],
                     pool_timeout=pool["pool_timeout"],
                     pool_pre_ping=True,
+                    connect_args={"timeout": 10},
                 )
                 logger.info("Created SLM database engine")
     return _slm_engine
@@ -110,6 +111,7 @@ def get_autobot_engine() -> AsyncEngine:
                     pool_recycle=pool["pool_recycle"],
                     pool_timeout=pool["pool_timeout"],
                     pool_pre_ping=True,
+                    connect_args={"timeout": 10},
                 )
                 logger.info("Created AutoBot database engine")
     return _autobot_engine


### PR DESCRIPTION
## Summary

Fixes MVA-514 — SLM backend health check timeout during installation (`/api/health` times out after 60 retry attempts × 0.5s).

- **asyncpg connection timeout**: Added `connect_args={"timeout": 10}` to `create_async_engine` in `services/database.py` and `user_management/database.py`. Previously asyncpg defaulted to 60s per connection attempt — if PostgreSQL was briefly unreachable at startup the service would hang rather than fail fast and restart.
- **Python import smoke test**: Added Ansible task that runs `python3 -c "import main"` as `slm_user` *before* starting the service. Logs to `slm-startup-smoke.log`. Any import error (missing dep, PermissionError on credentials file, syntax error) now surfaces inline in Ansible output instead of causing a silent restart loop.
- **Improved rescue block**: On health-check failure, writes crash log to `slm-health-check-failure.log`, shows last 30 lines in Ansible output, and includes both log file paths in the failure message.

## Root cause status

Root cause is not yet confirmed — the production install log was truncated. The import smoke test will reveal the exact error on next install attempt. User can also check now:
```
journalctl -u autobot-slm-backend -n 50 --no-pager
cat /var/log/autobot/slm-health-check-failure.log
```

## Test plan

- [x] `py_compile` passes on all modified Python files
- [x] `asyncpg connect timeout` verified in `services/database.py` and `user_management/database.py`
- [x] Ansible smoke test task positioned before service start in `slm_manager` role
- [ ] Full install smoke test on next MVA-514 install attempt — smoke test will surface exact error

Closes #MVA-514

🤖 Generated with [Claude Code](https://claude.ai/claude-code)