### PR TITLE
fix(initialization): close #6690 gaps — strict default + Ansible + test

### DIFF
--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -743,7 +743,7 @@ def load_feature_routers() -> List[Tuple]:
             len(failed),
             ", ".join(r["name"] for r in failed),
         )
-        if config.feature_routers_strict.lower() in {"1", "true", "yes"}:
+        if config.misc.feature_routers_strict.lower() in {"1", "true", "yes"}:
             raise RuntimeError(
                 f"AUTOBOT_FEATURE_ROUTERS_STRICT=1 — {len(failed)} feature router(s) "
                 f"failed to load: {', '.join(r['name'] for r in failed)}"

--- a/autobot-backend/tests/test_startup_imports.py
+++ b/autobot-backend/tests/test_startup_imports.py
@@ -349,7 +349,8 @@ def test_strict_mode_raises_on_router_import_failure(monkeypatch: pytest.MonkeyP
 
     monkeypatch.setenv("AUTOBOT_FEATURE_ROUTERS_STRICT", "1")
     monkeypatch.setattr(feature_routers.config.misc, "feature_routers_strict", "1")
-    monkeypatch.setattr(feature_routers, "importlib", type("_FakeImportlib", (), {"import_module": staticmethod(_failing_import)})())
+    _fake_importlib = type("_FakeImportlib", (), {"import_module": staticmethod(_failing_import)})()
+    monkeypatch.setattr(feature_routers, "importlib", _fake_importlib)
 
     with pytest.raises(RuntimeError, match="AUTOBOT_FEATURE_ROUTERS_STRICT=1"):
         feature_routers.load_feature_routers()

--- a/autobot-backend/tests/test_startup_imports.py
+++ b/autobot-backend/tests/test_startup_imports.py
@@ -299,3 +299,57 @@ def test_no_new_hardcoded_status_strings_in_agents() -> None:
         f"Use AgentStatus enum from agents/payloads.py instead.\n"
         f"All current violations:\n  " + "\n  ".join(violations)
     )
+
+
+def test_strict_mode_raises_on_router_import_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AUTOBOT_FEATURE_ROUTERS_STRICT=1 raises RuntimeError when any router import fails (#6690).
+
+    Verifies the strict-boot path end-to-end:
+    - ImportError injected for the first configured feature-router module.
+    - Config patched to strict=1 (default in dev/CI after #6690 fix).
+    - load_feature_routers() must raise RuntimeError mentioning AUTOBOT_FEATURE_ROUTERS_STRICT=1.
+    """
+    import importlib as _importlib
+    import importlib.util
+    import sys
+    import types
+    from pathlib import Path
+
+    # initialization/__init__.py transitively imports chat_history which may fail
+    # in certain local envs. Pre-populate parent-package stubs with __path__ set
+    # so the import machinery can find submodules without running __init__.py.
+    _backend_root = Path(__file__).resolve().parent.parent
+    _pkg_dirs = {
+        "initialization": str(_backend_root / "initialization"),
+        "initialization.router_registry": str(_backend_root / "initialization/router_registry"),
+    }
+    for _pkg, _pkg_dir in _pkg_dirs.items():
+        if _pkg not in sys.modules:
+            _stub = types.ModuleType(_pkg)
+            _stub.__path__ = [_pkg_dir]  # type: ignore[attr-defined]
+            _stub.__package__ = _pkg
+            monkeypatch.setitem(sys.modules, _pkg, _stub)
+
+    feature_routers = _importlib.import_module("initialization.router_registry.feature_routers")
+
+    # Narrow FEATURE_ROUTER_CONFIGS to one synthetic entry so load_feature_routers()
+    # doesn't try to import the entire real router list (many of which have
+    # pre-existing Python-version or dependency issues in the local test env).
+    _fake_module = "initialization._test_fake_router"
+    monkeypatch.setattr(
+        feature_routers,
+        "FEATURE_ROUTER_CONFIGS",
+        [(_fake_module, "/fake", ["fake"], "fake_router")],
+    )
+
+    def _failing_import(name: str, *args, **kwargs):
+        if name == _fake_module:
+            raise ImportError(f"injected failure for {name}")
+        return _importlib.import_module(name, *args, **kwargs)
+
+    monkeypatch.setenv("AUTOBOT_FEATURE_ROUTERS_STRICT", "1")
+    monkeypatch.setattr(feature_routers.config.misc, "feature_routers_strict", "1")
+    monkeypatch.setattr(feature_routers, "importlib", type("_FakeImportlib", (), {"import_module": staticmethod(_failing_import)})())
+
+    with pytest.raises(RuntimeError, match="AUTOBOT_FEATURE_ROUTERS_STRICT=1"):
+        feature_routers.load_feature_routers()

--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -90,6 +90,10 @@ AUTOBOT_POSTGRES_PASSWORD={{ backend_postgres_password }}
 # Logging
 LOG_LEVEL=INFO
 
+# Feature-router boot mode (#6690): prefer degraded service over hard-fail boot in production.
+# Dev/CI default is strict (1) so import failures surface at PR time, not deploy time.
+AUTOBOT_FEATURE_ROUTERS_STRICT=0
+
 # LLM Provider Configuration (#2553: 6-tier model mapping)
 AUTOBOT_LLM_PROVIDER={{ backend_llm_provider | default('ollama') }}
 AUTOBOT_LLM_ENDPOINT={{ backend_llm_endpoint | default('http://127.0.0.1:11434') }}

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1190,7 +1190,7 @@ class MiscConfig(BaseSettings):
     dev_mode: str = Field(default="", alias="AUTOBOT_DEV_MODE")
     encryption_key: str = Field(default="", alias="AUTOBOT_ENCRYPTION_KEY")
     env: str = Field(default="", alias="AUTOBOT_ENV")
-    feature_routers_strict: str = Field(default="", alias="AUTOBOT_FEATURE_ROUTERS_STRICT")
+    feature_routers_strict: str = Field(default="1", alias="AUTOBOT_FEATURE_ROUTERS_STRICT")
     gc_threshold_0: int = Field(default=0, alias="AUTOBOT_GC_THRESHOLD_0")
     gc_threshold_1: int = Field(default=0, alias="AUTOBOT_GC_THRESHOLD_1")
     gc_threshold_2: int = Field(default=0, alias="AUTOBOT_GC_THRESHOLD_2")


### PR DESCRIPTION
## Thinking Path

GH #6690 had three acceptance-criteria gaps after the initial implementation:
1. \`config.feature_routers_strict\` raised \`AttributeError\` at runtime because the field lives on \`config.misc\` (a \`MiscConfig\` subobject of \`AutoBotConfig\`), not the top-level proxy. This meant any router failure would crash with an unexpected \`AttributeError\` instead of the intended \`RuntimeError\` — even in non-strict mode, since the attribute access happens unconditionally.
2. The default was \`""\` (non-strict), so dev/CI would never see import failures until production deploy.
3. No test exercised the strict-boot path end-to-end.

## What Changed

- **\`ssot_config.py\`**: \`feature_routers_strict\` default changed \`""\` → \`"1"\`. Dev/CI is now strict by default; broken router imports surface at PR time instead of deploy time.
- **\`feature_routers.py\` line 746**: Access path corrected \`config.feature_routers_strict\` → \`config.misc.feature_routers_strict\` (was raising \`AttributeError\` on every partial boot regardless of strict setting).
- **\`backend.env.j2\`**: Adds \`AUTOBOT_FEATURE_ROUTERS_STRICT=0\` so production prefers degraded service over hard-fail boot when optional dependencies (playwright, docker, etc.) are absent.
- **\`test_startup_imports.py\`**: Adds \`test_strict_mode_raises_on_router_import_failure\` — injects an \`ImportError\` for one router, asserts \`RuntimeError\` mentioning \`AUTOBOT_FEATURE_ROUTERS_STRICT=1\`.

## Verification

- \`python3 -m pytest autobot-backend/tests/test_startup_imports.py::test_strict_mode_raises_on_router_import_failure -v\` → PASSED
- Pre-existing failure count unchanged: 249 failed / 49 passed on Dev_new_gui → 249 failed / 50 passed with this PR (exactly one new test added)
- \`ssot_config.py\` default verified as \`"1"\` at line 1193
- \`backend.env.j2\` has \`AUTOBOT_FEATURE_ROUTERS_STRICT=0\` in the Logging section
- \`feature_routers.py\` line 746 now correctly accesses \`config.misc.feature_routers_strict\`
- Black formatting: \`python3 -m black --check --line-length=120 --fast tests/test_startup_imports.py\` → unchanged

## Model Used

claude-sonnet-4-6

---

*Closes GH #6690*

🤖 Generated with [Claude Code](https://claude.com/claude-code)