### PR TITLE
fix(frontend): SW IP-gate, ChatController race warn, polling circuit-breaker (#6767/#6766/#6765)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/usePollingJob.test.ts
+++ b/autobot-frontend/src/composables/__tests__/usePollingJob.test.ts
@@ -265,6 +265,49 @@ describe('usePollingJob', () => {
     stop()
   })
 
+  it('stops after consecutiveErrorLimit consecutive errors (#6765 circuit-breaker)', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('404 Not Found'))
+    const { start, isPolling, error, attempts } = usePollingJob(fetcher, {
+      intervalMs: 100,
+      consecutiveErrorLimit: 3
+    })
+
+    start('task-404')
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(100)
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(attempts.value).toBe(3)
+    expect(isPolling.value).toBe(false)
+    expect(error.value?.message).toBe('404 Not Found')
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(fetcher).toHaveBeenCalledTimes(3)
+  })
+
+  it('resets consecutive error count on success (circuit-breaker survives recovery)', async () => {
+    const fetcher = vi.fn()
+      .mockRejectedValueOnce(new Error('blip'))
+      .mockRejectedValueOnce(new Error('blip'))
+      .mockResolvedValueOnce({ status: 'OK' })
+      .mockRejectedValueOnce(new Error('blip'))
+      .mockRejectedValueOnce(new Error('blip'))
+    const { start, isPolling, attempts } = usePollingJob(fetcher, {
+      intervalMs: 50,
+      consecutiveErrorLimit: 3
+    })
+
+    start('task-recovery')
+    await vi.advanceTimersByTimeAsync(0)   // error #1
+    await vi.advanceTimersByTimeAsync(50)  // error #2
+    await vi.advanceTimersByTimeAsync(50)  // success → resets counter
+    await vi.advanceTimersByTimeAsync(50)  // error #1 again
+    await vi.advanceTimersByTimeAsync(50)  // error #2 again — still below limit 3
+
+    expect(isPolling.value).toBe(true)
+    expect(attempts.value).toBe(5)
+  })
+
   it('picks up updated Ref<number> value when start() is called again', async () => {
     const fetcher = vi.fn().mockResolvedValue({ status: 'PENDING' })
     const intervalRef = ref(1000)

--- a/autobot-frontend/src/composables/usePollingJob.ts
+++ b/autobot-frontend/src/composables/usePollingJob.ts
@@ -39,6 +39,16 @@ export interface UsePollingJobOptions<T> {
   onDone?: (data: T) => void
   /** Return true to stop polling (terminal state reached). Default: never complete. */
   isComplete?: (data: T) => boolean
+  /**
+   * Stop polling after N consecutive errors (independent of `maxAttempts`).
+   * Resets to 0 on any successful poll tick.
+   *
+   * Use for endpoints that 404 repeatedly — these would otherwise spam the
+   * console forever when backend routes are missing.  Default: unlimited.
+   *
+   * #6765: circuit-breaker for mass-404 endpoints.
+   */
+  consecutiveErrorLimit?: number
 }
 
 export interface UsePollingJobReturn<T> {
@@ -62,7 +72,8 @@ export function usePollingJob<T>(
   const {
     maxAttempts = 60,
     onDone,
-    isComplete
+    isComplete,
+    consecutiveErrorLimit
   } = options
 
   const isPolling = ref(false)
@@ -72,6 +83,7 @@ export function usePollingJob<T>(
 
   let timer: ReturnType<typeof setInterval> | null = null
   let currentTaskId: string | null = null
+  let consecutiveErrors = 0
 
   function stop(): void {
     if (timer !== null) {
@@ -90,6 +102,7 @@ export function usePollingJob<T>(
     try {
       const result = await fetcher(taskId)
       if (taskId !== currentTaskId) return
+      consecutiveErrors = 0
       data.value = result
       if (isComplete?.(result) ?? false) {
         stop()
@@ -98,8 +111,14 @@ export function usePollingJob<T>(
       }
     } catch (err) {
       if (taskId !== currentTaskId) return
+      consecutiveErrors += 1
       error.value = err instanceof Error ? err : new Error(String(err))
       logger.warn(`polling attempt ${attempts.value} failed: ${error.value.message}`)
+      if (consecutiveErrorLimit !== undefined && consecutiveErrors >= consecutiveErrorLimit) {
+        logger.info(`polling stopped after ${consecutiveErrors} consecutive errors (consecutiveErrorLimit=${consecutiveErrorLimit})`)
+        stop()
+        return
+      }
     }
 
     if (attempts.value >= maxAttempts) {
@@ -112,6 +131,7 @@ export function usePollingJob<T>(
     stop()
     currentTaskId = taskId
     attempts.value = 0
+    consecutiveErrors = 0
     error.value = null
     data.value = null
     isPolling.value = true

--- a/autobot-frontend/src/main.ts
+++ b/autobot-frontend/src/main.ts
@@ -124,7 +124,15 @@ app.config.warnHandler = (msg, _instance, trace) => {
 app.mount('#app')
 
 // Register Service Worker for caching strategy (Issue #4015, #4041, #3275)
-if ('serviceWorker' in navigator) {
+// #6767: Skip registration on IP-based hosts (172.x, 10.x, 192.168.x, bare-IP) — these
+// deployments almost always use self-signed TLS.  Chrome emits an unrecoverable
+// SecurityError *before* our catch block, polluting the console with a red error.
+// Proactively gating on hostname prevents the attempt entirely.  Localhost is
+// explicitly allowed because it is a secure context even without HTTPS.
+const _swHostIsIp = window.location.hostname !== 'localhost' &&
+  /^(\d{1,3}\.){3}\d{1,3}$/.test(window.location.hostname)
+
+if ('serviceWorker' in navigator && !_swHostIsIp) {
   window.addEventListener('load', async () => {
     try {
       // Register the service worker with stale-while-revalidate strategy (Issue #4015)
@@ -176,6 +184,8 @@ if ('serviceWorker' in navigator) {
       }
     }
   })
+} else if (_swHostIsIp) {
+  logger.debug('Service Worker skipped (IP-based host — likely self-signed TLS; #6767)')
 }
 
 // Performance monitoring in development

--- a/autobot-frontend/src/models/controllers/ChatController.ts
+++ b/autobot-frontend/src/models/controllers/ChatController.ts
@@ -715,7 +715,9 @@ export class ChatController {
           this.chatStore.switchToSession(sessionId)
         }
       } else {
-        logger.error(`Session ${sessionId} not found in store`)
+        // #6766: session list may not be loaded yet during startup race.
+        // Downgrade to warn — the caller will retry once sessions are populated.
+        logger.warn(`Session ${sessionId} not found in store (may still be loading)`)
       }
 
     } catch (error: unknown) {


### PR DESCRIPTION
## Summary

Fixes three frontend runtime discovery bugs from batch 38 of Phase 3:

- **#6767** — `main.ts`: Pre-emptive IPv4 hostname gate prevents Service Worker registration on IP-based hosts (self-signed TLS deployments). Chrome emits an unrecoverable `SecurityError` before the catch block; this avoids the attempt entirely. `localhost` is explicitly allowed.
- **#6766** — `ChatController.ts`: Downgrade `logger.error` → `logger.warn` for "Session not found in store" — this is an expected startup race (session list not yet loaded), not a hard failure.
- **#6765** — `usePollingJob.ts`: Add `consecutiveErrorLimit` option — circuit-breaker stops polling after N consecutive errors, preventing infinite 404 console spam. Counter resets on any successful tick. Full endpoint reconciliation tracked in GH #6765.

## Test plan

- [ ] 14/14 Vitest tests pass (`usePollingJob.test.ts` — 2 new for circuit-breaker)
- [ ] No new TS errors in changed files (pre-existing Storybook story errors unaffected)
- [ ] SW skip verified: accessing app on LAN IP shows `[DEBUG] Service Worker skipped (IP-based host)` instead of SecurityError
- [ ] ChatController `warn` log appears at startup instead of `error`

## Closes

GH #6767, GH #6766 (GH #6765 remains open — endpoint reconciliation pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)