### PR TITLE
feat(connectors): output schema validation, parallel sync, event hooks (#8147, #8148, #8149)

### DIFF
--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -10,14 +10,18 @@ Connector configs are stored in Redis (knowledge DB) under
 ``connector:{connector_id}:history``.
 
 Endpoints:
+    GET  /api/knowledge_base/connector_types
     GET  /api/knowledge_base/connectors
     POST /api/knowledge_base/connectors
+    GET  /api/knowledge_base/connectors/health
+    GET  /api/knowledge_base/connectors/scheduler/leader      (Issue #8149)
     GET  /api/knowledge_base/connectors/{connector_id}
     PUT  /api/knowledge_base/connectors/{connector_id}
     DELETE /api/knowledge_base/connectors/{connector_id}
     POST /api/knowledge_base/connectors/{connector_id}/test
     POST /api/knowledge_base/connectors/{connector_id}/sync
     GET  /api/knowledge_base/connectors/{connector_id}/history
+    GET  /api/knowledge_base/connectors/{connector_id}/job    (Issue #8149)
 """
 
 import asyncio
@@ -45,6 +49,8 @@ from knowledge.schemas.connectors import (
     ConnectorHistoryResponse,
     ConnectorsHealthResponse,
     ConnectorsListResponse,
+    ConnectorJobResponse,
+    ConnectorLeaderResponse,
     ConnectorSyncResponse,
     ConnectorTestResponse,
     ConnectorTypesResponse,
@@ -69,7 +75,10 @@ _SUPPORTED_TYPES = ["file_server", "web_crawler", "database"]
 
 _REDIS_KEY_PREFIX = "connector:"
 _HISTORY_KEY_SUFFIX = ":history"
+_JOB_KEY_SUFFIX = ":job:current"
 _MAX_HISTORY = 50
+# Suffixes / infixes that mark non-config Redis keys under connector: namespace.
+_NON_CONFIG_INFIXES = (_HISTORY_KEY_SUFFIX, _JOB_KEY_SUFFIX, ":schedule:", "scheduler:")
 
 
 def _connector_key(connector_id: str) -> str:
@@ -97,6 +106,7 @@ async def _save_connector(cfg: ConnectorConfig) -> None:
         "exclude_patterns": cfg.exclude_patterns,
         "tier": int(getattr(cfg, "tier", 0)),
         "auth_type": getattr(cfg, "auth_type", None),
+        "max_concurrency": cfg.max_concurrency,
     }
     await asyncio.to_thread(
         redis.set,
@@ -119,6 +129,7 @@ def _deserialize_connector(raw: Any) -> ConnectorConfig:
     if isinstance(raw, bytes):
         raw = raw.decode("utf-8")
     data = json.loads(raw)
+    raw_mc = data.get("max_concurrency")
     return ConnectorConfig(
         connector_id=data["connector_id"],
         connector_type=data["connector_type"],
@@ -133,6 +144,7 @@ def _deserialize_connector(raw: Any) -> ConnectorConfig:
         exclude_patterns=data.get("exclude_patterns", []),
         tier=int(data.get("tier", 0)),
         auth_type=data.get("auth_type"),
+        max_concurrency=int(raw_mc) if raw_mc is not None else None,
     )
 
 
@@ -153,17 +165,21 @@ async def _list_connector_ids() -> List[str]:
     ids: List[str] = []
     async_scan = hasattr(redis, "scan_iter") and asyncio.iscoroutinefunction(getattr(redis, "scan_iter", None))
 
+    def _is_config_key(key_str: str) -> bool:
+        stripped = key_str[len(_REDIS_KEY_PREFIX):]
+        return not any(infix in stripped for infix in _NON_CONFIG_INFIXES)
+
     if async_scan:
         async for key in redis.scan_iter(match=pattern):
             key_str = key.decode("utf-8") if isinstance(key, bytes) else key
-            if _HISTORY_KEY_SUFFIX not in key_str:
-                ids.append(key_str[len(_REDIS_KEY_PREFIX) :])
+            if _is_config_key(key_str):
+                ids.append(key_str[len(_REDIS_KEY_PREFIX):])
     else:
         keys = await asyncio.to_thread(lambda: list(redis.scan_iter(match=pattern)))
         for key in keys:
             key_str = key.decode("utf-8") if isinstance(key, bytes) else key
-            if _HISTORY_KEY_SUFFIX not in key_str:
-                ids.append(key_str[len(_REDIS_KEY_PREFIX) :])
+            if _is_config_key(key_str):
+                ids.append(key_str[len(_REDIS_KEY_PREFIX):])
 
     return ids
 
@@ -221,17 +237,23 @@ async def _run_sync_background(connector_id: str, incremental: bool) -> None:
         cfg.last_sync_at = sync_result.completed_at or now_utc()
         await _save_connector(cfg)
 
+        completed_at = sync_result.completed_at
+        duration_seconds = None
+        if completed_at is not None:
+            duration_seconds = (completed_at - sync_result.started_at).total_seconds()
         history_entry = {
             "connector_id": connector_id,
             "started_at": sync_result.started_at.isoformat(),
-            "completed_at": (sync_result.completed_at.isoformat() if sync_result.completed_at else None),
+            "completed_at": (completed_at.isoformat() if completed_at else None),
             "status": sync_result.status,
             "added": sync_result.added,
             "updated": sync_result.updated,
             "deleted": sync_result.deleted,
             "errors": sync_result.errors,
-            # Issue #8146: expose whether this run resumed from a checkpoint.
             "resumed_from_checkpoint": getattr(sync_result, "resumed_from_checkpoint", False),
+            "duration_seconds": duration_seconds,
+            "sources_total": sync_result.sources_total,
+            "sources_done": sync_result.sources_done,
         }
         await _append_history(connector_id, history_entry)
 
@@ -260,6 +282,7 @@ async def list_connector_types():
             {
                 "connector_type": type_name,
                 "tier": int(getattr(klass, "tier", 0)),
+                "output_schema": klass.output_schema(),
             }
         )
     types.sort(key=lambda t: (t["tier"], t["connector_type"]))
@@ -333,6 +356,7 @@ async def create_connector(request: CreateConnectorRequest):
         exclude_patterns=request.exclude_patterns,
         tier=int(getattr(klass, "tier", 0)),
         auth_type=auth_type,
+        max_concurrency=request.max_concurrency,
     )
     instance = _load_or_create_instance(cfg)
     healthy = await instance.test_connection()
@@ -346,6 +370,32 @@ async def create_connector(request: CreateConnectorRequest):
     await _maybe_schedule(cfg)
     logger.info("Created connector %s (%s)", connector_id, request.connector_type)
     return {"connector_id": connector_id, "config": _cfg_to_dict(cfg)}
+
+
+@router.get("/knowledge_base/connectors/scheduler/leader", response_model=ConnectorLeaderResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_scheduler_leader",
+    error_code_prefix="KNOWLEDGE_CONNECTORS",
+)
+async def get_scheduler_leader():
+    """Return the currently elected scheduler leader worker ID (Issue #8149).
+
+    Returns ``leader: null`` when no worker holds the lease (scheduler idle or
+    between leader transitions).
+    """
+    from knowledge.connectors.scheduler import _LEADER_KEY
+
+    from autobot_shared.redis_client import get_async_redis_client
+
+    redis = await get_async_redis_client(database="knowledge")
+    if redis is None:
+        return {"leader": None}
+    raw = await redis.get(_LEADER_KEY)
+    if raw is None:
+        return {"leader": None}
+    leader = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+    return {"leader": leader}
 
 
 @router.get("/knowledge_base/connectors/health", response_model=ConnectorsHealthResponse)
@@ -533,6 +583,51 @@ async def get_sync_history(connector_id: str, limit: int = 20):
     return {"connector_id": connector_id, "history": history, "total": len(history)}
 
 
+@router.get("/knowledge_base/connectors/{connector_id}/job", response_model=ConnectorJobResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_connector_job",
+    error_code_prefix="KNOWLEDGE_CONNECTORS",
+)
+async def get_connector_job(connector_id: str):
+    """Return in-flight job state for a connector sync (Issue #8149).
+
+    Returns 404 when no sync is currently in flight (or the 24h TTL expired).
+    """
+    cfg = await _load_connector(connector_id)
+    if cfg is None:
+        raise HTTPException(status_code=404, detail=ERR_CONNECTOR_NOT_FOUND)
+
+    from autobot_shared.redis_client import get_async_redis_client
+
+    redis = await get_async_redis_client(database="knowledge")
+    if redis is None:
+        raise HTTPException(status_code=503, detail="Redis unavailable")
+
+    job_key = "connector:%s:job:current" % connector_id
+    raw = await redis.get(job_key)
+    if raw is None:
+        raise HTTPException(status_code=404, detail="No active job for connector %s" % connector_id)
+
+    try:
+        state = json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
+    except Exception as exc:
+        logger.warning("Malformed job state for connector %s: %s", connector_id, exc)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+    return {
+        "connector_id": connector_id,
+        "job_id": state.get("job_id", ""),
+        "started_at": state.get("started_at", ""),
+        "status": state.get("status", "unknown"),
+        "sources_total": state.get("sources_total", 0),
+        "sources_done": state.get("sources_done", 0),
+        "sources_failed": state.get("sources_failed", 0),
+        "worker_id": state.get("worker_id", ""),
+        "last_updated": state.get("last_updated", ""),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers (kept short per function-length policy)
 # ---------------------------------------------------------------------------
@@ -587,6 +682,7 @@ def _cfg_to_dict(cfg: ConnectorConfig) -> Dict[str, Any]:
         "exclude_patterns": cfg.exclude_patterns,
         "tier": _resolve_tier(cfg),
         "auth_type": getattr(cfg, "auth_type", None),
+        "max_concurrency": cfg.max_concurrency,
     }
 
 
@@ -620,6 +716,8 @@ def _apply_updates(cfg: ConnectorConfig, req: UpdateConnectorRequest) -> None:
         cfg.include_patterns = req.include_patterns
     if req.exclude_patterns is not None:
         cfg.exclude_patterns = req.exclude_patterns
+    if req.max_concurrency is not None:
+        cfg.max_concurrency = req.max_concurrency
 
 
 async def _maybe_schedule(cfg: ConnectorConfig) -> None:

--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -166,20 +166,20 @@ async def _list_connector_ids() -> List[str]:
     async_scan = hasattr(redis, "scan_iter") and asyncio.iscoroutinefunction(getattr(redis, "scan_iter", None))
 
     def _is_config_key(key_str: str) -> bool:
-        stripped = key_str[len(_REDIS_KEY_PREFIX):]
+        stripped = key_str[len(_REDIS_KEY_PREFIX) :]
         return not any(infix in stripped for infix in _NON_CONFIG_INFIXES)
 
     if async_scan:
         async for key in redis.scan_iter(match=pattern):
             key_str = key.decode("utf-8") if isinstance(key, bytes) else key
             if _is_config_key(key_str):
-                ids.append(key_str[len(_REDIS_KEY_PREFIX):])
+                ids.append(key_str[len(_REDIS_KEY_PREFIX) :])
     else:
         keys = await asyncio.to_thread(lambda: list(redis.scan_iter(match=pattern)))
         for key in keys:
             key_str = key.decode("utf-8") if isinstance(key, bytes) else key
             if _is_config_key(key_str):
-                ids.append(key_str[len(_REDIS_KEY_PREFIX):])
+                ids.append(key_str[len(_REDIS_KEY_PREFIX) :])
 
     return ids
 

--- a/autobot-backend/knowledge/connectors/base.py
+++ b/autobot-backend/knowledge/connectors/base.py
@@ -15,9 +15,11 @@ and updated sync() to skip already-processed sources on restart.
 """
 
 import asyncio
+import json
+import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Awaitable, Callable, List, Set, TypeVar
+from typing import Any, Awaitable, Callable, Dict, List, Set, TypeVar
 
 from autobot_shared.datetime_utils import datetime_now
 from autobot_shared.logging_manager import get_logger
@@ -37,6 +39,9 @@ _DEFAULT_RETRYABLE_STATUS: tuple = (429, 500, 502, 503, 504)
 
 # Issue #8146: Checkpoint TTL — 24h prevents stale state on repeated crash loops.
 _CHECKPOINT_TTL_SECONDS = 86400
+
+_JOB_KEY_SUFFIX = ":job:current"
+_JOB_TTL_S = 86400  # 24 h
 
 
 class RetryableError(Exception):
@@ -107,6 +112,25 @@ class AbstractConnector(ABC):
             return BearerAuth  # from knowledge.connectors.auth
         """
         return None
+
+    @classmethod
+    def output_schema(cls) -> Dict[str, Any]:
+        """Return a JSONSchema dict describing ContentResult.metadata shape.
+
+        Issue #8147: Used for validation at ingest time and UI field rendering.
+        Default returns an empty dict (no schema → backward compatible).
+        """
+        return {}
+
+    @property
+    def max_concurrency(self) -> int:
+        """Max parallel source fetches. Default 1 (sequential, backward compatible).
+
+        Issue #8148: Connectors opt in by overriding this to a value > 1.
+        The config field ``max_concurrency`` takes precedence when set.
+        """
+        cfg_val = self.config.max_concurrency
+        return cfg_val if cfg_val is not None else 1
 
     async def fetch_with_retry(
         self,
@@ -239,7 +263,8 @@ class AbstractConnector(ABC):
         Each source is processed independently so a single failure does not
         abort the rest of the sync.  On restart after a crash, sources that
         were already successfully processed are skipped via a Redis checkpoint
-        (Issue #8146).
+        (Issue #8146).  When ``max_concurrency > 1``, sources are processed
+        in parallel via ``asyncio.gather + Semaphore`` (Issue #8148).
 
         Args:
             incremental: When True, only process sources that changed since
@@ -262,6 +287,7 @@ class AbstractConnector(ABC):
             await self._clear_checkpoint()
 
         since = self.config.last_sync_at if incremental else None
+        job_id = str(uuid.uuid4())
 
         try:
             already_processed = await self._read_checkpoint()
@@ -274,6 +300,7 @@ class AbstractConnector(ABC):
                 result.resumed_from_checkpoint = True
 
             changes = await self.detect_changes(since=since)
+            result.sources_total = len(changes)
             self.logger.info(
                 "Connector %s detected %d changes (incremental=%s)",
                 self.config.connector_id,
@@ -281,11 +308,46 @@ class AbstractConnector(ABC):
                 incremental,
             )
 
-            for change in changes:
-                if change.source_id in already_processed:
-                    continue
-                await self._process_change(change, result)
-                await self._write_checkpoint(change.source_id)
+            await self._write_job_state(
+                job_id=job_id,
+                status="running",
+                started_at=started_at,
+                sources_total=result.sources_total,
+                sources_done=0,
+                sources_failed=0,
+            )
+
+            concurrency = self.max_concurrency
+            pending = [c for c in changes if c.source_id not in already_processed]
+            if concurrency <= 1:
+                for change in pending:
+                    await self._process_change(change, result)
+                    await self._write_checkpoint(change.source_id)
+                    await self._write_job_state(
+                        job_id=job_id,
+                        status="running",
+                        started_at=started_at,
+                        sources_total=result.sources_total,
+                        sources_done=result.sources_done,
+                        sources_failed=result.sources_failed,
+                    )
+            else:
+                sem = asyncio.Semaphore(concurrency)
+
+                async def bounded(change: ChangeInfo) -> None:
+                    async with sem:
+                        await self._process_change(change, result)
+                        await self._write_checkpoint(change.source_id)
+                        await self._write_job_state(
+                            job_id=job_id,
+                            status="running",
+                            started_at=started_at,
+                            sources_total=result.sources_total,
+                            sources_done=result.sources_done,
+                            sources_failed=result.sources_failed,
+                        )
+
+                await asyncio.gather(*[bounded(c) for c in pending], return_exceptions=True)
 
             result.status = "success" if not result.errors else "partial"
             await self._clear_checkpoint()
@@ -295,6 +357,14 @@ class AbstractConnector(ABC):
             result.status = "failed"
         finally:
             result.completed_at = datetime_now()
+            await self._write_job_state(
+                job_id=job_id,
+                status=result.status,
+                started_at=started_at,
+                sources_total=result.sources_total,
+                sources_done=result.sources_done,
+                sources_failed=result.sources_failed,
+            )
 
         return result
 
@@ -303,24 +373,75 @@ class AbstractConnector(ABC):
         try:
             if change.change_type == "deleted":
                 result.deleted += 1
+                result.sources_done += 1
                 return
 
             content = await self.fetch_content(change.source_id)
             if content is None:
                 self.logger.warning("fetch_content returned None for %s", change.source_id)
                 result.errors.append("No content for source_id=%s" % change.source_id)
+                result.sources_failed += 1
+                result.sources_done += 1
                 return
 
+            self._validate_metadata(content, result)
             await self._ingest_content(content)
 
             if change.change_type == "added":
                 result.added += 1
             else:
                 result.updated += 1
+            result.sources_done += 1
 
         except Exception as exc:
             self.logger.error("Error processing source %s: %s", change.source_id, exc)
             result.errors.append("source_id=%s: %s" % (change.source_id, exc))
+            result.sources_failed += 1
+            result.sources_done += 1
+
+    def _validate_metadata(self, content: ContentResult, result: SyncResult) -> None:
+        """Validate content.metadata against output_schema() if one is declared.
+
+        Issue #8147: Soft validation — logs a warning and appends to
+        result.errors but does NOT abort ingestion.
+        """
+        schema = self.output_schema()
+        if not schema:
+            return
+
+        required = schema.get("required", [])
+        props = schema.get("properties", {})
+
+        missing = [k for k in required if k not in content.metadata]
+        if missing:
+            msg = "source_id=%s: metadata missing required fields %s" % (content.source_id, missing)
+            self.logger.warning("Output schema violation: %s", msg)
+            result.errors.append(msg)
+
+        for key, prop_schema in props.items():
+            if key not in content.metadata:
+                continue
+            expected_type = prop_schema.get("type")
+            if expected_type is None:
+                continue
+            _TYPE_MAP: Dict[str, type] = {
+                "string": str,
+                "integer": int,
+                "number": (int, float),
+                "boolean": bool,
+                "array": list,
+                "object": dict,
+            }
+            py_type = _TYPE_MAP.get(expected_type)
+            if py_type and not isinstance(content.metadata[key], py_type):
+                msg = "source_id=%s: metadata field '%s' expected %s, got %s" % (
+                    content.source_id,
+                    key,
+                    expected_type,
+                    type(content.metadata[key]).__name__,
+                )
+                self.logger.warning("Output schema type mismatch: %s", msg)
+                result.errors.append(msg)
 
     async def _ingest_content(self, content: ContentResult) -> None:
         """Store fetched content in the knowledge base (Issue #1254: extracted).
@@ -355,3 +476,45 @@ class AbstractConnector(ABC):
             content.source_id,
             self.config.connector_id,
         )
+
+    # ------------------------------------------------------------------
+    # Job state helpers (Issue #8149)
+    # ------------------------------------------------------------------
+
+    def _job_redis_key(self) -> str:
+        return "connector:%s%s" % (self.config.connector_id, _JOB_KEY_SUFFIX)
+
+    async def _write_job_state(
+        self,
+        job_id: str,
+        status: str,
+        started_at: datetime,
+        sources_total: int,
+        sources_done: int,
+        sources_failed: int,
+    ) -> None:
+        """Write current job state to Redis with a 24h TTL."""
+        import os
+
+        from autobot_shared.redis_client import get_async_redis_client
+
+        redis = await get_async_redis_client(database="knowledge")
+        if redis is None:
+            return
+        try:
+            state = json.dumps(
+                {
+                    "job_id": job_id,
+                    "started_at": started_at.isoformat(),
+                    "status": status,
+                    "sources_total": sources_total,
+                    "sources_done": sources_done,
+                    "sources_failed": sources_failed,
+                    "worker_id": "%s-%d" % (os.uname().nodename, os.getpid()),
+                    "last_updated": datetime_now().isoformat(),
+                },
+                ensure_ascii=False,
+            )
+            await redis.set(self._job_redis_key(), state, ex=_JOB_TTL_S)
+        except Exception as exc:
+            self.logger.debug("Job state write failed (non-critical): %s", exc)

--- a/autobot-backend/knowledge/connectors/connector_batch_b_test.py
+++ b/autobot-backend/knowledge/connectors/connector_batch_b_test.py
@@ -64,7 +64,6 @@ from knowledge.connectors.models import (
 )
 from knowledge.connectors.web_crawler import WebCrawlerConnector
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/autobot-backend/knowledge/connectors/connector_batch_b_test.py
+++ b/autobot-backend/knowledge/connectors/connector_batch_b_test.py
@@ -1,0 +1,349 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""
+Tests for connector batch B features (Issues #8147, #8148, #8149).
+
+Covers:
+  - output_schema() classmethod defaults and concrete implementations (#8147)
+  - _validate_metadata() pass / fail / no-schema cases (#8147)
+  - max_concurrency property default and config override (#8148)
+  - sync() parallel path via asyncio.gather + Semaphore (#8148)
+  - SyncResult source counters populated correctly (#8148/#8149)
+"""
+
+import asyncio
+import os
+import sys
+import types
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_WORKTREE_ROOT = os.path.dirname(_BACKEND_DIR)
+for _p in (_WORKTREE_ROOT, _BACKEND_DIR):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# Stub web_fetch before any connector import triggers its load.
+# web_fetch.cache calls config.web_fetch_cache_ttl (a MiscConfig field) directly
+# on AutoBotConfig, which fails in test env.  Tests here don't exercise web_fetch
+# at runtime; stubs satisfy the import chain only.
+if "web_fetch" not in sys.modules:
+
+    def _make_wf_stub(name: str) -> types.ModuleType:
+        m = types.ModuleType(name)
+        m.__path__ = []  # type: ignore[attr-defined]
+        m.__package__ = name
+        m.__getattr__ = lambda attr: MagicMock()  # type: ignore[attr-defined]
+        sys.modules[name] = m
+        return m
+
+    _wf = _make_wf_stub("web_fetch")
+    _wf.ERR_CONNECTION = "err_connection"  # type: ignore[attr-defined]
+    _wf.FetchResult = MagicMock  # type: ignore[attr-defined]
+    _wf.Frontier = MagicMock  # type: ignore[attr-defined]
+    _wf.RenderMode = MagicMock  # type: ignore[attr-defined]
+    _wf.RobotsCache = MagicMock  # type: ignore[attr-defined]
+    _wf.WebFetcher = MagicMock  # type: ignore[attr-defined]
+    _make_wf_stub("web_fetch.extractors").extract_markdown = MagicMock()  # type: ignore[attr-defined]
+    _make_wf_stub("web_fetch.frontier").extract_links = MagicMock()  # type: ignore[attr-defined]
+    _make_wf_stub("web_fetch.cache")
+    _make_wf_stub("web_fetch.fetcher")
+
+from knowledge.connectors.base import AbstractConnector
+from knowledge.connectors.file_server import FileServerConnector
+from knowledge.connectors.models import (
+    ChangeInfo,
+    ConnectorConfig,
+    ContentResult,
+    SourceInfo,
+    SyncResult,
+)
+from knowledge.connectors.web_crawler import WebCrawlerConnector
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _config(extra: dict | None = None) -> ConnectorConfig:
+    base = {
+        "connector_id": "test-id",
+        "connector_type": "file_server",
+        "name": "test",
+        "config": {"base_path": "/tmp/test"},
+    }
+    if extra:
+        base.update(extra)
+    return ConnectorConfig(**base)
+
+
+def _web_config() -> ConnectorConfig:
+    return ConnectorConfig(
+        connector_id="web-id",
+        connector_type="web_crawler",
+        name="web test",
+        config={"urls": ["http://example.com"]},
+    )
+
+
+class _MinimalConnector(AbstractConnector):
+    """Concrete subclass that satisfies ABC with empty stubs."""
+
+    connector_type = "test"
+
+    async def test_connection(self) -> bool:
+        return True
+
+    async def discover_sources(self):
+        return []
+
+    async def fetch_content(self, source_id: str):
+        return None
+
+    async def detect_changes(self, since=None):
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Issue #8147 — output_schema()
+# ---------------------------------------------------------------------------
+
+
+class TestOutputSchema:
+    def test_base_default_empty(self):
+        assert AbstractConnector.output_schema() == {}
+
+    def test_minimal_connector_inherits_empty(self):
+        conn = _MinimalConnector(_config())
+        assert conn.output_schema() == {}
+
+    def test_file_server_schema_has_required(self):
+        schema = FileServerConnector.output_schema()
+        assert "required" in schema
+        assert "path" in schema["required"]
+        assert "name" in schema["required"]
+        assert "extension" in schema["required"]
+
+    def test_file_server_schema_properties(self):
+        schema = FileServerConnector.output_schema()
+        props = schema.get("properties", {})
+        assert "path" in props
+        assert "relative_path" in props
+        assert props["path"]["type"] == "string"
+
+    def test_web_crawler_schema_has_required(self):
+        schema = WebCrawlerConnector.output_schema()
+        assert "url" in schema.get("required", [])
+        assert "domain" in schema.get("required", [])
+
+    def test_web_crawler_schema_properties(self):
+        schema = WebCrawlerConnector.output_schema()
+        props = schema.get("properties", {})
+        assert "url" in props
+        assert "title" in props
+
+
+# ---------------------------------------------------------------------------
+# Issue #8147 — _validate_metadata()
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMetadata:
+    def setup_method(self):
+        self.conn = FileServerConnector(_config())
+        self.result = SyncResult(
+            connector_id="test-id",
+            started_at=datetime.now(timezone.utc),
+            completed_at=None,
+            status="running",
+        )
+
+    def _content(self, metadata: dict) -> ContentResult:
+        return ContentResult(
+            source_id="s1",
+            content="hello",
+            content_type="text/plain",
+            metadata=metadata,
+        )
+
+    def test_valid_metadata_no_errors(self):
+        content = self._content({"path": "/x", "name": "f.txt", "extension": ".txt"})
+        self.conn._validate_metadata(content, self.result)
+        assert len(self.result.errors) == 0
+
+    def test_missing_required_field(self):
+        content = self._content({"path": "/x", "name": "f.txt"})  # missing extension
+        self.conn._validate_metadata(content, self.result)
+        assert any("extension" in e for e in self.result.errors)
+
+    def test_wrong_type_logs_error(self):
+        content = self._content({"path": "/x", "name": "f.txt", "extension": 123})  # int not str
+        self.conn._validate_metadata(content, self.result)
+        assert any("extension" in e for e in self.result.errors)
+
+    def test_no_schema_no_errors(self):
+        conn = _MinimalConnector(_config())
+        result = SyncResult(
+            connector_id="test-id",
+            started_at=datetime.now(timezone.utc),
+            completed_at=None,
+            status="running",
+        )
+        conn._validate_metadata(self._content({}), result)
+        assert len(result.errors) == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #8148 — max_concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestMaxConcurrency:
+    def test_base_default_is_1(self):
+        conn = _MinimalConnector(_config())
+        assert conn.max_concurrency == 1
+
+    def test_config_override(self):
+        conn = _MinimalConnector(_config({"max_concurrency": 4}))
+        assert conn.max_concurrency == 4
+
+    def test_config_none_falls_back_to_default(self):
+        conn = _MinimalConnector(_config({"max_concurrency": None}))
+        assert conn.max_concurrency == 1
+
+    def test_web_crawler_default_is_5(self):
+        conn = WebCrawlerConnector(_web_config())
+        assert conn.max_concurrency == 5
+
+    def test_web_crawler_config_override(self):
+        cfg = _web_config()
+        cfg.max_concurrency = 2
+        conn = WebCrawlerConnector(cfg)
+        assert conn.max_concurrency == 2
+
+
+# ---------------------------------------------------------------------------
+# Issue #8148 — sync() parallel path
+# ---------------------------------------------------------------------------
+
+
+class TestSyncParallelPath:
+    """Verify that sync() uses asyncio.gather when max_concurrency > 1."""
+
+    def _make_connector(self, max_c: int, num_changes: int):
+        class _Spy(AbstractConnector):
+            connector_type = "spy"
+            _calls: list = []
+
+            @property
+            def max_concurrency(self):
+                return max_c
+
+            async def test_connection(self):
+                return True
+
+            async def discover_sources(self):
+                return []
+
+            async def fetch_content(self, source_id):
+                return ContentResult(
+                    source_id=source_id,
+                    content="x",
+                    content_type="text/plain",
+                    metadata={"path": "/p", "name": "n", "extension": ".txt"},
+                )
+
+            async def detect_changes(self, since=None):
+                return [
+                    ChangeInfo(
+                        source_id="s%d" % i,
+                        change_type="added",
+                        timestamp=datetime.now(timezone.utc),
+                    )
+                    for i in range(num_changes)
+                ]
+
+        return _Spy(_config({"max_concurrency": max_c}))
+
+    @pytest.mark.asyncio
+    async def test_sequential_path_all_added(self):
+        conn = self._make_connector(max_c=1, num_changes=3)
+        with (
+            patch.object(conn, "_ingest_content", new_callable=AsyncMock) as ingest,
+            patch.object(conn, "_write_job_state", new_callable=AsyncMock),
+        ):
+            result = await conn.sync(incremental=False)
+        assert result.added == 3
+        assert ingest.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_parallel_path_all_added(self):
+        conn = self._make_connector(max_c=3, num_changes=6)
+        with (
+            patch.object(conn, "_ingest_content", new_callable=AsyncMock) as ingest,
+            patch.object(conn, "_write_job_state", new_callable=AsyncMock),
+        ):
+            result = await conn.sync(incremental=False)
+        assert result.added == 6
+        assert ingest.call_count == 6
+
+    @pytest.mark.asyncio
+    async def test_parallel_error_isolation(self):
+        """A single source failure must not abort remaining sources."""
+
+        class _ErrConnector(AbstractConnector):
+            connector_type = "err"
+
+            @property
+            def max_concurrency(self):
+                return 3
+
+            async def test_connection(self):
+                return True
+
+            async def discover_sources(self):
+                return []
+
+            async def fetch_content(self, source_id):
+                if source_id == "s1":
+                    raise RuntimeError("boom")
+                return ContentResult(
+                    source_id=source_id,
+                    content="x",
+                    content_type="text/plain",
+                    metadata={},
+                )
+
+            async def detect_changes(self, since=None):
+                return [
+                    ChangeInfo(source_id="s%d" % i, change_type="added", timestamp=datetime.now(timezone.utc))
+                    for i in range(4)
+                ]
+
+        conn = _ErrConnector(_config({"max_concurrency": 3}))
+        with (
+            patch.object(conn, "_ingest_content", new_callable=AsyncMock),
+            patch.object(conn, "_write_job_state", new_callable=AsyncMock),
+        ):
+            result = await conn.sync(incremental=False)
+
+        assert result.status == "partial"
+        assert result.added == 3  # s0, s2, s3 succeed
+        assert any("s1" in e for e in result.errors)
+
+    @pytest.mark.asyncio
+    async def test_sources_total_and_done_counted(self):
+        conn = self._make_connector(max_c=1, num_changes=5)
+        with (
+            patch.object(conn, "_ingest_content", new_callable=AsyncMock),
+            patch.object(conn, "_write_job_state", new_callable=AsyncMock),
+        ):
+            result = await conn.sync(incremental=False)
+        assert result.sources_total == 5
+        assert result.sources_done == 5
+        assert result.sources_failed == 0

--- a/autobot-backend/knowledge/connectors/file_server.py
+++ b/autobot-backend/knowledge/connectors/file_server.py
@@ -68,6 +68,21 @@ class FileServerConnector(AbstractConnector):
     # Issue #4421: zero-config — needs only a mount point, no credentials.
     tier = 0
 
+    @classmethod
+    def output_schema(cls) -> dict:
+        """Issue #8147: JSONSchema for FileServerConnector ContentResult.metadata."""
+        return {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "name": {"type": "string"},
+                "relative_path": {"type": "string"},
+                "extension": {"type": "string"},
+                "connector_id": {"type": "string"},
+            },
+            "required": ["path", "name", "extension"],
+        }
+
     def __init__(self, config: ConnectorConfig) -> None:
         super().__init__(config)
         cfg = config.config

--- a/autobot-backend/knowledge/connectors/models.py
+++ b/autobot-backend/knowledge/connectors/models.py
@@ -78,6 +78,8 @@ class ConnectorConfig:
     # Issue #8145: auth type string derived from connector_class.auth_schema().__name__,
     # or None for connectors that declare no typed auth.
     auth_type: str | None = None
+    # Issue #8148: max parallel source fetches; None = use connector class default.
+    max_concurrency: int | None = None
 
 
 @dataclass
@@ -107,3 +109,7 @@ class SyncResult:
     # Issue #8146: True when sync resumed from a Redis checkpoint instead of
     # starting from scratch (crash-recovery path).
     resumed_from_checkpoint: bool = False
+    # Issue #8149: per-source progress counters for live job state tracking.
+    sources_total: int = 0
+    sources_done: int = 0
+    sources_failed: int = 0

--- a/autobot-backend/knowledge/connectors/registry.py
+++ b/autobot-backend/knowledge/connectors/registry.py
@@ -92,7 +92,7 @@ class ConnectorRegistry:
         logger.debug("Removed connector instance: %s", connector_id)
 
     @classmethod
-    def get(cls, connector_id: str) -> "object" | None:
+    def get(cls, connector_id: str) -> object | None:
         """Return a running connector by ID, or None if not found."""
         return cls._instances.get(connector_id)
 

--- a/autobot-backend/knowledge/connectors/web_crawler.py
+++ b/autobot-backend/knowledge/connectors/web_crawler.py
@@ -102,6 +102,27 @@ class WebCrawlerConnector(AbstractConnector):
     # Issue #4421: zero-config — unauthenticated crawl via web_fetch.
     tier = 0
 
+    @classmethod
+    def output_schema(cls) -> dict:
+        """Issue #8147: JSONSchema for WebCrawlerConnector ContentResult.metadata."""
+        return {
+            "type": "object",
+            "properties": {
+                "url": {"type": "string"},
+                "domain": {"type": "string"},
+                "title": {"type": "string"},
+                "connector_id": {"type": "string"},
+                "source": {"type": "string"},
+            },
+            "required": ["url", "domain"],
+        }
+
+    @property
+    def max_concurrency(self) -> int:
+        """Issue #8148: default 5 concurrent page fetches; config overrides."""
+        cfg_val = self.config.max_concurrency
+        return cfg_val if cfg_val is not None else 5
+
     def __init__(self, config: ConnectorConfig) -> None:
         super().__init__(config)
         cfg = config.config

--- a/autobot-backend/knowledge/schemas/connectors.py
+++ b/autobot-backend/knowledge/schemas/connectors.py
@@ -3,7 +3,7 @@
 # Author: mrveiss
 """Response schemas for the knowledge connector endpoints (Issue #5317)."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -15,6 +15,8 @@ class ConnectorTypeEntry(BaseModel):
 
     connector_type: str
     tier: int
+    # Issue #8147: JSONSchema describing ContentResult.metadata for this type.
+    output_schema: Dict[str, Any] = Field(default_factory=dict)
 
 
 class ConnectorTypesResponse(BaseModel):
@@ -57,6 +59,8 @@ class ConnectorConfigDict(BaseModel):
     include_patterns: List[str]
     exclude_patterns: List[str]
     tier: int
+    # Issue #8148: max parallel source fetches for this connector instance.
+    max_concurrency: int | None = None
 
 
 class ConnectorEntry(BaseModel):
@@ -135,7 +139,11 @@ class ConnectorSyncResponse(BaseModel):
 
 
 class ConnectorHistoryEntry(BaseModel):
-    """Single history record stored per sync run."""
+    """Single history record stored per sync run.
+
+    Issue #8149: enriched with duration_seconds, source counters, and
+    structured per-source error list.
+    """
 
     model_config = ConfigDict(extra="allow")
 
@@ -146,7 +154,11 @@ class ConnectorHistoryEntry(BaseModel):
     added: int | None = None
     updated: int | None = None
     deleted: int | None = None
-    errors: int | None = None
+    # Issue #8149: was scalar error count; now structured list.
+    errors: List[str] | int | None = None
+    duration_seconds: float | None = None
+    sources_total: int | None = None
+    sources_done: int | None = None
 
 
 class ConnectorHistoryResponse(BaseModel):
@@ -157,6 +169,37 @@ class ConnectorHistoryResponse(BaseModel):
     connector_id: str
     history: List[ConnectorHistoryEntry]
     total: int
+
+
+class ConnectorJobResponse(BaseModel):
+    """GET /knowledge_base/connectors/{connector_id}/job — in-flight job state.
+
+    Issue #8149: Returns 404 when no sync is currently in flight.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    connector_id: str
+    job_id: str
+    started_at: str
+    status: str  # "running" | "success" | "failed" | "partial"
+    sources_total: int
+    sources_done: int
+    sources_failed: int
+    worker_id: str
+    last_updated: str
+
+
+class ConnectorLeaderResponse(BaseModel):
+    """GET /knowledge_base/connectors/scheduler/leader.
+
+    Issue #8149: Returns the currently elected scheduler leader worker ID,
+    or leader=null when no leader holds the lease.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    leader: Optional[str] = None
 
 
 class CreateConnectorRequest(BaseModel):
@@ -170,6 +213,8 @@ class CreateConnectorRequest(BaseModel):
     schedule_cron: str | None = None
     include_patterns: List[str] = Field(default_factory=list)
     exclude_patterns: List[str] = Field(default_factory=list)
+    # Issue #8148: optional per-instance concurrency override (None = class default).
+    max_concurrency: int | None = None
 
 
 class UpdateConnectorRequest(BaseModel):
@@ -182,3 +227,5 @@ class UpdateConnectorRequest(BaseModel):
     schedule_cron: str | None = None
     include_patterns: List[str] | None = None
     exclude_patterns: List[str] | None = None
+    # Issue #8148: update per-instance concurrency without a full config replace.
+    max_concurrency: int | None = None

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorHistoryPanel.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorHistoryPanel.vue
@@ -1,0 +1,338 @@
+<script setup lang="ts">
+/**
+ * ConnectorHistoryPanel — per-connector sync history + live progress indicator.
+ *
+ * Issue #8149: shows past syncs with status badges, duration, source counts,
+ * expandable per-source errors, and a live progress bar while a sync is
+ * in-flight (polls every 5s, stops on terminal status).
+ */
+
+import { ref, computed, onMounted, watch } from 'vue'
+import BaseBadge from '@/components/base/BaseBadge.vue'
+import { useConnectorJob, fetchConnectorHistory } from '@/composables/knowledge/useConnectorJob'
+import { formatTimeAgo } from '@/utils/formatHelpers'
+import { createLogger } from '@/utils/debugUtils'
+import type { ConnectorHistoryEntry } from '@/types/knowledgeBase'
+
+const logger = createLogger('ConnectorHistoryPanel')
+
+const props = defineProps<{
+  connectorId: string
+  /** When true, immediately start polling for in-flight job state. */
+  syncActive?: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const history = ref<ConnectorHistoryEntry[]>([])
+const historyLoading = ref(false)
+const expandedRows = ref<Set<number>>(new Set())
+
+const { jobState, isPolling, start: startPoll, stop: stopPoll } = useConnectorJob()
+
+async function loadHistory() {
+  historyLoading.value = true
+  try {
+    history.value = await fetchConnectorHistory(props.connectorId)
+  } catch (err) {
+    logger.error('Failed to load history', err)
+  } finally {
+    historyLoading.value = false
+  }
+}
+
+onMounted(() => {
+  loadHistory()
+  if (props.syncActive) {
+    startPoll(props.connectorId)
+  }
+})
+
+watch(() => props.syncActive, (active) => {
+  if (active) startPoll(props.connectorId)
+  else stopPoll()
+})
+
+watch(isPolling, (active) => {
+  if (!active && jobState.value && jobState.value.status !== 'running') {
+    loadHistory()
+  }
+})
+
+function toggleRow(index: number) {
+  if (expandedRows.value.has(index)) {
+    expandedRows.value.delete(index)
+  } else {
+    expandedRows.value.add(index)
+  }
+}
+
+function statusVariant(status: string | null): 'success' | 'error' | 'warning' | 'default' {
+  switch (status) {
+    case 'success': return 'success'
+    case 'failed': return 'error'
+    case 'partial': return 'warning'
+    default: return 'default'
+  }
+}
+
+const progressPercent = computed(() => {
+  const j = jobState.value
+  if (!j || j.sources_total === 0) return 0
+  return Math.round((j.sources_done / j.sources_total) * 100)
+})
+
+function errorList(entry: ConnectorHistoryEntry): string[] {
+  if (!entry.errors) return []
+  if (Array.isArray(entry.errors)) return entry.errors
+  return []
+}
+
+function formatDuration(seconds: number | null): string {
+  if (seconds === null) return '—'
+  if (seconds < 60) return `${seconds.toFixed(1)}s`
+  const m = Math.floor(seconds / 60)
+  const s = Math.round(seconds % 60)
+  return `${m}m ${s}s`
+}
+</script>
+
+<template>
+  <div class="history-panel">
+    <div class="panel-header">
+      <h3 class="panel-title">Sync History</h3>
+      <button class="close-btn" aria-label="Close" @click="emit('close')">✕</button>
+    </div>
+
+    <!-- Live job progress -->
+    <div v-if="isPolling || (jobState && jobState.status === 'running')" class="live-job">
+      <div class="live-header">
+        <BaseBadge variant="warning" size="xs">Running</BaseBadge>
+        <span class="live-worker">{{ jobState?.worker_id }}</span>
+      </div>
+      <div class="progress-bar-track" role="progressbar" :aria-valuenow="progressPercent" aria-valuemin="0" aria-valuemax="100">
+        <div class="progress-bar-fill" :style="{ width: progressPercent + '%' }" />
+      </div>
+      <div class="live-counts">
+        {{ jobState?.sources_done ?? 0 }} / {{ jobState?.sources_total ?? '?' }} sources
+        <span v-if="jobState && jobState.sources_failed > 0" class="failed-count">
+          ({{ jobState.sources_failed }} failed)
+        </span>
+      </div>
+    </div>
+
+    <!-- History list -->
+    <div v-if="historyLoading" class="loading-state">Loading…</div>
+    <div v-else-if="history.length === 0" class="empty-state">No sync history yet.</div>
+    <ul v-else class="history-list">
+      <li
+        v-for="(entry, idx) in history"
+        :key="idx"
+        class="history-row"
+        :class="{ expanded: expandedRows.has(idx) }"
+      >
+        <div class="row-main" @click="errorList(entry).length > 0 && toggleRow(idx)">
+          <BaseBadge :variant="statusVariant(entry.status)" size="xs">
+            {{ entry.status ?? '?' }}
+          </BaseBadge>
+          <span class="row-time">{{ entry.started_at ? formatTimeAgo(entry.started_at) : '?' }}</span>
+          <span class="row-duration">{{ formatDuration(entry.duration_seconds) }}</span>
+          <span class="row-counts">
+            +{{ entry.added ?? 0 }} ~{{ entry.updated ?? 0 }} -{{ entry.deleted ?? 0 }}
+          </span>
+          <span class="row-sources" v-if="entry.sources_total">
+            {{ entry.sources_done ?? 0 }}/{{ entry.sources_total }} src
+          </span>
+          <span
+            v-if="errorList(entry).length > 0"
+            class="row-errors"
+            :title="'Click to expand ' + errorList(entry).length + ' errors'"
+          >
+            {{ errorList(entry).length }} err
+          </span>
+        </div>
+        <ul v-if="expandedRows.has(idx) && errorList(entry).length > 0" class="error-list">
+          <li v-for="(err, ei) in errorList(entry)" :key="ei" class="error-item">{{ err }}</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.history-panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-default);
+  padding: var(--spacing-4);
+  max-height: 480px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.panel-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  margin: 0;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  padding: var(--spacing-1);
+  line-height: 1;
+}
+
+/* Live job */
+.live-job {
+  padding: var(--spacing-3);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-xs);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.live-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.live-worker {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.progress-bar-track {
+  height: 6px;
+  background: var(--border-default);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background: var(--color-info);
+  border-radius: 3px;
+  transition: width 0.4s ease;
+}
+
+.live-counts {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+
+.failed-count {
+  color: var(--color-error);
+}
+
+/* History list */
+.loading-state,
+.empty-state {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  text-align: center;
+  padding: var(--spacing-4) 0;
+}
+
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.history-row {
+  border-radius: var(--radius-xs);
+  border: 1px solid var(--border-default);
+  overflow: hidden;
+}
+
+.row-main {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  cursor: default;
+  font-size: var(--text-xs);
+  font-family: var(--font-sans);
+}
+
+.history-row.expanded .row-main {
+  background: var(--bg-secondary);
+}
+
+.row-time {
+  color: var(--text-secondary);
+  flex: 1;
+}
+
+.row-duration {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  min-width: 48px;
+  text-align: right;
+}
+
+.row-counts {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+}
+
+.row-sources {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+}
+
+.row-errors {
+  color: var(--color-error);
+  font-family: var(--font-mono);
+  cursor: pointer;
+  text-decoration: underline dotted;
+}
+
+/* Error expansion */
+.error-list {
+  list-style: none;
+  padding: var(--spacing-2) var(--spacing-3);
+  margin: 0;
+  background: var(--color-error-bg);
+  border-top: 1px solid var(--border-default);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  max-height: 120px;
+  overflow-y: auto;
+}
+
+.error-item {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-error-dark);
+  word-break: break-all;
+  line-height: 1.4;
+}
+</style>

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
@@ -16,6 +16,7 @@ import type {
 } from '@/types/knowledgeBase'
 import ConnectorStatusCard from './ConnectorStatusCard.vue'
 import ConnectorConfigModal from './ConnectorConfigModal.vue'
+import ConnectorHistoryPanel from './ConnectorHistoryPanel.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import BaseModal from '@/components/ui/BaseModal.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
@@ -262,72 +263,18 @@ onMounted(() => {
       @saved="onConnectorSaved"
     />
 
-    <!-- History Modal -->
+    <!-- History Modal — Issue #8149: replaced with ConnectorHistoryPanel -->
     <BaseModal
       v-model="showHistoryModal"
       :title="t('knowledge.connectors.syncHistoryTitle', { name: historyConnectorName })"
       size="medium"
     >
-      <div v-if="historyLoading" class="loading-state compact">
-        <i class="fas fa-spinner fa-spin"></i>
-        <p>{{ $t('knowledge.connectors.loadingHistory') }}</p>
-      </div>
-
-      <div
-        v-else-if="historyItems.length === 0"
-        class="history-empty"
-      >
-        {{ $t('knowledge.connectors.noSyncHistory') }}
-      </div>
-
-      <div v-else class="history-list">
-        <div
-          v-for="(item, idx) in historyItems"
-          :key="idx"
-          class="history-item"
-        >
-          <div class="history-header">
-            <span
-              class="history-status"
-              :class="`status-${item.status}`"
-            >
-              {{ item.status }}
-            </span>
-            <span class="history-time">
-              {{ formatTimeAgo(item.started_at) }}
-            </span>
-          </div>
-          <div class="history-stats">
-            <span class="history-stat">
-              <span class="stat-num added">+{{ item.added }}</span>
-              {{ $t('knowledge.connectors.historyAdded') }}
-            </span>
-            <span class="history-stat">
-              <span class="stat-num updated">~{{ item.updated }}</span>
-              {{ $t('knowledge.connectors.historyUpdated') }}
-            </span>
-            <span class="history-stat">
-              <span class="stat-num deleted">-{{ item.deleted }}</span>
-              {{ $t('knowledge.connectors.historyDeleted') }}
-            </span>
-          </div>
-          <div v-if="item.errors.length > 0" class="history-errors">
-            <span
-              v-for="(err, eidx) in item.errors.slice(0, 3)"
-              :key="eidx"
-              class="history-error"
-            >
-              {{ err }}
-            </span>
-            <span
-              v-if="item.errors.length > 3"
-              class="history-more-errors"
-            >
-              {{ $t('knowledge.connectors.moreErrors', { count: item.errors.length - 3 }) }}
-            </span>
-          </div>
-        </div>
-      </div>
+      <ConnectorHistoryPanel
+        v-if="historyConnectorId"
+        :connector-id="historyConnectorId"
+        :sync-active="getStatus(historyConnectorId).last_sync_status === 'running'"
+        @close="showHistoryModal = false"
+      />
     </BaseModal>
   </div>
 </template>

--- a/autobot-frontend/src/composables/knowledge/useConnectorJob.ts
+++ b/autobot-frontend/src/composables/knowledge/useConnectorJob.ts
@@ -1,0 +1,103 @@
+/**
+ * useConnectorJob — live sync job state poller for a single connector.
+ *
+ * Issue #8149: polls GET /knowledge_base/connectors/{id}/job every 5 s
+ * while status is "running".  Stops automatically on terminal status or
+ * when the caller calls stop().
+ */
+
+import { ref, readonly, onUnmounted } from 'vue'
+import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+import type { ConnectorJobState, ConnectorLeaderState, ConnectorHistoryEntry } from '@/types/knowledgeBase'
+
+const logger = createLogger('useConnectorJob')
+
+const POLL_INTERVAL_MS = 5_000
+
+/** Fetch current in-flight job state. Returns null when no job is active (404). */
+export async function fetchConnectorJob(connectorId: string): Promise<ConnectorJobState | null> {
+  try {
+    return await apiClient.get<ConnectorJobState>(
+      `${getApiBase()}/knowledge_base/connectors/${connectorId}/job`
+    )
+  } catch (err: any) {
+    if (err?.status === 404 || err?.response?.status === 404) {
+      return null
+    }
+    logger.error('fetchConnectorJob error', err)
+    return null
+  }
+}
+
+/** Fetch sync history for a connector. */
+export async function fetchConnectorHistory(
+  connectorId: string,
+  limit = 20
+): Promise<ConnectorHistoryEntry[]> {
+  const res = await apiClient.get<{ history: ConnectorHistoryEntry[] }>(
+    `${getApiBase()}/knowledge_base/connectors/${connectorId}/history?limit=${limit}`
+  )
+  return res.history ?? []
+}
+
+/** Fetch the current scheduler leader worker ID. */
+export async function fetchSchedulerLeader(): Promise<string | null> {
+  const res = await apiClient.get<ConnectorLeaderState>(
+    `${getApiBase()}/knowledge_base/connectors/scheduler/leader`
+  )
+  return res.leader ?? null
+}
+
+/**
+ * Composable: reactive job state + auto-poll while running.
+ *
+ * @example
+ * const { jobState, isPolling, start, stop } = useConnectorJob()
+ * start('connector-uuid')
+ */
+export function useConnectorJob() {
+  const jobState = ref<ConnectorJobState | null>(null)
+  const isPolling = ref(false)
+  let timerId: ReturnType<typeof setTimeout> | null = null
+
+  function _clearTimer() {
+    if (timerId !== null) {
+      clearTimeout(timerId)
+      timerId = null
+    }
+  }
+
+  async function _poll(connectorId: string) {
+    if (!isPolling.value) return
+    const state = await fetchConnectorJob(connectorId)
+    jobState.value = state
+
+    if (state?.status === 'running' && isPolling.value) {
+      timerId = setTimeout(() => _poll(connectorId), POLL_INTERVAL_MS)
+    } else {
+      isPolling.value = false
+    }
+  }
+
+  function start(connectorId: string) {
+    _clearTimer()
+    isPolling.value = true
+    _poll(connectorId)
+  }
+
+  function stop() {
+    _clearTimer()
+    isPolling.value = false
+  }
+
+  onUnmounted(stop)
+
+  return {
+    jobState: readonly(jobState),
+    isPolling: readonly(isPolling),
+    start,
+    stop,
+  }
+}

--- a/autobot-frontend/src/types/knowledgeBase.ts
+++ b/autobot-frontend/src/types/knowledgeBase.ts
@@ -321,6 +321,8 @@ export interface ConnectorConfig {
    *   2 = Credentials / OAuth / cookie needed (e.g. database, private GitHub).
    */
   tier?: number
+  /** Issue #8148: max parallel source fetches. null = use connector class default. */
+  max_concurrency?: number | null
 }
 
 /**
@@ -347,4 +349,46 @@ export interface SyncResult {
   updated: number
   deleted: number
   errors: string[]
+}
+
+/**
+ * In-flight sync job state written to Redis during execution.
+ * Issue #8149: returned by GET /knowledge_base/connectors/{id}/job.
+ */
+export interface ConnectorJobState {
+  connector_id: string
+  job_id: string
+  started_at: string
+  status: 'running' | 'success' | 'failed' | 'partial'
+  sources_total: number
+  sources_done: number
+  sources_failed: number
+  worker_id: string
+  last_updated: string
+}
+
+/**
+ * Single enriched history record.
+ * Issue #8149: adds duration_seconds, sources_total, sources_done.
+ */
+export interface ConnectorHistoryEntry {
+  connector_id: string
+  started_at: string
+  completed_at: string | null
+  status: string | null
+  added: number | null
+  updated: number | null
+  deleted: number | null
+  errors: string[] | number | null
+  duration_seconds: number | null
+  sources_total: number | null
+  sources_done: number | null
+}
+
+/**
+ * Response from GET /knowledge_base/connectors/scheduler/leader.
+ * Issue #8149.
+ */
+export interface ConnectorLeaderState {
+  leader: string | null
 }


### PR DESCRIPTION
## Summary

Implements GH #8147, #8148, #8149 from MVA-656 (New batch B: connector output + parallel).

- **#8147** — AbstractConnector.output_schema() classmethod + _validate_metadata() soft validation at ingest; WebCrawlerConnector schema implementation
- **#8148** — Parallel sync support (connector-level concurrency via asyncio.gather + Semaphore)
- **#8149** — Event hooks for sync lifecycle (live job state in Redis, GET /job endpoint, ConnectorHistoryPanel UI)

## Thinking Path

1. Extended AbstractConnector with `output_schema()` classmethod returning JSONSchema dict (backward compatible: default returns `{}`).
2. Added `_validate_metadata()` soft validator — checks required fields and type constraints; appends warnings to SyncResult.errors but does NOT abort ingestion.
3. Parallel sync: added `max_concurrency` property (default 1 = sequential). When >1, sync() uses `asyncio.gather` + `asyncio.Semaphore` to cap concurrent fetches. Error isolation: individual source failures are caught per `_process_change`, so one failure does not abort remaining sources.
4. Job state: each sync generates a UUID job_id and writes progress to Redis key `connector:{id}:job:current` (24h TTL). New GET endpoint returns this state; 404 when no active job.
5. Frontend: new ConnectorHistoryPanel shows enriched history (duration, source counters, error list). useConnectorJob composable polls every 5s while status=running.

## What Changed

**Backend:**
- `knowledge/connectors/base.py`: `output_schema()`, `max_concurrency`, `_validate_metadata()`, parallel sync path, `_write_job_state()` helper
- `knowledge/connectors/models.py`: `ConnectorConfig.max_concurrency` field; `SyncResult.sources_total/done/failed` counters
- `knowledge/connectors/file_server.py`, `web_crawler.py`: concrete `output_schema()` implementations
- `knowledge/connectors/registry.py`: type annotation cleanup (`"object"` → `object`)
- `knowledge/schemas/connectors.py`: `ConnectorJobResponse`, `ConnectorLeaderResponse`, enriched `ConnectorHistoryEntry`
- `api/knowledge_connectors.py`: GET `/job` + GET `/scheduler/leader` endpoints; `_NON_CONFIG_INFIXES` key filter; `max_concurrency` persistence; history enriched with duration + source counters

**Frontend:**
- `types/knowledgeBase.ts`: `ConnectorJobState`, `ConnectorHistoryEntry`, `ConnectorLeaderState` types
- `composables/knowledge/useConnectorJob.ts`: reactive job poller (5s interval, auto-stops on terminal status)
- `components/knowledge/connectors/ConnectorHistoryPanel.vue`: history + live job state UI
- `components/knowledge/connectors/ConnectorManager.vue`: integrates ConnectorHistoryPanel

## Verification

- Gate 0: ⚠️ 4/5 commits partial duplicates (squash history), 1 truly new commit — non-blocking
- Gate 1: ✅ All 8 Python files pass syntax + py_compile
- Gate 2: ✅ registry.py `def get` is annotation-only change (`"object"` → `object`), 0 broken callers
- Gate 3: ⏭️ Skipped — test environment missing `web_fetch_cache_ttl` in AutoBotConfig (pre-existing: `audio_connector_test.py` fails identically on Dev_new_gui baseline)
- Gate 4: ✅ No TypeScript errors in PR-changed files
- Gate 5: ✅ E501 in web_crawler.py is pre-existing on Dev_new_gui baseline
- Black: Fixed in follow-up commit (fc7e4c10b)

## Model Used

claude-sonnet-4-6 (CodeReviewer agent, MVA-677)

Closes #8147, #8148, #8149