### PR TITLE
tech-debt(api): type bare DataResponse batch C — knowledge/chat-ext/multimodal (#6509c)

### DIFF
--- a/autobot-backend/api/chat_knowledge.py
+++ b/autobot-backend/api/chat_knowledge.py
@@ -48,6 +48,14 @@ from api.schemas_common import DataResponse
 from api.schemas_knowledge import (
     AddKnowledgeRequest,
     AssociateFileRequest,
+    ChatKnowledgeCompileData,
+    ChatKnowledgeContextData,
+    ChatKnowledgeDecisionData,
+    ChatKnowledgeFileAssocData,
+    ChatKnowledgePendingData,
+    ChatKnowledgeSearchResultData,
+    ChatKnowledgeTempData,
+    ChatKnowledgeUploadData,
     ChatKnowledgeSearchRequest,
     CompileChatRequest,
     CreateContextRequest,
@@ -490,7 +498,7 @@ chat_knowledge_manager = None
 # API Endpoints
 
 
-@router.post("/context/create", response_model=DataResponse)
+@router.post("/context/create", response_model=DataResponse[ChatKnowledgeContextData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="create_chat_context",
@@ -524,7 +532,7 @@ async def create_chat_context(request_data: CreateContextRequest, request: Reque
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/files/associate", response_model=DataResponse)
+@router.post("/files/associate", response_model=DataResponse[ChatKnowledgeFileAssocData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="associate_file_with_chat",
@@ -556,7 +564,7 @@ async def associate_file_with_chat(request_data: AssociateFileRequest, request: 
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/files/upload/{chat_id}", response_model=DataResponse)
+@router.post("/files/upload/{chat_id}", response_model=DataResponse[ChatKnowledgeUploadData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="upload_file_to_chat",
@@ -603,7 +611,7 @@ async def upload_file_to_chat(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/knowledge/add_temporary", response_model=DataResponse)
+@router.post("/knowledge/add_temporary", response_model=DataResponse[ChatKnowledgeTempData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="add_temporary_knowledge",
@@ -623,7 +631,7 @@ async def add_temporary_knowledge(request: AddKnowledgeRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/knowledge/pending/{chat_id}", response_model=DataResponse)
+@router.get("/knowledge/pending/{chat_id}", response_model=DataResponse[ChatKnowledgePendingData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_pending_knowledge_decisions",
@@ -645,7 +653,7 @@ async def get_pending_knowledge_decisions(chat_id: str):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/knowledge/decide", response_model=DataResponse)
+@router.post("/knowledge/decide", response_model=DataResponse[ChatKnowledgeDecisionData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="apply_knowledge_decision",
@@ -670,7 +678,7 @@ async def apply_knowledge_decision(request: KnowledgeDecisionRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/compile", response_model=DataResponse)
+@router.post("/compile", response_model=DataResponse[ChatKnowledgeCompileData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="compile_chat_to_knowledge",
@@ -693,7 +701,7 @@ async def compile_chat_to_knowledge(request_data: CompileChatRequest, request: R
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/search", response_model=DataResponse)
+@router.post("/search", response_model=DataResponse[ChatKnowledgeSearchResultData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="search_chat_knowledge",
@@ -715,7 +723,7 @@ async def search_chat_knowledge(request: ChatKnowledgeSearchRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/context/{chat_id}", response_model=DataResponse)
+@router.get("/context/{chat_id}", response_model=DataResponse[ChatKnowledgeContextData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_chat_context",

--- a/autobot-backend/api/conversation_files.py
+++ b/autobot-backend/api/conversation_files.py
@@ -18,6 +18,13 @@ import aiofiles
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, JSONResponse
 
+from api.schemas_chat import (
+    ConvFileInfoData,
+    ConvFileOpData,
+    ConvFileSearchData,
+    SessionMcpCallData,
+    SessionMcpToolsData,
+)
 from api.schemas_common import DataResponse
 from api.schemas_knowledge import (
     AgentGenerateFileRequest,
@@ -774,7 +781,7 @@ async def transfer_conversation_files(request: Request, session_id: str, transfe
 # ============================================================
 
 
-@router.post("/conversation/{session_id}/files/create", response_model=DataResponse)
+@router.post("/conversation/{session_id}/files/create", response_model=DataResponse[ConvFileInfoData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="create_conversation_file",
@@ -815,7 +822,7 @@ async def create_conversation_file(request: Request, session_id: str, body: Conv
         raise_internal_error("Error creating file")
 
 
-@router.put("/conversation/{session_id}/files/{file_id}/rename", response_model=DataResponse)
+@router.put("/conversation/{session_id}/files/{file_id}/rename", response_model=DataResponse[ConvFileOpData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="rename_conversation_file",
@@ -851,7 +858,7 @@ async def rename_conversation_file(request: Request, session_id: str, file_id: s
         raise_internal_error("Error renaming file")
 
 
-@router.get("/conversation/{session_id}/files/{file_id}/content", response_model=DataResponse)
+@router.get("/conversation/{session_id}/files/{file_id}/content", response_model=DataResponse[ConvFileOpData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_file_content",
@@ -878,7 +885,7 @@ async def get_file_content(request: Request, session_id: str, file_id: str):
         raise_internal_error("Error reading file")
 
 
-@router.put("/conversation/{session_id}/files/{file_id}/content", response_model=DataResponse)
+@router.put("/conversation/{session_id}/files/{file_id}/content", response_model=DataResponse[ConvFileOpData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_file_content",
@@ -913,7 +920,7 @@ async def update_file_content(request: Request, session_id: str, file_id: str, b
         raise_internal_error("Error updating file")
 
 
-@router.post("/conversation/{session_id}/files/{file_id}/copy", response_model=DataResponse)
+@router.post("/conversation/{session_id}/files/{file_id}/copy", response_model=DataResponse[ConvFileInfoData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="copy_conversation_file",
@@ -949,7 +956,7 @@ async def copy_conversation_file(request: Request, session_id: str, file_id: str
         raise_internal_error("Error copying file")
 
 
-@router.get("/conversation/{session_id}/files/search", response_model=DataResponse)
+@router.get("/conversation/{session_id}/files/search", response_model=DataResponse[ConvFileSearchData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="search_conversation_files",
@@ -972,7 +979,7 @@ async def search_conversation_files(request: Request, session_id: str, q: str = 
         raise_internal_error("Error searching files")
 
 
-@router.post("/conversation/{session_id}/generate", response_model=DataResponse)
+@router.post("/conversation/{session_id}/generate", response_model=DataResponse[ConvFileInfoData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="agent_generate_file",
@@ -1088,7 +1095,7 @@ SESSION_MCP_TOOLS = [
 ]
 
 
-@router.get("/conversation/{session_id}/mcp/tools", response_model=DataResponse)
+@router.get("/conversation/{session_id}/mcp/tools", response_model=DataResponse[SessionMcpToolsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_session_mcp_tools",
@@ -1148,7 +1155,7 @@ async def _dispatch_mcp_tool(file_manager, session_id: str, tool_name: str, args
     raise_invalid_input("tool_name", f"unknown tool: {tool_name}")
 
 
-@router.post("/conversation/{session_id}/mcp/call", response_model=DataResponse)
+@router.post("/conversation/{session_id}/mcp/call", response_model=DataResponse[SessionMcpCallData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="session_mcp_call_tool",

--- a/autobot-backend/api/embeddings.py
+++ b/autobot-backend/api/embeddings.py
@@ -14,7 +14,14 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.schemas_common import DataResponse
-from api.schemas_knowledge import EmbeddingUpdate
+from api.schemas_knowledge import (
+    EmbeddingModelsData,
+    EmbeddingRefreshData,
+    EmbeddingSettingsData,
+    EmbeddingStatusData,
+    EmbeddingUpdate,
+    EmbeddingUpdateData,
+)
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -27,7 +34,7 @@ logger = get_logger(__name__)
 router = APIRouter(tags=["embeddings"])
 
 
-@router.get("/settings", response_model=DataResponse)
+@router.get("/settings", response_model=DataResponse[EmbeddingSettingsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_embedding_settings",
@@ -73,7 +80,7 @@ async def get_embedding_settings(
         raise HTTPException(status_code=500, detail="Failed to get embedding settings")
 
 
-@router.put("/settings", response_model=DataResponse)
+@router.put("/settings", response_model=DataResponse[EmbeddingUpdateData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_embedding_settings",
@@ -126,7 +133,7 @@ async def update_embedding_settings(
         raise HTTPException(status_code=500, detail="Failed to update embedding settings")
 
 
-@router.get("/models", response_model=DataResponse)
+@router.get("/models", response_model=DataResponse[EmbeddingModelsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_available_embedding_models",
@@ -172,7 +179,7 @@ async def get_available_embedding_models(
         raise HTTPException(status_code=500, detail="Failed to get embedding models")
 
 
-@router.post("/providers/{provider_name}/refresh-models", response_model=DataResponse)
+@router.post("/providers/{provider_name}/refresh-models", response_model=DataResponse[EmbeddingRefreshData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="refresh_embedding_models",
@@ -229,7 +236,7 @@ async def refresh_embedding_models(
         raise HTTPException(status_code=500, detail="Failed to refresh embedding models")
 
 
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=DataResponse[EmbeddingStatusData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_embedding_status",

--- a/autobot-backend/api/knowledge_ai_stack.py
+++ b/autobot-backend/api/knowledge_ai_stack.py
@@ -17,9 +17,17 @@ from fastapi.responses import JSONResponse
 
 from api.schemas_common import DataResponse
 from api.schemas_knowledge import (
+    AIStackDocumentAnalysisData,
+    AIStackEnhancedHealthData,
+    AIStackEnhancedSearchData,
     AIStackEnhancedSearchRequest,
+    AIStackEnhancedStatsData,
+    AIStackKnowledgeExtractData,
     AIStackKnowledgeExtractionRequest,
+    AIStackQueryReformulateData,
     AIStackRAGQueryRequest,
+    AIStackRagSearchData,
+    AIStackSystemInsightsData,
     DocumentAnalysisRequest,
 )
 from auth_middleware import get_current_user
@@ -251,7 +259,7 @@ async def _run_all_search_sources(
     return results
 
 
-@router.post("/search/enhanced", response_model=DataResponse)
+@router.post("/search/enhanced", response_model=DataResponse[AIStackEnhancedSearchData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="enhanced_search",
@@ -302,7 +310,7 @@ async def enhanced_search(
         )
 
 
-@router.post("/search/rag", response_model=DataResponse)
+@router.post("/search/rag", response_model=DataResponse[AIStackRagSearchData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="rag_search",
@@ -429,7 +437,7 @@ async def _store_extracted_facts(
     return stored_facts
 
 
-@router.post("/extract", response_model=DataResponse)
+@router.post("/extract", response_model=DataResponse[AIStackKnowledgeExtractData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="extract_knowledge",
@@ -479,7 +487,7 @@ async def extract_knowledge(
         await handle_ai_stack_error(e, "Knowledge extraction")
 
 
-@router.post("/analyze/documents", response_model=DataResponse)
+@router.post("/analyze/documents", response_model=DataResponse[AIStackDocumentAnalysisData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_documents",
@@ -522,7 +530,7 @@ async def analyze_documents(
 # ====================================================================
 
 
-@router.post("/query/reformulate", response_model=DataResponse)
+@router.post("/query/reformulate", response_model=DataResponse[AIStackQueryReformulateData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="reformulate_query",
@@ -563,7 +571,7 @@ async def reformulate_query(
 # ====================================================================
 
 
-@router.get("/system/insights", response_model=DataResponse)
+@router.get("/system/insights", response_model=DataResponse[AIStackSystemInsightsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_system_knowledge_insights",
@@ -597,7 +605,7 @@ async def get_system_knowledge_insights(
 # ====================================================================
 
 
-@router.get("/stats/enhanced", response_model=DataResponse)
+@router.get("/stats/enhanced", response_model=DataResponse[AIStackEnhancedStatsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_enhanced_stats",
@@ -651,7 +659,7 @@ async def get_enhanced_stats(
         )
 
 
-@router.get("/health/enhanced", response_model=DataResponse)
+@router.get("/health/enhanced", response_model=DataResponse[AIStackEnhancedHealthData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="enhanced_knowledge_health",

--- a/autobot-backend/api/memory.py
+++ b/autobot-backend/api/memory.py
@@ -39,12 +39,15 @@ from api.schemas_knowledge import (
     InvalidateRelationRequest,
     MemoryDeleteEntityResponse,
     MemoryDeleteRelationResponse,
+    MemoryEntityData,
     MemoryEntityDetailResponse,
+    MemoryEntityGraphData,
     MemoryEntityInvalidateResponse,
     MemoryEntityListResponse,
     MemoryOrphanCleanupResponse,
     MemoryOrphanScanResponse,
     MemoryRelatedEntitiesResponse,
+    MemoryRelationData,
     MemoryRelationInvalidateResponse,
     MemorySearchResponse,
     ObservationAddRequest,
@@ -338,7 +341,7 @@ def _build_list_entities_response(
 # ====================================================================
 
 
-@router.post("/entities", status_code=201, response_model=DataResponse)
+@router.post("/entities", status_code=201, response_model=DataResponse[MemoryEntityData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="create_entity",
@@ -834,7 +837,7 @@ async def get_entity_by_id(
         raise HTTPException(status_code=500, detail="Failed to retrieve entity")
 
 
-@router.get("/entities", response_model=DataResponse)
+@router.get("/entities", response_model=DataResponse[MemoryEntityData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_entity_by_name",
@@ -888,7 +891,7 @@ async def get_entity_by_name(
         raise HTTPException(status_code=500, detail="Failed to search entity")
 
 
-@router.patch("/entities/{entity_id}/observations", response_model=DataResponse)
+@router.patch("/entities/{entity_id}/observations", response_model=DataResponse[MemoryEntityData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="add_observations",
@@ -1004,7 +1007,7 @@ async def delete_entity(
 # ====================================================================
 
 
-@router.post("/relations", status_code=201, response_model=DataResponse)
+@router.post("/relations", status_code=201, response_model=DataResponse[MemoryRelationData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="create_relation",
@@ -1263,7 +1266,7 @@ async def search_entities(
         raise HTTPException(status_code=500, detail="Search failed")
 
 
-@router.get("/graph", response_model=DataResponse)
+@router.get("/graph", response_model=DataResponse[MemoryEntityGraphData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_entity_graph",

--- a/autobot-backend/api/memory.py
+++ b/autobot-backend/api/memory.py
@@ -58,7 +58,7 @@ from auth_middleware import check_admin_permission
 from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.time_utils import now_utc, utc_timestamp
+from autobot_shared.time_utils import now_utc
 from utils.request_utils import generate_request_id
 
 # ====================================================================

--- a/autobot-backend/api/multimodal.py
+++ b/autobot-backend/api/multimodal.py
@@ -14,6 +14,15 @@ from typing import List
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 
 from ai_hardware_accelerator import HardwareDevice, accelerated_embedding_generation
+from api.schemas_ai_stack import (
+    MultimodalBatchSizeData,
+    MultimodalEmbeddingData,
+    MultimodalFusionData,
+    MultimodalOptimizeData,
+    MultimodalPerfStatsData,
+    MultimodalPerfSummaryData,
+    MultimodalStatsData,
+)
 from api.schemas_common import DataResponse
 from api.schemas_knowledge import (
     CrossModalSearchRequest,
@@ -280,7 +289,7 @@ async def process_text(
         )
 
 
-@router.post("/embeddings/generate", response_model=DataResponse)
+@router.post("/embeddings/generate", response_model=DataResponse[MultimodalEmbeddingData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="generate_embedding",
@@ -409,7 +418,7 @@ async def cross_modal_search(
         )
 
 
-@router.get("/stats", response_model=DataResponse)
+@router.get("/stats", response_model=DataResponse[MultimodalStatsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_multimodal_stats",
@@ -572,7 +581,7 @@ def _create_combined_input(
     )
 
 
-@router.post("/fusion/combine", response_model=DataResponse)
+@router.post("/fusion/combine", response_model=DataResponse[MultimodalFusionData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="combine_multimodal_inputs",
@@ -637,7 +646,7 @@ async def combine_multimodal_inputs(
 
 
 # Performance monitoring endpoints
-@router.get("/performance/stats", response_model=DataResponse)
+@router.get("/performance/stats", response_model=DataResponse[MultimodalPerfStatsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_performance_stats",
@@ -681,7 +690,7 @@ async def get_performance_stats(
         }
 
 
-@router.post("/performance/optimize", response_model=DataResponse)
+@router.post("/performance/optimize", response_model=DataResponse[MultimodalOptimizeData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="optimize_performance",
@@ -714,7 +723,7 @@ async def optimize_performance(
         }
 
 
-@router.get("/performance/summary", response_model=DataResponse)
+@router.get("/performance/summary", response_model=DataResponse[MultimodalPerfSummaryData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_performance_summary",
@@ -742,7 +751,7 @@ async def get_performance_summary(
         }
 
 
-@router.post("/performance/batch-size", response_model=DataResponse)
+@router.post("/performance/batch-size", response_model=DataResponse[MultimodalBatchSizeData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_batch_size",

--- a/autobot-backend/api/schemas_ai_stack.py
+++ b/autobot-backend/api/schemas_ai_stack.py
@@ -57,3 +57,50 @@ class AIStackAgentPayload(BaseModel):
     """
 
     model_config = {"extra": "allow"}
+
+
+# ---------------------------------------------------------------------------
+# multimodal.py response schemas (#6509c)
+# ---------------------------------------------------------------------------
+
+
+class MultimodalEmbeddingData(BaseModel):
+    """data payload for POST /embeddings/generate."""
+
+    model_config = {"extra": "allow"}
+
+
+class MultimodalStatsData(BaseModel):
+    """data payload for GET /stats."""
+
+    model_config = {"extra": "allow"}
+
+
+class MultimodalFusionData(BaseModel):
+    """data payload for POST /combine."""
+
+    model_config = {"extra": "allow"}
+
+
+class MultimodalPerfStatsData(BaseModel):
+    """data payload for GET /performance/stats."""
+
+    model_config = {"extra": "allow"}
+
+
+class MultimodalOptimizeData(BaseModel):
+    """data payload for POST /performance/optimize."""
+
+    model_config = {"extra": "allow"}
+
+
+class MultimodalPerfSummaryData(BaseModel):
+    """data payload for GET /performance/summary."""
+
+    model_config = {"extra": "allow"}
+
+
+class MultimodalBatchSizeData(BaseModel):
+    """data payload for PUT /performance/batch-size."""
+
+    model_config = {"extra": "allow"}

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -492,3 +492,47 @@ class CompareRequest(BaseModel):
         description="List of 'provider/model' strings, e.g. ['ollama/llama3', 'openai/gpt-4o']",
     )
     context: str | None = Field(None, max_length=50000)
+
+
+# ---------------------------------------------------------------------------
+# conversation_files.py response schemas (#6509c)
+# ---------------------------------------------------------------------------
+
+
+class ConvFileInfoData(BaseModel):
+    """data payload for create/copy/agent-generate conversation file endpoints."""
+
+    model_config = {"extra": "allow"}
+
+    success: bool
+
+
+class ConvFileOpData(BaseModel):
+    """data payload for rename/get-content/update-content conversation file endpoints."""
+
+    model_config = {"extra": "allow"}
+
+    success: bool
+
+
+class ConvFileSearchData(BaseModel):
+    """data payload for GET /sessions/{session_id}/files/search."""
+
+    success: bool
+    files: List[Any]
+    total: int
+
+
+class SessionMcpToolsData(BaseModel):
+    """data payload for GET /sessions/{session_id}/mcp/tools."""
+
+    tools: List[Dict[str, Any]]
+    session_id: str
+
+
+class SessionMcpCallData(BaseModel):
+    """data payload for POST /sessions/{session_id}/mcp/call."""
+
+    model_config = {"extra": "allow"}
+
+    success: bool

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -1952,6 +1952,186 @@ class AssignFactToCategoryRequest(BaseModel):
         return v
 
 
+# ---------------------------------------------------------------------------
+# chat_knowledge.py response schemas (#6509c)
+# ---------------------------------------------------------------------------
+
+
+class ChatKnowledgeContextData(BaseModel):
+    """data payload for create_chat_context / get_chat_context."""
+
+    model_config = {"extra": "allow"}
+
+    success: bool
+
+
+class ChatKnowledgeFileAssocData(BaseModel):
+    """data payload for associate_file_with_chat."""
+
+    model_config = {"extra": "allow"}
+
+    success: bool
+
+
+class ChatKnowledgeUploadData(BaseModel):
+    """data payload for upload_file_to_chat."""
+
+    model_config = {"extra": "allow"}
+
+    success: bool
+
+
+class ChatKnowledgeTempData(BaseModel):
+    """data payload for add_temporary_knowledge."""
+
+    model_config = {"extra": "allow"}
+
+    success: bool
+
+
+class ChatKnowledgePendingData(BaseModel):
+    """data payload for get_pending_knowledge_decisions."""
+
+    model_config = {"extra": "allow"}
+
+    success: bool
+
+
+class ChatKnowledgeDecisionData(BaseModel):
+    """data payload for apply_knowledge_decision."""
+
+    model_config = {"extra": "allow"}
+
+    success: bool
+
+
+class ChatKnowledgeCompileData(BaseModel):
+    """data payload for compile_chat_to_knowledge."""
+
+    model_config = {"extra": "allow"}
+
+    success: bool
+
+
+class ChatKnowledgeSearchResultData(BaseModel):
+    """data payload for search_chat_knowledge."""
+
+    model_config = {"extra": "allow"}
+
+    success: bool
+
+
+# ---------------------------------------------------------------------------
+# knowledge_ai_stack.py response schemas (#6509c)
+# ---------------------------------------------------------------------------
+
+
+class AIStackEnhancedSearchData(BaseModel):
+    """data payload for POST /search/enhanced."""
+
+    model_config = {"extra": "allow"}
+
+
+class AIStackRagSearchData(BaseModel):
+    """data payload for POST /search/rag."""
+
+    model_config = {"extra": "allow"}
+
+
+class AIStackKnowledgeExtractData(BaseModel):
+    """data payload for POST /knowledge/extract."""
+
+    model_config = {"extra": "allow"}
+
+
+class AIStackDocumentAnalysisData(BaseModel):
+    """data payload for POST /documents/analyze."""
+
+    model_config = {"extra": "allow"}
+
+
+class AIStackQueryReformulateData(BaseModel):
+    """data payload for POST /search/reformulate."""
+
+    model_config = {"extra": "allow"}
+
+
+class AIStackSystemInsightsData(BaseModel):
+    """data payload for GET /knowledge/system-insights."""
+
+    model_config = {"extra": "allow"}
+
+
+class AIStackEnhancedStatsData(BaseModel):
+    """data payload for GET /stats/enhanced."""
+
+    model_config = {"extra": "allow"}
+
+
+class AIStackEnhancedHealthData(BaseModel):
+    """data payload for GET /health/enhanced."""
+
+    model_config = {"extra": "allow"}
+
+
+# ---------------------------------------------------------------------------
+# memory.py bare DataResponse response schemas (#6509c)
+# ---------------------------------------------------------------------------
+
+
+class MemoryEntityData(BaseModel):
+    """data payload for create_entity / get_entity_by_name / add_observations."""
+
+    model_config = {"extra": "allow"}
+
+
+class MemoryRelationData(BaseModel):
+    """data payload for create_relation."""
+
+    model_config = {"extra": "allow"}
+
+
+class MemoryEntityGraphData(BaseModel):
+    """data payload for get_entity_graph."""
+
+    model_config = {"extra": "allow"}
+
+
+# ---------------------------------------------------------------------------
+# embeddings.py response schemas (#6509c)
+# ---------------------------------------------------------------------------
+
+
+class EmbeddingSettingsData(BaseModel):
+    """data payload for GET /settings."""
+
+    model_config = {"extra": "allow"}
+
+
+class EmbeddingUpdateData(BaseModel):
+    """data payload for PUT /settings."""
+
+    model_config = {"extra": "allow"}
+
+
+class EmbeddingModelsData(BaseModel):
+    """data payload for GET /models."""
+
+    model_config = {"extra": "allow"}
+
+
+class EmbeddingRefreshData(BaseModel):
+    """data payload for POST /providers/{provider_name}/refresh-models."""
+
+    model_config = {"extra": "allow"}
+
+
+class EmbeddingStatusData(BaseModel):
+    """data payload for GET /status."""
+
+    model_config = {"extra": "allow"}
+
+
 class SearchCategoriesByPathRequest(BaseModel):
     """
     Request model for searching categories by path pattern (Issue #411).

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -8,7 +8,7 @@ Knowledge base collection, category, fact, grounding, and audit schemas.
 import re
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 
 from pydantic import BaseModel, Field, field_validator
 


### PR DESCRIPTION
## Summary

Types all bare `response_model=DataResponse` route decorators across the knowledge and multimodal domain — Batch C of GH #6509.

- **43 bare `response_model=DataResponse` replaced** with typed `DataResponse[T]` across 6 files
- **35 new `*Data` schemas** added: 5 in `schemas_chat.py`, 23 in `schemas_knowledge.py`, 7 in `schemas_ai_stack.py`
- All 9 changed files pass `python3 -m py_compile`

### Files changed
| File | Occurrences typed |
|------|------------------|
| `autobot-backend/api/conversation_files.py` | 9 |
| `autobot-backend/api/chat_knowledge.py` | 9 |
| `autobot-backend/api/knowledge_ai_stack.py` | 8 |
| `autobot-backend/api/multimodal.py` | 7 |
| `autobot-backend/api/memory.py` | 5 |
| `autobot-backend/api/embeddings.py` | 5 |

## Test plan
- [x] All changed files pass `python3 -m py_compile`
- [ ] `/pre-merge-validate` passes
- [ ] No broken imports in changed files

Part of umbrella issue #6509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)