### PR TITLE
tech-debt(api): type bare DataResponse — analytics, orchestration, enterprise domain (GH #6509 Batch D)

### DIFF
--- a/autobot-backend/api/adapters.py
+++ b/autobot-backend/api/adapters.py
@@ -11,6 +11,13 @@ status endpoints for the formal adapter registry.
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from api.schemas_agent import (
+    AdapterListResponse,
+    AdapterModelsResponse,
+    AdapterOverrideClearResponse,
+    AdapterOverrideSetResponse,
+    AdapterTestResponse,
+)
 from api.schemas_common import DataResponse
 from api.system_health import ComponentHealth, register_health_probe
 from auth_middleware import get_current_user
@@ -23,7 +30,7 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-@router.get("/", response_model=DataResponse)
+@router.get("/", response_model=DataResponse[AdapterListResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_adapters",
@@ -41,7 +48,7 @@ async def list_adapters(
     )
 
 
-@router.get("/{adapter_type}/test", response_model=DataResponse)
+@router.get("/{adapter_type}/test", response_model=DataResponse[AdapterTestResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="test_adapter_environment",
@@ -65,7 +72,7 @@ async def test_adapter_environment(
     return JSONResponse(status_code=200, content=result.to_dict())
 
 
-@router.get("/{adapter_type}/models", response_model=DataResponse)
+@router.get("/{adapter_type}/models", response_model=DataResponse[AdapterModelsResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_adapter_models",
@@ -119,7 +126,7 @@ async def probe_adapters(
         )
 
 
-@router.post("/agent/{agent_id}/override", response_model=DataResponse)
+@router.post("/agent/{agent_id}/override", response_model=DataResponse[AdapterOverrideSetResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="set_agent_adapter_override",
@@ -152,7 +159,7 @@ async def set_agent_adapter_override(
     )
 
 
-@router.delete("/agent/{agent_id}/override", response_model=DataResponse)
+@router.delete("/agent/{agent_id}/override", response_model=DataResponse[AdapterOverrideClearResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="clear_agent_adapter_override",

--- a/autobot-backend/api/agent_config.py
+++ b/autobot-backend/api/agent_config.py
@@ -15,11 +15,16 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.schemas_agent import (
+    AgentConfigAllAgentsResponse,
     AgentConfigDetailResponse,
     AgentConfigEnableDisableResponse,
     AgentConfigHealthResponse,
+    AgentConfigListAgentsResponse,
     AgentConfigOverviewResponse,
+    AgentConfigSpecializedDetailResponse,
+    AgentConfigSpecializedListResponse,
     AgentConfigUpdateModelResponse,
+    AgentConfigUsageResponse,
     AgentModelUpdate,
 )
 from api.schemas_common import DataResponse
@@ -559,7 +564,7 @@ async def _resolve_agent_effective_config(agent_id: str, config: dict, unified_c
     return current_model, current_provider, enabled, "local"
 
 
-@router.get("/agents", response_model=DataResponse)
+@router.get("/agents", response_model=DataResponse[AgentConfigListAgentsResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_agents",
@@ -669,7 +674,7 @@ async def _resolve_agent_entry(agent_id: str, config: dict, unified_config_manag
     }
 
 
-@router.get("/agents/all", response_model=DataResponse)
+@router.get("/agents/all", response_model=DataResponse[AgentConfigAllAgentsResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_all_agents",
@@ -713,7 +718,7 @@ async def get_all_agents(admin_check: bool = Depends(check_admin_permission)):
     )
 
 
-@router.get("/agents/specialized", response_model=DataResponse)
+@router.get("/agents/specialized", response_model=DataResponse[AgentConfigSpecializedListResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_specialized_agents",
@@ -746,7 +751,7 @@ async def list_specialized_agents(
     )
 
 
-@router.get("/agents/specialized/{agent_id}", response_model=DataResponse)
+@router.get("/agents/specialized/{agent_id}", response_model=DataResponse[AgentConfigSpecializedDetailResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_specialized_agent",
@@ -776,7 +781,7 @@ async def get_specialized_agent(
     return JSONResponse(status_code=200, content=agent)
 
 
-@router.get("/agents/usage", response_model=DataResponse)
+@router.get("/agents/usage", response_model=DataResponse[AgentConfigUsageResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_agents_usage",

--- a/autobot-backend/api/analytics_cfg.py
+++ b/autobot-backend/api/analytics_cfg.py
@@ -30,6 +30,10 @@ from api.schemas_analytics import (
     IssueSeverity,
     IssueType,
     NodeType,
+    AnalyticsCFGAnalyzeResponse,
+    AnalyticsCFGComplexityResponse,
+    AnalyticsCFGInfiniteLoopsResponse,
+    AnalyticsCFGUnreachableResponse,
 )
 from api.schemas_common import DataResponse
 from auth_middleware import check_admin_permission
@@ -1039,7 +1043,7 @@ def _calculate_cfg_summary(graphs: List[ControlFlowGraph], all_issues: List[Dict
     }
 
 
-@router.post("/analyze", response_model=DataResponse)
+@router.post("/analyze", response_model=DataResponse[AnalyticsCFGAnalyzeResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_control_flow",
@@ -1199,7 +1203,7 @@ async def export_cfg_dot(
     )
 
 
-@router.post("/complexity", response_model=DataResponse)
+@router.post("/complexity", response_model=DataResponse[AnalyticsCFGComplexityResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_complexity_metrics",
@@ -1250,7 +1254,7 @@ async def get_complexity_metrics(
     )
 
 
-@router.post("/unreachable", response_model=DataResponse)
+@router.post("/unreachable", response_model=DataResponse[AnalyticsCFGUnreachableResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="detect_unreachable_code",
@@ -1286,7 +1290,7 @@ async def detect_unreachable_code(
     )
 
 
-@router.post("/infinite-loops", response_model=DataResponse)
+@router.post("/infinite-loops", response_model=DataResponse[AnalyticsCFGInfiniteLoopsResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="detect_infinite_loops",

--- a/autobot-backend/api/analytics_debt.py
+++ b/autobot-backend/api/analytics_debt.py
@@ -23,7 +23,15 @@ from typing import Any, Dict, List
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 
-from api.schemas_analytics import DebtCalculationRequest
+from api.schemas_analytics import (
+    AnalyticsDebtByCategoryResponse,
+    AnalyticsDebtCalculateResponse,
+    AnalyticsDebtReportResponse,
+    AnalyticsDebtROIPrioritiesResponse,
+    AnalyticsDebtSummaryResponse,
+    AnalyticsDebtTrendsResponse,
+    DebtCalculationRequest,
+)
 from api.schemas_common import DataResponse
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -463,7 +471,7 @@ def _get_latest_debt_data() -> Dict[str, Any] | None:
         return None
 
 
-@router.post("/calculate", response_model=DataResponse)
+@router.post("/calculate", response_model=DataResponse[AnalyticsDebtCalculateResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="calculate_technical_debt",
@@ -510,7 +518,7 @@ async def calculate_technical_debt(
         )
 
 
-@router.get("/summary", response_model=DataResponse)
+@router.get("/summary", response_model=DataResponse[AnalyticsDebtSummaryResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_debt_summary",
@@ -540,7 +548,7 @@ async def get_debt_summary(admin_check: bool = Depends(check_admin_permission)):
     return JSONResponse(_no_data_response("No debt analysis found. Run POST /calculate first."))
 
 
-@router.get("/by-category/{category}", response_model=DataResponse)
+@router.get("/by-category/{category}", response_model=DataResponse[AnalyticsDebtByCategoryResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_debt_by_category",
@@ -630,7 +638,7 @@ def _calculate_trend_change(trend_data: List[Dict[str, Any]]) -> tuple:
     return change, direction
 
 
-@router.get("/trends", response_model=DataResponse)
+@router.get("/trends", response_model=DataResponse[AnalyticsDebtTrendsResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_debt_trends",
@@ -662,7 +670,7 @@ async def get_debt_trends(
     )
 
 
-@router.get("/roi-priorities", response_model=DataResponse)
+@router.get("/roi-priorities", response_model=DataResponse[AnalyticsDebtROIPrioritiesResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_roi_priorities",
@@ -768,7 +776,7 @@ def _generate_markdown_report(debt_data: dict) -> str:
     return _build_debt_executive_summary(debt_data) + _build_debt_tables(debt_data) + _build_debt_recommendations()
 
 
-@router.get("/report", response_model=DataResponse)
+@router.get("/report", response_model=DataResponse[AnalyticsDebtReportResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_debt_report",

--- a/autobot-backend/api/analytics_embedding_patterns.py
+++ b/autobot-backend/api/analytics_embedding_patterns.py
@@ -26,7 +26,13 @@ from typing import Any, Dict
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
-from api.schemas_analytics import EmbeddingStatsResponse, EmbeddingUsageRequest
+from api.schemas_analytics import (
+    AnalyticsEmbeddingModelComparisonResponse,
+    AnalyticsEmbeddingOptimizationResponse,
+    AnalyticsEmbeddingRecordResponse,
+    EmbeddingStatsResponse,
+    EmbeddingUsageRequest,
+)
 from api.system_health import ComponentHealth, register_health_probe
 from auth_middleware import check_admin_permission
 from autobot_shared.logging_manager import get_logger
@@ -454,7 +460,7 @@ def get_embedding_analyzer() -> EmbeddingPatternAnalyzer:
 # =============================================================================
 
 
-@router.post("/record", response_model=DataResponse)
+@router.post("/record", response_model=DataResponse[AnalyticsEmbeddingRecordResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="record_embedding_usage",
@@ -507,7 +513,7 @@ async def get_embedding_stats(
     )
 
 
-@router.get("/model-comparison", response_model=DataResponse)
+@router.get("/model-comparison", response_model=DataResponse[AnalyticsEmbeddingModelComparisonResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_model_comparison",
@@ -532,7 +538,7 @@ async def get_model_comparison(
     )
 
 
-@router.get("/optimization-recommendations", response_model=DataResponse)
+@router.get("/optimization-recommendations", response_model=DataResponse[AnalyticsEmbeddingOptimizationResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_optimization_recommendations",

--- a/autobot-backend/api/analytics_evolution.py
+++ b/autobot-backend/api/analytics_evolution.py
@@ -23,6 +23,13 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from api.analytics_shared import resolve_source_or_404 as _resolve_source_or_404
 from api.schemas_analytics import (
+    AnalyticsEvolutionExportResponse,
+    AnalyticsEvolutionPatternSnapshotResponse,
+    AnalyticsEvolutionPatternsResponse,
+    AnalyticsEvolutionSnapshotResponse,
+    AnalyticsEvolutionSummaryResponse,
+    AnalyticsEvolutionTimelineResponse,
+    AnalyticsEvolutionTrendsResponse,
     DateRangeParams,
     EvolutionAnalysisRequest,
     EvolutionAnalysisResponse,
@@ -315,7 +322,7 @@ def _build_timeline_response(timeline: list, start_date: str, end_date: str, gra
     }
 
 
-@router.get("/timeline", response_model=DataResponse)
+@router.get("/timeline", response_model=DataResponse[AnalyticsEvolutionTimelineResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_evolution_timeline",
@@ -388,7 +395,7 @@ async def get_evolution_timeline(
         )
 
 
-@router.get("/patterns", response_model=DataResponse)
+@router.get("/patterns", response_model=DataResponse[AnalyticsEvolutionPatternsResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_pattern_evolution",
@@ -544,7 +551,7 @@ def _build_trends_success_response(trends: dict, days: int, snapshot_count: int)
     }
 
 
-@router.get("/trends", response_model=DataResponse)
+@router.get("/trends", response_model=DataResponse[AnalyticsEvolutionTrendsResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_quality_trends",
@@ -611,7 +618,7 @@ async def get_quality_trends(
         )
 
 
-@router.post("/snapshot", response_model=DataResponse)
+@router.post("/snapshot", response_model=DataResponse[AnalyticsEvolutionSnapshotResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="record_quality_snapshot",
@@ -648,7 +655,7 @@ async def record_quality_snapshot(
         )
 
 
-@router.post("/pattern-snapshot", response_model=DataResponse)
+@router.post("/pattern-snapshot", response_model=DataResponse[AnalyticsEvolutionPatternSnapshotResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="record_pattern_snapshot",
@@ -752,7 +759,7 @@ def _generate_json_export_response(timeline_data: list) -> JSONResponse:
     )
 
 
-@router.get("/export", response_model=DataResponse)
+@router.get("/export", response_model=DataResponse[AnalyticsEvolutionExportResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="export_evolution_data",
@@ -809,7 +816,7 @@ async def export_evolution_data(
         )
 
 
-@router.get("/summary", response_model=DataResponse)
+@router.get("/summary", response_model=DataResponse[AnalyticsEvolutionSummaryResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_evolution_summary",

--- a/autobot-backend/api/analytics_reporting.py
+++ b/autobot-backend/api/analytics_reporting.py
@@ -18,6 +18,11 @@ import aiohttp
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
+from api.schemas_analytics import (
+    AnalyticsReportingReportResponse,
+    AnalyticsReportingSummaryResponse,
+    AnalyticsReportingTrendsResponse,
+)
 from api.schemas_common import DataResponse
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
@@ -283,7 +288,7 @@ def _build_unified_report_response(
     }
 
 
-@router.get("/report", response_model=DataResponse)
+@router.get("/report", response_model=DataResponse[AnalyticsReportingReportResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_unified_report",
@@ -319,7 +324,7 @@ async def get_unified_report():
     return JSONResponse(content=response)
 
 
-@router.get("/summary", response_model=DataResponse)
+@router.get("/summary", response_model=DataResponse[AnalyticsReportingSummaryResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_quick_summary",
@@ -355,7 +360,7 @@ async def get_quick_summary():
     )
 
 
-@router.get("/trends", response_model=DataResponse)
+@router.get("/trends", response_model=DataResponse[AnalyticsReportingTrendsResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_trends",

--- a/autobot-backend/api/bi_export_endpoints.py
+++ b/autobot-backend/api/bi_export_endpoints.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 
 from api.schemas_agent import SavedReportRequest, SavedReportResponse, SavedReportsListResponse
+from api.schemas_analytics import SavedReportDeleteResponse, SavedReportRunResponse
 from api.schemas_common import DataResponse
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -79,7 +80,7 @@ async def list_saved_reports(
 # =========================================================================
 
 
-@router.get("/reports/saved/{report_id}", response_model=DataResponse)
+@router.get("/reports/saved/{report_id}", response_model=DataResponse[SavedReportResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_saved_report",
@@ -105,7 +106,7 @@ async def get_saved_report(
 # =========================================================================
 
 
-@router.put("/reports/saved/{report_id}", response_model=DataResponse)
+@router.put("/reports/saved/{report_id}", response_model=DataResponse[SavedReportResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_saved_report",
@@ -137,7 +138,7 @@ async def update_saved_report(
 # =========================================================================
 
 
-@router.delete("/reports/saved/{report_id}", response_model=DataResponse)
+@router.delete("/reports/saved/{report_id}", response_model=DataResponse[SavedReportDeleteResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="delete_saved_report",
@@ -163,7 +164,7 @@ async def delete_saved_report(
 # =========================================================================
 
 
-@router.post("/reports/saved/{report_id}/run", response_model=DataResponse)
+@router.post("/reports/saved/{report_id}/run", response_model=DataResponse[SavedReportRunResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="run_saved_report",

--- a/autobot-backend/api/enterprise_features.py
+++ b/autobot-backend/api/enterprise_features.py
@@ -10,6 +10,17 @@ import asyncio
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 
+from api.schemas_agent import (
+    EnterpriseBulkEnableResponse,
+    EnterpriseDeploymentResponse,
+    EnterpriseFeatureEnableAllResponse,
+    EnterpriseFeatureEnableResponse,
+    EnterpriseFeatureListResponse,
+    EnterpriseInfrastructureResponse,
+    EnterprisePerformanceOptimizeResponse,
+    EnterprisePhase4ValidationResponse,
+    EnterpriseStatusResponse,
+)
 from api.schemas_common import DataResponse
 from api.schemas_workflows import (
     BulkFeatureRequest,
@@ -246,7 +257,7 @@ def _build_service_distribution(vm_topology: dict) -> dict:
     return service_distribution
 
 
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=DataResponse[EnterpriseStatusResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_enterprise_status",
@@ -280,7 +291,7 @@ async def get_enterprise_status():
         raise HTTPException(status_code=500, detail="Failed to get enterprise status")
 
 
-@router.post("/features/enable", response_model=DataResponse)
+@router.post("/features/enable", response_model=DataResponse[EnterpriseFeatureEnableResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="enable_enterprise_feature",
@@ -331,7 +342,7 @@ async def enable_enterprise_feature(request: FeatureEnableRequest):
         raise HTTPException(status_code=500, detail="Failed to enable feature")
 
 
-@router.post("/features/enable-all", response_model=DataResponse)
+@router.post("/features/enable-all", response_model=DataResponse[EnterpriseFeatureEnableAllResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="enable_all_enterprise_features",
@@ -365,7 +376,7 @@ async def enable_all_enterprise_features():
         raise HTTPException(status_code=500, detail="Failed to enable enterprise features")
 
 
-@router.get("/features", response_model=DataResponse)
+@router.get("/features", response_model=DataResponse[EnterpriseFeatureListResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_enterprise_features",
@@ -417,7 +428,7 @@ async def list_enterprise_features(
         raise HTTPException(status_code=500, detail="Failed to list features")
 
 
-@router.post("/features/bulk-enable", response_model=DataResponse)
+@router.post("/features/bulk-enable", response_model=DataResponse[EnterpriseBulkEnableResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="bulk_enable_features",
@@ -473,7 +484,7 @@ async def bulk_enable_features(request: BulkFeatureRequest):
 register_singleton_probe("enterprise_features", get_enterprise_manager)
 
 
-@router.post("/performance/optimize", response_model=DataResponse)
+@router.post("/performance/optimize", response_model=DataResponse[EnterprisePerformanceOptimizeResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="optimize_system_performance",
@@ -514,7 +525,7 @@ async def optimize_system_performance(request: PerformanceOptimizationRequest):
         raise HTTPException(status_code=500, detail="Performance optimization failed")
 
 
-@router.get("/infrastructure", response_model=DataResponse)
+@router.get("/infrastructure", response_model=DataResponse[EnterpriseInfrastructureResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_infrastructure_status",
@@ -559,7 +570,7 @@ async def get_infrastructure_status():
         raise HTTPException(status_code=500, detail="Failed to get infrastructure status")
 
 
-@router.post("/deployment/zero-downtime", response_model=DataResponse)
+@router.post("/deployment/zero-downtime", response_model=DataResponse[EnterpriseDeploymentResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="deploy_zero_downtime",
@@ -604,7 +615,7 @@ async def deploy_zero_downtime():
         raise HTTPException(status_code=500, detail="Zero-downtime deployment failed")
 
 
-@router.get("/phase4/validation", response_model=DataResponse)
+@router.get("/phase4/validation", response_model=DataResponse[EnterprisePhase4ValidationResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="validate_phase4_completion",

--- a/autobot-backend/api/gpu_monitoring.py
+++ b/autobot-backend/api/gpu_monitoring.py
@@ -16,7 +16,14 @@ from dataclasses import asdict
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from api.schemas_common import DataResponse
-from api.schemas_system import GPUConfigUpdateRequest
+from api.schemas_system import (
+    GPUBenchmarkResponse,
+    GPUCapabilitiesResponse,
+    GPUConfigUpdateRequest,
+    GPUConfigUpdateResponse,
+    GPUEfficiencyResponse,
+    GPUOptimizeResponse,
+)
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -37,7 +44,7 @@ def _gpu_unavailable_error() -> HTTPException:
     )
 
 
-@router.get("/efficiency", response_model=DataResponse)
+@router.get("/efficiency", response_model=DataResponse[GPUEfficiencyResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_gpu_efficiency",
@@ -63,7 +70,7 @@ async def get_gpu_efficiency(
     return {"success": True, "efficiency": result}
 
 
-@router.get("/capabilities", response_model=DataResponse)
+@router.get("/capabilities", response_model=DataResponse[GPUCapabilitiesResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_gpu_capabilities",
@@ -86,7 +93,7 @@ async def get_gpu_capabilities(
     return {"success": True, "capabilities": caps}
 
 
-@router.post("/benchmark", response_model=DataResponse)
+@router.post("/benchmark", response_model=DataResponse[GPUBenchmarkResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="run_gpu_benchmark",
@@ -109,7 +116,7 @@ async def run_gpu_benchmark(
     return {"success": True, "benchmark": result}
 
 
-@router.post("/optimize", response_model=DataResponse)
+@router.post("/optimize", response_model=DataResponse[GPUOptimizeResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="optimize_gpu_multimodal",
@@ -136,7 +143,7 @@ async def optimize_gpu_multimodal(
     return {"success": True, "optimization": asdict(result)}
 
 
-@router.patch("/config", response_model=DataResponse)
+@router.patch("/config", response_model=DataResponse[GPUConfigUpdateResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_gpu_config",

--- a/autobot-backend/api/merge_conflict_resolution.py
+++ b/autobot-backend/api/merge_conflict_resolution.py
@@ -26,6 +26,14 @@ from api.schemas_code import (
     ConflictResolutionRequest,
     RepositoryAnalysisRequest,
 )
+from api.schemas_code import (
+    MergeConflictAnalyzeResponse,
+    MergeConflictApplyResponse,
+    MergeConflictCheckResponse,
+    MergeConflictRepositoryAnalyzeResponse,
+    MergeConflictResolveResponse,
+    MergeConflictStrategiesResponse,
+)
 from api.schemas_common import DataResponse
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -189,7 +197,7 @@ def _build_no_conflicts_response(file_path: str) -> JSONResponse:
 # =============================================================================
 
 
-@router.post("/analyze", response_model=DataResponse)
+@router.post("/analyze", response_model=DataResponse[MergeConflictAnalyzeResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_conflicts",
@@ -244,7 +252,7 @@ async def analyze_conflicts(
         )
 
 
-@router.post("/resolve", response_model=DataResponse)
+@router.post("/resolve", response_model=DataResponse[MergeConflictResolveResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="resolve_conflicts",
@@ -312,7 +320,7 @@ async def resolve_conflicts(
         )
 
 
-@router.post("/analyze-repository", response_model=DataResponse)
+@router.post("/analyze-repository", response_model=DataResponse[MergeConflictRepositoryAnalyzeResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_repository_conflicts",
@@ -374,7 +382,7 @@ async def analyze_repository_conflicts(
         )
 
 
-@router.post("/apply", response_model=DataResponse)
+@router.post("/apply", response_model=DataResponse[MergeConflictApplyResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="apply_resolution",
@@ -436,7 +444,7 @@ async def apply_resolution(
         )
 
 
-@router.get("/strategies", response_model=DataResponse)
+@router.get("/strategies", response_model=DataResponse[MergeConflictStrategiesResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_resolution_strategies",
@@ -503,7 +511,7 @@ async def get_resolution_strategies(
     )
 
 
-@router.get("/check", response_model=DataResponse)
+@router.get("/check", response_model=DataResponse[MergeConflictCheckResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="check_file_conflicts",

--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -28,6 +28,16 @@ else:
     get_logger(__name__).warning("orchestrator module not available")
 
 from api.schemas_common import DataResponse
+from api.schemas_workflows import (
+    OrchestrationActiveWorkflowsResponse,
+    OrchestrationAgentPerformanceResponse,
+    OrchestrationAgentRecommendResponse,
+    OrchestrationCapabilitiesResponse,
+    OrchestrationExamplesResponse,
+    OrchestrationStrategiesResponse,
+    OrchestrationStatusResponse,
+    OrchestrationWorkflowPlanResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
 router = APIRouter()
@@ -135,7 +145,7 @@ async def execute_workflow(
         raise HTTPException(status_code=500, detail="Workflow execution failed")
 
 
-@router.post("/workflow/plan", response_model=DataResponse)
+@router.post("/workflow/plan", response_model=DataResponse[OrchestrationWorkflowPlanResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="create_workflow_plan",
@@ -196,7 +206,7 @@ async def create_workflow_plan(
         raise HTTPException(status_code=500, detail="Plan creation failed")
 
 
-@router.get("/agents/performance", response_model=DataResponse)
+@router.get("/agents/performance", response_model=DataResponse[OrchestrationAgentPerformanceResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_agent_performance",
@@ -227,7 +237,7 @@ async def get_agent_performance(
         raise HTTPException(status_code=500, detail="Failed to get performance report")
 
 
-@router.post("/agents/recommend", response_model=DataResponse)
+@router.post("/agents/recommend", response_model=DataResponse[OrchestrationAgentRecommendResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="recommend_agents",
@@ -279,7 +289,7 @@ async def recommend_agents(
         raise HTTPException(status_code=500, detail="Failed to get recommendations")
 
 
-@router.get("/workflow/active", response_model=DataResponse)
+@router.get("/workflow/active", response_model=DataResponse[OrchestrationActiveWorkflowsResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_active_workflows",
@@ -330,7 +340,7 @@ async def get_active_workflows(
         raise HTTPException(status_code=500, detail="Failed to get active workflows")
 
 
-@router.get("/strategies", response_model=DataResponse)
+@router.get("/strategies", response_model=DataResponse[OrchestrationStrategiesResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_execution_strategies",
@@ -375,7 +385,7 @@ async def get_execution_strategies(
     return JSONResponse(status_code=200, content={"strategies": strategies, "default": "adaptive"})
 
 
-@router.get("/capabilities", response_model=DataResponse)
+@router.get("/capabilities", response_model=DataResponse[OrchestrationCapabilitiesResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_agent_capabilities",
@@ -441,7 +451,7 @@ async def get_agent_capabilities(
         raise HTTPException(status_code=500, detail="Failed to get capabilities")
 
 
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=DataResponse[OrchestrationStatusResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_orchestration_status",
@@ -496,7 +506,7 @@ async def get_orchestration_status(
         raise HTTPException(status_code=500, detail="Failed to get status")
 
 
-@router.get("/examples", response_model=DataResponse)
+@router.get("/examples", response_model=DataResponse[OrchestrationExamplesResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_orchestration_examples",

--- a/autobot-backend/api/project_state.py
+++ b/autobot-backend/api/project_state.py
@@ -15,6 +15,11 @@ from api.schemas_system import (
     PhaseValidationModel,
     ProjectStatus,
     ValidationResultModel,
+    ProjectStateActivatePhaseResponse,
+    ProjectStateAutoProgressResponse,
+    ProjectStatePhasesResponse,
+    ProjectStateReportResponse,
+    ProjectStateValidateResponse,
 )
 from api.system_health import register_singleton_probe
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -73,7 +78,7 @@ async def get_project_status(detailed: bool = False):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/validate", response_model=DataResponse)
+@router.post("/validate", response_model=DataResponse[ProjectStateValidateResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="run_validation",
@@ -114,7 +119,7 @@ async def run_validation():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/report", response_model=DataResponse)
+@router.get("/report", response_model=DataResponse[ProjectStateReportResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_validation_report",
@@ -141,7 +146,7 @@ async def get_validation_report():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/phases", response_model=DataResponse)
+@router.get("/phases", response_model=DataResponse[ProjectStatePhasesResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_all_phases",
@@ -191,7 +196,7 @@ async def get_all_phases():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/phase/{phase_id}/activate", response_model=DataResponse)
+@router.post("/phase/{phase_id}/activate", response_model=DataResponse[ProjectStateActivatePhaseResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="activate_phase",
@@ -232,7 +237,7 @@ async def activate_phase(phase_id: str):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/auto-progress", response_model=DataResponse)
+@router.post("/auto-progress", response_model=DataResponse[ProjectStateAutoProgressResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="auto_progress_phases",

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -1871,3 +1871,180 @@ class ConversationImportRequest(BaseModel):
         default="skip",
         description=("Conflict resolution strategy when session_id already exists. " "One of: skip, replace, rename."),
     )
+
+
+# ---------------------------------------------------------------------------
+# enterprise_features.py schemas (GH #6509 Batch D)
+# ---------------------------------------------------------------------------
+
+
+class EnterpriseStatusResponse(BaseModel):
+    """Response for GET /status."""
+
+    status: str
+    enterprise_status: Dict[str, Any] = Field(default_factory=dict)
+    message: str = ""
+
+
+class EnterpriseFeatureEnableResponse(BaseModel):
+    """Response for POST /features/enable."""
+
+    status: str
+    feature: str = ""
+    result: Dict[str, Any] = Field(default_factory=dict)
+    message: str = ""
+
+
+class EnterpriseFeatureEnableAllResponse(BaseModel):
+    """Response for POST /features/enable-all."""
+
+    status: str
+    enabled_features: List[str] = Field(default_factory=list)
+    failed_features: List[Any] = Field(default_factory=list)
+    total_features: int = 0
+    success_rate: float = 0.0
+    message: str = ""
+
+
+class EnterpriseFeatureListResponse(BaseModel):
+    """Response for GET /features."""
+
+    status: str
+    features: List[Dict[str, Any]] = Field(default_factory=list)
+    total_features: int = 0
+    categories: List[str] = Field(default_factory=list)
+    statuses: List[str] = Field(default_factory=list)
+
+
+class EnterpriseBulkEnableResponse(BaseModel):
+    """Response for POST /features/bulk-enable."""
+
+    status: str
+    results: Dict[str, Any] = Field(default_factory=dict)
+    summary: str = ""
+
+
+class EnterprisePerformanceOptimizeResponse(BaseModel):
+    """Response for POST /performance/optimize."""
+
+    status: str
+    optimization: Dict[str, Any] = Field(default_factory=dict)
+    message: str = ""
+
+
+class EnterpriseInfrastructureResponse(BaseModel):
+    """Response for GET /infrastructure."""
+
+    status: str
+    infrastructure: Dict[str, Any] = Field(default_factory=dict)
+    message: str = ""
+
+
+class EnterpriseDeploymentResponse(BaseModel):
+    """Response for POST /deployment/zero-downtime."""
+
+    status: str
+    deployment: Dict[str, Any] = Field(default_factory=dict)
+    message: str = ""
+
+
+class EnterprisePhase4ValidationResponse(BaseModel):
+    """Response for GET /phase4/validation."""
+
+    status: str
+    validation: Dict[str, Any] = Field(default_factory=dict)
+    message: str = ""
+
+
+# ---------------------------------------------------------------------------
+# agent_config.py schemas (GH #6509 Batch D)
+# ---------------------------------------------------------------------------
+
+
+class AgentConfigListAgentsResponse(BaseModel):
+    """Response for GET /agents."""
+
+    agents: List[Dict[str, Any]] = Field(default_factory=list)
+    total_count: int = 0
+    global_provider_type: str = ""
+    timestamp: str = ""
+
+
+class AgentConfigAllAgentsResponse(BaseModel):
+    """Response for GET /agents/all."""
+
+    agents: List[Dict[str, Any]] = Field(default_factory=list)
+    specialized_agents: List[Dict[str, Any]] = Field(default_factory=list)
+    summary: Dict[str, Any] = Field(default_factory=dict)
+    timestamp: str = ""
+
+
+class AgentConfigSpecializedListResponse(BaseModel):
+    """Response for GET /agents/specialized."""
+
+    agents: List[Dict[str, Any]] = Field(default_factory=list)
+    total_count: int = 0
+    categories: Dict[str, Any] = Field(default_factory=dict)
+    timestamp: str = ""
+
+
+class AgentConfigSpecializedDetailResponse(BaseModel):
+    """Response for GET /agents/specialized/{agent_id}."""
+
+    id: str = ""
+    name: str = ""
+    description: str = ""
+    tools: List[str] = Field(default_factory=list)
+    model: str | None = None
+    category: str | None = None
+
+
+class AgentConfigUsageResponse(BaseModel):
+    """Response for GET /agents/usage."""
+
+    agents: List[Dict[str, Any]] = Field(default_factory=list)
+    daily_trend: List[Dict[str, Any]] = Field(default_factory=list)
+    total_tasks: int = 0
+    timestamp: str = ""
+
+
+# ---------------------------------------------------------------------------
+# adapters.py schemas (GH #6509 Batch D)
+# ---------------------------------------------------------------------------
+
+
+class AdapterListResponse(BaseModel):
+    """Response for GET /."""
+
+    adapters: List[Any] = Field(default_factory=list)
+    total: int = 0
+
+
+class AdapterTestResponse(BaseModel):
+    """Response for GET /{adapter_type}/test."""
+
+    adapter_type: str = ""
+    status: str = ""
+    details: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AdapterModelsResponse(BaseModel):
+    """Response for GET /{adapter_type}/models."""
+
+    adapter_type: str
+    models: List[Any] = Field(default_factory=list)
+    total: int = 0
+
+
+class AdapterOverrideSetResponse(BaseModel):
+    """Response for POST /agent/{agent_id}/override."""
+
+    agent_id: str
+    adapter_type: str
+
+
+class AdapterOverrideClearResponse(BaseModel):
+    """Response for DELETE /agent/{agent_id}/override."""
+
+    agent_id: str
+    cleared: bool

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -3303,3 +3303,255 @@ class PredictionResult(BaseModel):
     risk_distribution: Dict[str, int] = Field(default_factory=dict)
     files: List[FileRisk] = Field(default_factory=list)
     top_risk_factors: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# analytics_evolution.py schemas (GH #6509 Batch D)
+# ---------------------------------------------------------------------------
+
+
+class AnalyticsEvolutionTimelineResponse(BaseModel):
+    """Response for GET /timeline."""
+
+    timeline: List[Dict[str, Any]] = Field(default_factory=list)
+    total_snapshots: int = 0
+    date_range: Dict[str, Any] = Field(default_factory=dict)
+    granularity: str = "daily"
+    metrics_available: List[str] = Field(default_factory=list)
+
+
+class AnalyticsEvolutionPatternsResponse(BaseModel):
+    """Response for GET /patterns."""
+
+    status: str
+    patterns: Dict[str, Any] = Field(default_factory=dict)
+    pattern_types: List[str] = Field(default_factory=list)
+    date_range: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AnalyticsEvolutionTrendsResponse(BaseModel):
+    """Response for GET /trends."""
+
+    status: str
+    trends: Dict[str, Any] = Field(default_factory=dict)
+    period_days: int = 30
+    snapshot_count: int = 0
+    analysis_timestamp: str = ""
+
+
+class AnalyticsEvolutionSnapshotResponse(BaseModel):
+    """Response for POST /snapshot."""
+
+    status: str
+    message: str = ""
+    snapshot: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AnalyticsEvolutionPatternSnapshotResponse(BaseModel):
+    """Response for POST /pattern-snapshot."""
+
+    status: str
+    message: str = ""
+    snapshot: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AnalyticsEvolutionExportResponse(BaseModel):
+    """Response for GET /export (JSON format path)."""
+
+    status: str
+    export_format: str = "json"
+    data: List[Dict[str, Any]] = Field(default_factory=list)
+    record_count: int = 0
+    exported_at: str = ""
+
+
+class AnalyticsEvolutionSummaryResponse(BaseModel):
+    """Response for GET /summary."""
+
+    total_snapshots: int = 0
+    date_range: Dict[str, Any] = Field(default_factory=dict)
+    latest_scores: Dict[str, Any] = Field(default_factory=dict)
+    trend_direction: str = "unknown"
+    pattern_counts: Dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# analytics_debt.py schemas (GH #6509 Batch D)
+# ---------------------------------------------------------------------------
+
+
+class AnalyticsDebtCalculateResponse(BaseModel):
+    """Response for POST /calculate."""
+
+    status: str
+    data: Dict[str, Any] = Field(default_factory=dict)
+    target_path: str | None = None
+
+
+class AnalyticsDebtSummaryResponse(BaseModel):
+    """Response for GET /summary."""
+
+    status: str
+    summary: Dict[str, Any] = Field(default_factory=dict)
+    top_files: List[Dict[str, Any]] = Field(default_factory=list)
+    roi_ranking: List[Dict[str, Any]] = Field(default_factory=list)
+    timestamp: str | None = None
+
+
+class AnalyticsDebtByCategoryResponse(BaseModel):
+    """Response for GET /by-category/{category}."""
+
+    status: str
+    category: str = ""
+    items: List[Dict[str, Any]] = Field(default_factory=list)
+    count: int = 0
+
+
+class AnalyticsDebtTrendsResponse(BaseModel):
+    """Response for GET /trends."""
+
+    status: str
+    trends: List[Dict[str, Any]] = Field(default_factory=list)
+    data_points: int = 0
+    change: Dict[str, Any] = Field(default_factory=dict)
+    direction: str = "unknown"
+
+
+class AnalyticsDebtROIPrioritiesResponse(BaseModel):
+    """Response for GET /roi-priorities."""
+
+    status: str
+    priorities: List[Dict[str, Any]] = Field(default_factory=list)
+    total_available: int = 0
+
+
+class AnalyticsDebtReportResponse(BaseModel):
+    """Response for GET /report."""
+
+    status: str
+    format: str = "json"
+    data: Dict[str, Any] | None = None
+    report: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# bi_export_endpoints.py schemas (GH #6509 Batch D)
+# ---------------------------------------------------------------------------
+
+
+class SavedReportDeleteResponse(BaseModel):
+    """Response for DELETE /reports/saved/{report_id}."""
+
+    report_id: str
+    deleted: bool
+
+
+class SavedReportRunResponse(BaseModel):
+    """Response for POST /reports/saved/{report_id}/run."""
+
+    status: str = ""
+    report_id: str = ""
+    data: Dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# analytics_cfg.py schemas (GH #6509 Batch D)
+# ---------------------------------------------------------------------------
+
+
+class AnalyticsCFGAnalyzeResponse(BaseModel):
+    """Response for POST /analyze."""
+
+    success: bool
+    graphs: List[Dict[str, Any]] = Field(default_factory=list)
+    summary: Dict[str, Any] = Field(default_factory=dict)
+    issues: List[Dict[str, Any]] = Field(default_factory=list)
+    analysis_time_ms: float = 0.0
+
+
+class AnalyticsCFGComplexityResponse(BaseModel):
+    """Response for POST /complexity."""
+
+    success: bool
+    metrics: List[Dict[str, Any]] = Field(default_factory=list)
+    summary: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AnalyticsCFGUnreachableResponse(BaseModel):
+    """Response for POST /unreachable."""
+
+    success: bool
+    unreachable_code: List[Dict[str, Any]] = Field(default_factory=list)
+    count: int = 0
+
+
+class AnalyticsCFGInfiniteLoopsResponse(BaseModel):
+    """Response for POST /infinite-loops."""
+
+    success: bool
+    loop_issues: List[Dict[str, Any]] = Field(default_factory=list)
+    definite_infinite: int = 0
+    potential_infinite: int = 0
+
+
+# ---------------------------------------------------------------------------
+# analytics_reporting.py schemas (GH #6509 Batch D)
+# ---------------------------------------------------------------------------
+
+
+class AnalyticsReportingReportResponse(BaseModel):
+    """Response for GET /report."""
+
+    status: str
+    generated_at: str = ""
+    summary: Dict[str, Any] = Field(default_factory=dict)
+    quality: Dict[str, Any] = Field(default_factory=dict)
+    categories: Dict[str, Any] = Field(default_factory=dict)
+    top_files: List[Any] = Field(default_factory=list)
+    technical_debt: Dict[str, Any] = Field(default_factory=dict)
+    performance: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AnalyticsReportingSummaryResponse(BaseModel):
+    """Response for GET /summary."""
+
+    health_score: float = 0.0
+    grade: str = "N/A"
+    total_issues: int = 0
+    high_priority: int = 0
+    timestamp: str = ""
+
+
+class AnalyticsReportingTrendsResponse(BaseModel):
+    """Response for GET /trends."""
+
+    status: str
+    message: str = ""
+    data: List[Any] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# analytics_embedding_patterns.py schemas (GH #6509 Batch D)
+# ---------------------------------------------------------------------------
+
+
+class AnalyticsEmbeddingRecordResponse(BaseModel):
+    """Response for POST /record."""
+
+    status: str = ""
+    message: str | None = None
+    data: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AnalyticsEmbeddingModelComparisonResponse(BaseModel):
+    """Response for GET /model-comparison."""
+
+    status: str = ""
+    data: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AnalyticsEmbeddingOptimizationResponse(BaseModel):
+    """Response for GET /optimization-recommendations."""
+
+    status: str = ""
+    data: Dict[str, Any] = Field(default_factory=dict)

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -2542,3 +2542,70 @@ class TemplateValidationRequest(BaseModel):
 
     template_id: str
     variables: Dict[str, str]
+
+
+# ---------------------------------------------------------------------------
+# merge_conflict_resolution.py schemas (GH #6509 Batch D)
+# ---------------------------------------------------------------------------
+
+
+class MergeConflictAnalyzeResponse(BaseModel):
+    """Response for POST /analyze."""
+
+    status: str
+    file_path: str = ""
+    conflict_count: int = 0
+    conflicts: List[Dict[str, Any]] = Field(default_factory=list)
+    severity_distribution: Dict[str, int] = Field(default_factory=dict)
+    timestamp: str = ""
+
+
+class MergeConflictResolveResponse(BaseModel):
+    """Response for POST /resolve."""
+
+    status: str
+    message: str = ""
+    file_path: str = ""
+    resolved_count: int = 0
+    results: List[Dict[str, Any]] = Field(default_factory=list)
+    timestamp: str = ""
+
+
+class MergeConflictRepositoryAnalyzeResponse(BaseModel):
+    """Response for POST /analyze-repository."""
+
+    status: str
+    repository: str = ""
+    total_files_with_conflicts: int = 0
+    total_conflicts: int = 0
+    files: List[Dict[str, Any]] = Field(default_factory=list)
+    timestamp: str = ""
+
+
+class MergeConflictApplyResponse(BaseModel):
+    """Response for POST /apply."""
+
+    status: str
+    message: str = ""
+    file_path: str = ""
+    backup_path: str | None = None
+    timestamp: str = ""
+
+
+class MergeConflictStrategiesResponse(BaseModel):
+    """Response for GET /strategies."""
+
+    status: str
+    strategies: Dict[str, Any] = Field(default_factory=dict)
+    default_strategy: str = "semantic_merge"
+    timestamp: str = ""
+
+
+class MergeConflictCheckResponse(BaseModel):
+    """Response for GET /check."""
+
+    status: str
+    file_path: str = ""
+    has_conflicts: bool = False
+    conflict_count: int = 0
+    timestamp: str = ""

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -3512,3 +3512,88 @@ class OnboardingStatus(BaseModel):
 
     preset_applied: bool
     preset_name: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# project_state.py schemas (GH #6509 Batch D)
+# ---------------------------------------------------------------------------
+
+
+class ProjectStateValidateResponse(BaseModel):
+    """Response for POST /validate."""
+
+    success: bool
+    message: str = ""
+    results: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ProjectStateReportResponse(BaseModel):
+    """Response for GET /report."""
+
+    success: bool
+    report: str = ""
+    generated_at: str | None = None
+
+
+class ProjectStatePhasesResponse(BaseModel):
+    """Response for GET /phases."""
+
+    success: bool
+    current_phase: str = ""
+    phases: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ProjectStateActivatePhaseResponse(BaseModel):
+    """Response for POST /phase/{phase_id}/activate."""
+
+    success: bool
+    message: str = ""
+    current_phase: str = ""
+
+
+class ProjectStateAutoProgressResponse(BaseModel):
+    """Response for POST /auto-progress."""
+
+    success: bool
+    message: str = ""
+    progression_result: Any = None
+
+
+# ---------------------------------------------------------------------------
+# gpu_monitoring.py schemas (GH #6509 Batch D)
+# ---------------------------------------------------------------------------
+
+
+class GPUEfficiencyResponse(BaseModel):
+    """Response for GET /efficiency."""
+
+    success: bool
+    efficiency: Dict[str, Any] = Field(default_factory=dict)
+
+
+class GPUCapabilitiesResponse(BaseModel):
+    """Response for GET /capabilities."""
+
+    success: bool
+    capabilities: Dict[str, Any] = Field(default_factory=dict)
+
+
+class GPUBenchmarkResponse(BaseModel):
+    """Response for POST /benchmark."""
+
+    success: bool
+    benchmark: Dict[str, Any] = Field(default_factory=dict)
+
+
+class GPUOptimizeResponse(BaseModel):
+    """Response for POST /optimize."""
+
+    success: bool
+    optimization: Dict[str, Any] = Field(default_factory=dict)
+
+
+class GPUConfigUpdateResponse(BaseModel):
+    """Response for PATCH /config."""
+
+    success: bool
+    updated_keys: List[str] = Field(default_factory=list)

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -2583,3 +2583,74 @@ class HTTPDeleteRequest(HTTPRequestBase):
 
 class HTTPHeadRequest(HTTPRequestBase):
     """HEAD request model."""
+
+
+# ---------------------------------------------------------------------------
+# orchestration.py schemas (GH #6509 Batch D)
+# ---------------------------------------------------------------------------
+
+
+class OrchestrationWorkflowPlanResponse(BaseModel):
+    """Response for POST /workflow/plan."""
+
+    status: str
+    plan: Dict[str, Any] = Field(default_factory=dict)
+    task_count: int = 0
+    message: str = ""
+
+
+class OrchestrationAgentPerformanceResponse(BaseModel):
+    """Response for GET /agents/performance."""
+
+    status: str
+    performance_data: Dict[str, Any] = Field(default_factory=dict)
+
+
+class OrchestrationAgentRecommendResponse(BaseModel):
+    """Response for POST /agents/recommend."""
+
+    status: str
+    task_type: str = ""
+    capabilities_requested: List[str] = Field(default_factory=list)
+    recommended_agents: List[Any] = Field(default_factory=list)
+    agent_count: int = 0
+
+
+class OrchestrationActiveWorkflowsResponse(BaseModel):
+    """Response for GET /workflow/active."""
+
+    status: str
+    active_count: int = 0
+    workflows: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class OrchestrationStrategiesResponse(BaseModel):
+    """Response for GET /strategies."""
+
+    strategies: Dict[str, Any] = Field(default_factory=dict)
+    default: str = "adaptive"
+
+
+class OrchestrationCapabilitiesResponse(BaseModel):
+    """Response for GET /capabilities."""
+
+    capability_coverage: Dict[str, Any] = Field(default_factory=dict)
+    agents: Dict[str, Any] = Field(default_factory=dict)
+    total_agents: int = 0
+
+
+class OrchestrationStatusResponse(BaseModel):
+    """Response for GET /status."""
+
+    status: str
+    active_workflows: int = 0
+    max_parallel_tasks: int = 0
+    total_agents: int = 0
+    capabilities: Dict[str, Any] = Field(default_factory=dict)
+
+
+class OrchestrationExamplesResponse(BaseModel):
+    """Response for GET /examples."""
+
+    examples: Dict[str, Any] = Field(default_factory=dict)
+    usage_tips: List[str] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- Defined 52 new typed Pydantic schemas across 5 domain schema files
- Replaced **70 bare \`response_model=DataResponse\`** with typed generics across 13 API files
  - analytics: \`analytics_evolution.py\` (7), \`analytics_debt.py\` (6), \`bi_export_endpoints.py\` (4), \`analytics_cfg.py\` (4), \`analytics_reporting.py\` (3), \`analytics_embedding_patterns.py\` (3)
  - orchestration: \`orchestration.py\` (8)
  - enterprise: \`enterprise_features.py\` (9), \`agent_config.py\` (5), \`adapters.py\` (5)
  - code: \`merge_conflict_resolution.py\` (6)
  - system: \`project_state.py\` (5), \`gpu_monitoring.py\` (5)
- All 18 modified files pass \`py_compile\` with zero errors

Closes GH #6509 Batch D. Part of [MVA-667](https://github.com/mrveiss/AutoBot-AI/issues/MVA-667).