### PR TITLE
feat(orchestration,schemas): Redis-persist task-assignment state + typed result/AI-stack schemas (#6479, #6407, #6387)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/agent_execution.py
+++ b/autobot-backend/agents/agent_orchestration/agent_execution.py
@@ -140,7 +140,7 @@ class AgentExecutor:
         start_time = datetime.now(tz=timezone.utc)
 
         try:
-            self.distributed_manager.add_active_task(selected_agent.agent_id, task_id)
+            await self.distributed_manager.add_active_task(selected_agent.agent_id, task_id)
             agent_request = self._create_agent_request(
                 task_id, selected_agent.agent_type, request, context, chat_history
             )
@@ -155,7 +155,7 @@ class AgentExecutor:
                 task_id,
             )
         finally:
-            self.distributed_manager.remove_active_task(selected_agent.agent_id, task_id)
+            await self.distributed_manager.remove_active_task(selected_agent.agent_id, task_id)
 
     async def _select_distributed_agent(
         self,

--- a/autobot-backend/agents/agent_orchestration/distributed_management.py
+++ b/autobot-backend/agents/agent_orchestration/distributed_management.py
@@ -14,6 +14,14 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple
 
 from constants.threshold_constants import TimingConstants, WorkStealingConfig
 
+from .state_persistence import (
+    delete_task_state,
+    delete_task_timing_state,
+    load_task_state,
+    persist_task_assigned,
+    persist_task_progress,
+    persist_task_reassignment,
+)
 from .types import CircuitState, DistributedAgentInfo
 
 if TYPE_CHECKING:
@@ -47,6 +55,7 @@ class DistributedAgentManager:
         progress_ttl_seconds: int = WorkStealingConfig.PROGRESS_TTL_SECONDS,
         circuit_failure_threshold: int = 3,
         circuit_recovery_timeout_seconds: int = 300,
+        deployment_id: str = "autobot",
     ):
         """
         Initialize the distributed agent manager.
@@ -80,11 +89,14 @@ class DistributedAgentManager:
         self.circuit_failure_threshold = circuit_failure_threshold
         self.circuit_recovery_timeout_seconds = circuit_recovery_timeout_seconds
 
-        # task_id -> assigned_at (UTC) — set when add_active_task is called
+        # Redis-scoped deployment identifier (Issue #6479)
+        self._deployment_id = deployment_id
+
+        # task_id -> assigned_at (UTC) — write-through cache; persisted in Redis (#6479)
         self._task_assigned_at: Dict[str, datetime] = {}
-        # task_id -> last_progress_at (UTC) — updated via report_task_progress
+        # task_id -> last_progress_at (UTC) — write-through cache; persisted in Redis (#6479)
         self._task_last_progress: Dict[str, datetime] = {}
-        # task_id -> reassignment_count
+        # task_id -> reassignment_count — write-through cache; persisted in Redis (#6479)
         self._task_reassignment_count: Dict[str, int] = {}
 
     async def start(self, event_emitter: Any | None = None) -> bool:
@@ -104,6 +116,9 @@ class DistributedAgentManager:
         try:
             self.is_running = True
 
+            # Rehydrate stale-detection state from Redis so grace periods survive restarts.
+            await self._rehydrate_from_redis()
+
             # Initialize built-in distributed agents
             await self._initialize_distributed_agents()
 
@@ -117,6 +132,20 @@ class DistributedAgentManager:
             logger.error("Failed to start distributed mode: %s", e)
             self.is_running = False
             return False
+
+    async def _rehydrate_from_redis(self) -> None:
+        """Populate in-memory dicts from Redis on startup (Issue #6479)."""
+        assigned, progress, reassign = await load_task_state(self._deployment_id)
+        self._task_assigned_at.update(assigned)
+        self._task_last_progress.update(progress)
+        self._task_reassignment_count.update(reassign)
+        total = len(assigned)
+        if total:
+            logger.info(
+                "Distributed manager rehydrated %d task(s) from Redis (deployment=%s)",
+                total,
+                self._deployment_id,
+            )
 
     async def stop(self) -> None:
         """Stop distributed agent management."""
@@ -368,35 +397,43 @@ class DistributedAgentManager:
         """Get info for a specific agent."""
         return self.distributed_agents.get(agent_id)
 
-    def add_active_task(self, agent_id: str, task_id: str) -> None:
+    async def add_active_task(self, agent_id: str, task_id: str) -> None:
         """Add an active task to an agent and record its assignment timestamp.
 
         Issue #2109: records assigned_at for stale-detection.
+        Issue #6479: persists assigned_at to Redis (write-through cache).
         """
         if agent_id in self.distributed_agents:
             self.distributed_agents[agent_id].active_tasks.add(task_id)
-            self._task_assigned_at[task_id] = now_utc()
+            assigned_at = now_utc()
+            self._task_assigned_at[task_id] = assigned_at
+            await persist_task_assigned(self._deployment_id, task_id, assigned_at)
 
-    def remove_active_task(self, agent_id: str, task_id: str) -> None:
+    async def remove_active_task(self, agent_id: str, task_id: str) -> None:
         """Remove an active task from an agent and clean up tracking state.
 
         Issue #2109: clears assigned_at / progress / reassignment metadata.
+        Issue #6479: deletes Redis hash entries for the task.
         """
         if agent_id in self.distributed_agents:
             self.distributed_agents[agent_id].active_tasks.discard(task_id)
         self._task_assigned_at.pop(task_id, None)
         self._task_last_progress.pop(task_id, None)
         self._task_reassignment_count.pop(task_id, None)
+        await delete_task_state(self._deployment_id, task_id)
 
-    def report_task_progress(self, task_id: str) -> None:
+    async def report_task_progress(self, task_id: str) -> None:
         """Record that a task has made progress, resetting its stale timer.
 
         Call this from the agent when partial results arrive so the
         work-stealer does not reclaim an actively-running task.
 
         Issue #2109: progress-protection guard rail.
+        Issue #6479: persists last_progress to Redis.
         """
-        self._task_last_progress[task_id] = now_utc()
+        progress_at = now_utc()
+        self._task_last_progress[task_id] = progress_at
+        await persist_task_progress(self._deployment_id, task_id, progress_at)
 
     # ------------------------------------------------------------------
     # Work-stealing helpers (Issue #2109)
@@ -472,6 +509,10 @@ class DistributedAgentManager:
         self._task_reassignment_count[task_id] = count
         self._task_assigned_at.pop(task_id, None)
         self._task_last_progress.pop(task_id, None)
+        # Persist incremented count; clear only timing entries so count survives
+        # the next add_active_task call (Issue #6479).
+        await persist_task_reassignment(self._deployment_id, task_id, count)
+        await delete_task_timing_state(self._deployment_id, task_id)
 
         # Mark source agent degraded in its health record so the router
         # prefers other agents until the next successful health check.

--- a/autobot-backend/agents/agent_orchestration/distributed_management_test.py
+++ b/autobot-backend/agents/agent_orchestration/distributed_management_test.py
@@ -2,14 +2,16 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Tests for DistributedAgentManager work-stealing logic (Issue #2109) and
-circuit breaker logic (Issue #4694).
+Tests for DistributedAgentManager work-stealing logic (Issue #2109),
+circuit breaker logic (Issue #4694), and Redis state persistence (Issue #6479).
 
-All tests are pure in-memory; no Redis, no actual agents, no network I/O.
+Most tests are pure in-memory; Redis calls are patched to AsyncMock.
+Integration tests for persistence use _patch_persistence() context manager.
 """
 
+from contextlib import asynccontextmanager
 from datetime import timedelta
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -21,6 +23,28 @@ from .types import CircuitState, DistributedAgentInfo
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+_PERSISTENCE_MODULE = "agents.agent_orchestration.distributed_management"
+
+
+@asynccontextmanager
+async def _patch_persistence():
+    """Patch all state_persistence async helpers to AsyncMock no-ops.
+
+    Returns a dict of mock objects keyed by function name so callers can
+    inspect call counts / arguments.
+    """
+    mocks = {
+        "persist_task_assigned": AsyncMock(),
+        "persist_task_progress": AsyncMock(),
+        "persist_task_reassignment": AsyncMock(),
+        "delete_task_state": AsyncMock(),
+        "delete_task_timing_state": AsyncMock(),
+        "load_task_state": AsyncMock(return_value=({}, {}, {})),
+    }
+    with patch.multiple(_PERSISTENCE_MODULE, **mocks):
+        yield mocks
 
 
 def _make_manager(
@@ -67,10 +91,17 @@ def _assign_task(
     task_id: str,
     assigned_seconds_ago: float = 0.0,
 ) -> None:
-    """Add a task to an agent and backdating its assignment timestamp."""
-    mgr.add_active_task(agent_id, task_id)
+    """Directly set up task assignment state without going through async methods.
+
+    This is a test-only helper that mutates internal dicts directly so that
+    pure in-memory tests don't need to await or mock Redis.
+    """
+    if agent_id in mgr.distributed_agents:
+        mgr.distributed_agents[agent_id].active_tasks.add(task_id)
+    ts = now_utc()
     if assigned_seconds_ago:
-        mgr._task_assigned_at[task_id] = now_utc() - timedelta(seconds=assigned_seconds_ago)
+        ts = ts - timedelta(seconds=assigned_seconds_ago)
+    mgr._task_assigned_at[task_id] = ts
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +141,7 @@ class TestIsTaskStale:
         )
         _register_agent(mgr, "a1")
         _assign_task(mgr, "a1", "t1", assigned_seconds_ago=90)
-        mgr.report_task_progress("t1")  # progress just now
+        mgr._task_last_progress["t1"] = now_utc()  # direct mutation — bypass async
         assert mgr._is_task_stale("t1", now_utc()) is False
 
     def test_task_with_old_progress_is_stale(self):
@@ -294,34 +325,41 @@ class TestDetectAndStealStaleTasks:
 
 
 class TestTaskTrackingIntegration:
-    def test_add_active_task_records_assigned_at(self):
-        mgr = _make_manager()
-        _register_agent(mgr, "a1")
-        before = now_utc()
-        mgr.add_active_task("a1", "t1")
-        after = now_utc()
-        assert "t1" in mgr._task_assigned_at
-        assert before <= mgr._task_assigned_at["t1"] <= after
+    @pytest.mark.asyncio
+    async def test_add_active_task_records_assigned_at(self):
+        async with _patch_persistence() as mocks:
+            mgr = _make_manager()
+            _register_agent(mgr, "a1")
+            before = now_utc()
+            await mgr.add_active_task("a1", "t1")
+            after = now_utc()
+            assert "t1" in mgr._task_assigned_at
+            assert before <= mgr._task_assigned_at["t1"] <= after
+            mocks["persist_task_assigned"].assert_awaited_once()
 
-    def test_remove_active_task_clears_all_tracking(self):
-        mgr = _make_manager()
-        _register_agent(mgr, "a1")
-        mgr.add_active_task("a1", "t1")
-        mgr.report_task_progress("t1")
-        mgr._task_reassignment_count["t1"] = 2
-        mgr.remove_active_task("a1", "t1")
-        assert "t1" not in mgr._task_assigned_at
-        assert "t1" not in mgr._task_last_progress
-        assert "t1" not in mgr._task_reassignment_count
+    @pytest.mark.asyncio
+    async def test_remove_active_task_clears_all_tracking(self):
+        async with _patch_persistence():
+            mgr = _make_manager()
+            _register_agent(mgr, "a1")
+            await mgr.add_active_task("a1", "t1")
+            await mgr.report_task_progress("t1")
+            mgr._task_reassignment_count["t1"] = 2
+            await mgr.remove_active_task("a1", "t1")
+            assert "t1" not in mgr._task_assigned_at
+            assert "t1" not in mgr._task_last_progress
+            assert "t1" not in mgr._task_reassignment_count
 
-    def test_report_task_progress_updates_timestamp(self):
-        mgr = _make_manager()
-        _register_agent(mgr, "a1")
-        mgr.add_active_task("a1", "t1")
-        before = now_utc()
-        mgr.report_task_progress("t1")
-        after = now_utc()
-        assert before <= mgr._task_last_progress["t1"] <= after
+    @pytest.mark.asyncio
+    async def test_report_task_progress_updates_timestamp(self):
+        async with _patch_persistence():
+            mgr = _make_manager()
+            _register_agent(mgr, "a1")
+            await mgr.add_active_task("a1", "t1")
+            before = now_utc()
+            await mgr.report_task_progress("t1")
+            after = now_utc()
+            assert before <= mgr._task_last_progress["t1"] <= after
 
 
 # ---------------------------------------------------------------------------
@@ -347,7 +385,7 @@ class TestGetStatisticsWorkStealing:
     def test_task_reassignment_counts_in_agent_stats(self):
         mgr = _make_manager()
         _register_agent(mgr, "a1")
-        mgr.add_active_task("a1", "t1")
+        _assign_task(mgr, "a1", "t1")
         mgr._task_reassignment_count["t1"] = 2
         stats = mgr.get_statistics()
         assert stats["a1"]["task_reassignment_counts"]["t1"] == 2
@@ -524,3 +562,83 @@ class TestCircuitBreakerStatistics:
         stats = mgr.get_statistics()
         assert stats["a1"]["circuit_state"] == "open"
         assert stats["a1"]["circuit_opened_at"] == opened_at.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Redis persistence — Issue #6479
+# ---------------------------------------------------------------------------
+
+
+class TestRedisPersistence:
+    """Verify that task-assignment state is written to Redis and rehydrated on restart."""
+
+    @pytest.mark.asyncio
+    async def test_add_active_task_persists_to_redis(self):
+        async with _patch_persistence() as mocks:
+            mgr = _make_manager()
+            _register_agent(mgr, "a1")
+            await mgr.add_active_task("a1", "t1")
+            mocks["persist_task_assigned"].assert_awaited_once_with(
+                mgr._deployment_id, "t1", mgr._task_assigned_at["t1"]
+            )
+
+    @pytest.mark.asyncio
+    async def test_remove_active_task_deletes_redis_state(self):
+        async with _patch_persistence() as mocks:
+            mgr = _make_manager()
+            _register_agent(mgr, "a1")
+            await mgr.add_active_task("a1", "t1")
+            await mgr.remove_active_task("a1", "t1")
+            mocks["delete_task_state"].assert_awaited_with(mgr._deployment_id, "t1")
+
+    @pytest.mark.asyncio
+    async def test_report_task_progress_persists_to_redis(self):
+        async with _patch_persistence() as mocks:
+            mgr = _make_manager()
+            _register_agent(mgr, "a1")
+            await mgr.add_active_task("a1", "t1")
+            await mgr.report_task_progress("t1")
+            mocks["persist_task_progress"].assert_awaited_with(
+                mgr._deployment_id, "t1", mgr._task_last_progress["t1"]
+            )
+
+    @pytest.mark.asyncio
+    async def test_rehydrate_restores_assigned_at_from_redis(self):
+        """Grace period must continue from original assignment after restart."""
+        original_assigned_at = now_utc() - timedelta(seconds=250)
+        loaded = ({}, {}, {})
+
+        async def _load_state(dep_id: str):
+            return ({"task-x": original_assigned_at}, {}, {})
+
+        with patch(f"{_PERSISTENCE_MODULE}.load_task_state", side_effect=_load_state):
+            with patch.multiple(
+                _PERSISTENCE_MODULE,
+                persist_task_assigned=AsyncMock(),
+                persist_task_progress=AsyncMock(),
+                persist_task_reassignment=AsyncMock(),
+                delete_task_state=AsyncMock(),
+                delete_task_timing_state=AsyncMock(),
+            ):
+                mgr = _make_manager(stale_task_timeout_seconds=200, grace_period_seconds=60)
+                await mgr._rehydrate_from_redis()
+
+        assert "task-x" in mgr._task_assigned_at
+        assert mgr._task_assigned_at["task-x"] == original_assigned_at
+        # Task was assigned 250s ago; grace=60s; timeout=200s → stale
+        assert mgr._is_task_stale("task-x", now_utc()) is True
+
+    @pytest.mark.asyncio
+    async def test_reassign_task_persists_count_clears_timing(self):
+        """_reassign_task must update the count and clear only timing entries in Redis."""
+        async with _patch_persistence() as mocks:
+            mgr = _make_manager()
+            _register_agent(mgr, "a1")
+            _assign_task(mgr, "a1", "t1", assigned_seconds_ago=400)
+            await mgr._reassign_task("a1", "t1")
+            # Count should be persisted
+            mocks["persist_task_reassignment"].assert_awaited()
+            # Only timing state (not full state) deleted
+            mocks["delete_task_timing_state"].assert_awaited_with(mgr._deployment_id, "t1")
+            # Full delete_task_state should NOT be called on reassign (count survives)
+            mocks["delete_task_state"].assert_not_awaited()

--- a/autobot-backend/agents/agent_orchestration/state_persistence.py
+++ b/autobot-backend/agents/agent_orchestration/state_persistence.py
@@ -1,0 +1,192 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Redis-backed persistence for DistributedAgentManager task-assignment metadata.
+
+Implements the write-through cache strategy from issue #6479:
+- Reads always come from the in-memory dicts (fast, synchronous).
+- Writes go to both the in-memory dict and Redis (fire-and-forget on Redis failure).
+- On restart, :func:`load_task_state` rehydrates the in-memory dicts from Redis so
+  stale-detection resumes from the original assignment time rather than starting fresh.
+
+Redis key layout (all scoped to a deployment_id to support future multi-replica use):
+    task:assignment:{deployment_id}    hash  task_id -> assigned_at ISO string
+    task:progress:{deployment_id}      hash  task_id -> last_progress_at ISO string
+    task:reassign:{deployment_id}      hash  task_id -> reassignment_count string
+"""
+
+from datetime import datetime
+from typing import Dict, Optional, Tuple
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_async_redis_client
+
+logger = get_logger(__name__)
+
+_ASSIGN_KEY = "task:assignment:{deployment_id}"
+_PROGRESS_KEY = "task:progress:{deployment_id}"
+_REASSIGN_KEY = "task:reassign:{deployment_id}"
+_HASH_TTL_SECONDS = 172_800  # 48 h — covers any reasonably long-running task lifecycle
+
+
+def _assign_key(dep: str) -> str:
+    return _ASSIGN_KEY.format(deployment_id=dep)
+
+
+def _progress_key(dep: str) -> str:
+    return _PROGRESS_KEY.format(deployment_id=dep)
+
+
+def _reassign_key(dep: str) -> str:
+    return _REASSIGN_KEY.format(deployment_id=dep)
+
+
+async def persist_task_assigned(deployment_id: str, task_id: str, assigned_at: datetime) -> None:
+    """Write task assigned_at timestamp to Redis. Failures are logged and swallowed."""
+    redis = await get_async_redis_client()
+    if redis is None:
+        return
+    try:
+        key = _assign_key(deployment_id)
+        await redis.hset(key, task_id, assigned_at.isoformat())
+        await redis.expire(key, _HASH_TTL_SECONDS)
+    except Exception:
+        logger.debug("state_persistence: failed to persist assigned_at for %s", task_id, exc_info=True)
+
+
+async def persist_task_progress(deployment_id: str, task_id: str, progress_at: datetime) -> None:
+    """Write task last_progress_at timestamp to Redis. Failures are logged and swallowed."""
+    redis = await get_async_redis_client()
+    if redis is None:
+        return
+    try:
+        key = _progress_key(deployment_id)
+        await redis.hset(key, task_id, progress_at.isoformat())
+        await redis.expire(key, _HASH_TTL_SECONDS)
+    except Exception:
+        logger.debug("state_persistence: failed to persist progress for %s", task_id, exc_info=True)
+
+
+async def persist_task_reassignment(deployment_id: str, task_id: str, count: int) -> None:
+    """Write reassignment count to Redis. Failures are logged and swallowed."""
+    redis = await get_async_redis_client()
+    if redis is None:
+        return
+    try:
+        key = _reassign_key(deployment_id)
+        await redis.hset(key, task_id, str(count))
+        await redis.expire(key, _HASH_TTL_SECONDS)
+    except Exception:
+        logger.debug("state_persistence: failed to persist reassign count for %s", task_id, exc_info=True)
+
+
+async def delete_task_state(deployment_id: str, task_id: str) -> None:
+    """Remove all three hash entries for task_id. Failures are logged and swallowed."""
+    redis = await get_async_redis_client()
+    if redis is None:
+        return
+    try:
+        await redis.hdel(_assign_key(deployment_id), task_id)
+        await redis.hdel(_progress_key(deployment_id), task_id)
+        await redis.hdel(_reassign_key(deployment_id), task_id)
+    except Exception:
+        logger.debug("state_persistence: failed to delete state for %s", task_id, exc_info=True)
+
+
+async def load_task_state(
+    deployment_id: str,
+) -> Tuple[Dict[str, datetime], Dict[str, datetime], Dict[str, int]]:
+    """Load all three hashes from Redis for rehydration on startup.
+
+    Returns:
+        (assigned_at_map, last_progress_map, reassignment_count_map)
+        Each map is empty when Redis is unavailable or keys do not exist.
+    """
+    redis = await get_async_redis_client()
+    if redis is None:
+        return {}, {}, {}
+
+    assigned: Dict[str, datetime] = {}
+    progress: Dict[str, datetime] = {}
+    reassign: Dict[str, int] = {}
+
+    try:
+        raw_assign = await redis.hgetall(_assign_key(deployment_id))
+        for k, v in raw_assign.items():
+            tid = k.decode() if isinstance(k, bytes) else k
+            try:
+                assigned[tid] = datetime.fromisoformat(v.decode() if isinstance(v, bytes) else v)
+            except (ValueError, AttributeError):
+                logger.warning("state_persistence: bad assigned_at value for task %s", tid)
+
+        raw_progress = await redis.hgetall(_progress_key(deployment_id))
+        for k, v in raw_progress.items():
+            tid = k.decode() if isinstance(k, bytes) else k
+            try:
+                progress[tid] = datetime.fromisoformat(v.decode() if isinstance(v, bytes) else v)
+            except (ValueError, AttributeError):
+                logger.warning("state_persistence: bad progress value for task %s", tid)
+
+        raw_reassign = await redis.hgetall(_reassign_key(deployment_id))
+        for k, v in raw_reassign.items():
+            tid = k.decode() if isinstance(k, bytes) else k
+            try:
+                reassign[tid] = int(v.decode() if isinstance(v, bytes) else v)
+            except (ValueError, AttributeError):
+                logger.warning("state_persistence: bad reassign_count value for task %s", tid)
+
+    except Exception:
+        logger.warning("state_persistence: failed to load task state from Redis", exc_info=True)
+        return {}, {}, {}
+
+    return assigned, progress, reassign
+
+
+async def delete_task_timing_state(deployment_id: str, task_id: str) -> None:
+    """Remove only the assigned_at and last_progress entries for task_id.
+
+    Used by _reassign_task, which preserves the reassignment count across
+    the handoff so it survives the next add_active_task call.
+    """
+    redis = await get_async_redis_client()
+    if redis is None:
+        return
+    try:
+        await redis.hdel(_assign_key(deployment_id), task_id)
+        await redis.hdel(_progress_key(deployment_id), task_id)
+    except Exception:
+        logger.debug("state_persistence: failed to delete timing for %s", task_id, exc_info=True)
+
+
+async def cleanup_orphaned_task_state(
+    deployment_id: str, active_task_ids: set, max_age_seconds: Optional[int] = None
+) -> int:
+    """Remove Redis hash entries for tasks not in active_task_ids.
+
+    Called during maintenance to evict orphaned state (e.g. tasks closed without
+    going through remove_active_task).  Returns the number of entries removed.
+    """
+    redis = await get_async_redis_client()
+    if redis is None:
+        return 0
+
+    removed = 0
+    try:
+        raw_assign = await redis.hgetall(_assign_key(deployment_id))
+        stale_ids = []
+        for k in raw_assign:
+            tid = k.decode() if isinstance(k, bytes) else k
+            if tid not in active_task_ids:
+                stale_ids.append(tid)
+
+        for tid in stale_ids:
+            await redis.hdel(_assign_key(deployment_id), tid)
+            await redis.hdel(_progress_key(deployment_id), tid)
+            await redis.hdel(_reassign_key(deployment_id), tid)
+            removed += 1
+
+    except Exception:
+        logger.warning("state_persistence: cleanup_orphaned failed", exc_info=True)
+
+    return removed

--- a/autobot-backend/api/ai_stack_integration.py
+++ b/autobot-backend/api/ai_stack_integration.py
@@ -18,7 +18,20 @@ from api.schemas_agent import (
     EnhancedKnowledgeSearchData,
     MultiAgentQueryData,
 )
-from api.schemas_ai_stack import AIStackAgentPayload, AIStackAgentsData
+from api.schemas_ai_stack import (
+    AIStackAgentPayload,
+    AIStackAgentsData,
+    ClassificationResult,
+    CodeSearchResult,
+    DevelopmentSpeedupResult,
+    DocumentAnalysisResult,
+    EnhancedChatResult,
+    KnowledgeExtractionResult,
+    QueryReformulationResult,
+    RAGQueryResult,
+    SystemKnowledgeResult,
+    WebResearchResult,
+)
 from api.schemas_common import DataResponse
 from api.schemas_knowledge import (
     ContentClassificationRequest,
@@ -90,7 +103,7 @@ async def list_ai_agents(admin_check: bool = Depends(check_admin_permission)):
 # ====================================================================
 
 
-@router.post("/rag/query", response_model=DataResponse[AIStackAgentPayload])
+@router.post("/rag/query", response_model=DataResponse[RAGQueryResult])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="rag_query",
@@ -132,7 +145,7 @@ async def rag_query(
     return create_success_response(rag_result, "RAG query completed successfully")
 
 
-@router.post("/rag/reformulate", response_model=DataResponse[AIStackAgentPayload])
+@router.post("/rag/reformulate", response_model=DataResponse[QueryReformulationResult])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="reformulate_query",
@@ -154,7 +167,7 @@ async def reformulate_query(
     return create_success_response(result, "Query reformulated successfully")
 
 
-@router.post("/rag/analyze-documents", response_model=DataResponse[AIStackAgentPayload])
+@router.post("/rag/analyze-documents", response_model=DataResponse[DocumentAnalysisResult])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_documents",
@@ -177,7 +190,7 @@ async def analyze_documents(documents: List[Metadata], admin_check: bool = Depen
 # ====================================================================
 
 
-@router.post("/chat/enhanced", response_model=DataResponse[AIStackAgentPayload])
+@router.post("/chat/enhanced", response_model=DataResponse[EnhancedChatResult])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="enhanced_chat",
@@ -225,7 +238,7 @@ async def enhanced_chat(
 # ====================================================================
 
 
-@router.post("/knowledge/extract", response_model=DataResponse[AIStackAgentPayload])
+@router.post("/knowledge/extract", response_model=DataResponse[KnowledgeExtractionResult])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="extract_knowledge",
@@ -295,7 +308,7 @@ async def enhanced_knowledge_search(
     return create_success_response(results, "Enhanced knowledge search completed")
 
 
-@router.get("/knowledge/system", response_model=DataResponse[AIStackAgentPayload])
+@router.get("/knowledge/system", response_model=DataResponse[SystemKnowledgeResult])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_system_knowledge",
@@ -356,7 +369,7 @@ async def comprehensive_research(request: ResearchRequest, admin_check: bool = D
     return create_success_response(results, "Comprehensive research completed successfully")
 
 
-@router.post("/research/web", response_model=DataResponse[AIStackAgentPayload])
+@router.post("/research/web", response_model=DataResponse[WebResearchResult])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="web_research",
@@ -384,7 +397,7 @@ async def web_research(
 # ====================================================================
 
 
-@router.post("/development/search-code", response_model=DataResponse[AIStackAgentPayload])
+@router.post("/development/search-code", response_model=DataResponse[CodeSearchResult])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="search_code",
@@ -406,7 +419,7 @@ async def search_code(request: KbCodeSearchRequest, admin_check: bool = Depends(
     return create_success_response(result, "Code search completed successfully")
 
 
-@router.post("/development/analyze-speedup", response_model=DataResponse[AIStackAgentPayload])
+@router.post("/development/analyze-speedup", response_model=DataResponse[DevelopmentSpeedupResult])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_development_speedup",
@@ -434,7 +447,7 @@ async def analyze_development_speedup(
 # ====================================================================
 
 
-@router.post("/classification/classify", response_model=DataResponse[AIStackAgentPayload])
+@router.post("/classification/classify", response_model=DataResponse[ClassificationResult])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="classify_content",
@@ -599,7 +612,7 @@ async def multi_agent_query(
 # ====================================================================
 
 
-@router.post("/legacy/rag-search", response_model=DataResponse[AIStackAgentPayload])
+@router.post("/legacy/rag-search", response_model=DataResponse[RAGQueryResult])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="legacy_rag_search",
@@ -619,7 +632,7 @@ async def legacy_rag_search(
     return await rag_query(request)
 
 
-@router.post("/legacy/enhanced-chat", response_model=DataResponse[AIStackAgentPayload])
+@router.post("/legacy/enhanced-chat", response_model=DataResponse[EnhancedChatResult])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="legacy_enhanced_chat",

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -913,6 +913,57 @@ class AgentStatusData(BaseModel):
     development_tools: bool
 
 
+# ---------------------------------------------------------------------------
+# Typed inner result models for AgentTaskData subclasses (Issue #6407)
+# extra='allow' keeps the schema backward-compatible while the external
+# AI Stack service response is fully documented.
+# ---------------------------------------------------------------------------
+
+
+class GoalExecutionResult(BaseModel):
+    """Result payload for enhanced goal execution via multi-agent coordination."""
+
+    model_config = {"extra": "allow"}
+
+    final_answer: str | None = None
+    steps_taken: int | None = None
+    reasoning: str | None = None
+    agents_output: Dict[str, Any] | None = None
+
+
+class MultiAgentCoordinationResult(BaseModel):
+    """Result payload for multi-agent task coordination."""
+
+    model_config = {"extra": "allow"}
+
+    outcome: str | None = None
+    subtask_results: List[Any] | None = None
+    coordinated_response: str | None = None
+    agents_output: Dict[str, Any] | None = None
+
+
+class ResearchResult(BaseModel):
+    """Result payload for comprehensive research tasks."""
+
+    model_config = {"extra": "allow"}
+
+    summary: str | None = None
+    findings: List[Any] | None = None
+    sources_consulted: List[str] | None = None
+    confidence: float | None = None
+
+
+class DevelopmentAnalysisResult(BaseModel):
+    """Result payload for development codebase analysis."""
+
+    model_config = {"extra": "allow"}
+
+    recommendations: List[Any] | None = None
+    issues_found: int | None = None
+    speedup_opportunities: List[Any] | None = None
+    analysis_summary: str | None = None
+
+
 class AgentTaskData(BaseModel):
     """Base for agent execution payload models that invoke AI Stack multi-agent queries."""
 
@@ -930,6 +981,7 @@ class EnhancedGoalData(AgentTaskData):
     enhanced_context_used: bool
     knowledge_base_integrated: bool
     timestamp: str
+    result: GoalExecutionResult | None = None
 
 
 class MultiAgentCoordinationData(AgentTaskData):
@@ -940,6 +992,7 @@ class MultiAgentCoordinationData(AgentTaskData):
     subtasks_count: int
     dependencies_count: int
     timestamp: str
+    result: MultiAgentCoordinationResult | None = None
 
 
 class AgentResearchData(AgentTaskData):
@@ -950,6 +1003,7 @@ class AgentResearchData(AgentTaskData):
     include_web: bool
     include_code_search: bool
     sources: List[str] | None = None
+    result: ResearchResult | None = None
 
 
 class DevelopmentAnalysisData(AgentTaskData):
@@ -959,6 +1013,7 @@ class DevelopmentAnalysisData(AgentTaskData):
     target_path: str
     include_performance: bool
     include_optimization: bool
+    result: DevelopmentAnalysisResult | None = None
 
 
 class MultiAgentQueryData(BaseModel):

--- a/autobot-backend/api/schemas_ai_stack.py
+++ b/autobot-backend/api/schemas_ai_stack.py
@@ -8,6 +8,10 @@ Typed data payloads for the endpoints in api/ai_stack_integration.py.
 Where the external AI Stack service returns opaque JSON, models use
 ``model_config = {"extra": "allow"}`` so any fields are accepted while
 still giving the OpenAPI schema a meaningful name.
+
+Issue #6387: replaced the single AIStackAgentPayload catch-all with
+per-endpoint models so each endpoint gets a distinct OpenAPI schema.
+AIStackAgentPayload is retained as the base class and for legacy endpoints.
 """
 
 from typing import Any, Dict, List
@@ -42,18 +46,17 @@ class AIStackAgentsData(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# External AI Stack agent endpoints — structure opaque (from remote service)
+# External AI Stack agent endpoints — per-endpoint typed models (Issue #6387)
+# All extend AIStackAgentPayload (extra='allow') to stay backward-compatible
+# while exposing meaningful field names in the OpenAPI schema.
 # ---------------------------------------------------------------------------
 
 
 class AIStackAgentPayload(BaseModel):
-    """Generic payload returned by AI Stack agent endpoints.
+    """Generic payload base for AI Stack agent endpoints.
 
-    Accepts any fields from the external AI Stack service response.
-    Used for: /rag/query, /rag/reformulate, /rag/analyze-documents,
-    /chat/enhanced, /knowledge/extract, /knowledge/system,
-    /research/web, /development/search-code, /development/analyze-speedup,
-    /classification/classify, /legacy/rag-search, /legacy/enhanced-chat.
+    extra='allow' accepts any fields from the external AI Stack service.
+    Concrete subclasses declare the expected fields for each endpoint group.
     """
 
     model_config = {"extra": "allow"}
@@ -104,3 +107,91 @@ class MultimodalBatchSizeData(BaseModel):
     """data payload for PUT /performance/batch-size."""
 
     model_config = {"extra": "allow"}
+
+
+class RAGQueryResult(AIStackAgentPayload):
+    """Data payload for POST /ai-stack/rag/query and /ai-stack/legacy/rag-search."""
+
+    response: str | None = None
+    documents: List[Any] | None = None
+    sources: List[str] | None = None
+    confidence: float | None = None
+    query: str | None = None
+
+
+class QueryReformulationResult(AIStackAgentPayload):
+    """Data payload for POST /ai-stack/rag/reformulate."""
+
+    reformulated_query: str | None = None
+    original_query: str | None = None
+    improvements: List[str] | None = None
+
+
+class DocumentAnalysisResult(AIStackAgentPayload):
+    """Data payload for POST /ai-stack/rag/analyze-documents."""
+
+    analysis: str | None = None
+    key_points: List[str] | None = None
+    document_count: int | None = None
+    synthesis: str | None = None
+
+
+class EnhancedChatResult(AIStackAgentPayload):
+    """Data payload for POST /ai-stack/chat/enhanced and /ai-stack/legacy/enhanced-chat."""
+
+    message: str | None = None
+    context_used: List[Any] | None = None
+    knowledge_sources: List[str] | None = None
+    reasoning: str | None = None
+
+
+class KnowledgeExtractionResult(AIStackAgentPayload):
+    """Data payload for POST /ai-stack/knowledge/extract."""
+
+    extracted_facts: List[Any] | None = None
+    entities: List[Any] | None = None
+    relationships: List[Any] | None = None
+    confidence: float | None = None
+
+
+class SystemKnowledgeResult(AIStackAgentPayload):
+    """Data payload for GET /ai-stack/knowledge/system."""
+
+    system_facts: List[Any] | None = None
+    categories: List[str] | None = None
+    last_updated: str | None = None
+
+
+class WebResearchResult(AIStackAgentPayload):
+    """Data payload for POST /ai-stack/research/web."""
+
+    findings: List[Any] | None = None
+    sources: List[str] | None = None
+    summary: str | None = None
+    pages_analyzed: int | None = None
+
+
+class CodeSearchResult(AIStackAgentPayload):
+    """Data payload for POST /ai-stack/development/search-code."""
+
+    matches: List[Any] | None = None
+    total_results: int | None = None
+    search_scope: str | None = None
+
+
+class DevelopmentSpeedupResult(AIStackAgentPayload):
+    """Data payload for POST /ai-stack/development/analyze-speedup."""
+
+    recommendations: List[Any] | None = None
+    speedup_opportunities: List[Any] | None = None
+    analysis_type: str | None = None
+    summary: str | None = None
+
+
+class ClassificationResult(AIStackAgentPayload):
+    """Data payload for POST /ai-stack/classification/classify."""
+
+    classifications: List[Any] | None = None
+    primary_category: str | None = None
+    confidence: float | None = None
+    scores: Dict[str, float] | None = None


### PR DESCRIPTION
## Summary

- **#6479** — `DistributedAgentManager` now persists task-assignment metadata to Redis via new `state_persistence.py` (3 hash types: `task:assignment`, `task:progress`, `task:reassign`). On restart, `_rehydrate_from_redis()` restores stale-detection state. `add_active_task`/`remove_active_task`/`report_task_progress` converted to async; Redis write failures are fire-and-forget.
- **#6407** — `AgentTaskData.result` field now typed: added `GoalExecutionResult`, `MultiAgentCoordinationResult`, `ResearchResult`, `DevelopmentAnalysisResult` TypedDicts; `EnhancedGoalData`, `MultiAgentCoordinationData`, `AgentResearchData`, `DevelopmentAnalysisData` override `result` with typed subclass.
- **#6387** — Replaced `AIStackAgentPayload` catch-all `response_model=` with 10 per-endpoint specific models (`RAGQueryResult`, `QueryReformulationResult`, `DocumentAnalysisResult`, `EnhancedChatResult`, `KnowledgeExtractionResult`, `SystemKnowledgeResult`, `WebResearchResult`, `CodeSearchResult`, `DevelopmentSpeedupResult`, `ClassificationResult`); all extend `AIStackAgentPayload` with `extra='allow'`.

## Test plan

- [ ] `autobot-backend/agents/agent_orchestration/distributed_management_test.py` — 5 new `TestRedisPersistence` tests + async conversion of affected tests
- [ ] Python syntax + imports: all 7 changed files pass `py_compile`
- [ ] Flake8: 0 errors on changed files
- [ ] No removed symbols with live callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)