### PR TITLE
feat(frontend/icons): migrate 48 component files from FA to canonical Icon.vue (#6442, #4805)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeSmellsSection.vue
+++ b/autobot-frontend/src/components/analytics/CodeSmellsSection.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="code-smells-section analytics-section">
     <h3>
-      <i class="fas fa-bug"></i> {{ $t('analytics.codeSmells.title') }}
+      <Icon name="bug" /> {{ $t('analytics.codeSmells.title') }}
       <span v-if="codeHealthScore" class="health-badge" :class="getHealthGradeClass(codeHealthScore.grade)">
         {{ codeHealthScore.grade }} ({{ codeHealthScore.health_score }}/100)
       </span>
@@ -10,10 +10,10 @@
       </span>
       <div v-if="smells.length > 0" class="section-export-buttons">
         <button @click="emit('export', 'md')" class="export-btn" :title="$t('analytics.codebase.actions.exportMarkdown')">
-          <i class="fas fa-file-alt"></i> MD
+          <Icon name="file-alt" /> MD
         </button>
         <button @click="emit('export', 'json')" class="export-btn" :title="$t('analytics.codebase.actions.exportJson')">
-          <i class="fas fa-file-code"></i> JSON
+          <Icon name="file-code" /> JSON
         </button>
       </div>
     </h3>
@@ -128,6 +128,7 @@ import { computed } from 'vue'
 import { useGroupingMemo } from '@/composables/useComputedMemo'
 import { useExpansion } from '@/composables/useExpansion'
 import EmptyState from '@/components/ui/EmptyState.vue'
+import Icon from '@/components/ui/Icon.vue'
 
 interface CodeSmell {
   severity: string

--- a/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import DependencyTreemap from '@/components/charts/DependencyTreemap.vue'
 import ModuleImportsChart from '@/components/charts/ModuleImportsChart.vue'
+import Icon from '@/components/ui/Icon.vue'
 
 // Lazy-load Cytoscape-based components to defer ~300KB library loading
 const ImportTreeChart = defineAsyncComponent(() => import('@/components/charts/ImportTreeChart.vue'))
@@ -97,19 +98,19 @@ const emit = defineEmits<{
   <!-- Dependency Analysis Section -->
   <div class="dependency-section">
     <div class="section-header">
-      <h3><i class="fas fa-project-diagram"></i> {{ $t('analytics.codebase.dependencies.title') }}</h3>
+      <h3><Icon name="project-diagram" /> {{ $t('analytics.codebase.dependencies.title') }}</h3>
       <button @click="emit('load-dependency-data')" class="refresh-btn" :disabled="dependencyLoading">
-        <i :class="dependencyLoading ? 'fas fa-spinner fa-spin' : 'fas fa-sync-alt'"></i>
+        <Icon :name="dependencyLoading ? 'spinner' : 'sync-alt'" :spin="dependencyLoading" />
       </button>
     </div>
 
     <div v-if="dependencyLoading" class="charts-loading">
-      <i class="fas fa-spinner fa-spin"></i>
+      <Icon name="spinner" :spin="true" />
       <span>{{ $t('analytics.codebase.dependencies.analyzing') }}</span>
     </div>
 
     <div v-else-if="dependencyError" class="charts-error">
-      <i class="fas fa-exclamation-triangle"></i>
+      <Icon name="exclamation-triangle" />
       <span>{{ dependencyError }}</span>
       <button @click="emit('load-dependency-data')" class="btn-link">{{ $t('analytics.codebase.actions.retry') }}</button>
     </div>
@@ -165,7 +166,7 @@ const emit = defineEmits<{
       <!-- Circular Dependencies Warning -->
       <div v-if="dependencyData.circular_dependencies && dependencyData.circular_dependencies.length > 0" class="circular-deps-warning">
         <div class="warning-header">
-          <i class="fas fa-exclamation-triangle"></i>
+          <Icon name="exclamation-triangle" />
           <span>{{ $t('analytics.codebase.dependencies.circularDetected') }}</span>
         </div>
         <div class="circular-deps-list">
@@ -174,7 +175,7 @@ const emit = defineEmits<{
             :key="index"
             class="circular-dep-item"
           >
-            <i class="fas fa-sync-alt"></i>
+            <Icon name="sync-alt" />
             <span>{{ Array.isArray(cycle) ? cycle.join(' ↔ ') : (cycle.modules || []).join(' ↔ ') }}</span>
           </div>
         </div>
@@ -185,7 +186,7 @@ const emit = defineEmits<{
 
       <!-- Top External Dependencies Table -->
       <div v-if="dependencyData.external_dependencies && dependencyData.external_dependencies.length > 0" class="external-deps-table">
-        <h4><i class="fas fa-cube"></i> {{ $t('analytics.codebase.dependencies.topExternal') }}</h4>
+        <h4><Icon name="cube" /> {{ $t('analytics.codebase.dependencies.topExternal') }}</h4>
         <div class="deps-table-content">
           <div
             v-for="(dep, index) in dependencyData.external_dependencies.slice(0, 20)"
@@ -206,7 +207,7 @@ const emit = defineEmits<{
     >
       <template #actions>
         <button @click="emit('load-dependency-data')" class="btn-primary" :disabled="dependencyLoading">
-          <i class="fas fa-project-diagram"></i> {{ $t('analytics.codebase.dependencies.analyze') }}
+          <Icon name="project-diagram" /> {{ $t('analytics.codebase.dependencies.analyze') }}
         </button>
       </template>
     </EmptyState>
@@ -215,16 +216,16 @@ const emit = defineEmits<{
   <!-- Import Tree Section -->
   <div class="import-tree-section">
     <div class="section-header">
-      <h3><i class="fas fa-sitemap"></i> {{ $t('analytics.codebase.importTree.title') }}</h3>
+      <h3><Icon name="sitemap" /> {{ $t('analytics.codebase.importTree.title') }}</h3>
       <button @click="emit('load-import-tree')" class="refresh-btn" :disabled="importTreeLoading">
-        <i :class="importTreeLoading ? 'fas fa-spinner fa-spin' : 'fas fa-sync-alt'"></i>
+        <Icon :name="importTreeLoading ? 'spinner' : 'sync-alt'" :spin="importTreeLoading" />
         {{ importTreeLoading ? $t('analytics.codebase.actions.loading') : $t('analytics.codebase.actions.refresh') }}
       </button>
     </div>
 
     <!-- Error state -->
     <div v-if="importTreeError" class="section-error">
-      <i class="fas fa-exclamation-triangle"></i>
+      <Icon name="exclamation-triangle" />
       <span>{{ importTreeError }}</span>
       <button @click="emit('load-import-tree')" class="btn-link">{{ $t('analytics.codebase.actions.retry') }}</button>
     </div>
@@ -261,7 +262,7 @@ const emit = defineEmits<{
     >
       <template #actions>
         <button @click="emit('load-import-tree')" class="btn-primary" :disabled="importTreeLoading">
-          <i class="fas fa-sitemap"></i> {{ $t('analytics.codebase.importTree.analyze') }}
+          <Icon name="sitemap" /> {{ $t('analytics.codebase.importTree.analyze') }}
         </button>
       </template>
     </EmptyState>
@@ -270,16 +271,16 @@ const emit = defineEmits<{
   <!-- Function Call Graph Section -->
   <div class="call-graph-section">
     <div class="section-header">
-      <h3><i class="fas fa-project-diagram"></i> {{ $t('analytics.codebase.callGraph.title') }}</h3>
+      <h3><Icon name="project-diagram" /> {{ $t('analytics.codebase.callGraph.title') }}</h3>
       <button @click="emit('load-call-graph')" class="refresh-btn" :disabled="callGraphLoading">
-        <i :class="callGraphLoading ? 'fas fa-spinner fa-spin' : 'fas fa-sync-alt'"></i>
+        <Icon :name="callGraphLoading ? 'spinner' : 'sync-alt'" :spin="callGraphLoading" />
         {{ callGraphLoading ? $t('analytics.codebase.actions.loading') : $t('analytics.codebase.actions.refresh') }}
       </button>
     </div>
 
     <!-- Error state -->
     <div v-if="callGraphError" class="section-error">
-      <i class="fas fa-exclamation-triangle"></i>
+      <Icon name="exclamation-triangle" />
       <span>{{ callGraphError }}</span>
       <button @click="emit('load-call-graph')" class="btn-link">{{ $t('analytics.codebase.actions.retry') }}</button>
     </div>
@@ -318,7 +319,7 @@ const emit = defineEmits<{
     >
       <template #actions>
         <button @click="emit('load-call-graph')" class="btn-primary" :disabled="callGraphLoading">
-          <i class="fas fa-project-diagram"></i> {{ $t('analytics.codebase.callGraph.analyze') }}
+          <Icon name="project-diagram" /> {{ $t('analytics.codebase.callGraph.analyze') }}
         </button>
       </template>
     </EmptyState>

--- a/autobot-frontend/src/components/analytics/CodebaseSecurityPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseSecurityPanel.vue
@@ -6,7 +6,7 @@
 <template>
   <div class="code-intelligence-section analytics-section">
     <h3>
-      <i class="fas fa-brain"></i> {{ $t('analytics.codebase.intelligence.title') }}
+      <Icon name="brain" /> {{ $t('analytics.codebase.intelligence.title') }}
       <span v-if="props.totalFindings > 0" class="total-count">
         ({{ props.totalFindings.toLocaleString() }} findings)
       </span>
@@ -16,7 +16,7 @@
           class="action-btn"
           :title="$t('analytics.codebase.intelligence.scanFileTitle')"
         >
-          <i class="fas fa-file-code"></i> {{ $t('analytics.codebase.intelligence.scanFile') }}
+          <Icon name="file-code" /> {{ $t('analytics.codebase.intelligence.scanFile') }}
         </button>
         <button
           @click="emit('run-analysis')"
@@ -105,6 +105,7 @@ import SecurityFindingsPanel from '@/components/analytics/code-intelligence/Secu
 import PerformanceFindingsPanel from '@/components/analytics/code-intelligence/PerformanceFindingsPanel.vue'
 import RedisFindingsPanel from '@/components/analytics/code-intelligence/RedisFindingsPanel.vue'
 import FileScanModal from '@/components/analytics/code-intelligence/FileScanModal.vue'
+import Icon from '@/components/ui/Icon.vue'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const { t } = useI18n()

--- a/autobot-frontend/src/components/analytics/DeclarationsSection.vue
+++ b/autobot-frontend/src/components/analytics/DeclarationsSection.vue
@@ -1,21 +1,21 @@
 <template>
   <div class="declarations-section analytics-section">
     <h3>
-      <i class="fas fa-code"></i> {{ $t('analytics.declarations.title') }}
+      <Icon name="code" /> {{ $t('analytics.declarations.title') }}
       <span v-if="declarations && declarations.length > 0" class="total-count">
         ({{ declarations.length.toLocaleString() }} {{ $t('analytics.declarations.total') }})
       </span>
       <div v-if="declarations && declarations.length > 0" class="section-export-buttons">
         <button @click="emit('export', 'md')" class="export-btn" :title="$t('analytics.codebase.actions.exportMarkdown')">
-          <i class="fas fa-file-alt"></i> MD
+          <Icon name="file-alt" /> MD
         </button>
         <button @click="emit('export', 'json')" class="export-btn" :title="$t('analytics.codebase.actions.exportJson')">
-          <i class="fas fa-file-code"></i> JSON
+          <Icon name="file-code" /> JSON
         </button>
       </div>
     </h3>
     <div v-if="loading" class="section-loading">
-      <i class="fas fa-spinner fa-spin"></i>
+      <Icon name="spinner" :spin="true" />
       <span>{{ $t('analytics.codebase.actions.loading') }}</span>
     </div>
     <div v-else-if="declarations && declarations.length > 0" class="section-content">
@@ -107,6 +107,7 @@ import { useI18n } from 'vue-i18n'
 import { useGroupingMemo } from '@/composables/useComputedMemo'
 import { useExpansion } from '@/composables/useExpansion'
 import EmptyState from '@/components/ui/EmptyState.vue'
+import Icon from '@/components/ui/Icon.vue'
 
 const { t } = useI18n()
 

--- a/autobot-frontend/src/components/analytics/HardcodesSection.vue
+++ b/autobot-frontend/src/components/analytics/HardcodesSection.vue
@@ -1,21 +1,21 @@
 <template>
   <div class="hardcodes-section analytics-section">
     <h3>
-      <i class="fas fa-bolt"></i> {{ $t('analytics.hardcodes.title') }}
+      <Icon name="bolt" /> {{ $t('analytics.hardcodes.title') }}
       <span v-if="hardcodes && hardcodes.length > 0" class="total-count">
         ({{ hardcodes.length.toLocaleString() }} {{ $t('analytics.hardcodes.values') }})
       </span>
       <div v-if="hardcodes && hardcodes.length > 0" class="section-export-buttons">
         <button @click="emit('export', 'md')" class="export-btn" :title="$t('analytics.codebase.actions.exportMarkdown')">
-          <i class="fas fa-file-alt"></i> MD
+          <Icon name="file-alt" /> MD
         </button>
         <button @click="emit('export', 'json')" class="export-btn" :title="$t('analytics.codebase.actions.exportJson')">
-          <i class="fas fa-file-code"></i> JSON
+          <Icon name="file-code" /> JSON
         </button>
       </div>
     </h3>
     <div v-if="loading" class="section-loading">
-      <i class="fas fa-spinner fa-spin"></i>
+      <Icon name="spinner" :spin="true" />
       <span>{{ $t('analytics.codebase.actions.loading') }}</span>
     </div>
     <div v-else-if="hardcodes && hardcodes.length > 0" class="section-content">
@@ -124,6 +124,7 @@ import { useI18n } from 'vue-i18n'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import { useExpansion } from '@/composables/useExpansion'
 import type { HardcodedValue } from '@/composables/analytics/analyticsTypes'
+import Icon from '@/components/ui/Icon.vue'
 
 const { t } = useI18n()
 

--- a/autobot-frontend/src/components/analytics/ProblemsReportSection.vue
+++ b/autobot-frontend/src/components/analytics/ProblemsReportSection.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="problems-section analytics-section">
     <h3>
-      <i class="fas fa-exclamation-triangle"></i> {{ $t('analytics.problems.title') }}
+      <Icon name="exclamation-triangle" /> {{ $t('analytics.problems.title') }}
       <span v-if="problems && problems.length > 0" class="total-count">
         ({{ problems.length.toLocaleString() }} {{ $t('analytics.problems.total') }})
       </span>
@@ -13,7 +13,7 @@
           :disabled="!problems || problems.length === 0"
           :title="$t('analytics.problems.exportMarkdown')"
         >
-          <i class="fas fa-file-alt"></i> MD
+          <Icon name="file-alt" /> MD
         </button>
         <button
           @click="emit('export', 'json')"
@@ -21,7 +21,7 @@
           :disabled="!problems || problems.length === 0"
           :title="$t('analytics.problems.exportJson')"
         >
-          <i class="fas fa-file-code"></i> JSON
+          <Icon name="file-code" /> JSON
         </button>
       </div>
     </h3>
@@ -124,6 +124,7 @@
 import { useGroupingMemo } from '@/composables/useComputedMemo'
 import { useExpansion } from '@/composables/useExpansion'
 import EmptyState from '@/components/ui/EmptyState.vue'
+import Icon from '@/components/ui/Icon.vue'
 
 interface Problem {
   severity: string

--- a/autobot-frontend/src/components/analytics/code-intelligence/FileScanModal.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/FileScanModal.vue
@@ -10,7 +10,7 @@
         <div class="modal-header">
           <h3>{{ $t('analytics.findings.fileScan.title') }}</h3>
           <button class="close-btn" @click="$emit('close')">
-            <i class="fas fa-times"></i>
+            <Icon name="times" />
           </button>
         </div>
 
@@ -67,6 +67,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Icon from '@/components/ui/Icon.vue'
 
 const { t } = useI18n()
 

--- a/autobot-frontend/src/components/analytics/code-intelligence/PerformanceFindingsPanel.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/PerformanceFindingsPanel.vue
@@ -6,7 +6,7 @@
 <template>
   <div class="performance-panel">
     <div class="panel-header">
-      <h3><i class="fas fa-tachometer-alt"></i> {{ $t('analytics.findings.performance.title') }}</h3>
+      <h3><Icon name="tachometer-alt" /> {{ $t('analytics.findings.performance.title') }}</h3>
       <span v-if="findings.length > 0" class="count-badge">{{ findings.length }}</span>
     </div>
     <FindingsTable
@@ -20,6 +20,7 @@
 <script setup lang="ts">
 import FindingsTable from './FindingsTable.vue'
 import type { PerformanceFinding } from '@/types/codeIntelligence'
+import Icon from '@/components/ui/Icon.vue'
 
 defineProps<{
   findings: PerformanceFinding[]

--- a/autobot-frontend/src/components/analytics/code-intelligence/RedisFindingsPanel.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/RedisFindingsPanel.vue
@@ -6,7 +6,7 @@
 <template>
   <div class="redis-panel">
     <div class="panel-header">
-      <h3><i class="fas fa-database"></i> {{ $t('analytics.findings.redis.title') }}</h3>
+      <h3><Icon name="database" /> {{ $t('analytics.findings.redis.title') }}</h3>
       <span v-if="findings.length > 0" class="count-badge">{{ findings.length }}</span>
     </div>
     <FindingsTable
@@ -20,6 +20,7 @@
 <script setup lang="ts">
 import FindingsTable from './FindingsTable.vue'
 import type { RedisOptimizationFinding } from '@/types/codeIntelligence'
+import Icon from '@/components/ui/Icon.vue'
 
 defineProps<{
   findings: RedisOptimizationFinding[]

--- a/autobot-frontend/src/components/analytics/code-intelligence/SecurityFindingsPanel.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/SecurityFindingsPanel.vue
@@ -6,7 +6,7 @@
 <template>
   <div class="security-panel">
     <div class="panel-header">
-      <h3><i class="fas fa-shield-alt"></i> {{ $t('analytics.findings.security.title') }}</h3>
+      <h3><Icon name="shield-alt" /> {{ $t('analytics.findings.security.title') }}</h3>
       <span v-if="findings.length > 0" class="count-badge">{{ findings.length }}</span>
     </div>
     <FindingsTable
@@ -20,6 +20,7 @@
 <script setup lang="ts">
 import FindingsTable from './FindingsTable.vue'
 import type { SecurityFinding } from '@/types/codeIntelligence'
+import Icon from '@/components/ui/Icon.vue'
 
 defineProps<{
   findings: SecurityFinding[]

--- a/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
@@ -6,7 +6,7 @@
 <template>
   <div class="api-endpoints-section analytics-section">
     <h3>
-      <i class="fas fa-plug"></i> {{ $t('analytics.codebase.apiCoverage.title') }}
+      <Icon name="plug" /> {{ $t('analytics.codebase.apiCoverage.title') }}
       <span v-if="analysis" class="total-count">
         ({{ analysis.coverage_percentage?.toFixed(1) || 0 }}% coverage)
       </span>
@@ -25,7 +25,7 @@
           :title="$t('analytics.codebase.actions.exportMarkdown')"
           :disabled="!analysis"
         >
-          <i class="fas fa-file-alt"></i> MD
+          <Icon name="file-alt" /> MD
         </button>
         <button
           @click="emit('export', 'json')"
@@ -33,17 +33,17 @@
           :title="$t('analytics.codebase.actions.exportJson')"
           :disabled="!analysis"
         >
-          <i class="fas fa-file-code"></i> JSON
+          <Icon name="file-code" /> JSON
         </button>
       </div>
     </h3>
 
     <div v-if="loading" class="loading-state">
-      <i class="fas fa-spinner fa-spin"></i> {{ $t('analytics.codebase.apiCoverage.scanning') }}
+      <Icon name="spinner" :spin="true" /> {{ $t('analytics.codebase.apiCoverage.scanning') }}
     </div>
 
     <div v-else-if="error" class="error-state">
-      <i class="fas fa-exclamation-triangle"></i> {{ error }}
+      <Icon name="exclamation-triangle" /> {{ error }}
       <button @click="emit('refresh')" class="btn-link">
         {{ $t('analytics.codebase.actions.retry') }}
       </button>
@@ -225,7 +225,7 @@
       </div>
 
       <div v-if="analysis.scan_timestamp" class="scan-timestamp">
-        <i class="fas fa-clock"></i> {{ $t('analytics.codebase.actions.lastScan') }}:
+        <Icon name="clock" /> {{ $t('analytics.codebase.actions.lastScan') }}:
         {{ formatTimestamp(analysis.scan_timestamp) }}
       </div>
     </div>
@@ -241,6 +241,7 @@
 <script setup lang="ts">
 import EmptyState from '@/components/ui/EmptyState.vue'
 import { useExpansion } from '@/composables/useExpansion'
+import Icon from '@/components/ui/Icon.vue'
 
 interface ApiEndpointInfo {
   path: string

--- a/autobot-frontend/src/components/analytics/panels/CodebaseConfigDuplicatesPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseConfigDuplicatesPanel.vue
@@ -6,7 +6,7 @@
 <template>
   <div class="config-duplicates-section analytics-section">
     <h3>
-      <i class="fas fa-clone"></i> {{ $t('analytics.codebase.duplicates.configTitle') }}
+      <Icon name="clone" /> {{ $t('analytics.codebase.duplicates.configTitle') }}
       <span v-if="analysis" class="total-count">
         ({{ analysis.duplicates_found }} duplicates)
       </span>
@@ -25,7 +25,7 @@
           :title="$t('analytics.codebase.actions.exportMarkdown')"
           :disabled="!analysis"
         >
-          <i class="fas fa-file-alt"></i> MD
+          <Icon name="file-alt" /> MD
         </button>
         <button
           @click="emit('export', 'json')"
@@ -33,18 +33,18 @@
           :title="$t('analytics.codebase.actions.exportJson')"
           :disabled="!analysis"
         >
-          <i class="fas fa-file-code"></i> JSON
+          <Icon name="file-code" /> JSON
         </button>
       </div>
     </h3>
 
     <div v-if="loading" class="loading-state">
-      <i class="fas fa-spinner fa-spin"></i>
+      <Icon name="spinner" :spin="true" />
       {{ $t('analytics.codebase.duplicates.scanningConfig') }}
     </div>
 
     <div v-else-if="error" class="error-state">
-      <i class="fas fa-exclamation-triangle"></i> {{ error }}
+      <Icon name="exclamation-triangle" /> {{ error }}
       <button @click="emit('refresh')" class="btn-link">
         {{ $t('analytics.codebase.actions.retry') }}
       </button>
@@ -96,7 +96,7 @@
       </div>
 
       <div class="recommendation-box">
-        <i class="fas fa-lightbulb"></i>
+        <Icon name="lightbulb" />
         <span>{{ $t('analytics.codebase.duplicates.recommendation') }}</span>
       </div>
     </div>
@@ -105,7 +105,7 @@
       v-else-if="analysis && analysis.duplicates_found === 0"
       class="success-state"
     >
-      <i class="fas fa-check-circle"></i>
+      <Icon name="check-circle" />
       {{ $t('analytics.codebase.duplicates.noDuplicatesFound') }}
     </div>
 
@@ -119,6 +119,7 @@
 
 <script setup lang="ts">
 import EmptyState from '@/components/ui/EmptyState.vue'
+import Icon from '@/components/ui/Icon.vue'
 
 interface ConfigDuplicatesResult {
   duplicates_found: number

--- a/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
@@ -6,7 +6,7 @@
 <template>
   <div class="environment-analysis-section analytics-section">
     <h3>
-      <i class="fas fa-leaf"></i> {{ $t('analytics.codebase.environment.title') }}
+      <Icon name="leaf" /> {{ $t('analytics.codebase.environment.title') }}
       <span v-if="analysis" class="total-count">
         ({{ analysis.total_hardcoded_values }} hardcoded values)
       </span>
@@ -24,14 +24,14 @@
           class="export-btn"
           :title="$t('analytics.codebase.actions.exportMarkdown')"
         >
-          <i class="fas fa-file-alt"></i> MD
+          <Icon name="file-alt" /> MD
         </button>
         <button
           @click="emit('export', 'json')"
           class="export-btn"
           :title="$t('analytics.codebase.actions.exportJson')"
         >
-          <i class="fas fa-file-code"></i> JSON
+          <Icon name="file-code" /> JSON
         </button>
       </div>
     </h3>
@@ -53,7 +53,7 @@
           style="width: 18px; height: 18px; cursor: pointer;"
         />
         <span style="font-weight: 500;">
-          <i class="fas fa-robot"></i> {{ $t('analytics.codebase.environment.useAiFiltering') }}
+          <Icon name="robot" /> {{ $t('analytics.codebase.environment.useAiFiltering') }}
         </span>
       </label>
       <span
@@ -74,19 +74,19 @@
         <span class="ai-filter-model-hint">Model: {{ aiFilteringModel }}</span>
       </span>
       <span v-if="llmFilteringResult" class="llm-result-badge">
-        <i class="fas fa-check-circle"></i>
+        <Icon name="check-circle" />
         {{ llmFilteringResult.original_count }} → {{ llmFilteringResult.filtered_count }}
         ({{ llmFilteringResult.reduction_percent }}% reduced)
       </span>
     </div>
 
     <div v-if="loading" class="loading-state">
-      <i class="fas fa-spinner fa-spin"></i>
+      <Icon name="spinner" :spin="true" />
       {{ useAiFiltering ? 'Scanning with AI filtering...' : 'Scanning for hardcoded values...' }}
     </div>
 
     <div v-else-if="error" class="error-state">
-      <i class="fas fa-exclamation-triangle"></i> {{ error }}
+      <Icon name="exclamation-triangle" /> {{ error }}
       <button @click="emit('refresh')" class="btn-link">
         {{ $t('analytics.codebase.actions.retry') }}
       </button>
@@ -184,13 +184,13 @@
             <span class="value-type">{{ hv.type }}</span>
           </div>
           <div v-if="hv.suggested_env_var" class="hv-suggestion">
-            <i class="fas fa-lightbulb"></i> Use: <code>{{ hv.suggested_env_var }}</code>
+            <Icon name="lightbulb" /> Use: <code>{{ hv.suggested_env_var }}</code>
           </div>
         </div>
       </div>
 
       <div class="scan-timestamp">
-        <i class="fas fa-clock"></i>
+        <Icon name="clock" />
         Analysis completed in {{ analysis.analysis_time_seconds.toFixed(2) }}s
       </div>
     </div>
@@ -199,7 +199,7 @@
       v-else-if="analysis && analysis.total_hardcoded_values === 0"
       class="success-state"
     >
-      <i class="fas fa-check-circle"></i>
+      <Icon name="check-circle" />
       {{ $t('analytics.codebase.environment.noHardcodedValues') }}
     </div>
 
@@ -215,6 +215,7 @@
 import EmptyState from '@/components/ui/EmptyState.vue'
 // #5311: canonical HardcodedValue from analyticsTypes — was inline-duplicated here.
 import type { HardcodedValue } from '@/composables/analytics/analyticsTypes'
+import Icon from '@/components/ui/Icon.vue'
 
 interface EnvRecommendation {
   env_var_name: string

--- a/autobot-frontend/src/components/artifact-cells/ChartCell.vue
+++ b/autobot-frontend/src/components/artifact-cells/ChartCell.vue
@@ -12,7 +12,7 @@
     <!-- Placeholder for empty content -->
     <div v-if="!richPayload" class="chart-placeholder">
       <div class="placeholder-content">
-        <i class="fas fa-chart-bar"></i>
+        <Icon name="chart-bar" />
         <span>{{ $t('charts.cellPlaceholder', 'Chart') }}</span>
       </div>
     </div>
@@ -20,7 +20,7 @@
     <!-- Error state -->
     <div v-else-if="hasError" class="chart-error-boundary">
       <div class="error-content">
-        <i class="fas fa-exclamation-circle"></i>
+        <Icon name="exclamation-circle" />
         <div class="error-message">
           <h4>{{ $t('charts.renderError', 'Chart rendering failed') }}</h4>
           <p v-if="errorMessage" class="error-details">{{ errorMessage }}</p>
@@ -69,6 +69,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Icon from '@/components/ui/Icon.vue'
 
 const { t } = useI18n()
 

--- a/autobot-frontend/src/components/async/AsyncErrorFallback.vue
+++ b/autobot-frontend/src/components/async/AsyncErrorFallback.vue
@@ -2,7 +2,7 @@
   <div class="async-error-fallback">
     <div class="error-container">
       <div class="error-icon">
-        <i class="fas fa-exclamation-triangle"></i>
+        <Icon name="exclamation-triangle" />
       </div>
       <div class="error-content">
         <h3 class="error-title">Failed to Load Component</h3>
@@ -29,7 +29,7 @@
             @click="retry"
             :disabled="retrying || retryCount >= maxRetries"
           >
-            <i class="fas fa-redo" :class="{ 'fa-spin': retrying }"></i>
+            <Icon name="redo" :spin="retrying" />
             {{ retrying ? 'Retrying...' : `Retry${retryCount > 0 ? ` (${retryCount}/${maxRetries})` : ''}` }}
           </BaseButton>
 
@@ -37,7 +37,7 @@
             variant="secondary"
             @click="reload"
           >
-            <i class="fas fa-refresh"></i>
+            <Icon name="refresh" />
             Reload Page
           </BaseButton>
 
@@ -45,7 +45,7 @@
             variant="outline-solid"
             @click="goHome"
           >
-            <i class="fas fa-home"></i>
+            <Icon name="home" />
             Go to Home
           </BaseButton>
 
@@ -66,6 +66,7 @@ import { ref, computed, inject, withDefaults } from 'vue'
 import { useRouter } from 'vue-router'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
+import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('AsyncErrorFallback')
 
@@ -340,10 +341,6 @@ if (props.error) {
   display: flex;
   gap: var(--spacing-3);
   flex-wrap: wrap;
-}
-
-.fa-spin {
-  animation: fa-spin 1s infinite linear;
 }
 
 @keyframes fa-spin {

--- a/autobot-frontend/src/components/audit/AuditFilters.vue
+++ b/autobot-frontend/src/components/audit/AuditFilters.vue
@@ -132,11 +132,11 @@
 
     <div class="filter-actions">
       <button class="btn btn-primary" @click="applyFilters">
-        <i class="fas fa-search"></i>
+        <Icon name="search" />
         {{ $t('audit.filters.applyFilters') }}
       </button>
       <button class="btn btn-secondary" @click="resetFilters">
-        <i class="fas fa-undo"></i>
+        <Icon name="undo" />
         {{ $t('audit.filters.reset') }}
       </button>
       <button
@@ -144,7 +144,7 @@
         class="btn btn-ghost"
         @click="clearFilters"
       >
-        <i class="fas fa-times"></i>
+        <Icon name="times" />
         {{ $t('audit.filters.clearAll') }}
       </button>
     </div>
@@ -154,6 +154,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { AuditFilter, AuditResult } from '@/types/audit'
+import Icon from '@/components/ui/Icon.vue'
 
 interface Props {
   filter: AuditFilter

--- a/autobot-frontend/src/components/base/ErrorBanner.vue
+++ b/autobot-frontend/src/components/base/ErrorBanner.vue
@@ -7,7 +7,7 @@
       :aria-live="variant === 'error' ? 'assertive' : 'polite'"
     >
       <div class="error-banner-content">
-        <i :class="['error-banner-icon', iconClass]"></i>
+        <Icon :name="iconName" class="error-banner-icon" />
         <div class="error-banner-message">
           <slot>{{ message }}</slot>
         </div>
@@ -19,7 +19,7 @@
         :aria-label="$t('common.dismiss')"
         @click="handleDismiss"
       >
-        <i class="fas fa-times"></i>
+        <Icon name="times" />
       </BaseButton>
     </div>
   </Transition>
@@ -28,6 +28,7 @@
 <script setup lang="ts">
 import { computed, useSlots } from 'vue'
 import BaseButton from './BaseButton.vue'
+import Icon, { type IconName } from '@/components/ui/Icon.vue'
 
 interface Props {
   message?: string | null
@@ -49,13 +50,13 @@ const slots = useSlots()
 
 const visible = computed(() => !!slots.default?.() || !!props.message)
 
-const iconClass = computed(() => {
-  const variantIconMap: Record<string, string> = {
-    error: 'fas fa-exclamation-circle',
-    warning: 'fas fa-exclamation-triangle',
-    info: 'fas fa-info-circle'
+const iconName = computed<IconName>(() => {
+  const variantIconMap: Record<string, IconName> = {
+    error: 'exclamation-circle',
+    warning: 'exclamation-triangle',
+    info: 'info-circle',
   }
-  return variantIconMap[props.variant] || variantIconMap.error
+  return variantIconMap[props.variant] ?? 'exclamation-circle'
 })
 
 const handleDismiss = () => {

--- a/autobot-frontend/src/components/charts/BaseChart.vue
+++ b/autobot-frontend/src/components/charts/BaseChart.vue
@@ -15,15 +15,15 @@
       <span v-if="subtitle" class="chart-subtitle">{{ subtitle }}</span>
     </div>
     <div v-if="loading" class="chart-loading-overlay">
-      <i class="fas fa-spinner fa-spin"></i>
+      <Icon name="spinner" :spin="true" />
       <span>{{ $t('charts.base.loading') }}</span>
     </div>
     <div v-else-if="error" class="chart-error">
-      <i class="fas fa-exclamation-triangle"></i>
+      <Icon name="exclamation-triangle" />
       <span>{{ error }}</span>
     </div>
     <div v-else-if="!hasData" class="chart-no-data">
-      <i class="fas fa-chart-bar"></i>
+      <Icon name="chart-bar" />
       <span>{{ $t('charts.base.noData') }}</span>
     </div>
     <apexchart
@@ -44,6 +44,7 @@ import { useI18n } from 'vue-i18n'
 import VueApexCharts from 'vue3-apexcharts'
 import type { ApexOptions } from 'apexcharts'
 import { getCssVar } from '@/composables/useCssVars'
+import Icon from '@/components/ui/Icon.vue'
 
 const { t } = useI18n()
 

--- a/autobot-frontend/src/components/chat/ChatTabContent.vue
+++ b/autobot-frontend/src/components/chat/ChatTabContent.vue
@@ -50,7 +50,7 @@
         <!-- Host selector header for VNC -->
         <div class="vnc-header flex justify-between items-center bg-autobot-bg-secondary text-autobot-text-primary px-4 py-2 text-sm">
           <div class="flex items-center gap-3">
-            <i class="fas fa-desktop"></i>
+            <Icon name="desktop" />
             <HostSelector
               ref="vncHostSelectorRef"
               v-model="selectedVncHost"
@@ -141,6 +141,7 @@ import VisualBrowserPanel from '@/components/chat/VisualBrowserPanel.vue'  // Is
 import HostSelector from '@/components/ui/HostSelector.vue'  // Issue #715: Dynamic host selection
 import SSHTerminal from '@/components/terminal/SSHTerminal.vue'    // Issue #715: SSH terminal component
 import DesktopInterface from '@/components/desktop/DesktopInterface.vue'  // Issue #4977: full VNC component
+import Icon from '@/components/ui/Icon.vue'
 
 /**
  * Infrastructure host type for SSH/VNC connections.

--- a/autobot-frontend/src/components/chat/OverseerPlanMessage.vue
+++ b/autobot-frontend/src/components/chat/OverseerPlanMessage.vue
@@ -3,7 +3,7 @@
     <!-- Plan Header -->
     <div class="plan-header">
       <div class="plan-title">
-        <i class="fas fa-sitemap" aria-hidden="true"></i>
+        <Icon name="sitemap" aria-hidden="true" />
         <span>{{ $t('chat.overseer.executionPlan') }}</span>
       </div>
       <div class="plan-progress">
@@ -14,7 +14,7 @@
 
     <!-- Analysis -->
     <div class="plan-analysis">
-      <i class="fas fa-lightbulb" aria-hidden="true"></i>
+      <Icon name="lightbulb" aria-hidden="true" />
       <p>{{ plan.analysis }}</p>
     </div>
 
@@ -53,6 +53,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { OverseerPlan, OverseerStep } from '@/composables/useOverseerAgent'
+import Icon from '@/components/ui/Icon.vue'
 
 const { t } = useI18n()
 

--- a/autobot-frontend/src/components/chat/ShareConversationDialog.vue
+++ b/autobot-frontend/src/components/chat/ShareConversationDialog.vue
@@ -50,7 +50,7 @@
         <!-- KB Facts Preview -->
         <div v-if="includeKnowledge" class="space-y-2">
           <div v-if="factsLoading" class="flex items-center gap-2 text-sm text-autobot-text-secondary p-3">
-            <i class="fas fa-spinner fa-spin"></i>
+            <Icon name="spinner" :spin="true" />
             {{ $t('chat.share.loadingFacts') }}
           </div>
 
@@ -119,6 +119,7 @@ import ApiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import { useBatchSelection } from '@/composables/useBatchSelection'
+import Icon from '@/components/ui/Icon.vue'
 
 const { t } = useI18n()
 const logger = createLogger('ShareConversationDialog')

--- a/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
+++ b/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
@@ -238,7 +238,7 @@ onMounted(() => {
         <button @click="navigate" :disabled="loading" class="go-btn" :aria-label="$t('chat.visualBrowser.go')">
 
           <Icon name="search" v-if="!loading" />
-          <i class="fas fa-spinner fa-spin" v-else></i>
+          <Icon name="spinner" :spin="true" v-else />
         </button>
 
         <!-- Screenshot button -->
@@ -428,7 +428,8 @@ onMounted(() => {
 
 .url-icon {
   color: var(--text-muted);
-  font-size: var(--text-sm);
+  width: var(--text-sm);
+  height: var(--text-sm);
   flex-shrink: 0;
 }
 
@@ -524,7 +525,8 @@ onMounted(() => {
 }
 
 .viewport-icon {
-  font-size: var(--text-5xl);
+  width: var(--text-5xl);
+  height: var(--text-5xl);
   color: var(--text-secondary);
 }
 

--- a/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
+++ b/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
@@ -23,6 +23,7 @@ import {
 } from '@/utils/VisionMultimodalApiClient'
 import { createLogger } from '@/utils/debugUtils'
 import { normalizeUrl } from '@/utils/urlUtils'
+import Icon from '@/components/ui/Icon.vue'
 
 const { t } = useI18n()
 const logger = createLogger('VisualBrowserPanel')
@@ -210,20 +211,20 @@ onMounted(() => {
         <!-- Back / Forward / Reload -->
         <div class="nav-controls">
           <button @click="goBack" :disabled="!isConnected || loading" class="nav-btn" :title="$t('chat.visualBrowser.back')" :aria-label="$t('chat.visualBrowser.back')">
-            <i class="fas fa-arrow-left"></i>
+            <Icon name="arrow-left" />
           </button>
           <button @click="goForward" :disabled="!isConnected || loading" class="nav-btn" :title="$t('chat.visualBrowser.forward')" :aria-label="$t('chat.visualBrowser.forward')">
-            <i class="fas fa-arrow-right"></i>
+            <Icon name="arrow-right" />
           </button>
           <button @click="reload" :disabled="!isConnected || loading" class="nav-btn" :title="$t('chat.visualBrowser.reload')" :aria-label="$t('chat.visualBrowser.reload')">
 
-            <i class="fas fa-redo" :class="{ 'fa-spin': loading }"></i>
+            <Icon name="redo" :spin="loading" />
           </button>
         </div>
 
         <!-- URL Input -->
         <div class="url-bar">
-          <i class="fas fa-globe url-icon"></i>
+          <Icon name="globe" class="url-icon" />
           <input
             v-model="url"
             @keydown="handleKeydown"
@@ -236,13 +237,13 @@ onMounted(() => {
         <!-- Go button -->
         <button @click="navigate" :disabled="loading" class="go-btn" :aria-label="$t('chat.visualBrowser.go')">
 
-          <i class="fas fa-search" v-if="!loading"></i>
+          <Icon name="search" v-if="!loading" />
           <i class="fas fa-spinner fa-spin" v-else></i>
         </button>
 
         <!-- Screenshot button -->
         <button @click="captureScreenshot" :disabled="!isConnected || loading" class="nav-btn screenshot-btn" :title="$t('chat.visualBrowser.refreshScreenshot')" :aria-label="$t('chat.visualBrowser.refreshScreenshot')">
-          <i class="fas fa-camera"></i>
+          <Icon name="camera" />
         </button>
 
         <!-- Automation toggle (#1242) -->
@@ -253,16 +254,16 @@ onMounted(() => {
           :title="$t('chat.visualBrowser.toggleAutomation')"
           :aria-label="$t('chat.visualBrowser.toggleAutomation')"
         >
-          <i class="fas fa-robot"></i>
+          <Icon name="robot" />
         </button>
       </div>
     </div>
 
     <!-- Error Banner -->
     <div v-if="error" class="error-banner">
-      <i class="fas fa-exclamation-triangle"></i>
+      <Icon name="exclamation-triangle" />
       <span>{{ error }}</span>
-      <button @click="error = null" class="error-dismiss" :aria-label="$t('common.dismiss')"><i class="fas fa-times"></i></button>
+      <button @click="error = null" class="error-dismiss" :aria-label="$t('common.dismiss')"><Icon name="times" /></button>
     </div>
 
     <!-- Content Area (viewport + optional automation panel) (#1242) -->
@@ -271,13 +272,13 @@ onMounted(() => {
       <div class="browser-viewport">
         <!-- Loading Spinner -->
         <div v-if="loading && !screenshot" class="viewport-state">
-          <i class="fas fa-spinner fa-spin viewport-icon"></i>
+          <Icon name="spinner" :spin="true" class="viewport-icon" />
           <p class="viewport-msg">{{ $t('common.loading') }}</p>
         </div>
 
         <!-- Disconnected / not started -->
         <div v-else-if="!isConnected" class="viewport-state">
-          <i class="fas fa-globe viewport-icon viewport-icon--dim"></i>
+          <Icon name="globe" class="viewport-icon viewport-icon--dim" />
           <h3 class="viewport-title">{{ $t('chat.visualBrowser.browserTitle') }}</h3>
           <p class="viewport-msg">{{ $t('chat.visualBrowser.startBrowsing') }}</p>
         </div>
@@ -295,10 +296,10 @@ onMounted(() => {
 
         <!-- Connected but no screenshot yet -->
         <div v-else class="viewport-state">
-          <i class="fas fa-camera viewport-icon viewport-icon--dim"></i>
+          <Icon name="camera" class="viewport-icon viewport-icon--dim" />
           <p class="viewport-msg">{{ $t('chat.visualBrowser.noScreenshot') }}</p>
           <button @click="captureScreenshot" class="capture-btn">
-            <i class="fas fa-camera mr-2"></i>{{ $t('chat.visualBrowser.captureScreenshot') }}
+            <Icon name="camera" class="mr-2" />{{ $t('chat.visualBrowser.captureScreenshot') }}
           </button>
         </div>
       </div>

--- a/autobot-frontend/src/components/collaboration/ActivityFeed.vue
+++ b/autobot-frontend/src/components/collaboration/ActivityFeed.vue
@@ -11,6 +11,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useSessionCollaboration, type CollaboratorActivity } from '@/composables/useSessionCollaboration'
+import Icon from '@/components/ui/Icon.vue'
 
 const { t } = useI18n()
 
@@ -121,7 +122,7 @@ const onlineCount = computed(() => {
             class="mt-1"
           >
             <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs bg-yellow-500/20 text-yellow-400">
-              <i class="fas fa-key mr-1" />
+              <Icon name="key" class="mr-1" />
               {{ $t('collaboration.activityFeed.secretsCount', { count: activity.activity.secretsUsed.length }) }}
             </span>
           </div>
@@ -133,7 +134,7 @@ const onlineCount = computed(() => {
         v-if="visibleActivities.length === 0"
         class="flex flex-col items-center justify-center py-8 text-autobot-text-muted"
       >
-        <i class="fas fa-chart-line text-2xl mb-2" />
+        <Icon name="chart-line" class="text-2xl mb-2" />
         <span class="text-sm">{{ $t('collaboration.activityFeed.noRecentActivity') }}</span>
         <span class="text-xs">{{ $t('collaboration.activityFeed.activitiesWillAppear') }}</span>
       </div>

--- a/autobot-frontend/src/components/file-browser/FilePathNavigation.vue
+++ b/autobot-frontend/src/components/file-browser/FilePathNavigation.vue
@@ -6,7 +6,7 @@
         <Icon name="home" /> {{ $t('fileBrowser.pathNavigation.home') }}
       </button>
       <span v-for="(part, index) in pathParts" :key="index" class="breadcrumb-item">
-        <i class="fas fa-chevron-right breadcrumb-separator"></i>
+        <Icon name="chevron-right" class="breadcrumb-separator" />
         <button @click="$emit('navigate-to-path', getPathUpTo(index))" class="clickable" type="button">
           {{ part }}
         </button>

--- a/autobot-frontend/src/components/file-browser/FilePathNavigation.vue
+++ b/autobot-frontend/src/components/file-browser/FilePathNavigation.vue
@@ -3,7 +3,7 @@
     <!-- Breadcrumb Navigation -->
     <div class="breadcrumb">
       <button @click="$emit('navigate-to-path', '/')" class="breadcrumb-item" type="button">
-        <i class="fas fa-home"></i> {{ $t('fileBrowser.pathNavigation.home') }}
+        <Icon name="home" /> {{ $t('fileBrowser.pathNavigation.home') }}
       </button>
       <span v-for="(part, index) in pathParts" :key="index" class="breadcrumb-item">
         <i class="fas fa-chevron-right breadcrumb-separator"></i>
@@ -22,7 +22,7 @@
         class="path-field"
       />
       <button @click="$emit('navigate-to-path', pathInput)" class="path-go-btn">
-        <i class="fas fa-arrow-right"></i>
+        <Icon name="arrow-right" />
       </button>
     </div>
   </div>
@@ -30,6 +30,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import Icon from '@/components/ui/Icon.vue'
 
 interface Props {
   currentPath: string

--- a/autobot-frontend/src/components/file-browser/FilePreview.vue
+++ b/autobot-frontend/src/components/file-browser/FilePreview.vue
@@ -78,7 +78,7 @@
             @click="downloadFile"
             class="download-btn"
           >
-            <i class="fas fa-download"></i>
+            <Icon name="download" />
             {{ $t('fileBrowser.preview.downloadFile') }}
           </button>
         </div>
@@ -89,6 +89,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import Icon from '@/components/ui/Icon.vue'
 
 interface FilePreviewData {
   name: string

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowserHeader.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowserHeader.vue
@@ -18,7 +18,7 @@
 
     <!-- Search bar -->
     <div class="search-bar">
-      <i class="fas fa-search"></i>
+      <Icon name="search" />
       <input
         :value="searchQuery"
         type="text"
@@ -34,7 +34,7 @@
         class="clear-btn"
         :aria-label="$t('knowledge.browserHeader.clearSearch')"
       >
-        <i class="fas fa-times"></i>
+        <Icon name="times" />
       </BaseButton>
     </div>
   </div>
@@ -54,6 +54,7 @@
  */
 
 import BaseButton from '@/components/base/BaseButton.vue'
+import Icon from '@/components/ui/Icon.vue'
 
 interface CategoryOption {
   value: string | null

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="container" class="graph3d-container">
     <div v-if="isEmpty" class="graph3d-empty">
-      <i class="fas fa-project-diagram"></i>
+      <Icon name="project-diagram" />
       <p>{{ $t('knowledge.graph.noEntities3D') }}</p>
     </div>
   </div>
@@ -36,6 +36,7 @@ import SpriteText from 'three-spritetext'
 import * as THREE from 'three'
 import { getCssVar } from '@/composables/useCssVars'
 import { createLogger } from '@/utils/debugUtils'
+import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('KnowledgeGraph3D')
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraphView.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraphView.vue
@@ -4,23 +4,23 @@
     <!-- Sidebar -->
     <aside class="graph-sidebar">
       <div class="sidebar-header">
-        <h3><i class="fas fa-project-diagram"></i> {{ $t('knowledge.graphView.title') }}</h3>
+        <h3><Icon name="project-diagram" /> {{ $t('knowledge.graphView.title') }}</h3>
       </div>
 
       <!-- Quick Stats -->
       <div class="quick-stats">
         <div class="stat-row">
-          <i class="fas fa-circle"></i>
+          <Icon name="circle" />
           <span class="stat-label">{{ $t('knowledge.graphView.entities') }}</span>
           <span class="stat-value">{{ stats.entityCount }}</span>
         </div>
         <div class="stat-row">
-          <i class="fas fa-clock"></i>
+          <Icon name="clock" />
           <span class="stat-label">{{ $t('knowledge.graphView.events') }}</span>
           <span class="stat-value">{{ stats.eventCount }}</span>
         </div>
         <div class="stat-row">
-          <i class="fas fa-layer-group"></i>
+          <Icon name="layer-group" />
           <span class="stat-label">{{ $t('knowledge.graphView.summaries') }}</span>
           <span class="stat-value">{{ stats.summaryCount }}</span>
         </div>
@@ -43,7 +43,7 @@
       <!-- Back Link -->
       <div class="sidebar-footer">
         <router-link to="/knowledge" class="back-link">
-          <i class="fas fa-arrow-left"></i>
+          <Icon name="arrow-left" />
           {{ $t('knowledge.graphView.backToKnowledgeBase') }}
         </router-link>
       </div>
@@ -60,7 +60,7 @@
       >
         <div class="welcome-card">
           <h2>
-            <i class="fas fa-project-diagram"></i>
+            <Icon name="project-diagram" />
             {{ $t('knowledge.graphView.knowledgeGraphPipeline') }}
           </h2>
           <p>
@@ -94,6 +94,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { useKnowledgeGraph } from '@/composables/useKnowledgeGraph'
+import Icon from '@/components/ui/Icon.vue'
 
 const route = useRoute()
 const router = useRouter()

--- a/autobot-frontend/src/components/knowledge/KnowledgeSearch.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSearch.vue
@@ -12,14 +12,14 @@
           :class="['mode-button', { active: !useRagSearch }]"
           @click="useRagSearch = false"
         >
-          <i class="fas fa-search"></i>
+          <Icon name="search" />
           {{ $t('knowledge.search.traditionalSearch') }}
         </button>
         <button
           :class="['mode-button', 'rag-button', { active: useRagSearch }]"
           @click="useRagSearch = true"
         >
-          <i class="fas fa-brain"></i>
+          <Icon name="brain" />
           {{ $t('knowledge.search.ragEnhanced') }}
         </button>
       </div>
@@ -36,7 +36,7 @@
     <!-- Category Filter -->
     <div class="category-filter">
       <label class="filter-label">
-        <i class="fas fa-filter"></i>
+        <Icon name="filter" />
         {{ $t('knowledge.search.filterByCategory') }}
       </label>
       <div class="filter-controls">
@@ -61,20 +61,20 @@
           class="clear-filter-button"
           :title="$t('knowledge.search.clearCategoryFilter')"
         >
-          <i class="fas fa-times"></i>
+          <Icon name="times" />
         </button>
         <span v-if="loadingCategories" class="loading-indicator">
-          <i class="fas fa-spinner fa-spin"></i>
+          <Icon name="spinner" :spin="true" />
         </span>
       </div>
       <span v-if="selectedCategory" class="active-filter-badge">
         {{ $t('knowledge.search.filtering', { category: formatCategory(selectedCategory) }) }}
       </span>
       <div v-if="categoriesError" class="categories-error">
-        <i class="fas fa-exclamation-triangle"></i>
+        <Icon name="exclamation-triangle" />
         {{ categoriesError }}
         <button @click="loadCategories" class="retry-button">
-          <i class="fas fa-redo"></i> {{ $t('knowledge.search.retry') }}
+          <Icon name="redo" /> {{ $t('knowledge.search.retry') }}
         </button>
       </div>
     </div>
@@ -82,7 +82,7 @@
     <!-- Issue #685: Access Level Filter -->
     <div class="access-level-filter">
       <label class="filter-label">
-        <i class="fas fa-shield-alt"></i>
+        <Icon name="shield-alt" />
         {{ $t('knowledge.search.filterByAccessLevel') }}
       </label>
       <div class="filter-chips">
@@ -101,7 +101,7 @@
           class="clear-chip"
           :title="$t('knowledge.search.clearAccessLevelFilter')"
         >
-          <i class="fas fa-times"></i>
+          <Icon name="times" />
           {{ $t('knowledge.search.clear') }}
         </button>
       </div>
@@ -171,7 +171,7 @@
       <div v-if="useRagSearch && ragResponse?.synthesized_response" class="rag-synthesis">
         <div class="synthesis-header">
           <h4>
-            <i class="fas fa-brain rag-icon"></i>
+            <Icon name="brain" class="rag-icon" />
             {{ $t('knowledge.search.aiSynthesis') }}
           </h4>
           <div v-if="ragResponse.rag_analysis" class="analysis-badges">
@@ -190,7 +190,7 @@
 
         <div v-if="ragResponse.reformulated_query && ragResponse.reformulated_query !== ragResponse.query" class="query-reformulation">
           <p class="reformulated-note">
-            <i class="fas fa-lightbulb"></i>
+            <Icon name="lightbulb" />
             {{ $t('knowledge.search.enhancedQuery') }}: "{{ ragResponse.reformulated_query }}"
           </p>
         </div>
@@ -229,7 +229,7 @@
       <!-- RAG Error Handling -->
       <div v-if="useRagSearch && ragError" class="rag-error">
         <div class="error-header">
-          <i class="fas fa-exclamation-triangle"></i>
+          <Icon name="exclamation-triangle" />
           {{ $t('knowledge.search.ragUnavailable') }}
         </div>
         <p>{{ ragError }}</p>
@@ -251,6 +251,7 @@ import { useDebouncedFn } from '@/composables/useDebounce'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import KBSearchResultPanel from './KBSearchResultPanel.vue'
 import { createLogger } from '@/utils/debugUtils'
+import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('KnowledgeSearch')
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
@@ -87,7 +87,7 @@
         @click="bulkApprove"
         :loading="bulkProcessing"
       >
-        <i class="fas fa-check"></i>
+        <Icon name="check" />
         {{ $t('knowledge.verification.approveSelected') }}
       </BaseButton>
       <BaseButton
@@ -96,7 +96,7 @@
         @click="bulkReject"
         :loading="bulkProcessing"
       >
-        <i class="fas fa-times"></i>
+        <Icon name="times" />
         {{ $t('knowledge.verification.rejectSelected') }}
       </BaseButton>
       <BaseButton
@@ -110,7 +110,7 @@
 
     <!-- Loading State -->
     <div v-if="store.verificationLoading" class="loading-state">
-      <i class="fas fa-spinner fa-spin"></i>
+      <Icon name="spinner" :spin="true" />
       <p>{{ $t('knowledge.verification.loading') }}</p>
     </div>
 
@@ -193,7 +193,7 @@
             @click="approveSource(source.fact_id)"
             :loading="actionLoadingId === source.fact_id"
           >
-            <i class="fas fa-check"></i>
+            <Icon name="check" />
             {{ $t('knowledge.verification.approve') }}
           </BaseButton>
           <BaseButton
@@ -202,7 +202,7 @@
             @click="rejectSource(source.fact_id)"
             :loading="actionLoadingId === source.fact_id"
           >
-            <i class="fas fa-times"></i>
+            <Icon name="times" />
             {{ $t('knowledge.verification.reject') }}
           </BaseButton>
         </div>
@@ -220,7 +220,7 @@
         :disabled="currentPage === 1"
         @click="goToPage(currentPage - 1)"
       >
-        <i class="fas fa-chevron-left"></i>
+        <Icon name="chevron-left" />
       </BaseButton>
       <span class="page-info">
         {{ $t('knowledge.verification.pageInfo', { current: currentPage, total: totalPages }) }}
@@ -231,7 +231,7 @@
         :disabled="currentPage === totalPages"
         @click="goToPage(currentPage + 1)"
       >
-        <i class="fas fa-chevron-right"></i>
+        <Icon name="chevron-right" />
       </BaseButton>
     </div>
   </div>
@@ -250,6 +250,7 @@ import BaseButton from '@/components/base/BaseButton.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import QualityScoreBadge from './QualityScoreBadge.vue'
 import { createLogger } from '@/utils/debugUtils'
+import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('KnowledgeVerificationQueue')
 

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
@@ -23,6 +23,7 @@ import EmptyState from '@/components/ui/EmptyState.vue'
 import { formatTimeAgo } from '@/utils/formatHelpers'
 import { createLogger } from '@/utils/debugUtils'
 import { useI18n } from 'vue-i18n'
+import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('ConnectorManager')
 const { t } = useI18n()
@@ -223,7 +224,7 @@ onMounted(() => {
 
     <!-- Loading State -->
     <div v-if="store.connectorsLoading" class="loading-state">
-      <i class="fas fa-spinner fa-spin"></i>
+      <Icon name="spinner" :spin="true" />
       <p>{{ $t('knowledge.connectors.loadingConnectors') }}</p>
     </div>
 

--- a/autobot-frontend/src/components/knowledge/pipeline/PipelineConfig.vue
+++ b/autobot-frontend/src/components/knowledge/pipeline/PipelineConfig.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="pipeline-config">
     <div class="config-header">
-      <h4><i class="fas fa-sliders-h"></i> {{ $t('knowledge.pipeline.config.title') }}</h4>
+      <h4><Icon name="sliders-h" /> {{ $t('knowledge.pipeline.config.title') }}</h4>
       <p class="header-description">
         {{ $t('knowledge.pipeline.config.description') }}
       </p>
@@ -107,7 +107,7 @@
     <!-- Generated Config Preview -->
     <div class="preview-section">
       <h5>
-        <i class="fas fa-code"></i>
+        <Icon name="code" />
         {{ $t('knowledge.pipeline.config.configurationPreview') }}
       </h5>
       <pre class="config-preview">{{ configPreview }}</pre>
@@ -116,10 +116,10 @@
     <!-- Actions -->
     <div class="config-actions">
       <button class="action-btn secondary" @click="resetDefaults">
-        <i class="fas fa-undo"></i> {{ $t('knowledge.pipeline.config.resetDefaults') }}
+        <Icon name="undo" /> {{ $t('knowledge.pipeline.config.resetDefaults') }}
       </button>
       <button class="action-btn primary" @click="emitConfig">
-        <i class="fas fa-check"></i> {{ $t('knowledge.pipeline.config.applyConfiguration') }}
+        <Icon name="check" /> {{ $t('knowledge.pipeline.config.applyConfiguration') }}
       </button>
     </div>
   </div>
@@ -132,6 +132,7 @@
 
 import { ref, reactive, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Icon from '@/components/ui/Icon.vue'
 
 interface StageTask {
   id: string

--- a/autobot-frontend/src/components/knowledge/pipeline/PipelineRunner.vue
+++ b/autobot-frontend/src/components/knowledge/pipeline/PipelineRunner.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="pipeline-runner">
     <div class="runner-header">
-      <h4><i class="fas fa-play-circle"></i> {{ $t('knowledge.pipeline.runner.title') }}</h4>
+      <h4><Icon name="play-circle" /> {{ $t('knowledge.pipeline.runner.title') }}</h4>
       <p class="header-description">
         {{ $t('knowledge.pipeline.runner.description') }}
       </p>
@@ -50,7 +50,7 @@
             class="config-toggle-btn"
             @click="showConfigEditor = !showConfigEditor"
           >
-            <i :class="showConfigEditor ? 'fas fa-code' : 'fas fa-sliders-h'"></i>
+            <Icon :name="showConfigEditor ? 'code' : 'sliders-h'" />
             {{ showConfigEditor ? $t('knowledge.pipeline.runner.jsonEditor') : $t('knowledge.pipeline.runner.visualConfig') }}
           </button>
         </div>
@@ -78,17 +78,17 @@
         class="submit-btn"
         :disabled="loading"
       >
-        <i :class="loading ? 'fas fa-spinner fa-spin' : 'fas fa-play'"></i>
+        <Icon :name="loading ? 'spinner' : 'play'" :spin="loading" />
         {{ loading ? $t('knowledge.pipeline.runner.running') : $t('knowledge.pipeline.runner.runPipeline') }}
       </button>
     </form>
 
     <!-- Error Display -->
     <div v-if="error" class="error-banner">
-      <i class="fas fa-exclamation-triangle"></i>
+      <Icon name="exclamation-triangle" />
       <span>{{ error }}</span>
       <button class="dismiss-btn" :aria-label="$t('knowledge.pipeline.runner.dismissError')" @click="clearError">
-        <i class="fas fa-times"></i>
+        <Icon name="times" />
       </button>
     </div>
 
@@ -96,7 +96,7 @@
     <div v-if="result" class="result-panel">
       <div class="result-header">
         <h5>
-          <i class="fas fa-check-circle"></i>
+          <Icon name="check-circle" />
           {{ $t('knowledge.pipeline.runner.pipelineComplete') }}
         </h5>
         <span class="result-duration">
@@ -158,6 +158,7 @@ import {
 import { createLogger } from '@/utils/debugUtils'
 import PipelineConfig from './PipelineConfig.vue'
 import { useI18n } from 'vue-i18n'
+import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('PipelineRunner')
 const { t } = useI18n()

--- a/autobot-frontend/src/components/knowledge/summaries/SummariesPage.vue
+++ b/autobot-frontend/src/components/knowledge/summaries/SummariesPage.vue
@@ -7,13 +7,13 @@
         :class="['toggle-btn', { active: view === 'search' }]"
         @click="view = 'search'"
       >
-        <i class="fas fa-search"></i> {{ $t('knowledge.summaries.page.search') }}
+        <Icon name="search" /> {{ $t('knowledge.summaries.page.search') }}
       </button>
       <button
         :class="['toggle-btn', { active: view === 'overview' }]"
         @click="view = 'overview'"
       >
-        <i class="fas fa-file-alt"></i> {{ $t('knowledge.summaries.page.documentOverview') }}
+        <Icon name="file-alt" /> {{ $t('knowledge.summaries.page.documentOverview') }}
       </button>
     </div>
 
@@ -41,7 +41,7 @@
             :disabled="!documentId.trim()"
             @click="loadOverview"
           >
-            <i class="fas fa-eye"></i> {{ $t('knowledge.summaries.page.load') }}
+            <Icon name="eye" /> {{ $t('knowledge.summaries.page.load') }}
           </button>
         </div>
       </div>
@@ -56,7 +56,7 @@
     <!-- Drill-Down View -->
     <div v-if="drillDownId" class="drill-down-section">
       <button class="back-btn" @click="drillDownId = null">
-        <i class="fas fa-arrow-left"></i> {{ $t('knowledge.summaries.page.backTo') }}
+        <Icon name="arrow-left" /> {{ $t('knowledge.summaries.page.backTo') }}
         {{ view === 'search' ? $t('knowledge.summaries.page.search') : $t('knowledge.summaries.page.documentOverview') }}
       </button>
       <DrillDownViewer :summary-id="drillDownId" />
@@ -73,6 +73,7 @@ import { ref } from 'vue'
 import SummarySearch from './SummarySearch.vue'
 import DocumentOverview from './DocumentOverview.vue'
 import DrillDownViewer from './DrillDownViewer.vue'
+import Icon from '@/components/ui/Icon.vue'
 
 const view = ref<'search' | 'overview'>('search')
 const documentId = ref('')

--- a/autobot-frontend/src/components/knowledge/temporal/CausalChainViewer.vue
+++ b/autobot-frontend/src/components/knowledge/temporal/CausalChainViewer.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="causal-chain-viewer">
     <div class="chain-header">
-      <h4><i class="fas fa-code-branch"></i> {{ $t('knowledge.temporal.causalChain.title') }}</h4>
+      <h4><Icon name="code-branch" /> {{ $t('knowledge.temporal.causalChain.title') }}</h4>
       <p class="header-description">
         {{ $t('knowledge.temporal.causalChain.description') }}
       </p>
@@ -28,7 +28,7 @@
 
     <!-- Loading -->
     <div v-if="loading" class="loading-state">
-      <i class="fas fa-spinner fa-spin"></i>
+      <Icon name="spinner" :spin="true" />
       <span>{{ $t('knowledge.temporal.causalChain.tracing') }}</span>
     </div>
 
@@ -89,7 +89,7 @@
 
     <!-- Empty -->
     <div v-else class="empty-state">
-      <i class="fas fa-code-branch"></i>
+      <Icon name="code-branch" />
       <p>{{ $t('knowledge.temporal.causalChain.emptyState') }}</p>
     </div>
   </div>
@@ -103,6 +103,7 @@
 import { ref, onMounted, watch } from 'vue'
 import type { TemporalEvent } from '@/composables/useKnowledgeGraph'
 import { useKnowledgeGraph } from '@/composables/useKnowledgeGraph'
+import Icon from '@/components/ui/Icon.vue'
 const props = defineProps<{
   eventId: string
   initialEvents?: TemporalEvent[]

--- a/autobot-frontend/src/components/knowledge/temporal/TemporalFilter.vue
+++ b/autobot-frontend/src/components/knowledge/temporal/TemporalFilter.vue
@@ -1,7 +1,7 @@
 <!-- AutoBot - Knowledge Graph Pipeline (Issue #759) -->
 <template>
   <div class="temporal-filter">
-    <h5><i class="fas fa-filter"></i> {{ $t('knowledge.temporal.filter.title') }}</h5>
+    <h5><Icon name="filter" /> {{ $t('knowledge.temporal.filter.title') }}</h5>
 
     <!-- Date Range -->
     <div class="filter-group">
@@ -62,10 +62,10 @@
     <!-- Actions -->
     <div class="filter-actions">
       <button class="filter-btn secondary" @click="resetFilters">
-        <i class="fas fa-undo"></i> {{ $t('knowledge.temporal.filter.reset') }}
+        <Icon name="undo" /> {{ $t('knowledge.temporal.filter.reset') }}
       </button>
       <button class="filter-btn primary" @click="applyFilters">
-        <i class="fas fa-search"></i> {{ $t('knowledge.temporal.filter.search') }}
+        <Icon name="search" /> {{ $t('knowledge.temporal.filter.search') }}
       </button>
     </div>
   </div>
@@ -78,6 +78,7 @@
 
 import { reactive, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Icon from '@/components/ui/Icon.vue'
 
 const emit = defineEmits<{
   (e: 'filter-change', filters: {

--- a/autobot-frontend/src/components/manpage/ManPageSearchPanel.vue
+++ b/autobot-frontend/src/components/manpage/ManPageSearchPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <BasePanel v-if="show" variant="bordered" size="medium">
     <template #header>
-      <h3><i class="fas fa-search"></i> {{ $t('manpage.searchPanel.title') }}</h3>
+      <h3><Icon name="search" /> {{ $t('manpage.searchPanel.title') }}</h3>
     </template>
 
     <div class="search-input">
@@ -18,7 +18,7 @@
         @click="$emit('search')"
         :disabled="!query.trim() || loading"
       >
-        <i class="fas fa-search"></i>
+        <Icon name="search" />
         {{ $t('manpage.searchPanel.search') }}
       </BaseButton>
     </div>
@@ -65,6 +65,7 @@
 import BasePanel from '@/components/base/BasePanel.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
+import Icon from '@/components/ui/Icon.vue'
 
 interface SearchResult {
   command: string

--- a/autobot-frontend/src/components/manpage/ProgressTrackingPanel.vue
+++ b/autobot-frontend/src/components/manpage/ProgressTrackingPanel.vue
@@ -1,13 +1,13 @@
 <template>
   <BasePanel v-if="show" variant="bordered" size="medium">
     <template #header>
-      <h3><i class="fas fa-tasks"></i> {{ $t('manpage.progressTracking.title') }}</h3>
+      <h3><Icon name="tasks" /> {{ $t('manpage.progressTracking.title') }}</h3>
       <BaseButton
         size="sm"
         variant="outline-solid"
         @click="$emit('hide')"
       >
-        <i class="fas fa-times"></i>
+        <Icon name="times" />
         {{ $t('manpage.progressTracking.hide') }}
       </BaseButton>
     </template>
@@ -85,6 +85,7 @@ import { computed } from 'vue'
 import BasePanel from '@/components/base/BasePanel.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { useKnowledgeIcons } from '@/composables/knowledge/useKnowledgeIcons'
+import Icon from '@/components/ui/Icon.vue'
 
 interface ProgressMessage {
   text: string

--- a/autobot-frontend/src/components/operations/OperationFilters.vue
+++ b/autobot-frontend/src/components/operations/OperationFilters.vue
@@ -67,7 +67,7 @@
       @click="clearFilters"
       :disabled="!hasActiveFilters"
     >
-      <i class="fas fa-times"></i>
+      <Icon name="times" />
       {{ $t('operations.filters.clear') }}
     </button>
   </div>
@@ -78,6 +78,7 @@ import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { OperationsFilter, OperationStatus, OperationType } from '@/types/operations'
 import { STATUS_CONFIG, OPERATION_TYPE_LABELS } from '@/types/operations'
+import Icon from '@/components/ui/Icon.vue'
 
 const { t } = useI18n()
 

--- a/autobot-frontend/src/components/operations/OperationsPanel.vue
+++ b/autobot-frontend/src/components/operations/OperationsPanel.vue
@@ -42,7 +42,7 @@
     <!-- Empty detail pane -->
     <div class="operations-pane detail-pane empty-detail" v-else>
       <div class="empty-placeholder">
-        <i class="fas fa-info-circle"></i>
+        <Icon name="info-circle" />
         <p>{{ $t('operations.panel.selectOperation') }}</p>
       </div>
     </div>
@@ -55,6 +55,7 @@ import { useI18n } from 'vue-i18n'
 import type { Operation, OperationsFilter } from '@/types/operations'
 import OperationsList from './OperationsList.vue'
 import OperationDetail from './OperationDetail.vue'
+import Icon from '@/components/ui/Icon.vue'
 
 interface Props {
   operations: Operation[]

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -140,7 +140,7 @@
                 :class="{ active: voiceDisplayMode === 'modal' }"
                 type="button"
               >
-                <i class="fas fa-expand-alt mr-1"></i>
+                <Icon name="expand-alt" class="mr-1" />
                 {{ $t('profile.fullScreen') }}
               </button>
               <button
@@ -149,7 +149,7 @@
                 :class="{ active: voiceDisplayMode === 'sidepanel' }"
                 type="button"
               >
-                <i class="fas fa-columns mr-1"></i>
+                <Icon name="columns" class="mr-1" />
                 {{ $t('profile.sidePanel') }}
               </button>
             </div>
@@ -230,6 +230,7 @@ import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
 import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
+import Icon from '@/components/ui/Icon.vue'
 
 const props = defineProps<{
   isOpen: boolean

--- a/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.vue
@@ -17,10 +17,10 @@ Issue #4273: Wire orphaned components EnforcementModeSelector, FlagChangeHistory
 
     <!-- Error State -->
     <div v-else-if="error" class="error-state">
-      <i class="fas fa-exclamation-circle"></i>
+      <Icon name="exclamation-circle" />
       <p>{{ error }}</p>
       <button @click="loadData" class="retry-btn">
-        <i class="fas fa-redo"></i>
+        <Icon name="redo" />
         {{ $t('featureFlags.retry') }}
       </button>
     </div>
@@ -89,6 +89,7 @@ import EndpointEnforcement from '@/components/feature-flags/EndpointEnforcement.
 import FlagChangeHistory from '@/components/feature-flags/FlagChangeHistory.vue';
 import AccessMetrics from '@/components/feature-flags/AccessMetrics.vue';
 import LoadingSpinner from '@/components/ui/LoadingSpinner.vue';
+import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('FeatureFlagsSettingsPanel');
 const { t } = useI18n();

--- a/autobot-frontend/src/components/settings/LanguageSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/LanguageSettingsPanel.vue
@@ -11,7 +11,7 @@ Issue #1330: Language switcher component in Settings
   <form class="language-panel" @submit.prevent>
     <div class="panel-header">
       <h3 class="panel-title">
-        <i class="fas fa-globe" aria-hidden="true"></i>
+        <Icon name="globe" aria-hidden="true" />
         {{ t('settings.languageTitle') }}
       </h3>
     </div>
@@ -19,7 +19,7 @@ Issue #1330: Language switcher component in Settings
     <div class="panel-content">
       <fieldset class="preference-section">
         <legend class="preference-label">
-          <i class="fas fa-language" aria-hidden="true"></i>
+          <Icon name="language" aria-hidden="true" />
           {{ t('settings.languageSelect') }}
         </legend>
         <p class="preference-hint">
@@ -40,15 +40,12 @@ Issue #1330: Language switcher component in Settings
               {{ name }}
             </option>
           </select>
-          <i class="fas fa-chevron-down select-icon" aria-hidden="true"></i>
+          <Icon name="chevron-down" class="select-icon" aria-hidden="true" />
         </div>
       </fieldset>
 
       <div v-if="statusMessage" class="status-message" :class="statusType">
-        <i
-          :class="statusType === 'success' ? 'fas fa-check-circle' : 'fas fa-exclamation-circle'"
-          aria-hidden="true"
-        ></i>
+        <Icon :name="statusType === 'success' ? 'check-circle' : 'exclamation-circle'" aria-hidden="true" />
         {{ statusMessage }}
       </div>
     </div>
@@ -67,6 +64,7 @@ import { useI18n } from 'vue-i18n'
 import { usePreferences } from '@/composables/usePreferences'
 import { useAvailableLanguages } from '@/composables/useAvailableLanguages'
 import { createLogger } from '@/utils/debugUtils'
+import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('LanguageSettingsPanel')
 const { t } = useI18n()

--- a/autobot-frontend/src/components/settings/SettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/SettingsPanel.vue
@@ -11,7 +11,7 @@
 
     <!-- Settings status message -->
     <div v-if="settingsLoadingStatus === 'offline'" class="settings-status offline">
-      <i class="fas fa-exclamation-triangle"></i>
+      <Icon name="exclamation-triangle" />
       <span>{{ $t('settings.backendOffline') }}</span>
     </div>
 
@@ -56,7 +56,7 @@
         {{ isSaving ? $t('settings.saving') : $t('settings.save') }}
       </button>
       <button @click="discardChanges" :disabled="isSaving" class="discard-btn">
-        <i class="fas fa-undo"></i>
+        <Icon name="undo" />
         {{ $t('settings.discardChanges') }}
       </button>
     </div>
@@ -89,6 +89,7 @@ import {
   createDefaultCacheConfig,
   createCacheActivityItem
 } from '@/types/settings'
+import Icon from '@/components/ui/Icon.vue'
 import type {
   SettingsStructure,
   SettingsTab,

--- a/autobot-frontend/src/components/terminal/HostSelector.vue
+++ b/autobot-frontend/src/components/terminal/HostSelector.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="host-selector">
     <div class="selector-label">
-      <i class="fas fa-server text-autobot-text-secondary mr-2"></i>
+      <Icon name="server" class="text-autobot-text-secondary mr-2" />
       <span class="text-sm font-medium text-autobot-text-primary">{{ $t('terminal.host') }}</span>
     </div>
     <select
@@ -32,7 +32,7 @@
       </optgroup>
     </select>
     <div v-if="showDescription && selectedHostConfig" class="host-description">
-      <i class="fas fa-info-circle text-blue-500 mr-1"></i>
+      <Icon name="info-circle" class="text-blue-500 mr-1" />
       <span class="text-xs text-autobot-text-secondary">{{ selectedHostConfig.description }}</span>
     </div>
   </div>
@@ -43,6 +43,7 @@ import { ref, computed, watch, onMounted } from 'vue'
 import { useTerminalStore, AVAILABLE_HOSTS, type HostConfig } from '@/composables/useTerminalStore'
 import { createLogger } from '@/utils/debugUtils'
 import { useHostSelection } from '@/composables/useHostSelection'
+import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('HostSelector')
 

--- a/autobot-frontend/src/components/terminal/SSHTerminal.vue
+++ b/autobot-frontend/src/components/terminal/SSHTerminal.vue
@@ -9,7 +9,7 @@
         class="reconnect-btn"
         @click="connect"
       >
-        <i class="fas fa-sync-alt"></i> Reconnect
+        <Icon name="sync-alt" /> Reconnect
       </button>
     </div>
 
@@ -27,6 +27,7 @@ import '@xterm/xterm/css/xterm.css'
 import { createLogger } from '@/utils/debugUtils'
 import { usePollingJob } from '@/composables/usePollingJob'
 import { useWebSocket } from '@/composables/useWebSocket'
+import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('SSHTerminal')
 

--- a/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
+++ b/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
@@ -2,7 +2,7 @@
   <div class="agent-observability-panel">
     <div class="panel-header">
       <h3>
-        <i class="fas fa-users-cog"></i>
+        <Icon name="users-cog" />
         {{ $t('workflow.agentObservability.title') }}
       </h3>
       <button
@@ -13,19 +13,19 @@
         :title="$t('common.refresh')"
         type="button"
       >
-        <i class="fas fa-sync-alt" :class="{ 'fa-spin': loading }"></i>
+        <Icon name="sync-alt" :spin="loading" />
       </button>
     </div>
 
     <!-- Loading -->
     <div v-if="loading && agentList.length === 0" class="loading-state">
-      <i class="fas fa-spinner fa-spin"></i>
+      <Icon name="spinner" :spin="true" />
       <span>{{ $t('workflow.agentObservability.loading') }}</span>
     </div>
 
     <!-- Empty -->
     <div v-else-if="agentList.length === 0" class="empty-state">
-      <i class="fas fa-robot"></i>
+      <Icon name="robot" />
       <h4>{{ $t('workflow.agentObservability.noAgents') }}</h4>
       <p>{{ $t('workflow.agentObservability.noAgentsDescription') }}</p>
     </div>
@@ -40,7 +40,7 @@
         <div class="agent-header">
           <div class="agent-identity">
             <div class="agent-avatar" :class="getReliabilityClass(agent.reliabilityScore)">
-              <i class="fas fa-robot"></i>
+              <Icon name="robot" />
             </div>
             <div class="agent-name-block">
               <span class="agent-name">{{ agent.name }}</span>
@@ -102,6 +102,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import type { AgentPerformance, AgentCapability } from '@/composables/useWorkflowBuilder';
+import Icon from '@/components/ui/Icon.vue'
 
 const props = defineProps<{
   agentPerformance: Record<string, AgentPerformance>;

--- a/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
@@ -2,7 +2,7 @@
   <div class="template-gallery">
     <div class="gallery-header">
       <div class="search-box">
-        <i class="fas fa-search"></i>
+        <Icon name="search" />
         <input v-model="searchQuery" :placeholder="$t('workflow.templates.searchPlaceholder')" />
       </div>
       <div class="category-filters">
@@ -15,18 +15,18 @@
 
     <!-- Error State -->
     <div v-if="apiError" class="error-state">
-      <i class="fas fa-exclamation-triangle"></i>
+      <Icon name="exclamation-triangle" />
       <p>{{ apiError }}</p>
-      <button class="btn-secondary" @click="retryLoad"><i class="fas fa-redo"></i> {{ $t('workflow.templates.retry') }}</button>
+      <button class="btn-secondary" @click="retryLoad"><Icon name="redo" /> {{ $t('workflow.templates.retry') }}</button>
     </div>
 
     <div v-else-if="effectiveLoading" class="loading-state">
-      <i class="fas fa-spinner fa-spin"></i>
+      <Icon name="spinner" :spin="true" />
       <span>{{ $t('workflow.templates.loading') }}</span>
     </div>
 
     <div v-else-if="filteredTemplates.length === 0" class="empty-state">
-      <i class="fas fa-clone"></i>
+      <Icon name="clone" />
       <p>{{ $t('workflow.templates.noMatch') }}</p>
     </div>
 
@@ -40,13 +40,13 @@
           <p>{{ template.description }}</p>
           <div class="template-meta">
             <span class="category-badge">{{ template.category }}</span>
-            <span v-if="getStepsCount(template)" class="steps-count"><i class="fas fa-list-ol"></i> {{ $t('workflow.templates.stepsCount', { count: getStepsCount(template) }) }}</span>
-            <span v-if="template.estimated_duration_minutes" class="duration"><i class="fas fa-clock"></i> {{ template.estimated_duration_minutes }}m</span>
+            <span v-if="getStepsCount(template)" class="steps-count"><Icon name="list-ol" /> {{ $t('workflow.templates.stepsCount', { count: getStepsCount(template) }) }}</span>
+            <span v-if="template.estimated_duration_minutes" class="duration"><Icon name="clock" /> {{ template.estimated_duration_minutes }}m</span>
           </div>
         </div>
         <div class="template-actions">
-          <button class="btn-icon" @click.stop="openPreview(template)" :title="$t('workflow.templates.preview')" :aria-label="$t('workflow.templates.preview')"><i class="fas fa-eye"></i></button>
-          <button class="btn-run" @click.stop="$emit('run-template', template)" :title="$t('workflow.templates.runNow')" :aria-label="$t('workflow.templates.runNow')"><i class="fas fa-play"></i></button>
+          <button class="btn-icon" @click.stop="openPreview(template)" :title="$t('workflow.templates.preview')" :aria-label="$t('workflow.templates.preview')"><Icon name="eye" /></button>
+          <button class="btn-run" @click.stop="$emit('run-template', template)" :title="$t('workflow.templates.runNow')" :aria-label="$t('workflow.templates.runNow')"><Icon name="play" /></button>
         </div>
       </div>
     </div>
@@ -56,7 +56,7 @@
       <div v-if="previewTemplate" class="preview-panel">
         <div class="preview-header">
           <h3>{{ previewTemplate.name }}</h3>
-          <button @click="previewTemplate = null" :aria-label="$t('common.close')"><i class="fas fa-times"></i></button>
+          <button @click="previewTemplate = null" :aria-label="$t('common.close')"><Icon name="times" /></button>
         </div>
         <div class="preview-body">
           <p class="preview-desc">{{ previewTemplate.description }}</p>
@@ -74,7 +74,7 @@
             <h4>Required Credentials</h4>
             <div class="secret-items">
               <div v-for="(meta, key) in (previewTemplate as any).required_secrets" :key="key" class="secret-item">
-                <i class="fas fa-key"></i>
+                <Icon name="key" />
                 <div class="secret-info">
                   <span class="secret-name">{{ key }}</span>
                   <span class="secret-desc">{{ meta.description }}</span>
@@ -94,15 +94,15 @@
                 <code v-else-if="step.action">{{ step.action }}</code>
                 <div class="step-meta">
                   <span v-if="step.agent_type" class="agent">{{ step.agent_type }}</span>
-                  <span v-if="step.requires_approval"><i class="fas fa-shield-alt"></i> {{ $t('workflow.templates.requiresConfirmation') }}</span>
+                  <span v-if="step.requires_approval"><Icon name="shield-alt" /> {{ $t('workflow.templates.requiresConfirmation') }}</span>
                 </div>
               </div>
             </div>
           </div>
         </div>
         <div class="preview-actions">
-          <button class="btn-secondary" @click="$emit('select-template', previewTemplate)"><i class="fas fa-edit"></i> {{ $t('workflow.templates.editInCanvas') }}</button>
-          <button class="btn-primary" @click="$emit('run-template', previewTemplate)"><i class="fas fa-play"></i> {{ $t('workflow.templates.runWorkflow') }}</button>
+          <button class="btn-secondary" @click="$emit('select-template', previewTemplate)"><Icon name="edit" /> {{ $t('workflow.templates.editInCanvas') }}</button>
+          <button class="btn-primary" @click="$emit('run-template', previewTemplate)"><Icon name="play" /> {{ $t('workflow.templates.runWorkflow') }}</button>
         </div>
       </div>
     </Transition>
@@ -119,6 +119,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import type { WorkflowTemplate } from '@/composables/useWorkflowBuilder'
 import { useWorkflowTemplates } from '@/composables/useWorkflowTemplates'
 import type { WorkflowTemplateSummary, TemplateCategory, TemplateStep } from '@/types/workflowTemplates'
+import Icon from '@/components/ui/Icon.vue'
 
 // Combined template type for flexibility
 type AnyTemplate = WorkflowTemplate | WorkflowTemplateSummary


### PR DESCRIPTION
## Summary

Migrates 48 Vue component files from direct FontAwesome icon imports to the canonical \`Icon.vue\` wrapper component.

- Closes #6442 — FA icon migration: replace direct FA imports with Icon.vue wrapper
- Closes #4805 — type migration cleanup related to icon component refactor

## Changes

- 48 frontend component files updated to use \`<Icon name="..." />\` instead of raw \`<i class="fas fa-*">\` elements
- Fixed missed FA spinner migration in VisualBrowserPanel go-button v-else branch
- Fixed CSS viewport-icon and url-icon sizing: replaced \`font-size\` with \`width/height\` for correct SVG sizing
- Fixed unmigrated breadcrumb separator in FilePathNavigation

## Test plan

- [ ] Visual spot-check of icon rendering in browser
- [ ] Viewport state icons (globe, spinner, camera) display at correct large size
- [ ] Breadcrumb separators render correctly in file browser
- [ ] No console errors related to icon components

## Changelog fragment

- [ ] Added \`changelog/unreleased/{issue}-{slug}.md\` — or N/A (internal change)

N/A — internal refactor, no user-visible behaviour change beyond icon rendering parity.