### PR TITLE
fix(llm): Ollama tool wiring — tool_choice, format conflict, review fixes (#7911)

### DIFF
--- a/autobot-backend/llm_shared/providers/ollama.py
+++ b/autobot-backend/llm_shared/providers/ollama.py
@@ -101,13 +101,14 @@ class OllamaProvider:
         Returns:
             Request data dictionary
         """
+        tools_will_be_sent = bool(request.tools) and _model_supports_tools(model)
         data: dict = {
             "model": model,
             "messages": request.messages,
             "stream": use_streaming,
             "temperature": request.temperature,
-            # Ollama rejects format=json when tools are present (#7911)
-            "format": "json" if (request.structured_output and not request.tools) else "",
+            # Ollama rejects format=json when tools are active (#7911)
+            "format": "json" if (request.structured_output and not tools_will_be_sent) else "",
             "options": {
                 "seed": 42,
                 "top_k": self.settings.top_k,
@@ -116,7 +117,7 @@ class OllamaProvider:
                 "num_ctx": self.settings.num_ctx,
             },
         }
-        if request.tools and _model_supports_tools(model):
+        if tools_will_be_sent:
             data["tools"] = [
                 {
                     "type": "function",
@@ -471,6 +472,9 @@ class OllamaProvider:
 
         model = request.model_name or self.settings.default_model
         use_streaming = self.streaming_manager.should_use_streaming(model)
+        # Streaming discards tool_call chunks; force non-streaming when tools active
+        if request.tools and _model_supports_tools(model):
+            use_streaming = False
         data = self.build_request_data(request, model, use_streaming)
         span_attrs = self._build_span_attributes(model, use_streaming, request)
 

--- a/autobot-backend/llm_shared/providers/ollama.py
+++ b/autobot-backend/llm_shared/providers/ollama.py
@@ -10,6 +10,7 @@ Issue #551: Added proper async cancellation handling and timeout fixes.
 
 import asyncio
 import time
+import uuid
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
@@ -105,7 +106,8 @@ class OllamaProvider:
             "messages": request.messages,
             "stream": use_streaming,
             "temperature": request.temperature,
-            "format": "json" if request.structured_output else "",
+            # Ollama rejects format=json when tools are present (#7911)
+            "format": "json" if (request.structured_output and not request.tools) else "",
             "options": {
                 "seed": 42,
                 "top_k": self.settings.top_k,
@@ -126,6 +128,8 @@ class OllamaProvider:
                 }
                 for t in request.tools
             ]
+            if request.tool_choice:
+                data["tool_choice"] = request.tool_choice
         return data
 
     def extract_content(self, response: dict) -> str:
@@ -165,7 +169,7 @@ class OllamaProvider:
             fn = tc.get("function", {}) if isinstance(tc, dict) else {}
             result.append(
                 ToolCall(
-                    id=tc.get("id", ""),
+                    id=tc.get("id") or str(uuid.uuid4()),
                     name=fn.get("name", ""),
                     arguments=fn.get("arguments", {}),
                 )
@@ -206,7 +210,7 @@ class OllamaProvider:
             metadata=response.get("stats", {}),
             usage=response.get("usage", {}),
             fallback_used=fallback_used,
-            tool_calls=tool_calls or None,
+            tool_calls=tool_calls,
         )
 
     def build_error_response(self, model: str, error: Exception) -> dict:
@@ -366,6 +370,9 @@ class OllamaProvider:
 
         logger.info(f"[{request_id}] Stream processing completed: " f"{len(accumulated_content)} chars")
 
+        # NOTE: Streaming mode accumulates only text content. tool_calls chunks
+        # from Ollama's streaming protocol are not captured here — use non-streaming
+        # mode when tool_calls extraction is required. Tracked in GH#7911.
         return {
             "message": {"role": "assistant", "content": accumulated_content},
             "done": True,
@@ -501,7 +508,7 @@ class OllamaProvider:
             response = await self._execute_request(url, headers, data, request.request_id, model, use_streaming)
             processing_time = time.time() - start_time
             content = self.extract_content(response)
-            tool_calls = self.extract_tool_calls(response) or None
+            tool_calls = self.extract_tool_calls(response)
             llm_response = self.build_response(
                 content, response, model, processing_time, request.request_id, tool_calls=tool_calls
             )
@@ -525,6 +532,4 @@ class OllamaProvider:
 
 __all__ = [
     "OllamaProvider",
-    "_model_supports_tools",
-    "_OLLAMA_TOOL_CAPABLE_MODELS",
 ]

--- a/autobot-backend/llm_shared/providers/ollama_test.py
+++ b/autobot-backend/llm_shared/providers/ollama_test.py
@@ -29,11 +29,13 @@ def _make_provider() -> OllamaProvider:
     return OllamaProvider(settings=settings, streaming_manager=streaming_manager)
 
 
-def _make_request(model: str = "llama3.1", tools=None) -> LLMRequest:
+def _make_request(model: str = "llama3.1", tools=None, tool_choice=None, structured_output=False) -> LLMRequest:
     return LLMRequest(
         messages=[{"role": "user", "content": "What is the weather in Paris?"}],
         model_name=model,
         tools=tools,
+        tool_choice=tool_choice,
+        structured_output=structured_output,
     )
 
 
@@ -91,6 +93,34 @@ class TestBuildRequestDataTools:
         data = provider.build_request_data(req, "llama3.1:8b", use_streaming=False)
 
         assert "tools" not in data
+
+    def test_tool_choice_forwarded_for_capable_model(self):
+        provider = _make_provider()
+        req = _make_request(model="llama3.1:8b", tools=[_TOOL], tool_choice="auto")
+        data = provider.build_request_data(req, "llama3.1:8b", use_streaming=False)
+
+        assert data.get("tool_choice") == "auto"
+
+    def test_tool_choice_not_forwarded_for_incapable_model(self):
+        provider = _make_provider()
+        req = _make_request(model="llama2", tools=[_TOOL], tool_choice="auto")
+        data = provider.build_request_data(req, "llama2", use_streaming=False)
+
+        assert "tool_choice" not in data
+
+    def test_format_json_suppressed_when_tools_present(self):
+        provider = _make_provider()
+        req = _make_request(model="llama3.1:8b", tools=[_TOOL], structured_output=True)
+        data = provider.build_request_data(req, "llama3.1:8b", use_streaming=False)
+
+        assert data["format"] == ""
+
+    def test_format_json_set_when_structured_output_no_tools(self):
+        provider = _make_provider()
+        req = _make_request(model="llama3.1:8b", tools=None, structured_output=True)
+        data = provider.build_request_data(req, "llama3.1:8b", use_streaming=False)
+
+        assert data["format"] == "json"
 
 
 # ---------------------------------------------------------------------------
@@ -151,6 +181,21 @@ class TestExtractToolCalls:
         assert len(calls) == 2
         assert calls[0].name == "tool_a"
         assert calls[1].name == "tool_b"
+
+    def test_missing_id_gets_uuid_fallback(self):
+        provider = _make_provider()
+        response = {
+            "message": {
+                "tool_calls": [
+                    {"function": {"name": "tool_a", "arguments": {}}},
+                ]
+            }
+        }
+        calls = provider.extract_tool_calls(response)
+
+        assert len(calls) == 1
+        assert calls[0].id != ""
+        assert len(calls[0].id) == 36  # uuid4 format
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llm_shared/providers/ollama_test.py
+++ b/autobot-backend/llm_shared/providers/ollama_test.py
@@ -231,3 +231,46 @@ class TestBuildResponseToolCalls:
         )
 
         assert llm_resp.tool_calls is None
+
+
+# ---------------------------------------------------------------------------
+# _prepare_chat_request — streaming override and format gate
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareCharRequestToolAwareness:
+    def test_streaming_forced_off_for_capable_model_with_tools(self):
+        """StreamingManager always returns True; must be overridden when tools active."""
+        provider = _make_provider()
+        provider.streaming_manager.should_use_streaming.return_value = True
+        provider.ollama_host = "http://localhost:11434"
+
+        req = _make_request(model="llama3.1:8b", tools=[_TOOL])
+        _, _, _, use_streaming, data, _ = provider._prepare_chat_request(req)
+
+        assert use_streaming is False
+        assert data["stream"] is False
+
+    def test_streaming_preserved_for_incapable_model(self):
+        """Non-capable model with tools: streaming unchanged, tools not injected."""
+        provider = _make_provider()
+        provider.streaming_manager.should_use_streaming.return_value = True
+        provider.ollama_host = "http://localhost:11434"
+
+        req = _make_request(model="llama2", tools=[_TOOL])
+        _, _, _, use_streaming, data, _ = provider._prepare_chat_request(req)
+
+        assert use_streaming is True
+        assert "tools" not in data
+
+    def test_format_json_preserved_for_incapable_model_with_structured_output(self):
+        """Incapable model with structured_output=True, tools=[...]: format=json must survive."""
+        provider = _make_provider()
+        provider.streaming_manager.should_use_streaming.return_value = False
+        provider.ollama_host = "http://localhost:11434"
+
+        req = _make_request(model="llama2", tools=[_TOOL], structured_output=True)
+        _, _, _, _, data, _ = provider._prepare_chat_request(req)
+
+        assert data["format"] == "json"
+        assert "tools" not in data


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #8305 addressing CodeReviewer blocking issues on Ollama tool wiring.

- Fix `format="json"` + `tools=` conflict — Ollama rejects both simultaneously; suppress `format` when tools are present
- Forward `request.tool_choice` to request data (was missing; every other provider does this)
- Use `uuid4()` fallback when Ollama omits `tool_call.id`
- Remove `or None` double-negation from `extract_tool_calls` and `build_response`
- Remove private symbols `_model_supports_tools` and `_OLLAMA_TOOL_CAPABLE_MODELS` from `__all__`
- Document streaming limitation: tool_calls chunks not captured in streaming mode
- 5 new tests: tool_choice forwarding, format suppression, uuid fallback

Resolves all 6 findings from CodeReviewer's review of PR #8305.

## Test plan

- [ ] `test_format_json_suppressed_when_tools_present` — format="" when tools+structured_output
- [ ] `test_format_json_set_when_structured_output_no_tools` — format="json" when no tools
- [ ] `test_tool_choice_forwarded_for_capable_model` — tool_choice in data for capable model
- [ ] `test_tool_choice_not_forwarded_for_incapable_model` — no tool_choice for incapable
- [ ] `test_missing_id_gets_uuid_fallback` — uuid4 assigned when id absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)