### PR TITLE
fix: unified_audit OOM/TTL + PersistStrategy.REDIS + chat_knowledge null data (#8301–#8304)

### DIFF
--- a/autobot-backend/api/chat_knowledge.py
+++ b/autobot-backend/api/chat_knowledge.py
@@ -517,7 +517,8 @@ async def create_chat_context(request_data: CreateContextRequest, request: Reque
 
         return {
             "success": True,
-            "context": {
+            "data": {
+                "success": True,
                 "chat_id": context.chat_id,
                 "topic": context.topic,
                 "keywords": context.keywords,
@@ -551,7 +552,8 @@ async def associate_file_with_chat(request_data: AssociateFileRequest, request: 
 
         return {
             "success": True,
-            "association": {
+            "data": {
+                "success": True,
                 "file_id": association.file_id,
                 "file_name": association.file_name,
                 "association_type": association.association_type.value,
@@ -604,7 +606,7 @@ async def upload_file_to_chat(
             metadata={"original_filename": file.filename},
         )
 
-        return {"success": True, "file_id": association.file_id, "file_path": file_path}
+        return {"success": True, "data": {"success": True, "file_id": association.file_id, "file_path": file_path}}
 
     except Exception as e:
         logger.error("Failed to upload file: %s", e)
@@ -624,7 +626,7 @@ async def add_temporary_knowledge(request: AddKnowledgeRequest):
             chat_id=request.chat_id, content=request.content, metadata=request.metadata
         )
 
-        return {"success": True, "knowledge_id": knowledge_id}
+        return {"success": True, "data": {"success": True, "knowledge_id": knowledge_id}}
 
     except Exception as e:
         logger.error("Failed to add temporary knowledge: %s", e)
@@ -644,8 +646,11 @@ async def get_pending_knowledge_decisions(chat_id: str):
 
         return {
             "success": True,
-            "pending_items": pending_items,
-            "count": len(pending_items),
+            "data": {
+                "success": True,
+                "pending_items": pending_items,
+                "count": len(pending_items),
+            },
         }
 
     except Exception as e:
@@ -669,8 +674,11 @@ async def apply_knowledge_decision(request: KnowledgeDecisionRequest):
         )
 
         return {
-            "success": success,
-            "message": f"Knowledge {request.decision.value} applied",
+            "success": True,
+            "data": {
+                "success": success,
+                "message": f"Knowledge {request.decision.value} applied",
+            },
         }
 
     except Exception as e:
@@ -694,7 +702,7 @@ async def compile_chat_to_knowledge(request_data: CompileChatRequest, request: R
             include_system_messages=request_data.include_system_messages,
         )
 
-        return {"success": True, "compiled": compiled}
+        return {"success": True, "data": {"success": True, "compiled": compiled}}
 
     except Exception as e:
         logger.error("Failed to compile chat: %s", e)
@@ -716,7 +724,7 @@ async def search_chat_knowledge(request: ChatKnowledgeSearchRequest):
             include_temporary=request.include_temporary,
         )
 
-        return {"success": True, "results": results, "count": len(results)}
+        return {"success": True, "data": {"success": True, "results": results, "count": len(results)}}
 
     except Exception as e:
         logger.error("Failed to search knowledge: %s", e)
@@ -735,13 +743,14 @@ async def get_chat_context(chat_id: str):
         context = chat_knowledge_manager.chat_contexts.get(chat_id)
 
         if not context:
-            return {"success": False, "message": "No context found for chat"}
+            return {"success": False, "message": "No context found for chat", "data": None}
 
         file_associations = chat_knowledge_manager.file_associations.get(chat_id, [])
 
         return {
             "success": True,
-            "context": {
+            "data": {
+                "success": True,
                 "chat_id": context.chat_id,
                 "topic": context.topic,
                 "keywords": context.keywords,

--- a/autobot-backend/events/bus.py
+++ b/autobot-backend/events/bus.py
@@ -71,6 +71,17 @@ class EventBus:
             payload: Event payload dict.
             persist: Which backend(s) receive the event.
         """
+        if persist is PersistStrategy.REDIS:
+            # #8304: REDIS strategy has no implementation in this facade.
+            # Callers needing durable Redis events must use RedisEventStreamManager
+            # directly.  Log a critical error instead of silently dropping.
+            logger.critical(
+                "PersistStrategy.REDIS is not implemented in EventBus — event dropped "
+                "(channel=%s, event_type=%s). Use RedisEventStreamManager directly.",
+                channel,
+                event_type,
+            )
+            return
         if persist in (PersistStrategy.NONE, PersistStrategy.BOTH):
             await get_event_manager().publish(event_type, {"channel": channel, **payload})
         if persist in (PersistStrategy.MEMORY, PersistStrategy.BOTH):

--- a/autobot-backend/services/audit/unified_audit.py
+++ b/autobot-backend/services/audit/unified_audit.py
@@ -93,8 +93,8 @@ async def record(event: AuditEvent) -> None:
     ttl = _CATEGORY_TTL.get(event.category.value, _COMPLIANCE_TTL)
     async with redis.pipeline() as pipe:
         await pipe.zadd(UNIFIED_KEY, {raw: event.occurred_at})
-        await pipe.expire(UNIFIED_KEY, ttl)
-        # Per-category secondary index for scoped queries
+        # UNIFIED_KEY spans all categories with different TTLs — never set expire
+        # on it (#8303). Per-category keys each carry their own TTL.
         cat_key = f"audit:category:{event.category.value}"
         await pipe.zadd(cat_key, {raw: event.occurred_at})
         await pipe.expire(cat_key, ttl)
@@ -122,6 +122,7 @@ async def query(
     to_ts: float | None = None,
     limit: int = 100,
     offset: int = 0,
+    max_scan: int = 10_000,
 ) -> List[Dict[str, Any]]:
     """Query audit events.  Filters are applied in-memory after a Redis scan."""
     redis = await get_async_redis_client(database="main")
@@ -130,7 +131,8 @@ async def query(
     key = f"audit:category:{category.value}" if category else UNIFIED_KEY
     min_score: Any = from_ts if from_ts is not None else 0
     max_score: Any = to_ts if to_ts is not None else "+inf"
-    raws = await redis.zrangebyscore(key, min_score, max_score)
+    # #8302: cap Redis scan before Python-side filtering to prevent OOM
+    raws = await redis.zrangebyscore(key, min_score, max_score, start=0, num=max_scan)
     results: List[Dict[str, Any]] = []
     for raw in raws:
         try:


### PR DESCRIPTION
## Summary

Fixes four independent backend bugs identified in GH#8301–#8304.

- **#8303 (critical)** `unified_audit.record()` called `pipe.expire(UNIFIED_KEY, ttl)` on every write. Because the unified sorted set spans all four audit categories with different retention windows (security/compliance = 90d, governance/knowledge = 365d), any write of a short-TTL category after a long-TTL write would silently shrink the key's lifetime to 90 days, evicting governance records. Fix: remove the `expire` call for `UNIFIED_KEY`; only per-category keys receive their own TTL.

- **#8302 (high)** `unified_audit.query()` called `zrangebyscore` with no LIMIT, loading the entire audit store into Python memory before paginating. Fix: add `start=0, num=max_scan` (default 10 000) to cap the Redis scan before in-memory filtering.

- **#8304 (high)** `PersistStrategy.REDIS` was a public enum member in `events/bus.py` with no code path in `EventBus.publish()`, causing events to be silently dropped. Fix: add an explicit guard that logs `CRITICAL` and returns early, so callers know they need `RedisEventStreamManager` directly.

- **#8301** All `DataResponse[ChatKnowledge*Data]` route handlers returned payloads as sibling keys (`context`, `association`, `results`, …) at the top level of the response dict. `DataResponse` only maps `success`, `data`, `message`, `timestamp`, so all other keys were stripped by Pydantic and `data` was always `None`. Fix: wrap every return payload under `data=`.

## Files changed

- `autobot-backend/services/audit/unified_audit.py` — #8302, #8303
- `autobot-backend/events/bus.py` — #8304
- `autobot-backend/api/chat_knowledge.py` — #8301

## Test plan

- [ ] `unified_audit`: call `record()` with a governance event followed by a security event; verify `UNIFIED_KEY` has no TTL (`TTL` returns -1) while `audit:category:security` has TTL ≈ 90d
- [ ] `unified_audit.query()`: with `from_ts`/`to_ts` spanning > 10k records, confirm no OOM; smaller sets return correct results
- [ ] `EventBus.publish(persist=PersistStrategy.REDIS)`: verify CRITICAL log appears and no event is published to EventManager or LiveEventManager
- [ ] `GET /api/chat-knowledge/context/{id}` and all sibling endpoints: confirm `data` field is non-null in response JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)