### PR TITLE
fix(models,connectors,config,ci): discovery fixes #8271 #8275 #8276 #8281

### DIFF
--- a/autobot-backend/chat_history/cache.py
+++ b/autobot-backend/chat_history/cache.py
@@ -33,7 +33,7 @@ logger = get_logger(__name__)
 # by default). Override via env var when tuning memory pressure.
 def _resolve_chat_session_cache_ttl() -> int:
     """Return TTL seconds for chat:session:* Redis keys."""
-    raw = config.chat_session_cache_ttl
+    raw = config.misc.chat_session_cache_ttl
     if raw is None:
         return TTL_24_HOURS
     try:
@@ -71,7 +71,7 @@ _CHAT_RECENT_MAX_ENTRIES_DEFAULT = 1000
 
 def _resolve_chat_recent_max_entries() -> int:
     """Return max members for the chat:recent sorted set."""
-    raw = config.chat_recent_max_entries
+    raw = config.misc.chat_recent_max_entries
     if raw is None:
         return _CHAT_RECENT_MAX_ENTRIES_DEFAULT
     try:

--- a/autobot-backend/chat_history/cache_test.py
+++ b/autobot-backend/chat_history/cache_test.py
@@ -22,7 +22,7 @@ def _reload_cache_with_env(env_value):
     if env_value is None:
         os.environ.pop("AUTOBOT_CHAT_SESSION_CACHE_TTL", None)
     else:
-        config.chat_session_cache_ttl = env_value
+        config.misc.chat_session_cache_ttl = env_value
     import chat_history.cache as cache_mod
 
     importlib.reload(cache_mod)
@@ -31,12 +31,12 @@ def _reload_cache_with_env(env_value):
 
 @pytest.fixture(autouse=True)
 def _restore_env():
-    saved = config.chat_session_cache_ttl
+    saved = config.misc.chat_session_cache_ttl
     yield
     if saved is None:
         os.environ.pop("AUTOBOT_CHAT_SESSION_CACHE_TTL", None)
     else:
-        config.chat_session_cache_ttl = saved
+        config.misc.chat_session_cache_ttl = saved
     import chat_history.cache as cache_mod
 
     importlib.reload(cache_mod)
@@ -86,7 +86,7 @@ def _reload_cache_with_recent_env(env_value):
     if env_value is None:
         os.environ.pop("AUTOBOT_CHAT_RECENT_MAX_ENTRIES", None)
     else:
-        config.chat_recent_max_entries = env_value
+        config.misc.chat_recent_max_entries = env_value
     import chat_history.cache as cache_mod
 
     importlib.reload(cache_mod)
@@ -95,12 +95,12 @@ def _reload_cache_with_recent_env(env_value):
 
 @pytest.fixture(autouse=False)
 def _restore_recent_env():
-    saved = config.chat_recent_max_entries
+    saved = config.misc.chat_recent_max_entries
     yield
     if saved is None:
         os.environ.pop("AUTOBOT_CHAT_RECENT_MAX_ENTRIES", None)
     else:
-        config.chat_recent_max_entries = saved
+        config.misc.chat_recent_max_entries = saved
     import chat_history.cache as cache_mod
 
     importlib.reload(cache_mod)

--- a/autobot-backend/knowledge/connectors/registry.py
+++ b/autobot-backend/knowledge/connectors/registry.py
@@ -19,6 +19,8 @@ Usage:
     running = ConnectorRegistry.get("my-connector-id")
 """
 
+from __future__ import annotations
+
 import asyncio
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Type

--- a/autobot-backend/user_management/models/api_key.py
+++ b/autobot-backend/user_management/models/api_key.py
@@ -7,6 +7,8 @@ API Key Model
 Long-lived API keys for programmatic access.
 """
 
+from __future__ import annotations
+
 import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional

--- a/autobot-slm-backend/requirements.txt
+++ b/autobot-slm-backend/requirements.txt
@@ -11,6 +11,7 @@ prometheus-client>=0.25.0
 
 # Web framework
 fastapi>=0.136.1                # SECURITY UPDATE - requires starlette >=0.52.1
+starlette>=0.52.1              # explicit pin — avoids python_multipart __all__ ImportError on older starlette (#8275)
 uvicorn[standard]>=0.47.0
 
 # Database - PostgreSQL (Issue #786)


### PR DESCRIPTION
## Summary

Four small discovery fixes in one atomic PR:

- **GH#8271** — `user_management/models/api_key.py`: add `from __future__ import annotations` to fix `Mapped["Team"|None]` PEP 604 TypeError on Python 3.10
- **GH#8276** — `knowledge/connectors/registry.py`: add `from __future__ import annotations` to fix `"object"|None` annotation evaluation error
- **GH#8281** — `chat_history/cache.py` + `cache_test.py`: `config.chat_session_cache_ttl` → `config.misc.chat_session_cache_ttl`, `config.chat_recent_max_entries` → `config.misc.chat_recent_max_entries` (6 occurrences; `MiscConfig` fields live at `config.misc` per `ssot_config.py:1464`)
- **GH#8275** — `autobot-slm-backend/requirements.txt`: explicit `starlette>=0.52.1` pin to prevent `python_multipart __all__` ImportError in CI when pip resolves an older starlette

## Code review

Reviewed by CodeReviewer (eefa6dd4):
- `from __future__ import annotations` placement is correct (before stdlib imports) in both files
- `config.misc.*` path verified against `ssot_config.py:1464` — `misc: MiscConfig = Field(default_factory=MiscConfig)`
- All 6 test occurrences updated consistently with production code
- `starlette` pin comment style matches existing `fastapi` constraint comment
- No other callers of `config.chat_session_cache_ttl` or `config.chat_recent_max_entries` outside `cache.py`/`cache_test.py`

✅ Approved for merge.

## Test plan

- [ ] `python -c 'from user_management.models.api_key import ApiKey'` — no TypeError on 3.10
- [ ] `python -c 'from knowledge.connectors.registry import ConnectorRegistry'` — no annotation error
- [ ] `pytest autobot-backend/chat_history/cache_test.py` — all TTL/recent-max tests pass
- [ ] SLM CI: `pip install -r autobot-slm-backend/requirements.txt` with Python 3.10/3.11 — no `python_multipart` ImportError

Closes GH#8271, GH#8275, GH#8276, GH#8281

🤖 Generated with [Claude Code](https://claude.ai/claude-code)