### PR TITLE
fix(api/health): wire NPU worker into npu_acceleration capability flag (#6768)

### DIFF
--- a/autobot-backend/initialization/endpoints.py
+++ b/autobot-backend/initialization/endpoints.py
@@ -59,14 +59,16 @@ def _build_services_status(state: Any) -> Dict[str, str]:
     }
 
 
-def _build_capabilities(ai_stack_ready: bool, ai_agents_ready: bool) -> Dict[str, bool]:
+def _build_capabilities(
+    ai_stack_ready: bool, ai_agents_ready: bool, npu_ready: bool
+) -> Dict[str, bool]:
     """Build capabilities dict from AI readiness flags."""
     return {
         "rag_enhanced_search": ai_stack_ready,
         "multi_agent_coordination": ai_agents_ready,
         "knowledge_extraction": ai_stack_ready,
         "enhanced_chat": ai_stack_ready,
-        "npu_acceleration": ai_agents_ready,
+        "npu_acceleration": npu_ready,
     }
 
 
@@ -125,6 +127,7 @@ def register_root_endpoints(app: FastAPI) -> None:
         services = _build_services_status(state)
         ai_stack_ready = services.get("ai_stack") == "connected"
         ai_agents_ready = services.get("ai_stack_agents") == "ready"
+        npu_ready = bool(getattr(state, "npu_worker_ready", False))
         return {
             "status": "healthy",
             "timestamp": datetime.now(tz=timezone.utc).isoformat(),
@@ -136,7 +139,7 @@ def register_root_endpoints(app: FastAPI) -> None:
             # consumers don't conflate this with the (much larger) total in
             # /api/agents/registry. (#6749 follow-up — Chrome-plugin TODO #8.)
             "ai_stack_agent_count": _get_agent_count(state),
-            "capabilities": _build_capabilities(ai_stack_ready, ai_agents_ready),
+            "capabilities": _build_capabilities(ai_stack_ready, ai_agents_ready, npu_ready),
             "circuit_breakers": _get_circuit_breaker_states(),
         }
 

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -493,21 +493,26 @@ async def _init_npu_worker_websocket():
         logger.warning("NPU worker WebSocket initialization failed: %s", npu_ws_error)
 
 
-async def _warmup_npu_connection():
+async def _warmup_npu_connection(app: FastAPI) -> None:
     """
     Warm up NPU worker connection for fast first-request embedding (NON-CRITICAL).
 
     Issue #165: Pre-initializes the NPU connection pool and performs a test
     embedding to ensure the NPU worker's model is ready. This eliminates
     cold-start latency on the first real embedding request.
+
+    Sets app.state.npu_worker_ready so /api/health can report accurate
+    npu_acceleration capability status (#6768).
     """
     logger.info("✅ [ 82%] NPU Warmup: Warming up NPU connection...")
+    npu_ready = False
     try:
         from knowledge.facts import warmup_npu_connection
 
         result = await warmup_npu_connection()
 
         if result["status"] == "success":
+            npu_ready = True
             logger.info(
                 "✅ [ 82%] NPU Warmup: Connection ready (%.1fms, %d dimensions)",
                 result.get("warmup_time_ms", 0),
@@ -520,6 +525,8 @@ async def _warmup_npu_connection():
 
     except Exception as warmup_error:
         logger.warning("NPU warmup failed: %s", warmup_error)
+    finally:
+        app.state.npu_worker_ready = npu_ready
 
 
 async def _start_doc_sync_queue_worker(app: FastAPI) -> None:
@@ -1409,7 +1416,7 @@ async def initialize_background_services(app: FastAPI):
         # self-health endpoint (circular deadlock). Phase 2 re-enabled (#970).
         await _init_knowledge_base(app)
         await _init_npu_worker_websocket()
-        await _warmup_npu_connection()
+        await _warmup_npu_connection(app)
         await _init_memory_graph(app)
         await _init_slm_client()
         await _init_background_llm_sync(app)


### PR DESCRIPTION
## Summary

- `npu_acceleration` in `/api/health` was always `false` because it read `ai_agents_ready` (AI Stack flag) instead of the NPU worker state
- Added `app.state.npu_worker_ready` set by `_warmup_npu_connection()` on successful warmup
- `_build_capabilities()` now accepts a dedicated `npu_ready` parameter
- `_health_payload()` reads `getattr(state, "npu_worker_ready", False)` for the NPU flag

## Test plan

- [ ] Start backend with NPU worker available → `/api/health` returns `npu_acceleration: true`
- [ ] Start backend without NPU → `/api/health` returns `npu_acceleration: false`
- [ ] Verify `ai_agents_ready` still reflects AI Stack agent status independently

Closes #6768

🤖 Generated with [Claude Code](https://claude.com/claude-code)