### PR TITLE
feat(mcp): admin endpoints to generate/revoke scoped tokens (#6453)

### DIFF
--- a/autobot-backend/api/mcp_token_admin.py
+++ b/autobot-backend/api/mcp_token_admin.py
@@ -1,0 +1,271 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Admin API: MCP client token management (Issue #6453).
+
+Endpoints:
+    POST   /api/mcp/tokens         — generate a new scoped MCP client token
+    GET    /api/mcp/tokens         — list active tokens (masked secret + last-used)
+    DELETE /api/mcp/tokens/{token_id} — revoke a token
+
+Access: admin or superadmin role required.
+
+Redis storage layout:
+    mcp:token:by_secret:{secret}  → JSON record {token_id, scopes, label,
+                                                  created_at, last_used}
+    mcp:tokens:index              → Redis set of token_ids
+    mcp:token:id:{token_id}       → secret (reverse-lookup for revoke)
+"""
+
+import json
+import secrets
+import time
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Request
+from pydantic import BaseModel, Field
+
+from auth_middleware import get_auth_middleware
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_async_redis_client
+from utils.catalog_http_exceptions import raise_auth_error
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/mcp", tags=["mcp", "admin", "mcp-tokens"])
+
+_VALID_SCOPES = {"kb", "memory", "agents"}
+_SECRET_BYTES = 32  # 256-bit entropy
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class CreateTokenRequest(BaseModel):
+    scopes: List[str] = Field(..., description="List of scopes: kb, memory, agents")
+    label: str = Field(default="", description="Human-readable label for this token")
+
+
+class TokenRecord(BaseModel):
+    token_id: str
+    label: str
+    scopes: List[str]
+    created_at: float
+    last_used: float | None
+    masked_secret: str  # first 4 chars + "..."
+
+
+class CreateTokenResponse(BaseModel):
+    token_id: str
+    token: str  # full "<secret>:<scopes>" — shown once, never again
+    scopes: List[str]
+    label: str
+
+
+class ListTokensResponse(BaseModel):
+    tokens: List[TokenRecord]
+    count: int
+
+
+class RevokeTokenResponse(BaseModel):
+    revoked: bool
+    token_id: str
+
+
+# ---------------------------------------------------------------------------
+# Auth dependency
+# ---------------------------------------------------------------------------
+
+
+def _require_admin(request: Request) -> bool:
+    """Dependency: reject callers without admin or superadmin role."""
+    user_data = get_auth_middleware().get_user_from_request(request)
+    if not user_data:
+        raise_auth_error("AUTH_0002", "Authentication required")
+    role = user_data.get("role", "")
+    if role not in ("admin", "superadmin"):
+        raise_auth_error("AUTH_0003", "Admin permission required")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _get_redis():
+    """Return async Redis client or raise 503."""
+    redis = await get_async_redis_client(database="main")
+    if redis is None:
+        raise HTTPException(status_code=503, detail="Redis unavailable")
+    return redis
+
+
+def _record_key(secret: str) -> str:
+    return f"mcp:token:by_secret:{secret}"
+
+
+def _id_key(token_id: str) -> str:
+    return f"mcp:token:id:{token_id}"
+
+
+_INDEX_KEY = "mcp:tokens:index"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/mcp/tokens
+# ---------------------------------------------------------------------------
+
+
+@router.post("/tokens", response_model=CreateTokenResponse, status_code=201)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="create_mcp_token",
+    error_code_prefix="MCP",
+)
+async def create_mcp_token(
+    body: CreateTokenRequest,
+    _admin: bool = Depends(_require_admin),
+) -> CreateTokenResponse:
+    """Generate a new scoped MCP client token.
+
+    The full token string (``<secret>:<scopes>``) is returned **once** in the
+    response and is never stored in plaintext — only the secret is kept in
+    Redis as a lookup key.  Callers must save the token immediately.
+
+    Valid scopes: ``kb``, ``memory``, ``agents``.
+    """
+    invalid = set(body.scopes) - _VALID_SCOPES
+    if invalid:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid scopes: {sorted(invalid)}. Allowed: {sorted(_VALID_SCOPES)}",
+        )
+    if not body.scopes:
+        raise HTTPException(status_code=422, detail="At least one scope is required")
+
+    secret = secrets.token_hex(_SECRET_BYTES)
+    token_id = secrets.token_hex(8)  # 16-char hex ID
+    scopes = sorted(set(body.scopes))
+    now = time.time()
+
+    record = {
+        "token_id": token_id,
+        "scopes": scopes,
+        "label": body.label,
+        "created_at": now,
+        "last_used": None,
+    }
+
+    redis = await _get_redis()
+    pipe = redis.pipeline()
+    pipe.set(_record_key(secret), json.dumps(record, ensure_ascii=False))
+    pipe.set(_id_key(token_id), secret)
+    pipe.sadd(_INDEX_KEY, token_id)
+    await pipe.execute()
+
+    token_string = f"{secret}:{','.join(scopes)}"
+    logger.info(
+        "mcp_token created token_id=%s scopes=%s label=%r",
+        token_id,
+        scopes,
+        body.label,
+    )
+    return CreateTokenResponse(
+        token_id=token_id,
+        token=token_string,
+        scopes=scopes,
+        label=body.label,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /api/mcp/tokens
+# ---------------------------------------------------------------------------
+
+
+@router.get("/tokens", response_model=ListTokensResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_mcp_tokens",
+    error_code_prefix="MCP",
+)
+async def list_mcp_tokens(
+    _admin: bool = Depends(_require_admin),
+) -> ListTokensResponse:
+    """List all active MCP tokens.
+
+    Secrets are masked (first 4 characters followed by ``...``) so the
+    response is safe to log and display in the admin UI.
+    """
+    redis = await _get_redis()
+
+    token_ids = await redis.smembers(_INDEX_KEY)
+    records: List[TokenRecord] = []
+
+    for tid in token_ids:
+        tid_str = tid if isinstance(tid, str) else tid.decode("utf-8")
+        secret_raw = await redis.get(_id_key(tid_str))
+        if secret_raw is None:
+            # Orphaned index entry — skip silently
+            continue
+        secret = secret_raw if isinstance(secret_raw, str) else secret_raw.decode("utf-8")
+        raw = await redis.get(_record_key(secret))
+        if raw is None:
+            continue
+        data = json.loads(raw if isinstance(raw, str) else raw.decode("utf-8"))
+        records.append(
+            TokenRecord(
+                token_id=data["token_id"],
+                label=data.get("label", ""),
+                scopes=data.get("scopes", []),
+                created_at=data["created_at"],
+                last_used=data.get("last_used"),
+                masked_secret=secret[:4] + "...",
+            )
+        )
+
+    records.sort(key=lambda r: r.created_at, reverse=True)
+    return ListTokensResponse(tokens=records, count=len(records))
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/mcp/tokens/{token_id}
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/tokens/{token_id}", response_model=RevokeTokenResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="revoke_mcp_token",
+    error_code_prefix="MCP",
+)
+async def revoke_mcp_token(
+    token_id: str = Path(..., description="Token ID to revoke"),
+    _admin: bool = Depends(_require_admin),
+) -> RevokeTokenResponse:
+    """Revoke an MCP token by its ID.
+
+    Removes the token record, the reverse-lookup key, and the index entry.
+    Revocation takes effect immediately — the next request using the token
+    will be rejected by ``AutoBotMCPServer._validate_redis_token()``.
+    """
+    redis = await _get_redis()
+
+    secret_raw = await redis.get(_id_key(token_id))
+    if secret_raw is None:
+        raise HTTPException(status_code=404, detail=f"Token not found: {token_id}")
+
+    secret = secret_raw if isinstance(secret_raw, str) else secret_raw.decode("utf-8")
+
+    pipe = redis.pipeline()
+    pipe.delete(_record_key(secret))
+    pipe.delete(_id_key(token_id))
+    pipe.srem(_INDEX_KEY, token_id)
+    await pipe.execute()
+
+    logger.info("mcp_token revoked token_id=%s", token_id)
+    return RevokeTokenResponse(revoked=True, token_id=token_id)

--- a/autobot-backend/api/mcp_token_admin_test.py
+++ b/autobot-backend/api/mcp_token_admin_test.py
@@ -1,0 +1,396 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for the MCP admin token management API (Issue #6453).
+
+Covers:
+- POST /api/mcp/tokens  — create token, scope validation
+- GET  /api/mcp/tokens  — list tokens with masked secrets
+- DELETE /api/mcp/tokens/{id} — revoke + 404 on second revoke
+- Non-admin access is rejected (401/403)
+- Redis-backed validation path in AutoBotMCPServer
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.mcp_token_admin import router
+
+# ---------------------------------------------------------------------------
+# App fixture
+# ---------------------------------------------------------------------------
+
+app = FastAPI()
+app.include_router(router, prefix="/api")
+
+
+# ---------------------------------------------------------------------------
+# Redis mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_redis_mock() -> AsyncMock:
+    """Return a pipeline-capable async Redis mock."""
+    redis = AsyncMock()
+    pipe = AsyncMock()
+    pipe.__aenter__ = AsyncMock(return_value=pipe)
+    pipe.__aexit__ = AsyncMock(return_value=False)
+    pipe.set = AsyncMock()
+    pipe.delete = AsyncMock()
+    pipe.sadd = AsyncMock()
+    pipe.srem = AsyncMock()
+    pipe.execute = AsyncMock(return_value=[True, True, True])
+    redis.pipeline = MagicMock(return_value=pipe)
+    redis.smembers = AsyncMock(return_value=set())
+    redis.get = AsyncMock(return_value=None)
+    return redis
+
+
+def _admin_user():
+    return {"user_id": "u1", "role": "admin"}
+
+
+# ---------------------------------------------------------------------------
+# POST /api/mcp/tokens
+# ---------------------------------------------------------------------------
+
+
+def test_create_token_success():
+    redis_mock = _make_redis_mock()
+    with (
+        patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
+        patch(
+            "api.mcp_token_admin.get_auth_middleware",
+            return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
+        ),
+    ):
+        client = TestClient(app)
+        resp = client.post(
+            "/api/mcp/tokens",
+            json={"scopes": ["kb", "memory"], "label": "test-token"},
+        )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert "token_id" in data
+    assert "token" in data
+    assert "kb" in data["scopes"]
+    assert "memory" in data["scopes"]
+    # Token format: <secret>:<scopes>
+    assert ":" in data["token"]
+    secret_part, scopes_part = data["token"].split(":", 1)
+    assert len(secret_part) == 64  # 32 bytes hex
+    assert set(scopes_part.split(",")) == {"kb", "memory"}
+
+
+def test_create_token_invalid_scope():
+    redis_mock = _make_redis_mock()
+    with (
+        patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
+        patch(
+            "api.mcp_token_admin.get_auth_middleware",
+            return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
+        ),
+    ):
+        client = TestClient(app)
+        resp = client.post(
+            "/api/mcp/tokens",
+            json={"scopes": ["kb", "invalid_scope"], "label": ""},
+        )
+    assert resp.status_code == 422
+
+
+def test_create_token_empty_scopes():
+    redis_mock = _make_redis_mock()
+    with (
+        patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
+        patch(
+            "api.mcp_token_admin.get_auth_middleware",
+            return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
+        ),
+    ):
+        client = TestClient(app)
+        resp = client.post("/api/mcp/tokens", json={"scopes": [], "label": ""})
+    assert resp.status_code == 422
+
+
+def test_create_token_non_admin_rejected():
+    non_admin = {"user_id": "u2", "role": "user"}
+    with patch(
+        "api.mcp_token_admin.get_auth_middleware",
+        return_value=MagicMock(get_user_from_request=MagicMock(return_value=non_admin)),
+    ):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/api/mcp/tokens",
+            json={"scopes": ["kb"], "label": ""},
+        )
+    # raise_auth_error raises HTTPException 403 or similar
+    assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/mcp/tokens
+# ---------------------------------------------------------------------------
+
+
+def test_list_tokens_empty():
+    redis_mock = _make_redis_mock()
+    redis_mock.smembers = AsyncMock(return_value=set())
+    with (
+        patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
+        patch(
+            "api.mcp_token_admin.get_auth_middleware",
+            return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
+        ),
+    ):
+        client = TestClient(app)
+        resp = client.get("/api/mcp/tokens")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 0
+    assert data["tokens"] == []
+
+
+def test_list_tokens_with_entries():
+    import time
+
+    secret = "a" * 64
+    tid = "abc123"
+    record = json.dumps(
+        {
+            "token_id": tid,
+            "scopes": ["kb"],
+            "label": "my-label",
+            "created_at": time.time() - 100,
+            "last_used": time.time() - 10,
+        }
+    )
+
+    async def _fake_get(key):
+        if "id:" in key:
+            return secret.encode("utf-8")
+        if "by_secret:" in key:
+            return record.encode("utf-8")
+        return None
+
+    redis_mock = _make_redis_mock()
+    redis_mock.smembers = AsyncMock(return_value={tid.encode("utf-8")})
+    redis_mock.get = AsyncMock(side_effect=_fake_get)
+
+    with (
+        patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
+        patch(
+            "api.mcp_token_admin.get_auth_middleware",
+            return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
+        ),
+    ):
+        client = TestClient(app)
+        resp = client.get("/api/mcp/tokens")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 1
+    token_rec = data["tokens"][0]
+    assert token_rec["token_id"] == tid
+    assert token_rec["masked_secret"] == "aaaa..."
+    assert "kb" in token_rec["scopes"]
+    assert token_rec["last_used"] is not None
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/mcp/tokens/{token_id}
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_token_success():
+    secret = "b" * 64
+    tid = "def456"
+    redis_mock = _make_redis_mock()
+    redis_mock.get = AsyncMock(return_value=secret.encode("utf-8"))
+
+    with (
+        patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
+        patch(
+            "api.mcp_token_admin.get_auth_middleware",
+            return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
+        ),
+    ):
+        client = TestClient(app)
+        resp = client.delete(f"/api/mcp/tokens/{tid}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["revoked"] is True
+    assert data["token_id"] == tid
+
+
+def test_revoke_token_not_found():
+    redis_mock = _make_redis_mock()
+    redis_mock.get = AsyncMock(return_value=None)
+
+    with (
+        patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
+        patch(
+            "api.mcp_token_admin.get_auth_middleware",
+            return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
+        ),
+    ):
+        client = TestClient(app)
+        resp = client.delete("/api/mcp/tokens/nonexistent")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Redis unavailable → 503
+# ---------------------------------------------------------------------------
+
+
+def test_create_token_redis_unavailable():
+    with (
+        patch("api.mcp_token_admin._get_redis", new=AsyncMock(side_effect=Exception("503 test"))),
+        patch(
+            "api.mcp_token_admin.get_auth_middleware",
+            return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
+        ),
+    ):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/api/mcp/tokens", json={"scopes": ["kb"], "label": ""})
+    assert resp.status_code in (500, 503)
+
+
+# ---------------------------------------------------------------------------
+# AutoBotMCPServer Redis validation path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_server_validates_redis_token():
+    """_validate_redis_token returns scopes for a valid Redis-backed token."""
+    import time
+
+    from mcp.autobot_server import AutoBotMCPServer
+
+    secret = "c" * 64
+    record = json.dumps(
+        {
+            "token_id": "tok1",
+            "scopes": ["kb", "memory"],
+            "label": "",
+            "created_at": time.time(),
+            "last_used": None,
+        }
+    )
+
+    async def _fake_get(key):
+        if f"by_secret:{secret}" in key:
+            return record.encode("utf-8")
+        return None
+
+    redis_mock = AsyncMock()
+    redis_mock.get = AsyncMock(side_effect=_fake_get)
+    redis_mock.set = AsyncMock()
+
+    server = AutoBotMCPServer()
+    with patch("mcp.autobot_server.get_async_redis_client", new=AsyncMock(return_value=redis_mock)):
+        scopes = await server._validate_redis_token(f"{secret}:kb,memory")
+
+    assert scopes is not None
+    assert set(scopes) == {"kb", "memory"}
+
+
+@pytest.mark.asyncio
+async def test_server_redis_token_updates_last_used():
+    """_validate_redis_token writes last_used timestamp back to Redis."""
+    import time
+
+    from mcp.autobot_server import AutoBotMCPServer
+
+    secret = "d" * 64
+    record = json.dumps(
+        {
+            "token_id": "tok2",
+            "scopes": ["agents"],
+            "label": "",
+            "created_at": time.time(),
+            "last_used": None,
+        }
+    )
+
+    async def _fake_get(key):
+        if f"by_secret:{secret}" in key:
+            return record.encode("utf-8")
+        return None
+
+    redis_mock = AsyncMock()
+    redis_mock.get = AsyncMock(side_effect=_fake_get)
+    redis_mock.set = AsyncMock()
+
+    server = AutoBotMCPServer()
+    with patch("mcp.autobot_server.get_async_redis_client", new=AsyncMock(return_value=redis_mock)):
+        await server._validate_redis_token(f"{secret}:agents")
+
+    redis_mock.set.assert_called_once()
+    call_args = redis_mock.set.call_args
+    key_arg = call_args[0][0]
+    assert f"by_secret:{secret}" in key_arg
+    written = json.loads(call_args[0][1])
+    assert written["last_used"] is not None
+
+
+@pytest.mark.asyncio
+async def test_server_redis_token_missing_returns_none():
+    """_validate_redis_token returns None when secret not in Redis."""
+    from mcp.autobot_server import AutoBotMCPServer
+
+    redis_mock = AsyncMock()
+    redis_mock.get = AsyncMock(return_value=None)
+
+    server = AutoBotMCPServer()
+    with patch("mcp.autobot_server.get_async_redis_client", new=AsyncMock(return_value=redis_mock)):
+        scopes = await server._validate_redis_token("nosecret:kb")
+
+    assert scopes is None
+
+
+@pytest.mark.asyncio
+async def test_handle_request_falls_back_to_redis_token():
+    """handle_request accepts a Redis-backed token when static token fails."""
+    import time
+
+    from mcp.autobot_server import AutoBotMCPServer
+
+    secret = "e" * 64
+    record = json.dumps(
+        {
+            "token_id": "tok3",
+            "scopes": ["kb"],
+            "label": "",
+            "created_at": time.time(),
+            "last_used": None,
+        }
+    )
+
+    async def _fake_get(key):
+        if f"by_secret:{secret}" in key:
+            return record.encode("utf-8")
+        return None
+
+    redis_mock = AsyncMock()
+    redis_mock.get = AsyncMock(side_effect=_fake_get)
+    redis_mock.set = AsyncMock()
+
+    server = AutoBotMCPServer()
+    with (
+        patch("mcp.autobot_server.get_async_redis_client", new=AsyncMock(return_value=redis_mock)),
+        patch.object(server, "_kb_list_categories", new=AsyncMock(return_value={"tree": []})),
+    ):
+        # Token is NOT in env var — static validation fails; Redis validation succeeds
+        resp = await server.handle_request(
+            "tools/call",
+            {"name": "kb.list_categories", "arguments": {}},
+            f"{secret}:kb",
+        )
+
+    assert "result" in resp, f"Expected result, got: {resp}"

--- a/autobot-backend/initialization/router_registry/mcp_routers.py
+++ b/autobot-backend/initialization/router_registry/mcp_routers.py
@@ -62,6 +62,8 @@ def load_mcp_routers():
         ("api.manual_mcp", "", ["manual_mcp", "mcp"], "manual_mcp"),
         # Issue #5072: AutoBot MCP server HTTP transport (POST /api/mcp/tool)
         ("api.autobot_mcp_router", "", ["mcp", "autobot-mcp"], "autobot_mcp_server"),
+        # Issue #6453: Admin endpoints to generate/revoke scoped MCP client tokens
+        ("api.mcp_token_admin", "", ["mcp", "admin", "mcp-tokens"], "mcp_token_admin"),
     ]
 
     for module_path, prefix, tags, name in optional_mcp_configs:

--- a/autobot-backend/mcp/autobot_server.py
+++ b/autobot-backend/mcp/autobot_server.py
@@ -31,10 +31,11 @@ Observability:
 import asyncio
 import json
 import time
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from autobot_shared.auth.jwt_core import JWTDecodeError, JWTExpiredError
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_config import config
 from services.run_jwt import validate_run_jwt
 
@@ -321,6 +322,49 @@ class AutoBotMCPServer:
         scopes = [s.strip() for s in scopes_part.split(",") if s.strip()]
         return scopes if scopes else None
 
+    async def _validate_redis_token(self, token: str) -> Optional[List[str]]:
+        """Look up *token* in Redis and return its scopes, or None if not found.
+
+        Token format: ``<secret>:<scope1>,<scope2>`` — the secret portion is
+        the Redis lookup key under ``mcp:token:by_secret:{secret}``.  On a
+        successful lookup ``last_used`` is updated in-place.
+
+        This method is called as a fallback when ``_validate_token()`` rejects
+        the token (i.e. the secret does not match the static env-var secret).
+        Redis-issued tokens created via ``POST /api/mcp/tokens`` are validated
+        here, enabling runtime token issuance and revocation without restart.
+        """
+        if not token:
+            return None
+        try:
+            secret_part, _ = token.split(":", 1)
+        except ValueError:
+            return None
+
+        try:
+            redis = await get_async_redis_client(database="main")
+            if redis is None:
+                logger.warning("_validate_redis_token: Redis unavailable")
+                return None
+
+            key = f"mcp:token:by_secret:{secret_part}"
+            raw = await redis.get(key)
+            if raw is None:
+                return None
+
+            record = json.loads(raw if isinstance(raw, str) else raw.decode("utf-8"))
+            scopes: List[str] = record.get("scopes") or []
+            if not scopes:
+                return None
+
+            # Update last_used timestamp
+            record["last_used"] = time.time()
+            await redis.set(key, json.dumps(record, ensure_ascii=False))
+            return scopes
+        except Exception as exc:
+            logger.warning("_validate_redis_token: unexpected error: %s", exc)
+            return None
+
     def _check_scope(self, scopes: List[str], tool_name: str) -> bool:
         """Return True if *scopes* grants access to *tool_name*."""
         prefix = tool_name.split(".")[0]  # "kb", "memory", "agents"
@@ -376,6 +420,9 @@ class AutoBotMCPServer:
             rate_key = run_jwt_token[:16]
         else:
             scopes = self._validate_token(auth_token)
+            if scopes is None:
+                # Fallback: check Redis-issued tokens (Issue #6453)
+                scopes = await self._validate_redis_token(auth_token)
             if scopes is None:
                 return _err(-32001, "Unauthorized: invalid or missing token", req_id)
             rate_key = auth_token[:16]


### PR DESCRIPTION
Implements MCP admin API endpoints for scoped token generation and revocation.\n\nCloses #6453\n\nPart of [MVA-616](/MVA/issues/MVA-616) — Phase 3 batch 44: MCP + LLM routing