### PR TITLE
feat(llm/tiered-routing): add expected_output_tokens factor (#7353)

### DIFF
--- a/autobot-backend/llm_shared/tiered_routing/complexity_scorer.py
+++ b/autobot-backend/llm_shared/tiered_routing/complexity_scorer.py
@@ -25,21 +25,23 @@ class TaskComplexityScorer:
     Rule-based complexity scorer for LLM requests.
 
     Analyzes messages using weighted heuristic factors:
-    - Message length (0.15 weight)
-    - Code detection (0.25 weight)
-    - Technical terms (0.20 weight)
-    - Multi-step indicators (0.20 weight)
-    - Question complexity (0.20 weight)
+    - Message length (0.13 weight)
+    - Code detection (0.23 weight)
+    - Technical terms (0.18 weight)
+    - Multi-step indicators (0.18 weight)
+    - Question complexity (0.18 weight)
+    - Output length (0.10 weight)
 
     Score is normalized to 0-10 scale.
     """
 
     # Factor weights (must sum to 1.0)
-    WEIGHT_LENGTH = 0.15
-    WEIGHT_CODE = 0.25
-    WEIGHT_TECHNICAL = 0.20
-    WEIGHT_MULTISTEP = 0.20
-    WEIGHT_QUESTION = 0.20
+    WEIGHT_LENGTH = 0.13
+    WEIGHT_CODE = 0.23
+    WEIGHT_TECHNICAL = 0.18
+    WEIGHT_MULTISTEP = 0.18
+    WEIGHT_QUESTION = 0.18
+    WEIGHT_OUTPUT_TOKENS = 0.10
 
     # Code detection patterns
     CODE_PATTERNS = [
@@ -195,6 +197,16 @@ class TaskComplexityScorer:
         r"^tell\s+me\s+",
     ]
 
+    # Output-length heuristic patterns
+    OUTPUT_LENGTH_PATTERNS = [
+        r"summarize|summarise",
+        r"list\s+(all|every|each)",
+        r"step[\s\-]by[\s\-]step",
+        r"enumerate\s+all",
+        r"write\s+a\s+(full|complete|detailed|comprehensive)",
+        r"generate\s+a\s+(complete|full|detailed)",
+    ]
+
     def __init__(self, config: TierConfig, tokenizer: Optional[Callable[[str], int]] = None):
         """
         Initialize complexity scorer.
@@ -216,13 +228,19 @@ class TaskComplexityScorer:
             re.compile(p, re.IGNORECASE) for p in self.COMPLEX_QUESTION_PATTERNS
         ]
         self._compiled_simple_question_patterns = [re.compile(p, re.IGNORECASE) for p in self.SIMPLE_QUESTION_PATTERNS]
+        self._compiled_output_length_patterns = [
+            re.compile(p, re.IGNORECASE) for p in self.OUTPUT_LENGTH_PATTERNS
+        ]
 
-    def score(self, messages: List[Dict]) -> ComplexityResult:
+    def score(self, messages: List[Dict], expected_output_tokens: Optional[int] = None) -> ComplexityResult:
         """
         Score the complexity of a request.
 
         Args:
             messages: List of message dicts with 'role' and 'content' keys
+            expected_output_tokens: Optional hint for the expected number of output
+                tokens. When provided, the output_length factor is derived directly
+                from this value instead of content heuristics.
 
         Returns:
             ComplexityResult with score, factors, tier, and reasoning
@@ -238,6 +256,14 @@ class TaskComplexityScorer:
                 reasoning="No user content to analyze",
             )
 
+        # Extract max_tokens hint from any message that carries it
+        max_tokens: Optional[int] = None
+        for msg in messages:
+            mt = msg.get("max_tokens")
+            if mt is not None and int(mt) > 0:
+                max_tokens = int(mt)
+                break
+
         # Calculate individual factor scores (0-3 scale)
         factors = {
             "length": self._score_length(user_content),
@@ -245,6 +271,7 @@ class TaskComplexityScorer:
             "technical": self._score_technical(user_content),
             "multistep": self._score_multistep(user_content),
             "question": self._score_question(user_content),
+            "output_length": self._score_output_length(user_content, expected_output_tokens, max_tokens),
         }
 
         # Calculate weighted score and build result
@@ -335,6 +362,47 @@ class TaskComplexityScorer:
         # Clamp to 0-3
         return max(0.0, min(3.0, net_score))
 
+    def _score_output_length(
+        self,
+        content: str,
+        expected_output_tokens: Optional[int],
+        max_tokens: Optional[int] = None,
+    ) -> float:
+        """Score based on expected output length (0-3).
+
+        Priority:
+        1. explicit expected_output_tokens hint
+        2. max_tokens from the message payload
+        3. heuristic pattern count from content
+
+        Thresholds (tokens): <100 -> 0.0, <500 -> 1.0, <2000 -> 2.0, >=2000 -> 3.0
+        """
+        if expected_output_tokens is not None:
+            tokens = expected_output_tokens
+            if tokens < 100:
+                return 0.0
+            elif tokens < 500:
+                return 1.0
+            elif tokens < 2000:
+                return 2.0
+            else:
+                return 3.0
+
+        if max_tokens is not None and max_tokens > 0:
+            tokens = max_tokens
+            if tokens < 100:
+                return 0.0
+            elif tokens < 500:
+                return 1.0
+            elif tokens < 2000:
+                return 2.0
+            else:
+                return 3.0
+
+        # Heuristic fallback: count matching patterns, cap at 3.0
+        matches = sum(1 for p in self._compiled_output_length_patterns if p.search(content))
+        return min(3.0, float(matches))
+
     def _calculate_weighted_score(self, factors: Dict[str, float]) -> float:
         """
         Calculate and normalize the weighted complexity score.
@@ -353,6 +421,7 @@ class TaskComplexityScorer:
             + factors["technical"] * self.WEIGHT_TECHNICAL
             + factors["multistep"] * self.WEIGHT_MULTISTEP
             + factors["question"] * self.WEIGHT_QUESTION
+            + factors["output_length"] * self.WEIGHT_OUTPUT_TOKENS
         )
         # Normalize to 0-10 scale (factors are 0-3, max weighted is 3)
         normalized_score = (weighted_score / 3.0) * 10.0
@@ -409,6 +478,7 @@ class TaskComplexityScorer:
             "technical": "technical terminology",
             "multistep": "multi-step requirements",
             "question": "question complexity",
+            "output_length": "output length",
         }
 
         dominant_names = [factor_names.get(f, f) for f in dominant]

--- a/autobot-backend/tests/llm_interface_pkg/test_output_token_scorer.py
+++ b/autobot-backend/tests/llm_interface_pkg/test_output_token_scorer.py
@@ -1,0 +1,199 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for expected_output_tokens factor in TaskComplexityScorer (GH #7353)."""
+
+import pytest
+from llm_shared.tiered_routing.complexity_scorer import TaskComplexityScorer
+from llm_shared.tiered_routing.tier_config import TierConfig
+
+
+def _make_scorer():
+    config = TierConfig()
+    return TaskComplexityScorer(config)
+
+
+def _messages(content: str) -> list:
+    return [{"role": "user", "content": content}]
+
+
+# ---------------------------------------------------------------------------
+# _score_output_length — explicit expected_output_tokens hint
+# ---------------------------------------------------------------------------
+
+
+class TestScoreOutputLengthExplicit:
+    def test_small_tokens_returns_zero(self):
+        scorer = _make_scorer()
+        assert scorer._score_output_length("anything", expected_output_tokens=50) == 0.0
+
+    def test_medium_tokens_returns_one(self):
+        scorer = _make_scorer()
+        assert scorer._score_output_length("anything", expected_output_tokens=200) == 1.0
+
+    def test_large_tokens_returns_two(self):
+        scorer = _make_scorer()
+        assert scorer._score_output_length("anything", expected_output_tokens=1000) == 2.0
+
+    def test_very_large_tokens_returns_three(self):
+        scorer = _make_scorer()
+        assert scorer._score_output_length("anything", expected_output_tokens=2000) == 3.0
+
+    def test_boundary_exactly_100_returns_one(self):
+        scorer = _make_scorer()
+        assert scorer._score_output_length("anything", expected_output_tokens=100) == 1.0
+
+    def test_boundary_exactly_500_returns_two(self):
+        scorer = _make_scorer()
+        assert scorer._score_output_length("anything", expected_output_tokens=500) == 2.0
+
+    def test_boundary_exactly_2000_returns_three(self):
+        scorer = _make_scorer()
+        assert scorer._score_output_length("anything", expected_output_tokens=2000) == 3.0
+
+    def test_zero_tokens_returns_zero(self):
+        scorer = _make_scorer()
+        assert scorer._score_output_length("anything", expected_output_tokens=0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _score_output_length — max_tokens fallback
+# ---------------------------------------------------------------------------
+
+
+class TestScoreOutputLengthMaxTokens:
+    def test_small_max_tokens_returns_zero(self):
+        scorer = _make_scorer()
+        assert scorer._score_output_length("anything", expected_output_tokens=None, max_tokens=50) == 0.0
+
+    def test_large_max_tokens_returns_three(self):
+        scorer = _make_scorer()
+        assert scorer._score_output_length("anything", expected_output_tokens=None, max_tokens=4096) == 3.0
+
+    def test_medium_max_tokens_returns_two(self):
+        scorer = _make_scorer()
+        assert scorer._score_output_length("anything", expected_output_tokens=None, max_tokens=800) == 2.0
+
+    def test_explicit_overrides_max_tokens(self):
+        """expected_output_tokens takes priority over max_tokens."""
+        scorer = _make_scorer()
+        # expected=50 (small) but max_tokens=4096 (large) — should return 0.0
+        result = scorer._score_output_length("anything", expected_output_tokens=50, max_tokens=4096)
+        assert result == 0.0
+
+    def test_zero_max_tokens_falls_through_to_heuristic(self):
+        """max_tokens=0 is treated as absent; heuristic runs instead."""
+        scorer = _make_scorer()
+        # No patterns in content → 0.0
+        result = scorer._score_output_length("hello world", expected_output_tokens=None, max_tokens=0)
+        assert result == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _score_output_length — heuristic pattern fallback
+# ---------------------------------------------------------------------------
+
+
+class TestScoreOutputLengthHeuristic:
+    def test_no_patterns_returns_zero(self):
+        scorer = _make_scorer()
+        assert scorer._score_output_length("Hello there", expected_output_tokens=None) == 0.0
+
+    def test_summarize_pattern_bumps_score(self):
+        scorer = _make_scorer()
+        result = scorer._score_output_length("Please summarize this document", expected_output_tokens=None)
+        assert result >= 1.0
+
+    def test_list_all_pattern_bumps_score(self):
+        scorer = _make_scorer()
+        result = scorer._score_output_length("List all the options available", expected_output_tokens=None)
+        assert result >= 1.0
+
+    def test_step_by_step_pattern_bumps_score(self):
+        scorer = _make_scorer()
+        result = scorer._score_output_length("Explain it step-by-step", expected_output_tokens=None)
+        assert result >= 1.0
+
+    def test_multiple_patterns_capped_at_three(self):
+        scorer = _make_scorer()
+        # Triggers summarize, list all, step-by-step, enumerate all — should cap at 3.0
+        content = "summarize and list all items step-by-step and enumerate all details"
+        result = scorer._score_output_length(content, expected_output_tokens=None)
+        assert result == 3.0
+
+    def test_write_full_pattern(self):
+        scorer = _make_scorer()
+        result = scorer._score_output_length("Write a full implementation", expected_output_tokens=None)
+        assert result >= 1.0
+
+    def test_generate_complete_pattern(self):
+        scorer = _make_scorer()
+        result = scorer._score_output_length("Generate a complete report", expected_output_tokens=None)
+        assert result >= 1.0
+
+    def test_summarise_british_spelling(self):
+        scorer = _make_scorer()
+        result = scorer._score_output_length("Please summarise the chapter", expected_output_tokens=None)
+        assert result >= 1.0
+
+
+# ---------------------------------------------------------------------------
+# score() integration — output_length factor included in result
+# ---------------------------------------------------------------------------
+
+
+class TestScoreIntegration:
+    def test_score_includes_output_length_factor(self):
+        scorer = _make_scorer()
+        result = scorer.score(_messages("Hello"), expected_output_tokens=1500)
+        assert "output_length" in result.factors
+        assert result.factors["output_length"] == 2.0
+
+    def test_score_backwards_compat_no_new_args(self):
+        """Calling score() without expected_output_tokens must still work."""
+        scorer = _make_scorer()
+        result = scorer.score(_messages("Hello"))
+        assert result.score >= 0.0
+        assert result.tier in ("simple", "complex")
+        assert "output_length" in result.factors
+
+    def test_large_output_hint_bumps_simple_to_complex(self):
+        """A request that would be simple gains enough score to become complex
+        when expected_output_tokens signals a long decode."""
+        scorer = _make_scorer()
+
+        simple_result = scorer.score(_messages("Hello"), expected_output_tokens=50)
+        complex_result = scorer.score(_messages("Hello"), expected_output_tokens=3000)
+
+        assert complex_result.score > simple_result.score
+        # With output_length=3.0 contributing 0.10 weight, the score delta is:
+        # (3.0 * 0.10 / 3.0) * 10 = 1.0 point — verify it moved
+        assert complex_result.factors["output_length"] == 3.0
+        assert simple_result.factors["output_length"] == 0.0
+
+    def test_max_tokens_in_message_is_extracted(self):
+        """max_tokens key inside a message dict is picked up as fallback."""
+        scorer = _make_scorer()
+        messages = [{"role": "user", "content": "Explain everything", "max_tokens": 2500}]
+        result = scorer.score(messages)
+        assert result.factors["output_length"] == 3.0
+
+    def test_output_length_in_reasoning_when_dominant(self):
+        """When output_length factor is dominant it appears in reasoning text."""
+        scorer = _make_scorer()
+        # All other inputs minimal; output_length = 3.0 → dominant
+        result = scorer.score(_messages("Hi"), expected_output_tokens=3000)
+        assert "output length" in result.reasoning
+
+    def test_heuristic_bumps_score_via_score_method(self):
+        """step-by-step content should raise output_length factor via heuristic."""
+        scorer = _make_scorer()
+        result = scorer.score(_messages("Explain step-by-step how to do this"))
+        assert result.factors["output_length"] >= 1.0
+
+    def test_existing_factors_still_present(self):
+        """All pre-existing factors remain in the result."""
+        scorer = _make_scorer()
+        result = scorer.score(_messages("Hello"))
+        for factor in ("length", "code", "technical", "multistep", "question", "output_length"):
+            assert factor in result.factors


### PR DESCRIPTION
Adds expected_output_tokens as a routing factor for LLM tiered routing decisions.\n\nCloses #7353\n\nPart of [MVA-616](/MVA/issues/MVA-616) — Phase 3 batch 44: MCP + LLM routing