### PR TITLE
fix: DataResponse bypass, web_crawler test patches, chromadb NameError (#8300, #8306, #8308)

### DIFF
--- a/autobot-backend/api/merge_conflict_resolution.py
+++ b/autobot-backend/api/merge_conflict_resolution.py
@@ -18,7 +18,6 @@ import asyncio
 from datetime import datetime, timezone
 from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi.responses import JSONResponse
 
 from api.schemas_code import (
     ApplyResolutionRequest,
@@ -36,6 +35,8 @@ from api.schemas_code import (
 )
 from api.schemas_common import DataResponse
 from auth_middleware import check_admin_permission
+from autobot_shared.time_utils import utc_timestamp
+from utils.response_helpers import create_success_response
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.security.path_validator import validate_path
@@ -93,8 +94,8 @@ def _calculate_severity_distribution(conflicts: list) -> dict:
     }
 
 
-def _build_resolution_response(results: list, file_path: str, safe_mode: bool) -> JSONResponse:
-    """Build the JSONResponse for a successful conflict resolution.
+def _build_resolution_response(results: list, file_path: str, safe_mode: bool) -> DataResponse[MergeConflictResolveResponse]:
+    """Build the DataResponse for a successful conflict resolution.
 
     Helper for resolve_conflicts. Ref: #1088.
     """
@@ -103,21 +104,20 @@ def _build_resolution_response(results: list, file_path: str, safe_mode: bool) -
     all_validated = all(r.is_validated for r in results)
     any_require_review = any(r.requires_review for r in results)
 
-    return JSONResponse(
-        status_code=200,
-        content={
-            "status": "success",
-            "file_path": file_path,
-            "resolution_count": len(results),
-            "resolutions": resolutions,
-            "summary": {
+    return create_success_response(
+        data=MergeConflictResolveResponse(
+            status="success",
+            file_path=file_path,
+            resolved_count=len(results),
+            results=resolutions,
+            summary={
                 "average_confidence": round(avg_confidence, 2),
                 "all_validated": all_validated,
                 "requires_review": any_require_review,
             },
-            "safe_mode": safe_mode,
-            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-        },
+            safe_mode=safe_mode,
+            timestamp=utc_timestamp(),
+        )
     )
 
 
@@ -178,17 +178,16 @@ async def _validate_conflict_file(file_path: str) -> Path:
     return safe
 
 
-def _build_no_conflicts_response(file_path: str) -> JSONResponse:
+def _build_no_conflicts_response(file_path: str) -> DataResponse[MergeConflictAnalyzeResponse]:
     """Helper for analyze_conflicts. Ref: #1088."""
-    return JSONResponse(
-        status_code=200,
-        content={
-            "status": "success",
-            "message": "No conflicts found in file",
-            "file_path": file_path,
-            "conflict_count": 0,
-            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-        },
+    return create_success_response(
+        data=MergeConflictAnalyzeResponse(
+            status="success",
+            file_path=file_path,
+            conflict_count=0,
+            timestamp=utc_timestamp(),
+        ),
+        message="No conflicts found in file",
     )
 
 
@@ -232,16 +231,15 @@ async def analyze_conflicts(
         conflicts_data = [_build_conflict_data(c) for c in conflicts]
         severity_counts = _calculate_severity_distribution(conflicts)
 
-        return JSONResponse(
-            status_code=200,
-            content={
-                "status": "success",
-                "file_path": str(safe_path),
-                "conflict_count": len(conflicts),
-                "conflicts": conflicts_data,
-                "severity_distribution": severity_counts,
-                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            },
+        return create_success_response(
+            data=MergeConflictAnalyzeResponse(
+                status="success",
+                file_path=str(safe_path),
+                conflict_count=len(conflicts),
+                conflicts=conflicts_data,
+                severity_distribution=severity_counts,
+                timestamp=utc_timestamp(),
+            )
         )
 
     except Exception as e:
@@ -300,14 +298,13 @@ async def resolve_conflicts(
         )
 
         if not results:
-            return JSONResponse(
-                status_code=200,
-                content={
-                    "status": "success",
-                    "message": "No conflicts found in file",
-                    "file_path": request.file_path,
-                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-                },
+            return create_success_response(
+                data=MergeConflictResolveResponse(
+                    status="success",
+                    file_path=request.file_path,
+                    timestamp=utc_timestamp(),
+                ),
+                message="No conflicts found in file",
             )
 
         return _build_resolution_response(results, request.file_path, request.safe_mode)
@@ -362,16 +359,15 @@ async def analyze_repository_conflicts(
         # Analyze repository
         analysis = await asyncio.to_thread(analyze_repository, str(safe_repo))
 
-        return JSONResponse(
-            status_code=200,
-            content={
-                "status": "success",
-                "repository": request.repo_path,
-                "total_files_with_conflicts": analysis["total_files"],
-                "total_conflicts": analysis["total_conflicts"],
-                "files": analysis["files"],
-                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            },
+        return create_success_response(
+            data=MergeConflictRepositoryAnalyzeResponse(
+                status="success",
+                repository=request.repo_path,
+                total_files_with_conflicts=analysis["total_files"],
+                total_conflicts=analysis["total_conflicts"],
+                files=analysis["files"],
+                timestamp=utc_timestamp(),
+            )
         )
 
     except Exception as e:
@@ -425,15 +421,14 @@ async def apply_resolution(
 
         logger.info("Applied resolution to %s", safe_path)
 
-        return JSONResponse(
-            status_code=200,
-            content={
-                "status": "success",
-                "message": "Resolution applied successfully",
-                "file_path": str(safe_path),
-                "backup_path": backup_path,
-                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            },
+        return create_success_response(
+            data=MergeConflictApplyResponse(
+                status="success",
+                message="Resolution applied successfully",
+                file_path=str(safe_path),
+                backup_path=backup_path,
+                timestamp=utc_timestamp(),
+            )
         )
 
     except Exception as e:
@@ -500,14 +495,13 @@ async def get_resolution_strategies(
         },
     }
 
-    return JSONResponse(
-        status_code=200,
-        content={
-            "status": "success",
-            "strategies": strategies,
-            "default_strategy": "semantic_merge",
-            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-        },
+    return create_success_response(
+        data=MergeConflictStrategiesResponse(
+            status="success",
+            strategies=strategies,
+            default_strategy="semantic_merge",
+            timestamp=utc_timestamp(),
+        )
     )
 
 
@@ -542,14 +536,13 @@ async def check_file_conflicts(
         parser = ConflictParser()
         has_conflicts = await asyncio.to_thread(parser.has_conflicts, str(safe_path))
 
-        return JSONResponse(
-            status_code=200,
-            content={
-                "status": "success",
-                "file_path": str(safe_path),
-                "has_conflicts": has_conflicts,
-                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            },
+        return create_success_response(
+            data=MergeConflictCheckResponse(
+                status="success",
+                file_path=str(safe_path),
+                has_conflicts=has_conflicts,
+                timestamp=utc_timestamp(),
+            )
         )
 
     except Exception as e:

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -2568,6 +2568,8 @@ class MergeConflictResolveResponse(BaseModel):
     file_path: str = ""
     resolved_count: int = 0
     results: List[Dict[str, Any]] = Field(default_factory=list)
+    summary: Dict[str, Any] = Field(default_factory=dict)
+    safe_mode: bool = True
     timestamp: str = ""
 
 

--- a/autobot-backend/knowledge/backends/chromadb_adapter.py
+++ b/autobot-backend/knowledge/backends/chromadb_adapter.py
@@ -14,7 +14,6 @@ Usage::
 
     from utils.chromadb_client import get_chromadb_client
     from knowledge.backends.chromadb_adapter import ChromaDBClient
-from autobot_shared.logging_manager import get_logger
 
     raw = get_chromadb_client()
     backend = ChromaDBClient(raw)
@@ -25,6 +24,7 @@ from __future__ import annotations
 
 from typing import Any, List, Sequence
 
+from autobot_shared.logging_manager import get_logger
 from knowledge.backends.base import (
     BaseClient,
     BaseCollection,

--- a/autobot-backend/tests/unit/knowledge/connectors/test_web_crawler.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_web_crawler.py
@@ -167,12 +167,12 @@ class TestHelpers:
 
 @pytest.fixture()
 def mock_bs4():
-    """Patch _fetch_bs4 to return fixture site pages (coroutine-compatible)."""
+    """Patch WebFetcher.fetch_raw_html to return fixture site pages (coroutine-compatible)."""
 
     async def _side_effect(url, timeout=30.0):
         return _fixture_bs4(url, timeout)
 
-    with patch("knowledge.connectors.web_crawler._fetch_bs4", side_effect=_side_effect):
+    with patch("knowledge.connectors.web_crawler.WebFetcher.fetch_raw_html", side_effect=_side_effect):
         yield
 
 


### PR DESCRIPTION
## Summary

Fixes 3 discovery/bug issues from [MVA-694](/MVA/issues/MVA-694).

- **GH#8300**: 6 routes in `merge_conflict_resolution.py` were using `JSONResponse` directly, bypassing FastAPI validation. Replaced with `create_success_response(data=Schema(...))`. Extended `MergeConflictResolveResponse` with `summary`/`safe_mode` fields.
- **GH#8306**: `mock_bs4` fixture was patching non-existent `_fetch_bs4`. Updated to patch `WebFetcher.fetch_raw_html` — all 27 tests now pass.
- **GH#8308**: `get_logger` import was trapped inside the module docstring in `chromadb_adapter.py`. Moved to proper imports section.

Closes #8300
Closes #8306
Closes #8308