### PR TITLE
fix(frontend): KnowledgePersistenceDialog reads response.data for pending_items/compiled (#8322)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
@@ -322,8 +322,9 @@ const decisionsCount = computed(() => {
     delete: 0
   };
 
+  const selectedIds = new Set(selectedPendingItems.value.map(item => item.id));
   Object.entries(itemDecisions.value).forEach(([itemId, decision]) => {
-    if (selectedItems.value[itemId] && decision) {
+    if (selectedIds.has(itemId) && decision) {
       counts[decision]++;
     }
   });
@@ -339,7 +340,7 @@ const loadPendingItems = async () => {
     const response = await apiService.get(`${getApiBase()}/chat-knowledge/knowledge/pending/${props.chatId}`);
 
     if (response.success) {
-      pendingItems.value = response.pending_items;
+      pendingItems.value = response.data?.pending_items ?? [];
 
       // Initialize decisions (useBatchSelection handles selection state)
       pendingItems.value.forEach(item => {
@@ -439,7 +440,7 @@ const compileChat = async () => {
 
     if (response.success) {
       showToast(t('knowledge.persistence.compiledSuccess'), 'success');
-      emit('chat-compiled', response.compiled);
+      emit('chat-compiled', response.data?.compiled);
       closeDialog();
     }
 


### PR DESCRIPTION
## Summary

Fixes KnowledgePersistenceDialog to correctly read API response data.

- `loadPendingItems`: `response.pending_items` → `response.data?.pending_items ?? []`
- `compileChat`: `response.compiled` → `response.data?.compiled`
- `decisionsCount`: undefined ref fixed — uses `selectedIds.has(itemId)` via pre-built Set

Closes #8322

Part of [MVA-709](/MVA/issues/MVA-709)