### PR TITLE
refactor(events): migrate 22 files from direct EventManager/LiveEventManager to events.bus (GH #8291)

### DIFF
--- a/autobot-backend/agents/interactive_terminal_agent.py
+++ b/autobot-backend/agents/interactive_terminal_agent.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from constants.threshold_constants import TimingConstants
-from event_manager import get_event_manager
+from events.bus import publish_event, PersistStrategy
 
 from .base_agent import AgentRequest
 from .standardized_agent import ActionHandler, StandardizedAgent
@@ -178,14 +178,14 @@ class InteractiveTerminalAgent(StandardizedAgent):
 
     async def _notify_session_started(self, command: str) -> None:
         """Publish session started event. Issue #620."""
-        await get_event_manager().publish(
+        await publish_event("global", 
             "terminal_session",
             {
                 "chat_id": self.chat_id,
                 "status": "started",
                 "command": command,
                 "pid": self.process.pid,
-            },
+            }, persist=PersistStrategy.NONE
         )
 
     async def start_session(self, command: str, env: dict = None, cwd: str = None) -> None:
@@ -308,7 +308,7 @@ class InteractiveTerminalAgent(StandardizedAgent):
 
     async def _handle_sudo_prompt(self, prompt_data: str):
         """Handle sudo password prompts"""
-        await get_event_manager().publish(
+        await publish_event("global", 
             "terminal_output",
             {
                 "chat_id": self.chat_id,
@@ -317,7 +317,7 @@ class InteractiveTerminalAgent(StandardizedAgent):
                 "requires_input": True,
                 "input_type": "password",
                 "message": ("🔐 Sudo password required. " "Click 'Send Input' to provide password."),
-            },
+            }, persist=PersistStrategy.NONE
         )
 
         # Switch to user input mode for password
@@ -325,7 +325,7 @@ class InteractiveTerminalAgent(StandardizedAgent):
 
     async def _handle_input_prompt(self, prompt_data: str):
         """Handle interactive prompts"""
-        await get_event_manager().publish(
+        await publish_event("global", 
             "terminal_output",
             {
                 "chat_id": self.chat_id,
@@ -334,31 +334,31 @@ class InteractiveTerminalAgent(StandardizedAgent):
                 "requires_input": True,
                 "input_type": "text",
                 "message": "⌨️ Input required. Enter your response.",
-            },
+            }, persist=PersistStrategy.NONE
         )
 
     async def _send_to_chat(self, output: str):
         """Send regular output to chat"""
-        await get_event_manager().publish(
+        await publish_event("global", 
             "terminal_output",
             {
                 "chat_id": self.chat_id,
                 "output": output,
                 "type": "output",
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            },
+            }, persist=PersistStrategy.NONE
         )
 
     async def _send_error(self, error: str):
         """Send error message to chat"""
-        await get_event_manager().publish(
+        await publish_event("global", 
             "terminal_output",
             {
                 "chat_id": self.chat_id,
                 "output": f"❌ Error: {error}",
                 "type": "error",
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            },
+            }, persist=PersistStrategy.NONE
         )
 
     async def send_input(self, user_input: str, is_password: bool = False):
@@ -392,25 +392,25 @@ class InteractiveTerminalAgent(StandardizedAgent):
     async def take_control(self):
         """Allow user to take full control of terminal"""
         self.input_mode = "user"
-        await get_event_manager().publish(
+        await publish_event("global", 
             "terminal_control",
             {
                 "chat_id": self.chat_id,
                 "status": "user_control",
                 "message": ("🎮 You now have control of the terminal. " "Type commands directly."),
-            },
+            }, persist=PersistStrategy.NONE
         )
 
     async def return_control(self):
         """Return control to agent"""
         self.input_mode = "agent"
-        await get_event_manager().publish(
+        await publish_event("global", 
             "terminal_control",
             {
                 "chat_id": self.chat_id,
                 "status": "agent_control",
                 "message": "🤖 Agent has resumed control of the terminal.",
-            },
+            }, persist=PersistStrategy.NONE
         )
 
     async def resize_terminal(self, cols: int, rows: int):
@@ -460,7 +460,7 @@ class InteractiveTerminalAgent(StandardizedAgent):
         async with self._buffer_lock:
             output_lines = len(self.output_buffer)
 
-        await get_event_manager().publish(
+        await publish_event("global", 
             "terminal_session",
             {
                 "chat_id": self.chat_id,
@@ -468,7 +468,7 @@ class InteractiveTerminalAgent(StandardizedAgent):
                 "exit_code": exit_code,
                 "duration": duration,
                 "output_lines": output_lines,
-            },
+            }, persist=PersistStrategy.NONE
         )
 
         # Cleanup

--- a/autobot-backend/agents/kb_librarian/librarian.py
+++ b/autobot-backend/agents/kb_librarian/librarian.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List
 
 from agents.web_researcher import WebResearcher as WebResearchAssistant
 from autobot_shared.logging_manager import get_logger
-from event_manager import get_event_manager
+from events.bus import publish_event, PersistStrategy
 from knowledge_base import KnowledgeBase
 
 from .formatters import ToolInfoFormatter
@@ -341,13 +341,13 @@ class EnhancedKBLibrarian:
         await self.knowledge_base.store_fact(document_content, metadata=metadata)
         logger.info("Stored knowledge for tool: %s", tool_name)
 
-        await get_event_manager().publish(
+        await publish_event("global", 
             "knowledge_update",
             {
                 "type": "new_tool",
                 "tool_name": tool_name,
                 "message": f"Added knowledge about {tool_name} to the knowledge base",
-            },
+            }, persist=PersistStrategy.NONE
         )
 
     async def get_tool_instructions(self, tool_name: str) -> Dict[str, Any]:

--- a/autobot-backend/agents/system_command_agent.py
+++ b/autobot-backend/agents/system_command_agent.py
@@ -15,7 +15,7 @@ from agents.interactive_terminal_agent import InteractiveTerminalAgent
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
 from constants.threshold_constants import TimingConstants
-from event_manager import get_event_manager
+from events.bus import publish_event, PersistStrategy
 from security.command_patterns import (
     SENSITIVE_REDIRECT_PATHS,
     UNRESTRICTED_ROOT_COMMANDS,
@@ -370,7 +370,7 @@ class SystemCommandAgent(StandardizedAgent):
         elif result:
             event_data["exit_code"] = result["exit_code"]
             event_data["duration"] = result["duration"]
-        await get_event_manager().publish("command_execution", event_data)
+        await publish_event("global", "command_execution", event_data, persist=PersistStrategy.NONE)
 
     def _build_execution_result(self, result: dict) -> Dict[str, Any]:
         """Build execution result dict (Issue #398: extracted)."""
@@ -458,14 +458,14 @@ class SystemCommandAgent(StandardizedAgent):
 
     async def _request_user_confirmation(self, command: str, chat_id: str) -> bool:
         """Request user confirmation for dangerous commands"""
-        await get_event_manager().publish(
+        await publish_event("global", 
             "command_confirmation",
             {
                 "chat_id": chat_id,
                 "command": command,
                 "warning": "⚠️ This command may be dangerous. Please confirm execution.",
                 "requires_confirmation": True,
-            },
+            }, persist=PersistStrategy.NONE
         )
 
         # Wait for user response (this would be handled by the frontend)

--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -50,6 +50,7 @@ from dependencies import get_config, get_knowledge_base
 from exceptions import InternalError, SubprocessError
 from monitoring.prometheus_metrics import get_metrics_manager
 from services.ai_stack_client import AIStackError, get_ai_stack_client
+from events.bus import PersistStrategy, get_event_bus
 from utils.response_helpers import create_success_response, handle_ai_stack_error
 
 router = APIRouter()
@@ -182,19 +183,14 @@ def _validate_command_request(command: str | None, security_layer, user_role: st
     return None
 
 
-async def _publish_event_safe(event_manager, event_name: str, data: dict) -> None:
+async def _publish_event_safe(event_name: str, data: dict) -> None:
     """
     Publish event with error handling (non-critical operation).
 
     Issue #281: Extracted helper for safe event publishing.
-
-    Args:
-        event_manager: Event manager instance
-        event_name: Name of event to publish
-        data: Event data
     """
     try:
-        await event_manager.publish(event_name, data)
+        await get_event_bus().publish("global", event_name, data, persist=PersistStrategy.NONE)
     except Exception as e:
         logger.warning("Failed to publish %s event: %s", event_name, e)
 
@@ -411,7 +407,6 @@ async def _publish_approval_to_redis(
 
 
 async def _handle_command_result(
-    event_manager,
     security_layer,
     user_role: str,
     command: str,
@@ -425,7 +420,6 @@ async def _handle_command_result(
     Issue #620.
 
     Args:
-        event_manager: Event manager instance
         security_layer: Security layer for audit logging
         user_role: User's role
         command: Executed command
@@ -442,7 +436,6 @@ async def _handle_command_result(
     if returncode == 0:
         response = _build_success_response(command, output, security_layer, user_role)
         await _publish_event_safe(
-            event_manager,
             "command_execution_end",
             {"command": command, "status": "success", "output": output},
         )
@@ -450,7 +443,6 @@ async def _handle_command_result(
 
     response = _build_error_response(command, output, error, returncode, security_layer, user_role)
     await _publish_event_safe(
-        event_manager,
         "command_execution_end",
         {
             "command": command,
@@ -558,23 +550,17 @@ def _check_goal_permission(security_layer, user_role: str, goal: str) -> JSONRes
     return None
 
 
-async def _publish_goal_events(event_manager, goal: str, use_phi2: bool) -> None:
+async def _publish_goal_events(goal: str, use_phi2: bool) -> None:
     """
     Publish goal-related events (user_message and goal_received).
 
     Issue #620.
-
-    Args:
-        event_manager: Event manager instance
-        goal: Goal string
-        use_phi2: Whether to use Phi-2 model
     """
-    await _publish_event_safe(event_manager, "user_message", {"message": goal})
-    await _publish_event_safe(event_manager, "goal_received", {"goal": goal, "use_phi2": use_phi2})
+    await _publish_event_safe("user_message", {"message": goal})
+    await _publish_event_safe("goal_received", {"goal": goal, "use_phi2": use_phi2})
 
 
 async def _handle_goal_result(
-    event_manager,
     security_layer,
     user_role: str,
     goal: str,
@@ -587,7 +573,6 @@ async def _handle_goal_result(
     Issue #620.
 
     Args:
-        event_manager: Event manager instance
         security_layer: Security layer for audit logging
         user_role: User's role
         goal: Original goal string
@@ -600,7 +585,7 @@ async def _handle_goal_result(
     response_message, tool_output_content, tool_name = _process_tool_result(result_dict)
 
     if tool_output_content and tool_name != "respond_conversationally":
-        await _publish_event_safe(event_manager, "tool_output", {"output": tool_output_content})
+        await _publish_event_safe("tool_output", {"output": tool_output_content})
 
     security_layer.audit_log(
         "submit_goal",
@@ -609,7 +594,7 @@ async def _handle_goal_result(
         {"goal": goal, "result": response_message},
     )
 
-    await _publish_event_safe(event_manager, "goal_completed", {"goal": goal, "result": response_message})
+    await _publish_event_safe("goal_completed", {"goal": goal, "result": response_message})
 
     _record_goal_metrics(task_start_time, "success")
 
@@ -691,8 +676,6 @@ async def receive_goal(
         JSONResponse: Returns a 403 error if permission is denied, or a 500
             error if an internal error occurs.
     """
-    from event_manager import get_event_manager
-
     orchestrator = getattr(request.app.state, "orchestrator", None)
     if orchestrator is None:
         raise HTTPException(
@@ -713,7 +696,7 @@ async def receive_goal(
     logging.info(f"Received goal via API: {goal}")
 
     # Publish events (Issue #620: uses helper)
-    await _publish_goal_events(get_event_manager(), goal, use_phi2)
+    await _publish_goal_events(goal, use_phi2)
 
     # Track task execution start time for Prometheus metrics
     task_start_time = time.time()
@@ -722,7 +705,7 @@ async def receive_goal(
     result_dict = await _execute_goal_with_error_handling(orchestrator, goal, task_start_time)
 
     # Process and return result (Issue #620: uses helper)
-    return await _handle_goal_result(get_event_manager(), security_layer, user_role, goal, result_dict, task_start_time)
+    return await _handle_goal_result(security_layer, user_role, goal, result_dict, task_start_time)
 
 
 @router.post("/pause", response_model=AgentMessageResponse)
@@ -742,8 +725,6 @@ async def pause_agent_api(
     without actual functionality. Full implementation will be added with
     backend integration.
     """
-    from event_manager import get_event_manager
-
     security_layer = request.app.state.security_layer
     orchestrator = getattr(request.app.state, "orchestrator", None)
     if orchestrator is None:
@@ -766,11 +747,7 @@ async def pause_agent_api(
         ) from e
 
     security_layer.audit_log("agent_pause", user_role, "success", {})
-    # Publish event (non-critical)
-    try:
-        await get_event_manager().publish("agent_paused", {"message": "Agent operation paused."})
-    except Exception as e:
-        logger.warning("Failed to publish agent_paused event: %s", e)
+    await _publish_event_safe("agent_paused", {"message": "Agent operation paused."})
     return {"message": "Agent paused successfully."}
 
 
@@ -791,8 +768,6 @@ async def resume_agent_api(
     actual functionality.
     Full implementation will be added with backend integration.
     """
-    from event_manager import get_event_manager
-
     security_layer = request.app.state.security_layer
     orchestrator = getattr(request.app.state, "orchestrator", None)
     if orchestrator is None:
@@ -815,11 +790,7 @@ async def resume_agent_api(
         ) from e
 
     security_layer.audit_log("agent_resume", user_role, "success", {})
-    # Publish event (non-critical)
-    try:
-        await get_event_manager().publish("agent_resumed", {"message": "Agent operation resumed."})
-    except Exception as e:
-        logger.warning("Failed to publish agent_resumed event: %s", e)
+    await _publish_event_safe("agent_resumed", {"message": "Agent operation resumed."})
     return {"message": "Agent resumed successfully."}
 
 
@@ -892,8 +863,6 @@ async def execute_command(
                       a 403 error if permission is denied,
                       or a 500 error if an internal error occurs.
     """
-    from event_manager import get_event_manager
-
     security_layer = request.app.state.security_layer
     command = command_data.get("command")
 
@@ -901,15 +870,11 @@ async def execute_command(
     validation_error = _validate_command_request(command, security_layer, user_role)
     if validation_error:
         if not command:
-            await _publish_event_safe(
-                get_event_manager(),
-                "error",
-                {"message": "No command provided for execution."},
-            )
+            await _publish_event_safe("error", {"message": "No command provided for execution."})
         return validation_error
 
     # Publish start event (Issue #281: uses helper)
-    await _publish_event_safe(get_event_manager(), "command_execution_start", {"command": command})
+    await _publish_event_safe("command_execution_start", {"command": command})
     logging.info(f"Executing command: {command}")
 
     # Execute subprocess (Issue #281: uses helper)
@@ -917,7 +882,7 @@ async def execute_command(
 
     # Handle result and publish completion event (Issue #620: uses helper)
     return await _handle_command_result(
-        get_event_manager(), security_layer, user_role, command, stdout, stderr, returncode
+        security_layer, user_role, command, stdout, stderr, returncode
     )
 
 

--- a/autobot-backend/api/live_events.py
+++ b/autobot-backend/api/live_events.py
@@ -27,7 +27,7 @@ from starlette.websockets import WebSocketState
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
-from live_event_manager import get_live_event_manager
+from events.bus import get_event_bus
 
 logger = get_logger(__name__)
 router = APIRouter()
@@ -76,7 +76,7 @@ async def _handle_subscribe(ws: WebSocket, channel: str, user_payload: dict | No
         if not is_admin and claimed_id not in (user_id, username):
             await _send_error(ws, f"Not authorized to subscribe to {channel}")
             return
-    ok = await get_live_event_manager().subscribe(ws, channel)
+    ok = await get_event_bus().subscribe_ws(ws, channel)
     if ok:
         await ws.send_json({"type": "subscribed", "channel": channel})
     else:
@@ -85,7 +85,7 @@ async def _handle_subscribe(ws: WebSocket, channel: str, user_payload: dict | No
 
 async def _handle_unsubscribe(ws: WebSocket, channel: str) -> None:
     """Process an unsubscribe action from the client."""
-    await get_live_event_manager().unsubscribe(ws, channel)
+    await get_event_bus().unsubscribe_ws(ws, channel)
     await ws.send_json({"type": "unsubscribed", "channel": channel})
 
 
@@ -172,5 +172,5 @@ async def live_events_endpoint(websocket: WebSocket):
             await keepalive_task
         except asyncio.CancelledError:
             pass
-        await get_live_event_manager().remove_client(websocket)
+        await get_event_bus().remove_client(websocket)
         logger.info("Live events WebSocket connection cleaned up")

--- a/autobot-backend/api/websockets.py
+++ b/autobot-backend/api/websockets.py
@@ -20,6 +20,7 @@ from starlette.websockets import WebSocketState
 from auth_middleware import authenticate_websocket
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from events.bus import get_event_bus
 from type_defs.common import SKIP_WEBSOCKET_PERSISTENCE_TYPES
 
 logger = get_logger(__name__)
@@ -644,12 +645,8 @@ def _register_event_manager_broadcast(broadcast_event: Callable) -> None:
         broadcast_event: Broadcast callback function
     """
     try:
-        from event_manager import get_event_manager
-
-        get_event_manager().register_websocket_broadcast(broadcast_event)
+        get_event_bus().register_ws_broadcast(broadcast_event)
         logger.info("Successfully registered WebSocket broadcast with event manager")
-    except ImportError as e:
-        logger.warning("Event manager not available, continuing without it: %s", e)
     except Exception as e:
         logger.warning("Failed to register WebSocket broadcast, continuing: %s", e)
 
@@ -661,12 +658,8 @@ def _unregister_event_manager_broadcast() -> None:
     Issue #665: Extracted from websocket_endpoint to reduce function length.
     """
     try:
-        from event_manager import get_event_manager
-
-        get_event_manager().register_websocket_broadcast(None)
+        get_event_bus().register_ws_broadcast(None)
         logger.info("WebSocket broadcast unregistered from event manager")
-    except ImportError:
-        logger.debug("Event manager not available for cleanup")
     except Exception as e:
         logger.error("Error during event manager cleanup: %s", e)
 
@@ -980,14 +973,12 @@ def init_npu_worker_websocket():
             return
 
         try:
-            from event_manager import get_event_manager
-
-            # Subscribe to all NPU worker events
-            get_event_manager().subscribe("npu.worker.status.changed", broadcast_npu_worker_event)
-            get_event_manager().subscribe("npu.worker.added", broadcast_npu_worker_event)
-            get_event_manager().subscribe("npu.worker.updated", broadcast_npu_worker_event)
-            get_event_manager().subscribe("npu.worker.removed", broadcast_npu_worker_event)
-            get_event_manager().subscribe("npu.worker.metrics.updated", broadcast_npu_worker_event)
+            bus = get_event_bus()
+            bus.subscribe("npu.worker.status.changed", broadcast_npu_worker_event)
+            bus.subscribe("npu.worker.added", broadcast_npu_worker_event)
+            bus.subscribe("npu.worker.updated", broadcast_npu_worker_event)
+            bus.subscribe("npu.worker.removed", broadcast_npu_worker_event)
+            bus.subscribe("npu.worker.metrics.updated", broadcast_npu_worker_event)
 
             _npu_events_subscribed = True
             logger.info("NPU worker WebSocket event subscriptions initialized")

--- a/autobot-backend/api/workflow.py
+++ b/autobot-backend/api/workflow.py
@@ -30,7 +30,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from constants.error_constants import ERR_WORKFLOW_NOT_FOUND
-from event_manager import get_event_manager as _get_event_manager
+from events.bus import publish_event, PersistStrategy
 from metrics.system_monitor import system_monitor
 from metrics.workflow_metrics import workflow_metrics
 from models.task_context import WorkflowStepContext
@@ -547,14 +547,14 @@ async def approve_workflow_step(
     await _update_step_status_and_metrics(workflow_id, approval)
 
     # Publish approval event
-    await _get_event_manager().publish(
+    await publish_event("global", 
         "workflow_approval",
         {
             "workflow_id": workflow_id,
             "step_id": approval.step_id,
             "approved": approval.approved,
             "user_input": approval.user_input,
-        },
+        }, persist=PersistStrategy.NONE
     )
 
     return {
@@ -637,7 +637,7 @@ async def _wait_for_step_approval(workflow_id: str, workflow: dict, step: dict) 
         pending_approvals[approval_key] = approval_future
 
     # Publish approval request event
-    await _get_event_manager().publish(
+    await publish_event("global", 
         "workflow_approval_required",
         {
             "workflow_id": workflow_id,
@@ -648,7 +648,7 @@ async def _wait_for_step_approval(workflow_id: str, workflow: dict, step: dict) 
                 "agent_type": step["agent_type"],
                 "action": step["action"],
             },
-        },
+        }, persist=PersistStrategy.NONE
     )
 
     try:
@@ -673,7 +673,7 @@ async def _publish_step_started(workflow_id: str, step: Metadata, step_index: in
         step_index: Current step index
         total_steps: Total number of steps
     """
-    await _get_event_manager().publish(
+    await publish_event("global", 
         "workflow_step_started",
         {
             "workflow_id": workflow_id,
@@ -681,7 +681,7 @@ async def _publish_step_started(workflow_id: str, step: Metadata, step_index: in
             "description": step["description"],
             "step_index": step_index,
             "total_steps": total_steps,
-        },
+        }, persist=PersistStrategy.NONE
     )
 
 
@@ -695,14 +695,14 @@ async def _publish_step_completed(workflow_id: str, step: Metadata) -> None:
         workflow_id: Workflow identifier
         step: Step data with result
     """
-    await _get_event_manager().publish(
+    await publish_event("global", 
         "workflow_step_completed",
         {
             "workflow_id": workflow_id,
             "step_id": step["step_id"],
             "description": step["description"],
             "result": step.get("result", "Step completed successfully"),
-        },
+        }, persist=PersistStrategy.NONE
     )
 
 
@@ -820,14 +820,14 @@ async def _finalize_workflow_completed(workflow_id: str, workflow: Metadata, ste
     # Record metrics (Issue #281: uses helper)
     _record_workflow_metrics(workflow_type, workflow_start_time, "success")
 
-    await _get_event_manager().publish(
+    await publish_event("global", 
         "workflow_completed",
         {
             "workflow_id": workflow_id,
             "user_message": workflow["user_message"],
             "total_steps": len(steps),
             "execution_time": "calculated_time_here",
-        },
+        }, persist=PersistStrategy.NONE
     )
 
 
@@ -846,13 +846,13 @@ async def _finalize_workflow_failed(workflow_id: str, workflow: Metadata, error:
     # Record metrics (Issue #281: uses helper)
     _record_workflow_metrics(workflow_type, workflow_start_time, "failed")
 
-    await _get_event_manager().publish(
+    await publish_event("global", 
         "workflow_failed",
         {
             "workflow_id": workflow_id,
             "error": str(error),
             "current_step": workflow.get("current_step", 0),
-        },
+        }, persist=PersistStrategy.NONE
     )
 
 
@@ -964,9 +964,9 @@ async def cancel_workflow(workflow_id: str, admin_check: bool = Depends(check_ad
                 if not future.done():
                     future.cancel()
 
-    await _get_event_manager().publish(
+    await publish_event("global", 
         "workflow_cancelled",
-        {"workflow_id": workflow_id, "user_message": user_message},
+        {"workflow_id": workflow_id, "user_message": user_message}, persist=PersistStrategy.NONE
     )
 
     return {"success": True, "message": "Workflow cancelled successfully"}

--- a/autobot-backend/chat_workflow/cot_events.py
+++ b/autobot-backend/chat_workflow/cot_events.py
@@ -185,18 +185,20 @@ def _try_publish(event_type: str, payload: dict) -> None:
     """Fire-and-forget publish to the global EventManager.
 
     Wraps the publish call in create_task so it never blocks the caller.
-    Silently skips if the event manager is unavailable (e.g. in unit tests).
+    Silently skips if the event bus is unavailable (e.g. in unit tests).
 
     Args:
         event_type: Dot-namespaced event type string (e.g. "agent.tool.call").
         payload:    Dict payload that will be broadcast to WebSocket clients.
     """
     try:
-        from event_manager import get_event_manager
+        from events.bus import PersistStrategy, get_event_bus
 
         try:
             loop = asyncio.get_running_loop()
-            task = loop.create_task(get_event_manager().publish(event_type, payload))
+            task = loop.create_task(
+                get_event_bus().publish("global", event_type, payload, persist=PersistStrategy.NONE)
+            )
             task.add_done_callback(
                 lambda t: (
                     logger.debug("cot_events: publish error: %s", t.exception())
@@ -207,8 +209,6 @@ def _try_publish(event_type: str, payload: dict) -> None:
         except RuntimeError:
             # No running loop — caller is in a sync context; skip silently.
             logger.debug("cot_events: no running event loop, skipping %s", event_type)
-    except ImportError:
-        logger.debug("cot_events: event_manager not available, skipping %s", event_type)
     except Exception as exc:
         logger.debug("cot_events: publish failed for %s: %s", event_type, exc)
 

--- a/autobot-backend/diagnostics.py
+++ b/autobot-backend/diagnostics.py
@@ -28,7 +28,7 @@ try:
         RetryConfig,
         TimingConstants,
     )
-    from event_manager import get_event_manager
+    from events.bus import publish_event, PersistStrategy
 except ImportError as e:
     logging.warning(f"Import error in diagnostics: {e}")
 
@@ -133,7 +133,7 @@ class PerformanceOptimizedDiagnostics:
     async def _publish_permission_request(self, task_id: str, report: Dict[str, Any], attempt: int) -> asyncio.Future:
         """Publish permission request and return future (Issue #315 - extracted helper)."""
         permission_future = asyncio.Future()
-        await get_event_manager().publish(
+        await publish_event("global", 
             "log_message",
             {
                 "task_id": task_id,
@@ -145,7 +145,7 @@ class PerformanceOptimizedDiagnostics:
                 "attempt": attempt + 1,
                 "max_attempts": self.permission_retry_attempts,
                 "timeout_seconds": self.max_user_permission_timeout,
-            },
+            }, persist=PersistStrategy.NONE
         )
         logger.info(
             "Permission request sent for task %s (attempt %d/%d)",
@@ -166,7 +166,7 @@ class PerformanceOptimizedDiagnostics:
         )
 
         if attempt < self.permission_retry_attempts - 1:
-            await get_event_manager().publish(
+            await publish_event("global", 
                 "log_message",
                 {
                     "level": "WARNING",
@@ -174,7 +174,7 @@ class PerformanceOptimizedDiagnostics:
                         f"Permission request timeout (attempt {attempt + 1}). Retrying... "
                         f"({self.permission_retry_attempts - attempt - 1} attempts remaining)"
                     ),
-                },
+                }, persist=PersistStrategy.NONE
             )
             await asyncio.sleep(RetryConfig.BACKOFF_BASE)
             return True  # Should retry
@@ -224,7 +224,7 @@ class PerformanceOptimizedDiagnostics:
 
     async def _handle_permission_timeout_fallback(self, task_id: str, elapsed_time: float):
         """Handle user permission timeout with intelligent fallback"""
-        await get_event_manager().publish(
+        await publish_event("global", 
             "log_message",
             {
                 "level": "WARNING",
@@ -233,7 +233,7 @@ class PerformanceOptimizedDiagnostics:
                     f"timed out after {elapsed_time:.2f}s. Using safe fallback (no fixes applied). "
                     f"This prevents system hangs. Previous timeout was 600s (10 minutes)."
                 ),
-            },
+            }, persist=PersistStrategy.NONE
         )
 
         # Log performance improvement

--- a/autobot-backend/enhanced_orchestration/workflow_runner.py
+++ b/autobot-backend/enhanced_orchestration/workflow_runner.py
@@ -25,7 +25,7 @@ from enhanced_orchestration.execution_strategies import ExecutionStrategyHandler
 from enhanced_orchestration.success_criteria import SuccessCriteriaEvaluator
 from enhanced_orchestration.types import AgentTask, WorkflowDependencies, WorkflowPlan
 from enhanced_orchestration.workflow_planning import StrategyPlanner
-from event_manager import get_event_manager as _get_event_manager
+from events.bus import publish_event, PersistStrategy
 from orchestration.performance_tracker import PerformanceTracker
 
 logger = get_logger("workflow_runner")
@@ -381,7 +381,7 @@ class WorkflowRunner:
         return task.to_completed_result(result)
 
     async def _publish_workflow_event(self, workflow_id: str, event_type: str, data: Dict[str, Any]) -> None:
-        await _get_event_manager().publish(
+        await publish_event("global", 
             "workflow_event",
-            {"workflow_id": workflow_id, "event_type": event_type, "timestamp": time.time(), "data": data},
+            {"workflow_id": workflow_id, "event_type": event_type, "timestamp": time.time(), "data": data}, persist=PersistStrategy.NONE
         )

--- a/autobot-backend/events/bus.py
+++ b/autobot-backend/events/bus.py
@@ -100,6 +100,12 @@ class EventBus:
         """Unsubscribe a listener from EventManager events."""
         get_event_manager().unsubscribe(event_type, listener)
 
+    def register_ws_broadcast(
+        self, callback: Callable[[Dict[str, Any]], Awaitable[None]] | None
+    ) -> None:
+        """Register (or clear) the EventManager WebSocket broadcast callback."""
+        get_event_manager().register_websocket_broadcast(callback)
+
 
 get_event_bus = lazy_singleton(EventBus)
 

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -828,11 +828,18 @@ class Orchestrator:
         self.config.phi2_enabled = enabled
         logger.info("Phi-2 enabled status set to: %s", self.config.phi2_enabled)
         try:
-            from utils.event_manager import event_manager
+            import asyncio
+            from events.bus import PersistStrategy, get_event_bus
 
-            event_manager.publish("settings_update", {"phi2_enabled": enabled})
-        except ImportError:
-            logger.debug("Event manager not available for settings update")
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                loop.create_task(
+                    get_event_bus().publish(
+                        "global", "settings_update", {"phi2_enabled": enabled}, persist=PersistStrategy.NONE
+                    )
+                )
+        except Exception:
+            logger.debug("Event bus not available for settings update")
 
     async def get_status(self) -> Dict[str, Any]:
         uptime = datetime.now(tz=timezone.utc) - self.start_time if self.start_time else 0

--- a/autobot-backend/services/agent_terminal/approval_handler.py
+++ b/autobot-backend/services/agent_terminal/approval_handler.py
@@ -165,9 +165,9 @@ class ApprovalHandler:
 
             # IMPLEMENTED: Real-time WebSocket broadcasting via event_manager
             try:
-                from event_manager import get_event_manager
+                from events.bus import publish_event, PersistStrategy
 
-                await get_event_manager().publish(
+                await publish_event("global", 
                     event_type="command_approval_status",
                     payload={
                         "conversation_id": session.conversation_id,
@@ -177,7 +177,7 @@ class ApprovalHandler:
                         "approved": approved,
                         "comment": comment,
                         "pre_approved": pre_approved,
-                    },
+                    }, persist=PersistStrategy.NONE
                 )
                 logger.info(
                     f"✅ Approval status broadcast sent: "

--- a/autobot-backend/services/approval_gate_service.py
+++ b/autobot-backend/services/approval_gate_service.py
@@ -343,9 +343,9 @@ class ApprovalGateService:
     ) -> None:
         """Publish WebSocket notification via get_event_manager()."""
         try:
-            from event_manager import get_event_manager
+            from events.bus import publish_event, PersistStrategy
 
-            await get_event_manager().publish(
+            await publish_event("global", 
                 event_type=event_type,
                 payload={
                     "approval_id": str(approval.id),
@@ -356,7 +356,7 @@ class ApprovalGateService:
                     "decided_by_user": approval.decided_by_user,
                     "workflow_id": approval.workflow_id,
                     "workflow_step": approval.workflow_step,
-                },
+                }, persist=PersistStrategy.NONE
             )
         except Exception as exc:
             logger.warning(

--- a/autobot-backend/services/autoresearch/auto_research_agent.py
+++ b/autobot-backend/services/autoresearch/auto_research_agent.py
@@ -1094,9 +1094,9 @@ class AutoResearchAgent(AsyncRedisClientMixin):
         )
 
         try:
-            from event_manager import get_event_manager
+            from events.bus import publish_event, PersistStrategy
 
-            await get_event_manager().publish(
+            await publish_event("global", 
                 event_type="research_checkpoint_pending",
                 payload={
                     "session_id": session.id,
@@ -1104,7 +1104,7 @@ class AutoResearchAgent(AsyncRedisClientMixin):
                     "decision_key": dec_key,
                     "context": context,
                     "timeout_seconds": self.config.checkpoint_timeout_seconds,
-                },
+                }, persist=PersistStrategy.NONE
             )
         except Exception:
             logger.warning(

--- a/autobot-backend/services/captcha_human_loop.py
+++ b/autobot-backend/services/captcha_human_loop.py
@@ -56,7 +56,7 @@ except ImportError:  # pragma: no cover
     from typing import Any as Page  # type: ignore[assignment, misc]
 
 from constants.threshold_constants import TimingConstants
-from event_manager import get_event_manager
+from events.bus import publish_event, PersistStrategy
 
 logger = get_logger(__name__)
 
@@ -499,7 +499,7 @@ class CaptchaHumanLoop:
         screenshot_b64: str,
     ) -> None:
         """Send WebSocket notification that CAPTCHA was detected."""
-        await get_event_manager().publish(
+        await publish_event("global", 
             "captcha_detected",
             {
                 "captcha_id": captcha_id,
@@ -510,31 +510,31 @@ class CaptchaHumanLoop:
                 "timeout_seconds": self.timeout_seconds,
                 "timestamp": utc_timestamp(),
                 "message": f"CAPTCHA detected at {url}. Please solve manually via VNC.",
-            },
+            }, persist=PersistStrategy.NONE
         )
 
     async def _notify_captcha_timeout(self, captcha_id: str, url: str) -> None:
         """Send WebSocket notification that CAPTCHA resolution timed out."""
-        await get_event_manager().publish(
+        await publish_event("global", 
             "captcha_timeout",
             {
                 "captcha_id": captcha_id,
                 "url": url,
                 "timestamp": utc_timestamp(),
                 "message": f"CAPTCHA resolution timed out for {url}. Source will be skipped.",
-            },
+            }, persist=PersistStrategy.NONE
         )
 
     async def _notify_captcha_resolved(self, captcha_id: str, url: str, status: CaptchaResolutionStatus) -> None:
         """Send WebSocket notification that CAPTCHA was resolved."""
-        await get_event_manager().publish(
+        await publish_event("global", 
             "captcha_resolved",
             {
                 "captcha_id": captcha_id,
                 "url": url,
                 "status": status.value,
                 "timestamp": utc_timestamp(),
-            },
+            }, persist=PersistStrategy.NONE
         )
 
     def get_pending_captchas(self) -> Dict[str, Any]:

--- a/autobot-backend/services/heartbeat_scheduler.py
+++ b/autobot-backend/services/heartbeat_scheduler.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
 from events.event_types import HEARTBEAT_RUN_COMPLETED, HEARTBEAT_RUN_STARTED
-from live_event_manager import publish_live_event
+from events.bus import publish_event
 from models.agent import Agent
 from models.heartbeat import (
     AgentRuntimeState,
@@ -235,7 +235,7 @@ class HeartbeatScheduler:
             run_jwt = ""
 
         logger.info("Heartbeat run %s started for agent %s", run_id, agent_id)
-        await publish_live_event(
+        await publish_event(
             f"heartbeat:{agent_id}",
             HEARTBEAT_RUN_STARTED,
             {"run_id": str(run_id), "agent_id": agent_id, "trigger": trigger.value},
@@ -305,7 +305,7 @@ class HeartbeatScheduler:
                 f"Run finished with status={final_status}",
             )
             await session.commit()
-        await publish_live_event(
+        await publish_event(
             f"heartbeat:{agent_id}",
             HEARTBEAT_RUN_COMPLETED,
             {

--- a/autobot-backend/services/load_balancer.py
+++ b/autobot-backend/services/load_balancer.py
@@ -31,7 +31,7 @@ from typing import Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from constants.threshold_constants import RetryConfig, TimingConstants
-from event_manager import get_event_manager
+from events.bus import publish_event, PersistStrategy
 from npu_integration import NPUWorkerClient
 from type_defs.common import Metadata
 
@@ -644,9 +644,9 @@ class NPULoadBalancer:
             reason: Reason for status change
         """
         try:
-            await get_event_manager().publish(
+            await publish_event("global", 
                 "npu_worker_status_change",
-                worker.to_status_event_dict(reason),
+                worker.to_status_event_dict(reason), persist=PersistStrategy.NONE
             )
         except Exception as e:
             logger.error("Failed to emit worker status change event: %s", e)

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -19,7 +19,7 @@ import yaml
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.threshold_constants import TimingConstants
-from event_manager import get_event_manager
+from events.bus import publish_event, PersistStrategy
 from models.npu_models import (
     LoadBalancingConfig,
     NPUWorkerConfig,
@@ -397,7 +397,7 @@ class NPUWorkerManager(AsyncInitializable):
             if event_type in _WORKER_FULL_DATA_EVENTS:
                 event_data["worker"] = worker_details.to_event_dict()
 
-            await get_event_manager().publish(f"npu.{event_type}", event_data)
+            await publish_event("global", f"npu.{event_type}", event_data, persist=PersistStrategy.NONE)
             logger.debug(f"Emitted event {event_type} for worker {worker_details.config.id}")
 
         except Exception as e:
@@ -576,13 +576,13 @@ class NPUWorkerManager(AsyncInitializable):
         await self._save_workers_to_config()
 
         # Emit worker removed event
-        await get_event_manager().publish(
+        await publish_event("global", 
             "npu.worker.removed",
             {
                 "event": "worker.removed",
                 "worker_id": worker_id,
                 "data": {"timestamp": utc_timestamp()},
-            },
+            }, persist=PersistStrategy.NONE
         )
 
     async def test_worker_connection(self, worker_config: NPUWorkerConfig) -> WorkerTestResult:

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -22,7 +22,7 @@ from constants.ttl_constants import TTL_30_DAYS
 from events.event_types import RAG_RETRIEVAL
 from knowledge.search_components.query_classifier import get_query_classifier
 from knowledge.search_components.retrieval_learner import GLOBAL_USER, get_retrieval_learner
-from live_event_manager import publish_live_event
+from events.bus import publish_event
 from services.context_sufficiency import (
     SufficiencyVerdict,
     get_context_sufficiency_evaluator,
@@ -521,7 +521,7 @@ class RAGService:
             "timestamp": time.time(),
         }
         try:
-            await publish_live_event("global", RAG_RETRIEVAL, payload)
+            await publish_event("global", RAG_RETRIEVAL, payload)
         except Exception as exc:
             logger.debug("Live event publish failed (non-fatal): %s", exc)
 

--- a/autobot-backend/task_handlers/communication_handlers.py
+++ b/autobot-backend/task_handlers/communication_handlers.py
@@ -11,7 +11,7 @@ from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.models.task_result import task_pending_approval, task_success
-from event_manager import get_event_manager
+from events.bus import publish_event, PersistStrategy
 from models.task_context import TaskExecutionContext
 
 from .base import TaskHandler
@@ -26,7 +26,7 @@ class RespondConversationallyHandler(TaskHandler):
         """Execute conversational response task and publish via event manager."""
         response_text = ctx.get_payload_value("response_text", "No response provided.")
 
-        await get_event_manager().publish("llm_response", {"response": response_text})
+        await publish_event("global", "llm_response", {"response": response_text}, persist=PersistStrategy.NONE)
 
         result = task_success(
             "Responded conversationally.",
@@ -50,13 +50,13 @@ class AskUserForManualHandler(TaskHandler):
         program_name = ctx.require_payload_value("program_name")
         question_text = ctx.require_payload_value("question_text")
 
-        await get_event_manager().publish(
+        await publish_event("global", 
             "ask_user_for_manual",
             {
                 "task_id": ctx.task_id,
                 "program_name": program_name,
                 "question_text": question_text,
-            },
+            }, persist=PersistStrategy.NONE
         )
 
         result = task_success(f"Asked user for manual for {program_name}.")
@@ -77,9 +77,9 @@ class AskUserCommandApprovalHandler(TaskHandler):
         """Execute command approval request task requiring user confirmation."""
         command_to_approve = ctx.require_payload_value("command")
 
-        await get_event_manager().publish(
+        await publish_event("global", 
             "ask_user_command_approval",
-            {"task_id": ctx.task_id, "command": command_to_approve},
+            {"task_id": ctx.task_id, "command": command_to_approve}, persist=PersistStrategy.NONE
         )
 
         result = task_pending_approval(f"Requested user approval for command: {command_to_approve}")

--- a/autobot-backend/worker_node.py
+++ b/autobot-backend/worker_node.py
@@ -41,7 +41,7 @@ from autobot_shared.redis_client import get_redis_client
 
 # Import the centralized ConfigManager and Redis client utility
 from config import config as global_config_manager
-from event_manager import get_event_manager
+from events.bus import publish_event, PersistStrategy
 from knowledge_base import KnowledgeBase
 from security_layer import SecurityLayer
 from services.llm_service import get_llm_service
@@ -264,7 +264,7 @@ class WorkerNode:
             logger.info("Worker capabilities reported to Redis channel '%s'.", channel)
         else:
             logger.debug("Worker capabilities detected (local mode): %s", capabilities)
-            await get_event_manager().publish("worker_capability_report", capabilities)
+            await publish_event("global", "worker_capability_report", capabilities, persist=PersistStrategy.NONE)
 
     def _validate_user_role(self, task_type: str, task_id: str, user_role: str | None) -> Dict[str, Any] | None:
         """Validate that user_role is provided for task execution.
@@ -361,9 +361,9 @@ class WorkerNode:
 
     async def _publish_task_start(self, task_id: str, task_type: str, user_role: str) -> None:
         """Publish task start event and log execution start. Issue #620."""
-        await get_event_manager().publish(
+        await publish_event("global", 
             "worker_task_start",
-            {"worker_id": self.worker_id, "task_id": task_id, "type": task_type},
+            {"worker_id": self.worker_id, "task_id": task_id, "type": task_type}, persist=PersistStrategy.NONE
         )
         logger.info(
             "Worker %s executing task %s of type '%s' for role '%s'",
@@ -375,9 +375,9 @@ class WorkerNode:
 
     async def _publish_task_completion(self, task_id: str, result: Dict[str, Any]) -> None:
         """Publish task completion event and log result. Issue #620."""
-        await get_event_manager().publish(
+        await publish_event("global", 
             "worker_task_end",
-            {"worker_id": self.worker_id, "task_id": task_id, "result": result},
+            {"worker_id": self.worker_id, "task_id": task_id, "result": result}, persist=PersistStrategy.NONE
         )
         logger.info(
             "Worker %s finished task %s with status: %s",


### PR DESCRIPTION
## Summary

- Migrated **22 backend files** from direct `EventManager`/`LiveEventManager` imports to `events.bus` facade (GH #8291)
- Added `register_ws_broadcast()` to `EventBus` in `events/bus.py`

## Changes

Migration patterns applied:
- `get_event_manager().publish(event_type, payload)` → `publish_event("global", event_type, payload, persist=PersistStrategy.NONE)`
- `publish_live_event(channel, event_type, payload)` → `publish_event(channel, event_type, payload)`
- `get_live_event_manager().subscribe/unsubscribe/remove_client` → `get_event_bus().*_ws()`
- `register_websocket_broadcast` → `get_event_bus().register_ws_broadcast()`
- `_publish_event_safe` helper in `api/agent.py` refactored to drop `event_manager` parameter
- `orchestrator.py` broken `utils.event_manager` + sync-without-await pattern fixed

## Acceptance Criteria

- [x] All callers use `events.bus.publish_event()` or `events.bus.get_event_bus()`
- [x] No direct imports of `EventManager` or `LiveEventManager` outside their own modules
- [x] The dual-publish pattern does not re-appear
- [x] All 22 modified files pass `py_compile`

## Test plan

- [ ] Verify no `EventManager`/`LiveEventManager` imports outside their own modules: `grep -r "from events.event_manager import\|from events.live_events import" autobot-backend/ --include="*.py" | grep -v "event_manager.py\|live_events.py"`
- [ ] Spot-check WebSocket broadcast still works via `/api/live_events` subscribe path
- [ ] Verify event publishing in workflow and agent API paths

Part of MVA-687 (events.bus consolidation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)