### PR TITLE
refactor(frontend/ws): Phase 2 — migrate useLiveEvents callers to useEventBus (GH #8292)

### DIFF
--- a/autobot-frontend/src/components/agents/HeartbeatPanel.vue
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.vue
@@ -155,12 +155,12 @@ import { computed, onUnmounted, ref, watch } from 'vue'
 import { getBackendUrl } from '@/config/ssot-config'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
-import { useLiveEvents } from '@/composables/useLiveEvents'
+import { useEventBus } from '@/composables/useEventBus'
 import { useExpansion } from '@/composables/useExpansion'
 import type { LiveEvent } from '@/services/LiveEventService'
 
 const logger = createLogger('HeartbeatPanel')
-const { subscribe, unsubscribe } = useLiveEvents()
+const { subscribe, unsubscribe } = useEventBus()
 
 interface HeartbeatConfig {
   agent_id: string

--- a/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
@@ -157,7 +157,8 @@
 import { computed, ref, onMounted, onUnmounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { createLogger } from '@/utils/debugUtils';
-import { useLiveEvents, type LiveEvent } from '@/composables/useLiveEvents';
+import { useEventBus } from '@/composables/useEventBus'
+import type { LiveEvent } from '@/services/LiveEventService'
 import AgentObservabilityPanel from './AgentObservabilityPanel.vue';
 import type {
   ActiveWorkflow,
@@ -186,7 +187,7 @@ const emit = defineEmits<{
 const maxVisibleSteps = 10;
 
 // Live event connection
-const { subscribe, isConnected: liveConnected, connectionState, connect } = useLiveEvents();
+const { subscribe, isConnected: liveConnected, connectionState, connect } = useEventBus()
 const isReconnecting = ref(false);
 
 const connectionStatusClass = computed(() => {

--- a/autobot-frontend/src/composables/useGlobalWebSocket.ts
+++ b/autobot-frontend/src/composables/useGlobalWebSocket.ts
@@ -4,6 +4,11 @@
 /**
  * Global WebSocket Composable
  *
+ * @deprecated For channel-based event subscriptions, prefer `useEventBus`
+ * from `@/composables/useEventBus` instead (#6488 Phase 2).
+ * This composable is preserved for callers that need `send()` or `state`
+ * access until backend endpoint unification (#8291) is complete.
+ *
  * Provides easy access to the global WebSocket service for any component.
  * Use this in any Vue component to get real-time updates regardless of page/tab.
  *

--- a/autobot-frontend/src/composables/useLiveEvents.ts
+++ b/autobot-frontend/src/composables/useLiveEvents.ts
@@ -4,14 +4,14 @@
 /**
  * Live Events Composable (#2064)
  *
+ * @deprecated Use `useEventBus` from `@/composables/useEventBus` instead.
+ * `useEventBus` is the canonical unified entry-point (#6488 Phase 2).
+ * This composable is preserved for backward compatibility; migrate callers to
+ * `useEventBus()` — the API is identical.
+ *
  * Provides Vue-friendly access to the scoped LiveEventService for
  * channel-based real-time event streaming (agent:{id}, task:{id},
  * workflow:{id}, global).
- *
- * Usage:
- *   const { subscribe, isConnected, connectionState } = useLiveEvents()
- *   const unsub = subscribe('global', (event) => { ... })
- *   // unsub() to stop listening, or it auto-cleans on component unmount
  */
 
 import { computed, onUnmounted, getCurrentInstance, type ComputedRef } from 'vue'

--- a/autobot-frontend/src/composables/useToolApproval.ts
+++ b/autobot-frontend/src/composables/useToolApproval.ts
@@ -18,7 +18,7 @@
 
 import { ref, type Ref, onUnmounted, getCurrentInstance } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
-import liveEventService from '@/services/LiveEventService'
+import { useEventBus } from '@/composables/useEventBus'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 
@@ -61,11 +61,12 @@ export interface UseToolApprovalReturn {
 export function useToolApproval(): UseToolApprovalReturn {
   const pendingToolApproval = ref<PendingToolApproval | null>(null)
   const submittingApproval = ref(false)
+  const { subscribe } = useEventBus()
 
   // Subscribe to the global channel for APPROVAL_REQUIRED events (#4952).
   // The agent loop publishes on the global channel with EventType.APPROVAL_REQUIRED
   // which serialises to the string "APPROVAL_REQUIRED" in the live_event payload.
-  const unsub = liveEventService.subscribe('global', (event) => {
+  const unsub = subscribe('global', (event) => {
     if (event.event_type !== 'APPROVAL_REQUIRED') return
     const p = event.payload as Record<string, unknown>
     const approval: PendingToolApproval = {


### PR DESCRIPTION
## Summary

- Migrates the 3 viable callers of `useLiveEvents`/`liveEventService` to canonical `useEventBus()` composable (Phase 2 of #6488)
- `HeartbeatPanel.vue`: `useLiveEvents()` → `useEventBus()`
- `WorkflowLiveDashboard.vue`: `useLiveEvents()` → `useEventBus()`
- `useToolApproval.ts`: `liveEventService.subscribe()` → `useEventBus().subscribe()`
- Adds `@deprecated` JSDoc to `useLiveEvents.ts` and `useGlobalWebSocket.ts` pointing to `useEventBus`

Remaining callers (captcha, terminal, SSH, Prometheus WebSocket) require backend endpoint unification (#8291, now merged) or are bidirectional channels not suited for the global event bus — tracked separately.

Closes #8292

## What Changed

- `HeartbeatPanel.vue`: Import swapped `useLiveEvents` → `useEventBus`; destructure unchanged (`subscribe`, `unsubscribe`)
- `WorkflowLiveDashboard.vue`: Import swapped; `LiveEvent` type moved to canonical source (`@/services/LiveEventService`)
- `useToolApproval.ts`: Replaced direct `liveEventService.subscribe()` with `useEventBus().subscribe()`, gaining auto-cleanup on component unmount
- `useLiveEvents.ts`: Added `@deprecated` JSDoc pointing to `useEventBus`; removed Usage section (now redundant)
- `useGlobalWebSocket.ts`: Added `@deprecated` JSDoc with migration note and scope boundary (retained for `send()`/`state` callers until #8291 unification completes)

## Thinking Path

`useEventBus` is a thin wrapper over the same `LiveEventService` singleton, so API surface is identical (`subscribe`, `unsubscribe`, `isConnected`, `connectionState`, `connect`, `disconnect`). The only behavioural difference is that `useEventBus` auto-unsubscribes on component unmount via tracked `unsubscribers[]`, whereas the old `liveEventService.subscribe()` path in `useToolApproval` required manual cleanup — this is a net improvement. `ConnectionState` and `LiveEventConnectionState` are the same underlying type (alias chain confirmed in `LiveEventService.ts:22`).

Remaining callers (captcha WS, terminal WS, SSH WS, Prometheus WS) are bidirectional channels that use `send()` and are not suitable for the read-only event bus; these are intentionally deferred and documented in the deprecation notice on `useGlobalWebSocket.ts`.

## Verification

- `vue-tsc --noEmit`: `HeartbeatPanel.vue:246` TS2769 is pre-existing on `Dev_new_gui` base (watch callback type annotation unrelated to composable swap); error count unchanged by this PR
- CI failures (`vue-tsc-baseline`, `Storybook visual regression`) are pre-existing npm vega/vega-lite peer-dep conflict affecting all PRs; SSOT violations (7) are pre-existing baseline violations
- API compatibility verified: `useEventBus` return shape is a superset of `useLiveEvents` — all destructured fields (`subscribe`, `unsubscribe`, `isConnected`, `connectionState`, `connect`) are present with identical types

## Model Used

claude-sonnet-4-6

## Test plan

- [ ] HeartbeatPanel heartbeat events still fire after migration
- [ ] WorkflowLiveDashboard live updates still work
- [ ] Tool approval flow still triggers correctly
- [ ] No `useLiveEvents` import errors in TS compiler

🤖 Generated with [Claude Code](https://claude.com/claude-code)