### PR TITLE
fix(orchestrator): use asyncio.get_running_loop() in set_phi2_enabled (#8330)

### DIFF
--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -828,16 +828,15 @@ class Orchestrator:
         self.config.phi2_enabled = enabled
         logger.info("Phi-2 enabled status set to: %s", self.config.phi2_enabled)
         try:
-            import asyncio
             from events.bus import PersistStrategy, get_event_bus
 
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                loop.create_task(
-                    get_event_bus().publish(
-                        "global", "settings_update", {"phi2_enabled": enabled}, persist=PersistStrategy.NONE
-                    )
+            asyncio.get_running_loop().create_task(
+                get_event_bus().publish(
+                    "global", "settings_update", {"phi2_enabled": enabled}, persist=PersistStrategy.NONE
                 )
+            )
+        except RuntimeError:
+            logger.debug("No running event loop; settings_update event not published")
         except Exception:
             logger.debug("Event bus not available for settings update")
 


### PR DESCRIPTION
## Summary
- Replaces deprecated `asyncio.get_event_loop() + is_running()` pattern with `asyncio.get_running_loop()` in `set_phi2_enabled`, matching the canonical fire-and-forget async pattern used in `tracking.py` and `base_provider.py`
- Removes the redundant inline `import asyncio` (already at module level)
- Adds explicit `except RuntimeError` to handle the no-running-loop case cleanly (separate from generic bus-unavailable errors)

## Context
GH#8330 tracked a regression risk: `set_phi2_enabled` originally imported `utils.event_manager` (module never existed → silent ImportError) and called `publish()` without `await` (unawaited coroutine). The initial fix landed in MVA-697 (#8291) using `get_event_loop()`. This PR tightens that fix to use the non-deprecated `get_running_loop()`.

## Test Plan
- [ ] `set_phi2_enabled(True/False)` in a running async context → event published via `get_event_bus()`
- [ ] `set_phi2_enabled` called outside an event loop → logs debug message, no exception raised
- [ ] No `DeprecationWarning` from `asyncio.get_event_loop()` in Python 3.10+

## Related Issues
Closes #8330