### PR TITLE
fix: SLM crash-loop (GH#8141) + heartbeat event drop (GH#8340)

### DIFF
--- a/autobot-backend/live_event_manager.py
+++ b/autobot-backend/live_event_manager.py
@@ -5,7 +5,7 @@
 Live Event Manager - Scoped Real-Time Events (#1408)
 
 In-memory channel router for WebSocket-based entity-scoped event streaming.
-Supports channels: agent:{id}, task:{id}, workflow:{id}, global
+Supports channels: agent:{id}, task:{id}, workflow:{id}, heartbeat:{id}, global
 """
 
 import asyncio
@@ -19,11 +19,11 @@ from autobot_shared.singleton_factory import lazy_singleton
 
 logger = get_logger(__name__)
 
-_VALID_PREFIXES = {"agent", "task", "workflow", "global"}
+_VALID_PREFIXES = {"agent", "task", "workflow", "global", "heartbeat"}
 
 
 def _is_valid_channel(channel: str) -> bool:
-    """Return True if channel matches agent:{id}, task:{id}, workflow:{id}, or global."""
+    """Return True if channel matches agent:{id}, task:{id}, workflow:{id}, heartbeat:{id}, or global."""
     if channel == "global":
         return True
     parts = channel.split(":", 1)

--- a/autobot-slm-backend/user_management/models/api_key.py
+++ b/autobot-slm-backend/user_management/models/api_key.py
@@ -9,7 +9,7 @@ Long-lived API keys for programmatic access.
 
 import uuid
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import JSONB, UUID
@@ -139,7 +139,7 @@ class APIKey(Base, TimestampMixin):
         foreign_keys=[user_id],
     )
 
-    team: Mapped[Optional["Team"]] = relationship(
+    team: Mapped["Team | None"] = relationship(
         "Team",
         back_populates="api_keys",
     )


### PR DESCRIPTION
## Summary

Two critical fixes bundled in one commit (`69c961a`):

- **GH#8141 — SLM crash loop**: Changed `Mapped[Optional["Team"]]` → `Mapped["Team | None"]` in `autobot-slm-backend/user_management/models/api_key.py`. SQLAlchemy 2.x fails to resolve `Optional["Team"]` forward references correctly, causing a startup crash-loop. The union syntax `Team | None` fixes the resolution.

- **GH#8340 — Heartbeat event drop**: Added `"heartbeat"` to `LiveEventManager._VALID_PREFIXES` in `autobot-backend/live_event_manager.py`. Without this, `heartbeat:{agent_id}` channels were silently rejected by `publish_live_event()`, making `HEARTBEAT_RUN_STARTED` / `HEARTBEAT_RUN_COMPLETED` events invisible since PR #8333.

## Files Changed

- `autobot-slm-backend/user_management/models/api_key.py` — 2-line fix (type annotation)
- `autobot-backend/live_event_manager.py` — 3-line fix (add prefix + update docstrings)

## Test Plan

- [ ] SLM starts without crash-loop after merge (no SQLAlchemy `NameError`/`InvalidRequestError` on `APIKey.team`)
- [ ] `heartbeat:{agent_id}` channels now pass `_is_valid_channel()` validation
- [ ] Existing channel prefixes (`agent`, `task`, `workflow`, `global`) still accepted

## Related

- Closes GH#8141
- Closes GH#8340
- Unblocks MVA-721

🤖 Generated with [Claude Code](https://claude.com/claude-code)