### PR TITLE
feat(llm): add ArchitectureFamily enum + attention_backend dispatch (#7347, #7350)

### DIFF
--- a/autobot-backend/llm_shared/optimization/attention_backend.py
+++ b/autobot-backend/llm_shared/optimization/attention_backend.py
@@ -28,6 +28,7 @@ from enum import Enum
 from typing import Any, List
 
 from autobot_shared.logging_manager import get_logger
+from llm_shared.types import ArchitectureFamily
 
 logger = get_logger(__name__)
 
@@ -70,11 +71,16 @@ class AttentionBackend(str, Enum):
     Values reflect capability tiers from highest (fastest) to lowest (most
     compatible).  The string values are stable identifiers safe for logging
     and serialisation.
+
+    NOT_APPLICABLE is returned for non-transformer architectures (state-space,
+    linear-attention, hybrid) where attention-backend selection is meaningless.
+    Issue #7350.
     """
 
     BETTER_TRANSFORMER = "better_transformer"
     SDPA = "sdpa"
     VANILLA = "vanilla"
+    NOT_APPLICABLE = "not_applicable"
 
 
 # ---------------------------------------------------------------------------
@@ -92,11 +98,15 @@ class ModelConfig:
             (e.g. ``mixtral``, ``mistral``, ``llama``).
         torch_dtype: Torch dtype string (e.g. ``float16``, ``bfloat16``).
             None means the model default will be used.
+        architecture_family: High-level architecture family from ``ArchitectureFamily``.
+            Defaults to ``TRANSFORMER`` for backwards compatibility.
+            Issue #7347/#7350: positive family signal for non-attention routing.
     """
 
     model_name: str = ""
     model_type: str = ""
     torch_dtype: str | None = None
+    architecture_family: ArchitectureFamily = ArchitectureFamily.TRANSFORMER
     extra: dict = field(default_factory=dict)
 
 
@@ -138,7 +148,13 @@ class AttentionBackendSelector:
     def select_backend(self, model_config: ModelConfig) -> AttentionBackend:
         """Determine the highest available backend tier for *model_config*.
 
-        Tries each tier in order.  A tier is skipped when:
+        Non-transformer architectures (state-space, linear-attention, hybrid)
+        have no scaled-dot-product attention to optimise.  For those families
+        this method returns ``NOT_APPLICABLE`` immediately so callers can skip
+        the optimisation step without emitting spurious warnings.
+        Issue #7350.
+
+        For transformer models, tries each tier in order.  A tier is skipped when:
         - The required library is absent, or
         - The model appears in the BetterTransformer blocklist (Tier 1 only).
 
@@ -146,8 +162,17 @@ class AttentionBackendSelector:
             model_config: Description of the model to be optimised.
 
         Returns:
-            The highest tier that is both available and compatible.
+            The highest tier that is both available and compatible, or
+            ``NOT_APPLICABLE`` for non-transformer architectures.
         """
+        if model_config.architecture_family != ArchitectureFamily.TRANSFORMER:
+            logger.debug(
+                "AttentionBackend: NOT_APPLICABLE for %s (architecture_family=%s)",
+                model_config.model_name or model_config.model_type,
+                model_config.architecture_family.value,
+            )
+            return AttentionBackend.NOT_APPLICABLE
+
         if self._can_use_better_transformer(model_config):
             logger.info(
                 "AttentionBackend: selected BetterTransformer for %s",
@@ -171,8 +196,11 @@ class AttentionBackendSelector:
     def apply_backend(self, model: Any, backend: AttentionBackend) -> Any:
         """Apply *backend* to *model*, falling through on any failure.
 
-        Each tier is attempted.  If it raises, GPU memory is freed and the
-        next tier is tried.  This mirrors the tier priority from
+        For ``NOT_APPLICABLE`` (non-transformer architectures) the model is
+        returned unchanged without any warning.  Issue #7350.
+
+        Each transformer tier is attempted.  If it raises, GPU memory is freed
+        and the next tier is tried.  This mirrors the tier priority from
         :meth:`select_backend` so callers receive a consistently optimised
         model regardless of environment specifics.
 
@@ -184,6 +212,9 @@ class AttentionBackendSelector:
             The model, potentially transformed in-place or replaced by a
             BetterTransformer-wrapped copy.
         """
+        if backend == AttentionBackend.NOT_APPLICABLE:
+            return model
+
         if backend == AttentionBackend.BETTER_TRANSFORMER:
             result = self._try_apply_better_transformer(model)
             if result is not None:

--- a/autobot-backend/llm_shared/optimization/attention_backend_test.py
+++ b/autobot-backend/llm_shared/optimization/attention_backend_test.py
@@ -17,6 +17,7 @@ from llm_shared.optimization.attention_backend import (
     _free_memory,
     get_attention_backend_selector,
 )
+from llm_shared.types import ArchitectureFamily
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -49,15 +50,16 @@ class TestAttentionBackendEnum:
             assert isinstance(backend.value, str)
 
     def test_expected_members(self):
-        """Enum must expose the three required tiers."""
+        """Enum must expose the three transformer tiers plus NOT_APPLICABLE."""
         names = {b.name for b in AttentionBackend}
-        assert names == {"BETTER_TRANSFORMER", "SDPA", "VANILLA"}
+        assert names == {"BETTER_TRANSFORMER", "SDPA", "VANILLA", "NOT_APPLICABLE"}
 
     def test_string_coercion(self):
         """AttentionBackend should be usable as a str subclass."""
         assert AttentionBackend.BETTER_TRANSFORMER == "better_transformer"
         assert AttentionBackend.SDPA == "sdpa"
         assert AttentionBackend.VANILLA == "vanilla"
+        assert AttentionBackend.NOT_APPLICABLE == "not_applicable"
 
 
 # ---------------------------------------------------------------------------
@@ -446,6 +448,11 @@ class TestModelConfig:
         assert cfg.torch_dtype is None
         assert cfg.extra == {}
 
+    def test_default_architecture_family_is_transformer(self):
+        """Default architecture_family must be TRANSFORMER for backwards compat."""
+        cfg = ModelConfig()
+        assert cfg.architecture_family == ArchitectureFamily.TRANSFORMER
+
     def test_custom_values(self):
         """ModelConfig should accept custom field values."""
         cfg = ModelConfig(
@@ -458,3 +465,76 @@ class TestModelConfig:
         assert cfg.model_type == "llama"
         assert cfg.torch_dtype == "float16"
         assert cfg.extra == {"revision": "main"}
+
+    def test_architecture_family_field(self):
+        """ModelConfig should accept and store architecture_family."""
+        cfg = ModelConfig(architecture_family=ArchitectureFamily.STATE_SPACE)
+        assert cfg.architecture_family == ArchitectureFamily.STATE_SPACE
+
+
+# ---------------------------------------------------------------------------
+# Architecture-family dispatch — Issue #7350
+# ---------------------------------------------------------------------------
+
+
+class TestArchitectureFamilyDispatch:
+    """Tests for architecture-family based NOT_APPLICABLE dispatch."""
+
+    def test_transformer_family_enters_normal_selection(self):
+        """TRANSFORMER family must fall through to normal tier selection."""
+        sel = _make_selector()
+        with patch(
+            "llm_shared.optimization.attention_backend._import_better_transformer",
+            return_value=None,
+        ), patch(
+            "llm_shared.optimization.attention_backend.AttentionBackendSelector._can_use_sdpa",
+            return_value=False,
+        ):
+            result = sel.select_backend(ModelConfig(architecture_family=ArchitectureFamily.TRANSFORMER))
+        assert result == AttentionBackend.VANILLA
+
+    def test_state_space_returns_not_applicable(self):
+        """STATE_SPACE architecture must return NOT_APPLICABLE immediately."""
+        sel = _make_selector()
+        result = sel.select_backend(ModelConfig(architecture_family=ArchitectureFamily.STATE_SPACE))
+        assert result == AttentionBackend.NOT_APPLICABLE
+
+    def test_linear_attention_returns_not_applicable(self):
+        """LINEAR_ATTENTION architecture must return NOT_APPLICABLE."""
+        sel = _make_selector()
+        result = sel.select_backend(ModelConfig(architecture_family=ArchitectureFamily.LINEAR_ATTENTION))
+        assert result == AttentionBackend.NOT_APPLICABLE
+
+    def test_hybrid_returns_not_applicable(self):
+        """HYBRID architecture must return NOT_APPLICABLE."""
+        sel = _make_selector()
+        result = sel.select_backend(ModelConfig(architecture_family=ArchitectureFamily.HYBRID))
+        assert result == AttentionBackend.NOT_APPLICABLE
+
+    def test_state_space_large_context_not_capped(self):
+        """State-space with 131072 context must not be routed through BT/SDPA."""
+        sel = _make_selector()
+        cfg = ModelConfig(
+            model_name="state-spaces/mamba-3b-131k",
+            architecture_family=ArchitectureFamily.STATE_SPACE,
+        )
+        result = sel.select_backend(cfg)
+        assert result == AttentionBackend.NOT_APPLICABLE
+
+    def test_apply_backend_not_applicable_is_noop(self):
+        """apply_backend with NOT_APPLICABLE must return model unchanged without warning."""
+        sel = _make_selector()
+        model = _make_model()
+        result = sel.apply_backend(model, AttentionBackend.NOT_APPLICABLE)
+        assert result is model
+
+    def test_not_applicable_blocklist_not_consulted(self):
+        """Non-transformer families must bypass the blocklist entirely."""
+        sel = _make_selector()
+        # Mamba model whose name might accidentally match "mamba" blocklist entries
+        cfg = ModelConfig(
+            model_type="mamba",
+            architecture_family=ArchitectureFamily.STATE_SPACE,
+        )
+        result = sel.select_backend(cfg)
+        assert result == AttentionBackend.NOT_APPLICABLE

--- a/autobot-backend/llm_shared/types.py
+++ b/autobot-backend/llm_shared/types.py
@@ -10,6 +10,18 @@ Extracted from llm_interface.py as part of Issue #381 god class refactoring.
 from enum import Enum
 
 
+class ArchitectureFamily(str, Enum):
+    """Model architecture family — governs attention backend and context window policy.
+
+    Issue #7347: positive family signal replacing substring-match heuristics.
+    """
+
+    TRANSFORMER = "transformer"
+    STATE_SPACE = "state_space"        # Mamba / S4 family
+    LINEAR_ATTENTION = "linear_attention"
+    HYBRID = "hybrid"                  # Jamba-style mixed architectures
+
+
 class ProviderType(Enum):
     """Supported LLM providers."""
 
@@ -41,6 +53,7 @@ class LLMType(Enum):
 
 
 __all__ = [
+    "ArchitectureFamily",
     "ProviderType",
     "LLMType",
 ]


### PR DESCRIPTION
## Summary

- **Closes #7347** — Add `ArchitectureFamily` enum (transformer/state_space/linear_attention/hybrid) to `llm_shared/types.py` with stable string values.
- **Closes #7350** — Architecture-family dispatch in `attention_backend.py`: `select_backend()` returns `NOT_APPLICABLE` immediately for non-transformer families instead of running the BetterTransformer/SDPA/Vanilla tier logic.

### Changes

**`autobot-backend/llm_shared/types.py`**
- New `ArchitectureFamily(str, Enum)` with values: `transformer`, `state_space`, `linear_attention`, `hybrid`

**`autobot-backend/llm_shared/optimization/attention_backend.py`**
- `AttentionBackend.NOT_APPLICABLE` added — returned for non-attention architectures
- `ModelConfig.architecture_family` field (default `TRANSFORMER`) — positive family signal replacing substring heuristics
- `select_backend()` fast-path for non-transformer families: blocklist never consulted, no tier selection
- `apply_backend()` no-op for `NOT_APPLICABLE` — model returned unchanged without warning

**`autobot-backend/llm_shared/optimization/attention_backend_test.py`**
- Updated `test_expected_members` to include `NOT_APPLICABLE`
- 8 new tests covering `ArchitectureFamily` dispatch, `NOT_APPLICABLE` flow, `ModelConfig` defaults

### Backwards Compatibility

- `ModelConfig.architecture_family` defaults to `TRANSFORMER` — existing callers unchanged
- All three existing transformer tiers behave identically
- `AttentionBackend.NOT_APPLICABLE` is a new value; existing switch/match sites unaffected

## Test plan

- [ ] `python3 -m py_compile autobot-backend/llm_shared/types.py`
- [ ] `python3 -m py_compile autobot-backend/llm_shared/optimization/attention_backend.py`
- [ ] `pytest autobot-backend/llm_shared/optimization/attention_backend_test.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)