### PR TITLE
tech-debt(api): type bare DataResponse Batch A — code-analysis domain (GH #6509)

### DIFF
--- a/autobot-backend/api/anti_pattern.py
+++ b/autobot-backend/api/anti_pattern.py
@@ -17,7 +17,15 @@ from fastapi.responses import JSONResponse
 from api.schemas_code import (
     AnalysisResponse,
     AntiPatternAnalysisRequest,
+    AntiPatternCachedResultResponse,
+    AntiPatternCircularDepsResultResponse,
+    AntiPatternCodeSmellsResultResponse,
+    AntiPatternDeadCodeResultResponse,
+    AntiPatternFeatureEnvyResultResponse,
+    AntiPatternGodClassesResultResponse,
+    AntiPatternHealthScoreResultResponse,
     AntiPatternSummary,
+    AntiPatternTypesResultResponse,
     SeveritySummary,
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -108,7 +116,7 @@ ANTI_PATTERN_TYPE_DEFINITIONS = (
 # Lazy initialization for detector (thread-safe)
 import asyncio
 
-from api.schemas_common import DataResponse
+from api.schemas_common import DataResponse  # noqa: E402
 
 _detector_instance = None
 _detector_lock = asyncio.Lock()
@@ -213,7 +221,7 @@ async def analyze_anti_patterns(request: AntiPatternAnalysisRequest):
         raise HTTPException(status_code=500, detail="Analysis failed")
 
 
-@router.get("/cached", response_model=DataResponse)
+@router.get("/cached", response_model=DataResponse[AntiPatternCachedResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_cached_analysis",
@@ -245,7 +253,7 @@ async def get_cached_analysis():
         raise HTTPException(status_code=500, detail="Failed to retrieve cache")
 
 
-@router.post("/god-classes", response_model=DataResponse)
+@router.post("/god-classes", response_model=DataResponse[AntiPatternGodClassesResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="detect_god_classes",
@@ -291,7 +299,7 @@ async def detect_god_classes(request: AntiPatternAnalysisRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/circular-dependencies", response_model=DataResponse)
+@router.post("/circular-dependencies", response_model=DataResponse[AntiPatternCircularDepsResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="detect_circular_dependencies",
@@ -332,7 +340,7 @@ async def detect_circular_dependencies(request: AntiPatternAnalysisRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/feature-envy", response_model=DataResponse)
+@router.post("/feature-envy", response_model=DataResponse[AntiPatternFeatureEnvyResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="detect_feature_envy",
@@ -373,7 +381,7 @@ async def detect_feature_envy(request: AntiPatternAnalysisRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/code-smells", response_model=DataResponse)
+@router.post("/code-smells", response_model=DataResponse[AntiPatternCodeSmellsResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="detect_code_smells",
@@ -424,7 +432,7 @@ async def detect_code_smells(request: AntiPatternAnalysisRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/dead-code", response_model=DataResponse)
+@router.post("/dead-code", response_model=DataResponse[AntiPatternDeadCodeResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="detect_dead_code",
@@ -465,7 +473,7 @@ async def detect_dead_code(request: AntiPatternAnalysisRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/health-score", response_model=DataResponse)
+@router.post("/health-score", response_model=DataResponse[AntiPatternHealthScoreResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_health_score",
@@ -517,7 +525,7 @@ async def get_health_score(request: AntiPatternAnalysisRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/types", response_model=DataResponse)
+@router.get("/types", response_model=DataResponse[AntiPatternTypesResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_anti_pattern_types",

--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -26,16 +26,37 @@ from api.schemas_code import (
     CachedSecurityScoreResponse,
     ClearStuckResponse,
     CodeIntelAnalysisRequest,
+    CodeIntelAnalysisResultResponse,
+    CodeIntelHealthScoreResultResponse,
     CodeIntelligenceTaskStatusResponse,
+    CodeIntelPatternTypesResultResponse,
     CodeIntelQuickScanRequest,
+    CodeIntelScanFileResultResponse,
     CodeIntelSuggestionsRequest,
+    EvolutionAnalyzeResultResponse,
+    EvolutionPatternsResultResponse,
+    EvolutionRefactoringsResultResponse,
+    EvolutionReportResultResponse,
+    EvolutionTimelineResultResponse,
     FindingsPlaceholderResponse,
     PerformanceAnalysisRequest,
+    PerformanceAnalyzeResultResponse,
     PerformanceFileScanRequest,
+    PerformanceIssueTypesResultResponse,
+    PerformanceScanFileResultResponse,
+    PerformanceScoreResultResponse,
     RedisAnalysisRequest,
+    RedisAnalyzeResultResponse,
     RedisFileScanRequest,
+    RedisHealthScoreResultResponse,
+    RedisOptimizationTypesResultResponse,
+    RedisScanFileResultResponse,
     SecurityAnalysisRequest,
+    SecurityAnalyzeResultResponse,
     SecurityFileScanRequest,
+    SecurityScanFileResultResponse,
+    SecurityScoreResultResponse,
+    SecurityVulnTypesResultResponse,
     StartTaskResponse,
     SuggestionsResponse,
 )
@@ -671,7 +692,7 @@ async def _generate_report_response(
     )
 
 
-@router.post("/analyze", response_model=DataResponse)
+@router.post("/analyze", response_model=DataResponse[CodeIntelAnalysisResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_codebase",
@@ -812,7 +833,7 @@ async def get_code_suggestions(
     return {"suggestions": suggestions}
 
 
-@router.post("/scan-file", response_model=DataResponse)
+@router.post("/scan-file", response_model=DataResponse[CodeIntelScanFileResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="quick_scan_file",
@@ -861,7 +882,7 @@ async def quick_scan_file(
         raise_internal_error("Scan failed")
 
 
-@router.get("/health-score", response_model=DataResponse)
+@router.get("/health-score", response_model=DataResponse[CodeIntelHealthScoreResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_codebase_health_score",
@@ -912,7 +933,7 @@ async def get_codebase_health_score(
         raise_internal_error("Health check failed")
 
 
-@router.get("/pattern-types", response_model=DataResponse)
+@router.get("/pattern-types", response_model=DataResponse[CodeIntelPatternTypesResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_supported_pattern_types",
@@ -947,7 +968,7 @@ async def get_supported_pattern_types(
 # =============================================================================
 
 
-@router.post("/redis/analyze", response_model=DataResponse)
+@router.post("/redis/analyze", response_model=DataResponse[RedisAnalyzeResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_redis_usage_endpoint",
@@ -991,7 +1012,7 @@ async def analyze_redis_usage_endpoint(
         raise_internal_error("Redis analysis failed")
 
 
-@router.post("/redis/scan-file", response_model=DataResponse)
+@router.post("/redis/scan-file", response_model=DataResponse[RedisScanFileResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="scan_redis_file",
@@ -1039,7 +1060,7 @@ async def scan_redis_file(
         raise_internal_error("Scan failed")
 
 
-@router.get("/redis/optimization-types", response_model=DataResponse)
+@router.get("/redis/optimization-types", response_model=DataResponse[RedisOptimizationTypesResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_redis_optimization_types",
@@ -1075,7 +1096,7 @@ _REDIS_HEALTH_CACHE_TTL = TTL_5_MINUTES
 _REDIS_HEALTH_TIMEOUT = 30.0  # seconds
 
 
-@router.get("/redis/health-score", response_model=DataResponse)
+@router.get("/redis/health-score", response_model=DataResponse[RedisHealthScoreResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_redis_usage_health_score",
@@ -1161,7 +1182,7 @@ async def _run_redis_health_analysis(path: str) -> Dict[str, Any]:
 # ============================================================================
 
 
-@router.post("/security/analyze", response_model=DataResponse)
+@router.post("/security/analyze", response_model=DataResponse[SecurityAnalyzeResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="security_analyze",
@@ -1214,7 +1235,7 @@ async def security_analyze(
         raise_internal_error("Security analysis failed")
 
 
-@router.post("/security/scan-file", response_model=DataResponse)
+@router.post("/security/scan-file", response_model=DataResponse[SecurityScanFileResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="security_scan_file",
@@ -1270,7 +1291,7 @@ async def security_scan_file(
         raise_internal_error("File scan failed")
 
 
-@router.get("/security/vulnerability-types", response_model=DataResponse)
+@router.get("/security/vulnerability-types", response_model=DataResponse[SecurityVulnTypesResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_vulnerability_types",
@@ -1309,7 +1330,7 @@ async def list_vulnerability_types(
     )
 
 
-@router.get("/security/score", response_model=DataResponse)
+@router.get("/security/score", response_model=DataResponse[SecurityScoreResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_security_score",
@@ -1404,7 +1425,7 @@ async def get_security_report(
 # ============================================================================
 
 
-@router.post("/performance/analyze", response_model=DataResponse)
+@router.post("/performance/analyze", response_model=DataResponse[PerformanceAnalyzeResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="performance_analyze",
@@ -1456,7 +1477,7 @@ async def performance_analyze(
         raise_internal_error("Performance analysis failed")
 
 
-@router.post("/performance/scan-file", response_model=DataResponse)
+@router.post("/performance/scan-file", response_model=DataResponse[PerformanceScanFileResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="performance_scan_file",
@@ -1512,7 +1533,7 @@ async def performance_scan_file(
         raise_internal_error("File scan failed")
 
 
-@router.get("/performance/issue-types", response_model=DataResponse)
+@router.get("/performance/issue-types", response_model=DataResponse[PerformanceIssueTypesResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_performance_issue_types",
@@ -1551,7 +1572,7 @@ async def list_performance_issue_types(
     )
 
 
-@router.get("/performance/score", response_model=DataResponse)
+@router.get("/performance/score", response_model=DataResponse[PerformanceScoreResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_performance_score",
@@ -1655,7 +1676,7 @@ async def get_performance_report(
 from code_intelligence.code_evolution_miner import CodeEvolutionMiner
 
 
-@router.post("/evolution/analyze", response_model=DataResponse)
+@router.post("/evolution/analyze", response_model=DataResponse[EvolutionAnalyzeResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_code_evolution",
@@ -1711,7 +1732,7 @@ async def analyze_code_evolution(
         raise_internal_error("Evolution analysis failed")
 
 
-@router.get("/evolution/patterns", response_model=DataResponse)
+@router.get("/evolution/patterns", response_model=DataResponse[EvolutionPatternsResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_pattern_evolution",
@@ -1767,7 +1788,7 @@ async def get_pattern_evolution(
         raise_internal_error("Pattern evolution failed")
 
 
-@router.get("/evolution/refactorings", response_model=DataResponse)
+@router.get("/evolution/refactorings", response_model=DataResponse[EvolutionRefactoringsResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="detect_refactorings",
@@ -1819,7 +1840,7 @@ async def detect_refactorings(
         raise_internal_error("Refactoring detection failed")
 
 
-@router.get("/evolution/timeline", response_model=DataResponse)
+@router.get("/evolution/timeline", response_model=DataResponse[EvolutionTimelineResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_evolution_timeline",
@@ -1887,7 +1908,7 @@ def _build_evolution_summary(evolution_report: dict) -> dict:
     }
 
 
-@router.get("/evolution/report", response_model=DataResponse)
+@router.get("/evolution/report", response_model=DataResponse[EvolutionReportResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_full_evolution_report",

--- a/autobot-backend/api/code_search.py
+++ b/autobot-backend/api/code_search.py
@@ -23,9 +23,18 @@ from agents.npu_code_search_agent import (
 )
 from api.schemas_code import (
     CodeAnalyticsRequest,
+    CodeSearchCacheClearResultResponse,
+    CodeSearchDeclarationsResultResponse,
+    CodeSearchDuplicatesResultResponse,
+    CodeSearchExamplesResultResponse,
     CodeSearchGetResponse,
     CodeSearchIndexRequest,
+    CodeSearchIndexResultResponse,
+    CodeSearchRefactorSuggestionsResultResponse,
     CodeSearchRequest,
+    CodeSearchSearchResultResponse,
+    CodeSearchStatsResultResponse,
+    CodeSearchStatusResultResponse,
 )
 from api.schemas_common import DataResponse
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -142,7 +151,7 @@ SEARCH_EXAMPLES_DATA = {
 _get_code_search_agent = lazy_singleton(get_npu_code_search)
 
 
-@router.post("/index", response_model=DataResponse)
+@router.post("/index", response_model=DataResponse[CodeSearchIndexResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="index_codebase",
@@ -194,7 +203,7 @@ async def index_codebase(request: CodeSearchIndexRequest):
         raise HTTPException(status_code=500, detail="Indexing failed")
 
 
-@router.post("/search", response_model=DataResponse)
+@router.post("/search", response_model=DataResponse[CodeSearchSearchResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="search_code",
@@ -291,7 +300,7 @@ async def search_code_get(
     return await search_code(request)
 
 
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=DataResponse[CodeSearchStatusResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_search_status",
@@ -348,7 +357,7 @@ async def get_search_status():
         raise HTTPException(status_code=500, detail="Status check failed")
 
 
-@router.delete("/cache", response_model=DataResponse)
+@router.delete("/cache", response_model=DataResponse[CodeSearchCacheClearResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="clear_search_cache",
@@ -386,7 +395,7 @@ async def clear_search_cache():
         raise HTTPException(status_code=500, detail="Cache clear failed")
 
 
-@router.get("/examples", response_model=DataResponse)
+@router.get("/examples", response_model=DataResponse[CodeSearchExamplesResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_search_examples",
@@ -712,7 +721,7 @@ async def _analyze_all_pattern_types() -> dict:
     return analysis_results
 
 
-@router.post("/analytics/declarations", response_model=DataResponse)
+@router.post("/analytics/declarations", response_model=DataResponse[CodeSearchDeclarationsResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_declarations",
@@ -745,7 +754,7 @@ async def analyze_declarations(request: CodeAnalyticsRequest):
         raise HTTPException(status_code=500, detail="Analysis failed")
 
 
-@router.post("/analytics/duplicates", response_model=DataResponse)
+@router.post("/analytics/duplicates", response_model=DataResponse[CodeSearchDuplicatesResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="find_code_duplicates",
@@ -790,7 +799,7 @@ async def find_code_duplicates(request: CodeAnalyticsRequest):
         raise HTTPException(status_code=500, detail="Duplicate detection failed")
 
 
-@router.get("/analytics/stats", response_model=DataResponse)
+@router.get("/analytics/stats", response_model=DataResponse[CodeSearchStatsResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_codebase_statistics",
@@ -874,7 +883,7 @@ def _build_refactor_response(root_path: str, suggestions: list) -> dict:
     }
 
 
-@router.post("/analytics/refactor-suggestions", response_model=DataResponse)
+@router.post("/analytics/refactor-suggestions", response_model=DataResponse[CodeSearchRefactorSuggestionsResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_refactor_suggestions",

--- a/autobot-backend/api/development_speedup.py
+++ b/autobot-backend/api/development_speedup.py
@@ -17,7 +17,19 @@ from agents.development_speedup_agent import (
     find_duplicates,
     get_development_speedup_agent,
 )
-from api.schemas_code import DevelopmentSpeedupAnalysisRequest
+from api.schemas_code import (
+    DevSpeedupAnalysisResultResponse,
+    DevSpeedupDeadCodeResultResponse,
+    DevSpeedupDuplicatesResultResponse,
+    DevSpeedupExamplesResultResponse,
+    DevSpeedupImportsResultResponse,
+    DevSpeedupPatternsResultResponse,
+    DevSpeedupQualityResultResponse,
+    DevSpeedupRecommendationsResultResponse,
+    DevSpeedupRefactoringResultResponse,
+    DevSpeedupStatusResultResponse,
+    DevelopmentSpeedupAnalysisRequest,
+)
 from api.schemas_common import DataResponse
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -86,7 +98,7 @@ ANALYSIS_TYPE_HANDLERS: Dict[str, AnalysisHandler] = {
 VALID_ANALYSIS_TYPES = ", ".join(ANALYSIS_TYPE_HANDLERS.keys())
 
 
-@router.post("/analyze", response_model=DataResponse)
+@router.post("/analyze", response_model=DataResponse[DevSpeedupAnalysisResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_codebase_endpoint",
@@ -133,7 +145,7 @@ async def analyze_codebase_endpoint(request: DevelopmentSpeedupAnalysisRequest):
         raise HTTPException(status_code=500, detail="Analysis failed")
 
 
-@router.get("/analyze", response_model=DataResponse)
+@router.get("/analyze", response_model=DataResponse[DevSpeedupAnalysisResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_codebase_get",
@@ -154,7 +166,7 @@ async def analyze_codebase_get(
     return await analyze_codebase_endpoint(request)
 
 
-@router.get("/duplicates", response_model=DataResponse)
+@router.get("/duplicates", response_model=DataResponse[DevSpeedupDuplicatesResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="find_duplicates_endpoint",
@@ -200,7 +212,7 @@ async def find_duplicates_endpoint(
         raise HTTPException(status_code=500, detail="Duplicate detection failed")
 
 
-@router.get("/patterns", response_model=DataResponse)
+@router.get("/patterns", response_model=DataResponse[DevSpeedupPatternsResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_patterns_endpoint",
@@ -244,7 +256,7 @@ async def analyze_patterns_endpoint(
         raise HTTPException(status_code=500, detail="Pattern analysis failed")
 
 
-@router.get("/imports", response_model=DataResponse)
+@router.get("/imports", response_model=DataResponse[DevSpeedupImportsResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_imports_endpoint",
@@ -284,7 +296,7 @@ async def analyze_imports_endpoint(
         raise HTTPException(status_code=500, detail="Import analysis failed")
 
 
-@router.get("/dead-code", response_model=DataResponse)
+@router.get("/dead-code", response_model=DataResponse[DevSpeedupDeadCodeResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="detect_dead_code_endpoint",
@@ -316,7 +328,7 @@ async def detect_dead_code_endpoint(path: str = Query(..., description="Root pat
         raise HTTPException(status_code=500, detail="Dead code detection failed")
 
 
-@router.get("/refactoring", response_model=DataResponse)
+@router.get("/refactoring", response_model=DataResponse[DevSpeedupRefactoringResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="find_refactoring_opportunities_endpoint",
@@ -363,7 +375,7 @@ async def find_refactoring_opportunities_endpoint(
         raise HTTPException(status_code=500, detail="Refactoring analysis failed")
 
 
-@router.get("/quality", response_model=DataResponse)
+@router.get("/quality", response_model=DataResponse[DevSpeedupQualityResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="analyze_quality_endpoint",
@@ -436,7 +448,7 @@ def _calculate_health_score(result: dict, metrics: dict) -> int:
     return max(0, 100 - (total_issues * 2))  # Simple scoring
 
 
-@router.get("/recommendations", response_model=DataResponse)
+@router.get("/recommendations", response_model=DataResponse[DevSpeedupRecommendationsResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_recommendations_endpoint",
@@ -476,7 +488,7 @@ async def get_recommendations_endpoint(path: str = Query(..., description="Root 
         raise HTTPException(status_code=500, detail="Recommendations failed")
 
 
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=DataResponse[DevSpeedupStatusResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_development_speedup_status",
@@ -539,7 +551,7 @@ async def get_development_speedup_status():
         raise HTTPException(status_code=500, detail="Status check failed")
 
 
-@router.get("/examples", response_model=DataResponse)
+@router.get("/examples", response_model=DataResponse[DevSpeedupExamplesResultResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_analysis_examples",

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -1600,6 +1600,486 @@ class CachedSecurityScoreResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# code_intelligence.py route response schemas (GH #6509 Batch A)
+# ---------------------------------------------------------------------------
+
+
+class CodeIntelAnalysisResultResponse(BaseModel):
+    """Response for POST /analyze (directory or inline code)."""
+
+    model_config = {"extra": "allow"}
+    status: str | None = None
+
+
+class CodeIntelScanFileResultResponse(BaseModel):
+    """Response for POST /scan-file."""
+
+    status: str
+    timestamp: str
+    file_path: str
+    patterns: List[Any]
+    statistics: Dict[str, Any]
+
+
+class CodeIntelHealthScoreResultResponse(BaseModel):
+    """Response for GET /health-score."""
+
+    status: str
+    timestamp: str
+    path: str
+    health_score: float
+    grade: str
+    total_issues: int
+    files_analyzed: int
+    severity_breakdown: Dict[str, Any]
+
+
+class CodeIntelPatternTypesResultResponse(BaseModel):
+    """Response for GET /pattern-types."""
+
+    status: str
+    pattern_types: Dict[str, Any]
+    total_types: int
+
+
+class RedisAnalyzeResultResponse(BaseModel):
+    """Response for POST /redis/analyze."""
+
+    status: str
+    timestamp: str
+    path: str
+    optimizations: List[Any]
+    summary: Dict[str, Any]
+
+
+class RedisScanFileResultResponse(BaseModel):
+    """Response for POST /redis/scan-file."""
+
+    status: str
+    timestamp: str
+    file_path: str
+    optimizations: List[Any]
+    total_findings: int
+    severity_breakdown: Dict[str, Any]
+
+
+class RedisOptimizationTypesResultResponse(BaseModel):
+    """Response for GET /redis/optimization-types."""
+
+    status: str
+    optimization_types: Dict[str, Any]
+    total_types: int
+    categories: List[str]
+
+
+class RedisHealthScoreResultResponse(BaseModel):
+    """Response for GET /redis/health-score."""
+
+    status: str
+    timestamp: str
+    path: str
+    health_score: float
+    grade: str
+    status_message: str
+    total_optimizations: int
+    files_with_issues: int
+    severity_breakdown: Dict[str, Any]
+    category_breakdown: Dict[str, Any]
+
+
+class SecurityAnalyzeResultResponse(BaseModel):
+    """Response for POST /security/analyze."""
+
+    status: str
+    timestamp: str
+    path: str
+    summary: Dict[str, Any]
+    findings: List[Any]
+    total_findings: int
+
+
+class SecurityScanFileResultResponse(BaseModel):
+    """Response for POST /security/scan-file."""
+
+    status: str
+    timestamp: str
+    file: str
+    findings: List[Any]
+    total_findings: int
+    by_type: Dict[str, Any]
+    severity_counts: Dict[str, Any]
+
+
+class SecurityVulnTypesResultResponse(BaseModel):
+    """Response for GET /security/vulnerability-types."""
+
+    status: str
+    timestamp: str
+    vulnerability_types: List[Any]
+    total_types: int
+    by_owasp_category: Dict[str, Any]
+
+
+class SecurityScoreResultResponse(BaseModel):
+    """Response for GET /security/score."""
+
+    status: str
+    timestamp: str
+    path: str
+    security_score: float
+    grade: str
+    risk_level: str
+    status_message: str
+    total_findings: int
+    critical_issues: int
+    high_issues: int
+    files_analyzed: int
+    severity_breakdown: Dict[str, Any]
+    owasp_breakdown: Dict[str, Any]
+
+
+class PerformanceAnalyzeResultResponse(BaseModel):
+    """Response for POST /performance/analyze."""
+
+    status: str
+    timestamp: str
+    path: str
+    summary: Dict[str, Any]
+    findings: List[Any]
+    total_findings: int
+
+
+class PerformanceScanFileResultResponse(BaseModel):
+    """Response for POST /performance/scan-file."""
+
+    status: str
+    timestamp: str
+    file: str
+    findings: List[Any]
+    total_findings: int
+    by_type: Dict[str, Any]
+    severity_counts: Dict[str, Any]
+
+
+class PerformanceIssueTypesResultResponse(BaseModel):
+    """Response for GET /performance/issue-types."""
+
+    status: str
+    timestamp: str
+    issue_types: List[Any]
+    total_types: int
+    by_category: Dict[str, Any]
+
+
+class PerformanceScoreResultResponse(BaseModel):
+    """Response for GET /performance/score (success or no_data)."""
+
+    model_config = {"extra": "allow"}
+    status: str
+
+
+class EvolutionAnalyzeResultResponse(BaseModel):
+    """Response for POST /evolution/analyze."""
+
+    status: str
+    timestamp: str
+    report: Dict[str, Any]
+
+
+class EvolutionPatternsResultResponse(BaseModel):
+    """Response for GET /evolution/patterns."""
+
+    status: str
+    timestamp: str
+    path: str
+    pattern_metrics: Dict[str, Any]
+
+
+class EvolutionRefactoringsResultResponse(BaseModel):
+    """Response for GET /evolution/refactorings."""
+
+    status: str
+    timestamp: str
+    path: str
+    refactorings: List[Any]
+    total: int
+
+
+class EvolutionTimelineResultResponse(BaseModel):
+    """Response for GET /evolution/timeline."""
+
+    status: str
+    timestamp: str
+    path: str
+    timeline: List[Any]
+
+
+class EvolutionReportResultResponse(BaseModel):
+    """Response for GET /evolution/report."""
+
+    status: str
+    timestamp: str
+    path: str
+    evolution: Dict[str, Any]
+    pattern_metrics: Dict[str, Any]
+    timeline: List[Any]
+    summary: Dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# anti_pattern.py route response schemas (GH #6509 Batch A)
+# ---------------------------------------------------------------------------
+
+
+class AntiPatternCachedResultResponse(BaseModel):
+    """Response for GET /cached (cached data or 404-style message)."""
+
+    model_config = {"extra": "allow"}
+    success: bool
+
+
+class AntiPatternGodClassesResultResponse(BaseModel):
+    """Response for POST /god-classes."""
+
+    success: bool
+    count: int
+    god_classes: List[Any]
+    recommendation: str
+
+
+class AntiPatternCircularDepsResultResponse(BaseModel):
+    """Response for POST /circular-dependencies."""
+
+    success: bool
+    count: int
+    circular_dependencies: List[Any]
+    recommendation: str
+
+
+class AntiPatternFeatureEnvyResultResponse(BaseModel):
+    """Response for POST /feature-envy."""
+
+    success: bool
+    count: int
+    feature_envy: List[Any]
+    recommendation: str
+
+
+class AntiPatternCodeSmellsResultResponse(BaseModel):
+    """Response for POST /code-smells."""
+
+    success: bool
+    total_count: int
+    by_type: Dict[str, Any]
+    recommendations: List[str]
+
+
+class AntiPatternDeadCodeResultResponse(BaseModel):
+    """Response for POST /dead-code."""
+
+    success: bool
+    count: int
+    dead_code: List[Any]
+    recommendation: str
+
+
+class AntiPatternHealthScoreResultResponse(BaseModel):
+    """Response for POST /health-score."""
+
+    success: bool
+    health_score: float
+    grade: str
+    status: str
+    issue_counts: Dict[str, Any]
+    top_recommendations: List[str]
+    analysis_time_seconds: float
+
+
+class AntiPatternTypesResultResponse(BaseModel):
+    """Response for GET /types."""
+
+    anti_pattern_types: List[Any]
+
+
+# ---------------------------------------------------------------------------
+# development_speedup.py route response schemas (GH #6509 Batch A)
+# ---------------------------------------------------------------------------
+
+
+class DevSpeedupAnalysisResultResponse(BaseModel):
+    """Response for POST|GET /analyze."""
+
+    analysis_type: str
+    root_path: str
+    results: Any
+    status: str
+
+
+class DevSpeedupDuplicatesResultResponse(BaseModel):
+    """Response for GET /duplicates."""
+
+    analysis_type: str
+    root_path: str
+    min_lines_threshold: int
+    results: Any
+    status: str
+
+
+class DevSpeedupPatternsResultResponse(BaseModel):
+    """Response for GET /patterns."""
+
+    analysis_type: str
+    root_path: str
+    pattern_filter: str | None
+    results: Any
+    status: str
+
+
+class DevSpeedupImportsResultResponse(BaseModel):
+    """Response for GET /imports."""
+
+    analysis_type: str
+    root_path: str
+    show_unused: bool
+    results: Any
+    status: str
+
+
+class DevSpeedupDeadCodeResultResponse(BaseModel):
+    """Response for GET /dead-code."""
+
+    analysis_type: str
+    root_path: str
+    results: Any
+    status: str
+
+
+class DevSpeedupRefactoringResultResponse(BaseModel):
+    """Response for GET /refactoring."""
+
+    analysis_type: str
+    root_path: str
+    min_complexity: float
+    results: Any
+    status: str
+
+
+class DevSpeedupQualityResultResponse(BaseModel):
+    """Response for GET /quality."""
+
+    analysis_type: str
+    root_path: str
+    severity_filter: str | None
+    results: Any
+    status: str
+
+
+class DevSpeedupRecommendationsResultResponse(BaseModel):
+    """Response for GET /recommendations."""
+
+    analysis_type: str
+    root_path: str
+    health_score: int
+    recommendations: List[Any]
+    metrics: Dict[str, Any]
+    priority_actions: List[Any]
+    status: str
+
+
+class DevSpeedupStatusResultResponse(BaseModel):
+    """Response for GET /status."""
+
+    status: str
+    capabilities: Dict[str, Any]
+    search_index: Dict[str, Any]
+    thresholds: Dict[str, Any]
+
+
+class DevSpeedupExamplesResultResponse(BaseModel):
+    """Response for GET /examples."""
+
+    examples: Dict[str, Any]
+    typical_workflow: List[str]
+    performance_tips: List[str]
+
+
+# ---------------------------------------------------------------------------
+# code_search.py route response schemas (GH #6509 Batch A)
+# ---------------------------------------------------------------------------
+
+
+class CodeSearchIndexResultResponse(BaseModel):
+    """Response for POST /index (success, already_indexed, or error)."""
+
+    model_config = {"extra": "allow"}
+
+
+class CodeSearchSearchResultResponse(BaseModel):
+    """Response for POST /search."""
+
+    results: List[Any]
+    stats: Dict[str, Any]
+    query: str
+    search_type: str
+    language_filter: str | None = None
+
+
+class CodeSearchStatusResultResponse(BaseModel):
+    """Response for GET /status."""
+
+    status: str
+    index_status: Dict[str, Any]
+    capabilities: Dict[str, Any]
+
+
+class CodeSearchCacheClearResultResponse(BaseModel):
+    """Response for DELETE /cache (success or error)."""
+
+    model_config = {"extra": "allow"}
+
+
+class CodeSearchExamplesResultResponse(BaseModel):
+    """Response for GET /examples."""
+
+    examples: Dict[str, Any]
+    language_filters: Any
+    usage_tips: Any
+
+
+class CodeSearchDeclarationsResultResponse(BaseModel):
+    """Response for POST /analytics/declarations."""
+
+    summary: Dict[str, Any]
+    declarations_by_type: Dict[str, Any]
+    reusability_insights: Dict[str, Any]
+
+
+class CodeSearchDuplicatesResultResponse(BaseModel):
+    """Response for POST /analytics/duplicates."""
+
+    summary: Dict[str, Any]
+    duplicate_candidates: List[Any]
+    recommendations: List[str]
+
+
+class CodeSearchStatsResultResponse(BaseModel):
+    """Response for GET /analytics/stats."""
+
+    index_statistics: Dict[str, Any]
+    redis_keys: int
+    search_performance: Dict[str, Any]
+    recommendations: List[str]
+
+
+class CodeSearchRefactorSuggestionsResultResponse(BaseModel):
+    """Response for POST /analytics/refactor-suggestions."""
+
+    refactor_suggestions: List[Any]
+    analysis_summary: Dict[str, Any]
+    next_steps: List[str]
+
+
+# ---------------------------------------------------------------------------
 # playwright request schemas (#6042)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Types all bare `response_model=DataResponse` route decorators in the **code-analysis domain** — Batch A of GH #6509.

Part of [MVA-664](/MVA/issues/MVA-664) — [MVA-608](/MVA/issues/MVA-608) DataResponse sub-tree.

## Test plan
- [ ] All changed files pass `python3 -m py_compile`
- [ ] No runtime regressions in code-analysis API routes

Closes #6509

🤖 Generated with [Claude Code](https://claude.com/claude-code)