### PR TITLE
tech-debt(api): type bare DataResponse Batch B — security, LLM, research routes (GH #6509)

### DIFF
--- a/autobot-backend/api/llm.py
+++ b/autobot-backend/api/llm.py
@@ -21,6 +21,18 @@ from api.schemas_agent import (
     LLMModelsResponse,
 )
 from api.schemas_common import DataResponse
+from api.schemas_workflows import (
+    LLMCacheClearData,
+    LLMComprehensiveStatusData,
+    LLMDeprecatedData,
+    LLMProvidersHealthData,
+    LLMProviderHealthData,
+    LLMQuickStatusData,
+    LLMTieredMetricsResetData,
+    LLMTieredRoutingConfigData,
+    LLMTieredRoutingMetricsData,
+    LLMTieredRoutingUpdateData,
+)
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -68,7 +80,7 @@ async def get_llm_config(
         raise HTTPException(status_code=500, detail="Error getting LLM config")
 
 
-@router.post("/config", response_model=DataResponse)
+@router.post("/config", response_model=DataResponse[LLMDeprecatedData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_llm_config",
@@ -226,7 +238,7 @@ def _build_llm_update_response() -> dict:
     }
 
 
-@router.post("/provider", response_model=DataResponse)
+@router.post("/provider", response_model=DataResponse[LLMDeprecatedData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_llm_provider",
@@ -326,7 +338,7 @@ async def _apply_embedding_config(provider: str, model: str, embedding_data: dic
     await asyncio.to_thread(config.save_config_to_yaml)
 
 
-@router.post("/embedding", response_model=DataResponse)
+@router.post("/embedding", response_model=DataResponse[LLMDeprecatedData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_embedding_model",
@@ -452,7 +464,7 @@ def _build_active_provider_info(provider_type: str, local_config: dict, cloud_co
     }
 
 
-@router.get("/status/comprehensive", response_model=DataResponse)
+@router.get("/status/comprehensive", response_model=DataResponse[LLMComprehensiveStatusData])
 @cache_response(cache_key="llm_status_comprehensive", ttl=30)  # Cache for 30 seconds
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -500,7 +512,7 @@ async def get_comprehensive_llm_status(
         return JSONResponse(status_code=500, content={"error": "Failed to get LLM status"})
 
 
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=DataResponse[LLMQuickStatusData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_llm_status",
@@ -562,7 +574,7 @@ def _get_model_from_cloud_config(unified_config: dict) -> str:
     return model if (api_key and model) else ""
 
 
-@router.get("/status/quick", response_model=DataResponse)
+@router.get("/status/quick", response_model=DataResponse[LLMQuickStatusData])
 @cache_response(cache_key="llm_status_quick", ttl=15)  # Cache for 15 seconds
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -631,7 +643,7 @@ def _build_providers_health_dict(results: dict) -> tuple:
     return providers_health, available_count
 
 
-@router.get("/health/providers", response_model=DataResponse)
+@router.get("/health/providers", response_model=DataResponse[LLMProvidersHealthData])
 @cache_response(cache_key="llm_providers_health", ttl=30)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -685,7 +697,7 @@ async def get_all_providers_health():
         )
 
 
-@router.get("/health/providers/{provider_name}", response_model=DataResponse)
+@router.get("/health/providers/{provider_name}", response_model=DataResponse[LLMProviderHealthData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_provider_health",
@@ -741,7 +753,7 @@ async def get_provider_health(provider_name: str, use_cache: bool = True):
         )
 
 
-@router.post("/health/providers/clear-cache", response_model=DataResponse)
+@router.post("/health/providers/clear-cache", response_model=DataResponse[LLMCacheClearData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="clear_provider_health_cache",
@@ -793,7 +805,7 @@ async def clear_provider_health_cache(
 # ============================================================================
 
 
-@router.get("/tiered-routing/metrics", response_model=DataResponse)
+@router.get("/tiered-routing/metrics", response_model=DataResponse[LLMTieredRoutingMetricsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_tiered_routing_metrics",
@@ -848,7 +860,7 @@ async def get_tiered_routing_metrics(
         )
 
 
-@router.get("/tiered-routing/config", response_model=DataResponse)
+@router.get("/tiered-routing/config", response_model=DataResponse[LLMTieredRoutingConfigData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_tiered_routing_config",
@@ -972,7 +984,7 @@ def _build_tiered_routing_response(tier_router) -> dict:
     }
 
 
-@router.post("/tiered-routing/config", response_model=DataResponse)
+@router.post("/tiered-routing/config", response_model=DataResponse[LLMTieredRoutingUpdateData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_tiered_routing_config",
@@ -1019,7 +1031,7 @@ async def update_tiered_routing_config(
         )
 
 
-@router.post("/tiered-routing/metrics/reset", response_model=DataResponse)
+@router.post("/tiered-routing/metrics/reset", response_model=DataResponse[LLMTieredMetricsResetData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="reset_tiered_routing_metrics",

--- a/autobot-backend/api/research_browser.py
+++ b/autobot-backend/api/research_browser.py
@@ -15,7 +15,13 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from api.schemas_common import DataResponse
 from api.schemas_workflows import (
+    BrowserInfoData,
     BrowserResearchRequest,
+    BrowserSessionActionData,
+    BrowserSessionCleanupData,
+    BrowserSessionListData,
+    BrowserSessionStatusData,
+    ChatBrowserSessionData,
     CreateChatBrowserRequest,
     NavigationRequest,
     SessionAction,
@@ -82,7 +88,7 @@ async def probe_research_browser(
         )
 
 
-@router.post("/url", response_model=DataResponse)
+@router.post("/url", response_model=DataResponse[BrowserSessionStatusData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="research_url",
@@ -98,7 +104,7 @@ async def research_url(request: BrowserResearchRequest):
     return JSONResponse(status_code=200, content=result)
 
 
-@router.post("/session/action", response_model=DataResponse)
+@router.post("/session/action", response_model=DataResponse[BrowserSessionActionData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="handle_session_action",
@@ -146,7 +152,7 @@ async def handle_session_action(request: SessionAction):
     return JSONResponse(status_code=200, content=result)
 
 
-@router.get("/session/{session_id}/status", response_model=DataResponse)
+@router.get("/session/{session_id}/status", response_model=DataResponse[BrowserSessionStatusData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_session_status",
@@ -219,7 +225,7 @@ async def download_mhtml(session_id: str, filename: str):
     )
 
 
-@router.delete("/session/{session_id}", response_model=DataResponse)
+@router.delete("/session/{session_id}", response_model=DataResponse[BrowserSessionCleanupData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="cleanup_session",
@@ -236,7 +242,7 @@ async def cleanup_session(session_id: str):
     )
 
 
-@router.get("/sessions", response_model=DataResponse)
+@router.get("/sessions", response_model=DataResponse[BrowserSessionListData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_sessions",
@@ -266,7 +272,7 @@ async def list_sessions():
     )
 
 
-@router.post("/session/{session_id}/navigate", response_model=DataResponse)
+@router.post("/session/{session_id}/navigate", response_model=DataResponse[BrowserSessionStatusData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="navigate_session",
@@ -285,7 +291,7 @@ async def navigate_session(session_id: str, request: NavigationRequest):
 
 
 # Browser integration endpoints for frontend
-@router.get("/browser/{session_id}", response_model=DataResponse)
+@router.get("/browser/{session_id}", response_model=DataResponse[BrowserInfoData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_browser_info",
@@ -382,7 +388,7 @@ def _get_browser_actions() -> list:
 # These endpoints tie browser sessions to chat conversations like terminal
 
 
-@router.post("/chat-session", response_model=DataResponse)
+@router.post("/chat-session", response_model=DataResponse[ChatBrowserSessionData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_or_create_chat_browser_session",
@@ -444,7 +450,7 @@ async def get_or_create_chat_browser_session(request: CreateChatBrowserRequest):
     )
 
 
-@router.get("/chat-session/{conversation_id}", response_model=DataResponse)
+@router.get("/chat-session/{conversation_id}", response_model=DataResponse[ChatBrowserSessionData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_chat_browser_session",
@@ -495,7 +501,7 @@ async def get_chat_browser_session(conversation_id: str):
     )
 
 
-@router.delete("/chat-session/{conversation_id}", response_model=DataResponse)
+@router.delete("/chat-session/{conversation_id}", response_model=DataResponse[BrowserSessionCleanupData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="delete_chat_browser_session",

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -3511,6 +3511,154 @@ class OnboardingStatus(BaseModel):
     """Response model for GET /api/onboarding/status."""
 
     preset_applied: bool
+
+
+# ---------------------------------------------------------------------------
+# security_assessment.py response data schemas (GH #6509)
+# ---------------------------------------------------------------------------
+
+
+class AssessmentData(BaseModel):
+    """Assessment entity from SecurityWorkflowManager.to_dict()."""
+
+    model_config = {"extra": "allow"}
+    id: str
+    name: str
+    target: str
+    phase: str
+    training_mode: bool = False
+    hosts: List[Dict[str, Any]] = Field(default_factory=list)
+    findings: List[Dict[str, Any]] = Field(default_factory=list)
+    actions: List[Dict[str, Any]] = Field(default_factory=list)
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class AssessmentListData(BaseModel):
+    """Response data for list_assessments."""
+
+    assessments: List[Dict[str, Any]]
+    count: int
+
+
+class AssessmentPhaseData(BaseModel):
+    """Response data for get_current_phase."""
+
+    current_phase: str
+    description: str = ""
+    available_actions: List[str] = Field(default_factory=list)
+    valid_transitions: List[str] = Field(default_factory=list)
+    training_mode: bool = False
+
+
+class AssessmentFindingsData(BaseModel):
+    """Response data for get_findings."""
+
+    findings: List[Dict[str, Any]]
+    vulnerabilities: List[Dict[str, Any]]
+    total_findings: int
+    total_vulnerabilities: int
+
+
+class ParseToolOutputData(BaseModel):
+    """Response data for parse_and_store_tool_output."""
+
+    tool: str
+    scan_type: str | None = None
+    hosts_added: int
+    ports_added: int
+    vulnerabilities_added: int
+    parsed_data: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AssessmentPhaseDefinitionsData(BaseModel):
+    """Response data for get_phase_definitions."""
+
+    phases: Dict[str, Any]
+    transitions: Dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# secrets.py response data schemas (GH #6509)
+# ---------------------------------------------------------------------------
+
+
+class SecretCreatedData(BaseModel):
+    """Response data for create_secret and update_secret."""
+
+    status: str
+    message: str
+    secret: Dict[str, Any]
+
+
+class SecretsListData(BaseModel):
+    """Response data for list_secrets."""
+
+    secrets: List[Dict[str, Any]]
+    total_count: int
+    filters: Dict[str, Any] = Field(default_factory=dict)
+
+
+class SecretTypesData(BaseModel):
+    """Response data for get_secret_types."""
+
+    types: List[Dict[str, str]]
+    scopes: List[Dict[str, str]]
+
+
+class SecretsStatsData(BaseModel):
+    """Response data for get_secrets_stats."""
+
+    total_secrets: int
+    by_scope: Dict[str, int]
+    by_type: Dict[str, int]
+    by_chat: Dict[str, int] = Field(default_factory=dict)
+    expired_count: int
+
+
+class SecretTransferData(BaseModel):
+    """Response data for transfer_secrets."""
+
+    status: str
+    message: str
+    result: Dict[str, Any]
+
+
+class ChatSecretsDeleteData(BaseModel):
+    """Response data for delete_chat_secrets."""
+
+    status: str
+    message: str
+    result: Dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# security.py response data schemas (GH #6509)
+# ---------------------------------------------------------------------------
+
+
+class PendingApprovalsData(BaseModel):
+    """Response data for get_pending_approvals."""
+
+    success: bool = True
+    pending_approvals: List[Dict[str, Any]]
+    count: int
+
+
+class CommandHistoryData(BaseModel):
+    """Response data for get_command_history."""
+
+    success: bool = True
+    command_history: List[Dict[str, Any]]
+    count: int
+
+
+class AuditLogData(BaseModel):
+    """Response data for get_audit_log."""
+
+    success: bool = True
+    audit_entries: List[Dict[str, Any]]
+    count: int
     preset_name: str | None = None
 
 

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -2654,3 +2654,251 @@ class OrchestrationExamplesResponse(BaseModel):
 
     examples: Dict[str, Any] = Field(default_factory=dict)
     usage_tips: List[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# llm.py response data schemas (GH #6509)
+# ---------------------------------------------------------------------------
+
+
+class LLMDeprecatedData(BaseModel):
+    """Response data for deprecated LLM config write endpoints (HTTP 410)."""
+
+    detail: str
+    redirect: str
+
+
+class LLMComprehensiveStatusData(BaseModel):
+    """Response data for get_comprehensive_llm_status."""
+
+    provider_type: str
+    providers: Dict[str, Any]
+    active_provider: Dict[str, Any]
+    settings: Dict[str, Any]
+
+
+class LLMQuickStatusData(BaseModel):
+    """Response data for get_quick_llm_status and get_llm_status."""
+
+    status: str
+    provider_type: str
+    model: str
+    timestamp: str
+    error: str | None = None
+
+
+class LLMProvidersHealthData(BaseModel):
+    """Response data for get_all_providers_health."""
+
+    overall_status: str
+    available_providers: int
+    total_providers: int
+    providers: Dict[str, Any]
+    cache_stats: Dict[str, Any] = Field(default_factory=dict)
+    timestamp: str
+    error: str | None = None
+
+
+class LLMProviderHealthData(BaseModel):
+    """Response data for get_provider_health."""
+
+    provider: str
+    status: str
+    available: bool
+    message: str
+    response_time_ms: float
+    details: Dict[str, Any] = Field(default_factory=dict)
+    timestamp: str
+    error: str | None = None
+
+
+class LLMCacheClearData(BaseModel):
+    """Response data for clear_provider_health_cache."""
+
+    success: bool
+    message: str
+    cache_stats: Dict[str, Any] = Field(default_factory=dict)
+
+
+class LLMTieredRoutingMetricsData(BaseModel):
+    """Response data for get_tiered_routing_metrics."""
+
+    enabled: bool
+    metrics: Dict[str, Any] | None = None
+    message: str | None = None
+
+
+class LLMTieredRoutingConfigData(BaseModel):
+    """Response data for get_tiered_routing_config."""
+
+    enabled: bool
+    complexity_threshold: float | None = None
+    models: Dict[str, str] | None = None
+    fallback_to_complex: bool | None = None
+    logging: Dict[str, Any] | None = None
+    message: str | None = None
+
+
+class LLMTieredRoutingUpdateData(BaseModel):
+    """Response data for update_tiered_routing_config."""
+
+    success: bool
+    message: str
+    config: Dict[str, Any]
+
+
+class LLMTieredMetricsResetData(BaseModel):
+    """Response data for reset_tiered_routing_metrics."""
+
+    success: bool
+    message: str
+    metrics: Dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# research_browser.py response data schemas (GH #6509)
+# ---------------------------------------------------------------------------
+
+
+class BrowserSessionStatusData(BaseModel):
+    """Response data for get_session_status."""
+
+    session_id: str
+    conversation_id: str
+    status: str
+    current_url: str | None = None
+    interaction_required: bool = False
+    interaction_message: str | None = None
+    created_at: str
+    last_activity: str
+    mhtml_files_count: int = 0
+
+
+class BrowserSessionListData(BaseModel):
+    """Response data for list_sessions."""
+
+    sessions: List[Dict[str, Any]]
+    total_sessions: int
+
+
+class BrowserSessionActionData(BaseModel):
+    """Response data for handle_session_action."""
+
+    success: bool
+    session_id: str
+    interaction_complete: bool | None = None
+    status: str | None = None
+    message: str | None = None
+    mhtml_path: str | None = None
+    browser_accessible: bool | None = None
+    current_url: str | None = None
+    content: Any | None = None
+    error: str | None = None
+
+
+class BrowserInfoData(BaseModel):
+    """Response data for get_browser_info."""
+
+    session_id: str
+    conversation_id: str
+    status: str
+    current_url: str | None = None
+    interaction_required: bool
+    interaction_message: str | None = None
+    docker_browser: Dict[str, Any]
+    actions: List[Dict[str, Any]]
+
+
+class ChatBrowserSessionData(BaseModel):
+    """Response data for chat browser session endpoints."""
+
+    session_id: str
+    conversation_id: str
+    browser_status: str
+    current_url: str | None = None
+    interaction_required: bool = False
+    interaction_message: str | None = None
+    created_at: str | None = None
+    last_activity: str | None = None
+    docker_browser: Dict[str, Any] | None = None
+    status: str | None = None
+
+
+class BrowserSessionCleanupData(BaseModel):
+    """Response data for cleanup_session and delete_chat_browser_session."""
+
+    success: bool | None = None
+    message: str | None = None
+    session_id: str | None = None
+    conversation_id: str | None = None
+    status: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# web_research_settings.py response data schemas (GH #6509)
+# ---------------------------------------------------------------------------
+
+
+class WebResearchStatusData(BaseModel):
+    """Response data for get_research_status."""
+
+    status: str
+    enabled: bool
+    preferred_method: str | None = None
+    health: Dict[str, Any] | None = None
+    circuit_breakers: Dict[str, Any] | None = None
+    cache_stats: Dict[str, Any] | None = None
+    timestamp: str
+    message: str | None = None
+
+
+class WebResearchToggleData(BaseModel):
+    """Response data for enable_web_research and disable_web_research."""
+
+    status: str
+    message: str
+    enabled: bool
+    timestamp: str
+
+
+class WebResearchSettingsData(BaseModel):
+    """Response data for get_research_settings."""
+
+    status: str
+    settings: Dict[str, Any]
+    timestamp: str
+
+
+class WebResearchSettingsUpdateData(BaseModel):
+    """Response data for update_research_settings."""
+
+    status: str
+    message: str
+    settings: Dict[str, Any]
+    timestamp: str
+
+
+class WebResearchTestData(BaseModel):
+    """Response data for test_web_research."""
+
+    status: str
+    test_query: str
+    result: Any | None = None
+    error: str | None = None
+    timestamp: str
+
+
+class WebResearchCacheClearData(BaseModel):
+    """Response data for clear_research_cache and reset_circuit_breakers."""
+
+    status: str
+    message: str
+    timestamp: str
+
+
+class WebResearchUsageStatsData(BaseModel):
+    """Response data for get_usage_stats."""
+
+    status: str
+    stats: Dict[str, Any]
+    timestamp: str

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -31,12 +31,18 @@ from fastapi.responses import JSONResponse
 
 from api.schemas_common import DataResponse
 from api.schemas_system import (
+    ChatSecretsDeleteData,
     SecretCreateRequest,
+    SecretCreatedData,
     SecretModel,
     SecretScope,
+    SecretsListData,
     SecretsStatusResponse,
+    SecretsStatsData,
+    SecretTransferData,
     SecretTransferRequest,
     SecretType,
+    SecretTypesData,
     SecretUpdateRequest,
 )
 from auth_middleware import check_admin_permission, get_auth_middleware
@@ -521,7 +527,7 @@ def audit_log(
 # API Endpoints
 
 
-@router.post("/", response_model=DataResponse)
+@router.post("/", response_model=DataResponse[SecretCreatedData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="create_secret",
@@ -574,7 +580,7 @@ async def create_secret(
         raise HTTPException(status_code=500, detail="Failed to create secret")
 
 
-@router.get("/", response_model=DataResponse)
+@router.get("/", response_model=DataResponse[SecretsListData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_secrets",
@@ -605,7 +611,7 @@ async def list_secrets(
         raise HTTPException(status_code=500, detail="Failed to list secrets")
 
 
-@router.get("/types", response_model=DataResponse)
+@router.get("/types", response_model=DataResponse[SecretTypesData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_secret_types",
@@ -656,7 +662,7 @@ async def get_secrets_status(
         }
 
 
-@router.get("/stats", response_model=DataResponse)
+@router.get("/stats", response_model=DataResponse[SecretsStatsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_secrets_stats",
@@ -705,7 +711,7 @@ async def get_secrets_stats(
         raise HTTPException(status_code=500, detail="Failed to get stats")
 
 
-@router.get("/{secret_id}", response_model=DataResponse)
+@router.get("/{secret_id}", response_model=DataResponse[SecretCreatedData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_secret",
@@ -770,7 +776,7 @@ async def get_secret(
         raise HTTPException(status_code=500, detail="Failed to get secret")
 
 
-@router.put("/{secret_id}", response_model=DataResponse)
+@router.put("/{secret_id}", response_model=DataResponse[SecretCreatedData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_secret",
@@ -827,7 +833,7 @@ async def update_secret(
         raise HTTPException(status_code=500, detail="Failed to update secret")
 
 
-@router.delete("/{secret_id}", response_model=DataResponse)
+@router.delete("/{secret_id}", response_model=DataResponse[SecretCreatedData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="delete_secret",
@@ -880,7 +886,7 @@ async def delete_secret(
         raise HTTPException(status_code=500, detail="Failed to delete secret")
 
 
-@router.post("/transfer", response_model=DataResponse)
+@router.post("/transfer", response_model=DataResponse[SecretTransferData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="transfer_secrets",
@@ -920,7 +926,7 @@ async def transfer_secrets(
         raise HTTPException(status_code=500, detail="Failed to transfer secrets")
 
 
-@router.get("/chat/{chat_id}/cleanup", response_model=DataResponse)
+@router.get("/chat/{chat_id}/cleanup", response_model=DataResponse[ChatSecretsDeleteData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_chat_cleanup_info",
@@ -940,7 +946,7 @@ async def get_chat_cleanup_info(
         raise HTTPException(status_code=500, detail="Failed to get cleanup info")
 
 
-@router.delete("/chat/{chat_id}", response_model=DataResponse)
+@router.delete("/chat/{chat_id}", response_model=DataResponse[ChatSecretsDeleteData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="delete_chat_secrets",

--- a/autobot-backend/api/security.py
+++ b/autobot-backend/api/security.py
@@ -16,9 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from api.schemas_common import DataResponse
 from api.schemas_system import (
+    AuditLogData,
     CommandApprovalRequest,
     CommandApprovalResponse,
+    CommandHistoryData,
     DomainSecurityStatsResponse,
+    PendingApprovalsData,
     SecurityStatusResponse,
     ThreatIntelStatusResponse,
     URLCheckRequest,
@@ -110,7 +113,7 @@ async def approve_command(request: Request, approval: CommandApprovalRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/pending-approvals", response_model=DataResponse)
+@router.get("/pending-approvals", response_model=DataResponse[PendingApprovalsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_pending_approvals",
@@ -132,7 +135,7 @@ async def get_pending_approvals(request: Request):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/command-history", response_model=DataResponse)
+@router.get("/command-history", response_model=DataResponse[CommandHistoryData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_command_history",
@@ -181,7 +184,7 @@ async def _read_audit_log_file(log_file: str, limit: int) -> list:
         return []
 
 
-@router.get("/audit-log", response_model=DataResponse)
+@router.get("/audit-log", response_model=DataResponse[AuditLogData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_audit_log",

--- a/autobot-backend/api/security_assessment.py
+++ b/autobot-backend/api/security_assessment.py
@@ -19,7 +19,13 @@ from api.schemas_system import (
     AddPortRequest,
     AddVulnerabilityRequest,
     AdvancePhaseRequest,
+    AssessmentData,
+    AssessmentFindingsData,
+    AssessmentListData,
+    AssessmentPhaseData,
+    AssessmentPhaseDefinitionsData,
     CreateAssessmentRequest,
+    ParseToolOutputData,
     ParseToolOutputRequest,
     RecoverErrorRequest,
 )
@@ -53,7 +59,7 @@ async def get_workflow_manager() -> SecurityWorkflowManager:
 # API Endpoints
 
 
-@router.post("/assessments", response_model=DataResponse)
+@router.post("/assessments", response_model=DataResponse[AssessmentData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="create_assessment",
@@ -102,7 +108,7 @@ async def create_assessment(
     )
 
 
-@router.get("/assessments", response_model=DataResponse)
+@router.get("/assessments", response_model=DataResponse[AssessmentListData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_assessments",
@@ -147,7 +153,7 @@ async def list_assessments(
     )
 
 
-@router.get("/assessments/{assessment_id}", response_model=DataResponse)
+@router.get("/assessments/{assessment_id}", response_model=DataResponse[AssessmentData])
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="get_assessment",
@@ -187,7 +193,7 @@ async def get_assessment(
     )
 
 
-@router.get("/assessments/{assessment_id}/summary", response_model=DataResponse)
+@router.get("/assessments/{assessment_id}/summary", response_model=DataResponse[AssessmentData])
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="get_assessment_summary",
@@ -267,7 +273,7 @@ async def delete_assessment(
     )
 
 
-@router.get("/assessments/{assessment_id}/phase", response_model=DataResponse)
+@router.get("/assessments/{assessment_id}/phase", response_model=DataResponse[AssessmentPhaseData])
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="get_phase",
@@ -317,7 +323,7 @@ async def get_current_phase(
     )
 
 
-@router.post("/assessments/{assessment_id}/phase", response_model=DataResponse)
+@router.post("/assessments/{assessment_id}/phase", response_model=DataResponse[AssessmentData])
 @with_error_handling(
     category=ErrorCategory.VALIDATION,
     operation="advance_phase",
@@ -570,7 +576,7 @@ async def add_finding(
     )
 
 
-@router.get("/assessments/{assessment_id}/findings", response_model=DataResponse)
+@router.get("/assessments/{assessment_id}/findings", response_model=DataResponse[AssessmentFindingsData])
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="get_findings",
@@ -715,7 +721,7 @@ async def _store_parsed_vulnerabilities(manager, assessment_id: str, parsed) -> 
     return vulns_added
 
 
-@router.post("/assessments/{assessment_id}/parse", response_model=DataResponse)
+@router.post("/assessments/{assessment_id}/parse", response_model=DataResponse[ParseToolOutputData])
 @with_error_handling(
     category=ErrorCategory.VALIDATION,
     operation="parse_tool_output",
@@ -783,7 +789,7 @@ async def parse_and_store_tool_output(
     )
 
 
-@router.post("/assessments/{assessment_id}/error", response_model=DataResponse)
+@router.post("/assessments/{assessment_id}/error", response_model=DataResponse[AssessmentData])
 @with_error_handling(
     category=ErrorCategory.NOT_FOUND,
     operation="set_error",
@@ -825,7 +831,7 @@ async def set_error_state(
     )
 
 
-@router.post("/assessments/{assessment_id}/recover", response_model=DataResponse)
+@router.post("/assessments/{assessment_id}/recover", response_model=DataResponse[AssessmentData])
 @with_error_handling(
     category=ErrorCategory.VALIDATION,
     operation="recover_from_error",
@@ -873,7 +879,7 @@ async def recover_from_error(
     )
 
 
-@router.get("/phases", response_model=DataResponse)
+@router.get("/phases", response_model=DataResponse[AssessmentPhaseDefinitionsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_phase_definitions",

--- a/autobot-backend/api/web_research_settings.py
+++ b/autobot-backend/api/web_research_settings.py
@@ -13,7 +13,16 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.schemas_common import DataResponse
-from api.schemas_workflows import WebResearchSettings
+from api.schemas_workflows import (
+    WebResearchCacheClearData,
+    WebResearchSettings,
+    WebResearchSettingsData,
+    WebResearchSettingsUpdateData,
+    WebResearchStatusData,
+    WebResearchTestData,
+    WebResearchToggleData,
+    WebResearchUsageStatsData,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 
@@ -22,7 +31,7 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/web-research", tags=["web-research"])
 
 
-@router.get("/status", response_model=DataResponse)
+@router.get("/status", response_model=DataResponse[WebResearchStatusData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_research_status",
@@ -71,7 +80,7 @@ async def get_research_status():
         )
 
 
-@router.post("/enable", response_model=DataResponse)
+@router.post("/enable", response_model=DataResponse[WebResearchToggleData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="enable_web_research",
@@ -123,7 +132,7 @@ async def enable_web_research():
         raise HTTPException(status_code=500, detail="Failed to enable web research")
 
 
-@router.post("/disable", response_model=DataResponse)
+@router.post("/disable", response_model=DataResponse[WebResearchToggleData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="disable_web_research",
@@ -175,7 +184,7 @@ async def disable_web_research():
         raise HTTPException(status_code=500, detail="Failed to disable web research")
 
 
-@router.get("/settings", response_model=DataResponse)
+@router.get("/settings", response_model=DataResponse[WebResearchSettingsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_research_settings",
@@ -221,7 +230,7 @@ async def get_research_settings():
         raise HTTPException(status_code=500, detail="Failed to get research settings")
 
 
-@router.put("/settings", response_model=DataResponse)
+@router.put("/settings", response_model=DataResponse[WebResearchSettingsUpdateData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_research_settings",
@@ -267,7 +276,7 @@ async def update_research_settings(settings: WebResearchSettings):
         raise HTTPException(status_code=500, detail="Failed to update research settings")
 
 
-@router.post("/test", response_model=DataResponse)
+@router.post("/test", response_model=DataResponse[WebResearchTestData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="test_web_research",
@@ -310,7 +319,7 @@ async def test_web_research(query: str = "test query"):
         )
 
 
-@router.post("/clear-cache", response_model=DataResponse)
+@router.post("/clear-cache", response_model=DataResponse[WebResearchCacheClearData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="clear_research_cache",
@@ -342,7 +351,7 @@ async def clear_research_cache():
         raise HTTPException(status_code=500, detail="Failed to clear research cache")
 
 
-@router.post("/reset-circuit-breakers", response_model=DataResponse)
+@router.post("/reset-circuit-breakers", response_model=DataResponse[WebResearchCacheClearData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="reset_circuit_breakers",
@@ -374,7 +383,7 @@ async def reset_circuit_breakers():
         raise HTTPException(status_code=500, detail="Failed to reset circuit breakers")
 
 
-@router.get("/usage-stats", response_model=DataResponse)
+@router.get("/usage-stats", response_model=DataResponse[WebResearchUsageStatsData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_usage_stats",


### PR DESCRIPTION
## Summary

Types all bare `response_model=DataResponse` route decorators in the **security, LLM, and research domains** — Batch B of GH #6509.

Part of [MVA-665](/MVA/issues/MVA-665) — [MVA-608](/MVA/issues/MVA-608) DataResponse sub-tree.

## Test plan
- [ ] All changed files pass `python3 -m py_compile`
- [ ] No runtime regressions in security/LLM/research API routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)