### PR TITLE
feat(llm): context_window_manager bypasses 4K/8K cap for non-transformer models (#7351)

### DIFF
--- a/autobot-backend/context_window_manager.py
+++ b/autobot-backend/context_window_manager.py
@@ -1,7 +1,15 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Centralized context window management for LLM interactions."""
+"""Centralized context window management for LLM interactions.
+
+Issue #7351: architecture_family-aware compression bypass.  Non-transformer
+models (state_space, linear_attention, hybrid) carry constant inference memory
+and do not face the quadratic attention cost that justifies the 4K/8K
+compression trigger.  For those families the model's declared
+``context_window_tokens`` is used directly as the compression threshold
+instead of hard-capping at 8192.
+"""
 
 from pathlib import Path
 from typing import Dict, List
@@ -12,6 +20,13 @@ from autobot_shared.logging_manager import get_logger
 from constants.model_constants import ModelConfig, ModelConstants
 
 logger = get_logger(__name__)
+
+# Architecture families whose cost curve does not require transformer caps.
+# Matches the string values of llm_shared.types.ArchitectureFamily; kept as a
+# frozenset of strings here to avoid a circular import with llm_shared.
+_NON_TRANSFORMER_FAMILIES: frozenset[str] = frozenset(
+    {"state_space", "linear_attention", "hybrid"}
+)
 
 # Lazy singleton — imported on first call to avoid circular imports.
 _compression_service = None
@@ -195,11 +210,35 @@ class ContextWindowManager:
         max_tokens = self.get_max_history_tokens(model_name)
         return estimated_tokens > max_tokens
 
-    def get_compression_threshold(self, model_name: str | None = None) -> int:
-        """Get the compression_threshold for a model (defaults to 8192).
+    def get_architecture_family(self, model_name: str | None = None) -> str:
+        """Return the architecture_family for a model (defaults to 'transformer').
 
-        Issue #3770: Models whose context_window_tokens <= 8192 trigger
-        compression when retrieved content exceeds this value.
+        Issue #7351: reads the ``architecture_family`` key from the YAML config
+        entry for the model.  When absent or unknown the safe default is
+        ``'transformer'``, preserving existing compression behaviour.
+
+        Args:
+            model_name: Optional model name, uses current if not specified.
+
+        Returns:
+            Architecture family string (e.g. ``'transformer'``, ``'state_space'``).
+        """
+        model = model_name or self.current_model
+        if model not in self.config["models"]:
+            model = self.config["models"]["default"]["name"]
+        return self.config["models"][model].get("architecture_family", "transformer")
+
+    def get_compression_threshold(self, model_name: str | None = None) -> int:
+        """Get the compression threshold for a model.
+
+        Issue #3770: transformer models whose context_window_tokens <= 8192
+        trigger compression when retrieved content exceeds this value.
+
+        Issue #7351: non-transformer families (state_space, linear_attention,
+        hybrid) return the model's declared ``context_window_tokens`` instead of
+        the 8192 default so that large-context models are not falsely capped.
+        When ``context_window_tokens`` is also absent the fallback is 8192
+        (same safe default as before, still transformer-conservative).
 
         Args:
             model_name: Optional model name, uses current if not specified.
@@ -210,13 +249,32 @@ class ContextWindowManager:
         model = model_name or self.current_model
         if model not in self.config["models"]:
             model = self.config["models"]["default"]["name"]
-        return self.config["models"][model].get("compression_threshold", 8192)
+
+        entry = self.config["models"][model]
+        family = entry.get("architecture_family", "transformer")
+
+        if family in _NON_TRANSFORMER_FAMILIES:
+            # Use the model's declared context window as the threshold —
+            # no artificial cap for non-attention architectures.
+            threshold = entry.get("context_window_tokens", 8192)
+            logger.debug(
+                "get_compression_threshold: %s (family=%s) → %d (no cap)",
+                model,
+                family,
+                threshold,
+            )
+            return threshold
+
+        return entry.get("compression_threshold", 8192)
 
     async def async_should_compress(self, content_tokens: int, model_name: str | None = None) -> bool:
         """Return True when content_tokens exceed the model compression threshold.
 
         Issue #3770: Delegates to ContextCompressionService which applies the
         large-model guard (threshold > 8192 -> always False).
+
+        Issue #7351: non-transformer families bypass compression entirely —
+        their cost curve does not justify the 4K/8K trigger.
 
         Args:
             content_tokens: Estimated token count of content to evaluate.
@@ -226,6 +284,14 @@ class ContextWindowManager:
             True when compression should be applied.
         """
         model = model_name or self.current_model
+        family = self.get_architecture_family(model)
+        if family in _NON_TRANSFORMER_FAMILIES:
+            logger.debug(
+                "async_should_compress: %s (family=%s) → False (bypass)",
+                model,
+                family,
+            )
+            return False
         svc = _get_compression_service()
         return await svc.should_compress(model, content_tokens)
 

--- a/autobot-backend/context_window_manager_test.py
+++ b/autobot-backend/context_window_manager_test.py
@@ -1,0 +1,221 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for context_window_manager — architecture-family-aware cap bypass.
+
+Issue #7351: non-transformer models must not be compressed at the 4K/8K cap.
+"""
+
+import pytest
+
+from context_window_manager import ContextWindowManager, _NON_TRANSFORMER_FAMILIES
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TRANSFORMER_CONFIG = {
+    "models": {
+        "default": {
+            "name": "llama3",
+            "context_window_tokens": 4096,
+            "max_output_tokens": 2048,
+            "message_budget": {
+                "system_prompt": 500,
+                "recent_messages": 20,
+                "max_history_tokens": 3000,
+            },
+        },
+        "llama3": {
+            "context_window_tokens": 4096,
+            "max_output_tokens": 2048,
+            "message_budget": {
+                "system_prompt": 500,
+                "recent_messages": 20,
+                "max_history_tokens": 3000,
+            },
+        },
+        "mamba-3b": {
+            "architecture_family": "state_space",
+            "context_window_tokens": 131072,
+            "max_output_tokens": 4096,
+            "message_budget": {
+                "system_prompt": 500,
+                "recent_messages": 50,
+                "max_history_tokens": 100000,
+            },
+        },
+        "jamba-7b": {
+            "architecture_family": "hybrid",
+            "context_window_tokens": 256000,
+            "max_output_tokens": 8192,
+            "message_budget": {
+                "system_prompt": 500,
+                "recent_messages": 100,
+                "max_history_tokens": 200000,
+            },
+        },
+        "linear-attn-2b": {
+            "architecture_family": "linear_attention",
+            "context_window_tokens": 65536,
+            "max_output_tokens": 2048,
+            "message_budget": {
+                "system_prompt": 500,
+                "recent_messages": 50,
+                "max_history_tokens": 50000,
+            },
+        },
+    },
+    "token_estimation": {"chars_per_token": 4, "safety_margin": 0.9},
+}
+
+
+def _manager_with_config(config: dict) -> ContextWindowManager:
+    """Return a ContextWindowManager with an injected config (no YAML load)."""
+    mgr = object.__new__(ContextWindowManager)
+    mgr.config = config
+    mgr.current_model = config["models"]["default"]["name"]
+    return mgr
+
+
+# ---------------------------------------------------------------------------
+# _NON_TRANSFORMER_FAMILIES constant
+# ---------------------------------------------------------------------------
+
+
+class TestNonTransformerFamilies:
+    def test_contains_expected_families(self):
+        assert "state_space" in _NON_TRANSFORMER_FAMILIES
+        assert "linear_attention" in _NON_TRANSFORMER_FAMILIES
+        assert "hybrid" in _NON_TRANSFORMER_FAMILIES
+
+    def test_transformer_not_in_set(self):
+        assert "transformer" not in _NON_TRANSFORMER_FAMILIES
+
+
+# ---------------------------------------------------------------------------
+# get_architecture_family
+# ---------------------------------------------------------------------------
+
+
+class TestGetArchitectureFamily:
+    def test_default_is_transformer(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        assert mgr.get_architecture_family("llama3") == "transformer"
+
+    def test_state_space_returned(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        assert mgr.get_architecture_family("mamba-3b") == "state_space"
+
+    def test_hybrid_returned(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        assert mgr.get_architecture_family("jamba-7b") == "hybrid"
+
+    def test_linear_attention_returned(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        assert mgr.get_architecture_family("linear-attn-2b") == "linear_attention"
+
+    def test_unknown_model_returns_transformer(self):
+        """Unknown model falls back to default entry which has no family → 'transformer'."""
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        assert mgr.get_architecture_family("nonexistent-model") == "transformer"
+
+    def test_uses_current_model_when_none(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        mgr.current_model = "mamba-3b"
+        assert mgr.get_architecture_family() == "state_space"
+
+
+# ---------------------------------------------------------------------------
+# get_compression_threshold — transformer caps unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestGetCompressionThresholdTransformer:
+    def test_transformer_returns_8192_default(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        assert mgr.get_compression_threshold("llama3") == 8192
+
+    def test_transformer_respects_explicit_compression_threshold(self):
+        config = {
+            "models": {
+                "default": {"name": "model-a", "message_budget": {"system_prompt": 0, "recent_messages": 10, "max_history_tokens": 1000}},
+                "model-a": {
+                    "compression_threshold": 16384,
+                    "context_window_tokens": 32768,
+                    "message_budget": {"system_prompt": 0, "recent_messages": 10, "max_history_tokens": 1000},
+                },
+            },
+            "token_estimation": {"chars_per_token": 4, "safety_margin": 0.9},
+        }
+        mgr = _manager_with_config(config)
+        assert mgr.get_compression_threshold("model-a") == 16384
+
+
+# ---------------------------------------------------------------------------
+# get_compression_threshold — non-transformer bypass
+# ---------------------------------------------------------------------------
+
+
+class TestGetCompressionThresholdNonTransformer:
+    def test_state_space_uses_context_window(self):
+        """State-space model's threshold must equal its declared context_window_tokens."""
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        assert mgr.get_compression_threshold("mamba-3b") == 131072
+
+    def test_hybrid_uses_context_window(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        assert mgr.get_compression_threshold("jamba-7b") == 256000
+
+    def test_linear_attention_uses_context_window(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        assert mgr.get_compression_threshold("linear-attn-2b") == 65536
+
+    def test_state_space_not_capped_at_8192(self):
+        """131072-token SSM must not receive the transformer 8192 cap."""
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        threshold = mgr.get_compression_threshold("mamba-3b")
+        assert threshold > 8192, f"SSM threshold {threshold} should exceed 8192"
+
+    def test_non_transformer_fallback_when_no_context_window(self):
+        """If context_window_tokens absent on a non-transformer, fall back to 8192."""
+        config = {
+            "models": {
+                "default": {"name": "ssm", "message_budget": {"system_prompt": 0, "recent_messages": 10, "max_history_tokens": 1000}},
+                "ssm": {
+                    "architecture_family": "state_space",
+                    # no context_window_tokens
+                    "message_budget": {"system_prompt": 0, "recent_messages": 10, "max_history_tokens": 1000},
+                },
+            },
+            "token_estimation": {"chars_per_token": 4, "safety_margin": 0.9},
+        }
+        mgr = _manager_with_config(config)
+        assert mgr.get_compression_threshold("ssm") == 8192
+
+
+# ---------------------------------------------------------------------------
+# async_should_compress
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncShouldCompress:
+    @pytest.mark.asyncio
+    async def test_non_transformer_always_returns_false(self):
+        """Non-transformer models must never trigger compression."""
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        result = await mgr.async_should_compress(200000, "mamba-3b")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_hybrid_always_returns_false(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        result = await mgr.async_should_compress(999999, "jamba-7b")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_linear_attention_always_returns_false(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        result = await mgr.async_should_compress(500000, "linear-attn-2b")
+        assert result is False


### PR DESCRIPTION
## Summary

**Closes #7351** — `context_window_manager.py` now reads `architecture_family` from model YAML config and skips the 4096/8192-token compression cap for state-space, linear-attention, and hybrid architectures.

### Changes

**`autobot-backend/context_window_manager.py`**
- `_NON_TRANSFORMER_FAMILIES` frozenset — string values matching `ArchitectureFamily` enum (avoids circular import)
- `get_architecture_family(model_name)` — reads `architecture_family` from YAML config entry, defaults to `"transformer"`
- `get_compression_threshold()` — for non-transformer families returns `context_window_tokens` directly instead of the 8192 default; transformer path unchanged
- `async_should_compress()` — non-transformer families return `False` immediately, bypassing `ContextCompressionService`

**`autobot-backend/context_window_manager_test.py`** (new file)
- 15 tests covering: `_NON_TRANSFORMER_FAMILIES` contents, `get_architecture_family` per-family, compression threshold bypass per family, fallback when `context_window_tokens` absent, `async_should_compress` bypass

### Acceptance Criteria

- ✅ `context_window_manager` reads `architecture_family` from model metadata
- ✅ Cap behaviour is family-conditional  
- ✅ A model with `architecture_family=state_space` and `context_window_tokens=131072` returns threshold=131072, not 8192
- ✅ `async_should_compress` returns `False` for non-transformer families (never triggers compression)
- ✅ Existing transformer behaviour unchanged — same 8192 default, same `ContextCompressionService` delegation

### Dependency

This PR depends on #8345 (ArchitectureFamily enum) being merged first. The `_NON_TRANSFORMER_FAMILIES` frozenset uses string literals matching those enum values.

## Test plan

- [ ] `python3 -m py_compile autobot-backend/context_window_manager.py`
- [ ] `pytest autobot-backend/context_window_manager_test.py -v`
- [ ] Verify existing `llm_handler.py:776` caller: `async_should_compress(content_tokens=..., model_name=...)` — kwargs unchanged, no break

🤖 Generated with [Claude Code](https://claude.com/claude-code)