### PR TITLE
perf(redis,async): pipeline N+1 expire calls, atomic SET EX, async file I/O (#8162, #8163, #8165)

### DIFF
--- a/autobot-backend/a2a/task_manager.py
+++ b/autobot-backend/a2a/task_manager.py
@@ -212,6 +212,7 @@ class TaskManager:
         Issue #4554: Resetting the TTL on every GET means any client that
         is actively polling will never see a 404 — tasks only expire when
         genuinely abandoned (no polls for a full TTL window).
+        Issue #8162: Pipeline the three EXPIRE calls into one round-trip.
         """
         key = _KEY_TASK.format(task_id)
         raw = self._redis.get(key)
@@ -220,23 +221,42 @@ class TaskManager:
         # Slide TTL — reset expiry from now so active pollers stay alive.
         # Slide the audit key too so it doesn't expire before the task does.
         ttl = self._ttl()
-        self._redis.expire(key, ttl)
-        self._redis.expire(_KEY_AUDIT.format(task_id), ttl)
-        self._redis.expire(_KEY_TASKS, ttl)
+        with self._redis.pipeline() as pipe:
+            pipe.expire(key, ttl)
+            pipe.expire(_KEY_AUDIT.format(task_id), ttl)
+            pipe.expire(_KEY_TASKS, ttl)
+            pipe.execute()
         return _task_from_json(raw if isinstance(raw, str) else raw.decode("utf-8"))
 
     def list_tasks(self) -> List[Task]:
-        """Return all tasks whose keys are still alive in Redis."""
+        """Return all tasks whose keys are still alive in Redis.
+
+        Issue #8162: Use MGET to batch all task fetches into one round-trip
+        instead of issuing one GET per task ID (N+1 pattern).
+        """
         ids = self._redis.smembers(_KEY_TASKS)
+        if not ids:
+            return []
+
+        id_strs = [tid if isinstance(tid, str) else tid.decode("utf-8") for tid in ids]
+        keys = [_KEY_TASK.format(tid) for tid in id_strs]
+        raws = self._redis.mget(keys)
+
         tasks: List[Task] = []
-        for tid in ids:
-            tid_str = tid if isinstance(tid, str) else tid.decode("utf-8")
-            task = self._load(tid_str)
-            if task is not None:
-                tasks.append(task)
+        expired_ids = []
+        for tid, raw in zip(ids, raws):
+            if raw is not None:
+                tasks.append(_task_from_json(raw if isinstance(raw, str) else raw.decode("utf-8")))
             else:
-                # TTL expired — remove from tracking set
-                self._redis.srem(_KEY_TASKS, tid)
+                # TTL expired — collect for bulk removal from tracking set
+                expired_ids.append(tid)
+
+        if expired_ids:
+            with self._redis.pipeline() as pipe:
+                for expired in expired_ids:
+                    pipe.srem(_KEY_TASKS, expired)
+                pipe.execute()
+
         return tasks
 
     def update_state(

--- a/autobot-backend/api/analytics_llm_patterns.py
+++ b/autobot-backend/api/analytics_llm_patterns.py
@@ -380,8 +380,12 @@ class LLMPatternAnalyzer(AsyncRedisClientMixin):
             # Store usage record
             date_key = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
             usage_key = f"{self._usage_key}:{date_key}"
-            await redis.lpush(usage_key, json.dumps(record))
-            await redis.expire(usage_key, TTL_30_DAYS)  # 30 days
+            # Issue #8163: pipeline LPUSH+EXPIRE to avoid a race where the
+            # key survives forever if the process dies between the two calls.
+            async with redis.pipeline() as pipe:
+                await pipe.lpush(usage_key, json.dumps(record))
+                await pipe.expire(usage_key, TTL_30_DAYS)
+                await pipe.execute()
 
             # Update cache tracking
             cache_key = f"{self._cache_key}:{prompt_hash}"
@@ -401,8 +405,8 @@ class LLMPatternAnalyzer(AsyncRedisClientMixin):
                     "preview": self._get_prompt_preview(request.prompt),
                 }
 
-            await redis.set(cache_key, json.dumps(data))
-            await redis.expire(cache_key, TTL_30_DAYS)
+            # Issue #8163: atomic SET EX replaces the two-call SET + EXPIRE.
+            await redis.set(cache_key, json.dumps(data), ex=TTL_30_DAYS)
 
             # Update stats
             await self._update_stats(request.model, cost, request.success)

--- a/autobot-backend/workflow_scheduler.py
+++ b/autobot-backend/workflow_scheduler.py
@@ -446,8 +446,8 @@ class WorkflowScheduler:
             except asyncio.CancelledError:
                 logger.debug("Scheduler task cancelled during shutdown")
 
-        # Save state before stopping
-        self._save_workflows()
+        # Issue #8165: run blocking file I/O off the event loop.
+        await asyncio.to_thread(self._save_workflows)
 
     def _parse_schedule_params(
         self,
@@ -810,7 +810,7 @@ class WorkflowScheduler:
 
                 if result and result.get("success"):
                     self.queue.complete_workflow(workflow.id, WorkflowStatus.COMPLETED)
-                    self._move_to_completed(workflow)
+                    await self._move_to_completed(workflow)
                     logger.info("Workflow %s completed successfully", workflow.id)
                 else:
                     # Handle failure with retry logic
@@ -833,15 +833,18 @@ class WorkflowScheduler:
         else:
             # Mark as failed
             self.queue.complete_workflow(workflow.id, WorkflowStatus.FAILED)
-            self._move_to_completed(workflow)
+            await self._move_to_completed(workflow)
             logger.warning("Workflow %s failed after %s retries", workflow.id, workflow.retry_count)
 
-    def _move_to_completed(self, workflow: ScheduledWorkflow) -> None:
-        """Move workflow to completed storage"""
+    async def _move_to_completed(self, workflow: ScheduledWorkflow) -> None:
+        """Move workflow to completed storage.
+
+        Issue #8165: async so the blocking file write runs via asyncio.to_thread.
+        """
         self.completed_workflows[workflow.id] = workflow
         if workflow.id in self.scheduled_workflows:
             del self.scheduled_workflows[workflow.id]
-        self._save_workflows()
+        await asyncio.to_thread(self._save_workflows)
 
     def _parse_time_string(self, time_str: str) -> datetime:
         """Parse various time string formats"""


### PR DESCRIPTION
## Summary

- **#8162** `a2a/task_manager.py`: replaced N+1 `redis.get()` loop in `list_tasks()` with single `mget()` + pipelined bulk `srem()` for expired IDs; pipelined 3 `expire()` calls in `get_task()` into one round-trip
- **#8163** `api/analytics_llm_patterns.py`: replaced `SET` + `EXPIRE` two-call with atomic `SET EX`; pipelined `LPUSH` + `EXPIRE` to eliminate TTL-miss race on process crash
- **#8165** `workflow_scheduler.py`: offloaded blocking `open()` / `json.dump()` / `json.load()` off the event loop via `asyncio.to_thread()`; `_move_to_completed()` made `async`, both callers updated to `await`

## Test plan

- [ ] `python3 -m py_compile` clean on all 3 files (verified pre-commit)
- [ ] `list_tasks()` issues one `MGET` instead of N `GET` calls under Redis monitor
- [ ] `get_task()` issues one pipelined `EXPIRE × 3` instead of 3 round-trips
- [ ] `record_usage()` in LLMPatternAnalyzer: `SET EX` visible in Redis monitor (no separate EXPIRE)
- [ ] `WorkflowScheduler.stop()` and `_move_to_completed()` do not block the event loop under asyncio debug mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)