### PR TITLE
feat(ci): add smoke-test for docker-compose.hardened.yml (#8094)

### DIFF
--- a/.github/workflows/hardened-smoke-test.yml
+++ b/.github/workflows/hardened-smoke-test.yml
@@ -1,0 +1,192 @@
+name: Hardened Smoke Test
+
+# Verifies that docker-compose.hardened.yml starts correctly on top of
+# the base compose — read-only filesystems, secrets, and PID limits
+# are only tested in CI via this job. Closes GH#8094.
+
+on:
+  push:
+    branches:
+      - Dev_new_gui
+  pull_request:
+    branches:
+      - Dev_new_gui
+  schedule:
+    - cron: '0 11 * * 0'  # Every Sunday at 11 AM UTC (offset from regular smoke test)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hardened-smoke-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-hardened-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-hardened-
+            ${{ runner.os }}-buildx-
+
+      - name: Create .env from .env.example
+        run: cp .env.example .env
+
+      - name: Create Docker secrets for hardened config
+        run: |
+          mkdir -p secrets
+          openssl rand -hex 32 > secrets/postgres_password.txt
+          openssl rand -hex 32 > secrets/slm_admin_password.txt
+          openssl rand -hex 32 > secrets/slm_jwt_secret.txt
+          chmod 600 secrets/*.txt
+
+      - name: Build images with layer cache
+        run: |
+          docker buildx build \
+            --cache-from type=local,src=/tmp/.buildx-cache \
+            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --file docker/backend/Dockerfile \
+            --tag autobot/backend:latest \
+            --load \
+            .
+          docker buildx build \
+            --cache-from type=local,src=/tmp/.buildx-cache \
+            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --file docker/slm/Dockerfile \
+            --tag autobot/slm:latest \
+            --load \
+            .
+          docker buildx build \
+            --cache-from type=local,src=/tmp/.buildx-cache \
+            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --file docker/frontend/Dockerfile \
+            --tag autobot/frontend:latest \
+            --load \
+            .
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Start services with hardened overlay
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.hardened.yml \
+            --env-file docker/.env.docker \
+            up -d
+
+      - name: Wait for services to be healthy
+        run: |
+          echo "Waiting for hardened services to become healthy..."
+          max_attempts=90
+          attempt=0
+
+          while [ $attempt -lt $max_attempts ]; do
+            attempt=$((attempt + 1))
+            echo "Attempt $attempt/$max_attempts: Checking service health..."
+
+            frontend_ok=false
+            backend_ok=false
+            slm_ok=false
+
+            curl -s -f http://localhost > /dev/null 2>&1            && frontend_ok=true
+            curl -s -f http://localhost/api/system/health > /dev/null 2>&1 && backend_ok=true
+            curl -s -f http://localhost/slm/api/health > /dev/null 2>&1    && slm_ok=true
+
+            if $frontend_ok && $backend_ok && $slm_ok; then
+              echo "OK Frontend responding on port 80"
+              echo "OK Backend health check passed"
+              echo "OK SLM health check passed"
+              exit 0
+            fi
+
+            $frontend_ok || echo "  waiting: frontend not yet responding"
+            $backend_ok  || echo "  waiting: backend not yet responding"
+            $slm_ok      || echo "  waiting: SLM not yet responding"
+
+            sleep 10
+          done
+
+          echo "Hardened services failed to become healthy within 15 minutes (900s)"
+          echo ""
+          echo "=== Docker Compose Logs ==="
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.hardened.yml \
+            --env-file docker/.env.docker \
+            logs
+          exit 1
+
+      - name: Verify hardened constraints are active
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "=== Service status ==="
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.hardened.yml \
+            --env-file docker/.env.docker \
+            ps
+
+          echo ""
+          echo "=== Verify read-only root filesystem on backend ==="
+          if docker exec autobot-backend sh -c "touch /readonly-test 2>/dev/null"; then
+            echo "FAIL: backend root filesystem is writable (read_only not enforced)"
+            exit 1
+          else
+            echo "OK backend root filesystem is read-only"
+          fi
+
+          echo ""
+          echo "=== Verify PID limit is set on backend ==="
+          pids_limit=$(docker inspect autobot-backend --format '{{.HostConfig.PidsLimit}}')
+          if [ "$pids_limit" = "0" ] || [ -z "$pids_limit" ]; then
+            echo "FAIL: backend PID limit not set (got: $pids_limit)"
+            exit 1
+          else
+            echo "OK backend PID limit: $pids_limit"
+          fi
+
+          echo ""
+          echo "=== Health endpoint checks ==="
+          curl -v http://localhost 2>&1 | head -20 || true
+          echo ""
+          curl -v http://localhost/api/system/health 2>&1 | head -20 || true
+          echo ""
+          curl -v http://localhost/slm/api/health 2>&1 | head -20 || true
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.hardened.yml \
+            --env-file docker/.env.docker \
+            logs > failure-logs.txt
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: hardened-docker-compose-logs
+          path: failure-logs.txt
+
+      - name: Clean up
+        if: always()
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.hardened.yml \
+            --env-file docker/.env.docker \
+            down
+          rm -rf secrets/


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/hardened-smoke-test.yml` — a dedicated CI job that runs `docker-compose.hardened.yml` on top of the base compose
- Generates ephemeral Docker secrets (postgres_password, slm_admin_password, slm_jwt_secret) via `openssl rand` before `up`
- Asserts that `read_only: true` is enforced on the backend container (write to `/` must fail)
- Asserts that `pids_limit` is set in `HostConfig`
- Runs on push/PR to `Dev_new_gui` and weekly on Sunday 11 AM UTC (offset from the base smoke test)

Closes #8094

## Test plan

- [ ] Workflow file is syntactically valid (actionlint will catch this)
- [ ] Job runs on PR merge to `Dev_new_gui`
- [ ] `Create Docker secrets` step generates non-empty files in `secrets/`
- [ ] Services start successfully with the hardened overlay (health-check loop passes)
- [ ] `read_only` assertion passes (write to `/` fails on backend container)
- [ ] `pids_limit` assertion passes (non-zero value in HostConfig)
- [ ] Cleanup step removes `secrets/` and tears down compose stack

---

Related: Paperclip [MVA-728](/MVA/issues/MVA-728)

🤖 Generated with [Claude Code](https://claude.com/claude-code)