### PR TITLE
perf(npu): add Redis-backed L2 embedding cache across uvicorn workers

### DIFF
--- a/autobot-backend/npu_semantic_search.py
+++ b/autobot-backend/npu_semantic_search.py
@@ -8,7 +8,9 @@ Integrates Intel NPU acceleration with ChromaDB and Redis vector store
 """
 
 import asyncio
+import hashlib
 import json
+import os
 import time
 import uuid
 from dataclasses import dataclass
@@ -25,6 +27,7 @@ from ai_hardware_accelerator import (
 )
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_llm_logger
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_config import config
 from config import cfg
 
@@ -53,6 +56,35 @@ except ImportError:
     CHROMADB_AVAILABLE = False
 
 logger = get_llm_logger("npu_semantic_search")
+
+# #8159: L2 embedding cache TTL. Override via AUTOBOT_NPU_EMBEDDING_CACHE_TTL (seconds).
+# Default 3600s (1h) — embeddings are stable within a model version.
+def _resolve_npu_embedding_cache_ttl() -> int:
+    """Return TTL seconds for emb:* Redis L2 cache keys."""
+    _default = 3600
+    raw = os.environ.get("AUTOBOT_NPU_EMBEDDING_CACHE_TTL")
+    if raw is None:
+        return _default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "AUTOBOT_NPU_EMBEDDING_CACHE_TTL=%r is not an integer; falling back to %ds (1h)",
+            raw,
+            _default,
+        )
+        return _default
+    if value <= 0:
+        logger.warning(
+            "AUTOBOT_NPU_EMBEDDING_CACHE_TTL=%d is not positive; falling back to %ds (1h)",
+            value,
+            _default,
+        )
+        return _default
+    return value
+
+
+_NPU_EMBEDDING_CACHE_TTL: int = _resolve_npu_embedding_cache_ttl()
 
 # Issue #380: Module-level tuple for default target modalities in cross-modal search
 _DEFAULT_TARGET_MODALITIES = ("text", "image", "audio", "multimodal")
@@ -191,6 +223,11 @@ class NPUSemanticSearch:
         # Issue #387: GPU-accelerated hybrid vector search
         self.hybrid_search: HybridVectorSearch | None = None
         self.use_gpu_search = cfg.get("vector_search.use_gpu", True)
+
+        # Issue #8159: L1/L2 embedding cache hit counters (per-worker, reset on restart)
+        self._l1_hits: int = 0
+        self._l2_hits: int = 0
+        self._cache_misses: int = 0
 
     async def initialize(self):
         """Initialize NPU semantic search engine."""
@@ -489,25 +526,61 @@ class NPUSemanticSearch:
         embeddings = chunker._compute_sentence_embeddings([text])
         return embeddings[0], "cpu_final_fallback"
 
+    async def _l2_cache_get(self, text: str) -> "np.ndarray | None":
+        """Check Redis L2 embedding cache. Issue #8159."""
+        redis = get_async_redis_client()
+        if redis is None:
+            return None
+        try:
+            key = f"emb:{hashlib.sha256(text.encode('utf-8')).hexdigest()[:16]}"
+            cached = await redis.get(key)
+            if cached:
+                return np.frombuffer(cached, dtype=np.float32).copy()
+        except Exception as exc:
+            logger.debug("L2 cache get failed (non-fatal): %s", exc)
+        return None
+
+    async def _l2_cache_set(self, text: str, embedding: np.ndarray) -> None:
+        """Store embedding in Redis L2 cache. Issue #8159."""
+        redis = get_async_redis_client()
+        if redis is None:
+            return
+        try:
+            key = f"emb:{hashlib.sha256(text.encode('utf-8')).hexdigest()[:16]}"
+            await redis.set(key, embedding.astype(np.float32).tobytes(), ex=_NPU_EMBEDDING_CACHE_TTL)
+        except Exception as exc:
+            logger.debug("L2 cache set failed (non-fatal): %s", exc)
+
     async def _generate_optimized_embedding(
         self, text: str, enable_npu: bool, force_device: HardwareDevice | None
     ) -> Tuple[np.ndarray, str]:
-        """Generate embedding using optimal hardware with caching. Issue #65 P0."""
+        """Generate embedding using optimal hardware with L1+L2 caching. Issue #65 P0, #8159."""
+        # L1: in-process cache (fastest)
         cached_embedding = await self.embedding_cache.get(text)
         if cached_embedding is not None:
-            logger.debug("✅ Using cached embedding for query: %s...", text[:50])
-            return np.array(cached_embedding), "cached"
+            self._l1_hits += 1
+            logger.debug("L1 cache hit for query: %s...", text[:50])
+            return np.array(cached_embedding), "l1_cached"
 
+        # L2: Redis shared cache (shared across uvicorn workers, survives restarts)
+        l2_result = await self._l2_cache_get(text)
+        if l2_result is not None:
+            self._l2_hits += 1
+            logger.debug("L2 cache hit for query: %s...", text[:50])
+            await self.embedding_cache.put(text, l2_result.tolist())  # warm L1
+            return l2_result, "l2_cached"
+
+        # Miss: generate via NPU/GPU/CPU
+        self._cache_misses += 1
         try:
             embedding, device_name = await self._generate_embedding_with_device(text, enable_npu, force_device)
-            await self.embedding_cache.put(text, embedding.tolist())
-            return embedding, device_name
-
         except Exception as e:
-            logger.warning(f"⚠️ Optimized embedding generation failed: {e}, using fallback")
+            logger.warning("Optimized embedding generation failed: %s, using fallback", e)
             embedding, device_name = await self._generate_fallback_embedding(text)
-            await self.embedding_cache.put(text, embedding.tolist())
-            return embedding, device_name
+
+        await self.embedding_cache.put(text, embedding.tolist())
+        await self._l2_cache_set(text, embedding)
+        return embedding, device_name
 
     def _convert_hybrid_results(
         self, hybrid_results: List[Any], hybrid_metrics: Any, device_used: str
@@ -617,8 +690,6 @@ class NPUSemanticSearch:
 
     def _generate_cache_key(self, query: str, top_k: int, filters: Dict[str, Any] | None) -> str:
         """Generate cache key for search results."""
-        import hashlib
-
         cache_data = {
             "query": query.strip().lower(),
             "top_k": top_k,
@@ -840,7 +911,13 @@ class NPUSemanticSearch:
         gpu_search_stats = self.hybrid_search.get_stats() if self.hybrid_search else None
 
         return {
-            "embedding_cache_stats": embedding_stats,  # Issue #65 P0 metrics
+            "embedding_cache_stats": {
+                **embedding_stats,  # Issue #65 P0 L1 stats
+                # Issue #8159: L1/L2 tier breakdown
+                "l1_hits": self._l1_hits,
+                "l2_hits": self._l2_hits,
+                "misses": self._cache_misses,
+            },
             "search_results_cache_stats": {
                 "cache_size": len(self.search_results_cache),
                 "cache_max_size": self.cache_max_size,

--- a/autobot-backend/tests/test_npu_redis_cache.py
+++ b/autobot-backend/tests/test_npu_redis_cache.py
@@ -1,0 +1,205 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for NPU Redis L2 embedding cache (#8159).
+
+Verifies that _l2_cache_get / _l2_cache_set and the integrated
+_generate_optimized_embedding L1→L2→NPU path work correctly.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_search_instance():
+    """Return an NPUSemanticSearch with __init__ bypassed to avoid real I/O."""
+    from npu_semantic_search import NPUSemanticSearch
+
+    obj = NPUSemanticSearch.__new__(NPUSemanticSearch)
+    obj._l1_hits = 0
+    obj._l2_hits = 0
+    obj._cache_misses = 0
+
+    # Minimal embedding_cache stub
+    cache = MagicMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.put = AsyncMock()
+    obj.embedding_cache = cache
+
+    return obj
+
+
+def _embedding_bytes(arr: np.ndarray) -> bytes:
+    return arr.astype(np.float32).tobytes()
+
+
+# ---------------------------------------------------------------------------
+# _l2_cache_get
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_l2_cache_get_returns_array_on_hit():
+    obj = _make_search_instance()
+    expected = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value=_embedding_bytes(expected))
+
+    with patch("npu_semantic_search.get_async_redis_client", return_value=mock_redis):
+        result = await obj._l2_cache_get("hello world")
+
+    assert result is not None
+    np.testing.assert_array_almost_equal(result, expected)
+
+
+@pytest.mark.asyncio
+async def test_l2_cache_get_returns_none_on_miss():
+    obj = _make_search_instance()
+
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value=None)
+
+    with patch("npu_semantic_search.get_async_redis_client", return_value=mock_redis):
+        result = await obj._l2_cache_get("no such text")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_l2_cache_get_returns_none_when_redis_unavailable():
+    obj = _make_search_instance()
+
+    with patch("npu_semantic_search.get_async_redis_client", return_value=None):
+        result = await obj._l2_cache_get("text")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_l2_cache_get_swallows_redis_exceptions():
+    obj = _make_search_instance()
+
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(side_effect=ConnectionError("redis down"))
+
+    with patch("npu_semantic_search.get_async_redis_client", return_value=mock_redis):
+        result = await obj._l2_cache_get("text")
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _l2_cache_set
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_l2_cache_set_stores_bytes():
+    obj = _make_search_instance()
+    embedding = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+
+    mock_redis = AsyncMock()
+    mock_redis.set = AsyncMock()
+
+    with patch("npu_semantic_search.get_async_redis_client", return_value=mock_redis):
+        await obj._l2_cache_set("store me", embedding)
+
+    mock_redis.set.assert_awaited_once()
+    call_args = mock_redis.set.call_args
+    # key, value positional + ex keyword
+    stored_bytes = call_args.args[1]
+    recovered = np.frombuffer(stored_bytes, dtype=np.float32)
+    np.testing.assert_array_almost_equal(recovered, embedding)
+    assert call_args.kwargs.get("ex") is not None
+
+
+@pytest.mark.asyncio
+async def test_l2_cache_set_noop_when_redis_unavailable():
+    obj = _make_search_instance()
+    embedding = np.array([1.0], dtype=np.float32)
+
+    with patch("npu_semantic_search.get_async_redis_client", return_value=None):
+        # Should not raise
+        await obj._l2_cache_set("text", embedding)
+
+
+@pytest.mark.asyncio
+async def test_l2_cache_set_swallows_redis_exceptions():
+    obj = _make_search_instance()
+    embedding = np.array([1.0], dtype=np.float32)
+
+    mock_redis = AsyncMock()
+    mock_redis.set = AsyncMock(side_effect=ConnectionError("redis down"))
+
+    with patch("npu_semantic_search.get_async_redis_client", return_value=mock_redis):
+        await obj._l2_cache_set("text", embedding)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _generate_optimized_embedding — L2 hit path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_generate_optimized_embedding_l2_hit_warms_l1():
+    """L2 hit must warm L1 and return 'l2_cached' device label."""
+    obj = _make_search_instance()
+    l2_embedding = np.array([0.5, 0.6], dtype=np.float32)
+
+    with patch.object(obj, "_l2_cache_get", AsyncMock(return_value=l2_embedding)):
+        with patch.object(obj, "_l2_cache_set", AsyncMock()):
+            embedding, label = await obj._generate_optimized_embedding("query", True, None)
+
+    assert label == "l2_cached"
+    np.testing.assert_array_almost_equal(embedding, l2_embedding)
+    # L1 must have been warmed
+    obj.embedding_cache.put.assert_awaited_once()
+    assert obj._l2_hits == 1
+    assert obj._l1_hits == 0
+    assert obj._cache_misses == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_optimized_embedding_l1_hit_skips_l2():
+    """L1 hit must not touch Redis at all."""
+    obj = _make_search_instance()
+    l1_embedding = [0.1, 0.2]
+    obj.embedding_cache.get = AsyncMock(return_value=l1_embedding)
+
+    with patch.object(obj, "_l2_cache_get", AsyncMock()) as mock_l2_get:
+        embedding, label = await obj._generate_optimized_embedding("query", True, None)
+
+    assert label == "l1_cached"
+    mock_l2_get.assert_not_awaited()
+    assert obj._l1_hits == 1
+    assert obj._l2_hits == 0
+    assert obj._cache_misses == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_optimized_embedding_miss_populates_both_caches():
+    """Full miss must call NPU, then populate L1 and L2."""
+    obj = _make_search_instance()
+    npu_embedding = np.array([9.0, 8.0], dtype=np.float32)
+
+    with patch.object(obj, "_l2_cache_get", AsyncMock(return_value=None)):
+        with patch.object(obj, "_l2_cache_set", AsyncMock()) as mock_l2_set:
+            with patch.object(
+                obj,
+                "_generate_embedding_with_device",
+                AsyncMock(return_value=(npu_embedding, "npu")),
+            ):
+                embedding, label = await obj._generate_optimized_embedding("new query", True, None)
+
+    assert label == "npu"
+    np.testing.assert_array_almost_equal(embedding, npu_embedding)
+    obj.embedding_cache.put.assert_awaited_once()
+    mock_l2_set.assert_awaited_once()
+    assert obj._cache_misses == 1
+    assert obj._l1_hits == 0
+    assert obj._l2_hits == 0


### PR DESCRIPTION
## Summary

- Adds Redis L2 cache to `npu_semantic_search.py` wrapping `accelerated_embedding_generation()` call
- L1 (in-process ARC) → L2 (Redis shared, 1hr TTL) → NPU generation cascade
- All 4 uvicorn workers share one Redis cache — miss on worker 1 populates for workers 2/3/4
- Key: `emb:<sha256[:16]>` in knowledge Redis DB; both helpers are fully non-fatal
- TTL configurable via `AUTOBOT_NPU_EMBEDDING_CACHE_TTL` env var (default 3600s, follows #6743 pattern)
- `get_search_statistics()` now exposes `l1_hits`, `l2_hits`, `misses` for monitoring

## Test Plan
- [x] `_l2_cache_get`: hit/miss/unavailable/exception paths
- [x] `_l2_cache_set`: correct bytes shape, unavailable, exception
- [x] L1 hit skips Redis entirely
- [x] L2 hit warms L1, returns correct embedding
- [x] Full miss populates both caches

Closes #8159

🤖 Generated with Claude Code