### PR TITLE
fix(api): align EnterpriseFeatureEnableAll + AnalyticsEvolutionExport response schemas (#8313, #8314)

### DIFF
--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -1954,11 +1954,12 @@ class EnterpriseFeatureEnableAllResponse(BaseModel):
     """Response for POST /features/enable-all."""
 
     status: str
-    enabled_features: List[str] = Field(default_factory=list)
-    failed_features: List[Any] = Field(default_factory=list)
-    total_features: int = 0
-    success_rate: float = 0.0
+    phase: str = ""
+    result: Dict[str, Any] = Field(default_factory=dict)
+    success_rate: str = ""
+    enterprise_capabilities: Dict[str, bool] = Field(default_factory=dict)
     message: str = ""
+    warnings: List[str] = Field(default_factory=list)
 
 
 class EnterpriseFeatureListResponse(BaseModel):

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -3360,7 +3360,7 @@ class AnalyticsEvolutionExportResponse(BaseModel):
 
     status: str
     export_format: str = "json"
-    data: List[Dict[str, Any]] = Field(default_factory=list)
+    data: List[EvolutionQualitySnapshot] = Field(default_factory=list)
     record_count: int = 0
     exported_at: str = ""
 


### PR DESCRIPTION
## Summary

- **GH#8313** — `EnterpriseFeatureEnableAllResponse` field mismatch: schema exposed flat fields (`enabled_features`, `failed_features`, `total_features`, `success_rate: float`) that do not match what `_build_enable_all_response` actually returns. Fixed to reflect the real response shape: nested `result: Dict`, `phase: str`, `success_rate: str` (formatted as `"80.0%"`), `enterprise_capabilities: Dict[str, bool]`, and conditional `warnings: List[str]`.
- **GH#8314** — `AnalyticsEvolutionExportResponse.data` typed as opaque `List[Dict[str, Any]]`. Tightened to `List[EvolutionQualitySnapshot]` — the model that describes the data Redis stores and the export returns.

## Files Changed

- `autobot-backend/api/schemas_agent.py` — `EnterpriseFeatureEnableAllResponse`
- `autobot-backend/api/schemas_analytics.py` — `AnalyticsEvolutionExportResponse`

## Verification

- `_build_enable_all_response` (`enterprise_features.py:144`) cross-checked — all returned keys match the updated schema exactly.
- `EvolutionQualitySnapshot` exists at `schemas_analytics.py:2169` and is the type stored/retrieved by the evolution Redis pipeline.
- No callers use `AnalyticsEvolutionExportResponse` as a `response_model` — it is schema-only (endpoint returns `JSONResponse` directly), so no runtime validation impact.
- No conflicts with `Dev_new_gui` in the two touched files.

## Test plan

- [ ] `GET /analytics/evolution/export` returns data in the shape of `EvolutionQualitySnapshot` items
- [ ] `POST /features/enable-all` returns `phase`, `result`, `success_rate` (string), `enterprise_capabilities`, `warnings` (when failures exist)
- [ ] OpenAPI schema at `/docs` reflects the corrected models

🤖 Generated with [Claude Code](https://claude.com/claude-code)