### PR TITLE
perf(vector-search): batch ChromaDB queries, expand search cache 100→10K, SQ8 quantization (#8153, #8154, #8155)

### DIFF
--- a/autobot-backend/knowledge/backends/async_base.py
+++ b/autobot-backend/knowledge/backends/async_base.py
@@ -99,6 +99,31 @@ class AsyncBaseCollection(ABC):
     ) -> Dict[str, Any]:
         """Vector search. Returns nested-list dict, one inner list per query."""
 
+    async def query_batch(
+        self,
+        query_embeddings: Sequence[Embedding],
+        n_results: int = 10,
+        where: Where | None = None,
+        where_document: WhereDocument | None = None,
+        include: Sequence[str] | None = None,
+    ) -> Dict[str, Any]:
+        """Batch vector search — multiple embeddings in a single backend call.
+
+        Issue #8153: default implementation forwards to ``query()`` so all
+        existing subclasses gain the method without changes. Backend adapters
+        that support native multi-query (ChromaDB, etc.) should override.
+
+        Returns nested-list dict: ``results["ids"][i]`` is the hit list for
+        query ``i``.
+        """
+        return await self.query(
+            query_embeddings=list(query_embeddings),
+            n_results=n_results,
+            where=where,
+            where_document=where_document,
+            include=include,
+        )
+
     @abstractmethod
     async def delete(
         self,

--- a/autobot-backend/knowledge/backends/async_chromadb_adapter.py
+++ b/autobot-backend/knowledge/backends/async_chromadb_adapter.py
@@ -131,6 +131,28 @@ class AsyncChromaDBCollection(AsyncBaseCollection):
             kwargs["include"] = list(include)
         return await self._raw.query(**kwargs)
 
+    async def query_batch(
+        self,
+        query_embeddings: Sequence[Embedding],
+        n_results: int = 10,
+        where: Where | None = None,
+        where_document: WhereDocument | None = None,
+        include: Sequence[str] | None = None,
+    ) -> dict:
+        """Issue #8153: batch multiple embeddings into a single ChromaDB call.
+
+        Delegates to ``AsyncChromaCollection.query_batch()`` which wraps the
+        underlying synchronous ``collection.query()`` in one ``asyncio.to_thread``
+        dispatch regardless of how many embeddings are in the batch.
+        """
+        return await self._raw.query_batch(
+            query_embeddings=[list(e) for e in query_embeddings],
+            n_results=n_results,
+            where=where,
+            where_document=where_document,
+            include=list(include) if include is not None else None,
+        )
+
     async def delete(
         self,
         *,

--- a/autobot-backend/knowledge/base.py
+++ b/autobot-backend/knowledge/base.py
@@ -90,6 +90,10 @@ class KnowledgeBaseCore:
         self.hnsw_construction_ef = config.get("memory.chromadb.hnsw.construction_ef", 300)
         self.hnsw_search_ef = config.get("memory.chromadb.hnsw.search_ef", 100)
         self.hnsw_m = config.get("memory.chromadb.hnsw.M", 32)
+        # Issue #8155: SQ8 scalar quantization — opt-in via AUTOBOT_HNSW_QUANTIZATION_TYPE=sq.
+        # Empty string (default) disables quantization (safe for ChromaDB 1.5.x which rejects
+        # the key; non-empty value is added to hnsw_metadata and tried at collection creation).
+        self.hnsw_quantization_type: str = ssot_config.misc.hnsw_quantization_type
 
     def _init_connection_vars(self) -> None:
         """Initialize connection and state variables (Issue #398: extracted)."""
@@ -337,12 +341,18 @@ class KnowledgeBaseCore:
 
     def _build_hnsw_metadata(self) -> dict:
         """Build HNSW metadata for ChromaDB collection (Issue #398: extracted)."""
-        return {
+        meta: dict = {
             "hnsw:space": self.hnsw_space,
             "hnsw:construction_ef": self.hnsw_construction_ef,
             "hnsw:search_ef": self.hnsw_search_ef,
             "hnsw:M": self.hnsw_m,
         }
+        if self.hnsw_quantization_type:
+            # Issue #8155: SQ8 scalar quantization reduces vector storage 4× with <1% recall
+            # loss. Gated by AUTOBOT_HNSW_QUANTIZATION_TYPE because ChromaDB 1.5.x rejects
+            # this key; set to "sq" on installations that support it.
+            meta["hnsw:quantization_type"] = self.hnsw_quantization_type
+        return meta
 
     async def _create_chroma_collection(self, chroma_client, hnsw_metadata: dict):
         """Create ChromaDB collection with HNSW parameters (Issue #398: extracted)."""

--- a/autobot-backend/npu_semantic_search.py
+++ b/autobot-backend/npu_semantic_search.py
@@ -33,7 +33,6 @@ from config import cfg
 
 # Import existing AutoBot components
 from constants.threshold_constants import TimingConstants
-from constants.ttl_constants import TTL_5_MINUTES
 from knowledge.backends import get_default_client
 from knowledge.embedding_cache import get_embedding_cache
 from knowledge_base import KnowledgeBase
@@ -85,6 +84,11 @@ def _resolve_npu_embedding_cache_ttl() -> int:
 
 
 _NPU_EMBEDDING_CACHE_TTL: int = _resolve_npu_embedding_cache_ttl()
+
+# Issue #8154: Search result cache — resolved from SSOT config with env-var overrides.
+# AUTOBOT_SEARCH_RESULT_CACHE_SIZE (default 10000) and AUTOBOT_SEARCH_RESULT_CACHE_TTL (default 1800s).
+_SEARCH_CACHE_MAX_SIZE: int = config.cache.l1.search_result_cache_max_size
+_SEARCH_CACHE_TTL: int = config.cache.l1.search_result_cache_ttl
 
 # Issue #380: Module-level tuple for default target modalities in cross-modal search
 _DEFAULT_TARGET_MODALITIES = ("text", "image", "audio", "multimodal")
@@ -189,8 +193,8 @@ class NPUSemanticSearch:
         # Use Issue #65 P0 optimized EmbeddingCache (60-80% improvement for repeated queries)
         self.embedding_cache = get_embedding_cache()
         self.search_results_cache = {}  # Cache for complete search results
-        self.cache_max_size = 100
-        self.cache_ttl_seconds = TTL_5_MINUTES
+        self.cache_max_size = _SEARCH_CACHE_MAX_SIZE
+        self.cache_ttl_seconds = _SEARCH_CACHE_TTL
 
         # Performance optimization settings
         self.batch_size_npu = 32  # Optimal NPU batch size
@@ -763,6 +767,76 @@ class NPUSemanticSearch:
                 processed_results.append(result)
         return processed_results
 
+    async def _batch_chromadb_search(
+        self,
+        miss_indices: List[int],
+        miss_embeddings: List[List[float]],
+        similarity_top_k: int,
+        filters: Dict[str, Any] | None,
+        embedding_device: str,
+    ) -> Dict[int, Tuple[List[SearchResult], SearchMetrics]]:
+        """Issue #8153: run all cache-miss queries against ChromaDB in one call.
+
+        Passes the full list of query embeddings to ``query_batch()`` so the
+        underlying ``asyncio.to_thread`` is dispatched once instead of N times.
+        Returns a dict mapping original query index → (results, metrics).
+        """
+        kb_collection = getattr(self.knowledge_base, "_async_chroma_collection", None)
+        if kb_collection is None:
+            return {}
+
+        start = time.time()
+        try:
+            batch_result = await kb_collection.query_batch(
+                query_embeddings=miss_embeddings,
+                n_results=similarity_top_k,
+                where=filters,
+            )
+        except Exception as exc:
+            logger.error("batch_chromadb_search failed: %s", exc)
+            return {}
+
+        query_time_ms = (time.time() - start) * 1000
+        out: Dict[int, Tuple[List[SearchResult], SearchMetrics]] = {}
+
+        ids_per_query = batch_result.get("ids") or []
+        docs_per_query = batch_result.get("documents") or [None] * len(ids_per_query)
+        metas_per_query = batch_result.get("metadatas") or [None] * len(ids_per_query)
+        dists_per_query = batch_result.get("distances") or [None] * len(ids_per_query)
+
+        for slice_idx, orig_idx in enumerate(miss_indices):
+            ids = ids_per_query[slice_idx] if slice_idx < len(ids_per_query) else []
+            docs = docs_per_query[slice_idx] if slice_idx < len(docs_per_query) else None
+            metas = metas_per_query[slice_idx] if slice_idx < len(metas_per_query) else None
+            dists = dists_per_query[slice_idx] if slice_idx < len(dists_per_query) else None
+
+            results: List[SearchResult] = []
+            for j, doc_id in enumerate(ids or []):
+                score = 1.0 - (dists[j] if dists else 0.0)
+                results.append(
+                    SearchResult(
+                        content=(docs[j] if docs else ""),
+                        metadata=(metas[j] if metas else {}),
+                        score=score,
+                        doc_id=doc_id,
+                        device_used=embedding_device,
+                        processing_time_ms=query_time_ms / max(len(miss_indices), 1),
+                        embedding_model="chromadb",
+                    )
+                )
+
+            metrics = SearchMetrics(
+                total_documents_searched=len(results),
+                embedding_generation_time_ms=0.0,
+                similarity_computation_time_ms=query_time_ms / max(len(miss_indices), 1),
+                total_search_time_ms=query_time_ms / max(len(miss_indices), 1),
+                device_used=embedding_device,
+                hardware_utilization={},
+            )
+            out[orig_idx] = (results, metrics)
+
+        return out
+
     async def batch_search(
         self,
         queries: List[str],
@@ -770,40 +844,94 @@ class NPUSemanticSearch:
         filters: Dict[str, Any] | None = None,
         enable_npu_acceleration: bool = True,
     ) -> List[Tuple[List[SearchResult], SearchMetrics]]:
-        """
-        Perform batch semantic search for multiple queries with NPU acceleration.
+        """Batch semantic search — uses a single ChromaDB call for all queries.
 
-        Args:
-            queries: List of search query strings
-            similarity_top_k: Number of results per query
-            filters: Optional metadata filters
-            enable_npu_acceleration: Whether to use NPU acceleration
+        Issue #8153: replaces N individual ``enhanced_search`` dispatches with:
+          1. Cache check for all queries (no I/O).
+          2. Concurrent embedding generation for cache misses.
+          3. One ``query_batch()`` call → one ``asyncio.to_thread`` dispatch.
+          4. Per-query result slicing from the batched response.
 
-        Returns:
-            List of tuples (search_results, metrics) for each query
+        Falls back to the individual ``enhanced_search`` path when the knowledge
+        base ChromaDB collection is not available.
         """
         if not queries:
             return []
 
         logger.info("🔍 Batch search: %s queries (top_k=%s)", len(queries), similarity_top_k)
 
-        semaphore = asyncio.Semaphore(10)
+        cache_keys = [self._generate_cache_key(q, similarity_top_k, filters) for q in queries]
+        output: List[Tuple[List[SearchResult], SearchMetrics] | None] = [None] * len(queries)
 
-        async def _search_with_semaphore(query: str):
-            """Execute single search with semaphore for concurrency control."""
-            async with semaphore:
-                return await self.enhanced_search(
-                    query=query,
-                    similarity_top_k=similarity_top_k,
-                    filters=filters,
-                    enable_npu_acceleration=enable_npu_acceleration,
-                )
+        miss_indices = [i for i, k in enumerate(cache_keys) if self._get_cached_result(k) is None]
 
-        results = await asyncio.gather(*[_search_with_semaphore(q) for q in queries], return_exceptions=True)
+        for i in range(len(queries)):
+            if i not in miss_indices:
+                output[i] = self._get_cached_result(cache_keys[i])
 
-        processed_results = self._process_batch_results(results)
-        logger.info("✅ Batch search completed: %s results", len(processed_results))
-        return processed_results
+        if not miss_indices:
+            logger.info("✅ Batch search: all %s queries from cache", len(queries))
+            return output  # type: ignore[return-value]
+
+        emb_tasks = [
+            self._generate_optimized_embedding(queries[i], enable_npu_acceleration, None)
+            for i in miss_indices
+        ]
+        emb_results = await asyncio.gather(*emb_tasks, return_exceptions=True)
+
+        valid_miss_indices: List[int] = []
+        valid_embeddings: List[List[float]] = []
+        embedding_device = "batch_mixed"
+
+        for pos, (orig_idx, emb_result) in enumerate(zip(miss_indices, emb_results)):
+            if isinstance(emb_result, Exception):
+                logger.error("Embedding failed for query %s: %s", orig_idx, emb_result)
+                output[orig_idx] = self._create_error_search_result()
+                continue
+            emb_array, device = emb_result
+            embedding_device = device
+            valid_miss_indices.append(orig_idx)
+            valid_embeddings.append(emb_array.tolist() if hasattr(emb_array, "tolist") else list(emb_array))
+
+        if valid_miss_indices and getattr(self.knowledge_base, "_async_chroma_collection", None) is not None:
+            batch_hits = await self._batch_chromadb_search(
+                valid_miss_indices, valid_embeddings, similarity_top_k, filters, embedding_device
+            )
+            for orig_idx, result_tuple in batch_hits.items():
+                output[orig_idx] = result_tuple
+                self._cache_result(cache_keys[orig_idx], result_tuple)
+            for orig_idx in valid_miss_indices:
+                if output[orig_idx] is None:
+                    output[orig_idx] = self._create_error_search_result()
+        elif valid_miss_indices:
+            semaphore = asyncio.Semaphore(10)
+
+            async def _search_with_semaphore(idx: int) -> Tuple[int, Any]:
+                async with semaphore:
+                    result = await self.enhanced_search(
+                        query=queries[idx],
+                        similarity_top_k=similarity_top_k,
+                        filters=filters,
+                        enable_npu_acceleration=enable_npu_acceleration,
+                    )
+                    return idx, result
+
+            fallback_results = await asyncio.gather(
+                *[_search_with_semaphore(i) for i in valid_miss_indices], return_exceptions=True
+            )
+            for item in fallback_results:
+                if isinstance(item, Exception):
+                    logger.error("Fallback search failed: %s", item)
+                else:
+                    idx, result_tuple = item
+                    output[idx] = result_tuple
+
+        for i in range(len(queries)):
+            if output[i] is None:
+                output[i] = self._create_error_search_result()
+
+        logger.info("✅ Batch search completed: %s results", len(output))
+        return output  # type: ignore[return-value]
 
     def _calculate_device_summary(self, device_results: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Calculate summary statistics for a device's benchmark results (Issue #665: extracted helper)."""
@@ -952,6 +1080,12 @@ class NPUSemanticSearch:
                 anonymized_telemetry=False,
             )
 
+            # Issue #8155: build collection metadata with hnsw:space + optional SQ8.
+            _quantization_type: str = config.misc.hnsw_quantization_type
+            _base_hnsw: Dict[str, Any] = {"hnsw:space": "cosine"}
+            if _quantization_type:
+                _base_hnsw["hnsw:quantization_type"] = _quantization_type
+
             # Initialize collections for each modality
             for modality, collection_name in self.collection_names.items():
                 try:
@@ -960,13 +1094,23 @@ class NPUSemanticSearch:
                     logger.info(f"✅ Loaded existing ChromaDB collection: {collection_name}")
                 except ValueError:
                     # Create new collection if it doesn't exist
-                    collection = self.chroma_client.create_collection(
-                        name=collection_name,
-                        metadata={
-                            "modality": modality,
-                            "description": f"AutoBot {modality} embeddings",
-                        },
-                    )
+                    col_meta: Dict[str, Any] = {
+                        "modality": modality,
+                        "description": f"AutoBot {modality} embeddings",
+                        **_base_hnsw,
+                    }
+                    try:
+                        collection = self.chroma_client.create_collection(
+                            name=collection_name,
+                            metadata=col_meta,
+                        )
+                    except Exception:
+                        # Quantization key rejected by this ChromaDB version — retry without it.
+                        fallback_meta = {k: v for k, v in col_meta.items() if k != "hnsw:quantization_type"}
+                        collection = self.chroma_client.create_collection(
+                            name=collection_name,
+                            metadata=fallback_meta,
+                        )
                     logger.info(f"✅ Created new ChromaDB collection: {collection_name}")
 
                 self.collections[modality] = collection

--- a/autobot-backend/utils/async_chromadb_client.py
+++ b/autobot-backend/utils/async_chromadb_client.py
@@ -162,6 +162,41 @@ class AsyncChromaCollection:
             include=include,
         )
 
+    async def query_batch(
+        self,
+        query_embeddings: List[List[float]],
+        n_results: int = 10,
+        where: Dict[str, Any] | None = None,
+        where_document: Dict[str, Any] | None = None,
+        include: List[str] | None = None,
+    ) -> Dict[str, Any]:
+        """Batch vector search — all embeddings in a single ChromaDB call.
+
+        Issue #8153: eliminates per-query thread dispatch overhead. ChromaDB
+        returns nested-list results: results["ids"][i] is the hit-list for
+        query i. Callers must slice the returned dict by query index.
+
+        Args:
+            query_embeddings: N query vectors; each is a list[float].
+            n_results: Number of results per query.
+            where: Optional metadata filter applied to every query.
+            where_document: Optional document content filter.
+            include: Fields to include (default: documents, metadatas, distances).
+
+        Returns:
+            Dict with nested lists, one inner list per query vector.
+        """
+        if include is None:
+            include = _DEFAULT_QUERY_INCLUDE
+        return await asyncio.to_thread(
+            self._collection.query,
+            query_embeddings=query_embeddings,
+            n_results=n_results,
+            where=where,
+            where_document=where_document,
+            include=include,
+        )
+
     async def get(
         self,
         ids: List[str] | None = None,

--- a/autobot-backend/utils/gpu_vector_search.py
+++ b/autobot-backend/utils/gpu_vector_search.py
@@ -70,6 +70,7 @@ class IndexType(Enum):
     IVF_FLAT = "ivf_flat"  # Inverted file index, faster for large datasets
     IVF_PQ = "ivf_pq"  # Product quantization, memory efficient
     HNSW = "hnsw"  # Hierarchical NSW, good recall/speed tradeoff
+    SQ8 = "sq8"  # Issue #8155: Scalar Quantization 8-bit — 4× memory reduction, <1% recall loss
 
 
 class SearchBackend(Enum):
@@ -265,6 +266,11 @@ class GPUVectorIndex:
             index.hnsw.efConstruction = 200
             index.hnsw.efSearch = 64
             return index
+
+        elif self.config.index_type == IndexType.SQ8:
+            # Issue #8155: Scalar Quantization 8-bit — 4× memory reduction vs float32.
+            # Uses inner-product metric (cosine after L2-norm) matching FLAT_IP behaviour.
+            return faiss.IndexScalarQuantizer(dim, faiss.ScalarQuantizer.QT_8bit, faiss.METRIC_INNER_PRODUCT)
 
         else:
             # Default to flat IP

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -711,6 +711,16 @@ class CacheL1Config(BaseSettings):
         alias="AUTOBOT_CACHE_L1_SEMANTIC_MAX_SIZE",
         description="Max entries in semantic query cache ChromaDB collection",
     )
+    search_result_cache_max_size: int = Field(
+        default=10000,
+        alias="AUTOBOT_SEARCH_RESULT_CACHE_SIZE",
+        description="Max entries in NPU semantic search result cache (#8154)",
+    )
+    search_result_cache_ttl: int = Field(
+        default=1800,
+        alias="AUTOBOT_SEARCH_RESULT_CACHE_TTL",
+        description="TTL in seconds for NPU search result cache entries (#8154)",
+    )
 
 
 class CacheL2Config(BaseSettings):
@@ -1196,6 +1206,15 @@ class MiscConfig(BaseSettings):
     gc_threshold_2: int = Field(default=0, alias="AUTOBOT_GC_THRESHOLD_2")
     hnsw_construction_ef: str = Field(default="", alias="AUTOBOT_HNSW_CONSTRUCTION_EF")
     hnsw_m: str = Field(default="", alias="AUTOBOT_HNSW_M")
+    hnsw_quantization_type: str = Field(
+        default="",
+        alias="AUTOBOT_HNSW_QUANTIZATION_TYPE",
+        description=(
+            "ChromaDB HNSW quantization type (e.g. 'sq' for SQ8). "
+            "Only applies to ChromaDB versions that support hnsw:quantization_type metadata (#8155). "
+            "Empty string disables quantization (safe default for ChromaDB 1.5.x)."
+        ),
+    )
     hnsw_search_ef: str = Field(default="", alias="AUTOBOT_HNSW_SEARCH_EF")
     hnsw_space: str = Field(default="", alias="AUTOBOT_HNSW_SPACE")
     inference_profiling: str = Field(default="", alias="AUTOBOT_INFERENCE_PROFILING")


### PR DESCRIPTION
## Summary

- **#8153** — `query_batch()` added to `AsyncChromaCollection`, `AsyncChromaDBCollection`, and `AsyncBaseCollection`; `batch_search()` in `npu_semantic_search.py` refactored to collect all embeddings and dispatch a single `asyncio.to_thread` instead of N concurrent per-query dispatches.
- **#8154** — Search result cache expanded from hardcoded 100 entries / 5-min TTL to 10 000 entries / 30-min TTL, both overridable via `AUTOBOT_SEARCH_RESULT_CACHE_SIZE` and `AUTOBOT_SEARCH_RESULT_CACHE_TTL` env vars; values are resolved from `CacheL1Config` in `ssot_config.py` (follows Issue #6743 pattern).
- **#8155** — Scalar Quantization SQ8 added as opt-in via `AUTOBOT_HNSW_QUANTIZATION_TYPE=sq`; safe by default (empty string disables) since ChromaDB 1.5.x rejects the `hnsw:quantization_type` key. FAISS `IndexType.SQ8` added in `gpu_vector_search.py` using `faiss.IndexScalarQuantizer(QT_8bit, METRIC_INNER_PRODUCT)`.

## Files changed

| File | Change |
|---|---|
| `autobot_shared/ssot_config.py` | Add `search_result_cache_max_size`, `search_result_cache_ttl` to `CacheL1Config`; add `hnsw_quantization_type` to `MiscConfig` |
| `autobot-backend/utils/async_chromadb_client.py` | Add `AsyncChromaCollection.query_batch()` |
| `autobot-backend/knowledge/backends/async_base.py` | Add `AsyncBaseCollection.query_batch()` default impl |
| `autobot-backend/knowledge/backends/async_chromadb_adapter.py` | Override `query_batch()` in `AsyncChromaDBCollection` |
| `autobot-backend/npu_semantic_search.py` | Cache constants from SSOT; `batch_search()` batch path; SQ8 metadata in `_initialize_chromadb()` |
| `autobot-backend/knowledge/base.py` | `_build_hnsw_metadata()` includes `hnsw:quantization_type` when configured; reads from `ssot_config.misc.hnsw_quantization_type` |
| `autobot-backend/utils/gpu_vector_search.py` | Add `IndexType.SQ8`; add `IndexScalarQuantizer` branch in `_create_base_index()` |

## Test plan

- [ ] Syntax check: all 7 files pass `python3 -m py_compile` ✅ (verified in commit)
- [ ] Config defaults: `config.cache.l1.search_result_cache_max_size == 10000`, `config.misc.hnsw_quantization_type == ""` ✅ (verified in commit)
- [ ] Env-var override: `AUTOBOT_SEARCH_RESULT_CACHE_SIZE=500` → cache_max_size=500
- [ ] `batch_search()` with cache hits: no ChromaDB call made
- [ ] `batch_search()` with 10 misses: one `query_batch()` call, results sliced per query
- [ ] ChromaDB SQ8 opt-in: `AUTOBOT_HNSW_QUANTIZATION_TYPE=sq` → `hnsw:quantization_type` in collection metadata
- [ ] FAISS SQ8: `VectorSearchConfig(index_type=IndexType.SQ8)` creates `IndexScalarQuantizer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)