### PR TITLE
test(autoresearch): edge-case and endpoint coverage (#3211)

### DIFF
--- a/autobot-backend/services/autoresearch/knowledge_synthesizer_test.py
+++ b/autobot-backend/services/autoresearch/knowledge_synthesizer_test.py
@@ -104,6 +104,21 @@ class TestKnowledgeSynthesizer:
         mock_chromadb.upsert.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_synthesize_empty_session_returns_empty(self, synthesizer) -> None:
+        """No experiments tagged with session returns [] without calling LLM — Issue #3211."""
+        insights = await synthesizer.synthesize_session("session-nonexistent")
+        assert insights == []
+
+    @pytest.mark.asyncio
+    async def test_synthesize_session_llm_failure_returns_empty(
+        self, synthesizer, mock_llm
+    ) -> None:
+        """LLM exception during synthesis returns [] gracefully — Issue #3211."""
+        mock_llm.chat.side_effect = RuntimeError("LLM service unavailable")
+        insights = await synthesizer.synthesize_session("session-1")
+        assert insights == []
+
+    @pytest.mark.asyncio
     async def test_query_insights(self, synthesizer, mock_chromadb) -> None:
         mock_chromadb.query.return_value = {
             "ids": [["i1"]],

--- a/autobot-backend/services/autoresearch/prompt_optimizer_test.py
+++ b/autobot-backend/services/autoresearch/prompt_optimizer_test.py
@@ -433,3 +433,38 @@ class TestPromptOptimizerLoop:
         optimizer._redis.get.return_value = None
         result = await optimizer.load_archive("nonexistent-session-id")
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_multi_scorer_final_score_is_average(self, mock_llm) -> None:
+        """final_score must be the mean of all scorer scores — Issue #3211."""
+        scorer_a = AsyncMock()
+        scorer_a.name = "scorer_a"
+        scorer_a.score.return_value = ScorerResult(score=0.6, raw_score=6, metadata={}, scorer_name="scorer_a")
+
+        scorer_b = AsyncMock()
+        scorer_b.name = "scorer_b"
+        scorer_b.score.return_value = ScorerResult(score=0.8, raw_score=8, metadata={}, scorer_name="scorer_b")
+
+        opt = PromptOptimizer(
+            scorers={"scorer_a": scorer_a, "scorer_b": scorer_b},
+            llm_service=mock_llm,
+        )
+        opt._redis = AsyncMock()
+
+        target = PromptOptTarget(
+            agent_name="test",
+            current_prompt="base",
+            scorer_chain=["scorer_a", "scorer_b"],
+            mutation_count=1,
+            top_k=1,
+        )
+
+        async def benchmark_fn(prompt: str) -> str:
+            return "output"
+
+        session = await opt.optimize(target, benchmark_fn, max_rounds=1)
+
+        assert session.best_variant is not None
+        assert abs(session.best_variant.final_score - 0.7) < 1e-9, (
+            f"Expected final_score=0.7 (average of 0.6+0.8), got {session.best_variant.final_score}"
+        )

--- a/autobot-backend/services/autoresearch/routes_test.py
+++ b/autobot-backend/services/autoresearch/routes_test.py
@@ -453,3 +453,160 @@ class TestCancelExperiment:
 
         assert response.status_code == 409
         assert "not currently running" in response.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Prompt Optimizer endpoints — Issue #3211
+# ---------------------------------------------------------------------------
+
+
+def _make_optimizer(
+    current_session=None,
+    registered_targets: list[str] | None = None,
+) -> MagicMock:
+    """Build a mock PromptOptimizer."""
+    opt = MagicMock()
+    opt.current_session = current_session
+    opt.get_registered_targets = MagicMock(return_value=registered_targets or [])
+    opt.get_target = MagicMock(return_value=None)
+    opt.cancel = MagicMock()
+    return opt
+
+
+def _build_app_with_optimizer(optimizer: MagicMock) -> FastAPI:
+    """Build app with autoresearch router and a pre-set optimizer on app.state."""
+    with patch("auth_middleware.check_admin_permission", return_value=True):
+        from services.autoresearch.routes import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/autoresearch")
+    app.state.autoresearch_optimizer = optimizer
+    app.state.autoresearch_store = _make_store()
+    app.state.autoresearch_runner = _make_runner()
+    return app
+
+
+class TestGetOptimizerStatus:
+    """Tests for GET /autoresearch/prompt-optimizer/status — Issue #3211."""
+
+    def test_status_no_session(self) -> None:
+        opt = _make_optimizer(current_session=None)
+        app = _build_app_with_optimizer(opt)
+        client = TestClient(app)
+
+        response = client.get("/autoresearch/prompt-optimizer/status")
+
+        assert response.status_code == 200
+        assert response.json() == {"running": False, "session": None}
+
+    def test_status_with_session(self) -> None:
+        session = MagicMock()
+        session.to_dict.return_value = {"status": "running", "round": 1}
+        opt = _make_optimizer(current_session=session)
+        app = _build_app_with_optimizer(opt)
+        client = TestClient(app)
+
+        response = client.get("/autoresearch/prompt-optimizer/status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["running"] is True
+        assert data["session"]["status"] == "running"
+
+
+class TestStartOptimization:
+    """Tests for POST /autoresearch/prompt-optimizer/start — Issue #3211."""
+
+    def test_start_success(self) -> None:
+        target_entry = (MagicMock(), MagicMock())
+        opt = _make_optimizer(current_session=None)
+        opt.get_target = MagicMock(return_value=target_entry)
+        app = _build_app_with_optimizer(opt)
+        client = TestClient(app)
+
+        response = client.post(
+            "/autoresearch/prompt-optimizer/start",
+            json={"agent_name": "autoresearch_hypothesis", "max_rounds": 2},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "started"
+        assert data["agent_name"] == "autoresearch_hypothesis"
+
+    def test_start_conflict_when_already_running(self) -> None:
+        session = MagicMock()
+        opt = _make_optimizer(current_session=session)
+        app = _build_app_with_optimizer(opt)
+        client = TestClient(app)
+
+        response = client.post(
+            "/autoresearch/prompt-optimizer/start",
+            json={"agent_name": "autoresearch_hypothesis"},
+        )
+
+        assert response.status_code == 409
+
+    def test_start_unknown_target_returns_400(self) -> None:
+        opt = _make_optimizer(current_session=None)
+        opt.get_target = MagicMock(return_value=None)
+        opt.get_registered_targets = MagicMock(return_value=["autoresearch_hypothesis"])
+        app = _build_app_with_optimizer(opt)
+        client = TestClient(app)
+
+        response = client.post(
+            "/autoresearch/prompt-optimizer/start",
+            json={"agent_name": "nonexistent_agent"},
+        )
+
+        assert response.status_code == 400
+        assert "nonexistent_agent" in response.json()["detail"]
+
+
+class TestCancelOptimization:
+    """Tests for POST /autoresearch/prompt-optimizer/cancel — Issue #3211."""
+
+    def test_cancel_running_session(self) -> None:
+        session = MagicMock()
+        opt = _make_optimizer(current_session=session)
+        app = _build_app_with_optimizer(opt)
+        client = TestClient(app)
+
+        response = client.post("/autoresearch/prompt-optimizer/cancel")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "cancelling"
+        opt.cancel.assert_called_once()
+
+    def test_cancel_no_session_returns_409(self) -> None:
+        opt = _make_optimizer(current_session=None)
+        app = _build_app_with_optimizer(opt)
+        client = TestClient(app)
+
+        response = client.post("/autoresearch/prompt-optimizer/cancel")
+
+        assert response.status_code == 409
+
+
+class TestListOptimizationTargets:
+    """Tests for GET /autoresearch/prompt-optimizer/targets — Issue #3211."""
+
+    def test_returns_registered_targets(self) -> None:
+        opt = _make_optimizer(registered_targets=["autoresearch_hypothesis", "agent_b"])
+        app = _build_app_with_optimizer(opt)
+        client = TestClient(app)
+
+        response = client.get("/autoresearch/prompt-optimizer/targets")
+
+        assert response.status_code == 200
+        assert response.json() == {"targets": ["autoresearch_hypothesis", "agent_b"]}
+
+    def test_returns_empty_when_no_targets(self) -> None:
+        opt = _make_optimizer(registered_targets=[])
+        app = _build_app_with_optimizer(opt)
+        client = TestClient(app)
+
+        response = client.get("/autoresearch/prompt-optimizer/targets")
+
+        assert response.status_code == 200
+        assert response.json() == {"targets": []}

--- a/autobot-backend/services/autoresearch/scorers_test.py
+++ b/autobot-backend/services/autoresearch/scorers_test.py
@@ -135,6 +135,39 @@ class TestLLMJudgeScorer:
         assert "error" in result.metadata
 
 
+class TestLLMJudgeScorerParseRating:
+    """Unit tests for LLMJudgeScorer._parse_rating edge cases — Issue #3211."""
+
+    def test_parse_rating_completely_unparseable_returns_zero(self) -> None:
+        result = LLMJudgeScorer._parse_rating("no numbers here at all")
+        assert result == 0
+
+    def test_parse_rating_json_path(self) -> None:
+        assert LLMJudgeScorer._parse_rating('{"rating": 7, "reasoning": "ok"}') == 7
+
+    def test_parse_rating_regex_path(self) -> None:
+        assert LLMJudgeScorer._parse_rating("I give this 8 out of 10") == 8
+
+    def test_parse_rating_clamps_to_10(self) -> None:
+        assert LLMJudgeScorer._parse_rating('{"rating": 15}') == 10
+
+    def test_parse_rating_clamps_to_0(self) -> None:
+        assert LLMJudgeScorer._parse_rating('{"rating": -3}') == 0
+
+
+class TestValBpbScorerRunExperimentException:
+    """ValBpbScorer should surface exceptions from run_experiment — Issue #3211."""
+
+    @pytest.mark.asyncio
+    async def test_score_propagates_run_experiment_exception(self) -> None:
+        runner = AsyncMock()
+        runner.run_experiment.side_effect = RuntimeError("training crashed")
+
+        scorer = ValBpbScorer(runner=runner, baseline_val_bpb=5.0)
+        with pytest.raises(RuntimeError, match="training crashed"):
+            await scorer.score("hypothesis", {"hyperparams": {}})
+
+
 class TestSubsetFractionPassthrough:
     """Verify subset_fraction=None is a no-op for all concrete scorers."""
 

--- a/autobot-backend/services/autoresearch/store_chromadb_test.py
+++ b/autobot-backend/services/autoresearch/store_chromadb_test.py
@@ -139,6 +139,16 @@ class TestBuildDocument:
         doc = store._build_document(exp)
         assert "val_bpb" not in doc
 
+    def test_val_bpb_none_with_baseline_set_omits_improvement(self) -> None:
+        """val_bpb=None but baseline_val_bpb set must not include Improvement — Issue #3211."""
+        store = _make_store()
+        exp = _make_experiment(val_bpb=None, baseline=6.0)
+        # result exists but val_bpb is None
+        exp.result = ExperimentResult(val_bpb=None)
+        doc = store._build_document(exp)
+        assert "Improvement" not in doc
+        assert "Baseline" not in doc
+
 
 # ---------------------------------------------------------------------------
 # _build_metadata tests


### PR DESCRIPTION
## Summary

- Adds missing test coverage identified in GH #3211 code review
- `LLMJudgeScorer._parse_rating`: unparseable → 0, JSON/regex paths, clamping
- `ValBpbScorer.score`: exception propagation from `run_experiment`
- `KnowledgeSynthesizer.synthesize_session`: empty session and LLM failure both return `[]`
- `ExperimentStore._build_document`: `val_bpb=None` with baseline set omits Improvement line
- `PromptOptimizer`: `final_score` averaging across multi-scorer chain (scorer_a=0.6, scorer_b=0.8 → 0.7)
- Routes: 9 tests covering prompt-optimizer status/start/cancel/targets endpoints

## Test plan

- All 5 modified test files pass `py_compile` syntax check ✅
- Pre-existing import failure (`services.knowledge` not found under `--import-mode=importlib`) blocks `pytest` locally; this is a pre-existing environment issue unrelated to these changes — verified it fails identically on the unmodified base branch
- CI will run with full dependency install

Closes #3211