### PR TITLE
feat(tools/lint): add --fix mode to check_decorator_order.py (#6787)

### DIFF
--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -339,6 +339,35 @@ Perf impact on [memory wake-up / KB search / entity lookup / tool dispatch / hoo
 
 ---
 
+## Decorator Order Fix Tool
+
+`tools/lint/check_decorator_order.py` enforces the `@router.*` / `@with_error_handling` decorator order (see #6558, #6633, #6638).
+
+**Check-only (default, used by pre-commit):**
+
+```bash
+python3 tools/lint/check_decorator_order.py <file-or-dir> ...
+```
+
+**Auto-fix mode (opt-in):**
+
+```bash
+pip install libcst   # one-time
+python3 tools/lint/check_decorator_order.py --fix <file-or-dir> ...
+```
+
+`--fix` uses libcst to correct violations in place while preserving formatting, comments, and docstrings.
+It fixes both patterns in a single pass:
+
+- **Pattern A** — `@with_error_handling` above `@router.*`: swapped so `@router.*` is outermost.
+- **Pattern B** — two adjacent `@with_error_handling` decorators: outer duplicate removed.
+
+The pre-commit hook entry in `.pre-commit-config.yaml` does **not** include `--fix` — CI always runs check-only so it never silently mutates files.  `--fix` is a developer convenience for bulk remediation.
+
+`libcst` is a soft dependency: if not installed, `--fix` prints an error and exits 1.
+
+---
+
 ## AUTOBOT_* Environment Variables
 
 All `AUTOBOT_*` environment variables must be registered in

--- a/tools/lint/check_decorator_order.py
+++ b/tools/lint/check_decorator_order.py
@@ -28,19 +28,32 @@ Exit codes:
   0 — clean
   1 — violations found
 
+``--fix`` mode (opt-in):
+  Pass ``--fix`` to auto-correct violations in place using libcst.
+  Requires ``pip install libcst``.  The pre-commit hook entry stays
+  check-only (no ``--fix``) so CI never silently mutates files.
+
 Background: #6558 (decorator order codebase-wide fix), #6633 (stacked
-duplicates), #6638 (this hook).
+duplicates), #6638 (this hook), #6787 (--fix mode).
 """
 from __future__ import annotations
 
+import argparse
 import ast
 import sys
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Sequence, Tuple
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _scan_helpers import iter_python_files  # noqa: E402
+
+try:
+    import libcst as cst
+
+    _LIBCST_AVAILABLE = True
+except ImportError:
+    _LIBCST_AVAILABLE = False
 
 HOOK_ID = "decorator-order"
 
@@ -172,9 +185,200 @@ def _check_file(path: Path, repo_root: Path) -> List[Tuple[int, str, str]]:
     return hits
 
 
+# ---------------------------------------------------------------------------
+# libcst-based fix helpers
+# ---------------------------------------------------------------------------
+
+
+def _cst_decorator_name(deco: "cst.Decorator") -> str:
+    """Best-effort fully-qualified name of a libcst Decorator node."""
+    node = deco.decorator
+    if isinstance(node, cst.Call):
+        node = node.func
+    parts: List[str] = []
+    while isinstance(node, cst.Attribute):
+        parts.append(node.attr.value)
+        node = node.value
+    if isinstance(node, cst.Name):
+        parts.append(node.value)
+        return ".".join(reversed(parts))
+    return ""
+
+
+def _cst_is_with_error_handling(deco: "cst.Decorator") -> bool:
+    return _cst_decorator_name(deco) == "with_error_handling"
+
+
+def _cst_is_router_decorator(deco: "cst.Decorator") -> bool:
+    name = _cst_decorator_name(deco)
+    if name.startswith("router."):
+        return True
+    if name.startswith("app.") and name.split(".", 1)[1] in {
+        "get",
+        "post",
+        "put",
+        "delete",
+        "patch",
+        "head",
+        "options",
+        "api_route",
+        "websocket",
+    }:
+        return True
+    return False
+
+
+if _LIBCST_AVAILABLE:
+
+    class _DecoratorOrderFixer(cst.CSTTransformer):
+        """CST transformer that fixes Pattern A (order) and Pattern B (stacked)."""
+
+        def __init__(self) -> None:
+            self.fix_count = 0
+
+        def _fix_decorator_list(
+            self,
+            decorators: Sequence["cst.Decorator"],
+        ) -> Tuple[Sequence["cst.Decorator"], int]:
+            """Return (new_decorators, fixes_applied) after correcting violations."""
+            decos = list(decorators)
+            fixes = 0
+            changed = True
+
+            while changed:
+                changed = False
+
+                # Pattern B first: remove the outer (earlier) duplicate @with_error_handling.
+                for i in range(len(decos) - 1):
+                    if _cst_is_with_error_handling(decos[i]) and _cst_is_with_error_handling(decos[i + 1]):
+                        removed = decos.pop(i)
+                        survivor = decos[i]
+                        # Transfer leading_lines from removed (outer) to survivor so
+                        # any blank lines before the block are preserved.
+                        combined = tuple(removed.leading_lines) + tuple(survivor.leading_lines)
+                        decos[i] = survivor.with_changes(leading_lines=combined)
+                        fixes += 1
+                        changed = True
+                        break
+
+                # Pattern A: swap @with_error_handling (at i) with @router.* (at j > i).
+                for i, deco in enumerate(decos):
+                    if not _cst_is_with_error_handling(deco):
+                        continue
+                    for j in range(i + 1, len(decos)):
+                        if _cst_is_router_decorator(decos[j]):
+                            weh = decos[i]
+                            router = decos[j]
+                            # Router moves to position i — inherits weh's leading_lines.
+                            decos[i] = router.with_changes(leading_lines=weh.leading_lines)
+                            # weh moves to position j — inherits router's leading_lines.
+                            decos[j] = weh.with_changes(leading_lines=router.leading_lines)
+                            fixes += 1
+                            changed = True
+                            break
+                    if changed:
+                        break
+
+            return tuple(decos), fixes
+
+        def leave_FunctionDef(
+            self,
+            original_node: "cst.FunctionDef",
+            updated_node: "cst.FunctionDef",
+        ) -> "cst.FunctionDef":
+            new_decos, count = self._fix_decorator_list(updated_node.decorators)
+            self.fix_count += count
+            if count:
+                return updated_node.with_changes(decorators=new_decos)
+            return updated_node
+
+        def leave_AsyncFunctionDef(
+            self,
+            original_node: "cst.AsyncFunctionDef",
+            updated_node: "cst.AsyncFunctionDef",
+        ) -> "cst.AsyncFunctionDef":
+            new_decos, count = self._fix_decorator_list(updated_node.decorators)
+            self.fix_count += count
+            if count:
+                return updated_node.with_changes(decorators=new_decos)
+            return updated_node
+
+
+def _fix_file(path: Path, repo_root: Path) -> int:
+    """Fix decorator-order violations in *path* using libcst.
+
+    Returns the number of fixes applied (0 if none).
+    Exits with code 1 if libcst is not installed.
+    """
+    if not _LIBCST_AVAILABLE:
+        print(
+            f"[{HOOK_ID}] --fix requires libcst.  Install with: pip install libcst",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not _is_target_file(path, repo_root):
+        return 0
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError:
+        return 0
+
+    try:
+        module = cst.parse_module(source)
+    except cst.ParserSyntaxError:
+        return 0
+
+    fixer = _DecoratorOrderFixer()
+    new_module = module.visit(fixer)
+
+    if fixer.fix_count == 0:
+        return 0
+
+    path.write_text(new_module.code, encoding="utf-8")
+
+    # Verify no violations remain after the fix.
+    remaining = _check_file(path, repo_root)
+    if remaining:
+        print(
+            f"[{HOOK_ID}] WARNING: {len(remaining)} violation(s) remain in {path} "
+            f"after auto-fix — manual review needed.",
+            file=sys.stderr,
+        )
+
+    return fixer.fix_count
+
+
 def main(argv: List[str]) -> int:
     repo_root = Path(__file__).resolve().parents[2]
-    files = list(iter_python_files(argv[1:], repo_root))
+
+    parser = argparse.ArgumentParser(
+        description="Check (or fix) @router.* / @with_error_handling decorator order.",
+        add_help=False,
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Auto-fix violations in place using libcst (requires: pip install libcst).",
+    )
+    args, remaining = parser.parse_known_args(argv[1:])
+    files = list(iter_python_files(remaining, repo_root))
+
+    if args.fix:
+        total_fixes = 0
+        for path in files:
+            total_fixes += _fix_file(path, repo_root)
+        if total_fixes:
+            print(
+                f"[{HOOK_ID}] Applied {total_fixes} fix(es).",
+                file=sys.stderr,
+            )
+        # Final validation pass — exit 1 only if violations couldn't be fixed.
+        unfixed = sum(len(_check_file(p, repo_root)) for p in files)
+        return 1 if unfixed else 0
+
+    # Check-only path (default, used by pre-commit hook).
     total_order = 0
     total_stacked = 0
     for path in files:
@@ -197,7 +401,8 @@ def main(argv: List[str]) -> int:
             f"{total_stacked} stacked-duplicate violation(s).\n"
             f"  Fix: ensure @router.* is OUTERMOST (top-most), with "
             f"@with_error_handling immediately below it. Remove any duplicate "
-            f"@with_error_handling stacks. See #6558 / #6633 for context.",
+            f"@with_error_handling stacks. See #6558 / #6633 for context.\n"
+            f"  Auto-fix: run with --fix (requires pip install libcst).",
             file=sys.stderr,
         )
         return 1

--- a/tools/lint/check_decorator_order_test.py
+++ b/tools/lint/check_decorator_order_test.py
@@ -1,19 +1,21 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Tests for tools/lint/check_decorator_order.py — see #6638.
+"""Tests for tools/lint/check_decorator_order.py — see #6638, #6787.
 
 Covers detection of:
   * Pattern A — @with_error_handling above @router.* (#6558)
   * Pattern B — adjacent stacked @with_error_handling (#6633)
 
-Plus path filtering, exit codes, and the negative case (correct ordering
-is not flagged).
+Plus path filtering, exit codes, the negative case (correct ordering
+is not flagged), and the ``--fix`` mode via libcst (#6787).
 """
 from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+
+import pytest
 
 _HOOK_PATH = Path(__file__).parent / "check_decorator_order.py"
 _spec = importlib.util.spec_from_file_location("_hook_under_test", _HOOK_PATH)
@@ -205,3 +207,240 @@ def test_decorator_name_helpers() -> None:
     assert hook._is_with_error_handling(decos[0]) is False
     assert hook._is_router_decorator(decos[1]) is False
     assert hook._is_with_error_handling(decos[1]) is True
+
+
+# ---------------------------------------------------------------------------
+# --fix mode tests (require libcst) — see #6787
+# ---------------------------------------------------------------------------
+
+_skip_no_libcst = pytest.mark.skipif(
+    not hook._LIBCST_AVAILABLE,
+    reason="libcst not installed; install with: pip install libcst",
+)
+
+
+@_skip_no_libcst
+def test_fix_pattern_a_corrects_order(tmp_path: Path) -> None:
+    """Pattern A (1): single function — decorator order corrected."""
+    path, repo_root = _write_api(
+        tmp_path,
+        "bad_order.py",
+        """\
+@with_error_handling(category="x")
+@router.get("/foo")
+async def foo():
+    return {}
+""",
+    )
+    fixes = hook._fix_file(path, repo_root)
+    assert fixes == 1
+    fixed = path.read_text(encoding="utf-8")
+    assert fixed.index("@router.get") < fixed.index("@with_error_handling")
+    assert hook._check_file(path, repo_root) == []
+
+
+@_skip_no_libcst
+def test_fix_pattern_a_idempotent(tmp_path: Path) -> None:
+    """Pattern A (2): second run on already-fixed file produces 0 changes."""
+    path, repo_root = _write_api(
+        tmp_path,
+        "ok.py",
+        """\
+@router.get("/foo")
+@with_error_handling(category="x")
+async def foo():
+    return {}
+""",
+    )
+    fixes = hook._fix_file(path, repo_root)
+    assert fixes == 0
+
+
+@_skip_no_libcst
+def test_fix_pattern_b_removes_duplicate(tmp_path: Path) -> None:
+    """Pattern B (3): single function — outer duplicate @with_error_handling removed."""
+    path, repo_root = _write_api(
+        tmp_path,
+        "stacked.py",
+        """\
+@router.get("/foo")
+@with_error_handling(category="x")
+@with_error_handling(category="x")
+async def foo():
+    return {}
+""",
+    )
+    fixes = hook._fix_file(path, repo_root)
+    assert fixes == 1
+    fixed = path.read_text(encoding="utf-8")
+    assert fixed.count("@with_error_handling") == 1
+    assert hook._check_file(path, repo_root) == []
+
+
+@_skip_no_libcst
+def test_fix_pattern_b_idempotent(tmp_path: Path) -> None:
+    """Pattern B (4): second run on already-fixed file produces 0 changes."""
+    path, repo_root = _write_api(
+        tmp_path,
+        "ok_b.py",
+        """\
+@router.get("/foo")
+@with_error_handling(category="x")
+async def foo():
+    return {}
+""",
+    )
+    fixes = hook._fix_file(path, repo_root)
+    assert fixes == 0
+
+
+@_skip_no_libcst
+def test_fix_pattern_a_and_b_mixed_in_one_pass(tmp_path: Path) -> None:
+    """Pattern A + B (5): mixed violations in same file — both fixed in one pass."""
+    path, repo_root = _write_api(
+        tmp_path,
+        "mixed.py",
+        """\
+@with_error_handling(category="x")
+@router.get("/foo")
+async def foo():
+    return {}
+
+
+@router.post("/bar")
+@with_error_handling(category="y")
+@with_error_handling(category="y")
+async def bar():
+    return {}
+""",
+    )
+    fixes = hook._fix_file(path, repo_root)
+    assert fixes == 2
+    assert hook._check_file(path, repo_root) == []
+
+
+@_skip_no_libcst
+def test_fix_pattern_a_preserves_docstring(tmp_path: Path) -> None:
+    """Pattern A (6): docstring inside function body is preserved after fix."""
+    path, repo_root = _write_api(
+        tmp_path,
+        "docstring.py",
+        """\
+@with_error_handling(category="x")
+@router.get("/foo")
+async def foo():
+    \"\"\"Return foo resource.\"\"\"
+    return {}
+""",
+    )
+    hook._fix_file(path, repo_root)
+    fixed = path.read_text(encoding="utf-8")
+    assert "Return foo resource." in fixed
+    assert hook._check_file(path, repo_root) == []
+
+
+@_skip_no_libcst
+def test_fix_pattern_a_preserves_type_annotations(tmp_path: Path) -> None:
+    """Pattern A (7): type annotations are preserved after fix."""
+    path, repo_root = _write_api(
+        tmp_path,
+        "typed.py",
+        """\
+@with_error_handling(category="x")
+@router.get("/foo")
+async def foo(item_id: int, q: str = "default") -> dict:
+    return {"id": item_id, "q": q}
+""",
+    )
+    hook._fix_file(path, repo_root)
+    fixed = path.read_text(encoding="utf-8")
+    assert "item_id: int" in fixed
+    assert "q: str" in fixed
+    assert "-> dict" in fixed
+    assert hook._check_file(path, repo_root) == []
+
+
+@_skip_no_libcst
+def test_fix_file_with_zero_violations_unchanged(tmp_path: Path) -> None:
+    """File with zero violations (8): content unchanged, 0 fixes returned."""
+    content = """\
+@router.get("/foo")
+@with_error_handling(category="x")
+async def foo():
+    return {}
+"""
+    path, repo_root = _write_api(tmp_path, "clean.py", content)
+    fixes = hook._fix_file(path, repo_root)
+    assert fixes == 0
+    assert path.read_text(encoding="utf-8") == content
+
+
+@_skip_no_libcst
+def test_fix_multiple_functions_mixed_violations(tmp_path: Path) -> None:
+    """Multiple functions (9): only violating functions are corrected."""
+    path, repo_root = _write_api(
+        tmp_path,
+        "multi.py",
+        """\
+@router.get("/ok")
+@with_error_handling()
+async def already_correct():
+    return {}
+
+
+@with_error_handling()
+@router.post("/bad")
+async def needs_fix():
+    return {}
+""",
+    )
+    fixes = hook._fix_file(path, repo_root)
+    assert fixes == 1
+    fixed = path.read_text(encoding="utf-8")
+    assert "@router.get" in fixed
+    assert hook._check_file(path, repo_root) == []
+
+
+@_skip_no_libcst
+def test_fix_three_decorators_only_wrong_pair_swapped(tmp_path: Path) -> None:
+    """Three decorators (10): only the violating pair (weh, router) is swapped."""
+    path, repo_root = _write_api(
+        tmp_path,
+        "three_decos.py",
+        """\
+@with_error_handling(category="x")
+@router.get("/foo")
+@other_decorator
+async def foo():
+    return {}
+""",
+    )
+    hook._fix_file(path, repo_root)
+    fixed = path.read_text(encoding="utf-8")
+    lines = [ln.strip() for ln in fixed.splitlines() if ln.strip().startswith("@")]
+    assert lines[0].startswith("@router.get")
+    assert lines[1].startswith("@with_error_handling")
+    assert "@other_decorator" in fixed
+    assert hook._check_file(path, repo_root) == []
+
+
+@_skip_no_libcst
+def test_fix_stacked_with_args_outer_removed_inner_preserved(tmp_path: Path) -> None:
+    """Stacked with args (11): outer removed, args on kept (inner) decorator preserved."""
+    path, repo_root = _write_api(
+        tmp_path,
+        "stacked_args.py",
+        """\
+@router.get("/foo")
+@with_error_handling(log=True)
+@with_error_handling(category="auth")
+async def foo():
+    return {}
+""",
+    )
+    fixes = hook._fix_file(path, repo_root)
+    assert fixes == 1
+    fixed = path.read_text(encoding="utf-8")
+    assert fixed.count("@with_error_handling") == 1
+    assert 'category="auth"' in fixed
+    assert hook._check_file(path, repo_root) == []


### PR DESCRIPTION
## Summary

- Extends `tools/lint/check_decorator_order.py` with an opt-in `--fix` flag using libcst
- Fixes Pattern A (wrong order) by swapping `@with_error_handling` / `@router.*` pair; Pattern B (stacked duplicates) by removing the outer duplicate
- libcst is a soft dependency (try/except import); `--fix` exits 1 with an install hint when absent
- Pre-commit hook default stays check-only — CI never silently mutates files
- 11 new unit tests covering all fix patterns (22 total, 22 passed)
- Documented in `docs/developer/CLAUDE_RULES.md` under \"Decorator Order Fix Tool\"

## Thinking Path

- Added `--fix` flag using `argparse.parse_known_args` so the check-only invocation (pre-commit) is untouched
- libcst chosen over AST for fix mode because it is a CST (preserves whitespace, comments, formatting)
- Soft dependency: wrapped `import libcst` in try/except; `_fix_file` exits 1 with install hint if absent
- `_DecoratorOrderFixer` defined conditionally inside `if _LIBCST_AVAILABLE:` to avoid forward-reference issues; `_fix_file` guards with early sys.exit before referencing it
- Pattern B deduplicated before Pattern A in the same while-loop pass to handle combined violations
- Post-fix `_check_file` verification run to warn if any residual violations remain after transform

## What Changed

- `tools/lint/check_decorator_order.py`: +209 lines — added argparse CLI, three CST helper functions (`_cst_decorator_name`, `_cst_is_with_error_handling`, `_cst_is_router_decorator`), `_DecoratorOrderFixer` CST transformer class, `_fix_file()` function, updated `main()` to route `--fix` vs check-only
- `tools/lint/check_decorator_order_test.py`: +242 lines — 11 new `@_skip_no_libcst`-guarded tests for `_fix_file`; all 22 tests pass
- `docs/developer/CLAUDE_RULES.md`: +29 lines — \"Decorator Order Fix Tool\" section documenting check-only and `--fix` usage

## Verification

- `python3 -m pytest tools/lint/check_decorator_order_test.py -v` → **22/22 passed**
- Pattern A idempotency: second `--fix` run on already-fixed file returns 0 changes ✅
- Pattern B: outer duplicate removed, inner decorator args preserved (`category=\"auth\"`) ✅
- Mixed A+B in one file: both fixed in single pass, 2 fixes reported ✅
- Formatting/docstrings/type annotations preserved (libcst CST-level transforms) ✅
- File outside `autobot-backend/api/` unchanged (path filter respected) ✅
- `.pre-commit-config.yaml` not modified — hook remains check-only ✅
- CI smoke-test/SSOT failures are pre-existing on base branch (npm vega-embed conflict; 7 SSOT violations) — unrelated to this PR's Python-only changes

## Model Used

claude-sonnet-4-6

## Test plan

- [x] `python3 -m pytest tools/lint/check_decorator_order_test.py -v` → 22/22 passed
- [x] Pattern A idempotency: running `--fix` twice produces 0 changes on second run
- [x] Pattern B: outer duplicate removed, inner decorator's args preserved
- [x] Mixed A+B in one file: both fixed in single pass
- [x] Formatting/docstrings/type annotations preserved (libcst CST-level transforms)
- [x] File outside `autobot-backend/api/` unchanged (path filter respected)
- [x] `.pre-commit-config.yaml` not modified — hook remains check-only

Closes GH#6787

🤖 Generated with [Claude Code](https://claude.com/claude-code)