### PR TITLE
refactor(backend): deduplicate router registrations + document registry (#4203)

### DIFF
--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -423,39 +423,10 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["knowledge-relations"],
         "knowledge_relations",
     ),
-    # Issue #708: knowledge_search_aggregator, knowledge_ai_stack, knowledge_debug
-    # consolidated into knowledge.py as sub-routers (backend.api.knowledge includes them)
-    # Issue #4179: Register unregistered knowledge routers
-    (
-        "api.knowledge_search_aggregator",
-        "/unified",
-        ["knowledge-unified"],
-        "knowledge_search_aggregator",
-    ),
-    (
-        "api.knowledge_ai_stack",
-        "",
-        ["knowledge-enhanced"],
-        "knowledge_ai_stack",
-    ),
-    (
-        "api.knowledge_debug",
-        "",
-        [],
-        "knowledge_debug",
-    ),
-    (
-        "api.knowledge_boards",
-        "",
-        [],
-        "knowledge_boards",
-    ),
-    (
-        "api.knowledge_vectorization",
-        "",
-        ["knowledge_vectorization"],
-        "knowledge_vectorization",
-    ),
+    # NOTE (#4203): knowledge_search_aggregator, knowledge_ai_stack, knowledge_debug,
+    # knowledge_boards, knowledge_vectorization removed from here — already registered
+    # unconditionally in core_routers.py (_get_knowledge_routers). Duplicate registration
+    # caused the same routes to appear twice in the OpenAPI schema.
     (
         "api.conversation_files",
         "/conversation-files",
@@ -606,15 +577,8 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["resilience", "monitoring"],
         "error_resilience",
     ),
-    # User management (users, teams, organizations) — router defines /user-management internally
-    (
-        "api.user_management",
-        "",
-        ["user-management", "users"],
-        "user_management",
-    ),
-    # Issue #1803: Plugin manager endpoints (list, discover, load/unload/enable/disable, config)
-    ("plugin_manager", "", ["plugins"], "plugin_manager"),
+    # NOTE (#4203): user_management and plugin_manager removed from here — already registered
+    # unconditionally in core_routers.py. Duplicate registration caused routes to appear twice.
     # Issue #1803: Plugin and agent marketplace — community catalog
     ("api.marketplace", "/marketplace", ["marketplace", "plugins"], "marketplace"),
     # Issue #6481: User-extensible marketplace sources (custom marketplaces)
@@ -629,12 +593,8 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
     ("api.chat_sessions", "", ["chat-sessions"], "chat_sessions"),
     # Issue #5061: First-run onboarding presets + doctor
     ("api.onboarding", "/onboarding", ["onboarding"], "onboarding"),
-    (
-        "api.diagnostics",
-        "/api/diagnostics",
-        ["diagnostics"],
-        "diagnostics",
-    ),
+    # NOTE (#4203): api.diagnostics removed — already registered in monitoring_routers.py
+    # at prefix "" (routes define their own /diagnostics path prefix internally).
     (
         "api.presence_ws",
         "",

--- a/docs/developer/ROUTER_REGISTRY.md
+++ b/docs/developer/ROUTER_REGISTRY.md
@@ -1,0 +1,85 @@
+# AutoBot Router Registry
+
+> Issue #4203 — consolidated and documented as of 2026-05-22
+
+## Overview
+
+The backend mounts all API routers through a two-level system:
+
+```
+app_factory._register_routers()
+├── load_core_routers()        → initialization/router_registry/core_routers.py
+└── load_optional_routers()    → initialization/routers.py
+    ├── load_analytics_routers()   → router_registry/analytics_routers.py
+    ├── load_terminal_routers()    → router_registry/terminal_routers.py
+    ├── load_monitoring_routers()  → router_registry/monitoring_routers.py
+    ├── load_integration_routers() → router_registry/integration_routers.py
+    ├── load_feature_routers()     → router_registry/feature_routers.py
+    └── load_mcp_routers()         → router_registry/mcp_routers.py
+```
+
+All core and optional routers are mounted under `/api<prefix>`.
+One special-case router (`api.openai_compat`) is mounted at `/v1` directly in
+`app_factory.py` for third-party client compatibility (Cursor, LibreChat, etc.).
+
+## Domain Registry Files
+
+| File | Domain | Load method |
+|------|---------|-------------|
+| `core_routers.py` | Auth, chat, settings, knowledge base, plugin manager, user management | Hard import — must not fail |
+| `analytics_routers.py` | Codebase analytics, code analysis | `try/except` graceful |
+| `terminal_routers.py` | Terminal, SSH, VNC | `try/except` graceful |
+| `monitoring_routers.py` | Metrics, Prometheus, GPU, alertmanager, RUM, diagnostics | `try/except` graceful |
+| `integration_routers.py` | External integrations (Slack, Notion, GitHub, etc.) | `try/except` graceful |
+| `feature_routers.py` | All remaining product features | `try/except` graceful |
+| `mcp_routers.py` | Model Context Protocol extensions | `try/except` graceful |
+
+## Adding a New Router
+
+1. **Choose the right file** based on the domain table above.
+2. **Add a 4-tuple** to the `*_ROUTER_CONFIGS` list in that file:
+   ```python
+   ("api.my_feature", "/my-feature", ["my-feature"], "my_feature"),
+   ```
+3. **Do NOT** add it to multiple files — check for existing registration first:
+   ```bash
+   grep -r "my_feature\|my-feature" autobot-backend/initialization/router_registry/
+   ```
+4. Core features that must always be available → `core_routers.py` (direct import, not tuple list).
+
+## Config Tuple Formats
+
+`feature_routers.py`, `analytics_routers.py`, `integration_routers.py`, `mcp_routers.py`:
+```python
+(module_path, prefix, tags, display_name)
+# e.g. ("api.workflow", "/workflow", ["workflow"], "workflow")
+```
+
+`monitoring_routers.py`, `terminal_routers.py`:
+```python
+(module_path, router_attr, prefix, tags, display_name)
+# e.g. ("api.monitoring", "router", "/monitoring", ["monitoring"], "monitoring")
+```
+
+## Deduplication Rule
+
+**Each router MUST appear in exactly one registry file.**
+`core_routers.py` takes precedence. If a module is imported in `core_routers.py`,
+it must not appear in any other registry file.
+
+Known previous duplicates fixed by #4203:
+- `api.knowledge_search_aggregator`, `api.knowledge_ai_stack`, `api.knowledge_debug`,
+  `api.knowledge_boards`, `api.knowledge_vectorization` — were in both `core_routers.py`
+  and `feature_routers.py`; removed from `feature_routers.py`
+- `plugin_manager`, `api.user_management` — same issue; removed from `feature_routers.py`
+- `api.diagnostics` — was in both `monitoring_routers.py` and `feature_routers.py`;
+  removed from `feature_routers.py`
+
+## Health Observability
+
+`feature_routers.py` publishes per-worker load results to Redis under
+`autobot:feature_routers:<pid>` (TTL 10 min, issue #6808). The health endpoint
+can aggregate across all workers via `get_cross_worker_load_results()`.
+
+The `📊 Loaded N/M optional routers` log line at startup shows how many
+router configs successfully imported vs total attempted.


### PR DESCRIPTION
## Summary

Addresses GH #4203 — router registry consolidation.

**Root cause found:** 8 router modules were registered in both `core_routers.py` (unconditional, hard import) AND `feature_routers.py` (graceful try/except). This caused the same routes to appear twice in the OpenAPI schema and be mounted twice in FastAPI.

**Duplicates removed from `feature_routers.py`:**
- `api.knowledge_search_aggregator`, `api.knowledge_ai_stack`, `api.knowledge_debug`, `api.knowledge_boards`, `api.knowledge_vectorization` → already in `core_routers._get_knowledge_routers()`
- `plugin_manager` → already in `core_routers._get_feature_routers()`
- `api.user_management` → already in `core_routers._get_system_routers()`
- `api.diagnostics` → already in `monitoring_routers.MONITORING_ROUTER_CONFIGS`

**Documentation added:** `docs/developer/ROUTER_REGISTRY.md` — load structure diagram, domain ownership table, config tuple formats, deduplication rule, health observability.

## Test plan

- `py_compile` on `feature_routers.py` ✅
- Route count in OpenAPI schema will decrease by count of removed duplicates (verifiable post-deploy with `curl /api/openapi.json | jq '.paths | keys | length'`)
- No new modules added — no wiring check needed

Closes #4203