### PR TITLE
feat(connectors): connector config schema versioning and migration (#8152)

### DIFF
--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -208,13 +208,13 @@ async def _delete_connector_keys(connector_id: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _load_or_create_instance(cfg: ConnectorConfig):
+async def _load_or_create_instance(cfg: ConnectorConfig):
     """Return existing instance or create+register a new one (Issue #1254)."""
     existing = ConnectorRegistry.get(cfg.connector_id)
     if existing is not None:
         existing.config = cfg
         return existing
-    instance = ConnectorRegistry.create(cfg)
+    instance = await ConnectorRegistry.create(cfg)
     ConnectorRegistry.add_instance(instance)
     return instance
 
@@ -226,7 +226,7 @@ async def _run_sync_background(connector_id: str, incremental: bool) -> None:
         logger.error("Background sync: connector %s not found", connector_id)
         return
 
-    instance = _load_or_create_instance(cfg)
+    instance = await _load_or_create_instance(cfg)
     try:
         sync_result = await instance.sync(incremental=incremental)
     except Exception as exc:
@@ -358,7 +358,7 @@ async def create_connector(request: CreateConnectorRequest):
         auth_type=auth_type,
         max_concurrency=request.max_concurrency,
     )
-    instance = _load_or_create_instance(cfg)
+    instance = await _load_or_create_instance(cfg)
     healthy = await instance.test_connection()
     if not healthy:
         ConnectorRegistry.remove_instance(connector_id)
@@ -446,7 +446,7 @@ async def _hydrate_all_instances() -> None:
             cfg = await _load_connector(cid)
             if cfg is None:
                 continue
-            _load_or_create_instance(cfg)
+            await _load_or_create_instance(cfg)
         except Exception as exc:  # noqa: BLE001 — isolate bad records per Issue #5055
             logger.warning("Skipping corrupted connector %s: %s", cid, exc)
 
@@ -520,7 +520,7 @@ async def test_connector_connection(connector_id: str):
     cfg = await _load_connector(connector_id)
     if cfg is None:
         raise HTTPException(status_code=404, detail=ERR_CONNECTOR_NOT_FOUND)
-    instance = _load_or_create_instance(cfg)
+    instance = await _load_or_create_instance(cfg)
     try:
         healthy = await instance.test_connection()
     except Exception as exc:

--- a/autobot-backend/knowledge/connectors/base.py
+++ b/autobot-backend/knowledge/connectors/base.py
@@ -12,6 +12,7 @@ built-in exponential-backoff retry on transient HTTP errors.
 Issue #8145: Added auth_schema() classmethod for typed credential declarations.
 Issue #8146: Added _write_checkpoint(), _read_checkpoint(), _clear_checkpoint()
 and updated sync() to skip already-processed sources on restart.
+Issue #8152: Added config_version and migrate_config() hook.
 """
 
 import asyncio
@@ -75,6 +76,16 @@ class AbstractConnector(ABC):
 
     connector_type: str = ""
     tier: int = 0
+    config_version: int = 1
+
+    @classmethod
+    def migrate_config(cls, stored_version: int, config: dict) -> dict:
+        """Migrate config dict from stored_version to current config_version.
+
+        No-op by default — subclasses override and apply sequential migrations.
+        Issue #8152.
+        """
+        return config
 
     def __init__(self, config: ConnectorConfig) -> None:
         self.config = config

--- a/autobot-backend/knowledge/connectors/models.py
+++ b/autobot-backend/knowledge/connectors/models.py
@@ -8,6 +8,7 @@ Issue #1254: Defines the dataclass models used across the connector framework â€
 SourceInfo, ContentResult, ChangeInfo, ConnectorConfig, ConnectorStatus, SyncResult.
 Issue #8145: Added auth_type field to ConnectorConfig for API introspection.
 Issue #8146: Added resumed_from_checkpoint to SyncResult.
+Issue #8152: Added config_version field to ConnectorConfig.
 """
 
 from dataclasses import dataclass, field
@@ -80,6 +81,9 @@ class ConnectorConfig:
     auth_type: str | None = None
     # Issue #8148: max parallel source fetches; None = use connector class default.
     max_concurrency: int | None = None
+    # Issue #8152: schema version â€” used by ConnectorRegistry.create() to detect
+    # and apply config migrations before instantiation.
+    config_version: int = 1
 
 
 @dataclass

--- a/autobot-backend/knowledge/connectors/registry.py
+++ b/autobot-backend/knowledge/connectors/registry.py
@@ -17,6 +17,8 @@ Usage:
     instance = ConnectorRegistry.create(config)
     ConnectorRegistry.add_instance(instance)
     running = ConnectorRegistry.get("my-connector-id")
+
+Issue #8152: create() now async with migration support.
 """
 
 from __future__ import annotations
@@ -62,16 +64,49 @@ class ConnectorRegistry:
         return decorator
 
     @classmethod
-    def create(cls, config: ConnectorConfig) -> "object":
+    async def create(cls, config: ConnectorConfig) -> "object":
         """Instantiate a connector from a :class:`ConnectorConfig`.
 
+        If the stored config version differs from the connector class's
+        ``config_version``, calls ``migrate_config()`` before instantiation
+        and persists the updated config back to Redis (Issue #8152).
+
         Raises:
-            ValueError: If ``config.connector_type`` is not registered.
+            ValueError: If ``config.connector_type`` is not registered or
+                        migration raises an exception.
         """
+        import json
+
         klass = cls._connectors.get(config.connector_type)
         if klass is None:
             registered = list(cls._connectors.keys())
             raise ValueError("Unknown connector type '%s'. Registered types: %s" % (config.connector_type, registered))
+
+        stored_version = config.config.get("_version", 1)
+        current_version = getattr(klass, "config_version", 1)
+        if stored_version != current_version:
+            try:
+                config.config = klass.migrate_config(stored_version, dict(config.config))
+                config.config["_version"] = current_version
+                logger.info(
+                    "Migrated connector %s config from v%d to v%d",
+                    config.connector_id,
+                    stored_version,
+                    current_version,
+                )
+                await cls._persist_config(config)
+            except Exception as exc:
+                logger.error(
+                    "Config migration failed for connector %s (v%d→v%d): %s",
+                    config.connector_id,
+                    stored_version,
+                    current_version,
+                    exc,
+                )
+                raise ValueError(
+                    "Config migration failed for connector '%s': %s" % (config.connector_id, exc)
+                ) from exc
+
         instance = klass(config)
         logger.info(
             "Created connector instance: id=%s type=%s",
@@ -79,6 +114,33 @@ class ConnectorRegistry:
             config.connector_type,
         )
         return instance
+
+    @classmethod
+    async def _persist_config(cls, config: "ConnectorConfig") -> None:
+        """Persist the migrated config dict back to Redis (Issue #8152).
+
+        Reads the existing blob, patches the ``config`` field, and writes it
+        back.  Failures are logged at WARNING and never propagate — a failed
+        persist means the migration runs again on next load, which is safe.
+        """
+        import json
+
+        try:
+            from autobot_shared.redis_client import get_async_redis_client
+
+            redis = await get_async_redis_client(database="knowledge")
+            if redis is None:
+                return
+            key = "connector:%s" % config.connector_id
+            raw = await redis.get(key)
+            if raw is None:
+                return
+            data = json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
+            data["config"] = config.config
+            await redis.set(key, json.dumps(data, ensure_ascii=False))
+            logger.debug("Persisted migrated config for connector %s", config.connector_id)
+        except Exception as exc:
+            logger.warning("Failed to persist migrated config for %s: %s", config.connector_id, exc)
 
     @classmethod
     def add_instance(cls, instance: "object") -> None:

--- a/autobot-backend/knowledge/connectors/versioning_test.py
+++ b/autobot-backend/knowledge/connectors/versioning_test.py
@@ -1,0 +1,121 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""
+Tests for connector config schema versioning and migration (Issue #8152).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge.connectors.base import AbstractConnector
+from knowledge.connectors.models import ConnectorConfig
+from knowledge.connectors.registry import ConnectorRegistry
+from knowledge.connectors.web_crawler import WebCrawlerConnector
+
+
+def _make_config(connector_type: str = "web_crawler", config: dict | None = None) -> ConnectorConfig:
+    return ConnectorConfig(
+        connector_id="test-conn-001",
+        connector_type=connector_type,
+        name="Test Connector",
+        config=config or {"urls": ["https://example.com"]},
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_no_migration_needed():
+    """When stored_version == config_version, no migration is called."""
+    cfg = _make_config(config={"urls": ["https://example.com"], "_version": 2, "crawl_depth": 3})
+    with patch.object(WebCrawlerConnector, "migrate_config", wraps=WebCrawlerConnector.migrate_config) as mock_migrate:
+        instance = await ConnectorRegistry.create(cfg)
+    mock_migrate.assert_not_called()
+    assert isinstance(instance, WebCrawlerConnector)
+
+
+@pytest.mark.asyncio
+async def test_create_migration_called_on_version_mismatch():
+    """When stored_version < config_version, migrate_config() is called."""
+    cfg = _make_config(config={"urls": ["https://example.com"], "max_depth": 3, "_version": 1})
+    with patch.object(ConnectorRegistry, "_persist_config", new=AsyncMock()) as mock_persist:
+        instance = await ConnectorRegistry.create(cfg)
+    assert "crawl_depth" in cfg.config
+    assert cfg.config.get("crawl_depth") == 3
+    assert "max_depth" not in cfg.config
+    assert cfg.config.get("_version") == 2
+    mock_persist.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_migration_failure_raises_value_error():
+    """When migrate_config() raises, create() raises ValueError."""
+    cfg = _make_config(config={"urls": ["https://example.com"], "_version": 1})
+    with patch.object(WebCrawlerConnector, "migrate_config", side_effect=RuntimeError("bad config")):
+        with pytest.raises(ValueError, match="Config migration failed"):
+            await ConnectorRegistry.create(cfg)
+
+
+@pytest.mark.asyncio
+async def test_no_version_key_treated_as_version_1():
+    """Configs without _version key are treated as version 1 (backward compat)."""
+    cfg = _make_config(config={"urls": ["https://example.com"], "max_depth": 2})
+    with patch.object(ConnectorRegistry, "_persist_config", new=AsyncMock()) as mock_persist:
+        instance = await ConnectorRegistry.create(cfg)
+    assert cfg.config.get("_version") == 2
+    assert cfg.config.get("crawl_depth") == 2
+    mock_persist.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_web_crawler_v1_to_v2_renames_max_depth():
+    """WebCrawlerConnector.migrate_config renames max_depth to crawl_depth."""
+    config = {"urls": ["https://example.com"], "max_depth": 5}
+    result = WebCrawlerConnector.migrate_config(1, config)
+    assert "crawl_depth" in result
+    assert result["crawl_depth"] == 5
+    assert "max_depth" not in result
+
+
+@pytest.mark.asyncio
+async def test_web_crawler_migrate_idempotent_when_crawl_depth_present():
+    """migrate_config does not overwrite crawl_depth if already present."""
+    config = {"urls": ["https://example.com"], "max_depth": 5, "crawl_depth": 2}
+    result = WebCrawlerConnector.migrate_config(1, config)
+    assert result["crawl_depth"] == 2
+    assert "max_depth" in result
+
+
+@pytest.mark.asyncio
+async def test_persist_config_patches_redis_blob():
+    """_persist_config reads, patches config field, and writes back."""
+    import json
+    cfg = _make_config(config={"urls": ["https://example.com"], "_version": 2})
+    existing_blob = json.dumps({
+        "connector_id": cfg.connector_id,
+        "connector_type": cfg.connector_type,
+        "name": cfg.name,
+        "config": {"urls": ["https://example.com"], "_version": 1},
+    })
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value=existing_blob.encode("utf-8"))
+    mock_redis.set = AsyncMock()
+    with patch("autobot_shared.redis_client.get_async_redis_client", return_value=mock_redis):
+        await ConnectorRegistry._persist_config(cfg)
+    mock_redis.set.assert_called_once()
+    stored = json.loads(mock_redis.set.call_args[0][1])
+    assert stored["config"]["_version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_abstract_connector_config_version_defaults_to_1():
+    """AbstractConnector.config_version defaults to 1."""
+    assert AbstractConnector.config_version == 1
+
+
+@pytest.mark.asyncio
+async def test_abstract_connector_migrate_config_is_noop():
+    """AbstractConnector.migrate_config returns config unchanged."""
+    config = {"key": "value"}
+    result = AbstractConnector.migrate_config(1, config)
+    assert result == {"key": "value"}

--- a/autobot-backend/knowledge/connectors/web_crawler.py
+++ b/autobot-backend/knowledge/connectors/web_crawler.py
@@ -10,6 +10,7 @@ Issue #8144: Migrated HTTP fetches to use AbstractConnector.fetch_with_retry() s
 transient 429/5xx responses are retried with exponential backoff instead of failing.
 Issue #8284: sync() override now integrates #8146 checkpoint (read/write/clear).
 Issue #8286: Connection-level failures (status_code=None) now also raise RetryableError.
+Issue #8152: Added config_version=2 and migrate_config() (v1→v2: max_depth→crawl_depth).
 """
 
 import hashlib
@@ -104,6 +105,8 @@ class WebCrawlerConnector(AbstractConnector):
     connector_type = "web_crawler"
     # Issue #4421: zero-config — unauthenticated crawl via web_fetch.
     tier = 0
+    # Issue #8152: v2 renamed max_depth → crawl_depth.
+    config_version = 2
 
     @classmethod
     def output_schema(cls) -> dict:
@@ -120,6 +123,17 @@ class WebCrawlerConnector(AbstractConnector):
             "required": ["url", "domain"],
         }
 
+    @classmethod
+    def migrate_config(cls, stored_version: int, config: dict) -> dict:
+        """Migrate WebCrawlerConnector config to current version (Issue #8152).
+
+        v1→v2: renamed ``max_depth`` to ``crawl_depth``.
+        """
+        if stored_version < 2:
+            if "max_depth" in config and "crawl_depth" not in config:
+                config["crawl_depth"] = config.pop("max_depth")
+        return config
+
     @property
     def max_concurrency(self) -> int:
         """Issue #8148: default 5 concurrent page fetches; config overrides."""
@@ -130,7 +144,7 @@ class WebCrawlerConnector(AbstractConnector):
         super().__init__(config)
         cfg = config.config
         self._seed_urls: List[str] = cfg.get("urls", [])
-        self._max_depth: int = int(cfg.get("max_depth", 1))
+        self._max_depth: int = int(cfg.get("crawl_depth", cfg.get("max_depth", 1)))
         self._max_pages: int = int(cfg.get("max_pages", 100))
         self._respect_robots: bool = bool(cfg.get("respect_robots", True))
         self._same_origin: bool = bool(cfg.get("same_origin", True))


### PR DESCRIPTION
## Summary
- Adds `AbstractConnector.config_version` class attribute (default 1) and `migrate_config()` no-op classmethod
- Adds `config_version: int = 1` to `ConnectorConfig` dataclass
- Makes `ConnectorRegistry.create()` async with version-mismatch detection, migration, and Redis persistence of migrated config
- Adds `WebCrawlerConnector` v1→v2 reference migration: renames `max_depth` → `crawl_depth`
- Makes `_load_or_create_instance()` async across all 4 call sites in `api/knowledge_connectors.py`
- 9 unit tests in `versioning_test.py`

## Call-site changes
All callers of `ConnectorRegistry.create()` now use `await`:
- `api/knowledge_connectors.py:_load_or_create_instance()` — converted to `async def`, 4 call sites updated (lines 229, 361, 449, 523)

## Backward compatibility
- Existing configs without `_version` key treated as version 1
- `migrate_config()` is a no-op on `AbstractConnector` — existing connectors unaffected
- `WebCrawlerConnector.__init__` falls back to `max_depth` for configs that bypass `create()` directly

## Test plan
- [ ] `python -m pytest autobot-backend/knowledge/connectors/versioning_test.py`
- [ ] `python -c 'import knowledge.connectors.registry'`
- [ ] Confirm `WebCrawlerConnector.config_version == 2`

Closes #8152

🤖 Generated with [Claude Code](https://claude.ai/claude-code)