### PR TITLE
feat(code-analysis): add COMPOSABLE_OPPORTUNITY Vue detector (#6748)

### DIFF
--- a/autobot-backend/api/codebase_analytics/README.md
+++ b/autobot-backend/api/codebase_analytics/README.md
@@ -77,11 +77,42 @@ The module is integrated into the main application via:
 - `backend/initialization/routers.py` - Router registration
 - `backend/api/analytics_debt.py` - Uses storage utilities
 
+## Anti-Pattern Detectors
+
+Cross-file analysis is provided by `code_analysis/src/anti_pattern_detector.py`
+via `AntiPatternDetector.analyze_cross_file_only()`. Detectors surface findings
+under `GET /codebase/problems`.
+
+| `AntiPatternType` value       | Introduced | Description |
+|-------------------------------|------------|-------------|
+| `god_class`                   | #221       | Class with >20 methods / high complexity |
+| `feature_envy`                | #221       | Methods that use other classes more than their own |
+| `circular_dependency`         | #221       | Module-level import cycles |
+| `long_method`                 | #221       | Functions exceeding complexity threshold |
+| `data_clump`                  | #221       | Parameter groups that recur across many call sites |
+| `dead_code`                   | #221       | Unreferenced classes / methods |
+| `lsp_signature_incompatible`  | #6661      | Child overrides that break Liskov Substitution |
+| `lsp_exception_contract_changed` | #6661  | Child method throws exceptions not declared in parent |
+| `duplicate_enum`              | #6684      | Enum pairs with overlapping value sets (Jaccard ≥ 0.85) |
+| `duplicate_class_shape`       | #6684      | Class pairs sharing method-name sets without a shared base |
+| `unwired_tracker`             | #6871      | Modules with tracker refs but zero production callers |
+| `composable_opportunity`      | #6748      | Vue components repeating the same `<script setup>` reactive boilerplate (≥ 5 files with identical API-call signature → suggest a composable) |
+
+### Tuning notes
+
+- `duplicate_enum` threshold bumped 0.7 → 0.85 (#6755) to suppress severity-scale FP pairs.
+- `composable_opportunity` threshold: 5 components. Excludes `src/composables/` and `node_modules/`.
+
 ## Testing
 
 Run module tests:
 ```bash
 python3 -m pytest tests/unit/test_api_endpoint_migrations.py -k codebase
+```
+
+Run consolidation and composable detector tests:
+```bash
+python3 -m pytest autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py -v
 ```
 
 ## Original File

--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -77,6 +77,29 @@ _ENTRY_POINT_SUFFIXES = (
 )
 
 
+# Issue #6748: Vue <script setup> composable-opportunity detector regexes
+_VUE_SCRIPT_SETUP_RE = re.compile(r"<script\b[^>]*\bsetup\b[^>]*>", re.IGNORECASE)
+_VUE_SCRIPT_END_RE = re.compile(r"</script\s*>", re.IGNORECASE)
+_VUE_COMP_CALL_RE = re.compile(
+    r"(?:const|let|var)\s+\w+\s*(?::[^=]+)?\s*=\s*"
+    r"(ref|reactive|computed|watch(?:Effect)?|on(?:Mounted|Unmounted|BeforeMount|Created))"
+    r"(<[^>]*>)?\s*\(",
+)
+_COMPOSABLE_THRESHOLD = 5
+_COMPOSABLE_EXCL_DIRS = frozenset({"composables", "node_modules", ".git", "__pycache__"})
+
+
+def _extract_script_setup(content: str) -> str | None:
+    """Return the text inside <script setup> … </script>, or None if absent."""
+    m_start = _VUE_SCRIPT_SETUP_RE.search(content)
+    if m_start is None:
+        return None
+    m_end = _VUE_SCRIPT_END_RE.search(content, m_start.end())
+    if m_end is None:
+        return None
+    return content[m_start.end() : m_end.start()]
+
+
 # Issue #6758: AST cache to avoid re-parsing files in cross-file finalize pass
 # Cache key: (file_path, mtime) -> AST. This prevents double-parsing when both
 # per-file and cross-file rules analyze the same file.
@@ -153,6 +176,8 @@ class AntiPatternType(Enum):
     DUPLICATE_CLASS_SHAPE = "duplicate_class_shape"
     # Issue #6871: modules with zero production callers (closed tracker, unwired code)
     UNWIRED_TRACKER = "unwired_tracker"
+    # Issue #6748: repeated reactive boilerplate that should be extracted to a composable
+    COMPOSABLE_OPPORTUNITY = "composable_opportunity"
 
 
 @dataclass
@@ -400,6 +425,8 @@ class AntiPatternDetector:
         anti_patterns.extend(await self._detect_duplicate_class_shapes())
         # Issue #6871: modules with zero production callers (closed tracker, unwired code)
         anti_patterns.extend(await self._detect_unwired_trackers(root_path))
+        # Issue #6748: repeated Vue reactive boilerplate that should be a composable
+        anti_patterns.extend(await self._detect_composable_opportunities(root_path))
 
         # Phase 3: Generate report
         analysis_time = time.time() - start_time
@@ -452,6 +479,8 @@ class AntiPatternDetector:
         results.extend(await self._detect_duplicate_class_shapes())
         # Issue #6871: include unwired-tracker findings in the cross-file pass
         results.extend(await self._detect_unwired_trackers(root_path))
+        # Issue #6748: repeated Vue reactive boilerplate
+        results.extend(await self._detect_composable_opportunities(root_path))
         return results
 
     async def _parse_codebase(self, root_path: str, patterns: List[str], exclude_patterns: List[str]) -> None:
@@ -1820,6 +1849,110 @@ class AntiPatternDetector:
 
         logger.info("[#6871] Unwired-tracker scan: %d findings in %s", len(issues), root_path)
         return issues
+
+    # ========== COMPOSABLE_OPPORTUNITY detector (#6748) ==========
+
+    async def _detect_composable_opportunities(self, root_path: str = ".") -> List[AntiPatternInstance]:
+        """Cluster Vue components that repeat the same reactive boilerplate.
+
+        Walks autobot-frontend/src/components/**/*.vue, extracts each
+        <script setup> block, normalises the composition-API calls into a
+        frozenset signature, and flags any signature that appears in
+        _COMPOSABLE_THRESHOLD or more distinct component files.
+        """
+        frontend_root = self._find_vue_components_root(root_path)
+        if frontend_root is None:
+            return []
+
+        sig_to_files: Dict[str, List[str]] = {}
+        for vue_file in sorted(frontend_root.rglob("*.vue")):
+            if any(part in _COMPOSABLE_EXCL_DIRS for part in vue_file.parts):
+                continue
+            sig = self._vue_file_signature(vue_file)
+            if not sig:
+                continue
+            sig_key = "|".join(sorted(sig))
+            sig_to_files.setdefault(sig_key, []).append(str(vue_file))
+
+        results: List[AntiPatternInstance] = []
+        for sig_key, files in sig_to_files.items():
+            if len(files) < _COMPOSABLE_THRESHOLD:
+                continue
+            sig = frozenset(sig_key.split("|"))
+            name = self._suggest_composable_name(sig)
+            results.append(
+                AntiPatternInstance(
+                    pattern_type=AntiPatternType.COMPOSABLE_OPPORTUNITY,
+                    severity=Severity.LOW,
+                    file_path=files[0],
+                    line_number=1,
+                    entity_name=name,
+                    description=(
+                        f"{len(files)} components share the same reactive boilerplate "
+                        f"({sig_key[:80]}). Extract to {name}()."
+                    ),
+                    metrics={
+                        "component_count": len(files),
+                        "files": files[:10],
+                        "pattern_hash": sig_key,
+                    },
+                    suggestion=(
+                        f"Create `composables/{name}.ts` and replace the repeated "
+                        f"reactive block with a single import."
+                    ),
+                    refactoring_effort="low",
+                    related_entities=files[:10],
+                )
+            )
+
+        logger.info("[#6748] Composable-opportunity scan: %d findings", len(results))
+        return results
+
+    @staticmethod
+    def _find_vue_components_root(root_path: str) -> Path | None:
+        """Walk up from root_path to find autobot-frontend/src/components/."""
+        p = Path(root_path).resolve()
+        for _ in range(6):
+            candidate = p / "autobot-frontend" / "src" / "components"
+            if candidate.is_dir():
+                return candidate
+            p = p.parent
+        return None
+
+    @staticmethod
+    def _vue_file_signature(vue_file: Path) -> frozenset[str]:
+        """Return normalised frozenset of composition-API calls in vue_file's <script setup>."""
+        try:
+            content = vue_file.read_text(encoding="utf-8")
+        except OSError:
+            return frozenset()
+        script = _extract_script_setup(content)
+        if script is None:
+            return frozenset()
+        calls: Set[str] = set()
+        for m in _VUE_COMP_CALL_RE.finditer(script):
+            api = m.group(1)
+            raw_generic = (m.group(2) or "").strip("<> ")
+            # Replace | with _or_ so the |-joined sig_key can be safely split
+            generic = raw_generic.replace(" ", "").replace("|", "_or_").lower()
+            calls.add(f"{api}_{generic}" if generic else api)
+        return frozenset(calls)
+
+    @staticmethod
+    def _suggest_composable_name(sig: frozenset[str]) -> str:
+        """Heuristically derive a composable name from its signature."""
+        normalised = {s.lower() for s in sig}
+        # loading + error pattern
+        if any("string" in s and "null" in s for s in normalised) and any(
+            s in ("ref", "ref_bool", "ref_false", "ref_true", "ref_boolean") for s in normalised
+        ):
+            return "useLoadingState"
+        ref_count = sum(1 for s in normalised if s.startswith("ref"))
+        if ref_count >= 2:
+            return "useSharedState"
+        if any("watch" in s for s in normalised):
+            return "useReactiveWatcher"
+        return "useSharedPattern"
 
     # ========== Report Generation ==========
 

--- a/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
@@ -514,3 +514,102 @@ async def test_duplicate_class_shape_still_flags_unrelated_classes_after_protoco
     )
     dup_shape = [ap for ap in report.anti_patterns if ap.pattern_type.value == "duplicate_class_shape"]
     assert dup_shape, "unrelated classes with identical shape should still be flagged"
+
+
+# ---------------------------------------------------------------------------
+# COMPOSABLE_OPPORTUNITY (#6748)
+# ---------------------------------------------------------------------------
+
+_LOADING_ERROR_VUE = """\
+<script setup lang="ts">
+import { ref } from 'vue'
+const loading = ref(false)
+const error = ref<string | null>(null)
+</script>
+<template><div>test</div></template>
+"""
+
+_DIFFERENT_PATTERN_VUE = """\
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+const count = ref(0)
+const doubled = computed(() => count.value * 2)
+</script>
+<template><div>{{ doubled }}</div></template>
+"""
+
+
+def _make_vue_root(root: Path) -> Path:
+    comp_dir = root / "autobot-frontend" / "src" / "components"
+    comp_dir.mkdir(parents=True)
+    return comp_dir
+
+
+@pytest.mark.asyncio
+async def test_composable_opportunity_loading_pattern(tmp_path):
+    """6 components with the same loading+error ref boilerplate trigger COMPOSABLE_OPPORTUNITY."""
+    apd = _load_detector_module()
+    comp_dir = _make_vue_root(tmp_path)
+    for i in range(6):
+        (comp_dir / f"Widget{i}.vue").write_text(_LOADING_ERROR_VUE, encoding="utf-8")
+
+    detector = apd.AntiPatternDetector()
+    findings = await detector._detect_composable_opportunities(str(tmp_path))
+
+    composable = [f for f in findings if f.pattern_type.value == "composable_opportunity"]
+    assert composable, "expected COMPOSABLE_OPPORTUNITY for 6 components sharing the same pattern"
+    assert composable[0].metrics["component_count"] >= 5
+    assert composable[0].entity_name == "useLoadingState"
+
+
+@pytest.mark.asyncio
+async def test_composable_opportunity_below_threshold(tmp_path):
+    """4 components (below threshold of 5) must NOT produce a COMPOSABLE_OPPORTUNITY finding."""
+    apd = _load_detector_module()
+    comp_dir = _make_vue_root(tmp_path)
+    for i in range(4):
+        (comp_dir / f"Widget{i}.vue").write_text(_LOADING_ERROR_VUE, encoding="utf-8")
+
+    detector = apd.AntiPatternDetector()
+    findings = await detector._detect_composable_opportunities(str(tmp_path))
+
+    composable = [f for f in findings if f.pattern_type.value == "composable_opportunity"]
+    assert not composable, "4 components should NOT trigger COMPOSABLE_OPPORTUNITY (below threshold of 5)"
+
+
+@pytest.mark.asyncio
+async def test_composable_opportunity_different_patterns_not_clustered(tmp_path):
+    """Components with different reactive patterns are not clustered together."""
+    apd = _load_detector_module()
+    comp_dir = _make_vue_root(tmp_path)
+    # 4 loading+error, 4 count+computed — neither group reaches threshold alone
+    for i in range(4):
+        (comp_dir / f"LoadWidget{i}.vue").write_text(_LOADING_ERROR_VUE, encoding="utf-8")
+    for i in range(4):
+        (comp_dir / f"CountWidget{i}.vue").write_text(_DIFFERENT_PATTERN_VUE, encoding="utf-8")
+
+    detector = apd.AntiPatternDetector()
+    findings = await detector._detect_composable_opportunities(str(tmp_path))
+
+    composable = [f for f in findings if f.pattern_type.value == "composable_opportunity"]
+    assert not composable, "two distinct 4-component groups should not each trigger COMPOSABLE_OPPORTUNITY"
+
+
+@pytest.mark.asyncio
+async def test_composable_opportunity_excludes_composables_dir(tmp_path):
+    """Files inside a 'composables' directory are excluded from detection."""
+    apd = _load_detector_module()
+    comp_dir = _make_vue_root(tmp_path)
+    composable_dir = comp_dir / "composables"
+    composable_dir.mkdir()
+    # 6 files in composables/ plus 3 outside — only outside 3 count; below threshold
+    for i in range(6):
+        (composable_dir / f"use{i}.vue").write_text(_LOADING_ERROR_VUE, encoding="utf-8")
+    for i in range(3):
+        (comp_dir / f"Widget{i}.vue").write_text(_LOADING_ERROR_VUE, encoding="utf-8")
+
+    detector = apd.AntiPatternDetector()
+    findings = await detector._detect_composable_opportunities(str(tmp_path))
+
+    composable = [f for f in findings if f.pattern_type.value == "composable_opportunity"]
+    assert not composable, "composables/ dir is excluded; only 3 real components remain — below threshold"


### PR DESCRIPTION
## Summary

- Adds `COMPOSABLE_OPPORTUNITY = "composable_opportunity"` to `AntiPatternType` in `anti_pattern_detector.py`
- New `_detect_composable_opportunities()` detector: walks `autobot-frontend/src/components/**/*.vue`, extracts `<script setup>` blocks, normalises composition-API calls (ref/reactive/computed/watch/onMounted) into a frozenset signature, clusters files by identical hash, and flags clusters with ≥ 5 distinct files
- Suggests `useLoadingState` for the canonical `loading + error` ref pattern; generic fallbacks for other patterns
- Wired into both `analyze()` and `analyze_cross_file_only()`
- 4 unit tests: positive (6 components → triggered), below-threshold (4 → not triggered), different patterns (not cross-clustered), composables dir excluded
- `api/codebase_analytics/README.md` updated with anti-pattern detector reference table

## Test plan

- [x] `python3 -m pytest autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py -v` → 16 passed
- [x] `python3 -m py_compile autobot-backend/code_analysis/src/anti_pattern_detector.py` → Syntax OK
- [x] False-positive prevention: `composables/` dir excluded; threshold of 5 files prevents single-component false positives

Closes #6748

🤖 Generated with [Claude Code](https://claude.com/claude-code)