### PR TITLE
feat(vector-store,llm): batch K — LSM write buffer, tiering, HNSW prefetch, shared rate limiter (#8158 #8160 #8161 #8170)

### DIFF
--- a/autobot-backend/knowledge/hnsw_prefetch.py
+++ b/autobot-backend/knowledge/hnsw_prefetch.py
@@ -1,0 +1,193 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+HNSW Neighbor-List Prefetch During Graph Traversal (Issue #8161)
+
+HNSW graph traversal follows a beam of candidate nodes across multiple levels.
+When the index is larger than the CPU cache (or memory-mapped from disk),
+traversal causes cache/page-fault stalls as each node's neighbor list is first
+touched during traversal — by which time the CPU is already stalled waiting.
+
+This module implements a two-phase prefetch:
+
+1. **Entry-point warmup** — before the actual search, touch the neighbor lists
+   of the entry point and its immediate neighborhood at the highest HNSW level.
+   This loads the top-of-graph data into CPU L3/LLC ahead of the traversal.
+
+2. **Speculative prefetch cache** — after a search completes, record which
+   nodes were in the result set and pre-touch their level-0 neighborhoods.
+   Subsequent near-duplicate queries (common in RAG pipelines) skip the page
+   faults because the data is already warm.
+
+The prefetch is best-effort: it silently degrades when the HNSW graph
+attributes are unavailable (e.g., FLAT indexes, GPU-resident indexes).
+
+Usage::
+
+    prefetcher = HNSWPrefetcher(index)
+    prefetcher.warmup_entry_point()          # call once before search loop
+    ids, dists = index.search(query, k)
+    prefetcher.speculative_prefetch(ids[0])  # warm cache for follow-up queries
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Sequence
+
+import numpy as np
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+
+class HNSWPrefetcher:
+    """
+    Prefetch HNSW neighbor lists to reduce traversal latency.
+
+    Attach one instance per FAISS ``IndexHNSWFlat`` (or HNSW variant).
+    Call ``warmup_entry_point`` before the first search on a query batch
+    and ``speculative_prefetch`` after each search to warm the cache for
+    expected follow-up traversals.
+    """
+
+    def __init__(self, index: Any, max_warmup_nodes: int = 64) -> None:
+        """
+        Args:
+            index: A ``faiss.IndexHNSWFlat`` (or subclass).  The ``hnsw``
+                   attribute and ``storage`` sub-index are accessed directly.
+            max_warmup_nodes: Cap on number of nodes touched during warmup.
+        """
+        self._index = index
+        self._max_warmup = max_warmup_nodes
+        self._hnsw = getattr(index, "hnsw", None)
+        self._storage = getattr(index, "storage", index)
+        self._enabled = self._hnsw is not None and hasattr(self._hnsw, "neighbor_range")
+
+        if not self._enabled:
+            logger.debug("HNSWPrefetcher: HNSW graph attributes not found — prefetch disabled")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def warmup_entry_point(self) -> int:
+        """
+        Touch the entry-point and its top-level neighbors to warm CPU cache.
+
+        Returns the number of neighbor-list entries touched (0 if disabled).
+        """
+        if not self._enabled:
+            return 0
+
+        try:
+            return self._touch_entry_neighbors()
+        except Exception:
+            logger.debug("HNSW entry-point warmup failed (non-critical)", exc_info=True)
+            return 0
+
+    def speculative_prefetch(self, result_ids: Sequence[int], level: int = 0) -> int:
+        """
+        Pre-touch level-0 neighbor lists for a set of result node IDs.
+
+        Call this immediately after ``index.search`` to pre-warm the
+        neighborhoods of returned nodes for likely follow-up traversals.
+
+        Args:
+            result_ids: FAISS internal IDs from a previous search result.
+            level: HNSW level to prefetch (0 = bottom/densest layer).
+
+        Returns the number of neighbor-list entries touched.
+        """
+        if not self._enabled:
+            return 0
+
+        try:
+            return self._touch_neighbors_for_ids(result_ids, level)
+        except Exception:
+            logger.debug("HNSW speculative prefetch failed (non-critical)", exc_info=True)
+            return 0
+
+    def warmup_query_path(self, query: np.ndarray, ef_warmup: int = 8) -> None:
+        """
+        Lightweight coarse traversal to warm the path a full-efSearch will follow.
+
+        Temporarily lowers ``efSearch`` to *ef_warmup* and executes a throwaway
+        search so the OS/CPU prefetcher sees the access pattern and starts
+        loading ahead.  Restores original ``efSearch`` afterwards.
+
+        This is most effective when the index is memory-mapped from disk and the
+        OS prefetch window is small relative to HNSW fan-out.
+        """
+        if not self._enabled:
+            return
+
+        original_ef = getattr(self._hnsw, "efSearch", None)
+        if original_ef is None:
+            return
+
+        try:
+            self._hnsw.efSearch = max(1, ef_warmup)
+            q = np.ascontiguousarray(query.reshape(1, -1).astype(np.float32))
+            self._index.search(q, 1)
+        except Exception:
+            logger.debug("HNSW query-path warmup failed (non-critical)", exc_info=True)
+        finally:
+            self._hnsw.efSearch = original_ef
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _touch_entry_neighbors(self) -> int:
+        """Touch neighbor list of the HNSW entry point at the top level."""
+        entry = getattr(self._hnsw, "entry_point", -1)
+        if entry < 0:
+            return 0
+
+        max_level = getattr(self._hnsw, "max_level", 0)
+        touched = 0
+
+        # Walk from the top level down to level 1; prefetch each level's neighbors
+        for lv in range(max_level, 0, -1):
+            begin, end = self._hnsw.neighbor_range(entry, lv)
+            neighbors_slice = self._hnsw.neighbors[begin:end]
+            # The slice access itself loads the memory into CPU cache
+            touched += len(neighbors_slice)
+            if touched >= self._max_warmup:
+                break
+
+            # Follow first valid neighbor one hop deeper
+            if len(neighbors_slice) > 0 and neighbors_slice[0] >= 0:
+                entry = int(neighbors_slice[0])
+
+        return touched
+
+    def _touch_neighbors_for_ids(self, node_ids: Sequence[int], level: int) -> int:
+        """Touch the level-*level* neighbor lists for each node in node_ids."""
+        touched = 0
+        for nid in node_ids:
+            if nid < 0:
+                continue
+            try:
+                begin, end = self._hnsw.neighbor_range(int(nid), level)
+                _ = self._hnsw.neighbors[begin:end]
+                touched += end - begin
+            except Exception:
+                continue
+            if touched >= self._max_warmup * len(node_ids):
+                break
+        return touched
+
+
+def attach_prefetcher(index: Any, max_warmup_nodes: int = 64) -> Optional[HNSWPrefetcher]:
+    """
+    Return an ``HNSWPrefetcher`` for *index* if it is HNSW-backed, else None.
+
+    Convenience factory used by ``GPUVectorIndex.search`` to avoid touching
+    the HNSW attributes on non-HNSW indexes.
+    """
+    if getattr(index, "hnsw", None) is not None:
+        return HNSWPrefetcher(index, max_warmup_nodes=max_warmup_nodes)
+    return None

--- a/autobot-backend/knowledge/tiering.py
+++ b/autobot-backend/knowledge/tiering.py
@@ -1,0 +1,307 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Hot/Warm/Cold Collection Tiering with DiskANN (Issue #8160)
+
+Implements three-tier storage for vector collections based on access frequency:
+
+- **Hot**  (in-memory FAISS): recently/frequently accessed collections.
+           Sub-millisecond query latency.
+- **Warm** (memory-mapped FAISS on SSD): moderate-use collections that exceed
+           the hot-tier memory budget.  Low-single-digit ms latency.
+- **Cold** (DiskANN or fallback to file-backed FAISS): rarely accessed
+           collections.  Query latency in the 5–50 ms range is acceptable.
+
+Promotion/demotion happens lazily on each query:
+- Any query promotes a collection one tier (cold→warm, warm→hot) if access
+  frequency crosses a configurable threshold.
+- A background reaper runs every REAP_INTERVAL_SECONDS and demotes collections
+  whose access timestamps have grown stale.
+
+DiskANN integration
+-------------------
+When ``diskann`` is importable (requires the ``diskann`` package, or a
+compatible library such as ``pydiskann``), the cold tier uses it for
+disk-resident ANN search.  When the package is absent, the cold tier falls
+back to a file-backed ``faiss.IndexHNSWFlat`` loaded on demand — still
+off-heap relative to the hot tier.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.missing_dep import MissingDep
+
+logger = get_logger(__name__)
+
+# Optional DiskANN import
+try:
+    import diskann  # type: ignore[import-untyped]
+
+    DISKANN_AVAILABLE = True
+except ImportError as _e:
+    diskann = MissingDep("diskann", _e)  # type: ignore[assignment]
+    DISKANN_AVAILABLE = False
+
+try:
+    import faiss  # type: ignore[import-untyped]
+
+    FAISS_AVAILABLE = True
+except ImportError as _e:
+    faiss = MissingDep("faiss", _e)  # type: ignore[assignment]
+    FAISS_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+HOT_MAX_COLLECTIONS = 16
+WARM_MAX_COLLECTIONS = 64
+PROMOTE_TO_HOT_ACCESSES = 10     # accesses in the last window to go hot
+PROMOTE_TO_WARM_ACCESSES = 3     # accesses to go warm
+REAP_INTERVAL_SECONDS = 60.0
+HOT_STALE_AFTER_SECONDS = 300.0  # demote hot→warm if not accessed in 5 min
+WARM_STALE_AFTER_SECONDS = 1800.0  # demote warm→cold if not accessed in 30 min
+
+
+class Tier(str, Enum):
+    HOT = "hot"
+    WARM = "warm"
+    COLD = "cold"
+
+
+@dataclass
+class TierEntry:
+    """Metadata tracked per collection for tiering decisions."""
+
+    collection_id: str
+    tier: Tier = Tier.COLD
+    access_count: int = 0
+    last_accessed: float = field(default_factory=time.monotonic)
+    index: Optional[Any] = None  # in-memory or mmap index handle
+
+
+# ---------------------------------------------------------------------------
+# DiskANN cold-tier index wrapper
+# ---------------------------------------------------------------------------
+
+class _DiskANNIndex:
+    """Thin wrapper around a DiskANN (or fallback FAISS) cold index."""
+
+    def __init__(self, index_path: str, dim: int) -> None:
+        self._path = index_path
+        self._dim = dim
+        self._handle: Optional[Any] = None
+
+    def load(self) -> None:
+        if DISKANN_AVAILABLE:
+            self._handle = diskann.load_index(self._path, num_threads=1)
+            logger.debug("DiskANN cold index loaded from %s", self._path)
+        elif FAISS_AVAILABLE:
+            # Fallback: load HNSW index stored on disk
+            self._handle = faiss.read_index(self._path)
+            logger.debug("FAISS cold index loaded (DiskANN unavailable) from %s", self._path)
+        else:
+            raise RuntimeError("Neither diskann nor faiss available for cold-tier search")
+
+    def search(self, query: List[float], k: int) -> Tuple[List[int], List[float]]:
+        if self._handle is None:
+            self.load()
+        import numpy as np  # noqa: PLC0415
+
+        q = np.array([query], dtype="float32")
+        if DISKANN_AVAILABLE:
+            ids, dists = self._handle.search(q, k)
+        else:
+            dists, ids = self._handle.search(q, k)
+        return ids[0].tolist(), dists[0].tolist()
+
+    def unload(self) -> None:
+        self._handle = None
+
+
+# ---------------------------------------------------------------------------
+# Tier manager
+# ---------------------------------------------------------------------------
+
+class CollectionTierManager:
+    """
+    Manages hot/warm/cold placement of vector collections.
+
+    Callers notify this manager on each collection access via ``record_access``.
+    The manager decides whether the collection should be promoted and, if so,
+    loads the appropriate index tier.  ``search`` delegates to whichever
+    tier currently holds the collection's index.
+    """
+
+    def __init__(
+        self,
+        hot_max: int = HOT_MAX_COLLECTIONS,
+        warm_max: int = WARM_MAX_COLLECTIONS,
+        reap_interval: float = REAP_INTERVAL_SECONDS,
+    ) -> None:
+        self._hot_max = hot_max
+        self._warm_max = warm_max
+        self._reap_interval = reap_interval
+        self._entries: Dict[str, TierEntry] = {}
+        self._lock = asyncio.Lock()
+        self._reaper: Optional[asyncio.Task] = None
+        # Pluggable index loaders — set by the caller for each tier
+        self._hot_loader: Optional[Any] = None   # callable(collection_id) → index
+        self._warm_loader: Optional[Any] = None
+        self._cold_loader: Optional[Any] = None  # returns _DiskANNIndex
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        if self._reaper is None or self._reaper.done():
+            self._reaper = asyncio.create_task(self._reap_loop(), name="tiering-reaper")
+            logger.info("CollectionTierManager started (hot=%d, warm=%d)", self._hot_max, self._warm_max)
+
+    async def stop(self) -> None:
+        if self._reaper and not self._reaper.done():
+            self._reaper.cancel()
+            try:
+                await self._reaper
+            except asyncio.CancelledError:
+                pass
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def register_loaders(
+        self,
+        hot_loader: Any,
+        warm_loader: Any,
+        cold_loader: Any,
+    ) -> None:
+        """Register index-loading callables for each tier."""
+        self._hot_loader = hot_loader
+        self._warm_loader = warm_loader
+        self._cold_loader = cold_loader
+
+    async def record_access(self, collection_id: str) -> Tier:
+        """
+        Record an access to collection_id. May trigger a tier promotion.
+        Returns the resulting tier.
+        """
+        async with self._lock:
+            entry = self._entries.setdefault(
+                collection_id, TierEntry(collection_id=collection_id)
+            )
+            entry.access_count += 1
+            entry.last_accessed = time.monotonic()
+            new_tier = self._desired_tier(entry)
+            if new_tier != entry.tier:
+                await self._promote(entry, new_tier)
+            return entry.tier
+
+    async def search(
+        self,
+        collection_id: str,
+        query: List[float],
+        k: int = 10,
+    ) -> Tuple[List[int], List[float]]:
+        """
+        Search collection_id using its current tier index.
+        Records the access and potentially triggers promotion.
+        """
+        await self.record_access(collection_id)
+        async with self._lock:
+            entry = self._entries.get(collection_id)
+
+        if entry is None or entry.index is None:
+            raise KeyError(f"Collection {collection_id!r} not loaded in any tier")
+
+        if asyncio.iscoroutinefunction(getattr(entry.index, "search", None)):
+            return await entry.index.search(query, k)
+        return await asyncio.to_thread(entry.index.search, query, k)
+
+    def tier_of(self, collection_id: str) -> Optional[Tier]:
+        entry = self._entries.get(collection_id)
+        return entry.tier if entry else None
+
+    def stats(self) -> Dict[str, Any]:
+        hot = sum(1 for e in self._entries.values() if e.tier == Tier.HOT)
+        warm = sum(1 for e in self._entries.values() if e.tier == Tier.WARM)
+        cold = sum(1 for e in self._entries.values() if e.tier == Tier.COLD)
+        return {"hot": hot, "warm": warm, "cold": cold, "total": len(self._entries)}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _desired_tier(self, entry: TierEntry) -> Tier:
+        if entry.access_count >= PROMOTE_TO_HOT_ACCESSES and len(
+            [e for e in self._entries.values() if e.tier == Tier.HOT]
+        ) < self._hot_max:
+            return Tier.HOT
+        if entry.access_count >= PROMOTE_TO_WARM_ACCESSES and len(
+            [e for e in self._entries.values() if e.tier == Tier.WARM]
+        ) < self._warm_max:
+            return Tier.WARM
+        return Tier.COLD
+
+    async def _promote(self, entry: TierEntry, new_tier: Tier) -> None:
+        old_tier = entry.tier
+        loader = {Tier.HOT: self._hot_loader, Tier.WARM: self._warm_loader, Tier.COLD: self._cold_loader}.get(new_tier)
+        if loader:
+            try:
+                if asyncio.iscoroutinefunction(loader):
+                    entry.index = await loader(entry.collection_id)
+                else:
+                    entry.index = await asyncio.to_thread(loader, entry.collection_id)
+            except Exception:
+                logger.exception("Failed to load %s-tier index for %s", new_tier, entry.collection_id)
+                return
+        entry.tier = new_tier
+        logger.info("Collection %s promoted %s→%s", entry.collection_id, old_tier, new_tier)
+
+    async def _demote(self, entry: TierEntry) -> None:
+        if entry.tier == Tier.HOT:
+            new_tier = Tier.WARM
+        elif entry.tier == Tier.WARM:
+            new_tier = Tier.COLD
+        else:
+            return
+        old_tier = entry.tier
+        entry.index = None
+        entry.tier = new_tier
+        logger.info("Collection %s demoted %s→%s (stale)", entry.collection_id, old_tier, new_tier)
+
+    async def _reap_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._reap_interval)
+            now = time.monotonic()
+            async with self._lock:
+                for entry in list(self._entries.values()):
+                    age = now - entry.last_accessed
+                    if entry.tier == Tier.HOT and age > HOT_STALE_AFTER_SECONDS:
+                        await self._demote(entry)
+                    elif entry.tier == Tier.WARM and age > WARM_STALE_AFTER_SECONDS:
+                        await self._demote(entry)
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_tier_manager: Optional[CollectionTierManager] = None
+
+
+def get_tier_manager() -> CollectionTierManager:
+    global _tier_manager
+    if _tier_manager is None:
+        _tier_manager = CollectionTierManager()
+    return _tier_manager

--- a/autobot-backend/knowledge/write_buffer.py
+++ b/autobot-backend/knowledge/write_buffer.py
@@ -1,0 +1,171 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+LSM-Style Write Buffer for Vector Store Updates (Issue #8158)
+
+Accepts vector writes into an in-memory buffer and asynchronously merges
+them to the underlying store. Duplicate IDs within a buffer window are
+deduplicated (last-write-wins) before each flush — matching LSM semantics.
+
+Flush is triggered by:
+- Buffer reaching FLUSH_SIZE_THRESHOLD entries
+- A background task firing every FLUSH_INTERVAL_SECONDS
+
+Usage::
+
+    buffer = VectorWriteBuffer(flush_fn=my_upsert, flush_size=500)
+    await buffer.start()
+    await buffer.write(id="doc-1", embedding=[...], document="text", metadata={})
+    await buffer.stop()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Coroutine, Dict, List, Optional
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+FLUSH_SIZE_THRESHOLD = 500
+FLUSH_INTERVAL_SECONDS = 5.0
+
+
+@dataclass
+class BufferedWrite:
+    """A single pending vector write."""
+
+    id: str
+    embedding: List[float]
+    document: str
+    metadata: Dict[str, Any]
+    queued_at: float = field(default_factory=time.monotonic)
+
+
+class VectorWriteBuffer:
+    """
+    LSM-style in-memory write buffer with async background flush.
+
+    Thread-safety: all mutations are protected by an asyncio.Lock so the
+    buffer can be safely shared across concurrent request handlers within a
+    single event-loop (uvicorn worker).
+    """
+
+    def __init__(
+        self,
+        flush_fn: Callable[[List[BufferedWrite]], Coroutine[Any, Any, None]],
+        flush_size: int = FLUSH_SIZE_THRESHOLD,
+        flush_interval: float = FLUSH_INTERVAL_SECONDS,
+    ) -> None:
+        self._flush_fn = flush_fn
+        self._flush_size = flush_size
+        self._flush_interval = flush_interval
+        # ID → entry; new writes overwrite stale ones (last-write-wins)
+        self._buffer: Dict[str, BufferedWrite] = {}
+        self._lock = asyncio.Lock()
+        self._bg_task: Optional[asyncio.Task] = None
+        self._flush_count = 0
+        self._write_count = 0
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Start the background flush task."""
+        if self._bg_task is None or self._bg_task.done():
+            self._bg_task = asyncio.create_task(self._flush_loop(), name="vector-write-buffer-flush")
+            logger.info("VectorWriteBuffer started (flush_size=%d, interval=%.1fs)", self._flush_size, self._flush_interval)
+
+    async def stop(self) -> None:
+        """Flush remaining entries and stop the background task."""
+        if self._bg_task and not self._bg_task.done():
+            self._bg_task.cancel()
+            try:
+                await self._bg_task
+            except asyncio.CancelledError:
+                pass
+        await self._flush()
+        logger.info("VectorWriteBuffer stopped (total writes=%d, flushes=%d)", self._write_count, self._flush_count)
+
+    # ------------------------------------------------------------------
+    # Public write API
+    # ------------------------------------------------------------------
+
+    async def write(
+        self,
+        id: str,
+        embedding: List[float],
+        document: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Buffer a vector write. If the buffer is full, flush immediately."""
+        async with self._lock:
+            self._buffer[id] = BufferedWrite(
+                id=id,
+                embedding=embedding,
+                document=document,
+                metadata=metadata or {},
+            )
+            self._write_count += 1
+            should_flush = len(self._buffer) >= self._flush_size
+
+        if should_flush:
+            await self._flush()
+
+    async def flush_now(self) -> int:
+        """Force an immediate flush. Returns number of entries flushed."""
+        return await self._flush()
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._buffer)
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _flush_loop(self) -> None:
+        """Background task: flush at regular intervals."""
+        while True:
+            await asyncio.sleep(self._flush_interval)
+            await self._flush()
+
+    async def _flush(self) -> int:
+        """Drain buffer and call flush_fn with the deduplicated batch."""
+        async with self._lock:
+            if not self._buffer:
+                return 0
+            batch = list(self._buffer.values())
+            self._buffer.clear()
+            self._flush_count += 1
+
+        try:
+            await self._flush_fn(batch)
+            logger.debug("VectorWriteBuffer flushed %d entries (flush #%d)", len(batch), self._flush_count)
+        except Exception:
+            logger.exception("VectorWriteBuffer flush failed — %d entries dropped", len(batch))
+
+        return len(batch)
+
+
+def make_chromadb_flush_fn(collection: Any) -> Callable[[List[BufferedWrite]], Coroutine[Any, Any, None]]:
+    """
+    Build a flush function that upserts buffered writes into a ChromaDB collection.
+
+    The collection argument must expose an async-compatible upsert interface or be
+    wrapped with asyncio.to_thread() — this factory handles the wrapping.
+    """
+
+    async def _flush(batch: List[BufferedWrite]) -> None:
+        ids = [e.id for e in batch]
+        embeddings = [e.embedding for e in batch]
+        documents = [e.document for e in batch]
+        metadatas = [e.metadata for e in batch]
+        await asyncio.to_thread(collection.upsert, ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas)
+
+    return _flush

--- a/autobot-backend/llm_shared/base_provider.py
+++ b/autobot-backend/llm_shared/base_provider.py
@@ -18,6 +18,7 @@ from typing import Any, AsyncIterator, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 
+from .cross_worker_rate_limiter import get_llm_rate_limiter
 from .models import LLMRequest, LLMResponse
 from .observability import registry as obs_registry
 
@@ -59,29 +60,36 @@ class BaseProvider(ABC):
         """
         Execute a chat completion and return a fully populated LLMResponse.
 
-        Wraps ``_chat_completion_impl`` with observer fan-out (GH#6593).
+        Wraps ``_chat_completion_impl`` with:
+        - Issue #8170: cross-worker Redis rate limiter (proactive token acquire)
+        - Observer fan-out (GH#6593)
+
         Errors are returned via ``LLMResponse.error`` so the registry can
         perform fallback — implementations must not raise.
         """
-        start = time.monotonic()
-        try:
-            response = await self._chat_completion_impl(request)
-            latency_ms = (time.monotonic() - start) * 1000
+        # Issue #8170: acquire a rate-limit token shared across all uvicorn
+        # workers via Redis.  Falls back to allow-all when Redis unavailable.
+        provider_key = self.provider_name or "default"
+        async with get_llm_rate_limiter().acquire(provider_key):
+            start = time.monotonic()
             try:
-                asyncio.get_running_loop().create_task(
-                    obs_registry.notify_response(response, latency_ms, 0.0)
-                )
-            except RuntimeError:
-                pass
-            return response
-        except Exception as exc:
-            try:
-                asyncio.get_running_loop().create_task(
-                    obs_registry.notify_error(exc, request)
-                )
-            except RuntimeError:
-                pass
-            raise
+                response = await self._chat_completion_impl(request)
+                latency_ms = (time.monotonic() - start) * 1000
+                try:
+                    asyncio.get_running_loop().create_task(
+                        obs_registry.notify_response(response, latency_ms, 0.0)
+                    )
+                except RuntimeError:
+                    pass
+                return response
+            except Exception as exc:
+                try:
+                    asyncio.get_running_loop().create_task(
+                        obs_registry.notify_error(exc, request)
+                    )
+                except RuntimeError:
+                    pass
+                raise
 
     @abstractmethod
     async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:

--- a/autobot-backend/llm_shared/cross_worker_rate_limiter.py
+++ b/autobot-backend/llm_shared/cross_worker_rate_limiter.py
@@ -1,0 +1,255 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Centralized LLM Rate Limiter — Shared Across All Uvicorn Workers (Issue #8170)
+
+When uvicorn runs with ``--workers N``, each worker is a separate OS process
+with its own memory space.  An in-process rate limiter (e.g., a Python
+``asyncio.Semaphore``) is invisible to sibling workers — so the effective
+aggregate rate is N× the configured limit, causing provider 429s.
+
+This module implements a **proactive** Redis-backed token-bucket rate limiter
+for each LLM provider.  Before issuing any request to a provider's API, callers
+acquire a token.  If the bucket is empty they wait (or raise immediately,
+depending on the ``blocking`` flag).  All workers share the same Redis keys, so
+the aggregate rate is correctly bounded regardless of worker count.
+
+Token bucket algorithm
+----------------------
+Each provider bucket has two parameters:
+
+- ``capacity`` (burst capacity, tokens)
+- ``refill_rate`` (tokens per second, i.e. sustained RPM / 60)
+
+Redis stores ``(tokens_float, last_refill_timestamp)`` per provider in a
+single hash key using a Lua script for atomic check-and-decrement.
+
+Key naming: ``autobot:llm:rl:{provider}``
+
+Provider defaults
+-----------------
+Defaults are conservative approximations of free-tier limits.  Operators
+should override via environment variables or ``ssot_config`` for their actual
+provider plan:
+
+  AUTOBOT_LLM_RL_{PROVIDER}_RPM   (requests per minute)
+  AUTOBOT_LLM_RL_{PROVIDER}_BURST (burst tokens, defaults to RPM)
+
+Usage::
+
+    limiter = get_llm_rate_limiter()
+    async with limiter.acquire("openai"):
+        response = await openai_client.chat(...)
+
+    # Or non-blocking:
+    allowed, retry_after = await limiter.try_acquire("anthropic")
+    if not allowed:
+        raise RateLimitError(f"Retry after {retry_after:.1f}s", retry_after=retry_after)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Provider defaults  (RPM = requests per minute)
+# ---------------------------------------------------------------------------
+_PROVIDER_DEFAULTS: Dict[str, Tuple[int, int]] = {
+    # (rpm, burst)
+    "openai": (500, 500),
+    "anthropic": (60, 60),
+    "groq": (30, 30),
+    "ollama": (600, 600),   # local, generous
+    "vllm": (600, 600),     # local
+    "huggingface": (30, 30),
+    "openrouter": (60, 60),
+    "custom_openai": (120, 120),
+    "default": (60, 60),
+}
+
+# Lua script: atomic token-bucket check-and-decrement.
+# Keys[1]  = hash key, e.g. "autobot:llm:rl:openai"
+# Args[1]  = capacity (float string)
+# Args[2]  = refill_rate (tokens/second, float string)
+# Args[3]  = current timestamp (float string)
+# Returns: "1" if token acquired, "0:{retry_after_seconds}" if denied
+_LUA_ACQUIRE = """
+local key      = KEYS[1]
+local capacity = tonumber(ARGV[1])
+local rate     = tonumber(ARGV[2])
+local now      = tonumber(ARGV[3])
+
+local data = redis.call('HMGET', key, 'tokens', 'ts')
+local tokens = tonumber(data[1]) or capacity
+local ts     = tonumber(data[2]) or now
+
+-- Refill
+local elapsed = math.max(0, now - ts)
+tokens = math.min(capacity, tokens + elapsed * rate)
+
+if tokens >= 1 then
+    -- Consume one token
+    tokens = tokens - 1
+    redis.call('HMSET', key, 'tokens', tostring(tokens), 'ts', tostring(now))
+    redis.call('EXPIRE', key, 3600)
+    return '1'
+else
+    -- Return seconds until one token is available
+    local wait = (1 - tokens) / rate
+    return '0:' .. tostring(wait)
+end
+"""
+
+_KEY_PREFIX = "autobot:llm:rl"
+
+
+def _env_int(key: str, default: int) -> int:
+    try:
+        return int(os.environ[key])
+    except (KeyError, ValueError):
+        return default
+
+
+def _provider_limits(provider: str) -> Tuple[float, float]:
+    """Return (capacity, refill_rate_tokens_per_second) for a provider."""
+    pname = provider.upper()
+    rpm_key = f"AUTOBOT_LLM_RL_{pname}_RPM"
+    burst_key = f"AUTOBOT_LLM_RL_{pname}_BURST"
+    defaults = _PROVIDER_DEFAULTS.get(provider.lower(), _PROVIDER_DEFAULTS["default"])
+    rpm = _env_int(rpm_key, defaults[0])
+    burst = _env_int(burst_key, defaults[1])
+    return float(burst), float(rpm) / 60.0  # capacity, tokens/sec
+
+
+class LLMCrossWorkerRateLimiter:
+    """
+    Redis-backed proactive token-bucket rate limiter for LLM providers.
+
+    Shared across all uvicorn workers via Redis.  Falls back gracefully to
+    allow-all when Redis is unavailable, ensuring a Redis outage never
+    hard-blocks LLM calls.
+    """
+
+    def __init__(self) -> None:
+        self._redis_available = True
+        self._script_sha: Optional[str] = None  # cached EVALSHA
+        self._local_fallback: asyncio.Semaphore | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @asynccontextmanager
+    async def acquire(
+        self,
+        provider: str,
+        timeout: float = 30.0,
+    ) -> AsyncIterator[None]:
+        """
+        Async context manager that blocks until a token is available.
+
+        Raises ``asyncio.TimeoutError`` if *timeout* seconds elapse without
+        a token becoming available.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            allowed, retry_after = await self.try_acquire(provider)
+            if allowed:
+                yield
+                return
+            if time.monotonic() + retry_after > deadline:
+                raise asyncio.TimeoutError(
+                    f"LLM rate limiter: timed out waiting for {provider!r} token (timeout={timeout}s)"
+                )
+            await asyncio.sleep(min(retry_after, 1.0))
+
+    async def try_acquire(self, provider: str) -> Tuple[bool, float]:
+        """
+        Non-blocking token acquire attempt.
+
+        Returns:
+            (True, 0.0)              if a token was granted.
+            (False, retry_after_sec) if the bucket is empty.
+        """
+        try:
+            return await self._redis_try_acquire(provider)
+        except Exception:
+            logger.debug("LLM rate limiter: Redis unavailable — allowing request (provider=%s)", provider, exc_info=True)
+            self._redis_available = False
+            return True, 0.0
+
+    async def peek_tokens(self, provider: str) -> float:
+        """
+        Return the approximate number of tokens currently available for *provider*.
+        Useful for monitoring / metrics endpoints.
+        """
+        try:
+            redis = await self._get_redis()
+            data = await redis.hmget(f"{_KEY_PREFIX}:{provider}", "tokens", "ts")
+            capacity, rate = _provider_limits(provider)
+            tokens_raw, ts_raw = data
+            tokens = float(tokens_raw) if tokens_raw else capacity
+            ts = float(ts_raw) if ts_raw else time.time()
+            elapsed = max(0.0, time.time() - ts)
+            return min(capacity, tokens + elapsed * rate)
+        except Exception:
+            return -1.0
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _get_redis(self):
+        from autobot_shared.redis_client import get_async_redis_client  # noqa: PLC0415
+        return await get_async_redis_client()
+
+    async def _load_script(self, redis) -> str:
+        if self._script_sha is None:
+            self._script_sha = await redis.script_load(_LUA_ACQUIRE)
+        return self._script_sha
+
+    async def _redis_try_acquire(self, provider: str) -> Tuple[bool, float]:
+        redis = await self._get_redis()
+        sha = await self._load_script(redis)
+        capacity, rate = _provider_limits(provider)
+        key = f"{_KEY_PREFIX}:{provider}"
+        now = time.time()
+
+        result: bytes = await redis.evalsha(
+            sha,
+            1,       # numkeys
+            key,
+            str(capacity),
+            str(rate),
+            str(now),
+        )
+        result_str = result.decode() if isinstance(result, bytes) else str(result)
+
+        if result_str == "1":
+            return True, 0.0
+        parts = result_str.split(":", 1)
+        retry_after = float(parts[1]) if len(parts) == 2 else 1.0
+        return False, retry_after
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_limiter: Optional[LLMCrossWorkerRateLimiter] = None
+
+
+def get_llm_rate_limiter() -> LLMCrossWorkerRateLimiter:
+    """Return the shared LLM rate limiter singleton."""
+    global _limiter
+    if _limiter is None:
+        _limiter = LLMCrossWorkerRateLimiter()
+    return _limiter

--- a/autobot-backend/utils/gpu_vector_search.py
+++ b/autobot-backend/utils/gpu_vector_search.py
@@ -29,6 +29,7 @@ import numpy as np
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.missing_dep import MissingDep as _MissingDep
 from knowledge.backends import BaseClient, BaseCollection
+from knowledge.hnsw_prefetch import attach_prefetcher
 from utils.async_initializable import AsyncInitializable
 
 # FAISS and ChromaDB are imported as whole-module objects (faiss.IndexFlatL2(),
@@ -152,6 +153,7 @@ class GPUVectorIndex:
         self.next_id: int = 0
         self.is_trained: bool = False
         self._lock = asyncio.Lock()
+        self._hnsw_prefetcher: Any | None = None  # Issue #8161: HNSW prefetch
 
         # Backend tracking
         self.backend = SearchBackend.CHROMADB  # Default fallback
@@ -264,6 +266,8 @@ class GPUVectorIndex:
             index = faiss.IndexHNSWFlat(dim, 32)  # 32 neighbors
             index.hnsw.efConstruction = 200
             index.hnsw.efSearch = 64
+            # Issue #8161: attach prefetcher after index creation
+            self._hnsw_prefetcher = attach_prefetcher(index)
             return index
 
         else:
@@ -460,8 +464,17 @@ class GPUVectorIndex:
         if hasattr(self.index, "nprobe"):
             self.index.nprobe = self.config.nprobe
 
+        # Issue #8161: warm HNSW entry-point neighbor lists before traversal
+        if self._hnsw_prefetcher is not None:
+            self._hnsw_prefetcher.warmup_entry_point()
+
         # Execute search
         distances, indices = await asyncio.to_thread(self.index.search, query, top_k)
+
+        # Issue #8161: speculatively prefetch level-0 neighbors of top results
+        if self._hnsw_prefetcher is not None:
+            valid_ids = [int(i) for i in indices[0] if i >= 0]
+            self._hnsw_prefetcher.speculative_prefetch(valid_ids)
 
         # Issue #620: Use helper for result conversion
         results = self._convert_search_results(distances, indices)


### PR DESCRIPTION
## Summary

- **#8158** `knowledge/write_buffer.py` — `VectorWriteBuffer`: LSM-style in-memory write buffer with last-write-wins dedup and async background flush (size threshold + interval trigger); `make_chromadb_flush_fn()` wires buffer to ChromaDB
- **#8160** `knowledge/tiering.py` — `CollectionTierManager`: hot (in-memory FAISS) / warm (mmap SSD) / cold (DiskANN with FAISS fallback) tiering; access-count promotion + stale-reaper demotion; `get_tier_manager()` singleton
- **#8161** `knowledge/hnsw_prefetch.py` + `utils/gpu_vector_search.py` — `HNSWPrefetcher`: entry-point neighbor-list warmup before traversal + speculative level-0 prefetch of result nodes; wired into `GPUVectorIndex.search()`; graceful no-op on non-HNSW indexes
- **#8170** `llm_shared/cross_worker_rate_limiter.py` + `llm_shared/base_provider.py` — `LLMCrossWorkerRateLimiter`: Redis Lua token-bucket per provider, shared key namespace `autobot:llm:rl:{provider}` across all uvicorn workers; wired into `BaseProvider.chat_completion()` as `async with ... .acquire(provider_key)`; allow-all fallback when Redis unavailable

## Test plan

- [ ] `VectorWriteBuffer`: write N > flush_size entries → verify flush_fn called with deduplicated batch
- [ ] `VectorWriteBuffer`: verify background flush fires after `flush_interval` without explicit trigger
- [ ] `CollectionTierManager`: record_access() past PROMOTE_TO_HOT_ACCESSES threshold → verify collection tier == HOT
- [ ] `CollectionTierManager`: stale reaper test — advance monotonic time mock past HOT_STALE_AFTER_SECONDS → verify demotion to WARM
- [ ] `HNSWPrefetcher`: warmup_entry_point() on a populated IndexHNSWFlat → verify non-zero touched count
- [ ] `HNSWPrefetcher`: speculative_prefetch() on non-HNSW index → verify no exception
- [ ] `LLMCrossWorkerRateLimiter`: Redis unavailable → try_acquire returns (True, 0.0) (allow-all fallback)
- [ ] `LLMCrossWorkerRateLimiter`: token bucket exhausted → try_acquire returns (False, retry_after > 0)
- [ ] `BaseProvider.chat_completion()`: confirm rate limiter acquire wraps `_chat_completion_impl` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)