### PR TITLE
batch(L): code-analysis consolidation + LLC interfaces + gateway + audit #6757 #8261 #8268 #8290 #8312

### DIFF
--- a/autobot-backend/api/admin_event_logs.py
+++ b/autobot-backend/api/admin_event_logs.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, Depends, Query, Request
 from auth_middleware import get_auth_middleware
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
-from services.event_log import EventType, query_events
+from services.audit.unified_audit import EventType, query_events  # GH#8290 Phase 2
 from utils.catalog_http_exceptions import raise_auth_error
 
 router = APIRouter(prefix="/admin", tags=["admin", "compliance"])

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -32,8 +32,8 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config as ssot_config
 from constants.error_constants import ERR_INVALID_CREDENTIALS, ERR_INVALID_TOKEN
-from services.event_log import EventType
-from services.event_log import emit as _emit_event  # Issue #4461
+from services.audit.unified_audit import EventType  # GH#8290 Phase 2
+from services.audit.unified_audit import emit as _emit_event  # GH#8290 Phase 2
 from user_management.database import db_session_context
 from user_management.services.user_service import UserService
 

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -51,7 +51,7 @@ from exceptions import get_exceptions_lazy
 from security.session_ownership import validate_session_ownership
 
 # Issue #6559: Wire audit_record into session create/delete/export endpoints
-from services.audit import AuditAction, audit_record
+from services.audit.unified_audit import AuditAction, audit_record  # GH#8290 Phase 2
 from type_defs.common import Metadata
 
 # Import reusable chat utilities

--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -99,7 +99,7 @@ from knowledge.schemas.stats import (
 # NOTE: Tag-related models moved to knowledge_tags.py
 # NOTE: Search models (EnhancedSearchRequest) moved to knowledge_search.py
 from knowledge_factory import get_or_create_knowledge_base
-from services.audit.audit_log import AuditAction, audit_record
+from services.audit.unified_audit import AuditAction, audit_record  # GH#8290 Phase 2
 from utils.path_validation import contains_path_traversal
 
 # =============================================================================

--- a/autobot-backend/api/knowledge_audit.py
+++ b/autobot-backend/api/knowledge_audit.py
@@ -23,7 +23,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.models.pagination import PaginationParams
 from autobot_shared.time_utils import now_utc
-from knowledge.audit_log import KnowledgeAuditLog
+from services.audit.unified_audit import KnowledgeAuditLog  # GH#8290 Phase 2
 from knowledge_factory import get_or_create_knowledge_base
 
 logger = get_logger(__name__)

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -2080,8 +2080,11 @@ class AdapterTestResponse(BaseModel):
     """Response for GET /{adapter_type}/test."""
 
     adapter_type: str = ""
-    status: str = ""
-    details: Dict[str, Any] = Field(default_factory=dict)
+    healthy: bool = False
+    diagnostics: List[Any] = Field(default_factory=list)
+    models_available: List[Any] = Field(default_factory=list)
+    response_time: float = 0.0
+    metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
 class AdapterModelsResponse(BaseModel):

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -4963,7 +4963,7 @@ class KBQueryResponse(BaseModel):
 
 from datetime import datetime as _datetime
 
-from knowledge.audit_log import AuditEventType as _AuditEventType
+from services.audit.unified_audit import AuditEventType as _AuditEventType  # GH#8290 Phase 2
 
 
 class AuditEvent(BaseModel):

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -51,7 +51,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import parse_utc_iso
 from middleware.proxy_utils import get_client_ip
-from services.audit.audit_log import AuditAction, audit_record
+from services.audit.unified_audit import AuditAction, audit_record  # GH#8290 Phase 2
 from type_defs.common import Metadata
 
 logger = get_logger(__name__)

--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -154,29 +154,58 @@ def clear_ast_cache() -> None:
 
 
 class AntiPatternType(Enum):
-    """Types of anti-patterns detected"""
+    """Types of anti-patterns detected.
 
+    Canonical SSOT (GH#6757): merged from code_analysis/src (per-file rules)
+    and code_intelligence/anti_pattern_detection (cross-file/naming rules).
+    Both modules previously kept diverged copies of this enum.
+    """
+
+    # --- Structural bloaters ---
     GOD_CLASS = "god_class"
+    LONG_METHOD = "long_method"
+    LONG_PARAMETER_LIST = "long_parameter_list"
+    LARGE_FILE = "large_file"
+    DEEP_NESTING = "deep_nesting"
+    # DATA_CLUMP / DATA_CLUMPS: canonical name is DATA_CLUMP ("data_clump");
+    # legacy code_intelligence used DATA_CLUMPS — kept as alias for migration.
+    DATA_CLUMP = "data_clump"
+    DATA_CLUMPS = "data_clumps"  # legacy alias from code_intelligence (GH#6757)
+    PRIMITIVE_OBSESSION = "primitive_obsession"
+
+    # --- Couplers ---
     FEATURE_ENVY = "feature_envy"
     CIRCULAR_DEPENDENCY = "circular_dependency"
     SHOTGUN_SURGERY = "shotgun_surgery"
+    MESSAGE_CHAINS = "message_chains"
+    INAPPROPRIATE_INTIMACY = "inappropriate_intimacy"
+
+    # --- Dispensables ---
     SPECULATIVE_GENERALITY = "speculative_generality"
     DEAD_CODE = "dead_code"
-    DATA_CLUMP = "data_clump"
-    LONG_METHOD = "long_method"
-    LONG_PARAMETER_LIST = "long_parameter_list"
-    PRIMITIVE_OBSESSION = "primitive_obsession"
     LAZY_CLASS = "lazy_class"
     REFUSED_BEQUEST = "refused_bequest"
-    # Issue #6661: Liskov Substitution Principle violations
+    # DUPLICATE_ABSTRACTION: legacy name from code_intelligence; canonical is
+    # DUPLICATE_CLASS_SHAPE (added in #6684).
+    DUPLICATE_CLASS_SHAPE = "duplicate_class_shape"
+    DUPLICATE_ABSTRACTION = "duplicate_abstraction"  # legacy alias (GH#6757)
+    DUPLICATE_ENUM = "duplicate_enum"
+
+    # --- Naming issues (from code_intelligence NamingDetector) ---
+    INCONSISTENT_NAMING = "inconsistent_naming"
+    SINGLE_LETTER_VARIABLE = "single_letter_variable"
+    MAGIC_NUMBER = "magic_number"
+
+    # --- Code clarity ---
+    COMPLEX_CONDITIONAL = "complex_conditional"
+    MISSING_DOCSTRING = "missing_docstring"
+
+    # --- LSP violations (Issue #6661) ---
     LSP_SIGNATURE_INCOMPATIBLE = "lsp_signature_incompatible"
     LSP_EXCEPTION_CONTRACT_CHANGED = "lsp_exception_contract_changed"
-    # Issue #6684: consolidation opportunities (missing-inheritance siblings to LSP)
-    DUPLICATE_ENUM = "duplicate_enum"
-    DUPLICATE_CLASS_SHAPE = "duplicate_class_shape"
-    # Issue #6871: modules with zero production callers (closed tracker, unwired code)
+
+    # --- Architecture-level (Issue #6871, #6748) ---
     UNWIRED_TRACKER = "unwired_tracker"
-    # Issue #6748: repeated reactive boilerplate that should be extracted to a composable
     COMPOSABLE_OPPORTUNITY = "composable_opportunity"
 
 

--- a/autobot-backend/code_intelligence/anti_pattern_detector.py
+++ b/autobot-backend/code_intelligence/anti_pattern_detector.py
@@ -26,19 +26,24 @@ New facade: ~100 lines (92% reduction)
 # Backward compatibility: Expose commonly used regex patterns
 import re
 
-# #6757: canonical AntiPatternDetector lives in code_analysis.src.
-# Expose it here so that all callers of this facade get the unified class
-# that has both per-file (analyze_file) and cross-file (analyze,
-# analyze_cross_file_only) support.  Fall back to the package-local class
-# if code_analysis is unavailable (e.g., isolated test environments).
+# GH#6757: canonical AntiPatternDetector + AntiPatternType live in
+# code_analysis.src.  This facade re-exports them so existing callers require
+# no import-path changes.  Fall back to the package-local implementations only
+# when code_analysis is unavailable (e.g., isolated test environments).
 try:
     from code_analysis.src.anti_pattern_detector import (
-        AntiPatternDetector,  # noqa: F401  (re-exported below)
+        AntiPatternDetector,  # noqa: F401
+        AntiPatternType,  # noqa: F401  — canonical SSOT enum (GH#6757)
     )
 except ImportError:
-    from .anti_pattern_detection import AntiPatternDetector  # type: ignore[assignment]
+    from .anti_pattern_detection import (  # type: ignore[assignment]
+        AntiPatternDetector,
+        AntiPatternType,
+    )
 
-# Re-export all public API from the package for backward compatibility
+# Re-export remaining public API from the package for backward compatibility.
+# NOTE: AntiPatternType is intentionally NOT imported from here — the canonical
+# version from code_analysis.src overrides it above.
 from .anti_pattern_detection import (  # Types and enums; Data models; Severity utilities; Detectors; Main analyzer
     ALLOWED_MAGIC_NUMBERS,
     ALLOWED_SINGLE_LETTER_VARS,
@@ -48,7 +53,6 @@ from .anti_pattern_detection import (  # Types and enums; Data models; Severity 
     AnalysisReport,
     AntiPatternResult,
     AntiPatternSeverity,
-    AntiPatternType,
     BloaterDetector,
     ClassInfo,
     CouplerDetector,

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -601,6 +601,8 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["collaboration", "websocket", "presence"],
         "presence_ws",
     ),
+    # GH#8251: LLC (Lean Lifecycle Controller) module skeleton
+    ("llc.api", "", ["llc"], "llc"),
 ]
 
 

--- a/autobot-backend/knowledge/audit_log.py
+++ b/autobot-backend/knowledge/audit_log.py
@@ -5,7 +5,20 @@
 Knowledge Audit Logging
 
 Issue #679: Comprehensive audit trail for knowledge access, modifications, and permission changes.
+
+.. deprecated::
+    Use ``services.audit.unified_audit`` directly (GH#8290 Phase 2).
+    This module will be removed in Phase 3 once all callers are migrated.
 """
+
+import warnings
+
+warnings.warn(
+    "knowledge.audit_log is deprecated (GH#8290). "
+    "Import from services.audit.unified_audit instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 import asyncio
 import json

--- a/autobot-backend/llc/__init__.py
+++ b/autobot-backend/llc/__init__.py
@@ -1,0 +1,11 @@
+"""LLC (Lean Lifecycle Controller) module (GH#8204).
+
+Entry point for the LLC module. Exports the FastAPI router so
+initialization/router_registry/feature_routers.py can include it.
+"""
+
+__version__ = "0.1.0"
+
+from .api import router
+
+__all__ = ["router"]

--- a/autobot-backend/llc/adapters/__init__.py
+++ b/autobot-backend/llc/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""LLC adapters package."""

--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -1,0 +1,10 @@
+"""LLC API router (GH#8251)."""
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/llc", tags=["llc"])
+
+
+@router.get("/health")
+async def health() -> dict:
+    return {"status": "ok", "module": "llc"}

--- a/autobot-backend/llc/conftest.py
+++ b/autobot-backend/llc/conftest.py
@@ -1,0 +1,61 @@
+"""LLC module shared pytest fixtures (GH#8251).
+
+Provides:
+- test_db_session: async SQLAlchemy session scoped to the test
+- company_factory: creates a minimal company row
+- agent_factory: creates a minimal agent row attached to a company
+"""
+
+import uuid
+from typing import AsyncGenerator, Callable
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from user_management.database import get_async_session_factory
+
+
+@pytest_asyncio.fixture
+async def test_db_session() -> AsyncGenerator[AsyncSession, None]:
+    """Async SQLAlchemy session for LLC tests.
+
+    Uses the same factory as the rest of the test suite so LLC tests share
+    the test database configuration from user_management/.
+    """
+    session_factory = get_async_session_factory()
+    async with session_factory() as session:
+        yield session
+        await session.rollback()
+
+
+@pytest.fixture
+def company_factory(test_db_session: AsyncSession) -> Callable:
+    """Factory that inserts a minimal company row and returns its id."""
+
+    async def _create(name: str = "Test LLC Co") -> str:
+        company_id = str(uuid.uuid4())
+        await test_db_session.execute(
+            "INSERT INTO companies (id, name) VALUES (:id, :name)",
+            {"id": company_id, "name": name},
+        )
+        return company_id
+
+    return _create
+
+
+@pytest.fixture
+def agent_factory(test_db_session: AsyncSession, company_factory: Callable) -> Callable:
+    """Factory that inserts a minimal agent row attached to a company."""
+
+    async def _create(company_id: str | None = None, name: str = "TestAgent") -> str:
+        if company_id is None:
+            company_id = await company_factory()
+        agent_id = str(uuid.uuid4())
+        await test_db_session.execute(
+            "INSERT INTO agents (id, company_id, name) VALUES (:id, :company_id, :name)",
+            {"id": agent_id, "company_id": company_id, "name": name},
+        )
+        return agent_id
+
+    return _create

--- a/autobot-backend/llc/kb/__init__.py
+++ b/autobot-backend/llc/kb/__init__.py
@@ -1,0 +1,5 @@
+"""LLC knowledge base package."""
+
+from .rag_assembler import AssemblerProfile, LLCContext, LLCRAGAssembler
+
+__all__ = ["AssemblerProfile", "LLCContext", "LLCRAGAssembler"]

--- a/autobot-backend/llc/kb/rag_assembler.py
+++ b/autobot-backend/llc/kb/rag_assembler.py
@@ -1,0 +1,70 @@
+"""LLC RAG assembler interface (GH#8261).
+
+GH#8236 (heartbeat context builder) and GH#8239 (handoff brief generator)
+both construct multi-source RAG queries over company/project/agent KB
+collections. This module provides a shared assembler with swappable query
+profiles so neither issue needs to duplicate ChromaDB call patterns.
+
+Concrete implementation lives in GH#8236. This file provides the interface
+stub so dependent issues can import and type-check against it.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class AssemblerProfile(str, Enum):
+    """Query profile for RAG context assembly.
+
+    HEARTBEAT: full organisation context for agent heartbeat runs.
+    HANDOFF:   transition brief for agent-to-agent handoff.
+    SUGGESTION: acceptance-criteria hints during work item creation.
+    """
+
+    HEARTBEAT = "heartbeat"
+    HANDOFF = "handoff"
+    SUGGESTION = "suggestion"
+
+
+@dataclass
+class LLCContext:
+    """Assembled RAG context returned by LLCRAGAssembler.assemble()."""
+
+    company_id: str
+    profile: AssemblerProfile
+    chunks: List[Dict[str, Any]] = field(default_factory=list)
+    sources: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class LLCRAGAssembler:
+    """Assembles multi-source RAG context for LLC operations.
+
+    Both GH#8236 and GH#8239 use this rather than calling ChromaDB directly,
+    ensuring consistent collection names, query parameters, and result merging.
+    """
+
+    async def assemble(
+        self,
+        company_id: str,
+        profile: AssemblerProfile,
+        project_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        work_item_id: Optional[str] = None,
+    ) -> LLCContext:
+        """Run parallel ChromaDB queries and return merged context.
+
+        Args:
+            company_id: Tenant company identifier.
+            profile: Which query profile to use (HEARTBEAT, HANDOFF, SUGGESTION).
+            project_id: Optional project scope filter.
+            agent_id: Optional agent scope filter.
+            work_item_id: Optional work item context.
+
+        Returns:
+            LLCContext with merged chunks from all relevant collections.
+        """
+        raise NotImplementedError(
+            "LLCRAGAssembler.assemble() — concrete impl in GH#8236"
+        )

--- a/autobot-backend/llc/models/__init__.py
+++ b/autobot-backend/llc/models/__init__.py
@@ -1,0 +1,23 @@
+"""LLC models package."""
+
+from .enums import (
+    ApprovalStatus,
+    AssignmentType,
+    LLCAgentStatus,
+    LLCCompanyStatus,
+    LLCRunStatus,
+    SprintStatus,
+    WorkItemStatus,
+    WorkItemType,
+)
+
+__all__ = [
+    "ApprovalStatus",
+    "AssignmentType",
+    "LLCAgentStatus",
+    "LLCCompanyStatus",
+    "LLCRunStatus",
+    "SprintStatus",
+    "WorkItemStatus",
+    "WorkItemType",
+]

--- a/autobot-backend/llc/models/enums.py
+++ b/autobot-backend/llc/models/enums.py
@@ -1,0 +1,108 @@
+"""LLC module enum SSOT (GH#8261).
+
+All LLC enums are defined here and imported everywhere — never redefined in
+service or API files. This prevents the 23+ *Status enum duplication pattern
+found in GH#7265 and GH#7504.
+
+LLCAgentStatus decision: define a separate LLC-scoped enum (not extending the
+canonical AgentStatus) because LLC agents have lifecycle states specific to
+sprint/work-item assignment that don't map cleanly to the system-level
+AgentStatus values. Cross-reference: GH#7504.
+"""
+
+from enum import Enum
+
+
+class WorkItemType(str, Enum):
+    """Type of LLC work item (GH#8213)."""
+
+    TASK = "task"
+    BUG = "bug"
+    STORY = "story"
+    EPIC = "epic"
+    SPIKE = "spike"
+    SUBTASK = "subtask"
+
+
+class WorkItemStatus(str, Enum):
+    """Status of an LLC work item (GH#8213)."""
+
+    BACKLOG = "backlog"
+    TODO = "todo"
+    IN_PROGRESS = "in_progress"
+    IN_REVIEW = "in_review"
+    DONE = "done"
+    CANCELLED = "cancelled"
+    BLOCKED = "blocked"
+
+
+class LLCCompanyStatus(str, Enum):
+    """Lifecycle status of a company within the LLC module (GH#8211)."""
+
+    ONBOARDING = "onboarding"
+    ACTIVE = "active"
+    PAUSED = "paused"
+    OFFBOARDING = "offboarding"
+    ARCHIVED = "archived"
+
+
+class LLCAgentStatus(str, Enum):
+    """LLC-scoped agent lifecycle status (GH#8225).
+
+    Separate from canonical AgentStatus — LLC agents have sprint/work-item
+    assignment states that don't exist at the system level. See module docstring
+    for the rationale.
+    """
+
+    AVAILABLE = "available"
+    ASSIGNED = "assigned"
+    IN_SPRINT = "in_sprint"
+    ON_LEAVE = "on_leave"
+    ONBOARDING = "onboarding"
+    OFFBOARDING = "offboarding"
+    INACTIVE = "inactive"
+
+
+class SprintStatus(str, Enum):
+    """Status of a sprint (GH#8219)."""
+
+    PLANNING = "planning"
+    ACTIVE = "active"
+    REVIEW = "review"
+    RETROSPECTIVE = "retrospective"
+    CLOSED = "closed"
+    CANCELLED = "cancelled"
+
+
+class ApprovalStatus(str, Enum):
+    """Status of an LLC approval request (GH#8214)."""
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    WITHDRAWN = "withdrawn"
+    EXPIRED = "expired"
+
+
+class LLCRunStatus(str, Enum):
+    """Unified run status for heartbeat and adapter runs (GH#8261).
+
+    Replaces the originally separate HeartbeatRunStatus (#8225) and
+    AdapterRunStatus (#8226) — both had identical values so they are collapsed
+    into a single enum to avoid enum-drift.
+    """
+
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    TIMEOUT = "timeout"
+    CANCELLED = "cancelled"
+
+
+class AssignmentType(str, Enum):
+    """How a work item was assigned to an agent (GH#8230)."""
+
+    MANUAL = "manual"
+    AUTO = "auto"
+    DELEGATED = "delegated"
+    INHERITED = "inherited"

--- a/autobot-backend/llc/notifications/__init__.py
+++ b/autobot-backend/llc/notifications/__init__.py
@@ -1,0 +1,5 @@
+"""LLC notifications package."""
+
+from .publisher import LLCEvent, LLCWebSocketPublisher
+
+__all__ = ["LLCEvent", "LLCWebSocketPublisher"]

--- a/autobot-backend/llc/notifications/publisher.py
+++ b/autobot-backend/llc/notifications/publisher.py
@@ -1,0 +1,67 @@
+"""LLC WebSocket publisher interface (GH#8261).
+
+GH#8255 (notification router) and GH#8221 (Kanban board real-time) both push
+LLC events to WebSocket clients filtered by company_id. This publisher ensures
+both callers use the same typed event envelope and company_id filter, and that
+events reach both the RedisEventStreamManager and the LiveEventManager.
+
+Concrete implementation in GH#8255. This file provides the interface stub.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class LLCEvent:
+    """Typed event envelope for LLC WebSocket messages.
+
+    Both WebSocket buses (RedisEventStreamManager and LiveEventManager) receive
+    this envelope so subscribers on either bus get consistent payloads.
+    """
+
+    company_id: str
+    event_type: str
+    entity_type: str
+    entity_id: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+    actor_id: Optional[str] = None
+
+
+class LLCWebSocketPublisher:
+    """Publishes LLC events to connected WebSocket clients.
+
+    Multi-tenant safety: company_id filter is applied before push so a client
+    subscribed to company A never receives events from company B.
+
+    Both GH#8255 (notification router) and GH#8221 (Kanban real-time) inject
+    this rather than calling the WebSocket manager directly.
+    """
+
+    async def publish(
+        self,
+        company_id: str,
+        event_type: str,
+        entity_type: str,
+        entity_id: str,
+        payload: Dict[str, Any],
+        actor_id: Optional[str] = None,
+    ) -> None:
+        """Publish an LLC event to all matching WebSocket subscribers.
+
+        Pushes to both RedisEventStreamManager and LiveEventManager with the
+        company_id filter applied. Never raises — publishing failures are
+        logged but must not break the calling operation.
+
+        Args:
+            company_id: Tenant scope — only subscribers for this company receive
+                the event.
+            event_type: Logical event kind (use ActivityEventType string values).
+            entity_type: Resource type name (e.g. "work_item", "sprint").
+            entity_id: PK of the affected resource.
+            payload: Serializable event data.
+            actor_id: Optional agent/user that triggered the event.
+        """
+        raise NotImplementedError(
+            "LLCWebSocketPublisher.publish() — concrete impl in GH#8255"
+        )

--- a/autobot-backend/llc/scheduler/__init__.py
+++ b/autobot-backend/llc/scheduler/__init__.py
@@ -1,0 +1,1 @@
+"""LLC scheduler package."""

--- a/autobot-backend/llc/services/__init__.py
+++ b/autobot-backend/llc/services/__init__.py
@@ -1,0 +1,25 @@
+"""LLC services package.
+
+LLCServiceBase provides the shared DI slot for the activity log service.
+All concrete LLC service classes should inherit from this base so they
+receive a typed ``activity_log`` reference at construction time.
+"""
+
+from typing import Optional
+
+from .activity_log import LLCActivityLogService
+
+
+class LLCServiceBase:
+    """Base class for all LLC services.
+
+    Subclasses receive the activity_log DI slot which is populated by the
+    LLC DI container once GH#8216 lands. Until then, the slot is None and
+    callers must guard with ``if self.activity_log``.
+    """
+
+    def __init__(self, activity_log: Optional[LLCActivityLogService] = None) -> None:
+        self.activity_log = activity_log
+
+
+__all__ = ["LLCServiceBase", "LLCActivityLogService"]

--- a/autobot-backend/llc/services/activity_log.py
+++ b/autobot-backend/llc/services/activity_log.py
@@ -1,0 +1,121 @@
+"""LLC activity log service (GH#8261).
+
+Single injectable service for all 13+ issues that write to llc_activity_log.
+Callers must inject rather than write to the table directly, ensuring
+consistent event_type strings and required field presence.
+"""
+
+from enum import Enum
+from typing import Any, Dict, Optional
+
+
+class ActivityEventType(str, Enum):
+    """Typed enum for all LLC activity log event_type strings.
+
+    Using an enum prevents bare string literals scattered across 13 issues
+    and catches misspellings at import time rather than at query time.
+    """
+
+    # Company lifecycle
+    COMPANY_CREATED = "company.created"
+    COMPANY_UPDATED = "company.updated"
+    COMPANY_STATUS_CHANGED = "company.status_changed"
+    COMPANY_ARCHIVED = "company.archived"
+
+    # Agent lifecycle
+    AGENT_HIRED = "agent.hired"
+    AGENT_ASSIGNED = "agent.assigned"
+    AGENT_UNASSIGNED = "agent.unassigned"
+    AGENT_STATUS_CHANGED = "agent.status_changed"
+    AGENT_OFFBOARDED = "agent.offboarded"
+
+    # Work item lifecycle
+    WORK_ITEM_CREATED = "work_item.created"
+    WORK_ITEM_UPDATED = "work_item.updated"
+    WORK_ITEM_STATUS_CHANGED = "work_item.status_changed"
+    WORK_ITEM_ASSIGNED = "work_item.assigned"
+    WORK_ITEM_COMPLETED = "work_item.completed"
+    WORK_ITEM_CANCELLED = "work_item.cancelled"
+
+    # Sprint lifecycle
+    SPRINT_CREATED = "sprint.created"
+    SPRINT_STARTED = "sprint.started"
+    SPRINT_COMPLETED = "sprint.completed"
+    SPRINT_CANCELLED = "sprint.cancelled"
+    SPRINT_ITEM_ADDED = "sprint.item_added"
+    SPRINT_ITEM_REMOVED = "sprint.item_removed"
+
+    # Approval lifecycle
+    APPROVAL_REQUESTED = "approval.requested"
+    APPROVAL_APPROVED = "approval.approved"
+    APPROVAL_REJECTED = "approval.rejected"
+    APPROVAL_WITHDRAWN = "approval.withdrawn"
+
+    # Heartbeat / run
+    HEARTBEAT_STARTED = "heartbeat.started"
+    HEARTBEAT_COMPLETED = "heartbeat.completed"
+    HEARTBEAT_FAILED = "heartbeat.failed"
+
+    # Adapter
+    ADAPTER_RUN_STARTED = "adapter_run.started"
+    ADAPTER_RUN_COMPLETED = "adapter_run.completed"
+    ADAPTER_RUN_FAILED = "adapter_run.failed"
+
+    # Notification
+    NOTIFICATION_SENT = "notification.sent"
+    NOTIFICATION_FAILED = "notification.failed"
+
+
+class LLCActivityLogService:
+    """Injectable service for writing to llc_activity_log.
+
+    All LLC services that need to record activity must inject this via the
+    ``activity_log`` slot on LLCServiceBase — never call the table directly.
+
+    Concrete implementation is built in GH#8216. This file provides the
+    interface contract so dependents can type-check against it.
+    """
+
+    async def record(
+        self,
+        session: Any,
+        company_id: str,
+        actor_id: str,
+        event_type: ActivityEventType,
+        entity_type: str,
+        entity_id: str,
+        before: Optional[Dict[str, Any]] = None,
+        after: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Record a single activity log entry.
+
+        Args:
+            session: Async SQLAlchemy session.
+            company_id: Tenant company identifier.
+            actor_id: Agent or user that triggered the event.
+            event_type: Typed event kind — use ActivityEventType enum values.
+            entity_type: Table/resource name (e.g. "work_item", "sprint").
+            entity_id: PK of the affected row.
+            before: State snapshot before the change (optional).
+            after: State snapshot after the change (optional).
+            metadata: Arbitrary extra context (optional).
+        """
+        raise NotImplementedError(
+            "LLCActivityLogService.record() — concrete impl in GH#8216"
+        )
+
+    async def record_bulk(
+        self,
+        session: Any,
+        entries: list,
+    ) -> None:
+        """Insert multiple activity log entries in a single transaction.
+
+        Args:
+            session: Async SQLAlchemy session.
+            entries: List of dicts matching the ``record()`` kwarg signature.
+        """
+        raise NotImplementedError(
+            "LLCActivityLogService.record_bulk() — concrete impl in GH#8216"
+        )

--- a/autobot-backend/llc/tests/__init__.py
+++ b/autobot-backend/llc/tests/__init__.py
@@ -1,0 +1,1 @@
+"""LLC test package."""

--- a/autobot-backend/services/audit/audit_log.py
+++ b/autobot-backend/services/audit/audit_log.py
@@ -17,7 +17,20 @@ Key design choices
 - ``record_event()`` is the async implementation for direct await use.
 - ``query_audit_log()`` filters in-memory after a Redis range scan — acceptable
   given the expected event volume and the 90-day retention window.
+
+.. deprecated::
+    Use ``services.audit.unified_audit`` directly (GH#8290 Phase 2).
+    This module will be removed in Phase 3 once all callers are migrated.
 """
+
+import warnings
+
+warnings.warn(
+    "services.audit.audit_log is deprecated (GH#8290). "
+    "Import from services.audit.unified_audit instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 import json
 import time

--- a/autobot-backend/services/audit/unified_audit.py
+++ b/autobot-backend/services/audit/unified_audit.py
@@ -9,9 +9,10 @@ This module provides one canonical surface; the three originals forward to it
 via shim helpers defined at the bottom of each legacy file.
 
 Migration plan:
-  Phase 1 (this PR):   unified_audit.py lands; legacy files add shim wrappers.
-  Phase 2 (follow-up): Migrate callers area-by-area (security → compliance →
-                        knowledge) to import directly from unified_audit.
+  Phase 1 (done):   unified_audit.py landed; legacy files have shim wrappers.
+  Phase 2 (GH#8290): Callers migrated area-by-area to import from here.
+                     Backwards-compatible bridge symbols are exported so callers
+                     only need to update their import line, not their call sites.
   Phase 3 (follow-up): Remove the three legacy files once all callers migrated.
 """
 
@@ -224,3 +225,130 @@ async def emit_knowledge(
             ip_address=ip_address,
         )
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 (GH#8290): Backwards-compatible bridge symbols for migrated callers
+#
+# Callers of the three legacy modules update only their import line.
+# These bridges accept the EXACT same signatures as the legacy functions so no
+# call-site edits are needed.
+# ---------------------------------------------------------------------------
+
+# --- Re-export legacy enum types so import-only callers need no changes ----
+
+import warnings as _warnings  # noqa: E402
+
+with _warnings.catch_warnings():
+    # Suppress the DeprecationWarnings these modules emit at import time — they
+    # are designed to warn external callers, not the canonical migration target.
+    _warnings.simplefilter("ignore", DeprecationWarning)
+    from services.event_log import EventType  # noqa: E402
+    from services.audit.audit_log import AuditAction  # noqa: E402
+    from knowledge.audit_log import AuditEventType, KnowledgeAuditLog as _KnowledgeAuditLog  # noqa: E402
+
+
+# --- Drop-in replacements for services/event_log.emit() and query_events() -
+
+def emit(  # type: ignore[misc]  — intentional override of local name
+    event_type: "EventType",
+    user_id: str | None = None,
+    resource_type: str | None = None,
+    resource_id: str | None = None,
+    metadata: Dict[str, Any] | None = None,
+    ip_address: str | None = None,
+) -> None:
+    """Bridge: drop-in for ``services.event_log.emit()`` (GH#8290 Phase 2)."""
+    emit_compliance(
+        action=event_type.value if hasattr(event_type, "value") else str(event_type),
+        actor_id=user_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        metadata=metadata,
+        ip_address=ip_address,
+    )
+
+
+async def query_events(
+    user_id: str | None = None,
+    event_type: str | None = None,
+    from_ts: float | None = None,
+    to_ts: float | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> List[Dict[str, Any]]:
+    """Bridge: drop-in for ``services.event_log.query_events()`` (GH#8290 Phase 2)."""
+    return await query(
+        category=AuditCategory.COMPLIANCE,
+        actor_id=user_id,
+        action=event_type,
+        from_ts=from_ts,
+        to_ts=to_ts,
+        limit=limit,
+        offset=offset,
+    )
+
+
+# --- Drop-in replacement for services/audit/audit_log.audit_record() -------
+
+def audit_record(
+    user_id: str,
+    action: "AuditAction",
+    resource_type: str | None = None,
+    resource_id: str | None = None,
+    metadata: Dict[str, Any] | None = None,
+    ip_address: str | None = None,
+    session_id: str | None = None,
+    outcome: str = "success",
+) -> None:
+    """Bridge: drop-in for ``services.audit.audit_log.audit_record()`` (GH#8290 Phase 2)."""
+    emit_security(
+        action=action.value if hasattr(action, "value") else str(action),
+        actor_id=user_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        metadata=metadata,
+        ip_address=ip_address,
+        session_id=session_id,
+        outcome=outcome,
+    )
+
+
+# --- Drop-in compatibility class for knowledge/audit_log.KnowledgeAuditLog --
+
+class KnowledgeAuditLog(_KnowledgeAuditLog):
+    """Bridge: subclass of ``KnowledgeAuditLog`` that delegates to unified_audit.
+
+    Callers that instantiate ``KnowledgeAuditLog(redis_client)`` and call
+    ``.log_event()`` continue to work unchanged (GH#8290 Phase 2).
+    The ``log_event`` override also writes to the unified Redis key so all
+    knowledge events appear in the unified audit stream.
+    """
+
+    async def log_event(
+        self,
+        event_type: "AuditEventType",
+        user_id: str,
+        fact_id: str | None = None,
+        organization_id: str | None = None,
+        details: Dict | None = None,
+        ip_address: str | None = None,
+    ) -> str:
+        event_id = await super().log_event(
+            event_type=event_type,
+            user_id=user_id,
+            fact_id=fact_id,
+            organization_id=organization_id,
+            details=details,
+            ip_address=ip_address,
+        )
+        # Also write to unified stream
+        await emit_knowledge(
+            action=event_type.value if hasattr(event_type, "value") else str(event_type),
+            actor_id=user_id,
+            resource_type="fact" if fact_id else "knowledge",
+            resource_id=fact_id or organization_id,
+            metadata=details or {},
+            ip_address=ip_address,
+        )
+        return event_id

--- a/autobot-backend/services/event_log.py
+++ b/autobot-backend/services/event_log.py
@@ -5,7 +5,20 @@
 
 Stores structured compliance events in a Redis sorted set keyed by Unix
 timestamp.  All writes are fire-and-forget — callers are never blocked.
+
+.. deprecated::
+    Use ``services.audit.unified_audit`` directly (GH#8290 Phase 2).
+    This module will be removed in Phase 3 once all callers are migrated.
 """
+
+import warnings
+
+warnings.warn(
+    "services.event_log is deprecated (GH#8290). "
+    "Import from services.audit.unified_audit instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 import json
 import time

--- a/autobot-backend/services/gateway/gateway.py
+++ b/autobot-backend/services/gateway/gateway.py
@@ -360,9 +360,20 @@ _gateway_instance: Gateway | None = None
 
 
 async def get_gateway() -> Gateway:
-    """Get the singleton Gateway instance."""
+    """Get the singleton Gateway instance.
+
+    GH#8268: injects DistributedAgentCoordinator._router so user-chat messages
+    flow through RLRouter's Q-learning selection (GH#881 prerequisite is closed).
+    """
     global _gateway_instance
     if _gateway_instance is None:
-        _gateway_instance = Gateway()
+        try:
+            from agents.agent_orchestration import get_distributed_agent_coordinator
+
+            coordinator = get_distributed_agent_coordinator()
+            _gateway_instance = Gateway(agent_router=coordinator._router)
+        except Exception:
+            logger.warning("DistributedAgentCoordinator unavailable; Gateway starts without RLRouter")
+            _gateway_instance = Gateway()
         await _gateway_instance.start()
     return _gateway_instance

--- a/autobot-backend/services/run_jwt.py
+++ b/autobot-backend/services/run_jwt.py
@@ -67,7 +67,7 @@ from autobot_shared.auth.jwt_core import (
 from autobot_shared.fire_and_forget import run_redis_write
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
-from services.audit.audit_log import AuditAction, audit_record
+from services.audit.unified_audit import AuditAction, audit_record  # GH#8290 Phase 2
 
 
 class JWTRefreshConflictError(Exception):


### PR DESCRIPTION
## Summary

Batch L — 5 backend issues across schema alignment, module consolidation, gateway wiring, audit migration, and LLC skeleton.

- **GH#8312** `AdapterTestResponse` schema corrected: `status`/`details` → `healthy`/`diagnostics`/`models_available`/`response_time`/`metadata` to match `EnvironmentTestResponse` field names
- **GH#8268** `get_gateway()` now injects `DistributedAgentCoordinator._router` for RLRouter Q-learning selection; gracefully degrades if coordinator unavailable
- **GH#8261** New `autobot-backend/llc/` skeleton: enum SSOT (8 enums, `LLCRunStatus` collapses 2 dupes), `LLCActivityLogService` + `ActivityEventType` (33 events), `LLCRAGAssembler`, `LLCWebSocketPublisher`; wired into `feature_routers.py`
- **GH#8290** Audit Phase 2: 8 callers migrated to `unified_audit` (import-only, no call-site edits); bridge shims added; 3 legacy files deprecated
- **GH#6757** `AntiPatternType` enum SSOT: 11 members from `code_intelligence` merged into canonical `code_analysis/src`; facade re-exports from canonical; legacy aliases preserved for backward compatibility

## Test plan

- [ ] All 7 key Python files parse cleanly (AST-verified in review)
- [ ] `AdapterTestResponse` only constructed via Pydantic defaults — no construction call sites to update
- [ ] Gateway falls back gracefully when `DistributedAgentCoordinator` unavailable
- [ ] LLC health endpoint responds at `/llc/health` (wired via `feature_routers`)
- [ ] Audit bridge symbols (`EventType`, `AuditAction`, `audit_record`, `emit`, `query_events`) re-exported from `unified_audit`
- [ ] `AntiPatternType` backward-compatible via legacy aliases (`DATA_CLUMPS`, `DUPLICATE_ABSTRACTION`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)