### PR TITLE
fix(api): align AdapterTestResponse schema with EnvironmentTestResult.to_dict() (MVA-748)

### DIFF
--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -2080,8 +2080,11 @@ class AdapterTestResponse(BaseModel):
     """Response for GET /{adapter_type}/test."""
 
     adapter_type: str = ""
-    status: str = ""
-    details: Dict[str, Any] = Field(default_factory=dict)
+    healthy: bool = False
+    diagnostics: List[Any] = Field(default_factory=list)
+    models_available: List[Any] = Field(default_factory=list)
+    response_time: float = 0.0
+    metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
 class AdapterModelsResponse(BaseModel):


### PR DESCRIPTION
## Summary

- Fixes `AdapterTestResponse` in `autobot-backend/api/schemas_agent.py` to match the actual fields returned by `EnvironmentTestResult.to_dict()`
- Removes stale `status: str` and `details: Dict` fields
- Adds `healthy: bool`, `diagnostics: List[Any]`, `models_available: List[Any]`, `response_time: float`, `metadata: Dict[str, Any]`
- OpenAPI docs and SDK clients will now reflect the correct response shape

## Related
- Closes MVA-748
- Discovered in PR #8307 / GH#8312

## Test plan
- [ ] Schema fields in OpenAPI docs match `EnvironmentTestResult.to_dict()` output
- [ ] `GET /{adapter_type}/test` endpoint returns correct JSON shape
- [ ] No runtime regression on existing adapter test calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)