### PR TITLE
fix(vector-search): batch M-A — 5 bugs GH#8385 GH#8386 GH#8387 GH#8388 GH#8389

### DIFF
--- a/autobot-backend/npu_semantic_search.py
+++ b/autobot-backend/npu_semantic_search.py
@@ -781,7 +781,7 @@ class NPUSemanticSearch:
         underlying ``asyncio.to_thread`` is dispatched once instead of N times.
         Returns a dict mapping original query index → (results, metrics).
         """
-        kb_collection = getattr(self.knowledge_base, "_async_chroma_collection", None)
+        kb_collection = self.collections.get("text")
         if kb_collection is None:
             return {}
 
@@ -812,11 +812,11 @@ class NPUSemanticSearch:
 
             results: List[SearchResult] = []
             for j, doc_id in enumerate(ids or []):
-                score = 1.0 - (dists[j] if dists else 0.0)
+                score = 1.0 - (dists[j] if dists and j < len(dists) else 0.0)
                 results.append(
                     SearchResult(
-                        content=(docs[j] if docs else ""),
-                        metadata=(metas[j] if metas else {}),
+                        content=(docs[j] if docs and j < len(docs) else ""),
+                        metadata=(metas[j] if metas and j < len(metas) else {}),
                         score=score,
                         doc_id=doc_id,
                         device_used=embedding_device,
@@ -873,11 +873,15 @@ class NPUSemanticSearch:
             logger.info("✅ Batch search: all %s queries from cache", len(queries))
             return output  # type: ignore[return-value]
 
-        emb_tasks = [
-            self._generate_optimized_embedding(queries[i], enable_npu_acceleration, None)
-            for i in miss_indices
-        ]
-        emb_results = await asyncio.gather(*emb_tasks, return_exceptions=True)
+        _emb_sem = asyncio.Semaphore(10)
+
+        async def _embed_with_limit(i: int):
+            async with _emb_sem:
+                return await self._generate_optimized_embedding(queries[i], enable_npu_acceleration, None)
+
+        emb_results = await asyncio.gather(
+            *[_embed_with_limit(i) for i in miss_indices], return_exceptions=True
+        )
 
         valid_miss_indices: List[int] = []
         valid_embeddings: List[List[float]] = []
@@ -893,17 +897,16 @@ class NPUSemanticSearch:
             valid_miss_indices.append(orig_idx)
             valid_embeddings.append(emb_array.tolist() if hasattr(emb_array, "tolist") else list(emb_array))
 
-        if valid_miss_indices and getattr(self.knowledge_base, "_async_chroma_collection", None) is not None:
+        if valid_miss_indices and self.collections.get("text") is not None:
             batch_hits = await self._batch_chromadb_search(
                 valid_miss_indices, valid_embeddings, similarity_top_k, filters, embedding_device
             )
             for orig_idx, result_tuple in batch_hits.items():
                 output[orig_idx] = result_tuple
                 self._cache_result(cache_keys[orig_idx], result_tuple)
-            for orig_idx in valid_miss_indices:
-                if output[orig_idx] is None:
-                    output[orig_idx] = self._create_error_search_result()
-        elif valid_miss_indices:
+
+        uncovered = [i for i in valid_miss_indices if output[i] is None]
+        if uncovered:
             semaphore = asyncio.Semaphore(10)
 
             async def _search_with_semaphore(idx: int) -> Tuple[int, Any]:
@@ -917,7 +920,7 @@ class NPUSemanticSearch:
                     return idx, result
 
             fallback_results = await asyncio.gather(
-                *[_search_with_semaphore(i) for i in valid_miss_indices], return_exceptions=True
+                *[_search_with_semaphore(i) for i in uncovered], return_exceptions=True
             )
             for item in fallback_results:
                 if isinstance(item, Exception):

--- a/autobot-backend/utils/gpu_vector_search.py
+++ b/autobot-backend/utils/gpu_vector_search.py
@@ -424,7 +424,7 @@ class GPUVectorIndex:
             # Convert distance to similarity score
             # For IP (inner product), higher is better
             # For L2, lower is better - convert to similarity
-            if self.config.index_type in (IndexType.FLAT_IP, IndexType.IVF_FLAT):
+            if self.config.index_type in (IndexType.FLAT_IP, IndexType.IVF_FLAT, IndexType.SQ8):
                 score = float(dist)  # Already similarity
             else:
                 score = 1.0 / (1.0 + float(dist))  # Convert L2 distance to similarity
@@ -541,7 +541,7 @@ class GPUVectorIndex:
 
                 doc_id = self.id_map.get(idx, f"unknown_{idx}")
 
-                if self.config.index_type in (IndexType.FLAT_IP, IndexType.IVF_FLAT):
+                if self.config.index_type in (IndexType.FLAT_IP, IndexType.IVF_FLAT, IndexType.SQ8):
                     score = float(dist)
                 else:
                     score = 1.0 / (1.0 + float(dist))


### PR DESCRIPTION
## Summary

Five correctness bugs in the NPU/GPU vector search stack, all traced to the batch-search path introduced in issue #8153.

- **GH#8387** — `IndexType.SQ8` was missing from the inner-product tuple in `_convert_search_results` and `_convert_batch_search_results`. SQ8 indexes are created with `METRIC_INNER_PRODUCT`, so the score should not be inverted via `1/(1+dist)` — every SQ8 result was being corrupted.
- **GH#8385** — `_batch_chromadb_search` read `knowledge_base._async_chroma_collection` (the `autobot_memory` corpus) instead of `self.collections.get("text")` (the `autobot_text_embeddings` corpus used by `enhanced_search`). On most deployments `autobot_memory` has no documents, so batch search silently returned empty results. Fixed both the method-level assignment and the `batch_search()` guard.
- **GH#8386** — The `elif valid_miss_indices` fallback was unreachable when `_batch_chromadb_search` returned `{}` due to an exception, because the enclosing `if` branch was taken regardless. Restructured so any uncovered index after the batch attempt falls through to `enhanced_search`.
- **GH#8388** — Embedding generation for cache misses used an unbounded `asyncio.gather`, which could flood the NPU/Redis dispatch queue. Wrapped with `asyncio.Semaphore(10)`.
- **GH#8389** — The inner loop in `_batch_chromadb_search` accessed `dists[j]`, `docs[j]`, and `metas[j]` without bounds checking. Added `j < len(...)` guards to prevent `IndexError` when ChromaDB returns mismatched-length arrays.

## Files changed

- `autobot-backend/utils/gpu_vector_search.py` — GH#8387 (2 hunks)
- `autobot-backend/npu_semantic_search.py` — GH#8385, GH#8386, GH#8388, GH#8389

## Verification

```
python3 -m py_compile autobot-backend/npu_semantic_search.py autobot-backend/utils/gpu_vector_search.py
# → OK
```

Closes #8385
Closes #8386
Closes #8387
Closes #8388
Closes #8389

[@CodeReviewer](agent://24536e3f-a21f-4ed9-950f-e883654cab27) — please review and merge.