### PR TITLE
fix(classification,llm-cache): batch M-B — crash guards and cache integrity (GH#8381 GH#8382 GH#8383 GH#8384)

### DIFF
--- a/autobot-backend/agents/gemma_classification_agent.py
+++ b/autobot-backend/agents/gemma_classification_agent.py
@@ -35,7 +35,15 @@ logger = get_logger(__name__)
 
 # Redis-backed classification result cache TTL (seconds).
 # Tunable via AUTOBOT_CLASSIFICATION_CACHE_TTL; default 5 minutes.
-_CLASSIFICATION_CACHE_TTL = int(os.environ.get("AUTOBOT_CLASSIFICATION_CACHE_TTL", "300"))
+try:
+    _CLASSIFICATION_CACHE_TTL = int(os.environ.get("AUTOBOT_CLASSIFICATION_CACHE_TTL", "300"))
+    if _CLASSIFICATION_CACHE_TTL <= 0:
+        _CLASSIFICATION_CACHE_TTL = 300
+        logger.warning("AUTOBOT_CLASSIFICATION_CACHE_TTL <= 0, using default 300s")
+except (ValueError, TypeError):
+    _CLASSIFICATION_CACHE_TTL = 300
+    logger.warning("Invalid AUTOBOT_CLASSIFICATION_CACHE_TTL=%r, using default 300s",
+                   os.environ.get("AUTOBOT_CLASSIFICATION_CACHE_TTL"))
 _CLASSIFICATION_REDIS_KEY_PREFIX = "gemma_classify:"
 
 
@@ -164,7 +172,7 @@ Respond with valid JSON:
 
         result = await self._gemma_classify(user_message)
 
-        if result and redis:
+        if result and redis and _CLASSIFICATION_CACHE_TTL > 0:
             try:
                 await redis.set(cache_key, json.dumps(result), ex=_CLASSIFICATION_CACHE_TTL)
             except Exception as exc:
@@ -207,12 +215,16 @@ Respond with valid JSON:
             async with sem:
                 return await self.classify_request(msg)
 
-        unique_results: dict[str, ClassificationResult] = dict(
-            zip(
-                hash_to_msg.keys(),
-                await asyncio.gather(*[_one(m) for m in hash_to_msg.values()]),
-            )
+        raw_results = await asyncio.gather(
+            *[_one(m) for m in hash_to_msg.values()], return_exceptions=True
         )
+        unique_results: dict[str, ClassificationResult] = {}
+        for h, msg, result in zip(hash_to_msg.keys(), hash_to_msg.values(), raw_results):
+            if isinstance(result, BaseException):
+                logger.warning("classify_multiple: task failed for hash %s: %s", h, result)
+                unique_results[h] = self._create_fallback_result(msg, TaskComplexity.SIMPLE)
+            else:
+                unique_results[h] = result
 
         return [unique_results[h] for h in msg_hashes]
 

--- a/autobot-backend/llm_shared/semantic_cache.py
+++ b/autobot-backend/llm_shared/semantic_cache.py
@@ -62,6 +62,7 @@ class SemanticLLMCache:
         # Parallel arrays: embeddings matrix + (cache_key, response) pairs.
         self._embeddings: list[np.ndarray] = []
         self._entries: list[tuple[str, Any]] = []  # (cache_key, CachedResponse)
+        self._entry_keys: set[str] = set()
         self._lock = asyncio.Lock()
 
         self._stats = {"semantic_hits": 0, "semantic_misses": 0, "entries": 0}
@@ -162,17 +163,20 @@ class SemanticLLMCache:
     def evict(self, count: int) -> int:
         return self._exact.evict(count)
 
-    def clear(self) -> None:
+    async def clear(self) -> None:
         self._exact.clear()
-        self._embeddings.clear()
-        self._entries.clear()
-        self._stats["entries"] = 0
+        async with self._lock:
+            self._embeddings.clear()
+            self._entries.clear()
+            self._entry_keys.clear()
+            self._stats["entries"] = 0
 
     async def clear_all(self) -> dict:
         result = await self._exact.clear_all()
         async with self._lock:
             self._embeddings.clear()
             self._entries.clear()
+            self._entry_keys.clear()
             self._stats["entries"] = 0
         return result
 
@@ -214,15 +218,16 @@ class SemanticLLMCache:
         return None, None
 
     def _add_entry(self, embedding: np.ndarray, cache_key: str, response: Any) -> None:
-        """
-        Insert a new embedding+entry pair.  Evicts the oldest when full.
-        Must be called inside self._lock.
-        """
+        """Insert a new embedding+entry pair. Deduplicates by cache_key. Evicts oldest when full.
+        Must be called inside self._lock."""
+        if cache_key in self._entry_keys:
+            return
         if len(self._entries) >= self._max_entries:
             self._embeddings.pop(0)
-            self._entries.pop(0)
+            evicted_key, _ = self._entries.pop(0)
+            self._entry_keys.discard(evicted_key)
             self._stats["entries"] = max(0, self._stats["entries"] - 1)
-
         self._embeddings.append(embedding)
         self._entries.append((cache_key, response))
+        self._entry_keys.add(cache_key)
         self._stats["entries"] += 1

--- a/autobot-backend/tests/test_semantic_llm_cache.py
+++ b/autobot-backend/tests/test_semantic_llm_cache.py
@@ -161,6 +161,19 @@ def test_eviction_when_index_full():
 
     assert len(sc._entries) == 3, "Index should evict oldest when full"
     assert sc._entries[0][0] == "key1", "key0 (oldest) should have been evicted"
+    assert "key0" not in sc._entry_keys, "Evicted key must be removed from _entry_keys"
+    assert "key1" in sc._entry_keys
+
+
+def test_add_entry_deduplicates_by_cache_key():
+    exact = MagicMock()
+    sc = SemanticLLMCache(exact)
+
+    sc._add_entry(_unit_vec(dim=4, seed=1), "dup_key", _resp("first"))
+    sc._add_entry(_unit_vec(dim=4, seed=2), "dup_key", _resp("second"))
+
+    assert sc._stats["entries"] == 1, "Duplicate cache_key must not add a second entry"
+    assert sc._entries[0][1].content == "first", "Original entry must be preserved"
 
 
 # ---------------------------------------------------------------------------
@@ -176,14 +189,16 @@ def test_evict_delegates_to_exact():
     exact.evict.assert_called_once_with(3)
 
 
-def test_clear_resets_index():
+@pytest.mark.asyncio
+async def test_clear_resets_index():
     exact = MagicMock()
     sc = SemanticLLMCache(exact)
     sc._add_entry(_unit_vec(4), "k", _resp())
     assert sc._stats["entries"] == 1
 
-    sc.clear()
+    await sc.clear()
     assert len(sc._entries) == 0
+    assert len(sc._entry_keys) == 0
     assert sc._stats["entries"] == 0
     exact.clear.assert_called_once()
 


### PR DESCRIPTION
## Summary

Batch M-B: 4 bug fixes in classification and llm-cache subsystems.

- **GH#8381** — `gemma_classification_agent.py`: wrap bare `int()` for `AUTOBOT_CLASSIFICATION_CACHE_TTL` in `try/except (ValueError, TypeError)` + non-positive guard; invalid env value logs warning and falls back to 300s
- **GH#8382** — `gemma_classification_agent.py`: add `return_exceptions=True` to `asyncio.gather` in `classify_multiple`; per-hash fallback via `_create_fallback_result(SIMPLE)` prevents single exception from dropping entire batch
- **GH#8383** — `semantic_cache.py`: add `_entry_keys: set[str]` field; `_add_entry` deduplicates by `cache_key` in O(1); eviction removes evicted key from set
- **GH#8384** — `semantic_cache.py`: `clear()` converted to `async def` + acquires `_lock` before clearing; `_entry_keys` cleared in both `clear()` and `clear_all()`; TTL > 0 guard added to `_cached_classify()` Redis write

Closes #8381
Closes #8382
Closes #8383
Closes #8384