### PR TITLE
feat(plugins): autobot-plugins/ monorepo + @autobot/terminal + @autobot/vnc extraction (#4984 #4983 #4985)

### DIFF
--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -44,6 +44,8 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@autobot/terminal": "file:../autobot-plugins/terminal",
+    "@autobot/vnc": "file:../autobot-plugins/vnc",
     "@fontsource/inter": "^5.2.8",
     "@fortawesome/fontawesome-free": "^7.2.0",
     "@heroicons/vue": "^2.2.0",

--- a/autobot-frontend/src/components/plugins/TerminalPlugin.vue
+++ b/autobot-frontend/src/components/plugins/TerminalPlugin.vue
@@ -1,0 +1,15 @@
+<template>
+  <SshTerminal v-bind="$props" v-on="$attrs" />
+</template>
+
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Wire-in for @autobot/terminal — satisfies GH#6836 wiring gate for autobot-frontend
+import { SshTerminal } from '@autobot/terminal'
+
+defineProps<{
+  hostId: string
+  chatSessionId?: string | null
+}>()
+</script>

--- a/autobot-frontend/src/components/plugins/VncPlugin.vue
+++ b/autobot-frontend/src/components/plugins/VncPlugin.vue
@@ -1,17 +1,42 @@
 <template>
-  <VncViewer v-bind="$props" v-on="$attrs" />
+  <div class="vnc-plugin">
+    <VncViewer
+      :model-value="modelValue"
+      :host="host"
+      :loading="loading"
+      @update:model-value="$emit('update:modelValue', $event)"
+    />
+    <VncToolbar
+      :connected="modelValue"
+      :api-base-url="apiBaseUrl"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">
 // AutoBot - AI-Powered Automation Platform
 // Copyright (c) 2025 mrveiss
 // Wire-in for @autobot/vnc — satisfies GH#6836 wiring gate for autobot-frontend
-import { VncViewer } from '@autobot/vnc'
+import { VncViewer, VncToolbar } from '@autobot/vnc'
 import type { VncHost } from '@autobot/vnc'
 
 defineProps<{
   modelValue: boolean
   host?: VncHost
   loading?: boolean
+  /** Base URL for VNC API calls propagated to VncToolbar. Defaults to /api in plugin. */
+  apiBaseUrl?: string
+}>()
+
+defineEmits<{
+  'update:modelValue': [value: boolean]
 }>()
 </script>
+
+<style scoped>
+.vnc-plugin {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+</style>

--- a/autobot-frontend/src/components/plugins/VncPlugin.vue
+++ b/autobot-frontend/src/components/plugins/VncPlugin.vue
@@ -1,0 +1,17 @@
+<template>
+  <VncViewer v-bind="$props" v-on="$attrs" />
+</template>
+
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Wire-in for @autobot/vnc — satisfies GH#6836 wiring gate for autobot-frontend
+import { VncViewer } from '@autobot/vnc'
+import type { VncHost } from '@autobot/vnc'
+
+defineProps<{
+  modelValue: boolean
+  host?: VncHost
+  loading?: boolean
+}>()
+</script>

--- a/autobot-frontend/src/plugins/registry.ts
+++ b/autobot-frontend/src/plugins/registry.ts
@@ -44,13 +44,16 @@ export const PLUGIN_MOUNT_REGISTRY: readonly PluginMountEntry[] = [
   // Built-in plugins bundled with AutoBot.
   // Third-party / marketplace plugins are discovered at runtime via the
   // backend API and resolved through getPluginComponent() below.
-  //
-  // Example entry (uncomment and adapt when a real plugin ships its UI):
-  // {
-  //   id: 'hello-plugin',
-  //   label: 'Hello Plugin',
-  //   loader: () => import('@/components/plugins/hello-plugin/HelloPlugin.vue'),
-  // },
+  {
+    id: 'terminal',
+    label: 'SSH Terminal',
+    loader: () => import('@/components/plugins/TerminalPlugin.vue'),
+  },
+  {
+    id: 'vnc',
+    label: 'VNC Viewer',
+    loader: () => import('@/components/plugins/VncPlugin.vue'),
+  },
 ] as const
 
 const _indexById = new Map<string, PluginMountEntry>(

--- a/autobot-plugins/terminal/index.ts
+++ b/autobot-plugins/terminal/index.ts
@@ -1,0 +1,22 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// @autobot/terminal — SSH terminal plugin for both frontends
+
+import type { App } from 'vue'
+import SshTerminal from './src/components/SshTerminal.vue'
+import BaseXTerminal from './src/components/BaseXTerminal.vue'
+
+export { SshTerminal, BaseXTerminal }
+export { useTerminalStore } from './src/composables/useTerminalStore'
+export type { HostConfig, TerminalSession, TerminalTab } from './src/composables/useTerminalStore'
+export { useWebSocket } from './src/composables/useWebSocket'
+export { usePollingJob } from './src/composables/usePollingJob'
+
+export const TerminalPlugin = {
+  install(app: App) {
+    app.component('SshTerminal', SshTerminal)
+    app.component('BaseXTerminal', BaseXTerminal)
+  },
+}
+
+export default TerminalPlugin

--- a/autobot-plugins/terminal/package.json
+++ b/autobot-plugins/terminal/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@autobot/terminal",
+  "version": "0.1.0",
+  "description": "AutoBot SSH terminal plugin — xterm.js + WebSocket SSH for both frontends",
+  "type": "module",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "scripts": {
+    "build": "vite build"
+  },
+  "peerDependencies": {
+    "@xterm/addon-fit": ">=0.11.0",
+    "@xterm/addon-web-links": ">=0.12.0",
+    "@xterm/xterm": ">=6.0.0",
+    "vue": ">=3.5.0"
+  },
+  "devDependencies": {
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.12.0",
+    "@xterm/xterm": "^6.0.0",
+    "@vitejs/plugin-vue": "^6.0.0",
+    "typescript": "~5.8.0",
+    "vite": "^6.0.0",
+    "vue": "^3.5.0"
+  }
+}

--- a/autobot-plugins/terminal/package.json
+++ b/autobot-plugins/terminal/package.json
@@ -12,7 +12,7 @@
     "@xterm/addon-fit": ">=0.11.0",
     "@xterm/addon-web-links": ">=0.12.0",
     "@xterm/xterm": ">=6.0.0",
-    "pinia": "^2.0.0",
+    "pinia": ">=2.0.0",
     "vue": ">=3.5.0"
   },
   "devDependencies": {

--- a/autobot-plugins/terminal/package.json
+++ b/autobot-plugins/terminal/package.json
@@ -12,6 +12,7 @@
     "@xterm/addon-fit": ">=0.11.0",
     "@xterm/addon-web-links": ">=0.12.0",
     "@xterm/xterm": ">=6.0.0",
+    "pinia": "^2.0.0",
     "vue": ">=3.5.0"
   },
   "devDependencies": {

--- a/autobot-plugins/terminal/src/components/BaseXTerminal.vue
+++ b/autobot-plugins/terminal/src/components/BaseXTerminal.vue
@@ -1,0 +1,264 @@
+<template>
+  <div class="base-xterm-container" ref="containerRef">
+    <div ref="terminalRef" class="xterm-wrapper"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+
+import { ref, shallowRef, onMounted, onUnmounted, watch, nextTick } from 'vue'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { WebLinksAddon } from '@xterm/addon-web-links'
+import '@xterm/xterm/css/xterm.css'
+import { createLogger } from '../utils'
+
+const logger = createLogger('BaseXTerminal')
+
+interface Props {
+  sessionId: string
+  autoConnect?: boolean
+  theme?: 'dark' | 'light'
+  readOnly?: boolean
+  fontSize?: number
+  fontFamily?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  autoConnect: true,
+  theme: 'dark',
+  readOnly: false,
+  fontSize: 14,
+  fontFamily: 'Monaco, Menlo, Ubuntu Mono, monospace',
+})
+
+const emit = defineEmits<{
+  ready: [terminal: Terminal]
+  data: [data: string]
+  resize: [cols: number, rows: number]
+  disposed: []
+  tabCompletion: [payload: { text: string; cursor: number }]
+  historyNavigate: [payload: { direction: 'up' | 'down'; lineBuffer: string }]
+  reverseSearch: [payload: { active: boolean; query: string }]
+  commandExecuted: [command: string]
+}>()
+
+const containerRef = ref<HTMLElement>()
+const terminalRef = ref<HTMLElement>()
+// CRITICAL: shallowRef prevents Vue proxy from intercepting xterm internals
+const terminal = shallowRef<Terminal>()
+const fitAddon = shallowRef<FitAddon>()
+const webLinksAddon = shallowRef<WebLinksAddon>()
+const addonsLoaded = ref(false)
+
+const currentLineBuffer = ref('')
+const cursorPosition = ref(0)
+const reverseSearchMode = ref(false)
+const reverseSearchQuery = ref('')
+
+const themes = {
+  dark: {
+    background: '#1a1b26', foreground: '#a9b1d6', cursor: '#c0caf5', cursorAccent: '#1a1b26',
+    selection: '#33467C', black: '#32344a', red: '#f7768e', green: '#9ece6a', yellow: '#e0af68',
+    blue: '#7aa2f7', magenta: '#ad8ee6', cyan: '#449dab', white: '#787c99',
+    brightBlack: '#444b6a', brightRed: '#ff7a93', brightGreen: '#b9f27c', brightYellow: '#ff9e64',
+    brightBlue: '#7da6ff', brightMagenta: '#bb9af7', brightCyan: '#0db9d7', brightWhite: '#acb0d0',
+  },
+  light: {
+    background: '#ffffff', foreground: '#3760bf', cursor: '#3760bf', cursorAccent: '#ffffff',
+    selection: '#b4dcfe', black: '#000000', red: '#e82424', green: '#587539', yellow: '#8c6c3e',
+    blue: '#2e7de9', magenta: '#9854f1', cyan: '#007197', white: '#6172b0',
+    brightBlack: '#a1a6c5', brightRed: '#f52a65', brightGreen: '#587539', brightYellow: '#8c6c3e',
+    brightBlue: '#2e7de9', brightMagenta: '#9854f1', brightCyan: '#007197', brightWhite: '#3760bf',
+  },
+}
+
+const handleEnterKey = () => { currentLineBuffer.value = ''; cursorPosition.value = 0 }
+const handleBackspace = () => {
+  if (cursorPosition.value > 0) {
+    currentLineBuffer.value = currentLineBuffer.value.slice(0, cursorPosition.value - 1) + currentLineBuffer.value.slice(cursorPosition.value)
+    cursorPosition.value--
+  }
+}
+const handleDeleteKey = () => {
+  if (cursorPosition.value < currentLineBuffer.value.length) {
+    currentLineBuffer.value = currentLineBuffer.value.slice(0, cursorPosition.value) + currentLineBuffer.value.slice(cursorPosition.value + 1)
+  }
+}
+const handleArrowKeys = (seq: string) => {
+  if (seq === 'D' && cursorPosition.value > 0) cursorPosition.value--
+  else if (seq === 'C' && cursorPosition.value < currentLineBuffer.value.length) cursorPosition.value++
+  else if (seq === 'H') cursorPosition.value = 0
+  else if (seq === 'F') cursorPosition.value = currentLineBuffer.value.length
+}
+const handleCtrlW = () => {
+  const before = currentLineBuffer.value.slice(0, cursorPosition.value)
+  const after = currentLineBuffer.value.slice(cursorPosition.value)
+  const match = before.match(/\S*\s*$/)
+  if (match) {
+    currentLineBuffer.value = before.slice(0, before.length - match[0].length) + after
+    cursorPosition.value -= match[0].length
+  }
+}
+const insertPrintableChar = (char: string) => {
+  currentLineBuffer.value = currentLineBuffer.value.slice(0, cursorPosition.value) + char + currentLineBuffer.value.slice(cursorPosition.value)
+  cursorPosition.value++
+}
+const updateLineBuffer = (data: string) => {
+  if (data === '\r' || data === '\n') { handleEnterKey(); return }
+  if (data === '\x7f' || data === '\b') { handleBackspace(); return }
+  if (data === '\x1b[3~') { handleDeleteKey(); return }
+  if (data.startsWith('\x1b[') && !data.includes('A') && !data.includes('B')) { handleArrowKeys(data.slice(2)); return }
+  if (data === '\x03' || data === '\x04' || data === '\x15') { handleEnterKey(); return }
+  if (data === '\x17') { handleCtrlW(); return }
+  if (data.length === 1 && data.charCodeAt(0) >= 32) insertPrintableChar(data)
+}
+
+const handleTerminalData = (data: string) => {
+  if (props.readOnly) return
+  if (data === '\x12') {
+    reverseSearchMode.value = !reverseSearchMode.value
+    reverseSearchQuery.value = ''
+    emit('reverseSearch', { active: reverseSearchMode.value, query: '' })
+    return
+  }
+  if (reverseSearchMode.value) {
+    if (data === '\x1b' || data === '\x03') { reverseSearchMode.value = false; emit('reverseSearch', { active: false, query: '' }); return }
+    if (data === '\r' || data === '\n') { reverseSearchMode.value = false; emit('reverseSearch', { active: false, query: reverseSearchQuery.value }) }
+    else if (data === '\x7f' || data === '\b') { reverseSearchQuery.value = reverseSearchQuery.value.slice(0, -1); emit('reverseSearch', { active: true, query: reverseSearchQuery.value }); return }
+    else if (data.length === 1 && data.charCodeAt(0) >= 32) { reverseSearchQuery.value += data; emit('reverseSearch', { active: true, query: reverseSearchQuery.value }); return }
+    return
+  }
+  if (data === '\x1b[A') { emit('historyNavigate', { direction: 'up', lineBuffer: currentLineBuffer.value }); return }
+  if (data === '\x1b[B') { emit('historyNavigate', { direction: 'down', lineBuffer: currentLineBuffer.value }); return }
+  if (data === '\t') { emit('tabCompletion', { text: currentLineBuffer.value, cursor: cursorPosition.value }); return }
+  updateLineBuffer(data)
+  if (data === '\r' || data === '\n') { if (currentLineBuffer.value.trim()) emit('commandExecuted', currentLineBuffer.value.trim()) }
+  emit('data', data)
+}
+
+const initTerminal = async () => {
+  if (!terminalRef.value) { logger.error('Terminal ref not available'); return }
+  try {
+    terminal.value = new Terminal({
+      cursorBlink: true, cursorStyle: 'block', fontSize: props.fontSize, fontFamily: props.fontFamily,
+      theme: themes[props.theme], allowTransparency: false, scrollback: 10000, tabStopWidth: 4,
+      convertEol: true, disableStdin: props.readOnly,
+    })
+    fitAddon.value = new FitAddon()
+    webLinksAddon.value = new WebLinksAddon()
+    terminal.value.loadAddon(fitAddon.value)
+    terminal.value.loadAddon(webLinksAddon.value)
+    addonsLoaded.value = true
+    terminal.value.open(terminalRef.value)
+    await nextTick()
+    fitAddon.value.fit()
+    terminal.value.onData(handleTerminalData)
+    terminal.value.onResize(({ cols, rows }) => emit('resize', cols, rows))
+    emit('ready', terminal.value)
+    logger.debug('Terminal initialized', { sessionId: props.sessionId })
+  } catch (error) {
+    logger.error('Failed to initialize terminal:', error)
+  }
+}
+
+const disposeTerminal = () => {
+  if (terminal.value) {
+    try {
+      if (addonsLoaded.value) terminal.value.dispose()
+      else logger.warn('Terminal addons not loaded, skipping full dispose')
+    } catch (error) {
+      logger.warn('Error disposing terminal:', error)
+    } finally {
+      terminal.value = undefined; fitAddon.value = undefined; webLinksAddon.value = undefined; addonsLoaded.value = false
+      emit('disposed')
+    }
+  }
+}
+
+const write = (data: string) => terminal.value?.write(data)
+const writeln = (data: string) => terminal.value?.writeln(data)
+const clear = () => terminal.value?.clear()
+const reset = () => { terminal.value?.reset(); currentLineBuffer.value = ''; cursorPosition.value = 0; reverseSearchMode.value = false; reverseSearchQuery.value = '' }
+const fit = () => fitAddon.value?.fit()
+const focus = () => terminal.value?.focus()
+const blur = () => terminal.value?.blur()
+const getTerminal = () => terminal.value
+const getLineBuffer = () => ({ text: currentLineBuffer.value, cursor: cursorPosition.value })
+const resetLineBuffer = () => { currentLineBuffer.value = ''; cursorPosition.value = 0 }
+const setLineBuffer = (text: string, cursor?: number) => { currentLineBuffer.value = text; cursorPosition.value = cursor !== undefined ? cursor : text.length }
+const applyCompletion = (prefix: string, completion: string) => {
+  if (!terminal.value) return
+  terminal.value.write('\x7f'.repeat(prefix.length) + completion)
+  const lastSpace = currentLineBuffer.value.lastIndexOf(' ')
+  currentLineBuffer.value = (lastSpace >= 0 ? currentLineBuffer.value.slice(0, lastSpace + 1) : '') + completion
+  cursorPosition.value = currentLineBuffer.value.length
+}
+const showCompletions = (completions: string[]) => {
+  if (!terminal.value || completions.length === 0) return
+  terminal.value.write('\r\n' + completions.join('  ') + '\r\n')
+}
+const handleCompletionResponse = (data: { completions: string[]; prefix: string; common_prefix?: string }) => {
+  const { completions, prefix, common_prefix: commonPrefix = '' } = data
+  if (completions.length === 0) return
+  if (completions.length === 1) applyCompletion(prefix, completions[0])
+  else if (commonPrefix && commonPrefix.length > prefix.length) applyCompletion(prefix, commonPrefix)
+  else showCompletions(completions)
+}
+const replaceLineWithHistoryCommand = (command: string) => {
+  if (!terminal.value) return
+  terminal.value.write('\x1b[D'.repeat(cursorPosition.value) + '\x1b[K' + command)
+  currentLineBuffer.value = command; cursorPosition.value = command.length
+}
+const showReverseSearchPrompt = (query: string, match: string) => {
+  if (!terminal.value) return
+  terminal.value.write('\r\x1b[K' + `\r(reverse-i-search)\`${query}': ${match}`)
+}
+const exitReverseSearch = () => { reverseSearchMode.value = false; reverseSearchQuery.value = '' }
+
+defineExpose({
+  write, writeln, clear, reset, fit, focus, blur, getTerminal,
+  getLineBuffer, resetLineBuffer, setLineBuffer, applyCompletion, showCompletions,
+  handleCompletionResponse, replaceLineWithHistoryCommand, showReverseSearchPrompt, exitReverseSearch,
+})
+
+watch(() => props.theme, (t) => { if (terminal.value) terminal.value.options.theme = themes[t] })
+watch(() => props.readOnly, (ro) => {
+  if (terminal.value) {
+    terminal.value.options.disableStdin = ro
+    if (!ro) nextTick(() => terminal.value?.focus())
+    else terminal.value.blur()
+  }
+})
+
+const handleResize = () => { fitAddon.value?.fit() }
+let visibilityObserver: IntersectionObserver | null = null
+
+onMounted(async () => {
+  await initTerminal()
+  window.addEventListener('resize', handleResize)
+  setTimeout(() => fitAddon.value?.fit(), 100)
+  if (containerRef.value) {
+    visibilityObserver = new IntersectionObserver((entries) => {
+      entries.forEach((e) => { if (e.isIntersecting && e.intersectionRatio > 0) setTimeout(() => fitAddon.value?.fit(), 50) })
+    }, { threshold: [0, 0.1] })
+    visibilityObserver.observe(containerRef.value)
+  }
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', handleResize)
+  if (visibilityObserver) { visibilityObserver.disconnect(); visibilityObserver = null }
+  disposeTerminal()
+})
+</script>
+
+<style scoped>
+.base-xterm-container { width: 100%; height: 100%; overflow: hidden; background-color: #1a1b26; }
+.xterm-wrapper { width: 100%; height: 100%; padding: 8px; }
+:deep(.xterm) { height: 100%; padding: 0; }
+:deep(.xterm-viewport) { overflow-y: auto; }
+:deep(.xterm-screen) { width: 100%; }
+</style>

--- a/autobot-plugins/terminal/src/components/BaseXTerminal.vue
+++ b/autobot-plugins/terminal/src/components/BaseXTerminal.vue
@@ -134,8 +134,9 @@ const handleTerminalData = (data: string) => {
   if (data === '\x1b[A') { emit('historyNavigate', { direction: 'up', lineBuffer: currentLineBuffer.value }); return }
   if (data === '\x1b[B') { emit('historyNavigate', { direction: 'down', lineBuffer: currentLineBuffer.value }); return }
   if (data === '\t') { emit('tabCompletion', { text: currentLineBuffer.value, cursor: cursorPosition.value }); return }
+  const command = (data === '\r' || data === '\n') ? currentLineBuffer.value.trim() : ''
   updateLineBuffer(data)
-  if (data === '\r' || data === '\n') { if (currentLineBuffer.value.trim()) emit('commandExecuted', currentLineBuffer.value.trim()) }
+  if (command) emit('commandExecuted', command)
   emit('data', data)
 }
 

--- a/autobot-plugins/terminal/src/components/SshTerminal.vue
+++ b/autobot-plugins/terminal/src/components/SshTerminal.vue
@@ -1,0 +1,282 @@
+<template>
+  <div class="ssh-terminal" ref="terminalContainer">
+    <div class="connection-bar" :class="connectionState">
+      <span class="status-indicator"></span>
+      <span class="status-text">{{ statusText }}</span>
+      <button
+        v-if="connectionState === 'error' || connectionState === 'disconnected'"
+        class="reconnect-btn"
+        @click="connect"
+      >
+        ↺ Reconnect
+      </button>
+    </div>
+    <div class="terminal-viewport" ref="terminalViewport"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+
+import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { WebLinksAddon } from '@xterm/addon-web-links'
+import '@xterm/xterm/css/xterm.css'
+import { createLogger } from '../utils'
+import { usePollingJob } from '../composables/usePollingJob'
+import { useWebSocket } from '../composables/useWebSocket'
+
+const logger = createLogger('SshTerminal')
+
+const props = defineProps<{
+  hostId: string
+  chatSessionId?: string | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'connected'): void
+  (e: 'disconnected'): void
+  (e: 'error', message: string): void
+}>()
+
+const terminalContainer = ref<HTMLDivElement>()
+const terminalViewport = ref<HTMLDivElement>()
+const connectionState = ref<'disconnected' | 'connecting' | 'connected' | 'error'>('disconnected')
+const errorMessage = ref('')
+
+let terminal: Terminal | null = null
+let fitAddon: FitAddon | null = null
+
+const wsUrl = ref('')
+
+const buildWsUrl = () => {
+  const params = props.chatSessionId ? `?conversation_id=${props.chatSessionId}` : ''
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const host = window.location.host
+  return `${protocol}//${host}/api/terminal/ws/ssh/${props.hostId}${params}`
+}
+
+const { send: wsSend, connect: wsConnect, disconnect: wsDisconnect, isConnected: wsIsConnected } = useWebSocket(wsUrl, {
+  autoConnect: false,
+  autoReconnect: false,
+  parseJSON: false,
+  onOpen: () => {
+    logger.info('SSH WebSocket connected')
+    connectionState.value = 'connected'
+    emit('connected')
+  },
+  onMessage: (data: unknown) => {
+    try {
+      handleMessage(JSON.parse(data as string))
+    } catch (e) {
+      logger.error('Failed to parse SSH message:', e)
+    }
+  },
+  onError: () => {
+    connectionState.value = 'error'
+    errorMessage.value = 'Connection error'
+    emit('error', 'Connection error')
+  },
+  onClose: (event: CloseEvent) => {
+    logger.info('SSH WebSocket closed:', { code: event.code, reason: event.reason })
+    connectionState.value = 'disconnected'
+    emit('disconnected')
+  },
+})
+
+const statusText = computed(() => {
+  switch (connectionState.value) {
+    case 'connecting': return 'Connecting to host...'
+    case 'connected': return 'Connected'
+    case 'error': return `Error: ${errorMessage.value}`
+    default: return 'Disconnected'
+  }
+})
+
+const initTerminal = () => {
+  if (!terminalViewport.value || terminal) return
+
+  terminal = new Terminal({
+    cursorBlink: true,
+    fontSize: 14,
+    fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+    theme: {
+      background: '#1e1e1e',
+      foreground: '#d4d4d4',
+      cursor: '#aeafad',
+      selectionBackground: '#264f78',
+      black: '#1e1e1e',
+      red: '#f44747',
+      green: '#608b4e',
+      yellow: '#dcdcaa',
+      blue: '#569cd6',
+      magenta: '#c586c0',
+      cyan: '#4ec9b0',
+      white: '#d4d4d4',
+      brightBlack: '#808080',
+      brightRed: '#f44747',
+      brightGreen: '#608b4e',
+      brightYellow: '#dcdcaa',
+      brightBlue: '#569cd6',
+      brightMagenta: '#c586c0',
+      brightCyan: '#4ec9b0',
+      brightWhite: '#ffffff',
+    },
+    scrollback: 10000,
+    allowProposedApi: true,
+  })
+
+  fitAddon = new FitAddon()
+  terminal.loadAddon(fitAddon)
+  terminal.loadAddon(new WebLinksAddon())
+  terminal.open(terminalViewport.value)
+
+  nextTick(() => { fitAddon?.fit() })
+
+  terminal.onData((data) => { sendToServer({ type: 'input', text: data }) })
+  terminal.onResize(({ cols, rows }) => { sendToServer({ type: 'resize', cols, rows }) })
+
+  logger.info('Terminal initialized')
+}
+
+const connect = () => {
+  if (wsIsConnected.value) return
+  connectionState.value = 'connecting'
+  errorMessage.value = ''
+  wsUrl.value = buildWsUrl()
+  logger.info(`Connecting to SSH WebSocket: ${wsUrl.value}`)
+  wsConnect()
+}
+
+interface SSHTerminalMessage {
+  type: 'input' | 'resize' | 'ping' | 'output' | 'connected' | 'error' | 'terminal_closed' | 'pong'
+  content?: string
+  text?: string
+  cols?: number
+  rows?: number
+  host?: { name?: string }
+}
+
+const sendToServer = (message: SSHTerminalMessage) => { wsSend(message) }
+
+const handleMessage = (message: SSHTerminalMessage) => {
+  switch (message.type) {
+    case 'output':
+      if (terminal && message.content) terminal.write(message.content)
+      break
+    case 'connected':
+      logger.info('SSH session established:', message.host?.name)
+      if (terminal && message.content) terminal.write(message.content)
+      break
+    case 'error':
+      logger.error('SSH error:', message.content)
+      errorMessage.value = message.content ?? ''
+      if (terminal) terminal.write(`\r\n\x1b[31mError: ${message.content}\x1b[0m\r\n`)
+      break
+    case 'terminal_closed':
+      logger.info('SSH session closed:', message.content)
+      connectionState.value = 'disconnected'
+      if (terminal) terminal.write(`\r\n\x1b[33m${message.content}\x1b[0m\r\n`)
+      break
+    case 'pong':
+      break
+    default:
+      logger.debug('Unknown message type:', message.type)
+  }
+}
+
+const disconnect = () => { wsDisconnect() }
+const handleResize = () => { if (fitAddon) fitAddon.fit() }
+
+const { start: startHeartbeat, stop: stopHeartbeat } = usePollingJob(
+  async (_: string) => { if (wsIsConnected.value) sendToServer({ type: 'ping' }) },
+  { intervalMs: 30000, maxAttempts: Number.MAX_SAFE_INTEGER }
+)
+
+watch(() => props.hostId, (newId, oldId) => {
+  if (newId !== oldId) {
+    disconnect()
+    nextTick(() => connect())
+  }
+})
+
+onMounted(() => {
+  initTerminal()
+  connect()
+  startHeartbeat()
+  window.addEventListener('resize', handleResize)
+})
+
+onUnmounted(() => {
+  stopHeartbeat()
+  window.removeEventListener('resize', handleResize)
+  if (terminal) { terminal.dispose(); terminal = null }
+})
+
+defineExpose({ connect, disconnect, sendToServer })
+</script>
+
+<style scoped>
+.ssh-terminal {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #1e1e1e;
+}
+
+.connection-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: 12px;
+  border-bottom: 1px solid #333;
+}
+
+.connection-bar.disconnected { background: #2d2d2d; color: #888; }
+.connection-bar.connecting { background: #3d3d00; color: #ffc107; }
+.connection-bar.connected { background: #1e3d1e; color: #4caf50; }
+.connection-bar.error { background: #3d1e1e; color: #f44336; }
+
+.status-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.connection-bar.connecting .status-indicator {
+  animation: pulse 1s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.status-text { flex: 1; }
+
+.reconnect-btn {
+  padding: 4px 12px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  color: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 150ms;
+}
+
+.reconnect-btn:hover { background: rgba(255, 255, 255, 0.2); }
+
+.terminal-viewport {
+  flex: 1;
+  padding: 4px;
+  overflow: hidden;
+}
+
+.terminal-viewport :deep(.xterm) { height: 100%; }
+.terminal-viewport :deep(.xterm-viewport) { overflow-y: auto !important; }
+</style>

--- a/autobot-plugins/terminal/src/components/SshTerminal.vue
+++ b/autobot-plugins/terminal/src/components/SshTerminal.vue
@@ -33,6 +33,8 @@ const logger = createLogger('SshTerminal')
 const props = defineProps<{
   hostId: string
   chatSessionId?: string | null
+  /** WebSocket base path for SSH connections. Defaults to /api/terminal/ws/ssh/ */
+  wsBasePath?: string
 }>()
 
 const emit = defineEmits<{
@@ -55,7 +57,8 @@ const buildWsUrl = () => {
   const params = props.chatSessionId ? `?conversation_id=${props.chatSessionId}` : ''
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
   const host = window.location.host
-  return `${protocol}//${host}/api/terminal/ws/ssh/${props.hostId}${params}`
+  const basePath = props.wsBasePath ?? '/api/terminal/ws/ssh/'
+  return `${protocol}//${host}${basePath}${props.hostId}${params}`
 }
 
 const { send: wsSend, connect: wsConnect, disconnect: wsDisconnect, isConnected: wsIsConnected } = useWebSocket(wsUrl, {

--- a/autobot-plugins/terminal/src/composables/usePollingJob.ts
+++ b/autobot-plugins/terminal/src/composables/usePollingJob.ts
@@ -1,0 +1,39 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+
+import { ref, onScopeDispose } from 'vue'
+
+export interface UsePollingJobOptions {
+  intervalMs?: number
+  maxAttempts?: number
+}
+
+export function usePollingJob(
+  fn: (arg: string) => Promise<void> | void,
+  options: UsePollingJobOptions = {}
+) {
+  const { intervalMs = 2000, maxAttempts = Number.MAX_SAFE_INTEGER } = options
+  const isPolling = ref(false)
+  let timer: ReturnType<typeof setInterval> | null = null
+  let attempts = 0
+
+  const start = (arg = '') => {
+    if (isPolling.value) return
+    isPolling.value = true
+    attempts = 0
+    timer = setInterval(async () => {
+      if (attempts >= maxAttempts) { stop(); return }
+      attempts++
+      await fn(arg)
+    }, intervalMs)
+  }
+
+  const stop = () => {
+    if (timer) { clearInterval(timer); timer = null }
+    isPolling.value = false
+  }
+
+  onScopeDispose(stop)
+
+  return { start, stop, isPolling }
+}

--- a/autobot-plugins/terminal/src/composables/useTerminalStore.ts
+++ b/autobot-plugins/terminal/src/composables/useTerminalStore.ts
@@ -1,0 +1,111 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { createLogger } from '../utils'
+
+const logger = createLogger('TerminalStore')
+
+export interface HostConfig {
+  id: string
+  name: string
+  ip: string
+  port: number
+  description: string
+}
+
+export interface TerminalSession {
+  id: string
+  host: HostConfig
+  status: 'disconnected' | 'connecting' | 'connected' | 'ready' | 'error' | 'reconnecting'
+  controlState: 'user' | 'agent'
+  createdAt: Date
+  lastActivityAt: Date
+}
+
+export interface TerminalTab {
+  id: string
+  name: string
+  sessionId: string
+  host: HostConfig
+  isActive: boolean
+}
+
+const DEFAULT_HOST: HostConfig = { id: 'main', name: 'Main', ip: '127.0.0.1', port: 22, description: 'Default SSH host' }
+
+export const useTerminalStore = defineStore('autobot-terminal', () => {
+  const sessions = ref<Map<string, TerminalSession>>(new Map())
+  const activeSessionId = ref<string | null>(null)
+  const selectedHost = ref<HostConfig>(DEFAULT_HOST)
+  const terminalTabs = ref<TerminalTab[]>([])
+  const commandHistory = ref<Map<string, string[]>>(new Map())
+  const agentControlEnabled = ref(false)
+
+  const activeSession = computed(() => activeSessionId.value ? getSession(activeSessionId.value) : null)
+  const activeTabs = computed(() => terminalTabs.value.filter(t => t.isActive))
+  const connectedSessions = computed(() =>
+    Array.from(sessions.value.values()).filter(s => s.status === 'connected' || s.status === 'ready')
+  )
+
+  const ensureMap = () => {
+    if (!(sessions.value instanceof Map)) {
+      sessions.value = new Map(Object.entries(sessions.value as unknown as Record<string, TerminalSession>))
+    }
+    return sessions.value
+  }
+
+  const getSession = (id: string) => ensureMap().get(id)
+
+  const createSession = (id: string, host: HostConfig): TerminalSession => {
+    const s: TerminalSession = { id, host, status: 'disconnected', controlState: 'agent', createdAt: new Date(), lastActivityAt: new Date() }
+    sessions.value.set(id, s); return s
+  }
+
+  const updateSessionStatus = (id: string, status: TerminalSession['status']) => {
+    const s = getSession(id); if (s) { s.status = status; s.lastActivityAt = new Date() }
+  }
+
+  const setActiveSession = (id: string | null) => { activeSessionId.value = id }
+
+  const removeSession = (id: string) => {
+    ensureMap().delete(id)
+    if (activeSessionId.value === id) activeSessionId.value = null
+  }
+
+  const setSelectedHost = (host: HostConfig) => { selectedHost.value = host }
+
+  const addCommandToHistory = (hostId: string, command: string) => {
+    if (!commandHistory.value.has(hostId)) commandHistory.value.set(hostId, [])
+    const h = commandHistory.value.get(hostId)!
+    if (h[h.length - 1] !== command) { h.push(command); if (h.length > 100) h.shift() }
+  }
+
+  const getCommandHistory = (hostId: string) => commandHistory.value.get(hostId) || []
+
+  const addTab = (tab: TerminalTab) => {
+    terminalTabs.value.forEach(t => (t.isActive = false))
+    terminalTabs.value.push({ ...tab, isActive: true })
+  }
+
+  const removeTab = (id: string) => {
+    const i = terminalTabs.value.findIndex(t => t.id === id)
+    if (i !== -1) {
+      terminalTabs.value.splice(i, 1)
+      if (terminalTabs.value.length > 0) terminalTabs.value[Math.max(0, i - 1)].isActive = true
+    }
+  }
+
+  const setActiveTab = (id: string) => terminalTabs.value.forEach(t => (t.isActive = t.id === id))
+
+  const cleanup = () => { ensureMap().clear(); terminalTabs.value = []; activeSessionId.value = null }
+
+  logger.debug('Terminal store initialized')
+
+  return {
+    sessions, activeSessionId, selectedHost, terminalTabs, commandHistory, agentControlEnabled,
+    activeSession, activeTabs, connectedSessions,
+    getSession, createSession, updateSessionStatus, setActiveSession, removeSession,
+    setSelectedHost, addCommandToHistory, getCommandHistory, addTab, removeTab, setActiveTab, cleanup,
+  }
+})

--- a/autobot-plugins/terminal/src/composables/useWebSocket.ts
+++ b/autobot-plugins/terminal/src/composables/useWebSocket.ts
@@ -129,7 +129,6 @@ export function useWebSocket(url: Ref<string> | string, options: UseWebSocketOpt
   const disconnect = () => {
     clearTimers()
     if (ws.value) {
-      ws.value.onclose = null
       ws.value.close(1000, 'Manual disconnect')
       ws.value = null
     }

--- a/autobot-plugins/terminal/src/composables/useWebSocket.ts
+++ b/autobot-plugins/terminal/src/composables/useWebSocket.ts
@@ -1,0 +1,157 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+
+import { ref, computed, onScopeDispose, unref, type Ref } from 'vue'
+import { createLogger } from '../utils'
+
+const logger = createLogger('useWebSocket')
+
+export interface UseWebSocketOptions {
+  autoConnect?: boolean
+  autoReconnect?: boolean
+  maxReconnectAttempts?: number
+  reconnectDelay?: number
+  maxReconnectDelay?: number
+  connectionTimeout?: number
+  parseJSON?: boolean
+  onOpen?: (event: Event) => void
+  onMessage?: (data: unknown) => void
+  onError?: (event: Event) => void
+  onClose?: (event: CloseEvent) => void
+}
+
+export function useWebSocket(url: Ref<string> | string, options: UseWebSocketOptions = {}) {
+  const opts = {
+    autoConnect: true,
+    autoReconnect: true,
+    maxReconnectAttempts: 5,
+    reconnectDelay: 1000,
+    maxReconnectDelay: 10000,
+    connectionTimeout: 5000,
+    parseJSON: false,
+    onOpen: (_e: Event) => {},
+    onMessage: (_d: unknown) => {},
+    onError: (_e: Event) => {},
+    onClose: (_e: CloseEvent) => {},
+    ...options,
+  }
+
+  const ws = ref<WebSocket | null>(null)
+  const isConnected = ref(false)
+  const isConnecting = ref(false)
+  const lastMessage = ref<unknown>(null)
+  const errorList = ref<Error[]>([])
+  const error = computed<Error | null>(() =>
+    errorList.value.length === 0 ? null : errorList.value[errorList.value.length - 1]
+  )
+  const reconnectAttempts = ref(0)
+
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  let connectionTimeoutTimer: ReturnType<typeof setTimeout> | null = null
+
+  const clearTimers = () => {
+    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null }
+    if (connectionTimeoutTimer) { clearTimeout(connectionTimeoutTimer); connectionTimeoutTimer = null }
+  }
+
+  const connect = () => {
+    if (isConnecting.value || (ws.value && ws.value.readyState === WebSocket.OPEN)) return
+
+    const wsUrl = unref(url)
+    if (!wsUrl) { logger.error('Invalid URL:', wsUrl); return }
+
+    isConnecting.value = true
+    errorList.value = []
+
+    try {
+      ws.value = new WebSocket(wsUrl)
+
+      if (opts.connectionTimeout > 0) {
+        connectionTimeoutTimer = setTimeout(() => {
+          if (isConnecting.value) {
+            errorList.value = [...errorList.value, new Error('Connection timeout')]
+            ws.value?.close()
+          }
+        }, opts.connectionTimeout)
+      }
+
+      ws.value.onopen = (event) => {
+        isConnected.value = true
+        isConnecting.value = false
+        reconnectAttempts.value = 0
+        errorList.value = []
+        clearTimers()
+        logger.info('Connected to:', wsUrl)
+        opts.onOpen(event)
+      }
+
+      ws.value.onmessage = (event) => {
+        try {
+          const data = opts.parseJSON ? JSON.parse(event.data as string) : event.data
+          lastMessage.value = data
+          opts.onMessage(data)
+        } catch {
+          lastMessage.value = event.data
+          opts.onMessage(event.data)
+        }
+      }
+
+      ws.value.onerror = (event) => {
+        logger.error('Error:', event)
+        errorList.value = [...errorList.value, new Error('WebSocket error')]
+        isConnecting.value = false
+        opts.onError(event)
+      }
+
+      ws.value.onclose = (event) => {
+        isConnected.value = false
+        isConnecting.value = false
+        clearTimers()
+        logger.info('Closed:', { code: event.code, reason: event.reason })
+        opts.onClose(event)
+
+        if (
+          opts.autoReconnect &&
+          event.code !== 1000 &&
+          (opts.maxReconnectAttempts === 0 || reconnectAttempts.value < opts.maxReconnectAttempts)
+        ) {
+          const delay = Math.min(opts.reconnectDelay * Math.pow(2, reconnectAttempts.value), opts.maxReconnectDelay)
+          reconnectTimer = setTimeout(() => { reconnectAttempts.value++; connect() }, delay)
+        }
+      }
+    } catch (err) {
+      logger.error('Failed to create WebSocket:', err)
+      isConnecting.value = false
+      errorList.value = [...errorList.value, err instanceof Error ? err : new Error(String(err))]
+    }
+  }
+
+  const disconnect = () => {
+    clearTimers()
+    if (ws.value) {
+      ws.value.onclose = null
+      ws.value.close(1000, 'Manual disconnect')
+      ws.value = null
+    }
+    isConnected.value = false
+    isConnecting.value = false
+  }
+
+  const send = (data: unknown) => {
+    if (!ws.value || ws.value.readyState !== WebSocket.OPEN) {
+      logger.warn('Cannot send: not connected')
+      return
+    }
+    const payload = typeof data === 'string' ? data : JSON.stringify(data)
+    ws.value.send(payload)
+  }
+
+  if (opts.autoConnect) connect()
+
+  onScopeDispose(() => {
+    clearTimers()
+    if (ws.value) { ws.value.onclose = null; ws.value.close(1000, 'Scope disposed') }
+  })
+
+  return { isConnected, isConnecting, lastMessage, error, reconnectAttempts, connect, disconnect, send }
+}

--- a/autobot-plugins/terminal/src/utils.ts
+++ b/autobot-plugins/terminal/src/utils.ts
@@ -1,0 +1,13 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+
+/** Minimal scoped logger for plugin-internal use. */
+export function createLogger(scope: string) {
+  const prefix = `[${scope}]`
+  return {
+    debug: (...args: unknown[]) => console.debug(prefix, ...args),
+    info: (...args: unknown[]) => console.info(prefix, ...args),
+    warn: (...args: unknown[]) => console.warn(prefix, ...args),
+    error: (...args: unknown[]) => console.error(prefix, ...args),
+  }
+}

--- a/autobot-plugins/terminal/vite.config.ts
+++ b/autobot-plugins/terminal/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import { resolve } from 'path'
+
+export default defineConfig({
+  plugins: [vue()],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'index.ts'),
+      name: 'AutobotTerminal',
+      fileName: 'autobot-terminal',
+      formats: ['es', 'cjs'],
+    },
+    rollupOptions: {
+      external: ['vue', '@xterm/xterm', '@xterm/addon-fit', '@xterm/addon-web-links'],
+      output: {
+        globals: {
+          vue: 'Vue',
+        },
+      },
+    },
+  },
+})

--- a/autobot-plugins/vnc/index.ts
+++ b/autobot-plugins/vnc/index.ts
@@ -1,0 +1,21 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// @autobot/vnc — VNC viewer + controls plugin for both frontends
+
+import type { App } from 'vue'
+import VncViewer from './src/components/VncViewer.vue'
+import VncToolbar from './src/components/VncToolbar.vue'
+
+export { VncViewer, VncToolbar }
+export { useVncControls } from './src/composables/useVncControls'
+export type { VncActionResponse, MouseClickParams, MouseDragParams, MouseScrollParams } from './src/composables/useVncControls'
+export type { VncHost } from './src/components/VncViewer.vue'
+
+export const VncPlugin = {
+  install(app: App) {
+    app.component('VncViewer', VncViewer)
+    app.component('VncToolbar', VncToolbar)
+  },
+}
+
+export default VncPlugin

--- a/autobot-plugins/vnc/package.json
+++ b/autobot-plugins/vnc/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@autobot/vnc",
+  "version": "0.1.0",
+  "description": "AutoBot VNC viewer plugin — iframe viewer + control toolbar for both frontends",
+  "type": "module",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "scripts": {
+    "build": "vite build"
+  },
+  "peerDependencies": {
+    "vue": ">=3.5.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.0",
+    "typescript": "~5.8.0",
+    "vite": "^6.0.0",
+    "vue": "^3.5.0"
+  }
+}

--- a/autobot-plugins/vnc/src/components/VncToolbar.vue
+++ b/autobot-plugins/vnc/src/components/VncToolbar.vue
@@ -1,0 +1,280 @@
+<template>
+  <div v-if="connected" class="vnc-toolbar">
+    <span class="vnc-toolbar-label">Desktop Actions</span>
+    <div class="vnc-toolbar-actions">
+      <button @click="handleScreenshot" :disabled="controls.loading.value" class="vnc-btn" title="Take Screenshot">
+        📷 Screenshot
+      </button>
+      <button @click="showTypeDialog = true" class="vnc-btn" title="Type Text">
+        ⌨ Type Text
+      </button>
+      <button @click="handleCtrlAltDel" :disabled="controls.loading.value" class="vnc-btn" title="Send Ctrl+Alt+Del">
+        Ctrl+Alt+Del
+      </button>
+      <button @click="handlePaste" :disabled="controls.loading.value" class="vnc-btn" title="Paste Clipboard">
+        📋 Paste
+      </button>
+      <button @click="handleFullscreen" class="vnc-btn" title="Toggle Fullscreen">
+        {{ isFullscreen ? '⊡' : '⛶' }} Fullscreen
+      </button>
+    </div>
+
+    <!-- Error feedback -->
+    <p v-if="lastError" class="vnc-toolbar-error">{{ lastError }}</p>
+
+    <!-- Type text dialog -->
+    <Teleport to="body">
+      <div v-if="showTypeDialog" class="vnc-dialog-backdrop" @click.self="showTypeDialog = false">
+        <div class="vnc-dialog">
+          <div class="vnc-dialog-header">
+            <span>Type Text on Desktop</span>
+            <button @click="showTypeDialog = false" class="vnc-dialog-close">×</button>
+          </div>
+          <div class="vnc-dialog-body">
+            <textarea
+              v-model="textToType"
+              placeholder="Enter text to type on the desktop..."
+              rows="4"
+              class="vnc-dialog-textarea"
+            ></textarea>
+          </div>
+          <div class="vnc-dialog-footer">
+            <button @click="handleTypeText" :disabled="!textToType.trim()" class="vnc-btn-primary">Type</button>
+            <button @click="showTypeDialog = false" class="vnc-btn-secondary">Cancel</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Screenshot modal -->
+      <div v-if="screenshotData" class="vnc-dialog-backdrop" @click.self="screenshotData = null">
+        <div class="vnc-screenshot-modal">
+          <div class="vnc-dialog-header">
+            <span>Desktop Screenshot</span>
+            <button @click="screenshotData = null" class="vnc-dialog-close">×</button>
+          </div>
+          <div class="vnc-screenshot-body">
+            <img :src="screenshotData" alt="Desktop Screenshot" class="vnc-screenshot-img" />
+          </div>
+          <div class="vnc-dialog-footer">
+            <button @click="downloadScreenshot" class="vnc-btn-primary">Download</button>
+            <button @click="screenshotData = null" class="vnc-btn-secondary">Close</button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+
+import { ref, onMounted, onUnmounted } from 'vue'
+import { useVncControls } from '../composables/useVncControls'
+import { createLogger } from '../utils'
+
+const logger = createLogger('VncToolbar')
+
+const props = defineProps<{
+  /** Whether VNC is currently connected */
+  connected: boolean
+  /** Base URL for VNC API calls — defaults to /api */
+  apiBaseUrl?: string
+  /** iframe element id to fullscreen */
+  frameId?: string
+}>()
+
+const emit = defineEmits<{
+  error: [message: string]
+}>()
+
+const controls = useVncControls(props.apiBaseUrl ?? '/api')
+const lastError = ref<string | null>(null)
+const isFullscreen = ref(false)
+const showTypeDialog = ref(false)
+const textToType = ref('')
+const screenshotData = ref<string | null>(null)
+
+const setError = (msg: string | null) => { lastError.value = msg; if (msg) emit('error', msg) }
+
+async function handleScreenshot() {
+  setError(null)
+  const result = await controls.captureScreenshot()
+  if (result.status === 'success' && result.image_data) {
+    screenshotData.value = `data:image/png;base64,${result.image_data}`
+  } else {
+    logger.error('Screenshot failed:', result.message)
+    setError(result.message)
+  }
+}
+
+async function handleTypeText() {
+  if (!textToType.value.trim()) return
+  const result = await controls.keyboardType(textToType.value)
+  if (result.status === 'success') { textToType.value = ''; showTypeDialog.value = false }
+  else { logger.error('Type text failed:', result.message); setError(result.message) }
+}
+
+async function handleCtrlAltDel() {
+  const result = await controls.sendCtrlAltDel()
+  if (result.status !== 'success') { logger.error('Ctrl+Alt+Del failed:', result.message); setError(result.message) }
+}
+
+async function handlePaste() {
+  try {
+    const text = await navigator.clipboard.readText()
+    const result = await controls.syncClipboard(text)
+    if (result.status !== 'success') { logger.error('Clipboard sync failed:', result.message); setError(result.message) }
+  } catch (err) {
+    logger.error('Clipboard read failed:', err)
+    setError('Failed to read clipboard')
+  }
+}
+
+function handleFullscreen() {
+  const frame = document.getElementById(props.frameId ?? 'vnc-frame')
+  if (!frame) return
+  if (!document.fullscreenElement) { frame.requestFullscreen(); isFullscreen.value = true }
+  else { document.exitFullscreen(); isFullscreen.value = false }
+}
+
+function downloadScreenshot() {
+  if (!screenshotData.value) return
+  const a = document.createElement('a')
+  a.href = screenshotData.value
+  a.download = `desktop-screenshot-${Date.now()}.png`
+  a.click()
+}
+
+function handleFullscreenChange() { isFullscreen.value = !!document.fullscreenElement }
+
+onMounted(() => document.addEventListener('fullscreenchange', handleFullscreenChange))
+onUnmounted(() => document.removeEventListener('fullscreenchange', handleFullscreenChange))
+</script>
+
+<style scoped>
+.vnc-toolbar {
+  padding: 12px 16px;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.vnc-toolbar-label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: #111827;
+  margin-bottom: 8px;
+}
+
+.vnc-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.vnc-btn {
+  padding: 6px 12px;
+  font-size: 13px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  border: 1px solid #93c5fd;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 150ms;
+}
+
+.vnc-btn:hover:not(:disabled) { background: #bfdbfe; }
+.vnc-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.vnc-toolbar-error {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #dc2626;
+}
+
+/* Dialog */
+.vnc-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.5);
+}
+
+.vnc-dialog {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+  width: 100%;
+  max-width: 28rem;
+}
+
+.vnc-screenshot-modal {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+  max-width: 56rem;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.vnc-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-bottom: 1px solid #e5e7eb;
+  font-weight: 600;
+  font-size: 15px;
+  color: #111827;
+}
+
+.vnc-dialog-close {
+  font-size: 20px;
+  color: #6b7280;
+  background: none;
+  border: none;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.vnc-dialog-close:hover { color: #374151; }
+
+.vnc-dialog-body, .vnc-screenshot-body {
+  padding: 24px;
+  overflow: auto;
+}
+
+.vnc-dialog-textarea {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  resize: vertical;
+  font-size: 14px;
+}
+
+.vnc-dialog-textarea:focus { outline: none; border-color: #60a5fa; box-shadow: 0 0 0 2px rgba(96,165,250,0.3); }
+
+.vnc-screenshot-img { max-width: 100%; height: auto; border-radius: 6px; }
+
+.vnc-dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 24px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.vnc-btn-primary { padding: 8px 16px; background: #2563eb; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 14px; transition: background 150ms; }
+.vnc-btn-primary:hover:not(:disabled) { background: #1d4ed8; }
+.vnc-btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+.vnc-btn-secondary { padding: 8px 16px; background: #e5e7eb; color: #374151; border: none; border-radius: 4px; cursor: pointer; font-size: 14px; transition: background 150ms; }
+.vnc-btn-secondary:hover { background: #d1d5db; }
+</style>

--- a/autobot-plugins/vnc/src/components/VncViewer.vue
+++ b/autobot-plugins/vnc/src/components/VncViewer.vue
@@ -1,0 +1,160 @@
+<template>
+  <div class="vnc-viewer">
+    <!-- Loading state -->
+    <div v-if="loading" class="vnc-state-overlay">
+      <div class="vnc-spinner"></div>
+      <p class="vnc-state-text">Connecting to {{ host?.name }}...</p>
+    </div>
+
+    <!-- Idle state -->
+    <div v-else-if="!modelValue" class="vnc-state-overlay">
+      <svg class="vnc-idle-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+      </svg>
+      <p class="vnc-state-text">Select a host and connect to start viewing</p>
+      <div v-if="host" class="vnc-host-info">
+        <p class="vnc-host-desc">{{ host.description }}</p>
+        <code class="vnc-host-addr">{{ host.host }}:{{ host.port }}</code>
+      </div>
+    </div>
+
+    <!-- External host (no embed proxy) -->
+    <div v-else-if="!canEmbed" class="vnc-state-overlay">
+      <svg class="vnc-idle-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+      </svg>
+      <p class="vnc-state-text">This host requires a separate browser tab</p>
+      <a :href="vncUrl" target="_blank" rel="noopener" class="vnc-open-btn">Open noVNC in New Tab</a>
+    </div>
+
+    <!-- Embedded iframe -->
+    <iframe
+      v-else
+      id="vnc-frame"
+      :src="vncUrl"
+      class="vnc-frame"
+      allow="fullscreen"
+      @load="onIframeLoad"
+    ></iframe>
+  </div>
+</template>
+
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+
+import { computed } from 'vue'
+
+export interface VncHost {
+  id: string
+  name: string
+  host: string
+  port: number
+  description?: string
+  /** If true, an nginx proxy exists for this host so it can be embedded. Default: id === 'main' */
+  proxied?: boolean
+}
+
+const props = defineProps<{
+  /** Whether the viewer is in connected/active state (v-model). */
+  modelValue: boolean
+  host?: VncHost
+  loading?: boolean
+}>()
+
+defineEmits<{ 'update:modelValue': [value: boolean] }>()
+
+/** URL to load in the iframe. Proxied main host uses relative path; others use direct URL. */
+const vncUrl = computed(() => {
+  if (!props.host) return ''
+  if (props.host.proxied ?? props.host.id === 'main') {
+    return `/tools/novnc/vnc.html?autoconnect=true&resize=scale`
+  }
+  return `http://${props.host.host}:${props.host.port}/vnc.html?autoconnect=true&resize=scale`
+})
+
+const canEmbed = computed(() => props.host?.proxied ?? props.host?.id === 'main')
+
+const onIframeLoad = () => {
+  // iframe loaded successfully — nothing needed
+}
+
+defineExpose({ vncUrl })
+</script>
+
+<style scoped>
+.vnc-viewer {
+  width: 100%;
+  height: 100%;
+  background: #111827;
+  position: relative;
+  display: flex;
+  align-items: stretch;
+}
+
+.vnc-frame {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.vnc-state-overlay {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 32px;
+  text-align: center;
+  color: #9ca3af;
+}
+
+.vnc-idle-icon {
+  width: 64px;
+  height: 64px;
+  color: #4b5563;
+  margin-bottom: 16px;
+}
+
+.vnc-state-text {
+  font-size: 14px;
+  color: #6b7280;
+  margin-top: 8px;
+}
+
+.vnc-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid #374151;
+  border-top-color: #60a5fa;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin-bottom: 16px;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.vnc-host-info {
+  margin-top: 16px;
+  padding: 16px;
+  background: #1f2937;
+  border-radius: 8px;
+}
+
+.vnc-host-desc { font-size: 13px; color: #9ca3af; }
+.vnc-host-addr { display: block; font-size: 11px; color: #6b7280; margin-top: 8px; font-family: monospace; }
+
+.vnc-open-btn {
+  margin-top: 16px;
+  padding: 8px 16px;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 6px;
+  text-decoration: none;
+  font-size: 14px;
+  transition: background 150ms;
+}
+
+.vnc-open-btn:hover { background: #1d4ed8; }
+</style>

--- a/autobot-plugins/vnc/src/composables/useVncControls.ts
+++ b/autobot-plugins/vnc/src/composables/useVncControls.ts
@@ -1,0 +1,79 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+
+import { ref } from 'vue'
+import { createLogger } from '../utils'
+
+const logger = createLogger('useVncControls')
+
+export interface MouseClickParams { x: number; y: number; button?: 'left' | 'middle' | 'right' }
+export interface MouseDragParams { x1: number; y1: number; x2: number; y2: number }
+export interface MouseScrollParams { direction: 'up' | 'down'; amount?: number }
+export interface VncActionResponse { status: 'success' | 'error'; message: string; image_data?: string }
+
+function extractErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === 'string') return err
+  return fallback
+}
+
+async function vncFetch<T>(method: 'GET' | 'POST', path: string, body?: unknown): Promise<T> {
+  const res = await fetch(path, {
+    method,
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+  return res.json() as Promise<T>
+}
+
+export function useVncControls(baseUrl = '/api') {
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function call<T>(fn: () => Promise<T>): Promise<T> {
+    loading.value = true
+    error.value = null
+    try { return await fn() }
+    finally { loading.value = false }
+  }
+
+  async function mouseClick(params: MouseClickParams): Promise<VncActionResponse> {
+    try { return await call(() => vncFetch('POST', `${baseUrl}/vnc/click`, params)) }
+    catch (err) { logger.error('Mouse click failed:', err); const m = extractErrorMessage(err, 'Mouse click failed'); error.value = m; return { status: 'error', message: m } }
+  }
+
+  async function keyboardType(text: string): Promise<VncActionResponse> {
+    try { return await call(() => vncFetch('POST', `${baseUrl}/vnc/type`, { text })) }
+    catch (err) { logger.error('Keyboard type failed:', err); const m = extractErrorMessage(err, 'Keyboard type failed'); error.value = m; return { status: 'error', message: m } }
+  }
+
+  async function specialKey(key: string): Promise<VncActionResponse> {
+    try { return await call(() => vncFetch('POST', `${baseUrl}/vnc/key`, { key })) }
+    catch (err) { logger.error('Special key failed:', err); const m = extractErrorMessage(err, 'Special key failed'); error.value = m; return { status: 'error', message: m } }
+  }
+
+  async function mouseScroll(params: MouseScrollParams): Promise<VncActionResponse> {
+    try { return await call(() => vncFetch('POST', `${baseUrl}/vnc/scroll`, params)) }
+    catch (err) { logger.error('Mouse scroll failed:', err); const m = extractErrorMessage(err, 'Mouse scroll failed'); error.value = m; return { status: 'error', message: m } }
+  }
+
+  async function mouseDrag(params: MouseDragParams): Promise<VncActionResponse> {
+    try { return await call(() => vncFetch('POST', `${baseUrl}/vnc/drag`, params)) }
+    catch (err) { logger.error('Mouse drag failed:', err); const m = extractErrorMessage(err, 'Mouse drag failed'); error.value = m; return { status: 'error', message: m } }
+  }
+
+  async function captureScreenshot(): Promise<VncActionResponse> {
+    try { return await call(() => vncFetch('GET', `${baseUrl}/vnc/screenshot`)) }
+    catch (err) { logger.error('Screenshot capture failed:', err); const m = extractErrorMessage(err, 'Screenshot capture failed'); error.value = m; return { status: 'error', message: m, image_data: '' } }
+  }
+
+  async function syncClipboard(content: string): Promise<VncActionResponse> {
+    try { return await call(() => vncFetch('POST', `${baseUrl}/vnc/clipboard`, { content })) }
+    catch (err) { logger.error('Clipboard sync failed:', err); const m = extractErrorMessage(err, 'Clipboard sync failed'); error.value = m; return { status: 'error', message: m } }
+  }
+
+  const sendCtrlAltDel = () => specialKey('ctrl+alt+Delete')
+
+  return { loading, error, mouseClick, keyboardType, specialKey, mouseScroll, mouseDrag, captureScreenshot, syncClipboard, sendCtrlAltDel }
+}

--- a/autobot-plugins/vnc/src/utils.ts
+++ b/autobot-plugins/vnc/src/utils.ts
@@ -1,0 +1,12 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+
+export function createLogger(scope: string) {
+  const prefix = `[${scope}]`
+  return {
+    debug: (...args: unknown[]) => console.debug(prefix, ...args),
+    info: (...args: unknown[]) => console.info(prefix, ...args),
+    warn: (...args: unknown[]) => console.warn(prefix, ...args),
+    error: (...args: unknown[]) => console.error(prefix, ...args),
+  }
+}

--- a/autobot-plugins/vnc/vite.config.ts
+++ b/autobot-plugins/vnc/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import { resolve } from 'path'
+
+export default defineConfig({
+  plugins: [vue()],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'index.ts'),
+      name: 'AutobotVnc',
+      fileName: 'autobot-vnc',
+      formats: ['es', 'cjs'],
+    },
+    rollupOptions: {
+      external: ['vue'],
+      output: {
+        globals: {
+          vue: 'Vue',
+        },
+      },
+    },
+  },
+})

--- a/autobot-slm-frontend/package.json
+++ b/autobot-slm-frontend/package.json
@@ -15,6 +15,11 @@
     "build-storybook": "VITE_API_URL=/slm storybook build"
   },
   "dependencies": {
+    "@autobot/terminal": "file:../autobot-plugins/terminal",
+    "@autobot/vnc": "file:../autobot-plugins/vnc",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.12.0",
+    "@xterm/xterm": "^6.0.0",
     "axios": "^1.16.0",
     "pinia": "^3.0.4",
     "vue": "^3.5.32",

--- a/autobot-slm-frontend/src/views/tools/admin/NoVNCTool.vue
+++ b/autobot-slm-frontend/src/views/tools/admin/NoVNCTool.vue
@@ -1,72 +1,35 @@
 // AutoBot - AI-Powered Automation Platform
 // Copyright (c) 2025 mrveiss
-// Author: mrveiss
 
 <script setup lang="ts">
 /**
  * NoVNCTool - noVNC Remote Desktop Viewer
  *
- * Remote desktop access via noVNC WebSocket connection.
- * Supports both static SSOT hosts and dynamic SLM-managed VNC endpoints.
- * Related to Issue #725, #729.
+ * Uses @autobot/vnc plugin (VncViewer + VncToolbar).
+ * GH#4985: Migrated to shared plugin components.
  */
 
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { VncViewer, VncToolbar } from '@autobot/vnc'
+import type { VncHost } from '@autobot/vnc'
 import { getVNCHosts } from '@/config/ssot-config'
 import { useSlmApi } from '@/composables/useSlmApi'
-import { useVncControls } from '@/composables/useVncControls'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('NoVNCTool')
 const api = useSlmApi()
 
-// VNC controls (Issue #74)
-const vncControls = useVncControls()
-const showScreenshotModal = ref(false)
-const screenshotData = ref<string | null>(null)
-const textToType = ref('')
-const showTypeDialog = ref(false)
-
-// State
 const loading = ref(false)
 const loadingEndpoints = ref(false)
 const error = ref<string | null>(null)
 const isConnected = ref(false)
-const isFullscreen = ref(false)
 
-interface VNCHost {
-  id: string
-  name: string
-  host: string
-  port: number
-  description: string
-  source: 'static' | 'dynamic'
-}
+const staticHosts = getVNCHosts().map(h => ({ ...h, proxied: h.id === 'main', source: 'static' as const }))
+const dynamicHosts = ref<VncHost[]>([])
 
-// Start with static SSOT hosts
-const staticHosts = getVNCHosts().map(h => ({ ...h, source: 'static' as const }))
-const dynamicHosts = ref<VNCHost[]>([])
-
-// Combined hosts (static + dynamic from SLM API)
-const hosts = computed(() => [...staticHosts, ...dynamicHosts.value])
-
-const selectedHost = ref<string>(staticHosts[0]?.id || '')
-const currentHost = computed(() => hosts.value.find(h => h.id === selectedHost.value))
-
-// VNC URL
-// Issue #1002: nginx proxies /tools/novnc/ → http://backend:6080/ for the main host.
-// Using the proxy path avoids mixed-content blocking (HTTP iframe in HTTPS page).
-// Dynamic/non-main hosts fall back to a new-tab link since no proxy exists for them.
-const vncUrl = computed(() => {
-  if (!currentHost.value) return ''
-  if (currentHost.value.id === 'main') {
-    return `/tools/novnc/vnc.html?autoconnect=true&resize=scale`
-  }
-  return `http://${currentHost.value.host}:${currentHost.value.port}/vnc.html?autoconnect=true&resize=scale`
-})
-
-// Whether the current host can be embedded (proxied) vs needs a new tab
-const canEmbedHost = computed(() => currentHost.value?.id === 'main')
+const hosts = computed<VncHost[]>(() => [...staticHosts, ...dynamicHosts.value])
+const selectedHostId = ref(staticHosts[0]?.id || '')
+const currentHost = computed(() => hosts.value.find(h => h.id === selectedHostId.value))
 
 async function fetchDynamicEndpoints(): Promise<void> {
   loadingEndpoints.value = true
@@ -78,10 +41,9 @@ async function fetchDynamicEndpoints(): Promise<void> {
       host: ep.ip_address,
       port: ep.port,
       description: `SLM-managed VNC on ${ep.hostname}`,
-      source: 'dynamic' as const,
+      proxied: false,
     }))
   } catch (e) {
-    // API not available - continue with static hosts only
     logger.warn('VNC endpoints API not available:', e)
   } finally {
     loadingEndpoints.value = false
@@ -89,111 +51,21 @@ async function fetchDynamicEndpoints(): Promise<void> {
 }
 
 function connect(): void {
-  if (!currentHost.value) {
-    error.value = 'Please select a host'
-    return
-  }
-
+  if (!currentHost.value) { error.value = 'Please select a host'; return }
   loading.value = true
   error.value = null
-
-  // VNC connection is handled by iframe
-  setTimeout(() => {
-    isConnected.value = true
-    loading.value = false
-  }, 1000)
+  setTimeout(() => { isConnected.value = true; loading.value = false }, 1000)
 }
 
-function disconnect(): void {
-  isConnected.value = false
-}
+function disconnect(): void { isConnected.value = false }
 
-function toggleFullscreen(): void {
-  const iframe = document.getElementById('vnc-frame') as HTMLIFrameElement
-  if (!iframe) return
+function onToolbarError(message: string) { error.value = message }
 
-  if (!document.fullscreenElement) {
-    iframe.requestFullscreen()
-    isFullscreen.value = true
-  } else {
-    document.exitFullscreen()
-    isFullscreen.value = false
-  }
-}
-
-function handleFullscreenChange(): void {
-  isFullscreen.value = !!document.fullscreenElement
-}
-
-// Desktop interaction actions (Issue #74)
-async function takeScreenshot(): Promise<void> {
-  const result = await vncControls.captureScreenshot()
-  if (result.status === 'success' && result.image_data) {
-    screenshotData.value = `data:image/png;base64,${result.image_data}`
-    showScreenshotModal.value = true
-  } else {
-    logger.error('Screenshot failed:', result.message)
-    error.value = result.message
-  }
-}
-
-async function handleTypeText(): Promise<void> {
-  if (!textToType.value.trim()) return
-
-  const result = await vncControls.keyboardType(textToType.value)
-  if (result.status === 'success') {
-    textToType.value = ''
-    showTypeDialog.value = false
-  } else {
-    logger.error('Type text failed:', result.message)
-    error.value = result.message
-  }
-}
-
-async function sendCtrlAltDel(): Promise<void> {
-  const result = await vncControls.sendCtrlAltDel()
-  if (result.status !== 'success') {
-    logger.error('Ctrl+Alt+Del failed:', result.message)
-    error.value = result.message
-  }
-}
-
-async function pasteFromClipboard(): Promise<void> {
-  try {
-    const text = await navigator.clipboard.readText()
-    const result = await vncControls.syncClipboard(text)
-    if (result.status !== 'success') {
-      logger.error('Clipboard sync failed:', result.message)
-      error.value = result.message
-    }
-  } catch (err) {
-    logger.error('Clipboard read failed:', err)
-    error.value = 'Failed to read clipboard'
-  }
-}
-
-function downloadScreenshot(): void {
-  if (!screenshotData.value) return
-
-  const link = document.createElement('a')
-  link.href = screenshotData.value
-  link.download = `desktop-screenshot-${Date.now()}.png`
-  link.click()
-}
-
-onMounted(() => {
-  document.addEventListener('fullscreenchange', handleFullscreenChange)
-  fetchDynamicEndpoints()
-})
-
-onUnmounted(() => {
-  document.removeEventListener('fullscreenchange', handleFullscreenChange)
-})
+onMounted(() => fetchDynamicEndpoints())
 </script>
 
 <template>
   <div class="p-6 h-full flex flex-col">
-    <!-- VNC Container -->
     <div class="bg-white rounded-lg shadow-xs border border-gray-200 flex-1 flex flex-col overflow-hidden">
       <!-- Header -->
       <div class="bg-gray-100 border-b border-gray-200 px-4 py-3 flex items-center justify-between">
@@ -205,9 +77,8 @@ onUnmounted(() => {
             <span class="font-medium text-gray-900">{{ $t('tools.admin.noVNCTool.noVNCRemoteDesktop') }}</span>
           </div>
 
-          <!-- Host Selector -->
           <select
-            v-model="selectedHost"
+            v-model="selectedHostId"
             :disabled="isConnected || loadingEndpoints"
             class="text-sm px-3 py-1.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 disabled:opacity-50"
           >
@@ -223,137 +94,47 @@ onUnmounted(() => {
             </optgroup>
           </select>
 
-          <!-- Refresh Button -->
           <button
             @click="fetchDynamicEndpoints"
             :disabled="loadingEndpoints || isConnected"
             class="p-1.5 text-gray-500 hover:bg-gray-200 rounded-sm transition-colors disabled:opacity-50"
             title="Refresh VNC endpoints"
           >
-            <svg
-              class="w-4 h-4"
-              :class="{ 'animate-spin': loadingEndpoints }"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
+            <svg class="w-4 h-4" :class="{ 'animate-spin': loadingEndpoints }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
             </svg>
           </button>
 
-          <!-- Connection Status -->
           <div class="flex items-center gap-2">
-            <div
-              class="w-2 h-2 rounded-full"
-              :class="isConnected ? 'bg-green-500' : 'bg-red-500'"
-            ></div>
+            <div class="w-2 h-2 rounded-full" :class="isConnected ? 'bg-green-500' : 'bg-red-500'"></div>
             <span class="text-xs text-gray-600">{{ isConnected ? 'Connected' : 'Disconnected' }}</span>
           </div>
-
-          <!-- Dynamic Badge -->
-          <span
-            v-if="currentHost?.source === 'dynamic'"
-            class="px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-700 rounded-sm"
-          >
-            SLM
-          </span>
         </div>
 
         <div class="flex items-center gap-2">
-          <!-- Connect/Disconnect -->
           <button
             @click="isConnected ? disconnect() : connect()"
-            :disabled="loading || !selectedHost"
+            :disabled="loading || !selectedHostId"
             :class="[
               'px-4 py-1.5 text-sm font-medium rounded-lg transition-colors',
-              isConnected
-                ? 'bg-red-100 text-red-700 hover:bg-red-200'
-                : 'bg-green-100 text-green-700 hover:bg-green-200'
+              isConnected ? 'bg-red-100 text-red-700 hover:bg-red-200' : 'bg-green-100 text-green-700 hover:bg-green-200'
             ]"
           >
             <span v-if="loading">{{ $t('tools.admin.noVNCTool.connecting') }}</span>
             <span v-else>{{ isConnected ? 'Disconnect' : 'Connect' }}</span>
           </button>
-
-          <!-- Fullscreen -->
-          <button
-            @click="toggleFullscreen"
-            :disabled="!isConnected"
-            class="p-2 text-gray-600 hover:bg-gray-200 rounded-lg transition-colors disabled:opacity-50"
-            title="Toggle Fullscreen"
-          >
-            <svg v-if="!isFullscreen" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
-            </svg>
-            <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
         </div>
       </div>
 
-      <!-- Error Message -->
       <div v-if="error" class="m-4 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
         {{ error }}
       </div>
 
-      <!-- VNC Viewport -->
-      <div class="flex-1 bg-gray-900 overflow-hidden">
-        <div v-if="loading" class="h-full flex items-center justify-center">
-          <div class="text-center">
-            <svg class="animate-spin w-8 h-8 mx-auto text-white" fill="none" viewBox="0 0 24 24">
-              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-            </svg>
-            <p class="mt-4 text-gray-400">Connecting to {{ currentHost?.name }}...</p>
-          </div>
-        </div>
-
-        <div v-else-if="!isConnected" class="h-full flex items-center justify-center">
-          <div class="text-center p-8">
-            <svg class="w-16 h-16 mx-auto text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-            </svg>
-            <h3 class="mt-4 text-lg font-medium text-gray-300">{{ $t('tools.admin.noVNCTool.noVNCRemoteDesktop') }}</h3>
-            <p class="mt-2 text-gray-500">{{ $t('tools.admin.noVNCTool.selectAHostAnd') }}</p>
-            <div v-if="currentHost" class="mt-4 p-4 bg-gray-800 rounded-lg">
-              <p class="text-sm text-gray-400">{{ currentHost.description }}</p>
-              <p class="text-xs text-gray-500 mt-2 font-mono">{{ currentHost.host }}:{{ currentHost.port }}</p>
-            </div>
-            <div v-if="dynamicHosts.length > 0" class="mt-4 text-xs text-gray-500">
-              {{ dynamicHosts.length }} SLM-managed VNC endpoint(s) available
-            </div>
-          </div>
-        </div>
-
-        <!-- Issue #1002: Embedded iframe for proxied main host; new-tab link for others -->
-        <iframe
-          v-else-if="canEmbedHost"
-          id="vnc-frame"
-          :src="vncUrl"
-          class="w-full h-full border-0"
-          allow="fullscreen"
-        ></iframe>
-        <div v-else class="h-full flex items-center justify-center">
-          <div class="text-center p-8">
-            <svg class="w-12 h-12 mx-auto text-gray-500 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-            </svg>
-            <p class="text-gray-300 mb-4">{{ $t('tools.admin.noVNCTool.thisHostRequiresA') }}</p>
-            <a
-              :href="vncUrl"
-              target="_blank"
-              rel="noopener"
-              class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-            >
-              {{ $t('tools.admin.noVNCTool.openNoVNCInNew') }}
-            </a>
-          </div>
-        </div>
+      <div class="flex-1 overflow-hidden">
+        <VncViewer v-model="isConnected" :host="currentHost" :loading="loading" class="h-full" />
       </div>
     </div>
 
-    <!-- Info Panel -->
     <div class="mt-4 p-4 bg-gray-100 rounded-lg">
       <h3 class="text-sm font-medium text-gray-900 mb-2">{{ $t('tools.admin.noVNCTool.connectionInfo') }}</h3>
       <div class="grid grid-cols-2 gap-4 text-sm">
@@ -371,88 +152,11 @@ onUnmounted(() => {
             {{ isConnected ? 'Connected' : 'Disconnected' }}
           </span>
         </div>
-        <div>
-          <span class="text-gray-500">{{ $t('tools.admin.noVNCTool.source') }}</span>
-          <span class="ml-2 text-gray-900">
-            {{ currentHost?.source === 'dynamic' ? 'SLM-Managed' : 'Static Config' }}
-          </span>
-        </div>
       </div>
     </div>
 
-    <!-- Desktop Actions Toolbar (Issue #74) -->
-    <div v-if="isConnected" class="mt-4 p-4 bg-gray-50 rounded-lg border border-gray-200">
-      <h3 class="text-sm font-medium text-gray-900 mb-3">{{ $t('tools.admin.noVNCTool.desktopActions') }}</h3>
-      <div class="flex items-center gap-2 flex-wrap">
-        <button @click="takeScreenshot" class="action-btn" title="Take Screenshot">
-          {{ $t('tools.admin.noVNCTool.screenshot') }}
-        </button>
-        <button @click="showTypeDialog = true" class="action-btn" title="Type Text">
-          {{ $t('tools.admin.noVNCTool.typeText') }}
-        </button>
-        <button @click="sendCtrlAltDel" class="action-btn" title="Send Ctrl+Alt+Del">
-          {{ $t('tools.admin.noVNCTool.ctrlAltDel') }}
-        </button>
-        <button @click="pasteFromClipboard" class="action-btn" title="Paste Clipboard">
-          {{ $t('tools.admin.noVNCTool.paste') }}
-        </button>
-      </div>
+    <div class="mt-4">
+      <VncToolbar :connected="isConnected" @error="onToolbarError" />
     </div>
-
-    <!-- Screenshot Modal (Issue #74) -->
-    <Teleport to="body">
-      <div v-if="showScreenshotModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black/75" @click="showScreenshotModal = false">
-        <div class="bg-white rounded-lg shadow-xl max-w-4xl max-h-[90vh] flex flex-col" @click.stop>
-          <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
-            <h3 class="text-lg font-semibold text-gray-900">{{ $t('tools.admin.noVNCTool.desktopScreenshot') }}</h3>
-            <button @click="showScreenshotModal = false" class="text-2xl text-gray-500 hover:text-gray-700 transition-colors">×</button>
-          </div>
-          <div class="p-6 overflow-auto flex-1">
-            <img v-if="screenshotData" :src="screenshotData" alt="Desktop Screenshot" class="max-w-full h-auto rounded-lg shadow-lg" />
-          </div>
-          <div class="px-6 py-4 border-t border-gray-200 flex items-center justify-end gap-2">
-            <button @click="downloadScreenshot" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-sm transition-colors">
-              {{ $t('tools.admin.noVNCTool.download') }}
-            </button>
-            <button @click="showScreenshotModal = false" class="px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-sm transition-colors">
-              {{ $t('tools.admin.noVNCTool.close') }}
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <!-- Type Text Dialog (Issue #74) -->
-      <div v-if="showTypeDialog" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click="showTypeDialog = false">
-        <div class="bg-white rounded-lg shadow-xl w-full max-w-md" @click.stop>
-          <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
-            <h3 class="text-lg font-semibold text-gray-900">{{ $t('tools.admin.noVNCTool.typeTextOnDesktop') }}</h3>
-            <button @click="showTypeDialog = false" class="text-2xl text-gray-500 hover:text-gray-700 transition-colors">×</button>
-          </div>
-          <div class="p-6">
-            <textarea
-              v-model="textToType"
-              placeholder="Enter text to type on the desktop..."
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
-              rows="4"
-            ></textarea>
-          </div>
-          <div class="px-6 py-4 border-t border-gray-200 flex items-center justify-end gap-2">
-            <button @click="handleTypeText" :disabled="!textToType.trim()" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
-              {{ $t('tools.admin.noVNCTool.type') }}
-            </button>
-            <button @click="showTypeDialog = false" class="px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-sm transition-colors">
-              {{ $t('tools.admin.noVNCTool.cancel') }}
-            </button>
-          </div>
-        </div>
-      </div>
-    </Teleport>
   </div>
 </template>
-
-<style scoped>
-@reference "../../../assets/styles/main.css";
-.action-btn {
-  @apply px-3 py-1.5 text-sm bg-blue-100 hover:bg-blue-200 text-blue-700 rounded border border-blue-300 transition-colors;
-}
-</style>

--- a/autobot-slm-frontend/src/views/tools/admin/NoVNCTool.vue
+++ b/autobot-slm-frontend/src/views/tools/admin/NoVNCTool.vue
@@ -12,7 +12,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { VncViewer, VncToolbar } from '@autobot/vnc'
 import type { VncHost } from '@autobot/vnc'
-import { getVNCHosts } from '@/config/ssot-config'
+import { getVNCHosts, getSlmApiBase } from '@/config/ssot-config'
 import { useSlmApi } from '@/composables/useSlmApi'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -156,7 +156,7 @@ onMounted(() => fetchDynamicEndpoints())
     </div>
 
     <div class="mt-4">
-      <VncToolbar :connected="isConnected" @error="onToolbarError" />
+      <VncToolbar :connected="isConnected" :api-base-url="getSlmApiBase()" @error="onToolbarError" />
     </div>
   </div>
 </template>

--- a/autobot-slm-frontend/src/views/tools/admin/TerminalTool.vue
+++ b/autobot-slm-frontend/src/views/tools/admin/TerminalTool.vue
@@ -11,7 +11,7 @@
 
 import { ref, computed } from 'vue'
 import { SshTerminal } from '@autobot/terminal'
-import { getHosts } from '@/config/ssot-config'
+import { getHosts, getSlmApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('TerminalTool')
@@ -92,6 +92,7 @@ function onError(message: string) {
         <SshTerminal
           v-if="selectedHostId"
           :host-id="selectedHostId"
+          :ws-base-path="`${getSlmApiBase()}/terminal/ws/ssh/`"
           class="h-full"
           @connected="onConnected"
           @disconnected="onDisconnected"

--- a/autobot-slm-frontend/src/views/tools/admin/TerminalTool.vue
+++ b/autobot-slm-frontend/src/views/tools/admin/TerminalTool.vue
@@ -1,30 +1,20 @@
 // AutoBot - AI-Powered Automation Platform
 // Copyright (c) 2025 mrveiss
-// Author: mrveiss
 
 <script setup lang="ts">
 /**
- * TerminalTool - Web Terminal Interface
+ * TerminalTool - SSH Terminal Interface
  *
- * Multi-tab terminal with host switching capabilities.
- * Migrated from main AutoBot frontend - Issue #729.
- * Note: Full xterm.js integration requires terminal components migration.
+ * Uses @autobot/terminal SshTerminal for real xterm.js + WebSocket SSH.
+ * GH#4983: Replaced fake text-input with real SSH terminal plugin.
  */
 
-import { ref, computed, onMounted } from 'vue'
-import { useAutobotApi } from '@/composables/useAutobotApi'
+import { ref, computed } from 'vue'
+import { SshTerminal } from '@autobot/terminal'
 import { getHosts } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
 
-const api = useAutobotApi()
-
-// State
-const loading = ref(false)
-const error = ref<string | null>(null)
-const commandInput = ref('')
-const commandHistory = ref<string[]>([])
-const output = ref<{ type: 'command' | 'output' | 'error'; text: string }[]>([])
-const isConnected = ref(false)
-const selectedHost = ref('main')
+const logger = createLogger('TerminalTool')
 
 interface Host {
   id: string
@@ -33,159 +23,37 @@ interface Host {
   description: string
 }
 
-// Use SSOT config for hosts - Issue #729
 const hosts = ref<Host[]>(getHosts())
+const selectedHostId = ref(hosts.value[0]?.id || '')
+const isConnected = ref(false)
+const connectionError = ref<string | null>(null)
 
-const currentHost = computed(() => hosts.value.find(h => h.id === selectedHost.value))
+const currentHost = computed(() => hosts.value.find(h => h.id === selectedHostId.value))
 
-// Terminal tabs
-interface Tab {
-  id: string
-  name: string
-  hostId: string
-  active: boolean
+function onConnected() {
+  isConnected.value = true
+  connectionError.value = null
+  logger.info('SSH session connected to', selectedHostId.value)
 }
 
-const tabs = ref<Tab[]>([
-  { id: 'tab-1', name: 'Terminal 1', hostId: 'main', active: true }
-])
-
-function addTab(): void {
-  const newId = `tab-${Date.now()}`
-  tabs.value.forEach(t => t.active = false)
-  tabs.value.push({
-    id: newId,
-    name: `Terminal ${tabs.value.length + 1}`,
-    hostId: selectedHost.value,
-    active: true
-  })
-}
-
-function closeTab(tabId: string): void {
-  if (tabs.value.length <= 1) return
-  const index = tabs.value.findIndex(t => t.id === tabId)
-  if (index > -1) {
-    const wasActive = tabs.value[index].active
-    tabs.value.splice(index, 1)
-    if (wasActive && tabs.value.length > 0) {
-      tabs.value[Math.max(0, index - 1)].active = true
-    }
-  }
-}
-
-function switchTab(tabId: string): void {
-  tabs.value.forEach(t => t.active = t.id === tabId)
-}
-
-async function connect(): Promise<void> {
-  loading.value = true
-  error.value = null
-
-  try {
-    output.value.push({
-      type: 'output',
-      text: `Connecting to ${currentHost.value?.name} (${currentHost.value?.ip})...`
-    })
-
-    // Issue #835 - verify connection with real command instead of fake setTimeout
-    const result = await api.executeTerminalCommand('echo connected', currentHost.value?.ip || '')
-
-    if (result.stdout?.includes('connected') || result.exit_code === 0) {
-      isConnected.value = true
-      output.value.push({
-        type: 'output',
-        text: `Connected to ${currentHost.value?.name}`
-      })
-      output.value.push({
-        type: 'output',
-        text: `Session started. Type 'help' for available commands.`
-      })
-    } else {
-      throw new Error(result.stderr || 'Connection test failed')
-    }
-  } catch (e) {
-    error.value = e instanceof Error ? e.message : 'Connection failed'
-    output.value.push({
-      type: 'error',
-      text: `Connection failed: ${error.value}`
-    })
-  } finally {
-    loading.value = false
-  }
-}
-
-function disconnect(): void {
+function onDisconnected() {
   isConnected.value = false
-  output.value.push({
-    type: 'output',
-    text: 'Disconnected from terminal session.'
-  })
+  logger.info('SSH session disconnected from', selectedHostId.value)
 }
 
-async function executeCommand(): Promise<void> {
-  if (!commandInput.value.trim()) return
-
-  const cmd = commandInput.value.trim()
-  commandHistory.value.push(cmd)
-  output.value.push({ type: 'command', text: `$ ${cmd}` })
-  commandInput.value = ''
-
-  if (!isConnected.value) {
-    output.value.push({ type: 'error', text: 'Not connected. Click Connect to start a session.' })
-    return
-  }
-
-  loading.value = true
-  try {
-    // Execute via backend terminal API (Issue #729 - use proper API method)
-    const result = await api.executeTerminalCommand(cmd, currentHost.value?.ip || '')
-
-    if (result.stdout) {
-      output.value.push({ type: 'output', text: result.stdout })
-    }
-    if (result.stderr) {
-      output.value.push({ type: 'error', text: result.stderr })
-    }
-  } catch (e) {
-    output.value.push({
-      type: 'error',
-      text: `Error: ${e instanceof Error ? e.message : 'Command execution failed'}`
-    })
-  } finally {
-    loading.value = false
-  }
+function onError(message: string) {
+  connectionError.value = message
+  isConnected.value = false
+  logger.error('SSH session error:', message)
 }
-
-function clearTerminal(): void {
-  output.value = []
-}
-
-function handleKeydown(event: KeyboardEvent): void {
-  if (event.key === 'Enter') {
-    executeCommand()
-  }
-}
-
-onMounted(() => {
-  output.value.push({
-    type: 'output',
-    text: 'AutoBot Terminal - Web Interface'
-  })
-  output.value.push({
-    type: 'output',
-    text: 'Select a host and click Connect to start a session.'
-  })
-})
 </script>
 
 <template>
   <div class="p-6 h-full flex flex-col">
-    <!-- Terminal Container -->
     <div class="bg-white rounded-lg shadow-xs border border-gray-200 flex-1 flex flex-col overflow-hidden">
       <!-- Header -->
       <div class="bg-gray-100 border-b border-gray-200 px-4 py-2 flex items-center justify-between">
         <div class="flex items-center gap-4">
-          <!-- Traffic lights -->
           <div class="flex gap-1.5">
             <div class="w-3 h-3 bg-red-500 rounded-full"></div>
             <div class="w-3 h-3 bg-yellow-500 rounded-full"></div>
@@ -199,9 +67,8 @@ onMounted(() => {
             <span class="font-medium">{{ $t('tools.admin.terminalTool.systemTerminal') }}</span>
           </div>
 
-          <!-- Host Selector -->
           <select
-            v-model="selectedHost"
+            v-model="selectedHostId"
             :disabled="isConnected"
             class="text-sm px-3 py-1 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 disabled:opacity-50"
           >
@@ -211,120 +78,31 @@ onMounted(() => {
           </select>
         </div>
 
-        <div class="flex items-center gap-2">
-          <!-- Add Tab -->
-          <button
-            @click="addTab"
-            class="p-1.5 text-gray-600 hover:text-gray-800 hover:bg-gray-200 rounded-sm transition-colors"
-            title="New Tab"
-            aria-label="Add terminal tab"
-          >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-            </svg>
-          </button>
-
-          <!-- Connect/Disconnect -->
-          <button
-            @click="isConnected ? disconnect() : connect()"
-            :class="[
-              'px-3 py-1.5 text-sm font-medium rounded-lg transition-colors',
-              isConnected
-                ? 'bg-red-100 text-red-700 hover:bg-red-200'
-                : 'bg-green-100 text-green-700 hover:bg-green-200'
-            ]"
-          >
-            {{ isConnected ? 'Disconnect' : 'Connect' }}
-          </button>
-
-          <!-- Clear -->
-          <button
-            @click="clearTerminal"
-            class="p-1.5 text-gray-600 hover:text-gray-800 hover:bg-gray-200 rounded-sm transition-colors"
-            title="Clear Terminal"
-            aria-label="Clear terminal"
-          >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
-          </button>
-
-          <!-- Connection Status -->
-          <div class="flex items-center gap-1.5 text-xs">
-            <div
-              class="w-2 h-2 rounded-full"
-              :class="isConnected ? 'bg-green-500' : 'bg-red-500'"
-            ></div>
-            <span class="text-gray-600">{{ isConnected ? 'Connected' : 'Disconnected' }}</span>
-          </div>
+        <div class="flex items-center gap-1.5 text-xs">
+          <div class="w-2 h-2 rounded-full" :class="isConnected ? 'bg-green-500' : 'bg-red-500'"></div>
+          <span class="text-gray-600">{{ isConnected ? 'Connected' : 'Disconnected' }}</span>
         </div>
       </div>
 
-      <!-- Tabs -->
-      <div v-if="tabs.length > 1" class="bg-gray-200 border-b border-gray-300 px-2 flex gap-1 overflow-x-auto">
-        <div
-          v-for="tab in tabs"
-          :key="tab.id"
-          @click="switchTab(tab.id)"
-          :class="[
-            'flex items-center gap-1 px-3 py-1.5 text-xs cursor-pointer rounded-t transition-colors',
-            tab.active
-              ? 'bg-white text-gray-900 border-t border-x border-gray-300'
-              : 'bg-gray-300 text-gray-700 hover:bg-gray-400'
-          ]"
-        >
-          <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-          </svg>
-          {{ tab.name }}
-          <button
-            v-if="tabs.length > 1"
-            @click.stop="closeTab(tab.id)"
-            class="ml-1 text-gray-500 hover:text-red-600"
-            :aria-label="`Close tab ${tab.id}`"
-          >
-            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
+      <div v-if="connectionError" class="m-3 p-3 bg-red-50 border border-red-200 rounded text-sm text-red-700">
+        {{ connectionError }}
       </div>
 
-      <!-- Terminal Body -->
-      <div class="flex-1 bg-gray-900 p-4 overflow-auto font-mono text-sm">
-        <div
-          v-for="(line, index) in output"
-          :key="index"
-          :class="[
-            line.type === 'command' ? 'text-green-400' : '',
-            line.type === 'output' ? 'text-gray-300' : '',
-            line.type === 'error' ? 'text-red-400' : ''
-          ]"
-          class="whitespace-pre-wrap mb-1"
-        >
-          {{ line.text }}
-        </div>
-
-        <!-- Input Line -->
-        <div class="flex items-center gap-2 mt-2">
-          <span class="text-green-400">$</span>
-          <input
-            v-model="commandInput"
-            @keydown="handleKeydown"
-            type="text"
-            class="flex-1 bg-transparent text-gray-100 outline-hidden"
-            placeholder="Enter command..."
-            :disabled="loading"
-          />
-          <svg v-if="loading" class="animate-spin w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24">
-            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-          </svg>
+      <div class="flex-1 overflow-hidden">
+        <SshTerminal
+          v-if="selectedHostId"
+          :host-id="selectedHostId"
+          class="h-full"
+          @connected="onConnected"
+          @disconnected="onDisconnected"
+          @error="onError"
+        />
+        <div v-else class="h-full flex items-center justify-center text-gray-500 text-sm">
+          Select a host above to start an SSH session.
         </div>
       </div>
     </div>
 
-    <!-- Host Info -->
     <div v-if="currentHost" class="mt-4 p-4 bg-gray-100 rounded-lg">
       <div class="flex items-center justify-between">
         <div>


### PR DESCRIPTION
## Summary

Implements three sequential GH issues in one PR:

### GH#4984 — `autobot-plugins/` monorepo structure
- New `autobot-plugins/terminal/` and `autobot-plugins/vnc/` sub-packages
- Each has `package.json` (`@autobot/terminal` / `@autobot/vnc`), `vite.config.ts` (library mode), `index.ts` barrel, and `src/`
- Both frontends reference plugins via `file:../autobot-plugins/{name}` in `package.json`

### GH#4983 — `@autobot/terminal` plugin
- `SshTerminal.vue` — xterm.js + WebSocket SSH driven by `host-id` prop
- `BaseXTerminal.vue` — raw xterm.js wrapper (resize, theme, tab completion, history)
- `useTerminalStore` — session/tab/history composable
- Plugin-internal `useWebSocket` and `usePollingJob` (no `@/` alias dependency)
- `app.use(TerminalPlugin)` registers both components globally
- `autobot-slm-frontend/TerminalTool.vue` upgraded from fake text-input `executeTerminalCommand` to real `<SshTerminal>`

### GH#4985 — `@autobot/vnc` plugin
- `VncViewer.vue` — iframe + loading/idle/external-host states, v-model for connected
- `VncToolbar.vue` — screenshot, type-text, Ctrl+Alt+Del, clipboard paste, fullscreen
- `useVncControls` — `fetch`-based VNC API calls (no `@/` alias dependency)
- `app.use(VncPlugin)` registers both components globally
- `autobot-slm-frontend/NoVNCTool.vue` migrated to `<VncViewer>` + `<VncToolbar>`

## Test plan

- [ ] `autobot-plugins/terminal/` and `autobot-plugins/vnc/` directories exist with correct structure
- [ ] Both frontend `package.json` files declare `file:` deps for both plugins
- [ ] SLM `TerminalTool.vue` imports `SshTerminal` from `@autobot/terminal`
- [ ] SLM `NoVNCTool.vue` imports `VncViewer`/`VncToolbar` from `@autobot/vnc`
- [ ] `npm install` in each frontend resolves symlinks correctly
- [ ] No `@/` alias references in plugin source (plugins are self-contained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)