### PR TITLE
fix(llm-cache,classification,knowledge): Batch S — 4 discovery follow-ups (#8399 #8398 #8401 #8402)

### DIFF
--- a/autobot-backend/agents/gemma_classification_agent.py
+++ b/autobot-backend/agents/gemma_classification_agent.py
@@ -37,9 +37,9 @@ logger = get_logger(__name__)
 # Tunable via AUTOBOT_CLASSIFICATION_CACHE_TTL; default 5 minutes.
 try:
     _CLASSIFICATION_CACHE_TTL = int(os.environ.get("AUTOBOT_CLASSIFICATION_CACHE_TTL", "300"))
-    if _CLASSIFICATION_CACHE_TTL <= 0:
+    if _CLASSIFICATION_CACHE_TTL < 0:
         _CLASSIFICATION_CACHE_TTL = 300
-        logger.warning("AUTOBOT_CLASSIFICATION_CACHE_TTL <= 0, using default 300s")
+        logger.warning("AUTOBOT_CLASSIFICATION_CACHE_TTL < 0, using default 300s (set to 0 to disable)")
 except (ValueError, TypeError):
     _CLASSIFICATION_CACHE_TTL = 300
     logger.warning("Invalid AUTOBOT_CLASSIFICATION_CACHE_TTL=%r, using default 300s",

--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -968,7 +968,7 @@ async def clear_cache(cache_name: str, admin_check: bool = Depends(check_admin_p
 
         coordinator = await get_cache_coordinator()
         if cache_name in coordinator._caches:
-            coordinator._caches[cache_name].clear()
+            await coordinator._caches[cache_name].clear()
             return {
                 "status": "cleared",
                 "cache": cache_name,

--- a/autobot-backend/cache/protocols.py
+++ b/autobot-backend/cache/protocols.py
@@ -51,6 +51,6 @@ class CacheProtocol(Protocol):
         """
         ...
 
-    def clear(self) -> None:
+    async def clear(self) -> None:
         """Clear all items from cache."""
         ...

--- a/autobot-backend/code_intelligence/shared/ast_cache.py
+++ b/autobot-backend/code_intelligence/shared/ast_cache.py
@@ -446,7 +446,7 @@ class ASTCache:
                 evicted += 1
         return evicted
 
-    def clear(self) -> None:
+    async def clear(self) -> None:
         """
         Clear all items from cache (CacheProtocol).
 

--- a/autobot-backend/code_intelligence/shared/file_cache.py
+++ b/autobot-backend/code_intelligence/shared/file_cache.py
@@ -312,7 +312,7 @@ class FileListCache:
                 self._stats.invalidations += 1
         return evicted
 
-    def clear(self) -> None:
+    async def clear(self) -> None:
         """
         Clear all items from cache (CacheProtocol).
 

--- a/autobot-backend/knowledge/base.py
+++ b/autobot-backend/knowledge/base.py
@@ -381,7 +381,7 @@ class KnowledgeBaseCore:
         # Issue #8391: Instantiate VectorWriteBuffer backed by this collection.
         # buffer.start() is called in lifespan after KB init succeeds.
         from knowledge.write_buffer import VectorWriteBuffer, make_chromadb_flush_fn
-        self._write_buffer = VectorWriteBuffer(flush_fn=make_chromadb_flush_fn(raw_collection))
+        self._write_buffer = VectorWriteBuffer(flush_fn=make_chromadb_flush_fn(self.vector_store))
 
         logger.info(
             "ChromaDB vector store initialized: collection='%s'",

--- a/autobot-backend/knowledge/embedding_cache.py
+++ b/autobot-backend/knowledge/embedding_cache.py
@@ -317,7 +317,7 @@ class EmbeddingCache:
             "arc_p": self._p,
         }
 
-    def clear(self) -> None:
+    async def clear(self) -> None:
         """Clear all cached embeddings and reset ARC state."""
         self._t1.clear()
         self._t2.clear()

--- a/autobot-backend/knowledge/embedding_cache_test.py
+++ b/autobot-backend/knowledge/embedding_cache_test.py
@@ -6,6 +6,7 @@ Tests the ARC cache with TTL for ChromaDB query embeddings.
 import asyncio
 
 import pytest
+import pytest_asyncio
 
 from knowledge_base import EmbeddingCache, get_embedding_cache
 
@@ -16,11 +17,11 @@ def cache():
     return EmbeddingCache(maxsize=3, ttl_seconds=2)
 
 
-@pytest.fixture
-def global_cache():
+@pytest_asyncio.fixture
+async def global_cache():
     """Get the global cache instance"""
     cache = get_embedding_cache()
-    cache.clear()  # Reset for testing
+    await cache.clear()  # Reset for testing
     return cache
 
 
@@ -204,7 +205,7 @@ class TestEmbeddingCache:
         assert stats["cache_size"] == 2
         assert stats["misses"] == 0
 
-        cache.clear()
+        await cache.clear()
 
         stats = cache.get_stats()
         assert stats["cache_size"] == 0

--- a/autobot-backend/knowledge/tiering.py
+++ b/autobot-backend/knowledge/tiering.py
@@ -154,6 +154,9 @@ class CollectionTierManager:
         self._entries: Dict[str, TierEntry] = {}
         self._lock = asyncio.Lock()
         self._reaper: Optional[asyncio.Task] = None
+        # O(1) tier counters — updated on every promote/demote (Issue #8402)
+        self._hot_count: int = 0
+        self._warm_count: int = 0
         # Pluggable index loaders — set by the caller for each tier
         self._hot_loader: Optional[Any] = None   # callable(collection_id) → index
         self._warm_loader: Optional[Any] = None
@@ -243,13 +246,9 @@ class CollectionTierManager:
     # ------------------------------------------------------------------
 
     def _desired_tier(self, entry: TierEntry) -> Tier:
-        if entry.access_count >= PROMOTE_TO_HOT_ACCESSES and len(
-            [e for e in self._entries.values() if e.tier == Tier.HOT]
-        ) < self._hot_max:
+        if entry.access_count >= PROMOTE_TO_HOT_ACCESSES and self._hot_count < self._hot_max:
             return Tier.HOT
-        if entry.access_count >= PROMOTE_TO_WARM_ACCESSES and len(
-            [e for e in self._entries.values() if e.tier == Tier.WARM]
-        ) < self._warm_max:
+        if entry.access_count >= PROMOTE_TO_WARM_ACCESSES and self._warm_count < self._warm_max:
             return Tier.WARM
         return Tier.COLD
 
@@ -265,14 +264,25 @@ class CollectionTierManager:
             except Exception:
                 logger.exception("Failed to load %s-tier index for %s", new_tier, entry.collection_id)
                 return
+        if old_tier == Tier.HOT:
+            self._hot_count -= 1
+        elif old_tier == Tier.WARM:
+            self._warm_count -= 1
+        if new_tier == Tier.HOT:
+            self._hot_count += 1
+        elif new_tier == Tier.WARM:
+            self._warm_count += 1
         entry.tier = new_tier
         logger.info("Collection %s promoted %s→%s", entry.collection_id, old_tier, new_tier)
 
     async def _demote(self, entry: TierEntry) -> None:
         if entry.tier == Tier.HOT:
             new_tier = Tier.WARM
+            self._hot_count -= 1
+            self._warm_count += 1
         elif entry.tier == Tier.WARM:
             new_tier = Tier.COLD
+            self._warm_count -= 1
         else:
             return
         old_tier = entry.tier

--- a/autobot-backend/knowledge/write_buffer.py
+++ b/autobot-backend/knowledge/write_buffer.py
@@ -153,19 +153,27 @@ class VectorWriteBuffer:
         return len(batch)
 
 
-def make_chromadb_flush_fn(collection: Any) -> Callable[[List[BufferedWrite]], Coroutine[Any, Any, None]]:
+def make_chromadb_flush_fn(vector_store: Any) -> Callable[[List[BufferedWrite]], Coroutine[Any, Any, None]]:
     """
-    Build a flush function that upserts buffered writes into a ChromaDB collection.
+    Build a flush function that adds buffered writes via a LlamaIndex ChromaVectorStore.
 
-    The collection argument must expose an async-compatible upsert interface or be
-    wrapped with asyncio.to_thread() — this factory handles the wrapping.
+    Uses vector_store.add(nodes) to preserve LlamaIndex internal metadata fields
+    (_node_content, _node_type, ref_doc_id) needed for NodeWithScore reconstruction.
+    Direct collection.upsert() bypasses these fields — Issue #8401.
     """
 
     async def _flush(batch: List[BufferedWrite]) -> None:
-        ids = [e.id for e in batch]
-        embeddings = [e.embedding for e in batch]
-        documents = [e.document for e in batch]
-        metadatas = [e.metadata for e in batch]
-        await asyncio.to_thread(collection.upsert, ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas)
+        from llama_index.core.schema import TextNode
+
+        nodes = [
+            TextNode(
+                id_=e.id,
+                text=e.document,
+                embedding=e.embedding,
+                metadata=e.metadata,
+            )
+            for e in batch
+        ]
+        await asyncio.to_thread(vector_store.add, nodes)
 
     return _flush

--- a/autobot-backend/llm_shared/cache.py
+++ b/autobot-backend/llm_shared/cache.py
@@ -347,7 +347,7 @@ class LLMResponseCache:
             "l1_max_size": self._memory_cache_max_size,
         }
 
-    def clear(self) -> None:
+    async def clear(self) -> None:
         """Clear L1 memory cache (CacheProtocol compliance)."""
         self._memory_cache.clear()
         self._memory_cache_access.clear()

--- a/autobot-backend/memory/cache.py
+++ b/autobot-backend/memory/cache.py
@@ -116,7 +116,7 @@ class LRUCacheManager:
         stats["enabled"] = True
         return stats
 
-    def clear(self) -> None:
+    async def clear(self) -> None:
         """Clear all items from cache."""
         with self._lock:
             self._cache.clear()


### PR DESCRIPTION
## Summary

Discovery follow-up fixes from Batch M/P merges — 4 structural correctness issues.

- **#8399** `CacheProtocol.clear()` async conformance: `SemanticLLMCache.clear()` was already `async def` but the Protocol defined it as sync, causing `api/system.py` to call it without `await` and silently drop the coroutine. Made all CacheProtocol implementations `async def clear()` and added `await` at the coordinator call site.

- **#8398** Allow `AUTOBOT_CLASSIFICATION_CACHE_TTL=0` to disable caching: guard was `<= 0` which clamped intentional zero to 300 s. Changed to `< 0` so only negative values are rejected.

- **#8401** VectorWriteBuffer LlamaIndex metadata: `make_chromadb_flush_fn` called `collection.upsert()` directly, bypassing `_node_content`/`_node_type`/`ref_doc_id` fields LlamaIndex needs for `NodeWithScore` reconstruction. Now builds `TextNode` objects and calls `vector_store.add(nodes)`. `base.py` passes `self.vector_store` instead of `raw_collection`.

- **#8402** O(n) scan removal: `CollectionTierManager._desired_tier()` did two list-comprehension passes on every `record_access()` call inside `asyncio.Lock`. Replaced with `_hot_count`/`_warm_count` int counters maintained in `_promote()` and `_demote()`.

## Files changed

| File | Fix |
|------|-----|
| `cache/protocols.py` | `async def clear()` in Protocol |
| `api/system.py` | `await` coordinator clear |
| `llm_shared/cache.py` | `async def clear()` |
| `memory/cache.py` | `async def clear()` |
| `knowledge/embedding_cache.py` | `async def clear()` |
| `code_intelligence/shared/ast_cache.py` | `async def clear()` |
| `code_intelligence/shared/file_cache.py` | `async def clear()` |
| `agents/gemma_classification_agent.py` | TTL=0 disable |
| `knowledge/write_buffer.py` | LlamaIndex flush via `vector_store.add()` |
| `knowledge/base.py` | Pass `self.vector_store` to flush fn |
| `knowledge/tiering.py` | O(1) counters for tier capacity |

## Test plan

- [ ] `python3 -m py_compile` passes on all 11 changed files ✅
- [ ] `SemanticLLMCache.clear()` now awaited correctly via coordinator
- [ ] `AUTOBOT_CLASSIFICATION_CACHE_TTL=0` disables caching; negative still defaults to 300 s
- [ ] VectorWriteBuffer flush preserves `_node_content`/`_node_type` in ChromaDB
- [ ] `CollectionTierManager._desired_tier()` is O(1) inside `asyncio.Lock`

Closes #8399, #8398, #8401, #8402

🤖 Generated with [Claude Code](https://claude.com/claude-code)