### PR TITLE
fix(frontend): KnowledgePersistenceDialog bulk-action buttons disabled when all selected (#8395)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
@@ -328,9 +328,13 @@ const {
   selectAll,
   clear: deselectAllItems,
   selectedItems: selectedPendingItems,
-  someSelected: hasSelectedItems,
+  selectedCount,
   selected: selectedKeys,
 } = useBatchSelection<PendingKnowledgeItem, string>(pendingItems, item => item.id);
+
+// someSelected is false when ALL items are selected — use selectedCount > 0 so
+// bulk-action buttons remain enabled when the user selects all (GH#8395).
+const hasSelectedItems = computed(() => selectedCount.value > 0);
 
 const compileOptions = ref({
   includeSystemMessages: false,


### PR DESCRIPTION
## Summary

- `useBatchSelection.someSelected` returns `false` when ALL items are selected (`count === total`), causing the Add/Keep/Delete bulk-action buttons to remain disabled when the user selects everything via "Select All".
- Fixed by replacing the `hasSelectedItems` alias (which mapped to `someSelected`) with a direct `computed(() => selectedCount.value > 0)` check, so all three buttons activate whenever at least one item is selected — regardless of whether it's a partial or full selection.

## Test plan

- [ ] Select a subset of items — bulk buttons enable ✅
- [ ] Select all items ("Select All") — bulk buttons still enable ✅  
- [ ] Deselect all — bulk buttons disable ✅
- [ ] `vue-tsc --noEmit` passes on changed file

Closes GH#8395

🤖 Generated with [Claude Code](https://claude.com/claude-code)