### PR TITLE
fix(cache): replace threading.Lock with asyncio.Lock in LRUCacheManager.clear() (#8421)

### DIFF
--- a/autobot-backend/memory/cache.py
+++ b/autobot-backend/memory/cache.py
@@ -5,6 +5,7 @@
 LRU Cache Manager - In-memory LRU caching with statistics
 """
 
+import asyncio
 import threading
 from collections import OrderedDict
 from typing import Any, Dict
@@ -37,7 +38,8 @@ class LRUCacheManager:
         self._cache: OrderedDict = OrderedDict()
         self._hits = 0
         self._misses = 0
-        self._lock = threading.Lock()  # Lock for thread-safe cache access
+        self._lock = threading.Lock()
+        self._async_lock = asyncio.Lock()
 
     @property
     def name(self) -> str:
@@ -118,7 +120,7 @@ class LRUCacheManager:
 
     async def clear(self) -> None:
         """Clear all items from cache."""
-        with self._lock:
+        async with self._async_lock:
             self._cache.clear()
             self._hits = 0
             self._misses = 0


### PR DESCRIPTION
## Problem

`LRUCacheManager.clear()` is `async def` (required by `CacheProtocol`) but held `self._lock` which is a `threading.Lock`. A contended `threading.Lock` inside an async method blocks the entire event loop thread until the lock is released.

## Fix

- Added `self._async_lock = asyncio.Lock()` in `__init__`
- `clear()` now uses `async with self._async_lock:` — non-blocking in async context
- All sync methods (`get`, `put`, `evict`, `get_stats`, `size` property) keep `threading.Lock` for thread safety

## Verification

```
python3 -m py_compile autobot-backend/memory/cache.py  → OK: syntax clean
```

Closes #8421