### PR TITLE
fix(terminal): commandExecuted emitted after buffer clear in autobot-frontend BaseXTerminal (GH#8422)

### DIFF
--- a/autobot-frontend/src/components/terminal/BaseXTerminal.vue
+++ b/autobot-frontend/src/components/terminal/BaseXTerminal.vue
@@ -240,15 +240,15 @@ const handleTerminalData = (data: string) => {
     return
   }
 
-  // Issue #749: Track line buffer for tab completion
-  updateLineBuffer(data)
-
-  // Issue #749: Emit commandExecuted when Enter is pressed
+  // Issue #749: Emit commandExecuted when Enter is pressed (BEFORE buffer clear)
   if (data === '\r' || data === '\n') {
     if (currentLineBuffer.value.trim()) {
       emit('commandExecuted', currentLineBuffer.value.trim())
     }
   }
+
+  // Issue #749: Track line buffer for tab completion
+  updateLineBuffer(data)
 
   // Emit data for normal processing
   emit('data', data)


### PR DESCRIPTION
## Summary

Applies the same fix as MVA-776 (Batch V) to the main frontend copy of BaseXTerminal.vue.

- `autobot-frontend/src/components/terminal/BaseXTerminal.vue`: emit `commandExecuted` BEFORE `updateLineBuffer(data)` in `handleTerminalData`
- Batch V fixed `autobot-plugins/terminal/src/components/BaseXTerminal.vue` but the identical bug existed in the main frontend copy

Closes #8422