### PR TITLE
fix(ansible): replace | last(N) with [-N:] slice to fix Jinja2 crash log display

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -663,7 +663,7 @@
     msg: >-
       SLM backend Python import failed — see error above and in
       {{ slm_log_dir }}/slm-startup-smoke.log.
-      Last output: {{ _slm_import_check.stdout_lines | default([]) | last(20) }}
+      Last output: {{ (_slm_import_check.stdout_lines | default([]))[-20:] }}
   when: _slm_import_check.rc | default(0) != 0
   tags: ['slm', 'service']
 
@@ -749,7 +749,7 @@
 
     - name: "SLM | Display last 30 lines of backend log on failure"
       ansible.builtin.debug:
-        msg: "{{ _slm_backend_log_output.stdout_lines | default([]) | last(30) }}"
+        msg: "{{ (_slm_backend_log_output.stdout_lines | default([]))[-30:] }}"
       tags: ['slm', 'service', 'debug']
 
     - name: "SLM | Fail with diagnostic context"


### PR DESCRIPTION
## Summary

- Fixes Jinja2 `do_last() takes 2 positional arguments but 3 were given` crash in the Ansible rescue block during SLM install
- The `last` filter in Ansible/Jinja2 takes 0 args; `last(30)` is invalid — replaced with `[-30:]` slice notation
- Two occurrences fixed: the import smoke check display (line 663) and the health-check failure display (line 752)
- This was causing the `deploy-slm-manager.yml` playbook to always fail on the error path, masking actual backend errors

## Root Cause

During installation (`deploy-slm-manager.yml`), if the SLM backend fails to start, Ansible enters a rescue block that tries to display the last 30 lines of logs using `| last(30)`. This filter syntax is invalid — `last` takes no arguments in Jinja2. The fix uses Python-style slice `[-30:]` which is natively supported.

The primary backend crash (`callable | None` TypeError in `playbook_executor.py`) was already fixed in commits `22fef20e9` and `da74c4192`.

## Test plan

- [ ] Run `ansible-playbook deploy-slm-manager.yml` on a clean install — health check passes, no Jinja2 error
- [ ] Manually trigger a simulated health-check failure (e.g. bad port) and verify the rescue block displays logs instead of crashing with `do_last()` error
- [ ] Verify `slm-backend.log` and `slm-backend-error.log` show clean startup after deployment

Fixes MVA-786

🤖 Generated with Claude Code (DevOpsEngineer agent)