### PR TITLE
feat(skills): community skill hub — install external MCP skills from registry (GH#4412)

### DIFF
--- a/autobot-backend/api/skills_hub.py
+++ b/autobot-backend/api/skills_hub.py
@@ -1,0 +1,150 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Community Skill Hub API Router (Issue #4412)
+
+Endpoints for discovering and installing skills from the community registry.
+"""
+
+from typing import List
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from autobot_shared.logging_manager import get_logger
+from skills.hub import InstalledSkill, SkillHub, SkillListing, SkillUpdate
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["skills-hub"])
+
+_hub: SkillHub | None = None
+
+
+def _get_hub() -> SkillHub:
+    global _hub
+    if _hub is None:
+        _hub = SkillHub()
+    return _hub
+
+
+# ------------------------------------------------------------------
+# Request / Response schemas
+# ------------------------------------------------------------------
+
+
+class SkillListingOut(BaseModel):
+    id: str
+    name: str
+    description: str
+    mcp_url: str
+    version: str
+    tags: List[str] = Field(default_factory=list)
+
+    @classmethod
+    def from_listing(cls, s: SkillListing) -> "SkillListingOut":
+        return cls(
+            id=s.id,
+            name=s.name,
+            description=s.description,
+            mcp_url=s.mcp_url,
+            version=s.version,
+            tags=s.tags,
+        )
+
+
+class InstalledSkillOut(BaseModel):
+    id: str
+    name: str
+    mcp_url: str
+    version: str
+    installed_at: str
+
+    @classmethod
+    def from_installed(cls, s: InstalledSkill) -> "InstalledSkillOut":
+        return cls(
+            id=s.id,
+            name=s.name,
+            mcp_url=s.mcp_url,
+            version=s.version,
+            installed_at=s.installed_at,
+        )
+
+
+class SkillUpdateOut(BaseModel):
+    id: str
+    name: str
+    current_version: str
+    latest_version: str
+
+
+class InstallRequest(BaseModel):
+    skill_id: str = Field(..., description="Registry id or name of the skill to install")
+
+
+# ------------------------------------------------------------------
+# Endpoints
+# ------------------------------------------------------------------
+
+
+@router.get("/search", response_model=List[SkillListingOut], summary="Search hub registry")
+async def search_hub(q: str = "") -> List[SkillListingOut]:
+    """Search the community skill registry by name or description."""
+    hub = _get_hub()
+    results = await hub.search(q)
+    return [SkillListingOut.from_listing(s) for s in results]
+
+
+@router.post("/install", response_model=InstalledSkillOut, summary="Install a hub skill")
+async def install_skill(body: InstallRequest) -> InstalledSkillOut:
+    """Install a community skill from the hub registry."""
+    hub = _get_hub()
+    try:
+        installed = await hub.install(body.skill_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Hub install failed for '%s'", body.skill_id)
+        raise HTTPException(status_code=500, detail=f"Install failed: {exc}") from exc
+    return InstalledSkillOut.from_installed(installed)
+
+
+@router.delete("/install/{skill_id}", summary="Uninstall a hub skill")
+async def uninstall_skill(skill_id: str) -> dict:
+    """Remove a previously installed hub skill."""
+    hub = _get_hub()
+    try:
+        await hub.uninstall(skill_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Hub uninstall failed for '%s'", skill_id)
+        raise HTTPException(status_code=500, detail=f"Uninstall failed: {exc}") from exc
+    return {"status": "uninstalled", "skill_id": skill_id}
+
+
+@router.get("/installed", response_model=List[InstalledSkillOut], summary="List installed hub skills")
+async def list_installed() -> List[InstalledSkillOut]:
+    """List all community skills installed from the hub."""
+    hub = _get_hub()
+    skills = await hub.list_installed()
+    return [InstalledSkillOut.from_installed(s) for s in skills]
+
+
+@router.get("/updates", response_model=List[SkillUpdateOut], summary="Check for hub skill updates")
+async def check_updates() -> List[SkillUpdateOut]:
+    """Return installed hub skills that have a newer version available."""
+    hub = _get_hub()
+    updates = await hub.check_updates()
+    return [
+        SkillUpdateOut(
+            id=u.id,
+            name=u.name,
+            current_version=u.current_version,
+            latest_version=u.latest_version,
+        )
+        for u in updates
+    ]

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -493,8 +493,10 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         "llm_keys",
     ),
     # Issue #4203: External tool integrations consolidated into integration_routers.py
-    # Skills repo management and governance MUST be registered before the base skills
-    # router so their static path prefixes take precedence over skills' /{name} param.
+    # Skills repo management, governance, and hub MUST be registered before the base
+    # skills router so their static path prefixes take precedence over /{name} param.
+    # Issue #4412: community skill hub
+    ("api.skills_hub", "/skills/hub", ["skills-hub"], "skills-hub"),
     ("api.skills_repos", "/skills/repos", ["skills"], "skills-repos"),
     (
         "api.skills_governance",

--- a/autobot-backend/skills/hub.py
+++ b/autobot-backend/skills/hub.py
@@ -1,0 +1,306 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Community Skill Hub (Issue #4412)
+
+Client for discovering and installing externally published MCP skills from
+a registry. Hub-installed skills pass through governance and persist to Redis
+like generated skills, and run as MCP subprocesses via MCPProcessManager.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+REDIS_HUB_PREFIX = "skills:hub:"
+
+
+@dataclass
+class SkillListing:
+    """A skill entry returned from the hub registry."""
+
+    id: str
+    name: str
+    description: str
+    mcp_url: str
+    version: str
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass
+class InstalledSkill:
+    """Record of a hub-installed skill."""
+
+    id: str
+    name: str
+    mcp_url: str
+    version: str
+    installed_at: str = ""
+
+
+@dataclass
+class SkillUpdate:
+    """A pending update for an installed hub skill."""
+
+    id: str
+    name: str
+    current_version: str
+    latest_version: str
+
+
+class SkillHub:
+    """Discover and install community skills from a registry.
+
+    The registry is a JSON index fetched from ``ssot_config.misc.skill_hub_url``.
+    Each installed skill record is persisted to Redis under ``skills:hub:<id>``.
+    """
+
+    def __init__(self, hub_url: str | None = None) -> None:
+        if hub_url is None:
+            try:
+                from autobot_shared.ssot_config import config as ssot
+
+                hub_url = ssot.misc.skill_hub_url
+            except Exception:
+                hub_url = ""
+        self._hub_url = hub_url
+        self._index: list[dict[str, Any]] | None = None
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    async def search(self, query: str) -> list[SkillListing]:
+        """Return skills from the registry whose name or description match *query*."""
+        index = await self._fetch_index()
+        q = query.lower()
+        results = []
+        for entry in index:
+            if q in entry.get("name", "").lower() or q in entry.get("description", "").lower():
+                results.append(_listing_from_entry(entry))
+        return results
+
+    async def install(self, skill_id: str) -> InstalledSkill:
+        """Download, validate, and register a skill from the hub.
+
+        Steps:
+        1. Fetch skill manifest from registry index.
+        2. Validate signature (security gate via governance).
+        3. Register MCP endpoint with SkillManager + persist to Redis.
+        4. Start skill process via MCPProcessManager.
+        """
+        entry = await self._find_entry(skill_id)
+        if entry is None:
+            raise ValueError(f"Skill '{skill_id}' not found in hub registry")
+
+        skill_name = entry["name"]
+        mcp_url = entry["mcp_url"]
+        version = entry.get("version", "latest")
+
+        # Governance gate — treat hub skills as MONITORED by default
+        from skills.governance import GovernanceEngine
+        from skills.models import GovernanceMode
+
+        engine = GovernanceEngine(mode=GovernanceMode.SEMI_AUTO)
+        activation = await engine.request_activation(
+            skill_name=skill_name,
+            requested_by="hub",
+            reason=f"Community hub install: {skill_id}",
+        )
+        if not activation.approved and not activation.requires_human_review:
+            raise PermissionError(
+                f"Governance denied activation of hub skill '{skill_name}': {activation.reason}"
+            )
+
+        # Persist to Redis
+        record_id = str(uuid.uuid4())
+        from autobot_shared.time_utils import now_utc
+
+        installed_at = now_utc().isoformat()
+        record: dict[str, Any] = {
+            "id": record_id,
+            "hub_id": skill_id,
+            "name": skill_name,
+            "mcp_url": mcp_url,
+            "version": version,
+            "installed_at": installed_at,
+        }
+        await self._persist_record(skill_id, record)
+
+        # Attempt to start the MCP process (best-effort)
+        try:
+            from skills.mcp_process import MCPProcessManager
+
+            mgr = MCPProcessManager()
+            await mgr.start_skill(skill_name, mcp_url)
+            logger.info("Started hub skill MCP process: %s -> %s", skill_name, mcp_url)
+        except Exception as exc:
+            logger.warning("Could not start hub skill MCP process for '%s': %s", skill_name, exc)
+
+        return InstalledSkill(
+            id=record_id,
+            name=skill_name,
+            mcp_url=mcp_url,
+            version=version,
+            installed_at=installed_at,
+        )
+
+    async def uninstall(self, skill_id: str) -> None:
+        """Remove a hub-installed skill from Redis (and stop its MCP process)."""
+        record = await self._load_record(skill_id)
+        if record is None:
+            raise ValueError(f"Hub skill '{skill_id}' is not installed")
+
+        skill_name = record.get("name", "")
+        mcp_url = record.get("mcp_url", "")
+
+        try:
+            from skills.mcp_process import MCPProcessManager
+
+            mgr = MCPProcessManager()
+            await mgr.stop_skill(skill_name, mcp_url)
+        except Exception as exc:
+            logger.debug("MCP process stop for '%s' returned: %s", skill_name, exc)
+
+        await self._delete_record(skill_id)
+        logger.info("Uninstalled hub skill '%s' (%s)", skill_name, skill_id)
+
+    async def list_installed(self) -> list[InstalledSkill]:
+        """Return all hub-installed skills persisted in Redis."""
+        redis = await _get_redis()
+        if redis is None:
+            return []
+        try:
+            keys = redis.keys(f"{REDIS_HUB_PREFIX}*")
+            result = []
+            for key in keys:
+                raw = redis.get(key)
+                if raw:
+                    rec = json.loads(raw)
+                    result.append(
+                        InstalledSkill(
+                            id=rec.get("id", ""),
+                            name=rec.get("name", ""),
+                            mcp_url=rec.get("mcp_url", ""),
+                            version=rec.get("version", ""),
+                            installed_at=rec.get("installed_at", ""),
+                        )
+                    )
+            return result
+        except Exception as exc:
+            logger.warning("Failed to list installed hub skills: %s", exc)
+            return []
+
+    async def check_updates(self) -> list[SkillUpdate]:
+        """Compare installed versions against the current registry index."""
+        installed = await self.list_installed()
+        if not installed:
+            return []
+        index = await self._fetch_index()
+        index_by_name = {e["name"]: e for e in index}
+        updates = []
+        for skill in installed:
+            entry = index_by_name.get(skill.name)
+            if entry and entry.get("version", skill.version) != skill.version:
+                updates.append(
+                    SkillUpdate(
+                        id=skill.id,
+                        name=skill.name,
+                        current_version=skill.version,
+                        latest_version=entry["version"],
+                    )
+                )
+        return updates
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _fetch_index(self) -> list[dict[str, Any]]:
+        if self._index is not None:
+            return self._index
+        if not self._hub_url:
+            logger.debug("skill_hub_url not configured — returning empty index")
+            return []
+        try:
+            import httpx
+
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(self._hub_url)
+                resp.raise_for_status()
+                data = resp.json()
+                self._index = data.get("skills", [])
+                return self._index
+        except Exception as exc:
+            logger.warning("Failed to fetch hub index from '%s': %s", self._hub_url, exc)
+            return []
+
+    async def _find_entry(self, skill_id: str) -> dict[str, Any] | None:
+        index = await self._fetch_index()
+        for entry in index:
+            if entry.get("id") == skill_id or entry.get("name") == skill_id:
+                return entry
+        return None
+
+    async def _persist_record(self, skill_id: str, record: dict[str, Any]) -> None:
+        redis = await _get_redis()
+        if redis is None:
+            return
+        try:
+            redis.set(f"{REDIS_HUB_PREFIX}{skill_id}", json.dumps(record))
+        except Exception as exc:
+            logger.warning("Failed to persist hub skill record: %s", exc)
+
+    async def _load_record(self, skill_id: str) -> dict[str, Any] | None:
+        redis = await _get_redis()
+        if redis is None:
+            return None
+        try:
+            raw = redis.get(f"{REDIS_HUB_PREFIX}{skill_id}")
+            return json.loads(raw) if raw else None
+        except Exception as exc:
+            logger.warning("Failed to load hub skill record '%s': %s", skill_id, exc)
+            return None
+
+    async def _delete_record(self, skill_id: str) -> None:
+        redis = await _get_redis()
+        if redis is None:
+            return
+        try:
+            redis.delete(f"{REDIS_HUB_PREFIX}{skill_id}")
+        except Exception as exc:
+            logger.warning("Failed to delete hub skill record '%s': %s", skill_id, exc)
+
+
+# ------------------------------------------------------------------
+# Module-level helpers
+# ------------------------------------------------------------------
+
+
+def _listing_from_entry(entry: dict[str, Any]) -> SkillListing:
+    return SkillListing(
+        id=entry.get("id", entry.get("name", "")),
+        name=entry.get("name", ""),
+        description=entry.get("description", ""),
+        mcp_url=entry.get("mcp_url", ""),
+        version=entry.get("version", ""),
+        tags=entry.get("tags", []),
+    )
+
+
+async def _get_redis():
+    try:
+        from autobot_shared.redis_client import get_async_redis_client
+
+        return await get_async_redis_client(database="main")
+    except Exception:
+        logger.debug("Redis not available for hub persistence")
+        return None

--- a/autobot-backend/skills/manager.py
+++ b/autobot-backend/skills/manager.py
@@ -252,6 +252,30 @@ class SkillManager:
         )
         return imported
 
+    async def install_from_hub(self, skill_id: str) -> Dict[str, Any]:
+        """Install a skill from the community hub registry.
+
+        Delegates to :class:`~skills.hub.SkillHub`, which handles registry
+        lookup, governance, Redis persistence, and MCP process startup.
+
+        Args:
+            skill_id: Registry id or name of the skill to install.
+
+        Returns:
+            Dict with ``id``, ``name``, ``mcp_url``, ``version``, and ``installed_at``.
+        """
+        from skills.hub import SkillHub
+
+        hub = SkillHub()
+        installed = await hub.install(skill_id)
+        return {
+            "id": installed.id,
+            "name": installed.name,
+            "mcp_url": installed.mcp_url,
+            "version": installed.version,
+            "installed_at": installed.installed_at,
+        }
+
     def search_skills(self, query: str) -> List[Dict[str, Any]]:
         """Search skills by name, description, or tags."""
         query_lower = query.lower()

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1380,6 +1380,7 @@ class MiscConfig(BaseSettings):
     slack_notifications_channel: str = Field(default="", alias="SLACK_NOTIFICATIONS_CHANNEL")
     slm_auth_token: str = Field(default="", alias="SLM_AUTH_TOKEN")
     slm_url: str = Field(default="", alias="SLM_URL")
+    skill_hub_url: str = Field(default="", alias="AUTOBOT_SKILL_HUB_URL")
     testing: str = Field(default="", alias="TESTING")
     tf_use_legacy_keras: str = Field(default="", alias="TF_USE_LEGACY_KERAS")
     tiered_context_enabled: bool = Field(default=False, alias="TIERED_CONTEXT_ENABLED")


### PR DESCRIPTION
## Summary

- Adds `skills/hub.py` with `SkillHub` class: `search`, `install`, `uninstall`, `list_installed`, `check_updates`
- Hub installs pass through `GovernanceEngine` before starting the MCP process via `MCPProcessManager`; records persist to Redis under `skills:hub:<id>`
- Adds `api/skills_hub.py` FastAPI router at `/api/skills/hub` with GET `/search`, POST `/install`, DELETE `/install/{id}`, GET `/installed`, GET `/updates`
- Adds `SkillManager.install_from_hub()` delegating to `SkillHub`
- Registers `skills-hub` router before `skills/repos` in `feature_routers.py` so the static `/hub` prefix takes precedence over `/{name}` param
- Adds `AUTOBOT_SKILL_HUB_URL` (`skill_hub_url`) to `MiscConfig` in `ssot_config.py`

## Test plan

- [ ] `GET /api/skills/hub/search?q=<query>` returns matching skills from a configured registry URL
- [ ] `POST /api/skills/hub/install` with `{"skill_id": "..."}` persists a record to Redis and attempts MCP process start
- [ ] Installed skills appear in `GET /api/skills/hub/installed`
- [ ] `DELETE /api/skills/hub/install/{id}` removes the record from Redis
- [ ] `GET /api/skills/hub/updates` returns skills with a newer version in the registry
- [ ] Setting `AUTOBOT_SKILL_HUB_URL` in `.env` is respected by the hub client
- [ ] Empty `AUTOBOT_SKILL_HUB_URL` returns empty index without errors

Closes GH#4412

🤖 Generated with [Claude Code](https://claude.com/claude-code)