### PR TITLE
fix(analytics): fix 3 Celery migration regressions (GH#8433 critical, GH#8434, GH#8435)

### DIFF
--- a/autobot-backend/api/analytics.py
+++ b/autobot-backend/api/analytics.py
@@ -17,7 +17,6 @@ from typing import Any, Dict, List, Tuple
 import httpx
 from fastapi import (
     APIRouter,
-    BackgroundTasks,
     Depends,
     HTTPException,
     Query,
@@ -1240,46 +1239,6 @@ async def analyze_root_cause(
 # ------------------------------------------------------------------
 
 
-async def _run_dashboard_analysis(task_id: str) -> None:
-    """Background worker for dashboard overview (#1304)."""
-    try:
-        await _dash_manager.update_progress(task_id, "Collecting system health", 10.0)
-        results = await asyncio.gather(
-            hardware_monitor.get_system_health(),
-            analytics_controller.collect_performance_metrics(),
-            analytics_controller.analyze_communication_patterns(),
-            analytics_controller.get_usage_statistics(),
-            analytics_controller.detect_trends(),
-            return_exceptions=True,
-        )
-
-        await _dash_manager.update_progress(task_id, "Processing metrics", 60.0)
-        system_health = _handle_task_exception(results[0], "system_health")
-        performance = _handle_task_exception(results[1], "performance")
-        communication = _handle_task_exception(results[2], "communication")
-        usage = _handle_task_exception(results[3], "usage")
-        trends = _handle_task_exception(results[4], "trends")
-
-        await _dash_manager.update_progress(task_id, "Building overview", 80.0)
-        code_status = await _get_code_analysis_status()
-        realtime = await _get_realtime_metrics()
-
-        result = {
-            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            "system_health": system_health,
-            "performance_metrics": performance,
-            "communication_patterns": communication,
-            "code_analysis_status": code_status,
-            "usage_statistics": usage,
-            "realtime_metrics": realtime,
-            "trends": trends,
-        }
-        await _dash_manager.complete_task(task_id, result)
-    except Exception as e:
-        logger.error("Dashboard analysis failed: %s", e)
-        await _dash_manager.fail_task(task_id, str(e))
-
-
 @router.post("/dashboard/overview/analyze", response_model=AnalyticsDashboardAnalyzeResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1287,13 +1246,12 @@ async def _run_dashboard_analysis(task_id: str) -> None:
     error_code_prefix="ANALYTICS",
 )
 async def start_dashboard_analysis(
-    background_tasks: BackgroundTasks,
     current_user: Dict = Depends(get_current_user),
 ):
-    """Start background dashboard overview analysis (#1304)."""
-    task_id = await _dash_manager.create_task()
-    background_tasks.add_task(_run_dashboard_analysis, task_id)
-    return {"task_id": task_id, "status": "pending"}
+    """Start background dashboard overview analysis (#1304, GH#8433)."""
+    celery_result = run_dashboard_analysis.delay()
+    await store_latest_task_id(_REDIS_PREFIX, celery_result.id)
+    return {"task_id": celery_result.id, "status": "pending"}
 
 
 @router.get("/dashboard/overview/status/{task_id}", response_model=AnalyticsDashboardStatusResponse)
@@ -1303,8 +1261,8 @@ async def start_dashboard_analysis(
     error_code_prefix="ANALYTICS",
 )
 async def get_dashboard_status(task_id: str):
-    """Get dashboard overview task status (#1304)."""
-    task = await _dash_manager.get_status(task_id)
+    """Get dashboard overview task status (#1304, GH#8433)."""
+    task = celery_result_to_status(AsyncResult(task_id))
     if task is None:
         raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
     return task
@@ -1322,9 +1280,8 @@ async def clear_stuck_dashboard_tasks(
         description="Force clear ALL running tasks",
     ),
 ):
-    """Clear stuck dashboard overview tasks (#1304)."""
-    cleaned = await _dash_manager.clear_stuck(force=force)
+    """Clear stuck dashboard overview tasks — no-op, Celery handles recovery (GH#8433)."""
     return {
-        "cleared_count": cleaned,
-        "message": f"Cleared {cleaned} task(s)" + (" (forced)" if force else ""),
+        "cleared_count": 0,
+        "message": "Celery handles task recovery automatically",
     }

--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -2032,7 +2032,7 @@ async def start_security_analysis(
 async def get_security_score_status(task_id: str):
     """Get security score analysis task status."""
     status = celery_result_to_status(AsyncResult(task_id))
-    if status is None or status["status"] == "pending":
+    if status is None:
         raise_not_found("Task", task_id)
     return status
 

--- a/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
@@ -148,7 +148,7 @@ async def start_pattern_analysis(request: PatternAnalysisRequest) -> PatternAnal
 async def get_analysis_status(task_id: str) -> PatternAnalysisStatus:
     """Get status of a pattern analysis task."""
     task = celery_result_to_status(AsyncResult(task_id))
-    if task is None or task["status"] == "pending":
+    if task is None:
         raise HTTPException(status_code=404, detail=f"Analysis task {task_id} not found")
     return PatternAnalysisStatus(
         task_id=task_id,
@@ -256,7 +256,7 @@ async def start_pattern_summary_analysis(
 async def get_pattern_summary_status(task_id: str):
     """Get pattern summary task status."""
     status = celery_result_to_status(AsyncResult(task_id))
-    if status is None or status["status"] == "pending":
+    if status is None:
         raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
     return status
 

--- a/autobot-backend/tasks/analytics_tasks.py
+++ b/autobot-backend/tasks/analytics_tasks.py
@@ -22,11 +22,19 @@ logger = get_logger(__name__)
 
 
 def _run_async(coro):
-    """Run *coro* in a fresh event loop (Celery workers are sync)."""
+    """Run *coro* in a fresh event loop (Celery workers are sync).
+
+    GH#8434: drain any fire-and-forget tasks (asyncio.create_task) spawned
+    inside *coro* before closing the loop so they are not orphaned.
+    """
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
-        return loop.run_until_complete(coro)
+        result = loop.run_until_complete(coro)
+        pending = asyncio.all_tasks(loop)
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        return result
     finally:
         loop.close()
 


### PR DESCRIPTION
## Summary

- **GH#8433 (critical)**: `analytics.py` dashboard endpoints crashed with `NameError: _dash_manager` — the Celery migration removed the `BackgroundTaskManager`-backed `_dash_manager` but left its call-sites intact. Fixed by wiring the three endpoints to the already-imported Celery task (`run_dashboard_analysis.delay()`) and `celery_result_to_status()`. Also removes the unused `BackgroundTasks` import.
- **GH#8435**: `get_analysis_status` (pattern_analysis.py), `get_pattern_summary_status` (pattern_analysis.py), and `get_security_score_status` (code_intelligence.py) raised HTTP 404 for **any PENDING task** — but Celery returns PENDING for freshly-queued tasks that do exist. Fix: only raise 404 when `celery_result_to_status` returns `None`.
- **GH#8434**: `asyncio.create_task(_safe_store_prediction_history(...))` inside `_run_bug_analysis` is orphaned when the Celery wrapper calls `loop.close()` before the fire-and-forget task runs, so prediction history is never written. Fix: drain all pending tasks via `asyncio.gather` before `loop.close()` in `_run_async`.

## Files changed

| File | Change |
|------|--------|
| `api/analytics.py` | Replace `_dash_manager` calls with Celery + `celery_result_to_status`; remove `BackgroundTasks` |
| `api/codebase_analytics/endpoints/pattern_analysis.py` | Drop `status == "pending"` from 404 condition (×2) |
| `api/code_intelligence.py` | Drop `status == "pending"` from 404 condition |
| `tasks/analytics_tasks.py` | Drain pending asyncio tasks before `loop.close()` in `_run_async` |

## Test plan

- [ ] `POST /analytics/dashboard/overview/analyze` returns `{"task_id": "...", "status": "pending"}` (not NameError)
- [ ] `GET /analytics/dashboard/overview/status/{task_id}` returns status dict for both `pending` and `completed` states
- [ ] `POST /analytics/dashboard/overview/tasks/clear-stuck` returns `{"cleared_count": 0, ...}`
- [ ] `GET /codebase/patterns/status/{new_task_id}` returns `pending` status (not 404)
- [ ] `GET /code-intelligence/security/score/status/{new_task_id}` returns `pending` status (not 404)
- [ ] Bug prediction `/analyze` stores prediction history after analysis completes

Closes #8433, closes #8434, closes #8435

🤖 Generated with [Claude Code](https://claude.com/claude-code)