### PR TITLE
fix(tests): set rich_payload=None in _make_cell to fix JSON export tests

### DIFF
--- a/autobot-backend/tests/api/test_canvas.py
+++ b/autobot-backend/tests/api/test_canvas.py
@@ -66,6 +66,7 @@ def _make_cell(
     cell.owner = owner
     cell.version = 1
     cell.locked_by = None
+    cell.rich_payload = None
     cell.created_at = _NOW
     cell.updated_at = _NOW
     return cell


### PR DESCRIPTION
## Summary

- Adds `cell.rich_payload = None` in `_make_cell` test helper to fix 2 pre-existing JSON serialization failures in `TestExportHelpers`
- 1-line fix; `rich_payload` field added to the canvas model but the test factory wasn't updated

## Test plan

- [ ] Verify `TestExportHelpers` JSON export tests pass
- [ ] No other tests affected (single helper function touched)

Closes MVA-800

🤖 Generated with [Claude Code](https://claude.ai/claude-code)