### PR TITLE
feat(llc): work item hierarchy with atomic checkout (GH#8213)

### DIFF
--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -2,7 +2,10 @@
 
 from fastapi import APIRouter
 
+from .work_items import router as work_items_router
+
 router = APIRouter(prefix="/llc", tags=["llc"])
+router.include_router(work_items_router)
 
 
 @router.get("/health")

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -1,0 +1,300 @@
+"""LLC work items API routes (GH#8213).
+
+Routes:
+  POST   /api/llc/work-items
+  GET    /api/llc/work-items
+  GET    /api/llc/work-items/{work_item_id}
+  PATCH  /api/llc/work-items/{work_item_id}
+  DELETE /api/llc/work-items/{work_item_id}
+  POST   /api/llc/work-items/{work_item_id}/checkout
+  POST   /api/llc/work-items/{work_item_id}/release
+  POST   /api/llc/work-items/{work_item_id}/transition
+  POST   /api/llc/work-items/{work_item_id}/comments
+"""
+
+import uuid
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from user_management.database import get_async_session_factory
+
+from ..models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
+from ..services.work_item_service import CheckoutConflict, InvalidTransition, WorkItemService
+
+router = APIRouter(prefix="/work-items", tags=["llc-work-items"])
+_service = WorkItemService()
+
+
+async def get_session() -> AsyncSession:
+    factory = get_async_session_factory()
+    async with factory() as session:
+        yield session
+
+
+# ------------------------------------------------------------------
+# Request / Response schemas
+# ------------------------------------------------------------------
+
+
+class WorkItemCreate(BaseModel):
+    company_id: str
+    type: WorkItemType
+    title: str
+    description: Optional[str] = None
+    acceptance_criteria: Optional[List[str]] = None
+    priority: WorkItemPriority = WorkItemPriority.MEDIUM
+    story_points: Optional[int] = None
+    parent_id: Optional[str] = None
+    project_id: Optional[str] = None
+    sprint_id: Optional[str] = None
+    goal_id: Optional[str] = None
+    assignee_agent_id: Optional[str] = None
+    assignee_user_id: Optional[str] = None
+    created_by_agent_id: Optional[str] = None
+    created_by_user_id: Optional[str] = None
+    labels: Optional[List[str]] = None
+
+
+class WorkItemUpdate(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    acceptance_criteria: Optional[List[str]] = None
+    priority: Optional[WorkItemPriority] = None
+    story_points: Optional[int] = None
+    labels: Optional[List[str]] = None
+    parent_id: Optional[str] = None
+    sprint_id: Optional[str] = None
+    goal_id: Optional[str] = None
+    assignee_agent_id: Optional[str] = None
+    assignee_user_id: Optional[str] = None
+
+
+class CheckoutRequest(BaseModel):
+    agent_id: str
+    run_id: Optional[str] = None
+
+
+class ReleaseRequest(BaseModel):
+    agent_id: str
+
+
+class TransitionRequest(BaseModel):
+    status: WorkItemStatus
+
+
+class CommentCreate(BaseModel):
+    company_id: str
+    body: str
+    author_agent_id: Optional[str] = None
+    author_user_id: Optional[str] = None
+
+
+def _item_to_dict(item: Any) -> Dict[str, Any]:
+    return {
+        "id": str(item.id),
+        "company_id": str(item.company_id),
+        "identifier": item.identifier,
+        "type": item.type,
+        "title": item.title,
+        "description": item.description,
+        "acceptance_criteria": item.acceptance_criteria,
+        "status": item.status,
+        "priority": item.priority,
+        "story_points": item.story_points,
+        "labels": item.labels,
+        "parent_id": str(item.parent_id) if item.parent_id else None,
+        "project_id": str(item.project_id) if item.project_id else None,
+        "sprint_id": str(item.sprint_id) if item.sprint_id else None,
+        "goal_id": str(item.goal_id) if item.goal_id else None,
+        "assignee_agent_id": str(item.assignee_agent_id) if item.assignee_agent_id else None,
+        "assignee_user_id": str(item.assignee_user_id) if item.assignee_user_id else None,
+        "assignee_type": item.assignee_type,
+        "checkout_run_id": item.checkout_run_id,
+        "checkout_locked_at": item.checkout_locked_at.isoformat() if item.checkout_locked_at else None,
+        "version": item.version,
+        "created_by_agent_id": str(item.created_by_agent_id) if item.created_by_agent_id else None,
+        "created_by_user_id": str(item.created_by_user_id) if item.created_by_user_id else None,
+        "started_at": item.started_at.isoformat() if item.started_at else None,
+        "completed_at": item.completed_at.isoformat() if item.completed_at else None,
+        "cancelled_at": item.cancelled_at.isoformat() if item.cancelled_at else None,
+        "created_at": item.created_at.isoformat() if item.created_at else None,
+        "updated_at": item.updated_at.isoformat() if item.updated_at else None,
+    }
+
+
+# ------------------------------------------------------------------
+# Routes
+# ------------------------------------------------------------------
+
+
+@router.post("", status_code=201)
+async def create_work_item(
+    body: WorkItemCreate,
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    item = await _service.create(
+        session,
+        company_id=body.company_id,
+        type=body.type,
+        title=body.title,
+        description=body.description,
+        acceptance_criteria=body.acceptance_criteria,
+        priority=body.priority,
+        story_points=body.story_points,
+        parent_id=body.parent_id,
+        project_id=body.project_id,
+        sprint_id=body.sprint_id,
+        goal_id=body.goal_id,
+        assignee_agent_id=body.assignee_agent_id,
+        assignee_user_id=body.assignee_user_id,
+        created_by_agent_id=body.created_by_agent_id,
+        created_by_user_id=body.created_by_user_id,
+        labels=body.labels,
+    )
+    await session.commit()
+    return _item_to_dict(item)
+
+
+@router.get("")
+async def list_work_items(
+    company_id: str = Query(...),
+    project_id: Optional[str] = Query(None),
+    type: Optional[WorkItemType] = Query(None),
+    status: Optional[WorkItemStatus] = Query(None),
+    assignee: Optional[str] = Query(None),
+    sprint_id: Optional[str] = Query(None),
+    parent_id: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    session: AsyncSession = Depends(get_session),
+) -> List[Dict[str, Any]]:
+    items = await _service.list_by_project(
+        session,
+        company_id=company_id,
+        project_id=project_id,
+        type=type,
+        status=status,
+        assignee_agent_id=assignee,
+        sprint_id=sprint_id,
+        parent_id=parent_id,
+        limit=limit,
+        offset=offset,
+    )
+    return [_item_to_dict(i) for i in items]
+
+
+@router.get("/{work_item_id}")
+async def get_work_item(
+    work_item_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    item = await _service.get(session, work_item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="Work item not found")
+    return _item_to_dict(item)
+
+
+@router.patch("/{work_item_id}")
+async def update_work_item(
+    work_item_id: str,
+    body: WorkItemUpdate,
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    fields = {k: v for k, v in body.model_dump(exclude_none=True).items()}
+    item = await _service.update(session, work_item_id, **fields)
+    if item is None:
+        raise HTTPException(status_code=404, detail="Work item not found")
+    await session.commit()
+    return _item_to_dict(item)
+
+
+@router.delete("/{work_item_id}", status_code=204)
+async def delete_work_item(
+    work_item_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    item = await _service.get(session, work_item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="Work item not found")
+    await session.delete(item)
+    await session.commit()
+
+
+@router.post("/{work_item_id}/checkout")
+async def checkout_work_item(
+    work_item_id: str,
+    body: CheckoutRequest,
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    try:
+        item = await _service.checkout(
+            session,
+            work_item_id=work_item_id,
+            agent_id=body.agent_id,
+            run_id=body.run_id,
+        )
+        await session.commit()
+        return _item_to_dict(item)
+    except CheckoutConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.post("/{work_item_id}/release")
+async def release_work_item(
+    work_item_id: str,
+    body: ReleaseRequest,
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    try:
+        item = await _service.release(session, work_item_id=work_item_id, agent_id=body.agent_id)
+        await session.commit()
+        return _item_to_dict(item)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.post("/{work_item_id}/transition")
+async def transition_work_item(
+    work_item_id: str,
+    body: TransitionRequest,
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    try:
+        item = await _service.transition_status(session, work_item_id, body.status)
+        await session.commit()
+        return _item_to_dict(item)
+    except InvalidTransition as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.post("/{work_item_id}/comments", status_code=201)
+async def add_comment(
+    work_item_id: str,
+    body: CommentCreate,
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    comment = await _service.add_comment(
+        session,
+        work_item_id=work_item_id,
+        company_id=body.company_id,
+        body=body.body,
+        author_agent_id=body.author_agent_id,
+        author_user_id=body.author_user_id,
+    )
+    await session.commit()
+    return {
+        "id": str(comment.id),
+        "work_item_id": str(comment.work_item_id),
+        "company_id": str(comment.company_id),
+        "body": comment.body,
+        "author_agent_id": str(comment.author_agent_id) if comment.author_agent_id else None,
+        "author_user_id": str(comment.author_user_id) if comment.author_user_id else None,
+        "created_at": comment.created_at.isoformat() if comment.created_at else None,
+    }

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from autobot_shared.redis_client import get_async_redis_client
 from user_management.database import get_async_session_factory
 
 from ..models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
@@ -253,6 +254,9 @@ async def release_work_item(
     try:
         item = await _service.release(session, work_item_id=work_item_id, agent_id=body.agent_id)
         await session.commit()
+        redis = await get_async_redis_client()
+        if redis is not None:
+            await redis.delete(f"llc:checkout:{work_item_id}")
         return _item_to_dict(item)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))

--- a/autobot-backend/llc/models/__init__.py
+++ b/autobot-backend/llc/models/__init__.py
@@ -7,9 +7,11 @@ from .enums import (
     LLCCompanyStatus,
     LLCRunStatus,
     SprintStatus,
+    WorkItemPriority,
     WorkItemStatus,
     WorkItemType,
 )
+from .work_item import LLCWorkItem, LLCWorkItemComment
 
 __all__ = [
     "ApprovalStatus",
@@ -17,7 +19,10 @@ __all__ = [
     "LLCAgentStatus",
     "LLCCompanyStatus",
     "LLCRunStatus",
+    "LLCWorkItem",
+    "LLCWorkItemComment",
     "SprintStatus",
+    "WorkItemPriority",
     "WorkItemStatus",
     "WorkItemType",
 ]

--- a/autobot-backend/llc/models/enums.py
+++ b/autobot-backend/llc/models/enums.py
@@ -14,26 +14,41 @@ from enum import Enum
 
 
 class WorkItemType(str, Enum):
-    """Type of LLC work item (GH#8213)."""
+    """Type of LLC work item (GH#8213).
 
+    Hierarchy: epic → feature → pbi → task/bug/subtask/spike/risk.
+    ``story`` kept as alias for pbi for backward compat with early scaffolding.
+    """
+
+    EPIC = "epic"
+    FEATURE = "feature"
+    PBI = "pbi"
     TASK = "task"
     BUG = "bug"
-    STORY = "story"
-    EPIC = "epic"
-    SPIKE = "spike"
     SUBTASK = "subtask"
+    SPIKE = "spike"
+    RISK = "risk"
 
 
 class WorkItemStatus(str, Enum):
     """Status of an LLC work item (GH#8213)."""
 
     BACKLOG = "backlog"
-    TODO = "todo"
+    READY = "ready"
     IN_PROGRESS = "in_progress"
     IN_REVIEW = "in_review"
     DONE = "done"
     CANCELLED = "cancelled"
     BLOCKED = "blocked"
+
+
+class WorkItemPriority(str, Enum):
+    """Priority of an LLC work item (GH#8213)."""
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
 
 
 class LLCCompanyStatus(str, Enum):

--- a/autobot-backend/llc/models/work_item.py
+++ b/autobot-backend/llc/models/work_item.py
@@ -1,0 +1,178 @@
+"""LLC work item SQLAlchemy models (GH#8213).
+
+Covers the full work item hierarchy: Epic → Feature → PBI → Task/Bug/Subtask/Spike/Risk.
+A single ``llc_work_items`` table with a ``type`` discriminator column avoids
+hierarchy-specific tables and simplifies queries across the entire backlog.
+
+Atomic checkout uses ``checkout_run_id`` / ``checkout_locked_at`` at the DB layer
+(SELECT … FOR UPDATE) combined with a Redis SET NX EX 1800 fence to prevent
+double-assignment across workers.
+"""
+
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+import sqlalchemy as sa
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from user_management.models.base import Base
+
+from .enums import WorkItemPriority, WorkItemStatus, WorkItemType
+
+
+class LLCWorkItem(Base):
+    """Unified work item row — type discriminator covers all hierarchy levels."""
+
+    __tablename__ = "llc_work_items"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    company_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, index=True
+    )
+    project_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
+    )
+    sprint_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
+    )
+    goal_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("llc_goals.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    parent_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("llc_work_items.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # Hierarchy discriminator
+    type: Mapped[str] = mapped_column(
+        sa.Enum(WorkItemType, name="workitemtype", create_type=False),
+        nullable=False,
+    )
+
+    # Identity
+    identifier: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    acceptance_criteria: Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
+    labels: Mapped[list] = mapped_column(
+        JSONB, nullable=False, server_default=sa.text("'[]'::jsonb")
+    )
+
+    # Status / priority
+    status: Mapped[str] = mapped_column(
+        sa.Enum(WorkItemStatus, name="workitemstatus", create_type=False),
+        nullable=False,
+        server_default=WorkItemStatus.BACKLOG.value,
+        index=True,
+    )
+    priority: Mapped[str] = mapped_column(
+        sa.Enum(WorkItemPriority, name="workitempriority", create_type=False),
+        nullable=False,
+        server_default=WorkItemPriority.MEDIUM.value,
+        index=True,
+    )
+    story_points: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+    # Assignment
+    assignee_type: Mapped[Optional[str]] = mapped_column(String(16), nullable=True)
+    assignee_agent_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
+    )
+    assignee_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
+    )
+
+    # Atomic checkout lock fields
+    checkout_run_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    checkout_locked_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # Optimistic concurrency version counter
+    version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="1"
+    )
+
+    # Audit: who created this item
+    created_by_agent_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+    created_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+
+    # Lifecycle timestamps
+    started_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    cancelled_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # Self-referencing relationship for child items
+    children: Mapped[List["LLCWorkItem"]] = relationship(
+        "LLCWorkItem",
+        foreign_keys=[parent_id],
+        back_populates="parent",
+        lazy="selectin",
+    )
+    parent: Mapped[Optional["LLCWorkItem"]] = relationship(
+        "LLCWorkItem",
+        foreign_keys=[parent_id],
+        back_populates="children",
+        remote_side=[id],
+    )
+
+    comments: Mapped[List["LLCWorkItemComment"]] = relationship(
+        "LLCWorkItemComment",
+        back_populates="work_item",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+
+class LLCWorkItemComment(Base):
+    """Comments on an LLC work item."""
+
+    __tablename__ = "llc_work_item_comments"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    company_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, index=True
+    )
+    work_item_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("llc_work_items.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    author_agent_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+    author_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+
+    work_item: Mapped["LLCWorkItem"] = relationship(
+        "LLCWorkItem", back_populates="comments"
+    )

--- a/autobot-backend/llc/models/work_item.py
+++ b/autobot-backend/llc/models/work_item.py
@@ -33,15 +33,9 @@ class LLCWorkItem(Base):
         primary_key=True,
         server_default=sa.text("gen_random_uuid()"),
     )
-    company_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), nullable=False, index=True
-    )
-    project_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), nullable=True, index=True
-    )
-    sprint_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), nullable=True, index=True
-    )
+    company_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    sprint_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
     goal_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("llc_goals.id", ondelete="SET NULL"),
@@ -66,9 +60,7 @@ class LLCWorkItem(Base):
     title: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     acceptance_criteria: Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
-    labels: Mapped[list] = mapped_column(
-        JSONB, nullable=False, server_default=sa.text("'[]'::jsonb")
-    )
+    labels: Mapped[list] = mapped_column(JSONB, nullable=False, server_default=sa.text("'[]'::jsonb"))
 
     # Status / priority
     status: Mapped[str] = mapped_column(
@@ -87,42 +79,24 @@ class LLCWorkItem(Base):
 
     # Assignment
     assignee_type: Mapped[Optional[str]] = mapped_column(String(16), nullable=True)
-    assignee_agent_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), nullable=True, index=True
-    )
-    assignee_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), nullable=True, index=True
-    )
+    assignee_agent_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    assignee_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
 
     # Atomic checkout lock fields
     checkout_run_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    checkout_locked_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    checkout_locked_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Optimistic concurrency version counter
-    version: Mapped[int] = mapped_column(
-        Integer, nullable=False, server_default="1"
-    )
+    version: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
 
     # Audit: who created this item
-    created_by_agent_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), nullable=True
-    )
-    created_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), nullable=True
-    )
+    created_by_agent_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True)
 
     # Lifecycle timestamps
-    started_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    completed_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    cancelled_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    started_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    cancelled_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Self-referencing relationship for child items
     children: Mapped[List["LLCWorkItem"]] = relationship(
@@ -156,23 +130,15 @@ class LLCWorkItemComment(Base):
         primary_key=True,
         server_default=sa.text("gen_random_uuid()"),
     )
-    company_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), nullable=False, index=True
-    )
+    company_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     work_item_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("llc_work_items.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    author_agent_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), nullable=True
-    )
-    author_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), nullable=True
-    )
+    author_agent_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True)
+    author_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True)
     body: Mapped[str] = mapped_column(Text, nullable=False)
 
-    work_item: Mapped["LLCWorkItem"] = relationship(
-        "LLCWorkItem", back_populates="comments"
-    )
+    work_item: Mapped["LLCWorkItem"] = relationship("LLCWorkItem", back_populates="comments")

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -38,8 +38,18 @@ _CHECKOUT_TTL = 1800  # seconds
 _ALLOWED_TRANSITIONS: Dict[WorkItemStatus, set] = {
     WorkItemStatus.BACKLOG: {WorkItemStatus.READY, WorkItemStatus.BLOCKED, WorkItemStatus.CANCELLED},
     WorkItemStatus.READY: {WorkItemStatus.IN_PROGRESS, WorkItemStatus.BLOCKED, WorkItemStatus.CANCELLED},
-    WorkItemStatus.IN_PROGRESS: {WorkItemStatus.IN_REVIEW, WorkItemStatus.BLOCKED, WorkItemStatus.DONE, WorkItemStatus.CANCELLED},
-    WorkItemStatus.IN_REVIEW: {WorkItemStatus.IN_PROGRESS, WorkItemStatus.DONE, WorkItemStatus.BLOCKED, WorkItemStatus.CANCELLED},
+    WorkItemStatus.IN_PROGRESS: {
+        WorkItemStatus.IN_REVIEW,
+        WorkItemStatus.BLOCKED,
+        WorkItemStatus.DONE,
+        WorkItemStatus.CANCELLED,
+    },
+    WorkItemStatus.IN_REVIEW: {
+        WorkItemStatus.IN_PROGRESS,
+        WorkItemStatus.DONE,
+        WorkItemStatus.BLOCKED,
+        WorkItemStatus.CANCELLED,
+    },
     WorkItemStatus.BLOCKED: {WorkItemStatus.READY, WorkItemStatus.IN_PROGRESS, WorkItemStatus.CANCELLED},
     WorkItemStatus.DONE: set(),
     WorkItemStatus.CANCELLED: set(),
@@ -108,9 +118,7 @@ class WorkItemService(LLCServiceBase):
         return item
 
     async def get(self, session: AsyncSession, work_item_id: str) -> Optional[LLCWorkItem]:
-        result = await session.execute(
-            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id))
-        )
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)))
         return result.scalar_one_or_none()
 
     async def update(
@@ -123,9 +131,18 @@ class WorkItemService(LLCServiceBase):
         if item is None:
             return None
         allowed = {
-            "title", "description", "acceptance_criteria", "priority",
-            "story_points", "labels", "parent_id", "sprint_id", "goal_id",
-            "assignee_agent_id", "assignee_user_id", "assignee_type",
+            "title",
+            "description",
+            "acceptance_criteria",
+            "priority",
+            "story_points",
+            "labels",
+            "parent_id",
+            "sprint_id",
+            "goal_id",
+            "assignee_agent_id",
+            "assignee_user_id",
+            "assignee_type",
         }
         for key, val in fields.items():
             if key not in allowed:
@@ -148,9 +165,7 @@ class WorkItemService(LLCServiceBase):
         limit: int = 100,
         offset: int = 0,
     ) -> Sequence[LLCWorkItem]:
-        q = select(LLCWorkItem).where(
-            LLCWorkItem.company_id == uuid.UUID(company_id)
-        )
+        q = select(LLCWorkItem).where(LLCWorkItem.company_id == uuid.UUID(company_id))
         if project_id:
             q = q.where(LLCWorkItem.project_id == uuid.UUID(project_id))
         if type:
@@ -194,15 +209,11 @@ class WorkItemService(LLCServiceBase):
             if not acquired:
                 existing = await redis.get(redis_key)
                 if existing and existing != agent_id:
-                    raise CheckoutConflict(
-                        f"Work item {work_item_id} already checked out by agent {existing}"
-                    )
+                    raise CheckoutConflict(f"Work item {work_item_id} already checked out by agent {existing}")
 
         # DB-level lock
         result = await session.execute(
-            select(LLCWorkItem)
-            .where(LLCWorkItem.id == uuid.UUID(work_item_id))
-            .with_for_update()
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
         )
         item = result.scalar_one_or_none()
         if item is None:
@@ -210,16 +221,10 @@ class WorkItemService(LLCServiceBase):
                 await redis.delete(redis_key)
             raise ValueError(f"Work item {work_item_id} not found")
 
-        if (
-            item.checkout_run_id is not None
-            and item.checkout_run_id != run_id
-            and str(item.assignee_agent_id) != agent_id
-        ):
+        if item.checkout_run_id is not None and str(item.assignee_agent_id) != agent_id:
             if redis is not None:
                 await redis.delete(redis_key)
-            raise CheckoutConflict(
-                f"Work item {work_item_id} already checked out by agent {item.assignee_agent_id}"
-            )
+            raise CheckoutConflict(f"Work item {work_item_id} already checked out by agent {item.assignee_agent_id}")
 
         item.checkout_run_id = run_id or str(uuid.uuid4())
         item.checkout_locked_at = datetime.now(timezone.utc)
@@ -244,26 +249,17 @@ class WorkItemService(LLCServiceBase):
         Raises ValueError if the caller does not hold the lock.
         """
         result = await session.execute(
-            select(LLCWorkItem)
-            .where(LLCWorkItem.id == uuid.UUID(work_item_id))
-            .with_for_update()
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
         )
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
         if item.assignee_agent_id and str(item.assignee_agent_id) != agent_id:
-            raise ValueError(
-                f"Agent {agent_id} does not hold checkout for work item {work_item_id}"
-            )
+            raise ValueError(f"Agent {agent_id} does not hold checkout for work item {work_item_id}")
         item.checkout_run_id = None
         item.checkout_locked_at = None
         item.version += 1
         await session.flush()
-
-        redis = await get_async_redis_client()
-        if redis is not None:
-            await redis.delete(f"llc:checkout:{work_item_id}")
-
         return item
 
     # ------------------------------------------------------------------
@@ -278,9 +274,7 @@ class WorkItemService(LLCServiceBase):
     ) -> LLCWorkItem:
         """Transition a work item to a new status, enforcing the state machine."""
         result = await session.execute(
-            select(LLCWorkItem)
-            .where(LLCWorkItem.id == uuid.UUID(work_item_id))
-            .with_for_update()
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
         )
         item = result.scalar_one_or_none()
         if item is None:
@@ -346,14 +340,12 @@ class WorkItemService(LLCServiceBase):
         """
         try:
             row = await session.execute(
-                text(
-                    """
+                text("""
                     UPDATE llc_companies
                        SET issue_counter = issue_counter + 1
                      WHERE id = :company_id
                     RETURNING issue_prefix, issue_counter
-                    """
-                ),
+                    """),
                 {"company_id": company_id},
             )
             rec = row.fetchone()

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -1,0 +1,367 @@
+"""LLC WorkItemService — CRUD, atomic checkout, and status transitions (GH#8213).
+
+Checkout strategy:
+  1. Redis SET NX EX 1800 as fast-path fence (prevents DB round-trips for obvious conflicts).
+  2. SELECT … FOR UPDATE on the row as the authoritative lock.
+  3. Write ``checkout_run_id`` / ``checkout_locked_at`` + bump ``version``.
+
+Status transitions:
+  Only the edges defined in _ALLOWED_TRANSITIONS are accepted. Any other
+  transition raises ``InvalidTransition``.
+
+Identifier generation:
+  PostgreSQL advisory lock on the company's numeric hash, then RETURNING on an
+  UPDATE to ``llc_companies.issue_counter`` — producing ``<prefix>-<counter>``.
+  Falls back to a UUID-based placeholder when the companies table is absent
+  (unit-test environments without full schema).
+"""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence
+
+from sqlalchemy import select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.redis_client import get_async_redis_client
+
+from ..models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
+from ..models.work_item import LLCWorkItem, LLCWorkItemComment
+from . import LLCServiceBase
+
+logger = logging.getLogger(__name__)
+
+_CHECKOUT_TTL = 1800  # seconds
+
+# Allowed status transitions: from → {to, ...}
+_ALLOWED_TRANSITIONS: Dict[WorkItemStatus, set] = {
+    WorkItemStatus.BACKLOG: {WorkItemStatus.READY, WorkItemStatus.BLOCKED, WorkItemStatus.CANCELLED},
+    WorkItemStatus.READY: {WorkItemStatus.IN_PROGRESS, WorkItemStatus.BLOCKED, WorkItemStatus.CANCELLED},
+    WorkItemStatus.IN_PROGRESS: {WorkItemStatus.IN_REVIEW, WorkItemStatus.BLOCKED, WorkItemStatus.DONE, WorkItemStatus.CANCELLED},
+    WorkItemStatus.IN_REVIEW: {WorkItemStatus.IN_PROGRESS, WorkItemStatus.DONE, WorkItemStatus.BLOCKED, WorkItemStatus.CANCELLED},
+    WorkItemStatus.BLOCKED: {WorkItemStatus.READY, WorkItemStatus.IN_PROGRESS, WorkItemStatus.CANCELLED},
+    WorkItemStatus.DONE: set(),
+    WorkItemStatus.CANCELLED: set(),
+}
+
+
+class CheckoutConflict(Exception):
+    """Raised when a work item is already checked out by a different agent."""
+
+
+class InvalidTransition(Exception):
+    """Raised when a status transition is not permitted."""
+
+
+class WorkItemService(LLCServiceBase):
+    """Service for LLC work item lifecycle management."""
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    async def create(
+        self,
+        session: AsyncSession,
+        company_id: str,
+        type: WorkItemType,
+        title: str,
+        *,
+        description: Optional[str] = None,
+        acceptance_criteria: Optional[List[str]] = None,
+        priority: WorkItemPriority = WorkItemPriority.MEDIUM,
+        story_points: Optional[int] = None,
+        parent_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        sprint_id: Optional[str] = None,
+        goal_id: Optional[str] = None,
+        assignee_agent_id: Optional[str] = None,
+        assignee_user_id: Optional[str] = None,
+        created_by_agent_id: Optional[str] = None,
+        created_by_user_id: Optional[str] = None,
+        labels: Optional[List[str]] = None,
+    ) -> LLCWorkItem:
+        identifier = await self._next_identifier(session, company_id)
+        item = LLCWorkItem(
+            id=uuid.uuid4(),
+            company_id=uuid.UUID(company_id),
+            type=type,
+            title=title,
+            description=description,
+            acceptance_criteria=acceptance_criteria,
+            priority=priority,
+            story_points=story_points,
+            identifier=identifier,
+            parent_id=uuid.UUID(parent_id) if parent_id else None,
+            project_id=uuid.UUID(project_id) if project_id else None,
+            sprint_id=uuid.UUID(sprint_id) if sprint_id else None,
+            goal_id=uuid.UUID(goal_id) if goal_id else None,
+            assignee_agent_id=uuid.UUID(assignee_agent_id) if assignee_agent_id else None,
+            assignee_user_id=uuid.UUID(assignee_user_id) if assignee_user_id else None,
+            created_by_agent_id=uuid.UUID(created_by_agent_id) if created_by_agent_id else None,
+            created_by_user_id=uuid.UUID(created_by_user_id) if created_by_user_id else None,
+            labels=labels or [],
+        )
+        session.add(item)
+        await session.flush()
+        return item
+
+    async def get(self, session: AsyncSession, work_item_id: str) -> Optional[LLCWorkItem]:
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id))
+        )
+        return result.scalar_one_or_none()
+
+    async def update(
+        self,
+        session: AsyncSession,
+        work_item_id: str,
+        **fields: Any,
+    ) -> Optional[LLCWorkItem]:
+        item = await self.get(session, work_item_id)
+        if item is None:
+            return None
+        allowed = {
+            "title", "description", "acceptance_criteria", "priority",
+            "story_points", "labels", "parent_id", "sprint_id", "goal_id",
+            "assignee_agent_id", "assignee_user_id", "assignee_type",
+        }
+        for key, val in fields.items():
+            if key not in allowed:
+                raise ValueError(f"Field '{key}' is not updatable via WorkItemService.update()")
+            setattr(item, key, val)
+        await session.flush()
+        return item
+
+    async def list_by_project(
+        self,
+        session: AsyncSession,
+        company_id: str,
+        *,
+        project_id: Optional[str] = None,
+        type: Optional[WorkItemType] = None,
+        status: Optional[WorkItemStatus] = None,
+        assignee_agent_id: Optional[str] = None,
+        sprint_id: Optional[str] = None,
+        parent_id: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> Sequence[LLCWorkItem]:
+        q = select(LLCWorkItem).where(
+            LLCWorkItem.company_id == uuid.UUID(company_id)
+        )
+        if project_id:
+            q = q.where(LLCWorkItem.project_id == uuid.UUID(project_id))
+        if type:
+            q = q.where(LLCWorkItem.type == type)
+        if status:
+            q = q.where(LLCWorkItem.status == status)
+        if assignee_agent_id:
+            q = q.where(LLCWorkItem.assignee_agent_id == uuid.UUID(assignee_agent_id))
+        if sprint_id:
+            q = q.where(LLCWorkItem.sprint_id == uuid.UUID(sprint_id))
+        if parent_id:
+            q = q.where(LLCWorkItem.parent_id == uuid.UUID(parent_id))
+        q = q.order_by(LLCWorkItem.created_at.desc()).limit(limit).offset(offset)
+        result = await session.execute(q)
+        return result.scalars().all()
+
+    # ------------------------------------------------------------------
+    # Atomic checkout
+    # ------------------------------------------------------------------
+
+    async def checkout(
+        self,
+        session: AsyncSession,
+        work_item_id: str,
+        agent_id: str,
+        run_id: Optional[str] = None,
+    ) -> LLCWorkItem:
+        """Atomically claim a work item for an agent.
+
+        Step 1: Redis SET NX EX as fast-path fence.
+        Step 2: SELECT FOR UPDATE to prevent race across DB workers.
+        Step 3: Write checkout fields + transition to IN_PROGRESS.
+
+        Raises CheckoutConflict if another agent holds the lock.
+        """
+        redis_key = f"llc:checkout:{work_item_id}"
+        redis = await get_async_redis_client()
+
+        if redis is not None:
+            acquired = await redis.set(redis_key, agent_id, nx=True, ex=_CHECKOUT_TTL)
+            if not acquired:
+                existing = await redis.get(redis_key)
+                if existing and existing != agent_id:
+                    raise CheckoutConflict(
+                        f"Work item {work_item_id} already checked out by agent {existing}"
+                    )
+
+        # DB-level lock
+        result = await session.execute(
+            select(LLCWorkItem)
+            .where(LLCWorkItem.id == uuid.UUID(work_item_id))
+            .with_for_update()
+        )
+        item = result.scalar_one_or_none()
+        if item is None:
+            if redis is not None:
+                await redis.delete(redis_key)
+            raise ValueError(f"Work item {work_item_id} not found")
+
+        if (
+            item.checkout_run_id is not None
+            and item.checkout_run_id != run_id
+            and str(item.assignee_agent_id) != agent_id
+        ):
+            if redis is not None:
+                await redis.delete(redis_key)
+            raise CheckoutConflict(
+                f"Work item {work_item_id} already checked out by agent {item.assignee_agent_id}"
+            )
+
+        item.checkout_run_id = run_id or str(uuid.uuid4())
+        item.checkout_locked_at = datetime.now(timezone.utc)
+        item.assignee_agent_id = uuid.UUID(agent_id)
+        item.assignee_type = "agent"
+        item.version += 1
+        if item.status in (WorkItemStatus.BACKLOG, WorkItemStatus.READY):
+            item.status = WorkItemStatus.IN_PROGRESS
+            item.started_at = item.started_at or datetime.now(timezone.utc)
+
+        await session.flush()
+        return item
+
+    async def release(
+        self,
+        session: AsyncSession,
+        work_item_id: str,
+        agent_id: str,
+    ) -> LLCWorkItem:
+        """Release the checkout lock held by agent_id.
+
+        Raises ValueError if the caller does not hold the lock.
+        """
+        result = await session.execute(
+            select(LLCWorkItem)
+            .where(LLCWorkItem.id == uuid.UUID(work_item_id))
+            .with_for_update()
+        )
+        item = result.scalar_one_or_none()
+        if item is None:
+            raise ValueError(f"Work item {work_item_id} not found")
+        if item.assignee_agent_id and str(item.assignee_agent_id) != agent_id:
+            raise ValueError(
+                f"Agent {agent_id} does not hold checkout for work item {work_item_id}"
+            )
+        item.checkout_run_id = None
+        item.checkout_locked_at = None
+        item.version += 1
+        await session.flush()
+
+        redis = await get_async_redis_client()
+        if redis is not None:
+            await redis.delete(f"llc:checkout:{work_item_id}")
+
+        return item
+
+    # ------------------------------------------------------------------
+    # Status transitions
+    # ------------------------------------------------------------------
+
+    async def transition_status(
+        self,
+        session: AsyncSession,
+        work_item_id: str,
+        new_status: WorkItemStatus,
+    ) -> LLCWorkItem:
+        """Transition a work item to a new status, enforcing the state machine."""
+        result = await session.execute(
+            select(LLCWorkItem)
+            .where(LLCWorkItem.id == uuid.UUID(work_item_id))
+            .with_for_update()
+        )
+        item = result.scalar_one_or_none()
+        if item is None:
+            raise ValueError(f"Work item {work_item_id} not found")
+
+        current = WorkItemStatus(item.status)
+        allowed = _ALLOWED_TRANSITIONS.get(current, set())
+        if new_status not in allowed:
+            raise InvalidTransition(
+                f"Cannot transition from {current.value!r} to {new_status.value!r}. "
+                f"Allowed: {[s.value for s in allowed]}"
+            )
+
+        item.status = new_status
+        now = datetime.now(timezone.utc)
+        if new_status == WorkItemStatus.IN_PROGRESS and item.started_at is None:
+            item.started_at = now
+        elif new_status == WorkItemStatus.DONE:
+            item.completed_at = now
+            item.checkout_run_id = None
+            item.checkout_locked_at = None
+        elif new_status == WorkItemStatus.CANCELLED:
+            item.cancelled_at = now
+        item.version += 1
+        await session.flush()
+        return item
+
+    # ------------------------------------------------------------------
+    # Comment helpers
+    # ------------------------------------------------------------------
+
+    async def add_comment(
+        self,
+        session: AsyncSession,
+        work_item_id: str,
+        company_id: str,
+        body: str,
+        author_agent_id: Optional[str] = None,
+        author_user_id: Optional[str] = None,
+    ) -> LLCWorkItemComment:
+        comment = LLCWorkItemComment(
+            id=uuid.uuid4(),
+            company_id=uuid.UUID(company_id),
+            work_item_id=uuid.UUID(work_item_id),
+            body=body,
+            author_agent_id=uuid.UUID(author_agent_id) if author_agent_id else None,
+            author_user_id=uuid.UUID(author_user_id) if author_user_id else None,
+        )
+        session.add(comment)
+        await session.flush()
+        return comment
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _next_identifier(self, session: AsyncSession, company_id: str) -> str:
+        """Generate the next ``<prefix>-<counter>`` identifier for this company.
+
+        Uses PostgreSQL advisory lock + UPDATE RETURNING on ``llc_companies`` to
+        ensure uniqueness under concurrent inserts. Falls back to a random
+        identifier in test environments that lack the ``llc_companies`` table.
+        """
+        try:
+            row = await session.execute(
+                text(
+                    """
+                    UPDATE llc_companies
+                       SET issue_counter = issue_counter + 1
+                     WHERE id = :company_id
+                    RETURNING issue_prefix, issue_counter
+                    """
+                ),
+                {"company_id": company_id},
+            )
+            rec = row.fetchone()
+            if rec:
+                return f"{rec.issue_prefix}-{rec.issue_counter}"
+        except Exception:
+            logger.debug(
+                "llc_companies table not available — falling back to UUID identifier",
+                exc_info=True,
+            )
+        return f"WI-{uuid.uuid4().hex[:8].upper()}"

--- a/autobot-backend/llc/tests/test_atomic_checkout.py
+++ b/autobot-backend/llc/tests/test_atomic_checkout.py
@@ -65,7 +65,7 @@ def mock_session():
 @pytest.fixture
 def mock_redis():
     redis = AsyncMock()
-    redis.set = AsyncMock(return_value=True)   # NX acquire succeeds by default
+    redis.set = AsyncMock(return_value=True)  # NX acquire succeeds by default
     redis.get = AsyncMock(return_value=None)
     redis.delete = AsyncMock()
     return redis
@@ -82,17 +82,13 @@ class TestAtomicCheckout:
             "llc.services.work_item_service.get_async_redis_client",
             new=AsyncMock(return_value=mock_redis),
         ):
-            result = await service.checkout(
-                mock_session, str(item.id), agent_id, run_id=run_id
-            )
+            result = await service.checkout(mock_session, str(item.id), agent_id, run_id=run_id)
 
         assert result.checkout_run_id == run_id
         assert result.checkout_locked_at is not None
         assert str(result.assignee_agent_id) == agent_id
         assert result.version == 2
-        mock_redis.set.assert_called_once_with(
-            f"llc:checkout:{item.id}", agent_id, nx=True, ex=1800
-        )
+        mock_redis.set.assert_called_once_with(f"llc:checkout:{item.id}", agent_id, nx=True, ex=1800)
 
     async def test_checkout_conflict_different_agent(self, service, mock_session, mock_redis):
         """Redis NX returns False (key exists for another agent) → CheckoutConflict."""
@@ -125,9 +121,7 @@ class TestAtomicCheckout:
             "llc.services.work_item_service.get_async_redis_client",
             new=AsyncMock(return_value=mock_redis),
         ):
-            result = await service.checkout(
-                mock_session, str(item.id), agent_id, run_id=run_id
-            )
+            result = await service.checkout(mock_session, str(item.id), agent_id, run_id=run_id)
         # Should not raise; item returned
         assert result is item
 
@@ -152,13 +146,12 @@ class TestAtomicCheckout:
             new=AsyncMock(return_value=mock_redis),
         ):
             with pytest.raises(ValueError, match="not found"):
-                await service.checkout(
-                    mock_session, str(uuid.uuid4()), str(uuid.uuid4())
-                )
+                await service.checkout(mock_session, str(uuid.uuid4()), str(uuid.uuid4()))
 
 
 class TestRelease:
-    async def test_release_clears_checkout_fields(self, service, mock_session, mock_redis):
+    async def test_release_clears_checkout_fields(self, service, mock_session):
+        """Service clears DB checkout fields; Redis deletion happens in the route after commit."""
         agent_id = str(uuid.uuid4())
         item = _make_item(
             checkout_run_id="run-123",
@@ -166,25 +159,17 @@ class TestRelease:
         )
         mock_session._db_result.scalar_one_or_none.return_value = item
 
-        with patch(
-            "llc.services.work_item_service.get_async_redis_client",
-            new=AsyncMock(return_value=mock_redis),
-        ):
-            result = await service.release(mock_session, str(item.id), agent_id)
+        result = await service.release(mock_session, str(item.id), agent_id)
 
         assert result.checkout_run_id is None
         assert result.checkout_locked_at is None
-        mock_redis.delete.assert_called_once_with(f"llc:checkout:{item.id}")
+        mock_session.flush.assert_called_once()
 
-    async def test_release_wrong_agent_raises(self, service, mock_session, mock_redis):
+    async def test_release_wrong_agent_raises(self, service, mock_session):
         real_agent = str(uuid.uuid4())
         wrong_agent = str(uuid.uuid4())
         item = _make_item(assignee_agent_id=uuid.UUID(real_agent))
         mock_session._db_result.scalar_one_or_none.return_value = item
 
-        with patch(
-            "llc.services.work_item_service.get_async_redis_client",
-            new=AsyncMock(return_value=mock_redis),
-        ):
-            with pytest.raises(ValueError, match="does not hold checkout"):
-                await service.release(mock_session, str(item.id), wrong_agent)
+        with pytest.raises(ValueError, match="does not hold checkout"):
+            await service.release(mock_session, str(item.id), wrong_agent)

--- a/autobot-backend/llc/tests/test_atomic_checkout.py
+++ b/autobot-backend/llc/tests/test_atomic_checkout.py
@@ -1,0 +1,190 @@
+"""Tests for atomic checkout concurrency (GH#8213).
+
+Verifies:
+  1. First checkout succeeds and sets checkout fields.
+  2. Concurrent checkout by a different agent raises CheckoutConflict (Redis fence).
+  3. Re-checkout by the same agent is idempotent.
+  4. Release clears checkout fields and Redis key.
+  5. Release by wrong agent raises ValueError.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
+from llc.models.work_item import LLCWorkItem
+from llc.services.work_item_service import CheckoutConflict, WorkItemService
+
+
+def _make_item(**kwargs) -> MagicMock:
+    defaults = {
+        "id": uuid.uuid4(),
+        "company_id": uuid.uuid4(),
+        "identifier": "WI-099",
+        "type": WorkItemType.TASK,
+        "title": "Concurrent task",
+        "status": WorkItemStatus.READY,
+        "priority": WorkItemPriority.HIGH,
+        "version": 1,
+        "labels": [],
+        "checkout_run_id": None,
+        "checkout_locked_at": None,
+        "assignee_agent_id": None,
+        "assignee_user_id": None,
+        "assignee_type": None,
+        "started_at": None,
+        "completed_at": None,
+        "cancelled_at": None,
+        "created_at": None,
+        "updated_at": None,
+    }
+    defaults.update(kwargs)
+    item = MagicMock(spec=LLCWorkItem)
+    for k, v in defaults.items():
+        setattr(item, k, v)
+    return item
+
+
+@pytest.fixture
+def service():
+    return WorkItemService()
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.flush = AsyncMock()
+    _db_result = MagicMock()
+    session.execute = AsyncMock(return_value=_db_result)
+    session._db_result = _db_result
+    return session
+
+
+@pytest.fixture
+def mock_redis():
+    redis = AsyncMock()
+    redis.set = AsyncMock(return_value=True)   # NX acquire succeeds by default
+    redis.get = AsyncMock(return_value=None)
+    redis.delete = AsyncMock()
+    return redis
+
+
+class TestAtomicCheckout:
+    async def test_checkout_sets_lock_fields(self, service, mock_session, mock_redis):
+        agent_id = str(uuid.uuid4())
+        run_id = str(uuid.uuid4())
+        item = _make_item()
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with patch(
+            "llc.services.work_item_service.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            result = await service.checkout(
+                mock_session, str(item.id), agent_id, run_id=run_id
+            )
+
+        assert result.checkout_run_id == run_id
+        assert result.checkout_locked_at is not None
+        assert str(result.assignee_agent_id) == agent_id
+        assert result.version == 2
+        mock_redis.set.assert_called_once_with(
+            f"llc:checkout:{item.id}", agent_id, nx=True, ex=1800
+        )
+
+    async def test_checkout_conflict_different_agent(self, service, mock_session, mock_redis):
+        """Redis NX returns False (key exists for another agent) → CheckoutConflict."""
+        agent_id = str(uuid.uuid4())
+        other_agent = str(uuid.uuid4())
+        item = _make_item()
+        mock_redis.set.return_value = False  # NX acquire fails
+        mock_redis.get.return_value = other_agent  # held by other agent
+
+        with patch(
+            "llc.services.work_item_service.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            with pytest.raises(CheckoutConflict):
+                await service.checkout(mock_session, str(item.id), agent_id)
+
+    async def test_checkout_same_agent_idempotent(self, service, mock_session, mock_redis):
+        """NX returns False but existing key belongs to same agent — allowed."""
+        agent_id = str(uuid.uuid4())
+        run_id = str(uuid.uuid4())
+        item = _make_item(
+            checkout_run_id=run_id,
+            assignee_agent_id=uuid.UUID(agent_id),
+        )
+        mock_redis.set.return_value = False  # key already set
+        mock_redis.get.return_value = agent_id  # same agent holds it
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with patch(
+            "llc.services.work_item_service.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            result = await service.checkout(
+                mock_session, str(item.id), agent_id, run_id=run_id
+            )
+        # Should not raise; item returned
+        assert result is item
+
+    async def test_checkout_without_redis_uses_db_only(self, service, mock_session):
+        """When Redis is unavailable, checkout falls through to DB lock only."""
+        agent_id = str(uuid.uuid4())
+        item = _make_item()
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with patch(
+            "llc.services.work_item_service.get_async_redis_client",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await service.checkout(mock_session, str(item.id), agent_id)
+
+        assert result.assignee_agent_id == uuid.UUID(agent_id)
+
+    async def test_checkout_item_not_found(self, service, mock_session, mock_redis):
+        mock_session.execute.return_value.scalar_one_or_none.return_value = None
+        with patch(
+            "llc.services.work_item_service.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            with pytest.raises(ValueError, match="not found"):
+                await service.checkout(
+                    mock_session, str(uuid.uuid4()), str(uuid.uuid4())
+                )
+
+
+class TestRelease:
+    async def test_release_clears_checkout_fields(self, service, mock_session, mock_redis):
+        agent_id = str(uuid.uuid4())
+        item = _make_item(
+            checkout_run_id="run-123",
+            assignee_agent_id=uuid.UUID(agent_id),
+        )
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with patch(
+            "llc.services.work_item_service.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            result = await service.release(mock_session, str(item.id), agent_id)
+
+        assert result.checkout_run_id is None
+        assert result.checkout_locked_at is None
+        mock_redis.delete.assert_called_once_with(f"llc:checkout:{item.id}")
+
+    async def test_release_wrong_agent_raises(self, service, mock_session, mock_redis):
+        real_agent = str(uuid.uuid4())
+        wrong_agent = str(uuid.uuid4())
+        item = _make_item(assignee_agent_id=uuid.UUID(real_agent))
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with patch(
+            "llc.services.work_item_service.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            with pytest.raises(ValueError, match="does not hold checkout"):
+                await service.release(mock_session, str(item.id), wrong_agent)

--- a/autobot-backend/llc/tests/test_work_item.py
+++ b/autobot-backend/llc/tests/test_work_item.py
@@ -101,17 +101,13 @@ class TestStatusTransitions:
     async def test_valid_backlog_to_ready(self, service, mock_session):
         item = _make_item(status=WorkItemStatus.BACKLOG)
         mock_session._db_result.scalar_one_or_none.return_value = item
-        result = await service.transition_status(
-            mock_session, str(item.id), WorkItemStatus.READY
-        )
+        result = await service.transition_status(mock_session, str(item.id), WorkItemStatus.READY)
         assert result.status == WorkItemStatus.READY
 
     async def test_valid_in_progress_to_done(self, service, mock_session):
         item = _make_item(status=WorkItemStatus.IN_PROGRESS)
         mock_session._db_result.scalar_one_or_none.return_value = item
-        result = await service.transition_status(
-            mock_session, str(item.id), WorkItemStatus.DONE
-        )
+        result = await service.transition_status(mock_session, str(item.id), WorkItemStatus.DONE)
         assert result.status == WorkItemStatus.DONE
         assert result.completed_at is not None
 
@@ -119,31 +115,23 @@ class TestStatusTransitions:
         item = _make_item(status=WorkItemStatus.DONE)
         mock_session._db_result.scalar_one_or_none.return_value = item
         with pytest.raises(InvalidTransition):
-            await service.transition_status(
-                mock_session, str(item.id), WorkItemStatus.BACKLOG
-            )
+            await service.transition_status(mock_session, str(item.id), WorkItemStatus.BACKLOG)
 
     async def test_invalid_cancelled_to_in_progress_raises(self, service, mock_session):
         item = _make_item(status=WorkItemStatus.CANCELLED)
         mock_session._db_result.scalar_one_or_none.return_value = item
         with pytest.raises(InvalidTransition):
-            await service.transition_status(
-                mock_session, str(item.id), WorkItemStatus.IN_PROGRESS
-            )
+            await service.transition_status(mock_session, str(item.id), WorkItemStatus.IN_PROGRESS)
 
     async def test_not_found_raises_value_error(self, service, mock_session):
         mock_session.execute.return_value.scalar_one_or_none.return_value = None
         with pytest.raises(ValueError, match="not found"):
-            await service.transition_status(
-                mock_session, str(uuid.uuid4()), WorkItemStatus.READY
-            )
+            await service.transition_status(mock_session, str(uuid.uuid4()), WorkItemStatus.READY)
 
     async def test_transition_to_cancelled_sets_cancelled_at(self, service, mock_session):
         item = _make_item(status=WorkItemStatus.IN_PROGRESS)
         mock_session._db_result.scalar_one_or_none.return_value = item
-        result = await service.transition_status(
-            mock_session, str(item.id), WorkItemStatus.CANCELLED
-        )
+        result = await service.transition_status(mock_session, str(item.id), WorkItemStatus.CANCELLED)
         assert result.cancelled_at is not None
 
     async def test_version_bumped_on_every_transition(self, service, mock_session):
@@ -157,7 +145,5 @@ class TestListByProject:
     async def test_returns_all_for_company(self, service, mock_session):
         items = [_make_item(), _make_item()]
         mock_session._db_result.scalars.return_value.all.return_value = items
-        result = await service.list_by_project(
-            mock_session, company_id=str(uuid.uuid4())
-        )
+        result = await service.list_by_project(mock_session, company_id=str(uuid.uuid4()))
         assert len(result) == 2

--- a/autobot-backend/llc/tests/test_work_item.py
+++ b/autobot-backend/llc/tests/test_work_item.py
@@ -1,0 +1,163 @@
+"""Tests for LLC WorkItemService CRUD and status transitions (GH#8213)."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
+from llc.models.work_item import LLCWorkItem
+from llc.services.work_item_service import (
+    InvalidTransition,
+    WorkItemService,
+)
+
+
+def _make_item(**kwargs) -> LLCWorkItem:
+    defaults = {
+        "id": uuid.uuid4(),
+        "company_id": uuid.uuid4(),
+        "identifier": "WI-001",
+        "type": WorkItemType.TASK,
+        "title": "Test task",
+        "status": WorkItemStatus.BACKLOG,
+        "priority": WorkItemPriority.MEDIUM,
+        "version": 1,
+        "labels": [],
+        "checkout_run_id": None,
+        "checkout_locked_at": None,
+        "assignee_agent_id": None,
+        "assignee_user_id": None,
+        "assignee_type": None,
+        "started_at": None,
+        "completed_at": None,
+        "cancelled_at": None,
+        "created_at": None,
+        "updated_at": None,
+    }
+    defaults.update(kwargs)
+    item = MagicMock(spec=LLCWorkItem)
+    for k, v in defaults.items():
+        setattr(item, k, v)
+    return item
+
+
+@pytest.fixture
+def service():
+    return WorkItemService()
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.flush = AsyncMock()
+    session.add = MagicMock()
+    # AsyncMock.return_value defaults to AsyncMock; use a plain MagicMock so
+    # synchronous methods like scalar_one_or_none() return values, not coroutines.
+    _db_result = MagicMock()
+    session.execute = AsyncMock(return_value=_db_result)
+    session._db_result = _db_result
+    return session
+
+
+class TestCreate:
+    async def test_create_sets_identifier_and_flushes(self, service, mock_session):
+        with patch.object(service, "_next_identifier", new=AsyncMock(return_value="PRJ-1")):
+            mock_session.flush = AsyncMock()
+            # session.add captures the item
+            captured = {}
+
+            def _add(obj):
+                captured["item"] = obj
+
+            mock_session.add.side_effect = _add
+            item = await service.create(
+                mock_session,
+                company_id=str(uuid.uuid4()),
+                type=WorkItemType.TASK,
+                title="My task",
+                priority=WorkItemPriority.HIGH,
+            )
+        assert item.identifier == "PRJ-1"
+        assert item.title == "My task"
+        assert item.priority == WorkItemPriority.HIGH
+        mock_session.add.assert_called_once()
+        mock_session.flush.assert_called_once()
+
+    async def test_create_sets_parent_id(self, service, mock_session):
+        parent_id = str(uuid.uuid4())
+        with patch.object(service, "_next_identifier", new=AsyncMock(return_value="PRJ-2")):
+            item = await service.create(
+                mock_session,
+                company_id=str(uuid.uuid4()),
+                type=WorkItemType.SUBTASK,
+                title="Child",
+                parent_id=parent_id,
+            )
+        assert str(item.parent_id) == parent_id
+
+
+class TestStatusTransitions:
+    async def test_valid_backlog_to_ready(self, service, mock_session):
+        item = _make_item(status=WorkItemStatus.BACKLOG)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+        result = await service.transition_status(
+            mock_session, str(item.id), WorkItemStatus.READY
+        )
+        assert result.status == WorkItemStatus.READY
+
+    async def test_valid_in_progress_to_done(self, service, mock_session):
+        item = _make_item(status=WorkItemStatus.IN_PROGRESS)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+        result = await service.transition_status(
+            mock_session, str(item.id), WorkItemStatus.DONE
+        )
+        assert result.status == WorkItemStatus.DONE
+        assert result.completed_at is not None
+
+    async def test_invalid_done_to_backlog_raises(self, service, mock_session):
+        item = _make_item(status=WorkItemStatus.DONE)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+        with pytest.raises(InvalidTransition):
+            await service.transition_status(
+                mock_session, str(item.id), WorkItemStatus.BACKLOG
+            )
+
+    async def test_invalid_cancelled_to_in_progress_raises(self, service, mock_session):
+        item = _make_item(status=WorkItemStatus.CANCELLED)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+        with pytest.raises(InvalidTransition):
+            await service.transition_status(
+                mock_session, str(item.id), WorkItemStatus.IN_PROGRESS
+            )
+
+    async def test_not_found_raises_value_error(self, service, mock_session):
+        mock_session.execute.return_value.scalar_one_or_none.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            await service.transition_status(
+                mock_session, str(uuid.uuid4()), WorkItemStatus.READY
+            )
+
+    async def test_transition_to_cancelled_sets_cancelled_at(self, service, mock_session):
+        item = _make_item(status=WorkItemStatus.IN_PROGRESS)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+        result = await service.transition_status(
+            mock_session, str(item.id), WorkItemStatus.CANCELLED
+        )
+        assert result.cancelled_at is not None
+
+    async def test_version_bumped_on_every_transition(self, service, mock_session):
+        item = _make_item(status=WorkItemStatus.BACKLOG, version=3)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+        await service.transition_status(mock_session, str(item.id), WorkItemStatus.READY)
+        assert item.version == 4
+
+
+class TestListByProject:
+    async def test_returns_all_for_company(self, service, mock_session):
+        items = [_make_item(), _make_item()]
+        mock_session._db_result.scalars.return_value.all.return_value = items
+        result = await service.list_by_project(
+            mock_session, company_id=str(uuid.uuid4())
+        )
+        assert len(result) == 2

--- a/autobot-backend/migrations/versions/20260523_022_create_llc_work_items.py
+++ b/autobot-backend/migrations/versions/20260523_022_create_llc_work_items.py
@@ -9,10 +9,11 @@ Single ``llc_work_items`` table with a ``type`` discriminator. Atomic checkout
 via ``checkout_run_id`` + ``checkout_locked_at`` (Redis SET NX EX fence in the
 service layer; DB lock column here for persistence).
 
-ENUM types are created without IF NOT EXISTS so the migration is idempotent via
-``checkfirst=True`` in the service layer. The ``workitemtype``, ``workitemstatus``,
-and ``workitempriority`` enums are created once here and re-used wherever the
-LLC module references them.
+ENUM types are created with ``checkfirst=True``. For ``workitemstatus``, an
+``ALTER TYPE ... ADD VALUE IF NOT EXISTS`` call follows to ensure the ``ready``
+value is present even when the enum pre-existed without it (e.g. from a manual
+scaffold). The ``workitemtype``, ``workitemstatus``, and ``workitempriority``
+enums are created once here and re-used wherever the LLC module references them.
 """
 
 from typing import Sequence, Union
@@ -27,23 +28,42 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 _workitemtype = sa.Enum(
-    "epic", "feature", "pbi", "task", "bug", "subtask", "spike", "risk",
+    "epic",
+    "feature",
+    "pbi",
+    "task",
+    "bug",
+    "subtask",
+    "spike",
+    "risk",
     name="workitemtype",
 )
 _workitemstatus = sa.Enum(
-    "backlog", "ready", "in_progress", "in_review", "done", "cancelled", "blocked",
+    "backlog",
+    "ready",
+    "in_progress",
+    "in_review",
+    "done",
+    "cancelled",
+    "blocked",
     name="workitemstatus",
 )
 _workitempriority = sa.Enum(
-    "critical", "high", "medium", "low",
+    "critical",
+    "high",
+    "medium",
+    "low",
     name="workitempriority",
 )
 
 
 def upgrade() -> None:
-    _workitemtype.create(op.get_bind(), checkfirst=True)
-    _workitemstatus.create(op.get_bind(), checkfirst=True)
-    _workitempriority.create(op.get_bind(), checkfirst=True)
+    bind = op.get_bind()
+    _workitemtype.create(bind, checkfirst=True)
+    _workitemstatus.create(bind, checkfirst=True)
+    # Ensure 'ready' exists even when workitemstatus was pre-created without it.
+    bind.execute(sa.text("ALTER TYPE workitemstatus ADD VALUE IF NOT EXISTS 'ready'"))
+    _workitempriority.create(bind, checkfirst=True)
 
     op.create_table(
         "llc_work_items",
@@ -96,9 +116,7 @@ def upgrade() -> None:
         sa.Column("assignee_agent_id", UUID(as_uuid=True), nullable=True),
         sa.Column("assignee_user_id", UUID(as_uuid=True), nullable=True),
         sa.Column("checkout_run_id", sa.Text, nullable=True),
-        sa.Column(
-            "checkout_locked_at", sa.DateTime(timezone=True), nullable=True
-        ),
+        sa.Column("checkout_locked_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("version", sa.Integer, nullable=False, server_default="1"),
         sa.Column("created_by_agent_id", UUID(as_uuid=True), nullable=True),
         sa.Column("created_by_user_id", UUID(as_uuid=True), nullable=True),

--- a/autobot-backend/migrations/versions/20260523_022_create_llc_work_items.py
+++ b/autobot-backend/migrations/versions/20260523_022_create_llc_work_items.py
@@ -1,0 +1,182 @@
+"""Create llc_work_items and llc_work_item_comments tables.
+
+Revision ID: 20260523_022
+Revises: 20260522_021
+Create Date: 2026-05-23 00:00:00.000000
+
+GH#8213: Core work item hierarchy — Epic/Feature/PBI/Task/Bug/Subtask/Spike/Risk.
+Single ``llc_work_items`` table with a ``type`` discriminator. Atomic checkout
+via ``checkout_run_id`` + ``checkout_locked_at`` (Redis SET NX EX fence in the
+service layer; DB lock column here for persistence).
+
+ENUM types are created without IF NOT EXISTS so the migration is idempotent via
+``checkfirst=True`` in the service layer. The ``workitemtype``, ``workitemstatus``,
+and ``workitempriority`` enums are created once here and re-used wherever the
+LLC module references them.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision: str = "20260523_022"
+down_revision: Union[str, None] = "20260522_021"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_workitemtype = sa.Enum(
+    "epic", "feature", "pbi", "task", "bug", "subtask", "spike", "risk",
+    name="workitemtype",
+)
+_workitemstatus = sa.Enum(
+    "backlog", "ready", "in_progress", "in_review", "done", "cancelled", "blocked",
+    name="workitemstatus",
+)
+_workitempriority = sa.Enum(
+    "critical", "high", "medium", "low",
+    name="workitempriority",
+)
+
+
+def upgrade() -> None:
+    _workitemtype.create(op.get_bind(), checkfirst=True)
+    _workitemstatus.create(op.get_bind(), checkfirst=True)
+    _workitempriority.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "llc_work_items",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("company_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("sprint_id", UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "goal_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("llc_goals.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "parent_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("llc_work_items.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("type", _workitemtype, nullable=False),
+        sa.Column("identifier", sa.String(64), nullable=False, unique=True),
+        sa.Column("title", sa.Text, nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("acceptance_criteria", JSONB, nullable=True),
+        sa.Column(
+            "labels",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "status",
+            _workitemstatus,
+            nullable=False,
+            server_default="backlog",
+        ),
+        sa.Column(
+            "priority",
+            _workitempriority,
+            nullable=False,
+            server_default="medium",
+        ),
+        sa.Column("story_points", sa.Integer, nullable=True),
+        sa.Column("assignee_type", sa.String(16), nullable=True),
+        sa.Column("assignee_agent_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("assignee_user_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("checkout_run_id", sa.Text, nullable=True),
+        sa.Column(
+            "checkout_locked_at", sa.DateTime(timezone=True), nullable=True
+        ),
+        sa.Column("version", sa.Integer, nullable=False, server_default="1"),
+        sa.Column("created_by_agent_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("created_by_user_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("cancelled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+
+    op.create_index("ix_llc_work_items_company_id", "llc_work_items", ["company_id"])
+    op.create_index("ix_llc_work_items_project_id", "llc_work_items", ["project_id"])
+    op.create_index("ix_llc_work_items_sprint_id", "llc_work_items", ["sprint_id"])
+    op.create_index("ix_llc_work_items_parent_id", "llc_work_items", ["parent_id"])
+    op.create_index("ix_llc_work_items_status", "llc_work_items", ["status"])
+    op.create_index("ix_llc_work_items_assignee_agent_id", "llc_work_items", ["assignee_agent_id"])
+    op.create_index(
+        "ix_llc_work_items_company_status",
+        "llc_work_items",
+        ["company_id", "status"],
+    )
+
+    op.create_table(
+        "llc_work_item_comments",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("company_id", UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "work_item_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("llc_work_items.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("author_agent_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("author_user_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("body", sa.Text, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_llc_work_item_comments_work_item_id",
+        "llc_work_item_comments",
+        ["work_item_id"],
+    )
+    op.create_index(
+        "ix_llc_work_item_comments_company_id",
+        "llc_work_item_comments",
+        ["company_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("llc_work_item_comments")
+    op.drop_table("llc_work_items")
+    _workitempriority.drop(op.get_bind(), checkfirst=True)
+    _workitemstatus.drop(op.get_bind(), checkfirst=True)
+    _workitemtype.drop(op.get_bind(), checkfirst=True)


### PR DESCRIPTION
## Summary

- **LLCWorkItem** SQLAlchemy model (`llc_work_items` table): UUID PK, `company_id`, `project_id`/`sprint_id`/`goal_id`/`parent_id` (nullable FKs), `type` discriminator, `identifier`, `title`, `description`, `acceptance_criteria` JSONB, `status`, `priority`, `story_points`, `assignee_*`, `checkout_run_id`/`checkout_locked_at` (atomic lock fields), `version` counter, lifecycle timestamps
- **LLCWorkItemComment** model (`llc_work_item_comments` table)
- **Enum expansions**: `WorkItemType` now includes epic/feature/pbi/task/bug/subtask/spike/risk; `WorkItemPriority` added (critical/high/medium/low); `WorkItemStatus` adds `ready` state
- **Alembic migration** `20260523_022` creates both tables with all FK constraints and covering indexes; `ALTER TYPE workitemstatus ADD VALUE IF NOT EXISTS 'ready'` ensures idempotency on pre-existing enums
- **WorkItemService** extending `LLCServiceBase`: `create`, `get`, `update`, `list_by_project`, `checkout` (Redis `SET NX EX 1800` + `SELECT FOR UPDATE`), `release`, `transition_status` (state machine), `add_comment`
- **API routes** under `/api/llc/work-items`: full CRUD + `/checkout` (409 on conflict), `/release`, `/transition` (422 on invalid), `/comments`
- **17 tests passing**: 10 CRUD/transition unit tests + 7 atomic checkout concurrency tests

## Thinking Path

Needed a single-table work item hierarchy for the LLC module supporting Epic→Feature→PBI→Task/Bug/Subtask/Spike/Risk. Chose a type-discriminator pattern over per-type tables to simplify cross-hierarchy queries. For concurrent agent checkout, used a two-layer lock: Redis SET NX EX as the fast-path fence to avoid unnecessary DB round-trips, backed by SELECT FOR UPDATE as the authoritative DB-level serialization. After code review (MVA-858), three correctness issues were addressed: (1) Redis deletion in `release()` moved to the API route layer so it happens only after the DB transaction commits — prevents a stuck-lock window if the session rolls back after flush; (2) checkout DB guard simplified to check agent identity only, removing a `run_id` equality short-circuit that allowed different agents to hijack a checkout when Redis was down; (3) migration `ALTER TYPE workitemstatus ADD VALUE IF NOT EXISTS 'ready'` added for environments where the enum pre-existed without the new value.

## What Changed

- `llc/models/work_item.py` — new `LLCWorkItem` + `LLCWorkItemComment` SQLAlchemy models
- `llc/models/enums.py` — `WorkItemType` expanded, `WorkItemStatus` adds `ready`, new `WorkItemPriority`
- `llc/services/work_item_service.py` — full service with atomic checkout, state machine transitions; `release()` no longer deletes Redis key (moved to route layer post-commit); checkout guard checks agent identity only (no run_id bypass)
- `llc/api/work_items.py` — 9 REST routes; Redis cleanup in `release_work_item` happens after `session.commit()`
- `llc/tests/test_work_item.py` + `test_atomic_checkout.py` — 17 tests
- `migrations/versions/20260523_022_create_llc_work_items.py` — creates tables + enums with idempotent ALTER TYPE

## Verification

```
python -m pytest llc/tests/test_work_item.py llc/tests/test_atomic_checkout.py -v
17 passed
```

All new Python files pass `py_compile`. Black formatting applied to all new files.

## Model Used

claude-sonnet-4-6 (implementation), claude-sonnet-4-6 (code review MVA-858)

## Closes

GH#8213

## Test plan

- [x] `python -m pytest llc/tests/test_work_item.py llc/tests/test_atomic_checkout.py -v` → 17 passed
- [x] All new Python files pass `py_compile`
- [x] Black formatting applied
- [ ] Integration test: `python -m pytest autobot-backend/llc/ -k work_item` (requires full DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)