### PR TITLE
fix(llc): address MVA-858 code review findings — work item service (GH#8213)

### DIFF
--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -20,13 +20,18 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.singleton_factory import lazy_singleton
 from user_management.database import get_async_session_factory
 
 from ..models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
 from ..services.work_item_service import CheckoutConflict, InvalidTransition, WorkItemService
 
 router = APIRouter(prefix="/work-items", tags=["llc-work-items"])
-_service = WorkItemService()
+_get_service = lazy_singleton(WorkItemService)
+
+
+def _service() -> WorkItemService:
+    return _get_service()
 
 
 async def get_session() -> AsyncSession:
@@ -136,7 +141,7 @@ async def create_work_item(
     body: WorkItemCreate,
     session: AsyncSession = Depends(get_session),
 ) -> Dict[str, Any]:
-    item = await _service.create(
+    item = await _service().create(
         session,
         company_id=body.company_id,
         type=body.type,
@@ -168,11 +173,12 @@ async def list_work_items(
     assignee: Optional[str] = Query(None),
     sprint_id: Optional[str] = Query(None),
     parent_id: Optional[str] = Query(None),
+    top_level_only: bool = Query(False),
     limit: int = Query(100, ge=1, le=500),
     offset: int = Query(0, ge=0),
     session: AsyncSession = Depends(get_session),
 ) -> List[Dict[str, Any]]:
-    items = await _service.list_by_project(
+    items = await _service().list_by_project(
         session,
         company_id=company_id,
         project_id=project_id,
@@ -181,6 +187,7 @@ async def list_work_items(
         assignee_agent_id=assignee,
         sprint_id=sprint_id,
         parent_id=parent_id,
+        top_level_only=top_level_only,
         limit=limit,
         offset=offset,
     )
@@ -192,7 +199,7 @@ async def get_work_item(
     work_item_id: str,
     session: AsyncSession = Depends(get_session),
 ) -> Dict[str, Any]:
-    item = await _service.get(session, work_item_id)
+    item = await _service().get(session, work_item_id)
     if item is None:
         raise HTTPException(status_code=404, detail="Work item not found")
     return _item_to_dict(item)
@@ -205,7 +212,7 @@ async def update_work_item(
     session: AsyncSession = Depends(get_session),
 ) -> Dict[str, Any]:
     fields = {k: v for k, v in body.model_dump(exclude_none=True).items()}
-    item = await _service.update(session, work_item_id, **fields)
+    item = await _service().update(session, work_item_id, **fields)
     if item is None:
         raise HTTPException(status_code=404, detail="Work item not found")
     await session.commit()
@@ -217,7 +224,7 @@ async def delete_work_item(
     work_item_id: str,
     session: AsyncSession = Depends(get_session),
 ) -> None:
-    item = await _service.get(session, work_item_id)
+    item = await _service().get(session, work_item_id)
     if item is None:
         raise HTTPException(status_code=404, detail="Work item not found")
     await session.delete(item)
@@ -231,7 +238,7 @@ async def checkout_work_item(
     session: AsyncSession = Depends(get_session),
 ) -> Dict[str, Any]:
     try:
-        item = await _service.checkout(
+        item = await _service().checkout(
             session,
             work_item_id=work_item_id,
             agent_id=body.agent_id,
@@ -252,7 +259,7 @@ async def release_work_item(
     session: AsyncSession = Depends(get_session),
 ) -> Dict[str, Any]:
     try:
-        item = await _service.release(session, work_item_id=work_item_id, agent_id=body.agent_id)
+        item = await _service().release(session, work_item_id=work_item_id, agent_id=body.agent_id)
         await session.commit()
         redis = await get_async_redis_client()
         if redis is not None:
@@ -269,7 +276,7 @@ async def transition_work_item(
     session: AsyncSession = Depends(get_session),
 ) -> Dict[str, Any]:
     try:
-        item = await _service.transition_status(session, work_item_id, body.status)
+        item = await _service().transition_status(session, work_item_id, body.status)
         await session.commit()
         return _item_to_dict(item)
     except InvalidTransition as exc:
@@ -284,7 +291,7 @@ async def add_comment(
     body: CommentCreate,
     session: AsyncSession = Depends(get_session),
 ) -> Dict[str, Any]:
-    comment = await _service.add_comment(
+    comment = await _service().add_comment(
         session,
         work_item_id=work_item_id,
         company_id=body.company_id,

--- a/autobot-backend/llc/models/enums.py
+++ b/autobot-backend/llc/models/enums.py
@@ -17,7 +17,6 @@ class WorkItemType(str, Enum):
     """Type of LLC work item (GH#8213).
 
     Hierarchy: epic → feature → pbi → task/bug/subtask/spike/risk.
-    ``story`` kept as alias for pbi for backward compat with early scaffolding.
     """
 
     EPIC = "epic"

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -162,6 +162,7 @@ class WorkItemService(LLCServiceBase):
         assignee_agent_id: Optional[str] = None,
         sprint_id: Optional[str] = None,
         parent_id: Optional[str] = None,
+        top_level_only: bool = False,
         limit: int = 100,
         offset: int = 0,
     ) -> Sequence[LLCWorkItem]:
@@ -176,7 +177,9 @@ class WorkItemService(LLCServiceBase):
             q = q.where(LLCWorkItem.assignee_agent_id == uuid.UUID(assignee_agent_id))
         if sprint_id:
             q = q.where(LLCWorkItem.sprint_id == uuid.UUID(sprint_id))
-        if parent_id:
+        if top_level_only:
+            q = q.where(LLCWorkItem.parent_id.is_(None))
+        elif parent_id is not None:
             q = q.where(LLCWorkItem.parent_id == uuid.UUID(parent_id))
         q = q.order_by(LLCWorkItem.created_at.desc()).limit(limit).offset(offset)
         result = await session.execute(q)
@@ -351,9 +354,14 @@ class WorkItemService(LLCServiceBase):
             rec = row.fetchone()
             if rec:
                 return f"{rec.issue_prefix}-{rec.issue_counter}"
-        except Exception:
-            logger.debug(
-                "llc_companies table not available — falling back to UUID identifier",
-                exc_info=True,
-            )
+        except Exception as exc:
+            from sqlalchemy.exc import ProgrammingError, OperationalError
+            if isinstance(exc, (ProgrammingError, OperationalError)):
+                logger.debug("llc_companies table not available — using UUID identifier fallback")
+            else:
+                logger.warning(
+                    "Unexpected error generating identifier for company %s — using UUID fallback",
+                    company_id,
+                    exc_info=True,
+                )
         return f"WI-{uuid.uuid4().hex[:8].upper()}"

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -22,6 +22,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence
 
 from sqlalchemy import select, text, update
+from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.redis_client import get_async_redis_client
@@ -179,7 +180,7 @@ class WorkItemService(LLCServiceBase):
             q = q.where(LLCWorkItem.sprint_id == uuid.UUID(sprint_id))
         if top_level_only:
             q = q.where(LLCWorkItem.parent_id.is_(None))
-        elif parent_id is not None:
+        elif parent_id:
             q = q.where(LLCWorkItem.parent_id == uuid.UUID(parent_id))
         q = q.order_by(LLCWorkItem.created_at.desc()).limit(limit).offset(offset)
         result = await session.execute(q)
@@ -355,7 +356,6 @@ class WorkItemService(LLCServiceBase):
             if rec:
                 return f"{rec.issue_prefix}-{rec.issue_counter}"
         except Exception as exc:
-            from sqlalchemy.exc import ProgrammingError, OperationalError
             if isinstance(exc, (ProgrammingError, OperationalError)):
                 logger.debug("llc_companies table not available — using UUID identifier fallback")
             else:


### PR DESCRIPTION
## Summary

Follow-up to PR #8453. Addresses the 4 non-blocking findings from MVA-858 code review:

- **`_next_identifier()` exception handling**: narrowed bare `except Exception` — `ProgrammingError`/`OperationalError` logged at DEBUG (expected in test envs); other exceptions logged at WARNING with traceback
- **Module-level singleton**: replaced `_service = WorkItemService()` with `lazy_singleton(WorkItemService)` per project convention (#5622/#5626); 9 route call sites updated to `_service()`
- **`list_by_project` top-level filter**: added `top_level_only: bool = False` parameter + `?top_level_only=` query param so callers can request `WHERE parent_id IS NULL` explicitly
- **Misleading docstring**: removed false claim about `story` backward-compat alias from `WorkItemType` docstring

Note: The 3 blocking findings (Redis-before-commit in release, checkout conflict guard, migration enum) were already applied by CodeReviewer before merging PR #8453.

## Test plan

- [x] 17 tests still passing
- [x] `py_compile` on all 3 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)