### PR TITLE
fix(llc): address MVA-820 CR medium-priority findings for GH#8211

### DIFF
--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -33,6 +33,7 @@ from llc.models.enums import LLCCompanyStatus
 from llc.services.company import (
     CompanyBudgetError,
     CompanyCycleError,
+    CompanyHasChildrenError,
     CompanyIssuePrefixConflictError,
     CompanyNotFoundError,
     CompanyService,
@@ -85,13 +86,20 @@ async def create_company(
         await svc.session.commit()
         return _to_read(org)
     except CompanyIssuePrefixConflictError as exc:
+        await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
     except CompanyBudgetError as exc:
+        await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
     except CompanyCycleError as exc:
+        await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
     except CompanyNotFoundError as exc:
+        await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except Exception:
+        await svc.session.rollback()
+        raise
 
 
 @router.get("/{company_id}", response_model=CompanyRead)
@@ -117,11 +125,17 @@ async def update_company(
         await svc.session.commit()
         return _to_read(org)
     except CompanyNotFoundError as exc:
+        await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
     except CompanyIssuePrefixConflictError as exc:
+        await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
     except CompanyBudgetError as exc:
+        await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+    except Exception:
+        await svc.session.rollback()
+        raise
 
 
 @router.delete("/{company_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -133,7 +147,14 @@ async def delete_company(
         await svc.delete(company_id)
         await svc.session.commit()
     except CompanyNotFoundError as exc:
+        await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except CompanyHasChildrenError as exc:
+        await svc.session.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+    except Exception:
+        await svc.session.rollback()
+        raise
 
 
 @router.get("/{company_id}/tree", response_model=CompanyTreeNode)

--- a/autobot-backend/llc/models/company.py
+++ b/autobot-backend/llc/models/company.py
@@ -52,7 +52,12 @@ class CompanyCreate(CompanyBase):
 
 
 class CompanyUpdate(BaseModel):
-    """Request body for PATCH /companies/{id}.  All fields optional."""
+    """Request body for PATCH /companies/{id}.  All fields optional.
+
+    ``llc_status`` is intentionally excluded — use the dedicated
+    ``suspend()`` / ``archive()`` service methods so transition guards and
+    audit trail are always applied.
+    """
 
     name: Optional[str] = Field(None, min_length=1, max_length=255)
     description: Optional[str] = None
@@ -60,7 +65,6 @@ class CompanyUpdate(BaseModel):
     budget_monthly_cents: Optional[int] = Field(None, ge=0)
     brand_color: Optional[str] = Field(None, pattern=r"^#[0-9A-Fa-f]{6}$")
     require_approval_for_hires: Optional[bool] = None
-    llc_status: Optional[LLCCompanyStatus] = None
     pause_reason: Optional[str] = None
 
     model_config = {"from_attributes": True}

--- a/autobot-backend/llc/services/company.py
+++ b/autobot-backend/llc/services/company.py
@@ -8,6 +8,7 @@ ancestry lookup, budget enforcement, and status lifecycle transitions
 (suspend / archive).
 """
 
+import asyncio
 import uuid
 from typing import List, Optional
 
@@ -158,9 +159,26 @@ class CompanyService(LLCServiceBase):
     # Status transitions
     # ------------------------------------------------------------------
 
+    # Valid states from which suspend() is allowed
+    _SUSPEND_FROM: frozenset[str] = frozenset(
+        {LLCCompanyStatus.ONBOARDING.value, LLCCompanyStatus.ACTIVE.value}
+    )
+    # Valid states from which archive() is allowed
+    _ARCHIVE_FROM: frozenset[str] = frozenset(
+        {LLCCompanyStatus.PAUSED.value, LLCCompanyStatus.OFFBOARDING.value}
+    )
+
     async def suspend(self, company_id: uuid.UUID, reason: Optional[str] = None) -> Organization:
-        """Transition company to PAUSED status."""
+        """Transition company to PAUSED status.
+
+        Only allowed from ONBOARDING or ACTIVE — raises ValueError otherwise.
+        """
         org = await self._get_or_404(company_id)
+        if org.llc_status not in self._SUSPEND_FROM:
+            raise ValueError(
+                f"Cannot suspend company in '{org.llc_status}' state "
+                f"(allowed from: {', '.join(sorted(self._SUSPEND_FROM))})"
+            )
         org.llc_status = LLCCompanyStatus.PAUSED.value
         org.pause_reason = reason
         org.paused_at = now_utc()
@@ -169,8 +187,16 @@ class CompanyService(LLCServiceBase):
         return org
 
     async def archive(self, company_id: uuid.UUID) -> Organization:
-        """Transition company to ARCHIVED status."""
+        """Transition company to ARCHIVED status.
+
+        Only allowed from PAUSED or OFFBOARDING — raises ValueError otherwise.
+        """
         org = await self._get_or_404(company_id)
+        if org.llc_status not in self._ARCHIVE_FROM:
+            raise ValueError(
+                f"Cannot archive company in '{org.llc_status}' state "
+                f"(allowed from: {', '.join(sorted(self._ARCHIVE_FROM))})"
+            )
         org.llc_status = LLCCompanyStatus.ARCHIVED.value
         await self.session.flush()
         logger.info("LLC company archived: %s (id=%s)", org.name, org.id)
@@ -196,10 +222,11 @@ class CompanyService(LLCServiceBase):
             if current_id in visited:
                 break
             parent = await self._get_or_404(current_id)
-            chain.insert(0, parent)
+            chain.append(parent)
             visited.add(parent.id)
             current_id = parent.parent_org_id
 
+        chain.reverse()
         return chain
 
     # ------------------------------------------------------------------
@@ -218,7 +245,11 @@ class CompanyService(LLCServiceBase):
     async def _assert_prefix_unique(self, prefix: Optional[str]) -> None:
         if prefix is None:
             return
-        result = await self.session.execute(select(Organization.id).where(Organization.issue_prefix == prefix))
+        result = await self.session.execute(
+            select(Organization.id)
+            .where(Organization.issue_prefix == prefix)
+            .where(Organization.deleted_at.is_(None))
+        )
         if result.scalar_one_or_none() is not None:
             raise CompanyIssuePrefixConflictError(f"issue_prefix '{prefix}' is already taken")
 
@@ -268,7 +299,9 @@ class CompanyService(LLCServiceBase):
             raise CompanyCycleError(f"Cycle detected in company tree at id={org.id}")
         current_visited = visited | {org.id}
         children_orgs = await self.list_children(org.id)
-        children_nodes = [await self._build_tree_node(c, current_visited) for c in children_orgs]
+        children_nodes = list(
+            await asyncio.gather(*[self._build_tree_node(c, current_visited) for c in children_orgs])
+        )
         return CompanyTreeNode(
             id=org.id,
             name=org.name,


### PR DESCRIPTION
## Summary

Follow-up to #8452. Addresses medium and low-priority findings from the MVA-820 code review that were not covered by the critical-fix squash.

- **#5** `_assert_prefix_unique` — adds `deleted_at IS NULL` so soft-deleted orgs no longer permanently poison their `issue_prefix` slot.
- **#6** `CompanyUpdate` — removes `llc_status` field; callers must use `suspend()`/`archive()` to enforce transition guards.
- **#7** API handlers — `session.rollback()` added in all except branches + bare `Exception` fallback; `DELETE /{id}` now catches `CompanyHasChildrenError` → 409.
- **#8** `suspend()`/`archive()` — state transition matrix enforced; `suspend` only from `ONBOARDING`/`ACTIVE`, `archive` only from `PAUSED`/`OFFBOARDING`.
- **#9** `get_ancestry` — `append` + `reverse()` replaces `insert(0)`, O(n) instead of O(n²).
- **#10** `_build_tree_node` — `asyncio.gather` for children, O(depth) DB round-trips instead of O(breadth × depth).

## Test plan

- [ ] `python -m py_compile llc/services/company.py llc/models/company.py llc/api/companies.py` — passes
- [ ] `python -m pytest autobot-backend/llc/ -k company -v` — existing tests pass
- [ ] Manual: PATCH /{id} with `llc_status` should be rejected by Pydantic
- [ ] Manual: suspend(ARCHIVED_company) should raise ValueError
- [ ] Manual: soft-delete + re-create same prefix — should succeed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)