### PR TITLE
feat(llc): per-agent budget enforcement — hard stop, soft alert, cost ingest (#8215)

### DIFF
--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -2,11 +2,13 @@
 
 from fastapi import APIRouter
 
+from .budget import router as budget_router
 from .companies import router as companies_router
 from .goals import router as goals_router
 from .work_items import router as work_items_router
 
 router = APIRouter(prefix="/llc", tags=["llc"])
+router.include_router(budget_router)
 router.include_router(companies_router)
 router.include_router(goals_router)
 router.include_router(work_items_router)

--- a/autobot-backend/llc/api/budget.py
+++ b/autobot-backend/llc/api/budget.py
@@ -8,11 +8,12 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from user_management.database import get_async_session
 
+from llc.exceptions import BudgetExhausted
 from llc.models.budget import LLCAgentBudget
 from llc.services.budget import BudgetService
 
@@ -68,8 +69,6 @@ async def get_budget(
     svc = BudgetService()
     remaining, is_over, alert = await svc.check_budget(session, agent_id)
 
-    from sqlalchemy import select
-
     result = await session.execute(
         select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id)
     )
@@ -87,9 +86,12 @@ async def ingest_cost(
     session: AsyncSession = Depends(get_async_session),
 ) -> IngestResponse:
     svc = BudgetService()
-    cost = await svc.ingest_cost_event(
-        session, agent_id, body.tokens_in, body.tokens_out, body.model
-    )
+    try:
+        cost = await svc.ingest_cost_event(
+            session, agent_id, body.tokens_in, body.tokens_out, body.model
+        )
+    except BudgetExhausted as exc:
+        raise HTTPException(status_code=402, detail=str(exc)) from exc
     return IngestResponse(cost=cost)
 
 

--- a/autobot-backend/llc/api/budget.py
+++ b/autobot-backend/llc/api/budget.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import select, text
+from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from user_management.database import get_async_session
@@ -101,8 +101,6 @@ async def update_limit(
     body: UpdateLimitRequest,
     session: AsyncSession = Depends(get_async_session),
 ) -> BudgetResponse:
-    from sqlalchemy import select, update
-
     result = await session.execute(
         select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id)
     )

--- a/autobot-backend/llc/api/budget.py
+++ b/autobot-backend/llc/api/budget.py
@@ -1,0 +1,124 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLC per-agent budget API routes (GH#8215)."""
+
+from decimal import Decimal
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from user_management.database import get_async_session
+
+from llc.models.budget import LLCAgentBudget
+from llc.services.budget import BudgetService
+
+router = APIRouter(prefix="/budget", tags=["llc-budget"])
+
+
+class BudgetResponse(BaseModel):
+    agent_id: str
+    budget_limit: Decimal
+    budget_spent: Decimal
+    alert_threshold: float
+    remaining: Decimal
+    is_over_limit: bool
+    alert_triggered: bool
+
+    model_config = {"from_attributes": True}
+
+
+class IngestRequest(BaseModel):
+    tokens_in: int
+    tokens_out: int
+    model: str
+
+
+class IngestResponse(BaseModel):
+    cost: Decimal
+
+
+class UpdateLimitRequest(BaseModel):
+    budget_limit: Decimal
+    alert_threshold: Optional[float] = None
+
+
+def _build_response(
+    row: LLCAgentBudget, remaining: Decimal, is_over: bool, alert: bool
+) -> BudgetResponse:
+    return BudgetResponse(
+        agent_id=row.agent_id,
+        budget_limit=Decimal(str(row.budget_limit)),
+        budget_spent=Decimal(str(row.budget_spent)),
+        alert_threshold=row.alert_threshold,
+        remaining=remaining,
+        is_over_limit=is_over,
+        alert_triggered=alert,
+    )
+
+
+@router.get("/{agent_id}", response_model=BudgetResponse)
+async def get_budget(
+    agent_id: str,
+    session: AsyncSession = Depends(get_async_session),
+) -> BudgetResponse:
+    svc = BudgetService()
+    remaining, is_over, alert = await svc.check_budget(session, agent_id)
+
+    from sqlalchemy import select
+
+    result = await session.execute(
+        select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id)
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"No budget row for agent {agent_id}")
+
+    return _build_response(row, remaining, is_over, alert)
+
+
+@router.post("/{agent_id}/ingest", response_model=IngestResponse)
+async def ingest_cost(
+    agent_id: str,
+    body: IngestRequest,
+    session: AsyncSession = Depends(get_async_session),
+) -> IngestResponse:
+    svc = BudgetService()
+    cost = await svc.ingest_cost_event(
+        session, agent_id, body.tokens_in, body.tokens_out, body.model
+    )
+    return IngestResponse(cost=cost)
+
+
+@router.patch("/{agent_id}/limit", response_model=BudgetResponse)
+async def update_limit(
+    agent_id: str,
+    body: UpdateLimitRequest,
+    session: AsyncSession = Depends(get_async_session),
+) -> BudgetResponse:
+    from sqlalchemy import select, update
+
+    result = await session.execute(
+        select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id)
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"No budget row for agent {agent_id}")
+
+    values: dict = {"budget_limit": str(body.budget_limit)}
+    if body.alert_threshold is not None:
+        values["alert_threshold"] = body.alert_threshold
+
+    await session.execute(
+        update(LLCAgentBudget)
+        .where(LLCAgentBudget.agent_id == agent_id)
+        .values(**values)
+    )
+    await session.refresh(row)
+
+    svc = BudgetService()
+    remaining, is_over, alert = await svc.check_budget(session, agent_id)
+    return _build_response(row, remaining, is_over, alert)

--- a/autobot-backend/llc/exceptions.py
+++ b/autobot-backend/llc/exceptions.py
@@ -1,0 +1,16 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLC domain exceptions (GH#8215)."""
+
+
+class BudgetExhausted(Exception):
+    """Raised when an agent's budget_spent exceeds budget_limit."""
+
+    def __init__(self, agent_id: str, spent: float, limit: float) -> None:
+        self.agent_id = agent_id
+        self.spent = spent
+        self.limit = limit
+        super().__init__(
+            f"Agent {agent_id} budget exhausted: spent={spent:.6f} limit={limit:.6f}"
+        )

--- a/autobot-backend/llc/models/__init__.py
+++ b/autobot-backend/llc/models/__init__.py
@@ -1,5 +1,6 @@
 """LLC models package."""
 
+from .budget import LLCAgentBudget
 from .company import (
     CompanyAncestor,
     CompanyCreate,
@@ -31,6 +32,7 @@ __all__ = [
     "CompanyUpdate",
     "GoalLevel",
     "GoalStatus",
+    "LLCAgentBudget",
     "LLCAgentStatus",
     "LLCCompanyStatus",
     "LLCGoal",

--- a/autobot-backend/llc/models/budget.py
+++ b/autobot-backend/llc/models/budget.py
@@ -1,0 +1,37 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLC per-agent budget model (GH#8215)."""
+
+import uuid
+from decimal import Decimal
+
+from sqlalchemy import Float, Index, Numeric, String, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from user_management.models.base import Base
+
+
+class LLCAgentBudget(Base):
+    """Per-agent spend tracking with hard-stop and alert threshold.
+
+    budget_limit and budget_spent use Numeric(15,6) — not Float — so that
+    decimal arithmetic is exact (Float loses precision at ~7 sig figs).
+    """
+
+    __tablename__ = "llc_agent_budgets"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    company_id: Mapped[str] = mapped_column(String(255), index=True, nullable=False)
+    agent_id: Mapped[str] = mapped_column(
+        String(255), unique=True, index=True, nullable=False
+    )
+    budget_limit: Mapped[Decimal] = mapped_column(Numeric(15, 6), nullable=False)
+    budget_spent: Mapped[Decimal] = mapped_column(
+        Numeric(15, 6), nullable=False, default=Decimal("0")
+    )
+    alert_threshold: Mapped[float] = mapped_column(
+        Float, nullable=False, default=0.8
+    )

--- a/autobot-backend/llc/services/__init__.py
+++ b/autobot-backend/llc/services/__init__.py
@@ -5,23 +5,9 @@ All concrete LLC service classes should inherit from this base so they
 receive a typed ``activity_log`` reference at construction time.
 """
 
-from typing import Optional
-
 from .activity_log import LLCActivityLogService
+from .base import LLCServiceBase
+from .budget import BudgetService
+from .goal import GoalService
 
-
-class LLCServiceBase:
-    """Base class for all LLC services.
-
-    Subclasses receive the activity_log DI slot which is populated by the
-    LLC DI container once GH#8216 lands. Until then, the slot is None and
-    callers must guard with ``if self.activity_log``.
-    """
-
-    def __init__(self, activity_log: Optional[LLCActivityLogService] = None) -> None:
-        self.activity_log = activity_log
-
-
-__all__ = ["GoalService", "LLCActivityLogService", "LLCServiceBase"]
-
-from .goal import GoalService  # noqa: E402 — after base class definition
+__all__ = ["BudgetService", "GoalService", "LLCActivityLogService", "LLCServiceBase"]

--- a/autobot-backend/llc/services/base.py
+++ b/autobot-backend/llc/services/base.py
@@ -3,7 +3,10 @@
 # Author: mrveiss
 """LLCServiceBase — shared DI slot for all LLC services."""
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from .activity_log import LLCActivityLogService
 
 
 class LLCServiceBase:
@@ -14,5 +17,5 @@ class LLCServiceBase:
     callers must guard with ``if self.activity_log``.
     """
 
-    def __init__(self, activity_log: Optional[object] = None) -> None:
+    def __init__(self, activity_log: "Optional[LLCActivityLogService]" = None) -> None:
         self.activity_log = activity_log

--- a/autobot-backend/llc/services/base.py
+++ b/autobot-backend/llc/services/base.py
@@ -1,0 +1,18 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLCServiceBase — shared DI slot for all LLC services."""
+
+from typing import Optional
+
+
+class LLCServiceBase:
+    """Base class for all LLC services.
+
+    Subclasses receive the activity_log DI slot which is populated by the
+    LLC DI container once GH#8216 lands. Until then, the slot is None and
+    callers must guard with ``if self.activity_log``.
+    """
+
+    def __init__(self, activity_log: Optional[object] = None) -> None:
+        self.activity_log = activity_log

--- a/autobot-backend/llc/services/budget.py
+++ b/autobot-backend/llc/services/budget.py
@@ -1,0 +1,153 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLC per-agent budget service (GH#8215).
+
+Provides cost ingest with atomic DB update, hard-stop via BudgetExhausted,
+and soft alert via Redis publish on threshold crossing.
+"""
+
+import json
+import logging
+from decimal import Decimal
+from typing import Tuple
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.ssot_constants import MODEL_PRICING_PER_1M_TOKENS
+
+from llc.exceptions import BudgetExhausted
+from llc.models.budget import LLCAgentBudget
+
+from .base import LLCServiceBase
+
+logger = logging.getLogger(__name__)
+
+
+class BudgetService(LLCServiceBase):
+    """Per-agent budget enforcement: cost ingest, hard stop, soft alert."""
+
+    async def ingest_cost_event(
+        self,
+        session: AsyncSession,
+        agent_id: str,
+        tokens_in: int,
+        tokens_out: int,
+        model: str,
+    ) -> Decimal:
+        """Record token cost for an agent and enforce budget limits.
+
+        Uses an atomic UPDATE (budget_spent = budget_spent + cost) to avoid
+        read-modify-write races across 4 uvicorn workers sharing one DB.
+
+        Returns the cost added this call.
+        Raises BudgetExhausted if spending exceeds budget_limit.
+        """
+        pricing = MODEL_PRICING_PER_1M_TOKENS.get(model)
+        if pricing is None:
+            logger.warning(
+                "Unknown model %r in ingest_cost_event for agent %s — treating cost as 0",
+                model,
+                agent_id,
+            )
+            cost = Decimal("0")
+        else:
+            cost = Decimal(
+                str(
+                    (tokens_in * pricing["input"] + tokens_out * pricing["output"])
+                    / 1_000_000
+                )
+            )
+
+        # Atomic increment — prevents lost-update across concurrent workers
+        await session.execute(
+            text(
+                "UPDATE llc_agent_budgets"
+                " SET budget_spent = budget_spent + :cost"
+                " WHERE agent_id = :agent_id"
+            ),
+            {"cost": str(cost), "agent_id": agent_id},
+        )
+
+        result = await session.execute(
+            select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id)
+        )
+        row = result.scalar_one_or_none()
+
+        if row is None:
+            logger.warning(
+                "No budget row for agent %s after ingest — skipping enforcement",
+                agent_id,
+            )
+            return cost
+
+        spent = Decimal(str(row.budget_spent))
+        limit = Decimal(str(row.budget_limit))
+        threshold = Decimal(str(row.alert_threshold))
+
+        if spent > limit:
+            raise BudgetExhausted(
+                agent_id=agent_id, spent=float(spent), limit=float(limit)
+            )
+
+        if limit > Decimal("0") and spent / limit >= threshold:
+            await self._emit_alert(agent_id, float(spent), float(limit))
+
+        return cost
+
+    async def check_budget(
+        self, session: AsyncSession, agent_id: str
+    ) -> Tuple[Decimal, bool, bool]:
+        """Return (remaining, is_over_limit, alert_triggered) for an agent.
+
+        remaining can be negative when spent exceeds limit.
+        """
+        result = await session.execute(
+            select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id)
+        )
+        row = result.scalar_one_or_none()
+
+        if row is None:
+            return Decimal("0"), False, False
+
+        spent = Decimal(str(row.budget_spent))
+        limit = Decimal(str(row.budget_limit))
+        threshold = Decimal(str(row.alert_threshold))
+
+        remaining = limit - spent
+        is_over_limit = spent > limit
+        alert_triggered = limit > Decimal("0") and spent / limit >= threshold
+
+        return remaining, is_over_limit, alert_triggered
+
+    async def _emit_alert(
+        self, agent_id: str, spent: float, limit: float
+    ) -> None:
+        """Publish llc:budget_alert to Redis.
+
+        Swallows all exceptions — Redis failure must NOT roll back the budget
+        ingest transaction.
+        """
+        redis = await get_async_redis_client()
+        if redis is None:
+            logger.warning(
+                "Redis unavailable — skipping llc:budget_alert for %s", agent_id
+            )
+            return
+        try:
+            await redis.publish(
+                "llc:budget_alert",
+                json.dumps(
+                    {
+                        "agent_id": agent_id,
+                        "spent": spent,
+                        "limit": limit,
+                    }
+                ),
+            )
+        except Exception:
+            logger.exception(
+                "Failed to emit llc:budget_alert for %s", agent_id
+            )

--- a/autobot-backend/llc/tests/test_budget_service.py
+++ b/autobot-backend/llc/tests/test_budget_service.py
@@ -1,0 +1,140 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for BudgetService (GH#8215)."""
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.exceptions import BudgetExhausted
+from llc.services.budget import BudgetService
+
+
+def _make_row(spent: float, limit: float, threshold: float = 0.8) -> MagicMock:
+    row = MagicMock()
+    row.agent_id = "agent-001"
+    row.budget_spent = Decimal(str(spent))
+    row.budget_limit = Decimal(str(limit))
+    row.alert_threshold = threshold
+    return row
+
+
+def _make_session(row: MagicMock | None = None) -> AsyncMock:
+    session = AsyncMock()
+    # MagicMock (not AsyncMock) so scalar_one_or_none() returns synchronously
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = row
+    session.execute.return_value = result
+    return session
+
+
+@pytest.mark.asyncio
+async def test_ingest_accumulates_cost() -> None:
+    row = _make_row(spent=0.5, limit=10.0)
+    session = _make_session(row)
+
+    svc = BudgetService()
+    with patch(
+        "llc.services.budget.get_async_redis_client", new_callable=AsyncMock
+    ) as mock_redis:
+        mock_redis.return_value = None
+        await svc.ingest_cost_event(session, "agent-001", 100, 50, "claude-sonnet-4-6")
+        await svc.ingest_cost_event(session, "agent-001", 100, 50, "claude-sonnet-4-6")
+
+    # session.execute called twice per ingest (UPDATE + SELECT) = 4 total
+    assert session.execute.call_count == 4
+
+
+@pytest.mark.asyncio
+async def test_hard_stop_raises_budget_exhausted() -> None:
+    row = _make_row(spent=10.5, limit=10.0)
+    session = _make_session(row)
+
+    svc = BudgetService()
+    with patch(
+        "llc.services.budget.get_async_redis_client", new_callable=AsyncMock
+    ):
+        with pytest.raises(BudgetExhausted) as exc_info:
+            await svc.ingest_cost_event(
+                session, "agent-001", 1000, 500, "claude-sonnet-4-6"
+            )
+
+    assert exc_info.value.agent_id == "agent-001"
+    assert exc_info.value.spent > exc_info.value.limit
+
+
+@pytest.mark.asyncio
+async def test_alert_emitted_at_threshold() -> None:
+    # 8.5 / 10.0 = 85% >= 80% threshold
+    row = _make_row(spent=8.5, limit=10.0, threshold=0.8)
+    session = _make_session(row)
+
+    mock_redis_client = AsyncMock()
+    mock_redis_client.publish = AsyncMock()
+
+    svc = BudgetService()
+    with patch(
+        "llc.services.budget.get_async_redis_client",
+        new_callable=AsyncMock,
+        return_value=mock_redis_client,
+    ):
+        await svc.ingest_cost_event(session, "agent-001", 0, 0, "claude-sonnet-4-6")
+
+    mock_redis_client.publish.assert_called_once()
+    call_args = mock_redis_client.publish.call_args
+    assert call_args[0][0] == "llc:budget_alert"
+
+
+@pytest.mark.asyncio
+async def test_alert_not_emitted_below_threshold() -> None:
+    # 5.0 / 10.0 = 50% < 80% threshold
+    row = _make_row(spent=5.0, limit=10.0, threshold=0.8)
+    session = _make_session(row)
+
+    mock_redis_client = AsyncMock()
+    mock_redis_client.publish = AsyncMock()
+
+    svc = BudgetService()
+    with patch(
+        "llc.services.budget.get_async_redis_client",
+        new_callable=AsyncMock,
+        return_value=mock_redis_client,
+    ):
+        await svc.ingest_cost_event(session, "agent-001", 0, 0, "claude-sonnet-4-6")
+
+    mock_redis_client.publish.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_budget_over_limit() -> None:
+    row = _make_row(spent=12.0, limit=10.0, threshold=0.8)
+    session = _make_session(row)
+
+    svc = BudgetService()
+    remaining, is_over, alert = await svc.check_budget(session, "agent-001")
+
+    assert remaining == Decimal("10.0") - Decimal("12.0")
+    assert remaining < Decimal("0")
+    assert is_over is True
+    assert alert is True
+
+
+@pytest.mark.asyncio
+async def test_unknown_model_zero_cost() -> None:
+    row = _make_row(spent=0.0, limit=10.0)
+    session = _make_session(row)
+
+    svc = BudgetService()
+    with patch(
+        "llc.services.budget.get_async_redis_client", new_callable=AsyncMock
+    ) as mock_redis:
+        mock_redis.return_value = None
+        cost = await svc.ingest_cost_event(
+            session, "agent-001", 1000, 500, "unknown-model-xyz"
+        )
+
+    assert cost == Decimal("0")
+    # UPDATE was still called (with cost=0)
+    assert session.execute.call_count >= 1

--- a/autobot-backend/migrations/versions/20260523_022_llc_agent_budgets.py
+++ b/autobot-backend/migrations/versions/20260523_022_llc_agent_budgets.py
@@ -1,0 +1,55 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLC per-agent budget table (GH#8215).
+
+Revision ID: 20260523_022
+Revises: 20260522_021
+Create Date: 2026-05-23
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260523_022"
+down_revision = "20260522_021"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "llc_agent_budgets",
+        sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True),
+        sa.Column("company_id", sa.String(255), nullable=False),
+        sa.Column("agent_id", sa.String(255), nullable=False, unique=True),
+        sa.Column("budget_limit", sa.Numeric(15, 6), nullable=False),
+        sa.Column(
+            "budget_spent", sa.Numeric(15, 6), nullable=False, server_default="0"
+        ),
+        sa.Column("alert_threshold", sa.Float, nullable=False, server_default="0.8"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_llc_agent_budgets_company_id", "llc_agent_budgets", ["company_id"]
+    )
+    op.create_index(
+        "ix_llc_agent_budgets_agent_id", "llc_agent_budgets", ["agent_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_llc_agent_budgets_agent_id", table_name="llc_agent_budgets")
+    op.drop_index("ix_llc_agent_budgets_company_id", table_name="llc_agent_budgets")
+    op.drop_table("llc_agent_budgets")


### PR DESCRIPTION
## Thinking Path

GH#8215 requires per-agent budget enforcement with a hard stop (raise exception when over limit) and soft alert (Redis event at threshold). The key architectural constraint is multi-worker safety: 4 uvicorn workers share one Postgres DB, so `budget_spent` must be incremented atomically (`UPDATE SET budget_spent = budget_spent + cost`) rather than with a read-modify-write. `Numeric(15,6)` is used instead of `Float` to preserve exact decimal arithmetic for currency.

## What Changed

- `llc/models/budget.py` (new): `LLCAgentBudget` model with `Numeric(15,6)` budget columns, `agent_id` unique constraint
- `migrations/versions/20260523_022_llc_agent_budgets.py` (new): creates `llc_agent_budgets` table with two indexes
- `llc/exceptions.py` (new): `BudgetExhausted` exception carrying `agent_id`, `spent`, `limit`
- `llc/services/base.py` (new): `LLCServiceBase` extracted from `__init__.py` to its own file
- `llc/services/budget.py` (new): `BudgetService` with `ingest_cost_event` (atomic UPDATE + hard-stop + alert) and `check_budget`
- `llc/api/budget.py` (new): three FastAPI routes — `GET /llc/budget/{agent_id}`, `POST /llc/budget/{agent_id}/ingest` (returns 402 on `BudgetExhausted`), `PATCH /llc/budget/{agent_id}/limit`
- `llc/models/__init__.py`, `llc/services/__init__.py`, `llc/api/__init__.py`: add new exports and router registration
- `llc/tests/test_budget_service.py` (new): 6 unit tests

## Verification

```bash
# Syntax check
python3 -m py_compile autobot-backend/llc/api/budget.py
python3 -m py_compile autobot-backend/llc/services/budget.py

# Unit tests
cd autobot-backend && pytest llc/tests/test_budget_service.py -v
# Expected: 6 passed

# Import smoke
python3 -c "from llc.models.budget import LLCAgentBudget; from llc.services.budget import BudgetService; from llc.exceptions import BudgetExhausted; print('OK')"
```

## Risks

- `text()` raw SQL for atomic UPDATE bypasses ORM type checking — verified safe with Postgres Numeric parameters.
- `session.refresh(row)` in PATCH endpoint reads stale data if another worker updates concurrently between UPDATE and refresh — acceptable for a limit-update operation (not a high-frequency path).
- Alert fires on every ingest call that crosses the threshold, not just the first crossing — callers should be idempotent.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Closes #8215

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (6 unit tests covering hard-stop and alert threshold)
- [x] Documentation updated if behavior changed (N/A — new module)
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff