### PR TITLE
hotfix(migrations): fix 4 duplicate LLC Alembic revision IDs + FK chain (#8460 v2)

### DIFF
--- a/autobot-backend/migrations/versions/20260523_022_create_llc_work_items.py
+++ b/autobot-backend/migrations/versions/20260523_022_create_llc_work_items.py
@@ -79,7 +79,6 @@ def upgrade() -> None:
         sa.Column(
             "goal_id",
             UUID(as_uuid=True),
-            sa.ForeignKey("llc_goals.id", ondelete="SET NULL"),
             nullable=True,
         ),
         sa.Column(

--- a/autobot-backend/migrations/versions/20260523_023_organization_llc_extensions.py
+++ b/autobot-backend/migrations/versions/20260523_023_organization_llc_extensions.py
@@ -1,7 +1,7 @@
 """Add LLC extension columns to organizations table.
 
-Revision ID: 20260523_022
-Revises: 20260522_021
+Revision ID: 20260523_023
+Revises: 20260523_022
 Create Date: 2026-05-23 00:00:00.000000
 
 GH#8211: Extends the organizations table with sub-company hierarchy, budget
@@ -14,8 +14,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "20260523_022"
-down_revision: Union[str, None] = "20260522_021"
+revision: str = "20260523_023"
+down_revision: Union[str, None] = "20260523_022"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/autobot-backend/migrations/versions/20260523_024_llc_goals.py
+++ b/autobot-backend/migrations/versions/20260523_024_llc_goals.py
@@ -53,9 +53,17 @@ def upgrade() -> None:
     op.create_index("ix_llc_goals_level", "llc_goals", ["level"])
     op.create_index("ix_llc_goals_status", "llc_goals", ["status"])
     op.create_index("ix_llc_goals_owner_agent_id", "llc_goals", ["owner_agent_id"])
+    # llc_goals must exist before this FK can be wired — deferred from migration 022.
+    op.create_foreign_key(
+        "fk_llc_work_items_goal_id",
+        "llc_work_items", "llc_goals",
+        ["goal_id"], ["id"],
+        ondelete="SET NULL",
+    )
 
 
 def downgrade() -> None:
+    op.drop_constraint("fk_llc_work_items_goal_id", "llc_work_items", type_="foreignkey")
     op.drop_index("ix_llc_goals_owner_agent_id", table_name="llc_goals")
     op.drop_index("ix_llc_goals_status", table_name="llc_goals")
     op.drop_index("ix_llc_goals_level", table_name="llc_goals")

--- a/autobot-backend/migrations/versions/20260523_024_llc_goals.py
+++ b/autobot-backend/migrations/versions/20260523_024_llc_goals.py
@@ -1,7 +1,7 @@
 """Create llc_goals table for 4-level goal hierarchy (GH#8212).
 
-Revision ID: 20260523_022
-Revises: 20260522_021
+Revision ID: 20260523_024
+Revises: 20260523_023
 Create Date: 2026-05-23 00:00:00.000000
 """
 
@@ -11,8 +11,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision: str = "20260523_022"
-down_revision: Union[str, None] = "20260522_021"
+revision: str = "20260523_024"
+down_revision: Union[str, None] = "20260523_023"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/autobot-backend/migrations/versions/20260523_025_llc_agent_budgets.py
+++ b/autobot-backend/migrations/versions/20260523_025_llc_agent_budgets.py
@@ -3,8 +3,8 @@
 # Author: mrveiss
 """LLC per-agent budget table (GH#8215).
 
-Revision ID: 20260523_022
-Revises: 20260522_021
+Revision ID: 20260523_025
+Revises: 20260523_024
 Create Date: 2026-05-23
 """
 

--- a/autobot-backend/migrations/versions/20260523_025_llc_agent_budgets.py
+++ b/autobot-backend/migrations/versions/20260523_025_llc_agent_budgets.py
@@ -11,8 +11,8 @@ Create Date: 2026-05-23
 from alembic import op
 import sqlalchemy as sa
 
-revision = "20260523_022"
-down_revision = "20260522_021"
+revision = "20260523_025"
+down_revision = "20260523_024"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Problem

Three LLC migrations were merged concurrently with identical `revision = "20260523_022"`, breaking `alembic upgrade head`. A first attempt (PR #8460) was created but became conflicting when `6091fb4a5` (GH#8215 budget enforcement) landed on `Dev_new_gui` with `down_revision = "20260523_022"`.

## Fix

Establishes a correct linear chain:

```
021 (heartbeat_wakeup)             — existing anchor
022 (create_llc_work_items)        — table only; FK to llc_goals deferred
023 (organization_llc_extensions)  — no LLC FK deps
024 (llc_goals)                    — creates table + wires fk_llc_work_items_goal_id
025 (llc_agent_budgets)            — down_revision = 024 (corrected from 022)
```

Files renamed (`022_organization_llc_extensions` → `023_*`, `022_llc_goals` → `024_*`) with matching `revision` / `down_revision` updates.

The FK from `llc_work_items.goal_id → llc_goals.id` could not live in migration 022 (goals table didn't exist yet). It is deferred to `024_llc_goals.py` which runs after both tables exist — ensuring `CREATE TABLE` succeeds and `alembic downgrade` tears down in reverse order cleanly.

## Downgrade safety

| Migration | downgrade action |
|-----------|-----------------|
| 025 | drop `llc_agent_budget_events`, `llc_budget_limits` |
| 024 | drop FK constraint → drop `llc_goals` |
| 023 | remove columns from `organizations` |
| 022 | drop `llc_work_item_comments`, `llc_work_items` |

## Unblocks

- PR #8457 (GH#8216 activity log) — needs rebase to set `down_revision = "20260523_025"`
- PR #8458 (GH#8214 board approval gates)
- PR #8459 (GH#8215 budget enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)