### PR TITLE
feat(llc): backlog view API — priority ordering, bulk sprint assign, type/status filter (GH#8222)

### DIFF
--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -6,6 +6,7 @@ from .activity import router as activity_router
 from .agent_api import router as agent_router
 from .api_keys import router as api_keys_router
 from .approvals import router as approvals_router
+from .backlog import router as backlog_router
 from .budget import router as budget_router
 from .companies import router as companies_router
 from .goals import router as goals_router
@@ -15,6 +16,7 @@ from .work_items import router as work_items_router
 router = APIRouter(prefix="/llc", tags=["llc"])
 router.include_router(activity_router)
 router.include_router(approvals_router)
+router.include_router(backlog_router)
 router.include_router(budget_router)
 router.include_router(companies_router)
 router.include_router(goals_router)

--- a/autobot-backend/llc/api/backlog.py
+++ b/autobot-backend/llc/api/backlog.py
@@ -1,0 +1,146 @@
+"""LLC Backlog view API routes (GH#8222).
+
+Routes:
+  GET  /api/llc/backlog  — priority-ordered backlog with type/status/sprint filters + pagination
+  POST /api/llc/backlog/bulk-assign-sprint — assign multiple items to a sprint in one call
+"""
+
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.singleton_factory import lazy_singleton
+from user_management.database import get_async_session_factory
+
+from ..models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
+from ..models.work_item import LLCWorkItem
+from ..services.backlog import BacklogService
+
+router = APIRouter(prefix="/backlog", tags=["llc-backlog"])
+_get_service = lazy_singleton(BacklogService)
+
+
+def _service() -> BacklogService:
+    return _get_service()
+
+
+async def get_session() -> AsyncSession:
+    factory = get_async_session_factory()
+    async with factory() as session:
+        yield session
+
+
+def _item_to_dict(item: LLCWorkItem) -> Dict[str, Any]:
+    return {
+        "id": str(item.id),
+        "company_id": str(item.company_id),
+        "identifier": item.identifier,
+        "type": item.type,
+        "title": item.title,
+        "description": item.description,
+        "status": item.status,
+        "priority": item.priority,
+        "story_points": item.story_points,
+        "labels": item.labels,
+        "parent_id": str(item.parent_id) if item.parent_id else None,
+        "project_id": str(item.project_id) if item.project_id else None,
+        "sprint_id": str(item.sprint_id) if item.sprint_id else None,
+        "goal_id": str(item.goal_id) if item.goal_id else None,
+        "assignee_agent_id": str(item.assignee_agent_id) if item.assignee_agent_id else None,
+        "assignee_user_id": str(item.assignee_user_id) if item.assignee_user_id else None,
+        "assignee_type": item.assignee_type,
+        "version": item.version,
+        "created_by_agent_id": str(item.created_by_agent_id) if item.created_by_agent_id else None,
+        "created_by_user_id": str(item.created_by_user_id) if item.created_by_user_id else None,
+        "started_at": item.started_at.isoformat() if item.started_at else None,
+        "completed_at": item.completed_at.isoformat() if item.completed_at else None,
+        "cancelled_at": item.cancelled_at.isoformat() if item.cancelled_at else None,
+        "created_at": item.created_at.isoformat() if hasattr(item, "created_at") and item.created_at else None,
+        "updated_at": item.updated_at.isoformat() if hasattr(item, "updated_at") and item.updated_at else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+
+
+class BacklogResponse(BaseModel):
+    items: List[Dict[str, Any]]
+    total: int
+    limit: int
+    offset: int
+
+
+class BulkAssignSprintRequest(BaseModel):
+    company_id: str
+    sprint_id: str
+    work_item_ids: List[str] = Field(..., min_length=1, max_length=500)
+
+
+class BulkAssignSprintResponse(BaseModel):
+    updated: int
+    sprint_id: str
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=BacklogResponse)
+async def get_backlog(
+    company_id: str = Query(..., description="Company UUID"),
+    project_id: Optional[str] = Query(None, description="Filter by project"),
+    status: Optional[WorkItemStatus] = Query(None, description="Filter by work item status"),
+    type: Optional[WorkItemType] = Query(None, description="Filter by work item type"),
+    sprint_id: Optional[str] = Query(
+        None,
+        description="Filter by sprint UUID. When omitted, returns unassigned items (sprint_id IS NULL).",
+    ),
+    limit: int = Query(50, ge=1, le=500, description="Page size"),
+    offset: int = Query(0, ge=0, description="Page offset"),
+    session: AsyncSession = Depends(get_session),
+) -> BacklogResponse:
+    """Return backlog items ordered by priority (CRITICAL → HIGH → MEDIUM → LOW), then age."""
+    items, total = await _service().list_backlog(
+        session,
+        company_id=company_id,
+        project_id=project_id,
+        status=status,
+        type=type,
+        sprint_id=sprint_id,
+        limit=limit,
+        offset=offset,
+    )
+    return BacklogResponse(
+        items=[_item_to_dict(i) for i in items],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post("/bulk-assign-sprint", response_model=BulkAssignSprintResponse)
+async def bulk_assign_sprint(
+    body: BulkAssignSprintRequest,
+    session: AsyncSession = Depends(get_session),
+) -> BulkAssignSprintResponse:
+    """Assign multiple backlog items to a sprint in a single DB round-trip.
+
+    Items that don't belong to the given company are silently excluded.
+    Returns the count of rows actually updated.
+    """
+    if not body.work_item_ids:
+        raise HTTPException(status_code=422, detail="work_item_ids must not be empty")
+
+    updated = await _service().bulk_assign_sprint(
+        session,
+        company_id=body.company_id,
+        work_item_ids=body.work_item_ids,
+        sprint_id=body.sprint_id,
+    )
+    await session.commit()
+    return BulkAssignSprintResponse(updated=updated, sprint_id=body.sprint_id)

--- a/autobot-backend/llc/services/backlog.py
+++ b/autobot-backend/llc/services/backlog.py
@@ -1,0 +1,103 @@
+"""LLC BacklogService — priority-ordered backlog queries and bulk sprint assignment (GH#8222).
+
+Priority ordering is CRITICAL > HIGH > MEDIUM > LOW, implemented via a SQL CASE
+expression so the DB handles sorting rather than Python.  Bulk sprint assignment
+is done in a single UPDATE … WHERE id = ANY(:ids) to avoid N round-trips.
+"""
+
+import uuid
+import logging
+from typing import List, Optional, Sequence, Tuple
+
+from sqlalchemy import case, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
+from ..models.work_item import LLCWorkItem
+from . import LLCServiceBase
+
+logger = logging.getLogger(__name__)
+
+# Numeric rank for SQL ORDER BY — lower = higher priority
+_PRIORITY_RANK = case(
+    (LLCWorkItem.priority == WorkItemPriority.CRITICAL.value, 1),
+    (LLCWorkItem.priority == WorkItemPriority.HIGH.value, 2),
+    (LLCWorkItem.priority == WorkItemPriority.MEDIUM.value, 3),
+    (LLCWorkItem.priority == WorkItemPriority.LOW.value, 4),
+    else_=5,
+)
+
+
+class BacklogService(LLCServiceBase):
+    """Backlog-specific queries: filtered list, pagination, bulk sprint assign."""
+
+    async def list_backlog(
+        self,
+        session: AsyncSession,
+        company_id: str,
+        *,
+        project_id: Optional[str] = None,
+        status: Optional[WorkItemStatus] = None,
+        type: Optional[WorkItemType] = None,
+        sprint_id: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Tuple[Sequence[LLCWorkItem], int]:
+        """Return (items, total_count) matching filters, ordered by priority then created_at."""
+        q = select(LLCWorkItem).where(LLCWorkItem.company_id == uuid.UUID(company_id))
+
+        if project_id:
+            q = q.where(LLCWorkItem.project_id == uuid.UUID(project_id))
+        if status:
+            q = q.where(LLCWorkItem.status == status)
+        if type:
+            q = q.where(LLCWorkItem.type == type)
+        if sprint_id:
+            q = q.where(LLCWorkItem.sprint_id == uuid.UUID(sprint_id))
+        else:
+            # Default backlog view: items not yet assigned to any sprint
+            q = q.where(LLCWorkItem.sprint_id.is_(None))
+
+        count_q = select(func.count()).select_from(q.subquery())
+        total = (await session.execute(count_q)).scalar_one()
+
+        q = q.order_by(_PRIORITY_RANK, LLCWorkItem.created_at.asc()).limit(limit).offset(offset)
+        rows = (await session.execute(q)).scalars().all()
+        return rows, total
+
+    async def bulk_assign_sprint(
+        self,
+        session: AsyncSession,
+        company_id: str,
+        work_item_ids: List[str],
+        sprint_id: str,
+    ) -> int:
+        """Assign all given work items to a sprint in one UPDATE.
+
+        Returns the number of rows actually updated.  Items that don't belong to
+        company_id are silently excluded (safety guard).
+        """
+        if not work_item_ids:
+            return 0
+
+        parsed_ids = [uuid.UUID(wid) for wid in work_item_ids]
+        stmt = (
+            update(LLCWorkItem)
+            .where(
+                LLCWorkItem.id.in_(parsed_ids),
+                LLCWorkItem.company_id == uuid.UUID(company_id),
+            )
+            .values(sprint_id=uuid.UUID(sprint_id))
+            .execution_options(synchronize_session=False)
+        )
+        result = await session.execute(stmt)
+        await session.flush()
+        updated = result.rowcount
+        logger.info(
+            "bulk_assign_sprint: %d/%d items assigned to sprint %s for company %s",
+            updated,
+            len(parsed_ids),
+            sprint_id,
+            company_id,
+        )
+        return updated

--- a/autobot-backend/llc/tests/test_backlog.py
+++ b/autobot-backend/llc/tests/test_backlog.py
@@ -1,0 +1,292 @@
+"""Tests for LLC BacklogService and backlog API routes (GH#8222)."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from llc.models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
+from llc.models.work_item import LLCWorkItem
+from llc.services.backlog import BacklogService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_item(
+    *,
+    priority: WorkItemPriority = WorkItemPriority.MEDIUM,
+    status: WorkItemStatus = WorkItemStatus.BACKLOG,
+    type: WorkItemType = WorkItemType.TASK,
+    sprint_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+) -> LLCWorkItem:
+    item = MagicMock(spec=LLCWorkItem)
+    item.id = uuid.uuid4()
+    item.company_id = uuid.uuid4()
+    item.identifier = f"WI-{uuid.uuid4().hex[:4]}"
+    item.type = type
+    item.title = "Test item"
+    item.description = None
+    item.status = status
+    item.priority = priority
+    item.story_points = None
+    item.labels = []
+    item.sprint_id = sprint_id
+    item.project_id = project_id
+    item.parent_id = None
+    item.goal_id = None
+    item.assignee_agent_id = None
+    item.assignee_user_id = None
+    item.assignee_type = None
+    item.version = 1
+    item.checkout_run_id = None
+    item.checkout_locked_at = None
+    item.created_by_agent_id = None
+    item.created_by_user_id = None
+    item.started_at = None
+    item.completed_at = None
+    item.cancelled_at = None
+    item.created_at = None
+    item.updated_at = None
+    return item
+
+
+@pytest.fixture
+def service():
+    return BacklogService()
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.flush = AsyncMock()
+    db_result = MagicMock()
+    session.execute = AsyncMock(return_value=db_result)
+    session._db_result = db_result
+    return session
+
+
+# ---------------------------------------------------------------------------
+# BacklogService.list_backlog
+# ---------------------------------------------------------------------------
+
+
+class TestListBacklog:
+    async def test_returns_items_and_total(self, service, mock_session):
+        items = [_make_item(priority=WorkItemPriority.HIGH), _make_item(priority=WorkItemPriority.LOW)]
+        # First execute call returns count, second returns items
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 2
+        items_result = MagicMock()
+        items_result.scalars.return_value.all.return_value = items
+        mock_session.execute = AsyncMock(side_effect=[count_result, items_result])
+
+        result_items, total = await service.list_backlog(mock_session, company_id=str(uuid.uuid4()))
+
+        assert total == 2
+        assert len(result_items) == 2
+
+    async def test_no_sprint_filter_restricts_to_unassigned(self, service, mock_session):
+        """Without sprint_id param, query filters sprint_id IS NULL."""
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 0
+        items_result = MagicMock()
+        items_result.scalars.return_value.all.return_value = []
+        mock_session.execute = AsyncMock(side_effect=[count_result, items_result])
+
+        # No exception — verifies the IS NULL branch executes without error
+        result_items, total = await service.list_backlog(mock_session, company_id=str(uuid.uuid4()))
+        assert total == 0
+
+    async def test_sprint_id_filter_applied(self, service, mock_session):
+        sprint_id = str(uuid.uuid4())
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 1
+        items_result = MagicMock()
+        items_result.scalars.return_value.all.return_value = [_make_item(sprint_id=uuid.UUID(sprint_id))]
+        mock_session.execute = AsyncMock(side_effect=[count_result, items_result])
+
+        result_items, total = await service.list_backlog(
+            mock_session, company_id=str(uuid.uuid4()), sprint_id=sprint_id
+        )
+        assert total == 1
+
+    async def test_type_filter(self, service, mock_session):
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 0
+        items_result = MagicMock()
+        items_result.scalars.return_value.all.return_value = []
+        mock_session.execute = AsyncMock(side_effect=[count_result, items_result])
+
+        result_items, total = await service.list_backlog(
+            mock_session, company_id=str(uuid.uuid4()), type=WorkItemType.BUG
+        )
+        assert total == 0
+
+    async def test_status_filter(self, service, mock_session):
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 0
+        items_result = MagicMock()
+        items_result.scalars.return_value.all.return_value = []
+        mock_session.execute = AsyncMock(side_effect=[count_result, items_result])
+
+        result_items, total = await service.list_backlog(
+            mock_session, company_id=str(uuid.uuid4()), status=WorkItemStatus.READY
+        )
+        assert total == 0
+
+    async def test_empty_backlog_returns_zero_total(self, service, mock_session):
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 0
+        items_result = MagicMock()
+        items_result.scalars.return_value.all.return_value = []
+        mock_session.execute = AsyncMock(side_effect=[count_result, items_result])
+
+        result_items, total = await service.list_backlog(mock_session, company_id=str(uuid.uuid4()))
+        assert total == 0
+        assert result_items == []
+
+
+# ---------------------------------------------------------------------------
+# BacklogService.bulk_assign_sprint
+# ---------------------------------------------------------------------------
+
+
+class TestBulkAssignSprint:
+    async def test_updates_rows_and_returns_count(self, service, mock_session):
+        update_result = MagicMock()
+        update_result.rowcount = 3
+        mock_session.execute = AsyncMock(return_value=update_result)
+
+        item_ids = [str(uuid.uuid4()) for _ in range(3)]
+        updated = await service.bulk_assign_sprint(
+            mock_session,
+            company_id=str(uuid.uuid4()),
+            work_item_ids=item_ids,
+            sprint_id=str(uuid.uuid4()),
+        )
+        assert updated == 3
+        mock_session.flush.assert_called_once()
+
+    async def test_empty_list_returns_zero_without_db_call(self, service, mock_session):
+        updated = await service.bulk_assign_sprint(
+            mock_session,
+            company_id=str(uuid.uuid4()),
+            work_item_ids=[],
+            sprint_id=str(uuid.uuid4()),
+        )
+        assert updated == 0
+        mock_session.execute.assert_not_called()
+
+    async def test_partial_update_when_some_ids_not_in_company(self, service, mock_session):
+        update_result = MagicMock()
+        update_result.rowcount = 2  # only 2 of 3 belong to this company
+        mock_session.execute = AsyncMock(return_value=update_result)
+
+        item_ids = [str(uuid.uuid4()) for _ in range(3)]
+        updated = await service.bulk_assign_sprint(
+            mock_session,
+            company_id=str(uuid.uuid4()),
+            work_item_ids=item_ids,
+            sprint_id=str(uuid.uuid4()),
+        )
+        assert updated == 2
+
+
+# ---------------------------------------------------------------------------
+# Backlog API routes (via TestClient)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_client():
+    """Minimal FastAPI app wiring only the backlog router for route-level tests."""
+    from fastapi import FastAPI
+
+    from llc.api.backlog import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/llc")
+    return TestClient(app, raise_server_exceptions=True)
+
+
+class TestBacklogRoute:
+    def test_get_backlog_missing_company_id_returns_422(self, app_client):
+        response = app_client.get("/api/llc/backlog")
+        assert response.status_code == 422
+
+    def test_get_backlog_calls_service(self, app_client):
+        company_id = str(uuid.uuid4())
+        items = [_make_item(priority=WorkItemPriority.CRITICAL)]
+
+        with (
+            patch("llc.api.backlog._service") as mock_svc_factory,
+            patch("llc.api.backlog.get_async_session_factory"),
+        ):
+            svc = AsyncMock()
+            svc.list_backlog = AsyncMock(return_value=(items, 1))
+            mock_svc_factory.return_value = svc
+
+            # Override the session dependency
+            from llc.api.backlog import get_session, router
+            from fastapi import FastAPI
+
+            app = FastAPI()
+
+            async def _fake_session():
+                yield AsyncMock()
+
+            app.include_router(router, prefix="/api/llc")
+            app.dependency_overrides[get_session] = _fake_session
+
+            from fastapi.testclient import TestClient as TC
+
+            client = TC(app)
+            response = client.get(f"/api/llc/backlog?company_id={company_id}")
+            assert response.status_code == 200
+            data = response.json()
+            assert "items" in data
+            assert "total" in data
+            assert data["total"] == 1
+            assert data["limit"] == 50
+            assert data["offset"] == 0
+
+    def test_bulk_assign_sprint_missing_body_returns_422(self, app_client):
+        response = app_client.post("/api/llc/backlog/bulk-assign-sprint", json={})
+        assert response.status_code == 422
+
+    def test_bulk_assign_sprint_calls_service(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient as TC
+
+        from llc.api.backlog import get_session, router
+
+        app = FastAPI()
+
+        async def _fake_session():
+            yield AsyncMock()
+
+        app.include_router(router, prefix="/api/llc")
+        app.dependency_overrides[get_session] = _fake_session
+
+        with patch("llc.api.backlog._service") as mock_svc_factory:
+            svc = AsyncMock()
+            svc.bulk_assign_sprint = AsyncMock(return_value=2)
+            mock_svc_factory.return_value = svc
+
+            client = TC(app)
+            sprint_id = str(uuid.uuid4())
+            payload = {
+                "company_id": str(uuid.uuid4()),
+                "sprint_id": sprint_id,
+                "work_item_ids": [str(uuid.uuid4()), str(uuid.uuid4())],
+            }
+            response = client.post("/api/llc/backlog/bulk-assign-sprint", json=payload)
+            assert response.status_code == 200
+            data = response.json()
+            assert data["updated"] == 2
+            assert data["sprint_id"] == sprint_id


### PR DESCRIPTION
## Summary

- **BacklogService** (`llc/services/backlog.py`): priority-ordered backlog list using SQL `CASE` expression (no Python-side sort), unassigned-by-default filter, type/status/project/sprint filters, count+items in two queries.
- **Bulk sprint assign** (`BacklogService.bulk_assign_sprint`): single `UPDATE … WHERE id = ANY(ids) AND company_id = ?` — no N+1 pattern, returns actual rowcount.
- **GET /api/llc/backlog** with `company_id`, `project_id`, `status`, `type`, `sprint_id`, `limit`, `offset`; omitting `sprint_id` returns only un-sprinted items.
- **POST /api/llc/backlog/bulk-assign-sprint** accepting `company_id`, `sprint_id`, `work_item_ids[]`.
- Router registered in `llc/api/__init__.py`.
- Tests: 11 test cases covering list variants (type/status/sprint/no-sprint), bulk-assign edge cases (empty list, partial cross-company update), route-level 422 guards.

## Test plan

- [x] All new files pass `py_compile` (syntax verified)
- [x] Service and route logic unit-tested (11 cases)
- [ ] Note: `personality_service` import chain breaks LLC test collection in this environment — pre-existing, affects all LLC tests (`test_work_item.py`, `test_budget_service.py` same error); needs separate fix

## Resolves

GH#8222 — Backlog view API (LLC P2-D, MVA-815)

🤖 Generated with [Claude Code](https://claude.com/claude-code)