### PR TITLE
fix(ansible): sync autobot-plugins + Vite preserveSymlinks for file: workspace packages (MVA-893)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -424,6 +424,23 @@
 # ==========================================================
 # Frontend build
 # ==========================================================
+# Sync autobot-plugins so file: workspace symlinks resolve (MVA-893).
+# package.json declares "@autobot/vnc": "file:../autobot-plugins/vnc" and
+# "@autobot/terminal": "file:../autobot-plugins/terminal". npm install
+# creates symlinks from node_modules/@autobot/* → ../../../autobot-plugins/*
+# at install time; if the target directory is absent the symlinks dangle
+# and Vite's rolldown bundler fails to resolve the import at build time.
+- name: "SLM | Sync autobot-plugins from code_source (MVA-893)"
+  ansible.posix.synchronize:
+    src: "{{ code_source_dir | default('/opt/autobot/code_source') }}/autobot-plugins/"
+    dest: "{{ slm_base_dir }}/autobot-plugins/"
+    rsync_opts:
+      - "--exclude=node_modules"
+      - "--exclude=dist"
+      - "--exclude=.git"
+    delete: true
+  tags: ['slm', 'frontend']
+
 - name: "SLM | Check if package.json exists"
   ansible.builtin.stat:
     path: "{{ slm_frontend_dir }}/package.json"

--- a/autobot-slm-frontend/vite.config.ts
+++ b/autobot-slm-frontend/vite.config.ts
@@ -56,6 +56,12 @@ export default defineConfig(({ mode }) => {
     base: '/slm/',
     plugins: [vue(), coLocatedApiUrlGuard()],
     resolve: {
+      // preserveSymlinks: true keeps module resolution relative to the symlink
+      // path (node_modules/@autobot/vnc, @autobot/terminal) rather than the
+      // real path (../../autobot-plugins/…). Without this, rolldown walks up
+      // from the real plugin path and never finds pinia/vue in the frontend's
+      // own node_modules. Required for file: workspace packages (MVA-893).
+      preserveSymlinks: true,
       alias: {
         '@': fileURLToPath(new URL('./src', import.meta.url)),
         '@shared': fileURLToPath(new URL('../autobot_shared', import.meta.url))


### PR DESCRIPTION
## Summary

- **Root cause**: `ae6e37c` added `autobot-plugins/` as `file:` workspace packages but never synced the directory to the deployment server, and did not configure Vite to resolve symlinked workspace packages correctly.
- **Fix 1** (`slm_manager/tasks/main.yml`): Add rsync task to copy `code_source/autobot-plugins/` → `/opt/autobot/autobot-plugins/` before `npm install`, so the symlink targets exist when npm creates `node_modules/@autobot/vnc` and `@autobot/terminal` symlinks.
- **Fix 2** (`vite.config.ts`): Add `resolve.preserveSymlinks: true`. Without it, rolldown follows symlinks to the real path (`/opt/autobot/autobot-plugins/terminal/…`) and walks up from there, never reaching `autobot-slm-frontend/node_modules/pinia`.

## Test plan

- [x] Direct build verified: `sudo -u autobot npm run build` in `/opt/autobot/autobot-slm-frontend` — 367 modules, NoVNCTool + TerminalTool chunks present, `✓ built in ~4s`
- [x] Ansible task `SLM | Build frontend for production` now reports `changed: [00-SLM-Manager]` (was `fatal`)
- [x] Remaining playbook failure is pre-existing: missing monitoring health check scripts, unrelated to this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)