### PR TITLE
fix(auth): forward user_id from JWT payload in authenticate_websocket (MVA-801)

### DIFF
--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -755,12 +755,15 @@ async def authenticate_websocket(websocket) -> dict | None:
             auth = AuthenticationMiddleware()
             token_data = auth.verify_jwt_token(token)
             if token_data:
-                return {
+                result = {
                     "username": token_data["username"],
                     "role": token_data["role"],
                     "email": token_data.get("email", ""),
                     "auth_method": "jwt_websocket",
                 }
+                if token_data.get("user_id"):
+                    result["user_id"] = token_data["user_id"]
+                return result
         except Exception:
             logger.warning("WebSocket JWT authentication failed")
             return None


### PR DESCRIPTION
## Summary

- `authenticate_websocket` was building the WS user dict with only `username`, `role`, `email`, and `auth_method` — omitting `user_id` even when the JWT payload contains one
- `_extract_user_from_jwt` (REST path, line 415) already correctly forwards `user_id`; this PR makes the WS path consistent
- Fixes the `canvas_cancel` ownership check: without this, `cell.user_id` (UUID) never matched `current_user_id` (username fallback) for WS users, so legitimate owners could never cancel their own streaming tasks

## Changes

- `autobot-backend/auth_middleware.py` — `authenticate_websocket` (line ~758): build result dict first, then conditionally add `user_id` if present in `token_data`

## Security Impact

None — this is a false-positive fix (too strict), not a bypass. Cross-user attacks remain blocked.

## Test plan

- [ ] JWT with `user_id` field → WS user dict includes `user_id`
- [ ] JWT without `user_id` field → WS user dict unchanged (no `user_id` key)
- [ ] Canvas cancel via WS: owner can cancel their own streaming task
- [ ] Canvas cancel via WS: non-owner still rejected

Fixes [MVA-801](/MVA/issues/MVA-801). Discovered in [MVA-536](/MVA/issues/MVA-536).

🤖 Generated with [Claude Code](https://claude.com/claude-code)