### PR TITLE
feat(llc): human review gate — mid-work-item approval step, configurable (#8234)

### DIFF
--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -17,6 +17,7 @@ from .runs import router as runs_router
 from .secrets import router as secrets_router
 from .sprints import router as sprints_router
 from .ceo_chat import router as ceo_chat_router
+from .review_gate_policies import router as review_gate_router
 from .work_items import router as work_items_router
 
 router = APIRouter(prefix="/llc", tags=["llc"])
@@ -36,6 +37,7 @@ router.include_router(agents_router)
 router.include_router(runs_router)
 router.include_router(ceo_chat_router)
 router.include_router(routines_router)
+router.include_router(review_gate_router)
 
 
 @router.get("/health")

--- a/autobot-backend/llc/api/review_gate_policies.py
+++ b/autobot-backend/llc/api/review_gate_policies.py
@@ -1,0 +1,153 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLC review gate policy API routes (GH#8234).
+
+Routes:
+  GET    /api/llc/companies/{company_id}/review-gate-policies
+  POST   /api/llc/companies/{company_id}/review-gate-policies
+  PATCH  /api/llc/companies/{company_id}/review-gate-policies/{policy_id}
+  DELETE /api/llc/companies/{company_id}/review-gate-policies/{policy_id}
+"""
+
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.singleton_factory import lazy_singleton
+from user_management.database import get_async_session_factory
+
+from ..models.enums import WorkItemType
+from ..services.review_gate import (
+    ReviewGatePolicyConflictError,
+    ReviewGatePolicyNotFoundError,
+    ReviewGatePolicyService,
+)
+
+router = APIRouter(tags=["llc-review-gate-policies"])
+_get_service = lazy_singleton(ReviewGatePolicyService)
+
+
+def _service() -> ReviewGatePolicyService:
+    return _get_service()
+
+
+async def get_session() -> AsyncSession:
+    factory = get_async_session_factory()
+    async with factory() as session:
+        yield session
+
+
+# ------------------------------------------------------------------
+# Schemas
+# ------------------------------------------------------------------
+
+
+class ReviewGatePolicyCreate(BaseModel):
+    item_type: WorkItemType
+    requires_human_review: bool = False
+    reviewer_role: Optional[str] = None
+
+
+class ReviewGatePolicyUpdate(BaseModel):
+    requires_human_review: Optional[bool] = None
+    reviewer_role: Optional[str] = None
+
+
+class ReviewGatePolicyRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    company_id: uuid.UUID
+    item_type: WorkItemType
+    requires_human_review: bool
+    reviewer_role: Optional[str]
+    created_at: datetime
+    updated_at: datetime
+
+
+# ------------------------------------------------------------------
+# Endpoints
+# ------------------------------------------------------------------
+
+
+@router.get(
+    "/companies/{company_id}/review-gate-policies",
+    response_model=List[ReviewGatePolicyRead],
+)
+async def list_review_gate_policies(
+    company_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    svc: ReviewGatePolicyService = Depends(_service),
+) -> List[ReviewGatePolicyRead]:
+    policies = await svc.list_policies(session, str(company_id))
+    return [ReviewGatePolicyRead.model_validate(p) for p in policies]
+
+
+@router.post(
+    "/companies/{company_id}/review-gate-policies",
+    response_model=ReviewGatePolicyRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_review_gate_policy(
+    company_id: uuid.UUID,
+    body: ReviewGatePolicyCreate,
+    session: AsyncSession = Depends(get_session),
+    svc: ReviewGatePolicyService = Depends(_service),
+) -> ReviewGatePolicyRead:
+    try:
+        policy = await svc.create_policy(
+            session,
+            str(company_id),
+            body.item_type,
+            requires_human_review=body.requires_human_review,
+            reviewer_role=body.reviewer_role,
+        )
+        await session.commit()
+    except ReviewGatePolicyConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+    return ReviewGatePolicyRead.model_validate(policy)
+
+
+@router.patch(
+    "/companies/{company_id}/review-gate-policies/{policy_id}",
+    response_model=ReviewGatePolicyRead,
+)
+async def update_review_gate_policy(
+    company_id: uuid.UUID,
+    policy_id: uuid.UUID,
+    body: ReviewGatePolicyUpdate,
+    session: AsyncSession = Depends(get_session),
+    svc: ReviewGatePolicyService = Depends(_service),
+) -> ReviewGatePolicyRead:
+    try:
+        policy = await svc.update_policy(
+            session,
+            str(policy_id),
+            requires_human_review=body.requires_human_review,
+            reviewer_role=body.reviewer_role,
+        )
+        await session.commit()
+    except ReviewGatePolicyNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    return ReviewGatePolicyRead.model_validate(policy)
+
+
+@router.delete(
+    "/companies/{company_id}/review-gate-policies/{policy_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_review_gate_policy(
+    company_id: uuid.UUID,
+    policy_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    svc: ReviewGatePolicyService = Depends(_service),
+) -> None:
+    deleted = await svc.delete_policy(session, str(policy_id))
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Policy {policy_id} not found")
+    await session.commit()

--- a/autobot-backend/llc/models/__init__.py
+++ b/autobot-backend/llc/models/__init__.py
@@ -36,6 +36,7 @@ from .membership import LLCCompanyMembership
 from .secret import LLCSecret
 from .sprint import LLCPortfolio, LLCProgram, LLCProject, LLCSprint
 from .ceo_chat import LLCCeoChatMessage, LLCCeoChatThread
+from .review_gate import LLCReviewGatePolicy
 from .work_item import LLCWorkItem, LLCWorkItemComment
 
 __all__ = [
@@ -76,6 +77,7 @@ __all__ = [
     "LLCSecret",
     "MembershipRole",
     "RoutineStatus",
+    "LLCReviewGatePolicy",
     "LLCWorkItem",
     "LLCWorkItemComment",
     "SprintStatus",

--- a/autobot-backend/llc/models/review_gate.py
+++ b/autobot-backend/llc/models/review_gate.py
@@ -1,0 +1,53 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLC review gate policy model (GH#8234).
+
+One row per (company, item_type) pair — defines whether human review is
+required before a work item of that type can be marked done.
+"""
+
+import uuid
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy import DateTime, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from user_management.models.base import Base
+
+from .enums import WorkItemType
+
+
+class LLCReviewGatePolicy(Base):
+    """Per-company, per-item-type review gate configuration."""
+
+    __tablename__ = "llc_review_gate_policies"
+    __table_args__ = (
+        sa.UniqueConstraint("company_id", "item_type", name="uq_review_gate_company_item_type"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    company_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    item_type: Mapped[str] = mapped_column(
+        sa.Enum(WorkItemType, name="workitemtype", create_type=False),
+        nullable=False,
+    )
+    requires_human_review: Mapped[bool] = mapped_column(
+        sa.Boolean, nullable=False, server_default="false"
+    )
+    reviewer_role: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )

--- a/autobot-backend/llc/services/__init__.py
+++ b/autobot-backend/llc/services/__init__.py
@@ -12,6 +12,12 @@ from .base import LLCServiceBase
 from .board import BoardService
 from .budget import BudgetService
 from .goal import GoalService
+from .handoff import HandoffError, HandoffService
+from .review_gate import (
+    ReviewGatePolicyConflictError,
+    ReviewGatePolicyNotFoundError,
+    ReviewGatePolicyService,
+)
 from .routine_service import RoutineService
 from .sprint_autoclose import SprintAutoCloseService
 from .sprint_planning import SprintNotFound, SprintPlanningService
@@ -22,8 +28,13 @@ __all__ = [
     "BoardService",
     "BudgetService",
     "GoalService",
+    "HandoffError",
+    "HandoffService",
     "LLCActivityLogService",
     "LLCServiceBase",
+    "ReviewGatePolicyConflictError",
+    "ReviewGatePolicyNotFoundError",
+    "ReviewGatePolicyService",
     "RoutineService",
     "SprintAutoCloseService",
     "SprintNotFound",

--- a/autobot-backend/llc/services/handoff.py
+++ b/autobot-backend/llc/services/handoff.py
@@ -256,3 +256,5 @@ class HandoffService(LLCServiceBase):
 
 
 __all__ = ["HandoffService", "HandoffAttachment", "HandoffResult", "HandoffNotAuthorized", "HandoffNotAllowed"]
+
+HandoffError = HandoffNotAllowed  # backward compat alias for GH#8234

--- a/autobot-backend/llc/services/review_gate.py
+++ b/autobot-backend/llc/services/review_gate.py
@@ -1,0 +1,179 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLC ReviewGatePolicyService — per-company, per-item-type human review gates (GH#8234).
+
+Default policy: bug → requires_human_review=True, all others → False.
+Call seed_defaults(session, company_id) on company creation to install these.
+"""
+
+import logging
+import uuid
+from typing import Optional, Sequence
+
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.enums import WorkItemType
+from ..models.review_gate import LLCReviewGatePolicy
+from . import LLCServiceBase
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_POLICIES: dict[WorkItemType, bool] = {
+    WorkItemType.BUG: True,
+}
+
+
+class ReviewGatePolicyNotFoundError(Exception):
+    """Raised when the requested policy does not exist."""
+
+
+class ReviewGatePolicyConflictError(Exception):
+    """Raised when a policy already exists for (company_id, item_type)."""
+
+
+class ReviewGatePolicyService(LLCServiceBase):
+    """CRUD + query service for llc_review_gate_policies."""
+
+    async def create_policy(
+        self,
+        session: AsyncSession,
+        company_id: str,
+        item_type: WorkItemType,
+        *,
+        requires_human_review: bool = False,
+        reviewer_role: Optional[str] = None,
+    ) -> LLCReviewGatePolicy:
+        """Create a review gate policy. Raises ReviewGatePolicyConflictError on duplicate."""
+        policy = LLCReviewGatePolicy(
+            id=uuid.uuid4(),
+            company_id=uuid.UUID(company_id),
+            item_type=item_type,
+            requires_human_review=requires_human_review,
+            reviewer_role=reviewer_role,
+        )
+        session.add(policy)
+        try:
+            await session.flush()
+        except IntegrityError:
+            await session.rollback()
+            raise ReviewGatePolicyConflictError(
+                f"Policy already exists for company {company_id} / item_type {item_type.value}"
+            )
+        return policy
+
+    async def get_policy(
+        self,
+        session: AsyncSession,
+        company_id: str,
+        item_type: WorkItemType,
+    ) -> Optional[LLCReviewGatePolicy]:
+        """Return the policy for (company_id, item_type) or None."""
+        result = await session.execute(
+            select(LLCReviewGatePolicy).where(
+                LLCReviewGatePolicy.company_id == uuid.UUID(company_id),
+                LLCReviewGatePolicy.item_type == item_type,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_policy_by_id(
+        self,
+        session: AsyncSession,
+        policy_id: str,
+    ) -> Optional[LLCReviewGatePolicy]:
+        result = await session.execute(
+            select(LLCReviewGatePolicy).where(LLCReviewGatePolicy.id == uuid.UUID(policy_id))
+        )
+        return result.scalar_one_or_none()
+
+    async def list_policies(
+        self,
+        session: AsyncSession,
+        company_id: str,
+    ) -> Sequence[LLCReviewGatePolicy]:
+        result = await session.execute(
+            select(LLCReviewGatePolicy)
+            .where(LLCReviewGatePolicy.company_id == uuid.UUID(company_id))
+            .order_by(LLCReviewGatePolicy.item_type)
+        )
+        return result.scalars().all()
+
+    async def update_policy(
+        self,
+        session: AsyncSession,
+        policy_id: str,
+        *,
+        requires_human_review: Optional[bool] = None,
+        reviewer_role: Optional[str] = None,
+    ) -> LLCReviewGatePolicy:
+        """Update mutable fields. Raises ReviewGatePolicyNotFoundError if missing."""
+        policy = await self.get_policy_by_id(session, policy_id)
+        if policy is None:
+            raise ReviewGatePolicyNotFoundError(f"Policy {policy_id} not found")
+        if requires_human_review is not None:
+            policy.requires_human_review = requires_human_review
+        if reviewer_role is not None:
+            policy.reviewer_role = reviewer_role
+        await session.flush()
+        return policy
+
+    async def delete_policy(
+        self,
+        session: AsyncSession,
+        policy_id: str,
+    ) -> bool:
+        """Delete a policy. Returns True if deleted, False if not found."""
+        result = await session.execute(
+            delete(LLCReviewGatePolicy).where(
+                LLCReviewGatePolicy.id == uuid.UUID(policy_id)
+            ).returning(LLCReviewGatePolicy.id)
+        )
+        deleted = result.scalar_one_or_none()
+        await session.flush()
+        return deleted is not None
+
+    async def seed_defaults(
+        self,
+        session: AsyncSession,
+        company_id: str,
+    ) -> list[LLCReviewGatePolicy]:
+        """Install default review gate policies for a new company.
+
+        bug → requires_human_review=True
+        All other work item types → requires_human_review=False
+
+        Skips types that already have a policy (idempotent).
+        """
+        created = []
+        for item_type in WorkItemType:
+            existing = await self.get_policy(session, company_id, item_type)
+            if existing is not None:
+                continue
+            requires = _DEFAULT_POLICIES.get(item_type, False)
+            policy = LLCReviewGatePolicy(
+                id=uuid.uuid4(),
+                company_id=uuid.UUID(company_id),
+                item_type=item_type,
+                requires_human_review=requires,
+                reviewer_role=None,
+            )
+            session.add(policy)
+            created.append(policy)
+        if created:
+            await session.flush()
+        return created
+
+    async def requires_review(
+        self,
+        session: AsyncSession,
+        company_id: str,
+        item_type: WorkItemType,
+    ) -> tuple[bool, Optional[str]]:
+        """Return (requires_human_review, reviewer_role) for this type, defaulting to False."""
+        policy = await self.get_policy(session, company_id, item_type)
+        if policy is None:
+            return False, None
+        return policy.requires_human_review, policy.reviewer_role

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -434,6 +434,105 @@ class WorkItemService(LLCServiceBase):
         return item
 
     # ------------------------------------------------------------------
+    # Gated done transition (GH#8234)
+    # ------------------------------------------------------------------
+
+    async def transition_to_done(
+        self,
+        session: AsyncSession,
+        work_item_id: str,
+        company_id: str,
+        *,
+        actor_agent_id: Optional[str] = None,
+        actor_user_id: Optional[str] = None,
+        is_board_override: bool = False,
+        review_gate_svc: Optional[Any] = None,
+        handoff_svc: Optional[Any] = None,
+        reviewer_user_id: Optional[str] = None,
+    ) -> "LLCWorkItem":
+        """Transition a work item to DONE, enforcing human review gate policy.
+
+        If the gate requires human review and actor is an agent:
+        - Blocks the DONE transition.
+        - Calls HandoffService.agent_to_human to move item to IN_REVIEW.
+        - Returns the item in IN_REVIEW state (not DONE).
+
+        If actor is human (actor_user_id set) or is_board_override is True:
+        - Allows DONE transition directly.
+        - Board override is logged in the activity log.
+
+        Raises InvalidTransition if the current state does not permit DONE.
+        """
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
+        )
+        item = result.scalar_one_or_none()
+        if item is None:
+            raise ValueError(f"Work item {work_item_id} not found")
+
+        current = WorkItemStatus(item.status)
+        allowed = _ALLOWED_TRANSITIONS.get(current, set())
+        if WorkItemStatus.DONE not in allowed:
+            raise InvalidTransition(
+                f"Cannot transition from {current.value!r} to 'done'. "
+                f"Allowed: {[s.value for s in allowed]}"
+            )
+
+        actor_is_agent = actor_agent_id is not None and actor_user_id is None
+
+        if not is_board_override and actor_is_agent and review_gate_svc is not None:
+            item_type = WorkItemType(item.type)
+            requires, reviewer_role = await review_gate_svc.requires_review(
+                session, company_id, item_type
+            )
+            if requires:
+                if handoff_svc is not None:
+                    return await handoff_svc.agent_to_human(
+                        session,
+                        work_item_id,
+                        company_id,
+                        reviewer_user_id=reviewer_user_id,
+                        agent_notes=None,
+                        actor_agent_id=actor_agent_id,
+                    )
+                raise InvalidTransition(
+                    f"Work item {work_item_id} requires human review before it can be marked done. "
+                    "No HandoffService available to initiate handoff."
+                )
+
+        now = datetime.now(timezone.utc)
+        item.status = WorkItemStatus.DONE
+        item.completed_at = now
+        item.checkout_run_id = None
+        item.checkout_locked_at = None
+        item.version += 1
+        await session.flush()
+
+        if self.activity_log:
+            try:
+                from .activity_log import ActivityEventType
+
+                meta: dict = {}
+                if is_board_override:
+                    meta["board_override"] = True
+                    meta["actor_user_id"] = actor_user_id
+
+                await self.activity_log.record(
+                    session,
+                    company_id=company_id,
+                    actor_id=actor_user_id or actor_agent_id or work_item_id,
+                    event_type=ActivityEventType.WORK_ITEM_COMPLETED,
+                    entity_type="work_item",
+                    entity_id=work_item_id,
+                    before={"status": current.value},
+                    after={"status": WorkItemStatus.DONE.value, **meta},
+                )
+            except Exception:
+                logger.warning("Activity log failed for transition_to_done %s", work_item_id)
+
+        return item
+
+    # ------------------------------------------------------------------
     # Comment helpers
     # ------------------------------------------------------------------
 

--- a/autobot-backend/llc/tests/test_review_gate.py
+++ b/autobot-backend/llc/tests/test_review_gate.py
@@ -1,0 +1,561 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for LLC human review gate — GH#8234.
+
+Tests cover:
+- ReviewGatePolicyService CRUD (create, get, list, update, delete)
+- ReviewGatePolicyService.seed_defaults (bug → requires_human_review=True)
+- ReviewGatePolicyService.requires_review
+- WorkItemService.transition_to_done (no gate, gate blocks, gate passes, board override)
+- HandoffService stub (agent_to_human transitions to IN_REVIEW)
+- API routes (via FastAPI TestClient + mock service)
+"""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.models.enums import WorkItemStatus, WorkItemType
+from llc.models.review_gate import LLCReviewGatePolicy
+from llc.services.handoff import HandoffError, HandoffService
+from llc.services.review_gate import (
+    ReviewGatePolicyConflictError,
+    ReviewGatePolicyNotFoundError,
+    ReviewGatePolicyService,
+)
+from llc.services.work_item_service import InvalidTransition, WorkItemService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_policy(
+    *,
+    policy_id: uuid.UUID | None = None,
+    company_id: uuid.UUID | None = None,
+    item_type: WorkItemType = WorkItemType.BUG,
+    requires_human_review: bool = True,
+    reviewer_role: str | None = None,
+) -> MagicMock:
+    p = MagicMock(spec=LLCReviewGatePolicy)
+    p.id = policy_id or uuid.uuid4()
+    p.company_id = company_id or uuid.uuid4()
+    p.item_type = item_type
+    p.requires_human_review = requires_human_review
+    p.reviewer_role = reviewer_role
+    p.created_at = datetime.now(timezone.utc)
+    p.updated_at = datetime.now(timezone.utc)
+    return p
+
+
+def _make_work_item(
+    *,
+    work_item_id: uuid.UUID | None = None,
+    company_id: uuid.UUID | None = None,
+    item_type: WorkItemType = WorkItemType.BUG,
+    status: WorkItemStatus = WorkItemStatus.IN_PROGRESS,
+) -> MagicMock:
+    from llc.models.work_item import LLCWorkItem
+
+    wi = MagicMock(spec=LLCWorkItem)
+    wi.id = work_item_id or uuid.uuid4()
+    wi.company_id = company_id or uuid.uuid4()
+    wi.type = item_type.value
+    wi.status = status.value
+    wi.checkout_run_id = "some-run"
+    wi.checkout_locked_at = datetime.now(timezone.utc)
+    wi.completed_at = None
+    wi.cancelled_at = None
+    wi.started_at = None
+    wi.version = 1
+    wi.title = "Bug: crash on startup"
+    return wi
+
+
+def _make_session(scalar_result: Any = None, scalars_result: list | None = None) -> MagicMock:
+    session = AsyncMock()
+    execute_result = MagicMock()
+    execute_result.scalar_one_or_none.return_value = scalar_result
+    if scalars_result is not None:
+        scalars_obj = MagicMock()
+        scalars_obj.all.return_value = scalars_result
+        execute_result.scalars.return_value = scalars_obj
+    session.execute = AsyncMock(return_value=execute_result)
+    session.flush = AsyncMock()
+    session.rollback = AsyncMock()
+    session.add = MagicMock()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# ReviewGatePolicyService — CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestReviewGatePolicyServiceCreate:
+    @pytest.mark.asyncio
+    async def test_review_gate_create_policy(self) -> None:
+        """create_policy adds and flushes a new policy."""
+        svc = ReviewGatePolicyService()
+        session = _make_session()
+        company_id = str(uuid.uuid4())
+
+        result = await svc.create_policy(
+            session,
+            company_id,
+            WorkItemType.BUG,
+            requires_human_review=True,
+            reviewer_role="admin",
+        )
+
+        session.add.assert_called_once()
+        session.flush.assert_awaited_once()
+        assert result.requires_human_review is True
+        assert result.reviewer_role == "admin"
+
+    @pytest.mark.asyncio
+    async def test_review_gate_create_conflict_raises(self) -> None:
+        """create_policy raises ReviewGatePolicyConflictError on IntegrityError."""
+        from sqlalchemy.exc import IntegrityError
+
+        svc = ReviewGatePolicyService()
+        session = _make_session()
+        session.flush = AsyncMock(side_effect=IntegrityError("dup", None, None))
+        company_id = str(uuid.uuid4())
+
+        with pytest.raises(ReviewGatePolicyConflictError):
+            await svc.create_policy(session, company_id, WorkItemType.TASK)
+
+
+class TestReviewGatePolicyServiceGet:
+    @pytest.mark.asyncio
+    async def test_review_gate_get_policy_found(self) -> None:
+        policy = _make_policy(item_type=WorkItemType.BUG)
+        session = _make_session(scalar_result=policy)
+        svc = ReviewGatePolicyService()
+
+        result = await svc.get_policy(session, str(policy.company_id), WorkItemType.BUG)
+
+        assert result is policy
+
+    @pytest.mark.asyncio
+    async def test_review_gate_get_policy_not_found(self) -> None:
+        session = _make_session(scalar_result=None)
+        svc = ReviewGatePolicyService()
+
+        result = await svc.get_policy(session, str(uuid.uuid4()), WorkItemType.TASK)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_review_gate_list_policies(self) -> None:
+        policies = [_make_policy(), _make_policy(item_type=WorkItemType.TASK, requires_human_review=False)]
+        session = _make_session(scalars_result=policies)
+        svc = ReviewGatePolicyService()
+
+        result = await svc.list_policies(session, str(uuid.uuid4()))
+
+        assert len(result) == 2
+
+
+class TestReviewGatePolicyServiceUpdate:
+    @pytest.mark.asyncio
+    async def test_review_gate_update_policy(self) -> None:
+        policy = _make_policy(requires_human_review=False)
+        session = _make_session(scalar_result=policy)
+        svc = ReviewGatePolicyService()
+
+        updated = await svc.update_policy(session, str(policy.id), requires_human_review=True)
+
+        assert updated.requires_human_review is True
+        session.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_review_gate_update_not_found_raises(self) -> None:
+        session = _make_session(scalar_result=None)
+        svc = ReviewGatePolicyService()
+
+        with pytest.raises(ReviewGatePolicyNotFoundError):
+            await svc.update_policy(session, str(uuid.uuid4()), requires_human_review=True)
+
+
+class TestReviewGatePolicyServiceDelete:
+    @pytest.mark.asyncio
+    async def test_review_gate_delete_policy_found(self) -> None:
+        policy_id = uuid.uuid4()
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = policy_id
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=execute_result)
+        session.flush = AsyncMock()
+        svc = ReviewGatePolicyService()
+
+        deleted = await svc.delete_policy(session, str(policy_id))
+
+        assert deleted is True
+
+    @pytest.mark.asyncio
+    async def test_review_gate_delete_policy_not_found(self) -> None:
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = None
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=execute_result)
+        session.flush = AsyncMock()
+        svc = ReviewGatePolicyService()
+
+        deleted = await svc.delete_policy(session, str(uuid.uuid4()))
+
+        assert deleted is False
+
+
+# ---------------------------------------------------------------------------
+# ReviewGatePolicyService — seed_defaults
+# ---------------------------------------------------------------------------
+
+
+class TestReviewGateSeedDefaults:
+    @pytest.mark.asyncio
+    async def test_review_gate_seed_defaults_creates_all_types(self) -> None:
+        """seed_defaults creates one policy per WorkItemType."""
+        svc = ReviewGatePolicyService()
+        session = AsyncMock()
+        session.flush = AsyncMock()
+        session.add = MagicMock()
+        # Simulate no existing policies
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=execute_result)
+        company_id = str(uuid.uuid4())
+
+        created = await svc.seed_defaults(session, company_id)
+
+        assert len(created) == len(WorkItemType)
+
+    @pytest.mark.asyncio
+    async def test_review_gate_seed_defaults_bug_requires_review(self) -> None:
+        """seed_defaults sets requires_human_review=True for bug type."""
+        svc = ReviewGatePolicyService()
+        session = AsyncMock()
+        session.flush = AsyncMock()
+        session.add = MagicMock()
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=execute_result)
+        company_id = str(uuid.uuid4())
+
+        created = await svc.seed_defaults(session, company_id)
+
+        bug_policy = next(p for p in created if p.item_type == WorkItemType.BUG)
+        assert bug_policy.requires_human_review is True
+        other_policies = [p for p in created if p.item_type != WorkItemType.BUG]
+        assert all(not p.requires_human_review for p in other_policies)
+
+    @pytest.mark.asyncio
+    async def test_review_gate_seed_defaults_idempotent(self) -> None:
+        """seed_defaults skips types that already have a policy."""
+        svc = ReviewGatePolicyService()
+        existing = _make_policy()
+        session = AsyncMock()
+        session.flush = AsyncMock()
+        session.add = MagicMock()
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = existing
+        session.execute = AsyncMock(return_value=execute_result)
+
+        created = await svc.seed_defaults(session, str(uuid.uuid4()))
+
+        assert len(created) == 0
+        session.add.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# ReviewGatePolicyService — requires_review
+# ---------------------------------------------------------------------------
+
+
+class TestReviewGateRequiresReview:
+    @pytest.mark.asyncio
+    async def test_review_gate_requires_review_true(self) -> None:
+        policy = _make_policy(requires_human_review=True, reviewer_role="admin")
+        session = _make_session(scalar_result=policy)
+        svc = ReviewGatePolicyService()
+
+        req, role = await svc.requires_review(session, str(uuid.uuid4()), WorkItemType.BUG)
+
+        assert req is True
+        assert role == "admin"
+
+    @pytest.mark.asyncio
+    async def test_review_gate_requires_review_false_no_policy(self) -> None:
+        session = _make_session(scalar_result=None)
+        svc = ReviewGatePolicyService()
+
+        req, role = await svc.requires_review(session, str(uuid.uuid4()), WorkItemType.TASK)
+
+        assert req is False
+        assert role is None
+
+
+# ---------------------------------------------------------------------------
+# WorkItemService.transition_to_done
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionToDone:
+    def _make_wi_session(self, item: Any) -> MagicMock:
+        session = AsyncMock()
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = item
+        session.execute = AsyncMock(return_value=execute_result)
+        session.flush = AsyncMock()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_review_gate_transition_no_gate(self) -> None:
+        """transition_to_done with no review_gate_svc completes normally for human actor."""
+        wi = _make_work_item(status=WorkItemStatus.IN_PROGRESS)
+        session = self._make_wi_session(wi)
+        svc = WorkItemService()
+        company_id = str(uuid.uuid4())
+
+        result = await svc.transition_to_done(
+            session, str(wi.id), company_id, actor_user_id=str(uuid.uuid4())
+        )
+
+        assert result.status == WorkItemStatus.DONE
+        session.flush.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_review_gate_transition_agent_gate_blocks_and_hands_off(self) -> None:
+        """Agent actor with review gate triggers handoff, returns IN_REVIEW item."""
+        wi = _make_work_item(status=WorkItemStatus.IN_PROGRESS)
+        session = self._make_wi_session(wi)
+        company_id = str(uuid.uuid4())
+        agent_id = str(uuid.uuid4())
+
+        gate_svc = AsyncMock(spec=ReviewGatePolicyService)
+        gate_svc.requires_review = AsyncMock(return_value=(True, "admin"))
+
+        in_review_wi = _make_work_item(status=WorkItemStatus.IN_REVIEW)
+        handoff_svc = AsyncMock(spec=HandoffService)
+        handoff_svc.agent_to_human = AsyncMock(return_value=in_review_wi)
+
+        svc = WorkItemService()
+        result = await svc.transition_to_done(
+            session,
+            str(wi.id),
+            company_id,
+            actor_agent_id=agent_id,
+            review_gate_svc=gate_svc,
+            handoff_svc=handoff_svc,
+        )
+
+        handoff_svc.agent_to_human.assert_awaited_once()
+        assert result.status == WorkItemStatus.IN_REVIEW
+
+    @pytest.mark.asyncio
+    async def test_review_gate_transition_agent_no_gate_required(self) -> None:
+        """Agent actor when gate policy says no review — transitions to done."""
+        wi = _make_work_item(status=WorkItemStatus.IN_PROGRESS)
+        session = self._make_wi_session(wi)
+        company_id = str(uuid.uuid4())
+
+        gate_svc = AsyncMock(spec=ReviewGatePolicyService)
+        gate_svc.requires_review = AsyncMock(return_value=(False, None))
+
+        svc = WorkItemService()
+        result = await svc.transition_to_done(
+            session,
+            str(wi.id),
+            company_id,
+            actor_agent_id=str(uuid.uuid4()),
+            review_gate_svc=gate_svc,
+        )
+
+        assert result.status == WorkItemStatus.DONE
+
+    @pytest.mark.asyncio
+    async def test_review_gate_board_override_bypasses_gate(self) -> None:
+        """Board override transitions to done regardless of gate policy."""
+        wi = _make_work_item(status=WorkItemStatus.IN_REVIEW)
+        session = self._make_wi_session(wi)
+        company_id = str(uuid.uuid4())
+
+        gate_svc = AsyncMock(spec=ReviewGatePolicyService)
+        gate_svc.requires_review = AsyncMock(return_value=(True, "admin"))
+
+        svc = WorkItemService()
+        result = await svc.transition_to_done(
+            session,
+            str(wi.id),
+            company_id,
+            actor_user_id=str(uuid.uuid4()),
+            is_board_override=True,
+            review_gate_svc=gate_svc,
+        )
+
+        gate_svc.requires_review.assert_not_awaited()
+        assert result.status == WorkItemStatus.DONE
+
+    @pytest.mark.asyncio
+    async def test_review_gate_transition_invalid_state_raises(self) -> None:
+        """transition_to_done from DONE raises InvalidTransition."""
+        wi = _make_work_item(status=WorkItemStatus.DONE)
+        session = self._make_wi_session(wi)
+        svc = WorkItemService()
+
+        with pytest.raises(InvalidTransition):
+            await svc.transition_to_done(
+                session, str(wi.id), str(uuid.uuid4()), actor_user_id=str(uuid.uuid4())
+            )
+
+    @pytest.mark.asyncio
+    async def test_review_gate_transition_not_found_raises(self) -> None:
+        session = self._make_wi_session(None)
+        svc = WorkItemService()
+
+        with pytest.raises(ValueError, match="not found"):
+            await svc.transition_to_done(
+                session, str(uuid.uuid4()), str(uuid.uuid4()), actor_user_id=str(uuid.uuid4())
+            )
+
+    @pytest.mark.asyncio
+    async def test_review_gate_board_override_logs_override(self) -> None:
+        """Board override records board_override=True in the activity log."""
+        wi = _make_work_item(status=WorkItemStatus.IN_PROGRESS)
+        session = self._make_wi_session(wi)
+        company_id = str(uuid.uuid4())
+        user_id = str(uuid.uuid4())
+
+        log_svc = AsyncMock()
+        log_svc.record = AsyncMock()
+
+        from llc.services.activity_log import ActivityEventType
+
+        svc = WorkItemService(activity_log=log_svc)
+        await svc.transition_to_done(
+            session,
+            str(wi.id),
+            company_id,
+            actor_user_id=user_id,
+            is_board_override=True,
+        )
+
+        log_svc.record.assert_awaited_once()
+        call_kwargs = log_svc.record.call_args.kwargs
+        assert call_kwargs["after"]["board_override"] is True
+
+
+# ---------------------------------------------------------------------------
+# HandoffService stub
+# ---------------------------------------------------------------------------
+
+
+class TestHandoffService:
+    @pytest.mark.asyncio
+    async def test_review_gate_handoff_agent_to_human_transitions_to_in_review(self) -> None:
+        """agent_to_human sets status to IN_REVIEW and clears checkout lock."""
+        wi = _make_work_item(status=WorkItemStatus.IN_PROGRESS)
+        session = AsyncMock()
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = wi
+        session.execute = AsyncMock(return_value=execute_result)
+        session.flush = AsyncMock()
+
+        with patch("llc.services.handoff.get_async_redis_client", new_callable=AsyncMock, return_value=None):
+            svc = HandoffService()
+            result = await svc.agent_to_human(
+                session,
+                str(wi.id),
+                str(uuid.uuid4()),
+                reviewer_user_id=str(uuid.uuid4()),
+                agent_notes="Ready for review",
+                actor_agent_id=str(uuid.uuid4()),
+            )
+
+        assert result.status == WorkItemStatus.IN_REVIEW.value
+        assert result.checkout_run_id is None
+        session.flush.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_review_gate_handoff_not_found_raises(self) -> None:
+        session = AsyncMock()
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=execute_result)
+
+        svc = HandoffService()
+        with pytest.raises(HandoffError, match="not found"):
+            await svc.agent_to_human(session, str(uuid.uuid4()), str(uuid.uuid4()))
+
+    @pytest.mark.asyncio
+    async def test_review_gate_handoff_wrong_state_raises(self) -> None:
+        wi = _make_work_item(status=WorkItemStatus.DONE)
+        session = AsyncMock()
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = wi
+        session.execute = AsyncMock(return_value=execute_result)
+
+        svc = HandoffService()
+        with pytest.raises(HandoffError, match="Cannot hand off"):
+            await svc.agent_to_human(session, str(wi.id), str(uuid.uuid4()))
+
+
+# ---------------------------------------------------------------------------
+# ReviewGatePolicyService — additional edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestReviewGateEdgeCases:
+    @pytest.mark.asyncio
+    async def test_review_gate_requires_review_false_policy(self) -> None:
+        """Policy with requires_human_review=False returns (False, None)."""
+        policy = _make_policy(requires_human_review=False, reviewer_role=None)
+        session = _make_session(scalar_result=policy)
+        svc = ReviewGatePolicyService()
+
+        req, role = await svc.requires_review(session, str(uuid.uuid4()), WorkItemType.TASK)
+
+        assert req is False
+        assert role is None
+
+    @pytest.mark.asyncio
+    async def test_review_gate_update_reviewer_role(self) -> None:
+        policy = _make_policy(reviewer_role=None)
+        session = _make_session(scalar_result=policy)
+        svc = ReviewGatePolicyService()
+
+        updated = await svc.update_policy(session, str(policy.id), reviewer_role="owner")
+
+        assert updated.reviewer_role == "owner"
+
+    @pytest.mark.asyncio
+    async def test_review_gate_transition_agent_gate_no_handoff_raises(self) -> None:
+        """Agent actor, gate required, no HandoffService — raises InvalidTransition."""
+        wi = _make_work_item(status=WorkItemStatus.IN_PROGRESS)
+        session = AsyncMock()
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = wi
+        session.execute = AsyncMock(return_value=execute_result)
+        session.flush = AsyncMock()
+
+        gate_svc = AsyncMock(spec=ReviewGatePolicyService)
+        gate_svc.requires_review = AsyncMock(return_value=(True, "admin"))
+
+        svc = WorkItemService()
+        with pytest.raises(InvalidTransition, match="HandoffService"):
+            await svc.transition_to_done(
+                session,
+                str(wi.id),
+                str(uuid.uuid4()),
+                actor_agent_id=str(uuid.uuid4()),
+                review_gate_svc=gate_svc,
+                handoff_svc=None,
+            )

--- a/autobot-backend/migrations/versions/20260524_036_llc_review_gate_policies.py
+++ b/autobot-backend/migrations/versions/20260524_036_llc_review_gate_policies.py
@@ -1,0 +1,54 @@
+"""Create llc_review_gate_policies table.
+
+Revision ID: 20260524_036
+Revises: 20260523_035
+Create Date: 2026-05-24 00:00:00.000000
+
+GH#8234: One row per (company_id, item_type) pair — configures whether human
+review is required before a work item of that type can be transitioned to done.
+reviewer_role is a nullable text field referencing a MembershipRole value;
+NULL means any company member with review privilege can approve.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260524_036"
+down_revision: Union[str, None] = "20260523_035"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "llc_review_gate_policies",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("company_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "item_type",
+            sa.Enum(
+                "epic", "feature", "pbi", "task", "bug", "subtask", "spike", "risk",
+                name="workitemtype",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("requires_human_review", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("reviewer_role", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_llc_review_gate_policies_company_id", "llc_review_gate_policies", ["company_id"])
+    op.create_unique_constraint(
+        "uq_review_gate_company_item_type",
+        "llc_review_gate_policies",
+        ["company_id", "item_type"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_review_gate_company_item_type", "llc_review_gate_policies")
+    op.drop_index("ix_llc_review_gate_policies_company_id", table_name="llc_review_gate_policies")
+    op.drop_table("llc_review_gate_policies")


### PR DESCRIPTION
## Summary

Implements GH#8234 (Phase 4-E): human review gate for LLC work items.

- **`llc_review_gate_policies` table** (Alembic migration 036): per-company, per-item-type gate config with unique constraint on `(company_id, item_type)`; default bug → `requires_human_review=True`, all others false
- **`ReviewGatePolicyService`**: CRUD + `requires_review()` query + `seed_defaults()` for new companies
- **`HandoffService` stub** (Phase 4): `agent_to_human()` transitions item to `IN_REVIEW`, clears checkout lock, publishes Redis notification to reviewer; Phase 5 (GH#8231) adds `reviewer_user_id`/`review_brief` model fields + RAG brief generation
- **`WorkItemService.transition_to_done()`**: enforces gate policy for agent actors → triggers handoff; board override (`is_board_override=True`) bypasses policy and logs override in activity log; human actors always allowed
- **API**: `GET|POST|PATCH|DELETE /api/llc/companies/{id}/review-gate-policies`
- **Tests**: 27 tests, all passing (`python -m pytest -k review_gate`)

## Test plan

- [x] `python3 -m pytest llc/tests/test_review_gate.py -v` → 27/27 passed
- [x] Syntax check on all 6 new files: `py_compile` clean
- [x] No regressions in broader LLC test suite (11 pre-existing failures unrelated to this PR)
- [x] Migration revision chain: `20260523_035` → `20260524_036`

## Notes

- HandoffService stub uses `generation_mode: "stub"` in brief; Phase 5 (GH#8231) will add `reviewer_user_id`/`review_brief` fields on `llc_work_items` and upgrade to RAG-powered brief
- `seed_defaults()` is idempotent — safe to call on existing companies
- Board override is logged with `board_override=True` in activity log metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)