### PR TITLE
feat(llc): agent-to-human handoff — KB brief generation, reviewer notification (#8231)

### DIFF
--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -1,5 +1,4 @@
-"""LLC work items API routes (GH#8213, GH#8223, GH#8232).
-
+"""LLC work items API routes (GH#8213, GH#8223, GH#8231, GH#8232).
 Routes:
   POST   /api/llc/work-items
   GET    /api/llc/work-items
@@ -13,7 +12,10 @@ Routes:
   POST   /api/llc/work-items/{work_item_id}/claim    (human claim — GH#8223)
   POST   /api/llc/work-items/{work_item_id}/unclaim  (human unclaim — GH#8223)
   POST   /api/llc/work-items/{work_item_id}/handoff/to-agent  (GH#8232)
-"""
+  POST   /api/llc/work-items/{work_item_id}/handoff/to-human   (GH#8231)
+  POST   /api/llc/work-items/{work_item_id}/review/approve     (GH#8231)
+  POST   /api/llc/work-items/{work_item_id}/review/request-changes (GH#8231)
+  GET    /api/llc/work-items/{work_item_id}/handoff-brief       (GH#8231)"""
 
 import uuid
 from typing import Any, Dict, List, Optional
@@ -27,7 +29,7 @@ from autobot_shared.singleton_factory import lazy_singleton
 from user_management.database import get_async_session_factory
 
 from ..models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
-from ..services.handoff import HandoffAttachment, HandoffNotAuthorized, HandoffService
+from ..services.handoff import HandoffAttachment, HandoffNotAllowed, HandoffNotAuthorized, HandoffService
 from ..services.work_item_service import CheckoutConflict, InvalidTransition, WorkItemService
 
 
@@ -134,6 +136,24 @@ class HandoffToAgentRequest(BaseModel):
     attachments: Optional[List[HandoffAttachmentRequest]] = None
 
 
+class HandoffToHumanRequest(BaseModel):
+    agent_id: str
+    reviewer_user_id: str
+    company_id: str
+    agent_notes: Optional[str] = None
+
+
+class ReviewApproveRequest(BaseModel):
+    reviewer_user_id: str
+    company_id: str
+
+
+class ReviewChangesRequest(BaseModel):
+    reviewer_user_id: str
+    company_id: str
+    change_request: str
+    return_to_agent_id: Optional[str] = None
+
 def _assignee_display(item: Any) -> Optional[Dict[str, Any]]:
     """Return structured assignee display info (GH#8223).
 
@@ -183,6 +203,9 @@ def _item_to_dict(item: Any) -> Dict[str, Any]:
         "version": item.version,
         "created_by_agent_id": str(item.created_by_agent_id) if item.created_by_agent_id else None,
         "created_by_user_id": str(item.created_by_user_id) if item.created_by_user_id else None,
+        "reviewer_user_id": str(item.reviewer_user_id) if item.reviewer_user_id else None,
+        "reviewer_agent_id": str(item.reviewer_agent_id) if item.reviewer_agent_id else None,
+        "review_brief": item.review_brief,
         "started_at": item.started_at.isoformat() if item.started_at else None,
         "completed_at": item.completed_at.isoformat() if item.completed_at else None,
         "cancelled_at": item.cancelled_at.isoformat() if item.cancelled_at else None,
@@ -449,5 +472,87 @@ async def handoff_to_agent(
         }
     except HandoffNotAuthorized as exc:
         raise HTTPException(status_code=403, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+# ------------------------------------------------------------------
+# Handoff routes (GH#8231)
+# ------------------------------------------------------------------
+
+
+@router.post("/{work_item_id}/handoff/to-human")
+async def handoff_to_human(
+    work_item_id: str,
+    body: HandoffToHumanRequest,
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    try:
+        item = await _handoff_service().agent_to_human(
+            session,
+            work_item_id=work_item_id,
+            agent_id=body.agent_id,
+            reviewer_user_id=body.reviewer_user_id,
+            company_id=body.company_id,
+            agent_notes=body.agent_notes,
+        )
+        await session.commit()
+        return _item_to_dict(item)
+    except HandoffNotAllowed as exc:
+        raise HTTPException(status_code=403, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.post("/{work_item_id}/review/approve")
+async def review_approve(
+    work_item_id: str,
+    body: ReviewApproveRequest,
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    try:
+        item = await _handoff_service().approve(
+            session,
+            work_item_id=work_item_id,
+            reviewer_user_id=body.reviewer_user_id,
+            company_id=body.company_id,
+        )
+        await session.commit()
+        return _item_to_dict(item)
+    except HandoffNotAllowed as exc:
+        raise HTTPException(status_code=403, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.post("/{work_item_id}/review/request-changes")
+async def review_request_changes(
+    work_item_id: str,
+    body: ReviewChangesRequest,
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    try:
+        item = await _handoff_service().request_changes(
+            session,
+            work_item_id=work_item_id,
+            reviewer_user_id=body.reviewer_user_id,
+            company_id=body.company_id,
+            change_request=body.change_request,
+            return_to_agent_id=body.return_to_agent_id,
+        )
+        await session.commit()
+        return _item_to_dict(item)
+    except HandoffNotAllowed as exc:
+        raise HTTPException(status_code=403, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.get("/{work_item_id}/handoff-brief")
+async def get_handoff_brief(
+    work_item_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    try:
+        brief = await _handoff_service().get_brief(session, work_item_id)
+        return {"work_item_id": work_item_id, "brief": brief}
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/autobot-backend/llc/models/work_item.py
+++ b/autobot-backend/llc/models/work_item.py
@@ -95,7 +95,9 @@ class LLCWorkItem(Base):
     created_by_agent_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True)
     created_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True)
 
-    # Handoff context (GH#8232): written by HandoffService.human_to_agent()
+    # Review / handoff fields (GH#8231, GH#8232)
+    reviewer_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    reviewer_agent_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
     review_brief: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
 
     # Lifecycle timestamps

--- a/autobot-backend/llc/services/activity_log.py
+++ b/autobot-backend/llc/services/activity_log.py
@@ -53,6 +53,9 @@ class ActivityEventType(str, Enum):
     WORK_ITEM_ASSIGNED = "work_item.assigned"
     WORK_ITEM_COMPLETED = "work_item.completed"
     WORK_ITEM_CANCELLED = "work_item.cancelled"
+    WORK_ITEM_HANDOFF = "work_item.handoff"
+    WORK_ITEM_REVIEW_APPROVED = "work_item.review_approved"
+    WORK_ITEM_REVIEW_CHANGES_REQUESTED = "work_item.review_changes_requested"
 
     # Sprint lifecycle
     SPRINT_CREATED = "sprint.created"

--- a/autobot-backend/llc/services/handoff.py
+++ b/autobot-backend/llc/services/handoff.py
@@ -1,23 +1,13 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""LLC HandoffService — Human→Agent work item handoff (GH#8232).
-
-Responsibilities:
-  1. Validate the human holds the item (claimed or co-worker).
-  2. Ingest human_notes + text attachments into the per-work-item KB collection.
-  3. Transition the item: status=ready, assignee_type=agent, assignee_agent_id=target.
-  4. Release the human claim.
-  5. Write a context brief into review_brief JSONB.
-  6. Publish a notification to ``llc:notifications:{company_id}`` so the agent's
-     next heartbeat picks up the item.
-  7. Record an activity log entry.
-"""
+"""LLC HandoffService — bi-directional work item handoff (GH#8231, GH#8232)."""
 
 import json
 import logging
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import select
@@ -31,15 +21,20 @@ from . import LLCServiceBase
 
 logger = logging.getLogger(__name__)
 
+_CHECKOUT_REDIS_PREFIX = "llc:checkout:"
+_NOTIFICATION_CHANNEL_PREFIX = "llc:notifications:"
+
 
 class HandoffNotAuthorized(Exception):
-    """Raised when the human does not hold the item or is not a co-worker."""
+    """Raised when the human does not hold the item."""
+
+
+class HandoffNotAllowed(Exception):
+    """Raised when the agent does not hold the checkout lock."""
 
 
 @dataclass
 class HandoffAttachment:
-    """Attachment submitted alongside human notes."""
-
     attachment_id: str
     filename: str
     content: str
@@ -48,8 +43,6 @@ class HandoffAttachment:
 
 @dataclass
 class HandoffResult:
-    """Summary returned by HandoffService.human_to_agent()."""
-
     work_item_id: str
     target_agent_id: str
     kb_doc_ids: List[str] = field(default_factory=list)
@@ -57,7 +50,7 @@ class HandoffResult:
 
 
 class HandoffService(LLCServiceBase):
-    """Service for Human→Agent work item handoff."""
+    """Bi-directional work item handoff (human↔agent)."""
 
     async def human_to_agent(
         self,
@@ -71,36 +64,13 @@ class HandoffService(LLCServiceBase):
         user_display: str = "",
         attachments: Optional[List[HandoffAttachment]] = None,
     ) -> HandoffResult:
-        """Hand off a work item from a human to an agent.
-
-        Steps:
-          1. Validate human holds the item.
-          2. Ingest notes + text attachments into KB.
-          3. Set status=ready, assignee_type=agent, assignee_agent_id.
-          4. Release the human checkout key in Redis.
-          5. Write review_brief JSONB.
-          6. Publish Redis notification.
-          7. Record activity log entry.
-
-        Raises:
-            HandoffNotAuthorized: when the human does not hold the item.
-            ValueError: when the work item is not found.
-        """
-        item = await self._get_and_validate(session, work_item_id, user_id)
-
-        kb_doc_ids = await self._ingest_kb(
-            work_item_id=work_item_id,
-            user_id=user_id,
-            human_notes=human_notes,
-            attachments=attachments or [],
-        )
-
+        item = await self._get_and_validate_human(session, work_item_id, user_id)
+        kb_doc_ids = await self._ingest_kb(work_item_id, user_id, human_notes, attachments or [])
         review_brief: Dict[str, Any] = {
             "handed_off_by": user_display or user_id,
             "notes": human_notes,
             "kb_indexed": bool(kb_doc_ids),
         }
-
         item.status = WorkItemStatus.READY
         item.assignee_type = "agent"
         item.assignee_agent_id = uuid.UUID(target_agent_id)
@@ -110,149 +80,179 @@ class HandoffService(LLCServiceBase):
         item.review_brief = review_brief
         item.version += 1
         await session.flush()
-
         await self._release_redis_key(work_item_id, user_id)
-        await self._publish_notification(company_id, target_agent_id, work_item_id)
-        await self._record_activity(
-            session,
-            company_id=company_id,
-            user_id=user_id,
-            work_item_id=work_item_id,
-            target_agent_id=target_agent_id,
-        )
+        await self._publish_h2a_notification(company_id, target_agent_id, work_item_id)
+        await self._record_h2a_activity(session, company_id, user_id, work_item_id, target_agent_id)
+        return HandoffResult(work_item_id=work_item_id, target_agent_id=target_agent_id, kb_doc_ids=kb_doc_ids, review_brief=review_brief)
 
-        return HandoffResult(
-            work_item_id=work_item_id,
-            target_agent_id=target_agent_id,
-            kb_doc_ids=kb_doc_ids,
-            review_brief=review_brief,
-        )
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    async def _get_and_validate(
+    async def agent_to_human(
         self,
         session: AsyncSession,
         work_item_id: str,
-        user_id: str,
+        agent_id: str,
+        reviewer_user_id: str,
+        company_id: str,
+        agent_notes: Optional[str] = None,
     ) -> LLCWorkItem:
-        result = await session.execute(
-            select(LLCWorkItem)
-            .where(LLCWorkItem.id == uuid.UUID(work_item_id))
-            .with_for_update()
-        )
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
-
-        holder_user_id = str(item.assignee_user_id) if item.assignee_user_id else None
-        if item.assignee_type != "user" or holder_user_id != user_id:
-            raise HandoffNotAuthorized(
-                f"User {user_id} does not hold work item {work_item_id} "
-                f"(current holder: {holder_user_id!r}, type: {item.assignee_type!r})"
-            )
+        if item.assignee_agent_id is None or str(item.assignee_agent_id) != agent_id:
+            raise HandoffNotAllowed(f"Agent {agent_id} does not hold checkout for work item {work_item_id}")
+        brief = self._generate_brief(item, agent_notes)
+        item.status = WorkItemStatus.IN_REVIEW
+        item.reviewer_user_id = uuid.UUID(reviewer_user_id)
+        item.review_brief = brief
+        item.assignee_type = "user"
+        item.assignee_agent_id = None
+        item.assignee_user_id = uuid.UUID(reviewer_user_id)
+        item.checkout_run_id = None
+        item.checkout_locked_at = None
+        item.version += 1
+        await session.flush()
+        redis = await get_async_redis_client()
+        if redis is not None:
+            await redis.delete(f"{_CHECKOUT_REDIS_PREFIX}{work_item_id}")
+        await self._publish_a2h_notification(company_id, work_item_id, reviewer_user_id, brief)
+        if self.activity_log:
+            try:
+                from .activity_log import ActivityEventType
+                from ..models.activity import ActorType
+                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.AGENT, actor_id=agent_id, event_type=ActivityEventType.WORK_ITEM_HANDOFF, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_REVIEW.value, "reviewer_user_id": reviewer_user_id}, metadata={"brief": brief})
+            except Exception:
+                logger.warning("Activity log failed for agent_to_human %s", work_item_id)
         return item
 
-    async def _ingest_kb(
-        self,
-        work_item_id: str,
-        user_id: str,
-        human_notes: str,
-        attachments: List[HandoffAttachment],
-    ) -> List[str]:
-        from ..kb.work_item_kb import WorkItemKB
+    async def approve(self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str) -> LLCWorkItem:
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+        item = result.scalar_one_or_none()
+        if item is None:
+            raise ValueError(f"Work item {work_item_id} not found")
+        self._assert_reviewer(item, reviewer_user_id)
+        now = datetime.now(timezone.utc)
+        item.status = WorkItemStatus.DONE
+        item.completed_at = now
+        item.assignee_user_id = None
+        item.assignee_agent_id = None
+        item.assignee_type = None
+        item.checkout_run_id = None
+        item.checkout_locked_at = None
+        item.version += 1
+        await session.flush()
+        if self.activity_log:
+            try:
+                from .activity_log import ActivityEventType
+                from ..models.activity import ActorType
+                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_APPROVED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.DONE.value, "completed_at": now.isoformat()})
+            except Exception:
+                logger.warning("Activity log failed for approve %s", work_item_id)
+        return item
 
+    async def request_changes(self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str, change_request: str, return_to_agent_id: Optional[str] = None) -> LLCWorkItem:
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+        item = result.scalar_one_or_none()
+        if item is None:
+            raise ValueError(f"Work item {work_item_id} not found")
+        self._assert_reviewer(item, reviewer_user_id)
+        item.status = WorkItemStatus.IN_PROGRESS
+        item.reviewer_user_id = None
+        item.review_brief = None
+        item.assignee_type = "agent" if return_to_agent_id else None
+        item.assignee_agent_id = uuid.UUID(return_to_agent_id) if return_to_agent_id else None
+        item.assignee_user_id = None
+        item.version += 1
+        await session.flush()
+        from ..models.work_item import LLCWorkItemComment
+        comment = LLCWorkItemComment(id=uuid.uuid4(), company_id=uuid.UUID(company_id), work_item_id=uuid.UUID(work_item_id), body=change_request, author_user_id=uuid.UUID(reviewer_user_id))
+        session.add(comment)
+        await session.flush()
+        if self.activity_log:
+            try:
+                from .activity_log import ActivityEventType
+                from ..models.activity import ActorType
+                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_CHANGES_REQUESTED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_PROGRESS.value, "assignee_agent_id": return_to_agent_id}, metadata={"change_request": change_request})
+            except Exception:
+                logger.warning("Activity log failed for request_changes %s", work_item_id)
+        return item
+
+    async def get_brief(self, session: AsyncSession, work_item_id: str) -> Optional[Dict[str, Any]]:
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)))
+        item = result.scalar_one_or_none()
+        if item is None:
+            raise ValueError(f"Work item {work_item_id} not found")
+        return item.review_brief
+
+    async def _get_and_validate_human(self, session: AsyncSession, work_item_id: str, user_id: str) -> LLCWorkItem:
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+        item = result.scalar_one_or_none()
+        if item is None:
+            raise ValueError(f"Work item {work_item_id} not found")
+        holder_user_id = str(item.assignee_user_id) if item.assignee_user_id else None
+        if item.assignee_type != "user" or holder_user_id != user_id:
+            raise HandoffNotAuthorized(f"User {user_id} does not hold work item {work_item_id} (current holder: {holder_user_id!r}, type: {item.assignee_type!r})")
+        return item
+
+    async def _ingest_kb(self, work_item_id: str, user_id: str, human_notes: str, attachments: List[HandoffAttachment]) -> List[str]:
+        from ..kb.work_item_kb import WorkItemKB
         kb = WorkItemKB()
         doc_ids: List[str] = []
-
         if human_notes.strip():
-            doc_id = await kb.ingest_notes(
-                work_item_id=work_item_id,
-                notes=human_notes,
-                source_user_id=user_id,
-            )
+            doc_id = await kb.ingest_notes(work_item_id=work_item_id, notes=human_notes, source_user_id=user_id)
             doc_ids.append(doc_id)
-
         for att in attachments:
-            doc_id = await kb.ingest_attachment(
-                work_item_id=work_item_id,
-                attachment_id=att.attachment_id,
-                filename=att.filename,
-                content=att.content,
-                mime_type=att.mime_type,
-            )
+            doc_id = await kb.ingest_attachment(work_item_id=work_item_id, attachment_id=att.attachment_id, filename=att.filename, content=att.content, mime_type=att.mime_type)
             if doc_id:
                 doc_ids.append(doc_id)
-
         return doc_ids
 
     async def _release_redis_key(self, work_item_id: str, user_id: str) -> None:
         redis = await get_async_redis_client()
         if redis is None:
             return
-        key = f"llc:checkout:{work_item_id}"
+        key = f"{_CHECKOUT_REDIS_PREFIX}{work_item_id}"
         existing = await redis.get(key)
         if existing in (f"user:{user_id}", user_id):
             await redis.delete(key)
 
-    async def _publish_notification(
-        self,
-        company_id: str,
-        target_agent_id: str,
-        work_item_id: str,
-    ) -> None:
-        payload = json.dumps(
-            {
-                "event": "work_item.handoff_ready",
-                "work_item_id": work_item_id,
-                "target_agent_id": target_agent_id,
-                "has_human_handoff_context": True,
-            }
-        )
-        channel = f"llc:notifications:{company_id}"
+    async def _publish_h2a_notification(self, company_id: str, target_agent_id: str, work_item_id: str) -> None:
+        payload = json.dumps({"event": "work_item.handoff_ready", "work_item_id": work_item_id, "target_agent_id": target_agent_id, "has_human_handoff_context": True})
+        channel = f"{_NOTIFICATION_CHANNEL_PREFIX}{company_id}"
         try:
             redis = await get_async_redis_client()
             if redis is None:
                 return
             await redis.publish(channel, payload)
         except Exception:
-            logger.exception(
-                "Failed to publish handoff notification for work_item %s — non-fatal",
-                work_item_id,
-            )
+            logger.exception("Failed to publish h2a handoff notification for work_item %s — non-fatal", work_item_id)
 
-    async def _record_activity(
-        self,
-        session: AsyncSession,
-        company_id: str,
-        user_id: str,
-        work_item_id: str,
-        target_agent_id: str,
-    ) -> None:
+    async def _publish_a2h_notification(self, company_id: str, work_item_id: str, reviewer_user_id: str, brief: Dict[str, Any]) -> None:
+        redis = await get_async_redis_client()
+        if redis is None:
+            logger.warning("HandoffService: Redis unavailable, dropping a2h notification")
+            return
+        try:
+            channel = f"{_NOTIFICATION_CHANNEL_PREFIX}{company_id}"
+            await redis.publish(channel, json.dumps({"event_type": "work_item.handoff", "work_item_id": work_item_id, "reviewer_user_id": reviewer_user_id, "brief_title": brief.get("title"), "brief_identifier": brief.get("identifier")}))
+        except Exception:
+            logger.debug("HandoffService._publish_a2h_notification failed (swallowed)")
+
+    async def _record_h2a_activity(self, session: AsyncSession, company_id: str, user_id: str, work_item_id: str, target_agent_id: str) -> None:
         if not self.activity_log:
             return
         try:
             from .activity_log import ActivityEventType
-
-            await self.activity_log.record(
-                session,
-                company_id=company_id,
-                actor_type="user",
-                actor_id=user_id,
-                event_type=ActivityEventType.WORK_ITEM_ASSIGNED,
-                entity_type="work_item",
-                entity_id=work_item_id,
-                after={
-                    "assignee_type": "agent",
-                    "assignee_agent_id": target_agent_id,
-                    "status": WorkItemStatus.READY.value,
-                    "has_human_handoff_context": True,
-                },
-            )
+            await self.activity_log.record(session, company_id=company_id, actor_type="user", actor_id=user_id, event_type=ActivityEventType.WORK_ITEM_ASSIGNED, entity_type="work_item", entity_id=work_item_id, after={"assignee_type": "agent", "assignee_agent_id": target_agent_id, "status": WorkItemStatus.READY.value, "has_human_handoff_context": True})
         except Exception:
-            logger.warning("Activity log failed for handoff work_item=%s", work_item_id)
+            logger.warning("Activity log failed for h2a handoff work_item=%s", work_item_id)
+
+    def _generate_brief(self, item: LLCWorkItem, agent_notes: Optional[str]) -> Dict[str, Any]:
+        comment_excerpts = [{"author_agent_id": str(c.author_agent_id) if c.author_agent_id else None, "author_user_id": str(c.author_user_id) if c.author_user_id else None, "excerpt": c.body[:200]} for c in (item.comments or [])]
+        return {"work_item_id": str(item.id), "identifier": item.identifier, "title": item.title, "type": item.type.value if hasattr(item.type, "value") else item.type, "status_before_handoff": item.status.value if hasattr(item.status, "value") else item.status, "priority": item.priority.value if hasattr(item.priority, "value") else item.priority, "description_excerpt": (item.description or "")[:500], "acceptance_criteria": item.acceptance_criteria or [], "comment_count": len(item.comments or []), "recent_comments": comment_excerpts[-5:], "agent_notes": agent_notes, "generated_at": datetime.now(timezone.utc).isoformat(), "generator": "stub-phase4"}
+
+    def _assert_reviewer(self, item: LLCWorkItem, reviewer_user_id: str) -> None:
+        if item.reviewer_user_id is None or str(item.reviewer_user_id) != reviewer_user_id:
+            raise HandoffNotAllowed(f"User {reviewer_user_id} is not the reviewer for work item {item.id}")
 
 
-__all__ = ["HandoffService", "HandoffAttachment", "HandoffResult", "HandoffNotAuthorized"]
+__all__ = ["HandoffService", "HandoffAttachment", "HandoffResult", "HandoffNotAuthorized", "HandoffNotAllowed"]

--- a/autobot-backend/llc/tests/test_handoff_to_human.py
+++ b/autobot-backend/llc/tests/test_handoff_to_human.py
@@ -1,0 +1,425 @@
+"""Tests for HandoffService — agent-to-human handoff (GH#8231)."""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
+from llc.models.work_item import LLCWorkItem, LLCWorkItemComment
+from llc.services.handoff import HandoffNotAllowed, HandoffService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_item(**kwargs) -> LLCWorkItem:
+    item_id = uuid.uuid4()
+    defaults = {
+        "id": item_id,
+        "company_id": uuid.uuid4(),
+        "identifier": "WI-001",
+        "type": WorkItemType.TASK,
+        "title": "Test task",
+        "description": "Some description text",
+        "status": WorkItemStatus.IN_PROGRESS,
+        "priority": WorkItemPriority.MEDIUM,
+        "version": 1,
+        "labels": [],
+        "acceptance_criteria": ["AC-1", "AC-2"],
+        "checkout_run_id": "run-123",
+        "checkout_locked_at": datetime.now(timezone.utc),
+        "assignee_agent_id": None,
+        "assignee_user_id": None,
+        "reviewer_user_id": None,
+        "reviewer_agent_id": None,
+        "review_brief": None,
+        "assignee_type": "agent",
+        "started_at": None,
+        "completed_at": None,
+        "cancelled_at": None,
+        "created_at": None,
+        "updated_at": None,
+        "comments": [],
+    }
+    defaults.update(kwargs)
+    item = MagicMock(spec=LLCWorkItem)
+    for k, v in defaults.items():
+        setattr(item, k, v)
+    return item
+
+
+@pytest.fixture
+def service():
+    return HandoffService()
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.flush = AsyncMock()
+    session.add = MagicMock()
+    _db_result = MagicMock()
+    session.execute = AsyncMock(return_value=_db_result)
+    session._db_result = _db_result
+    return session
+
+
+# ---------------------------------------------------------------------------
+# agent_to_human
+# ---------------------------------------------------------------------------
+
+
+class TestAgentToHuman:
+    async def test_raises_if_work_item_not_found(self, service, mock_session):
+        mock_session._db_result.scalar_one_or_none.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            await service.agent_to_human(
+                mock_session,
+                work_item_id=str(uuid.uuid4()),
+                agent_id=str(uuid.uuid4()),
+                reviewer_user_id=str(uuid.uuid4()),
+                company_id=str(uuid.uuid4()),
+            )
+
+    async def test_raises_if_agent_does_not_hold_checkout(self, service, mock_session):
+        agent_id = uuid.uuid4()
+        other_agent_id = uuid.uuid4()
+        item = _make_item(assignee_agent_id=other_agent_id)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with pytest.raises(HandoffNotAllowed, match="does not hold checkout"):
+            await service.agent_to_human(
+                mock_session,
+                work_item_id=str(item.id),
+                agent_id=str(agent_id),
+                reviewer_user_id=str(uuid.uuid4()),
+                company_id=str(item.company_id),
+            )
+
+    async def test_raises_if_no_agent_assigned(self, service, mock_session):
+        item = _make_item(assignee_agent_id=None)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with pytest.raises(HandoffNotAllowed):
+            await service.agent_to_human(
+                mock_session,
+                work_item_id=str(item.id),
+                agent_id=str(uuid.uuid4()),
+                reviewer_user_id=str(uuid.uuid4()),
+                company_id=str(item.company_id),
+            )
+
+    async def test_sets_status_in_review_and_reviewer(self, service, mock_session):
+        agent_id = uuid.uuid4()
+        reviewer_id = uuid.uuid4()
+        item = _make_item(assignee_agent_id=agent_id)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with patch("llc.services.handoff.get_async_redis_client", new=AsyncMock(return_value=None)):
+            result = await service.agent_to_human(
+                mock_session,
+                work_item_id=str(item.id),
+                agent_id=str(agent_id),
+                reviewer_user_id=str(reviewer_id),
+                company_id=str(item.company_id),
+            )
+
+        assert result.status == WorkItemStatus.IN_REVIEW
+        assert str(result.reviewer_user_id) == str(reviewer_id)
+        assert str(result.assignee_user_id) == str(reviewer_id)
+        assert result.assignee_agent_id is None
+        assert result.checkout_run_id is None
+
+    async def test_generates_brief_with_required_fields(self, service, mock_session):
+        agent_id = uuid.uuid4()
+        item = _make_item(assignee_agent_id=agent_id, title="My work item")
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with patch("llc.services.handoff.get_async_redis_client", new=AsyncMock(return_value=None)):
+            result = await service.agent_to_human(
+                mock_session,
+                work_item_id=str(item.id),
+                agent_id=str(agent_id),
+                reviewer_user_id=str(uuid.uuid4()),
+                company_id=str(item.company_id),
+                agent_notes="Work is done, please review",
+            )
+
+        brief = result.review_brief
+        assert brief is not None
+        assert brief["title"] == "My work item"
+        assert brief["agent_notes"] == "Work is done, please review"
+        assert brief["generator"] == "stub-phase4"
+        assert "generated_at" in brief
+        assert "acceptance_criteria" in brief
+
+    async def test_increments_version(self, service, mock_session):
+        agent_id = uuid.uuid4()
+        item = _make_item(assignee_agent_id=agent_id, version=3)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with patch("llc.services.handoff.get_async_redis_client", new=AsyncMock(return_value=None)):
+            await service.agent_to_human(
+                mock_session,
+                work_item_id=str(item.id),
+                agent_id=str(agent_id),
+                reviewer_user_id=str(uuid.uuid4()),
+                company_id=str(item.company_id),
+            )
+
+        assert item.version == 4
+
+    async def test_deletes_redis_checkout_key(self, service, mock_session):
+        agent_id = uuid.uuid4()
+        item = _make_item(assignee_agent_id=agent_id)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        redis_mock = AsyncMock()
+        with patch("llc.services.handoff.get_async_redis_client", new=AsyncMock(return_value=redis_mock)):
+            await service.agent_to_human(
+                mock_session,
+                work_item_id=str(item.id),
+                agent_id=str(agent_id),
+                reviewer_user_id=str(uuid.uuid4()),
+                company_id=str(item.company_id),
+            )
+
+        redis_mock.delete.assert_called_once_with(f"llc:checkout:{item.id}")
+
+    async def test_publishes_notification(self, service, mock_session):
+        agent_id = uuid.uuid4()
+        reviewer_id = uuid.uuid4()
+        company_id = uuid.uuid4()
+        item = _make_item(assignee_agent_id=agent_id, company_id=company_id)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        redis_mock = AsyncMock()
+        with patch("llc.services.handoff.get_async_redis_client", new=AsyncMock(return_value=redis_mock)):
+            await service.agent_to_human(
+                mock_session,
+                work_item_id=str(item.id),
+                agent_id=str(agent_id),
+                reviewer_user_id=str(reviewer_id),
+                company_id=str(company_id),
+            )
+
+        redis_mock.publish.assert_called_once()
+        channel, payload_str = redis_mock.publish.call_args[0]
+        assert channel == f"llc:notifications:{company_id}"
+        import json
+        payload = json.loads(payload_str)
+        assert payload["event_type"] == "work_item.handoff"
+        assert payload["reviewer_user_id"] == str(reviewer_id)
+
+    async def test_flushes_session(self, service, mock_session):
+        agent_id = uuid.uuid4()
+        item = _make_item(assignee_agent_id=agent_id)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with patch("llc.services.handoff.get_async_redis_client", new=AsyncMock(return_value=None)):
+            await service.agent_to_human(
+                mock_session,
+                work_item_id=str(item.id),
+                agent_id=str(agent_id),
+                reviewer_user_id=str(uuid.uuid4()),
+                company_id=str(item.company_id),
+            )
+
+        mock_session.flush.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# approve
+# ---------------------------------------------------------------------------
+
+
+class TestApprove:
+    async def test_raises_if_not_found(self, service, mock_session):
+        mock_session._db_result.scalar_one_or_none.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            await service.approve(
+                mock_session,
+                work_item_id=str(uuid.uuid4()),
+                reviewer_user_id=str(uuid.uuid4()),
+                company_id=str(uuid.uuid4()),
+            )
+
+    async def test_raises_if_not_reviewer(self, service, mock_session):
+        real_reviewer = uuid.uuid4()
+        caller = uuid.uuid4()
+        item = _make_item(reviewer_user_id=real_reviewer, status=WorkItemStatus.IN_REVIEW)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with pytest.raises(HandoffNotAllowed, match="not the reviewer"):
+            await service.approve(
+                mock_session,
+                work_item_id=str(item.id),
+                reviewer_user_id=str(caller),
+                company_id=str(item.company_id),
+            )
+
+    async def test_sets_status_done_and_completed_at(self, service, mock_session):
+        reviewer_id = uuid.uuid4()
+        item = _make_item(reviewer_user_id=reviewer_id, status=WorkItemStatus.IN_REVIEW)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        await service.approve(
+            mock_session,
+            work_item_id=str(item.id),
+            reviewer_user_id=str(reviewer_id),
+            company_id=str(item.company_id),
+        )
+
+        assert item.status == WorkItemStatus.DONE
+        assert item.completed_at is not None
+        assert item.assignee_user_id is None
+        assert item.assignee_agent_id is None
+
+
+# ---------------------------------------------------------------------------
+# request_changes
+# ---------------------------------------------------------------------------
+
+
+class TestRequestChanges:
+    async def test_raises_if_not_found(self, service, mock_session):
+        mock_session._db_result.scalar_one_or_none.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            await service.request_changes(
+                mock_session,
+                work_item_id=str(uuid.uuid4()),
+                reviewer_user_id=str(uuid.uuid4()),
+                company_id=str(uuid.uuid4()),
+                change_request="Please fix X",
+            )
+
+    async def test_raises_if_not_reviewer(self, service, mock_session):
+        real_reviewer = uuid.uuid4()
+        item = _make_item(reviewer_user_id=real_reviewer, status=WorkItemStatus.IN_REVIEW)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        with pytest.raises(HandoffNotAllowed):
+            await service.request_changes(
+                mock_session,
+                work_item_id=str(item.id),
+                reviewer_user_id=str(uuid.uuid4()),
+                company_id=str(item.company_id),
+                change_request="Fix Y",
+            )
+
+    async def test_sets_in_progress_and_clears_reviewer(self, service, mock_session):
+        reviewer_id = uuid.uuid4()
+        agent_id = uuid.uuid4()
+        item = _make_item(reviewer_user_id=reviewer_id, status=WorkItemStatus.IN_REVIEW)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        await service.request_changes(
+            mock_session,
+            work_item_id=str(item.id),
+            reviewer_user_id=str(reviewer_id),
+            company_id=str(item.company_id),
+            change_request="Please refactor this",
+            return_to_agent_id=str(agent_id),
+        )
+
+        assert item.status == WorkItemStatus.IN_PROGRESS
+        assert item.reviewer_user_id is None
+        assert item.review_brief is None
+        assert str(item.assignee_agent_id) == str(agent_id)
+
+    async def test_adds_comment_with_change_request(self, service, mock_session):
+        reviewer_id = uuid.uuid4()
+        item = _make_item(reviewer_user_id=reviewer_id, status=WorkItemStatus.IN_REVIEW)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        added_objects = []
+        mock_session.add.side_effect = lambda obj: added_objects.append(obj)
+
+        await service.request_changes(
+            mock_session,
+            work_item_id=str(item.id),
+            reviewer_user_id=str(reviewer_id),
+            company_id=str(item.company_id),
+            change_request="Need more tests",
+        )
+
+        assert any(
+            isinstance(obj, LLCWorkItemComment) and obj.body == "Need more tests"
+            for obj in added_objects
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_brief
+# ---------------------------------------------------------------------------
+
+
+class TestGetBrief:
+    async def test_returns_none_when_no_brief(self, service, mock_session):
+        item = _make_item(review_brief=None)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        result = await service.get_brief(mock_session, str(item.id))
+        assert result is None
+
+    async def test_returns_brief_when_set(self, service, mock_session):
+        brief = {"title": "Test", "generator": "stub-phase4"}
+        item = _make_item(review_brief=brief)
+        mock_session._db_result.scalar_one_or_none.return_value = item
+
+        result = await service.get_brief(mock_session, str(item.id))
+        assert result == brief
+
+    async def test_raises_if_not_found(self, service, mock_session):
+        mock_session._db_result.scalar_one_or_none.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            await service.get_brief(mock_session, str(uuid.uuid4()))
+
+
+# ---------------------------------------------------------------------------
+# _generate_brief
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateBrief:
+    def test_includes_all_required_fields(self):
+        service = HandoffService()
+        agent_id = uuid.uuid4()
+        item = _make_item(
+            assignee_agent_id=agent_id,
+            title="My task",
+            description="Some desc",
+            acceptance_criteria=["AC-1"],
+            comments=[],
+        )
+        brief = service._generate_brief(item, "notes here")
+
+        assert brief["title"] == "My task"
+        assert brief["agent_notes"] == "notes here"
+        assert brief["generator"] == "stub-phase4"
+        assert brief["acceptance_criteria"] == ["AC-1"]
+        assert "generated_at" in brief
+
+    def test_truncates_description_at_500(self):
+        service = HandoffService()
+        item = _make_item(description="x" * 1000)
+        brief = service._generate_brief(item, None)
+        assert len(brief["description_excerpt"]) <= 500
+
+    def test_includes_recent_comments_up_to_5(self):
+        service = HandoffService()
+        comments = []
+        for i in range(8):
+            c = MagicMock(spec=LLCWorkItemComment)
+            c.body = f"comment {i}"
+            c.author_agent_id = None
+            c.author_user_id = None
+            comments.append(c)
+        item = _make_item(comments=comments)
+        brief = service._generate_brief(item, None)
+        assert len(brief["recent_comments"]) == 5
+        assert brief["comment_count"] == 8


### PR DESCRIPTION
## Summary

- Extends `LLCWorkItem` with `reviewer_user_id`, `reviewer_agent_id`, `review_brief` (JSONB)
- Adds `HandoffService` with full agent→human handoff lifecycle (checkout validation, brief stub, lock release, Redis notification, activity log)
- Adds 4 API routes: `POST /handoff/to-human`, `POST /review/approve`, `POST /review/request-changes`, `GET /handoff-brief`
- Phase 4 brief is a structured stub from work item fields + comments; Phase 5 (#8236) wires RAG

## Test plan

- [ ] `python -m pytest autobot-backend/llc/ -k handoff_to_human` → 22 passed
- [ ] `HandoffNotAllowed` raised when agent does not hold checkout
- [ ] `status=IN_REVIEW`, `reviewer_user_id` set after successful handoff
- [ ] Redis checkout key deleted on handoff
- [ ] Notification published to `llc:notifications:{company_id}`
- [ ] Approve sets `status=DONE`; request-changes reverts to `IN_PROGRESS` with comment

Closes #8231

🤖 Generated with [Claude Code](https://claude.com/claude-code)