### PR TITLE
feat(llc/kb): AC suggester — RAG over company policies + past PBIs (GH#8240)

### DIFF
--- a/autobot-backend/agents/audio_processing_agent.py
+++ b/autobot-backend/agents/audio_processing_agent.py
@@ -26,8 +26,6 @@ from .standardized_agent import ActionHandler, StandardizedAgent
 # Author: mrveiss
 
 
-
-
 logger = get_logger(__name__)
 
 

--- a/autobot-backend/agents/code_generation_agent.py
+++ b/autobot-backend/agents/code_generation_agent.py
@@ -26,8 +26,6 @@ from .standardized_agent import ActionHandler, StandardizedAgent
 # Author: mrveiss
 
 
-
-
 logger = get_logger(__name__)
 
 

--- a/autobot-backend/agents/data_analysis_agent.py
+++ b/autobot-backend/agents/data_analysis_agent.py
@@ -26,8 +26,6 @@ from .standardized_agent import ActionHandler, StandardizedAgent
 # Author: mrveiss
 
 
-
-
 logger = get_logger(__name__)
 
 

--- a/autobot-backend/agents/image_analysis_agent.py
+++ b/autobot-backend/agents/image_analysis_agent.py
@@ -27,8 +27,6 @@ from .standardized_agent import ActionHandler, StandardizedAgent
 # Author: mrveiss
 
 
-
-
 logger = get_logger(__name__)
 
 

--- a/autobot-backend/agents/sentiment_analysis_agent.py
+++ b/autobot-backend/agents/sentiment_analysis_agent.py
@@ -26,8 +26,6 @@ from .standardized_agent import ActionHandler, StandardizedAgent
 # Author: mrveiss
 
 
-
-
 logger = get_logger(__name__)
 
 

--- a/autobot-backend/agents/summarization_agent.py
+++ b/autobot-backend/agents/summarization_agent.py
@@ -26,8 +26,6 @@ from .standardized_agent import ActionHandler, StandardizedAgent
 # Author: mrveiss
 
 
-
-
 logger = get_logger(__name__)
 
 

--- a/autobot-backend/agents/translation_agent.py
+++ b/autobot-backend/agents/translation_agent.py
@@ -26,8 +26,6 @@ from .standardized_agent import ActionHandler, StandardizedAgent
 # Author: mrveiss
 
 
-
-
 logger = get_logger(__name__)
 
 

--- a/autobot-backend/api/agent_terminal.py
+++ b/autobot-backend/api/agent_terminal.py
@@ -268,8 +268,6 @@ from services.command_execution_queue import get_command_queue
 # Author: mrveiss
 
 
-
-
 logger = get_logger(__name__)
 
 # Create router

--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -10,14 +10,14 @@ from .approvals import router as approvals_router
 from .backlog import router as backlog_router
 from .boards import router as boards_router
 from .budget import router as budget_router
+from .ceo_chat import router as ceo_chat_router
 from .companies import router as companies_router
 from .goals import router as goals_router
+from .review_gate_policies import router as review_gate_router
 from .routines import router as routines_router
 from .runs import router as runs_router
 from .secrets import router as secrets_router
 from .sprints import router as sprints_router
-from .ceo_chat import router as ceo_chat_router
-from .review_gate_policies import router as review_gate_router
 from .work_items import router as work_items_router
 
 router = APIRouter(prefix="/llc", tags=["llc"])

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -18,6 +18,7 @@ Routes:
   POST   /api/llc/work-items/{work_item_id}/review/request-changes (GH#8231)
   GET    /api/llc/work-items/{work_item_id}/handoff-brief       (GH#8231)
   POST   /api/llc/work-items/{work_item_id}/coworker   (set/clear co-worker — GH#8230)
+  POST   /api/llc/work-items/suggest-ac               (GH#8240)
 """
 
 import uuid
@@ -31,6 +32,7 @@ from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 from user_management.database import get_async_session_factory
 
+from ..kb.ac_suggester import AcSuggester
 from ..models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
 from ..services.handoff import HandoffAttachment, HandoffNotAllowed, HandoffNotAuthorized, HandoffService
 from ..services.work_item_service import CheckoutConflict, InvalidTransition, WorkItemService
@@ -68,6 +70,7 @@ class CoworkerRequest(BaseModel):
 router = APIRouter(prefix="/work-items", tags=["llc-work-items"])
 _get_service = lazy_singleton(WorkItemService)
 _get_handoff_service = lazy_singleton(HandoffService)
+_get_ac_suggester = lazy_singleton(AcSuggester)
 
 
 def _service() -> WorkItemService:
@@ -76,6 +79,10 @@ def _service() -> WorkItemService:
 
 def _handoff_service() -> HandoffService:
     return _get_handoff_service()
+
+
+def _ac_suggester() -> AcSuggester:
+    return _get_ac_suggester()
 
 
 async def get_session() -> AsyncSession:
@@ -175,6 +182,14 @@ class ReviewChangesRequest(BaseModel):
     company_id: str
     change_request: str
     return_to_agent_id: Optional[str] = None
+
+
+class SuggestAcRequest(BaseModel):
+    company_id: str
+    project_id: str
+    title: str
+    description: str = ""
+
 
 def _assignee_display(item: Any) -> Optional[Dict[str, Any]]:
     """Return structured primary assignee display info (GH#8223).
@@ -329,6 +344,23 @@ async def list_work_items(
         offset=offset,
     )
     return [_item_to_dict(i) for i in items]
+
+
+@router.post("/suggest-ac")
+async def suggest_ac(body: SuggestAcRequest) -> Dict[str, Any]:
+    """Propose draft acceptance criteria for a new work item (GH#8240).
+
+    RAG-queries company policy/standards and similar completed PBIs, then
+    asks the LLM to synthesise 3-6 testable ACs. Results are cached 5 min
+    per unique title+description pair. Suggestions are advisory.
+    """
+    result = await _ac_suggester().suggest(
+        company_id=body.company_id,
+        project_id=body.project_id,
+        item_title=body.title,
+        item_description=body.description,
+    )
+    return result
 
 
 @router.get("/{work_item_id}")

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -35,7 +35,6 @@ from user_management.database import get_async_session_factory
 from ..kb.ac_suggester import AcSuggester
 from ..models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
 from ..services.handoff import HandoffAttachment, HandoffNotAllowed, HandoffNotAuthorized, HandoffService
-from ..services.work_item_service import CheckoutConflict, InvalidTransition, WorkItemService
 from ..services.work_item_service import (
     CheckoutConflict,
     CoWorkingPermissionError,
@@ -54,12 +53,12 @@ class HumanUnclaimRequest(BaseModel):
     company_id: str
 
 
-
 class CoworkerRequest(BaseModel):
     """Set or clear a co-worker on a work item (GH#8230).
     To clear the co-worker, omit co_worker_type (or send null).
     caller_role must be 'owner', 'admin', or 'lead' to mutate co-working state.
     """
+
     company_id: str
     co_worker_type: Optional[str] = None
     co_worker_agent_id: Optional[str] = None
@@ -67,6 +66,8 @@ class CoworkerRequest(BaseModel):
     actor_agent_id: Optional[str] = None
     actor_user_id: Optional[str] = None
     caller_role: str = "member"
+
+
 router = APIRouter(prefix="/work-items", tags=["llc-work-items"])
 _get_service = lazy_singleton(WorkItemService)
 _get_handoff_service = lazy_singleton(HandoffService)
@@ -600,6 +601,8 @@ async def handoff_to_agent(
         raise HTTPException(status_code=403, detail=str(exc))
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
+
+
 # ------------------------------------------------------------------
 # Handoff routes (GH#8231)
 # ------------------------------------------------------------------

--- a/autobot-backend/llc/kb/__init__.py
+++ b/autobot-backend/llc/kb/__init__.py
@@ -1,5 +1,6 @@
 """LLC knowledge base package."""
 
+from .ac_suggester import AcSuggester
 from .rag_assembler import AssemblerProfile, LLCContext, LLCRAGAssembler
 
-__all__ = ["AssemblerProfile", "LLCContext", "LLCRAGAssembler"]
+__all__ = ["AcSuggester", "AssemblerProfile", "LLCContext", "LLCRAGAssembler"]

--- a/autobot-backend/llc/kb/ac_suggester.py
+++ b/autobot-backend/llc/kb/ac_suggester.py
@@ -231,10 +231,7 @@ def _zip_results(results: Dict[str, Any]) -> List[Dict[str, Any]]:
     ids = results.get("ids", [[]])[0]
     docs = results.get("documents", [[]])[0]
     metas = results.get("metadatas", [[]])[0]
-    return [
-        {"id": doc_id, "document": doc, "metadata": meta}
-        for doc_id, doc, meta in zip(ids, docs, metas)
-    ]
+    return [{"id": doc_id, "document": doc, "metadata": meta} for doc_id, doc, meta in zip(ids, docs, metas)]
 
 
 def _format_chunks(chunks: List[Dict[str, Any]]) -> str:
@@ -248,7 +245,7 @@ def _parse_bullet_list(raw: str) -> List[str]:
         stripped = line.strip()
         for prefix in ("- ", "* ", "• "):
             if stripped.startswith(prefix):
-                text = stripped[len(prefix):].strip()
+                text = stripped[len(prefix) :].strip()
                 if text:
                     items.append(text)
                 break

--- a/autobot-backend/llc/kb/ac_suggester.py
+++ b/autobot-backend/llc/kb/ac_suggester.py
@@ -1,0 +1,258 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""AC suggester — RAG over company policies + past PBIs (GH#8240).
+
+On PBI/Story creation, suggests draft acceptance criteria by running parallel
+RAG queries over company standards and similar completed items, then asking
+the LLM to synthesise 3-6 testable ACs.
+
+Results are cached in Redis for 5 minutes, keyed by sha256(title+description),
+to avoid repeated LLM calls for identical inputs during rapid backlog grooming.
+"""
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# #8240: suggestion cache TTL (seconds).
+# Override via AUTOBOT_AC_SUGGESTER_CACHE_TTL for environments where 5 min
+# is too short (low-traffic dev) or too long (high-churn grooming sessions).
+_DEFAULT_CACHE_TTL = 300
+
+
+def _resolve_cache_ttl() -> int:
+    raw = os.environ.get("AUTOBOT_AC_SUGGESTER_CACHE_TTL")
+    if raw is None:
+        return _DEFAULT_CACHE_TTL
+    try:
+        val = int(raw)
+        if val > 0:
+            return val
+    except ValueError:
+        pass
+    logger.warning(
+        "Invalid AUTOBOT_AC_SUGGESTER_CACHE_TTL=%r — using default %d s",
+        raw,
+        _DEFAULT_CACHE_TTL,
+    )
+    return _DEFAULT_CACHE_TTL
+
+
+_CACHE_TTL: int = _resolve_cache_ttl()
+
+_SYSTEM_PROMPT = (
+    "You are a product manager helping write acceptance criteria for a new work item. "
+    "Based on the company standards and similar completed work items provided, "
+    "propose 3-6 specific, testable acceptance criteria as a bullet list. "
+    "Each criterion must start with '- '. Be concise and specific."
+)
+
+_USER_PROMPT_TEMPLATE = """\
+New work item:
+Title: {title}
+Description: {description}
+
+Company standards / policies (top matches):
+{policies}
+
+Similar completed work items:
+{past_items}
+
+Propose 3-6 acceptance criteria for this work item as a bullet list."""
+
+
+class AcSuggester:
+    """RAG-backed acceptance-criteria suggester for new work items (GH#8240).
+
+    Parallel ChromaDB queries:
+      - ``company:{company_id}`` — top-3 policy/standards docs matching the title
+      - ``project:{project_id}`` filtered by type=pbi AND status=done — top-3 similar items
+
+    Combined context is sent to the LLM (LLMType.RAG) to produce draft ACs.
+    Suggestions are advisory; the caller decides which to accept.
+    """
+
+    async def suggest(
+        self,
+        company_id: str,
+        project_id: str,
+        item_title: str,
+        item_description: str,
+    ) -> Dict[str, Any]:
+        """Return suggested ACs and the source document IDs used.
+
+        Args:
+            company_id: Tenant company identifier.
+            project_id: Project the work item belongs to.
+            item_title: Title of the new work item.
+            item_description: Description of the new work item.
+
+        Returns:
+            ``{"suggestions": List[str], "sources": List[str]}``
+            where ``suggestions`` are the proposed AC strings and ``sources``
+            are the ChromaDB document IDs used as context.
+        """
+        cache_key = self._cache_key(item_title, item_description)
+        cached = await self._get_cached(cache_key)
+        if cached is not None:
+            logger.debug("AC suggestion cache hit for key=%s", cache_key[:16])
+            return cached
+
+        query = f"{item_title} {item_description}".strip()
+        policies, past_items = await asyncio.gather(
+            self._query_policies(company_id, query),
+            self._query_past_items(project_id, query),
+        )
+
+        suggestions = await self._call_llm(item_title, item_description, policies, past_items)
+        sources = [c["id"] for c in policies + past_items if c.get("id")]
+
+        result: Dict[str, Any] = {"suggestions": suggestions, "sources": sources}
+        await self._set_cached(cache_key, result)
+        return result
+
+    async def _query_policies(self, company_id: str, query: str) -> List[Dict[str, Any]]:
+        """Query ``company:{company_id}`` for top-3 policy/standards matches."""
+        try:
+            from utils.async_chromadb_client import get_async_chromadb_client
+
+            client = await get_async_chromadb_client()
+            try:
+                collection = await client.get_collection(f"company:{company_id}")
+            except Exception:
+                return []
+            count = await collection.count()
+            if count == 0:
+                return []
+            results = await collection.query(
+                query_texts=[query],
+                n_results=min(3, count),
+                include=["documents", "metadatas"],
+            )
+            return _zip_results(results)
+        except Exception:
+            logger.exception("Failed to query policies for company_id=%s", company_id)
+            return []
+
+    async def _query_past_items(self, project_id: str, query: str) -> List[Dict[str, Any]]:
+        """Query ``project:{project_id}`` for top-3 completed similar PBIs."""
+        try:
+            from utils.async_chromadb_client import get_async_chromadb_client
+
+            client = await get_async_chromadb_client()
+            try:
+                collection = await client.get_collection(f"project:{project_id}")
+            except Exception:
+                return []
+            count = await collection.count()
+            if count == 0:
+                return []
+            results = await collection.query(
+                query_texts=[query],
+                n_results=min(3, count),
+                where={"$and": [{"type": {"$eq": "pbi"}}, {"status": {"$eq": "done"}}]},
+                include=["documents", "metadatas"],
+            )
+            return _zip_results(results)
+        except Exception:
+            logger.exception("Failed to query past items for project_id=%s", project_id)
+            return []
+
+    async def _call_llm(
+        self,
+        title: str,
+        description: str,
+        policies: List[Dict[str, Any]],
+        past_items: List[Dict[str, Any]],
+    ) -> List[str]:
+        """Send assembled context to LLM and parse bullet-list response."""
+        try:
+            from llm_shared.types import LLMType
+            from services.llm_service import get_llm_service
+
+            user_msg = _USER_PROMPT_TEMPLATE.format(
+                title=title,
+                description=description or "(no description)",
+                policies=_format_chunks(policies) or "(none available)",
+                past_items=_format_chunks(past_items) or "(none available)",
+            )
+            svc = get_llm_service()
+            response = await svc.chat(
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": user_msg},
+                ],
+                llm_type=LLMType.RAG,
+            )
+            return _parse_bullet_list((response.content or "").strip())
+        except Exception:
+            logger.exception("LLM call failed in AcSuggester — returning empty suggestions")
+            return []
+
+    @staticmethod
+    def _cache_key(title: str, description: str) -> str:
+        digest = hashlib.sha256(f"{title}{description}".encode("utf-8")).hexdigest()
+        return f"llc:ac_suggestions:{digest}"
+
+    async def _get_cached(self, key: str) -> Optional[Dict[str, Any]]:
+        try:
+            from autobot_shared.redis_client import get_async_redis_client
+
+            redis = await get_async_redis_client()
+            if redis is None:
+                return None
+            raw = await redis.get(key)
+            if raw is None:
+                return None
+            return json.loads(raw)
+        except Exception:
+            logger.debug("Cache read error for key=%s", key[:16])
+            return None
+
+    async def _set_cached(self, key: str, value: Dict[str, Any]) -> None:
+        try:
+            from autobot_shared.redis_client import get_async_redis_client
+
+            redis = await get_async_redis_client()
+            if redis is None:
+                return
+            await redis.setex(key, _CACHE_TTL, json.dumps(value))
+        except Exception:
+            logger.debug("Failed to write AC suggestion cache for key=%s", key[:16])
+
+
+def _zip_results(results: Dict[str, Any]) -> List[Dict[str, Any]]:
+    ids = results.get("ids", [[]])[0]
+    docs = results.get("documents", [[]])[0]
+    metas = results.get("metadatas", [[]])[0]
+    return [
+        {"id": doc_id, "document": doc, "metadata": meta}
+        for doc_id, doc, meta in zip(ids, docs, metas)
+    ]
+
+
+def _format_chunks(chunks: List[Dict[str, Any]]) -> str:
+    return "\n\n".join(c["document"] for c in chunks if c.get("document"))
+
+
+def _parse_bullet_list(raw: str) -> List[str]:
+    """Extract bullet items from LLM response. Handles -, *, • prefixes."""
+    items = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        for prefix in ("- ", "* ", "• "):
+            if stripped.startswith(prefix):
+                text = stripped[len(prefix):].strip()
+                if text:
+                    items.append(text)
+                break
+    return items
+
+
+__all__ = ["AcSuggester"]

--- a/autobot-backend/llc/kb/ac_suggester.py
+++ b/autobot-backend/llc/kb/ac_suggester.py
@@ -101,7 +101,7 @@ class AcSuggester:
         cache_key = self._cache_key(item_title, item_description)
         cached = await self._get_cached(cache_key)
         if cached is not None:
-            logger.debug("AC suggestion cache hit for key=%s", cache_key[:16])
+            logger.debug("AC suggestion cache hit for key=%s", cache_key[-16:])
             return cached
 
         query = f"{item_title} {item_description}".strip()
@@ -197,7 +197,7 @@ class AcSuggester:
 
     @staticmethod
     def _cache_key(title: str, description: str) -> str:
-        digest = hashlib.sha256(f"{title}{description}".encode("utf-8")).hexdigest()
+        digest = hashlib.sha256(f"{title}\x00{description}".encode("utf-8")).hexdigest()
         return f"llc:ac_suggestions:{digest}"
 
     async def _get_cached(self, key: str) -> Optional[Dict[str, Any]]:

--- a/autobot-backend/llc/kb/work_item_kb.py
+++ b/autobot-backend/llc/kb/work_item_kb.py
@@ -18,7 +18,31 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 _TEXT_MIME_PREFIXES = ("text/", "application/json", "application/xml")
-_TEXT_EXTENSIONS = {".md", ".txt", ".py", ".js", ".ts", ".go", ".rs", ".java", ".c", ".cpp", ".h", ".rb", ".sh", ".yaml", ".yml", ".toml", ".ini", ".cfg", ".sql", ".html", ".css", ".jsx", ".tsx"}
+_TEXT_EXTENSIONS = {
+    ".md",
+    ".txt",
+    ".py",
+    ".js",
+    ".ts",
+    ".go",
+    ".rs",
+    ".java",
+    ".c",
+    ".cpp",
+    ".h",
+    ".rb",
+    ".sh",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".ini",
+    ".cfg",
+    ".sql",
+    ".html",
+    ".css",
+    ".jsx",
+    ".tsx",
+}
 
 
 def _collection_name(work_item_id: str) -> str:
@@ -33,6 +57,7 @@ def _is_text_indexable(filename: Optional[str], mime_type: Optional[str]) -> boo
                 return True
     if filename:
         import os
+
         ext = os.path.splitext(filename)[1].lower()
         if ext in _TEXT_EXTENSIONS:
             return True
@@ -145,10 +170,7 @@ class WorkItemKB:
                 docs = results.get("documents", [])
                 metas = results.get("metadatas", [])
 
-            return [
-                {"id": doc_id, "document": doc, "metadata": meta}
-                for doc_id, doc, meta in zip(ids, docs, metas)
-            ]
+            return [{"id": doc_id, "document": doc, "metadata": meta} for doc_id, doc, meta in zip(ids, docs, metas)]
         except Exception:
             logger.exception(
                 "Failed to retrieve KB context for work_item %s — returning empty",

--- a/autobot-backend/llc/models/__init__.py
+++ b/autobot-backend/llc/models/__init__.py
@@ -4,6 +4,7 @@ from .activity import ActorType, LLCActivityLog, LLCBase
 from .approval import LLCApproval
 from .board import LLCBoard, LLCBoardColumn
 from .budget import LLCAgentBudget
+from .ceo_chat import LLCCeoChatMessage, LLCCeoChatThread
 from .company import (
     CompanyAncestor,
     CompanyCreate,
@@ -33,10 +34,9 @@ from .enums import (
 from .goal import GoalLevel, GoalStatus, LLCGoal
 from .heartbeat_run import LLCHeartbeatRun
 from .membership import LLCCompanyMembership
+from .review_gate import LLCReviewGatePolicy
 from .secret import LLCSecret
 from .sprint import LLCPortfolio, LLCProgram, LLCProject, LLCSprint
-from .ceo_chat import LLCCeoChatMessage, LLCCeoChatThread
-from .review_gate import LLCReviewGatePolicy
 from .work_item import LLCWorkItem, LLCWorkItemComment
 
 __all__ = [

--- a/autobot-backend/llc/models/heartbeat_run.py
+++ b/autobot-backend/llc/models/heartbeat_run.py
@@ -66,9 +66,7 @@ class LLCHeartbeatRun(Base):
     # Rate-limit retry fields (GH#8204).
     # retry_after: when the scheduler should next re-dispatch this agent.
     # retry_count: number of rate-limit retries so far (drives exponential backoff).
-    retry_after: Mapped[Optional[datetime]] = mapped_column(
-        sa.DateTime(timezone=True), nullable=True, index=True
-    )
+    retry_after: Mapped[Optional[datetime]] = mapped_column(sa.DateTime(timezone=True), nullable=True, index=True)
     retry_count: Mapped[int] = mapped_column(sa.Integer, nullable=False, server_default="0")
 
     created_at: Mapped[datetime] = mapped_column(

--- a/autobot-backend/llc/models/review_gate.py
+++ b/autobot-backend/llc/models/review_gate.py
@@ -24,9 +24,7 @@ class LLCReviewGatePolicy(Base):
     """Per-company, per-item-type review gate configuration."""
 
     __tablename__ = "llc_review_gate_policies"
-    __table_args__ = (
-        sa.UniqueConstraint("company_id", "item_type", name="uq_review_gate_company_item_type"),
-    )
+    __table_args__ = (sa.UniqueConstraint("company_id", "item_type", name="uq_review_gate_company_item_type"),)
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
@@ -38,13 +36,9 @@ class LLCReviewGatePolicy(Base):
         sa.Enum(WorkItemType, name="workitemtype", create_type=False),
         nullable=False,
     )
-    requires_human_review: Mapped[bool] = mapped_column(
-        sa.Boolean, nullable=False, server_default="false"
-    )
+    requires_human_review: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default="false")
     reviewer_role: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=sa.func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=sa.func.now())
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/autobot-backend/llc/scheduler/heartbeat_scheduler.py
+++ b/autobot-backend/llc/scheduler/heartbeat_scheduler.py
@@ -50,7 +50,7 @@ _SCHEDULE_KEY = "llc:heartbeat:schedule"
 _POLL_INTERVAL = 5.0  # seconds between sorted-set polls
 
 # Rate-limit backoff: delay = min(_RL_BASE_SECONDS * 2**retry_count, _RL_MAX_SECONDS)
-_RL_BASE_SECONDS = 300   # 5 minutes for the first retry
+_RL_BASE_SECONDS = 300  # 5 minutes for the first retry
 _RL_MAX_SECONDS = 14400  # cap at 4 hours
 _MAX_RATE_LIMIT_RETRIES = 10  # demote to failed after this many consecutive retries
 
@@ -164,9 +164,7 @@ class HeartbeatScheduler:
 
         if mapping:
             await redis.zadd(_SCHEDULE_KEY, mapping, nx=True)
-            logger.info(
-                "Re-queued %d rate-limited agents after restart", len(mapping)
-            )
+            logger.info("Re-queued %d rate-limited agents after restart", len(mapping))
 
     async def _load_enabled_agents(self) -> list[Dict[str, Any]]:
         """SELECT heartbeat-enabled agents from agent_org_nodes.
@@ -275,9 +273,7 @@ class HeartbeatScheduler:
                         source=HeartbeatInvocationSource.SCHEDULER,
                     )
                 except ValueError as exc:
-                    logger.warning(
-                        "Skipping heartbeat for agent %s (no organization): %s", agent_id, exc
-                    )
+                    logger.warning("Skipping heartbeat for agent %s (no organization): %s", agent_id, exc)
                     retry_ts = datetime.now(tz=timezone.utc).timestamp() + _POLL_INTERVAL * 6
                     await redis.zadd(_SCHEDULE_KEY, {agent_id: retry_ts})
                     return
@@ -306,9 +302,7 @@ class HeartbeatScheduler:
             next_ts,
         )
 
-    async def _find_rate_limited_run(
-        self, session: AsyncSession, agent_id: str
-    ) -> Optional[LLCHeartbeatRun]:
+    async def _find_rate_limited_run(self, session: AsyncSession, agent_id: str) -> Optional[LLCHeartbeatRun]:
         """Return the most recent ``rate_limited`` run for *agent_id*, or None."""
         result = await session.execute(
             select(LLCHeartbeatRun)
@@ -349,9 +343,7 @@ class HeartbeatScheduler:
         await session.flush()
         return run, agent
 
-    def dispatch_run(
-        self, agent: Dict[str, Any], run_id: uuid.UUID, context: Optional[Dict[str, Any]] = None
-    ) -> None:
+    def dispatch_run(self, agent: Dict[str, Any], run_id: uuid.UUID, context: Optional[Dict[str, Any]] = None) -> None:
         """Schedule adapter execution as a fire-and-forget task.
 
         Must be called after the DB session containing the run INSERT has been
@@ -391,14 +383,8 @@ class HeartbeatScheduler:
     ) -> LLCHeartbeatRun:
         company_id_raw = agent.get("company_id")
         if company_id_raw is None:
-            raise ValueError(
-                f"Agent {agent['agent_id']!r} has no organization — cannot create heartbeat run"
-            )
-        company_id = (
-            company_id_raw
-            if isinstance(company_id_raw, uuid.UUID)
-            else uuid.UUID(str(company_id_raw))
-        )
+            raise ValueError(f"Agent {agent['agent_id']!r} has no organization — cannot create heartbeat run")
+        company_id = company_id_raw if isinstance(company_id_raw, uuid.UUID) else uuid.UUID(str(company_id_raw))
         run = LLCHeartbeatRun(
             id=uuid.uuid4(),
             company_id=company_id,
@@ -409,9 +395,7 @@ class HeartbeatScheduler:
         session.add(run)
         return run
 
-    async def _run_adapter(
-        self, agent: Dict[str, Any], run_id: uuid.UUID, context: Dict[str, Any]
-    ) -> None:
+    async def _run_adapter(self, agent: Dict[str, Any], run_id: uuid.UUID, context: Dict[str, Any]) -> None:
         """Execute adapter, update run status on completion/failure.
 
         ProviderRateLimited is handled specially: the run is marked
@@ -424,9 +408,7 @@ class HeartbeatScheduler:
         # Fetch current retry_count before marking RUNNING so backoff is correct.
         try:
             async with factory() as session:
-                result = await session.execute(
-                    select(LLCHeartbeatRun.retry_count).where(LLCHeartbeatRun.id == run_id)
-                )
+                result = await session.execute(select(LLCHeartbeatRun.retry_count).where(LLCHeartbeatRun.id == run_id))
                 retry_count: int = result.scalar_one_or_none() or 0
                 await session.execute(
                     update(LLCHeartbeatRun)
@@ -485,10 +467,7 @@ class HeartbeatScheduler:
                 )
                 if final_status == HeartbeatRunStatus.SUCCEEDED.value:
                     await session.execute(
-                        text(
-                            "UPDATE agent_org_nodes SET last_heartbeat_at = now()"
-                            " WHERE agent_id = :aid"
-                        ),
+                        text("UPDATE agent_org_nodes SET last_heartbeat_at = now()" " WHERE agent_id = :aid"),
                         {"aid": agent["agent_id"]},
                     )
                 await session.commit()
@@ -542,7 +521,7 @@ class HeartbeatScheduler:
         if exc.retry_after_seconds > 0:
             delay_seconds = exc.retry_after_seconds
         else:
-            delay_seconds = min(_RL_BASE_SECONDS * (2 ** retry_count), _RL_MAX_SECONDS)
+            delay_seconds = min(_RL_BASE_SECONDS * (2**retry_count), _RL_MAX_SECONDS)
 
         retry_after_dt = datetime.now(tz=timezone.utc) + timedelta(seconds=delay_seconds)
 
@@ -586,9 +565,7 @@ class HeartbeatScheduler:
                 if existing_score is None or retry_ts < float(existing_score):
                     await redis.zadd(_SCHEDULE_KEY, {agent_id: retry_ts})
         except Exception:
-            logger.exception(
-                "Could not re-queue rate-limited agent %s in Redis for run %s", agent_id, run_id
-            )
+            logger.exception("Could not re-queue rate-limited agent %s in Redis for run %s", agent_id, run_id)
 
 
 # ------------------------------------------------------------------

--- a/autobot-backend/llc/services/__init__.py
+++ b/autobot-backend/llc/services/__init__.py
@@ -6,11 +6,11 @@ receive a typed ``activity_log`` reference at construction time.
 """
 
 from .activity_log import LLCActivityLogService
-from .ceo_chat import CeoChatService
 from .approval import ApprovalService
 from .base import LLCServiceBase
 from .board import BoardService
 from .budget import BudgetService
+from .ceo_chat import CeoChatService
 from .goal import GoalService
 from .handoff import HandoffError, HandoffService
 from .review_gate import (

--- a/autobot-backend/llc/services/ceo_chat.py
+++ b/autobot-backend/llc/services/ceo_chat.py
@@ -71,9 +71,7 @@ class CeoChatService(LLCServiceBase):
         session: AsyncSession,
         thread_id: str,
     ) -> Optional[LLCCeoChatThread]:
-        result = await session.execute(
-            select(LLCCeoChatThread).where(LLCCeoChatThread.id == thread_id)
-        )
+        result = await session.execute(select(LLCCeoChatThread).where(LLCCeoChatThread.id == thread_id))
         return result.scalar_one_or_none()
 
     async def list_threads(

--- a/autobot-backend/llc/services/ceo_chat.py
+++ b/autobot-backend/llc/services/ceo_chat.py
@@ -26,8 +26,8 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from . import LLCServiceBase
 from ..models.ceo_chat import LLCCeoChatMessage, LLCCeoChatThread
+from . import LLCServiceBase
 
 logger = logging.getLogger(__name__)
 
@@ -201,8 +201,8 @@ class CeoChatService(LLCServiceBase):
     ) -> Dict[str, Any]:
         """Call the LLM and return parsed resolution dict."""
         try:
-            from services.llm_service import get_llm_service
             from llm_shared.types import LLMType
+            from services.llm_service import get_llm_service
 
             svc = get_llm_service()
             context = "\n".join(kb_chunks) if kb_chunks else ""
@@ -244,8 +244,8 @@ class CeoChatService(LLCServiceBase):
 
         try:
             if intent == "create_task":
+                from ..models.enums import WorkItemPriority, WorkItemType
                 from .work_item_service import WorkItemService
-                from ..models.enums import WorkItemType, WorkItemPriority
 
                 item_svc = WorkItemService()
                 item = await item_svc.create(
@@ -269,8 +269,8 @@ class CeoChatService(LLCServiceBase):
                     return "goal", uuid.UUID(goal_id)
 
             if intent == "request_approval":
+                from ..models.enums import ApprovalStatus, ApprovalType
                 from .approval import ApprovalService
-                from ..models.enums import ApprovalType, ApprovalStatus
 
                 appr_svc = ApprovalService()
                 appr = await appr_svc.create(

--- a/autobot-backend/llc/services/handoff.py
+++ b/autobot-backend/llc/services/handoff.py
@@ -117,8 +117,8 @@ class HandoffService(LLCServiceBase):
         await self._publish_a2h_notification(company_id, work_item_id, reviewer_user_id, brief)
         if self.activity_log:
             try:
-                from .activity_log import ActivityEventType
                 from ..models.activity import ActorType
+                from .activity_log import ActivityEventType
                 await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.AGENT, actor_id=agent_id, event_type=ActivityEventType.WORK_ITEM_HANDOFF, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_REVIEW.value, "reviewer_user_id": reviewer_user_id}, metadata={"brief": brief})
             except Exception:
                 logger.warning("Activity log failed for agent_to_human %s", work_item_id)
@@ -142,8 +142,8 @@ class HandoffService(LLCServiceBase):
         await session.flush()
         if self.activity_log:
             try:
-                from .activity_log import ActivityEventType
                 from ..models.activity import ActorType
+                from .activity_log import ActivityEventType
                 await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_APPROVED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.DONE.value, "completed_at": now.isoformat()})
             except Exception:
                 logger.warning("Activity log failed for approve %s", work_item_id)
@@ -169,8 +169,8 @@ class HandoffService(LLCServiceBase):
         await session.flush()
         if self.activity_log:
             try:
-                from .activity_log import ActivityEventType
                 from ..models.activity import ActorType
+                from .activity_log import ActivityEventType
                 await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_CHANGES_REQUESTED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_PROGRESS.value, "assignee_agent_id": return_to_agent_id}, metadata={"change_request": change_request})
             except Exception:
                 logger.warning("Activity log failed for request_changes %s", work_item_id)

--- a/autobot-backend/llc/services/handoff.py
+++ b/autobot-backend/llc/services/handoff.py
@@ -83,7 +83,9 @@ class HandoffService(LLCServiceBase):
         await self._release_redis_key(work_item_id, user_id)
         await self._publish_h2a_notification(company_id, target_agent_id, work_item_id)
         await self._record_h2a_activity(session, company_id, user_id, work_item_id, target_agent_id)
-        return HandoffResult(work_item_id=work_item_id, target_agent_id=target_agent_id, kb_doc_ids=kb_doc_ids, review_brief=review_brief)
+        return HandoffResult(
+            work_item_id=work_item_id, target_agent_id=target_agent_id, kb_doc_ids=kb_doc_ids, review_brief=review_brief
+        )
 
     async def agent_to_human(
         self,
@@ -94,7 +96,9 @@ class HandoffService(LLCServiceBase):
         company_id: str,
         agent_notes: Optional[str] = None,
     ) -> LLCWorkItem:
-        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
+        )
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -119,13 +123,28 @@ class HandoffService(LLCServiceBase):
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.AGENT, actor_id=agent_id, event_type=ActivityEventType.WORK_ITEM_HANDOFF, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_REVIEW.value, "reviewer_user_id": reviewer_user_id}, metadata={"brief": brief})
+
+                await self.activity_log.record(
+                    session,
+                    company_id=company_id,
+                    actor_type=ActorType.AGENT,
+                    actor_id=agent_id,
+                    event_type=ActivityEventType.WORK_ITEM_HANDOFF,
+                    entity_type="work_item",
+                    entity_id=work_item_id,
+                    after={"status": WorkItemStatus.IN_REVIEW.value, "reviewer_user_id": reviewer_user_id},
+                    metadata={"brief": brief},
+                )
             except Exception:
                 logger.warning("Activity log failed for agent_to_human %s", work_item_id)
         return item
 
-    async def approve(self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str) -> LLCWorkItem:
-        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+    async def approve(
+        self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str
+    ) -> LLCWorkItem:
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
+        )
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -144,13 +163,33 @@ class HandoffService(LLCServiceBase):
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_APPROVED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.DONE.value, "completed_at": now.isoformat()})
+
+                await self.activity_log.record(
+                    session,
+                    company_id=company_id,
+                    actor_type=ActorType.USER,
+                    actor_id=reviewer_user_id,
+                    event_type=ActivityEventType.WORK_ITEM_REVIEW_APPROVED,
+                    entity_type="work_item",
+                    entity_id=work_item_id,
+                    after={"status": WorkItemStatus.DONE.value, "completed_at": now.isoformat()},
+                )
             except Exception:
                 logger.warning("Activity log failed for approve %s", work_item_id)
         return item
 
-    async def request_changes(self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str, change_request: str, return_to_agent_id: Optional[str] = None) -> LLCWorkItem:
-        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+    async def request_changes(
+        self,
+        session: AsyncSession,
+        work_item_id: str,
+        reviewer_user_id: str,
+        company_id: str,
+        change_request: str,
+        return_to_agent_id: Optional[str] = None,
+    ) -> LLCWorkItem:
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
+        )
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -164,14 +203,32 @@ class HandoffService(LLCServiceBase):
         item.version += 1
         await session.flush()
         from ..models.work_item import LLCWorkItemComment
-        comment = LLCWorkItemComment(id=uuid.uuid4(), company_id=uuid.UUID(company_id), work_item_id=uuid.UUID(work_item_id), body=change_request, author_user_id=uuid.UUID(reviewer_user_id))
+
+        comment = LLCWorkItemComment(
+            id=uuid.uuid4(),
+            company_id=uuid.UUID(company_id),
+            work_item_id=uuid.UUID(work_item_id),
+            body=change_request,
+            author_user_id=uuid.UUID(reviewer_user_id),
+        )
         session.add(comment)
         await session.flush()
         if self.activity_log:
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_CHANGES_REQUESTED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_PROGRESS.value, "assignee_agent_id": return_to_agent_id}, metadata={"change_request": change_request})
+
+                await self.activity_log.record(
+                    session,
+                    company_id=company_id,
+                    actor_type=ActorType.USER,
+                    actor_id=reviewer_user_id,
+                    event_type=ActivityEventType.WORK_ITEM_REVIEW_CHANGES_REQUESTED,
+                    entity_type="work_item",
+                    entity_id=work_item_id,
+                    after={"status": WorkItemStatus.IN_PROGRESS.value, "assignee_agent_id": return_to_agent_id},
+                    metadata={"change_request": change_request},
+                )
             except Exception:
                 logger.warning("Activity log failed for request_changes %s", work_item_id)
         return item
@@ -184,24 +241,37 @@ class HandoffService(LLCServiceBase):
         return item.review_brief
 
     async def _get_and_validate_human(self, session: AsyncSession, work_item_id: str, user_id: str) -> LLCWorkItem:
-        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
+        )
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
         holder_user_id = str(item.assignee_user_id) if item.assignee_user_id else None
         if item.assignee_type != "user" or holder_user_id != user_id:
-            raise HandoffNotAuthorized(f"User {user_id} does not hold work item {work_item_id} (current holder: {holder_user_id!r}, type: {item.assignee_type!r})")
+            raise HandoffNotAuthorized(
+                f"User {user_id} does not hold work item {work_item_id} (current holder: {holder_user_id!r}, type: {item.assignee_type!r})"
+            )
         return item
 
-    async def _ingest_kb(self, work_item_id: str, user_id: str, human_notes: str, attachments: List[HandoffAttachment]) -> List[str]:
+    async def _ingest_kb(
+        self, work_item_id: str, user_id: str, human_notes: str, attachments: List[HandoffAttachment]
+    ) -> List[str]:
         from ..kb.work_item_kb import WorkItemKB
+
         kb = WorkItemKB()
         doc_ids: List[str] = []
         if human_notes.strip():
             doc_id = await kb.ingest_notes(work_item_id=work_item_id, notes=human_notes, source_user_id=user_id)
             doc_ids.append(doc_id)
         for att in attachments:
-            doc_id = await kb.ingest_attachment(work_item_id=work_item_id, attachment_id=att.attachment_id, filename=att.filename, content=att.content, mime_type=att.mime_type)
+            doc_id = await kb.ingest_attachment(
+                work_item_id=work_item_id,
+                attachment_id=att.attachment_id,
+                filename=att.filename,
+                content=att.content,
+                mime_type=att.mime_type,
+            )
             if doc_id:
                 doc_ids.append(doc_id)
         return doc_ids
@@ -216,7 +286,14 @@ class HandoffService(LLCServiceBase):
             await redis.delete(key)
 
     async def _publish_h2a_notification(self, company_id: str, target_agent_id: str, work_item_id: str) -> None:
-        payload = json.dumps({"event": "work_item.handoff_ready", "work_item_id": work_item_id, "target_agent_id": target_agent_id, "has_human_handoff_context": True})
+        payload = json.dumps(
+            {
+                "event": "work_item.handoff_ready",
+                "work_item_id": work_item_id,
+                "target_agent_id": target_agent_id,
+                "has_human_handoff_context": True,
+            }
+        )
         channel = f"{_NOTIFICATION_CHANNEL_PREFIX}{company_id}"
         try:
             redis = await get_async_redis_client()
@@ -226,29 +303,80 @@ class HandoffService(LLCServiceBase):
         except Exception:
             logger.exception("Failed to publish h2a handoff notification for work_item %s — non-fatal", work_item_id)
 
-    async def _publish_a2h_notification(self, company_id: str, work_item_id: str, reviewer_user_id: str, brief: Dict[str, Any]) -> None:
+    async def _publish_a2h_notification(
+        self, company_id: str, work_item_id: str, reviewer_user_id: str, brief: Dict[str, Any]
+    ) -> None:
         redis = await get_async_redis_client()
         if redis is None:
             logger.warning("HandoffService: Redis unavailable, dropping a2h notification")
             return
         try:
             channel = f"{_NOTIFICATION_CHANNEL_PREFIX}{company_id}"
-            await redis.publish(channel, json.dumps({"event_type": "work_item.handoff", "work_item_id": work_item_id, "reviewer_user_id": reviewer_user_id, "brief_title": brief.get("title"), "brief_identifier": brief.get("identifier")}))
+            await redis.publish(
+                channel,
+                json.dumps(
+                    {
+                        "event_type": "work_item.handoff",
+                        "work_item_id": work_item_id,
+                        "reviewer_user_id": reviewer_user_id,
+                        "brief_title": brief.get("title"),
+                        "brief_identifier": brief.get("identifier"),
+                    }
+                ),
+            )
         except Exception:
             logger.debug("HandoffService._publish_a2h_notification failed (swallowed)")
 
-    async def _record_h2a_activity(self, session: AsyncSession, company_id: str, user_id: str, work_item_id: str, target_agent_id: str) -> None:
+    async def _record_h2a_activity(
+        self, session: AsyncSession, company_id: str, user_id: str, work_item_id: str, target_agent_id: str
+    ) -> None:
         if not self.activity_log:
             return
         try:
             from .activity_log import ActivityEventType
-            await self.activity_log.record(session, company_id=company_id, actor_type="user", actor_id=user_id, event_type=ActivityEventType.WORK_ITEM_ASSIGNED, entity_type="work_item", entity_id=work_item_id, after={"assignee_type": "agent", "assignee_agent_id": target_agent_id, "status": WorkItemStatus.READY.value, "has_human_handoff_context": True})
+
+            await self.activity_log.record(
+                session,
+                company_id=company_id,
+                actor_type="user",
+                actor_id=user_id,
+                event_type=ActivityEventType.WORK_ITEM_ASSIGNED,
+                entity_type="work_item",
+                entity_id=work_item_id,
+                after={
+                    "assignee_type": "agent",
+                    "assignee_agent_id": target_agent_id,
+                    "status": WorkItemStatus.READY.value,
+                    "has_human_handoff_context": True,
+                },
+            )
         except Exception:
             logger.warning("Activity log failed for h2a handoff work_item=%s", work_item_id)
 
     def _generate_brief(self, item: LLCWorkItem, agent_notes: Optional[str]) -> Dict[str, Any]:
-        comment_excerpts = [{"author_agent_id": str(c.author_agent_id) if c.author_agent_id else None, "author_user_id": str(c.author_user_id) if c.author_user_id else None, "excerpt": c.body[:200]} for c in (item.comments or [])]
-        return {"work_item_id": str(item.id), "identifier": item.identifier, "title": item.title, "type": item.type.value if hasattr(item.type, "value") else item.type, "status_before_handoff": item.status.value if hasattr(item.status, "value") else item.status, "priority": item.priority.value if hasattr(item.priority, "value") else item.priority, "description_excerpt": (item.description or "")[:500], "acceptance_criteria": item.acceptance_criteria or [], "comment_count": len(item.comments or []), "recent_comments": comment_excerpts[-5:], "agent_notes": agent_notes, "generated_at": datetime.now(timezone.utc).isoformat(), "generator": "stub-phase4"}
+        comment_excerpts = [
+            {
+                "author_agent_id": str(c.author_agent_id) if c.author_agent_id else None,
+                "author_user_id": str(c.author_user_id) if c.author_user_id else None,
+                "excerpt": c.body[:200],
+            }
+            for c in (item.comments or [])
+        ]
+        return {
+            "work_item_id": str(item.id),
+            "identifier": item.identifier,
+            "title": item.title,
+            "type": item.type.value if hasattr(item.type, "value") else item.type,
+            "status_before_handoff": item.status.value if hasattr(item.status, "value") else item.status,
+            "priority": item.priority.value if hasattr(item.priority, "value") else item.priority,
+            "description_excerpt": (item.description or "")[:500],
+            "acceptance_criteria": item.acceptance_criteria or [],
+            "comment_count": len(item.comments or []),
+            "recent_comments": comment_excerpts[-5:],
+            "agent_notes": agent_notes,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "generator": "stub-phase4",
+        }
 
     def _assert_reviewer(self, item: LLCWorkItem, reviewer_user_id: str) -> None:
         if item.reviewer_user_id is None or str(item.reviewer_user_id) != reviewer_user_id:

--- a/autobot-backend/llc/services/review_gate.py
+++ b/autobot-backend/llc/services/review_gate.py
@@ -127,9 +127,9 @@ class ReviewGatePolicyService(LLCServiceBase):
     ) -> bool:
         """Delete a policy. Returns True if deleted, False if not found."""
         result = await session.execute(
-            delete(LLCReviewGatePolicy).where(
-                LLCReviewGatePolicy.id == uuid.UUID(policy_id)
-            ).returning(LLCReviewGatePolicy.id)
+            delete(LLCReviewGatePolicy)
+            .where(LLCReviewGatePolicy.id == uuid.UUID(policy_id))
+            .returning(LLCReviewGatePolicy.id)
         )
         deleted = result.scalar_one_or_none()
         await session.flush()

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -637,17 +637,14 @@ class WorkItemService(LLCServiceBase):
         allowed = _ALLOWED_TRANSITIONS.get(current, set())
         if WorkItemStatus.DONE not in allowed:
             raise InvalidTransition(
-                f"Cannot transition from {current.value!r} to 'done'. "
-                f"Allowed: {[s.value for s in allowed]}"
+                f"Cannot transition from {current.value!r} to 'done'. " f"Allowed: {[s.value for s in allowed]}"
             )
 
         actor_is_agent = actor_agent_id is not None and actor_user_id is None
 
         if not is_board_override and actor_is_agent and review_gate_svc is not None:
             item_type = WorkItemType(item.type)
-            requires, reviewer_role = await review_gate_svc.requires_review(
-                session, company_id, item_type
-            )
+            requires, reviewer_role = await review_gate_svc.requires_review(session, company_id, item_type)
             if requires:
                 if handoff_svc is not None:
                     return await handoff_svc.agent_to_human(

--- a/autobot-backend/llc/tests/test_ac_suggester.py
+++ b/autobot-backend/llc/tests/test_ac_suggester.py
@@ -1,0 +1,199 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for AcSuggester (GH#8240)."""
+
+import hashlib
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.kb.ac_suggester import AcSuggester, _format_chunks, _parse_bullet_list, _zip_results
+
+
+# ------------------------------------------------------------------ Helpers
+
+
+def _make_chroma_result(ids, docs, metas=None):
+    if metas is None:
+        metas = [{}] * len(ids)
+    return {"ids": [ids], "documents": [docs], "metadatas": [metas]}
+
+
+# ------------------------------------------------------------------ Unit: helpers
+
+
+def test_parse_bullet_list_dash():
+    raw = "- Criterion one\n- Criterion two\n- Criterion three"
+    assert _parse_bullet_list(raw) == ["Criterion one", "Criterion two", "Criterion three"]
+
+
+def test_parse_bullet_list_asterisk():
+    raw = "* Item A\n* Item B"
+    assert _parse_bullet_list(raw) == ["Item A", "Item B"]
+
+
+def test_parse_bullet_list_bullet():
+    raw = "• Point one\n• Point two"
+    assert _parse_bullet_list(raw) == ["Point one", "Point two"]
+
+
+def test_parse_bullet_list_skips_non_bullets():
+    raw = "Some preamble\n- Real criterion\nTrailing text"
+    assert _parse_bullet_list(raw) == ["Real criterion"]
+
+
+def test_parse_bullet_list_empty():
+    assert _parse_bullet_list("") == []
+
+
+def test_zip_results_normal():
+    result = _make_chroma_result(["id1", "id2"], ["doc1", "doc2"], [{"k": 1}, {"k": 2}])
+    chunks = _zip_results(result)
+    assert len(chunks) == 2
+    assert chunks[0] == {"id": "id1", "document": "doc1", "metadata": {"k": 1}}
+
+
+def test_format_chunks_joins_with_blank_line():
+    chunks = [{"document": "A"}, {"document": "B"}, {"id": "x"}]
+    assert _format_chunks(chunks) == "A\n\nB"
+
+
+def test_format_chunks_empty():
+    assert _format_chunks([]) == ""
+
+
+# ------------------------------------------------------------------ AcSuggester.suggest — cache hit
+
+
+@pytest.mark.asyncio
+async def test_suggest_returns_cached_result():
+    suggester = AcSuggester()
+    cached_value = {"suggestions": ["AC 1", "AC 2"], "sources": ["doc:1"]}
+
+    with patch.object(suggester, "_get_cached", new=AsyncMock(return_value=cached_value)):
+        with patch.object(suggester, "_call_llm", new=AsyncMock()) as mock_llm:
+            result = await suggester.suggest("co1", "proj1", "Login page", "Allow users to log in")
+
+    assert result == cached_value
+    mock_llm.assert_not_called()
+
+
+# ------------------------------------------------------------------ AcSuggester.suggest — full path
+
+
+@pytest.mark.asyncio
+async def test_suggest_full_path_calls_llm_and_caches():
+    suggester = AcSuggester()
+
+    policies = [{"id": "pol:1", "document": "Policy text", "metadata": {}}]
+    past_items = [{"id": "pbi:1", "document": "Past PBI text", "metadata": {}}]
+    suggestions = [
+        "System accepts valid credentials",
+        "System rejects invalid credentials",
+        "Lockout after 5 attempts",
+    ]
+
+    mock_set_cached = AsyncMock()
+
+    with patch.object(suggester, "_get_cached", new=AsyncMock(return_value=None)):
+        with patch.object(suggester, "_query_policies", new=AsyncMock(return_value=policies)):
+            with patch.object(suggester, "_query_past_items", new=AsyncMock(return_value=past_items)):
+                with patch.object(suggester, "_call_llm", new=AsyncMock(return_value=suggestions)):
+                    with patch.object(suggester, "_set_cached", new=mock_set_cached):
+                        result = await suggester.suggest("co1", "proj1", "Login page", "desc")
+
+    assert result["suggestions"] == suggestions
+    assert "pol:1" in result["sources"]
+    assert "pbi:1" in result["sources"]
+    mock_set_cached.assert_called_once()
+
+
+# ------------------------------------------------------------------ AcSuggester.suggest — empty collections
+
+
+@pytest.mark.asyncio
+async def test_suggest_with_empty_collections_still_calls_llm():
+    suggester = AcSuggester()
+
+    with patch.object(suggester, "_get_cached", new=AsyncMock(return_value=None)):
+        with patch.object(suggester, "_query_policies", new=AsyncMock(return_value=[])):
+            with patch.object(suggester, "_query_past_items", new=AsyncMock(return_value=[])):
+                with patch.object(suggester, "_call_llm", new=AsyncMock(return_value=["Generic criterion"])):
+                    with patch.object(suggester, "_set_cached", new=AsyncMock()):
+                        result = await suggester.suggest("co1", "proj1", "New feature", "")
+
+    assert result["suggestions"] == ["Generic criterion"]
+    assert result["sources"] == []
+
+
+# ------------------------------------------------------------------ AcSuggester.suggest — LLM failure
+
+
+@pytest.mark.asyncio
+async def test_suggest_llm_failure_returns_empty_suggestions():
+    suggester = AcSuggester()
+
+    with patch.object(suggester, "_get_cached", new=AsyncMock(return_value=None)):
+        with patch.object(suggester, "_query_policies", new=AsyncMock(return_value=[])):
+            with patch.object(suggester, "_query_past_items", new=AsyncMock(return_value=[])):
+                with patch.object(suggester, "_call_llm", new=AsyncMock(return_value=[])):
+                    with patch.object(suggester, "_set_cached", new=AsyncMock()):
+                        result = await suggester.suggest("co1", "proj1", "Feature", "desc")
+
+    assert result["suggestions"] == []
+
+
+# ------------------------------------------------------------------ AcSuggester — parallel queries
+
+
+@pytest.mark.asyncio
+async def test_suggest_runs_queries_in_parallel():
+    """Both _query_policies and _query_past_items must be awaited."""
+    import asyncio
+
+    suggester = AcSuggester()
+    call_log = []
+
+    async def _fake_policies(*_):
+        call_log.append("policies")
+        await asyncio.sleep(0)
+        return []
+
+    async def _fake_past(*_):
+        call_log.append("past")
+        await asyncio.sleep(0)
+        return []
+
+    with patch.object(suggester, "_get_cached", new=AsyncMock(return_value=None)):
+        with patch.object(suggester, "_query_policies", side_effect=_fake_policies):
+            with patch.object(suggester, "_query_past_items", side_effect=_fake_past):
+                with patch.object(suggester, "_call_llm", new=AsyncMock(return_value=[])):
+                    with patch.object(suggester, "_set_cached", new=AsyncMock()):
+                        await suggester.suggest("co1", "proj1", "T", "D")
+
+    assert set(call_log) == {"policies", "past"}
+
+
+# ------------------------------------------------------------------ AcSuggester — cache key stability
+
+
+def test_cache_key_is_deterministic():
+    s = AcSuggester()
+    k1 = s._cache_key("Title", "Description")
+    k2 = s._cache_key("Title", "Description")
+    assert k1 == k2
+    assert k1.startswith("llc:ac_suggestions:")
+
+
+def test_cache_key_differs_on_different_inputs():
+    s = AcSuggester()
+    assert s._cache_key("A", "B") != s._cache_key("A", "C")
+    assert s._cache_key("A", "B") != s._cache_key("B", "B")
+
+
+def test_cache_key_matches_sha256():
+    s = AcSuggester()
+    expected = "llc:ac_suggestions:" + hashlib.sha256("TitleDesc".encode("utf-8")).hexdigest()
+    assert s._cache_key("Title", "Desc") == expected

--- a/autobot-backend/llc/tests/test_ac_suggester.py
+++ b/autobot-backend/llc/tests/test_ac_suggester.py
@@ -194,5 +194,11 @@ def test_cache_key_differs_on_different_inputs():
 
 def test_cache_key_matches_sha256():
     s = AcSuggester()
-    expected = "llc:ac_suggestions:" + hashlib.sha256("TitleDesc".encode("utf-8")).hexdigest()
+    expected = "llc:ac_suggestions:" + hashlib.sha256("Title\x00Desc".encode("utf-8")).hexdigest()
     assert s._cache_key("Title", "Desc") == expected
+
+
+def test_cache_key_no_collision_with_concat():
+    s = AcSuggester()
+    # "AB"+"C" must not collide with "A"+"BC" — the \x00 separator prevents this
+    assert s._cache_key("AB", "C") != s._cache_key("A", "BC")

--- a/autobot-backend/llc/tests/test_ac_suggester.py
+++ b/autobot-backend/llc/tests/test_ac_suggester.py
@@ -11,7 +11,6 @@ import pytest
 
 from llc.kb.ac_suggester import AcSuggester, _format_chunks, _parse_bullet_list, _zip_results
 
-
 # ------------------------------------------------------------------ Helpers
 
 

--- a/autobot-backend/llc/tests/test_assignment.py
+++ b/autobot-backend/llc/tests/test_assignment.py
@@ -334,9 +334,7 @@ class TestCoworkerSubtaskInvariant:
         )
 
         # create() fetches a fresh item; mock the identifier generation
-        mock_session._db_result.fetchone.return_value = MagicMock(
-            issue_prefix="WI", issue_counter=99
-        )
+        mock_session._db_result.fetchone.return_value = MagicMock(issue_prefix="WI", issue_counter=99)
 
         # create() should succeed without any checkout validation on parent
         co_worker_agent_id = str(uuid.uuid4())

--- a/autobot-backend/llc/tests/test_ceo_chat.py
+++ b/autobot-backend/llc/tests/test_ceo_chat.py
@@ -76,9 +76,7 @@ async def test_create_thread_with_user(svc: CeoChatService) -> None:
     session.flush = AsyncMock()
     user_id = str(uuid.uuid4())
 
-    thread = await svc.create_thread(
-        session, company_id="co1", title="Board Session", created_by_user_id=user_id
-    )
+    thread = await svc.create_thread(session, company_id="co1", title="Board Session", created_by_user_id=user_id)
 
     assert str(thread.created_by_user_id) == user_id
 
@@ -177,9 +175,7 @@ async def test_send_create_task_intent(svc: CeoChatService) -> None:
         patch.object(svc, "get_thread", new=AsyncMock(return_value=thread)),
         patch.object(svc, "_dispatch_intent", new=AsyncMock(return_value=("work_item", fake_item.id))),
     ):
-        msg = await svc.send(
-            session, thread_id=thread_id, message="Create a Q3 roadmap task", user_id=None
-        )
+        msg = await svc.send(session, thread_id=thread_id, message="Create a Q3 roadmap task", user_id=None)
 
     assert msg.author_type == "system"
     assert "work_item" in msg.body or "Resolved" in msg.body
@@ -200,15 +196,11 @@ async def test_send_record_decision_intent(svc: CeoChatService) -> None:
         patch.object(
             svc,
             "_resolve_via_llm",
-            new=AsyncMock(
-                return_value={"intent": "record_decision", "summary": "Approved budget", "entity": {}}
-            ),
+            new=AsyncMock(return_value={"intent": "record_decision", "summary": "Approved budget", "entity": {}}),
         ),
         patch.object(svc, "get_thread", new=AsyncMock(return_value=thread)),
     ):
-        msg = await svc.send(
-            session, thread_id=thread_id, message="We approved the budget", user_id=None
-        )
+        msg = await svc.send(session, thread_id=thread_id, message="We approved the budget", user_id=None)
 
     assert msg.author_type == "system"
     assert "decision" in msg.body.lower() or "Recorded" in msg.body
@@ -218,9 +210,7 @@ async def test_send_record_decision_intent(svc: CeoChatService) -> None:
 
 
 def test_build_reply_clarify() -> None:
-    body = CeoChatService._build_reply(
-        {"intent": "clarify", "summary": "Need more info", "entity": {}}, None, None
-    )
+    body = CeoChatService._build_reply({"intent": "clarify", "summary": "Need more info", "entity": {}}, None, None)
     assert "clarify" in body.lower() or "could you" in body.lower()
 
 

--- a/autobot-backend/llc/tests/test_ceo_chat.py
+++ b/autobot-backend/llc/tests/test_ceo_chat.py
@@ -12,7 +12,6 @@ import pytest
 from llc.models.ceo_chat import LLCCeoChatMessage, LLCCeoChatThread
 from llc.services.ceo_chat import CeoChatService
 
-
 # ----------------------------------------------------------------- Helpers
 
 

--- a/autobot-backend/llc/tests/test_handoff_to_agent.py
+++ b/autobot-backend/llc/tests/test_handoff_to_agent.py
@@ -285,6 +285,7 @@ class TestHumanToAgent:
         channel, payload_json = mock_redis.publish.call_args[0]
         assert channel == f"llc:notifications:{company_id}"
         import json
+
         payload = json.loads(payload_json)
         assert payload["event"] == "work_item.handoff_ready"
         assert payload["work_item_id"] == str(item.id)

--- a/autobot-backend/llc/tests/test_handoff_to_human.py
+++ b/autobot-backend/llc/tests/test_handoff_to_human.py
@@ -10,7 +10,6 @@ from llc.models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
 from llc.models.work_item import LLCWorkItem, LLCWorkItemComment
 from llc.services.handoff import HandoffNotAllowed, HandoffService
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llc/tests/test_handoff_to_human.py
+++ b/autobot-backend/llc/tests/test_handoff_to_human.py
@@ -210,6 +210,7 @@ class TestAgentToHuman:
         channel, payload_str = redis_mock.publish.call_args[0]
         assert channel == f"llc:notifications:{company_id}"
         import json
+
         payload = json.loads(payload_str)
         assert payload["event_type"] == "work_item.handoff"
         assert payload["reviewer_user_id"] == str(reviewer_id)
@@ -346,10 +347,7 @@ class TestRequestChanges:
             change_request="Need more tests",
         )
 
-        assert any(
-            isinstance(obj, LLCWorkItemComment) and obj.body == "Need more tests"
-            for obj in added_objects
-        )
+        assert any(isinstance(obj, LLCWorkItemComment) and obj.body == "Need more tests" for obj in added_objects)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llc/tests/test_provider_rate_limit_recovery.py
+++ b/autobot-backend/llc/tests/test_provider_rate_limit_recovery.py
@@ -26,10 +26,10 @@ from llc.exceptions import ProviderRateLimited
 from llc.models.enums import HeartbeatRunStatus
 from llc.models.heartbeat_run import LLCHeartbeatRun
 from llc.scheduler.heartbeat_scheduler import (
-    HeartbeatScheduler,
     _MAX_RATE_LIMIT_RETRIES,
     _RL_BASE_SECONDS,
     _RL_MAX_SECONDS,
+    HeartbeatScheduler,
 )
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llc/tests/test_provider_rate_limit_recovery.py
+++ b/autobot-backend/llc/tests/test_provider_rate_limit_recovery.py
@@ -235,9 +235,7 @@ async def test_handle_rate_limited_demotes_after_max_retries():
         patch("llc.scheduler.heartbeat_scheduler.get_async_session_factory", return_value=lambda: ctx_mgr),
         patch("llc.scheduler.heartbeat_scheduler.get_async_redis_client", AsyncMock(return_value=redis)),
     ):
-        await scheduler._handle_rate_limited(
-            agent, _RUN_ID, retry_count=_MAX_RATE_LIMIT_RETRIES, exc=exc
-        )
+        await scheduler._handle_rate_limited(agent, _RUN_ID, retry_count=_MAX_RATE_LIMIT_RETRIES, exc=exc)
 
     # FAILED written, not re-queued
     compiled = str(session_mock.execute.call_args[0][0].compile(compile_kwargs={"literal_binds": True}))

--- a/autobot-backend/llc/tests/test_review_gate.py
+++ b/autobot-backend/llc/tests/test_review_gate.py
@@ -324,9 +324,7 @@ class TestTransitionToDone:
         svc = WorkItemService()
         company_id = str(uuid.uuid4())
 
-        result = await svc.transition_to_done(
-            session, str(wi.id), company_id, actor_user_id=str(uuid.uuid4())
-        )
+        result = await svc.transition_to_done(session, str(wi.id), company_id, actor_user_id=str(uuid.uuid4()))
 
         assert result.status == WorkItemStatus.DONE
         session.flush.assert_awaited()
@@ -411,9 +409,7 @@ class TestTransitionToDone:
         svc = WorkItemService()
 
         with pytest.raises(InvalidTransition):
-            await svc.transition_to_done(
-                session, str(wi.id), str(uuid.uuid4()), actor_user_id=str(uuid.uuid4())
-            )
+            await svc.transition_to_done(session, str(wi.id), str(uuid.uuid4()), actor_user_id=str(uuid.uuid4()))
 
     @pytest.mark.asyncio
     async def test_review_gate_transition_not_found_raises(self) -> None:
@@ -421,9 +417,7 @@ class TestTransitionToDone:
         svc = WorkItemService()
 
         with pytest.raises(ValueError, match="not found"):
-            await svc.transition_to_done(
-                session, str(uuid.uuid4()), str(uuid.uuid4()), actor_user_id=str(uuid.uuid4())
-            )
+            await svc.transition_to_done(session, str(uuid.uuid4()), str(uuid.uuid4()), actor_user_id=str(uuid.uuid4()))
 
     @pytest.mark.asyncio
     async def test_review_gate_board_override_logs_override(self) -> None:

--- a/autobot-backend/llc/tests/test_review_gate.py
+++ b/autobot-backend/llc/tests/test_review_gate.py
@@ -30,7 +30,6 @@ from llc.services.review_gate import (
 )
 from llc.services.work_item_service import InvalidTransition, WorkItemService
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llm_multi_provider.py
+++ b/autobot-backend/llm_multi_provider.py
@@ -247,6 +247,7 @@ class UnifiedLLMInterface:
         # Claude escalation (#8171): attempt top-tier routing before local providers.
         # Returns None when disabled, score too low, or Claude errors — safe fallthrough.
         from llm_shared.tiered_routing.complexity_router import ComplexityRouter
+
         _escalation_result = await ComplexityRouter().route_with_escalation(request)
         if _escalation_result is not None:
             return _escalation_result

--- a/autobot-backend/llm_shared/model_param_registry.py
+++ b/autobot-backend/llm_shared/model_param_registry.py
@@ -38,7 +38,6 @@ from autobot_shared.ssot_config import config
 # Author: mrveiss
 
 
-
 logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llm_shared/providers/anthropic.py
+++ b/autobot-backend/llm_shared/providers/anthropic.py
@@ -200,9 +200,7 @@ class AnthropicProvider(BaseProvider):
             # request metadata the system message is sent as a content-block
             # list so Anthropic can cache it across repeated requests.
             if request.metadata.get("enable_prompt_cache"):
-                kwargs["system"] = [
-                    {"type": "text", "text": system_content, "cache_control": {"type": "ephemeral"}}
-                ]
+                kwargs["system"] = [{"type": "text", "text": system_content, "cache_control": {"type": "ephemeral"}}]
             else:
                 kwargs["system"] = system_content
 

--- a/autobot-backend/migrations/versions/20260524_036_llc_review_gate_policies.py
+++ b/autobot-backend/migrations/versions/20260524_036_llc_review_gate_policies.py
@@ -24,12 +24,24 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.create_table(
         "llc_review_gate_policies",
-        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column(
+            "id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
         sa.Column("company_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column(
             "item_type",
             sa.Enum(
-                "epic", "feature", "pbi", "task", "bug", "subtask", "spike", "risk",
+                "epic",
+                "feature",
+                "pbi",
+                "task",
+                "bug",
+                "subtask",
+                "spike",
+                "risk",
                 name="workitemtype",
                 create_type=False,
             ),

--- a/autobot-backend/tests/test_claude_escalation.py
+++ b/autobot-backend/tests/test_claude_escalation.py
@@ -67,6 +67,7 @@ def _make_error_response() -> LLMResponse:
 def _make_provider_with_resolved_key():
     """Build a bare AnthropicProvider instance with _api_key set via env (no literal)."""
     import os
+
     from llm_shared.providers.anthropic import AnthropicProvider
 
     provider = AnthropicProvider.__new__(AnthropicProvider)


### PR DESCRIPTION
## Summary

- Adds `AcSuggester` in `llc/kb/ac_suggester.py` — parallel ChromaDB RAG over `company:{id}` (policy/standards) and `project:{id}` (completed PBIs), fed to LLM to propose 3-6 draft acceptance criteria
- Adds `POST /api/llc/work-items/suggest-ac` returning `{suggestions, sources}` — advisory, caller decides which to accept
- Redis cache keyed by `sha256(title+description)`, TTL 5 min (env-tunable via `AUTOBOT_AC_SUGGESTER_CACHE_TTL`, follows #6743 pattern)
- 16 unit tests (all passing): helpers, cache hit/miss, empty collections, LLM failure, parallel execution, cache key stability

## Dependency note

This PR targets `Dev_new_gui` directly. It uses the collection naming convention (`company:{id}`, `project:{id}`) established in GH#8235 (PR #8519, pending). The implementation does not import `KbCollectionManager` — it queries ChromaDB collections by canonical name, so this PR can land once #8519 merges and the collections are populated.

## Test plan

- [x] `python3 -m pytest autobot-backend/llc/tests/test_ac_suggester.py -v` — 16 passed
- [x] Syntax check: `python3 -m py_compile` on all 4 files
- [ ] Integration: manual `POST /api/llc/work-items/suggest-ac` once #8235 is merged and company/project collections are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)