### PR TITLE
feat(llc/kb): artifact ingestor — work products indexed into project KB on done (#8242)

### DIFF
--- a/autobot-backend/database/migrations/005_create_llc_work_products_table.py
+++ b/autobot-backend/database/migrations/005_create_llc_work_products_table.py
@@ -1,0 +1,100 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Create llc_work_products table for artifact indexing into project KB (GH#8242).
+
+Work products are the deliverables produced by agents when completing work items:
+code, documents, reports, plans, screenshots, PR links, and other artifacts.
+The ArtifactIngestor picks up rows where kb_indexed=false and indexes them into
+the project ChromaDB collection for future RAG retrieval.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-05-24
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "005"
+down_revision = "004"
+branch_labels = None
+depends_on = None
+
+
+def _create_llc_work_products_table() -> None:
+    op.create_table(
+        "llc_work_products",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("company_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "work_item_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("llc_work_items.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "heartbeat_run_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("llc_heartbeat_runs.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "type",
+            sa.String(32),
+            nullable=False,
+            comment="code|document|report|plan|screenshot|pr_link|other",
+        ),
+        sa.Column("title", sa.String(512), nullable=False),
+        sa.Column("content_text", sa.Text, nullable=True),
+        sa.Column(
+            "storage_path",
+            sa.Text,
+            nullable=True,
+            comment="Path to binary/large file; text-only paths are also indexed",
+        ),
+        sa.Column("url", sa.Text, nullable=True),
+        sa.Column(
+            "kb_indexed",
+            sa.Boolean,
+            nullable=False,
+            server_default="false",
+            comment="True after ArtifactIngestor has indexed into project KB",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def _create_llc_work_products_indices() -> None:
+    op.create_index("ix_llc_work_products_company_id", "llc_work_products", ["company_id"])
+    op.create_index("ix_llc_work_products_work_item_id", "llc_work_products", ["work_item_id"])
+    op.create_index("ix_llc_work_products_kb_indexed", "llc_work_products", ["kb_indexed"])
+    op.create_index("ix_llc_work_products_created_at", "llc_work_products", ["created_at"])
+
+
+def upgrade() -> None:
+    _create_llc_work_products_table()
+    _create_llc_work_products_indices()
+
+
+def _drop_llc_work_products_indices() -> None:
+    op.drop_index("ix_llc_work_products_created_at", table_name="llc_work_products")
+    op.drop_index("ix_llc_work_products_kb_indexed", table_name="llc_work_products")
+    op.drop_index("ix_llc_work_products_work_item_id", table_name="llc_work_products")
+    op.drop_index("ix_llc_work_products_company_id", table_name="llc_work_products")
+
+
+def downgrade() -> None:
+    _drop_llc_work_products_indices()
+    op.drop_table("llc_work_products")

--- a/autobot-backend/llc/api/agent_api.py
+++ b/autobot-backend/llc/api/agent_api.py
@@ -81,16 +81,45 @@ async def post_comment(body: CommentBody, request: Request) -> Dict[str, Any]:
 
 class WorkProduct(BaseModel):
     work_item_id: str
-    artifact_type: str
-    content: str
-    metadata: Optional[Dict[str, Any]] = None
+    type: str
+    title: str
+    content_text: Optional[str] = None
+    storage_path: Optional[str] = None
+    url: Optional[str] = None
+    heartbeat_run_id: Optional[str] = None
 
 
 @router.post("/products")
 async def upload_work_product(body: WorkProduct, request: Request) -> Dict[str, Any]:
     agent_id, company_id = _agent_context(request)
-    # Phase 5: KB storage + RAG indexing
-    return {"artifact_id": None, "recorded": True}
+    from ..models.enums import WorkProductType
+    from ..services.work_product_service import WorkProductService
+    from autobot_shared.singleton_factory import lazy_singleton
+    from user_management.database import get_async_session_factory
+
+    try:
+        product_type = WorkProductType(body.type)
+    except ValueError:
+        from fastapi import HTTPException as _HTTPException
+
+        raise _HTTPException(status_code=422, detail=f"Unknown product type: {body.type!r}")
+
+    svc = lazy_singleton(WorkProductService)()
+    factory = get_async_session_factory()
+    async with factory() as session:
+        async with session.begin():
+            product = await svc.create(
+                session,
+                company_id=company_id,
+                work_item_id=body.work_item_id,
+                type=product_type,
+                title=body.title,
+                content_text=body.content_text,
+                storage_path=body.storage_path,
+                url=body.url,
+                heartbeat_run_id=body.heartbeat_run_id,
+            )
+    return {"artifact_id": str(product.id), "recorded": True}
 
 
 class HeartbeatReport(BaseModel):

--- a/autobot-backend/llc/api/agent_api.py
+++ b/autobot-backend/llc/api/agent_api.py
@@ -92,10 +92,11 @@ class WorkProduct(BaseModel):
 @router.post("/products")
 async def upload_work_product(body: WorkProduct, request: Request) -> Dict[str, Any]:
     agent_id, company_id = _agent_context(request)
-    from ..models.enums import WorkProductType
-    from ..services.work_product_service import WorkProductService
     from autobot_shared.singleton_factory import lazy_singleton
     from user_management.database import get_async_session_factory
+
+    from ..models.enums import WorkProductType
+    from ..services.work_product_service import WorkProductService
 
     try:
         product_type = WorkProductType(body.type)

--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -560,3 +560,31 @@ async def get_sprint_burndown(
         return await _planning_svc.get_burndown(session, sprint_id)
     except SprintNotFound as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get("/projects/{project_id}/knowledge")
+async def get_project_knowledge(
+    project_id: uuid.UUID,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+) -> dict:
+    """Return recently indexed work product artifacts for a project (GH#8242).
+
+    Queries the ``project:{project_id}`` ChromaDB collection — available
+    once ArtifactIngestor has indexed at least one work product.
+    """
+    from ..services.work_product_service import WorkProductService
+    from autobot_shared.singleton_factory import lazy_singleton
+
+    svc = lazy_singleton(WorkProductService)()
+    artifacts = await svc.list_indexed_by_project(
+        session=None,  # type: ignore[arg-type]  — no DB needed, reads ChromaDB directly
+        project_id=str(project_id),
+        limit=limit,
+        offset=offset,
+    )
+    return {
+        "project_id": str(project_id),
+        "artifacts": artifacts,
+        "total": len(artifacts),
+    }

--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -573,8 +573,9 @@ async def get_project_knowledge(
     Queries the ``project:{project_id}`` ChromaDB collection — available
     once ArtifactIngestor has indexed at least one work product.
     """
-    from ..services.work_product_service import WorkProductService
     from autobot_shared.singleton_factory import lazy_singleton
+
+    from ..services.work_product_service import WorkProductService
 
     svc = lazy_singleton(WorkProductService)()
     artifacts = await svc.list_indexed_by_project(

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -34,6 +34,13 @@ from ..kb.collections import KbCollectionManager
 from ..models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
 from ..services.handoff import HandoffAttachment, HandoffNotAllowed, HandoffNotAuthorized, HandoffService
 from ..services.work_item_service import CheckoutConflict, InvalidTransition, WorkItemService
+from ..services.work_item_service import (
+    CheckoutConflict,
+    CoWorkingPermissionError,
+    InvalidTransition,
+    WorkItemService,
+)
+from ..services.work_product_service import WorkProductService
 
 
 class HumanClaimRequest(BaseModel):
@@ -46,8 +53,21 @@ class HumanUnclaimRequest(BaseModel):
     company_id: str
 
 
+class CoworkerRequest(BaseModel):
+    """Set or clear a co-worker on a work item (GH#8230).
+    To clear the co-worker, omit co_worker_type (or send null).
+    caller_role must be 'owner', 'admin', or 'lead' to mutate co-working state.
+    """
+    company_id: str
+    co_worker_type: Optional[str] = None
+    co_worker_agent_id: Optional[str] = None
+    co_worker_user_id: Optional[str] = None
+    actor_agent_id: Optional[str] = None
+    actor_user_id: Optional[str] = None
+    caller_role: str = "member"
 router = APIRouter(prefix="/work-items", tags=["llc-work-items"])
 _get_service = lazy_singleton(WorkItemService)
+_get_product_service = lazy_singleton(WorkProductService)
 _get_handoff_service = lazy_singleton(HandoffService)
 _kb_manager = KbCollectionManager()
 
@@ -157,7 +177,6 @@ class ReviewChangesRequest(BaseModel):
     company_id: str
     change_request: str
     return_to_agent_id: Optional[str] = None
-
 
 def _assignee_display(item: Any) -> Optional[Dict[str, Any]]:
     """Return structured assignee display info (GH#8223).
@@ -482,8 +501,6 @@ async def handoff_to_agent(
         raise HTTPException(status_code=403, detail=str(exc))
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
-
-
 # ------------------------------------------------------------------
 # Handoff routes (GH#8231)
 # ------------------------------------------------------------------
@@ -566,3 +583,36 @@ async def get_handoff_brief(
         return {"work_item_id": work_item_id, "brief": brief}
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
+
+@router.get("/{work_item_id}/products")
+async def list_work_products(
+    work_item_id: str,
+    limit: int = Query(100, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    """List all work products for a work item (GH#8242)."""
+    products = await _get_product_service().list_by_work_item(
+        session,
+        work_item_id=work_item_id,
+        limit=limit,
+        offset=offset,
+    )
+    return {
+        "work_item_id": work_item_id,
+        "products": [
+            {
+                "id": str(p.id),
+                "type": p.type if isinstance(p.type, str) else p.type.value,
+                "title": p.title,
+                "content_text": p.content_text,
+                "storage_path": p.storage_path,
+                "url": p.url,
+                "kb_indexed": p.kb_indexed,
+                "heartbeat_run_id": str(p.heartbeat_run_id) if p.heartbeat_run_id else None,
+                "created_at": p.created_at.isoformat() if p.created_at else None,
+            }
+            for p in products
+        ],
+        "total": len(products),
+    }

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -58,6 +58,7 @@ class CoworkerRequest(BaseModel):
     To clear the co-worker, omit co_worker_type (or send null).
     caller_role must be 'owner', 'admin', or 'lead' to mutate co-working state.
     """
+
     company_id: str
     co_worker_type: Optional[str] = None
     co_worker_agent_id: Optional[str] = None
@@ -65,6 +66,8 @@ class CoworkerRequest(BaseModel):
     actor_agent_id: Optional[str] = None
     actor_user_id: Optional[str] = None
     caller_role: str = "member"
+
+
 router = APIRouter(prefix="/work-items", tags=["llc-work-items"])
 _get_service = lazy_singleton(WorkItemService)
 _get_product_service = lazy_singleton(WorkProductService)
@@ -177,6 +180,7 @@ class ReviewChangesRequest(BaseModel):
     company_id: str
     change_request: str
     return_to_agent_id: Optional[str] = None
+
 
 def _assignee_display(item: Any) -> Optional[Dict[str, Any]]:
     """Return structured assignee display info (GH#8223).
@@ -501,6 +505,8 @@ async def handoff_to_agent(
         raise HTTPException(status_code=403, detail=str(exc))
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
+
+
 # ------------------------------------------------------------------
 # Handoff routes (GH#8231)
 # ------------------------------------------------------------------
@@ -583,6 +589,7 @@ async def get_handoff_brief(
         return {"work_item_id": work_item_id, "brief": brief}
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
+
 
 @router.get("/{work_item_id}/products")
 async def list_work_products(

--- a/autobot-backend/llc/kb/__init__.py
+++ b/autobot-backend/llc/kb/__init__.py
@@ -4,4 +4,5 @@ from .ac_suggester import AcSuggester
 from .collections import KbCollectionManager
 from .rag_assembler import AssemblerProfile, LLCContext, LLCRAGAssembler
 from .diary_writer import AgentDiaryKbWriter
-__all__ = ["AcSuggester", "AgentDiaryKbWriter", "AssemblerProfile", "KbCollectionManager", "LLCContext", "LLCRAGAssembler"]
+from .artifact_ingestor import ArtifactIngestor
+__all__ = ["AcSuggester", "AgentDiaryKbWriter", "ArtifactIngestor", "AssemblerProfile", "KbCollectionManager", "LLCContext", "LLCRAGAssembler"]

--- a/autobot-backend/llc/kb/artifact_ingestor.py
+++ b/autobot-backend/llc/kb/artifact_ingestor.py
@@ -29,9 +29,29 @@ _CHUNK_OVERLAP = 200
 
 # Extensions treated as plain text (match WorkItemKB._TEXT_EXTENSIONS).
 _TEXT_EXTENSIONS = {
-    ".md", ".txt", ".py", ".js", ".ts", ".go", ".rs", ".java",
-    ".c", ".cpp", ".h", ".rb", ".sh", ".yaml", ".yml", ".toml",
-    ".ini", ".cfg", ".sql", ".html", ".css", ".jsx", ".tsx",
+    ".md",
+    ".txt",
+    ".py",
+    ".js",
+    ".ts",
+    ".go",
+    ".rs",
+    ".java",
+    ".c",
+    ".cpp",
+    ".h",
+    ".rb",
+    ".sh",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".ini",
+    ".cfg",
+    ".sql",
+    ".html",
+    ".css",
+    ".jsx",
+    ".tsx",
 }
 
 
@@ -78,9 +98,7 @@ class ArtifactIngestor:
         """
         from sqlalchemy import select
 
-        result = await session.execute(
-            select(LLCWorkProduct).where(LLCWorkProduct.id == uuid.UUID(work_product_id))
-        )
+        result = await session.execute(select(LLCWorkProduct).where(LLCWorkProduct.id == uuid.UUID(work_product_id)))
         product = result.scalar_one_or_none()
         if product is None:
             logger.warning("ArtifactIngestor: work product %s not found", work_product_id)

--- a/autobot-backend/llc/kb/artifact_ingestor.py
+++ b/autobot-backend/llc/kb/artifact_ingestor.py
@@ -1,0 +1,206 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""ArtifactIngestor — indexes work product artifacts into the project KB (GH#8242).
+
+Called automatically when a work item transitions to ``done`` via WorkItemService.
+Reads ``content_text`` or fetches text from ``storage_path`` (text-only; binary
+files are skipped with ``kb_indexed = false``).
+
+Text is split into ≤1000-token chunks (approximated as ≤4000 characters) and
+added to the ``project:{project_id}`` ChromaDB collection with metadata that
+links each chunk back to the source work item.
+"""
+
+import logging
+import os
+import uuid
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.work_product import LLCWorkProduct
+
+logger = logging.getLogger(__name__)
+
+# Approximate 1 token ≈ 4 chars; target ≤1000 tokens ≈ 4000 chars per chunk.
+_CHUNK_SIZE = 4000
+_CHUNK_OVERLAP = 200
+
+# Extensions treated as plain text (match WorkItemKB._TEXT_EXTENSIONS).
+_TEXT_EXTENSIONS = {
+    ".md", ".txt", ".py", ".js", ".ts", ".go", ".rs", ".java",
+    ".c", ".cpp", ".h", ".rb", ".sh", ".yaml", ".yml", ".toml",
+    ".ini", ".cfg", ".sql", ".html", ".css", ".jsx", ".tsx",
+}
+
+
+def _is_text_path(path: str) -> bool:
+    ext = os.path.splitext(path)[1].lower()
+    return ext in _TEXT_EXTENSIONS
+
+
+def _split_text(text: str) -> List[str]:
+    """Split text into overlapping chunks of ~_CHUNK_SIZE characters."""
+    if len(text) <= _CHUNK_SIZE:
+        return [text]
+    chunks: List[str] = []
+    start = 0
+    while start < len(text):
+        end = start + _CHUNK_SIZE
+        chunks.append(text[start:end])
+        start += _CHUNK_SIZE - _CHUNK_OVERLAP
+    return chunks
+
+
+class ArtifactIngestor:
+    """Indexes work product text content into the project ChromaDB collection."""
+
+    async def ingest(
+        self,
+        session: AsyncSession,
+        work_product_id: str,
+        project_id: Optional[str],
+        work_item_identifier: str,
+        completed_at: Optional[Any] = None,
+    ) -> bool:
+        """Read a work product row, chunk its text, index into project KB.
+
+        Args:
+            session: Async SQLAlchemy session.
+            work_product_id: UUID of the ``llc_work_products`` row.
+            project_id: UUID of the project (determines target collection).
+            work_item_identifier: Human-readable identifier (e.g. ``MVA-123``).
+            completed_at: When the work item was completed (used as metadata).
+
+        Returns:
+            True if indexed successfully; False if skipped (binary/no project).
+        """
+        from sqlalchemy import select
+
+        result = await session.execute(
+            select(LLCWorkProduct).where(LLCWorkProduct.id == uuid.UUID(work_product_id))
+        )
+        product = result.scalar_one_or_none()
+        if product is None:
+            logger.warning("ArtifactIngestor: work product %s not found", work_product_id)
+            return False
+
+        if not project_id:
+            logger.info(
+                "ArtifactIngestor: work product %s has no project — skipping KB index",
+                work_product_id,
+            )
+            return False
+
+        text = await self._resolve_text(product)
+        if text is None:
+            product.kb_indexed = False
+            await session.flush()
+            return False
+
+        chunks = _split_text(text)
+        collection_name = f"project:{project_id}"
+        meta: Dict[str, Any] = {
+            "work_item_id": str(product.work_item_id),
+            "work_item_identifier": work_item_identifier,
+            "product_type": product.type if isinstance(product.type, str) else product.type.value,
+            "completed_at": str(completed_at) if completed_at else "",
+            "work_product_id": str(product.id),
+            "title": product.title,
+        }
+
+        try:
+            from utils.async_chromadb_client import get_async_chromadb_client
+
+            client = await get_async_chromadb_client()
+            collection = await client.get_or_create_collection(collection_name)
+            ids = [f"wp:{product.id}:chunk:{i}" for i in range(len(chunks))]
+            metadatas = [meta.copy() for _ in chunks]
+            await collection.upsert(ids=ids, documents=chunks, metadatas=metadatas)
+            logger.info(
+                "ArtifactIngestor: indexed %d chunk(s) for work product %s into %s",
+                len(chunks),
+                work_product_id,
+                collection_name,
+            )
+        except Exception:
+            logger.exception(
+                "ArtifactIngestor: failed to index work product %s — marking kb_indexed=false",
+                work_product_id,
+            )
+            product.kb_indexed = False
+            await session.flush()
+            return False
+
+        product.kb_indexed = True
+        await session.flush()
+        return True
+
+    async def ingest_all_pending(
+        self,
+        session: AsyncSession,
+        work_item_id: str,
+        project_id: Optional[str],
+        work_item_identifier: str,
+        completed_at: Optional[Any] = None,
+    ) -> int:
+        """Ingest all non-indexed products for a work item (called on done transition).
+
+        Returns:
+            Number of products successfully indexed.
+        """
+        from sqlalchemy import select
+
+        result = await session.execute(
+            select(LLCWorkProduct).where(
+                LLCWorkProduct.work_item_id == uuid.UUID(work_item_id),
+                LLCWorkProduct.kb_indexed == False,  # noqa: E712
+            )
+        )
+        products = result.scalars().all()
+        count = 0
+        for p in products:
+            ok = await self.ingest(
+                session,
+                str(p.id),
+                project_id,
+                work_item_identifier,
+                completed_at,
+            )
+            if ok:
+                count += 1
+        return count
+
+    async def _resolve_text(self, product: LLCWorkProduct) -> Optional[str]:
+        """Return indexable text from content_text or storage_path, or None to skip."""
+        if product.content_text:
+            return product.content_text
+
+        if product.storage_path:
+            if not _is_text_path(product.storage_path):
+                logger.info(
+                    "ArtifactIngestor: skipping binary storage_path %s for product %s",
+                    product.storage_path,
+                    product.id,
+                )
+                return None
+            try:
+                with open(product.storage_path, encoding="utf-8", errors="replace") as fh:
+                    return fh.read()
+            except Exception:
+                logger.exception(
+                    "ArtifactIngestor: could not read storage_path %s for product %s",
+                    product.storage_path,
+                    product.id,
+                )
+                return None
+
+        logger.info(
+            "ArtifactIngestor: work product %s has no text content — skipping",
+            product.id,
+        )
+        return None
+
+
+__all__ = ["ArtifactIngestor"]

--- a/autobot-backend/llc/models/__init__.py
+++ b/autobot-backend/llc/models/__init__.py
@@ -30,6 +30,7 @@ from .enums import (
     WorkItemPriority,
     WorkItemStatus,
     WorkItemType,
+    WorkProductType,
 )
 from .goal import GoalLevel, GoalStatus, LLCGoal
 from .heartbeat_run import LLCHeartbeatRun
@@ -38,6 +39,7 @@ from .review_gate import LLCReviewGatePolicy
 from .secret import LLCSecret
 from .sprint import LLCPortfolio, LLCProgram, LLCProject, LLCSprint
 from .work_item import LLCWorkItem, LLCWorkItemComment
+from .work_product import LLCWorkProduct
 
 __all__ = [
     "ActorType",
@@ -80,8 +82,10 @@ __all__ = [
     "LLCReviewGatePolicy",
     "LLCWorkItem",
     "LLCWorkItemComment",
+    "LLCWorkProduct",
     "SprintStatus",
     "WorkItemPriority",
     "WorkItemStatus",
     "WorkItemType",
+    "WorkProductType",
 ]

--- a/autobot-backend/llc/models/enums.py
+++ b/autobot-backend/llc/models/enums.py
@@ -164,18 +164,23 @@ class RoutineProduces(str, Enum):
 
 class ExternalPMType(str, Enum):
     """External project management system type (GH#8257)."""
-
     JIRA = "jira"
     AZURE_DEVOPS = "azure_devops"
     TRELLO = "trello"
     ASANA = "asana"
     NONE = "none"
-
-
 class LLCSyncEvent(str, Enum):
     """LLC work item events published to Redis pub/sub (GH#8257)."""
-
     CREATED = "created"
     TRANSITIONED = "transitioned"
     COMMENTED = "commented"
     COMPLETED = "completed"
+class WorkProductType(str, Enum):
+    """Type of work product artifact produced by an agent (GH#8242)."""
+    CODE = "code"
+    DOCUMENT = "document"
+    REPORT = "report"
+    PLAN = "plan"
+    SCREENSHOT = "screenshot"
+    PR_LINK = "pr_link"
+    OTHER = "other"

--- a/autobot-backend/llc/models/work_item.py
+++ b/autobot-backend/llc/models/work_item.py
@@ -136,6 +136,12 @@ class LLCWorkItem(Base):
         cascade="all, delete-orphan",
         lazy="selectin",
     )
+    work_products: Mapped[List["LLCWorkProduct"]] = relationship(  # type: ignore[name-defined]
+        "LLCWorkProduct",
+        back_populates="work_item",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
 
 
 class LLCWorkItemComment(Base):

--- a/autobot-backend/llc/models/work_product.py
+++ b/autobot-backend/llc/models/work_product.py
@@ -1,0 +1,64 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLC work product model — artifacts produced by agents on work item completion (GH#8242)."""
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from user_management.models.base import Base
+
+from .enums import WorkProductType
+
+
+class LLCWorkProduct(Base):
+    """Artifact produced by an agent during or after completing a work item.
+
+    ``kb_indexed`` is set to True by ArtifactIngestor after the content has
+    been chunked and indexed into the project ChromaDB collection.
+    """
+
+    __tablename__ = "llc_work_products"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    company_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    work_item_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        sa.ForeignKey("llc_work_items.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    heartbeat_run_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        sa.ForeignKey("llc_heartbeat_runs.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    type: Mapped[str] = mapped_column(
+        sa.Enum(WorkProductType, name="workproducttype", create_type=False),
+        nullable=False,
+    )
+    title: Mapped[str] = mapped_column(sa.String(512), nullable=False)
+    content_text: Mapped[Optional[str]] = mapped_column(sa.Text, nullable=True)
+    storage_path: Mapped[Optional[str]] = mapped_column(sa.Text, nullable=True)
+    url: Mapped[Optional[str]] = mapped_column(sa.Text, nullable=True)
+    kb_indexed: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default="false")
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+    )
+
+    work_item: Mapped["LLCWorkItem"] = relationship(  # type: ignore[name-defined]
+        "LLCWorkItem",
+        back_populates="work_products",
+        lazy="selectin",
+    )

--- a/autobot-backend/llc/services/__init__.py
+++ b/autobot-backend/llc/services/__init__.py
@@ -21,6 +21,7 @@ from .review_gate import (
 from .routine_service import RoutineService
 from .sprint_autoclose import SprintAutoCloseService
 from .sprint_planning import SprintNotFound, SprintPlanningService
+from .work_product_service import WorkProductService
 
 __all__ = [
     "ApprovalService",
@@ -39,4 +40,5 @@ __all__ = [
     "SprintAutoCloseService",
     "SprintNotFound",
     "SprintPlanningService",
+    "WorkProductService",
 ]

--- a/autobot-backend/llc/services/handoff.py
+++ b/autobot-backend/llc/services/handoff.py
@@ -83,9 +83,7 @@ class HandoffService(LLCServiceBase):
         await self._release_redis_key(work_item_id, user_id)
         await self._publish_h2a_notification(company_id, target_agent_id, work_item_id)
         await self._record_h2a_activity(session, company_id, user_id, work_item_id, target_agent_id)
-        return HandoffResult(
-            work_item_id=work_item_id, target_agent_id=target_agent_id, kb_doc_ids=kb_doc_ids, review_brief=review_brief
-        )
+        return HandoffResult(work_item_id=work_item_id, target_agent_id=target_agent_id, kb_doc_ids=kb_doc_ids, review_brief=review_brief)
 
     async def agent_to_human(
         self,
@@ -96,9 +94,7 @@ class HandoffService(LLCServiceBase):
         company_id: str,
         agent_notes: Optional[str] = None,
     ) -> LLCWorkItem:
-        result = await session.execute(
-            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
-        )
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -123,28 +119,13 @@ class HandoffService(LLCServiceBase):
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-
-                await self.activity_log.record(
-                    session,
-                    company_id=company_id,
-                    actor_type=ActorType.AGENT,
-                    actor_id=agent_id,
-                    event_type=ActivityEventType.WORK_ITEM_HANDOFF,
-                    entity_type="work_item",
-                    entity_id=work_item_id,
-                    after={"status": WorkItemStatus.IN_REVIEW.value, "reviewer_user_id": reviewer_user_id},
-                    metadata={"brief": brief},
-                )
+                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.AGENT, actor_id=agent_id, event_type=ActivityEventType.WORK_ITEM_HANDOFF, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_REVIEW.value, "reviewer_user_id": reviewer_user_id}, metadata={"brief": brief})
             except Exception:
                 logger.warning("Activity log failed for agent_to_human %s", work_item_id)
         return item
 
-    async def approve(
-        self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str
-    ) -> LLCWorkItem:
-        result = await session.execute(
-            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
-        )
+    async def approve(self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str) -> LLCWorkItem:
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -163,33 +144,13 @@ class HandoffService(LLCServiceBase):
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-
-                await self.activity_log.record(
-                    session,
-                    company_id=company_id,
-                    actor_type=ActorType.USER,
-                    actor_id=reviewer_user_id,
-                    event_type=ActivityEventType.WORK_ITEM_REVIEW_APPROVED,
-                    entity_type="work_item",
-                    entity_id=work_item_id,
-                    after={"status": WorkItemStatus.DONE.value, "completed_at": now.isoformat()},
-                )
+                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_APPROVED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.DONE.value, "completed_at": now.isoformat()})
             except Exception:
                 logger.warning("Activity log failed for approve %s", work_item_id)
         return item
 
-    async def request_changes(
-        self,
-        session: AsyncSession,
-        work_item_id: str,
-        reviewer_user_id: str,
-        company_id: str,
-        change_request: str,
-        return_to_agent_id: Optional[str] = None,
-    ) -> LLCWorkItem:
-        result = await session.execute(
-            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
-        )
+    async def request_changes(self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str, change_request: str, return_to_agent_id: Optional[str] = None) -> LLCWorkItem:
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -203,32 +164,14 @@ class HandoffService(LLCServiceBase):
         item.version += 1
         await session.flush()
         from ..models.work_item import LLCWorkItemComment
-
-        comment = LLCWorkItemComment(
-            id=uuid.uuid4(),
-            company_id=uuid.UUID(company_id),
-            work_item_id=uuid.UUID(work_item_id),
-            body=change_request,
-            author_user_id=uuid.UUID(reviewer_user_id),
-        )
+        comment = LLCWorkItemComment(id=uuid.uuid4(), company_id=uuid.UUID(company_id), work_item_id=uuid.UUID(work_item_id), body=change_request, author_user_id=uuid.UUID(reviewer_user_id))
         session.add(comment)
         await session.flush()
         if self.activity_log:
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-
-                await self.activity_log.record(
-                    session,
-                    company_id=company_id,
-                    actor_type=ActorType.USER,
-                    actor_id=reviewer_user_id,
-                    event_type=ActivityEventType.WORK_ITEM_REVIEW_CHANGES_REQUESTED,
-                    entity_type="work_item",
-                    entity_id=work_item_id,
-                    after={"status": WorkItemStatus.IN_PROGRESS.value, "assignee_agent_id": return_to_agent_id},
-                    metadata={"change_request": change_request},
-                )
+                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_CHANGES_REQUESTED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_PROGRESS.value, "assignee_agent_id": return_to_agent_id}, metadata={"change_request": change_request})
             except Exception:
                 logger.warning("Activity log failed for request_changes %s", work_item_id)
         return item
@@ -241,37 +184,24 @@ class HandoffService(LLCServiceBase):
         return item.review_brief
 
     async def _get_and_validate_human(self, session: AsyncSession, work_item_id: str, user_id: str) -> LLCWorkItem:
-        result = await session.execute(
-            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
-        )
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
         holder_user_id = str(item.assignee_user_id) if item.assignee_user_id else None
         if item.assignee_type != "user" or holder_user_id != user_id:
-            raise HandoffNotAuthorized(
-                f"User {user_id} does not hold work item {work_item_id} (current holder: {holder_user_id!r}, type: {item.assignee_type!r})"
-            )
+            raise HandoffNotAuthorized(f"User {user_id} does not hold work item {work_item_id} (current holder: {holder_user_id!r}, type: {item.assignee_type!r})")
         return item
 
-    async def _ingest_kb(
-        self, work_item_id: str, user_id: str, human_notes: str, attachments: List[HandoffAttachment]
-    ) -> List[str]:
+    async def _ingest_kb(self, work_item_id: str, user_id: str, human_notes: str, attachments: List[HandoffAttachment]) -> List[str]:
         from ..kb.work_item_kb import WorkItemKB
-
         kb = WorkItemKB()
         doc_ids: List[str] = []
         if human_notes.strip():
             doc_id = await kb.ingest_notes(work_item_id=work_item_id, notes=human_notes, source_user_id=user_id)
             doc_ids.append(doc_id)
         for att in attachments:
-            doc_id = await kb.ingest_attachment(
-                work_item_id=work_item_id,
-                attachment_id=att.attachment_id,
-                filename=att.filename,
-                content=att.content,
-                mime_type=att.mime_type,
-            )
+            doc_id = await kb.ingest_attachment(work_item_id=work_item_id, attachment_id=att.attachment_id, filename=att.filename, content=att.content, mime_type=att.mime_type)
             if doc_id:
                 doc_ids.append(doc_id)
         return doc_ids
@@ -286,14 +216,7 @@ class HandoffService(LLCServiceBase):
             await redis.delete(key)
 
     async def _publish_h2a_notification(self, company_id: str, target_agent_id: str, work_item_id: str) -> None:
-        payload = json.dumps(
-            {
-                "event": "work_item.handoff_ready",
-                "work_item_id": work_item_id,
-                "target_agent_id": target_agent_id,
-                "has_human_handoff_context": True,
-            }
-        )
+        payload = json.dumps({"event": "work_item.handoff_ready", "work_item_id": work_item_id, "target_agent_id": target_agent_id, "has_human_handoff_context": True})
         channel = f"{_NOTIFICATION_CHANNEL_PREFIX}{company_id}"
         try:
             redis = await get_async_redis_client()
@@ -303,80 +226,29 @@ class HandoffService(LLCServiceBase):
         except Exception:
             logger.exception("Failed to publish h2a handoff notification for work_item %s — non-fatal", work_item_id)
 
-    async def _publish_a2h_notification(
-        self, company_id: str, work_item_id: str, reviewer_user_id: str, brief: Dict[str, Any]
-    ) -> None:
+    async def _publish_a2h_notification(self, company_id: str, work_item_id: str, reviewer_user_id: str, brief: Dict[str, Any]) -> None:
         redis = await get_async_redis_client()
         if redis is None:
             logger.warning("HandoffService: Redis unavailable, dropping a2h notification")
             return
         try:
             channel = f"{_NOTIFICATION_CHANNEL_PREFIX}{company_id}"
-            await redis.publish(
-                channel,
-                json.dumps(
-                    {
-                        "event_type": "work_item.handoff",
-                        "work_item_id": work_item_id,
-                        "reviewer_user_id": reviewer_user_id,
-                        "brief_title": brief.get("title"),
-                        "brief_identifier": brief.get("identifier"),
-                    }
-                ),
-            )
+            await redis.publish(channel, json.dumps({"event_type": "work_item.handoff", "work_item_id": work_item_id, "reviewer_user_id": reviewer_user_id, "brief_title": brief.get("title"), "brief_identifier": brief.get("identifier")}))
         except Exception:
             logger.debug("HandoffService._publish_a2h_notification failed (swallowed)")
 
-    async def _record_h2a_activity(
-        self, session: AsyncSession, company_id: str, user_id: str, work_item_id: str, target_agent_id: str
-    ) -> None:
+    async def _record_h2a_activity(self, session: AsyncSession, company_id: str, user_id: str, work_item_id: str, target_agent_id: str) -> None:
         if not self.activity_log:
             return
         try:
             from .activity_log import ActivityEventType
-
-            await self.activity_log.record(
-                session,
-                company_id=company_id,
-                actor_type="user",
-                actor_id=user_id,
-                event_type=ActivityEventType.WORK_ITEM_ASSIGNED,
-                entity_type="work_item",
-                entity_id=work_item_id,
-                after={
-                    "assignee_type": "agent",
-                    "assignee_agent_id": target_agent_id,
-                    "status": WorkItemStatus.READY.value,
-                    "has_human_handoff_context": True,
-                },
-            )
+            await self.activity_log.record(session, company_id=company_id, actor_type="user", actor_id=user_id, event_type=ActivityEventType.WORK_ITEM_ASSIGNED, entity_type="work_item", entity_id=work_item_id, after={"assignee_type": "agent", "assignee_agent_id": target_agent_id, "status": WorkItemStatus.READY.value, "has_human_handoff_context": True})
         except Exception:
             logger.warning("Activity log failed for h2a handoff work_item=%s", work_item_id)
 
     def _generate_brief(self, item: LLCWorkItem, agent_notes: Optional[str]) -> Dict[str, Any]:
-        comment_excerpts = [
-            {
-                "author_agent_id": str(c.author_agent_id) if c.author_agent_id else None,
-                "author_user_id": str(c.author_user_id) if c.author_user_id else None,
-                "excerpt": c.body[:200],
-            }
-            for c in (item.comments or [])
-        ]
-        return {
-            "work_item_id": str(item.id),
-            "identifier": item.identifier,
-            "title": item.title,
-            "type": item.type.value if hasattr(item.type, "value") else item.type,
-            "status_before_handoff": item.status.value if hasattr(item.status, "value") else item.status,
-            "priority": item.priority.value if hasattr(item.priority, "value") else item.priority,
-            "description_excerpt": (item.description or "")[:500],
-            "acceptance_criteria": item.acceptance_criteria or [],
-            "comment_count": len(item.comments or []),
-            "recent_comments": comment_excerpts[-5:],
-            "agent_notes": agent_notes,
-            "generated_at": datetime.now(timezone.utc).isoformat(),
-            "generator": "stub-phase4",
-        }
+        comment_excerpts = [{"author_agent_id": str(c.author_agent_id) if c.author_agent_id else None, "author_user_id": str(c.author_user_id) if c.author_user_id else None, "excerpt": c.body[:200]} for c in (item.comments or [])]
+        return {"work_item_id": str(item.id), "identifier": item.identifier, "title": item.title, "type": item.type.value if hasattr(item.type, "value") else item.type, "status_before_handoff": item.status.value if hasattr(item.status, "value") else item.status, "priority": item.priority.value if hasattr(item.priority, "value") else item.priority, "description_excerpt": (item.description or "")[:500], "acceptance_criteria": item.acceptance_criteria or [], "comment_count": len(item.comments or []), "recent_comments": comment_excerpts[-5:], "agent_notes": agent_notes, "generated_at": datetime.now(timezone.utc).isoformat(), "generator": "stub-phase4"}
 
     def _assert_reviewer(self, item: LLCWorkItem, reviewer_user_id: str) -> None:
         if item.reviewer_user_id is None or str(item.reviewer_user_id) != reviewer_user_id:

--- a/autobot-backend/llc/services/handoff.py
+++ b/autobot-backend/llc/services/handoff.py
@@ -83,7 +83,9 @@ class HandoffService(LLCServiceBase):
         await self._release_redis_key(work_item_id, user_id)
         await self._publish_h2a_notification(company_id, target_agent_id, work_item_id)
         await self._record_h2a_activity(session, company_id, user_id, work_item_id, target_agent_id)
-        return HandoffResult(work_item_id=work_item_id, target_agent_id=target_agent_id, kb_doc_ids=kb_doc_ids, review_brief=review_brief)
+        return HandoffResult(
+            work_item_id=work_item_id, target_agent_id=target_agent_id, kb_doc_ids=kb_doc_ids, review_brief=review_brief
+        )
 
     async def agent_to_human(
         self,
@@ -94,7 +96,9 @@ class HandoffService(LLCServiceBase):
         company_id: str,
         agent_notes: Optional[str] = None,
     ) -> LLCWorkItem:
-        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
+        )
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -119,13 +123,28 @@ class HandoffService(LLCServiceBase):
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.AGENT, actor_id=agent_id, event_type=ActivityEventType.WORK_ITEM_HANDOFF, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_REVIEW.value, "reviewer_user_id": reviewer_user_id}, metadata={"brief": brief})
+
+                await self.activity_log.record(
+                    session,
+                    company_id=company_id,
+                    actor_type=ActorType.AGENT,
+                    actor_id=agent_id,
+                    event_type=ActivityEventType.WORK_ITEM_HANDOFF,
+                    entity_type="work_item",
+                    entity_id=work_item_id,
+                    after={"status": WorkItemStatus.IN_REVIEW.value, "reviewer_user_id": reviewer_user_id},
+                    metadata={"brief": brief},
+                )
             except Exception:
                 logger.warning("Activity log failed for agent_to_human %s", work_item_id)
         return item
 
-    async def approve(self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str) -> LLCWorkItem:
-        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+    async def approve(
+        self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str
+    ) -> LLCWorkItem:
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
+        )
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -144,13 +163,33 @@ class HandoffService(LLCServiceBase):
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_APPROVED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.DONE.value, "completed_at": now.isoformat()})
+
+                await self.activity_log.record(
+                    session,
+                    company_id=company_id,
+                    actor_type=ActorType.USER,
+                    actor_id=reviewer_user_id,
+                    event_type=ActivityEventType.WORK_ITEM_REVIEW_APPROVED,
+                    entity_type="work_item",
+                    entity_id=work_item_id,
+                    after={"status": WorkItemStatus.DONE.value, "completed_at": now.isoformat()},
+                )
             except Exception:
                 logger.warning("Activity log failed for approve %s", work_item_id)
         return item
 
-    async def request_changes(self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str, change_request: str, return_to_agent_id: Optional[str] = None) -> LLCWorkItem:
-        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+    async def request_changes(
+        self,
+        session: AsyncSession,
+        work_item_id: str,
+        reviewer_user_id: str,
+        company_id: str,
+        change_request: str,
+        return_to_agent_id: Optional[str] = None,
+    ) -> LLCWorkItem:
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
+        )
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -164,14 +203,32 @@ class HandoffService(LLCServiceBase):
         item.version += 1
         await session.flush()
         from ..models.work_item import LLCWorkItemComment
-        comment = LLCWorkItemComment(id=uuid.uuid4(), company_id=uuid.UUID(company_id), work_item_id=uuid.UUID(work_item_id), body=change_request, author_user_id=uuid.UUID(reviewer_user_id))
+
+        comment = LLCWorkItemComment(
+            id=uuid.uuid4(),
+            company_id=uuid.UUID(company_id),
+            work_item_id=uuid.UUID(work_item_id),
+            body=change_request,
+            author_user_id=uuid.UUID(reviewer_user_id),
+        )
         session.add(comment)
         await session.flush()
         if self.activity_log:
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_CHANGES_REQUESTED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_PROGRESS.value, "assignee_agent_id": return_to_agent_id}, metadata={"change_request": change_request})
+
+                await self.activity_log.record(
+                    session,
+                    company_id=company_id,
+                    actor_type=ActorType.USER,
+                    actor_id=reviewer_user_id,
+                    event_type=ActivityEventType.WORK_ITEM_REVIEW_CHANGES_REQUESTED,
+                    entity_type="work_item",
+                    entity_id=work_item_id,
+                    after={"status": WorkItemStatus.IN_PROGRESS.value, "assignee_agent_id": return_to_agent_id},
+                    metadata={"change_request": change_request},
+                )
             except Exception:
                 logger.warning("Activity log failed for request_changes %s", work_item_id)
         return item
@@ -184,24 +241,37 @@ class HandoffService(LLCServiceBase):
         return item.review_brief
 
     async def _get_and_validate_human(self, session: AsyncSession, work_item_id: str, user_id: str) -> LLCWorkItem:
-        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
+        )
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
         holder_user_id = str(item.assignee_user_id) if item.assignee_user_id else None
         if item.assignee_type != "user" or holder_user_id != user_id:
-            raise HandoffNotAuthorized(f"User {user_id} does not hold work item {work_item_id} (current holder: {holder_user_id!r}, type: {item.assignee_type!r})")
+            raise HandoffNotAuthorized(
+                f"User {user_id} does not hold work item {work_item_id} (current holder: {holder_user_id!r}, type: {item.assignee_type!r})"
+            )
         return item
 
-    async def _ingest_kb(self, work_item_id: str, user_id: str, human_notes: str, attachments: List[HandoffAttachment]) -> List[str]:
+    async def _ingest_kb(
+        self, work_item_id: str, user_id: str, human_notes: str, attachments: List[HandoffAttachment]
+    ) -> List[str]:
         from ..kb.work_item_kb import WorkItemKB
+
         kb = WorkItemKB()
         doc_ids: List[str] = []
         if human_notes.strip():
             doc_id = await kb.ingest_notes(work_item_id=work_item_id, notes=human_notes, source_user_id=user_id)
             doc_ids.append(doc_id)
         for att in attachments:
-            doc_id = await kb.ingest_attachment(work_item_id=work_item_id, attachment_id=att.attachment_id, filename=att.filename, content=att.content, mime_type=att.mime_type)
+            doc_id = await kb.ingest_attachment(
+                work_item_id=work_item_id,
+                attachment_id=att.attachment_id,
+                filename=att.filename,
+                content=att.content,
+                mime_type=att.mime_type,
+            )
             if doc_id:
                 doc_ids.append(doc_id)
         return doc_ids
@@ -216,7 +286,14 @@ class HandoffService(LLCServiceBase):
             await redis.delete(key)
 
     async def _publish_h2a_notification(self, company_id: str, target_agent_id: str, work_item_id: str) -> None:
-        payload = json.dumps({"event": "work_item.handoff_ready", "work_item_id": work_item_id, "target_agent_id": target_agent_id, "has_human_handoff_context": True})
+        payload = json.dumps(
+            {
+                "event": "work_item.handoff_ready",
+                "work_item_id": work_item_id,
+                "target_agent_id": target_agent_id,
+                "has_human_handoff_context": True,
+            }
+        )
         channel = f"{_NOTIFICATION_CHANNEL_PREFIX}{company_id}"
         try:
             redis = await get_async_redis_client()
@@ -226,29 +303,80 @@ class HandoffService(LLCServiceBase):
         except Exception:
             logger.exception("Failed to publish h2a handoff notification for work_item %s — non-fatal", work_item_id)
 
-    async def _publish_a2h_notification(self, company_id: str, work_item_id: str, reviewer_user_id: str, brief: Dict[str, Any]) -> None:
+    async def _publish_a2h_notification(
+        self, company_id: str, work_item_id: str, reviewer_user_id: str, brief: Dict[str, Any]
+    ) -> None:
         redis = await get_async_redis_client()
         if redis is None:
             logger.warning("HandoffService: Redis unavailable, dropping a2h notification")
             return
         try:
             channel = f"{_NOTIFICATION_CHANNEL_PREFIX}{company_id}"
-            await redis.publish(channel, json.dumps({"event_type": "work_item.handoff", "work_item_id": work_item_id, "reviewer_user_id": reviewer_user_id, "brief_title": brief.get("title"), "brief_identifier": brief.get("identifier")}))
+            await redis.publish(
+                channel,
+                json.dumps(
+                    {
+                        "event_type": "work_item.handoff",
+                        "work_item_id": work_item_id,
+                        "reviewer_user_id": reviewer_user_id,
+                        "brief_title": brief.get("title"),
+                        "brief_identifier": brief.get("identifier"),
+                    }
+                ),
+            )
         except Exception:
             logger.debug("HandoffService._publish_a2h_notification failed (swallowed)")
 
-    async def _record_h2a_activity(self, session: AsyncSession, company_id: str, user_id: str, work_item_id: str, target_agent_id: str) -> None:
+    async def _record_h2a_activity(
+        self, session: AsyncSession, company_id: str, user_id: str, work_item_id: str, target_agent_id: str
+    ) -> None:
         if not self.activity_log:
             return
         try:
             from .activity_log import ActivityEventType
-            await self.activity_log.record(session, company_id=company_id, actor_type="user", actor_id=user_id, event_type=ActivityEventType.WORK_ITEM_ASSIGNED, entity_type="work_item", entity_id=work_item_id, after={"assignee_type": "agent", "assignee_agent_id": target_agent_id, "status": WorkItemStatus.READY.value, "has_human_handoff_context": True})
+
+            await self.activity_log.record(
+                session,
+                company_id=company_id,
+                actor_type="user",
+                actor_id=user_id,
+                event_type=ActivityEventType.WORK_ITEM_ASSIGNED,
+                entity_type="work_item",
+                entity_id=work_item_id,
+                after={
+                    "assignee_type": "agent",
+                    "assignee_agent_id": target_agent_id,
+                    "status": WorkItemStatus.READY.value,
+                    "has_human_handoff_context": True,
+                },
+            )
         except Exception:
             logger.warning("Activity log failed for h2a handoff work_item=%s", work_item_id)
 
     def _generate_brief(self, item: LLCWorkItem, agent_notes: Optional[str]) -> Dict[str, Any]:
-        comment_excerpts = [{"author_agent_id": str(c.author_agent_id) if c.author_agent_id else None, "author_user_id": str(c.author_user_id) if c.author_user_id else None, "excerpt": c.body[:200]} for c in (item.comments or [])]
-        return {"work_item_id": str(item.id), "identifier": item.identifier, "title": item.title, "type": item.type.value if hasattr(item.type, "value") else item.type, "status_before_handoff": item.status.value if hasattr(item.status, "value") else item.status, "priority": item.priority.value if hasattr(item.priority, "value") else item.priority, "description_excerpt": (item.description or "")[:500], "acceptance_criteria": item.acceptance_criteria or [], "comment_count": len(item.comments or []), "recent_comments": comment_excerpts[-5:], "agent_notes": agent_notes, "generated_at": datetime.now(timezone.utc).isoformat(), "generator": "stub-phase4"}
+        comment_excerpts = [
+            {
+                "author_agent_id": str(c.author_agent_id) if c.author_agent_id else None,
+                "author_user_id": str(c.author_user_id) if c.author_user_id else None,
+                "excerpt": c.body[:200],
+            }
+            for c in (item.comments or [])
+        ]
+        return {
+            "work_item_id": str(item.id),
+            "identifier": item.identifier,
+            "title": item.title,
+            "type": item.type.value if hasattr(item.type, "value") else item.type,
+            "status_before_handoff": item.status.value if hasattr(item.status, "value") else item.status,
+            "priority": item.priority.value if hasattr(item.priority, "value") else item.priority,
+            "description_excerpt": (item.description or "")[:500],
+            "acceptance_criteria": item.acceptance_criteria or [],
+            "comment_count": len(item.comments or []),
+            "recent_comments": comment_excerpts[-5:],
+            "agent_notes": agent_notes,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "generator": "stub-phase4",
+        }
 
     def _assert_reviewer(self, item: LLCWorkItem, reviewer_user_id: str) -> None:
         if item.reviewer_user_id is None or str(item.reviewer_user_id) != reviewer_user_id:

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -594,6 +594,10 @@ class WorkItemService(LLCServiceBase):
             item.cancelled_at = now
         item.version += 1
         await session.flush()
+
+        if new_status == WorkItemStatus.DONE:
+            await self._trigger_artifact_ingest(session, item)
+
         return item
 
     # ------------------------------------------------------------------
@@ -667,6 +671,8 @@ class WorkItemService(LLCServiceBase):
         item.checkout_locked_at = None
         item.version += 1
         await session.flush()
+
+        await self._trigger_artifact_ingest(session, item)
 
         if self.activity_log:
             try:
@@ -751,3 +757,27 @@ class WorkItemService(LLCServiceBase):
                     exc_info=True,
                 )
         return f"WI-{uuid.uuid4().hex[:8].upper()}"
+
+    async def _trigger_artifact_ingest(
+        self,
+        session: AsyncSession,
+        item: LLCWorkItem,
+    ) -> None:
+        """Non-fatally call ArtifactIngestor for all pending products on this item."""
+        try:
+            from ..kb.artifact_ingestor import ArtifactIngestor
+
+            ingestor = ArtifactIngestor()
+            await ingestor.ingest_all_pending(
+                session,
+                work_item_id=str(item.id),
+                project_id=str(item.project_id) if item.project_id else None,
+                work_item_identifier=item.identifier,
+                completed_at=item.completed_at,
+            )
+        except Exception:
+            logger.warning(
+                "ArtifactIngestor failed for work item %s — transition still succeeds",
+                item.id,
+                exc_info=True,
+            )

--- a/autobot-backend/llc/services/work_product_service.py
+++ b/autobot-backend/llc/services/work_product_service.py
@@ -97,10 +97,7 @@ class WorkProductService(LLCServiceBase):
             ids = results.get("ids", [])
             docs = results.get("documents", [])
             metas = results.get("metadatas", [])
-            return [
-                {"id": doc_id, "document": doc, "metadata": meta}
-                for doc_id, doc, meta in zip(ids, docs, metas)
-            ]
+            return [{"id": doc_id, "document": doc, "metadata": meta} for doc_id, doc, meta in zip(ids, docs, metas)]
         except Exception:
             import logging
 

--- a/autobot-backend/llc/services/work_product_service.py
+++ b/autobot-backend/llc/services/work_product_service.py
@@ -1,0 +1,111 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""WorkProductService — CRUD for LLC work products (GH#8242)."""
+
+import uuid
+from typing import List, Optional, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.enums import WorkProductType
+from ..models.work_product import LLCWorkProduct
+from . import LLCServiceBase
+
+
+class WorkProductService(LLCServiceBase):
+    """Creates and retrieves work products; indexing is handled by ArtifactIngestor."""
+
+    async def create(
+        self,
+        session: AsyncSession,
+        company_id: str,
+        work_item_id: str,
+        type: WorkProductType,
+        title: str,
+        *,
+        content_text: Optional[str] = None,
+        storage_path: Optional[str] = None,
+        url: Optional[str] = None,
+        heartbeat_run_id: Optional[str] = None,
+    ) -> LLCWorkProduct:
+        product = LLCWorkProduct(
+            id=uuid.uuid4(),
+            company_id=uuid.UUID(company_id),
+            work_item_id=uuid.UUID(work_item_id),
+            type=type,
+            title=title,
+            content_text=content_text,
+            storage_path=storage_path,
+            url=url,
+            heartbeat_run_id=uuid.UUID(heartbeat_run_id) if heartbeat_run_id else None,
+        )
+        session.add(product)
+        await session.flush()
+        return product
+
+    async def list_by_work_item(
+        self,
+        session: AsyncSession,
+        work_item_id: str,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> Sequence[LLCWorkProduct]:
+        result = await session.execute(
+            select(LLCWorkProduct)
+            .where(LLCWorkProduct.work_item_id == uuid.UUID(work_item_id))
+            .order_by(LLCWorkProduct.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        return result.scalars().all()
+
+    async def list_indexed_by_project(
+        self,
+        session: AsyncSession,
+        project_id: str,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[dict]:
+        """Return recent KB-indexed artifacts for a project via ChromaDB query.
+
+        Falls back to an empty list if ChromaDB is unavailable.
+        """
+        collection_name = f"project:{project_id}"
+        try:
+            from utils.async_chromadb_client import get_async_chromadb_client
+
+            client = await get_async_chromadb_client()
+            try:
+                collection = await client.get_collection(collection_name)
+            except Exception:
+                return []
+
+            count = await collection.count()
+            if count == 0:
+                return []
+
+            n = min(limit, count)
+            results = await collection.get(
+                limit=n,
+                offset=offset,
+                include=["documents", "metadatas"],
+            )
+            ids = results.get("ids", [])
+            docs = results.get("documents", [])
+            metas = results.get("metadatas", [])
+            return [
+                {"id": doc_id, "document": doc, "metadata": meta}
+                for doc_id, doc, meta in zip(ids, docs, metas)
+            ]
+        except Exception:
+            import logging
+
+            logging.getLogger(__name__).exception(
+                "WorkProductService.list_indexed_by_project: ChromaDB error for project %s",
+                project_id,
+            )
+            return []

--- a/autobot-backend/llc/tests/test_artifact_ingestor.py
+++ b/autobot-backend/llc/tests/test_artifact_ingestor.py
@@ -12,7 +12,6 @@ from llc.kb.artifact_ingestor import ArtifactIngestor, _is_text_path, _split_tex
 from llc.models.enums import WorkProductType
 from llc.models.work_product import LLCWorkProduct
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llc/tests/test_artifact_ingestor.py
+++ b/autobot-backend/llc/tests/test_artifact_ingestor.py
@@ -1,0 +1,248 @@
+"""Tests for ArtifactIngestor — work products indexed into project KB (GH#8242)."""
+
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.kb.artifact_ingestor import ArtifactIngestor, _is_text_path, _split_text
+from llc.models.enums import WorkProductType
+from llc.models.work_product import LLCWorkProduct
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_product(
+    *,
+    id: Optional[uuid.UUID] = None,
+    work_item_id: Optional[uuid.UUID] = None,
+    type: WorkProductType = WorkProductType.CODE,
+    title: str = "My artifact",
+    content_text: Optional[str] = None,
+    storage_path: Optional[str] = None,
+    url: Optional[str] = None,
+    kb_indexed: bool = False,
+) -> LLCWorkProduct:
+    p = MagicMock(spec=LLCWorkProduct)
+    p.id = id or uuid.uuid4()
+    p.work_item_id = work_item_id or uuid.uuid4()
+    p.type = type
+    p.title = title
+    p.content_text = content_text
+    p.storage_path = storage_path
+    p.url = url
+    p.kb_indexed = kb_indexed
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_is_text_path_recognises_text_extensions():
+    assert _is_text_path("file.py")
+    assert _is_text_path("README.md")
+    assert _is_text_path("schema.sql")
+    assert _is_text_path("/some/path/config.yml")
+
+
+def test_is_text_path_rejects_binary_extensions():
+    assert not _is_text_path("image.png")
+    assert not _is_text_path("archive.zip")
+    assert not _is_text_path("binary.exe")
+
+
+def test_split_text_short_returns_single_chunk():
+    text = "hello world"
+    chunks = _split_text(text)
+    assert chunks == [text]
+
+
+def test_split_text_long_returns_multiple_chunks():
+    # Produce text longer than _CHUNK_SIZE (4000 chars)
+    text = "x" * 9000
+    chunks = _split_text(text)
+    assert len(chunks) > 1
+    # Every chunk is at most 4000 characters
+    assert all(len(c) <= 4000 for c in chunks)
+    # All original content is present (with overlap, total chars may exceed original)
+    assert any("x" in c for c in chunks)
+
+
+def test_split_text_overlap_between_chunks():
+    # First chunk ends at 4000; second starts at 4000-200=3800
+    text = "a" * 8000
+    chunks = _split_text(text)
+    assert len(chunks) >= 2
+    # Overlap: first chunk[3800:4000] should equal second chunk[0:200]
+    assert chunks[0][3800:4000] == chunks[1][0:200]
+
+
+# ---------------------------------------------------------------------------
+# ArtifactIngestor.ingest — mocked ChromaDB
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ingestor():
+    return ArtifactIngestor()
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    session.flush = AsyncMock()
+    return session
+
+
+@pytest.mark.asyncio
+async def test_ingest_indexes_content_text(ingestor, mock_session):
+    product = _make_product(content_text="def hello(): pass", type=WorkProductType.CODE)
+    project_id = str(uuid.uuid4())
+
+    mock_scalar = MagicMock()
+    mock_scalar.scalar_one_or_none = MagicMock(return_value=product)
+    mock_session.execute.return_value = mock_scalar
+
+    mock_collection = AsyncMock()
+    mock_client = AsyncMock()
+    mock_client.get_or_create_collection = AsyncMock(return_value=mock_collection)
+
+    mock_chroma_module = MagicMock()
+    mock_chroma_module.get_async_chromadb_client = AsyncMock(return_value=mock_client)
+
+    with patch.dict(sys.modules, {"utils.async_chromadb_client": mock_chroma_module}):
+        result = await ingestor.ingest(
+            mock_session,
+            work_product_id=str(product.id),
+            project_id=project_id,
+            work_item_identifier="MVA-1",
+        )
+
+    assert result is True
+    assert product.kb_indexed is True
+    assert mock_session.flush.called
+
+
+@pytest.mark.asyncio
+async def test_ingest_skips_when_no_project(ingestor, mock_session):
+    product = _make_product(content_text="some text")
+    mock_scalar = MagicMock()
+    mock_scalar.scalar_one_or_none = MagicMock(return_value=product)
+    mock_session.execute.return_value = mock_scalar
+
+    result = await ingestor.ingest(
+        mock_session,
+        work_product_id=str(product.id),
+        project_id=None,
+        work_item_identifier="MVA-2",
+    )
+
+    assert result is False
+    # kb_indexed should not have been set to True
+    assert product.kb_indexed != True  # noqa: E712
+
+
+@pytest.mark.asyncio
+async def test_ingest_returns_false_for_missing_product(ingestor, mock_session):
+    mock_scalar = MagicMock()
+    mock_scalar.scalar_one_or_none = MagicMock(return_value=None)
+    mock_session.execute.return_value = mock_scalar
+
+    result = await ingestor.ingest(
+        mock_session,
+        work_product_id=str(uuid.uuid4()),
+        project_id=str(uuid.uuid4()),
+        work_item_identifier="MVA-3",
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_ingest_skips_binary_storage_path(ingestor, mock_session):
+    product = _make_product(storage_path="/tmp/binary.png")
+    mock_scalar = MagicMock()
+    mock_scalar.scalar_one_or_none = MagicMock(return_value=product)
+    mock_session.execute.return_value = mock_scalar
+
+    result = await ingestor.ingest(
+        mock_session,
+        work_product_id=str(product.id),
+        project_id=str(uuid.uuid4()),
+        work_item_identifier="MVA-4",
+    )
+
+    assert result is False
+    assert product.kb_indexed is False
+
+
+@pytest.mark.asyncio
+async def test_ingest_skips_product_with_no_content(ingestor, mock_session):
+    product = _make_product()  # no content_text, no storage_path
+    mock_scalar = MagicMock()
+    mock_scalar.scalar_one_or_none = MagicMock(return_value=product)
+    mock_session.execute.return_value = mock_scalar
+
+    result = await ingestor.ingest(
+        mock_session,
+        work_product_id=str(product.id),
+        project_id=str(uuid.uuid4()),
+        work_item_identifier="MVA-5",
+    )
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_ingest_all_pending_calls_ingest_for_each(ingestor, mock_session):
+    item_id = uuid.uuid4()
+    products = [
+        _make_product(work_item_id=item_id, content_text="chunk1"),
+        _make_product(work_item_id=item_id, content_text="chunk2"),
+    ]
+
+    mock_scalars = MagicMock()
+    mock_scalars.scalars.return_value.all.return_value = products
+    mock_session.execute.return_value = mock_scalars
+
+    with patch.object(ingestor, "ingest", new=AsyncMock(return_value=True)) as mock_ingest:
+        count = await ingestor.ingest_all_pending(
+            mock_session,
+            work_item_id=str(item_id),
+            project_id=str(uuid.uuid4()),
+            work_item_identifier="MVA-6",
+        )
+
+    assert count == 2
+    assert mock_ingest.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_ingest_all_pending_counts_only_successful(ingestor, mock_session):
+    item_id = uuid.uuid4()
+    products = [
+        _make_product(work_item_id=item_id, content_text="ok"),
+        _make_product(work_item_id=item_id, storage_path="/tmp/img.png"),
+    ]
+    mock_scalars = MagicMock()
+    mock_scalars.scalars.return_value.all.return_value = products
+    mock_session.execute.return_value = mock_scalars
+
+    # First succeeds, second fails
+    with patch.object(ingestor, "ingest", new=AsyncMock(side_effect=[True, False])) as mock_ingest:
+        count = await ingestor.ingest_all_pending(
+            mock_session,
+            work_item_id=str(item_id),
+            project_id=str(uuid.uuid4()),
+            work_item_identifier="MVA-7",
+        )
+
+    assert count == 1


### PR DESCRIPTION
## Summary

- Implements GH#8242 (Phase 5): artifact ingestor that indexes agent work products into the project ChromaDB KB when a work item transitions to `done`
- Adds `llc_work_products` table, `ArtifactIngestor`, `WorkProductService`, and three new API endpoints
- Hook in `WorkItemService` fires automatically on both done-transition paths (non-fatal)

## Changes

**Migration:**
- `005_create_llc_work_products_table.py` — `llc_work_products` with `id`, `company_id`, `work_item_id` FK, `heartbeat_run_id` FK nullable, `type`, `title`, `content_text`, `storage_path`, `url`, `kb_indexed`, `created_at`

**Model / Enum:**
- `WorkProductType` enum: `code|document|report|plan|screenshot|pr_link|other`
- `LLCWorkProduct` SQLAlchemy model
- `LLCWorkItem.work_products` relationship added

**KB:**
- `ArtifactIngestor.ingest()` — reads `content_text` or text `storage_path`, splits into ≤1000-token chunks, upserts into `project:{project_id}` ChromaDB collection, sets `kb_indexed=True`
- `ArtifactIngestor.ingest_all_pending()` — called by `WorkItemService` hook on done transition
- Binary files skipped with `kb_indexed=false`

**Services:**
- `WorkProductService`: `create()`, `list_by_work_item()`, `list_indexed_by_project()`
- `WorkItemService._trigger_artifact_ingest()` — non-fatal hook wired into `transition_status()` and `transition_to_done()`

**API:**
- `POST /llc/agent/products` — real implementation replacing Phase 1 stub
- `GET /llc/work-items/{id}/products` — list work products for an item
- `GET /llc/projects/{id}/knowledge` — recent indexed artifacts from project KB

**Tests:**
- `test_artifact_ingestor.py` — 12 tests covering text/binary detection, chunking with overlap, ingest success/skip/error paths, `ingest_all_pending` count accuracy

## Test plan

- [ ] `python -m pytest autobot-backend/llc/tests/test_artifact_ingestor.py` — 12/12 pass
- [ ] Upload a work product via `POST /llc/agent/products`, transition work item to done, verify `kb_indexed=true` and document appears in `GET /llc/projects/{id}/knowledge`
- [ ] Upload a `.png` via `storage_path`, verify it is skipped with `kb_indexed=false`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)