### PR TITLE
feat(llc): company import — collision detection, preview, namespace remapping (#8246)

### DIFF
--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -14,12 +14,12 @@ from .ceo_chat import router as ceo_chat_router
 from .companies import router as companies_router
 from .context import router as context_router
 from .goals import router as goals_router
+from .portability import router as portability_router
 from .review_gate_policies import router as review_gate_router
 from .routines import router as routines_router
 from .runs import router as runs_router
 from .secrets import router as secrets_router
 from .sprints import router as sprints_router
-from .portability import router as portability_router
 from .work_items import router as work_items_router
 
 router = APIRouter(prefix="/llc", tags=["llc"])

--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -19,6 +19,7 @@ from .routines import router as routines_router
 from .runs import router as runs_router
 from .secrets import router as secrets_router
 from .sprints import router as sprints_router
+from .portability import router as portability_router
 from .work_items import router as work_items_router
 
 router = APIRouter(prefix="/llc", tags=["llc"])
@@ -38,6 +39,7 @@ router.include_router(agents_router)
 router.include_router(runs_router)
 router.include_router(ceo_chat_router)
 router.include_router(routines_router)
+router.include_router(portability_router)
 router.include_router(review_gate_router)
 router.include_router(context_router)
 

--- a/autobot-backend/llc/api/portability.py
+++ b/autobot-backend/llc/api/portability.py
@@ -11,12 +11,12 @@ Route group: /llc/import
 import uuid
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
-from fastapi import Depends
 
-from llc.services.portability import ImportError as LLCImportError, PortabilityService
+from llc.services.portability import ImportError as LLCImportError
+from llc.services.portability import PortabilityService
 from user_management.database import get_async_session
 
 router = APIRouter(prefix="/import", tags=["llc-import"])

--- a/autobot-backend/llc/api/portability.py
+++ b/autobot-backend/llc/api/portability.py
@@ -1,0 +1,102 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLC Company Import API routes (GH#8246).
+
+Route group: /llc/import
+  POST /preview  — collision-detection preview (no writes)
+  POST /execute  — transactional import
+"""
+
+import uuid
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import Depends
+
+from llc.services.portability import ImportError as LLCImportError, PortabilityService
+from user_management.database import get_async_session
+
+router = APIRouter(prefix="/import", tags=["llc-import"])
+
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+
+class ImportPreviewRequest(BaseModel):
+    template: Dict[str, Any]
+
+
+class ImportPreviewResponse(BaseModel):
+    collisions: List[Dict[str, Any]]
+    will_create: Dict[str, int]
+    warnings: List[str]
+
+
+class RemappingOptions(BaseModel):
+    require_approval_for_hires: Optional[bool] = None
+
+
+class ImportExecuteRequest(BaseModel):
+    template: Dict[str, Any]
+    target_company_id: Optional[uuid.UUID] = None
+    remapping_options: Optional[RemappingOptions] = None
+    secret_mapping: Optional[Dict[str, str]] = None
+
+
+class ImportExecuteResponse(BaseModel):
+    company_id: str
+    created_entities: Dict[str, List[str]]
+    skipped: Dict[str, List[str]]
+    warnings: List[str]
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/preview",
+    response_model=ImportPreviewResponse,
+    summary="Preview import collisions (no writes)",
+)
+async def preview_import(
+    body: ImportPreviewRequest,
+    session: AsyncSession = Depends(get_async_session),
+) -> ImportPreviewResponse:
+    svc = PortabilityService(session=session)
+    try:
+        result = await svc.preview_import(body.template)
+    except LLCImportError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+    return ImportPreviewResponse(**result)
+
+
+@router.post(
+    "/execute",
+    response_model=ImportExecuteResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Execute transactional company import",
+)
+async def execute_import(
+    body: ImportExecuteRequest,
+    session: AsyncSession = Depends(get_async_session),
+) -> ImportExecuteResponse:
+    remapping = body.remapping_options.model_dump(exclude_none=True) if body.remapping_options else {}
+    svc = PortabilityService(session=session)
+    try:
+        result = await svc.execute_import(
+            body.template,
+            target_company_id=body.target_company_id,
+            remapping_options=remapping,
+            secret_mapping=body.secret_mapping or {},
+        )
+    except LLCImportError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+    await session.commit()
+    return ImportExecuteResponse(**result)

--- a/autobot-backend/llc/api/portability.py
+++ b/autobot-backend/llc/api/portability.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from llc.services.portability import ImportError as LLCImportError
+from llc.services.portability import TemplateImportError as LLCImportError
 from llc.services.portability import PortabilityService
 from user_management.database import get_async_session
 
@@ -29,6 +29,7 @@ router = APIRouter(prefix="/import", tags=["llc-import"])
 
 class ImportPreviewRequest(BaseModel):
     template: Dict[str, Any]
+    target_company_id: Optional[uuid.UUID] = None
 
 
 class ImportPreviewResponse(BaseModel):
@@ -71,7 +72,7 @@ async def preview_import(
 ) -> ImportPreviewResponse:
     svc = PortabilityService(session=session)
     try:
-        result = await svc.preview_import(body.template)
+        result = await svc.preview_import(body.template, target_company_id=body.target_company_id)
     except LLCImportError as exc:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
     return ImportPreviewResponse(**result)

--- a/autobot-backend/llc/services/handoff.py
+++ b/autobot-backend/llc/services/handoff.py
@@ -83,9 +83,7 @@ class HandoffService(LLCServiceBase):
         await self._release_redis_key(work_item_id, user_id)
         await self._publish_h2a_notification(company_id, target_agent_id, work_item_id)
         await self._record_h2a_activity(session, company_id, user_id, work_item_id, target_agent_id)
-        return HandoffResult(
-            work_item_id=work_item_id, target_agent_id=target_agent_id, kb_doc_ids=kb_doc_ids, review_brief=review_brief
-        )
+        return HandoffResult(work_item_id=work_item_id, target_agent_id=target_agent_id, kb_doc_ids=kb_doc_ids, review_brief=review_brief)
 
     async def agent_to_human(
         self,
@@ -96,9 +94,7 @@ class HandoffService(LLCServiceBase):
         company_id: str,
         agent_notes: Optional[str] = None,
     ) -> LLCWorkItem:
-        result = await session.execute(
-            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
-        )
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -123,28 +119,13 @@ class HandoffService(LLCServiceBase):
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-
-                await self.activity_log.record(
-                    session,
-                    company_id=company_id,
-                    actor_type=ActorType.AGENT,
-                    actor_id=agent_id,
-                    event_type=ActivityEventType.WORK_ITEM_HANDOFF,
-                    entity_type="work_item",
-                    entity_id=work_item_id,
-                    after={"status": WorkItemStatus.IN_REVIEW.value, "reviewer_user_id": reviewer_user_id},
-                    metadata={"brief": brief},
-                )
+                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.AGENT, actor_id=agent_id, event_type=ActivityEventType.WORK_ITEM_HANDOFF, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_REVIEW.value, "reviewer_user_id": reviewer_user_id}, metadata={"brief": brief})
             except Exception:
                 logger.warning("Activity log failed for agent_to_human %s", work_item_id)
         return item
 
-    async def approve(
-        self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str
-    ) -> LLCWorkItem:
-        result = await session.execute(
-            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
-        )
+    async def approve(self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str) -> LLCWorkItem:
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -163,33 +144,13 @@ class HandoffService(LLCServiceBase):
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-
-                await self.activity_log.record(
-                    session,
-                    company_id=company_id,
-                    actor_type=ActorType.USER,
-                    actor_id=reviewer_user_id,
-                    event_type=ActivityEventType.WORK_ITEM_REVIEW_APPROVED,
-                    entity_type="work_item",
-                    entity_id=work_item_id,
-                    after={"status": WorkItemStatus.DONE.value, "completed_at": now.isoformat()},
-                )
+                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_APPROVED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.DONE.value, "completed_at": now.isoformat()})
             except Exception:
                 logger.warning("Activity log failed for approve %s", work_item_id)
         return item
 
-    async def request_changes(
-        self,
-        session: AsyncSession,
-        work_item_id: str,
-        reviewer_user_id: str,
-        company_id: str,
-        change_request: str,
-        return_to_agent_id: Optional[str] = None,
-    ) -> LLCWorkItem:
-        result = await session.execute(
-            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
-        )
+    async def request_changes(self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str, change_request: str, return_to_agent_id: Optional[str] = None) -> LLCWorkItem:
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -203,32 +164,14 @@ class HandoffService(LLCServiceBase):
         item.version += 1
         await session.flush()
         from ..models.work_item import LLCWorkItemComment
-
-        comment = LLCWorkItemComment(
-            id=uuid.uuid4(),
-            company_id=uuid.UUID(company_id),
-            work_item_id=uuid.UUID(work_item_id),
-            body=change_request,
-            author_user_id=uuid.UUID(reviewer_user_id),
-        )
+        comment = LLCWorkItemComment(id=uuid.uuid4(), company_id=uuid.UUID(company_id), work_item_id=uuid.UUID(work_item_id), body=change_request, author_user_id=uuid.UUID(reviewer_user_id))
         session.add(comment)
         await session.flush()
         if self.activity_log:
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-
-                await self.activity_log.record(
-                    session,
-                    company_id=company_id,
-                    actor_type=ActorType.USER,
-                    actor_id=reviewer_user_id,
-                    event_type=ActivityEventType.WORK_ITEM_REVIEW_CHANGES_REQUESTED,
-                    entity_type="work_item",
-                    entity_id=work_item_id,
-                    after={"status": WorkItemStatus.IN_PROGRESS.value, "assignee_agent_id": return_to_agent_id},
-                    metadata={"change_request": change_request},
-                )
+                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_CHANGES_REQUESTED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_PROGRESS.value, "assignee_agent_id": return_to_agent_id}, metadata={"change_request": change_request})
             except Exception:
                 logger.warning("Activity log failed for request_changes %s", work_item_id)
         return item
@@ -241,37 +184,24 @@ class HandoffService(LLCServiceBase):
         return item.review_brief
 
     async def _get_and_validate_human(self, session: AsyncSession, work_item_id: str, user_id: str) -> LLCWorkItem:
-        result = await session.execute(
-            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
-        )
+        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
         holder_user_id = str(item.assignee_user_id) if item.assignee_user_id else None
         if item.assignee_type != "user" or holder_user_id != user_id:
-            raise HandoffNotAuthorized(
-                f"User {user_id} does not hold work item {work_item_id} (current holder: {holder_user_id!r}, type: {item.assignee_type!r})"
-            )
+            raise HandoffNotAuthorized(f"User {user_id} does not hold work item {work_item_id} (current holder: {holder_user_id!r}, type: {item.assignee_type!r})")
         return item
 
-    async def _ingest_kb(
-        self, work_item_id: str, user_id: str, human_notes: str, attachments: List[HandoffAttachment]
-    ) -> List[str]:
+    async def _ingest_kb(self, work_item_id: str, user_id: str, human_notes: str, attachments: List[HandoffAttachment]) -> List[str]:
         from ..kb.work_item_kb import WorkItemKB
-
         kb = WorkItemKB()
         doc_ids: List[str] = []
         if human_notes.strip():
             doc_id = await kb.ingest_notes(work_item_id=work_item_id, notes=human_notes, source_user_id=user_id)
             doc_ids.append(doc_id)
         for att in attachments:
-            doc_id = await kb.ingest_attachment(
-                work_item_id=work_item_id,
-                attachment_id=att.attachment_id,
-                filename=att.filename,
-                content=att.content,
-                mime_type=att.mime_type,
-            )
+            doc_id = await kb.ingest_attachment(work_item_id=work_item_id, attachment_id=att.attachment_id, filename=att.filename, content=att.content, mime_type=att.mime_type)
             if doc_id:
                 doc_ids.append(doc_id)
         return doc_ids
@@ -286,14 +216,7 @@ class HandoffService(LLCServiceBase):
             await redis.delete(key)
 
     async def _publish_h2a_notification(self, company_id: str, target_agent_id: str, work_item_id: str) -> None:
-        payload = json.dumps(
-            {
-                "event": "work_item.handoff_ready",
-                "work_item_id": work_item_id,
-                "target_agent_id": target_agent_id,
-                "has_human_handoff_context": True,
-            }
-        )
+        payload = json.dumps({"event": "work_item.handoff_ready", "work_item_id": work_item_id, "target_agent_id": target_agent_id, "has_human_handoff_context": True})
         channel = f"{_NOTIFICATION_CHANNEL_PREFIX}{company_id}"
         try:
             redis = await get_async_redis_client()
@@ -303,80 +226,29 @@ class HandoffService(LLCServiceBase):
         except Exception:
             logger.exception("Failed to publish h2a handoff notification for work_item %s — non-fatal", work_item_id)
 
-    async def _publish_a2h_notification(
-        self, company_id: str, work_item_id: str, reviewer_user_id: str, brief: Dict[str, Any]
-    ) -> None:
+    async def _publish_a2h_notification(self, company_id: str, work_item_id: str, reviewer_user_id: str, brief: Dict[str, Any]) -> None:
         redis = await get_async_redis_client()
         if redis is None:
             logger.warning("HandoffService: Redis unavailable, dropping a2h notification")
             return
         try:
             channel = f"{_NOTIFICATION_CHANNEL_PREFIX}{company_id}"
-            await redis.publish(
-                channel,
-                json.dumps(
-                    {
-                        "event_type": "work_item.handoff",
-                        "work_item_id": work_item_id,
-                        "reviewer_user_id": reviewer_user_id,
-                        "brief_title": brief.get("title"),
-                        "brief_identifier": brief.get("identifier"),
-                    }
-                ),
-            )
+            await redis.publish(channel, json.dumps({"event_type": "work_item.handoff", "work_item_id": work_item_id, "reviewer_user_id": reviewer_user_id, "brief_title": brief.get("title"), "brief_identifier": brief.get("identifier")}))
         except Exception:
             logger.debug("HandoffService._publish_a2h_notification failed (swallowed)")
 
-    async def _record_h2a_activity(
-        self, session: AsyncSession, company_id: str, user_id: str, work_item_id: str, target_agent_id: str
-    ) -> None:
+    async def _record_h2a_activity(self, session: AsyncSession, company_id: str, user_id: str, work_item_id: str, target_agent_id: str) -> None:
         if not self.activity_log:
             return
         try:
             from .activity_log import ActivityEventType
-
-            await self.activity_log.record(
-                session,
-                company_id=company_id,
-                actor_type="user",
-                actor_id=user_id,
-                event_type=ActivityEventType.WORK_ITEM_ASSIGNED,
-                entity_type="work_item",
-                entity_id=work_item_id,
-                after={
-                    "assignee_type": "agent",
-                    "assignee_agent_id": target_agent_id,
-                    "status": WorkItemStatus.READY.value,
-                    "has_human_handoff_context": True,
-                },
-            )
+            await self.activity_log.record(session, company_id=company_id, actor_type="user", actor_id=user_id, event_type=ActivityEventType.WORK_ITEM_ASSIGNED, entity_type="work_item", entity_id=work_item_id, after={"assignee_type": "agent", "assignee_agent_id": target_agent_id, "status": WorkItemStatus.READY.value, "has_human_handoff_context": True})
         except Exception:
             logger.warning("Activity log failed for h2a handoff work_item=%s", work_item_id)
 
     def _generate_brief(self, item: LLCWorkItem, agent_notes: Optional[str]) -> Dict[str, Any]:
-        comment_excerpts = [
-            {
-                "author_agent_id": str(c.author_agent_id) if c.author_agent_id else None,
-                "author_user_id": str(c.author_user_id) if c.author_user_id else None,
-                "excerpt": c.body[:200],
-            }
-            for c in (item.comments or [])
-        ]
-        return {
-            "work_item_id": str(item.id),
-            "identifier": item.identifier,
-            "title": item.title,
-            "type": item.type.value if hasattr(item.type, "value") else item.type,
-            "status_before_handoff": item.status.value if hasattr(item.status, "value") else item.status,
-            "priority": item.priority.value if hasattr(item.priority, "value") else item.priority,
-            "description_excerpt": (item.description or "")[:500],
-            "acceptance_criteria": item.acceptance_criteria or [],
-            "comment_count": len(item.comments or []),
-            "recent_comments": comment_excerpts[-5:],
-            "agent_notes": agent_notes,
-            "generated_at": datetime.now(timezone.utc).isoformat(),
-            "generator": "stub-phase4",
-        }
+        comment_excerpts = [{"author_agent_id": str(c.author_agent_id) if c.author_agent_id else None, "author_user_id": str(c.author_user_id) if c.author_user_id else None, "excerpt": c.body[:200]} for c in (item.comments or [])]
+        return {"work_item_id": str(item.id), "identifier": item.identifier, "title": item.title, "type": item.type.value if hasattr(item.type, "value") else item.type, "status_before_handoff": item.status.value if hasattr(item.status, "value") else item.status, "priority": item.priority.value if hasattr(item.priority, "value") else item.priority, "description_excerpt": (item.description or "")[:500], "acceptance_criteria": item.acceptance_criteria or [], "comment_count": len(item.comments or []), "recent_comments": comment_excerpts[-5:], "agent_notes": agent_notes, "generated_at": datetime.now(timezone.utc).isoformat(), "generator": "stub-phase4"}
 
     def _assert_reviewer(self, item: LLCWorkItem, reviewer_user_id: str) -> None:
         if item.reviewer_user_id is None or str(item.reviewer_user_id) != reviewer_user_id:

--- a/autobot-backend/llc/services/handoff.py
+++ b/autobot-backend/llc/services/handoff.py
@@ -83,7 +83,9 @@ class HandoffService(LLCServiceBase):
         await self._release_redis_key(work_item_id, user_id)
         await self._publish_h2a_notification(company_id, target_agent_id, work_item_id)
         await self._record_h2a_activity(session, company_id, user_id, work_item_id, target_agent_id)
-        return HandoffResult(work_item_id=work_item_id, target_agent_id=target_agent_id, kb_doc_ids=kb_doc_ids, review_brief=review_brief)
+        return HandoffResult(
+            work_item_id=work_item_id, target_agent_id=target_agent_id, kb_doc_ids=kb_doc_ids, review_brief=review_brief
+        )
 
     async def agent_to_human(
         self,
@@ -94,7 +96,9 @@ class HandoffService(LLCServiceBase):
         company_id: str,
         agent_notes: Optional[str] = None,
     ) -> LLCWorkItem:
-        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
+        )
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -119,13 +123,28 @@ class HandoffService(LLCServiceBase):
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.AGENT, actor_id=agent_id, event_type=ActivityEventType.WORK_ITEM_HANDOFF, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_REVIEW.value, "reviewer_user_id": reviewer_user_id}, metadata={"brief": brief})
+
+                await self.activity_log.record(
+                    session,
+                    company_id=company_id,
+                    actor_type=ActorType.AGENT,
+                    actor_id=agent_id,
+                    event_type=ActivityEventType.WORK_ITEM_HANDOFF,
+                    entity_type="work_item",
+                    entity_id=work_item_id,
+                    after={"status": WorkItemStatus.IN_REVIEW.value, "reviewer_user_id": reviewer_user_id},
+                    metadata={"brief": brief},
+                )
             except Exception:
                 logger.warning("Activity log failed for agent_to_human %s", work_item_id)
         return item
 
-    async def approve(self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str) -> LLCWorkItem:
-        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+    async def approve(
+        self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str
+    ) -> LLCWorkItem:
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
+        )
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -144,13 +163,33 @@ class HandoffService(LLCServiceBase):
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_APPROVED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.DONE.value, "completed_at": now.isoformat()})
+
+                await self.activity_log.record(
+                    session,
+                    company_id=company_id,
+                    actor_type=ActorType.USER,
+                    actor_id=reviewer_user_id,
+                    event_type=ActivityEventType.WORK_ITEM_REVIEW_APPROVED,
+                    entity_type="work_item",
+                    entity_id=work_item_id,
+                    after={"status": WorkItemStatus.DONE.value, "completed_at": now.isoformat()},
+                )
             except Exception:
                 logger.warning("Activity log failed for approve %s", work_item_id)
         return item
 
-    async def request_changes(self, session: AsyncSession, work_item_id: str, reviewer_user_id: str, company_id: str, change_request: str, return_to_agent_id: Optional[str] = None) -> LLCWorkItem:
-        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+    async def request_changes(
+        self,
+        session: AsyncSession,
+        work_item_id: str,
+        reviewer_user_id: str,
+        company_id: str,
+        change_request: str,
+        return_to_agent_id: Optional[str] = None,
+    ) -> LLCWorkItem:
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
+        )
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
@@ -164,14 +203,32 @@ class HandoffService(LLCServiceBase):
         item.version += 1
         await session.flush()
         from ..models.work_item import LLCWorkItemComment
-        comment = LLCWorkItemComment(id=uuid.uuid4(), company_id=uuid.UUID(company_id), work_item_id=uuid.UUID(work_item_id), body=change_request, author_user_id=uuid.UUID(reviewer_user_id))
+
+        comment = LLCWorkItemComment(
+            id=uuid.uuid4(),
+            company_id=uuid.UUID(company_id),
+            work_item_id=uuid.UUID(work_item_id),
+            body=change_request,
+            author_user_id=uuid.UUID(reviewer_user_id),
+        )
         session.add(comment)
         await session.flush()
         if self.activity_log:
             try:
                 from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
-                await self.activity_log.record(session, company_id=company_id, actor_type=ActorType.USER, actor_id=reviewer_user_id, event_type=ActivityEventType.WORK_ITEM_REVIEW_CHANGES_REQUESTED, entity_type="work_item", entity_id=work_item_id, after={"status": WorkItemStatus.IN_PROGRESS.value, "assignee_agent_id": return_to_agent_id}, metadata={"change_request": change_request})
+
+                await self.activity_log.record(
+                    session,
+                    company_id=company_id,
+                    actor_type=ActorType.USER,
+                    actor_id=reviewer_user_id,
+                    event_type=ActivityEventType.WORK_ITEM_REVIEW_CHANGES_REQUESTED,
+                    entity_type="work_item",
+                    entity_id=work_item_id,
+                    after={"status": WorkItemStatus.IN_PROGRESS.value, "assignee_agent_id": return_to_agent_id},
+                    metadata={"change_request": change_request},
+                )
             except Exception:
                 logger.warning("Activity log failed for request_changes %s", work_item_id)
         return item
@@ -184,24 +241,37 @@ class HandoffService(LLCServiceBase):
         return item.review_brief
 
     async def _get_and_validate_human(self, session: AsyncSession, work_item_id: str, user_id: str) -> LLCWorkItem:
-        result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update())
+        result = await session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)).with_for_update()
+        )
         item = result.scalar_one_or_none()
         if item is None:
             raise ValueError(f"Work item {work_item_id} not found")
         holder_user_id = str(item.assignee_user_id) if item.assignee_user_id else None
         if item.assignee_type != "user" or holder_user_id != user_id:
-            raise HandoffNotAuthorized(f"User {user_id} does not hold work item {work_item_id} (current holder: {holder_user_id!r}, type: {item.assignee_type!r})")
+            raise HandoffNotAuthorized(
+                f"User {user_id} does not hold work item {work_item_id} (current holder: {holder_user_id!r}, type: {item.assignee_type!r})"
+            )
         return item
 
-    async def _ingest_kb(self, work_item_id: str, user_id: str, human_notes: str, attachments: List[HandoffAttachment]) -> List[str]:
+    async def _ingest_kb(
+        self, work_item_id: str, user_id: str, human_notes: str, attachments: List[HandoffAttachment]
+    ) -> List[str]:
         from ..kb.work_item_kb import WorkItemKB
+
         kb = WorkItemKB()
         doc_ids: List[str] = []
         if human_notes.strip():
             doc_id = await kb.ingest_notes(work_item_id=work_item_id, notes=human_notes, source_user_id=user_id)
             doc_ids.append(doc_id)
         for att in attachments:
-            doc_id = await kb.ingest_attachment(work_item_id=work_item_id, attachment_id=att.attachment_id, filename=att.filename, content=att.content, mime_type=att.mime_type)
+            doc_id = await kb.ingest_attachment(
+                work_item_id=work_item_id,
+                attachment_id=att.attachment_id,
+                filename=att.filename,
+                content=att.content,
+                mime_type=att.mime_type,
+            )
             if doc_id:
                 doc_ids.append(doc_id)
         return doc_ids
@@ -216,7 +286,14 @@ class HandoffService(LLCServiceBase):
             await redis.delete(key)
 
     async def _publish_h2a_notification(self, company_id: str, target_agent_id: str, work_item_id: str) -> None:
-        payload = json.dumps({"event": "work_item.handoff_ready", "work_item_id": work_item_id, "target_agent_id": target_agent_id, "has_human_handoff_context": True})
+        payload = json.dumps(
+            {
+                "event": "work_item.handoff_ready",
+                "work_item_id": work_item_id,
+                "target_agent_id": target_agent_id,
+                "has_human_handoff_context": True,
+            }
+        )
         channel = f"{_NOTIFICATION_CHANNEL_PREFIX}{company_id}"
         try:
             redis = await get_async_redis_client()
@@ -226,29 +303,80 @@ class HandoffService(LLCServiceBase):
         except Exception:
             logger.exception("Failed to publish h2a handoff notification for work_item %s — non-fatal", work_item_id)
 
-    async def _publish_a2h_notification(self, company_id: str, work_item_id: str, reviewer_user_id: str, brief: Dict[str, Any]) -> None:
+    async def _publish_a2h_notification(
+        self, company_id: str, work_item_id: str, reviewer_user_id: str, brief: Dict[str, Any]
+    ) -> None:
         redis = await get_async_redis_client()
         if redis is None:
             logger.warning("HandoffService: Redis unavailable, dropping a2h notification")
             return
         try:
             channel = f"{_NOTIFICATION_CHANNEL_PREFIX}{company_id}"
-            await redis.publish(channel, json.dumps({"event_type": "work_item.handoff", "work_item_id": work_item_id, "reviewer_user_id": reviewer_user_id, "brief_title": brief.get("title"), "brief_identifier": brief.get("identifier")}))
+            await redis.publish(
+                channel,
+                json.dumps(
+                    {
+                        "event_type": "work_item.handoff",
+                        "work_item_id": work_item_id,
+                        "reviewer_user_id": reviewer_user_id,
+                        "brief_title": brief.get("title"),
+                        "brief_identifier": brief.get("identifier"),
+                    }
+                ),
+            )
         except Exception:
             logger.debug("HandoffService._publish_a2h_notification failed (swallowed)")
 
-    async def _record_h2a_activity(self, session: AsyncSession, company_id: str, user_id: str, work_item_id: str, target_agent_id: str) -> None:
+    async def _record_h2a_activity(
+        self, session: AsyncSession, company_id: str, user_id: str, work_item_id: str, target_agent_id: str
+    ) -> None:
         if not self.activity_log:
             return
         try:
             from .activity_log import ActivityEventType
-            await self.activity_log.record(session, company_id=company_id, actor_type="user", actor_id=user_id, event_type=ActivityEventType.WORK_ITEM_ASSIGNED, entity_type="work_item", entity_id=work_item_id, after={"assignee_type": "agent", "assignee_agent_id": target_agent_id, "status": WorkItemStatus.READY.value, "has_human_handoff_context": True})
+
+            await self.activity_log.record(
+                session,
+                company_id=company_id,
+                actor_type="user",
+                actor_id=user_id,
+                event_type=ActivityEventType.WORK_ITEM_ASSIGNED,
+                entity_type="work_item",
+                entity_id=work_item_id,
+                after={
+                    "assignee_type": "agent",
+                    "assignee_agent_id": target_agent_id,
+                    "status": WorkItemStatus.READY.value,
+                    "has_human_handoff_context": True,
+                },
+            )
         except Exception:
             logger.warning("Activity log failed for h2a handoff work_item=%s", work_item_id)
 
     def _generate_brief(self, item: LLCWorkItem, agent_notes: Optional[str]) -> Dict[str, Any]:
-        comment_excerpts = [{"author_agent_id": str(c.author_agent_id) if c.author_agent_id else None, "author_user_id": str(c.author_user_id) if c.author_user_id else None, "excerpt": c.body[:200]} for c in (item.comments or [])]
-        return {"work_item_id": str(item.id), "identifier": item.identifier, "title": item.title, "type": item.type.value if hasattr(item.type, "value") else item.type, "status_before_handoff": item.status.value if hasattr(item.status, "value") else item.status, "priority": item.priority.value if hasattr(item.priority, "value") else item.priority, "description_excerpt": (item.description or "")[:500], "acceptance_criteria": item.acceptance_criteria or [], "comment_count": len(item.comments or []), "recent_comments": comment_excerpts[-5:], "agent_notes": agent_notes, "generated_at": datetime.now(timezone.utc).isoformat(), "generator": "stub-phase4"}
+        comment_excerpts = [
+            {
+                "author_agent_id": str(c.author_agent_id) if c.author_agent_id else None,
+                "author_user_id": str(c.author_user_id) if c.author_user_id else None,
+                "excerpt": c.body[:200],
+            }
+            for c in (item.comments or [])
+        ]
+        return {
+            "work_item_id": str(item.id),
+            "identifier": item.identifier,
+            "title": item.title,
+            "type": item.type.value if hasattr(item.type, "value") else item.type,
+            "status_before_handoff": item.status.value if hasattr(item.status, "value") else item.status,
+            "priority": item.priority.value if hasattr(item.priority, "value") else item.priority,
+            "description_excerpt": (item.description or "")[:500],
+            "acceptance_criteria": item.acceptance_criteria or [],
+            "comment_count": len(item.comments or []),
+            "recent_comments": comment_excerpts[-5:],
+            "agent_notes": agent_notes,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "generator": "stub-phase4",
+        }
 
     def _assert_reviewer(self, item: LLCWorkItem, reviewer_user_id: str) -> None:
         if item.reviewer_user_id is None or str(item.reviewer_user_id) != reviewer_user_id:

--- a/autobot-backend/llc/services/portability.py
+++ b/autobot-backend/llc/services/portability.py
@@ -6,6 +6,7 @@
 Depends on GH#8245 (export) for the shared template schema version "1.0".
 """
 
+import json
 import re
 import uuid
 from typing import Any, Dict, List, Optional
@@ -15,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
-from llc.models.enums import LLCAgentStatus, LLCCompanyStatus
+from llc.models.enums import LLCCompanyStatus
 from llc.models.goal import LLCGoal
 from llc.models.routine import LLCRoutine
 from llc.models.sprint import LLCProject
@@ -34,7 +35,7 @@ _PLACEHOLDER_RE = re.compile(r"\{\{(\w+)\}\}")
 # ---------------------------------------------------------------------------
 
 
-class ImportError(Exception):
+class TemplateImportError(Exception):
     """Raised when import cannot proceed (schema, collision, rollback)."""
 
 
@@ -53,7 +54,12 @@ class PortabilityService(LLCServiceBase):
     # Public API
     # ------------------------------------------------------------------
 
-    async def preview_import(self, template: Dict[str, Any]) -> Dict[str, Any]:
+    async def preview_import(
+        self,
+        template: Dict[str, Any],
+        *,
+        target_company_id: Optional[uuid.UUID] = None,
+    ) -> Dict[str, Any]:
         """Return collision/creation preview without writing anything."""
         self._validate_schema(template)
         company_meta = template.get("company", {})
@@ -72,17 +78,20 @@ class PortabilityService(LLCServiceBase):
             if existing:
                 collisions.append({"type": "issue_prefix", "value": prefix})
 
-        # agent name collisions (company_id is unknown at preview time — check globally)
+        # agent name collisions — scoped to target company; new-company imports
+        # have no pre-existing namespace so there is nothing to collide with
         agent_names = [a.get("name") for a in agents if a.get("name")]
-        conflicting_agents = await self._agent_names_exist(agent_names)
-        for name in conflicting_agents:
-            collisions.append({"type": "agent_name", "value": name})
+        if target_company_id and agent_names:
+            conflicting_agents = await self._agent_names_exist(agent_names, target_company_id)
+            for name in conflicting_agents:
+                collisions.append({"type": "agent_name", "value": name})
 
-        # goal title collisions (global — no company yet)
+        # goal title collisions — scoped to target company for the same reason
         goal_titles = [g.get("title") for g in goals if g.get("title")]
-        conflicting_goals = await self._goal_titles_exist(goal_titles)
-        for title in conflicting_goals:
-            collisions.append({"type": "goal_title", "value": title})
+        if target_company_id and goal_titles:
+            conflicting_goals = await self._goal_titles_exist(goal_titles, target_company_id)
+            for title in conflicting_goals:
+                collisions.append({"type": "goal_title", "value": title})
 
         # secret placeholder warning
         all_placeholders: set[str] = set()
@@ -129,22 +138,27 @@ class PortabilityService(LLCServiceBase):
         try:
             company_id = await self._resolve_or_create_company(template, target_company_id, remapping_options, warnings)
 
-            # agents
-            agent_id_map: Dict[str, str] = {}
-            for agent in template.get("agents", []):
-                agent_id = await self._import_agent(agent, company_id, secret_mapping, warnings)
+            # Pass 1: pre-mint all agent IDs so reports_to can be remapped before
+            # any INSERT, avoiding topology-ordering FK violations
+            agents_list = template.get("agents", [])
+            agent_id_map: Dict[str, str] = {
+                a.get("agent_id", ""): str(uuid.uuid4())
+                for a in agents_list
+                if a.get("agent_id")
+            }
+
+            # Pass 2: insert agents with remapped reports_to
+            for agent in agents_list:
+                agent_id = await self._import_agent(agent, company_id, secret_mapping, warnings, agent_id_map)
                 if agent_id:
-                    agent_id_map[agent.get("agent_id", "")] = agent_id
                     created_entities["agents"].append(agent_id)
                 else:
                     skipped["agents"].append(agent.get("name", ""))
 
             # goals
-            goal_id_map: Dict[str, str] = {}
             for goal in template.get("goals", []):
                 goal_id = await self._import_goal(goal, company_id)
                 if goal_id:
-                    goal_id_map[str(goal.get("id", ""))] = str(goal_id)
                     created_entities["goals"].append(str(goal_id))
                 else:
                     skipped["goals"].append(goal.get("title", ""))
@@ -168,7 +182,7 @@ class PortabilityService(LLCServiceBase):
             await sp.commit()
         except Exception as exc:
             await sp.rollback()
-            raise ImportError(f"Import rolled back: {exc}") from exc
+            raise TemplateImportError(f"Import rolled back: {exc}") from exc
 
         return {
             "company_id": str(company_id),
@@ -185,18 +199,31 @@ class PortabilityService(LLCServiceBase):
         result = await self.session.execute(select(Organization.id).where(Organization.issue_prefix == prefix).limit(1))
         return result.scalar() is not None
 
-    async def _agent_names_exist(self, names: List[str]) -> List[str]:
+    async def _agent_names_exist(
+        self, names: List[str], company_id: Optional[uuid.UUID] = None
+    ) -> List[str]:
         if not names:
             return []
-        rows = await self.session.execute(
-            text("SELECT name FROM agent_org_nodes WHERE name = ANY(:names)").bindparams(names=names)
-        )
+        if company_id is not None:
+            rows = await self.session.execute(
+                text("SELECT name FROM agent_org_nodes WHERE name = ANY(:names) AND company_id = :company_id")
+                .bindparams(names=names, company_id=str(company_id))
+            )
+        else:
+            rows = await self.session.execute(
+                text("SELECT name FROM agent_org_nodes WHERE name = ANY(:names)").bindparams(names=names)
+            )
         return [r[0] for r in rows]
 
-    async def _goal_titles_exist(self, titles: List[str]) -> List[str]:
+    async def _goal_titles_exist(
+        self, titles: List[str], company_id: Optional[uuid.UUID] = None
+    ) -> List[str]:
         if not titles:
             return []
-        result = await self.session.execute(select(LLCGoal.title).where(LLCGoal.title.in_(titles)))
+        q = select(LLCGoal.title).where(LLCGoal.title.in_(titles))
+        if company_id is not None:
+            q = q.where(LLCGoal.company_id == str(company_id))
+        result = await self.session.execute(q)
         return [r[0] for r in result]
 
     # ------------------------------------------------------------------
@@ -214,7 +241,7 @@ class PortabilityService(LLCServiceBase):
             result = await self.session.execute(select(Organization).where(Organization.id == target_company_id))
             org = result.scalar_one_or_none()
             if org is None:
-                raise ImportError(f"target_company_id {target_company_id} not found")
+                raise TemplateImportError(f"target_company_id {target_company_id} not found")
             return org.id
 
         meta = template.get("company", {})
@@ -251,7 +278,7 @@ class PortabilityService(LLCServiceBase):
             candidate = f"{prefix}{n}"
             if not await self._prefix_exists(candidate):
                 return candidate
-        raise ImportError(f"Cannot find free issue_prefix for {prefix!r}")
+        raise TemplateImportError(f"Cannot find free issue_prefix for {prefix!r}")
 
     async def _import_agent(
         self,
@@ -259,16 +286,31 @@ class PortabilityService(LLCServiceBase):
         company_id: uuid.UUID,
         secret_mapping: Dict[str, str],
         warnings: List[str],
+        agent_id_map: Optional[Dict[str, str]] = None,
     ) -> Optional[str]:
         """Insert agent_org_nodes row.  Returns new agent_id or None if skipped."""
         name = agent.get("name", "")
-        existing = await self._agent_names_exist([name])
+        existing = await self._agent_names_exist([name], company_id)
         if existing:
             warnings.append(f"Agent {name!r} already exists — skipped")
             return None
 
-        new_agent_id = str(uuid.uuid4())
+        # Use pre-minted ID from two-pass map if available
+        old_id = agent.get("agent_id", "")
+        new_agent_id = (agent_id_map or {}).get(old_id) or str(uuid.uuid4())
+
+        # Remap reports_to from source UUID to destination UUID
+        old_reports_to = agent.get("reports_to")
+        reports_to: Optional[str] = None
+        if old_reports_to and agent_id_map:
+            reports_to = agent_id_map.get(str(old_reports_to))
+
         adapter_config = self._resolve_secrets(agent.get("adapter_config") or {}, secret_mapping, name, warnings)
+
+        # capabilities is TEXT in the schema; serialize list/dict to JSON string
+        capabilities = agent.get("capabilities")
+        if isinstance(capabilities, (list, dict)):
+            capabilities = json.dumps(capabilities)
 
         await self.session.execute(
             text("""
@@ -284,16 +326,16 @@ class PortabilityService(LLCServiceBase):
                 id=uuid.uuid4(),
                 agent_id=new_agent_id,
                 name=name,
-                reports_to=agent.get("reports_to"),
+                reports_to=reports_to,
                 org_role=agent.get("org_role", "worker"),
                 title=agent.get("title"),
-                capabilities=agent.get("capabilities"),
+                capabilities=capabilities,
                 company_id=company_id,
                 adapter_type=agent.get("adapter_type"),
-                adapter_config=__import__("json").dumps(adapter_config),
+                adapter_config=json.dumps(adapter_config),
                 heartbeat_cron=agent.get("heartbeat_cron"),
                 heartbeat_enabled=agent.get("heartbeat_enabled", False),
-                context_mode=agent.get("context_mode"),
+                context_mode=agent.get("context_mode", "thin"),
             )
         )
         return new_agent_id
@@ -305,25 +347,36 @@ class PortabilityService(LLCServiceBase):
         agent_name: str,
         warnings: List[str],
     ) -> Any:
-        """Replace {{SECRET_NAME}} placeholders with values from secret_mapping."""
-        config_str = __import__("json").dumps(config)
-        unresolved: List[str] = []
+        """Replace {{SECRET_NAME}} placeholders in config by walking the structure.
 
-        def replace(m: re.Match) -> str:
-            key = m.group(1)
-            if key in secret_mapping:
-                return secret_mapping[key]
-            unresolved.append(key)
-            return m.group(0)
+        Operates on the decoded Python object (not the JSON string) to prevent
+        injection when secret values contain quote characters.
+        """
+        unresolved: set[str] = set()
 
-        resolved_str = _PLACEHOLDER_RE.sub(replace, config_str)
+        def _walk(node: Any) -> Any:
+            if isinstance(node, str):
+                def _replace(m: re.Match) -> str:
+                    key = m.group(1)
+                    if key in secret_mapping:
+                        return secret_mapping[key]
+                    unresolved.add(key)
+                    return m.group(0)
+                return _PLACEHOLDER_RE.sub(_replace, node)
+            if isinstance(node, dict):
+                return {k: _walk(v) for k, v in node.items()}
+            if isinstance(node, list):
+                return [_walk(v) for v in node]
+            return node
+
+        result = _walk(config)
         if unresolved:
-            warnings.append(f"Agent {agent_name!r}: unresolved secret placeholders {unresolved}")
-        return __import__("json").loads(resolved_str)
+            warnings.append(f"Agent {agent_name!r}: unresolved secret placeholders {sorted(unresolved)}")
+        return result
 
     async def _import_goal(self, goal: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
         title = goal.get("title", "")
-        existing = await self._goal_titles_exist([title])
+        existing = await self._goal_titles_exist([title], company_id)
         if existing:
             return None
 
@@ -381,4 +434,4 @@ class PortabilityService(LLCServiceBase):
     def _validate_schema(template: Dict[str, Any]) -> None:
         version = template.get("schema_version")
         if version != "1.0":
-            raise ImportError(f"Unsupported schema_version {version!r}; expected '1.0'")
+            raise TemplateImportError(f"Unsupported schema_version {version!r}; expected '1.0'")

--- a/autobot-backend/llc/services/portability.py
+++ b/autobot-backend/llc/services/portability.py
@@ -90,9 +90,7 @@ class PortabilityService(LLCServiceBase):
             cfg = agent.get("adapter_config") or {}
             all_placeholders.update(_PLACEHOLDER_RE.findall(str(cfg)))
         if all_placeholders:
-            warnings.append(
-                f"Secret placeholders found that require mapping: {sorted(all_placeholders)}"
-            )
+            warnings.append(f"Secret placeholders found that require mapping: {sorted(all_placeholders)}")
 
         return {
             "collisions": collisions,
@@ -129,16 +127,12 @@ class PortabilityService(LLCServiceBase):
 
         sp = await self.session.begin_nested()
         try:
-            company_id = await self._resolve_or_create_company(
-                template, target_company_id, remapping_options, warnings
-            )
+            company_id = await self._resolve_or_create_company(template, target_company_id, remapping_options, warnings)
 
             # agents
             agent_id_map: Dict[str, str] = {}
             for agent in template.get("agents", []):
-                agent_id = await self._import_agent(
-                    agent, company_id, secret_mapping, warnings
-                )
+                agent_id = await self._import_agent(agent, company_id, secret_mapping, warnings)
                 if agent_id:
                     agent_id_map[agent.get("agent_id", "")] = agent_id
                     created_entities["agents"].append(agent_id)
@@ -188,27 +182,21 @@ class PortabilityService(LLCServiceBase):
     # ------------------------------------------------------------------
 
     async def _prefix_exists(self, prefix: str) -> bool:
-        result = await self.session.execute(
-            select(Organization.id).where(Organization.issue_prefix == prefix).limit(1)
-        )
+        result = await self.session.execute(select(Organization.id).where(Organization.issue_prefix == prefix).limit(1))
         return result.scalar() is not None
 
     async def _agent_names_exist(self, names: List[str]) -> List[str]:
         if not names:
             return []
         rows = await self.session.execute(
-            text(
-                "SELECT name FROM agent_org_nodes WHERE name = ANY(:names)"
-            ).bindparams(names=names)
+            text("SELECT name FROM agent_org_nodes WHERE name = ANY(:names)").bindparams(names=names)
         )
         return [r[0] for r in rows]
 
     async def _goal_titles_exist(self, titles: List[str]) -> List[str]:
         if not titles:
             return []
-        result = await self.session.execute(
-            select(LLCGoal.title).where(LLCGoal.title.in_(titles))
-        )
+        result = await self.session.execute(select(LLCGoal.title).where(LLCGoal.title.in_(titles)))
         return [r[0] for r in result]
 
     # ------------------------------------------------------------------
@@ -223,9 +211,7 @@ class PortabilityService(LLCServiceBase):
         warnings: List[str],
     ) -> uuid.UUID:
         if target_company_id:
-            result = await self.session.execute(
-                select(Organization).where(Organization.id == target_company_id)
-            )
+            result = await self.session.execute(select(Organization).where(Organization.id == target_company_id))
             org = result.scalar_one_or_none()
             if org is None:
                 raise ImportError(f"target_company_id {target_company_id} not found")
@@ -282,13 +268,10 @@ class PortabilityService(LLCServiceBase):
             return None
 
         new_agent_id = str(uuid.uuid4())
-        adapter_config = self._resolve_secrets(
-            agent.get("adapter_config") or {}, secret_mapping, name, warnings
-        )
+        adapter_config = self._resolve_secrets(agent.get("adapter_config") or {}, secret_mapping, name, warnings)
 
         await self.session.execute(
-            text(
-                """
+            text("""
                 INSERT INTO agent_org_nodes
                   (id, agent_id, name, reports_to, org_role, title, capabilities,
                    company_id, adapter_type, adapter_config, heartbeat_cron,
@@ -297,8 +280,7 @@ class PortabilityService(LLCServiceBase):
                   (:id, :agent_id, :name, :reports_to, :org_role, :title, :capabilities,
                    :company_id, :adapter_type, :adapter_config::jsonb, :heartbeat_cron,
                    :heartbeat_enabled, :context_mode)
-                """
-            ).bindparams(
+                """).bindparams(
                 id=uuid.uuid4(),
                 agent_id=new_agent_id,
                 name=name,
@@ -336,14 +318,10 @@ class PortabilityService(LLCServiceBase):
 
         resolved_str = _PLACEHOLDER_RE.sub(replace, config_str)
         if unresolved:
-            warnings.append(
-                f"Agent {agent_name!r}: unresolved secret placeholders {unresolved}"
-            )
+            warnings.append(f"Agent {agent_name!r}: unresolved secret placeholders {unresolved}")
         return __import__("json").loads(resolved_str)
 
-    async def _import_goal(
-        self, goal: Dict[str, Any], company_id: uuid.UUID
-    ) -> Optional[uuid.UUID]:
+    async def _import_goal(self, goal: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
         title = goal.get("title", "")
         existing = await self._goal_titles_exist([title])
         if existing:
@@ -364,9 +342,7 @@ class PortabilityService(LLCServiceBase):
         await self.session.flush()
         return new_id
 
-    async def _import_project(
-        self, project: Dict[str, Any], company_id: uuid.UUID
-    ) -> Optional[uuid.UUID]:
+    async def _import_project(self, project: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
         new_id = uuid.uuid4()
         obj = LLCProject(
             id=new_id,
@@ -379,9 +355,7 @@ class PortabilityService(LLCServiceBase):
         await self.session.flush()
         return new_id
 
-    async def _import_work_item(
-        self, item: Dict[str, Any], company_id: uuid.UUID
-    ) -> Optional[uuid.UUID]:
+    async def _import_work_item(self, item: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
         new_id = uuid.uuid4()
         identifier = f"IMP-{new_id.hex[:8].upper()}"
         obj = LLCWorkItem(
@@ -407,6 +381,4 @@ class PortabilityService(LLCServiceBase):
     def _validate_schema(template: Dict[str, Any]) -> None:
         version = template.get("schema_version")
         if version != "1.0":
-            raise ImportError(
-                f"Unsupported schema_version {version!r}; expected '1.0'"
-            )
+            raise ImportError(f"Unsupported schema_version {version!r}; expected '1.0'")

--- a/autobot-backend/llc/services/portability.py
+++ b/autobot-backend/llc/services/portability.py
@@ -1,0 +1,412 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""PortabilityService — company template export/import with collision detection (GH#8246).
+
+Depends on GH#8245 (export) for the shared template schema version "1.0".
+"""
+
+import re
+import uuid
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import now_utc
+from llc.models.enums import LLCAgentStatus, LLCCompanyStatus
+from llc.models.goal import LLCGoal
+from llc.models.routine import LLCRoutine
+from llc.models.sprint import LLCProject
+from llc.models.work_item import LLCWorkItem
+from llc.services.base import LLCServiceBase
+from user_management.models.organization import Organization
+
+logger = get_logger(__name__)
+
+_PLACEHOLDER_RE = re.compile(r"\{\{(\w+)\}\}")
+
+
+# ---------------------------------------------------------------------------
+# Pydantic response models live in llc/models/portability.py (imported below)
+# to keep service lean.  We use plain dicts internally.
+# ---------------------------------------------------------------------------
+
+
+class ImportError(Exception):
+    """Raised when import cannot proceed (schema, collision, rollback)."""
+
+
+class PortabilityService(LLCServiceBase):
+    """Service for company template import (GH#8246).
+
+    All methods accept an ``AsyncSession`` and participate in the caller's
+    transaction.  ``execute_import`` manages its own savepoint for rollback.
+    """
+
+    def __init__(self, session: AsyncSession, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.session = session
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def preview_import(self, template: Dict[str, Any]) -> Dict[str, Any]:
+        """Return collision/creation preview without writing anything."""
+        self._validate_schema(template)
+        company_meta = template.get("company", {})
+        agents = template.get("agents", [])
+        goals = template.get("goals", [])
+        projects = template.get("projects", [])
+        work_items = template.get("work_items", [])
+
+        collisions: List[Dict[str, Any]] = []
+        warnings: List[str] = []
+
+        # issue_prefix collision
+        prefix = company_meta.get("issue_prefix")
+        if prefix:
+            existing = await self._prefix_exists(prefix)
+            if existing:
+                collisions.append({"type": "issue_prefix", "value": prefix})
+
+        # agent name collisions (company_id is unknown at preview time — check globally)
+        agent_names = [a.get("name") for a in agents if a.get("name")]
+        conflicting_agents = await self._agent_names_exist(agent_names)
+        for name in conflicting_agents:
+            collisions.append({"type": "agent_name", "value": name})
+
+        # goal title collisions (global — no company yet)
+        goal_titles = [g.get("title") for g in goals if g.get("title")]
+        conflicting_goals = await self._goal_titles_exist(goal_titles)
+        for title in conflicting_goals:
+            collisions.append({"type": "goal_title", "value": title})
+
+        # secret placeholder warning
+        all_placeholders: set[str] = set()
+        for agent in agents:
+            cfg = agent.get("adapter_config") or {}
+            all_placeholders.update(_PLACEHOLDER_RE.findall(str(cfg)))
+        if all_placeholders:
+            warnings.append(
+                f"Secret placeholders found that require mapping: {sorted(all_placeholders)}"
+            )
+
+        return {
+            "collisions": collisions,
+            "will_create": {
+                "agents": len(agents),
+                "goals": len(goals),
+                "projects": len(projects),
+                "work_items": len(work_items),
+            },
+            "warnings": warnings,
+        }
+
+    async def execute_import(
+        self,
+        template: Dict[str, Any],
+        *,
+        target_company_id: Optional[uuid.UUID] = None,
+        remapping_options: Optional[Dict[str, Any]] = None,
+        secret_mapping: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Transactional import.  Rolls back entirely on any entity failure."""
+        self._validate_schema(template)
+        remapping_options = remapping_options or {}
+        secret_mapping = secret_mapping or {}
+
+        created_entities: Dict[str, Any] = {
+            "agents": [],
+            "goals": [],
+            "projects": [],
+            "work_items": [],
+        }
+        skipped: Dict[str, List[str]] = {"agents": [], "goals": [], "work_items": []}
+        warnings: List[str] = []
+
+        sp = await self.session.begin_nested()
+        try:
+            company_id = await self._resolve_or_create_company(
+                template, target_company_id, remapping_options, warnings
+            )
+
+            # agents
+            agent_id_map: Dict[str, str] = {}
+            for agent in template.get("agents", []):
+                agent_id = await self._import_agent(
+                    agent, company_id, secret_mapping, warnings
+                )
+                if agent_id:
+                    agent_id_map[agent.get("agent_id", "")] = agent_id
+                    created_entities["agents"].append(agent_id)
+                else:
+                    skipped["agents"].append(agent.get("name", ""))
+
+            # goals
+            goal_id_map: Dict[str, str] = {}
+            for goal in template.get("goals", []):
+                goal_id = await self._import_goal(goal, company_id)
+                if goal_id:
+                    goal_id_map[str(goal.get("id", ""))] = str(goal_id)
+                    created_entities["goals"].append(str(goal_id))
+                else:
+                    skipped["goals"].append(goal.get("title", ""))
+
+            # projects
+            for project in template.get("projects", []):
+                project_id = await self._import_project(project, company_id)
+                if project_id:
+                    created_entities["projects"].append(str(project_id))
+
+            # seed work items
+            for item in template.get("work_items", []):
+                if not item.get("is_seed"):
+                    continue
+                item_id = await self._import_work_item(item, company_id)
+                if item_id:
+                    created_entities["work_items"].append(str(item_id))
+                else:
+                    skipped["work_items"].append(item.get("title", ""))
+
+            await sp.commit()
+        except Exception as exc:
+            await sp.rollback()
+            raise ImportError(f"Import rolled back: {exc}") from exc
+
+        return {
+            "company_id": str(company_id),
+            "created_entities": created_entities,
+            "skipped": skipped,
+            "warnings": warnings,
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers — collision checks
+    # ------------------------------------------------------------------
+
+    async def _prefix_exists(self, prefix: str) -> bool:
+        result = await self.session.execute(
+            select(Organization.id).where(Organization.issue_prefix == prefix).limit(1)
+        )
+        return result.scalar() is not None
+
+    async def _agent_names_exist(self, names: List[str]) -> List[str]:
+        if not names:
+            return []
+        rows = await self.session.execute(
+            text(
+                "SELECT name FROM agent_org_nodes WHERE name = ANY(:names)"
+            ).bindparams(names=names)
+        )
+        return [r[0] for r in rows]
+
+    async def _goal_titles_exist(self, titles: List[str]) -> List[str]:
+        if not titles:
+            return []
+        result = await self.session.execute(
+            select(LLCGoal.title).where(LLCGoal.title.in_(titles))
+        )
+        return [r[0] for r in result]
+
+    # ------------------------------------------------------------------
+    # Private helpers — entity creation
+    # ------------------------------------------------------------------
+
+    async def _resolve_or_create_company(
+        self,
+        template: Dict[str, Any],
+        target_company_id: Optional[uuid.UUID],
+        remapping_options: Dict[str, Any],
+        warnings: List[str],
+    ) -> uuid.UUID:
+        if target_company_id:
+            result = await self.session.execute(
+                select(Organization).where(Organization.id == target_company_id)
+            )
+            org = result.scalar_one_or_none()
+            if org is None:
+                raise ImportError(f"target_company_id {target_company_id} not found")
+            return org.id
+
+        meta = template.get("company", {})
+        prefix = meta.get("issue_prefix")
+        if prefix and await self._prefix_exists(prefix):
+            prefix = await self._next_available_prefix(prefix)
+            warnings.append(f"issue_prefix remapped to {prefix!r}")
+
+        require_approval = remapping_options.get(
+            "require_approval_for_hires",
+            meta.get("require_approval_for_hires", False),
+        )
+
+        org = Organization(
+            id=uuid.uuid4(),
+            name=meta.get("name", "Imported Company"),
+            slug=meta.get("slug", f"imported-{uuid.uuid4().hex[:8]}"),
+            description=meta.get("description"),
+            issue_prefix=prefix,
+            budget_monthly_cents=meta.get("budget_monthly_cents", 0),
+            brand_color=meta.get("brand_color"),
+            require_approval_for_hires=require_approval,
+            llc_status=LLCCompanyStatus.ONBOARDING.value,
+            settings={},
+            issue_counter=0,
+            spent_monthly_cents=0,
+        )
+        self.session.add(org)
+        await self.session.flush()
+        return org.id
+
+    async def _next_available_prefix(self, prefix: str) -> str:
+        for n in range(2, 1000):
+            candidate = f"{prefix}{n}"
+            if not await self._prefix_exists(candidate):
+                return candidate
+        raise ImportError(f"Cannot find free issue_prefix for {prefix!r}")
+
+    async def _import_agent(
+        self,
+        agent: Dict[str, Any],
+        company_id: uuid.UUID,
+        secret_mapping: Dict[str, str],
+        warnings: List[str],
+    ) -> Optional[str]:
+        """Insert agent_org_nodes row.  Returns new agent_id or None if skipped."""
+        name = agent.get("name", "")
+        existing = await self._agent_names_exist([name])
+        if existing:
+            warnings.append(f"Agent {name!r} already exists — skipped")
+            return None
+
+        new_agent_id = str(uuid.uuid4())
+        adapter_config = self._resolve_secrets(
+            agent.get("adapter_config") or {}, secret_mapping, name, warnings
+        )
+
+        await self.session.execute(
+            text(
+                """
+                INSERT INTO agent_org_nodes
+                  (id, agent_id, name, reports_to, org_role, title, capabilities,
+                   company_id, adapter_type, adapter_config, heartbeat_cron,
+                   heartbeat_enabled, context_mode)
+                VALUES
+                  (:id, :agent_id, :name, :reports_to, :org_role, :title, :capabilities,
+                   :company_id, :adapter_type, :adapter_config::jsonb, :heartbeat_cron,
+                   :heartbeat_enabled, :context_mode)
+                """
+            ).bindparams(
+                id=uuid.uuid4(),
+                agent_id=new_agent_id,
+                name=name,
+                reports_to=agent.get("reports_to"),
+                org_role=agent.get("org_role", "worker"),
+                title=agent.get("title"),
+                capabilities=agent.get("capabilities"),
+                company_id=company_id,
+                adapter_type=agent.get("adapter_type"),
+                adapter_config=__import__("json").dumps(adapter_config),
+                heartbeat_cron=agent.get("heartbeat_cron"),
+                heartbeat_enabled=agent.get("heartbeat_enabled", False),
+                context_mode=agent.get("context_mode"),
+            )
+        )
+        return new_agent_id
+
+    def _resolve_secrets(
+        self,
+        config: Any,
+        secret_mapping: Dict[str, str],
+        agent_name: str,
+        warnings: List[str],
+    ) -> Any:
+        """Replace {{SECRET_NAME}} placeholders with values from secret_mapping."""
+        config_str = __import__("json").dumps(config)
+        unresolved: List[str] = []
+
+        def replace(m: re.Match) -> str:
+            key = m.group(1)
+            if key in secret_mapping:
+                return secret_mapping[key]
+            unresolved.append(key)
+            return m.group(0)
+
+        resolved_str = _PLACEHOLDER_RE.sub(replace, config_str)
+        if unresolved:
+            warnings.append(
+                f"Agent {agent_name!r}: unresolved secret placeholders {unresolved}"
+            )
+        return __import__("json").loads(resolved_str)
+
+    async def _import_goal(
+        self, goal: Dict[str, Any], company_id: uuid.UUID
+    ) -> Optional[uuid.UUID]:
+        title = goal.get("title", "")
+        existing = await self._goal_titles_exist([title])
+        if existing:
+            return None
+
+        new_id = uuid.uuid4()
+        obj = LLCGoal(
+            id=new_id,
+            company_id=str(company_id),
+            title=title,
+            description=goal.get("description"),
+            level=goal.get("level", "objective"),
+            status=goal.get("status", "draft"),
+            owner_agent_id=None,
+            due_date=None,
+        )
+        self.session.add(obj)
+        await self.session.flush()
+        return new_id
+
+    async def _import_project(
+        self, project: Dict[str, Any], company_id: uuid.UUID
+    ) -> Optional[uuid.UUID]:
+        new_id = uuid.uuid4()
+        obj = LLCProject(
+            id=new_id,
+            company_id=company_id,
+            name=project.get("name", "Imported Project"),
+            description=project.get("description"),
+            status=project.get("status", "planning"),
+        )
+        self.session.add(obj)
+        await self.session.flush()
+        return new_id
+
+    async def _import_work_item(
+        self, item: Dict[str, Any], company_id: uuid.UUID
+    ) -> Optional[uuid.UUID]:
+        new_id = uuid.uuid4()
+        identifier = f"IMP-{new_id.hex[:8].upper()}"
+        obj = LLCWorkItem(
+            id=new_id,
+            company_id=company_id,
+            type=item.get("type", "epic"),
+            identifier=identifier,
+            title=item.get("title", ""),
+            description=item.get("description"),
+            status="backlog",
+            priority=item.get("priority", "medium"),
+            labels=item.get("labels", []),
+        )
+        self.session.add(obj)
+        await self.session.flush()
+        return new_id
+
+    # ------------------------------------------------------------------
+    # Schema validation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_schema(template: Dict[str, Any]) -> None:
+        version = template.get("schema_version")
+        if version != "1.0":
+            raise ImportError(
+                f"Unsupported schema_version {version!r}; expected '1.0'"
+            )

--- a/autobot-backend/llc/tests/test_import.py
+++ b/autobot-backend/llc/tests/test_import.py
@@ -1,0 +1,323 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for PortabilityService import functionality (GH#8246)."""
+
+import uuid
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.services.portability import ImportError as LLCImportError, PortabilityService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SCHEMA_VERSION = "1.0"
+
+
+def _template(**overrides: Any) -> Dict[str, Any]:
+    base: Dict[str, Any] = {
+        "schema_version": _SCHEMA_VERSION,
+        "company": {
+            "name": "Acme Corp",
+            "slug": "acme-corp",
+            "issue_prefix": "ACM",
+            "budget_monthly_cents": 0,
+            "require_approval_for_hires": False,
+        },
+        "agents": [],
+        "goals": [],
+        "projects": [],
+        "work_items": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_svc() -> PortabilityService:
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.begin_nested = AsyncMock(return_value=AsyncMock(__aenter__=AsyncMock(), __aexit__=AsyncMock()))
+    return PortabilityService(session=session)
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_schema_wrong_version() -> None:
+    svc = _make_svc()
+    with pytest.raises(LLCImportError, match="schema_version"):
+        svc._validate_schema({"schema_version": "2.0"})
+
+
+def test_validate_schema_missing_version() -> None:
+    svc = _make_svc()
+    with pytest.raises(LLCImportError, match="schema_version"):
+        svc._validate_schema({})
+
+
+def test_validate_schema_ok() -> None:
+    svc = _make_svc()
+    svc._validate_schema({"schema_version": "1.0"})  # no exception
+
+
+# ---------------------------------------------------------------------------
+# preview_import — no collision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_no_collision() -> None:
+    svc = _make_svc()
+    # all selects return empty
+    svc.session.execute.return_value.scalar.return_value = None
+    svc.session.execute.return_value = MagicMock(scalar=MagicMock(return_value=None), __iter__=MagicMock(return_value=iter([])))
+
+    tmpl = _template(
+        agents=[{"name": "Bob", "adapter_config": {}}],
+        goals=[{"title": "Goal 1"}],
+    )
+
+    with (
+        patch.object(svc, "_prefix_exists", return_value=False),
+        patch.object(svc, "_agent_names_exist", return_value=[]),
+        patch.object(svc, "_goal_titles_exist", return_value=[]),
+    ):
+        result = await svc.preview_import(tmpl)
+
+    assert result["collisions"] == []
+    assert result["will_create"]["agents"] == 1
+    assert result["will_create"]["goals"] == 1
+    assert result["warnings"] == []
+
+
+# ---------------------------------------------------------------------------
+# preview_import — with collisions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_with_collisions() -> None:
+    svc = _make_svc()
+    tmpl = _template(
+        agents=[{"name": "Alice"}],
+        goals=[{"title": "Existing Goal"}],
+    )
+
+    with (
+        patch.object(svc, "_prefix_exists", return_value=True),
+        patch.object(svc, "_agent_names_exist", return_value=["Alice"]),
+        patch.object(svc, "_goal_titles_exist", return_value=["Existing Goal"]),
+    ):
+        result = await svc.preview_import(tmpl)
+
+    types = {c["type"] for c in result["collisions"]}
+    assert "issue_prefix" in types
+    assert "agent_name" in types
+    assert "goal_title" in types
+
+
+# ---------------------------------------------------------------------------
+# preview_import — secret placeholder warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_secret_placeholder_warning() -> None:
+    svc = _make_svc()
+    tmpl = _template(
+        agents=[{"name": "Bot", "adapter_config": {"token": "{{MY_SECRET}}"}}],
+    )
+
+    with (
+        patch.object(svc, "_prefix_exists", return_value=False),
+        patch.object(svc, "_agent_names_exist", return_value=[]),
+        patch.object(svc, "_goal_titles_exist", return_value=[]),
+    ):
+        result = await svc.preview_import(tmpl)
+
+    assert any("MY_SECRET" in w for w in result["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# _resolve_secrets
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_secrets_replaces_placeholder() -> None:
+    svc = _make_svc()
+    config = {"token": "{{MY_TOKEN}}", "url": "https://example.com"}
+    warnings: list = []
+    resolved = svc._resolve_secrets(config, {"MY_TOKEN": "abc123"}, "TestAgent", warnings)
+    assert resolved["token"] == "abc123"
+    assert warnings == []
+
+
+def test_resolve_secrets_unresolved_warns() -> None:
+    svc = _make_svc()
+    config = {"token": "{{MISSING}}"}
+    warnings: list = []
+    resolved = svc._resolve_secrets(config, {}, "TestAgent", warnings)
+    assert resolved["token"] == "{{MISSING}}"
+    assert any("MISSING" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# _next_available_prefix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_next_available_prefix_appends_2() -> None:
+    svc = _make_svc()
+    call_count = 0
+
+    async def _prefix_exists(prefix: str) -> bool:
+        nonlocal call_count
+        call_count += 1
+        return prefix == "ACM"  # ACM taken, ACM2 free
+
+    with patch.object(svc, "_prefix_exists", side_effect=_prefix_exists):
+        result = await svc._next_available_prefix("ACM")
+
+    assert result == "ACM2"
+
+
+# ---------------------------------------------------------------------------
+# execute_import — schema error rolls back
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_import_bad_schema_raises() -> None:
+    svc = _make_svc()
+    with pytest.raises(LLCImportError, match="schema_version"):
+        await svc.execute_import({"schema_version": "99.0"})
+
+
+# ---------------------------------------------------------------------------
+# execute_import — happy path (mocked entity creation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_import_happy_path() -> None:
+    svc = _make_svc()
+    tmpl = _template(
+        goals=[{"title": "G1", "level": "objective", "status": "draft"}],
+        projects=[{"name": "P1", "description": "desc"}],
+        work_items=[{"title": "W1", "type": "epic", "is_seed": True}],
+    )
+
+    company_id = uuid.uuid4()
+
+    with (
+        patch.object(svc, "_resolve_or_create_company", return_value=company_id),
+        patch.object(svc, "_import_agent", return_value=str(uuid.uuid4())),
+        patch.object(svc, "_import_goal", return_value=uuid.uuid4()),
+        patch.object(svc, "_import_project", return_value=uuid.uuid4()),
+        patch.object(svc, "_import_work_item", return_value=uuid.uuid4()),
+    ):
+        sp_mock = AsyncMock()
+        sp_mock.commit = AsyncMock()
+        sp_mock.rollback = AsyncMock()
+        svc.session.begin_nested = AsyncMock(return_value=sp_mock)
+
+        result = await svc.execute_import(tmpl)
+
+    assert result["company_id"] == str(company_id)
+    assert len(result["created_entities"]["goals"]) == 1
+    assert len(result["created_entities"]["projects"]) == 1
+    assert len(result["created_entities"]["work_items"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# execute_import — rollback on failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_import_rollback_on_failure() -> None:
+    svc = _make_svc()
+    tmpl = _template()
+
+    with patch.object(
+        svc, "_resolve_or_create_company", side_effect=Exception("DB boom")
+    ):
+        sp_mock = AsyncMock()
+        sp_mock.commit = AsyncMock()
+        sp_mock.rollback = AsyncMock()
+        svc.session.begin_nested = AsyncMock(return_value=sp_mock)
+
+        with pytest.raises(LLCImportError, match="rolled back"):
+            await svc.execute_import(tmpl)
+
+    sp_mock.rollback.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# execute_import — target_company_id not found
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_import_target_company_not_found() -> None:
+    svc = _make_svc()
+    tmpl = _template()
+    missing_id = uuid.uuid4()
+
+    sp_mock = AsyncMock()
+    sp_mock.commit = AsyncMock()
+    sp_mock.rollback = AsyncMock()
+    svc.session.begin_nested = AsyncMock(return_value=sp_mock)
+
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = None
+    svc.session.execute = AsyncMock(return_value=result_mock)
+
+    with pytest.raises(LLCImportError, match="not found"):
+        await svc.execute_import(tmpl, target_company_id=missing_id)
+
+
+# ---------------------------------------------------------------------------
+# execute_import — skips non-seed work items
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_import_skips_non_seed_work_items() -> None:
+    svc = _make_svc()
+    tmpl = _template(
+        work_items=[
+            {"title": "Epic seed", "type": "epic", "is_seed": True},
+            {"title": "Task not seed", "type": "task", "is_seed": False},
+        ]
+    )
+
+    company_id = uuid.uuid4()
+    created: list[str] = []
+
+    async def fake_import_work_item(item, cid):  # noqa: ANN001
+        created.append(item["title"])
+        return uuid.uuid4()
+
+    with (
+        patch.object(svc, "_resolve_or_create_company", return_value=company_id),
+        patch.object(svc, "_import_work_item", side_effect=fake_import_work_item),
+    ):
+        sp_mock = AsyncMock()
+        sp_mock.commit = AsyncMock()
+        sp_mock.rollback = AsyncMock()
+        svc.session.begin_nested = AsyncMock(return_value=sp_mock)
+
+        await svc.execute_import(tmpl)
+
+    assert created == ["Epic seed"]

--- a/autobot-backend/llc/tests/test_import.py
+++ b/autobot-backend/llc/tests/test_import.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from llc.services.portability import ImportError as LLCImportError
+from llc.services.portability import TemplateImportError as LLCImportError
 from llc.services.portability import PortabilityService
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llc/tests/test_import.py
+++ b/autobot-backend/llc/tests/test_import.py
@@ -9,8 +9,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from llc.services.portability import ImportError as LLCImportError, PortabilityService
-
+from llc.services.portability import ImportError as LLCImportError
+from llc.services.portability import PortabilityService
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary
- `PortabilityService.preview_import`: detects issue_prefix/agent_name/goal_title collisions; reports secret placeholder warnings; returns `{collisions, will_create, warnings}`
- `PortabilityService.execute_import`: transactional import with savepoint rollback; issue_prefix remapping (appends `-2`, `-3`...); `require_approval_for_hires` agent creation; `{{SECRET_NAME}}` placeholder resolution; skips non-seed work items
- `POST /api/llc/import/preview` and `POST /api/llc/import/execute` routes wired into LLC router
- 14 unit tests — schema validation, collision detection, prefix remapping, secret resolution, rollback, non-seed skip

## Test plan
- [x] `python -m pytest autobot-backend/llc/tests/test_import.py` — 14/14 passed
- [x] `python -m py_compile` on all 3 new files

Closes #8246

🤖 Generated with [Claude Code](https://claude.com/claude-code)