### PR TITLE
feat(llc): notification routing service — relay llc:* Redis events to WebSocket (#8255)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1399,6 +1399,25 @@ async def _start_community_clustering_loop(app: FastAPI) -> None:
     )
 
 
+async def _start_llc_notification_router(app: FastAPI) -> None:
+    """Start the LLC notification router background task (GH#8255).
+
+    Subscribes to llc:* Redis pub/sub patterns and fans out events to WebSocket
+    clients filtered by company_id. NON-CRITICAL: failure logs a warning but
+    does not block startup.
+    """
+    try:
+        from llc.notifications.router import get_llc_notification_router
+
+        router = get_llc_notification_router()
+        await router.start()
+        app.state.llc_notification_router = router
+        logger.info("✅ LLC notification router started")
+    except Exception as exc:
+        logger.warning("LLC notification router failed to start (non-critical): %s", exc)
+        app.state.llc_notification_router = None
+
+
 async def _init_web_researcher(app: FastAPI) -> None:
     """Initialize the WebResearcher singleton so web browsing is available in chat.
 
@@ -1508,6 +1527,7 @@ async def initialize_background_services(app: FastAPI):
         await _init_llm_key_rotation_scheduler(app)
         await _start_autonomous_loop(app)
         await _start_community_clustering_loop(app)
+        await _start_llc_notification_router(app)
 
         await update_app_state_multi(
             initialization_status="ready",
@@ -1604,6 +1624,10 @@ async def cleanup_services(app: FastAPI):
         if hasattr(app.state, "llc_outbound_sync") and app.state.llc_outbound_sync:
             await app.state.llc_outbound_sync.stop()
             logger.info("✅ LLC outbound sync service stopped")
+        # GH#8255: Stop LLC notification router
+        if hasattr(app.state, "llc_notification_router") and app.state.llc_notification_router:
+            await app.state.llc_notification_router.stop()
+            logger.info("✅ LLC notification router stopped")
 
         # GH#8229: Stop LLC routine scheduler
         if hasattr(app.state, "llc_routine_scheduler") and app.state.llc_routine_scheduler:

--- a/autobot-backend/live_event_manager.py
+++ b/autobot-backend/live_event_manager.py
@@ -19,11 +19,11 @@ from autobot_shared.singleton_factory import lazy_singleton
 
 logger = get_logger(__name__)
 
-_VALID_PREFIXES = {"agent", "task", "workflow", "heartbeat"}
+_VALID_PREFIXES = {"agent", "task", "workflow", "heartbeat", "company"}
 
 
 def _is_valid_channel(channel: str) -> bool:
-    """Return True if channel matches agent:{id}, task:{id}, workflow:{id}, heartbeat:{id}, or global."""
+    """Return True if channel matches agent:{id}, task:{id}, workflow:{id}, heartbeat:{id}, company:{id}, or global."""
     if channel == "global":
         return True
     parts = channel.split(":", 1)

--- a/autobot-backend/llc/notifications/__init__.py
+++ b/autobot-backend/llc/notifications/__init__.py
@@ -1,5 +1,11 @@
 """LLC notifications package."""
 
 from .publisher import LLCEvent, LLCWebSocketPublisher
+from .router import LLCNotificationRouter, get_llc_notification_router
 
-__all__ = ["LLCEvent", "LLCWebSocketPublisher"]
+__all__ = [
+    "LLCEvent",
+    "LLCWebSocketPublisher",
+    "LLCNotificationRouter",
+    "get_llc_notification_router",
+]

--- a/autobot-backend/llc/notifications/publisher.py
+++ b/autobot-backend/llc/notifications/publisher.py
@@ -1,24 +1,32 @@
-"""LLC WebSocket publisher interface (GH#8261).
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLC WebSocket publisher (GH#8255).
 
-GH#8255 (notification router) and GH#8221 (Kanban board real-time) both push
-LLC events to WebSocket clients filtered by company_id. This publisher ensures
-both callers use the same typed event envelope and company_id filter, and that
-events reach both the RedisEventStreamManager and the LiveEventManager.
-
-Concrete implementation in GH#8255. This file provides the interface stub.
+Publishes LLC events to WebSocket clients filtered by company_id using both
+the LiveEventManager (company:{id} channel) and the EventManager broadcast.
 """
 
+from __future__ import annotations
+
+import logging
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    from live_event_manager import get_live_event_manager
+    from event_manager import get_event_manager
+except ImportError:
+    get_live_event_manager = None  # type: ignore[assignment]
+    get_event_manager = None  # type: ignore[assignment]
 
 
 @dataclass
 class LLCEvent:
-    """Typed event envelope for LLC WebSocket messages.
-
-    Both WebSocket buses (RedisEventStreamManager and LiveEventManager) receive
-    this envelope so subscribers on either bus get consistent payloads.
-    """
+    """Typed event envelope for LLC WebSocket messages."""
 
     company_id: str
     event_type: str
@@ -31,11 +39,11 @@ class LLCEvent:
 class LLCWebSocketPublisher:
     """Publishes LLC events to connected WebSocket clients.
 
-    Multi-tenant safety: company_id filter is applied before push so a client
-    subscribed to company A never receives events from company B.
+    Uses the LiveEventManager channel ``company:{company_id}`` so only clients
+    subscribed to that company receive the event (multi-tenant isolation).
 
-    Both GH#8255 (notification router) and GH#8221 (Kanban real-time) inject
-    this rather than calling the WebSocket manager directly.
+    Also fans out via EventManager for clients using the broadcast path.
+    Never raises — failures are logged but must not break the caller.
     """
 
     async def publish(
@@ -47,19 +55,24 @@ class LLCWebSocketPublisher:
         payload: Dict[str, Any],
         actor_id: Optional[str] = None,
     ) -> None:
-        """Publish an LLC event to all matching WebSocket subscribers.
+        channel = f"company:{company_id}"
+        envelope: Dict[str, Any] = {
+            "event_type": event_type,
+            "company_id": company_id,
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "payload": payload,
+            "actor_id": actor_id,
+            "ts": datetime.now(timezone.utc).isoformat(),
+        }
+        try:
+            if get_live_event_manager is not None:
+                await get_live_event_manager().publish(channel, event_type, envelope)
+        except Exception as exc:
+            logger.warning("LLC publisher: LiveEventManager push failed: %s", exc)
 
-        Pushes to both RedisEventStreamManager and LiveEventManager with the
-        company_id filter applied. Never raises — publishing failures are
-        logged but must not break the calling operation.
-
-        Args:
-            company_id: Tenant scope — only subscribers for this company receive
-                the event.
-            event_type: Logical event kind (use ActivityEventType string values).
-            entity_type: Resource type name (e.g. "work_item", "sprint").
-            entity_id: PK of the affected resource.
-            payload: Serializable event data.
-            actor_id: Optional agent/user that triggered the event.
-        """
-        raise NotImplementedError("LLCWebSocketPublisher.publish() — concrete impl in GH#8255")
+        try:
+            if get_event_manager is not None:
+                await get_event_manager().publish_event(f"llc:{event_type}", envelope)
+        except Exception as exc:
+            logger.warning("LLC publisher: EventManager push failed: %s", exc)

--- a/autobot-backend/llc/notifications/router.py
+++ b/autobot-backend/llc/notifications/router.py
@@ -1,0 +1,150 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLC notification router (GH#8255).
+
+Subscribes to llc:* Redis pub/sub patterns and routes each event to the
+correct WebSocket clients filtered by company_id.
+
+Watched patterns:
+  llc:company:*   — company-level lifecycle events
+  llc:budget:*    — budget_warning_80, budget_warning_95, budget_exhausted
+  llc:approval:*  — approval_created, approval_resolved
+  llc:sprint:*    — sprint_closed, sprint_started
+  llc:agent:*     — agent_paused, agent_resumed, heartbeat_ok, heartbeat_missed
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Optional
+
+from autobot_shared.redis_client import get_async_redis_client
+
+from .publisher import LLCEvent, LLCWebSocketPublisher
+
+logger = logging.getLogger(__name__)
+
+_PATTERNS = [
+    "llc:company:*",
+    "llc:budget:*",
+    "llc:approval:*",
+    "llc:sprint:*",
+    "llc:agent:*",
+]
+
+_RECONNECT_DELAY = 5  # seconds between reconnect attempts
+
+
+class LLCNotificationRouter:
+    """Subscribes to llc:* Redis pub/sub and fans out events to WebSocket clients.
+
+    Lifecycle:
+      await router.start()   # called from lifespan
+      await router.stop()    # called from shutdown
+    """
+
+    def __init__(self, publisher: Optional[LLCWebSocketPublisher] = None) -> None:
+        self._publisher = publisher or LLCWebSocketPublisher()
+        self._task: Optional[asyncio.Task] = None
+        self._stop_event = asyncio.Event()
+
+    async def start(self) -> None:
+        if self._task and not self._task.done():
+            return
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._run(), name="llc-notification-router")
+        logger.info("LLC notification router started")
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("LLC notification router stopped")
+
+    async def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                await self._subscribe_loop()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("LLC router disconnected (%s), reconnecting in %ds", exc, _RECONNECT_DELAY)
+                try:
+                    await asyncio.wait_for(self._stop_event.wait(), timeout=_RECONNECT_DELAY)
+                except asyncio.TimeoutError:
+                    pass
+
+    async def _subscribe_loop(self) -> None:
+        redis = await get_async_redis_client(database="main")
+        if redis is None:
+            raise RuntimeError("Redis unavailable")
+
+        pubsub = redis.pubsub()
+        try:
+            for pattern in _PATTERNS:
+                await pubsub.psubscribe(pattern)
+            logger.info("LLC router subscribed to %d patterns", len(_PATTERNS))
+
+            async for message in pubsub.listen():
+                if self._stop_event.is_set():
+                    break
+                if message["type"] not in ("pmessage", "message"):
+                    continue
+                await self._dispatch(message)
+        finally:
+            try:
+                await pubsub.punsubscribe()
+                await pubsub.aclose()
+            except Exception:
+                pass
+
+    async def _dispatch(self, message: dict) -> None:
+        raw = message.get("data")
+        if not raw:
+            return
+        try:
+            data = json.loads(raw) if isinstance(raw, (str, bytes)) else raw
+        except (json.JSONDecodeError, TypeError):
+            logger.debug("LLC router: unparseable message on %s", message.get("channel"))
+            return
+
+        if not isinstance(data, dict):
+            return
+
+        company_id = data.get("company_id")
+        if not company_id:
+            return
+
+        event = LLCEvent(
+            company_id=company_id,
+            event_type=data.get("event_type", ""),
+            entity_type=data.get("entity_type", ""),
+            entity_id=str(data.get("entity_id", "")),
+            payload=data.get("payload", {}),
+            actor_id=data.get("actor_id"),
+        )
+        await self._publisher.publish(
+            company_id=event.company_id,
+            event_type=event.event_type,
+            entity_type=event.entity_type,
+            entity_id=event.entity_id,
+            payload=event.payload,
+            actor_id=event.actor_id,
+        )
+
+
+_router_instance: Optional[LLCNotificationRouter] = None
+
+
+def get_llc_notification_router() -> LLCNotificationRouter:
+    global _router_instance
+    if _router_instance is None:
+        _router_instance = LLCNotificationRouter()
+    return _router_instance

--- a/autobot-backend/llc/services/handoff.py
+++ b/autobot-backend/llc/services/handoff.py
@@ -121,8 +121,8 @@ class HandoffService(LLCServiceBase):
         await self._publish_a2h_notification(company_id, work_item_id, reviewer_user_id, brief)
         if self.activity_log:
             try:
-                from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
+                from ..models.activity import ActorType
 
                 await self.activity_log.record(
                     session,
@@ -161,8 +161,8 @@ class HandoffService(LLCServiceBase):
         await session.flush()
         if self.activity_log:
             try:
-                from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
+                from ..models.activity import ActorType
 
                 await self.activity_log.record(
                     session,
@@ -215,8 +215,8 @@ class HandoffService(LLCServiceBase):
         await session.flush()
         if self.activity_log:
             try:
-                from ..models.activity import ActorType
                 from .activity_log import ActivityEventType
+                from ..models.activity import ActorType
 
                 await self.activity_log.record(
                     session,

--- a/autobot-backend/llc/services/handoff.py
+++ b/autobot-backend/llc/services/handoff.py
@@ -121,8 +121,8 @@ class HandoffService(LLCServiceBase):
         await self._publish_a2h_notification(company_id, work_item_id, reviewer_user_id, brief)
         if self.activity_log:
             try:
-                from .activity_log import ActivityEventType
                 from ..models.activity import ActorType
+                from .activity_log import ActivityEventType
 
                 await self.activity_log.record(
                     session,
@@ -161,8 +161,8 @@ class HandoffService(LLCServiceBase):
         await session.flush()
         if self.activity_log:
             try:
-                from .activity_log import ActivityEventType
                 from ..models.activity import ActorType
+                from .activity_log import ActivityEventType
 
                 await self.activity_log.record(
                     session,
@@ -215,8 +215,8 @@ class HandoffService(LLCServiceBase):
         await session.flush()
         if self.activity_log:
             try:
-                from .activity_log import ActivityEventType
                 from ..models.activity import ActorType
+                from .activity_log import ActivityEventType
 
                 await self.activity_log.record(
                     session,

--- a/autobot-backend/llc/tests/test_notification_router.py
+++ b/autobot-backend/llc/tests/test_notification_router.py
@@ -1,0 +1,231 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for LLC notification router (GH#8255)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.notifications.publisher import LLCEvent, LLCWebSocketPublisher
+from llc.notifications.router import LLCNotificationRouter
+
+
+class _FakePublisher:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def publish(self, company_id, event_type, entity_type, entity_id, payload, actor_id=None):
+        self.calls.append(
+            dict(
+                company_id=company_id,
+                event_type=event_type,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                payload=payload,
+                actor_id=actor_id,
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_to_publisher():
+    pub = _FakePublisher()
+    router = LLCNotificationRouter(publisher=pub)
+
+    msg = {
+        "type": "pmessage",
+        "channel": b"llc:budget:warning",
+        "data": json.dumps(
+            {
+                "event_type": "budget_warning_80",
+                "company_id": "company-abc",
+                "entity_type": "budget",
+                "entity_id": "budget-1",
+                "payload": {"threshold": 80},
+            }
+        ).encode(),
+    }
+    await router._dispatch(msg)
+
+    assert len(pub.calls) == 1
+    assert pub.calls[0]["company_id"] == "company-abc"
+    assert pub.calls[0]["event_type"] == "budget_warning_80"
+    assert pub.calls[0]["payload"] == {"threshold": 80}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_missing_company_id():
+    pub = _FakePublisher()
+    router = LLCNotificationRouter(publisher=pub)
+
+    msg = {
+        "type": "pmessage",
+        "channel": b"llc:agent:paused",
+        "data": json.dumps({"event_type": "agent_paused", "entity_type": "agent", "entity_id": "a1"}).encode(),
+    }
+    await router._dispatch(msg)
+    assert pub.calls == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_ignores_non_message_types():
+    pub = _FakePublisher()
+    router = LLCNotificationRouter(publisher=pub)
+
+    msg = {"type": "subscribe", "channel": b"llc:budget:*", "data": 1}
+    await router._dispatch(msg)
+    assert pub.calls == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_handles_invalid_json():
+    pub = _FakePublisher()
+    router = LLCNotificationRouter(publisher=pub)
+
+    msg = {"type": "pmessage", "channel": b"llc:budget:*", "data": b"not-json"}
+    await router._dispatch(msg)
+    assert pub.calls == []
+
+
+@pytest.mark.asyncio
+async def test_start_stop_lifecycle():
+    pub = _FakePublisher()
+    router = LLCNotificationRouter(publisher=pub)
+
+    async def _fake_subscribe_loop():
+        await asyncio.sleep(10)
+
+    with patch.object(router, "_subscribe_loop", side_effect=_fake_subscribe_loop):
+        await router.start()
+        assert router._task and not router._task.done()
+        await router.stop()
+        assert router._task.done()
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent():
+    pub = _FakePublisher()
+    router = LLCNotificationRouter(publisher=pub)
+
+    async def _sleep():
+        await asyncio.sleep(10)
+
+    with patch.object(router, "_subscribe_loop", side_effect=_sleep):
+        await router.start()
+        task_before = router._task
+        await router.start()
+        assert router._task is task_before
+        await router.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconnects_on_redis_failure():
+    pub = _FakePublisher()
+    router = LLCNotificationRouter(publisher=pub)
+    call_count = 0
+
+    async def _flaky_subscribe():
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise ConnectionError("redis down")
+        router._stop_event.set()
+
+    with patch.object(router, "_subscribe_loop", side_effect=_flaky_subscribe):
+        with patch("llc.notifications.router._RECONNECT_DELAY", 0):
+            await router.start()
+            await asyncio.wait_for(router._task, timeout=2)
+
+    assert call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_publisher_pushes_to_live_event_manager():
+    pub = LLCWebSocketPublisher()
+    mock_lem = AsyncMock()
+    mock_em = AsyncMock()
+
+    import llc.notifications.publisher as pub_mod
+
+    orig_lem = pub_mod.get_live_event_manager
+    orig_em = pub_mod.get_event_manager
+    pub_mod.get_live_event_manager = lambda: mock_lem  # type: ignore[assignment]
+    pub_mod.get_event_manager = lambda: mock_em  # type: ignore[assignment]
+    try:
+        await pub.publish(
+            company_id="c1",
+            event_type="agent_paused",
+            entity_type="agent",
+            entity_id="a1",
+            payload={"reason": "budget"},
+        )
+    finally:
+        pub_mod.get_live_event_manager = orig_lem  # type: ignore[assignment]
+        pub_mod.get_event_manager = orig_em  # type: ignore[assignment]
+
+    mock_lem.publish.assert_awaited_once()
+    call_args = mock_lem.publish.call_args
+    assert call_args[0][0] == "company:c1"
+    assert call_args[0][1] == "agent_paused"
+    envelope = call_args[0][2]
+    assert envelope["company_id"] == "c1"
+    assert envelope["entity_id"] == "a1"
+
+
+@pytest.mark.asyncio
+async def test_publisher_survives_live_event_manager_failure():
+    pub = LLCWebSocketPublisher()
+    mock_lem = AsyncMock()
+    mock_lem.publish.side_effect = RuntimeError("lem down")
+    mock_em = AsyncMock()
+
+    import llc.notifications.publisher as pub_mod
+
+    orig_lem = pub_mod.get_live_event_manager
+    orig_em = pub_mod.get_event_manager
+    pub_mod.get_live_event_manager = lambda: mock_lem  # type: ignore[assignment]
+    pub_mod.get_event_manager = lambda: mock_em  # type: ignore[assignment]
+    try:
+        await pub.publish(
+            company_id="c1",
+            event_type="budget_exhausted",
+            entity_type="budget",
+            entity_id="b1",
+            payload={},
+        )
+    finally:
+        pub_mod.get_live_event_manager = orig_lem  # type: ignore[assignment]
+        pub_mod.get_event_manager = orig_em  # type: ignore[assignment]
+
+    mock_em.publish_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_integration_publish_then_dispatch():
+    """Publish event through router dispatch and verify publisher receives it."""
+    pub = _FakePublisher()
+    router = LLCNotificationRouter(publisher=pub)
+
+    event_data = {
+        "event_type": "approval_created",
+        "company_id": "co-xyz",
+        "entity_type": "approval",
+        "entity_id": "appr-1",
+        "payload": {"title": "Hire engineer"},
+        "actor_id": "agent-ceo",
+    }
+    msg = {
+        "type": "pmessage",
+        "channel": b"llc:approval:created",
+        "data": json.dumps(event_data).encode(),
+    }
+    await router._dispatch(msg)
+
+    assert pub.calls[0]["company_id"] == "co-xyz"
+    assert pub.calls[0]["actor_id"] == "agent-ceo"
+    assert pub.calls[0]["payload"] == {"title": "Hire engineer"}

--- a/autobot-frontend/src/composables/useLLCNotifications.ts
+++ b/autobot-frontend/src/composables/useLLCNotifications.ts
@@ -1,0 +1,125 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * useLLCNotifications (GH#8255)
+ *
+ * Subscribes to LLC real-time events arriving via the global WebSocket and
+ * exposes a reactive stream of events filtered to the given company_id.
+ *
+ * Events relayed:
+ *   llc:budget:*    — budget_warning_80, budget_warning_95, budget_exhausted
+ *   llc:agent:*     — agent_paused, agent_resumed, heartbeat_ok, heartbeat_missed
+ *   llc:approval:*  — approval_created, approval_resolved
+ *   llc:sprint:*    — sprint_started, sprint_closed
+ *   llc:company:*   — company-level lifecycle events
+ *
+ * Usage:
+ *   const { events, on, clear } = useLLCNotifications(companyId)
+ *   on('budget_exhausted', (e) => showAlert(e.payload))
+ */
+
+import { ref, onUnmounted, getCurrentInstance, type Ref } from 'vue'
+import { createLogger } from '@/utils/debugUtils'
+import globalWebSocketService from '@/services/GlobalWebSocketService'
+
+const logger = createLogger('useLLCNotifications')
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LLCNotificationEvent {
+  event_type: string
+  company_id: string
+  entity_type: string
+  entity_id: string
+  payload: Record<string, unknown>
+  actor_id?: string
+  ts: string
+}
+
+type LLCEventHandler = (event: LLCNotificationEvent) => void
+
+// Event types that carry the llc event_type directly on msg.type
+const LLC_EVENT_TYPES = [
+  'budget_warning_80',
+  'budget_warning_95',
+  'budget_exhausted',
+  'agent_paused',
+  'agent_resumed',
+  'heartbeat_ok',
+  'heartbeat_missed',
+  'approval_created',
+  'approval_resolved',
+  'sprint_started',
+  'sprint_closed',
+]
+
+// ---------------------------------------------------------------------------
+// Composable
+// ---------------------------------------------------------------------------
+
+export function useLLCNotifications(companyId: string) {
+  const events: Ref<LLCNotificationEvent[]> = ref([])
+  const handlers = new Map<string, Set<LLCEventHandler>>()
+  const unsubscribers: Array<() => void> = []
+
+  function _handleMessage(data: unknown) {
+    const msg = data as Record<string, unknown>
+    if (typeof msg !== 'object' || msg === null) return
+    // Filter to this company only
+    if (msg.company_id !== companyId) return
+
+    const event = msg as LLCNotificationEvent
+    events.value.push(event)
+
+    const specific = handlers.get(event.event_type)
+    if (specific) specific.forEach((cb) => cb(event))
+
+    const wildcards = handlers.get('*')
+    if (wildcards) wildcards.forEach((cb) => cb(event))
+  }
+
+  // Subscribe to each LLC event type on the global WS
+  for (const evtType of LLC_EVENT_TYPES) {
+    unsubscribers.push(globalWebSocketService.on(evtType, _handleMessage))
+  }
+
+  // Also listen on generic 'message' for LLC events emitted without a top-level type
+  unsubscribers.push(
+    globalWebSocketService.on('message', (data: unknown) => {
+      const msg = data as Record<string, unknown>
+      if (typeof msg !== 'object' || msg === null) return
+      const evtType = msg.event_type as string | undefined
+      if (!evtType || !LLC_EVENT_TYPES.includes(evtType)) return
+      _handleMessage(data)
+    }),
+  )
+
+  function on(eventType: string, handler: LLCEventHandler): () => void {
+    if (!handlers.has(eventType)) handlers.set(eventType, new Set())
+    handlers.get(eventType)!.add(handler)
+    return () => handlers.get(eventType)?.delete(handler)
+  }
+
+  function clear() {
+    events.value = []
+  }
+
+  function cleanup() {
+    unsubscribers.forEach((unsub) => unsub())
+    handlers.clear()
+  }
+
+  const instance = getCurrentInstance()
+  if (instance) {
+    onUnmounted(cleanup)
+  } else {
+    logger.warn('useLLCNotifications called outside Vue component — manual cleanup required')
+  }
+
+  return { events, on, clear, cleanup }
+}
+
+export default useLLCNotifications


### PR DESCRIPTION
## Summary

Implements GH#8255 — the LLC notification routing service that bridges Redis pub/sub to WebSocket clients.

- **`LLCNotificationRouter`** (`llc/notifications/router.py`) — subscribes to `llc:company:*`, `llc:budget:*`, `llc:approval:*`, `llc:sprint:*`, `llc:agent:*` pub/sub patterns; routes each event to WebSocket clients filtered by `company_id`; auto-reconnects on Redis disconnect
- **`LLCWebSocketPublisher`** (`llc/notifications/publisher.py`) — concrete impl replacing stub; pushes to both `LiveEventManager` (`company:{id}` channel) and `EventManager` broadcast; never raises on failure
- **`live_event_manager.py`** — adds `company` to valid channel prefixes to support `company:{id}` routing
- **`lifespan.py`** — starts router as non-critical Phase 2 background task; stops cleanly on shutdown
- **`useLLCNotifications.ts`** — Vue composable that subscribes via `GlobalWebSocketService` and exposes `events`, `on(eventType, handler)`, and `clear()`

## Event schema

```json
{ "event_type": "budget_warning_80", "company_id": "...", "entity_type": "budget", "entity_id": "...", "payload": {}, "actor_id": null, "ts": "..." }
```

## Test plan

- [x] 10 unit tests: routing, dispatch guards, lifecycle (start/stop/idempotent), reconnect on Redis failure, publisher resilience on LEM failure
- [x] All tests pass (`10 passed in 0.55s`)
- [x] Syntax check clean on all new/modified Python files

🤖 Generated with [Claude Code](https://claude.ai/claude-code)