### PR TITLE
feat(llc/frontend): Approvals Inbox + Cost Dashboard + Heartbeat Monitor + CEO Chat (#8249)

### DIFF
--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -932,27 +932,19 @@ export const routes: RouteRecordRaw[] = [
       hideInNav: true,
     }
   },
-  {
     path: '/llc/companies/:companyId/boards/:boardId/sprint',
     name: 'llc-sprint-board',
     component: () => import('@/views/llc/SprintBoardView.vue'),
-    meta: {
       title: 'Sprint Board',
-      requiresAuth: true,
-      hideInNav: true,
-    }
-  },
-  {
     path: '/llc/companies/:companyId/boards/:boardId/kanban',
     name: 'llc-kanban-board',
     component: () => import('@/views/llc/KanbanBoardView.vue'),
-    meta: {
       title: 'Kanban Board',
-      requiresAuth: true,
-      hideInNav: true,
-    }
-  },
-  {
+  // LLC module routes — GH#8249
+  { path: '/llc/approvals', name: 'llc-approvals', component: () => import('@/views/llc/ApprovalsInbox.vue'), meta: { title: 'Approvals Inbox', requiresAuth: true } },
+  { path: '/llc/costs', name: 'llc-costs', component: () => import('@/views/llc/CostDashboard.vue'), meta: { title: 'Cost Dashboard', requiresAuth: true } },
+  { path: '/llc/heartbeat', name: 'llc-heartbeat', component: () => import('@/views/llc/HeartbeatMonitor.vue'), meta: { title: 'Heartbeat Monitor', requiresAuth: true } },
+  { path: '/llc/ceo-chat', name: 'llc-ceo-chat', component: () => import('@/views/llc/CeoChatView.vue'), meta: { title: 'CEO Chat', requiresAuth: true } },
     path: '/:pathMatch(.*)*',
     name: 'not-found',
     component: NotFoundView,

--- a/autobot-frontend/src/views/llc/ApprovalsInbox.vue
+++ b/autobot-frontend/src/views/llc/ApprovalsInbox.vue
@@ -1,0 +1,533 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025 mrveiss -->
+<!-- Author: mrveiss -->
+<template>
+  <div class="approvals-inbox">
+    <div class="inbox-header">
+      <div class="header-left">
+        <h2 class="view-title">Approvals Inbox</h2>
+        <span v-if="pendingCount > 0" class="pending-badge">{{ pendingCount }}</span>
+      </div>
+      <div class="header-tabs">
+        <button
+          class="tab-btn"
+          :class="{ active: activeTab === 'pending' }"
+          @click="activeTab = 'pending'"
+        >
+          Pending
+        </button>
+        <button
+          class="tab-btn"
+          :class="{ active: activeTab === 'history' }"
+          @click="activeTab = 'history'"
+        >
+          History
+        </button>
+      </div>
+    </div>
+
+    <!-- Filters -->
+    <div class="inbox-filters">
+      <select v-model="filters.type" class="filter-select">
+        <option value="">All Types</option>
+        <option v-for="t in APPROVAL_TYPES" :key="t" :value="t">{{ formatType(t) }}</option>
+      </select>
+      <select v-if="activeTab === 'history'" v-model="filters.status" class="filter-select">
+        <option value="">All Statuses</option>
+        <option value="approved">Approved</option>
+        <option value="rejected">Rejected</option>
+        <option value="changes_requested">Changes Requested</option>
+      </select>
+      <input v-model="filters.search" class="filter-search" placeholder="Search..." type="text" />
+    </div>
+
+    <!-- Pending Tab -->
+    <div v-if="activeTab === 'pending'" class="approval-list">
+      <div v-if="isLoading" class="state-msg">Loading...</div>
+      <div v-else-if="filteredPending.length === 0" class="state-msg">No pending approvals.</div>
+      <div
+        v-for="item in filteredPending"
+        :key="item.id"
+        class="approval-card"
+      >
+        <div class="card-header">
+          <span class="type-badge" :class="`type-${item.type}`">{{ formatType(item.type) }}</span>
+          <span class="card-meta">Requested by: {{ item.requested_by_agent_id }}</span>
+          <span class="card-meta">{{ formatDate(item.created_at) }}</span>
+        </div>
+
+        <div class="payload-section">
+          <button class="toggle-payload" @click="togglePayload(item.id)">
+            {{ expandedPayloads.has(item.id) ? 'Hide' : 'Show' }} Payload
+          </button>
+          <pre v-if="expandedPayloads.has(item.id)" class="payload-json">{{ formatJson(item.payload) }}</pre>
+        </div>
+
+        <div class="card-actions">
+          <button
+            class="btn-approve"
+            :disabled="processing.has(item.id)"
+            @click="decide(item.id, 'approved')"
+          >
+            Approve
+          </button>
+          <button
+            class="btn-reject"
+            :disabled="processing.has(item.id)"
+            @click="openDecisionNote(item.id, 'rejected')"
+          >
+            Reject
+          </button>
+          <button
+            class="btn-changes"
+            :disabled="processing.has(item.id)"
+            @click="openDecisionNote(item.id, 'changes_requested')"
+          >
+            Request Changes
+          </button>
+        </div>
+
+        <div v-if="noteTarget?.id === item.id" class="note-form">
+          <textarea
+            v-model="decisionNote"
+            class="note-textarea"
+            placeholder="Decision note (required)..."
+            rows="3"
+          />
+          <div class="note-actions">
+            <button class="btn-secondary" @click="noteTarget = null">Cancel</button>
+            <button
+              class="btn-primary"
+              :disabled="!decisionNote.trim() || processing.has(item.id)"
+              @click="submitWithNote(item.id)"
+            >
+              Confirm
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- History Tab -->
+    <div v-if="activeTab === 'history'" class="approval-list">
+      <div v-if="isLoading" class="state-msg">Loading...</div>
+      <div v-else-if="filteredHistory.length === 0" class="state-msg">No history found.</div>
+      <div
+        v-for="item in filteredHistory"
+        :key="item.id"
+        class="approval-card history-card"
+      >
+        <div class="card-header">
+          <span class="type-badge" :class="`type-${item.type}`">{{ formatType(item.type) }}</span>
+          <span class="status-badge" :class="`status-${item.status}`">{{ formatType(item.status) }}</span>
+          <span class="card-meta">Decided by: {{ item.decided_by_agent_id ?? '—' }}</span>
+          <span class="card-meta">{{ formatDate(item.decided_at ?? item.updated_at) }}</span>
+        </div>
+        <div class="payload-section">
+          <button class="toggle-payload" @click="togglePayload(item.id)">
+            {{ expandedPayloads.has(item.id) ? 'Hide' : 'Show' }} Payload
+          </button>
+          <pre v-if="expandedPayloads.has(item.id)" class="payload-json">{{ formatJson(item.payload) }}</pre>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useApiClient } from '@/plugins/api'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('ApprovalsInbox')
+const api = useApiClient()
+
+const props = defineProps<{ companyId?: string }>()
+const companyId = computed(() => props.companyId ?? '00000000-0000-0000-0000-000000000000')
+
+const APPROVAL_TYPES = [
+  'budget_increase', 'agent_spawn', 'external_api', 'code_deploy',
+  'data_access', 'policy_change', 'contract_sign', 'hiring',
+]
+
+interface Approval {
+  id: string
+  company_id: string
+  type: string
+  status: string
+  requested_by_agent_id: string
+  payload: Record<string, unknown>
+  decided_by_agent_id: string | null
+  decided_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+const approvals = ref<Approval[]>([])
+const isLoading = ref(false)
+const activeTab = ref<'pending' | 'history'>('pending')
+const expandedPayloads = ref<Set<string>>(new Set())
+const processing = ref<Set<string>>(new Set())
+const filters = ref({ type: '', status: '', search: '' })
+const noteTarget = ref<{ id: string; decision: string } | null>(null)
+const decisionNote = ref('')
+
+const pendingItems = computed(() => approvals.value.filter(a => a.status === 'pending'))
+const historyItems = computed(() => approvals.value.filter(a => a.status !== 'pending'))
+const pendingCount = computed(() => pendingItems.value.length)
+
+const filteredPending = computed(() => {
+  return pendingItems.value.filter(a => {
+    if (filters.value.type && a.type !== filters.value.type) return false
+    if (filters.value.search) {
+      const q = filters.value.search.toLowerCase()
+      if (!a.type.includes(q) && !a.requested_by_agent_id.includes(q)) return false
+    }
+    return true
+  })
+})
+
+const filteredHistory = computed(() => {
+  return historyItems.value.filter(a => {
+    if (filters.value.type && a.type !== filters.value.type) return false
+    if (filters.value.status && a.status !== filters.value.status) return false
+    if (filters.value.search) {
+      const q = filters.value.search.toLowerCase()
+      if (!a.type.includes(q)) return false
+    }
+    return true
+  })
+})
+
+function formatType(val: string) {
+  return val.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+}
+
+function formatDate(iso: string | null) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString()
+}
+
+function formatJson(payload: Record<string, unknown>) {
+  try {
+    return JSON.stringify(payload, null, 2)
+  } catch {
+    return String(payload)
+  }
+}
+
+function togglePayload(id: string) {
+  const next = new Set(expandedPayloads.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  expandedPayloads.value = next
+}
+
+function openDecisionNote(id: string, decision: string) {
+  noteTarget.value = { id, decision }
+  decisionNote.value = ''
+}
+
+async function decide(id: string, decision: string, note?: string) {
+  const next = new Set(processing.value)
+  next.add(id)
+  processing.value = next
+  try {
+    await api.post<unknown>(`/api/llc/approvals/${id}/decide`, {
+      decision,
+      decided_by_agent_id: '00000000-0000-0000-0000-000000000001',
+      ...(note ? { note } : {}),
+    })
+    await fetchApprovals()
+  } catch (err) {
+    logger.error('Decision failed', err)
+  } finally {
+    const s = new Set(processing.value)
+    s.delete(id)
+    processing.value = s
+  }
+}
+
+async function submitWithNote(id: string) {
+  if (!noteTarget.value || !decisionNote.value.trim()) return
+  const { decision } = noteTarget.value
+  noteTarget.value = null
+  await decide(id, decision, decisionNote.value.trim())
+  decisionNote.value = ''
+}
+
+async function fetchApprovals() {
+  isLoading.value = true
+  try {
+    const data = await api.get<Approval[] | { items: Approval[] }>(
+      `/api/llc/approvals?company_id=${companyId.value}`
+    )
+    approvals.value = Array.isArray(data) ? data : (data as { items: Approval[] }).items ?? []
+  } catch (err) {
+    logger.error('Failed to fetch approvals', err)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+let pollInterval: ReturnType<typeof setInterval> | null = null
+
+onMounted(() => {
+  fetchApprovals()
+  pollInterval = setInterval(fetchApprovals, 30_000)
+})
+
+onUnmounted(() => {
+  if (pollInterval !== null) clearInterval(pollInterval)
+})
+</script>
+
+<style scoped>
+.approvals-inbox {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1.5rem;
+  gap: 1rem;
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+.inbox-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.view-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.pending-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.4rem;
+  background: #ef4444;
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 700;
+  border-radius: 9999px;
+}
+
+.header-tabs {
+  display: flex;
+  gap: 0.25rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.375rem;
+  overflow: hidden;
+}
+
+.tab-btn {
+  padding: 0.375rem 1rem;
+  font-size: 0.875rem;
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.tab-btn.active {
+  background: var(--color-primary, #3b82f6);
+  color: white;
+}
+
+.inbox-filters {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.filter-select,
+.filter-search {
+  padding: 0.4rem 0.75rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 0.375rem;
+  background: var(--color-surface, #fff);
+  color: var(--color-text);
+  font-size: 0.875rem;
+}
+
+.filter-search {
+  flex: 1;
+  min-width: 180px;
+}
+
+.approval-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.state-msg {
+  text-align: center;
+  padding: 3rem;
+  color: var(--color-text-secondary, #9ca3af);
+}
+
+.approval-card {
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: var(--color-surface, #fff);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.history-card {
+  opacity: 0.85;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.card-meta {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.type-badge,
+.status-badge {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.type-budget_increase { background: #fef3c7; color: #92400e; }
+.type-agent_spawn { background: #ddd6fe; color: #5b21b6; }
+.type-external_api { background: #bfdbfe; color: #1d4ed8; }
+.type-code_deploy { background: #fee2e2; color: #991b1b; }
+.type-data_access { background: #d1fae5; color: #065f46; }
+.type-policy_change { background: #fce7f3; color: #9d174d; }
+.type-contract_sign { background: #ffedd5; color: #9a3412; }
+.type-hiring { background: #e0f2fe; color: #0369a1; }
+
+.status-approved { background: #d1fae5; color: #065f46; }
+.status-rejected { background: #fee2e2; color: #991b1b; }
+.status-changes_requested { background: #fef3c7; color: #92400e; }
+
+.toggle-payload {
+  font-size: 0.8rem;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 0.25rem;
+  background: var(--color-surface-elevated, #f9fafb);
+  cursor: pointer;
+}
+
+.payload-json {
+  background: var(--color-surface-elevated, #f9fafb);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.375rem;
+  padding: 0.75rem;
+  font-size: 0.8rem;
+  overflow-x: auto;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.card-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.btn-approve,
+.btn-reject,
+.btn-changes {
+  padding: 0.4rem 0.875rem;
+  border: none;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.btn-approve { background: #10b981; color: white; }
+.btn-reject { background: #ef4444; color: white; }
+.btn-changes { background: #f59e0b; color: white; }
+
+.btn-approve:disabled,
+.btn-reject:disabled,
+.btn-changes:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.note-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border-top: 1px solid var(--color-border, #e5e7eb);
+  padding-top: 0.75rem;
+}
+
+.note-textarea {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 0.375rem;
+  background: var(--color-surface, #fff);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  resize: vertical;
+}
+
+.note-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.btn-primary {
+  padding: 0.4rem 1rem;
+  background: var(--color-primary, #3b82f6);
+  color: white;
+  border: none;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  padding: 0.4rem 1rem;
+  background: var(--color-surface, #fff);
+  color: var(--color-text);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+</style>

--- a/autobot-frontend/src/views/llc/CeoChatView.vue
+++ b/autobot-frontend/src/views/llc/CeoChatView.vue
@@ -1,0 +1,553 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025 mrveiss -->
+<!-- Author: mrveiss -->
+<template>
+  <div class="ceo-chat-view">
+    <!-- Thread sidebar -->
+    <div class="thread-sidebar">
+      <div class="sidebar-header">
+        <span class="sidebar-title">Threads</span>
+        <button class="btn-new-thread" @click="showNewThread = true">+ New</button>
+      </div>
+      <div v-if="threadsLoading" class="state-msg-sm">Loading...</div>
+      <div v-else-if="threads.length === 0" class="state-msg-sm">No threads yet.</div>
+      <div class="thread-list">
+        <div
+          v-for="t in threads"
+          :key="t.id"
+          class="thread-item"
+          :class="{ active: activeThread?.id === t.id }"
+          @click="selectThread(t)"
+        >
+          <div class="thread-title">{{ t.title }}</div>
+          <div v-if="t.resolved_entity_type" class="thread-entity">
+            {{ t.resolved_entity_type }}
+          </div>
+          <div class="thread-date">{{ formatDate(t.updated_at) }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Chat window -->
+    <div class="chat-window">
+      <div v-if="!activeThread" class="chat-empty">
+        <p>Select a thread or create a new one.</p>
+      </div>
+
+      <template v-else>
+        <div class="chat-header">
+          <span class="chat-title">{{ activeThread.title }}</span>
+          <span v-if="activeThread.resolved_entity_type" class="entity-chip">
+            {{ activeThread.resolved_entity_type }}
+            <span v-if="activeThread.resolved_entity_id">
+              #{{ activeThread.resolved_entity_id }}
+            </span>
+          </span>
+        </div>
+
+        <div class="messages-area" ref="messagesArea">
+          <div v-if="messagesLoading" class="state-msg-sm">Loading messages...</div>
+          <template v-else>
+            <div
+              v-for="msg in messages"
+              :key="msg.id"
+              class="message-row"
+              :class="msg.author_type === 'human' ? 'row-right' : 'row-left'"
+            >
+              <div class="message-bubble" :class="msg.author_type === 'human' ? 'bubble-human' : 'bubble-system'">
+                <div class="message-body">{{ msg.body }}</div>
+                <div v-if="msg.author_type === 'system' && activeThread.resolved_entity_type" class="entity-link">
+                  {{ activeThread.resolved_entity_type }}
+                  <template v-if="activeThread.resolved_entity_id">
+                    #{{ activeThread.resolved_entity_id }}
+                  </template>
+                </div>
+                <div class="message-time">{{ formatTime(msg.created_at) }}</div>
+              </div>
+            </div>
+            <div v-if="messages.length === 0" class="state-msg-sm">No messages yet.</div>
+          </template>
+        </div>
+
+        <div class="message-input-area">
+          <textarea
+            v-model="inputText"
+            class="message-input"
+            placeholder="Type a message..."
+            rows="2"
+            @keydown.enter.exact.prevent="sendMessage"
+          />
+          <button
+            class="btn-send"
+            :disabled="!inputText.trim() || sending"
+            @click="sendMessage"
+          >
+            {{ sending ? '...' : 'Send' }}
+          </button>
+        </div>
+      </template>
+    </div>
+
+    <!-- New thread modal -->
+    <div v-if="showNewThread" class="modal-overlay" @click.self="showNewThread = false">
+      <div class="modal-panel">
+        <h3>New Thread</h3>
+        <div class="form-field">
+          <label>Title</label>
+          <input v-model="newThreadTitle" type="text" class="form-input" placeholder="Thread title..." />
+        </div>
+        <div class="modal-actions">
+          <button class="btn-secondary" @click="showNewThread = false">Cancel</button>
+          <button
+            class="btn-primary"
+            :disabled="!newThreadTitle.trim() || creatingThread"
+            @click="createThread"
+          >
+            {{ creatingThread ? 'Creating...' : 'Create' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, nextTick, onMounted } from 'vue'
+import { useApiClient } from '@/plugins/api'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('CeoChatView')
+const api = useApiClient()
+
+const props = defineProps<{ companyId?: string }>()
+const companyId = computed(() => props.companyId ?? '00000000-0000-0000-0000-000000000000')
+
+interface ChatMessage {
+  id: string
+  thread_id: string
+  author_type: 'human' | 'system'
+  author_user_id?: string
+  body: string
+  created_at: string
+}
+
+interface ChatThread {
+  id: string
+  company_id: string
+  title: string
+  resolved_entity_type?: string
+  resolved_entity_id?: string
+  created_by_user_id?: string
+  created_at: string
+  updated_at: string
+  messages?: ChatMessage[]
+}
+
+const threads = ref<ChatThread[]>([])
+const threadsLoading = ref(false)
+const activeThread = ref<ChatThread | null>(null)
+const messages = ref<ChatMessage[]>([])
+const messagesLoading = ref(false)
+const inputText = ref('')
+const sending = ref(false)
+const showNewThread = ref(false)
+const newThreadTitle = ref('')
+const creatingThread = ref(false)
+const messagesArea = ref<HTMLElement | null>(null)
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString()
+}
+
+function formatTime(iso: string) {
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+async function scrollToBottom() {
+  await nextTick()
+  if (messagesArea.value) {
+    messagesArea.value.scrollTop = messagesArea.value.scrollHeight
+  }
+}
+
+async function fetchThreads() {
+  threadsLoading.value = true
+  try {
+    const data = await api.get<ChatThread[] | { items: ChatThread[] }>(
+      `/api/llc/companies/${companyId.value}/ceo-chat/threads`
+    )
+    threads.value = Array.isArray(data) ? data : (data as { items: ChatThread[] }).items ?? []
+  } catch (err) {
+    logger.error('Failed to fetch threads', err)
+  } finally {
+    threadsLoading.value = false
+  }
+}
+
+async function selectThread(thread: ChatThread) {
+  activeThread.value = thread
+  messagesLoading.value = true
+  messages.value = []
+  try {
+    const data = await api.get<ChatThread>(`/api/llc/ceo-chat/threads/${thread.id}`)
+    activeThread.value = data
+    messages.value = data.messages ?? []
+    scrollToBottom()
+  } catch (err) {
+    logger.error('Failed to load thread', err)
+  } finally {
+    messagesLoading.value = false
+  }
+}
+
+async function sendMessage() {
+  if (!inputText.value.trim() || !activeThread.value || sending.value) return
+  sending.value = true
+  const body = inputText.value.trim()
+  inputText.value = ''
+  try {
+    const msg = await api.post<ChatMessage>(`/api/llc/ceo-chat/threads/${activeThread.value.id}/messages`, {
+      message: body,
+      company_name: companyId.value,
+    })
+    messages.value.push(msg)
+    scrollToBottom()
+  } catch (err) {
+    logger.error('Failed to send message', err)
+    inputText.value = body
+  } finally {
+    sending.value = false
+  }
+}
+
+async function createThread() {
+  if (!newThreadTitle.value.trim()) return
+  creatingThread.value = true
+  try {
+    const thread = await api.post<ChatThread>(
+      `/api/llc/companies/${companyId.value}/ceo-chat/threads`,
+      { title: newThreadTitle.value.trim() }
+    )
+    threads.value.unshift(thread)
+    showNewThread.value = false
+    newThreadTitle.value = ''
+    await selectThread(thread)
+  } catch (err) {
+    logger.error('Failed to create thread', err)
+  } finally {
+    creatingThread.value = false
+  }
+}
+
+onMounted(fetchThreads)
+</script>
+
+<style scoped>
+.ceo-chat-view {
+  display: flex;
+  height: 100%;
+  background: var(--color-background);
+  color: var(--color-text);
+  overflow: hidden;
+}
+
+.thread-sidebar {
+  width: 260px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--color-border, #e5e7eb);
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface, #fff);
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.sidebar-title {
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+.btn-new-thread {
+  font-size: 0.8rem;
+  padding: 0.25rem 0.625rem;
+  background: var(--color-primary, #3b82f6);
+  color: white;
+  border: none;
+  border-radius: 0.375rem;
+  cursor: pointer;
+}
+
+.thread-list {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.thread-item {
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  border-bottom: 1px solid var(--color-border, #f3f4f6);
+  transition: background 0.1s;
+}
+
+.thread-item:hover {
+  background: var(--color-surface-hover, #f9fafb);
+}
+
+.thread-item.active {
+  background: var(--color-primary-subtle, #eff6ff);
+}
+
+.thread-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.thread-entity {
+  font-size: 0.75rem;
+  color: var(--color-primary, #3b82f6);
+  margin-top: 0.125rem;
+}
+
+.thread-date {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #9ca3af);
+  margin-top: 0.125rem;
+}
+
+.chat-window {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.chat-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-secondary, #9ca3af);
+}
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1.25rem;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  background: var(--color-surface, #fff);
+}
+
+.chat-title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.entity-chip {
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  background: #ddd6fe;
+  color: #5b21b6;
+  border-radius: 9999px;
+}
+
+.messages-area {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.message-row {
+  display: flex;
+}
+
+.row-right {
+  justify-content: flex-end;
+}
+
+.row-left {
+  justify-content: flex-start;
+}
+
+.message-bubble {
+  max-width: 70%;
+  padding: 0.625rem 0.875rem;
+  border-radius: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.bubble-human {
+  background: var(--color-primary, #3b82f6);
+  color: white;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.bubble-system {
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  color: var(--color-text);
+  border-bottom-left-radius: 0.25rem;
+}
+
+.message-body {
+  font-size: 0.875rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.entity-link {
+  font-size: 0.75rem;
+  color: var(--color-primary, #3b82f6);
+  text-decoration: underline;
+  cursor: default;
+}
+
+.bubble-human .entity-link {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.message-time {
+  font-size: 0.7rem;
+  opacity: 0.6;
+  align-self: flex-end;
+}
+
+.message-input-area {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.875rem 1.25rem;
+  border-top: 1px solid var(--color-border, #e5e7eb);
+  background: var(--color-surface, #fff);
+}
+
+.message-input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 0.375rem;
+  background: var(--color-background);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  resize: none;
+  line-height: 1.4;
+}
+
+.btn-send {
+  padding: 0.5rem 1.25rem;
+  background: var(--color-primary, #3b82f6);
+  color: white;
+  border: none;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  align-self: flex-end;
+}
+
+.btn-send:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.state-msg-sm {
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--color-text-secondary, #9ca3af);
+  font-size: 0.875rem;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal-panel {
+  background: var(--color-surface, #fff);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal-panel h3 {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.form-field label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.form-input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 0.375rem;
+  background: var(--color-surface, #fff);
+  color: var(--color-text);
+  font-size: 0.875rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.btn-primary {
+  padding: 0.5rem 1rem;
+  background: var(--color-primary, #3b82f6);
+  color: white;
+  border: none;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  padding: 0.5rem 1rem;
+  background: var(--color-surface, #fff);
+  color: var(--color-text);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+</style>

--- a/autobot-frontend/src/views/llc/CostDashboard.vue
+++ b/autobot-frontend/src/views/llc/CostDashboard.vue
@@ -1,0 +1,516 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025 mrveiss -->
+<!-- Author: mrveiss -->
+<template>
+  <div class="cost-dashboard">
+    <div class="dash-header">
+      <h2 class="view-title">Cost Dashboard</h2>
+      <button class="btn-export" @click="exportCsv">Export CSV</button>
+    </div>
+
+    <!-- Summary cards -->
+    <div class="summary-cards">
+      <div class="summary-card">
+        <div class="card-label">Total This Month</div>
+        <div class="card-value">${{ totalThisMonth.toFixed(4) }}</div>
+      </div>
+      <div class="summary-card">
+        <div class="card-label">By Company</div>
+        <div class="card-value">${{ totalByCompany.toFixed(4) }}</div>
+        <div class="card-sub">{{ companyId }}</div>
+      </div>
+      <div
+        v-for="agent in topAgents"
+        :key="agent.id"
+        class="summary-card"
+      >
+        <div class="card-label">{{ agent.name }}</div>
+        <div class="card-value">${{ agent.cost.toFixed(4) }}</div>
+        <div class="card-sub">top agent</div>
+      </div>
+    </div>
+
+    <!-- Budget health -->
+    <div v-if="budgets.length > 0" class="budget-section">
+      <h3 class="section-title">Budget Health</h3>
+      <div class="budget-rows">
+        <div v-for="b in budgets" :key="b.agent_id" class="budget-row">
+          <span class="budget-agent">{{ b.agent_name ?? b.agent_id }}</span>
+          <div class="gauge-track">
+            <div
+              class="gauge-fill"
+              :class="{ 'gauge-warn': b.pct >= 80, 'gauge-over': b.pct >= 100 }"
+              :style="{ width: Math.min(b.pct, 100) + '%' }"
+            />
+          </div>
+          <span class="gauge-label" :class="{ 'text-warn': b.pct >= 80 }">
+            {{ b.pct.toFixed(0) }}%
+            <span v-if="b.pct >= 80"> ⚠</span>
+          </span>
+          <span class="budget-amounts">${{ b.spent.toFixed(4) }} / ${{ b.budget.toFixed(4) }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Bar chart: daily spend -->
+    <div class="chart-section">
+      <h3 class="section-title">Daily Spend – Last 30 Days</h3>
+      <div v-if="dailyBars.length === 0" class="state-msg">No spend data available.</div>
+      <div v-else class="bar-chart">
+        <div
+          v-for="bar in dailyBars"
+          :key="bar.date"
+          class="bar-col"
+          :title="`${bar.date}: $${bar.amount.toFixed(4)}`"
+        >
+          <div class="bar-fill" :style="{ height: bar.heightPct + '%' }" />
+          <div class="bar-label">{{ bar.shortDate }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Filters -->
+    <div class="table-filters">
+      <select v-model="filters.agent" class="filter-select">
+        <option value="">All Agents</option>
+        <option v-for="a in agentOptions" :key="a" :value="a">{{ a }}</option>
+      </select>
+      <input v-model="filters.dateFrom" type="date" class="filter-date" />
+      <span class="date-sep">to</span>
+      <input v-model="filters.dateTo" type="date" class="filter-date" />
+    </div>
+
+    <!-- Cost events table -->
+    <div class="table-wrapper">
+      <div v-if="costEventsUnavailable" class="state-msg">
+        Cost events endpoint not available (404).
+      </div>
+      <table v-else class="cost-table">
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Agent</th>
+            <th>Work Item</th>
+            <th>Model</th>
+            <th>Provider</th>
+            <th>Input Tokens</th>
+            <th>Output Tokens</th>
+            <th>Cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="isLoading">
+            <td colspan="8" class="state-msg">Loading...</td>
+          </tr>
+          <tr v-else-if="filteredEvents.length === 0">
+            <td colspan="8" class="state-msg">No cost events match filters.</td>
+          </tr>
+          <tr v-for="ev in filteredEvents" :key="ev.id">
+            <td>{{ formatDate(ev.created_at) }}</td>
+            <td>{{ ev.agent_id }}</td>
+            <td>{{ ev.work_item_id ?? '—' }}</td>
+            <td>{{ ev.model }}</td>
+            <td>{{ ev.provider }}</td>
+            <td class="num-cell">{{ ev.input_tokens.toLocaleString() }}</td>
+            <td class="num-cell">{{ ev.output_tokens.toLocaleString() }}</td>
+            <td class="num-cell">${{ ev.cost.toFixed(6) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useApiClient } from '@/plugins/api'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('CostDashboard')
+const api = useApiClient()
+
+const props = defineProps<{ companyId?: string }>()
+const companyId = computed(() => props.companyId ?? '00000000-0000-0000-0000-000000000000')
+
+interface BudgetEntry {
+  agent_id: string
+  agent_name?: string
+  budget: number
+  spent: number
+  pct: number
+}
+
+interface CostEvent {
+  id: string
+  agent_id: string
+  work_item_id?: string
+  model: string
+  provider: string
+  input_tokens: number
+  output_tokens: number
+  cost: number
+  created_at: string
+}
+
+const budgets = ref<BudgetEntry[]>([])
+const costEvents = ref<CostEvent[]>([])
+const isLoading = ref(false)
+const costEventsUnavailable = ref(false)
+const filters = ref({ agent: '', dateFrom: '', dateTo: '' })
+
+const totalThisMonth = computed(() => {
+  const now = new Date()
+  return costEvents.value
+    .filter(ev => {
+      const d = new Date(ev.created_at)
+      return d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear()
+    })
+    .reduce((s, ev) => s + ev.cost, 0)
+})
+
+const totalByCompany = computed(() => costEvents.value.reduce((s, ev) => s + ev.cost, 0))
+
+const agentTotals = computed(() => {
+  const map: Record<string, number> = {}
+  for (const ev of costEvents.value) {
+    map[ev.agent_id] = (map[ev.agent_id] ?? 0) + ev.cost
+  }
+  return map
+})
+
+const topAgents = computed(() =>
+  Object.entries(agentTotals.value)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([id, cost]) => ({ id, name: id, cost }))
+)
+
+const agentOptions = computed(() => [...new Set(costEvents.value.map(ev => ev.agent_id))])
+
+const filteredEvents = computed(() => {
+  return costEvents.value.filter(ev => {
+    if (filters.value.agent && ev.agent_id !== filters.value.agent) return false
+    if (filters.value.dateFrom && ev.created_at < filters.value.dateFrom) return false
+    if (filters.value.dateTo && ev.created_at > filters.value.dateTo + 'T23:59:59') return false
+    return true
+  })
+})
+
+const dailyBars = computed(() => {
+  const map: Record<string, number> = {}
+  const now = new Date()
+  for (let i = 29; i >= 0; i--) {
+    const d = new Date(now)
+    d.setDate(d.getDate() - i)
+    const key = d.toISOString().slice(0, 10)
+    map[key] = 0
+  }
+  for (const ev of costEvents.value) {
+    const key = ev.created_at.slice(0, 10)
+    if (key in map) map[key] += ev.cost
+  }
+  const entries = Object.entries(map)
+  const max = Math.max(...entries.map(([, v]) => v), 0.0001)
+  return entries.map(([date, amount]) => ({
+    date,
+    amount,
+    shortDate: date.slice(5),
+    heightPct: (amount / max) * 100,
+  }))
+})
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString()
+}
+
+function exportCsv() {
+  const rows = [
+    ['Date', 'Agent', 'Work Item', 'Model', 'Provider', 'Input Tokens', 'Output Tokens', 'Cost'],
+    ...filteredEvents.value.map(ev => [
+      formatDate(ev.created_at),
+      ev.agent_id,
+      ev.work_item_id ?? '',
+      ev.model,
+      ev.provider,
+      String(ev.input_tokens),
+      String(ev.output_tokens),
+      ev.cost.toFixed(6),
+    ]),
+  ]
+  const csv = rows.map(r => r.map(c => `"${c.replace(/"/g, '""')}"`).join(',')).join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `cost-events-${new Date().toISOString().slice(0, 10)}.csv`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+async function fetchBudgets() {
+  try {
+    const data = await api.get<BudgetEntry[] | { items: BudgetEntry[] }>(`/api/llc/budget?company_id=${companyId.value}`)
+    const raw = Array.isArray(data) ? data : (data as { items: BudgetEntry[] }).items ?? []
+    budgets.value = raw.map(b => ({
+      ...b,
+      pct: b.budget > 0 ? (b.spent / b.budget) * 100 : 0,
+    }))
+  } catch (err) {
+    logger.warn('Budget fetch failed', err)
+  }
+}
+
+async function fetchCostEvents() {
+  isLoading.value = true
+  try {
+    const data = await api.get<CostEvent[] | { items: CostEvent[] }>(`/api/llc/cost-events?company_id=${companyId.value}`)
+    costEvents.value = Array.isArray(data) ? data : (data as { items: CostEvent[] }).items ?? []
+    costEventsUnavailable.value = false
+  } catch (err: unknown) {
+    const status = (err as { status?: number })?.status
+    if (status === 404) {
+      costEventsUnavailable.value = true
+    } else {
+      logger.error('Cost events fetch failed', err)
+    }
+  } finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([fetchBudgets(), fetchCostEvents()])
+})
+</script>
+
+<style scoped>
+.cost-dashboard {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1.5rem;
+  gap: 1.25rem;
+  background: var(--color-background);
+  color: var(--color-text);
+  overflow-y: auto;
+}
+
+.dash-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.view-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.btn-export {
+  padding: 0.4rem 1rem;
+  background: var(--color-surface, #fff);
+  color: var(--color-text);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.summary-cards {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.summary-card {
+  flex: 1;
+  min-width: 160px;
+  padding: 1rem;
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.card-label {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, #6b7280);
+  font-weight: 500;
+}
+
+.card-value {
+  font-size: 1.375rem;
+  font-weight: 700;
+}
+
+.card-sub {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #9ca3af);
+  word-break: break-all;
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+}
+
+.budget-section,
+.chart-section {
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.budget-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.budget-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+}
+
+.budget-agent {
+  min-width: 10rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gauge-track {
+  flex: 1;
+  height: 0.5rem;
+  background: var(--color-surface-elevated, #f3f4f6);
+  border-radius: 9999px;
+  overflow: hidden;
+}
+
+.gauge-fill {
+  height: 100%;
+  background: #10b981;
+  border-radius: 9999px;
+  transition: width 0.3s;
+}
+
+.gauge-warn { background: #f59e0b; }
+.gauge-over { background: #ef4444; }
+
+.gauge-label {
+  min-width: 3.5rem;
+  text-align: right;
+  font-size: 0.8rem;
+}
+
+.text-warn { color: #f59e0b; font-weight: 600; }
+
+.budget-amounts {
+  min-width: 10rem;
+  text-align: right;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.bar-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.125rem;
+  height: 120px;
+  padding-bottom: 1.25rem;
+  position: relative;
+}
+
+.bar-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  height: 100%;
+  gap: 0.2rem;
+  cursor: default;
+}
+
+.bar-fill {
+  width: 100%;
+  background: var(--color-primary, #3b82f6);
+  border-radius: 0.125rem 0.125rem 0 0;
+  min-height: 2px;
+  transition: height 0.3s;
+}
+
+.bar-label {
+  font-size: 0.6rem;
+  color: var(--color-text-secondary, #9ca3af);
+  transform: rotate(-45deg);
+  transform-origin: center;
+  white-space: nowrap;
+}
+
+.table-filters {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.filter-select,
+.filter-date {
+  padding: 0.4rem 0.75rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 0.375rem;
+  background: var(--color-surface, #fff);
+  color: var(--color-text);
+  font-size: 0.875rem;
+}
+
+.date-sep {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.table-wrapper {
+  overflow: auto;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+}
+
+.cost-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.cost-table th {
+  padding: 0.625rem 0.75rem;
+  text-align: left;
+  font-weight: 600;
+  background: var(--color-surface-elevated, #f9fafb);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  white-space: nowrap;
+}
+
+.cost-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--color-border, #f3f4f6);
+}
+
+.num-cell {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.state-msg {
+  text-align: center;
+  padding: 2rem;
+  color: var(--color-text-secondary, #9ca3af);
+}
+</style>

--- a/autobot-frontend/src/views/llc/HeartbeatMonitor.vue
+++ b/autobot-frontend/src/views/llc/HeartbeatMonitor.vue
@@ -1,0 +1,428 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025 mrveiss -->
+<!-- Author: mrveiss -->
+<template>
+  <div class="heartbeat-monitor">
+    <div class="monitor-header">
+      <h2 class="view-title">Heartbeat Monitor</h2>
+      <span class="refresh-note">Auto-refreshes every 15s</span>
+    </div>
+
+    <div v-if="isLoading && agents.length === 0" class="state-msg">Loading agents...</div>
+    <div v-else-if="heartbeatAgents.length === 0" class="state-msg">No heartbeat-enabled agents found.</div>
+
+    <div v-else class="agent-grid-wrapper">
+      <table class="agent-grid">
+        <thead>
+          <tr>
+            <th>Agent</th>
+            <th>Adapter</th>
+            <th>Last Heartbeat</th>
+            <th>Status</th>
+            <th>Run Duration</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="agent in heartbeatAgents"
+            :key="agent.id"
+            class="agent-row"
+            @click="openHistory(agent)"
+          >
+            <td class="agent-name">{{ agent.name }}</td>
+            <td class="agent-adapter">{{ agent.adapter_type ?? '—' }}</td>
+            <td class="agent-hb">{{ formatDate(agent.last_heartbeat_at) }}</td>
+            <td>
+              <span class="status-dot" :class="`status-${agent.last_run_status ?? 'unknown'}`" />
+              <span class="status-label" :class="`status-${agent.last_run_status ?? 'unknown'}`">
+                {{ agent.last_run_status ?? 'unknown' }}
+              </span>
+            </td>
+            <td class="agent-duration">{{ formatDuration(agent.current_run_started_at) }}</td>
+            <td @click.stop>
+              <button
+                class="btn-trigger"
+                :disabled="triggering.has(agent.id)"
+                @click="triggerHeartbeat(agent)"
+              >
+                {{ triggering.has(agent.id) ? 'Triggering...' : 'Trigger Now' }}
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Run history drawer -->
+    <div v-if="selectedAgent" class="drawer-overlay" @click.self="selectedAgent = null">
+      <div class="history-drawer">
+        <div class="drawer-header">
+          <h3>Run History – {{ selectedAgent.name }}</h3>
+          <button class="btn-close" @click="selectedAgent = null">✕</button>
+        </div>
+        <div v-if="historyLoading" class="state-msg">Loading runs...</div>
+        <div v-else-if="runHistory.length === 0" class="state-msg">No runs found.</div>
+        <div v-else class="run-list">
+          <div v-for="run in runHistory" :key="run.id" class="run-item">
+            <div class="run-meta">
+              <span class="status-dot" :class="`status-${run.status}`" />
+              <span class="run-status" :class="`status-${run.status}`">{{ run.status }}</span>
+              <span class="run-date">{{ formatDate(run.started_at) }}</span>
+              <span v-if="run.completed_at" class="run-duration">
+                {{ computeDuration(run.started_at, run.completed_at) }}
+              </span>
+            </div>
+            <div class="run-toggle">
+              <button class="toggle-payload" @click="toggleRun(run.id)">
+                {{ expandedRuns.has(run.id) ? 'Hide' : 'Show' }} Context
+              </button>
+            </div>
+            <pre v-if="expandedRuns.has(run.id)" class="run-context">{{ formatJson(run.context_snapshot) }}</pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { useApiClient } from '@/plugins/api'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('HeartbeatMonitor')
+const api = useApiClient()
+
+interface Agent {
+  id: string
+  name: string
+  adapter_type?: string
+  heartbeat_enabled: boolean
+  last_heartbeat_at?: string
+  last_run_status?: string
+  current_run_started_at?: string
+}
+
+interface AgentRun {
+  id: string
+  status: string
+  started_at: string
+  completed_at?: string
+  context_snapshot?: Record<string, unknown>
+}
+
+const agents = ref<Agent[]>([])
+const isLoading = ref(false)
+const triggering = ref<Set<string>>(new Set())
+const selectedAgent = ref<Agent | null>(null)
+const runHistory = ref<AgentRun[]>([])
+const historyLoading = ref(false)
+const expandedRuns = ref<Set<string>>(new Set())
+
+const heartbeatAgents = computed(() => agents.value.filter(a => a.heartbeat_enabled))
+
+function formatDate(iso?: string) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString()
+}
+
+function formatDuration(startedAt?: string) {
+  if (!startedAt) return '—'
+  const ms = Date.now() - new Date(startedAt).getTime()
+  if (ms < 0) return '—'
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  return `${Math.floor(s / 60)}m ${s % 60}s`
+}
+
+function computeDuration(start: string, end: string) {
+  const ms = new Date(end).getTime() - new Date(start).getTime()
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  return `${Math.floor(s / 60)}m ${s % 60}s`
+}
+
+function formatJson(data?: Record<string, unknown>) {
+  if (!data) return '(empty)'
+  try {
+    return JSON.stringify(data, null, 2)
+  } catch {
+    return String(data)
+  }
+}
+
+function toggleRun(id: string) {
+  const next = new Set(expandedRuns.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  expandedRuns.value = next
+}
+
+async function fetchAgents() {
+  isLoading.value = true
+  try {
+    const data = await api.get<Agent[] | { items: Agent[] }>('/api/llc/agents')
+    agents.value = Array.isArray(data) ? data : (data as { items: Agent[] }).items ?? []
+  } catch (err) {
+    logger.error('Failed to fetch agents', err)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function triggerHeartbeat(agent: Agent) {
+  const next = new Set(triggering.value)
+  next.add(agent.id)
+  triggering.value = next
+  try {
+    await api.post<{ run_id: string; status: string }>(`/api/llc/agents/${agent.id}/heartbeat/trigger`, {})
+    await fetchAgents()
+  } catch (err) {
+    logger.error('Heartbeat trigger failed', err)
+  } finally {
+    const s = new Set(triggering.value)
+    s.delete(agent.id)
+    triggering.value = s
+  }
+}
+
+async function openHistory(agent: Agent) {
+  selectedAgent.value = agent
+  expandedRuns.value = new Set()
+  historyLoading.value = true
+  try {
+    const data = await api.get<AgentRun[] | { items: AgentRun[] }>(`/api/llc/agents/${agent.id}/runs`)
+    runHistory.value = Array.isArray(data) ? data : (data as { items: AgentRun[] }).items ?? []
+  } catch (err) {
+    logger.error('Failed to fetch run history', err)
+    runHistory.value = []
+  } finally {
+    historyLoading.value = false
+  }
+}
+
+let refreshInterval: ReturnType<typeof setInterval> | null = null
+
+onMounted(() => {
+  fetchAgents()
+  refreshInterval = setInterval(fetchAgents, 15_000)
+})
+
+onUnmounted(() => {
+  if (refreshInterval !== null) clearInterval(refreshInterval)
+})
+</script>
+
+<style scoped>
+.heartbeat-monitor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1.5rem;
+  gap: 1rem;
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+.monitor-header {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.view-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.refresh-note {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, #9ca3af);
+}
+
+.state-msg {
+  text-align: center;
+  padding: 3rem;
+  color: var(--color-text-secondary, #9ca3af);
+}
+
+.agent-grid-wrapper {
+  overflow: auto;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+  flex: 1;
+}
+
+.agent-grid {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.agent-grid th {
+  padding: 0.625rem 0.75rem;
+  text-align: left;
+  font-weight: 600;
+  background: var(--color-surface-elevated, #f9fafb);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  white-space: nowrap;
+}
+
+.agent-row {
+  border-bottom: 1px solid var(--color-border, #f3f4f6);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.agent-row:hover {
+  background: var(--color-surface-hover, #f9fafb);
+}
+
+.agent-grid td {
+  padding: 0.625rem 0.75rem;
+}
+
+.agent-name {
+  font-weight: 500;
+}
+
+.status-dot {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  margin-right: 0.375rem;
+  vertical-align: middle;
+}
+
+.status-label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-transform: capitalize;
+}
+
+.status-succeeded { color: #10b981; }
+.status-succeeded.status-dot { background: #10b981; }
+.status-running { color: #3b82f6; }
+.status-running.status-dot { background: #3b82f6; }
+.status-queued { color: #f59e0b; }
+.status-queued.status-dot { background: #f59e0b; }
+.status-failed { color: #ef4444; }
+.status-failed.status-dot { background: #ef4444; }
+.status-timed_out { color: #ef4444; }
+.status-timed_out.status-dot { background: #ef4444; }
+.status-unknown { color: var(--color-text-secondary, #9ca3af); }
+.status-unknown.status-dot { background: var(--color-border, #d1d5db); }
+
+.btn-trigger {
+  padding: 0.3rem 0.75rem;
+  background: var(--color-primary, #3b82f6);
+  color: white;
+  border: none;
+  border-radius: 0.375rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.btn-trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 50;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.history-drawer {
+  width: 480px;
+  max-width: 100%;
+  height: 100%;
+  background: var(--color-surface, #fff);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.drawer-header h3 {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.btn-close {
+  background: none;
+  border: none;
+  font-size: 1.125rem;
+  cursor: pointer;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.run-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.run-item {
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.375rem;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.run-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.run-date,
+.run-duration {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.toggle-payload {
+  font-size: 0.8rem;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 0.25rem;
+  background: var(--color-surface-elevated, #f9fafb);
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.run-context {
+  background: var(--color-surface-elevated, #f9fafb);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.375rem;
+  padding: 0.75rem;
+  font-size: 0.8rem;
+  overflow-x: auto;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+</style>

--- a/autobot-frontend/src/views/llc/index.ts
+++ b/autobot-frontend/src/views/llc/index.ts
@@ -1,0 +1,8 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+export { default as ApprovalsInbox } from './ApprovalsInbox.vue'
+export { default as CostDashboard } from './CostDashboard.vue'
+export { default as HeartbeatMonitor } from './HeartbeatMonitor.vue'
+export { default as CeoChatView } from './CeoChatView.vue'


### PR DESCRIPTION
## Summary
- Implements GH#8249 (Phase 6 frontend) — 4 new Vue 3 views in `autobot-frontend/src/views/llc/`
- `ApprovalsInbox.vue`: pending queue, inline approve/reject/request-changes, 30s polling, history tab
- `CostDashboard.vue`: summary cards, CSS/SVG bar chart, cost events table, CSV export, budget gauges
- `HeartbeatMonitor.vue`: live agent grid (15s refresh), status colors, trigger-now button, run history drawer
- `CeoChatView.vue`: thread sidebar, chat window (human right / system left), resolved entity links, new thread modal

## Test plan
- [ ] Navigate to `/llc/approvals` — pending list loads, approve/reject buttons work, note required on reject
- [ ] Navigate to `/llc/costs` — cards and bar chart render, CSV export downloads file
- [ ] Navigate to `/llc/heartbeat` — agent grid shows, Trigger Now posts to correct endpoint, run history drawer opens
- [ ] Navigate to `/llc/ceo-chat` — threads load, send message shows response with resolved entity
- [ ] `vue-tsc --noEmit` passes 0 errors

Closes #8249

🤖 Generated with [Claude Code](https://claude.com/claude-code)