### PR TITLE
feat(llc): Company template & snapshot export with secret scrubbing (#8245)

### DIFF
--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -1,19 +1,21 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""LLC Company API routes (GH#8211, GH#8223).
+"""LLC Company API routes (GH#8211, GH#8223, GH#8245).
 
 Route group: /llc/companies
-  GET    /                       — list root companies (no parent)
-  POST   /                       — create a company
-  GET    /{id}                   — get a single company
-  PATCH  /{id}                   — update a company
-  DELETE /{id}                   — soft-delete a company
-  GET    /{id}/tree              — recursive sub-company tree
-  GET    /{id}/ancestry          — ancestors from root to this company
-  POST   /{id}/members           — add a member (GH#8223)
-  DELETE /{id}/members/{user_id} — remove a member (GH#8223)
-  GET    /{id}/members           — list members (GH#8223)
+  GET    /                         — list root companies (no parent)
+  POST   /                         — create a company
+  GET    /{id}                     — get a single company
+  PATCH  /{id}                     — update a company
+  DELETE /{id}                     — soft-delete a company
+  GET    /{id}/tree                — recursive sub-company tree
+  GET    /{id}/ancestry            — ancestors from root to this company
+  POST   /{id}/members             — add a member (GH#8223)
+  DELETE /{id}/members/{user_id}   — remove a member (GH#8223)
+  GET    /{id}/members             — list members (GH#8223)
+  POST   /{id}/export/template     — export structural template, secrets scrubbed (GH#8245)
+  POST   /{id}/export/snapshot     — full-state export for backup/migration (GH#8245)
 
 All endpoints enforce company_id scoping via the org_id path or
 the authenticated session's organization context.
@@ -22,7 +24,8 @@ the authenticated session's organization context.
 import uuid
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -49,6 +52,7 @@ from llc.services.membership_service import (
     MemberNotFoundError,
     MembershipService,
 )
+from llc.services.portability import PortabilityService
 from user_management.database import get_async_session
 from user_management.models.organization import Organization
 
@@ -286,18 +290,12 @@ async def remove_member(
 # ------------------------------------------------------------------
 # External PM config (GH#8257)
 # ------------------------------------------------------------------
-
-
 class PMConfigSetRequest(BaseModel):
     pm_type: ExternalPMType
     credentials: Dict[str, Any]
-
-
 class PMConfigRead(BaseModel):
     pm_type: Optional[str]
     configured: bool
-
-
 @router.patch("/{company_id}/pm-config", response_model=PMConfigRead)
 async def set_pm_config(
     company_id: uuid.UUID,
@@ -306,15 +304,11 @@ async def set_pm_config(
 ) -> PMConfigRead:
     """Store encrypted PM credentials for a company (GH#8257)."""
     import json
-
     from sqlalchemy import select, update
-
     from autobot_shared.field_encryption import encrypt_field
-
     row = await session.execute(select(Organization.id).where(Organization.id == company_id))
     if row.one_or_none() is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
-
     encrypted = encrypt_field(json.dumps(body.credentials, ensure_ascii=False))
     await session.execute(
         update(Organization)
@@ -323,59 +317,36 @@ async def set_pm_config(
     )
     await session.commit()
     return PMConfigRead(pm_type=body.pm_type.value, configured=True)
-
-
 @router.post("/{company_id}/pm-config/test")
 async def test_pm_config(
-    company_id: uuid.UUID,
-    session: AsyncSession = Depends(get_async_session),
 ) -> Dict[str, Any]:
     """Test connectivity to the configured external PM system (GH#8257)."""
-    import json
-
     from sqlalchemy import select
-
     from autobot_shared.field_encryption import decrypt_field
     from integrations.base import IntegrationConfig
-
     row = await session.execute(
         select(Organization.external_pm_type, Organization.external_pm_config).where(Organization.id == company_id)
-    )
     result = row.one_or_none()
     if result is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
-
     pm_type, encrypted_config = result
     if not pm_type or pm_type == "none" or not encrypted_config:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No PM integration configured for this company",
-        )
-
     try:
         pm_config = json.loads(decrypt_field(encrypted_config))
     except Exception:
-        raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to decrypt PM config",
-        )
-
-    try:
         health = await _test_pm_connectivity(pm_type, pm_config)
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
-
     return {"ok": health.get("ok", False), "details": health}
-
-
 async def _test_pm_connectivity(pm_type: str, pm_config: Dict[str, Any]) -> Dict[str, Any]:
-    from integrations.base import IntegrationConfig
     from integrations.project_management_integration import (
         AsanaIntegration,
         JiraIntegration,
         TrelloIntegration,
-    )
-
     if pm_type == "jira":
         cfg = IntegrationConfig(
             name="jira",
@@ -383,27 +354,47 @@ async def _test_pm_connectivity(pm_type: str, pm_config: Dict[str, Any]) -> Dict
             base_url=pm_config.get("base_url", ""),
             username=pm_config.get("username", ""),
             api_key=pm_config.get("api_key", ""),
-        )
         health = await JiraIntegration(cfg).test_connection()
     elif pm_type == "trello":
-        cfg = IntegrationConfig(
             name="trello",
             provider="trello",
-            api_key=pm_config.get("api_key", ""),
             token=pm_config.get("token", ""),
-        )
         health = await TrelloIntegration(cfg).test_connection()
     elif pm_type == "asana":
         cfg = IntegrationConfig(name="asana", provider="asana", token=pm_config.get("token", ""))
         health = await AsanaIntegration(cfg).test_connection()
     else:
         return {"ok": False, "error": f"Unsupported pm_type: {pm_type}"}
-
     from integrations.base import IntegrationStatus
-
     return {
         "ok": health.status == IntegrationStatus.CONNECTED,
         "status": health.status.value,
         "message": health.message,
         "details": health.details,
     }
+# Export endpoints (GH#8245)
+def _get_portability_service(session: AsyncSession = Depends(get_async_session)) -> PortabilityService:
+    return PortabilityService(session=session)
+@router.post("/{company_id}/export/template")
+async def export_template(
+    svc: PortabilityService = Depends(_get_portability_service),
+) -> JSONResponse:
+    """Export a portable structural template for the company.
+    Returns a JSON file download with company meta, agents (secrets scrubbed),
+    goals, active routines, projects, portfolios, and up to 20 seed work items.
+    Secret values are never exported — only ``{{SECRET_NAME}}`` placeholders.
+    """
+        payload = await svc.export_template(company_id)
+        await session.rollback()
+        raise
+    filename = f"company_{company_id}_template.json"
+    return JSONResponse(
+        content=payload,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+@router.post("/{company_id}/export/snapshot")
+async def export_snapshot(
+    """Export a full-state snapshot for backup/migration.
+    Extends the template export with all work items, sprint history, and KB
+    collection names (not content).
+        payload = await svc.export_snapshot(company_id)
+    filename = f"company_{company_id}_snapshot.json"

--- a/autobot-backend/llc/models/export.py
+++ b/autobot-backend/llc/models/export.py
@@ -1,0 +1,53 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLC export artifact model (GH#8245).
+
+Lightweight record of each template / snapshot export produced by
+PortabilityService. The exported JSON payload is written to Redis under
+``storage_path`` (a ``llc:export:<company_id>:<artifact_id>`` key) with a 7-day TTL.
+"""
+
+import uuid
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from user_management.models.base import Base
+
+
+class LLCExportArtifact(Base):
+    """Record of a company template or snapshot export."""
+
+    __tablename__ = "llc_export_artifacts"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    company_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    type: Mapped[str] = mapped_column(
+        sa.String(32),
+        nullable=False,
+        server_default="export_artifact",
+        comment="export_artifact",
+    )
+    export_kind: Mapped[str] = mapped_column(
+        sa.String(32),
+        nullable=False,
+        comment="template | snapshot",
+    )
+    schema_version: Mapped[str] = mapped_column(sa.String(16), nullable=False, server_default="1.0")
+    storage_path: Mapped[str] = mapped_column(sa.Text, nullable=False, comment="Redis key holding the JSON payload")
+    created_by: Mapped[str] = mapped_column(sa.String(255), nullable=False, server_default="system")
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+    )
+
+    __table_args__ = (sa.Index("ix_llc_export_artifacts_company_id", "company_id"),)
+
+
+__all__ = ["LLCExportArtifact"]

--- a/autobot-backend/llc/services/__init__.py
+++ b/autobot-backend/llc/services/__init__.py
@@ -13,6 +13,7 @@ from .budget import BudgetService
 from .ceo_chat import CeoChatService
 from .goal import GoalService
 from .handoff import HandoffError, HandoffService
+from .portability import PortabilityService
 from .review_gate import (
     ReviewGatePolicyConflictError,
     ReviewGatePolicyNotFoundError,
@@ -20,7 +21,6 @@ from .review_gate import (
 )
 from .routine_service import RoutineService
 from .sprint_autoclose import SprintAutoCloseService
-from .portability import PortabilityService
 from .sprint_planning import SprintNotFound, SprintPlanningService
 from .work_product_service import WorkProductService
 

--- a/autobot-backend/llc/services/__init__.py
+++ b/autobot-backend/llc/services/__init__.py
@@ -20,6 +20,7 @@ from .review_gate import (
 )
 from .routine_service import RoutineService
 from .sprint_autoclose import SprintAutoCloseService
+from .portability import PortabilityService
 from .sprint_planning import SprintNotFound, SprintPlanningService
 from .work_product_service import WorkProductService
 
@@ -38,6 +39,7 @@ __all__ = [
     "ReviewGatePolicyService",
     "RoutineService",
     "SprintAutoCloseService",
+    "PortabilityService",
     "SprintNotFound",
     "SprintPlanningService",
     "WorkProductService",

--- a/autobot-backend/llc/services/activity_log.py
+++ b/autobot-backend/llc/services/activity_log.py
@@ -38,6 +38,8 @@ class ActivityEventType(str, Enum):
     COMPANY_UPDATED = "company.updated"
     COMPANY_STATUS_CHANGED = "company.status_changed"
     COMPANY_ARCHIVED = "company.archived"
+    COMPANY_EXPORT_TEMPLATE = "company.export_template"
+    COMPANY_EXPORT_SNAPSHOT = "company.export_snapshot"
 
     # Agent lifecycle
     AGENT_HIRED = "agent.hired"

--- a/autobot-backend/llc/services/ceo_chat.py
+++ b/autobot-backend/llc/services/ceo_chat.py
@@ -26,7 +26,6 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .base import LLCServiceBase
 from ..models.ceo_chat import LLCCeoChatMessage, LLCCeoChatThread
 from .base import LLCServiceBase
 from . import LLCServiceBase

--- a/autobot-backend/llc/services/ceo_chat.py
+++ b/autobot-backend/llc/services/ceo_chat.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from .base import LLCServiceBase
 from ..models.ceo_chat import LLCCeoChatMessage, LLCCeoChatThread
 from .base import LLCServiceBase
 from . import LLCServiceBase

--- a/autobot-backend/llc/services/company.py
+++ b/autobot-backend/llc/services/company.py
@@ -19,7 +19,7 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
 from llc.models.company import CompanyCreate, CompanyRead, CompanyTreeNode, CompanyUpdate
 from llc.models.enums import LLCCompanyStatus
-from llc.services import LLCServiceBase
+from llc.services.base import LLCServiceBase
 from user_management.models.organization import Organization
 
 logger = get_logger(__name__)

--- a/autobot-backend/llc/services/portability.py
+++ b/autobot-backend/llc/services/portability.py
@@ -2,18 +2,14 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """PortabilityService — company template export/import with collision detection (GH#8246).
-
 Depends on GH#8245 (export) for the shared template schema version "1.0".
 """
-
 import json
 import re
 import uuid
 from typing import Any, Dict, List, Optional
-
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
-
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
 from llc.models.enums import LLCCompanyStatus
@@ -23,31 +19,74 @@ from llc.models.sprint import LLCProject
 from llc.models.work_item import LLCWorkItem
 from llc.services.base import LLCServiceBase
 from user_management.models.organization import Organization
-
 logger = get_logger(__name__)
-
 _PLACEHOLDER_RE = re.compile(r"\{\{(\w+)\}\}")
-
-
 # ---------------------------------------------------------------------------
 # Pydantic response models live in llc/models/portability.py (imported below)
 # to keep service lean.  We use plain dicts internally.
-# ---------------------------------------------------------------------------
-
-
 class TemplateImportError(Exception):
     """Raised when import cannot proceed (schema, collision, rollback)."""
-
-
 class PortabilityService(LLCServiceBase):
     """Service for company template import (GH#8246).
-
     All methods accept an ``AsyncSession`` and participate in the caller's
     transaction.  ``execute_import`` manages its own savepoint for rollback.
-    """
-
     def __init__(self, session: AsyncSession, **kwargs) -> None:
         super().__init__(**kwargs)
+"""PortabilityService — company template and snapshot export (GH#8245).
+Two export modes:
+  template  — structural skeleton: company meta, agents (secrets scrubbed),
+               goals, active routines, projects + portfolios (no sprint data),
+               up to 20 seed work items (epic/feature only).
+  snapshot  — full state: everything in template PLUS all work items,
+               sprint history rows, and KB collection names (not content).
+Secret scrubbing rules (NEVER export secret values):
+  - adapter_config values matching known secret patterns → replaced with
+    ``{{SECRET_NAME}}`` placeholder where SECRET_NAME is the bound secret name
+    from llc_secrets, or the key name uppercased if no binding exists.
+  - Agent API keys from llc_agent_api_keys are never included.
+Export storage:
+  - JSON payload stored in Redis under ``llc:export:<company_id>:<artifact_id>``
+    with a 7-day TTL.
+  - LLCExportArtifact row written to DB for audit trail.
+  - Activity log entry appended (event_type COMPANY_EXPORT_TEMPLATE or
+    COMPANY_EXPORT_SNAPSHOT).
+import logging
+from datetime import timezone
+import sqlalchemy as sa
+from autobot_shared.redis_client import get_async_redis_client
+from ..models.export import LLCExportArtifact
+from ..models.goal import LLCGoal
+from ..models.routine import LLCRoutine
+from ..models.secret import LLCSecret
+from ..models.sprint import LLCPortfolio, LLCProgram, LLCProject, LLCSprint
+from ..models.work_item import LLCWorkItem
+from .activity_log import ActivityEventType, LLCActivityLogService
+from .base import LLCServiceBase
+logger = logging.getLogger(__name__)
+_SCHEMA_VERSION = "1.0"
+_EXPORT_TTL_SECONDS = 7 * 24 * 3600  # 7 days
+_SEED_ITEM_TYPES = ("epic", "feature")
+_SEED_ITEM_LIMIT = 20
+# Keys in adapter_config that may hold secret values and should be scrubbed.
+_SECRET_LIKE_KEYS = frozenset(
+    {
+        "api_key",
+        "api_secret",
+        "token",
+        "access_token",
+        "secret",
+        "password",
+        "credentials",
+        "private_key",
+        "client_secret",
+        "auth_token",
+        "bearer_token",
+        "key",
+    }
+)
+    """Export company state as a portable JSON template or full snapshot."""
+    def __init__(self, session: AsyncSession, activity_log: Optional[LLCActivityLogService] = None) -> None:
+        super().__init__(activity_log=activity_log)
         self.session = session
 
     # ------------------------------------------------------------------
@@ -67,17 +106,14 @@ class PortabilityService(LLCServiceBase):
         goals = template.get("goals", [])
         projects = template.get("projects", [])
         work_items = template.get("work_items", [])
-
         collisions: List[Dict[str, Any]] = []
         warnings: List[str] = []
-
         # issue_prefix collision
         prefix = company_meta.get("issue_prefix")
         if prefix:
             existing = await self._prefix_exists(prefix)
             if existing:
                 collisions.append({"type": "issue_prefix", "value": prefix})
-
         # agent name collisions — scoped to target company; new-company imports
         # have no pre-existing namespace so there is nothing to collide with
         agent_names = [a.get("name") for a in agents if a.get("name")]
@@ -85,14 +121,12 @@ class PortabilityService(LLCServiceBase):
             conflicting_agents = await self._agent_names_exist(agent_names, target_company_id)
             for name in conflicting_agents:
                 collisions.append({"type": "agent_name", "value": name})
-
         # goal title collisions — scoped to target company for the same reason
         goal_titles = [g.get("title") for g in goals if g.get("title")]
         if target_company_id and goal_titles:
             conflicting_goals = await self._goal_titles_exist(goal_titles, target_company_id)
             for title in conflicting_goals:
                 collisions.append({"type": "goal_title", "value": title})
-
         # secret placeholder warning
         all_placeholders: set[str] = set()
         for agent in agents:
@@ -100,7 +134,6 @@ class PortabilityService(LLCServiceBase):
             all_placeholders.update(_PLACEHOLDER_RE.findall(str(cfg)))
         if all_placeholders:
             warnings.append(f"Secret placeholders found that require mapping: {sorted(all_placeholders)}")
-
         return {
             "collisions": collisions,
             "will_create": {
@@ -111,33 +144,21 @@ class PortabilityService(LLCServiceBase):
             },
             "warnings": warnings,
         }
-
     async def execute_import(
-        self,
-        template: Dict[str, Any],
-        *,
-        target_company_id: Optional[uuid.UUID] = None,
         remapping_options: Optional[Dict[str, Any]] = None,
         secret_mapping: Optional[Dict[str, str]] = None,
-    ) -> Dict[str, Any]:
         """Transactional import.  Rolls back entirely on any entity failure."""
-        self._validate_schema(template)
         remapping_options = remapping_options or {}
         secret_mapping = secret_mapping or {}
-
         created_entities: Dict[str, Any] = {
             "agents": [],
             "goals": [],
             "projects": [],
             "work_items": [],
-        }
         skipped: Dict[str, List[str]] = {"agents": [], "goals": [], "work_items": []}
-        warnings: List[str] = []
-
         sp = await self.session.begin_nested()
         try:
             company_id = await self._resolve_or_create_company(template, target_company_id, remapping_options, warnings)
-
             # Pass 1: pre-mint all agent IDs so reports_to can be remapped before
             # any INSERT, avoiding topology-ordering FK violations
             agents_list = template.get("agents", [])
@@ -145,8 +166,6 @@ class PortabilityService(LLCServiceBase):
                 a.get("agent_id", ""): str(uuid.uuid4())
                 for a in agents_list
                 if a.get("agent_id")
-            }
-
             # Pass 2: insert agents with remapped reports_to
             for agent in agents_list:
                 agent_id = await self._import_agent(agent, company_id, secret_mapping, warnings, agent_id_map)
@@ -154,21 +173,17 @@ class PortabilityService(LLCServiceBase):
                     created_entities["agents"].append(agent_id)
                 else:
                     skipped["agents"].append(agent.get("name", ""))
-
             # goals
             for goal in template.get("goals", []):
                 goal_id = await self._import_goal(goal, company_id)
                 if goal_id:
                     created_entities["goals"].append(str(goal_id))
-                else:
                     skipped["goals"].append(goal.get("title", ""))
-
             # projects
             for project in template.get("projects", []):
                 project_id = await self._import_project(project, company_id)
                 if project_id:
                     created_entities["projects"].append(str(project_id))
-
             # seed work items
             for item in template.get("work_items", []):
                 if not item.get("is_seed"):
@@ -176,29 +191,19 @@ class PortabilityService(LLCServiceBase):
                 item_id = await self._import_work_item(item, company_id)
                 if item_id:
                     created_entities["work_items"].append(str(item_id))
-                else:
                     skipped["work_items"].append(item.get("title", ""))
-
             await sp.commit()
         except Exception as exc:
             await sp.rollback()
             raise TemplateImportError(f"Import rolled back: {exc}") from exc
-
-        return {
             "company_id": str(company_id),
             "created_entities": created_entities,
             "skipped": skipped,
-            "warnings": warnings,
-        }
-
     # ------------------------------------------------------------------
     # Private helpers — collision checks
-    # ------------------------------------------------------------------
-
     async def _prefix_exists(self, prefix: str) -> bool:
         result = await self.session.execute(select(Organization.id).where(Organization.issue_prefix == prefix).limit(1))
         return result.scalar() is not None
-
     async def _agent_names_exist(
         self, names: List[str], company_id: Optional[uuid.UUID] = None
     ) -> List[str]:
@@ -209,9 +214,743 @@ class PortabilityService(LLCServiceBase):
                 text("SELECT name FROM agent_org_nodes WHERE name = ANY(:names) AND company_id = :company_id")
                 .bindparams(names=names, company_id=str(company_id))
             )
+                text("SELECT name FROM agent_org_nodes WHERE name = ANY(:names)").bindparams(names=names)
+        return [r[0] for r in rows]
+    async def _goal_titles_exist(
+        self, titles: List[str], company_id: Optional[uuid.UUID] = None
+        if not titles:
+        q = select(LLCGoal.title).where(LLCGoal.title.in_(titles))
+            q = q.where(LLCGoal.company_id == str(company_id))
+        result = await self.session.execute(q)
+        return [r[0] for r in result]
+    # Private helpers — entity creation
+    async def _resolve_or_create_company(
+        target_company_id: Optional[uuid.UUID],
+        remapping_options: Dict[str, Any],
+        warnings: List[str],
+    ) -> uuid.UUID:
+        if target_company_id:
+            result = await self.session.execute(select(Organization).where(Organization.id == target_company_id))
+            org = result.scalar_one_or_none()
+            if org is None:
+                raise TemplateImportError(f"target_company_id {target_company_id} not found")
+            return org.id
+        meta = template.get("company", {})
+        prefix = meta.get("issue_prefix")
+        if prefix and await self._prefix_exists(prefix):
+            prefix = await self._next_available_prefix(prefix)
+            warnings.append(f"issue_prefix remapped to {prefix!r}")
+        require_approval = remapping_options.get(
+            "require_approval_for_hires",
+            meta.get("require_approval_for_hires", False),
+        org = Organization(
+            id=uuid.uuid4(),
+            name=meta.get("name", "Imported Company"),
+            slug=meta.get("slug", f"imported-{uuid.uuid4().hex[:8]}"),
+            description=meta.get("description"),
+            issue_prefix=prefix,
+            budget_monthly_cents=meta.get("budget_monthly_cents", 0),
+            brand_color=meta.get("brand_color"),
+            require_approval_for_hires=require_approval,
+            llc_status=LLCCompanyStatus.ONBOARDING.value,
+            settings={},
+            issue_counter=0,
+            spent_monthly_cents=0,
+        self.session.add(org)
+        await self.session.flush()
+    async def _next_available_prefix(self, prefix: str) -> str:
+        for n in range(2, 1000):
+            candidate = f"{prefix}{n}"
+            if not await self._prefix_exists(candidate):
+                return candidate
+        raise TemplateImportError(f"Cannot find free issue_prefix for {prefix!r}")
+    async def _import_agent(
+        agent: Dict[str, Any],
+        company_id: uuid.UUID,
+        secret_mapping: Dict[str, str],
+        agent_id_map: Optional[Dict[str, str]] = None,
+    ) -> Optional[str]:
+        """Insert agent_org_nodes row.  Returns new agent_id or None if skipped."""
+        name = agent.get("name", "")
+        existing = await self._agent_names_exist([name], company_id)
+            warnings.append(f"Agent {name!r} already exists — skipped")
+            return None
+        # Use pre-minted ID from two-pass map if available
+        old_id = agent.get("agent_id", "")
+        new_agent_id = (agent_id_map or {}).get(old_id) or str(uuid.uuid4())
+        # Remap reports_to from source UUID to destination UUID
+        old_reports_to = agent.get("reports_to")
+        reports_to: Optional[str] = None
+        if old_reports_to and agent_id_map:
+            reports_to = agent_id_map.get(str(old_reports_to))
+        adapter_config = self._resolve_secrets(agent.get("adapter_config") or {}, secret_mapping, name, warnings)
+        # capabilities is TEXT in the schema; serialize list/dict to JSON string
+        capabilities = agent.get("capabilities")
+        if isinstance(capabilities, (list, dict)):
+            capabilities = json.dumps(capabilities)
+        await self.session.execute(
+            text("""
+                INSERT INTO agent_org_nodes
+                  (id, agent_id, name, reports_to, org_role, title, capabilities,
+                   company_id, adapter_type, adapter_config, heartbeat_cron,
+                   heartbeat_enabled, context_mode)
+                VALUES
+                  (:id, :agent_id, :name, :reports_to, :org_role, :title, :capabilities,
+                   :company_id, :adapter_type, :adapter_config::jsonb, :heartbeat_cron,
+                   :heartbeat_enabled, :context_mode)
+                """).bindparams(
+                agent_id=new_agent_id,
+                name=name,
+                reports_to=reports_to,
+                org_role=agent.get("org_role", "worker"),
+                title=agent.get("title"),
+                capabilities=capabilities,
+                company_id=company_id,
+                adapter_type=agent.get("adapter_type"),
+                adapter_config=json.dumps(adapter_config),
+                heartbeat_cron=agent.get("heartbeat_cron"),
+                heartbeat_enabled=agent.get("heartbeat_enabled", False),
+                context_mode=agent.get("context_mode", "thin"),
+        return new_agent_id
+    def _resolve_secrets(
+        config: Any,
+        agent_name: str,
+    ) -> Any:
+        """Replace {{SECRET_NAME}} placeholders in config by walking the structure.
+        Operates on the decoded Python object (not the JSON string) to prevent
+        injection when secret values contain quote characters.
+        """
+        unresolved: set[str] = set()
+        def _walk(node: Any) -> Any:
+            if isinstance(node, str):
+                def _replace(m: re.Match) -> str:
+                    key = m.group(1)
+                    if key in secret_mapping:
+                        return secret_mapping[key]
+                    unresolved.add(key)
+                    return m.group(0)
+                return _PLACEHOLDER_RE.sub(_replace, node)
+            if isinstance(node, dict):
+                return {k: _walk(v) for k, v in node.items()}
+            if isinstance(node, list):
+                return [_walk(v) for v in node]
+            return node
+        result = _walk(config)
+        if unresolved:
+            warnings.append(f"Agent {agent_name!r}: unresolved secret placeholders {sorted(unresolved)}")
+        return result
+    async def _import_goal(self, goal: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
+        title = goal.get("title", "")
+        existing = await self._goal_titles_exist([title], company_id)
+        new_id = uuid.uuid4()
+        obj = LLCGoal(
+            id=new_id,
+            company_id=str(company_id),
+            title=title,
+            description=goal.get("description"),
+            level=goal.get("level", "objective"),
+            status=goal.get("status", "draft"),
+            owner_agent_id=None,
+            due_date=None,
+        self.session.add(obj)
+        return new_id
+    async def _import_project(self, project: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
+        obj = LLCProject(
+            name=project.get("name", "Imported Project"),
+            description=project.get("description"),
+            status=project.get("status", "planning"),
+    async def _import_work_item(self, item: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
+        identifier = f"IMP-{new_id.hex[:8].upper()}"
+        obj = LLCWorkItem(
+            type=item.get("type", "epic"),
+            identifier=identifier,
+            title=item.get("title", ""),
+            description=item.get("description"),
+            status="backlog",
+            priority=item.get("priority", "medium"),
+            labels=item.get("labels", []),
+    # Schema validation
+    @staticmethod
+    def _validate_schema(template: Dict[str, Any]) -> None:
+        version = template.get("schema_version")
+        if version != "1.0":
+            raise TemplateImportError(f"Unsupported schema_version {version!r}; expected '1.0'")
+    async def export_template(self, company_id: uuid.UUID, actor: str = "system") -> Dict[str, Any]:
+        """Return a portable template dict for the company.
+        Includes company meta, agents (secrets scrubbed), goals, active
+        routines, projects + portfolios (no sprint data), and up to 20 seed
+        work items (epic/feature) marked ``is_seed=true``.  Secret values are
+        never exported.
+        cid = str(company_id)
+        secret_map = await self._build_secret_map(cid)
+        company_data = await self._export_company(cid)
+        agents_data = await self._export_agents(cid, secret_map)
+        goals_data = await self._export_goals(cid)
+        routines_data = await self._export_routines(cid)
+        projects_data, portfolios_data = await self._export_projects_portfolios(cid)
+        seed_items = await self._export_seed_items(cid)
+        payload = {
+            "schema_version": _SCHEMA_VERSION,
+            "export_kind": "template",
+            "company": company_data,
+            "agents": agents_data,
+            "goals": goals_data,
+            "routines": routines_data,
+            "portfolios": portfolios_data,
+            "projects": projects_data,
+            "seed_work_items": seed_items,
+        artifact_id = await self._persist(company_id, "template", payload, actor)
+        payload["artifact_id"] = str(artifact_id)
+        return payload
+    async def export_snapshot(self, company_id: uuid.UUID, actor: str = "system") -> Dict[str, Any]:
+        """Return a full-state snapshot for backup/migration.
+        Extends the template with ALL work items, sprint history rows, and KB
+        collection names (not KB content).
+        all_items = await self._export_all_work_items(cid)
+        sprints_data = await self._export_sprints(cid)
+        kb_collections = await self._list_kb_collections(cid)
+            "export_kind": "snapshot",
+            "work_items": all_items,
+            "sprints": sprints_data,
+            "kb_collection_names": kb_collections,
+        artifact_id = await self._persist(company_id, "snapshot", payload, actor)
+    # Data collectors
+    async def _export_company(self, company_id: str) -> Dict[str, Any]:
+        result = await self.session.execute(
+            text(
+                SELECT id, name, slug, description, issue_prefix,
+                       budget_monthly_cents, brand_color, require_approval_for_hires,
+                       parent_org_id, llc_status, created_at
+                FROM organizations
+                WHERE id = :cid
+            ),
+            {"cid": company_id},
+        row = result.mappings().first()
+        if row is None:
+            return {}
+        data = dict(row)
+        data["id"] = str(data["id"]) if data.get("id") else None
+        if data.get("parent_org_id"):
+            data["parent_org_id"] = str(data["parent_org_id"])
+        if data.get("created_at"):
+            data["created_at"] = data["created_at"].isoformat()
+        return data
+    async def _build_secret_map(self, company_id: str) -> Dict[str, str]:
+        """Map secret binding names for this company (name → name).
+        Returns {name: name} so scrubber can substitute ``{{NAME}}``.
+        Only active (non-revoked) secrets are included.
+            select(LLCSecret.name).where(
+                sa.and_(
+                    LLCSecret.company_id == company_id,
+                    LLCSecret.revoked_at.is_(None),
+        return {row[0]: row[0] for row in result}
+    async def _export_agents(self, company_id: str, secret_map: Dict[str, str]) -> List[Dict[str, Any]]:
+        """Export agents from agent_org_nodes with adapter_config secrets scrubbed."""
+                SELECT agent_id, name, adapter_type, adapter_config,
+                       context_mode, heartbeat_cron, heartbeat_enabled,
+                       llc_agent_status, created_at
+                FROM agent_org_nodes
+                WHERE company_id = :cid
+                ORDER BY created_at
+        agents = []
+        for row in result.mappings():
+            d = dict(row)
+            d["agent_id"] = str(d["agent_id"]) if d.get("agent_id") else None
+            if d.get("created_at"):
+                d["created_at"] = d["created_at"].isoformat()
+            if d.get("adapter_config"):
+                d["adapter_config"] = _scrub_adapter_config(d["adapter_config"], secret_map)
+            agents.append(d)
+        return agents
+    async def _export_goals(self, company_id: str) -> List[Dict[str, Any]]:
+            select(LLCGoal).where(LLCGoal.company_id == company_id).order_by(LLCGoal.created_at)
+        goals = []
+        for (goal,) in result:
+            goals.append(
+                {
+                    "id": str(goal.id),
+                    "parent_goal_id": str(goal.parent_goal_id) if goal.parent_goal_id else None,
+                    "title": goal.title,
+                    "description": goal.description,
+                    "level": goal.level,
+                    "status": goal.status,
+                    "owner_agent_id": goal.owner_agent_id,
+                    "created_at": goal.created_at.isoformat() if goal.created_at else None,
+        return goals
+    async def _export_routines(self, company_id: str) -> List[Dict[str, Any]]:
+        """Export only ACTIVE routines (status='active')."""
+            select(LLCRoutine).where(
+                    LLCRoutine.company_id == company_id,
+                    LLCRoutine.status == "active",
+        routines = []
+        for (routine,) in result:
+            routines.append(
+                    "id": str(routine.id),
+                    "name": routine.name,
+                    "description": routine.description,
+                    "cron_schedule": routine.cron_schedule,
+                    "assignee_agent_id": str(routine.assignee_agent_id) if routine.assignee_agent_id else None,
+                    "produces": routine.produces,
+                    "work_item_template": routine.work_item_template,
+                    "env": routine.env,
+        return routines
+    async def _export_projects_portfolios(
+        self, company_id: str
+    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        portfolios_result = await self.session.execute(
+            select(LLCPortfolio).where(LLCPortfolio.company_id == company_id)
+        portfolios = [
+                "id": str(p.id),
+                "name": p.name,
+                "description": p.description,
+                "status": p.status,
+            for (p,) in portfolios_result
+        ]
+        projects_result = await self.session.execute(
+            select(LLCProject).where(LLCProject.company_id == company_id)
+        projects = [
+                "program_id": str(p.program_id) if p.program_id else None,
+                "goal_id": str(p.goal_id) if p.goal_id else None,
+                "target_date": p.target_date.isoformat() if p.target_date else None,
+                "env": p.env,
+                "auto_rollover": p.auto_rollover,
+            for (p,) in projects_result
+        return projects, portfolios
+    async def _export_seed_items(self, company_id: str) -> List[Dict[str, Any]]:
+        """Up to 20 epic/feature work items as seed tasks (is_seed=true)."""
+            select(LLCWorkItem)
+            .where(
+                    LLCWorkItem.company_id == company_id,
+                    LLCWorkItem.type.in_(list(_SEED_ITEM_TYPES)),
+            .order_by(LLCWorkItem.created_at)
+            .limit(_SEED_ITEM_LIMIT)
+        items = []
+        for (item,) in result:
+            items.append({**_work_item_dict(item), "is_seed": True})
+        return items
+    async def _export_all_work_items(self, company_id: str) -> List[Dict[str, Any]]:
+            .where(LLCWorkItem.company_id == company_id)
+        return [_work_item_dict(item) for (item,) in result]
+    async def _export_sprints(self, company_id: str) -> List[Dict[str, Any]]:
+            select(LLCSprint).where(LLCSprint.company_id == company_id).order_by(LLCSprint.start_date)
+        sprints = []
+        for (s,) in result:
+            sprints.append(
+                    "id": str(s.id),
+                    "project_id": str(s.project_id) if s.project_id else None,
+                    "name": s.name,
+                    "status": s.status,
+                    "start_date": s.start_date.isoformat() if s.start_date else None,
+                    "end_date": s.end_date.isoformat() if s.end_date else None,
+                    "goal": s.goal,
+        return sprints
+    async def _list_kb_collections(self, company_id: str) -> List[str]:
+        """Return KB collection names for the company (not content)."""
+        redis = await get_async_redis_client()
+        if redis is None:
+        pattern = f"llc:kb:{company_id}:*"
+        keys = await redis.keys(pattern)
+        names = []
+        for k in keys:
+            key_str = k.decode("utf-8") if isinstance(k, bytes) else k
+            parts = key_str.split(":")
+            if len(parts) >= 4:
+                names.append(":".join(parts[3:]))
+        return sorted(names)
+    # Persistence
+    async def _persist(
+        self, company_id: uuid.UUID, export_kind: str, payload: Dict[str, Any], actor: str
+        artifact_id = uuid.uuid4()
+        storage_path = f"llc:export:{company_id}:{artifact_id}"
+        if redis is not None:
+            await redis.set(
+                storage_path,
+                json.dumps(payload, default=str, ensure_ascii=False),
+                ex=_EXPORT_TTL_SECONDS,
+        artifact = LLCExportArtifact(
+            id=artifact_id,
+            type="export_artifact",
+            export_kind=export_kind,
+            schema_version=_SCHEMA_VERSION,
+            storage_path=storage_path,
+            created_by=actor,
+        self.session.add(artifact)
+        if self.activity_log:
+            event_type = (
+                ActivityEventType.COMPANY_EXPORT_TEMPLATE
+                if export_kind == "template"
+                else ActivityEventType.COMPANY_EXPORT_SNAPSHOT
+            await self.activity_log.append(
+                session=self.session,
+                event_type=event_type,
+                after={"artifact_id": str(artifact_id), "storage_path": storage_path},
+        return artifact_id
+# Helpers
+def _scrub_adapter_config(config: Dict[str, Any], secret_map: Dict[str, str]) -> Dict[str, Any]:
+    """Replace secret values in adapter_config with ``{{NAME}}`` placeholders.
+    Uses secret_map (name→name) for known bound secrets; falls back to
+    uppercasing the key name for unrecognised secret-like keys.
+    scrubbed: Dict[str, Any] = {}
+    for k, v in config.items():
+        key_lower = k.lower()
+        if key_lower in _SECRET_LIKE_KEYS and v:
+            # Use bound secret name if available, else derive from key
+            bound = secret_map.get(str(v)) or secret_map.get(k)
+            placeholder_name = bound if bound else k.upper()
+            scrubbed[k] = f"{{{{{placeholder_name}}}}}"
+            scrubbed[k] = v
+    return scrubbed
+def _work_item_dict(item: LLCWorkItem) -> Dict[str, Any]:
+        "id": str(item.id),
+        "parent_id": str(item.parent_id) if item.parent_id else None,
+        "project_id": str(item.project_id) if item.project_id else None,
+        "sprint_id": str(item.sprint_id) if item.sprint_id else None,
+        "goal_id": str(item.goal_id) if item.goal_id else None,
+        "type": item.type,
+        "title": item.title,
+        "description": item.description,
+        "status": item.status,
+        "priority": item.priority,
+        "assignee_agent_id": str(item.assignee_agent_id) if item.assignee_agent_id else None,
+        "assignee_user_id": str(item.assignee_user_id) if item.assignee_user_id else None,
+        "created_at": item.created_at.isoformat() if item.created_at else None,
+__all__ = ["
+
+        redis = await get_async_redis_client()
+        if redis is not None:
+            await redis.set(
+                storage_path,
+                json.dumps(payload, default=str, ensure_ascii=False),
+                ex=_EXPORT_TTL_SECONDS,
+            )
+
+        artifact = LLCExportArtifact(
+            id=artifact_id,
+            company_id=company_id,
+            type=", "
+                INSERT INTO agent_org_nodes
+                  (id, agent_id, name, reports_to, org_role, title, capabilities,
+                   company_id, adapter_type, adapter_config, heartbeat_cron,
+                   heartbeat_enabled, context_mode)
+                VALUES
+                  (:id, :agent_id, :name, :reports_to, :org_role, :title, :capabilities,
+                   :company_id, :adapter_type, :adapter_config::jsonb, :heartbeat_cron,
+                   :heartbeat_enabled, :context_mode)
+                ", "
+                SELECT agent_id, name, adapter_type, adapter_config,
+                       context_mode, heartbeat_cron, heartbeat_enabled,
+                       llc_agent_status, created_at
+                FROM agent_org_nodes
+                WHERE company_id = :cid
+                ORDER BY created_at
+                ", "
+                SELECT id, name, slug, description, issue_prefix,
+                       budget_monthly_cents, brand_color, require_approval_for_hires,
+                       parent_org_id, llc_status, created_at
+                FROM organizations
+                WHERE id = :cid
+                ", "
+                else ActivityEventType.COMPANY_EXPORT_SNAPSHOT
+            )
+            await self.activity_log.append(
+                session=self.session,
+                company_id=company_id,
+                event_type=event_type,
+                after={", "
+            ),
+            {", "
+            if not await self._prefix_exists(candidate):
+                return candidate
+        raise TemplateImportError(f", "
+        cid = str(company_id)
+        secret_map = await self._build_secret_map(cid)
+
+        company_data = await self._export_company(cid)
+        agents_data = await self._export_agents(cid, secret_map)
+        goals_data = await self._export_goals(cid)
+        routines_data = await self._export_routines(cid)
+        projects_data, portfolios_data = await self._export_projects_portfolios(cid)
+        all_items = await self._export_all_work_items(cid)
+        sprints_data = await self._export_sprints(cid)
+        kb_collections = await self._list_kb_collections(cid)
+
+        payload = {
+            ", "
+        cid = str(company_id)
+        secret_map = await self._build_secret_map(cid)
+
+        company_data = await self._export_company(cid)
+        agents_data = await self._export_agents(cid, secret_map)
+        goals_data = await self._export_goals(cid)
+        routines_data = await self._export_routines(cid)
+        projects_data, portfolios_data = await self._export_projects_portfolios(cid)
+        seed_items = await self._export_seed_items(cid)
+
+        payload = {
+            ", "
+        else:
+            scrubbed[k] = v
+    return scrubbed
+
+
+def _work_item_dict(item: LLCWorkItem) -> Dict[str, Any]:
+    return {
+        ", "
+        keys = await redis.keys(pattern)
+        names = []
+        for k in keys:
+            key_str = k.decode(", "
+        name = agent.get(", "
+        obj = LLCWorkItem(
+            id=new_id,
+            company_id=company_id,
+            type=item.get(", "
+        redis = await get_async_redis_client()
+        if redis is None:
+            return []
+        pattern = f", "
+        result = await self.session.execute(
+            select(LLCRoutine).where(
+                sa.and_(
+                    LLCRoutine.company_id == company_id,
+                    LLCRoutine.status == ", "
+        result = await self.session.execute(
+            select(LLCSecret.name).where(
+                sa.and_(
+                    LLCSecret.company_id == company_id,
+                    LLCSecret.revoked_at.is_(None),
+                )
+            )
+        )
+        return {row[0]: row[0] for row in result}
+
+    async def _export_agents(self, company_id: str, secret_map: Dict[str, str]) -> List[Dict[str, Any]]:
+        ", "
+        result = await self.session.execute(
+            select(LLCWorkItem)
+            .where(
+                sa.and_(
+                    LLCWorkItem.company_id == company_id,
+                    LLCWorkItem.type.in_(list(_SEED_ITEM_TYPES)),
+                )
+            )
+            .order_by(LLCWorkItem.created_at)
+            .limit(_SEED_ITEM_LIMIT)
+        )
+        items = []
+        for (item,) in result:
+            items.append({**_work_item_dict(item), ", "
+        result = await self.session.execute(
+            text(
+                ", "
+        self._validate_schema(template)
+        company_meta = template.get(", "
+        self._validate_schema(template)
+        remapping_options = remapping_options or {}
+        secret_mapping = secret_mapping or {}
+
+        created_entities: Dict[str, Any] = {
+            ", "
+        unresolved: set[str] = set()
+
+        def _walk(node: Any) -> Any:
+            if isinstance(node, str):
+                def _replace(m: re.Match) -> str:
+                    key = m.group(1)
+                    if key in secret_mapping:
+                        return secret_mapping[key]
+                    unresolved.add(key)
+                    return m.group(0)
+                return _PLACEHOLDER_RE.sub(_replace, node)
+            if isinstance(node, dict):
+                return {k: _walk(v) for k, v in node.items()}
+            if isinstance(node, list):
+                return [_walk(v) for v in node]
+            return node
+
+        result = _walk(config)
+        if unresolved:
+            warnings.append(f", "
+    scrubbed: Dict[str, Any] = {}
+    for k, v in config.items():
+        key_lower = k.lower()
+        if key_lower in _SECRET_LIKE_KEYS and v:
+            # Use bound secret name if available, else derive from key
+            bound = secret_map.get(str(v)) or secret_map.get(k)
+            placeholder_name = bound if bound else k.upper()
+            scrubbed[k] = f", ")
+
+        require_approval = remapping_options.get(
+            ", ")
+
+        return {
+            ", ")
+
+    async def _import_agent(
+        self,
+        agent: Dict[str, Any],
+        company_id: uuid.UUID,
+        secret_mapping: Dict[str, str],
+        warnings: List[str],
+        agent_id_map: Optional[Dict[str, str]] = None,
+    ) -> Optional[str]:
+        ", ")
+                .bindparams(names=names, company_id=str(company_id))
+            )
         else:
             rows = await self.session.execute(
-                text("SELECT name FROM agent_org_nodes WHERE name = ANY(:names)").bindparams(names=names)
+                text(", ")
+            if len(parts) >= 4:
+                names.append(", ")
+            return None
+
+        # Use pre-minted ID from two-pass map if available
+        old_id = agent.get(", ")
+            return org.id
+
+        meta = template.get(", ")
+            }
+
+            # Pass 2: insert agents with remapped reports_to
+            for agent in agents_list:
+                agent_id = await self._import_agent(agent, company_id, secret_mapping, warnings, agent_id_map)
+                if agent_id:
+                    created_entities[", ")
+        existing = await self._agent_names_exist([name], company_id)
+        if existing:
+            warnings.append(f", ")
+        existing = await self._goal_titles_exist([title], company_id)
+        if existing:
+            return None
+
+        new_id = uuid.uuid4()
+        obj = LLCGoal(
+            id=new_id,
+            company_id=str(company_id),
+            title=title,
+            description=goal.get(", ")
+        if isinstance(capabilities, (list, dict)):
+            capabilities = json.dumps(capabilities)
+
+        await self.session.execute(
+            text(", ")
+        if prefix and await self._prefix_exists(prefix):
+            prefix = await self._next_available_prefix(prefix)
+            warnings.append(f", ")
+        if prefix:
+            existing = await self._prefix_exists(prefix)
+            if existing:
+                collisions.append({", ")
+        if version != ", ")
+        new_agent_id = (agent_id_map or {}).get(old_id) or str(uuid.uuid4())
+
+        # Remap reports_to from source UUID to destination UUID
+        old_reports_to = agent.get(", ")
+        reports_to: Optional[str] = None
+        if old_reports_to and agent_id_map:
+            reports_to = agent_id_map.get(str(old_reports_to))
+
+        adapter_config = self._resolve_secrets(agent.get(", ")
+        return result
+
+    async def _import_goal(self, goal: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
+        title = goal.get(", ")
+    async def export_template(self, company_id: uuid.UUID, actor: str = ", ") -> Dict[str, Any]:
+        ", ") else None
+            if d.get(", ") else None
+        if data.get(", ") for a in agents if a.get(", ") for g in goals if g.get(", ") from exc
+
+        return {
+            ", ") if isinstance(k, bytes) else k
+            parts = key_str.split(", ") or {}
+            all_placeholders.update(_PLACEHOLDER_RE.findall(str(cfg)))
+        if all_placeholders:
+            warnings.append(f", ") or {}, secret_mapping, name, warnings)
+
+        # capabilities is TEXT in the schema; serialize list/dict to JSON string
+        capabilities = agent.get(", "))
+
+            # goals
+            for goal in template.get(", "))
+
+            # projects
+            for project in template.get(", "))
+
+            await sp.commit()
+        except Exception as exc:
+            await sp.rollback()
+            raise TemplateImportError(f", "),
+                adapter_config=json.dumps(adapter_config),
+                heartbeat_cron=agent.get(", "),
+                capabilities=capabilities,
+                company_id=company_id,
+                adapter_type=agent.get(", "),
+                heartbeat_enabled=agent.get(", "),
+                title=agent.get(", "),
+            )
+        )
+        return new_agent_id
+
+    def _resolve_secrets(
+        self,
+        config: Any,
+        secret_mapping: Dict[str, str],
+        agent_name: str,
+        warnings: List[str],
+    ) -> Any:
+        ", "),
+            description=item.get(", "),
+            description=meta.get(", "),
+            description=project.get(", "),
+            identifier=identifier,
+            title=item.get(", "),
+            issue_prefix=prefix,
+            budget_monthly_cents=meta.get(", "),
+            labels=item.get(", "),
+            level=goal.get(", "),
+            owner_agent_id=None,
+            due_date=None,
+        )
+        self.session.add(obj)
+        await self.session.flush()
+        return new_id
+
+    async def _import_project(self, project: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
+        new_id = uuid.uuid4()
+        obj = LLCProject(
+            id=new_id,
+            company_id=company_id,
+            name=project.get(", "),
+            require_approval_for_hires=require_approval,
+            llc_status=LLCCompanyStatus.ONBOARDING.value,
+            settings={},
+            issue_counter=0,
+            spent_monthly_cents=0,
+        )
+        self.session.add(org)
+        await self.session.flush()
+        return org.id
+
+    async def _next_available_prefix(self, prefix: str) -> str:
+        for n in range(2, 1000):
+            candidate = f", "),
+            slug=meta.get(", "),
+            status=", "),
+            status=goal.get(", "),
+            status=project.get(", "),
+        )
+        self.session.add(obj)
+        await self.session.flush()
+        return new_id
+
+    async def _import_work_item(self, item: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
+        new_id = uuid.uuid4()
+        identifier = f", ").bindparams(
+                id=uuid.uuid4(),
+                agent_id=new_agent_id,
+                name=name,
+                reports_to=reports_to,
+                org_role=agent.get(", ").bindparams(names=names)
             )
         return [r[0] for r in rows]
 
@@ -241,186 +980,63 @@ class PortabilityService(LLCServiceBase):
             result = await self.session.execute(select(Organization).where(Organization.id == target_company_id))
             org = result.scalar_one_or_none()
             if org is None:
-                raise TemplateImportError(f"target_company_id {target_company_id} not found")
-            return org.id
+                raise TemplateImportError(f", "):
+                    continue
+                item_id = await self._import_work_item(item, company_id)
+                if item_id:
+                    created_entities[", "):
+                d[", "):
+            data[", "): str(uuid.uuid4())
+                for a in agents_list
+                if a.get(", ")]
+        if target_company_id and agent_names:
+            conflicting_agents = await self._agent_names_exist(agent_names, target_company_id)
+            for name in conflicting_agents:
+                collisions.append({", ")]
+        if target_company_id and goal_titles:
+            conflicting_goals = await self._goal_titles_exist(goal_titles, target_company_id)
+            for title in conflicting_goals:
+                collisions.append({", ",
+            ", ",
+                )
+            )
+        )
+        routines = []
+        for (routine,) in result:
+            routines.append(
+                {
+                    ", ",
+            export_kind=export_kind,
+            schema_version=_SCHEMA_VERSION,
+            storage_path=storage_path,
+            created_by=actor,
+        )
+        self.session.add(artifact)
 
-        meta = template.get("company", {})
-        prefix = meta.get("issue_prefix")
-        if prefix and await self._prefix_exists(prefix):
-            prefix = await self._next_available_prefix(prefix)
-            warnings.append(f"issue_prefix remapped to {prefix!r}")
-
-        require_approval = remapping_options.get(
-            "require_approval_for_hires",
-            meta.get("require_approval_for_hires", False),
+        if self.activity_log:
+            event_type = (
+                ActivityEventType.COMPANY_EXPORT_TEMPLATE
+                if export_kind == ", ",
+            meta.get(", ",
+            priority=item.get(", ", ", ", 0),
+            brand_color=meta.get(", ", False),
+                context_mode=agent.get(", ", False),
         )
 
         org = Organization(
             id=uuid.uuid4(),
-            name=meta.get("name", "Imported Company"),
-            slug=meta.get("slug", f"imported-{uuid.uuid4().hex[:8]}"),
-            description=meta.get("description"),
-            issue_prefix=prefix,
-            budget_monthly_cents=meta.get("budget_monthly_cents", 0),
-            brand_color=meta.get("brand_color"),
-            require_approval_for_hires=require_approval,
-            llc_status=LLCCompanyStatus.ONBOARDING.value,
-            settings={},
-            issue_counter=0,
-            spent_monthly_cents=0,
-        )
-        self.session.add(org)
-        await self.session.flush()
-        return org.id
+            name=meta.get(", ", [])
 
-    async def _next_available_prefix(self, prefix: str) -> str:
-        for n in range(2, 1000):
-            candidate = f"{prefix}{n}"
-            if not await self._prefix_exists(candidate):
-                return candidate
-        raise TemplateImportError(f"Cannot find free issue_prefix for {prefix!r}")
+        collisions: List[Dict[str, Any]] = []
+        warnings: List[str] = []
 
-    async def _import_agent(
-        self,
-        agent: Dict[str, Any],
-        company_id: uuid.UUID,
-        secret_mapping: Dict[str, str],
-        warnings: List[str],
-        agent_id_map: Optional[Dict[str, str]] = None,
-    ) -> Optional[str]:
-        """Insert agent_org_nodes row.  Returns new agent_id or None if skipped."""
-        name = agent.get("name", "")
-        existing = await self._agent_names_exist([name], company_id)
-        if existing:
-            warnings.append(f"Agent {name!r} already exists — skipped")
-            return None
-
-        # Use pre-minted ID from two-pass map if available
-        old_id = agent.get("agent_id", "")
-        new_agent_id = (agent_id_map or {}).get(old_id) or str(uuid.uuid4())
-
-        # Remap reports_to from source UUID to destination UUID
-        old_reports_to = agent.get("reports_to")
-        reports_to: Optional[str] = None
-        if old_reports_to and agent_id_map:
-            reports_to = agent_id_map.get(str(old_reports_to))
-
-        adapter_config = self._resolve_secrets(agent.get("adapter_config") or {}, secret_mapping, name, warnings)
-
-        # capabilities is TEXT in the schema; serialize list/dict to JSON string
-        capabilities = agent.get("capabilities")
-        if isinstance(capabilities, (list, dict)):
-            capabilities = json.dumps(capabilities)
-
-        await self.session.execute(
-            text("""
-                INSERT INTO agent_org_nodes
-                  (id, agent_id, name, reports_to, org_role, title, capabilities,
-                   company_id, adapter_type, adapter_config, heartbeat_cron,
-                   heartbeat_enabled, context_mode)
-                VALUES
-                  (:id, :agent_id, :name, :reports_to, :org_role, :title, :capabilities,
-                   :company_id, :adapter_type, :adapter_config::jsonb, :heartbeat_cron,
-                   :heartbeat_enabled, :context_mode)
-                """).bindparams(
-                id=uuid.uuid4(),
-                agent_id=new_agent_id,
-                name=name,
-                reports_to=reports_to,
-                org_role=agent.get("org_role", "worker"),
-                title=agent.get("title"),
-                capabilities=capabilities,
-                company_id=company_id,
-                adapter_type=agent.get("adapter_type"),
-                adapter_config=json.dumps(adapter_config),
-                heartbeat_cron=agent.get("heartbeat_cron"),
-                heartbeat_enabled=agent.get("heartbeat_enabled", False),
-                context_mode=agent.get("context_mode", "thin"),
-            )
-        )
-        return new_agent_id
-
-    def _resolve_secrets(
-        self,
-        config: Any,
-        secret_mapping: Dict[str, str],
-        agent_name: str,
-        warnings: List[str],
-    ) -> Any:
-        """Replace {{SECRET_NAME}} placeholders in config by walking the structure.
-
-        Operates on the decoded Python object (not the JSON string) to prevent
-        injection when secret values contain quote characters.
-        """
-        unresolved: set[str] = set()
-
-        def _walk(node: Any) -> Any:
-            if isinstance(node, str):
-                def _replace(m: re.Match) -> str:
-                    key = m.group(1)
-                    if key in secret_mapping:
-                        return secret_mapping[key]
-                    unresolved.add(key)
-                    return m.group(0)
-                return _PLACEHOLDER_RE.sub(_replace, node)
-            if isinstance(node, dict):
-                return {k: _walk(v) for k, v in node.items()}
-            if isinstance(node, list):
-                return [_walk(v) for v in node]
-            return node
-
-        result = _walk(config)
-        if unresolved:
-            warnings.append(f"Agent {agent_name!r}: unresolved secret placeholders {sorted(unresolved)}")
-        return result
-
-    async def _import_goal(self, goal: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
-        title = goal.get("title", "")
-        existing = await self._goal_titles_exist([title], company_id)
-        if existing:
-            return None
-
-        new_id = uuid.uuid4()
-        obj = LLCGoal(
-            id=new_id,
-            company_id=str(company_id),
-            title=title,
-            description=goal.get("description"),
-            level=goal.get("level", "objective"),
-            status=goal.get("status", "draft"),
-            owner_agent_id=None,
-            due_date=None,
-        )
-        self.session.add(obj)
-        await self.session.flush()
-        return new_id
-
-    async def _import_project(self, project: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
-        new_id = uuid.uuid4()
-        obj = LLCProject(
-            id=new_id,
-            company_id=company_id,
-            name=project.get("name", "Imported Project"),
-            description=project.get("description"),
-            status=project.get("status", "planning"),
-        )
-        self.session.add(obj)
-        await self.session.flush()
-        return new_id
-
-    async def _import_work_item(self, item: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
-        new_id = uuid.uuid4()
-        identifier = f"IMP-{new_id.hex[:8].upper()}"
-        obj = LLCWorkItem(
-            id=new_id,
-            company_id=company_id,
-            type=item.get("type", "epic"),
-            identifier=identifier,
-            title=item.get("title", ""),
-            description=item.get("description"),
-            status="backlog",
-            priority=item.get("priority", "medium"),
-            labels=item.get("labels", []),
+        # issue_prefix collision
+        prefix = company_meta.get(", ", [])
+            agent_id_map: Dict[str, str] = {
+                a.get(", ", [])
+        goals = template.get(", ", [])
+        projects = template.get(", ", [])
+        work_items = template.get(", ", []),
         )
         self.session.add(obj)
         await self.session.flush()
@@ -432,6 +1048,294 @@ class PortabilityService(LLCServiceBase):
 
     @staticmethod
     def _validate_schema(template: Dict[str, Any]) -> None:
-        version = template.get("schema_version")
-        if version != "1.0":
-            raise TemplateImportError(f"Unsupported schema_version {version!r}; expected '1.0'")
+        version = template.get(", ", []):
+                goal_id = await self._import_goal(goal, company_id)
+                if goal_id:
+                    created_entities[", ", []):
+                if not item.get(", ", []):
+                project_id = await self._import_project(project, company_id)
+                if project_id:
+                    created_entities[", ", f", ", payload, actor)
+        payload[", ", {})
+        agents = template.get(", ", {})
+        prefix = meta.get(", ".join(parts[3:]))
+        return sorted(names)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    async def _persist(
+        self, company_id: uuid.UUID, export_kind: str, payload: Dict[str, Any], actor: str
+    ) -> uuid.UUID:
+        artifact_id = uuid.uuid4()
+        storage_path = f", ":
+            raise TemplateImportError(f", ": ", ": True})
+        return items
+
+    async def _export_all_work_items(self, company_id: str) -> List[Dict[str, Any]]:
+        result = await self.session.execute(
+            select(LLCWorkItem)
+            .where(LLCWorkItem.company_id == company_id)
+            .order_by(LLCWorkItem.created_at)
+        )
+        return [_work_item_dict(item) for (item,) in result]
+
+    async def _export_sprints(self, company_id: str) -> List[Dict[str, Any]]:
+        result = await self.session.execute(
+            select(LLCSprint).where(LLCSprint.company_id == company_id).order_by(LLCSprint.start_date)
+        )
+        sprints = []
+        for (s,) in result:
+            sprints.append(
+                {
+                    ", ": [],
+            ", ": [],
+        }
+        skipped: Dict[str, List[str]] = {", ": [], ", ": []}
+        warnings: List[str] = []
+
+        sp = await self.session.begin_nested()
+        try:
+            company_id = await self._resolve_or_create_company(template, target_company_id, remapping_options, warnings)
+
+            # Pass 1: pre-mint all agent IDs so reports_to can be remapped before
+            # any INSERT, avoiding topology-ordering FK violations
+            agents_list = template.get(", ": _SCHEMA_VERSION,
+            ", ": agents_data,
+            ", ": all_items,
+            ", ": collisions,
+            ", ": company_data,
+            ", ": company_id},
+        )
+        agents = []
+        for row in result.mappings():
+            d = dict(row)
+            d[", ": company_id},
+        )
+        row = result.mappings().first()
+        if row is None:
+            return {}
+        data = dict(row)
+        data[", ": created_entities,
+            ", ": goal.created_at.isoformat() if goal.created_at else None,
+                }
+            )
+        return goals
+
+    async def _export_routines(self, company_id: str) -> List[Dict[str, Any]]:
+        ", ": goal.description,
+                    ", ": goal.level,
+                    ", ": goal.owner_agent_id,
+                    ", ": goal.status,
+                    ", ": goal.title,
+                    ", ": goals_data,
+            ", ": item.created_at.isoformat() if item.created_at else None,
+    }
+
+
+__all__ = [", ": item.description,
+        ", ": item.priority,
+        ", ": item.status,
+        ", ": item.title,
+        ", ": item.type,
+        ", ": kb_collections,
+        }
+
+        artifact_id = await self._persist(company_id, ", ": len(agents),
+                ", ": len(goals),
+                ", ": len(projects),
+                ", ": len(work_items),
+            },
+            ", ": name})
+
+        # goal title collisions — scoped to target company for the same reason
+        goal_titles = [g.get(", ": p.auto_rollover,
+            }
+            for (p,) in projects_result
+        ]
+        return projects, portfolios
+
+    async def _export_seed_items(self, company_id: str) -> List[Dict[str, Any]]:
+        ", ": p.description,
+                ", ": p.env,
+                ", ": p.name,
+                ", ": p.status,
+                ", ": p.status,
+            }
+            for (p,) in portfolios_result
+        ]
+
+        projects_result = await self.session.execute(
+            select(LLCProject).where(LLCProject.company_id == company_id)
+        )
+        projects = [
+            {
+                ", ": p.target_date.isoformat() if p.target_date else None,
+                ", ": portfolios_data,
+            ", ": prefix})
+
+        # agent name collisions — scoped to target company; new-company imports
+        # have no pre-existing namespace so there is nothing to collide with
+        agent_names = [a.get(", ": projects_data,
+            ", ": routine.cron_schedule,
+                    ", ": routine.description,
+                    ", ": routine.env,
+                }
+            )
+        return routines
+
+    async def _export_projects_portfolios(
+        self, company_id: str
+    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        portfolios_result = await self.session.execute(
+            select(LLCPortfolio).where(LLCPortfolio.company_id == company_id)
+        )
+        portfolios = [
+            {
+                ", ": routine.name,
+                    ", ": routine.produces,
+                    ", ": routine.work_item_template,
+                    ", ": routines_data,
+            ", ": s.end_date.isoformat() if s.end_date else None,
+                    ", ": s.goal,
+                }
+            )
+        return sprints
+
+    async def _list_kb_collections(self, company_id: str) -> List[str]:
+        ", ": s.name,
+                    ", ": s.start_date.isoformat() if s.start_date else None,
+                    ", ": s.status,
+                    ", ": seed_items,
+        }
+
+        artifact_id = await self._persist(company_id, ", ": skipped,
+            ", ": sprints_data,
+            ", ": storage_path},
+            )
+
+        return artifact_id
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _scrub_adapter_config(config: Dict[str, Any], secret_map: Dict[str, str]) -> Dict[str, Any]:
+    ", ": str(artifact_id), ", ": str(company_id),
+            ", ": str(goal.id),
+                    ", ": str(goal.parent_goal_id) if goal.parent_goal_id else None,
+                    ", ": str(item.assignee_agent_id) if item.assignee_agent_id else None,
+        ", ": str(item.assignee_user_id) if item.assignee_user_id else None,
+        ", ": str(item.goal_id) if item.goal_id else None,
+        ", ": str(item.id),
+        ", ": str(item.parent_id) if item.parent_id else None,
+        ", ": str(item.project_id) if item.project_id else None,
+        ", ": str(item.sprint_id) if item.sprint_id else None,
+        ", ": str(p.goal_id) if p.goal_id else None,
+                ", ": str(p.id),
+                ", ": str(p.program_id) if p.program_id else None,
+                ", ": str(routine.assignee_agent_id) if routine.assignee_agent_id else None,
+                    ", ": str(routine.id),
+                    ", ": str(s.id),
+                    ", ": str(s.project_id) if s.project_id else None,
+                    ", ": title})
+
+        # secret placeholder warning
+        all_placeholders: set[str] = set()
+        for agent in agents:
+            cfg = agent.get(", ": warnings,
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers — collision checks
+    # ------------------------------------------------------------------
+
+    async def _prefix_exists(self, prefix: str) -> bool:
+        result = await self.session.execute(select(Organization.id).where(Organization.issue_prefix == prefix).limit(1))
+        return result.scalar() is not None
+
+    async def _agent_names_exist(
+        self, names: List[str], company_id: Optional[uuid.UUID] = None
+    ) -> List[str]:
+        if not names:
+            return []
+        if company_id is not None:
+            rows = await self.session.execute(
+                text(", ": warnings,
+        }
+
+    async def execute_import(
+        self,
+        template: Dict[str, Any],
+        *,
+        target_company_id: Optional[uuid.UUID] = None,
+        remapping_options: Optional[Dict[str, Any]] = None,
+        secret_mapping: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        ", ": {
+                ", "Export agents from agent_org_nodes with adapter_config secrets scrubbed.", "Export only ACTIVE routines (status='active').", "Insert agent_org_nodes row.  Returns new agent_id or None if skipped.", "Map secret binding names for this company (name → name).
+
+        Returns {name: name} so scrubber can substitute ``{{NAME}}``.
+        Only active (non-revoked) secrets are included.
+        ", "Replace secret values in adapter_config with ``{{NAME}}`` placeholders.
+
+    Uses secret_map (name→name) for known bound secrets; falls back to
+    uppercasing the key name for unrecognised secret-like keys.
+    ", "Replace {{SECRET_NAME}} placeholders in config by walking the structure.
+
+        Operates on the decoded Python object (not the JSON string) to prevent
+        injection when secret values contain quote characters.
+        ", "Return KB collection names for the company (not content).", "Return a full-state snapshot for backup/migration.
+
+        Extends the template with ALL work items, sprint history rows, and KB
+        collection names (not KB content).
+        ", "Return a portable template dict for the company.
+
+        Includes company meta, agents (secrets scrubbed), goals, active
+        routines, projects + portfolios (no sprint data), and up to 20 seed
+        work items (epic/feature) marked ``is_seed=true``.  Secret values are
+        never exported.
+        ", "Return collision/creation preview without writing anything.", "Transactional import.  Rolls back entirely on any entity failure.", "Up to 20 epic/feature work items as seed tasks (is_seed=true).", "] = _scrub_adapter_config(d[", "] = d[", "] = data[", "] = str(artifact_id)
+        return payload
+
+    # ------------------------------------------------------------------
+    # Data collectors
+    # ------------------------------------------------------------------
+
+    async def _export_company(self, company_id: str) -> Dict[str, Any]:
+        result = await self.session.execute(
+            text(
+                ", "] = str(artifact_id)
+        return payload
+
+    async def export_snapshot(self, company_id: uuid.UUID, actor: str = ", "] = str(d[", "] = str(data[", "])
+        if data.get(", "]) if d.get(", "]) if data.get(", "], secret_map)
+            agents.append(d)
+        return agents
+
+    async def _export_goals(self, company_id: str) -> List[Dict[str, Any]]:
+        result = await self.session.execute(
+            select(LLCGoal).where(LLCGoal.company_id == company_id).order_by(LLCGoal.created_at)
+        )
+        goals = []
+        for (goal,) in result:
+            goals.append(
+                {
+                    ", "].append(agent.get(", "].append(agent_id)
+                else:
+                    skipped[", "].append(goal.get(", "].append(item.get(", "].append(str(goal_id))
+                else:
+                    skipped[", "].append(str(item_id))
+                else:
+                    skipped[", "].append(str(project_id))
+
+            # seed work items
+            for item in template.get(", "].isoformat()
+            if d.get(", "].isoformat()
+        return data
+
+    async def _build_secret_map(self, company_id: str) -> Dict[str, str]:
+        "]

--- a/autobot-backend/llc/tests/test_export.py
+++ b/autobot-backend/llc/tests/test_export.py
@@ -1,0 +1,282 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for PortabilityService — company template and snapshot export (GH#8245)."""
+
+import json
+import uuid
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.services.portability import PortabilityService, _scrub_adapter_config
+
+
+# ------------------------------------------------------------------
+# Unit tests for _scrub_adapter_config
+# ------------------------------------------------------------------
+
+
+def test_scrub_replaces_known_secret_keys():
+    config = {"api_key": "sk-secret-123", "model": "gpt-4", "timeout": 30}
+    result = _scrub_adapter_config(config, {})
+    assert result["api_key"] == "{{API_KEY}}"
+    assert result["model"] == "gpt-4"
+    assert result["timeout"] == 30
+
+
+def test_scrub_uses_bound_secret_name_when_available():
+    config = {"api_key": "my_openai_key", "endpoint": "https://api.openai.com"}
+    secret_map = {"my_openai_key": "my_openai_key"}
+    result = _scrub_adapter_config(config, secret_map)
+    assert result["api_key"] == "{{my_openai_key}}"
+
+
+def test_scrub_falls_back_to_uppercased_key():
+    config = {"token": "bearer-xyz"}
+    result = _scrub_adapter_config(config, {})
+    assert result["token"] == "{{TOKEN}}"
+
+
+def test_scrub_leaves_non_secret_keys_intact():
+    config = {"base_url": "https://example.com", "retries": 3, "stream": True}
+    result = _scrub_adapter_config(config, {})
+    assert result == {"base_url": "https://example.com", "retries": 3, "stream": True}
+
+
+def test_scrub_empty_config():
+    assert _scrub_adapter_config({}, {}) == {}
+
+
+def test_scrub_skips_empty_string_values():
+    config = {"api_key": "", "model": "gpt-4"}
+    result = _scrub_adapter_config(config, {})
+    # Empty string is falsy — should NOT be replaced with placeholder
+    assert result["api_key"] == ""
+    assert result["model"] == "gpt-4"
+
+
+def test_scrub_multiple_secret_keys():
+    config = {
+        "api_key": "key1",
+        "token": "tok1",
+        "password": "pass1",
+        "host": "db.local",
+    }
+    result = _scrub_adapter_config(config, {})
+    assert "{{" in result["api_key"]
+    assert "{{" in result["token"]
+    assert "{{" in result["password"]
+    assert result["host"] == "db.local"
+
+
+# ------------------------------------------------------------------
+# PortabilityService integration-style tests (mocked session)
+# ------------------------------------------------------------------
+
+
+def _make_service(session: AsyncMock | None = None) -> PortabilityService:
+    if session is None:
+        session = AsyncMock()
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+    return PortabilityService(session=session)
+
+
+def _mock_execute_mapping(rows: list) -> AsyncMock:
+    """Return a mock that .execute() → .mappings().first() or .all()."""
+    result = MagicMock()
+    result.mappings.return_value.first.return_value = rows[0] if rows else None
+    result.mappings.return_value.all.return_value = rows
+    result.__iter__ = MagicMock(return_value=iter(rows))
+    return result
+
+
+@pytest.fixture
+def company_id() -> uuid.UUID:
+    return uuid.UUID("12345678-1234-5678-1234-567812345678")
+
+
+@pytest.mark.asyncio
+async def test_export_template_returns_schema_version(company_id):
+    svc = _make_service()
+    cid = str(company_id)
+
+    async def _fake_execute(stmt, params=None):
+        mock = MagicMock()
+        mock.mappings.return_value.first.return_value = {
+            "id": company_id,
+            "name": "Test Co",
+            "slug": "test-co",
+            "description": None,
+            "issue_prefix": "TC",
+            "budget_monthly_cents": 0,
+            "brand_color": None,
+            "require_approval_for_hires": False,
+            "parent_org_id": None,
+            "llc_status": "active",
+            "created_at": None,
+        }
+        mock.mappings.return_value.all.return_value = []
+        mock.__iter__ = MagicMock(return_value=iter([]))
+        return mock
+
+    svc.session.execute = _fake_execute
+
+    with patch("llc.services.portability.get_async_redis_client", return_value=AsyncMock(return_value=None)):
+        result = await svc.export_template(company_id)
+
+    assert result["schema_version"] == "1.0"
+    assert result["export_kind"] == "template"
+    assert "company" in result
+    assert "agents" in result
+    assert "goals" in result
+    assert "routines" in result
+    assert "portfolios" in result
+    assert "projects" in result
+    assert "seed_work_items" in result
+    assert "artifact_id" in result
+
+
+@pytest.mark.asyncio
+async def test_export_snapshot_includes_work_items_and_sprints(company_id):
+    svc = _make_service()
+
+    async def _fake_execute(stmt, params=None):
+        mock = MagicMock()
+        mock.mappings.return_value.first.return_value = {
+            "id": company_id,
+            "name": "Test Co",
+            "slug": "test-co",
+            "description": None,
+            "issue_prefix": None,
+            "budget_monthly_cents": 0,
+            "brand_color": None,
+            "require_approval_for_hires": False,
+            "parent_org_id": None,
+            "llc_status": "active",
+            "created_at": None,
+        }
+        mock.mappings.return_value.all.return_value = []
+        mock.__iter__ = MagicMock(return_value=iter([]))
+        return mock
+
+    svc.session.execute = _fake_execute
+
+    with patch("llc.services.portability.get_async_redis_client", return_value=AsyncMock(return_value=None)):
+        result = await svc.export_snapshot(company_id)
+
+    assert result["export_kind"] == "snapshot"
+    assert "work_items" in result
+    assert "sprints" in result
+    assert "kb_collection_names" in result
+
+
+@pytest.mark.asyncio
+async def test_export_template_no_snapshot_keys(company_id):
+    svc = _make_service()
+
+    async def _fake_execute(stmt, params=None):
+        mock = MagicMock()
+        mock.mappings.return_value.first.return_value = {
+            "id": company_id,
+            "name": "Acme",
+            "slug": "acme",
+            "description": None,
+            "issue_prefix": None,
+            "budget_monthly_cents": 0,
+            "brand_color": None,
+            "require_approval_for_hires": False,
+            "parent_org_id": None,
+            "llc_status": "active",
+            "created_at": None,
+        }
+        mock.mappings.return_value.all.return_value = []
+        mock.__iter__ = MagicMock(return_value=iter([]))
+        return mock
+
+    svc.session.execute = _fake_execute
+
+    with patch("llc.services.portability.get_async_redis_client", return_value=AsyncMock(return_value=None)):
+        result = await svc.export_template(company_id)
+
+    assert "work_items" not in result
+    assert "sprints" not in result
+    assert "kb_collection_names" not in result
+
+
+@pytest.mark.asyncio
+async def test_export_stores_artifact_in_redis(company_id):
+    svc = _make_service()
+
+    async def _fake_execute(stmt, params=None):
+        mock = MagicMock()
+        mock.mappings.return_value.first.return_value = {
+            "id": company_id,
+            "name": "Co",
+            "slug": "co",
+            "description": None,
+            "issue_prefix": None,
+            "budget_monthly_cents": 0,
+            "brand_color": None,
+            "require_approval_for_hires": False,
+            "parent_org_id": None,
+            "llc_status": "active",
+            "created_at": None,
+        }
+        mock.mappings.return_value.all.return_value = []
+        mock.__iter__ = MagicMock(return_value=iter([]))
+        return mock
+
+    svc.session.execute = _fake_execute
+
+    redis_mock = AsyncMock()
+    redis_mock.set = AsyncMock()
+    redis_mock.keys = AsyncMock(return_value=[])
+
+    with patch("llc.services.portability.get_async_redis_client", new=AsyncMock(return_value=redis_mock)):
+        result = await svc.export_template(company_id)
+
+    redis_mock.set.assert_called_once()
+    call_kwargs = redis_mock.set.call_args
+    key = call_kwargs[0][0]
+    assert str(company_id) in key
+    assert key.startswith("llc:export:")
+
+
+@pytest.mark.asyncio
+async def test_export_adds_artifact_row_to_session(company_id):
+    svc = _make_service()
+
+    async def _fake_execute(stmt, params=None):
+        mock = MagicMock()
+        mock.mappings.return_value.first.return_value = {
+            "id": company_id,
+            "name": "Co",
+            "slug": "co",
+            "description": None,
+            "issue_prefix": None,
+            "budget_monthly_cents": 0,
+            "brand_color": None,
+            "require_approval_for_hires": False,
+            "parent_org_id": None,
+            "llc_status": "active",
+            "created_at": None,
+        }
+        mock.mappings.return_value.all.return_value = []
+        mock.__iter__ = MagicMock(return_value=iter([]))
+        return mock
+
+    svc.session.execute = _fake_execute
+
+    with patch("llc.services.portability.get_async_redis_client", return_value=AsyncMock(return_value=None)):
+        await svc.export_template(company_id)
+
+    svc.session.add.assert_called_once()
+    artifact = svc.session.add.call_args[0][0]
+    from llc.models.export import LLCExportArtifact
+
+    assert isinstance(artifact, LLCExportArtifact)
+    assert artifact.export_kind == "template"
+    assert artifact.company_id == company_id


### PR DESCRIPTION
## Summary

- Implements `PortabilityService.export_template()` and `export_snapshot()` (GH#8245 Phase 6A)
- Adds `POST /api/llc/companies/{id}/export/template` and `/export/snapshot` endpoints
- Creates `LLCExportArtifact` model for audit trail (storage_path = Redis key)
- Secret values in `adapter_config` **never exported** — replaced with `{{SECRET_NAME}}` placeholders
- Activity log events: `company.export_template` and `company.export_snapshot`
- Fixes pre-existing circular import in 9 LLC service files (`from . import LLCServiceBase` → `from .base import LLCServiceBase`)

## Test plan

- [x] `python3 -m pytest autobot-backend/llc/tests/test_export.py -q` — 12/12 pass
- [x] `pytest -k export` (with pre-existing adapter collection error excluded) — 12/12 pass
- [x] All modified files syntax-checked via `py_compile`
- [ ] Manual API test against running backend

## Acceptance Criteria Coverage

- ✅ `PortabilityService.export_template()` — company meta, agents (scrubbed), goals, active routines, projects+portfolios, ≤20 seed items
- ✅ `PortabilityService.export_snapshot()` — template + all work items + sprints + KB collection names
- ✅ `POST /export/template` returns JSON file download
- ✅ `POST /export/snapshot` returns JSON file download
- ✅ `schema_version: "1.0"` tagged in every export
- ✅ Secret values never exported — `{{SECRET_NAME}}` placeholders only
- ✅ Agent API keys not included
- ✅ Export artifact record written to DB with `type=export_artifact` and `storage_path`
- ✅ Activity log entry appended on every export
- ✅ `pytest -k export` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)