### PR TITLE
feat(llc/kb): agent capability indexing on hire/update (#8244)

### DIFF
--- a/autobot-backend/llc/api/agent_api.py
+++ b/autobot-backend/llc/api/agent_api.py
@@ -247,7 +247,8 @@ async def search_peer_agents(
         agents = []
         if results.get("ids") and len(results["ids"]) > 0:
             docs = results.get("documents", [[]])[0] if results.get("documents") else []
-            for idx, (doc_id, metadata) in enumerate(zip(results["ids"][0], results.get("metadatas", [[]])[0])):
+            metadatas = results.get("metadatas", [[]])[0] if results.get("metadatas") else []
+            for idx, (doc_id, metadata) in enumerate(zip(results["ids"][0], metadatas)):
                 agents.append(PeerAgent(
                     agent_id=metadata.get("agent_id", ""),
                     agent_name=metadata.get("agent_name", ""),

--- a/autobot-backend/llc/api/agent_api.py
+++ b/autobot-backend/llc/api/agent_api.py
@@ -194,4 +194,76 @@ async def get_item_context(item_id: uuid.UUID, request: Request) -> Dict[str, An
     }
 
 
+class PeerAgent(BaseModel):
+    agent_id: str
+    agent_name: str
+    title: str
+    role: str
+    capabilities: str
+    manager_name: Optional[str] = None
+
+
+@router.get("/peers/search")
+async def search_peer_agents(
+    q: str,
+    limit: int = 10,
+    request: Request = None,
+) -> Dict[str, Any]:
+    """Search peer agents by capabilities (for delegation decisions).
+
+    Agents use this to discover peers who can handle specific work.
+    Returns matching agents from the company agents KB collection.
+
+    Args:
+        q: Search query (\"who handles cloud devops?\", etc.)
+        limit: Max results to return
+        request: Request context injected by middleware
+
+    Returns:
+        List of matching peer agents with capability metadata.
+    """
+    agent_id, company_id = _agent_context(request)
+    try:
+        from autobot_shared.logging_manager import get_logger
+        from ..kb import AgentCapabilityIndexer
+        from knowledge import get_knowledge_base
+
+        logger_inner = get_logger(__name__)
+        indexer = AgentCapabilityIndexer()
+        kb = await get_knowledge_base()
+        collection_name = indexer._collection_name(company_id)
+
+        try:
+            collection = await kb._async_chroma_client.get_collection(collection_name)
+        except Exception:
+            return {"agents": [], "count": 0, "query": q}
+
+        results = await collection.query(
+            query_texts=[q],
+            n_results=min(limit, 50),
+            include=["documents", "metadatas"],
+        )
+
+        agents = []
+        if results.get("ids") and len(results["ids"]) > 0:
+            docs = results.get("documents", [[]])[0] if results.get("documents") else []
+            for idx, (doc_id, metadata) in enumerate(zip(results["ids"][0], results.get("metadatas", [[]])[0])):
+                agents.append(PeerAgent(
+                    agent_id=metadata.get("agent_id", ""),
+                    agent_name=metadata.get("agent_name", ""),
+                    title=metadata.get("title", ""),
+                    role=metadata.get("role", ""),
+                    capabilities=docs[idx] if idx < len(docs) else "",
+                    manager_name=metadata.get("manager_name"),
+                ))
+
+        return {"agents": agents, "count": len(agents), "query": q, "querying_agent": agent_id}
+    except Exception as e:
+        from autobot_shared.logging_manager import get_logger
+
+        logger_inner = get_logger(__name__)
+        logger_inner.exception("Peer agent search failed for agent %s: %s", agent_id, str(e))
+        raise HTTPException(status_code=500, detail=f"Peer search failed: {str(e)}")
+
+
 __all__ = ["router"]

--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -30,10 +30,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.logging_manager import get_logger
-
 from llc.kb.collections import KbCollectionManager
-
-logger = get_logger(__name__)
 from llc.models.company import (
     CompanyAncestor,
     CompanyCreate,
@@ -59,6 +56,8 @@ from llc.services.membership_service import (
 from llc.services.portability import PortabilityService
 from user_management.database import get_async_session
 from user_management.models.organization import Organization
+
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/companies", tags=["llc-companies"])
 
@@ -502,13 +501,14 @@ async def search_agents(
 
         agents = []
         if results.get("ids") and len(results["ids"]) > 0:
-            for doc_id, metadata in zip(results["ids"][0], results.get("metadatas", [[]])[0]):
+            docs = results.get("documents", [[]])[0] if results.get("documents") else []
+            for idx, (doc_id, metadata) in enumerate(zip(results["ids"][0], results.get("metadatas", [[]])[0])):
                 agents.append(AgentSearchResult(
                     agent_id=metadata.get("agent_id", ""),
                     agent_name=metadata.get("agent_name", ""),
                     title=metadata.get("title", ""),
                     role=metadata.get("role", ""),
-                    capabilities=results.get("documents", [[]])[0][len(agents)] if len(agents) < len(results.get("documents", [[]])[0]) else "",
+                    capabilities=docs[idx] if idx < len(docs) else "",
                     manager_name=metadata.get("manager_name"),
                 ))
 

--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -29,7 +29,11 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from autobot_shared.logging_manager import get_logger
+
 from llc.kb.collections import KbCollectionManager
+
+logger = get_logger(__name__)
 from llc.models.company import (
     CompanyAncestor,
     CompanyCreate,
@@ -442,6 +446,79 @@ async def _test_pm_connectivity(pm_type: str, pm_config: Dict[str, Any]) -> Dict
         "message": health.message,
         "details": health.details,
     }
+
+
+# ------------------------------------------------------------------
+# Agent search endpoints (GH#8244)
+# ------------------------------------------------------------------
+
+
+class AgentSearchResult(BaseModel):
+    agent_id: str
+    agent_name: str
+    title: str
+    role: str
+    capabilities: str
+    manager_name: Optional[str] = None
+
+
+@router.get("/{company_id}/agents/search")
+async def search_agents(
+    company_id: uuid.UUID,
+    q: str = Query(..., min_length=1, description="Search query for agent capabilities"),
+    limit: int = Query(10, ge=1, le=100, description="Max results"),
+) -> Dict[str, Any]:
+    """Search agents in company by capabilities using RAG.
+
+    Queries the company:agents KB collection for agents matching the capability
+    search query. Returns agent metadata and capability descriptions.
+
+    Args:
+        company_id: Company ID to search within
+        q: Search query (\"who can do X?\", \"security audit expertise\", etc.)
+        limit: Max results to return (default 10, max 100)
+
+    Returns:
+        List of matching agents with capability metadata.
+    """
+    try:
+        from llc.kb import AgentCapabilityIndexer
+        from knowledge import get_knowledge_base
+
+        indexer = AgentCapabilityIndexer()
+        kb = await get_knowledge_base()
+        collection_name = indexer._collection_name(str(company_id))
+
+        try:
+            collection = await kb._async_chroma_client.get_collection(collection_name)
+        except Exception:
+            return {"agents": [], "count": 0, "query": q}
+
+        results = await collection.query(
+            query_texts=[q],
+            n_results=limit,
+            include=["documents", "metadatas"],
+        )
+
+        agents = []
+        if results.get("ids") and len(results["ids"]) > 0:
+            for doc_id, metadata in zip(results["ids"][0], results.get("metadatas", [[]])[0]):
+                agents.append(AgentSearchResult(
+                    agent_id=metadata.get("agent_id", ""),
+                    agent_name=metadata.get("agent_name", ""),
+                    title=metadata.get("title", ""),
+                    role=metadata.get("role", ""),
+                    capabilities=results.get("documents", [[]])[0][len(agents)] if len(agents) < len(results.get("documents", [[]])[0]) else "",
+                    manager_name=metadata.get("manager_name"),
+                ))
+
+        return {"agents": agents, "count": len(agents), "query": q}
+    except Exception as e:
+        logger.exception("Agent search failed for company %s: %s", company_id, str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Agent search failed: {str(e)}",
+        )
 
 
 # Export endpoints (GH#8245)

--- a/autobot-backend/llc/kb/__init__.py
+++ b/autobot-backend/llc/kb/__init__.py
@@ -2,6 +2,7 @@
 
 from .ac_suggester import AcSuggester
 from .artifact_ingestor import ArtifactIngestor
+from .capability_indexer import AgentCapabilityIndexer
 from .collections import KbCollectionManager
 from .diary_writer import AgentDiaryKbWriter
 from .handoff_brief import HandoffBriefGenerator
@@ -10,6 +11,7 @@ from .rag_assembler import AssemblerProfile, LLCContext, LLCRAGAssembler
 
 __all__ = [
     "AcSuggester",
+    "AgentCapabilityIndexer",
     "AgentDiaryKbWriter",
     "ArtifactIngestor",
     "AssemblerProfile",

--- a/autobot-backend/llc/kb/capability_indexer.py
+++ b/autobot-backend/llc/kb/capability_indexer.py
@@ -1,0 +1,199 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Agent capability indexing into KB (GH#8244).
+
+When agents are hired, their capabilities are indexed into the company's agents
+collection ``company:{company_id}:agents`` so they can be discovered via RAG queries
+(\"who can handle security audits?\", \"who has cloud devops experience?\").
+
+On agent capability update or termination, documents are updated or deleted.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from autobot_shared.logging_manager import get_logger
+from knowledge import get_knowledge_base
+
+logger = get_logger(__name__)
+
+
+async def _fetch_agent_row(agent_id: str, company_id: str) -> Optional[Dict[str, Any]]:
+    """Read agent data from agent_org_nodes for capability indexing."""
+    from sqlalchemy import text
+    from llc.db import get_async_session_factory
+
+    factory = get_async_session_factory()
+    async with factory() as session:
+        result = await session.execute(
+            text("""
+                SELECT aon.agent_id, aon.name, aon.title, aon.org_role,
+                       aon.capabilities, aon.reports_to,
+                       mgr.name AS manager_name
+                FROM agent_org_nodes aon
+                LEFT JOIN agent_org_nodes mgr ON mgr.agent_id = aon.reports_to
+                WHERE aon.agent_id = :agent_id
+                  AND aon.company_id = :company_id
+            """).bindparams(agent_id=agent_id, company_id=company_id)
+        )
+        row = result.mappings().first()
+        return dict(row) if row else None
+
+
+class AgentCapabilityIndexer:
+    """Indexes agent capabilities into the company KB agents collection."""
+
+    @classmethod
+    def _collection_name(cls, company_id: str) -> str:
+        """Return the canonical collection name for agent capabilities."""
+        return f"company:{company_id}:agents"
+
+    @classmethod
+    def _doc_id(cls, agent_id: str) -> str:
+        """Return the canonical document ID for an agent capability document."""
+        return f"agent:{agent_id}"
+
+    async def index(
+        self,
+        agent_id: str,
+        company_id: str,
+        agent_name: str,
+        title: str,
+        role: str,
+        capabilities: str,
+        manager_name: Optional[str] = None,
+    ) -> str:
+        """Index agent capabilities into the company agents collection.
+
+        Reads agent name, title, role, capabilities text and creates a document
+        in the company:agents collection keyed by agent_id. Old documents are
+        deleted and new ones inserted (upsert).
+
+        Args:
+            agent_id: Unique agent identifier
+            company_id: Company that owns the agent
+            agent_name: Display name for the agent
+            title: Agent's title/role
+            role: Agent's functional role
+            capabilities: Freetext description of capabilities
+            manager_name: Optional manager name for reporting structure
+
+        Returns:
+            The document ID inserted (format: ``agent:{agent_id}``).
+        """
+        doc_id = self._doc_id(agent_id)
+
+        # Compose capability document text
+        doc_text = f"Agent {agent_name} ({title}) handles: {capabilities}."
+        if manager_name:
+            doc_text += f" Reports to: {manager_name}."
+
+        meta: Dict[str, Any] = {
+            "agent_id": agent_id,
+            "company_id": company_id,
+            "agent_name": agent_name,
+            "title": title,
+            "role": role,
+        }
+        if manager_name:
+            meta["manager_name"] = manager_name
+
+        await self._upsert(company_id, doc_id, doc_text, meta)
+        return doc_id
+
+    async def index_from_db(self, agent_id: str, company_id: str) -> Optional[str]:
+        """Index agent capabilities by reading from agent_org_nodes.
+
+        Convenience method for post-save hooks — fetches all required fields
+        from the DB and delegates to :meth:`index`.
+
+        Args:
+            agent_id: Agent to index
+            company_id: Company that owns the agent
+
+        Returns:
+            Document ID if indexed, or None if agent not found in DB.
+        """
+        row = await _fetch_agent_row(agent_id, company_id)
+        if not row:
+            logger.warning("Agent %s not found in agent_org_nodes; skipping capability index", agent_id)
+            return None
+        return await self.index(
+            agent_id=agent_id,
+            company_id=company_id,
+            agent_name=row.get("name") or "",
+            title=row.get("title") or "",
+            role=row.get("org_role") or "",
+            capabilities=row.get("capabilities") or "",
+            manager_name=row.get("manager_name"),
+        )
+
+    async def remove(self, agent_id: str, company_id: str) -> None:
+        """Remove agent capability document from the company agents collection.
+
+        Called when agent is terminated or deleted.
+
+        Args:
+            agent_id: Agent to remove
+            company_id: Company that owns the agent
+        """
+        doc_id = self._doc_id(agent_id)
+        await self._delete(company_id, doc_id)
+
+    async def _upsert(
+        self,
+        company_id: str,
+        doc_id: str,
+        content: str,
+        metadata: Dict[str, Any],
+    ) -> None:
+        """Upsert document into the company agents collection."""
+        try:
+            kb = await get_knowledge_base()
+            collection_name = self._collection_name(company_id)
+            collection = await kb._async_chroma_client.get_or_create_collection(
+                name=collection_name,
+                metadata={"entity_type": "company", "entity_id": company_id},
+            )
+            await collection.upsert(
+                ids=[doc_id],
+                documents=[content],
+                metadatas=[metadata],
+            )
+            logger.info("Indexed agent capability: doc_id=%s, company_id=%s", doc_id, company_id)
+        except Exception as e:
+            logger.exception(
+                "Failed to upsert agent capability %s for company %s: %s",
+                doc_id,
+                company_id,
+                str(e),
+            )
+
+    async def _delete(
+        self,
+        company_id: str,
+        doc_id: str,
+    ) -> None:
+        """Delete document from the company agents collection."""
+        try:
+            kb = await get_knowledge_base()
+            collection_name = self._collection_name(company_id)
+            try:
+                collection = await kb._async_chroma_client.get_collection(collection_name)
+            except Exception:
+                logger.debug("Agent collection %s not found; nothing to delete", collection_name)
+                return
+
+            await collection.delete(ids=[doc_id])
+            logger.info("Deleted agent capability: doc_id=%s, company_id=%s", doc_id, company_id)
+        except Exception as e:
+            logger.exception(
+                "Failed to delete agent capability %s for company %s: %s",
+                doc_id,
+                company_id,
+                str(e),
+            )
+
+
+__all__ = ["AgentCapabilityIndexer"]

--- a/autobot-backend/llc/services/portability.py
+++ b/autobot-backend/llc/services/portability.py
@@ -675,6 +675,14 @@ class PortabilityService(LLCServiceBase):
                 context_mode=agent.get("context_mode", "thin"),
             )
         )
+
+        # Index capabilities into company KB (GH#8244)
+        try:
+            from llc.kb import AgentCapabilityIndexer
+
+            await AgentCapabilityIndexer().index_from_db(new_agent_id, str(company_id))
+        except Exception:
+            logger.exception("Capability index failed for imported agent %s (non-fatal)", new_agent_id)
         return new_agent_id
 
     def _resolve_secrets(

--- a/autobot-backend/llc/tests/test_capability_indexer.py
+++ b/autobot-backend/llc/tests/test_capability_indexer.py
@@ -1,0 +1,231 @@
+"""Tests for AgentCapabilityIndexer — agent capabilities indexed into company KB (GH#8244)."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.kb.capability_indexer import AgentCapabilityIndexer
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def indexer():
+    return AgentCapabilityIndexer()
+
+
+@pytest.fixture
+def company_id():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def agent_id():
+    return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for collection naming
+# ---------------------------------------------------------------------------
+
+
+def test_collection_name_format(indexer, company_id):
+    """Collection name should be company:{company_id}:agents."""
+    expected = f"company:{company_id}:agents"
+    assert indexer._collection_name(company_id) == expected
+
+
+def test_doc_id_format(indexer, agent_id):
+    """Document ID should be agent:{agent_id}."""
+    expected = f"agent:{agent_id}"
+    assert indexer._doc_id(agent_id) == expected
+
+
+# ---------------------------------------------------------------------------
+# Async tests for indexing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_index_creates_capability_document(indexer, company_id, agent_id):
+    """Index should create a capability document in the company agents collection."""
+    mock_collection = AsyncMock()
+    mock_kb = MagicMock()
+    mock_kb._async_chroma_client.get_or_create_collection = AsyncMock(
+        return_value=mock_collection
+    )
+
+    with patch("llc.kb.capability_indexer.get_knowledge_base", return_value=mock_kb):
+        doc_id = await indexer.index(
+            agent_id=agent_id,
+            company_id=company_id,
+            agent_name="Alice",
+            title="Security Engineer",
+            role="security",
+            capabilities="Security audits, penetration testing, vulnerability assessment",
+            manager_name="Bob",
+        )
+
+    assert doc_id == f"agent:{agent_id}"
+    mock_kb._async_chroma_client.get_or_create_collection.assert_called_once_with(
+        name=f"company:{company_id}:agents",
+        metadata={"entity_type": "company", "entity_id": company_id},
+    )
+    mock_collection.upsert.assert_called_once()
+    call_args = mock_collection.upsert.call_args
+    assert call_args[1]["ids"] == [f"agent:{agent_id}"]
+    assert "Alice" in call_args[1]["documents"][0]
+    assert "Security audits" in call_args[1]["documents"][0]
+    assert "Reports to: Bob" in call_args[1]["documents"][0]
+
+
+@pytest.mark.asyncio
+async def test_index_without_manager_name(indexer, company_id, agent_id):
+    """Index should work without manager_name."""
+    mock_collection = AsyncMock()
+    mock_kb = MagicMock()
+    mock_kb._async_chroma_client.get_or_create_collection = AsyncMock(
+        return_value=mock_collection
+    )
+
+    with patch("llc.kb.capability_indexer.get_knowledge_base", return_value=mock_kb):
+        await indexer.index(
+            agent_id=agent_id,
+            company_id=company_id,
+            agent_name="Charlie",
+            title="Developer",
+            role="engineering",
+            capabilities="Backend development, API design",
+        )
+
+    call_args = mock_collection.upsert.call_args
+    doc_text = call_args[1]["documents"][0]
+    assert "Charlie" in doc_text
+    assert "Backend development" in doc_text
+    assert "Reports to:" not in doc_text
+
+
+@pytest.mark.asyncio
+async def test_index_handles_kb_failure(indexer, company_id, agent_id):
+    """Index should handle KB failures gracefully and log."""
+    mock_kb = MagicMock()
+    mock_kb._async_chroma_client.get_or_create_collection = AsyncMock(
+        side_effect=RuntimeError("KB connection failed")
+    )
+
+    with patch("llc.kb.capability_indexer.get_knowledge_base", return_value=mock_kb):
+        with patch("llc.kb.capability_indexer.logger") as mock_logger:
+            await indexer.index(
+                agent_id=agent_id,
+                company_id=company_id,
+                agent_name="Dave",
+                title="Manager",
+                role="management",
+                capabilities="Team leadership",
+            )
+
+            mock_logger.exception.assert_called_once()
+            assert "Failed to upsert agent capability" in str(
+                mock_logger.exception.call_args
+            )
+
+
+# ---------------------------------------------------------------------------
+# Async tests for removal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remove_deletes_capability_document(indexer, company_id, agent_id):
+    """Remove should delete the agent capability document from the collection."""
+    mock_collection = AsyncMock()
+    mock_kb = MagicMock()
+    mock_kb._async_chroma_client.get_collection = AsyncMock(
+        return_value=mock_collection
+    )
+
+    with patch("llc.kb.capability_indexer.get_knowledge_base", return_value=mock_kb):
+        await indexer.remove(agent_id=agent_id, company_id=company_id)
+
+    mock_kb._async_chroma_client.get_collection.assert_called_once_with(
+        f"company:{company_id}:agents"
+    )
+    mock_collection.delete.assert_called_once_with(ids=[f"agent:{agent_id}"])
+
+
+@pytest.mark.asyncio
+async def test_remove_handles_missing_collection(indexer, company_id, agent_id):
+    """Remove should handle missing collection gracefully."""
+    mock_kb = MagicMock()
+    mock_kb._async_chroma_client.get_collection = AsyncMock(
+        side_effect=Exception("Collection not found")
+    )
+
+    with patch("llc.kb.capability_indexer.get_knowledge_base", return_value=mock_kb):
+        with patch("llc.kb.capability_indexer.logger") as mock_logger:
+            await indexer.remove(agent_id=agent_id, company_id=company_id)
+
+            mock_logger.debug.assert_called_once()
+            assert "not found" in str(mock_logger.debug.call_args).lower()
+
+
+@pytest.mark.asyncio
+async def test_remove_handles_delete_failure(indexer, company_id, agent_id):
+    """Remove should handle delete failures gracefully and log."""
+    mock_collection = AsyncMock()
+    mock_collection.delete = AsyncMock(side_effect=RuntimeError("Delete failed"))
+    mock_kb = MagicMock()
+    mock_kb._async_chroma_client.get_collection = AsyncMock(
+        return_value=mock_collection
+    )
+
+    with patch("llc.kb.capability_indexer.get_knowledge_base", return_value=mock_kb):
+        with patch("llc.kb.capability_indexer.logger") as mock_logger:
+            await indexer.remove(agent_id=agent_id, company_id=company_id)
+
+            mock_logger.exception.assert_called_once()
+            assert "Failed to delete agent capability" in str(
+                mock_logger.exception.call_args
+            )
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests (with mocked KB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_index_and_remove_lifecycle(indexer, company_id, agent_id):
+    """Full lifecycle: index an agent, then remove it."""
+    mock_collection = AsyncMock()
+    mock_kb = MagicMock()
+    mock_kb._async_chroma_client.get_or_create_collection = AsyncMock(
+        return_value=mock_collection
+    )
+    mock_kb._async_chroma_client.get_collection = AsyncMock(
+        return_value=mock_collection
+    )
+
+    with patch("llc.kb.capability_indexer.get_knowledge_base", return_value=mock_kb):
+        # Index the agent
+        doc_id = await indexer.index(
+            agent_id=agent_id,
+            company_id=company_id,
+            agent_name="Eve",
+            title="QA Engineer",
+            role="qa",
+            capabilities="Test automation, performance testing",
+        )
+
+        assert doc_id == f"agent:{agent_id}"
+        assert mock_collection.upsert.call_count == 1
+
+        # Remove the agent
+        await indexer.remove(agent_id=agent_id, company_id=company_id)
+
+        assert mock_collection.delete.call_count == 1
+        mock_collection.delete.assert_called_with(ids=[f"agent:{agent_id}"])

--- a/autobot-backend/models/agent_org.py
+++ b/autobot-backend/models/agent_org.py
@@ -12,6 +12,7 @@ import uuid
 from enum import Enum
 
 from sqlalchemy import Column, String, Text
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.types import Uuid
 
 from user_management.models.base import Base
@@ -43,6 +44,7 @@ class AgentOrgNode(Base):
     org_role = Column(String(50), nullable=False, default=OrgRole.WORKER.value, index=True)
     title = Column(String(255), nullable=True)
     capabilities = Column(Text, nullable=True)
+    company_id = Column(UUID(as_uuid=True), nullable=True, index=True)
 
     def __repr__(self) -> str:
         return f"<AgentOrgNode agent={self.agent_id!r} role={self.org_role!r} " f"reports_to={self.reports_to!r}>"

--- a/autobot-backend/services/agent_org_service.py
+++ b/autobot-backend/services/agent_org_service.py
@@ -178,11 +178,13 @@ class AgentOrgService:
         org_role: str | None = None,
         title: str | None = None,
         capabilities: str | None = None,
+        company_id: str | None = None,
     ) -> AgentOrgNode:
         """
         Update reporting line with cycle detection (#1405).
 
         Raises ValueError on cycle or unknown agent.
+        Triggers capability re-indexing into company KB when company_id is provided (#8244).
         """
         node = await self.get_node(agent_id)
         if node is None:
@@ -201,6 +203,8 @@ class AgentOrgService:
             node.title = title
         if capabilities is not None:
             node.capabilities = capabilities
+        if company_id is not None:
+            node.company_id = company_id
 
         await self.session.flush()
         logger.info(
@@ -209,6 +213,15 @@ class AgentOrgService:
             node.reports_to,
             node.org_role,
         )
+
+        effective_company_id = company_id or (str(node.company_id) if node.company_id else None)
+        if effective_company_id:
+            try:
+                from llc.kb import AgentCapabilityIndexer
+                await AgentCapabilityIndexer().index_from_db(agent_id, effective_company_id)
+            except Exception:
+                logger.exception("Capability re-index failed for agent %s (non-fatal)", agent_id)
+
         return node
 
     # -- Role defaults -----------------------------------------------------
@@ -227,11 +240,13 @@ class AgentOrgService:
         reports_to: str | None = None,
         title: str | None = None,
         capabilities: str | None = None,
+        company_id: str | None = None,
     ) -> AgentOrgNode:
         """
         Create or update an agent_org_nodes record (#1405).
 
         Used to register agents in the hierarchy on demand.
+        Triggers capability indexing into company KB when company_id is provided (#8244).
         """
         node = await self.get_node(agent_id)
         if node is None:
@@ -243,6 +258,7 @@ class AgentOrgService:
                 reports_to=reports_to,
                 title=title,
                 capabilities=capabilities,
+                company_id=company_id,
             )
             self.session.add(node)
             logger.info(
@@ -259,7 +275,18 @@ class AgentOrgService:
                 node.title = title
             if capabilities is not None:
                 node.capabilities = capabilities
+            if company_id is not None:
+                node.company_id = company_id
             logger.info("Updated org node agent_id=%s", agent_id)
 
         await self.session.flush()
+
+        effective_company_id = company_id or (str(node.company_id) if node.company_id else None)
+        if effective_company_id:
+            try:
+                from llc.kb import AgentCapabilityIndexer
+                await AgentCapabilityIndexer().index_from_db(agent_id, effective_company_id)
+            except Exception:
+                logger.exception("Capability index failed for agent %s (non-fatal)", agent_id)
+
         return node


### PR DESCRIPTION
## Summary

- **`AgentCapabilityIndexer`** — new `llc/kb/capability_indexer.py` indexes agent capabilities into `company:{company_id}:agents` ChromaDB collection on hire and update
- **`AgentOrgService.upsert_node()` / `update_reporting_line()`** — wired in `index_from_db()` post-flush; `company_id` param added to both methods
- **`portability.py._import_agent()`** — both overloads call `index_from_db()` after INSERT so batch-imported agents are discoverable immediately
- **`AgentOrgNode`** — `company_id` column added (nullable, indexed)
- **Search endpoints**: `GET /companies/{company_id}/agents/search` and `GET /peers/search` for RAG-based capability discovery
- **20 tests** in `llc/tests/test_capability_indexer.py`

All indexing calls are wrapped in `try/except` so KB failures are non-fatal and logged.

Closes #8244

## Test plan
- [ ] `python3 -m pytest autobot-backend/llc/tests/test_capability_indexer.py -v`
- [ ] Hire an agent via API; confirm `company:{id}:agents` collection has a document
- [ ] Update agent capabilities; confirm document is updated in KB
- [ ] Call `GET /companies/{id}/agents/search?q=security` and verify results