### PR TITLE
fix(llc): repair syntax errors + Black/isort formatting on LLC files

### DIFF
--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -15,8 +15,8 @@ from .companies import router as companies_router
 from .context import router as context_router
 from .decisions import router as decisions_router
 from .goals import router as goals_router
-from .portability import router as portability_router
 from .labels import router as labels_router
+from .portability import router as portability_router
 from .review_gate_policies import router as review_gate_router
 from .routines import router as routines_router
 from .runs import router as runs_router

--- a/autobot-backend/llc/api/agent_api.py
+++ b/autobot-backend/llc/api/agent_api.py
@@ -150,8 +150,10 @@ async def agent_upload_attachment(
     """Agent uploads a file attachment to a work item (GH#8253)."""
     agent_id, company_id = _agent_context(request)
     from autobot_shared.singleton_factory import lazy_singleton
-    from ..services.attachment_service import AttachmentService, AttachmentTooLarge
     from user_management.database import get_async_session_factory
+
+    from ..services.attachment_service import AttachmentService, AttachmentTooLarge
+
     content = await file.read()
     factory = get_async_session_factory()
     try:
@@ -174,15 +176,22 @@ async def agent_upload_attachment(
         }
     except AttachmentTooLarge as exc:
         raise HTTPException(status_code=413, detail=str(exc))
+
+
 @router.get("/context/{item_id}")
 async def get_item_context(item_id: uuid.UUID, request: Request) -> Dict[str, Any]:
     """Return agent context for a work item, including any human handoff KB notes (GH#8232)."""
     from ..kb.work_item_kb import WorkItemKB
+
     kb = WorkItemKB()
     handoff_chunks = await kb.get_context(str(item_id))
+    return {
         "item_id": str(item_id),
         "handoff_notes": handoff_chunks,
         "has_human_handoff_context": bool(handoff_chunks),
         "context": {},
         "message": "Handoff KB notes included; full RAG context available in Phase 5",
+    }
+
+
 __all__ = ["router"]

--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -293,9 +293,13 @@ async def remove_member(
 class PMConfigSetRequest(BaseModel):
     pm_type: ExternalPMType
     credentials: Dict[str, Any]
+
+
 class PMConfigRead(BaseModel):
     pm_type: Optional[str]
     configured: bool
+
+
 @router.patch("/{company_id}/pm-config", response_model=PMConfigRead)
 async def set_pm_config(
     company_id: uuid.UUID,
@@ -304,8 +308,11 @@ async def set_pm_config(
 ) -> PMConfigRead:
     """Store encrypted PM credentials for a company (GH#8257)."""
     import json
+
     from sqlalchemy import select, update
+
     from autobot_shared.field_encryption import encrypt_field
+
     row = await session.execute(select(Organization.id).where(Organization.id == company_id))
     if row.one_or_none() is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
@@ -317,36 +324,54 @@ async def set_pm_config(
     )
     await session.commit()
     return PMConfigRead(pm_type=body.pm_type.value, configured=True)
+
+
 @router.post("/{company_id}/pm-config/test")
 async def test_pm_config(
+    company_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
 ) -> Dict[str, Any]:
     """Test connectivity to the configured external PM system (GH#8257)."""
+    import json
+
     from sqlalchemy import select
+
     from autobot_shared.field_encryption import decrypt_field
-    from integrations.base import IntegrationConfig
+
     row = await session.execute(
         select(Organization.external_pm_type, Organization.external_pm_config).where(Organization.id == company_id)
+    )
     result = row.one_or_none()
     if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
     pm_type, encrypted_config = result
     if not pm_type or pm_type == "none" or not encrypted_config:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No PM integration configured for this company",
+        )
     try:
         pm_config = json.loads(decrypt_field(encrypted_config))
     except Exception:
+        raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to decrypt PM config",
+        )
+    try:
         health = await _test_pm_connectivity(pm_type, pm_config)
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
     return {"ok": health.get("ok", False), "details": health}
+
+
 async def _test_pm_connectivity(pm_type: str, pm_config: Dict[str, Any]) -> Dict[str, Any]:
+    from integrations.base import IntegrationConfig, IntegrationStatus
     from integrations.project_management_integration import (
         AsanaIntegration,
         JiraIntegration,
         TrelloIntegration,
+    )
+
     if pm_type == "jira":
         cfg = IntegrationConfig(
             name="jira",
@@ -354,47 +379,65 @@ async def _test_pm_connectivity(pm_type: str, pm_config: Dict[str, Any]) -> Dict
             base_url=pm_config.get("base_url", ""),
             username=pm_config.get("username", ""),
             api_key=pm_config.get("api_key", ""),
+        )
         health = await JiraIntegration(cfg).test_connection()
     elif pm_type == "trello":
+        cfg = IntegrationConfig(
             name="trello",
             provider="trello",
             token=pm_config.get("token", ""),
+        )
         health = await TrelloIntegration(cfg).test_connection()
     elif pm_type == "asana":
         cfg = IntegrationConfig(name="asana", provider="asana", token=pm_config.get("token", ""))
         health = await AsanaIntegration(cfg).test_connection()
     else:
         return {"ok": False, "error": f"Unsupported pm_type: {pm_type}"}
-    from integrations.base import IntegrationStatus
     return {
         "ok": health.status == IntegrationStatus.CONNECTED,
         "status": health.status.value,
         "message": health.message,
         "details": health.details,
     }
+
+
 # Export endpoints (GH#8245)
 def _get_portability_service(session: AsyncSession = Depends(get_async_session)) -> PortabilityService:
     return PortabilityService(session=session)
+
+
 @router.post("/{company_id}/export/template")
 async def export_template(
+    company_id: uuid.UUID,
     svc: PortabilityService = Depends(_get_portability_service),
 ) -> JSONResponse:
     """Export a portable structural template for the company.
+
     Returns a JSON file download with company meta, agents (secrets scrubbed),
     goals, active routines, projects, portfolios, and up to 20 seed work items.
     Secret values are never exported — only ``{{SECRET_NAME}}`` placeholders.
     """
-        payload = await svc.export_template(company_id)
-        await session.rollback()
-        raise
+    payload = await svc.export_template(company_id)
     filename = f"company_{company_id}_template.json"
     return JSONResponse(
         content=payload,
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
 @router.post("/{company_id}/export/snapshot")
 async def export_snapshot(
+    company_id: uuid.UUID,
+    svc: PortabilityService = Depends(_get_portability_service),
+) -> JSONResponse:
     """Export a full-state snapshot for backup/migration.
+
     Extends the template export with all work items, sprint history, and KB
     collection names (not content).
-        payload = await svc.export_snapshot(company_id)
+    """
+    payload = await svc.export_snapshot(company_id)
     filename = f"company_{company_id}_snapshot.json"
+    return JSONResponse(
+        content=payload,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/autobot-backend/llc/api/portability.py
+++ b/autobot-backend/llc/api/portability.py
@@ -15,8 +15,8 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from llc.services.portability import TemplateImportError as LLCImportError
 from llc.services.portability import PortabilityService
+from llc.services.portability import TemplateImportError as LLCImportError
 from user_management.database import get_async_session
 
 router = APIRouter(prefix="/import", tags=["llc-import"])

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -1,6 +1,4 @@
-"""LLC work items API routes (GH#8213, GH#8223, GH#8231, GH#8232).
-"""LLC work items API routes (GH#8213, GH#8223, GH#8231, GH#8232, GH#8252).
-"""LLC work items API routes (GH#8213, GH#8223, GH#8231, GH#8232, GH#8253).
+"""LLC work items API routes (GH#8213, GH#8223, GH#8231, GH#8232, GH#8252, GH#8253).
 Routes:
   POST   /api/llc/work-items
   GET    /api/llc/work-items
@@ -39,7 +37,7 @@ from autobot_shared.singleton_factory import lazy_singleton
 from user_management.database import get_async_session_factory
 
 from ..kb.collections import KbCollectionManager
-from ..models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
+from ..models.enums import WorkItemPriority, WorkItemRelationType, WorkItemStatus, WorkItemType
 from ..services.attachment_service import (
     LLC_ATTACHMENT_MAX_BYTES,
     AttachmentNotFound,
@@ -47,14 +45,13 @@ from ..services.attachment_service import (
     AttachmentTooLarge,
 )
 from ..services.handoff import HandoffAttachment, HandoffNotAllowed, HandoffNotAuthorized, HandoffService
+from ..services.work_item_relations import RelationConflict, WorkItemRelationService
 from ..services.work_item_service import (
     CheckoutConflict,
     CoWorkingPermissionError,
     InvalidTransition,
     WorkItemService,
 )
-from ..models.enums import WorkItemPriority, WorkItemRelationType, WorkItemStatus, WorkItemType
-from ..services.work_item_relations import RelationConflict, WorkItemRelationService
 from ..services.work_product_service import WorkProductService
 
 
@@ -102,8 +99,12 @@ def _handoff_service() -> HandoffService:
 
 def _relation_service() -> WorkItemRelationService:
     return _get_relation_service()
+
+
 def _attachment_service() -> AttachmentService:
     return _get_attachment_service()
+
+
 async def get_session() -> AsyncSession:
     factory = get_async_session_factory()
     async with factory() as session:
@@ -209,9 +210,13 @@ class RelationCreate(BaseModel):
     relation_type: WorkItemRelationType
     created_by_agent_id: Optional[str] = None
     created_by_user_id: Optional[str] = None
+
+
 class RelationDelete(BaseModel):
     actor_agent_id: Optional[str] = None
     actor_user_id: Optional[str] = None
+
+
 def _assignee_display(item: Any) -> Optional[Dict[str, Any]]:
     """Return structured assignee display info (GH#8223).
 
@@ -247,8 +252,15 @@ def _coworker_display(item: Any) -> Optional[Dict[str, Any]]:
             "name": None,
         }
     if item.co_worker_type == "agent" and item.co_worker_agent_id:
+        return {
             "type": "agent",
             "id": str(item.co_worker_agent_id),
+            "display_name": None,
+            "name": None,
+        }
+    return None
+
+
 def _relations_to_list(item: Any) -> List[Dict[str, Any]]:
     """Serialize outgoing + incoming relations for GET response (GH#8252)."""
     rows = []
@@ -265,6 +277,8 @@ def _relations_to_list(item: Any) -> List[Dict[str, Any]]:
             }
         )
     return rows
+
+
 def _item_to_dict(item: Any) -> Dict[str, Any]:
     return {
         "id": str(item.id),
@@ -656,6 +670,8 @@ async def get_handoff_brief(
         return {"work_item_id": work_item_id, "brief": brief}
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
+
+
 @router.get("/{work_item_id}/products")
 async def list_work_products(
     work_item_id: str,
@@ -687,11 +703,20 @@ async def list_work_products(
             for p in products
         ],
         "total": len(products),
+    }
+
+
 # ------------------------------------------------------------------
 # Relation endpoints (GH#8252)
+# ------------------------------------------------------------------
+
+
 @router.post("/{work_item_id}/relations", status_code=201)
 async def add_relation(
+    work_item_id: str,
     body: RelationCreate,
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
     try:
         rel = await _relation_service().add(
             company_id=body.company_id,
@@ -700,30 +725,48 @@ async def add_relation(
             relation_type=body.relation_type,
             created_by_agent_id=body.created_by_agent_id,
             created_by_user_id=body.created_by_user_id,
+        )
         await session.commit()
+        return {
             "id": str(rel.id),
             "source_id": work_item_id,
             "target_id": body.target_id,
             "relation_type": rel.relation_type,
+        }
     except RelationConflict as exc:
         raise HTTPException(status_code=409, detail=str(exc))
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
+
+
 @router.delete("/{work_item_id}/relations/{relation_id}", status_code=204)
 async def remove_relation(
+    work_item_id: str,
     relation_id: str,
     company_id: str = Query(...),
     actor_agent_id: Optional[str] = Query(None),
     actor_user_id: Optional[str] = Query(None),
+    session: AsyncSession = Depends(get_session),
 ) -> None:
+    try:
         await _relation_service().remove(
             company_id=company_id,
             relation_id=relation_id,
             actor_agent_id=actor_agent_id,
             actor_user_id=actor_user_id,
+        )
+        await session.commit()
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
 # ---------------------------------------------------------------------------
 # Attachment routes (GH#8253)
+# ---------------------------------------------------------------------------
+
+
 def _attachment_to_dict(row: Any) -> Dict[str, Any]:
+    return {
         "id": str(row.id),
         "work_item_id": str(row.work_item_id),
         "company_id": str(row.company_id),
@@ -734,42 +777,97 @@ def _attachment_to_dict(row: Any) -> Dict[str, Any]:
         "uploaded_by_agent_id": str(row.uploaded_by_agent_id) if row.uploaded_by_agent_id else None,
         "uploaded_by_user_id": str(row.uploaded_by_user_id) if row.uploaded_by_user_id else None,
         "created_at": row.created_at.isoformat() if row.created_at else None,
+    }
+
+
 @router.post("/{work_item_id}/attachments", status_code=201)
 async def upload_attachment(
+    work_item_id: str,
+    company_id: str = Query(...),
     file: UploadFile = File(...),
     uploaded_by_agent_id: Optional[str] = Query(None),
     uploaded_by_user_id: Optional[str] = Query(None),
-    content = await file.read()
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    try:
+        content = await file.read()
         row = await _attachment_service().upload(
+            session,
+            work_item_id=work_item_id,
+            company_id=company_id,
             filename=file.filename or "upload",
             content_type=file.content_type or "application/octet-stream",
             content=content,
             uploaded_by_agent_id=uploaded_by_agent_id,
             uploaded_by_user_id=uploaded_by_user_id,
+        )
     except AttachmentTooLarge as exc:
         raise HTTPException(status_code=413, detail=str(exc))
     return _attachment_to_dict(row)
+
+
 @router.get("/{work_item_id}/attachments")
 async def list_attachments(
-    rows = await _attachment_service().list_attachments(
-        session, work_item_id=work_item_id, company_id=company_id
+    work_item_id: str,
+    company_id: str = Query(...),
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
     rows = await _attachment_service().list_attachments(session, work_item_id=work_item_id, company_id=company_id)
     return {"attachments": [_attachment_to_dict(r) for r in rows]}
+
+
 @router.get("/{work_item_id}/attachments/{attachment_id}/download")
 async def download_attachment(
+    work_item_id: str,
     attachment_id: str,
+    company_id: str = Query(...),
+    session: AsyncSession = Depends(get_session),
 ) -> Response:
+    try:
         row, content = await _attachment_service().download(
+            session,
             attachment_id=attachment_id,
+            work_item_id=work_item_id,
+            company_id=company_id,
+        )
     except AttachmentNotFound:
         raise HTTPException(status_code=404, detail="Attachment not found")
     return Response(
+        content=content,
         media_type=row.content_type,
         headers={"Content-Disposition": f'attachment; filename="{row.filename}"'},
+    )
+
+
 @router.get("/{work_item_id}/attachments/{attachment_id}/text")
 async def get_attachment_text(
-        text = await _attachment_service().get_text(
+    work_item_id: str,
+    attachment_id: str,
+    company_id: str = Query(...),
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, Any]:
+    text = await _attachment_service().get_text(
+        session,
+        attachment_id=attachment_id,
+        work_item_id=work_item_id,
+        company_id=company_id,
+    )
     return {"attachment_id": attachment_id, "text": text, "text_extracted": text is not None}
+
+
 @router.delete("/{work_item_id}/attachments/{attachment_id}", status_code=204)
 async def delete_attachment(
+    work_item_id: str,
+    attachment_id: str,
+    company_id: str = Query(...),
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    try:
         await _attachment_service().delete(
+            session,
+            attachment_id=attachment_id,
+            work_item_id=work_item_id,
+            company_id=company_id,
+        )
+    except AttachmentNotFound:
+        raise HTTPException(status_code=404, detail="Attachment not found")

--- a/autobot-backend/llc/kb/__init__.py
+++ b/autobot-backend/llc/kb/__init__.py
@@ -1,8 +1,17 @@
 """LLC knowledge base package."""
 
 from .ac_suggester import AcSuggester
-from .collections import KbCollectionManager
-from .rag_assembler import AssemblerProfile, LLCContext, LLCRAGAssembler
-from .diary_writer import AgentDiaryKbWriter
 from .artifact_ingestor import ArtifactIngestor
-__all__ = ["AcSuggester", "AgentDiaryKbWriter", "ArtifactIngestor", "AssemblerProfile", "KbCollectionManager", "LLCContext", "LLCRAGAssembler"]
+from .collections import KbCollectionManager
+from .diary_writer import AgentDiaryKbWriter
+from .rag_assembler import AssemblerProfile, LLCContext, LLCRAGAssembler
+
+__all__ = [
+    "AcSuggester",
+    "AgentDiaryKbWriter",
+    "ArtifactIngestor",
+    "AssemblerProfile",
+    "KbCollectionManager",
+    "LLCContext",
+    "LLCRAGAssembler",
+]

--- a/autobot-backend/llc/models/__init__.py
+++ b/autobot-backend/llc/models/__init__.py
@@ -39,11 +39,8 @@ from .membership import LLCCompanyMembership
 from .review_gate import LLCReviewGatePolicy
 from .secret import LLCSecret
 from .sprint import LLCPortfolio, LLCProgram, LLCProject, LLCSprint
-from .work_item import LLCWorkItem, LLCWorkItemComment
-from .work_product import LLCWorkProduct
-from .ceo_chat import LLCCeoChatMessage, LLCCeoChatThread
-from .review_gate import LLCReviewGatePolicy
 from .work_item import LLCWorkItem, LLCWorkItemComment, LLCWorkItemRelation
+from .work_product import LLCWorkProduct
 
 __all__ = [
     "ActorType",

--- a/autobot-backend/llc/models/enums.py
+++ b/autobot-backend/llc/models/enums.py
@@ -164,19 +164,26 @@ class RoutineProduces(str, Enum):
 
 class ExternalPMType(str, Enum):
     """External project management system type (GH#8257)."""
+
     JIRA = "jira"
     AZURE_DEVOPS = "azure_devops"
     TRELLO = "trello"
     ASANA = "asana"
     NONE = "none"
+
+
 class LLCSyncEvent(str, Enum):
     """LLC work item events published to Redis pub/sub (GH#8257)."""
+
     CREATED = "created"
     TRANSITIONED = "transitioned"
     COMMENTED = "commented"
     COMPLETED = "completed"
+
+
 class WorkProductType(str, Enum):
     """Type of work product artifact produced by an agent (GH#8242)."""
+
     CODE = "code"
     DOCUMENT = "document"
     REPORT = "report"
@@ -184,10 +191,13 @@ class WorkProductType(str, Enum):
     SCREENSHOT = "screenshot"
     PR_LINK = "pr_link"
     OTHER = "other"
+
+
 class WorkItemRelationType(str, Enum):
     """Relation type between two LLC work items (GH#8252).
     ``blocks`` and ``blocked_by`` are mirrors: adding A→B blocks creates B→A blocked_by.
     """
+
     BLOCKS = "blocks"
     BLOCKED_BY = "blocked_by"
     DUPLICATES = "duplicates"

--- a/autobot-backend/llc/notifications/publisher.py
+++ b/autobot-backend/llc/notifications/publisher.py
@@ -17,8 +17,8 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 try:
-    from live_event_manager import get_live_event_manager
     from event_manager import get_event_manager
+    from live_event_manager import get_live_event_manager
 except ImportError:
     get_live_event_manager = None  # type: ignore[assignment]
     get_event_manager = None  # type: ignore[assignment]

--- a/autobot-backend/llc/scheduler/heartbeat_scheduler.py
+++ b/autobot-backend/llc/scheduler/heartbeat_scheduler.py
@@ -282,9 +282,7 @@ class HeartbeatScheduler:
                 if agent.get("context_mode") == "fat":
                     company_id_val = agent.get("company_id")
                     if company_id_val:
-                        context["recent_decisions"] = await _fetch_recent_decisions(
-                            str(company_id_val)
-                        )
+                        context["recent_decisions"] = await _fetch_recent_decisions(str(company_id_val))
 
             await session.commit()
 

--- a/autobot-backend/llc/services/approval.py
+++ b/autobot-backend/llc/services/approval.py
@@ -291,4 +291,3 @@ __all__ = [
     "_EVENT_REQUESTED",
     "_EVENT_DECIDED",
 ]
-

--- a/autobot-backend/llc/services/portability.py
+++ b/autobot-backend/llc/services/portability.py
@@ -2,72 +2,41 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """PortabilityService — company template export/import with collision detection (GH#8246).
+
 Depends on GH#8245 (export) for the shared template schema version "1.0".
 """
+
 import json
 import re
 import uuid
 from typing import Any, Dict, List, Optional
+
+import sqlalchemy as sa
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
+
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.time_utils import now_utc
 from llc.models.enums import LLCCompanyStatus
+from llc.models.export import LLCExportArtifact
 from llc.models.goal import LLCGoal
 from llc.models.routine import LLCRoutine
-from llc.models.sprint import LLCProject
+from llc.models.secret import LLCSecret
+from llc.models.sprint import LLCPortfolio, LLCProgram, LLCProject, LLCSprint
 from llc.models.work_item import LLCWorkItem
+from llc.services.activity_log import ActivityEventType, LLCActivityLogService
 from llc.services.base import LLCServiceBase
 from user_management.models.organization import Organization
+
 logger = get_logger(__name__)
+
 _PLACEHOLDER_RE = re.compile(r"\{\{(\w+)\}\}")
-# ---------------------------------------------------------------------------
-# Pydantic response models live in llc/models/portability.py (imported below)
-# to keep service lean.  We use plain dicts internally.
-class TemplateImportError(Exception):
-    """Raised when import cannot proceed (schema, collision, rollback)."""
-class PortabilityService(LLCServiceBase):
-    """Service for company template import (GH#8246).
-    All methods accept an ``AsyncSession`` and participate in the caller's
-    transaction.  ``execute_import`` manages its own savepoint for rollback.
-    def __init__(self, session: AsyncSession, **kwargs) -> None:
-        super().__init__(**kwargs)
-"""PortabilityService — company template and snapshot export (GH#8245).
-Two export modes:
-  template  — structural skeleton: company meta, agents (secrets scrubbed),
-               goals, active routines, projects + portfolios (no sprint data),
-               up to 20 seed work items (epic/feature only).
-  snapshot  — full state: everything in template PLUS all work items,
-               sprint history rows, and KB collection names (not content).
-Secret scrubbing rules (NEVER export secret values):
-  - adapter_config values matching known secret patterns → replaced with
-    ``{{SECRET_NAME}}`` placeholder where SECRET_NAME is the bound secret name
-    from llc_secrets, or the key name uppercased if no binding exists.
-  - Agent API keys from llc_agent_api_keys are never included.
-Export storage:
-  - JSON payload stored in Redis under ``llc:export:<company_id>:<artifact_id>``
-    with a 7-day TTL.
-  - LLCExportArtifact row written to DB for audit trail.
-  - Activity log entry appended (event_type COMPANY_EXPORT_TEMPLATE or
-    COMPANY_EXPORT_SNAPSHOT).
-import logging
-from datetime import timezone
-import sqlalchemy as sa
-from autobot_shared.redis_client import get_async_redis_client
-from ..models.export import LLCExportArtifact
-from ..models.goal import LLCGoal
-from ..models.routine import LLCRoutine
-from ..models.secret import LLCSecret
-from ..models.sprint import LLCPortfolio, LLCProgram, LLCProject, LLCSprint
-from ..models.work_item import LLCWorkItem
-from .activity_log import ActivityEventType, LLCActivityLogService
-from .base import LLCServiceBase
-logger = logging.getLogger(__name__)
+
 _SCHEMA_VERSION = "1.0"
 _EXPORT_TTL_SECONDS = 7 * 24 * 3600  # 7 days
 _SEED_ITEM_TYPES = ("epic", "feature")
 _SEED_ITEM_LIMIT = 20
-# Keys in adapter_config that may hold secret values and should be scrubbed.
 _SECRET_LIKE_KEYS = frozenset(
     {
         "api_key",
@@ -84,13 +53,105 @@ _SECRET_LIKE_KEYS = frozenset(
         "key",
     }
 )
-    """Export company state as a portable JSON template or full snapshot."""
+
+
+# ---------------------------------------------------------------------------
+# Pydantic response models live in llc/models/portability.py (imported below)
+# to keep service lean.  We use plain dicts internally.
+# ---------------------------------------------------------------------------
+
+
+class TemplateImportError(Exception):
+    """Raised when import cannot proceed (schema, collision, rollback)."""
+
+
+class PortabilityService(LLCServiceBase):
+    """Service for company template export/import (GH#8245, GH#8246).
+
+    All methods accept an ``AsyncSession`` and participate in the caller's
+    transaction.  ``execute_import`` manages its own savepoint for rollback.
+    """
+
     def __init__(self, session: AsyncSession, activity_log: Optional[LLCActivityLogService] = None) -> None:
         super().__init__(activity_log=activity_log)
         self.session = session
 
     # ------------------------------------------------------------------
-    # Public API
+    # Export — Public API
+    # ------------------------------------------------------------------
+
+    async def export_template(self, company_id: uuid.UUID, actor: str = "system") -> Dict[str, Any]:
+        """Return a portable template dict for the company.
+
+        Includes company meta, agents (secrets scrubbed), goals, active
+        routines, projects + portfolios (no sprint data), and up to 20 seed
+        work items (epic/feature) marked ``is_seed=true``.  Secret values are
+        never exported.
+        """
+        cid = str(company_id)
+        secret_map = await self._build_secret_map(cid)
+
+        company_data = await self._export_company(cid)
+        agents_data = await self._export_agents(cid, secret_map)
+        goals_data = await self._export_goals(cid)
+        routines_data = await self._export_routines(cid)
+        projects_data, portfolios_data = await self._export_projects_portfolios(cid)
+        seed_items = await self._export_seed_items(cid)
+
+        payload = {
+            "schema_version": _SCHEMA_VERSION,
+            "export_kind": "template",
+            "company": company_data,
+            "agents": agents_data,
+            "goals": goals_data,
+            "routines": routines_data,
+            "portfolios": portfolios_data,
+            "projects": projects_data,
+            "seed_work_items": seed_items,
+        }
+
+        artifact_id = await self._persist(company_id, "template", payload, actor)
+        payload["artifact_id"] = str(artifact_id)
+        return payload
+
+    async def export_snapshot(self, company_id: uuid.UUID, actor: str = "system") -> Dict[str, Any]:
+        """Return a full-state snapshot for backup/migration.
+
+        Extends the template with ALL work items, sprint history rows, and KB
+        collection names (not KB content).
+        """
+        cid = str(company_id)
+        secret_map = await self._build_secret_map(cid)
+
+        company_data = await self._export_company(cid)
+        agents_data = await self._export_agents(cid, secret_map)
+        goals_data = await self._export_goals(cid)
+        routines_data = await self._export_routines(cid)
+        projects_data, portfolios_data = await self._export_projects_portfolios(cid)
+        all_items = await self._export_all_work_items(cid)
+        sprints_data = await self._export_sprints(cid)
+        kb_collections = await self._list_kb_collections(cid)
+
+        payload = {
+            "schema_version": _SCHEMA_VERSION,
+            "export_kind": "snapshot",
+            "company": company_data,
+            "agents": agents_data,
+            "goals": goals_data,
+            "routines": routines_data,
+            "portfolios": portfolios_data,
+            "projects": projects_data,
+            "work_items": all_items,
+            "sprints": sprints_data,
+            "kb_collection_names": kb_collections,
+        }
+
+        artifact_id = await self._persist(company_id, "snapshot", payload, actor)
+        payload["artifact_id"] = str(artifact_id)
+        return payload
+
+    # ------------------------------------------------------------------
+    # Import — Public API
     # ------------------------------------------------------------------
 
     async def preview_import(
@@ -106,14 +167,17 @@ _SECRET_LIKE_KEYS = frozenset(
         goals = template.get("goals", [])
         projects = template.get("projects", [])
         work_items = template.get("work_items", [])
+
         collisions: List[Dict[str, Any]] = []
         warnings: List[str] = []
+
         # issue_prefix collision
         prefix = company_meta.get("issue_prefix")
         if prefix:
             existing = await self._prefix_exists(prefix)
             if existing:
                 collisions.append({"type": "issue_prefix", "value": prefix})
+
         # agent name collisions — scoped to target company; new-company imports
         # have no pre-existing namespace so there is nothing to collide with
         agent_names = [a.get("name") for a in agents if a.get("name")]
@@ -121,12 +185,14 @@ _SECRET_LIKE_KEYS = frozenset(
             conflicting_agents = await self._agent_names_exist(agent_names, target_company_id)
             for name in conflicting_agents:
                 collisions.append({"type": "agent_name", "value": name})
+
         # goal title collisions — scoped to target company for the same reason
         goal_titles = [g.get("title") for g in goals if g.get("title")]
         if target_company_id and goal_titles:
             conflicting_goals = await self._goal_titles_exist(goal_titles, target_company_id)
             for title in conflicting_goals:
                 collisions.append({"type": "goal_title", "value": title})
+
         # secret placeholder warning
         all_placeholders: set[str] = set()
         for agent in agents:
@@ -134,6 +200,7 @@ _SECRET_LIKE_KEYS = frozenset(
             all_placeholders.update(_PLACEHOLDER_RE.findall(str(cfg)))
         if all_placeholders:
             warnings.append(f"Secret placeholders found that require mapping: {sorted(all_placeholders)}")
+
         return {
             "collisions": collisions,
             "will_create": {
@@ -144,28 +211,40 @@ _SECRET_LIKE_KEYS = frozenset(
             },
             "warnings": warnings,
         }
+
     async def execute_import(
+        self,
+        template: Dict[str, Any],
+        *,
+        target_company_id: Optional[uuid.UUID] = None,
         remapping_options: Optional[Dict[str, Any]] = None,
         secret_mapping: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
         """Transactional import.  Rolls back entirely on any entity failure."""
+        self._validate_schema(template)
         remapping_options = remapping_options or {}
         secret_mapping = secret_mapping or {}
+
         created_entities: Dict[str, Any] = {
             "agents": [],
             "goals": [],
             "projects": [],
             "work_items": [],
+        }
         skipped: Dict[str, List[str]] = {"agents": [], "goals": [], "work_items": []}
+        warnings: List[str] = []
+
         sp = await self.session.begin_nested()
         try:
             company_id = await self._resolve_or_create_company(template, target_company_id, remapping_options, warnings)
+
             # Pass 1: pre-mint all agent IDs so reports_to can be remapped before
             # any INSERT, avoiding topology-ordering FK violations
             agents_list = template.get("agents", [])
             agent_id_map: Dict[str, str] = {
-                a.get("agent_id", ""): str(uuid.uuid4())
-                for a in agents_list
-                if a.get("agent_id")
+                a.get("agent_id", ""): str(uuid.uuid4()) for a in agents_list if a.get("agent_id")
+            }
+
             # Pass 2: insert agents with remapped reports_to
             for agent in agents_list:
                 agent_id = await self._import_agent(agent, company_id, secret_mapping, warnings, agent_id_map)
@@ -173,17 +252,21 @@ _SECRET_LIKE_KEYS = frozenset(
                     created_entities["agents"].append(agent_id)
                 else:
                     skipped["agents"].append(agent.get("name", ""))
+
             # goals
             for goal in template.get("goals", []):
                 goal_id = await self._import_goal(goal, company_id)
                 if goal_id:
                     created_entities["goals"].append(str(goal_id))
+                else:
                     skipped["goals"].append(goal.get("title", ""))
+
             # projects
             for project in template.get("projects", []):
                 project_id = await self._import_project(project, company_id)
                 if project_id:
                     created_entities["projects"].append(str(project_id))
+
             # seed work items
             for item in template.get("work_items", []):
                 if not item.get("is_seed"):
@@ -191,40 +274,302 @@ _SECRET_LIKE_KEYS = frozenset(
                 item_id = await self._import_work_item(item, company_id)
                 if item_id:
                     created_entities["work_items"].append(str(item_id))
+                else:
                     skipped["work_items"].append(item.get("title", ""))
+
             await sp.commit()
         except Exception as exc:
             await sp.rollback()
             raise TemplateImportError(f"Import rolled back: {exc}") from exc
+
+        return {
             "company_id": str(company_id),
             "created_entities": created_entities,
             "skipped": skipped,
+            "warnings": warnings,
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers — export data collectors
+    # ------------------------------------------------------------------
+
+    async def _export_company(self, company_id: str) -> Dict[str, Any]:
+        result = await self.session.execute(
+            text("""
+                SELECT id, name, slug, description, issue_prefix,
+                       budget_monthly_cents, brand_color, require_approval_for_hires,
+                       parent_org_id, llc_status, created_at
+                FROM organizations
+                WHERE id = :cid
+                """),
+            {"cid": company_id},
+        )
+        row = result.mappings().first()
+        if row is None:
+            return {}
+        data = dict(row)
+        data["id"] = str(data["id"]) if data.get("id") else None
+        if data.get("parent_org_id"):
+            data["parent_org_id"] = str(data["parent_org_id"])
+        if data.get("created_at"):
+            data["created_at"] = data["created_at"].isoformat()
+        return data
+
+    async def _build_secret_map(self, company_id: str) -> Dict[str, str]:
+        """Map secret binding names for this company (name -> name).
+
+        Returns {name: name} so scrubber can substitute ``{{NAME}}``.
+        Only active (non-revoked) secrets are included.
+        """
+        result = await self.session.execute(
+            select(LLCSecret.name).where(
+                sa.and_(
+                    LLCSecret.company_id == company_id,
+                    LLCSecret.revoked_at.is_(None),
+                )
+            )
+        )
+        return {row[0]: row[0] for row in result}
+
+    async def _export_agents(self, company_id: str, secret_map: Dict[str, str]) -> List[Dict[str, Any]]:
+        """Export agents from agent_org_nodes with adapter_config secrets scrubbed."""
+        result = await self.session.execute(
+            text("""
+                SELECT agent_id, name, adapter_type, adapter_config,
+                       context_mode, heartbeat_cron, heartbeat_enabled,
+                       llc_agent_status, created_at
+                FROM agent_org_nodes
+                WHERE company_id = :cid
+                ORDER BY created_at
+                """),
+            {"cid": company_id},
+        )
+        agents = []
+        for row in result.mappings():
+            d = dict(row)
+            d["agent_id"] = str(d["agent_id"]) if d.get("agent_id") else None
+            if d.get("created_at"):
+                d["created_at"] = d["created_at"].isoformat()
+            if d.get("adapter_config"):
+                d["adapter_config"] = _scrub_adapter_config(d["adapter_config"], secret_map)
+            agents.append(d)
+        return agents
+
+    async def _export_goals(self, company_id: str) -> List[Dict[str, Any]]:
+        result = await self.session.execute(
+            select(LLCGoal).where(LLCGoal.company_id == company_id).order_by(LLCGoal.created_at)
+        )
+        goals = []
+        for (goal,) in result:
+            goals.append(
+                {
+                    "id": str(goal.id),
+                    "parent_goal_id": str(goal.parent_goal_id) if goal.parent_goal_id else None,
+                    "title": goal.title,
+                    "description": goal.description,
+                    "level": goal.level,
+                    "status": goal.status,
+                    "owner_agent_id": goal.owner_agent_id,
+                    "created_at": goal.created_at.isoformat() if goal.created_at else None,
+                }
+            )
+        return goals
+
+    async def _export_routines(self, company_id: str) -> List[Dict[str, Any]]:
+        """Export only ACTIVE routines (status='active')."""
+        result = await self.session.execute(
+            select(LLCRoutine).where(
+                sa.and_(
+                    LLCRoutine.company_id == company_id,
+                    LLCRoutine.status == "active",
+                )
+            )
+        )
+        routines = []
+        for (routine,) in result:
+            routines.append(
+                {
+                    "id": str(routine.id),
+                    "name": routine.name,
+                    "description": routine.description,
+                    "cron_schedule": routine.cron_schedule,
+                    "assignee_agent_id": str(routine.assignee_agent_id) if routine.assignee_agent_id else None,
+                    "produces": routine.produces,
+                    "work_item_template": routine.work_item_template,
+                    "env": routine.env,
+                }
+            )
+        return routines
+
+    async def _export_projects_portfolios(self, company_id: str) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        portfolios_result = await self.session.execute(
+            select(LLCPortfolio).where(LLCPortfolio.company_id == company_id)
+        )
+        portfolios = [
+            {
+                "id": str(p.id),
+                "name": p.name,
+                "description": p.description,
+                "status": p.status,
+            }
+            for (p,) in portfolios_result
+        ]
+
+        projects_result = await self.session.execute(select(LLCProject).where(LLCProject.company_id == company_id))
+        projects = [
+            {
+                "id": str(p.id),
+                "name": p.name,
+                "description": p.description,
+                "status": p.status,
+                "program_id": str(p.program_id) if p.program_id else None,
+                "goal_id": str(p.goal_id) if p.goal_id else None,
+                "target_date": p.target_date.isoformat() if p.target_date else None,
+                "env": p.env,
+                "auto_rollover": p.auto_rollover,
+            }
+            for (p,) in projects_result
+        ]
+        return projects, portfolios
+
+    async def _export_seed_items(self, company_id: str) -> List[Dict[str, Any]]:
+        """Up to 20 epic/feature work items as seed tasks (is_seed=true)."""
+        result = await self.session.execute(
+            select(LLCWorkItem)
+            .where(
+                sa.and_(
+                    LLCWorkItem.company_id == company_id,
+                    LLCWorkItem.type.in_(list(_SEED_ITEM_TYPES)),
+                )
+            )
+            .order_by(LLCWorkItem.created_at)
+            .limit(_SEED_ITEM_LIMIT)
+        )
+        items = []
+        for (item,) in result:
+            items.append({**_work_item_dict(item), "is_seed": True})
+        return items
+
+    async def _export_all_work_items(self, company_id: str) -> List[Dict[str, Any]]:
+        result = await self.session.execute(
+            select(LLCWorkItem).where(LLCWorkItem.company_id == company_id).order_by(LLCWorkItem.created_at)
+        )
+        return [_work_item_dict(item) for (item,) in result]
+
+    async def _export_sprints(self, company_id: str) -> List[Dict[str, Any]]:
+        result = await self.session.execute(
+            select(LLCSprint).where(LLCSprint.company_id == company_id).order_by(LLCSprint.start_date)
+        )
+        sprints = []
+        for (s,) in result:
+            sprints.append(
+                {
+                    "id": str(s.id),
+                    "project_id": str(s.project_id) if s.project_id else None,
+                    "name": s.name,
+                    "status": s.status,
+                    "start_date": s.start_date.isoformat() if s.start_date else None,
+                    "end_date": s.end_date.isoformat() if s.end_date else None,
+                    "goal": s.goal,
+                }
+            )
+        return sprints
+
+    async def _list_kb_collections(self, company_id: str) -> List[str]:
+        """Return KB collection names for the company (not content)."""
+        redis = await get_async_redis_client()
+        if redis is None:
+            return []
+        pattern = f"llc:kb:{company_id}:*"
+        keys = await redis.keys(pattern)
+        names = []
+        for k in keys:
+            key_str = k.decode("utf-8") if isinstance(k, bytes) else k
+            parts = key_str.split(":")
+            if len(parts) >= 4:
+                names.append(":".join(parts[3:]))
+        return sorted(names)
+
+    # ------------------------------------------------------------------
+    # Private helpers — export persistence
+    # ------------------------------------------------------------------
+
+    async def _persist(self, company_id: uuid.UUID, export_kind: str, payload: Dict[str, Any], actor: str) -> uuid.UUID:
+        artifact_id = uuid.uuid4()
+        storage_path = f"llc:export:{company_id}:{artifact_id}"
+
+        redis = await get_async_redis_client()
+        if redis is not None:
+            await redis.set(
+                storage_path,
+                json.dumps(payload, default=str, ensure_ascii=False),
+                ex=_EXPORT_TTL_SECONDS,
+            )
+
+        artifact = LLCExportArtifact(
+            id=artifact_id,
+            company_id=company_id,
+            export_kind=export_kind,
+            schema_version=_SCHEMA_VERSION,
+            storage_path=storage_path,
+            created_by=actor,
+        )
+        self.session.add(artifact)
+
+        if self.activity_log:
+            event_type = (
+                ActivityEventType.COMPANY_EXPORT_TEMPLATE
+                if export_kind == "template"
+                else ActivityEventType.COMPANY_EXPORT_SNAPSHOT
+            )
+            await self.activity_log.append(
+                session=self.session,
+                company_id=company_id,
+                event_type=event_type,
+                after={"artifact_id": str(artifact_id), "storage_path": storage_path},
+            )
+
+        return artifact_id
+
     # ------------------------------------------------------------------
     # Private helpers — collision checks
+    # ------------------------------------------------------------------
+
     async def _prefix_exists(self, prefix: str) -> bool:
         result = await self.session.execute(select(Organization.id).where(Organization.issue_prefix == prefix).limit(1))
         return result.scalar() is not None
-    async def _agent_names_exist(
-        self, names: List[str], company_id: Optional[uuid.UUID] = None
-    ) -> List[str]:
+
+    async def _agent_names_exist(self, names: List[str], company_id: Optional[uuid.UUID] = None) -> List[str]:
         if not names:
             return []
         if company_id is not None:
             rows = await self.session.execute(
-                text("SELECT name FROM agent_org_nodes WHERE name = ANY(:names) AND company_id = :company_id")
-                .bindparams(names=names, company_id=str(company_id))
+                text(
+                    "SELECT name FROM agent_org_nodes WHERE name = ANY(:names) AND company_id = :company_id"
+                ).bindparams(names=names, company_id=str(company_id))
             )
+        else:
+            rows = await self.session.execute(
                 text("SELECT name FROM agent_org_nodes WHERE name = ANY(:names)").bindparams(names=names)
+            )
         return [r[0] for r in rows]
-    async def _goal_titles_exist(
-        self, titles: List[str], company_id: Optional[uuid.UUID] = None
+
+    async def _goal_titles_exist(self, titles: List[str], company_id: Optional[uuid.UUID] = None) -> List[str]:
         if not titles:
+            return []
         q = select(LLCGoal.title).where(LLCGoal.title.in_(titles))
+        if company_id is not None:
             q = q.where(LLCGoal.company_id == str(company_id))
         result = await self.session.execute(q)
         return [r[0] for r in result]
+
+    # ------------------------------------------------------------------
     # Private helpers — entity creation
+    # ------------------------------------------------------------------
+
     async def _resolve_or_create_company(
+        self,
+        template: Dict[str, Any],
         target_company_id: Optional[uuid.UUID],
         remapping_options: Dict[str, Any],
         warnings: List[str],
@@ -235,14 +580,18 @@ _SECRET_LIKE_KEYS = frozenset(
             if org is None:
                 raise TemplateImportError(f"target_company_id {target_company_id} not found")
             return org.id
+
         meta = template.get("company", {})
         prefix = meta.get("issue_prefix")
         if prefix and await self._prefix_exists(prefix):
             prefix = await self._next_available_prefix(prefix)
             warnings.append(f"issue_prefix remapped to {prefix!r}")
+
         require_approval = remapping_options.get(
             "require_approval_for_hires",
             meta.get("require_approval_for_hires", False),
+        )
+
         org = Organization(
             id=uuid.uuid4(),
             name=meta.get("name", "Imported Company"),
@@ -256,38 +605,50 @@ _SECRET_LIKE_KEYS = frozenset(
             settings={},
             issue_counter=0,
             spent_monthly_cents=0,
+        )
         self.session.add(org)
         await self.session.flush()
+        return org.id
+
     async def _next_available_prefix(self, prefix: str) -> str:
         for n in range(2, 1000):
             candidate = f"{prefix}{n}"
             if not await self._prefix_exists(candidate):
                 return candidate
         raise TemplateImportError(f"Cannot find free issue_prefix for {prefix!r}")
+
     async def _import_agent(
+        self,
         agent: Dict[str, Any],
         company_id: uuid.UUID,
         secret_mapping: Dict[str, str],
+        warnings: List[str],
         agent_id_map: Optional[Dict[str, str]] = None,
     ) -> Optional[str]:
         """Insert agent_org_nodes row.  Returns new agent_id or None if skipped."""
         name = agent.get("name", "")
         existing = await self._agent_names_exist([name], company_id)
+        if existing:
             warnings.append(f"Agent {name!r} already exists — skipped")
             return None
+
         # Use pre-minted ID from two-pass map if available
         old_id = agent.get("agent_id", "")
         new_agent_id = (agent_id_map or {}).get(old_id) or str(uuid.uuid4())
+
         # Remap reports_to from source UUID to destination UUID
         old_reports_to = agent.get("reports_to")
         reports_to: Optional[str] = None
         if old_reports_to and agent_id_map:
             reports_to = agent_id_map.get(str(old_reports_to))
+
         adapter_config = self._resolve_secrets(agent.get("adapter_config") or {}, secret_mapping, name, warnings)
+
         # capabilities is TEXT in the schema; serialize list/dict to JSON string
         capabilities = agent.get("capabilities")
         if isinstance(capabilities, (list, dict)):
             capabilities = json.dumps(capabilities)
+
         await self.session.execute(
             text("""
                 INSERT INTO agent_org_nodes
@@ -299,6 +660,7 @@ _SECRET_LIKE_KEYS = frozenset(
                    :company_id, :adapter_type, :adapter_config::jsonb, :heartbeat_cron,
                    :heartbeat_enabled, :context_mode)
                 """).bindparams(
+                id=uuid.uuid4(),
                 agent_id=new_agent_id,
                 name=name,
                 reports_to=reports_to,
@@ -311,37 +673,52 @@ _SECRET_LIKE_KEYS = frozenset(
                 heartbeat_cron=agent.get("heartbeat_cron"),
                 heartbeat_enabled=agent.get("heartbeat_enabled", False),
                 context_mode=agent.get("context_mode", "thin"),
+            )
+        )
         return new_agent_id
+
     def _resolve_secrets(
+        self,
         config: Any,
+        secret_mapping: Dict[str, str],
         agent_name: str,
+        warnings: List[str],
     ) -> Any:
         """Replace {{SECRET_NAME}} placeholders in config by walking the structure.
+
         Operates on the decoded Python object (not the JSON string) to prevent
         injection when secret values contain quote characters.
         """
         unresolved: set[str] = set()
+
         def _walk(node: Any) -> Any:
             if isinstance(node, str):
+
                 def _replace(m: re.Match) -> str:
                     key = m.group(1)
                     if key in secret_mapping:
                         return secret_mapping[key]
                     unresolved.add(key)
                     return m.group(0)
+
                 return _PLACEHOLDER_RE.sub(_replace, node)
             if isinstance(node, dict):
                 return {k: _walk(v) for k, v in node.items()}
             if isinstance(node, list):
                 return [_walk(v) for v in node]
             return node
+
         result = _walk(config)
         if unresolved:
             warnings.append(f"Agent {agent_name!r}: unresolved secret placeholders {sorted(unresolved)}")
         return result
+
     async def _import_goal(self, goal: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
         title = goal.get("title", "")
         existing = await self._goal_titles_exist([title], company_id)
+        if existing:
+            return None
+
         new_id = uuid.uuid4()
         obj = LLCGoal(
             id=new_id,
@@ -352,16 +729,30 @@ _SECRET_LIKE_KEYS = frozenset(
             status=goal.get("status", "draft"),
             owner_agent_id=None,
             due_date=None,
+        )
         self.session.add(obj)
+        await self.session.flush()
         return new_id
+
     async def _import_project(self, project: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
+        new_id = uuid.uuid4()
         obj = LLCProject(
+            id=new_id,
+            company_id=company_id,
             name=project.get("name", "Imported Project"),
             description=project.get("description"),
             status=project.get("status", "planning"),
+        )
+        self.session.add(obj)
+        await self.session.flush()
+        return new_id
+
     async def _import_work_item(self, item: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
+        new_id = uuid.uuid4()
         identifier = f"IMP-{new_id.hex[:8].upper()}"
         obj = LLCWorkItem(
+            id=new_id,
+            company_id=company_id,
             type=item.get("type", "epic"),
             identifier=identifier,
             title=item.get("title", ""),
@@ -369,238 +760,47 @@ _SECRET_LIKE_KEYS = frozenset(
             status="backlog",
             priority=item.get("priority", "medium"),
             labels=item.get("labels", []),
+        )
+        self.session.add(obj)
+        await self.session.flush()
+        return new_id
+
+    # ------------------------------------------------------------------
     # Schema validation
+    # ------------------------------------------------------------------
+
     @staticmethod
     def _validate_schema(template: Dict[str, Any]) -> None:
         version = template.get("schema_version")
         if version != "1.0":
             raise TemplateImportError(f"Unsupported schema_version {version!r}; expected '1.0'")
-    async def export_template(self, company_id: uuid.UUID, actor: str = "system") -> Dict[str, Any]:
-        """Return a portable template dict for the company.
-        Includes company meta, agents (secrets scrubbed), goals, active
-        routines, projects + portfolios (no sprint data), and up to 20 seed
-        work items (epic/feature) marked ``is_seed=true``.  Secret values are
-        never exported.
-        cid = str(company_id)
-        secret_map = await self._build_secret_map(cid)
-        company_data = await self._export_company(cid)
-        agents_data = await self._export_agents(cid, secret_map)
-        goals_data = await self._export_goals(cid)
-        routines_data = await self._export_routines(cid)
-        projects_data, portfolios_data = await self._export_projects_portfolios(cid)
-        seed_items = await self._export_seed_items(cid)
-        payload = {
-            "schema_version": _SCHEMA_VERSION,
-            "export_kind": "template",
-            "company": company_data,
-            "agents": agents_data,
-            "goals": goals_data,
-            "routines": routines_data,
-            "portfolios": portfolios_data,
-            "projects": projects_data,
-            "seed_work_items": seed_items,
-        artifact_id = await self._persist(company_id, "template", payload, actor)
-        payload["artifact_id"] = str(artifact_id)
-        return payload
-    async def export_snapshot(self, company_id: uuid.UUID, actor: str = "system") -> Dict[str, Any]:
-        """Return a full-state snapshot for backup/migration.
-        Extends the template with ALL work items, sprint history rows, and KB
-        collection names (not KB content).
-        all_items = await self._export_all_work_items(cid)
-        sprints_data = await self._export_sprints(cid)
-        kb_collections = await self._list_kb_collections(cid)
-            "export_kind": "snapshot",
-            "work_items": all_items,
-            "sprints": sprints_data,
-            "kb_collection_names": kb_collections,
-        artifact_id = await self._persist(company_id, "snapshot", payload, actor)
-    # Data collectors
-    async def _export_company(self, company_id: str) -> Dict[str, Any]:
-        result = await self.session.execute(
-            text(
-                SELECT id, name, slug, description, issue_prefix,
-                       budget_monthly_cents, brand_color, require_approval_for_hires,
-                       parent_org_id, llc_status, created_at
-                FROM organizations
-                WHERE id = :cid
-            ),
-            {"cid": company_id},
-        row = result.mappings().first()
-        if row is None:
-            return {}
-        data = dict(row)
-        data["id"] = str(data["id"]) if data.get("id") else None
-        if data.get("parent_org_id"):
-            data["parent_org_id"] = str(data["parent_org_id"])
-        if data.get("created_at"):
-            data["created_at"] = data["created_at"].isoformat()
-        return data
-    async def _build_secret_map(self, company_id: str) -> Dict[str, str]:
-        """Map secret binding names for this company (name → name).
-        Returns {name: name} so scrubber can substitute ``{{NAME}}``.
-        Only active (non-revoked) secrets are included.
-            select(LLCSecret.name).where(
-                sa.and_(
-                    LLCSecret.company_id == company_id,
-                    LLCSecret.revoked_at.is_(None),
-        return {row[0]: row[0] for row in result}
-    async def _export_agents(self, company_id: str, secret_map: Dict[str, str]) -> List[Dict[str, Any]]:
-        """Export agents from agent_org_nodes with adapter_config secrets scrubbed."""
-                SELECT agent_id, name, adapter_type, adapter_config,
-                       context_mode, heartbeat_cron, heartbeat_enabled,
-                       llc_agent_status, created_at
-                FROM agent_org_nodes
-                WHERE company_id = :cid
-                ORDER BY created_at
-        agents = []
-        for row in result.mappings():
-            d = dict(row)
-            d["agent_id"] = str(d["agent_id"]) if d.get("agent_id") else None
-            if d.get("created_at"):
-                d["created_at"] = d["created_at"].isoformat()
-            if d.get("adapter_config"):
-                d["adapter_config"] = _scrub_adapter_config(d["adapter_config"], secret_map)
-            agents.append(d)
-        return agents
-    async def _export_goals(self, company_id: str) -> List[Dict[str, Any]]:
-            select(LLCGoal).where(LLCGoal.company_id == company_id).order_by(LLCGoal.created_at)
-        goals = []
-        for (goal,) in result:
-            goals.append(
-                {
-                    "id": str(goal.id),
-                    "parent_goal_id": str(goal.parent_goal_id) if goal.parent_goal_id else None,
-                    "title": goal.title,
-                    "description": goal.description,
-                    "level": goal.level,
-                    "status": goal.status,
-                    "owner_agent_id": goal.owner_agent_id,
-                    "created_at": goal.created_at.isoformat() if goal.created_at else None,
-        return goals
-    async def _export_routines(self, company_id: str) -> List[Dict[str, Any]]:
-        """Export only ACTIVE routines (status='active')."""
-            select(LLCRoutine).where(
-                    LLCRoutine.company_id == company_id,
-                    LLCRoutine.status == "active",
-        routines = []
-        for (routine,) in result:
-            routines.append(
-                    "id": str(routine.id),
-                    "name": routine.name,
-                    "description": routine.description,
-                    "cron_schedule": routine.cron_schedule,
-                    "assignee_agent_id": str(routine.assignee_agent_id) if routine.assignee_agent_id else None,
-                    "produces": routine.produces,
-                    "work_item_template": routine.work_item_template,
-                    "env": routine.env,
-        return routines
-    async def _export_projects_portfolios(
-        self, company_id: str
-    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-        portfolios_result = await self.session.execute(
-            select(LLCPortfolio).where(LLCPortfolio.company_id == company_id)
-        portfolios = [
-                "id": str(p.id),
-                "name": p.name,
-                "description": p.description,
-                "status": p.status,
-            for (p,) in portfolios_result
-        ]
-        projects_result = await self.session.execute(
-            select(LLCProject).where(LLCProject.company_id == company_id)
-        projects = [
-                "program_id": str(p.program_id) if p.program_id else None,
-                "goal_id": str(p.goal_id) if p.goal_id else None,
-                "target_date": p.target_date.isoformat() if p.target_date else None,
-                "env": p.env,
-                "auto_rollover": p.auto_rollover,
-            for (p,) in projects_result
-        return projects, portfolios
-    async def _export_seed_items(self, company_id: str) -> List[Dict[str, Any]]:
-        """Up to 20 epic/feature work items as seed tasks (is_seed=true)."""
-            select(LLCWorkItem)
-            .where(
-                    LLCWorkItem.company_id == company_id,
-                    LLCWorkItem.type.in_(list(_SEED_ITEM_TYPES)),
-            .order_by(LLCWorkItem.created_at)
-            .limit(_SEED_ITEM_LIMIT)
-        items = []
-        for (item,) in result:
-            items.append({**_work_item_dict(item), "is_seed": True})
-        return items
-    async def _export_all_work_items(self, company_id: str) -> List[Dict[str, Any]]:
-            .where(LLCWorkItem.company_id == company_id)
-        return [_work_item_dict(item) for (item,) in result]
-    async def _export_sprints(self, company_id: str) -> List[Dict[str, Any]]:
-            select(LLCSprint).where(LLCSprint.company_id == company_id).order_by(LLCSprint.start_date)
-        sprints = []
-        for (s,) in result:
-            sprints.append(
-                    "id": str(s.id),
-                    "project_id": str(s.project_id) if s.project_id else None,
-                    "name": s.name,
-                    "status": s.status,
-                    "start_date": s.start_date.isoformat() if s.start_date else None,
-                    "end_date": s.end_date.isoformat() if s.end_date else None,
-                    "goal": s.goal,
-        return sprints
-    async def _list_kb_collections(self, company_id: str) -> List[str]:
-        """Return KB collection names for the company (not content)."""
-        redis = await get_async_redis_client()
-        if redis is None:
-        pattern = f"llc:kb:{company_id}:*"
-        keys = await redis.keys(pattern)
-        names = []
-        for k in keys:
-            key_str = k.decode("utf-8") if isinstance(k, bytes) else k
-            parts = key_str.split(":")
-            if len(parts) >= 4:
-                names.append(":".join(parts[3:]))
-        return sorted(names)
-    # Persistence
-    async def _persist(
-        self, company_id: uuid.UUID, export_kind: str, payload: Dict[str, Any], actor: str
-        artifact_id = uuid.uuid4()
-        storage_path = f"llc:export:{company_id}:{artifact_id}"
-        if redis is not None:
-            await redis.set(
-                storage_path,
-                json.dumps(payload, default=str, ensure_ascii=False),
-                ex=_EXPORT_TTL_SECONDS,
-        artifact = LLCExportArtifact(
-            id=artifact_id,
-            type="export_artifact",
-            export_kind=export_kind,
-            schema_version=_SCHEMA_VERSION,
-            storage_path=storage_path,
-            created_by=actor,
-        self.session.add(artifact)
-        if self.activity_log:
-            event_type = (
-                ActivityEventType.COMPANY_EXPORT_TEMPLATE
-                if export_kind == "template"
-                else ActivityEventType.COMPANY_EXPORT_SNAPSHOT
-            await self.activity_log.append(
-                session=self.session,
-                event_type=event_type,
-                after={"artifact_id": str(artifact_id), "storage_path": storage_path},
-        return artifact_id
+
+
+# ------------------------------------------------------------------
 # Helpers
+# ------------------------------------------------------------------
+
+
 def _scrub_adapter_config(config: Dict[str, Any], secret_map: Dict[str, str]) -> Dict[str, Any]:
     """Replace secret values in adapter_config with ``{{NAME}}`` placeholders.
-    Uses secret_map (name→name) for known bound secrets; falls back to
+
+    Uses secret_map (name->name) for known bound secrets; falls back to
     uppercasing the key name for unrecognised secret-like keys.
+    """
     scrubbed: Dict[str, Any] = {}
     for k, v in config.items():
         key_lower = k.lower()
         if key_lower in _SECRET_LIKE_KEYS and v:
-            # Use bound secret name if available, else derive from key
             bound = secret_map.get(str(v)) or secret_map.get(k)
             placeholder_name = bound if bound else k.upper()
             scrubbed[k] = f"{{{{{placeholder_name}}}}}"
+        else:
             scrubbed[k] = v
     return scrubbed
+
+
 def _work_item_dict(item: LLCWorkItem) -> Dict[str, Any]:
+    return {
         "id": str(item.id),
         "parent_id": str(item.parent_id) if item.parent_id else None,
         "project_id": str(item.project_id) if item.project_id else None,
@@ -614,728 +814,7 @@ def _work_item_dict(item: LLCWorkItem) -> Dict[str, Any]:
         "assignee_agent_id": str(item.assignee_agent_id) if item.assignee_agent_id else None,
         "assignee_user_id": str(item.assignee_user_id) if item.assignee_user_id else None,
         "created_at": item.created_at.isoformat() if item.created_at else None,
-__all__ = ["
-
-        redis = await get_async_redis_client()
-        if redis is not None:
-            await redis.set(
-                storage_path,
-                json.dumps(payload, default=str, ensure_ascii=False),
-                ex=_EXPORT_TTL_SECONDS,
-            )
-
-        artifact = LLCExportArtifact(
-            id=artifact_id,
-            company_id=company_id,
-            type=", "
-                INSERT INTO agent_org_nodes
-                  (id, agent_id, name, reports_to, org_role, title, capabilities,
-                   company_id, adapter_type, adapter_config, heartbeat_cron,
-                   heartbeat_enabled, context_mode)
-                VALUES
-                  (:id, :agent_id, :name, :reports_to, :org_role, :title, :capabilities,
-                   :company_id, :adapter_type, :adapter_config::jsonb, :heartbeat_cron,
-                   :heartbeat_enabled, :context_mode)
-                ", "
-                SELECT agent_id, name, adapter_type, adapter_config,
-                       context_mode, heartbeat_cron, heartbeat_enabled,
-                       llc_agent_status, created_at
-                FROM agent_org_nodes
-                WHERE company_id = :cid
-                ORDER BY created_at
-                ", "
-                SELECT id, name, slug, description, issue_prefix,
-                       budget_monthly_cents, brand_color, require_approval_for_hires,
-                       parent_org_id, llc_status, created_at
-                FROM organizations
-                WHERE id = :cid
-                ", "
-                else ActivityEventType.COMPANY_EXPORT_SNAPSHOT
-            )
-            await self.activity_log.append(
-                session=self.session,
-                company_id=company_id,
-                event_type=event_type,
-                after={", "
-            ),
-            {", "
-            if not await self._prefix_exists(candidate):
-                return candidate
-        raise TemplateImportError(f", "
-        cid = str(company_id)
-        secret_map = await self._build_secret_map(cid)
-
-        company_data = await self._export_company(cid)
-        agents_data = await self._export_agents(cid, secret_map)
-        goals_data = await self._export_goals(cid)
-        routines_data = await self._export_routines(cid)
-        projects_data, portfolios_data = await self._export_projects_portfolios(cid)
-        all_items = await self._export_all_work_items(cid)
-        sprints_data = await self._export_sprints(cid)
-        kb_collections = await self._list_kb_collections(cid)
-
-        payload = {
-            ", "
-        cid = str(company_id)
-        secret_map = await self._build_secret_map(cid)
-
-        company_data = await self._export_company(cid)
-        agents_data = await self._export_agents(cid, secret_map)
-        goals_data = await self._export_goals(cid)
-        routines_data = await self._export_routines(cid)
-        projects_data, portfolios_data = await self._export_projects_portfolios(cid)
-        seed_items = await self._export_seed_items(cid)
-
-        payload = {
-            ", "
-        else:
-            scrubbed[k] = v
-    return scrubbed
-
-
-def _work_item_dict(item: LLCWorkItem) -> Dict[str, Any]:
-    return {
-        ", "
-        keys = await redis.keys(pattern)
-        names = []
-        for k in keys:
-            key_str = k.decode(", "
-        name = agent.get(", "
-        obj = LLCWorkItem(
-            id=new_id,
-            company_id=company_id,
-            type=item.get(", "
-        redis = await get_async_redis_client()
-        if redis is None:
-            return []
-        pattern = f", "
-        result = await self.session.execute(
-            select(LLCRoutine).where(
-                sa.and_(
-                    LLCRoutine.company_id == company_id,
-                    LLCRoutine.status == ", "
-        result = await self.session.execute(
-            select(LLCSecret.name).where(
-                sa.and_(
-                    LLCSecret.company_id == company_id,
-                    LLCSecret.revoked_at.is_(None),
-                )
-            )
-        )
-        return {row[0]: row[0] for row in result}
-
-    async def _export_agents(self, company_id: str, secret_map: Dict[str, str]) -> List[Dict[str, Any]]:
-        ", "
-        result = await self.session.execute(
-            select(LLCWorkItem)
-            .where(
-                sa.and_(
-                    LLCWorkItem.company_id == company_id,
-                    LLCWorkItem.type.in_(list(_SEED_ITEM_TYPES)),
-                )
-            )
-            .order_by(LLCWorkItem.created_at)
-            .limit(_SEED_ITEM_LIMIT)
-        )
-        items = []
-        for (item,) in result:
-            items.append({**_work_item_dict(item), ", "
-        result = await self.session.execute(
-            text(
-                ", "
-        self._validate_schema(template)
-        company_meta = template.get(", "
-        self._validate_schema(template)
-        remapping_options = remapping_options or {}
-        secret_mapping = secret_mapping or {}
-
-        created_entities: Dict[str, Any] = {
-            ", "
-        unresolved: set[str] = set()
-
-        def _walk(node: Any) -> Any:
-            if isinstance(node, str):
-                def _replace(m: re.Match) -> str:
-                    key = m.group(1)
-                    if key in secret_mapping:
-                        return secret_mapping[key]
-                    unresolved.add(key)
-                    return m.group(0)
-                return _PLACEHOLDER_RE.sub(_replace, node)
-            if isinstance(node, dict):
-                return {k: _walk(v) for k, v in node.items()}
-            if isinstance(node, list):
-                return [_walk(v) for v in node]
-            return node
-
-        result = _walk(config)
-        if unresolved:
-            warnings.append(f", "
-    scrubbed: Dict[str, Any] = {}
-    for k, v in config.items():
-        key_lower = k.lower()
-        if key_lower in _SECRET_LIKE_KEYS and v:
-            # Use bound secret name if available, else derive from key
-            bound = secret_map.get(str(v)) or secret_map.get(k)
-            placeholder_name = bound if bound else k.upper()
-            scrubbed[k] = f", ")
-
-        require_approval = remapping_options.get(
-            ", ")
-
-        return {
-            ", ")
-
-    async def _import_agent(
-        self,
-        agent: Dict[str, Any],
-        company_id: uuid.UUID,
-        secret_mapping: Dict[str, str],
-        warnings: List[str],
-        agent_id_map: Optional[Dict[str, str]] = None,
-    ) -> Optional[str]:
-        ", ")
-                .bindparams(names=names, company_id=str(company_id))
-            )
-        else:
-            rows = await self.session.execute(
-                text(", ")
-            if len(parts) >= 4:
-                names.append(", ")
-            return None
-
-        # Use pre-minted ID from two-pass map if available
-        old_id = agent.get(", ")
-            return org.id
-
-        meta = template.get(", ")
-            }
-
-            # Pass 2: insert agents with remapped reports_to
-            for agent in agents_list:
-                agent_id = await self._import_agent(agent, company_id, secret_mapping, warnings, agent_id_map)
-                if agent_id:
-                    created_entities[", ")
-        existing = await self._agent_names_exist([name], company_id)
-        if existing:
-            warnings.append(f", ")
-        existing = await self._goal_titles_exist([title], company_id)
-        if existing:
-            return None
-
-        new_id = uuid.uuid4()
-        obj = LLCGoal(
-            id=new_id,
-            company_id=str(company_id),
-            title=title,
-            description=goal.get(", ")
-        if isinstance(capabilities, (list, dict)):
-            capabilities = json.dumps(capabilities)
-
-        await self.session.execute(
-            text(", ")
-        if prefix and await self._prefix_exists(prefix):
-            prefix = await self._next_available_prefix(prefix)
-            warnings.append(f", ")
-        if prefix:
-            existing = await self._prefix_exists(prefix)
-            if existing:
-                collisions.append({", ")
-        if version != ", ")
-        new_agent_id = (agent_id_map or {}).get(old_id) or str(uuid.uuid4())
-
-        # Remap reports_to from source UUID to destination UUID
-        old_reports_to = agent.get(", ")
-        reports_to: Optional[str] = None
-        if old_reports_to and agent_id_map:
-            reports_to = agent_id_map.get(str(old_reports_to))
-
-        adapter_config = self._resolve_secrets(agent.get(", ")
-        return result
-
-    async def _import_goal(self, goal: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
-        title = goal.get(", ")
-    async def export_template(self, company_id: uuid.UUID, actor: str = ", ") -> Dict[str, Any]:
-        ", ") else None
-            if d.get(", ") else None
-        if data.get(", ") for a in agents if a.get(", ") for g in goals if g.get(", ") from exc
-
-        return {
-            ", ") if isinstance(k, bytes) else k
-            parts = key_str.split(", ") or {}
-            all_placeholders.update(_PLACEHOLDER_RE.findall(str(cfg)))
-        if all_placeholders:
-            warnings.append(f", ") or {}, secret_mapping, name, warnings)
-
-        # capabilities is TEXT in the schema; serialize list/dict to JSON string
-        capabilities = agent.get(", "))
-
-            # goals
-            for goal in template.get(", "))
-
-            # projects
-            for project in template.get(", "))
-
-            await sp.commit()
-        except Exception as exc:
-            await sp.rollback()
-            raise TemplateImportError(f", "),
-                adapter_config=json.dumps(adapter_config),
-                heartbeat_cron=agent.get(", "),
-                capabilities=capabilities,
-                company_id=company_id,
-                adapter_type=agent.get(", "),
-                heartbeat_enabled=agent.get(", "),
-                title=agent.get(", "),
-            )
-        )
-        return new_agent_id
-
-    def _resolve_secrets(
-        self,
-        config: Any,
-        secret_mapping: Dict[str, str],
-        agent_name: str,
-        warnings: List[str],
-    ) -> Any:
-        ", "),
-            description=item.get(", "),
-            description=meta.get(", "),
-            description=project.get(", "),
-            identifier=identifier,
-            title=item.get(", "),
-            issue_prefix=prefix,
-            budget_monthly_cents=meta.get(", "),
-            labels=item.get(", "),
-            level=goal.get(", "),
-            owner_agent_id=None,
-            due_date=None,
-        )
-        self.session.add(obj)
-        await self.session.flush()
-        return new_id
-
-    async def _import_project(self, project: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
-        new_id = uuid.uuid4()
-        obj = LLCProject(
-            id=new_id,
-            company_id=company_id,
-            name=project.get(", "),
-            require_approval_for_hires=require_approval,
-            llc_status=LLCCompanyStatus.ONBOARDING.value,
-            settings={},
-            issue_counter=0,
-            spent_monthly_cents=0,
-        )
-        self.session.add(org)
-        await self.session.flush()
-        return org.id
-
-    async def _next_available_prefix(self, prefix: str) -> str:
-        for n in range(2, 1000):
-            candidate = f", "),
-            slug=meta.get(", "),
-            status=", "),
-            status=goal.get(", "),
-            status=project.get(", "),
-        )
-        self.session.add(obj)
-        await self.session.flush()
-        return new_id
-
-    async def _import_work_item(self, item: Dict[str, Any], company_id: uuid.UUID) -> Optional[uuid.UUID]:
-        new_id = uuid.uuid4()
-        identifier = f", ").bindparams(
-                id=uuid.uuid4(),
-                agent_id=new_agent_id,
-                name=name,
-                reports_to=reports_to,
-                org_role=agent.get(", ").bindparams(names=names)
-            )
-        return [r[0] for r in rows]
-
-    async def _goal_titles_exist(
-        self, titles: List[str], company_id: Optional[uuid.UUID] = None
-    ) -> List[str]:
-        if not titles:
-            return []
-        q = select(LLCGoal.title).where(LLCGoal.title.in_(titles))
-        if company_id is not None:
-            q = q.where(LLCGoal.company_id == str(company_id))
-        result = await self.session.execute(q)
-        return [r[0] for r in result]
-
-    # ------------------------------------------------------------------
-    # Private helpers — entity creation
-    # ------------------------------------------------------------------
-
-    async def _resolve_or_create_company(
-        self,
-        template: Dict[str, Any],
-        target_company_id: Optional[uuid.UUID],
-        remapping_options: Dict[str, Any],
-        warnings: List[str],
-    ) -> uuid.UUID:
-        if target_company_id:
-            result = await self.session.execute(select(Organization).where(Organization.id == target_company_id))
-            org = result.scalar_one_or_none()
-            if org is None:
-                raise TemplateImportError(f", "):
-                    continue
-                item_id = await self._import_work_item(item, company_id)
-                if item_id:
-                    created_entities[", "):
-                d[", "):
-            data[", "): str(uuid.uuid4())
-                for a in agents_list
-                if a.get(", ")]
-        if target_company_id and agent_names:
-            conflicting_agents = await self._agent_names_exist(agent_names, target_company_id)
-            for name in conflicting_agents:
-                collisions.append({", ")]
-        if target_company_id and goal_titles:
-            conflicting_goals = await self._goal_titles_exist(goal_titles, target_company_id)
-            for title in conflicting_goals:
-                collisions.append({", ",
-            ", ",
-                )
-            )
-        )
-        routines = []
-        for (routine,) in result:
-            routines.append(
-                {
-                    ", ",
-            export_kind=export_kind,
-            schema_version=_SCHEMA_VERSION,
-            storage_path=storage_path,
-            created_by=actor,
-        )
-        self.session.add(artifact)
-
-        if self.activity_log:
-            event_type = (
-                ActivityEventType.COMPANY_EXPORT_TEMPLATE
-                if export_kind == ", ",
-            meta.get(", ",
-            priority=item.get(", ", ", ", 0),
-            brand_color=meta.get(", ", False),
-                context_mode=agent.get(", ", False),
-        )
-
-        org = Organization(
-            id=uuid.uuid4(),
-            name=meta.get(", ", [])
-
-        collisions: List[Dict[str, Any]] = []
-        warnings: List[str] = []
-
-        # issue_prefix collision
-        prefix = company_meta.get(", ", [])
-            agent_id_map: Dict[str, str] = {
-                a.get(", ", [])
-        goals = template.get(", ", [])
-        projects = template.get(", ", [])
-        work_items = template.get(", ", []),
-        )
-        self.session.add(obj)
-        await self.session.flush()
-        return new_id
-
-    # ------------------------------------------------------------------
-    # Schema validation
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _validate_schema(template: Dict[str, Any]) -> None:
-        version = template.get(", ", []):
-                goal_id = await self._import_goal(goal, company_id)
-                if goal_id:
-                    created_entities[", ", []):
-                if not item.get(", ", []):
-                project_id = await self._import_project(project, company_id)
-                if project_id:
-                    created_entities[", ", f", ", payload, actor)
-        payload[", ", {})
-        agents = template.get(", ", {})
-        prefix = meta.get(", ".join(parts[3:]))
-        return sorted(names)
-
-    # ------------------------------------------------------------------
-    # Persistence
-    # ------------------------------------------------------------------
-
-    async def _persist(
-        self, company_id: uuid.UUID, export_kind: str, payload: Dict[str, Any], actor: str
-    ) -> uuid.UUID:
-        artifact_id = uuid.uuid4()
-        storage_path = f", ":
-            raise TemplateImportError(f", ": ", ": True})
-        return items
-
-    async def _export_all_work_items(self, company_id: str) -> List[Dict[str, Any]]:
-        result = await self.session.execute(
-            select(LLCWorkItem)
-            .where(LLCWorkItem.company_id == company_id)
-            .order_by(LLCWorkItem.created_at)
-        )
-        return [_work_item_dict(item) for (item,) in result]
-
-    async def _export_sprints(self, company_id: str) -> List[Dict[str, Any]]:
-        result = await self.session.execute(
-            select(LLCSprint).where(LLCSprint.company_id == company_id).order_by(LLCSprint.start_date)
-        )
-        sprints = []
-        for (s,) in result:
-            sprints.append(
-                {
-                    ", ": [],
-            ", ": [],
-        }
-        skipped: Dict[str, List[str]] = {", ": [], ", ": []}
-        warnings: List[str] = []
-
-        sp = await self.session.begin_nested()
-        try:
-            company_id = await self._resolve_or_create_company(template, target_company_id, remapping_options, warnings)
-
-            # Pass 1: pre-mint all agent IDs so reports_to can be remapped before
-            # any INSERT, avoiding topology-ordering FK violations
-            agents_list = template.get(", ": _SCHEMA_VERSION,
-            ", ": agents_data,
-            ", ": all_items,
-            ", ": collisions,
-            ", ": company_data,
-            ", ": company_id},
-        )
-        agents = []
-        for row in result.mappings():
-            d = dict(row)
-            d[", ": company_id},
-        )
-        row = result.mappings().first()
-        if row is None:
-            return {}
-        data = dict(row)
-        data[", ": created_entities,
-            ", ": goal.created_at.isoformat() if goal.created_at else None,
-                }
-            )
-        return goals
-
-    async def _export_routines(self, company_id: str) -> List[Dict[str, Any]]:
-        ", ": goal.description,
-                    ", ": goal.level,
-                    ", ": goal.owner_agent_id,
-                    ", ": goal.status,
-                    ", ": goal.title,
-                    ", ": goals_data,
-            ", ": item.created_at.isoformat() if item.created_at else None,
     }
 
 
-__all__ = [", ": item.description,
-        ", ": item.priority,
-        ", ": item.status,
-        ", ": item.title,
-        ", ": item.type,
-        ", ": kb_collections,
-        }
-
-        artifact_id = await self._persist(company_id, ", ": len(agents),
-                ", ": len(goals),
-                ", ": len(projects),
-                ", ": len(work_items),
-            },
-            ", ": name})
-
-        # goal title collisions — scoped to target company for the same reason
-        goal_titles = [g.get(", ": p.auto_rollover,
-            }
-            for (p,) in projects_result
-        ]
-        return projects, portfolios
-
-    async def _export_seed_items(self, company_id: str) -> List[Dict[str, Any]]:
-        ", ": p.description,
-                ", ": p.env,
-                ", ": p.name,
-                ", ": p.status,
-                ", ": p.status,
-            }
-            for (p,) in portfolios_result
-        ]
-
-        projects_result = await self.session.execute(
-            select(LLCProject).where(LLCProject.company_id == company_id)
-        )
-        projects = [
-            {
-                ", ": p.target_date.isoformat() if p.target_date else None,
-                ", ": portfolios_data,
-            ", ": prefix})
-
-        # agent name collisions — scoped to target company; new-company imports
-        # have no pre-existing namespace so there is nothing to collide with
-        agent_names = [a.get(", ": projects_data,
-            ", ": routine.cron_schedule,
-                    ", ": routine.description,
-                    ", ": routine.env,
-                }
-            )
-        return routines
-
-    async def _export_projects_portfolios(
-        self, company_id: str
-    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-        portfolios_result = await self.session.execute(
-            select(LLCPortfolio).where(LLCPortfolio.company_id == company_id)
-        )
-        portfolios = [
-            {
-                ", ": routine.name,
-                    ", ": routine.produces,
-                    ", ": routine.work_item_template,
-                    ", ": routines_data,
-            ", ": s.end_date.isoformat() if s.end_date else None,
-                    ", ": s.goal,
-                }
-            )
-        return sprints
-
-    async def _list_kb_collections(self, company_id: str) -> List[str]:
-        ", ": s.name,
-                    ", ": s.start_date.isoformat() if s.start_date else None,
-                    ", ": s.status,
-                    ", ": seed_items,
-        }
-
-        artifact_id = await self._persist(company_id, ", ": skipped,
-            ", ": sprints_data,
-            ", ": storage_path},
-            )
-
-        return artifact_id
-
-
-# ------------------------------------------------------------------
-# Helpers
-# ------------------------------------------------------------------
-
-
-def _scrub_adapter_config(config: Dict[str, Any], secret_map: Dict[str, str]) -> Dict[str, Any]:
-    ", ": str(artifact_id), ", ": str(company_id),
-            ", ": str(goal.id),
-                    ", ": str(goal.parent_goal_id) if goal.parent_goal_id else None,
-                    ", ": str(item.assignee_agent_id) if item.assignee_agent_id else None,
-        ", ": str(item.assignee_user_id) if item.assignee_user_id else None,
-        ", ": str(item.goal_id) if item.goal_id else None,
-        ", ": str(item.id),
-        ", ": str(item.parent_id) if item.parent_id else None,
-        ", ": str(item.project_id) if item.project_id else None,
-        ", ": str(item.sprint_id) if item.sprint_id else None,
-        ", ": str(p.goal_id) if p.goal_id else None,
-                ", ": str(p.id),
-                ", ": str(p.program_id) if p.program_id else None,
-                ", ": str(routine.assignee_agent_id) if routine.assignee_agent_id else None,
-                    ", ": str(routine.id),
-                    ", ": str(s.id),
-                    ", ": str(s.project_id) if s.project_id else None,
-                    ", ": title})
-
-        # secret placeholder warning
-        all_placeholders: set[str] = set()
-        for agent in agents:
-            cfg = agent.get(", ": warnings,
-        }
-
-    # ------------------------------------------------------------------
-    # Private helpers — collision checks
-    # ------------------------------------------------------------------
-
-    async def _prefix_exists(self, prefix: str) -> bool:
-        result = await self.session.execute(select(Organization.id).where(Organization.issue_prefix == prefix).limit(1))
-        return result.scalar() is not None
-
-    async def _agent_names_exist(
-        self, names: List[str], company_id: Optional[uuid.UUID] = None
-    ) -> List[str]:
-        if not names:
-            return []
-        if company_id is not None:
-            rows = await self.session.execute(
-                text(", ": warnings,
-        }
-
-    async def execute_import(
-        self,
-        template: Dict[str, Any],
-        *,
-        target_company_id: Optional[uuid.UUID] = None,
-        remapping_options: Optional[Dict[str, Any]] = None,
-        secret_mapping: Optional[Dict[str, str]] = None,
-    ) -> Dict[str, Any]:
-        ", ": {
-                ", "Export agents from agent_org_nodes with adapter_config secrets scrubbed.", "Export only ACTIVE routines (status='active').", "Insert agent_org_nodes row.  Returns new agent_id or None if skipped.", "Map secret binding names for this company (name → name).
-
-        Returns {name: name} so scrubber can substitute ``{{NAME}}``.
-        Only active (non-revoked) secrets are included.
-        ", "Replace secret values in adapter_config with ``{{NAME}}`` placeholders.
-
-    Uses secret_map (name→name) for known bound secrets; falls back to
-    uppercasing the key name for unrecognised secret-like keys.
-    ", "Replace {{SECRET_NAME}} placeholders in config by walking the structure.
-
-        Operates on the decoded Python object (not the JSON string) to prevent
-        injection when secret values contain quote characters.
-        ", "Return KB collection names for the company (not content).", "Return a full-state snapshot for backup/migration.
-
-        Extends the template with ALL work items, sprint history rows, and KB
-        collection names (not KB content).
-        ", "Return a portable template dict for the company.
-
-        Includes company meta, agents (secrets scrubbed), goals, active
-        routines, projects + portfolios (no sprint data), and up to 20 seed
-        work items (epic/feature) marked ``is_seed=true``.  Secret values are
-        never exported.
-        ", "Return collision/creation preview without writing anything.", "Transactional import.  Rolls back entirely on any entity failure.", "Up to 20 epic/feature work items as seed tasks (is_seed=true).", "] = _scrub_adapter_config(d[", "] = d[", "] = data[", "] = str(artifact_id)
-        return payload
-
-    # ------------------------------------------------------------------
-    # Data collectors
-    # ------------------------------------------------------------------
-
-    async def _export_company(self, company_id: str) -> Dict[str, Any]:
-        result = await self.session.execute(
-            text(
-                ", "] = str(artifact_id)
-        return payload
-
-    async def export_snapshot(self, company_id: uuid.UUID, actor: str = ", "] = str(d[", "] = str(data[", "])
-        if data.get(", "]) if d.get(", "]) if data.get(", "], secret_map)
-            agents.append(d)
-        return agents
-
-    async def _export_goals(self, company_id: str) -> List[Dict[str, Any]]:
-        result = await self.session.execute(
-            select(LLCGoal).where(LLCGoal.company_id == company_id).order_by(LLCGoal.created_at)
-        )
-        goals = []
-        for (goal,) in result:
-            goals.append(
-                {
-                    ", "].append(agent.get(", "].append(agent_id)
-                else:
-                    skipped[", "].append(goal.get(", "].append(item.get(", "].append(str(goal_id))
-                else:
-                    skipped[", "].append(str(item_id))
-                else:
-                    skipped[", "].append(str(project_id))
-
-            # seed work items
-            for item in template.get(", "].isoformat()
-            if d.get(", "].isoformat()
-        return data
-
-    async def _build_secret_map(self, company_id: str) -> Dict[str, str]:
-        "]
+__all__ = ["PortabilityService", "TemplateImportError"]

--- a/autobot-backend/llc/sync/outbound_sync.py
+++ b/autobot-backend/llc/sync/outbound_sync.py
@@ -156,9 +156,7 @@ def _decrypt_pm_config(encrypted_blob: str) -> Dict[str, Any]:
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-async def _resolve_jira_transition_id(
-    integration: Any, issue_key: str, transition_name: str
-) -> Optional[str]:
+async def _resolve_jira_transition_id(integration: Any, issue_key: str, transition_name: str) -> Optional[str]:
     """Fetch available transitions and map a human-readable name to its numeric ID.
 
     Jira's POST /transitions endpoint requires a numeric ID (e.g. "31"), not
@@ -202,9 +200,7 @@ async def _dispatch_to_jira(pm_config: Dict[str, Any], event: str, payload: Dict
             transition_name = map_status(pm_config, payload.get("status", ""))
             transition_id = await _resolve_jira_transition_id(integration, issue_key, transition_name)
             if transition_id is None:
-                raise ValueError(
-                    f"No Jira transition found matching '{transition_name}' on {issue_key}"
-                )
+                raise ValueError(f"No Jira transition found matching '{transition_name}' on {issue_key}")
             await integration.execute_action(
                 "update_issue_status",
                 {"issue_key": issue_key, "transition_id": transition_id},
@@ -330,9 +326,7 @@ class LLCOutboundSyncService:
     async def start(self) -> None:
         """Start the background subscriber task and leader election loop."""
         self._stop_event.clear()
-        self._leader_task = asyncio.create_task(
-            self._leader_loop(), name="llc-outbound-sync-leader"
-        )
+        self._leader_task = asyncio.create_task(self._leader_loop(), name="llc-outbound-sync-leader")
         self._task = asyncio.create_task(self._run(), name="llc-outbound-sync")
         logger.info("LLCOutboundSyncService started (worker=%s)", self._worker_id)
 
@@ -358,16 +352,12 @@ class LLCOutboundSyncService:
                     logger.info("LLCOutboundSyncService: became leader (%s)", self._worker_id)
                     self._is_leader = True
                 elif not won and self._is_leader:
-                    logger.warning(
-                        "LLCOutboundSyncService: lost leadership (%s)", self._worker_id
-                    )
+                    logger.warning("LLCOutboundSyncService: lost leadership (%s)", self._worker_id)
                     self._is_leader = False
 
                 sleep_s = _LEADER_REFRESH_S if self._is_leader else _LEADER_POLL_S
                 try:
-                    await asyncio.wait_for(
-                        asyncio.shield(self._stop_event.wait()), timeout=sleep_s
-                    )
+                    await asyncio.wait_for(asyncio.shield(self._stop_event.wait()), timeout=sleep_s)
                     return  # stop_event fired — exit gracefully
                 except asyncio.TimeoutError:
                     pass  # normal: sleep interval elapsed, loop again

--- a/autobot-backend/llc/tests/test_export.py
+++ b/autobot-backend/llc/tests/test_export.py
@@ -12,7 +12,6 @@ import pytest
 
 from llc.services.portability import PortabilityService, _scrub_adapter_config
 
-
 # ------------------------------------------------------------------
 # Unit tests for _scrub_adapter_config
 # ------------------------------------------------------------------

--- a/autobot-backend/llc/tests/test_import.py
+++ b/autobot-backend/llc/tests/test_import.py
@@ -9,8 +9,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from llc.services.portability import TemplateImportError as LLCImportError
 from llc.services.portability import PortabilityService
+from llc.services.portability import TemplateImportError as LLCImportError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -79,7 +79,9 @@ async def test_preview_no_collision() -> None:
     svc = _make_svc()
     # all selects return empty
     svc.session.execute.return_value.scalar.return_value = None
-    svc.session.execute.return_value = MagicMock(scalar=MagicMock(return_value=None), __iter__=MagicMock(return_value=iter([])))
+    svc.session.execute.return_value = MagicMock(
+        scalar=MagicMock(return_value=None), __iter__=MagicMock(return_value=iter([]))
+    )
 
     tmpl = _template(
         agents=[{"name": "Bob", "adapter_config": {}}],
@@ -249,9 +251,7 @@ async def test_execute_import_rollback_on_failure() -> None:
     svc = _make_svc()
     tmpl = _template()
 
-    with patch.object(
-        svc, "_resolve_or_create_company", side_effect=Exception("DB boom")
-    ):
+    with patch.object(svc, "_resolve_or_create_company", side_effect=Exception("DB boom")):
         sp_mock = AsyncMock()
         sp_mock.commit = AsyncMock()
         sp_mock.rollback = AsyncMock()

--- a/autobot-backend/llc/tests/test_labels.py
+++ b/autobot-backend/llc/tests/test_labels.py
@@ -12,8 +12,8 @@ from fastapi.testclient import TestClient
 
 from llc.models.label import LLCLabel, LLCWorkItemLabel
 from llc.services.label_service import (  # noqa: E402
-    LLCLabelService,
     LabelNotFound,
+    LLCLabelService,
     WorkItemNotFound,
 )
 

--- a/autobot-backend/llc/tests/test_outbound_sync.py
+++ b/autobot-backend/llc/tests/test_outbound_sync.py
@@ -299,9 +299,7 @@ async def test_non_leader_skips_dispatch():
 
     message = {
         "channel": b"llc:work_item:created",
-        "data": json.dumps(
-            {"company_id": "00000000-0000-0000-0000-000000000099", "work_item_id": "wi_x"}
-        ).encode(),
+        "data": json.dumps({"company_id": "00000000-0000-0000-0000-000000000099", "work_item_id": "wi_x"}).encode(),
     }
 
     with patch("llc.sync.outbound_sync._DISPATCHER") as mock_dispatcher:
@@ -328,9 +326,7 @@ async def test_resolve_jira_transition_id_maps_name_to_numeric_id():
     result = await _resolve_jira_transition_id(integration, "PROJ-42", "In Progress")
     assert result == "21"
 
-    integration.execute_action.assert_called_once_with(
-        "list_transitions", {"issue_key": "PROJ-42"}
-    )
+    integration.execute_action.assert_called_once_with("list_transitions", {"issue_key": "PROJ-42"})
 
 
 @pytest.mark.asyncio
@@ -339,9 +335,7 @@ async def test_resolve_jira_transition_id_case_insensitive():
     from llc.sync.outbound_sync import _resolve_jira_transition_id
 
     integration = AsyncMock()
-    integration.execute_action = AsyncMock(
-        return_value={"transitions": [{"id": "31", "name": "Done"}]}
-    )
+    integration.execute_action = AsyncMock(return_value={"transitions": [{"id": "31", "name": "Done"}]})
 
     assert await _resolve_jira_transition_id(integration, "PROJ-1", "done") == "31"
     assert await _resolve_jira_transition_id(integration, "PROJ-1", "DONE") == "31"
@@ -353,9 +347,7 @@ async def test_resolve_jira_transition_id_returns_none_when_not_found():
     from llc.sync.outbound_sync import _resolve_jira_transition_id
 
     integration = AsyncMock()
-    integration.execute_action = AsyncMock(
-        return_value={"transitions": [{"id": "11", "name": "Backlog"}]}
-    )
+    integration.execute_action = AsyncMock(return_value={"transitions": [{"id": "11", "name": "Backlog"}]})
 
     result = await _resolve_jira_transition_id(integration, "PROJ-1", "NonExistent")
     assert result is None


### PR DESCRIPTION
## Thinking Path

Dev_new_gui had 4 Python files with syntax errors (corrupted merge artifacts from multiple LLC feature PRs landing on the same files). Black's AST parser rejected them, causing code-quality CI to fail on all 6 remaining open PRs. Fix path: identify the last clean git history for each file, reconstruct the corrupted sections, apply Black+isort.

## What Changed

**Syntax reconstruction (4 files):**
- llc/services/portability.py — 1342-line corrupted merge artifact fully replaced; re-implemented all export methods from the clean import base
- llc/api/work_items.py — fixed duplicate docstring; added missing return statements; reconstructed 7 endpoint functions with missing params/bodies
- llc/api/companies.py — reconstructed test_pm_config and _test_pm_connectivity
- llc/api/agent_api.py — added missing return { in get_item_context

**Formatting (13 additional files):** Applied Black (line-length=120) and isort.

## Verification

- All 4 syntax-broken files: python3 ast.parse check → OK
- python3 -m black --check → 2834 files unchanged
- python3 -m isort --check-only → All done

Unblocks PRs: #8537, #8538, #8539, #8540, #8553, #8554

## Model Used

claude-sonnet-4-6

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>