### PR TITLE
fix(llc): fix 4 CR bugs in board controls — liveness/scheduler/service/api (GH#8256)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -151,6 +151,7 @@ for _svc_mod in [
     "services",
     "services.llm_api_key_service",
     "services.llm_cost_tracker",
+    "services.llm_service",
     "services.tool_output_filter",
     "services.personality_service",
 ]:

--- a/autobot-backend/llc/api/controls.py
+++ b/autobot-backend/llc/api/controls.py
@@ -135,9 +135,7 @@ async def resume_agent(
 ) -> Dict[str, Any]:
     actor_id = await _require_board_role(company_id, current_user, _membership_svc(), session)
     try:
-        result = await _controls_svc().resume_agent(
-            session, str(company_id), str(agent_id), actor_id
-        )
+        result = await _controls_svc().resume_agent(session, str(company_id), str(agent_id), actor_id)
         await session.commit()
         return result
     except AgentNotFoundError:
@@ -196,9 +194,7 @@ async def resume_sprint(
 ) -> Dict[str, Any]:
     actor_id = await _require_board_role(company_id, current_user, _membership_svc(), session)
     try:
-        result = await _controls_svc().resume_sprint(
-            session, str(company_id), str(sprint_id), actor_id
-        )
+        result = await _controls_svc().resume_sprint(session, str(company_id), str(sprint_id), actor_id)
         await session.commit()
         return result
     except SprintNotFoundError:
@@ -219,9 +215,7 @@ async def pause_all(
 ) -> Dict[str, Any]:
     actor_id = await _require_board_role(company_id, current_user, _membership_svc(), session)
     try:
-        result = await _controls_svc().pause_company(
-            session, str(company_id), actor_id, reason=body.reason
-        )
+        result = await _controls_svc().pause_company(session, str(company_id), actor_id, reason=body.reason)
         await session.commit()
         return result
     except CompanyNotFoundError:

--- a/autobot-backend/llc/api/controls.py
+++ b/autobot-backend/llc/api/controls.py
@@ -218,11 +218,14 @@ async def pause_all(
     current_user: dict = Depends(get_current_user),
 ) -> Dict[str, Any]:
     actor_id = await _require_board_role(company_id, current_user, _membership_svc(), session)
-    result = await _controls_svc().pause_company(
-        session, str(company_id), actor_id, reason=body.reason
-    )
-    await session.commit()
-    return result
+    try:
+        result = await _controls_svc().pause_company(
+            session, str(company_id), actor_id, reason=body.reason
+        )
+        await session.commit()
+        return result
+    except CompanyNotFoundError:
+        raise HTTPException(status_code=404, detail=f"Company {company_id} not found")
 
 
 @router.post("/companies/{company_id}/controls/resume-all")
@@ -232,9 +235,12 @@ async def resume_all(
     current_user: dict = Depends(get_current_user),
 ) -> Dict[str, Any]:
     actor_id = await _require_board_role(company_id, current_user, _membership_svc(), session)
-    result = await _controls_svc().resume_company(session, str(company_id), actor_id)
-    await session.commit()
-    return result
+    try:
+        result = await _controls_svc().resume_company(session, str(company_id), actor_id)
+        await session.commit()
+        return result
+    except CompanyNotFoundError:
+        raise HTTPException(status_code=404, detail=f"Company {company_id} not found")
 
 
 __all__ = ["router"]

--- a/autobot-backend/llc/scheduler/liveness_monitor.py
+++ b/autobot-backend/llc/scheduler/liveness_monitor.py
@@ -109,12 +109,24 @@ class LivenessMonitor:
         )
         return list(result.scalars().all())
 
-    async def _agent_deliberately_paused(self, agent_id: str) -> bool:
-        """Return True if a FR-GOV-05 pause/terminate flag is set for this agent."""
+    async def _agent_deliberately_paused(
+        self, session: AsyncSession, agent_id: str, company_id: str
+    ) -> bool:
+        """Return True if agent is deliberately paused or terminated (Redis + DB fallback)."""
         redis = await get_async_redis_client()
-        if redis is None:
-            return False
-        return bool(await redis.exists(f"llc:agent:{agent_id}:paused"))
+        if redis is not None:
+            if await redis.exists(f"llc:agent:{agent_id}:paused"):
+                return True
+        # DB fallback — consulted when Redis is unavailable or key was evicted
+        result = await session.execute(
+            text(
+                "SELECT status FROM agent_org_nodes"
+                " WHERE agent_id = :agent_id AND company_id = :company_id LIMIT 1"
+            ),
+            {"agent_id": agent_id, "company_id": company_id},
+        )
+        row = result.fetchone()
+        return row is not None and row[0] in ("paused", "terminated")
 
     async def _recover(self, session: AsyncSession, run: LLCHeartbeatRun) -> None:
         """Perform the six-step recovery protocol for a single stuck run."""
@@ -123,7 +135,7 @@ class LivenessMonitor:
         company_id = str(run.company_id)
 
         # FR-GOV-05: skip recovery for deliberately paused/terminated agents
-        if await self._agent_deliberately_paused(str(agent_id)):
+        if await self._agent_deliberately_paused(session, str(agent_id), company_id):
             logger.info(
                 "LivenessMonitor: skipping recovery for run %s — agent %s is deliberately paused",
                 run_id,

--- a/autobot-backend/llc/scheduler/liveness_monitor.py
+++ b/autobot-backend/llc/scheduler/liveness_monitor.py
@@ -109,9 +109,7 @@ class LivenessMonitor:
         )
         return list(result.scalars().all())
 
-    async def _agent_deliberately_paused(
-        self, session: AsyncSession, agent_id: str, company_id: str
-    ) -> bool:
+    async def _agent_deliberately_paused(self, session: AsyncSession, agent_id: str, company_id: str) -> bool:
         """Return True if agent is deliberately paused or terminated (Redis + DB fallback)."""
         redis = await get_async_redis_client()
         if redis is not None:
@@ -120,8 +118,7 @@ class LivenessMonitor:
         # DB fallback — consulted when Redis is unavailable or key was evicted
         result = await session.execute(
             text(
-                "SELECT status FROM agent_org_nodes"
-                " WHERE agent_id = :agent_id AND company_id = :company_id LIMIT 1"
+                "SELECT status FROM agent_org_nodes" " WHERE agent_id = :agent_id AND company_id = :company_id LIMIT 1"
             ),
             {"agent_id": agent_id, "company_id": company_id},
         )

--- a/autobot-backend/llc/scheduler/routine_scheduler.py
+++ b/autobot-backend/llc/scheduler/routine_scheduler.py
@@ -178,14 +178,10 @@ class RoutineScheduler:
                         routine_id_str,
                     )
                     # Re-queue at next fire time so the routine resumes automatically when unpaused
-                    next_ts_skip: float = croniter(
-                        routine.cron_schedule, datetime.now(tz=timezone.utc)
-                    ).get_next(float)
+                    next_ts_skip: float = croniter(routine.cron_schedule, datetime.now(tz=timezone.utc)).get_next(float)
                     redis = await get_async_redis_client()
                     if redis is None:
-                        raise RuntimeError(
-                            f"Redis unavailable — cannot re-queue paused routine {routine_id_str}"
-                        )
+                        raise RuntimeError(f"Redis unavailable — cannot re-queue paused routine {routine_id_str}")
                     await redis.zadd(_SCHEDULE_KEY, {f"routine:{routine_id}": next_ts_skip})
                     return
 

--- a/autobot-backend/llc/scheduler/routine_scheduler.py
+++ b/autobot-backend/llc/scheduler/routine_scheduler.py
@@ -182,8 +182,11 @@ class RoutineScheduler:
                         routine.cron_schedule, datetime.now(tz=timezone.utc)
                     ).get_next(float)
                     redis = await get_async_redis_client()
-                    if redis is not None:
-                        await redis.zadd(_SCHEDULE_KEY, {f"routine:{routine_id}": next_ts_skip})
+                    if redis is None:
+                        raise RuntimeError(
+                            f"Redis unavailable — cannot re-queue paused routine {routine_id_str}"
+                        )
+                    await redis.zadd(_SCHEDULE_KEY, {f"routine:{routine_id}": next_ts_skip})
                     return
 
                 cron_schedule = routine.cron_schedule

--- a/autobot-backend/llc/services/controls_service.py
+++ b/autobot-backend/llc/services/controls_service.py
@@ -74,14 +74,16 @@ class ControlsService:
 
         await session.execute(
             text(
-                "UPDATE agent_org_nodes SET status = :status, pause_reason = :reason,"
-                " paused_at = :now"
+                "UPDATE agent_org_nodes"
+                " SET status = :status, pause_reason = :reason, paused_at = :now,"
+                " pre_pause_status = :before_status"
                 " WHERE company_id = :company_id AND agent_id = :agent_id"
             ),
             {
                 "status": LLCAgentStatus.PAUSED.value,
                 "reason": reason,
                 "now": datetime.now(tz=timezone.utc),
+                "before_status": before_status,
                 "company_id": company_id,
                 "agent_id": agent_id,
             },
@@ -116,14 +118,21 @@ class ControlsService:
             raise AgentNotFoundError(agent_id)
         before_status = row["status"]
 
+        restore_status = (
+            LLCAgentStatus(row["pre_pause_status"]).value
+            if row.get("pre_pause_status")
+            else LLCAgentStatus.AVAILABLE.value
+        )
+
         await session.execute(
             text(
-                "UPDATE agent_org_nodes SET status = :status, pause_reason = NULL,"
-                " paused_at = NULL"
+                "UPDATE agent_org_nodes"
+                " SET status = :status, pause_reason = NULL, paused_at = NULL,"
+                " pre_pause_status = NULL"
                 " WHERE company_id = :company_id AND agent_id = :agent_id"
             ),
             {
-                "status": LLCAgentStatus.AVAILABLE.value,
+                "status": restore_status,
                 "company_id": company_id,
                 "agent_id": agent_id,
             },
@@ -140,10 +149,10 @@ class ControlsService:
             entity_type="agent",
             entity_id=agent_id,
             before={"status": before_status},
-            after={"status": LLCAgentStatus.AVAILABLE.value},
+            after={"status": restore_status},
         )
 
-        return {"agent_id": agent_id, "status": LLCAgentStatus.AVAILABLE.value}
+        return {"agent_id": agent_id, "status": restore_status}
 
     async def terminate_agent(
         self,
@@ -270,6 +279,8 @@ class ControlsService:
         reason: Optional[str] = None,
     ) -> dict:
         """Set company-wide Redis pause flag — blocks all new heartbeat runs."""
+        if await self._get_company_row(session, company_id) is None:
+            raise CompanyNotFoundError(company_id)
         await self._set_redis_flag(
             _COMPANY_PAUSED_KEY.format(company_id=company_id), reason or "1"
         )
@@ -294,6 +305,8 @@ class ControlsService:
         actor_user_id: str,
     ) -> dict:
         """Lift company-wide pause flag."""
+        if await self._get_company_row(session, company_id) is None:
+            raise CompanyNotFoundError(company_id)
         await self._del_redis_flag(_COMPANY_PAUSED_KEY.format(company_id=company_id))
 
         await self._activity_log.record(
@@ -316,13 +329,21 @@ class ControlsService:
     async def _get_agent_row(self, session: AsyncSession, company_id: str, agent_id: str) -> Optional[dict]:
         result = await session.execute(
             text(
-                "SELECT status FROM agent_org_nodes"
+                "SELECT status, pre_pause_status FROM agent_org_nodes"
                 " WHERE company_id = :company_id AND agent_id = :agent_id LIMIT 1"
             ),
             {"company_id": company_id, "agent_id": agent_id},
         )
         row = result.fetchone()
-        return {"status": row[0]} if row else None
+        return {"status": row[0], "pre_pause_status": row[1]} if row else None
+
+    async def _get_company_row(self, session: AsyncSession, company_id: str) -> Optional[dict]:
+        result = await session.execute(
+            text("SELECT id FROM llc_companies WHERE id = :id LIMIT 1"),
+            {"id": company_id},
+        )
+        row = result.fetchone()
+        return {"id": str(row[0])} if row else None
 
     async def _get_sprint(self, session: AsyncSession, company_id: str, sprint_id: str) -> Optional[dict]:
         result = await session.execute(

--- a/autobot-backend/llc/services/controls_service.py
+++ b/autobot-backend/llc/services/controls_service.py
@@ -281,9 +281,7 @@ class ControlsService:
         """Set company-wide Redis pause flag — blocks all new heartbeat runs."""
         if await self._get_company_row(session, company_id) is None:
             raise CompanyNotFoundError(company_id)
-        await self._set_redis_flag(
-            _COMPANY_PAUSED_KEY.format(company_id=company_id), reason or "1"
-        )
+        await self._set_redis_flag(_COMPANY_PAUSED_KEY.format(company_id=company_id), reason or "1")
 
         await self._activity_log.record(
             session=session,

--- a/autobot-backend/llc/tests/test_controls.py
+++ b/autobot-backend/llc/tests/test_controls.py
@@ -27,7 +27,6 @@ from llc.services.controls_service import (
     SprintNotFoundError,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -458,11 +457,14 @@ async def test_routine_scheduler_pause_requeue_raises_on_redis_none():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("initial_status", [
-    LLCAgentStatus.ONBOARDING.value,
-    LLCAgentStatus.AVAILABLE.value,
-    LLCAgentStatus.ONBOARDING.value,
-])
+@pytest.mark.parametrize(
+    "initial_status",
+    [
+        LLCAgentStatus.ONBOARDING.value,
+        LLCAgentStatus.AVAILABLE.value,
+        LLCAgentStatus.ONBOARDING.value,
+    ],
+)
 async def test_resume_agent_restores_pre_pause_status(initial_status):
     """resume_agent must restore the status that was active before pausing."""
     company_id = str(uuid.uuid4())

--- a/autobot-backend/llc/tests/test_controls.py
+++ b/autobot-backend/llc/tests/test_controls.py
@@ -331,13 +331,15 @@ async def test_liveness_monitor_skips_paused_agent():
 
     monitor = LivenessMonitor()
     agent_id = str(uuid.uuid4())
+    company_id = str(uuid.uuid4())
+    session = _mock_session()
 
     with patch("llc.scheduler.liveness_monitor.get_async_redis_client") as mock_redis:
         redis = AsyncMock()
         redis.exists = AsyncMock(return_value=True)  # agent paused flag
         mock_redis.return_value = redis
 
-        result = await monitor._agent_deliberately_paused(agent_id)
+        result = await monitor._agent_deliberately_paused(session, agent_id, company_id)
 
     assert result is True
 
@@ -349,12 +351,189 @@ async def test_liveness_monitor_recovers_non_paused_agent():
 
     monitor = LivenessMonitor()
     agent_id = str(uuid.uuid4())
+    company_id = str(uuid.uuid4())
+    # Redis says not paused; DB also returns no matching row
+    session = _mock_session(rows=[])
 
     with patch("llc.scheduler.liveness_monitor.get_async_redis_client") as mock_redis:
         redis = AsyncMock()
         redis.exists = AsyncMock(return_value=False)
         mock_redis.return_value = redis
 
-        result = await monitor._agent_deliberately_paused(agent_id)
+        result = await monitor._agent_deliberately_paused(session, agent_id, company_id)
 
     assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Bug #1 — liveness_monitor DB fallback for terminated agents (GH#8256 CR)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_liveness_monitor_db_fallback_skips_terminated():
+    """When Redis is unavailable, DB fallback must catch terminated agents."""
+    from llc.scheduler.liveness_monitor import LivenessMonitor
+
+    monitor = LivenessMonitor()
+    agent_id = str(uuid.uuid4())
+    company_id = str(uuid.uuid4())
+
+    # Redis unavailable
+    session = _mock_session(rows=[("terminated",)])
+
+    with patch("llc.scheduler.liveness_monitor.get_async_redis_client") as mock_redis:
+        mock_redis.return_value = None  # Redis down
+
+        result = await monitor._agent_deliberately_paused(session, agent_id, company_id)
+
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Bug #2 — routine_scheduler raises when Redis None during pause re-queue (GH#8256 CR)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_routine_scheduler_pause_requeue_raises_on_redis_none():
+    """When Redis is None during pause re-queue, RuntimeError propagates to the
+    outer except handler, which re-adds the routine with a 60s retry delay."""
+    from llc.scheduler.routine_scheduler import RoutineScheduler
+
+    scheduler = RoutineScheduler()
+    routine_id_str = str(uuid.uuid4())
+    company_id = str(uuid.uuid4())
+    agent_id_val = str(uuid.uuid4())
+
+    mock_routine = MagicMock()
+    mock_routine.status = "active"  # RoutineStatus.ACTIVE (str enum)
+    mock_routine.company_id = uuid.UUID(company_id)
+    mock_routine.assignee_agent_id = uuid.UUID(agent_id_val)
+    mock_routine.cron_schedule = "* * * * *"
+    mock_routine.last_fired_at = None
+
+    # Async context manager for session factory
+    mock_session = AsyncMock()
+    mock_session_cm = AsyncMock()
+    mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_factory = MagicMock(return_value=mock_session_cm)
+
+    mock_svc_instance = AsyncMock()
+    mock_svc_instance.get = AsyncMock(return_value=mock_routine)
+    mock_svc_instance.record_run = AsyncMock()
+    mock_svc_cls = MagicMock(return_value=mock_svc_instance)
+
+    # Redis call counter:
+    #  call 1 — _company_or_agent_paused: company paused flag → True
+    #  call 2 — pause re-queue: returns None → raises RuntimeError
+    #  call 3 — outer except re-add handler
+    re_add_redis = AsyncMock()
+    re_add_redis.zadd = AsyncMock()
+    redis_call_count = 0
+
+    async def redis_side_effect():
+        nonlocal redis_call_count
+        redis_call_count += 1
+        if redis_call_count == 1:
+            r = AsyncMock()
+            r.exists = AsyncMock(return_value=True)
+            return r
+        if redis_call_count == 2:
+            return None
+        return re_add_redis
+
+    with patch("user_management.database.get_async_session_factory", return_value=mock_factory):
+        with patch("llc.services.routine_service.RoutineService", mock_svc_cls):
+            with patch("llc.scheduler.routine_scheduler.get_async_redis_client", side_effect=redis_side_effect):
+                await scheduler._dispatch_routine(routine_id_str)
+
+    re_add_redis.zadd.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Bug #3 — resume_agent restores pre-pause status (GH#8256 CR)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("initial_status", [
+    LLCAgentStatus.ONBOARDING.value,
+    LLCAgentStatus.AVAILABLE.value,
+    LLCAgentStatus.ONBOARDING.value,
+])
+async def test_resume_agent_restores_pre_pause_status(initial_status):
+    """resume_agent must restore the status that was active before pausing."""
+    company_id = str(uuid.uuid4())
+    agent_id = str(uuid.uuid4())
+    actor_id = str(uuid.uuid4())
+    log = _activity_log_mock()
+    svc = ControlsService(activity_log=log)
+
+    call_count = 0
+
+    def make_session_for_status(pre_pause):
+        session = AsyncMock()
+        result_pre = MagicMock()
+        result_pre.fetchone.return_value = (LLCAgentStatus.PAUSED.value, pre_pause)
+        result_update = MagicMock()
+        result_update.fetchone.return_value = None
+
+        async def execute_side(query, params=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return result_pre
+            return result_update
+
+        session.execute = AsyncMock(side_effect=execute_side)
+        return session
+
+    session = make_session_for_status(initial_status)
+
+    with patch("llc.services.controls_service.get_async_redis_client") as mock_redis:
+        redis = AsyncMock()
+        redis.delete = AsyncMock()
+        mock_redis.return_value = redis
+
+        result = await svc.resume_agent(session, company_id, agent_id, actor_id)
+
+    assert result["status"] == initial_status
+
+
+# ---------------------------------------------------------------------------
+# Bug #4 — CompanyNotFoundError raised for unknown company (GH#8256 CR)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pause_company_raises_company_not_found():
+    """pause_company must raise CompanyNotFoundError for an unknown company_id."""
+    from llc.services.controls_service import CompanyNotFoundError
+
+    company_id = str(uuid.uuid4())
+    actor_id = str(uuid.uuid4())
+
+    session = _mock_session(rows=[])  # llc_companies lookup returns nothing
+    log = _activity_log_mock()
+    svc = ControlsService(activity_log=log)
+
+    with pytest.raises(CompanyNotFoundError):
+        await svc.pause_company(session, company_id, actor_id)
+
+
+@pytest.mark.asyncio
+async def test_resume_company_raises_company_not_found():
+    """resume_company must raise CompanyNotFoundError for an unknown company_id."""
+    from llc.services.controls_service import CompanyNotFoundError
+
+    company_id = str(uuid.uuid4())
+    actor_id = str(uuid.uuid4())
+
+    session = _mock_session(rows=[])
+    log = _activity_log_mock()
+    svc = ControlsService(activity_log=log)
+
+    with pytest.raises(CompanyNotFoundError):
+        await svc.resume_company(session, company_id, actor_id)

--- a/autobot-backend/migrations/versions/20260525_039_agent_org_nodes_pre_pause_status.py
+++ b/autobot-backend/migrations/versions/20260525_039_agent_org_nodes_pre_pause_status.py
@@ -3,6 +3,7 @@
 Revision ID: 20260525_039
 Revises: 20260523_038
 """
+
 from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op

--- a/autobot-backend/migrations/versions/20260525_039_agent_org_nodes_pre_pause_status.py
+++ b/autobot-backend/migrations/versions/20260525_039_agent_org_nodes_pre_pause_status.py
@@ -1,0 +1,21 @@
+"""Add pre_pause_status to agent_org_nodes (GH#8256 CR fix).
+
+Revision ID: 20260525_039
+Revises: 20260523_038
+"""
+from typing import Sequence, Union
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260525_039"
+down_revision: Union[str, None] = "20260523_038"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("agent_org_nodes", sa.Column("pre_pause_status", sa.String(32), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("agent_org_nodes", "pre_pause_status")


### PR DESCRIPTION
## Summary

Fixes 4 runtime-correctness bugs from CR round-2 on merged PR #8538 — spec in [MVA-1005](/MVA/issues/MVA-1005).

- **Bug #1 (CRITICAL)** `liveness_monitor._agent_deliberately_paused`: added `session` + `company_id` params; DB fallback when Redis unavailable or key evicted — terminated agents no longer get spurious recovery runs.
- **Bug #2 (HIGH)** `routine_scheduler._dispatch_routine`: raise `RuntimeError` instead of silent return when Redis `None` in pause re-queue branch. Outer `except` re-adds with 60 s retry — routine never permanently lost.
- **Bug #3 (HIGH)** `controls_service.resume_agent` + migration: new `pre_pause_status` column; `resume_agent` restores pre-pause status instead of hardcoding `AVAILABLE`.
- **Bug #4 (LOW)** `controls.pause_all`/`resume_all`: catch `CompanyNotFoundError` → HTTP 404. Service gains `_get_company_row` guard.

## Thinking Path

Reviewed the 4 CR findings (Bug #1–#4). Each fix is minimal and targeted:
- Bug #1 needs DB consultation when Redis key is absent; passing `session` to the helper is the cleanest way to do it without opening a new connection.
- Bug #2: the outer except block already handles retry — raising RuntimeError lets it do its job.
- Bug #3: storing `pre_pause_status` in the DB (not Redis) is the only durable approach; a new nullable column avoids schema breakage.
- Bug #4: `CompanyNotFoundError` was imported but never raised anywhere — added `_get_company_row` guard in the two company-level service methods and handlers in the two API endpoints.

## What Changed

| File | Change |
|------|--------|
| `llc/scheduler/liveness_monitor.py` | Bug #1: DB fallback in `_agent_deliberately_paused` |
| `llc/scheduler/routine_scheduler.py` | Bug #2: `raise RuntimeError` when Redis None in pause branch |
| `llc/services/controls_service.py` | Bug #3 + #4: `pre_pause_status` column usage + `_get_company_row` guard |
| `llc/api/controls.py` | Bug #4: `CompanyNotFoundError` → 404 in `pause_all`/`resume_all` |
| `migrations/versions/20260525_039_agent_org_nodes_pre_pause_status.py` | Bug #3: adds `pre_pause_status VARCHAR(32) NULLABLE` |
| `llc/tests/test_controls.py` | 6 new assertions covering all 4 bugs |
| `conftest.py` | Pre-existing fix: `services.llm_service` stub restores LLC test collection |

## Verification

- `python3 -m py_compile` passes on all 7 files ✅
- `python3 -m black --check --line-length=120` passes on all 7 files ✅
- 6 new unit tests: `test_liveness_monitor_db_fallback_skips_terminated`, `test_routine_scheduler_pause_requeue_raises_on_redis_none`, `test_resume_agent_restores_pre_pause_status` (parametrized ×2), `test_pause_company_raises_company_not_found`, `test_resume_company_raises_company_not_found`
- Alembic migration `20260525_039` chains from `20260523_038` with nullable column — no existing-row impact ✅

## Model Used

claude-sonnet-4-6 (SeniorCodeArchitect spec) / claude-sonnet-4-6 (BackendEngineer impl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)