### PR TITLE
fix(llc/kb): address round-2 CR findings in sprint KB summarizer (GH#8238)

### DIFF
--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -590,6 +590,8 @@ async def get_project_knowledge(
         "artifacts": artifacts,
         "total": len(artifacts),
     }
+
+
 class SprintSummaryResponse(BaseModel):
     sprint_id: uuid.UUID
     sprint_name: str

--- a/autobot-backend/llc/kb/sprint_summarizer.py
+++ b/autobot-backend/llc/kb/sprint_summarizer.py
@@ -15,8 +15,9 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.logging_manager import get_logger
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.logging_manager import get_logger
 
 from ..kb.collections import KbCollectionManager
 from ..models.sprint import LLCSprint
@@ -67,24 +68,28 @@ class SprintKbSummarizer:
         Returns:
             Summary text if LLM summarization occurred, else None.
         """
-        sprint_collection = KbCollectionManager.collection_name(
-            KbCollectionManager.SPRINT_PREFIX, sprint_id
-        )
+        sprint_collection = KbCollectionManager.collection_name(KbCollectionManager.SPRINT_PREFIX, sprint_id)
+
+        if session is None:
+            logger.warning(
+                "summarize_and_merge called without session for sprint %s; "
+                "cannot resolve project_id — merge skipped, archive only",
+                sprint_id,
+            )
+            await self._km.archive_collection(KbCollectionManager.SPRINT_PREFIX, sprint_id)
+            return None
+
         sprint, project_id = await self._load_sprint_context(sprint_id, session)
 
         if project_id is None:
             logger.warning(
-                "Cannot resolve project_id for sprint %s; skipping KB merge",
+                "Sprint %s has no parent project in DB; skipping KB merge",
                 sprint_id,
             )
-            await self._km.archive_collection(
-                KbCollectionManager.SPRINT_PREFIX, sprint_id
-            )
+            await self._km.archive_collection(KbCollectionManager.SPRINT_PREFIX, sprint_id)
             return None
 
-        project_collection = KbCollectionManager.collection_name(
-            KbCollectionManager.PROJECT_PREFIX, project_id
-        )
+        project_collection = KbCollectionManager.collection_name(KbCollectionManager.PROJECT_PREFIX, project_id)
 
         docs = await self._fetch_documents(sprint_collection)
         doc_count = len(docs)
@@ -100,9 +105,7 @@ class SprintKbSummarizer:
                 docs, project_collection, sprint_id, project_id, sprint=sprint
             )
 
-        await self._km.archive_collection(
-            KbCollectionManager.SPRINT_PREFIX, sprint_id
-        )
+        await self._km.archive_collection(KbCollectionManager.SPRINT_PREFIX, sprint_id)
 
         if summary_text and session is not None and sprint is not None:
             sprint.kb_summary = summary_text  # type: ignore[attr-defined]
@@ -138,11 +141,20 @@ class SprintKbSummarizer:
             kb = await get_knowledge_base()
             col = await kb._async_chroma_client.get_collection(collection_name)
             raw = await col.get(include=["documents", "metadatas", "embeddings"])
-        except Exception:
-            logger.warning(
-                "Collection %s not found or empty; returning []", collection_name
+        except Exception as exc:
+            exc_msg = str(exc).lower()
+            if "not found" in exc_msg or "does not exist" in exc_msg:
+                logger.info(
+                    "Collection %s does not exist; treating as empty",
+                    collection_name,
+                )
+                return []
+            logger.error(
+                "Failed to fetch documents from %s: %s — archive will be skipped",
+                collection_name,
+                exc,
             )
-            return []
+            raise
 
         ids = raw.get("ids") or []
         documents = raw.get("documents") or []
@@ -184,9 +196,7 @@ class SprintKbSummarizer:
         else:
             await dst.add(ids=ids, documents=texts, metadatas=metadatas)
 
-        logger.info(
-            "Direct-merged %d docs from sprint:%s into %s", len(docs), sprint_id, dst_collection
-        )
+        logger.info("Direct-merged %d docs from sprint:%s into %s", len(docs), sprint_id, dst_collection)
 
     async def _llm_summarize_and_index(
         self,
@@ -210,14 +220,19 @@ class SprintKbSummarizer:
         )
 
         if response.error:
-            logger.error(
-                "LLM summarization failed for sprint %s: %s", sprint_id, response.error
-            )
+            logger.error("LLM summarization failed for sprint %s: %s", sprint_id, response.error)
             # Fall back to direct merge on LLM failure
             await self._direct_merge(docs, dst_collection, sprint_id, project_id)
             return "[direct-merged: LLM summarization failed]"
 
         summary_text: str = response.content or ""
+        if not summary_text:
+            logger.error(
+                "LLM returned empty content for sprint %s; falling back to direct merge",
+                sprint_id,
+            )
+            await self._direct_merge(docs, dst_collection, sprint_id, project_id)
+            return "[direct-merged: LLM returned empty content]"
         closed_at = datetime.now(timezone.utc).isoformat()
         sprint_name = sprint.name if sprint else str(sprint_id)
 

--- a/autobot-backend/llc/tests/conftest.py
+++ b/autobot-backend/llc/tests/conftest.py
@@ -30,3 +30,25 @@ def _make_knowledge_stub() -> types.ModuleType:
 # Unconditionally replace with a stub so every lazy ``from knowledge import X``
 # receives our mock instead of triggering the broken chain.
 sys.modules["knowledge"] = _make_knowledge_stub()
+
+
+def _make_services_stub() -> types.ModuleType:
+    """Return a thin stub for the ``services`` package hierarchy."""
+    services_mod = types.ModuleType("services")
+    services_mod.__path__ = []  # type: ignore[attr-defined]
+    services_mod.__package__ = "services"
+
+    llm_mod = types.ModuleType("services.llm_service")
+    llm_mod.__package__ = "services"
+    llm_mod.get_llm_service = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
+
+    services_mod.llm_service = llm_mod  # type: ignore[attr-defined]
+    sys.modules["services"] = services_mod
+    sys.modules["services.llm_service"] = llm_mod
+    return services_mod
+
+
+# ``services.llm_service`` is imported at module level by llc/kb/handoff_brief.py
+# (merged to Dev_new_gui after issue-8238).  Stub it so the test collection
+# phase does not fail when the full service stack is absent.
+_make_services_stub()

--- a/autobot-backend/llc/tests/test_sprint_summarizer.py
+++ b/autobot-backend/llc/tests/test_sprint_summarizer.py
@@ -80,7 +80,7 @@ async def test_empty_collection_skips_merge(summarizer, km_mock):
         patch.object(summarizer, "_load_sprint_context", new=AsyncMock(return_value=(None, uuid.uuid4()))),
         patch.object(summarizer, "_fetch_documents", new=AsyncMock(return_value=[])),
     ):
-        result = await summarizer.summarize_and_merge(sprint_id)
+        result = await summarizer.summarize_and_merge(sprint_id, session=MagicMock())
 
     assert result is None
     km_mock.archive_collection.assert_called_once()
@@ -98,7 +98,7 @@ async def test_small_collection_direct_merge(summarizer, km_mock):
         patch.object(summarizer, "_direct_merge", new=AsyncMock()) as dm,
         patch.object(summarizer, "_llm_summarize_and_index", new=AsyncMock()) as lsi,
     ):
-        result = await summarizer.summarize_and_merge(sprint_id)
+        result = await summarizer.summarize_and_merge(sprint_id, session=MagicMock())
 
     dm.assert_called_once()
     lsi.assert_not_called()
@@ -117,7 +117,7 @@ async def test_large_collection_llm_summarize(summarizer, km_mock):
         patch.object(summarizer, "_direct_merge", new=AsyncMock()) as dm,
         patch.object(summarizer, "_llm_summarize_and_index", new=AsyncMock(return_value="summary text")) as lsi,
     ):
-        result = await summarizer.summarize_and_merge(sprint_id)
+        result = await summarizer.summarize_and_merge(sprint_id, session=MagicMock())
 
     lsi.assert_called_once()
     dm.assert_not_called()
@@ -132,7 +132,7 @@ async def test_no_project_id_archives_and_skips_merge(summarizer, km_mock):
     with (
         patch.object(summarizer, "_load_sprint_context", new=AsyncMock(return_value=(None, None))),
     ):
-        result = await summarizer.summarize_and_merge(sprint_id)
+        result = await summarizer.summarize_and_merge(sprint_id, session=MagicMock())
 
     assert result is None
     km_mock.archive_collection.assert_called_once_with(
@@ -154,7 +154,7 @@ async def test_llm_failure_falls_back_to_direct_merge(summarizer, km_mock):
         patch.object(summarizer, "_direct_merge", new=AsyncMock()) as dm,
         patch.object(summarizer, "_llm_summarize_and_index", new=AsyncMock(return_value=_SENTINEL)) as lsi,
     ):
-        result = await summarizer.summarize_and_merge(sprint_id)
+        result = await summarizer.summarize_and_merge(sprint_id, session=MagicMock())
 
     # LLM fallback returns sentinel so caller if-guard fires and persists kb_summary
     lsi.assert_called_once()
@@ -172,9 +172,76 @@ async def test_archive_always_called_on_success(summarizer, km_mock):
         patch.object(summarizer, "_fetch_documents", new=AsyncMock(return_value=docs)),
         patch.object(summarizer, "_direct_merge", new=AsyncMock()),
     ):
-        await summarizer.summarize_and_merge(sprint_id)
+        await summarizer.summarize_and_merge(sprint_id, session=MagicMock())
 
     km_mock.archive_collection.assert_called_once_with(
         KbCollectionManager.SPRINT_PREFIX, sprint_id
     )
     assert km_mock.archive_collection.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_llm_empty_content_falls_back_to_direct_merge(summarizer, km_mock):
+    """Fix 1: empty LLM content must trigger direct merge, not index empty doc."""
+    import sys
+
+    sprint_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    docs = _make_docs(20)
+    dst_collection = KbCollectionManager.collection_name(
+        KbCollectionManager.PROJECT_PREFIX, project_id
+    )
+
+    llm_response = MagicMock()
+    llm_response.error = None
+    llm_response.content = ""
+
+    llm_instance = MagicMock()
+    llm_instance.chat = AsyncMock(return_value=llm_response)
+
+    fake_llm_module = MagicMock()
+    fake_llm_module.get_llm_service = MagicMock(return_value=llm_instance)
+
+    with (
+        patch.dict(sys.modules, {"services.llm_service": fake_llm_module}),
+        patch.object(summarizer, "_direct_merge", new=AsyncMock()) as dm,
+    ):
+        result = await summarizer._llm_summarize_and_index(
+            docs, dst_collection, sprint_id, project_id
+        )
+
+    dm.assert_called_once()
+    assert result == "[direct-merged: LLM returned empty content]"
+
+
+@pytest.mark.asyncio
+async def test_fetch_documents_reraises_non_notfound_exception(summarizer, km_mock):
+    """Fix 2: transient ChromaDB errors must propagate, not silently return []."""
+    kb_mock = AsyncMock()
+    kb_mock._async_chroma_client = AsyncMock()
+    kb_mock._async_chroma_client.get_collection = AsyncMock(
+        side_effect=RuntimeError("connection refused")
+    )
+
+    import sys
+
+    fake_kb_module = MagicMock()
+    fake_kb_module.get_knowledge_base = AsyncMock(return_value=kb_mock)
+    with patch.dict(sys.modules, {"knowledge": fake_kb_module}):
+        with pytest.raises(RuntimeError, match="connection refused"):
+            await summarizer._fetch_documents("sprint:xxx")
+
+
+@pytest.mark.asyncio
+async def test_no_session_skips_load_sprint_context(summarizer, km_mock):
+    """Fix 3: calling without session must skip _load_sprint_context and archive."""
+    sprint_id = uuid.uuid4()
+
+    with patch.object(
+        summarizer, "_load_sprint_context", new=AsyncMock()
+    ) as load_mock:
+        result = await summarizer.summarize_and_merge(sprint_id)
+
+    assert load_mock.call_count == 0
+    km_mock.archive_collection.assert_called_once()
+    assert result is None


### PR DESCRIPTION
## Summary

Implements all 4 findings from the Round-2 code review of GH PR #8539 (sprint KB summarizer), tracked in MVA-1006.

### Fix 1 — RED: empty LLM content silently indexes empty doc + skips persist
Empty/None `response.content` (with no `response.error`) now triggers `_direct_merge` and returns a non-empty sentinel `"[direct-merged: LLM returned empty content]"`, preventing an empty string from being indexed into the project KB and ensuring `kb_summary` is persisted by the caller.

### Fix 2 — ORANGE: broad `except Exception` in `_fetch_documents` causes data loss
Transient ChromaDB errors (network timeout, connection refused, etc.) now re-raise instead of silently returning `[]`. Only messages containing `"not found"` or `"does not exist"` are treated as legitimately empty collections. This prevents `archive_collection` from running (and permanently deleting the sprint collection) when data was actually available.

### Fix 3 — YELLOW: `session=None` logs misleading "no parent project" message
Added an explicit `session is None` guard at the top of `summarize_and_merge`, before the `_load_sprint_context` call. The new log message clearly states "merge skipped, archive only" rather than the confusing "Cannot resolve project_id" message that implied a data integrity issue.

### Nit: missing 2 blank lines before `SprintSummaryResponse` class (PEP 8 E302)
Added the required 2 blank lines in `autobot-backend/llc/api/sprints.py`.

## Tests

3 new tests added to `autobot-backend/llc/tests/test_sprint_summarizer.py`:
- `test_llm_empty_content_falls_back_to_direct_merge` — verifies Fix 1
- `test_fetch_documents_reraises_non_notfound_exception` — verifies Fix 2
- `test_no_session_skips_load_sprint_context` — verifies Fix 3

Existing tests updated to pass `session=MagicMock()` since Fix 3 added a session guard that correctly exits early when `session=None`.

Conftest updated to stub `services.llm_service` at module level — required because `llc/kb/handoff_brief.py` (merged after issue-8238) imports `get_llm_service` at import time, which was blocking test collection on `Dev_new_gui`.

All 10 tests pass:
```
10 passed in 0.37s
```

## PR Checklist

- [x] `python -m pytest autobot-backend/llc/tests/test_sprint_summarizer.py` — 10/10 pass
- [x] `python -m black --check` — passes
- [x] `python -m isort --check` — passes
- [x] PR title matches issue spec
- [x] Targets `Dev_new_gui`
- [x] References MVA-1006 and lists all 4 fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)