### PR TITLE
fix(llc/enums): add missing CoWorkerType enum (#8558)

### DIFF
--- a/autobot-backend/llc/models/enums.py
+++ b/autobot-backend/llc/models/enums.py
@@ -146,6 +146,13 @@ class ContextMode(str, Enum):
     FAT = "fat"
 
 
+class CoWorkerType(str, Enum):
+    """Identifies whether the co-worker is an agent or human (GH#8230)."""
+
+    AGENT = "agent"
+    HUMAN = "human"
+
+
 class AssignmentType(str, Enum):
     """How a work item was assigned to an agent (GH#8230)."""
 


### PR DESCRIPTION
## Summary

- `commit 325eb211a` restored 3 of the 4 enums deleted by PR #8521 — `CoWorkerType` was missed
- `work_item_service.py` imports `CoWorkerType` at line 36 and uses it at lines 454–457, causing an `ImportError` on any import of the LLC module
- This PR adds only the 7-line `CoWorkerType` class on top of the already-merged fix

## Verification

```
OK — CoWorkerType and all other enums present
```
(Direct `importlib` load confirms `CoWorkerType.AGENT == "agent"` and `CoWorkerType.HUMAN == "human"`)

## Related

Closes GH #8558. Unblocks MVA-967.

🤖 Generated with [Claude Code](https://claude.com/claude-code)