### PR TITLE
fix(llc): noload lazy for LLCRoutine.runs, fix falsy-zero token fallback (#8496 #8493)

### DIFF
--- a/autobot-backend/llc/adapters/autobot_agent_adapter.py
+++ b/autobot-backend/llc/adapters/autobot_agent_adapter.py
@@ -315,8 +315,10 @@ class AutoBotAgentAdapter:
             return
 
         metadata = getattr(response, "metadata", None) or {}
-        tokens_in: int = metadata.get("prompt_tokens", 0) or metadata.get("input_tokens", 0)
-        tokens_out: int = metadata.get("completion_tokens", 0) or metadata.get("output_tokens", 0)
+        _pt = metadata.get("prompt_tokens")
+        tokens_in: int = _pt if _pt is not None else metadata.get("input_tokens", 0)
+        _ct = metadata.get("completion_tokens")
+        tokens_out: int = _ct if _ct is not None else metadata.get("output_tokens", 0)
         model: str = metadata.get("model", "")
 
         if not model or (tokens_in == 0 and tokens_out == 0):

--- a/autobot-backend/llc/models/routine.py
+++ b/autobot-backend/llc/models/routine.py
@@ -75,7 +75,7 @@ class LLCRoutine(Base):
         "LLCRoutineRun",
         back_populates="routine",
         cascade="all, delete-orphan",
-        lazy="raise",
+        lazy="noload",
     )
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Summary

- **GH#8496** — `LLCRoutine.runs` relationship changed from `lazy="raise"` to `lazy="noload"` so run history is never loaded (even implicitly) when fetching routine rows. The paginated `RoutineService.list_runs()` already queries `LLCRoutineRun` directly via a scoped `SELECT`, so no call-sites are affected.
- **GH#8493** — Token metadata fallback in `AutoBotAgentAdapter._maybe_forward_cost` replaced `or`-based chaining with explicit `is not None` guards. Previously, a legitimate `0` value for `prompt_tokens` / `completion_tokens` would be treated as falsy and silently fall through to the alternate key, causing incorrect cost accounting.

## Files changed

- `autobot-backend/llc/models/routine.py` — `lazy="raise"` → `lazy="noload"` on `LLCRoutine.runs`
- `autobot-backend/llc/adapters/autobot_agent_adapter.py` — explicit `None` checks for `prompt_tokens` / `completion_tokens` fallback

## Test plan

- [ ] Syntax check passes (`ast.parse`) for both files — verified locally
- [ ] Existing `test_routine.py` suite covers `list_runs` paginated query; no regressions expected since `runs` was already `raise`-guarded before this change
- [ ] `test_autobot_agent_adapter.py` token assertion at line 497 (`assert args[2] == 10`) continues to pass with non-zero values; new edge: passing `prompt_tokens=0` now correctly uses `0` rather than falling back to `input_tokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)