### PR TITLE
fix(llc/sprint): add SELECT FOR UPDATE to lifecycle, strip status from PATCH (#8479 #8478)

### DIFF
--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -167,7 +167,7 @@ class SprintUpdate(BaseModel):
     goal_description: Optional[str] = None
     start_date: Optional[date] = None
     end_date: Optional[date] = None
-    status: Optional[SprintStatus] = None
+    # status is intentionally absent: use POST /sprints/{id}/start or /close
     committed_points: Optional[int] = None
 
 
@@ -470,7 +470,9 @@ async def update_sprint(
     body: SprintUpdate,
     session: AsyncSession = Depends(get_async_session),
 ) -> LLCSprint:
-    result = await session.execute(select(LLCSprint).where(LLCSprint.id == sprint_id))
+    result = await session.execute(
+        select(LLCSprint).where(LLCSprint.id == sprint_id).with_for_update()
+    )
     sprint = result.scalar_one_or_none()
     if sprint is None:
         raise HTTPException(status_code=404, detail="Sprint not found")


### PR DESCRIPTION
## Summary

- **#8479 — SELECT FOR UPDATE on sprint PATCH**: Added `.with_for_update()` to the `SELECT` inside `PATCH /llc/sprints/{id}` so that concurrent PATCH requests serialize on the row and cannot double-write conflicting field updates.
- **#8478 — Status field stripped from SprintUpdate**: Removed `status` from the `SprintUpdate` Pydantic schema so `PATCH /llc/sprints/{id}` can no longer bypass lifecycle guards. Status transitions must now go through the dedicated `/sprints/{id}/close` endpoint (and the future `/start` endpoint), which enforce the correct approval flow and FOR UPDATE locking.

## Files changed

- `autobot-backend/llc/api/sprints.py`
  - `SprintUpdate` schema: removed `status: Optional[SprintStatus]` field
  - `update_sprint` handler: SELECT now uses `.with_for_update()`

## Test plan

- [ ] `PATCH /llc/sprints/{id}` with `{"status": "active"}` in body — should be ignored (field not present in schema)
- [ ] `PATCH /llc/sprints/{id}` with valid fields (name, dates, committed_points) — should succeed
- [ ] Concurrent PATCH requests to the same sprint — second request should block until first commits, not produce a lost update
- [ ] Sprint close via `POST /llc/sprints/{id}/close` — still works normally
- [ ] Sprint status still readable via `GET /llc/sprints/{id}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)