### PR TITLE
fix: ws org_id propagation, portability TOCTOU+dragleave, ansible health-check guard (#8492 #8561 #8562 #8483)

### DIFF
--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -761,8 +761,10 @@ async def authenticate_websocket(websocket) -> dict | None:
                     "email": token_data.get("email", ""),
                     "auth_method": "jwt_websocket",
                 }
-                if token_data.get("user_id"):
+                if token_data.get("user_id") is not None:
                     result["user_id"] = token_data["user_id"]
+                if token_data.get("org_id") is not None:
+                    result["org_id"] = token_data["org_id"]
                 return result
         except Exception:
             logger.warning("WebSocket JWT authentication failed")

--- a/autobot-frontend/src/views/llc/CompanyPortabilityView.vue
+++ b/autobot-frontend/src/views/llc/CompanyPortabilityView.vue
@@ -64,7 +64,7 @@
           class="drop-zone"
           :class="{ 'drop-zone--over': isDragOver, 'drop-zone--loaded': !!importFile }"
           @dragover.prevent="isDragOver = true"
-          @dragleave="isDragOver = false"
+          @dragleave="onDragLeave"
           @drop.prevent="onDrop"
           @click="fileInputRef?.click()"
         >
@@ -227,6 +227,7 @@ const importFile = ref<File | null>(null)
 const isDragOver = ref(false)
 const loadingPreview = ref(false)
 const importPreview = ref<ImportPreview | null>(null)
+const previewPayload = ref<unknown>(null)
 const secretMapping = ref<Record<string, string>>({})
 const executingImport = ref(false)
 const importResult = ref<ImportResultDisplay | null>(null)
@@ -330,6 +331,12 @@ function onDrop(e: DragEvent): void {
   if (file) loadFile(file)
 }
 
+// GH#8562: guard against dragleave firing on child elements (flicker fix)
+function onDragLeave(e: DragEvent): void {
+  if ((e.currentTarget as Element).contains(e.relatedTarget as Node)) return
+  isDragOver.value = false
+}
+
 function onFileChange(e: Event): void {
   const file = (e.target as HTMLInputElement).files?.[0]
   if (file) loadFile(file)
@@ -342,6 +349,7 @@ function loadFile(file: File): void {
   }
   importFile.value = file
   importPreview.value = null
+  previewPayload.value = null
   importResult.value = null
   secretMapping.value = {}
   secretPlaceholders.value = []
@@ -350,6 +358,7 @@ function loadFile(file: File): void {
 function clearFile(): void {
   importFile.value = null
   importPreview.value = null
+  previewPayload.value = null
   importResult.value = null
   secretMapping.value = {}
   secretPlaceholders.value = []
@@ -361,6 +370,7 @@ async function runPreview(): Promise<void> {
   if (!importFile.value) return
   loadingPreview.value = true
   importPreview.value = null
+  previewPayload.value = null
   importResult.value = null
   try {
     const text = await importFile.value.text()
@@ -381,6 +391,8 @@ async function runPreview(): Promise<void> {
     for (const p of placeholders) {
       if (!secretMapping.value[p]) secretMapping.value[p] = ''
     }
+    // GH#8561: store parsed payload to avoid re-reading file on execute (TOCTOU fix)
+    previewPayload.value = parsed
     importPreview.value = preview
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Preview failed'
@@ -393,12 +405,12 @@ async function runPreview(): Promise<void> {
 
 // ── execute ───────────────────────────────────────────────────────────────────
 async function executeImport(): Promise<void> {
-  if (!importFile.value || !importPreview.value) return
+  if (!importPreview.value || !previewPayload.value) return
   executingImport.value = true
   importResult.value = null
   try {
-    const text = await importFile.value.text()
-    const parsed: unknown = JSON.parse(text)
+    // GH#8561: reuse the payload captured during preview instead of re-reading file
+    const parsed: unknown = previewPayload.value
     const res = await fetchWithAuth(`${getApiBase()}/llc/import/execute`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/health_check_cron.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/health_check_cron.yml
@@ -24,13 +24,21 @@
     mode: "0755"
   tags: ["monitoring", "health_check"]
 
-- name: "Health Check Cron | Ensure health check scripts are executable"
-  ansible.builtin.file:
+- name: "Health Check Cron | Stat health check scripts"
+  ansible.builtin.stat:
     path: "{{ autobot_repo_dir }}/scripts/{{ item }}"
-    mode: "0755"
   loop:
     - daily_health_check.py
     - post_health_check.py
+  register: _health_check_script_stat
+  tags: ["monitoring", "health_check"]
+
+- name: "Health Check Cron | Ensure health check scripts are executable"
+  ansible.builtin.file:
+    path: "{{ autobot_repo_dir }}/scripts/{{ item.item }}"
+    mode: "0755"
+  loop: "{{ _health_check_script_stat.results }}"
+  when: item.stat.exists
   tags: ["monitoring", "health_check"]
 
 - name: "Health Check Cron | Install cron job via Ansible cron module"


### PR DESCRIPTION
## Summary

- **GH#8492** (`auth_middleware.py`): `authenticate_websocket` now extracts and propagates `org_id` from the JWT payload, matching the REST auth path (`_extract_user_from_jwt`). Changed truthy guards to `is not None` for both `user_id` and `org_id`.
- **GH#8561** (`CompanyPortabilityView.vue`): Added `previewPayload` ref that captures the parsed JSON during `runPreview`. `executeImport` now reuses this stored payload instead of re-reading and re-parsing the file from disk (eliminates the TOCTOU window).
- **GH#8562** (`CompanyPortabilityView.vue`): Replaced the inline `@dragleave="isDragOver = false"` with a dedicated `onDragLeave` handler that guards with `currentTarget.contains(relatedTarget)` before resetting the drag state, preventing flicker when the pointer moves over child elements.
- **GH#8483** (`health_check_cron.yml`): Added a `stat` task before the `chmod` loop; the chmod task now has a `when: item.stat.exists` guard so the role no longer fails if `daily_health_check.py` or `post_health_check.py` are absent from `/opt/autobot/scripts/`.

## Test plan

- [ ] WebSocket connections with a JWT containing `org_id` should have `org_id` present in the returned user dict
- [ ] WebSocket connections with JWTs missing `org_id`/`user_id` (value is `None`) should not error
- [ ] Upload a JSON template, run Preview, then immediately execute — verify the same payload is submitted without re-reading the file
- [ ] Drag a file into the drop zone and move cursor over child elements — verify no flicker on the drop zone border
- [ ] Run the Ansible monitoring role on a host where health check scripts are absent — verify no task failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)