### PR TITLE
fix(llc): consolidate budget SELECT, fix str cast, add sprint columns migration, stub assignee display

### DIFF
--- a/autobot-backend/database/migrations/007_add_llc_sprints_velocity_capacity_fk.py
+++ b/autobot-backend/database/migrations/007_add_llc_sprints_velocity_capacity_fk.py
@@ -1,0 +1,48 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Migration 007: Add velocity_actual, capacity_points columns and project_id FK to llc_sprints (GH#8474).
+
+After GH#8220 introduced sprint planning analytics, the llc_sprints table was
+missing three schema elements required by SprintPlanningService:
+
+  velocity_actual  FLOAT    NULL — actual velocity computed on sprint close
+  capacity_points  INTEGER  NULL — total story-point capacity planned for the sprint
+  FK llc_sprints.project_id -> llc_projects.id (RESTRICT) — previously the
+    column existed without a DB-level foreign key constraint.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade() -> None:
+    # Add velocity_actual column (FLOAT, nullable — populated on sprint close)
+    op.add_column(
+        "llc_sprints",
+        sa.Column("velocity_actual", sa.Float, nullable=True),
+    )
+
+    # Add capacity_points column (INTEGER, nullable — set during sprint planning)
+    op.add_column(
+        "llc_sprints",
+        sa.Column("capacity_points", sa.Integer, nullable=True),
+    )
+
+    # Add the missing FK constraint from llc_sprints.project_id -> llc_projects.id.
+    # The column was created without the FK in the original GH#8219 table-create
+    # migration; this migration adds the constraint retroactively.
+    op.create_foreign_key(
+        "fk_llc_sprints_project_id",
+        "llc_sprints",
+        "llc_projects",
+        ["project_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_llc_sprints_project_id", "llc_sprints", type_="foreignkey")
+    op.drop_column("llc_sprints", "capacity_points")
+    op.drop_column("llc_sprints", "velocity_actual")

--- a/autobot-backend/llc/api/budget.py
+++ b/autobot-backend/llc/api/budget.py
@@ -63,13 +63,20 @@ async def get_budget(
     agent_id: str,
     session: AsyncSession = Depends(get_async_session),
 ) -> BudgetResponse:
-    svc = BudgetService()
-    remaining, is_over, alert = await svc.check_budget(session, agent_id)
-
+    # GH#8461: single SELECT — fetch the row directly and compute derived fields
+    # here rather than calling check_budget() (which does its own SELECT) then
+    # re-fetching the same row.
     result = await session.execute(select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id))
     row = result.scalar_one_or_none()
     if row is None:
         raise HTTPException(status_code=404, detail=f"No budget row for agent {agent_id}")
+
+    spent = Decimal(str(row.budget_spent))
+    limit = Decimal(str(row.budget_limit))
+    threshold = Decimal(str(row.alert_threshold))
+    remaining = limit - spent
+    is_over = spent > limit
+    alert = limit > Decimal("0") and spent / limit >= threshold
 
     return _build_response(row, remaining, is_over, alert)
 
@@ -99,7 +106,9 @@ async def update_limit(
     if row is None:
         raise HTTPException(status_code=404, detail=f"No budget row for agent {agent_id}")
 
-    values: dict = {"budget_limit": str(body.budget_limit)}
+    # GH#8462: pass Decimal directly — Pydantic already validates it as Decimal,
+    # no str() conversion needed (which would silently coerce to TEXT in the ORM).
+    values: dict = {"budget_limit": body.budget_limit}
     if body.alert_threshold is not None:
         values["alert_threshold"] = body.alert_threshold
 

--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -160,6 +160,8 @@ class SprintCreate(BaseModel):
     start_date: Optional[date] = None
     end_date: Optional[date] = None
     committed_points: int = 0
+    # GH#8474: sprint planning analytics fields
+    capacity_points: Optional[int] = None
 
 
 class SprintUpdate(BaseModel):
@@ -169,6 +171,9 @@ class SprintUpdate(BaseModel):
     end_date: Optional[date] = None
     status: Optional[SprintStatus] = None
     committed_points: Optional[int] = None
+    # GH#8474: sprint planning analytics fields
+    velocity_actual: Optional[float] = None
+    capacity_points: Optional[int] = None
 
 
 class SprintResponse(BaseModel):
@@ -182,6 +187,9 @@ class SprintResponse(BaseModel):
     status: str
     committed_points: int
     actual_points: int
+    # GH#8474: sprint planning analytics columns (migration 007)
+    velocity_actual: Optional[float] = None
+    capacity_points: Optional[int] = None
     pending_close_approval_id: Optional[uuid.UUID]
     kb_summary: Optional[str] = None
     created_at: datetime
@@ -444,6 +452,7 @@ async def create_sprint(
         start_date=body.start_date,
         end_date=body.end_date,
         committed_points=body.committed_points,
+        capacity_points=body.capacity_points,  # GH#8474
     )
     session.add(sprint)
     await session.commit()

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -30,11 +30,13 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import Response
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 from user_management.database import get_async_session_factory
+from user_management.models.user import User
 
 from ..kb.collections import KbCollectionManager
 from ..models.enums import WorkItemPriority, WorkItemRelationType, WorkItemStatus, WorkItemType
@@ -217,20 +219,47 @@ class RelationDelete(BaseModel):
     actor_user_id: Optional[str] = None
 
 
-def _assignee_display(item: Any) -> Optional[Dict[str, Any]]:
-    """Return structured assignee display info (GH#8223).
+async def _resolve_user_display(
+    session: AsyncSession,
+    user_id: Any,
+) -> Dict[str, Optional[str]]:
+    """Resolve display_name and email for a user from user_management.users (GH#8476).
 
-    display_name and name are None until user_management JOIN is implemented
-    (see discovery issue filed in GH#8223 implementation).
+    Query:
+        SELECT display_name, email FROM users WHERE id = :user_id
+    Returns a dict with keys ``display_name`` and ``email``, both None on miss.
+    """
+    try:
+        result = await session.execute(select(User.display_name, User.email).where(User.id == user_id))
+        row = result.one_or_none()
+        if row:
+            return {"display_name": row.display_name, "email": row.email}
+    except Exception:
+        pass
+    return {"display_name": None, "email": None}
+
+
+def _assignee_display(
+    item: Any,
+    resolved_user: Optional[Dict[str, Optional[str]]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Return structured assignee display info (GH#8223, GH#8476).
+
+    Pass ``resolved_user`` (from ``_resolve_user_display``) to populate
+    display_name/email for user assignees.  Agent display_name resolution
+    requires the agent registry and is left as a future TODO.
     """
     if item.assignee_type == "user" and item.assignee_user_id:
+        display = resolved_user or {}
         return {
             "type": "user",
             "id": str(item.assignee_user_id),
-            "display_name": None,
-            "name": None,
+            "display_name": display.get("display_name"),
+            "email": display.get("email"),
+            "name": display.get("display_name"),
         }
     if item.assignee_type == "agent" and item.assignee_agent_id:
+        # TODO(GH#8476): resolve display_name from agent registry
         return {
             "type": "agent",
             "id": str(item.assignee_agent_id),
@@ -279,7 +308,10 @@ def _relations_to_list(item: Any) -> List[Dict[str, Any]]:
     return rows
 
 
-def _item_to_dict(item: Any) -> Dict[str, Any]:
+def _item_to_dict(
+    item: Any,
+    resolved_user: Optional[Dict[str, Optional[str]]] = None,
+) -> Dict[str, Any]:
     return {
         "id": str(item.id),
         "company_id": str(item.company_id),
@@ -299,7 +331,7 @@ def _item_to_dict(item: Any) -> Dict[str, Any]:
         "assignee_agent_id": str(item.assignee_agent_id) if item.assignee_agent_id else None,
         "assignee_user_id": str(item.assignee_user_id) if item.assignee_user_id else None,
         "assignee_type": item.assignee_type,
-        "assignee_display": _assignee_display(item),
+        "assignee_display": _assignee_display(item, resolved_user),
         "checkout_run_id": item.checkout_run_id,
         "checkout_locked_at": item.checkout_locked_at.isoformat() if item.checkout_locked_at else None,
         "version": item.version,
@@ -350,7 +382,11 @@ async def create_work_item(
     )
     await session.commit()
     await _kb_manager.ensure_collection(KbCollectionManager.WORK_ITEM_PREFIX, item.id)
-    return _item_to_dict(item)
+    # GH#8476: resolve user display_name/email for user assignees
+    resolved_user = None
+    if item.assignee_type == "user" and item.assignee_user_id:
+        resolved_user = await _resolve_user_display(session, item.assignee_user_id)
+    return _item_to_dict(item, resolved_user)
 
 
 @router.get("")
@@ -386,7 +422,14 @@ async def list_work_items(
         limit=limit,
         offset=offset,
     )
-    return [_item_to_dict(i) for i in items]
+    # GH#8476: resolve user display_name/email for each item's user assignee
+    result = []
+    for i in items:
+        resolved_user = None
+        if i.assignee_type == "user" and i.assignee_user_id:
+            resolved_user = await _resolve_user_display(session, i.assignee_user_id)
+        result.append(_item_to_dict(i, resolved_user))
+    return result
 
 
 @router.get("/{work_item_id}")
@@ -397,7 +440,11 @@ async def get_work_item(
     item = await _service().get(session, work_item_id)
     if item is None:
         raise HTTPException(status_code=404, detail="Work item not found")
-    return _item_to_dict(item)
+    # GH#8476: resolve user display_name/email for user assignees
+    resolved_user = None
+    if item.assignee_type == "user" and item.assignee_user_id:
+        resolved_user = await _resolve_user_display(session, item.assignee_user_id)
+    return _item_to_dict(item, resolved_user)
 
 
 @router.patch("/{work_item_id}")
@@ -411,7 +458,11 @@ async def update_work_item(
     if item is None:
         raise HTTPException(status_code=404, detail="Work item not found")
     await session.commit()
-    return _item_to_dict(item)
+    # GH#8476: resolve user display_name/email for user assignees
+    resolved_user = None
+    if item.assignee_type == "user" and item.assignee_user_id:
+        resolved_user = await _resolve_user_display(session, item.assignee_user_id)
+    return _item_to_dict(item, resolved_user)
 
 
 @router.delete("/{work_item_id}", status_code=204)

--- a/autobot-backend/llc/models/sprint.py
+++ b/autobot-backend/llc/models/sprint.py
@@ -18,7 +18,7 @@ from datetime import date, datetime
 from typing import Optional
 
 import sqlalchemy as sa
-from sqlalchemy import Date, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import Date, DateTime, Float, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -180,6 +180,9 @@ class LLCSprint(Base):
     )
     committed_points: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     actual_points: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    # GH#8474: sprint planning analytics columns (added by migration 007)
+    velocity_actual: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    capacity_points: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     # Stores the approval_id once a sprint_close gate is requested.
     pending_close_approval_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True)
     # LLM-generated KB summary stored on sprint close (GH#8238).


### PR DESCRIPTION
## Summary

- **GH#8461** — `GET /llc/budget/{agent_id}` now performs a single `SELECT` instead of two: previously `check_budget()` fetched the row and the endpoint then re-fetched it. The derived fields (`remaining`, `is_over_limit`, `alert_triggered`) are now computed inline from the single row.
- **GH#8462** — `PATCH /{agent_id}/limit` no longer wraps `body.budget_limit` in `str()` before passing it to the SQLAlchemy `UPDATE`. Pydantic already delivers a `Decimal`; the cast was silently coercing to TEXT.
- **GH#8474** — New migration `007_add_llc_sprints_velocity_capacity_fk.py` adds `velocity_actual FLOAT NULL`, `capacity_points INTEGER NULL`, and the missing FK constraint `project_id -> llc_projects.id` to `llc_sprints`. The `LLCSprint` SQLAlchemy model and the `SprintCreate` / `SprintUpdate` / `SprintResponse` Pydantic schemas are updated to match.
- **GH#8476** — `_assignee_display()` now resolves `display_name` and `email` for `user`-type assignees via `SELECT display_name, email FROM users WHERE id = :user_id`. A new async helper `_resolve_user_display()` is threaded through all endpoints that return work item data (`create`, `get`, `list`, `update`). Agent display_name resolution is documented as a TODO pending agent registry integration.

## Files changed

- `autobot-backend/llc/api/budget.py` — issues #8461, #8462
- `autobot-backend/llc/models/sprint.py` — issue #8474
- `autobot-backend/llc/api/sprints.py` — issue #8474
- `autobot-backend/database/migrations/007_add_llc_sprints_velocity_capacity_fk.py` — issue #8474 (new file)
- `autobot-backend/llc/api/work_items.py` — issue #8476

## Test plan

- [ ] `GET /llc/budget/{agent_id}` returns correct data; confirm only 1 DB query fires (e.g. via SQLAlchemy event logging or `EXPLAIN ANALYZE`).
- [ ] `PATCH /llc/budget/{agent_id}/limit` with a decimal value (`9.99`) stores as NUMERIC, not as a string in the DB.
- [ ] Run migration 007 against a test DB; verify `llc_sprints` gains `velocity_actual`, `capacity_points`, and the FK constraint.
- [ ] `GET /llc/work-items/{id}` with a user assignee returns `assignee_display.display_name` and `assignee_display.email` populated from `users` table.
- [ ] `GET /llc/work-items` list endpoint similarly resolves user assignee display fields.
- [ ] Agent-assigned work items still return `display_name: null` with `type: "agent"` (agent registry TODO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)