### PR TITLE
fix(llc/kb): concurrent AsyncSession, JSON shape, orphaned tasks, unnecessary LLCRAGAssembler (#8566 #8567 #8569 #8570)

### DIFF
--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -484,8 +484,8 @@ async def search_agents(
         List of matching agents with capability metadata.
     """
     try:
-        from llc.kb import AgentCapabilityIndexer
         from knowledge import get_knowledge_base
+        from llc.kb import AgentCapabilityIndexer
 
         indexer = AgentCapabilityIndexer()
         kb = await get_knowledge_base()

--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -272,9 +272,9 @@ async def get_kb_ancestry_collections(
     a sub-company agent inherits.
     """
     from llc.kb.inheritance import KbInheritanceResolver
-    from llc.kb.rag_assembler import LLCRAGAssembler
 
-    resolver = KbInheritanceResolver(rag_assembler=LLCRAGAssembler())
+    # get_query_collections only needs the session; no RAG assembler required (GH#8570).
+    resolver = KbInheritanceResolver()
     try:
         chain = await resolver.get_query_collections(session, str(company_id))
     except ValueError as exc:

--- a/autobot-backend/llc/kb/context_builder.py
+++ b/autobot-backend/llc/kb/context_builder.py
@@ -112,11 +112,9 @@ class HeartbeatContextBuilder:
     ) -> Dict[str, Any]:
         """Build rich context with parallel RAG queries (GH#8236).
 
-        Parallel queries:
-        - company:{company_id} top 5 docs matching work_item.title + description
-        - project:{project_id} top 8 docs matching work_item.title
-        - agent:{agent_id} top 5 docs matching work_item.title (agent memory)
-        - project:{project_id} filtered by status=done, top 3 similar items
+        DB-dependent steps run sequentially first to avoid sharing an AsyncSession
+        across concurrent tasks (GH#8566). RAG queries (no session) then run in
+        parallel for performance (P95 ≤ 2s total).
 
         Returns:
             Dict with goal_ancestry, company_context, project_context, agent_memory,
@@ -128,23 +126,30 @@ class HeartbeatContextBuilder:
 
         company_id = str(work_item.company_id)
         project_id = str(work_item.project_id) if work_item.project_id else None
-
-        # Start parallel tasks (P95 ≤ 2s per task, 4 tasks → ≤ 2s total)
         query_text = f"{work_item.title}\n{work_item.description or ''}"
 
-        # Task 1: Company context with inheritance (top 5, GH#8241)
+        # Step 1: Resolve inheritance collection chain from DB (sequential — session safety).
+        company_collections: List = []
+        if hasattr(self.inheritance_resolver, "get_query_collections"):
+            try:
+                company_collections = await self.inheritance_resolver.get_query_collections(session, company_id)
+            except Exception as e:
+                logger.warning("Failed to resolve KB collections for company %s: %s", company_id, e)
+
+        # Step 2: Fetch similar completed items from DB (sequential — session safety).
+        past_work = await self._get_similar_completed_items(session, project_id, query_text, max_results=3)
+
+        # Step 3: Parallel RAG queries — no session needed after this point (GH#8566).
         company_task = (
-            self.inheritance_resolver.search_with_inheritance(
-                session=session,
-                company_id=company_id,
+            self.inheritance_resolver.search_with_collections(
+                collections=company_collections,
                 query_text=query_text,
                 top_k=5,
             )
-            if hasattr(self.inheritance_resolver, "search_with_inheritance")
+            if company_collections and hasattr(self.inheritance_resolver, "search_with_collections")
             else asyncio.sleep(0)
         )
 
-        # Task 2: Project context (top 8) — optional if no project
         project_task = (
             self.rag_assembler.assemble(
                 company_id=company_id,
@@ -158,7 +163,6 @@ class HeartbeatContextBuilder:
             else asyncio.sleep(0)
         )
 
-        # Task 3: Agent memory (top 5)
         agent_task = (
             self.rag_assembler.assemble(
                 company_id=company_id,
@@ -172,25 +176,21 @@ class HeartbeatContextBuilder:
             else asyncio.sleep(0)
         )
 
-        # Task 4: Similar past work (top 3, status=done)
-        past_work_task = self._get_similar_completed_items(session, project_id, query_text, max_results=3)
-
-        # Run all queries in parallel
-        results = await asyncio.gather(
+        rag_results = await asyncio.gather(
             company_task,
             project_task,
             agent_task,
-            past_work_task,
             return_exceptions=True,
         )
 
-        company_ctx_raw = results[0] if not isinstance(results[0], Exception) else None
-        project_ctx = results[1] if not isinstance(results[1], Exception) else None
-        agent_mem = results[2] if not isinstance(results[2], Exception) else None
-        past_work = results[3] if not isinstance(results[3], Exception) else []
+        company_ctx_raw = rag_results[0] if not isinstance(rag_results[0], Exception) else None
+        project_ctx_raw = rag_results[1] if not isinstance(rag_results[1], Exception) else None
+        agent_mem_raw = rag_results[2] if not isinstance(rag_results[2], Exception) else None
 
-        # Format company_context from inheritance results (GH#8241)
+        # Normalize all three contexts to the same {chunks, sources} dict shape (GH#8567).
         company_ctx = self._format_inherited_context(company_ctx_raw)
+        project_ctx = self._normalize_rag_context(project_ctx_raw)
+        agent_mem = self._normalize_rag_context(agent_mem_raw)
 
         # Build goal ancestry
         goal_ancestry = []
@@ -210,9 +210,9 @@ class HeartbeatContextBuilder:
                 "acceptance_criteria": work_item.acceptance_criteria,
             },
             "goal_ancestry": goal_ancestry,
-            "company_context": company_ctx or {"chunks": [], "sources": []},
-            "project_context": project_ctx or {"chunks": [], "sources": []},
-            "agent_memory": agent_mem or {"chunks": [], "sources": []},
+            "company_context": company_ctx,
+            "project_context": project_ctx,
+            "agent_memory": agent_mem,
             "similar_past_work": past_work,
             "api_base": "http://localhost:8001/api",
             "agent_api_key": "<injected-at-runtime>",
@@ -249,6 +249,22 @@ class HeartbeatContextBuilder:
         return {
             "chunks": chunks,
             "sources": list(sources_set),
+        }
+
+    def _normalize_rag_context(self, result: Any) -> Dict[str, Any]:
+        """Normalize LLCContext or dict from rag_assembler.assemble() to {chunks, sources} (GH#8567).
+
+        Ensures project_context and agent_memory have the same shape as company_context,
+        regardless of whether assemble() returns an LLCContext object or a raw dict.
+        """
+        if result is None:
+            return {"chunks": [], "sources": []}
+        if isinstance(result, dict):
+            return {"chunks": result.get("chunks", []), "sources": result.get("sources", [])}
+        # LLCContext dataclass
+        return {
+            "chunks": getattr(result, "chunks", []),
+            "sources": getattr(result, "sources", []),
         }
 
     async def _get_similar_completed_items(

--- a/autobot-backend/llc/kb/inheritance.py
+++ b/autobot-backend/llc/kb/inheritance.py
@@ -29,11 +29,12 @@ class KbInheritanceResolver:
     grandparent (0.36), etc. (configurable multiplier, default 0.6 per level).
     """
 
-    def __init__(self, rag_assembler: LLCRAGAssembler):
-        """Initialize resolver with RAG assembler.
+    def __init__(self, rag_assembler: Optional[LLCRAGAssembler] = None):
+        """Initialize resolver with optional RAG assembler.
 
         Args:
-            rag_assembler: RAG service for KB queries
+            rag_assembler: RAG service for KB queries (required only for search_with_inheritance
+                and search_with_collections; not needed for get_query_collections alone).
         """
         self.rag_assembler = rag_assembler
 
@@ -64,7 +65,6 @@ class KbInheritanceResolver:
 
             from user_management.models.organization import Organization
 
-            # Fetch company
             company_uuid = uuid.UUID(company_id)
             stmt = select(Organization).where(Organization.id == company_uuid)
             result = await session.execute(stmt)
@@ -73,7 +73,6 @@ class KbInheritanceResolver:
             if not company:
                 raise ValueError(f"Company {company_id} not found")
 
-            # Walk parent chain from company to root
             collections = []
             current = company
             weight = 1.0
@@ -83,9 +82,7 @@ class KbInheritanceResolver:
                 weight_multiplier = current.kb_inheritance_weight
                 collections.append((f"{str(current.id)}:company", weight))
 
-                # Move to parent if exists
                 if current.parent_org_id:
-                    # Cycle detection: break if we've seen this org before
                     if current.parent_org_id in visited:
                         logger.warning(
                             "Circular parent_org_id detected for company %s, stopping traversal",
@@ -115,6 +112,100 @@ class KbInheritanceResolver:
             logger.error("Failed to resolve KB collections for company %s: %s", company_id, e)
             raise
 
+    async def search_with_collections(
+        self,
+        collections: List[Tuple[str, float]],
+        query_text: str,
+        top_k: int = 10,
+    ) -> List[Dict[str, Any]]:
+        """Search KB across pre-fetched collection chain and re-rank by weight.
+
+        Runs parallel RAG queries without a DB session — call get_query_collections()
+        first to obtain the list. Uses coroutines directly in asyncio.gather to avoid
+        orphaned tasks on cancellation (GH#8569).
+
+        Args:
+            collections: List of (collection_name, weight) from get_query_collections()
+            query_text: Query text for similarity search
+            top_k: Number of top results to return
+
+        Returns:
+            List of merged KbResult-like dicts with source_company_id annotation,
+            sorted by weighted score (descending).
+        """
+        if not self.rag_assembler:
+            raise RuntimeError("rag_assembler required for search_with_collections")
+
+        if not collections:
+            return []
+
+        # Build (coroutine, source_company_id, weight) triples — coroutines, not Tasks,
+        # so cancellation of the gather also cancels each query (GH#8569).
+        coro_specs = [
+            (
+                self.rag_assembler.assemble(
+                    company_id=collection_name.split(":")[0],
+                    profile=AssemblerProfile.HEARTBEAT,
+                    query_text=query_text,
+                ),
+                collection_name.split(":")[0],
+                weight,
+            )
+            for collection_name, weight in collections
+        ]
+
+        results = await asyncio.gather(
+            *[coro for coro, _, _ in coro_specs],
+            return_exceptions=True,
+        )
+
+        merged: Dict[str, Any] = {}
+
+        for (_, source_company_id, weight), result in zip(coro_specs, results):
+            if isinstance(result, Exception):
+                logger.warning("Query failed for collection %s: %s", source_company_id, result)
+                continue
+
+            if hasattr(result, "chunks"):
+                chunks = result.chunks
+            elif isinstance(result, dict) and "chunks" in result:
+                chunks = result["chunks"]
+            else:
+                chunks = []
+
+            for chunk in chunks:
+                doc_id = chunk.get("id", chunk.get("metadata", {}).get("id"))
+                if not doc_id:
+                    continue
+
+                score = chunk.get("similarity_score", chunk.get("score", 0.0))
+                weighted_score = score * weight
+
+                if doc_id not in merged or merged[doc_id]["weighted_score"] < weighted_score:
+                    merged[doc_id] = {
+                        "id": doc_id,
+                        "content": chunk.get("content", ""),
+                        "score": score,
+                        "weight": weight,
+                        "weighted_score": weighted_score,
+                        "source_company_id": source_company_id,
+                        "metadata": chunk.get("metadata", {}),
+                    }
+
+        sorted_results = sorted(
+            merged.values(),
+            key=lambda x: x["weighted_score"],
+            reverse=True,
+        )[:top_k]
+
+        logger.debug(
+            "Merged %d results from %d collections, returning top %d",
+            len(merged),
+            len(collections),
+            len(sorted_results),
+        )
+        return sorted_results
+
     async def search_with_inheritance(
         self,
         session: AsyncSession,
@@ -124,11 +215,12 @@ class KbInheritanceResolver:
     ) -> List[Dict[str, Any]]:
         """Search KB across company hierarchy and re-rank by weight.
 
-        Issues parallel RAG queries across all collections in the inheritance
-        chain, then merges and re-ranks results by score * weight.
+        Resolves the collection chain from DB sequentially, then issues parallel
+        RAG queries via search_with_collections. The DB session is not passed to
+        any concurrent task (GH#8566 fix).
 
         Args:
-            session: DB session
+            session: DB session (used only for the sequential collection lookup)
             company_id: Company UUID to search from
             query_text: Query text for similarity search
             top_k: Number of top results to return
@@ -138,89 +230,13 @@ class KbInheritanceResolver:
             sorted by weighted score (descending).
         """
         try:
-            # Get collections with weights
             collections = await self.get_query_collections(session, company_id)
 
             if not collections:
                 logger.warning("No KB collections found for company %s", company_id)
                 return []
 
-            # Issue parallel queries across all collections
-            tasks = []
-            for collection_name, weight in collections:
-                # Extract company_id from collection_name (format: "comp-uuid:company")
-                source_company_id = collection_name.split(":")[0]
-
-                task = asyncio.create_task(
-                    self.rag_assembler.assemble(
-                        company_id=source_company_id,
-                        profile=AssemblerProfile.HEARTBEAT,
-                        query_text=query_text,
-                    )
-                )
-                tasks.append((task, source_company_id, weight))
-
-            # Gather results
-            results = await asyncio.gather(
-                *[task for task, _, _ in tasks],
-                return_exceptions=True,
-            )
-
-            # Merge and re-rank by weighted score
-            merged = {}  # doc_id -> {score, weight, source_company_id, ...}
-
-            for (task, source_company_id, weight), result in zip(tasks, results):
-                if isinstance(result, Exception):
-                    logger.warning(
-                        "Query failed for collection %s: %s",
-                        source_company_id,
-                        result,
-                    )
-                    continue
-
-                # Extract chunks from result (result is LLCContext)
-                if hasattr(result, "chunks"):
-                    chunks = result.chunks
-                elif isinstance(result, dict) and "chunks" in result:
-                    chunks = result["chunks"]
-                else:
-                    chunks = []
-
-                for chunk in chunks:
-                    doc_id = chunk.get("id", chunk.get("metadata", {}).get("id"))
-                    if not doc_id:
-                        continue
-
-                    # Use similarity_score from production (fallback to score for tests)
-                    score = chunk.get("similarity_score", chunk.get("score", 0.0))
-                    weighted_score = score * weight
-
-                    if doc_id not in merged or merged[doc_id]["weighted_score"] < weighted_score:
-                        merged[doc_id] = {
-                            "id": doc_id,
-                            "content": chunk.get("content", ""),
-                            "score": score,
-                            "weight": weight,
-                            "weighted_score": weighted_score,
-                            "source_company_id": source_company_id,
-                            "metadata": chunk.get("metadata", {}),
-                        }
-
-            # Sort by weighted_score descending and return top_k
-            sorted_results = sorted(
-                merged.values(),
-                key=lambda x: x["weighted_score"],
-                reverse=True,
-            )[:top_k]
-
-            logger.debug(
-                "Merged %d results from %d collections for company %s, returning top %d",
-                len(merged),
-                len(collections),
-                company_id,
-                len(sorted_results),
-            )
-            return sorted_results
+            return await self.search_with_collections(collections, query_text, top_k)
 
         except Exception as e:
             logger.error("Failed to search KB with inheritance for company %s: %s", company_id, e)


### PR DESCRIPTION
## Summary

Fixes 4 unresolved LLC/KB bugs from GH#8241 discovery.

- **GH#8566** (HIGH): `AsyncSession` shared across `asyncio.gather` branches in `_build_fat`. Fix: DB lookups (`get_query_collections`, similar items) now run sequentially before the gather; only session-free RAG coroutines run in parallel.
- **GH#8567** (HIGH): `project_context` and `agent_memory` were raw `LLCContext` objects while `company_context` was a `{chunks,sources}` dict. Added `_normalize_rag_context()` to normalise all three to the same shape.
- **GH#8569** (MEDIUM): `asyncio.create_task()` in `search_with_inheritance` left orphaned tasks on cancellation. Replaced with new `search_with_collections()` method that passes coroutines directly to `asyncio.gather`.
- **GH#8570** (LOW): `get_kb_ancestry_collections` endpoint instantiated `LLCRAGAssembler` unnecessarily (`get_query_collections` never uses it). `KbInheritanceResolver.rag_assembler` is now Optional; endpoint no longer imports or creates one.

## Test plan
- All 10 existing heartbeat context tests pass (`10 passed`)
- `py_compile` + Black clean on all 3 changed files