### PR TITLE
fix(ansible): deploy health check scripts from code_source before chmod (MVA-1038)

### DIFF
--- a/autobot-slm-backend/ansible/roles/monitoring/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/defaults/main.yml
@@ -48,5 +48,6 @@ slm_metrics_endpoint: "/api/metrics"
 # Daily health check cron settings (MVA-291)
 monitoring_install_health_check_cron: true
 autobot_repo_dir: "/opt/autobot"  # Override per inventory for your deployment path
+code_source_dir: "/opt/autobot/code_source"  # Full repo clone; matches slm_manager default
 autobot_log_dir: "/var/log/autobot"
 health_check_cron_wrapper: "/usr/local/bin/autobot-health-check-cron.sh"

--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/health_check_cron.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/health_check_cron.yml
@@ -24,6 +24,28 @@
     mode: "0755"
   tags: ["monitoring", "health_check"]
 
+- name: "Health Check Cron | Ensure scripts directory exists"
+  ansible.builtin.file:
+    path: "{{ autobot_repo_dir }}/scripts"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tags: ["monitoring", "health_check"]
+
+- name: "Health Check Cron | Deploy health check scripts from code_source (MVA-1038)"
+  ansible.builtin.copy:
+    src: "{{ code_source_dir | default('/opt/autobot/code_source') }}/scripts/{{ item }}"
+    dest: "{{ autobot_repo_dir }}/scripts/{{ item }}"
+    owner: root
+    group: root
+    mode: "0755"
+    remote_src: true
+  loop:
+    - daily_health_check.py
+    - post_health_check.py
+  tags: ["monitoring", "health_check"]
+
 - name: "Health Check Cron | Stat health check scripts"
   ansible.builtin.stat:
     path: "{{ autobot_repo_dir }}/scripts/{{ item }}"


### PR DESCRIPTION
## Summary

Fixes Ansible deploy failure 2026-05-23 where health check scripts were absent from /opt/autobot/scripts/ on the SLM manager.

**Root cause:** slm_manager syncs only autobot-slm-backend/ to /opt/autobot/. The repo-root scripts/ directory was never copied. GH#8483 added a stat guard but scripts still never arrived.

**Fix:** Add a dedicated Ansible task to sync scripts/ from code_source before the chmod step.

## Thinking Path

The deployment role was missing a copy step for the scripts/ directory. Since slm_manager only syncs the backend subdir, repo-root scripts had to be explicitly copied. Added before the chmod task to ensure scripts exist before permissions are set.

## What Changed

- Ansible deploy role: added task to copy scripts/ from code_source to /opt/autobot/scripts/ before chmod

## Verification

- scripts/ directory present on SLM manager after deploy
- chmod task no longer fails on missing files
- daily_health_check.py and post_health_check.py exist at expected paths

## Model Used

claude-sonnet-4-6

Fixes [MVA-1038](/MVA/issues/MVA-1038)