### PR TITLE
fix(ansible/redis): use 127.0.0.1 for nightly Redis backup cron

### DIFF
--- a/autobot-slm-backend/ansible/roles/redis/templates/redis-backup.sh.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/redis-backup.sh.j2
@@ -14,12 +14,12 @@ echo "[$(date)] Starting Redis Stack backup..."
 # Create backup directory if it doesn't exist
 mkdir -p "$BACKUP_DIR"
 
-# Trigger Redis save
-redis-cli -h {{ ansible_facts['default_ipv4'].address | default(ansible_host) }} -p {{ redis_port }} BGSAVE
+# Trigger Redis save — connect to localhost since this script runs on the Redis host
+redis-cli -h 127.0.0.1 -p {{ redis_port }} BGSAVE
 
 # Wait for save to complete
 sleep 5
-while redis-cli -h {{ ansible_facts['default_ipv4'].address | default(ansible_host) }} -p {{ redis_port }} LASTSAVE | grep -q "$(date +%s)"; do
+while redis-cli -h 127.0.0.1 -p {{ redis_port }} LASTSAVE | grep -q "$(date +%s)"; do
     echo "Waiting for BGSAVE to complete..."
     sleep 2
 done


### PR DESCRIPTION
## Summary

Fixes nightly Redis backup cron failing with Connection timed out to 192.168.168.21:6379.

**Root cause:** redis-backup.sh.j2 used ansible_facts['default_ipv4'].address which resolves to the VM's Hyper-V network IP instead of localhost.

**Fix:** Hardcode 127.0.0.1 since the backup script runs directly on the Redis host.

## Thinking Path

The backup script connects to Redis from the same host it runs on. Using the default IPv4 address (Hyper-V bridge IP) causes connection timeouts because that interface isn't routing Redis traffic. Hardcoding localhost is correct and simpler.

## What Changed

- autobot-slm-backend/ansible/roles/redis/templates/redis-backup.sh.j2: changed Redis host from ansible_facts address to 127.0.0.1

## Verification

- Nightly cron connects to Redis successfully
- No more Connection timed out errors
- Redis backup file created on expected schedule

## Model Used

claude-sonnet-4-6

Fixes [MVA-1037](/MVA/issues/MVA-1037)