### PR TITLE
feat(voice): WebRTC Realtime mode in voice conversation UI (#7345)

### DIFF
--- a/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
@@ -24,6 +24,7 @@
           <option value="walkie-talkie">{{ $t('chat.voice.walkieTalkie') }}</option>
           <option value="hands-free">{{ $t('chat.voice.handsFree') }}</option>
           <option value="full-duplex">{{ $t('chat.voice.fullDuplex') }}</option>
+          <option value="realtime-webrtc">{{ $t('chat.voice.realtimeWebrtc') }}</option>
         </select>
 
         <!-- Language indicator (#1334) -->
@@ -39,8 +40,16 @@
         <div
           v-if="voiceConversation.mode.value === 'full-duplex'"
           class="voice-panel__ws-dot"
-          :class="{ 'voice-panel__ws-dot--connected': voiceConversation.wsConnected.value }"
-          :title="voiceConversation.wsConnected.value ? $t('chat.voice.connected') : $t('chat.voice.disconnected')"
+          :class="{ 'voice-panel__ws-dot--connected': voiceConversation.wsConnected?.value }"
+          :title="voiceConversation.wsConnected?.value ? $t('chat.voice.connected') : $t('chat.voice.disconnected')"
+        ></div>
+
+        <!-- RTC connection indicator (realtime-webrtc) -->
+        <div
+          v-if="voiceConversation.mode.value === 'realtime-webrtc'"
+          class="voice-panel__ws-dot"
+          :class="{ 'voice-panel__ws-dot--connected': voiceConversation.realtimeConnectionState.value === 'connected' }"
+          :title="voiceConversation.realtimeConnectionState.value === 'connected' ? $t('chat.voice.connected') : $t('chat.voice.disconnected')"
         ></div>
 
         <!-- Close -->
@@ -162,6 +171,7 @@ import Icon from '@/components/ui/Icon.vue'
 import { computed, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useVoiceConversation } from '@/composables/useVoiceConversation'
+import type { ConversationMode } from '@/composables/useVoiceConversation'
 
 const emit = defineEmits<{
   (e: 'close'): void
@@ -176,8 +186,11 @@ const isFullDuplex = computed(
 const isHandsFree = computed(
   () => voiceConversation.mode.value === 'hands-free',
 )
+const isRealtimeWebrtc = computed(
+  () => voiceConversation.mode.value === 'realtime-webrtc',
+)
 const isAutoMode = computed(
-  () => isFullDuplex.value || isHandsFree.value,
+  () => isFullDuplex.value || isHandsFree.value || isRealtimeWebrtc.value,
 )
 
 const showInsecureContextWarning = computed(
@@ -245,9 +258,7 @@ function handleMicClick(): void {
 
 function handleModeChange(event: Event): void {
   const target = event.target as HTMLSelectElement
-  voiceConversation.setMode(
-    target.value as 'walkie-talkie' | 'hands-free' | 'full-duplex',
-  )
+  voiceConversation.setMode(target.value as ConversationMode)
 }
 
 function close(): void {

--- a/autobot-frontend/src/composables/__tests__/useRealtimeVoice.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useRealtimeVoice.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Unit Tests for useRealtimeVoice composable (#7345)
+ *
+ * Covers:
+ * - Mode transition (connect / disconnect)
+ * - SDP exchange via mocked fetch (POST /api/voice/realtime/session)
+ * - Tool registration message shape (session.update)
+ * - Tool-call routing (response.function_call_arguments.done → POST tools/call)
+ * - Disconnect cleanup (peer closed, tracks stopped, pending calls aborted)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+// ─── Dependency mocks ────────────────────────────────────
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => 'http://localhost:8001/api',
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}))
+
+const mockFetchWithAuth = vi.fn()
+vi.mock('@/utils/fetchWithAuth', () => ({
+  fetchWithAuth: (...args: unknown[]) => mockFetchWithAuth(...args),
+}))
+
+// ─── Browser API mocks ───────────────────────────────────
+
+const sentMessages: string[] = []
+
+// Data-channel mock — callbacks stored as plain props so triggerX helpers work
+const mockDC = {
+  readyState: 'open' as RTCDataChannelState,
+  onopen: null as (() => void) | null,
+  onmessage: null as ((ev: { data: string }) => void) | null,
+  onclose: null as (() => void) | null,
+  send: vi.fn((msg: string) => sentMessages.push(msg)),
+  close: vi.fn(),
+}
+
+const mockTrack = { stop: vi.fn() }
+const mockStream = { getTracks: () => [mockTrack] }
+
+// PeerConnection mock — stored separately so we can spy per-test
+const mockPC = {
+  addTrack: vi.fn(),
+  createDataChannel: vi.fn().mockReturnValue(mockDC),
+  createOffer: vi.fn().mockResolvedValue({ sdp: 'offer-sdp', type: 'offer' as RTCSdpType }),
+  setLocalDescription: vi.fn().mockResolvedValue(undefined),
+  setRemoteDescription: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn(),
+  connectionState: 'connected' as RTCPeerConnectionState,
+  onconnectionstatechange: null as (() => void) | null,
+}
+
+// RTCPeerConnection must be a class (arrow fn can't be a constructor)
+class RTCPeerConnectionMock {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor() { return mockPC as any }
+}
+vi.stubGlobal('RTCPeerConnection', RTCPeerConnectionMock)
+vi.stubGlobal('RTCSessionDescription', function RTCSessionDescriptionMock(
+  init: RTCSessionDescriptionInit,
+) { return init })
+vi.stubGlobal('navigator', {
+  mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(mockStream) },
+})
+vi.stubGlobal('window', { isSecureContext: true })
+
+// ─── Helpers ─────────────────────────────────────────────
+
+function makeJsonResponse(body: unknown, ok = true): Response {
+  return { ok, status: ok ? 200 : 500, json: async () => body } as unknown as Response
+}
+
+function setFetchMock(overrides: Record<string, unknown> = {}) {
+  mockFetchWithAuth.mockImplementation(async (url: string) => {
+    if (url.includes('/voice/realtime/session')) {
+      return makeJsonResponse(overrides['session'] ?? { sdp: 'answer-sdp' })
+    }
+    if (url.includes('/voice/realtime/tools/call')) {
+      return overrides['toolsCall']
+        ? makeJsonResponse(overrides['toolsCall'])
+        : makeJsonResponse({}, false)
+    }
+    if (url.includes('/voice/realtime/tools')) {
+      return makeJsonResponse({ tools: overrides['tools'] ?? [] })
+    }
+    return makeJsonResponse({})
+  })
+}
+
+// ─── Composable import ───────────────────────────────────
+
+import { useRealtimeVoice } from '../useRealtimeVoice'
+
+// ─── Tests ───────────────────────────────────────────────
+
+describe('useRealtimeVoice', () => {
+  let rtv: ReturnType<typeof useRealtimeVoice>
+
+  beforeEach(() => {
+    sentMessages.length = 0
+    mockDC.onopen = null
+    mockDC.onmessage = null
+    mockDC.send.mockClear()
+    mockDC.close.mockClear()
+    mockPC.addTrack.mockClear()
+    mockPC.createDataChannel.mockClear().mockReturnValue(mockDC)
+    mockPC.createOffer.mockClear().mockResolvedValue({ sdp: 'offer-sdp', type: 'offer' as RTCSdpType })
+    mockPC.setLocalDescription.mockClear().mockResolvedValue(undefined)
+    mockPC.setRemoteDescription.mockClear().mockResolvedValue(undefined)
+    mockPC.close.mockClear()
+    mockTrack.stop.mockClear()
+    ;(navigator.mediaDevices.getUserMedia as ReturnType<typeof vi.fn>)
+      .mockClear()
+      .mockResolvedValue(mockStream)
+    setFetchMock({ session: { sdp: 'answer-sdp' }, tools: [] })
+    rtv = useRealtimeVoice()
+  })
+
+  afterEach(() => {
+    rtv.disconnect()
+  })
+
+  // ── Connection lifecycle ─────────────────────────────
+
+  it('starts disconnected', () => {
+    expect(rtv.connectionState.value).toBe('disconnected')
+  })
+
+  it('performs full SDP exchange on connect()', async () => {
+    const connectPromise = rtv.connect()
+    expect(rtv.connectionState.value).toBe('connecting')
+    await connectPromise
+
+    expect(mockPC.createOffer).toHaveBeenCalledOnce()
+    expect(mockPC.setLocalDescription).toHaveBeenCalledWith(
+      expect.objectContaining({ sdp: 'offer-sdp' }),
+    )
+    expect(mockFetchWithAuth).toHaveBeenCalledWith(
+      expect.stringContaining('/voice/realtime/session'),
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(mockPC.setRemoteDescription).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'answer', sdp: 'answer-sdp' }),
+    )
+  })
+
+  it('sets failed state when SDP proxy returns non-200', async () => {
+    setFetchMock({ session: undefined })
+    mockFetchWithAuth.mockImplementation(async () => makeJsonResponse({}, false))
+    await rtv.connect()
+    expect(rtv.connectionState.value).toBe('failed')
+    expect(rtv.errorMessage.value).toMatch(/SDP proxy/i)
+  })
+
+  it('closes peer and stops mic tracks on disconnect()', async () => {
+    await rtv.connect()
+    rtv.disconnect()
+    expect(mockPC.close).toHaveBeenCalledOnce()
+    expect(mockTrack.stop).toHaveBeenCalledOnce()
+    expect(rtv.connectionState.value).toBe('disconnected')
+  })
+
+  it('does not start a second connection when already connected', async () => {
+    await rtv.connect()
+    const callsBefore = mockPC.createOffer.mock.calls.length
+    await rtv.connect()
+    expect(mockPC.createOffer.mock.calls.length).toBe(callsBefore)
+  })
+
+  // ── Tool registration ────────────────────────────────
+
+  it('sends session.update with correct tool shape when data channel opens', async () => {
+    const tools = [
+      { name: 'search', description: 'Search KB', parameters: { type: 'object', properties: {} } },
+    ]
+    setFetchMock({ session: { sdp: 'answer-sdp' }, tools })
+
+    await rtv.connect()
+
+    // Simulate browser firing the datachannel open event
+    mockDC.onopen?.()
+    await nextTick()
+    await new Promise((r) => setTimeout(r, 20))
+
+    const raw = sentMessages.find((m) => {
+      try { return (JSON.parse(m) as { type: string }).type === 'session.update' } catch { return false }
+    })
+    expect(raw).toBeDefined()
+    const msg = JSON.parse(raw!) as { session: { tools: Array<{ name: string; type: string }> } }
+    expect(msg.session.tools).toHaveLength(1)
+    expect(msg.session.tools[0]).toMatchObject({ type: 'function', name: 'search', description: 'Search KB' })
+  })
+
+  it('skips session.update when tool list is empty', async () => {
+    setFetchMock({ session: { sdp: 'answer-sdp' }, tools: [] })
+    await rtv.connect()
+    mockDC.onopen?.()
+    await nextTick()
+    await new Promise((r) => setTimeout(r, 20))
+
+    const raw = sentMessages.find((m) => {
+      try { return (JSON.parse(m) as { type: string }).type === 'session.update' } catch { return false }
+    })
+    expect(raw).toBeUndefined()
+  })
+
+  // ── Tool-call routing ────────────────────────────────
+
+  it('dispatches tool call to backend and returns result via data channel', async () => {
+    setFetchMock({ session: { sdp: 'answer-sdp' }, tools: [], toolsCall: { answer: 42 } })
+    await rtv.connect()
+
+    mockDC.onmessage?.({ data: JSON.stringify({
+      type: 'response.function_call_arguments.done',
+      call_id: 'call_abc',
+      name: 'search',
+      arguments: '{"query":"hello"}',
+    }) })
+    await nextTick()
+    await new Promise((r) => setTimeout(r, 20))
+
+    expect(mockFetchWithAuth).toHaveBeenCalledWith(
+      expect.stringContaining('/voice/realtime/tools/call'),
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('call_abc'),
+      }),
+    )
+    const raw = sentMessages.find((m) => {
+      try { return (JSON.parse(m) as { type: string }).type === 'conversation.item.create' } catch { return false }
+    })
+    expect(raw).toBeDefined()
+    const out = JSON.parse(raw!) as { item: { type: string; call_id: string; output: string } }
+    expect(out.item).toMatchObject({ type: 'function_call_output', call_id: 'call_abc' })
+    expect(JSON.parse(out.item.output)).toEqual({ answer: 42 })
+  })
+
+  it('sends error output when tool call backend returns non-200', async () => {
+    setFetchMock({ session: { sdp: 'answer-sdp' }, tools: [] })
+    // toolsCall not set → defaults to non-200 in setFetchMock
+    await rtv.connect()
+
+    mockDC.onmessage?.({ data: JSON.stringify({
+      type: 'response.function_call_arguments.done',
+      call_id: 'call_err',
+      name: 'search',
+      arguments: '{}',
+    }) })
+    await nextTick()
+    await new Promise((r) => setTimeout(r, 20))
+
+    const raw = sentMessages.find((m) => {
+      try {
+        const p = JSON.parse(m) as { item?: { output?: string } }
+        return typeof p.item?.output === 'string' && p.item.output.includes('error')
+      } catch { return false }
+    })
+    expect(raw).toBeDefined()
+  })
+
+  it('ignores non-JSON and unknown event types without throwing', async () => {
+    await rtv.connect()
+    expect(() => {
+      mockDC.onmessage?.({ data: 'not-json' })
+      mockDC.onmessage?.({ data: JSON.stringify({ type: 'session.created' }) })
+    }).not.toThrow()
+  })
+
+  // ── Disconnect cleanup ───────────────────────────────
+
+  it('aborts in-flight tool calls when disconnected', async () => {
+    let capturedSignal: AbortSignal | undefined
+    mockFetchWithAuth.mockImplementation(async (url: string, opts: { signal?: AbortSignal }) => {
+      if (url.includes('/voice/realtime/tools/call')) {
+        capturedSignal = opts.signal
+        return new Promise<Response>((_, reject) => {
+          opts.signal?.addEventListener('abort', () =>
+            reject(new DOMException('Aborted', 'AbortError')),
+          )
+        })
+      }
+      if (url.includes('/voice/realtime/session')) return makeJsonResponse({ sdp: 'answer-sdp' })
+      return makeJsonResponse({ tools: [] })
+    })
+
+    await rtv.connect()
+
+    mockDC.onmessage?.({ data: JSON.stringify({
+      type: 'response.function_call_arguments.done',
+      call_id: 'call_slow',
+      name: 'slow_fn',
+      arguments: '{}',
+    }) })
+    await nextTick()
+
+    rtv.disconnect()
+    expect(capturedSignal?.aborted).toBe(true)
+  })
+})

--- a/autobot-frontend/src/composables/useRealtimeVoice.ts
+++ b/autobot-frontend/src/composables/useRealtimeVoice.ts
@@ -1,0 +1,291 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * useRealtimeVoice.ts - WebRTC Realtime voice mode (#7345)
+ * RTCPeerConnection to OpenAI Realtime via backend SDP proxy.
+ * Tool calls round-trip through POST /api/voice/realtime/tools/call.
+ */
+
+import { ref } from 'vue'
+import { getApiBase } from '@/config/ssot-config'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useRealtimeVoice')
+
+// ─── Types ───────────────────────────────────────────────
+
+export interface RealtimeTool {
+  name: string
+  description: string
+  parameters: Record<string, unknown>
+}
+
+export type RealtimeConnectionState =
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'failed'
+
+interface OaiToolCall {
+  call_id: string
+  name: string
+  arguments: string
+}
+
+// ─── Module-level state (singleton) ─────────────────────
+
+const connectionState = ref<RealtimeConnectionState>('disconnected')
+const errorMessage = ref('')
+
+let _peerConnection: RTCPeerConnection | null = null
+let _dataChannel: RTCDataChannel | null = null
+let _localStream: MediaStream | null = null
+// In-flight tool calls keyed by call_id — aborted on disconnect
+const _pendingToolCalls = new Map<string, AbortController>()
+
+// ─── Helpers ─────────────────────────────────────────────
+
+function _cleanup(): void {
+  _pendingToolCalls.forEach((ctrl) => ctrl.abort())
+  _pendingToolCalls.clear()
+
+  if (_dataChannel) {
+    _dataChannel.close()
+    _dataChannel = null
+  }
+  if (_peerConnection) {
+    _peerConnection.close()
+    _peerConnection = null
+  }
+  if (_localStream) {
+    _localStream.getTracks().forEach((t) => t.stop())
+    _localStream = null
+  }
+}
+
+function _sendDataChannelEvent(event: Record<string, unknown>): void {
+  if (_dataChannel?.readyState !== 'open') {
+    logger.warn('Data channel not open — dropping event:', event.type)
+    return
+  }
+  _dataChannel.send(JSON.stringify(event))
+}
+
+async function _registerTools(tools: RealtimeTool[]): Promise<void> {
+  if (!tools.length) return
+  _sendDataChannelEvent({
+    type: 'session.update',
+    session: {
+      tools: tools.map((t) => ({
+        type: 'function',
+        name: t.name,
+        description: t.description,
+        parameters: t.parameters,
+      })),
+      tool_choice: 'auto',
+    },
+  })
+  logger.debug('Registered %d tools via session.update', tools.length)
+}
+
+async function _fetchTools(): Promise<RealtimeTool[]> {
+  try {
+    const res = await fetchWithAuth(`${getApiBase()}/voice/realtime/tools`, {
+      method: 'GET',
+    })
+    if (!res.ok) {
+      logger.warn('Failed to fetch realtime tools: %s', res.status)
+      return []
+    }
+    const data = await res.json() as { tools?: RealtimeTool[] }
+    return data.tools ?? []
+  } catch (e) {
+    logger.warn('Tool fetch error:', e)
+    return []
+  }
+}
+
+async function _dispatchToolCall(call: OaiToolCall): Promise<void> {
+  const ctrl = new AbortController()
+  _pendingToolCalls.set(call.call_id, ctrl)
+
+  try {
+    const res = await fetchWithAuth(`${getApiBase()}/voice/realtime/tools/call`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        call_id: call.call_id,
+        name: call.name,
+        arguments: call.arguments,
+      }),
+      signal: ctrl.signal,
+    })
+
+    if (!res.ok) {
+      logger.warn('Tool call %s failed: %s', call.call_id, res.status)
+      _sendDataChannelEvent({
+        type: 'conversation.item.create',
+        item: {
+          type: 'function_call_output',
+          call_id: call.call_id,
+          output: JSON.stringify({ error: `Backend returned ${res.status}` }),
+        },
+      })
+      return
+    }
+
+    const result = await res.json() as unknown
+    _sendDataChannelEvent({
+      type: 'conversation.item.create',
+      item: {
+        type: 'function_call_output',
+        call_id: call.call_id,
+        output: JSON.stringify(result),
+      },
+    })
+    // Ask the model to generate a response after tool output
+    _sendDataChannelEvent({ type: 'response.create' })
+    logger.debug('Tool call %s dispatched and result sent', call.call_id)
+  } catch (e) {
+    if (e instanceof DOMException && e.name === 'AbortError') return
+    logger.error('Tool call dispatch error:', e)
+  } finally {
+    _pendingToolCalls.delete(call.call_id)
+  }
+}
+
+// ─── oai-events handler ──────────────────────────────────
+
+function _handleDataChannelMessage(raw: string): void {
+  let event: { type?: string; [k: string]: unknown }
+  try {
+    event = JSON.parse(raw) as typeof event
+  } catch {
+    logger.warn('Non-JSON data channel message — ignoring')
+    return
+  }
+
+  switch (event.type) {
+    case 'session.created':
+      logger.debug('Realtime session created')
+      break
+    case 'response.function_call_arguments.done': {
+      const call = event as unknown as {
+        type: string; call_id: string; name: string; arguments: string
+      }
+      void _dispatchToolCall({
+        call_id: call.call_id,
+        name: call.name,
+        arguments: call.arguments,
+      })
+      break
+    }
+    case 'error':
+      logger.error('oai-events error:', event)
+      errorMessage.value = String((event as { message?: string }).message ?? 'Realtime error')
+      break
+    default:
+      logger.debug('oai-event:', event.type)
+  }
+}
+
+// ─── Main composable ─────────────────────────────────────
+
+export function useRealtimeVoice() {
+  /**
+   * Connect to OpenAI Realtime via backend SDP proxy.
+   * 1. getUserMedia
+   * 2. create RTCPeerConnection + oai-events data channel
+   * 3. createOffer → POST /api/voice/realtime/session → setRemoteDescription
+   * 4. register tool list via session.update
+   */
+  async function connect(): Promise<void> {
+    if (_peerConnection) {
+      logger.warn('Already connected — ignoring connect() call')
+      return
+    }
+
+    connectionState.value = 'connecting'
+    errorMessage.value = ''
+
+    try {
+      // Step 1: mic
+      if (!navigator.mediaDevices?.getUserMedia || !window.isSecureContext) {
+        throw new Error('Microphone unavailable: HTTPS with a trusted cert is required.')
+      }
+      _localStream = await navigator.mediaDevices.getUserMedia({ audio: true })
+
+      // Step 2: peer + data channel
+      _peerConnection = new RTCPeerConnection()
+
+      _localStream.getTracks().forEach((track) => {
+        _peerConnection!.addTrack(track, _localStream!)
+      })
+
+      _dataChannel = _peerConnection.createDataChannel('oai-events')
+      _dataChannel.onopen = () => {
+        logger.debug('oai-events data channel open')
+        void _fetchTools().then((tools) => _registerTools(tools))
+      }
+      _dataChannel.onmessage = (ev) => _handleDataChannelMessage(ev.data as string)
+      _dataChannel.onclose = () => logger.debug('oai-events data channel closed')
+
+      _peerConnection.onconnectionstatechange = () => {
+        const s = _peerConnection?.connectionState
+        logger.debug('PeerConnection state:', s)
+        if (s === 'connected') {
+          connectionState.value = 'connected'
+        } else if (s === 'failed' || s === 'closed') {
+          connectionState.value = s === 'failed' ? 'failed' : 'disconnected'
+          if (s === 'failed') {
+            errorMessage.value = 'WebRTC connection failed.'
+          }
+        }
+      }
+
+      // Step 3: SDP exchange
+      const offer = await _peerConnection.createOffer()
+      await _peerConnection.setLocalDescription(offer)
+
+      const sessionRes = await fetchWithAuth(`${getApiBase()}/voice/realtime/session`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sdp: offer.sdp }),
+      })
+
+      if (!sessionRes.ok) {
+        throw new Error(`SDP proxy returned ${sessionRes.status}`)
+      }
+
+      const sessionData = await sessionRes.json() as { sdp: string }
+      await _peerConnection.setRemoteDescription(
+        new RTCSessionDescription({ type: 'answer', sdp: sessionData.sdp }),
+      )
+
+      logger.debug('WebRTC Realtime connection established')
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error(String(e))
+      logger.error('Realtime connect failed:', err)
+      errorMessage.value = err.message || 'Realtime connection failed.'
+      connectionState.value = 'failed'
+      _cleanup()
+    }
+  }
+
+  function disconnect(): void {
+    _cleanup()
+    connectionState.value = 'disconnected'
+    errorMessage.value = ''
+    logger.debug('Realtime voice disconnected')
+  }
+
+  return {
+    connectionState,
+    errorMessage,
+    connect,
+    disconnect,
+  }
+}

--- a/autobot-frontend/src/composables/useVoiceConversation.ts
+++ b/autobot-frontend/src/composables/useVoiceConversation.ts
@@ -13,6 +13,7 @@ import { ref, computed, watch } from 'vue'
 import type { ChatMessage } from '@/stores/useChatStore'
 import { useVoiceOutput } from '@/composables/useVoiceOutput'
 import { useVoiceProfiles } from '@/composables/useVoiceProfiles'
+import { useRealtimeVoice } from '@/composables/useRealtimeVoice'
 import { useChatController } from '@/models/controllers'
 import { useChatStore } from '@/stores/useChatStore'
 import { usePreferences } from '@/composables/usePreferences'
@@ -22,7 +23,7 @@ import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useVoiceConversation')
 
-export type ConversationMode = 'walkie-talkie' | 'hands-free' | 'full-duplex'
+export type ConversationMode = 'walkie-talkie' | 'hands-free' | 'full-duplex' | 'realtime-webrtc'
 export type ConversationState =
   | 'idle'
   | 'listening'
@@ -39,6 +40,8 @@ export interface VoiceBubble {
 // Module-level singletons — shared across all component instances (#1037)
 const state = ref<ConversationState>('idle')
 const mode = ref<ConversationMode>('walkie-talkie')
+// Realtime WebRTC singleton (#7345) — lazy-initialised on first use
+const _realtimeVoice = useRealtimeVoice()
 const currentTranscript = ref('')
 const bubbles = ref<VoiceBubble[]>([])
 const isActive = ref(false)
@@ -703,6 +706,13 @@ export function useVoiceConversation() {
   const isProcessing = computed(() => state.value === 'processing')
 
   const stateLabel = computed(() => {
+    if (mode.value === 'realtime-webrtc') {
+      const rtcState = _realtimeVoice.connectionState.value
+      if (rtcState === 'connecting') return 'Connecting...'
+      if (rtcState === 'connected') return 'Realtime — speak anytime'
+      if (rtcState === 'failed') return 'Connection failed'
+      return 'Realtime WebRTC'
+    }
     const auto = mode.value === 'full-duplex' || mode.value === 'hands-free'
     switch (state.value) {
       case 'idle':
@@ -731,6 +741,8 @@ export function useVoiceConversation() {
       _startListeningInternal()
     } else if (mode.value === 'hands-free') {
       await _startHandsFree()
+    } else if (mode.value === 'realtime-webrtc') {
+      await _realtimeVoice.connect()
     }
     logger.debug('Voice conversation activated, mode:', mode.value)
   }
@@ -742,6 +754,9 @@ export function useVoiceConversation() {
     _teardownVad()
     stopSpeaking()
     if (_ttsCooldownTimer) { clearTimeout(_ttsCooldownTimer); _ttsCooldownTimer = null }
+    if (mode.value === 'realtime-webrtc') {
+      _realtimeVoice.disconnect()
+    }
     isActive.value = false
     state.value = 'idle'
     currentTranscript.value = ''
@@ -798,6 +813,9 @@ export function useVoiceConversation() {
       _teardownVad()
       stopSpeaking()
       if (_ttsCooldownTimer) { clearTimeout(_ttsCooldownTimer); _ttsCooldownTimer = null }
+      if (mode.value === 'realtime-webrtc') {
+        _realtimeVoice.disconnect()
+      }
       state.value = 'idle'
       currentTranscript.value = ''
     }
@@ -809,6 +827,8 @@ export function useVoiceConversation() {
       _initVad().then(() => _startListeningInternal())
     } else if (wasActive && newMode === 'hands-free') {
       _startHandsFree()
+    } else if (wasActive && newMode === 'realtime-webrtc') {
+      void _realtimeVoice.connect()
     }
     logger.debug('Mode switched to:', newMode)
   }
@@ -853,6 +873,7 @@ export function useVoiceConversation() {
     isListening,
     isProcessing,
     stateLabel,
+    realtimeConnectionState: _realtimeVoice.connectionState,
     activate,
     deactivate,
     startListening,

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -592,7 +592,10 @@
       "hintResponding": "AutoBot is responding...",
       "hintRespondingShort": "Responding...",
       "hintAutoStart": "Listening will start automatically",
-      "hintTapToSpeak": "Tap to speak"
+      "hintTapToSpeak": "Tap to speak",
+      "realtimeWebrtc": "Realtime WebRTC",
+      "realtimeConnecting": "Connecting to Realtime...",
+      "realtimeConnected": "Realtime — speak anytime"
     },
     "typing": {
       "aiAssistant": "AI Assistant",


### PR DESCRIPTION
## Summary

- New composable `useRealtimeVoice.ts` (~250 LOC): browser `RTCPeerConnection` to OpenAI Realtime via backend SDP proxy (`POST /api/voice/realtime/session`)
- `ConversationMode` type extended: `'walkie-talkie' | 'hands-free' | 'full-duplex' | 'realtime-webrtc'`
- `useVoiceConversation` integrates new mode into `activate()`, `deactivate()`, `setMode()` lifecycle
- Tool list fetched from `GET /api/voice/realtime/tools` and registered via `session.update` on data channel open
- Tool calls round-tripped through `POST /api/voice/realtime/tools/call`; result emitted back as `function_call_output`
- Disconnect cleanup: closes peer, stops mic tracks, aborts in-flight tool calls via `AbortController`
- `VoiceConversationPanel.vue`: Realtime WebRTC option in mode select; RTC connection state indicator
- 11 Vitest tests: SDP exchange, tool registration shape, tool-call routing, disconnect cleanup, error paths
- `en.json` i18n key `chat.voice.realtimeWebrtc` added

## Thinking Path

Added WebRTC Realtime voice mode to the existing voice conversation system. The new composable wraps `RTCPeerConnection` lifecycle, SDP exchange with the backend proxy, and bidirectional data-channel tool calls. Integrated into `useVoiceConversation` as a new `realtime-webrtc` mode so existing modes are not affected.

## What Changed

- `autobot-frontend/src/composables/useRealtimeVoice.ts` — new composable (RTCPeerConnection, SDP, tool routing)
- `autobot-frontend/src/composables/useVoiceConversation.ts` — added `realtime-webrtc` branch in activate/deactivate/setMode
- `autobot-frontend/src/components/voice/VoiceConversationPanel.vue` — mode select option + RTC state indicator
- `autobot-frontend/src/i18n/en.json` — added `chat.voice.realtimeWebrtc` key

## Verification

- `npx vitest run src/composables/__tests__/useRealtimeVoice.test.ts` — 11/11 passed
- `npx vue-tsc --noEmit -p tsconfig.app.json` — no new errors in changed files
- Frontend degrades gracefully if backend SDP proxy (GH#7342) is unavailable

## Model Used

claude-sonnet-4-6

## Test plan

- [x] `npx vitest run src/composables/__tests__/useRealtimeVoice.test.ts` — 11/11 passed
- [x] `npx vue-tsc --noEmit -p tsconfig.app.json` — no new errors in changed files
- [ ] Manual: select "Realtime WebRTC" in voice panel, confirm connection indicator updates
- [ ] Manual: voice round-trip < 500ms (requires backend SDP proxy from #7342 to be deployed)
- [ ] Regression: existing walkie-talkie, hands-free, full-duplex tests still pass

## Depends on

- #7342 (backend SDP proxy) — frontend gracefully shows "failed" state if proxy unavailable
- #7343 (MCP-to-Realtime tool bridge)
- #7344 (voice toolset bundles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
