### PR TITLE
feat(orchestration): atomic task checkout via Redis lock (GH#6468)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/distributed_management.py
+++ b/autobot-backend/agents/agent_orchestration/distributed_management.py
@@ -23,6 +23,7 @@ from .state_persistence import (
     persist_task_reassignment,
 )
 from .types import CircuitState, DistributedAgentInfo
+from services.task_claim import claim_task, is_claim_alive, release_claim, renew_claim
 
 if TYPE_CHECKING:
     from agents.base_agent import AgentHealth, BaseAgent
@@ -397,23 +398,39 @@ class DistributedAgentManager:
         """Get info for a specific agent."""
         return self.distributed_agents.get(agent_id)
 
-    async def add_active_task(self, agent_id: str, task_id: str) -> None:
-        """Add an active task to an agent and record its assignment timestamp.
+    async def add_active_task(self, agent_id: str, task_id: str) -> bool:
+        """Add an active task to an agent if the atomic Redis claim is granted.
+
+        Returns True when the claim was granted and the task was added.
+        Returns False when another agent already holds the claim — the caller
+        must not proceed with the task (double-pickup guard, GH#6468).
 
         Issue #2109: records assigned_at for stale-detection.
         Issue #6479: persists assigned_at to Redis (write-through cache).
+        Issue #6468: atomic claim via Redis SET NX EX.
         """
+        claimed = await claim_task(task_id, agent_id)
+        if not claimed:
+            logger.warning(
+                "add_active_task: task %s already claimed by another agent — agent %s skipping",
+                task_id,
+                agent_id,
+            )
+            return False
+
         if agent_id in self.distributed_agents:
             self.distributed_agents[agent_id].active_tasks.add(task_id)
             assigned_at = now_utc()
             self._task_assigned_at[task_id] = assigned_at
             await persist_task_assigned(self._deployment_id, task_id, assigned_at)
+        return True
 
     async def remove_active_task(self, agent_id: str, task_id: str) -> None:
         """Remove an active task from an agent and clean up tracking state.
 
         Issue #2109: clears assigned_at / progress / reassignment metadata.
         Issue #6479: deletes Redis hash entries for the task.
+        Issue #6468: releases the atomic Redis claim.
         """
         if agent_id in self.distributed_agents:
             self.distributed_agents[agent_id].active_tasks.discard(task_id)
@@ -421,19 +438,23 @@ class DistributedAgentManager:
         self._task_last_progress.pop(task_id, None)
         self._task_reassignment_count.pop(task_id, None)
         await delete_task_state(self._deployment_id, task_id)
+        await release_claim(task_id, agent_id)
 
-    async def report_task_progress(self, task_id: str) -> None:
+    async def report_task_progress(self, task_id: str, agent_id: str = "") -> None:
         """Record that a task has made progress, resetting its stale timer.
 
-        Call this from the agent when partial results arrive so the
-        work-stealer does not reclaim an actively-running task.
+        Also renews the Redis claim TTL so the task is not freed while the
+        agent is actively working.
 
         Issue #2109: progress-protection guard rail.
         Issue #6479: persists last_progress to Redis.
+        Issue #6468: renews claim TTL on each progress heartbeat.
         """
         progress_at = now_utc()
         self._task_last_progress[task_id] = progress_at
         await persist_task_progress(self._deployment_id, task_id, progress_at)
+        if agent_id:
+            await renew_claim(task_id, agent_id)
 
     # ------------------------------------------------------------------
     # Work-stealing helpers (Issue #2109)
@@ -442,12 +463,15 @@ class DistributedAgentManager:
     def _is_task_stale(self, task_id: str, now: datetime) -> bool:
         """Return True when a task has exceeded the stale timeout.
 
-        Guards:
+        Guards (checked in order):
         - grace period: task assigned less than grace_period_seconds ago → not stale
-        - progress protection: task reported progress within progress_ttl_seconds → not stale
         - max reassignments exceeded → not stale (stop trying)
+        - progress protection: task reported progress within progress_ttl_seconds → not stale
+        - falls through to time-based check (age >= stale_task_timeout_seconds)
 
         Issue #2109.
+        Issue #6468: Redis claim TTL expiry is checked asynchronously via
+        _collect_stale_tasks to supplement in-memory timestamps.
         """
         assigned_at = self._task_assigned_at.get(task_id)
         if assigned_at is None:
@@ -468,15 +492,31 @@ class DistributedAgentManager:
 
         return age_seconds >= self.stale_task_timeout_seconds
 
-    def _collect_stale_tasks(self, now: datetime) -> List[Tuple[str, str]]:
+    async def _collect_stale_tasks(self, now: datetime) -> List[Tuple[str, str]]:
         """Return list of (agent_id, task_id) pairs where the task is stale.
 
+        A task is stale when either:
+        - its in-memory timestamps breach the timeout thresholds, or
+        - its Redis claim key has expired (agent died without releasing).
+
         Issue #2109: extracted helper keeps _detect_stale_tasks short.
+        Issue #6468: Redis claim TTL expiry supplements in-memory timestamps.
         """
         stale: List[Tuple[str, str]] = []
         for agent_id, agent_info in self.distributed_agents.items():
             for task_id in list(agent_info.active_tasks):
                 if self._is_task_stale(task_id, now):
+                    stale.append((agent_id, task_id))
+                    continue
+                # Also reclaim tasks whose Redis claim key has expired but
+                # whose in-memory timestamp has not yet breached the threshold
+                # (e.g. agent crashed mid-grace-period).
+                if not await is_claim_alive(task_id):
+                    logger.info(
+                        "task_claim: Redis claim expired for task=%s agent=%s — marking stale",
+                        task_id,
+                        agent_id,
+                    )
                     stale.append((agent_id, task_id))
         return stale
 
@@ -555,7 +595,7 @@ class DistributedAgentManager:
         Issue #2109: called once per health-monitor cycle.
         """
         now = now_utc()
-        stale_pairs = self._collect_stale_tasks(now)
+        stale_pairs = await self._collect_stale_tasks(now)
         if not stale_pairs:
             return 0
 

--- a/autobot-backend/services/heartbeat_scheduler.py
+++ b/autobot-backend/services/heartbeat_scheduler.py
@@ -33,6 +33,7 @@ from models.heartbeat import (
     WakeupTrigger,
 )
 from services.run_jwt import get_run_jwt_scopes, mint_run_jwt, revoke_run_jwt_async
+from services.task_claim import renew_claim
 
 logger = get_logger(__name__)
 
@@ -218,6 +219,10 @@ class HeartbeatScheduler:
             agent_row = agent_result.scalar_one_or_none()
             agent_type = agent_row.agent_type if agent_row else "worker"
             await session.commit()
+
+        # Renew Redis task claim on each heartbeat tick (GH#6468)
+        if state.current_task_id:
+            await renew_claim(state.current_task_id, agent_id)
 
         # Mint run-scoped JWT with minimum required scopes (SEC-2 #6473, MVA-204)
         try:

--- a/autobot-backend/services/task_claim.py
+++ b/autobot-backend/services/task_claim.py
@@ -1,0 +1,183 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Atomic task-claim service via Redis SET NX EX (GH#6468).
+
+Eliminates double-pickup races in distributed agent fleets.  A single
+Redis round-trip atomically grants or denies the claim; the TTL auto-frees
+a claim when the agent dies.
+
+Key layout:
+    task:claim:{task_id}  ->  agent_id string, TTL = claim_ttl_seconds
+
+Claim lifecycle:
+  1. claim_task()    -- SET NX EX; returns True only to the first caller.
+  2. renew_claim()   -- Lua EXPIRE guard; keeps TTL alive while agent works.
+  3. release_claim() -- Lua DEL-if-owner; prevents stealing the delete.
+
+The in-memory dicts in DistributedAgentManager remain as an observability
+cache, not the source of truth for claim ownership.
+"""
+
+from __future__ import annotations
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_async_redis_client
+from services.audit.unified_audit import AuditCategory, AuditEvent, emit
+
+logger = get_logger(__name__)
+
+_CLAIM_KEY_TPL = "task:claim:{task_id}"
+_DEFAULT_TTL = 300  # seconds — covers a full heartbeat run with margin
+
+# Lua: release only if the caller still owns the key.
+_RELEASE_LUA = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+else
+    return 0
+end
+"""
+
+# Lua: extend TTL only if the caller still owns the key.
+_RENEW_LUA = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('expire', KEYS[1], ARGV[2])
+else
+    return 0
+end
+"""
+
+
+def _key(task_id: str) -> str:
+    return _CLAIM_KEY_TPL.format(task_id=task_id)
+
+
+async def claim_task(task_id: str, agent_id: str, ttl: int = _DEFAULT_TTL) -> bool:
+    """Atomically claim task_id for agent_id.
+
+    Uses SET NX EX — only one agent can win for a given task_id.  Returns
+    True when the claim was granted, False when already owned by another agent.
+    Redis unavailability is treated as granted (fail-open) so a Redis outage
+    does not block all work.
+    """
+    redis = await get_async_redis_client()
+    if redis is None:
+        logger.warning(
+            "task_claim: Redis unavailable — allowing claim task=%s agent=%s (fail-open)",
+            task_id,
+            agent_id,
+        )
+        _emit_audit("task.claim", agent_id, task_id, outcome="redis_unavailable")
+        return True
+    try:
+        result = await redis.set(_key(task_id), agent_id, nx=True, ex=ttl)
+        granted = result is not None
+        outcome = "granted" if granted else "denied"
+        logger.debug("task_claim: task=%s agent=%s %s", task_id, agent_id, outcome)
+        _emit_audit("task.claim", agent_id, task_id, outcome=outcome)
+        return granted
+    except Exception:
+        logger.warning(
+            "task_claim: Redis error during claim task=%s agent=%s — fail-open",
+            task_id,
+            agent_id,
+            exc_info=True,
+        )
+        _emit_audit("task.claim", agent_id, task_id, outcome="redis_error")
+        return True
+
+
+async def renew_claim(task_id: str, agent_id: str, ttl: int = _DEFAULT_TTL) -> bool:
+    """Extend TTL on an existing claim owned by agent_id.
+
+    Returns True when the renewal succeeded, False when the key is gone or
+    owned by a different agent (claim was stolen or expired).
+    """
+    redis = await get_async_redis_client()
+    if redis is None:
+        return True  # fail-open
+    try:
+        script = redis.register_script(_RENEW_LUA)
+        result = await script(keys=[_key(task_id)], args=[agent_id, str(ttl)])
+        renewed = bool(result)
+        if not renewed:
+            logger.warning(
+                "task_claim: renew failed (claim lost?) task=%s agent=%s",
+                task_id,
+                agent_id,
+            )
+        _emit_audit("task.renew", agent_id, task_id, outcome="ok" if renewed else "lost")
+        return renewed
+    except Exception:
+        logger.warning(
+            "task_claim: Redis error during renew task=%s agent=%s",
+            task_id,
+            agent_id,
+            exc_info=True,
+        )
+        return True  # fail-open
+
+
+async def release_claim(task_id: str, agent_id: str) -> bool:
+    """Release the claim on task_id if still owned by agent_id.
+
+    Returns True when the key was deleted, False when not owned (already
+    expired or stolen).
+    """
+    redis = await get_async_redis_client()
+    if redis is None:
+        return True  # fail-open
+    try:
+        script = redis.register_script(_RELEASE_LUA)
+        result = await script(keys=[_key(task_id)], args=[agent_id])
+        released = bool(result)
+        logger.debug(
+            "task_claim: release task=%s agent=%s released=%s",
+            task_id,
+            agent_id,
+            released,
+        )
+        _emit_audit("task.release", agent_id, task_id, outcome="released" if released else "not_owned")
+        return released
+    except Exception:
+        logger.warning(
+            "task_claim: Redis error during release task=%s agent=%s",
+            task_id,
+            agent_id,
+            exc_info=True,
+        )
+        return True  # fail-open
+
+
+async def is_claim_alive(task_id: str) -> bool:
+    """Return True when the Redis claim key for task_id still exists.
+
+    Used by stale-task detection: if the key is gone its TTL has expired,
+    meaning the agent died and the task is free to be reassigned.
+    """
+    redis = await get_async_redis_client()
+    if redis is None:
+        return True  # fail-open: assume alive when Redis is down
+    try:
+        return bool(await redis.exists(_key(task_id)))
+    except Exception:
+        logger.debug(
+            "task_claim: Redis error checking claim existence for task=%s",
+            task_id,
+            exc_info=True,
+        )
+        return True  # fail-open
+
+
+def _emit_audit(action: str, agent_id: str, task_id: str, outcome: str = "ok") -> None:
+    emit(
+        AuditEvent(
+            category=AuditCategory.GOVERNANCE,
+            action=action,
+            actor_id=agent_id,
+            resource_type="task",
+            resource_id=task_id,
+            outcome=outcome,
+        )
+    )

--- a/autobot-backend/tests/integration/test_task_claim_race.py
+++ b/autobot-backend/tests/integration/test_task_claim_race.py
@@ -127,9 +127,7 @@ async def test_concurrent_pickup_only_one_wins(fake_redis):
     task_id = "task-race-1"
     n_agents = 10
 
-    results = await asyncio.gather(
-        *[claim_task(task_id, f"agent-{i}") for i in range(n_agents)]
-    )
+    results = await asyncio.gather(*[claim_task(task_id, f"agent-{i}") for i in range(n_agents)])
 
     winners = [i for i, r in enumerate(results) if r is True]
     assert len(winners) == 1, f"Expected exactly 1 winner, got {len(winners)}: {winners}"

--- a/autobot-backend/tests/integration/test_task_claim_race.py
+++ b/autobot-backend/tests/integration/test_task_claim_race.py
@@ -1,0 +1,180 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Integration tests for atomic task-claim race elimination (GH#6468).
+
+Verifies that concurrent agent pickup attempts result in exactly one winner.
+Requires a real Redis instance (set REDIS_URL / REDIS_HOST or use the
+test fixture that spins up fakeredis).
+"""
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+# ---------------------------------------------------------------------------
+# Redis fixture: prefer fakeredis for isolation; fall back to real Redis.
+# ---------------------------------------------------------------------------
+
+try:
+    import fakeredis.aioredis as fakeredis_async
+
+    _FAKEREDIS_AVAILABLE = True
+except ImportError:
+    _FAKEREDIS_AVAILABLE = False
+
+
+@pytest_asyncio.fixture
+async def fake_redis(monkeypatch):
+    """Patch get_async_redis_client to return a shared fakeredis instance."""
+    if not _FAKEREDIS_AVAILABLE:
+        pytest.skip("fakeredis not installed — skipping Redis-backed tests")
+
+    server = fakeredis_async.FakeServer()
+    client = fakeredis_async.FakeRedis(server=server, decode_responses=True)
+
+    # Patch module-level helper in task_claim so all calls hit the fake client.
+    import services.task_claim as tc_mod
+
+    async def _fake_get_client(*_args, **_kwargs):
+        return client
+
+    monkeypatch.setattr(tc_mod, "get_async_redis_client", _fake_get_client)
+    yield client
+    await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# claim_task / renew_claim / release_claim unit-level integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_claim_granted_to_first_caller(fake_redis):
+    """Only the first claimant for a task_id wins."""
+    from services.task_claim import claim_task
+
+    result_a = await claim_task("task-1", "agent-A")
+    result_b = await claim_task("task-1", "agent-B")
+
+    assert result_a is True, "First caller should be granted the claim"
+    assert result_b is False, "Second caller should be denied"
+
+
+@pytest.mark.asyncio
+async def test_claim_different_tasks_both_win(fake_redis):
+    """Two agents claiming different tasks should both succeed."""
+    from services.task_claim import claim_task
+
+    result_a = await claim_task("task-2", "agent-A")
+    result_b = await claim_task("task-3", "agent-B")
+
+    assert result_a is True
+    assert result_b is True
+
+
+@pytest.mark.asyncio
+async def test_release_frees_task_for_reclaim(fake_redis):
+    """After release, a different agent can claim the same task."""
+    from services.task_claim import claim_task, release_claim
+
+    assert await claim_task("task-4", "agent-A") is True
+    await release_claim("task-4", "agent-A")
+    assert await claim_task("task-4", "agent-B") is True, "After release, task should be re-claimable"
+
+
+@pytest.mark.asyncio
+async def test_release_by_non_owner_has_no_effect(fake_redis):
+    """An agent that does not own the claim cannot release it."""
+    from services.task_claim import claim_task, is_claim_alive, release_claim
+
+    assert await claim_task("task-5", "agent-A") is True
+    released = await release_claim("task-5", "agent-B")
+    assert released is False, "Non-owner release should return False"
+    assert await is_claim_alive("task-5"), "Claim should still be alive after non-owner release attempt"
+
+
+@pytest.mark.asyncio
+async def test_renew_extends_ttl(fake_redis):
+    """Renew call by the owner should succeed."""
+    from services.task_claim import claim_task, renew_claim
+
+    assert await claim_task("task-6", "agent-A", ttl=30) is True
+    renewed = await renew_claim("task-6", "agent-A", ttl=300)
+    assert renewed is True
+
+
+@pytest.mark.asyncio
+async def test_renew_by_non_owner_fails(fake_redis):
+    """Renew call by a different agent should return False."""
+    from services.task_claim import claim_task, renew_claim
+
+    assert await claim_task("task-7", "agent-A") is True
+    assert await renew_claim("task-7", "agent-B") is False
+
+
+# ---------------------------------------------------------------------------
+# Concurrent pickup simulation — the core race test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_pickup_only_one_wins(fake_redis):
+    """Spawn N concurrent claim attempts; exactly one should win."""
+    from services.task_claim import claim_task
+
+    task_id = "task-race-1"
+    n_agents = 10
+
+    results = await asyncio.gather(
+        *[claim_task(task_id, f"agent-{i}") for i in range(n_agents)]
+    )
+
+    winners = [i for i, r in enumerate(results) if r is True]
+    assert len(winners) == 1, f"Expected exactly 1 winner, got {len(winners)}: {winners}"
+
+
+# ---------------------------------------------------------------------------
+# DistributedAgentManager integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_active_task_blocked_on_second_agent(fake_redis, monkeypatch):
+    """add_active_task returns False for the second agent on the same task."""
+    from agents.agent_orchestration.distributed_management import DistributedAgentManager
+    from agents.agent_orchestration.types import CircuitState, DistributedAgentInfo
+
+    mgr = DistributedAgentManager(builtin_agents={})
+
+    # Minimal stub agent info
+    class _FakeHealth:
+        class status:
+            value = "healthy"
+
+    class _FakeAgent:
+        agent_id = "agent-A"
+
+    info_a = DistributedAgentInfo(agent=_FakeAgent(), health=_FakeHealth(), active_tasks=set())
+    info_b_agent = type("B", (), {"agent_id": "agent-B"})()
+    info_b = DistributedAgentInfo(agent=info_b_agent, health=_FakeHealth(), active_tasks=set())
+
+    mgr.distributed_agents["agent-A"] = info_a
+    mgr.distributed_agents["agent-B"] = info_b
+
+    # Also stub out Redis persistence helpers to avoid real DB calls
+    import agents.agent_orchestration.distributed_management as dm_mod
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(dm_mod, "persist_task_assigned", _noop)
+
+    result_a = await mgr.add_active_task("agent-A", "shared-task")
+    result_b = await mgr.add_active_task("agent-B", "shared-task")
+
+    assert result_a is True, "First agent should win the claim"
+    assert result_b is False, "Second agent should be refused"
+    assert "shared-task" in mgr.distributed_agents["agent-A"].active_tasks
+    assert "shared-task" not in mgr.distributed_agents["agent-B"].active_tasks

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1164,8 +1164,12 @@ class MiscConfig(BaseSettings):
     autoresearch_timeout: int = Field(default=0, alias="AUTOBOT_AUTORESEARCH_TIMEOUT")
     cache_enabled: bool = Field(default=False, alias="AUTOBOT_CACHE_ENABLED")
     cache_size: int = Field(default=0, alias="AUTOBOT_CACHE_SIZE")
-    cache_l1_size: int = Field(default=100, alias="AUTOBOT_CACHE_L1_SIZE", description="L1 in-memory LLM response cache size")
-    cache_l2_ttl: int = Field(default=300, alias="AUTOBOT_CACHE_L2_TTL", description="L2 Redis LLM response cache TTL in seconds")
+    cache_l1_size: int = Field(
+        default=100, alias="AUTOBOT_CACHE_L1_SIZE", description="L1 in-memory LLM response cache size"
+    )
+    cache_l2_ttl: int = Field(
+        default=300, alias="AUTOBOT_CACHE_L2_TTL", description="L2 Redis LLM response cache TTL in seconds"
+    )
     celery_result_expires: str = Field(default="", alias="AUTOBOT_CELERY_RESULT_EXPIRES")
     celery_visibility_timeout: int = Field(default=0, alias="AUTOBOT_CELERY_VISIBILITY_TIMEOUT")
     chats_directory: str = Field(default="", alias="AUTOBOT_CHATS_DIRECTORY")
@@ -1872,8 +1876,21 @@ class AutoBotConfig(BaseSettings):
         Many legacy call sites use config.X where X was a MiscConfig or sub-config
         field. Delegate unknown lookups to llm/timeout/misc etc. in priority order.
         """
-        _sub_config_names = ("llm", "timeout", "vm", "port", "redis", "cache",
-                             "tls", "feature", "permission", "database_pool", "auth", "path", "misc")
+        _sub_config_names = (
+            "llm",
+            "timeout",
+            "vm",
+            "port",
+            "redis",
+            "cache",
+            "tls",
+            "feature",
+            "permission",
+            "database_pool",
+            "auth",
+            "path",
+            "misc",
+        )
         if name in _sub_config_names:
             raise AttributeError(f"'AutoBotConfig' object has no attribute {name!r}")
         for sub_name in _sub_config_names:
@@ -1881,7 +1898,11 @@ class AutoBotConfig(BaseSettings):
                 sub = object.__getattribute__(self, sub_name)
                 val = getattr(sub, name)
                 # Skip empty-string fallbacks from MiscConfig for numeric attrs
-                if sub_name == "misc" and val == "" and name.endswith(("_timeout", "_port", "_size", "_ttl", "_max", "_min")):
+                if (
+                    sub_name == "misc"
+                    and val == ""
+                    and name.endswith(("_timeout", "_port", "_size", "_ttl", "_max", "_min"))
+                ):
                     continue
                 return val
             except AttributeError:


### PR DESCRIPTION
## Summary

- **`services/task_claim.py`** — new module with `claim_task`, `renew_claim`, `release_claim`, `is_claim_alive` backed by Redis `SET NX EX` and Lua guard scripts; eliminates the double-pickup race window entirely
- **`distributed_management.py`** — `add_active_task` calls `claim_task` and returns `False` on denied claim; `remove_active_task` calls `release_claim`; `report_task_progress` calls `renew_claim`; `_collect_stale_tasks` promoted to async and checks `is_claim_alive` as a TTL-based stale signal
- **`heartbeat_scheduler.py`** — renews claim in `_start_run` on each heartbeat tick when `current_task_id` is set
- **`tests/integration/test_task_claim_race.py`** — concurrent pickup test: 10 simultaneous `claim_task` calls → exactly 1 winner

Closes GH#6468 | Paperclip: MVA-1058

## Thinking Path

GH#6468 requires atomic task checkout to prevent two agents picking up the same task in a race window. Existing Redis primitives support `SET NX EX` for distributed locks. The solution wraps claim/renew/release in Lua scripts to make them atomic, then integrates them into `add_active_task` and `report_task_progress` so the lock is automatically maintained throughout a task's lifecycle.

## What Changed

- `services/task_claim.py`: new module — claim/renew/release/is_alive primitives using Redis Lua scripts
- `distributed_management.py`: `add_active_task` now calls `claim_task` (returns False on conflict); `remove_active_task` calls `release_claim`; `report_task_progress` calls `renew_claim`; `_collect_stale_tasks` async + TTL-based
- `heartbeat_scheduler.py`: claim renewal on each tick
- `tests/integration/test_task_claim_race.py`: concurrent pickup test (10 parallel claims → exactly 1 winner) + unit-level integration tests
- All claim/release/renew emit `GOVERNANCE` audit events

## Verification

- `pytest autobot-backend/tests/integration/test_task_claim_race.py` — all tests pass
- Concurrent claim test: 10 simultaneous `claim_task` calls produce exactly 1 winner
- Audit log shows `task.claim`, `task.renew`, `task.release` governance events

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)