### PR TITLE
feat(ui): Live Canvas — agent-driven visual canvas workspace (GH#7425)

### DIFF
--- a/autobot-frontend/src/components/canvas/CanvasCell.vue
+++ b/autobot-frontend/src/components/canvas/CanvasCell.vue
@@ -30,13 +30,13 @@
 
     <!-- Rich artifact rendering (Phase 2) -->
     <ChartCell
-      v-if="cell.contentType === 'chart' && cell.richPayload"
-      :rich-payload="cell.richPayload"
+      v-if="chartPayload"
+      :rich-payload="chartPayload"
       data-testid="chart-cell"
     />
     <CodeCell
-      v-else-if="cell.contentType === 'code' && cell.richPayload"
-      :rich-payload="cell.richPayload"
+      v-else-if="codePayload"
+      :rich-payload="codePayload"
       data-testid="code-cell"
     />
 
@@ -160,7 +160,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { CanvasCell } from '@/types/canvas'
+import type { CanvasCell, ChartPayload, CodePayload } from '@/types/canvas'
 import ChartCell from './ChartCell.vue'
 import CodeCell from './CodeCell.vue'
 
@@ -177,6 +177,16 @@ const emit = defineEmits<{
 }>()
 
 const isAgentCell = computed(() => props.cell.owner === 'agent')
+
+const chartPayload = computed<ChartPayload | null>(() => {
+  const p = props.cell.richPayload
+  return p?.payloadType === 'vega-lite' ? (p as ChartPayload) : null
+})
+
+const codePayload = computed<CodePayload | null>(() => {
+  const p = props.cell.richPayload
+  return p?.payloadType === 'code' ? (p as CodePayload) : null
+})
 
 const prefersReducedMotion = typeof window !== 'undefined'
   ? window.matchMedia('(prefers-reduced-motion: reduce)').matches

--- a/autobot-frontend/src/components/canvas/ChartCell.vue
+++ b/autobot-frontend/src/components/canvas/ChartCell.vue
@@ -70,14 +70,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
-import type { TopLevelSpec } from 'vega-lite'
-
-interface ChartPayload {
-  payloadType: 'vega-lite'
-  specVersion: '5'
-  spec: TopLevelSpec
-  executable?: boolean
-}
+import type { ChartPayload } from '@/types/canvas'
 
 const props = defineProps<{
   richPayload: ChartPayload | null

--- a/autobot-frontend/src/components/canvas/CodeCell.vue
+++ b/autobot-frontend/src/components/canvas/CodeCell.vue
@@ -67,13 +67,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
-
-interface CodePayload {
-  payloadType: 'code'
-  code: string
-  language?: string
-  executable?: boolean
-}
+import type { CodePayload } from '@/types/canvas'
 
 const props = defineProps<{
   richPayload: CodePayload | null

--- a/autobot-frontend/src/composables/useCanvasWebSocket.ts
+++ b/autobot-frontend/src/composables/useCanvasWebSocket.ts
@@ -1,7 +1,6 @@
 // AutoBot - AI-Powered Automation Platform
 // Copyright (c) 2025 mrveiss
 // Author: mrveiss
-import { watch } from 'vue'
 import { useWebSocket } from '@/composables/useWebSocket'
 import { useCanvasStore } from '@/stores/useCanvasStore'
 import { getBackendUrl } from '@/config/ssot-config'
@@ -14,16 +13,9 @@ export function useCanvasWebSocket(canvasId: string) {
   const store = useCanvasStore()
   const wsUrl = `${getBackendUrl().replace(/^http/, 'ws')}/api/canvas/${canvasId}/ws`
 
-  const { messages, connect, disconnect, status } = useWebSocket(wsUrl, {
-    autoConnect: true,
-    autoReconnect: true,
-  })
-
-  watch(messages, (msgs) => {
-    const latest = msgs[msgs.length - 1]
-    if (!latest) return
+  function handleMessage(data: unknown) {
     try {
-      const msg = JSON.parse(latest as string) as CanvasWsMessage
+      const msg = JSON.parse(data as string) as CanvasWsMessage
       if (msg.type !== 'canvas_cell') return
 
       if (store.conflict?.cellId === msg.cellId) {
@@ -37,7 +29,13 @@ export function useCanvasWebSocket(canvasId: string) {
     } catch (err) {
       logger.error('WS parse error', err)
     }
+  }
+
+  const { connect, disconnect, isConnected } = useWebSocket(wsUrl, {
+    autoConnect: true,
+    autoReconnect: true,
+    onMessage: handleMessage,
   })
 
-  return { connect, disconnect, status }
+  return { connect, disconnect, isConnected }
 }

--- a/autobot-frontend/src/test/vitest-setup.ts
+++ b/autobot-frontend/src/test/vitest-setup.ts
@@ -36,6 +36,21 @@ class MockResizeObserver {
 }
 global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
 
+// Mock window.matchMedia (not available in jsdom)
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
 // Mock WebSocket
 class MockWebSocket {
   static CONNECTING = 0

--- a/docs/user/canvas.md
+++ b/docs/user/canvas.md
@@ -1,0 +1,100 @@
+# Live Canvas
+
+The Live Canvas is an agent-controlled workspace that renders structured artifacts alongside the chat panel. Agents can stream rich content blocks — markdown, code, charts, and images — directly into the canvas where you can view, edit, and export them.
+
+## Opening the Canvas
+
+Navigate to **Canvas** in the sidebar, or use the keyboard shortcut **⌘L** (or **Ctrl+L**) from within the canvas view to toggle focus between chat and canvas.
+
+## Layout modes
+
+The canvas supports four layout modes, toggled by double-clicking the divider or using the toolbar:
+
+| Mode | Description |
+|------|-------------|
+| **Split** (default) | Chat (35%) and canvas (65%) side by side |
+| **Canvas focus** | Canvas expanded, chat minimised |
+| **Chat focus** | Chat expanded, canvas hidden |
+| **Full canvas** | Canvas fills the full width |
+
+On narrow viewports (≤390 px), the layout switches to a tab bar so you can switch between Chat and Canvas.
+
+Drag the divider to set a custom split ratio.
+
+## Cell types
+
+Each piece of content the agent writes is a **cell**. Cells come in three types:
+
+| Type | Content |
+|------|---------|
+| **Markdown** | Formatted text with bold, italics, headings, and inline code |
+| **Code** | Syntax-highlighted code block with a one-click copy button |
+| **Chart** | Interactive Vega-Lite chart with a data table fallback for screen readers |
+
+## Streaming states
+
+While the agent is writing, cells show a live streaming state:
+
+- **Skeleton** — agent has started, content loading
+- **Partial** — content streaming in with a blinking cursor
+- **Complete** — agent finished; you can Accept, Edit, or Discard
+- **Error** — stream failed; you can Keep, Retry, or Discard
+
+## Accepting and editing agent output
+
+Agent cells appear with a coloured left border and a 🤖 badge. When the agent finishes writing a cell you can:
+
+- **Accept (⌥Enter)** — promote the cell to user-owned content
+- **Edit (Enter)** — open the cell for editing and take ownership
+- **Discard (Esc)** — remove the cell
+
+Use **⌘↑** / **⌘↓** to reorder any focused cell, and use the cell toolbar (visible on hover) to duplicate, copy, or delete.
+
+## Conflict resolution
+
+If you edit a cell while the agent is still writing it, the agent automatically continues in a new cell below. A **Conflict** banner appears at the top of the canvas — click **Resume** to keep both versions, or **Dismiss** to discard the agent continuation.
+
+## Undo / Redo
+
+Use **⌘Z** / **⌘⇧Z** to step through the edit history. Up to 100 history states are kept per session.
+
+## Auto-save
+
+Canvas content saves automatically one second after each edit. The toolbar shows the save status:
+
+- ✓ Saved *HH:MM* — last successful save
+- 💾 Saving… — save in progress
+- ⚠ Save failed — tap **Retry** in the toolbar
+
+## Exporting
+
+Click **Export** in the toolbar (or press **⌘⇧E**) to open the export sheet. Choose a format and which cell types to include:
+
+| Format | Output |
+|--------|--------|
+| Markdown | `.md` file |
+| HTML | `.html` file |
+| JSON | `.json` file (full cell objects) |
+| PDF | `.txt` fallback (browser PDF via print) |
+
+## Keyboard shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| ⌘Z | Undo |
+| ⌘⇧Z | Redo |
+| ⌘L | Focus chat panel |
+| ⌥Enter | Accept focused agent cell |
+| Enter | Edit focused agent cell |
+| Esc | Discard focused agent cell |
+| ⌘↑ | Move focused cell up |
+| ⌘↓ | Move focused cell down |
+
+## Feature flag
+
+The canvas is gated behind the `VITE_FEATURE_CANVAS=true` environment variable. When the flag is not set the `/canvas` route is still reachable but the nav item respects the flag if filtered server-side.
+
+## Related
+
+- [GH#7425](https://github.com/mrveiss/AutoBot-AI/issues/7425) — implementation issue
+- [GH#5136](https://github.com/mrveiss/AutoBot-AI/issues/5136) — browser panel integration (phases 3-5)


### PR DESCRIPTION
## Summary

- Adds type-narrowed computed guards for `richPayload` in `CanvasCell.vue` (`chartPayload`/`codePayload`) eliminating duplicate `v-if` conditions and propagating typed props to child cells
- Deduplicates `ChartPayload`/`CodePayload` type definitions — `ChartCell.vue` and `CodeCell.vue` now import from `@/types/canvas` instead of re-declaring local interfaces
- Refactors `useCanvasWebSocket` to `onMessage` callback pattern; drops unused `watch` import; returns `isConnected`
- Adds `window.matchMedia` mock to `vitest-setup.ts` for jsdom compatibility with the canvas layout composable
- Adds `docs/user/canvas.md` — user-facing Live Canvas documentation

## Thinking Path

The Live Canvas core (CanvasView, CanvasPanel, store, types, router) was merged in a prior run. This PR ships the remaining refinements: type-narrowed guards to avoid duplicate v-if conditions, deduplication of ChartPayload/CodePayload types, a cleaner onMessage callback in the WebSocket composable, and user documentation.

## What Changed

- `autobot-frontend/src/components/canvas/CanvasCell.vue` — type-narrowed `chartPayload`/`codePayload` computed guards
- `autobot-frontend/src/components/canvas/ChartCell.vue` — imports `ChartPayload` from `@/types/canvas`
- `autobot-frontend/src/components/canvas/CodeCell.vue` — imports `CodePayload` from `@/types/canvas`
- `autobot-frontend/src/composables/useCanvasWebSocket.ts` — `onMessage` callback pattern, drops `watch` import
- `autobot-frontend/tests/setup/vitest-setup.ts` — adds `window.matchMedia` mock
- `docs/user/canvas.md` — new user-facing Live Canvas documentation

## Verification

- TypeScript strict-mode: no new errors in changed files
- Vitest: canvas composable tests pass with `window.matchMedia` mock
- `CanvasView.vue` renders streamed canvas events (WebSocket → store → panel)
- Mobile responsive layout collapses to tab drawer on ≤390 px

## Model Used

claude-sonnet-4-6

## Context

The core Live Canvas implementation (CanvasView, CanvasPanel, CanvasSplitLayout, CanvasStore, canvas types, router entry, navItems) was merged to Dev_new_gui in prior runs. This PR ships the remaining refinements and the user documentation.

## Acceptance criteria met

- ✅ `CanvasView.vue` renders streamed canvas events (WebSocket → store → panel)
- ✅ Agent-driven `canvas.update` events wired via `useCanvasWebSocket`
- ✅ User edits sync back via `useCanvasAutoSave`
- ✅ Mobile/responsive layout: CanvasSplitLayout collapses to tab drawer on ≤390 px
- ✅ Keyboard shortcut ⌘L/Ctrl+L toggles canvas
- ✅ Documented in `docs/user/canvas.md`
- ⚠️ Redis canvas state persistence: backend `/api/canvas/:id` endpoint stub — backend team to implement storage layer (tracked separately)

## Test plan

- [ ] Navigate to `/canvas` — canvas view loads with split layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)