### PR TITLE
feat(npu-pipeline): provider_registry hook + latency guard (MVA-1099)

### DIFF
--- a/autobot-backend/llm_shared/npu_pipeline_routing_test.py
+++ b/autobot-backend/llm_shared/npu_pipeline_routing_test.py
@@ -22,11 +22,11 @@ import types
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 # ---------------------------------------------------------------------------
 # Bootstrap: load real provider_registry module without triggering the
 # conftest.py stub that replaces the entire llm_shared package.
 # ---------------------------------------------------------------------------
+
 
 def _load_module_from_file(name: str, path: str) -> types.ModuleType:
     spec = importlib.util.spec_from_file_location(name, path)
@@ -38,12 +38,14 @@ def _load_module_from_file(name: str, path: str) -> types.ModuleType:
 
 def _bootstrap_provider_registry():
     import os
+
     backend = os.path.join(os.path.dirname(__file__), "..")
 
     # Minimal stubs for provider_registry's top-level imports that are heavy
     # or absent in the test venv.
     for heavy in [
-        "autobot_shared", "autobot_shared.ssot_config",
+        "autobot_shared",
+        "autobot_shared.ssot_config",
         "autobot_shared.logging_manager",
         "prepared_facts",
     ]:
@@ -58,6 +60,7 @@ def _bootstrap_provider_registry():
 
     # logging_manager.get_logger must return a real logger (pytest captures it)
     import logging
+
     log_stub = sys.modules["autobot_shared.logging_manager"]
     if not hasattr(log_stub, "get_logger"):
         log_stub.get_logger = logging.getLogger
@@ -108,11 +111,11 @@ _NPU_POOL_PROVIDER_NAME = _pr_mod._NPU_POOL_PROVIDER_NAME
 # Load real pipeline_dispatcher module
 # ---------------------------------------------------------------------------
 
+
 def _bootstrap_pipeline_dispatcher():
     import os
-    path = os.path.join(
-        os.path.dirname(__file__), "..", "services", "npu_pipeline", "pipeline_dispatcher.py"
-    )
+
+    path = os.path.join(os.path.dirname(__file__), "..", "services", "npu_pipeline", "pipeline_dispatcher.py")
     return _load_module_from_file("services.npu_pipeline.pipeline_dispatcher", path)
 
 
@@ -124,6 +127,7 @@ WorkerState = _pd_mod.WorkerState
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_request(model_bytes: int):
     req = MagicMock()
@@ -161,6 +165,7 @@ def _make_provider(name: str):
 # Tests
 # ---------------------------------------------------------------------------
 
+
 class TestNpuPipelineRouting(unittest.IsolatedAsyncioTestCase):
 
     def _make_registry_with_npu_provider(self, dispatcher):
@@ -176,13 +181,13 @@ class TestNpuPipelineRouting(unittest.IsolatedAsyncioTestCase):
     async def test_oversized_model_routes_to_pipeline(self):
         """Model bytes > max single-worker VRAM → PipelineDispatcher returned."""
         workers = [
-            _make_worker("w0", vram_bytes=8 * (1024 ** 3)),
-            _make_worker("w1", vram_bytes=8 * (1024 ** 3)),
+            _make_worker("w0", vram_bytes=8 * (1024**3)),
+            _make_worker("w1", vram_bytes=8 * (1024**3)),
         ]
         dispatcher = _make_dispatcher(workers, hop_latency_ms=2.5)
         registry, _ = self._make_registry_with_npu_provider(dispatcher)
 
-        request = _make_request(model_bytes=16 * (1024 ** 3))
+        request = _make_request(model_bytes=16 * (1024**3))
         result = await registry.get_provider_for_request(
             provider_name=_NPU_POOL_PROVIDER_NAME,
             request=request,
@@ -192,13 +197,13 @@ class TestNpuPipelineRouting(unittest.IsolatedAsyncioTestCase):
     async def test_single_worker_sized_model_routes_normally(self):
         """Model bytes ≤ max single-worker VRAM → regular provider returned."""
         workers = [
-            _make_worker("w0", vram_bytes=16 * (1024 ** 3)),
-            _make_worker("w1", vram_bytes=16 * (1024 ** 3)),
+            _make_worker("w0", vram_bytes=16 * (1024**3)),
+            _make_worker("w1", vram_bytes=16 * (1024**3)),
         ]
         dispatcher = _make_dispatcher(workers, hop_latency_ms=2.5)
         registry, npu_provider = self._make_registry_with_npu_provider(dispatcher)
 
-        request = _make_request(model_bytes=8 * (1024 ** 3))
+        request = _make_request(model_bytes=8 * (1024**3))
         result = await registry.get_provider_for_request(
             provider_name=_NPU_POOL_PROVIDER_NAME,
             request=request,
@@ -208,27 +213,25 @@ class TestNpuPipelineRouting(unittest.IsolatedAsyncioTestCase):
     async def test_latency_fallback_fires_on_high_latency_pair(self):
         """High hop latency exceeds threshold → _should_use_npu_pipeline returns False."""
         workers = [
-            _make_worker("w0", vram_bytes=8 * (1024 ** 3)),
-            _make_worker("w1", vram_bytes=8 * (1024 ** 3)),
+            _make_worker("w0", vram_bytes=8 * (1024**3)),
+            _make_worker("w1", vram_bytes=8 * (1024**3)),
         ]
         # hop=600 ms, baseline=200 ms, multiplier=2.0 → threshold=400 ms < 600 ms
         dispatcher = _make_dispatcher(workers, hop_latency_ms=600.0)
         registry, npu_provider = self._make_registry_with_npu_provider(dispatcher)
 
-        request = _make_request(model_bytes=16 * (1024 ** 3))
-        should_pipeline = await registry._should_use_npu_pipeline(
-            request, baseline_ttft_ms=200.0
-        )
+        request = _make_request(model_bytes=16 * (1024**3))
+        should_pipeline = await registry._should_use_npu_pipeline(request, baseline_ttft_ms=200.0)
         self.assertFalse(should_pipeline)
 
     async def test_pipeline_disabled_skips_pipeline(self):
         """npu_pipeline_enabled=False → regular provider returned even for oversized model."""
-        workers = [_make_worker("w0", 8 * (1024 ** 3)), _make_worker("w1", 8 * (1024 ** 3))]
+        workers = [_make_worker("w0", 8 * (1024**3)), _make_worker("w1", 8 * (1024**3))]
         dispatcher = _make_dispatcher(workers)
         registry, npu_provider = self._make_registry_with_npu_provider(dispatcher)
         registry._npu_pipeline_enabled = False
 
-        request = _make_request(model_bytes=16 * (1024 ** 3))
+        request = _make_request(model_bytes=16 * (1024**3))
         result = await registry.get_provider_for_request(
             provider_name=_NPU_POOL_PROVIDER_NAME,
             request=request,
@@ -237,7 +240,7 @@ class TestNpuPipelineRouting(unittest.IsolatedAsyncioTestCase):
 
     async def test_no_npu_model_bytes_skips_pipeline(self):
         """Request without npu_model_bytes metadata → route normally."""
-        workers = [_make_worker("w0", 8 * (1024 ** 3)), _make_worker("w1", 8 * (1024 ** 3))]
+        workers = [_make_worker("w0", 8 * (1024**3)), _make_worker("w1", 8 * (1024**3))]
         dispatcher = _make_dispatcher(workers)
         registry, npu_provider = self._make_registry_with_npu_provider(dispatcher)
 

--- a/autobot-backend/llm_shared/npu_pipeline_routing_test.py
+++ b/autobot-backend/llm_shared/npu_pipeline_routing_test.py
@@ -1,0 +1,257 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for NPU pipeline dispatch hook in ProviderRegistry (MVA-1099).
+
+Covers:
+- Oversized model routes to PipelineDispatcher
+- Single-worker-sized model routes normally (no pipeline)
+- Latency guard: high-latency pair falls back to single-worker
+
+These tests import ProviderRegistry directly via file path to bypass the
+top-level conftest.py llm_shared stub, which prevents importing the real
+module for tests that exercise the registry logic.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap: load real provider_registry module without triggering the
+# conftest.py stub that replaces the entire llm_shared package.
+# ---------------------------------------------------------------------------
+
+def _load_module_from_file(name: str, path: str) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _bootstrap_provider_registry():
+    import os
+    backend = os.path.join(os.path.dirname(__file__), "..")
+
+    # Minimal stubs for provider_registry's top-level imports that are heavy
+    # or absent in the test venv.
+    for heavy in [
+        "autobot_shared", "autobot_shared.ssot_config",
+        "autobot_shared.logging_manager",
+        "prepared_facts",
+    ]:
+        if heavy not in sys.modules:
+            stub = types.ModuleType(heavy)
+            sys.modules[heavy] = stub
+
+    # ssot_config.config must be an object with attribute access
+    cfg_stub = sys.modules.setdefault("autobot_shared.ssot_config", types.ModuleType("autobot_shared.ssot_config"))
+    if not hasattr(cfg_stub, "config"):
+        cfg_stub.config = MagicMock()
+
+    # logging_manager.get_logger must return a real logger (pytest captures it)
+    import logging
+    log_stub = sys.modules["autobot_shared.logging_manager"]
+    if not hasattr(log_stub, "get_logger"):
+        log_stub.get_logger = logging.getLogger
+
+    # prepared_facts.ProviderRuntimeFact
+    pf_stub = sys.modules["prepared_facts"]
+    if not hasattr(pf_stub, "ProviderRuntimeFact"):
+        pf_stub.ProviderRuntimeFact = MagicMock()
+
+    # llm_shared.model_param_registry
+    mp_name = "llm_shared.model_param_registry"
+    if mp_name not in sys.modules:
+        mp_stub = types.ModuleType(mp_name)
+        mp_stub.apply_model_defaults = lambda model, provider, kw: kw
+        mp_stub.apply_prompt_prefix = lambda model, msgs: None
+        sys.modules[mp_name] = mp_stub
+
+    # llm_shared.models.LLMRequest (lightweight stub)
+    lm_name = "llm_shared.models"
+    if lm_name not in sys.modules:
+        lm_stub = types.ModuleType(lm_name)
+        lm_stub.LLMRequest = MagicMock  # tests use MagicMock(spec=...) anyway
+        sys.modules[lm_name] = lm_stub
+
+    # llm_shared.base_provider.BaseProvider
+    bp_name = "llm_shared.base_provider"
+    if bp_name not in sys.modules:
+        bp_stub = types.ModuleType(bp_name)
+        bp_stub.BaseProvider = object
+        sys.modules[bp_name] = bp_stub
+
+    # Ensure the llm_shared package stub won't shadow what we're about to load.
+    # We keep it (to avoid breaking other imports) but patch provider_registry in.
+    module_path = os.path.join(backend, "llm_shared", "provider_registry.py")
+    mod = _load_module_from_file("llm_shared.provider_registry", module_path)
+    # Also attach to llm_shared package if a stub exists there.
+    if "llm_shared" in sys.modules:
+        sys.modules["llm_shared"].provider_registry = mod  # type: ignore[attr-defined]
+    return mod
+
+
+_pr_mod = _bootstrap_provider_registry()
+ProviderRegistry = _pr_mod.ProviderRegistry
+_NPU_POOL_PROVIDER_NAME = _pr_mod._NPU_POOL_PROVIDER_NAME
+
+
+# ---------------------------------------------------------------------------
+# Load real pipeline_dispatcher module
+# ---------------------------------------------------------------------------
+
+def _bootstrap_pipeline_dispatcher():
+    import os
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "services", "npu_pipeline", "pipeline_dispatcher.py"
+    )
+    return _load_module_from_file("services.npu_pipeline.pipeline_dispatcher", path)
+
+
+_pd_mod = _bootstrap_pipeline_dispatcher()
+WorkerNode = _pd_mod.WorkerNode
+WorkerState = _pd_mod.WorkerState
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_request(model_bytes: int):
+    req = MagicMock()
+    req.metadata = {"npu_model_bytes": model_bytes}
+    req.model_name = "test-model"
+    req.messages = []
+    return req
+
+
+def _make_worker(worker_id: str, vram_bytes: int, online: bool = True):
+    w = WorkerNode(worker_id=worker_id, vram_bytes=vram_bytes)
+    if not online:
+        w.state = WorkerState.OFFLINE
+    return w
+
+
+def _make_dispatcher(workers, hop_latency_ms: float = 2.5):
+    disp = MagicMock()
+    disp.workers = workers
+
+    async def _sim_transfer(src, dst):
+        return hop_latency_ms
+
+    disp._simulate_layer_transfer = _sim_transfer
+    return disp
+
+
+def _make_provider(name: str):
+    p = MagicMock()
+    p.provider_name = name
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestNpuPipelineRouting(unittest.IsolatedAsyncioTestCase):
+
+    def _make_registry_with_npu_provider(self, dispatcher):
+        registry = ProviderRegistry()
+        npu_provider = _make_provider(_NPU_POOL_PROVIDER_NAME)
+        registry._check_health_cached = AsyncMock(return_value=True)
+        registry._providers[_NPU_POOL_PROVIDER_NAME] = npu_provider
+        registry._fallback_chain = [_NPU_POOL_PROVIDER_NAME]
+        registry.set_npu_pipeline_dispatcher(dispatcher, enabled=True)
+        registry.enrich_request = lambda req, name: req
+        return registry, npu_provider
+
+    async def test_oversized_model_routes_to_pipeline(self):
+        """Model bytes > max single-worker VRAM → PipelineDispatcher returned."""
+        workers = [
+            _make_worker("w0", vram_bytes=8 * (1024 ** 3)),
+            _make_worker("w1", vram_bytes=8 * (1024 ** 3)),
+        ]
+        dispatcher = _make_dispatcher(workers, hop_latency_ms=2.5)
+        registry, _ = self._make_registry_with_npu_provider(dispatcher)
+
+        request = _make_request(model_bytes=16 * (1024 ** 3))
+        result = await registry.get_provider_for_request(
+            provider_name=_NPU_POOL_PROVIDER_NAME,
+            request=request,
+        )
+        self.assertIs(result, dispatcher)
+
+    async def test_single_worker_sized_model_routes_normally(self):
+        """Model bytes ≤ max single-worker VRAM → regular provider returned."""
+        workers = [
+            _make_worker("w0", vram_bytes=16 * (1024 ** 3)),
+            _make_worker("w1", vram_bytes=16 * (1024 ** 3)),
+        ]
+        dispatcher = _make_dispatcher(workers, hop_latency_ms=2.5)
+        registry, npu_provider = self._make_registry_with_npu_provider(dispatcher)
+
+        request = _make_request(model_bytes=8 * (1024 ** 3))
+        result = await registry.get_provider_for_request(
+            provider_name=_NPU_POOL_PROVIDER_NAME,
+            request=request,
+        )
+        self.assertIs(result, npu_provider)
+
+    async def test_latency_fallback_fires_on_high_latency_pair(self):
+        """High hop latency exceeds threshold → _should_use_npu_pipeline returns False."""
+        workers = [
+            _make_worker("w0", vram_bytes=8 * (1024 ** 3)),
+            _make_worker("w1", vram_bytes=8 * (1024 ** 3)),
+        ]
+        # hop=600 ms, baseline=200 ms, multiplier=2.0 → threshold=400 ms < 600 ms
+        dispatcher = _make_dispatcher(workers, hop_latency_ms=600.0)
+        registry, npu_provider = self._make_registry_with_npu_provider(dispatcher)
+
+        request = _make_request(model_bytes=16 * (1024 ** 3))
+        should_pipeline = await registry._should_use_npu_pipeline(
+            request, baseline_ttft_ms=200.0
+        )
+        self.assertFalse(should_pipeline)
+
+    async def test_pipeline_disabled_skips_pipeline(self):
+        """npu_pipeline_enabled=False → regular provider returned even for oversized model."""
+        workers = [_make_worker("w0", 8 * (1024 ** 3)), _make_worker("w1", 8 * (1024 ** 3))]
+        dispatcher = _make_dispatcher(workers)
+        registry, npu_provider = self._make_registry_with_npu_provider(dispatcher)
+        registry._npu_pipeline_enabled = False
+
+        request = _make_request(model_bytes=16 * (1024 ** 3))
+        result = await registry.get_provider_for_request(
+            provider_name=_NPU_POOL_PROVIDER_NAME,
+            request=request,
+        )
+        self.assertIs(result, npu_provider)
+
+    async def test_no_npu_model_bytes_skips_pipeline(self):
+        """Request without npu_model_bytes metadata → route normally."""
+        workers = [_make_worker("w0", 8 * (1024 ** 3)), _make_worker("w1", 8 * (1024 ** 3))]
+        dispatcher = _make_dispatcher(workers)
+        registry, npu_provider = self._make_registry_with_npu_provider(dispatcher)
+
+        req = MagicMock()
+        req.metadata = {}
+        req.model_name = "test"
+        req.messages = []
+
+        result = await registry.get_provider_for_request(
+            provider_name=_NPU_POOL_PROVIDER_NAME,
+            request=req,
+        )
+        self.assertIs(result, npu_provider)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/autobot-backend/llm_shared/provider_registry.py
+++ b/autobot-backend/llm_shared/provider_registry.py
@@ -29,9 +29,11 @@ from autobot_shared.logging_manager import get_logger
 from __future__ import annotations
 
 import asyncio
+import os
 import time
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
+from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
 from llm_shared.model_param_registry import apply_model_defaults, apply_prompt_prefix
 from llm_shared.models import LLMRequest
@@ -43,6 +45,15 @@ logger = get_logger(__name__)
 
 # Cache health results for 30 s to avoid a health check on every request.
 _HEALTH_CACHE_TTL = 30.0
+
+# Multiplier applied to baseline single-worker TTFT when evaluating whether
+# cross-worker hop latency makes pipeline dispatch too expensive (MVA-1099).
+_NPU_PIPELINE_MAX_LATENCY_MULTIPLIER: float = float(
+    os.environ.get("NPU_PIPELINE_MAX_LATENCY_MULTIPLIER", "2.0")
+)
+
+# Provider name used for the NPU worker pool.
+_NPU_POOL_PROVIDER_NAME = "npu_pool"
 
 
 class ProviderRegistry:
@@ -62,6 +73,9 @@ class ProviderRegistry:
         self._health_lock = asyncio.Lock()
         self._initialized = False
         self._provider_facts: Dict[str, ProviderRuntimeFact] = {}
+        # Optional PipelineDispatcher wired in by set_npu_pipeline_dispatcher() (MVA-1099).
+        self._npu_pipeline_dispatcher: Optional[Any] = None
+        self._npu_pipeline_enabled: bool = False
 
     # ------------------------------------------------------------------
     # Registration
@@ -201,6 +215,88 @@ class ProviderRegistry:
         return request
 
     # ------------------------------------------------------------------
+    # NPU pipeline dispatch (MVA-1099)
+    # ------------------------------------------------------------------
+
+    def set_npu_pipeline_dispatcher(self, dispatcher: Any, *, enabled: bool = True) -> None:
+        """Attach a PipelineDispatcher and enable pipeline routing for oversized models."""
+        self._npu_pipeline_dispatcher = dispatcher
+        self._npu_pipeline_enabled = enabled
+        logger.info("NPU pipeline dispatcher registered (enabled=%s)", enabled)
+
+    async def _probe_hop_latency_ms(self) -> float:
+        """Return estimated cross-worker hop latency in ms from the dispatcher's workers.
+
+        Falls back to 0.0 when the dispatcher has fewer than two online workers.
+        """
+        if self._npu_pipeline_dispatcher is None:
+            return 0.0
+        from services.npu_pipeline.pipeline_dispatcher import WorkerState as WS
+
+        online = [w for w in self._npu_pipeline_dispatcher.workers if w.state == WS.ONLINE]
+        if len(online) < 2:
+            return 0.0
+        # Simulate a single cross-worker transfer to get the representative latency.
+        try:
+            latency = await self._npu_pipeline_dispatcher._simulate_layer_transfer(
+                online[0], online[1]
+            )
+        except Exception as exc:
+            logger.debug("hop latency probe failed: %s", exc)
+            return 0.0
+        return latency
+
+    async def _should_use_npu_pipeline(
+        self,
+        request: LLMRequest | None,
+        baseline_ttft_ms: float = 500.0,
+    ) -> bool:
+        """Return True when pipeline dispatch is appropriate for *request*.
+
+        Conditions (all must hold):
+        - Pipeline is enabled via :meth:`set_npu_pipeline_dispatcher`
+        - *request* carries a ``npu_model_bytes`` metadata key larger than the
+          maximum single-worker VRAM in the registered dispatcher pool
+        - Estimated cross-worker hop latency would not inflate TTFT beyond
+          ``NPU_PIPELINE_MAX_LATENCY_MULTIPLIER × baseline_ttft_ms``
+        """
+        if not self._npu_pipeline_enabled or self._npu_pipeline_dispatcher is None:
+            return False
+        if request is None:
+            return False
+
+        model_bytes: int = request.metadata.get("npu_model_bytes", 0)
+        if model_bytes <= 0:
+            return False
+
+        from services.npu_pipeline.pipeline_dispatcher import WorkerState as WS
+
+        online = [w for w in self._npu_pipeline_dispatcher.workers if w.state == WS.ONLINE]
+        if not online:
+            return False
+
+        max_single_vram = max(w.vram_bytes for w in online)
+        if model_bytes <= max_single_vram:
+            # Model fits on a single worker — no need for pipeline.
+            return False
+
+        # Latency guard: don't pipeline if hop cost exceeds the threshold.
+        hop_ms = await self._probe_hop_latency_ms()
+        # Each pipeline stage adds one hop; there are len(online)-1 hops total.
+        total_hop_ms = hop_ms * max(0, len(online) - 1)
+        threshold_ms = _NPU_PIPELINE_MAX_LATENCY_MULTIPLIER * baseline_ttft_ms
+        if total_hop_ms > threshold_ms:
+            logger.warning(
+                "NPU pipeline hop latency %.1f ms exceeds threshold %.1f ms — "
+                "falling back to single-worker dispatch",
+                total_hop_ms,
+                threshold_ms,
+            )
+            return False
+
+        return True
+
+    # ------------------------------------------------------------------
     # Provider selection
     # ------------------------------------------------------------------
 
@@ -268,6 +364,15 @@ class ProviderRegistry:
                         name,
                         primary,
                     )
+                # NPU pipeline hook (MVA-1099): when the chosen provider is the
+                # NPU pool and the model is oversized for a single worker, route
+                # through PipelineDispatcher instead.
+                if name == _NPU_POOL_PROVIDER_NAME and await self._should_use_npu_pipeline(request):
+                    logger.info(
+                        "NPU pipeline dispatch activated for model_bytes=%s",
+                        request.metadata.get("npu_model_bytes") if request else "n/a",
+                    )
+                    return self._npu_pipeline_dispatcher  # type: ignore[return-value]
                 return provider
 
         logger.error("All providers unavailable or not configured")

--- a/autobot-backend/llm_shared/provider_registry.py
+++ b/autobot-backend/llm_shared/provider_registry.py
@@ -48,9 +48,7 @@ _HEALTH_CACHE_TTL = 30.0
 
 # Multiplier applied to baseline single-worker TTFT when evaluating whether
 # cross-worker hop latency makes pipeline dispatch too expensive (MVA-1099).
-_NPU_PIPELINE_MAX_LATENCY_MULTIPLIER: float = float(
-    os.environ.get("NPU_PIPELINE_MAX_LATENCY_MULTIPLIER", "2.0")
-)
+_NPU_PIPELINE_MAX_LATENCY_MULTIPLIER: float = float(os.environ.get("NPU_PIPELINE_MAX_LATENCY_MULTIPLIER", "2.0"))
 
 # Provider name used for the NPU worker pool.
 _NPU_POOL_PROVIDER_NAME = "npu_pool"
@@ -238,9 +236,7 @@ class ProviderRegistry:
             return 0.0
         # Simulate a single cross-worker transfer to get the representative latency.
         try:
-            latency = await self._npu_pipeline_dispatcher._simulate_layer_transfer(
-                online[0], online[1]
-            )
+            latency = await self._npu_pipeline_dispatcher._simulate_layer_transfer(online[0], online[1])
         except Exception as exc:
             logger.debug("hop latency probe failed: %s", exc)
             return 0.0

--- a/autobot-backend/models/npu_models.py
+++ b/autobot-backend/models/npu_models.py
@@ -175,6 +175,10 @@ class LoadBalancingConfig(BaseModel):
         le=600,
         description="Cooldown period before retrying failed workers (10-600 seconds)",
     )
+    npu_pipeline_enabled: bool = Field(
+        default=False,
+        description="Enable multi-worker NPU pipeline dispatch for oversized models (MVA-1099)",
+    )
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -184,6 +188,7 @@ class LoadBalancingConfig(BaseModel):
                 "timeout_seconds": 10,
                 "retry_failed_workers": True,
                 "retry_cooldown_seconds": 60,
+                "npu_pipeline_enabled": False,
             }
         }
     )

--- a/changelog/unreleased/MVA-1099-npu-pipeline-routing.md
+++ b/changelog/unreleased/MVA-1099-npu-pipeline-routing.md
@@ -1,0 +1,7 @@
+---
+type: feat
+scope: backend
+issue: 1099
+pr: 8644
+---
+Route oversized NPU models through PipelineDispatcher in ProviderRegistry; add npu_pipeline_enabled config flag and NPU_PIPELINE_MAX_LATENCY_MULTIPLIER latency guard.


### PR DESCRIPTION
## Summary

- Adds \`npu_pipeline_enabled\` config flag to \`LoadBalancingConfig\` (opt-in, default \`False\`)
- Adds \`NPU_PIPELINE_MAX_LATENCY_MULTIPLIER\` env var (default \`2.0\`) for hop-latency guard
- Hooks \`get_provider_for_request()\` in \`ProviderRegistry\`: when chosen provider is \`npu_pool\` and model bytes exceed the max single-worker VRAM, routes through \`PipelineDispatcher\` instead
- Falls back to single-worker if cross-worker hop latency exceeds \`multiplier × baseline_TTFT\`
- Fixes pre-existing bug: \`get_logger\` import was accidentally inside the module docstring
- Copies \`pipeline_dispatcher.py\` from MVA-1097 into \`services/npu_pipeline/\`
- Adds 5 unit tests covering all routing branches

Depends on: MVA-1097, MVA-1098 | Parent: MVA-1082

## Changes

- \`autobot-backend/models/npu_models.py\` — \`LoadBalancingConfig.npu_pipeline_enabled: bool\` field
- \`autobot-backend/llm_shared/provider_registry.py\` — \`_NPU_POOL_PROVIDER_NAME\`, \`_NPU_PIPELINE_MAX_LATENCY_MULTIPLIER\`, \`set_npu_pipeline_dispatcher()\`, \`_probe_hop_latency_ms()\`, \`_should_use_npu_pipeline()\`, NPU dispatch hook in \`get_provider_for_request()\`; fixed \`get_logger\` import placement
- \`autobot-backend/services/npu_pipeline/pipeline_dispatcher.py\` — \`PipelineDispatcher\` (from MVA-1097)
- \`autobot-backend/llm_shared/npu_pipeline_routing_test.py\` — 5 unit tests
- \`changelog/unreleased/MVA-1099-npu-pipeline-routing.md\` — changelog fragment

## Changelog fragment

See \`changelog/unreleased/MVA-1099-npu-pipeline-routing.md\` (type: feat, scope: backend).

## Test plan

- [x] oversized model routes to PipelineDispatcher
- [x] single-worker model routes normally
- [x] latency fallback fires on high-latency pair
- [x] disabled flag skips pipeline
- [x] missing npu_model_bytes metadata skips pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)