### PR TITLE
feat(npu-pipeline): pipeline dispatcher — cross-worker forward-pass coordinator (MVA-1097)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -157,7 +157,30 @@ for _svc_mod in [
 ]:
     if _svc_mod not in sys.modules:
         _svc_stub = _make_pkg_stub(_svc_mod)
+        # Prevent pytest from calling __getattr__("pytest_plugins") which would
+        # return a MagicMock and cause a UsageError during test collection.
+        _svc_stub.pytest_plugins = []  # type: ignore[attr-defined]
         sys.modules[_svc_mod] = _svc_stub
+
+# npu_pipeline — stub the package and its sub-modules so that the __init__.py
+# import chain (which pulls in Redis/config) doesn't break test collection.
+# pytest_plugins must be explicitly set to [] so that pytest doesn't call
+# __getattr__("pytest_plugins") on the stub which returns a MagicMock and
+# triggers a UsageError. (MVA-1096/1097)
+_NPU_PKG_DIR = backend_root / "services" / "npu_pipeline"
+for _npu_mod in [
+    "services.npu_pipeline",
+    "services.npu_pipeline.shard_planner",
+    "services.npu_pipeline.plan_cache",
+    "services.npu_pipeline.invalidation",
+    "services.npu_pipeline.dispatcher",
+]:
+    if _npu_mod not in sys.modules:
+        _npu_stub = _make_pkg_stub(_npu_mod)
+        _npu_stub.pytest_plugins = []  # type: ignore[attr-defined]
+        if _npu_mod == "services.npu_pipeline":
+            _npu_stub.__path__ = [str(_NPU_PKG_DIR)]
+        sys.modules[_npu_mod] = _npu_stub
 # Provide the SUPPORTED_LANGUAGES symbol consumed by api.schemas_agent
 if not hasattr(sys.modules.get("services.personality_service", object()), "SUPPORTED_LANGUAGES"):
     sys.modules["services.personality_service"].SUPPORTED_LANGUAGES = {}  # type: ignore[attr-defined]
@@ -258,7 +281,7 @@ if "llm_shared" not in sys.modules:
     # and LLMResponse are real instantiatable dataclasses (tests call them).
     try:
         _load_llm_sub("llm_shared.models", "models.py")
-    except Exception as _models_exc:
+    except Exception:
         # Fall back to a MagicMock stub if models.py has import issues
         _models_stub = _make_pkg_stub("llm_shared.models")
         _models_stub.LLMRequest = MagicMock()  # type: ignore[attr-defined]
@@ -295,7 +318,7 @@ if "auth_middleware" not in sys.modules:
 # do ``redis = await get_async_redis_client()`` fall back to in-process logic
 # instead of awaiting a MagicMock (which raises TypeError).
 if "autobot_shared.redis_client" not in sys.modules:
-    import asyncio as _asyncio_stub
+    pass
 
     _redis_client_mod = types.ModuleType("autobot_shared.redis_client")
 

--- a/autobot-backend/services/npu_pipeline/dispatcher.py
+++ b/autobot-backend/services/npu_pipeline/dispatcher.py
@@ -1,0 +1,230 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+PipelineDispatcher — cross-worker forward-pass coordinator.
+
+Streams a prompt through the shard pipeline:
+  1. POST hidden state to worker[0] with its layer range
+  2. Stream the response hidden state to worker[1], and so on
+  3. Last worker produces a token stream which is yielded to the caller
+
+Worker-drop handling: if a worker fails mid-pass, the dispatcher looks for a
+peer that has a cached shard covering the same layer range and retries there.
+If no peer exists, raises WorkerDropError with a clear message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import AsyncIterator, Dict, List, Optional
+
+import aiohttp
+
+from autobot_shared.logging_manager import get_logger
+from services.npu_pipeline.shard_planner import ShardAssignment
+
+logger = get_logger(__name__)
+
+WORKER_TIMEOUT_S = 30
+FORWARD_PASS_PATH = "/forward"
+TOKEN_STREAM_PATH = "/generate"
+
+
+class WorkerDropError(Exception):
+    """Raised when a worker drops mid-pass and no failover peer exists."""
+
+
+@dataclass
+class PipelinePlan:
+    """Ordered list of shard assignments that describe one pipeline pass."""
+
+    assignments: List[ShardAssignment]
+    # Optional map of worker_id → peer worker_ids that hold the same shard
+    peer_map: Dict[str, List[str]] = field(default_factory=dict)
+
+
+class PipelineDispatcher:
+    """Coordinate a forward pass across NPU workers.
+
+    Usage::
+
+        async with PipelineDispatcher(worker_urls) as d:
+            async for token in d.run_pipeline(plan, prompt_tokens):
+                print(token)
+    """
+
+    def __init__(
+        self,
+        worker_urls: Dict[str, str],
+        timeout: float = WORKER_TIMEOUT_S,
+    ) -> None:
+        self._worker_urls = worker_urls  # worker_id → base URL
+        self._timeout = timeout
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    # ------------------------------------------------------------------
+    # Async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> "PipelineDispatcher":
+        self._session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=self._timeout)
+        )
+        logger.debug("PipelineDispatcher: session opened")
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        if self._session:
+            await self._session.close()
+            self._session = None
+        logger.debug("PipelineDispatcher: session closed")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def run_pipeline(
+        self,
+        plan: PipelinePlan,
+        prompt_tokens: List[int],
+    ) -> AsyncIterator[str]:
+        """Execute a full forward pass and yield tokens from the last worker.
+
+        Args:
+            plan: Ordered shard assignments with optional peer map.
+            prompt_tokens: Tokenised prompt as a list of ints.
+
+        Yields:
+            Decoded tokens as strings from the final worker's token stream.
+
+        Raises:
+            WorkerDropError: When a worker fails and no failover peer exists.
+            RuntimeError: When called outside an async context manager.
+        """
+        if self._session is None:
+            raise RuntimeError(
+                "PipelineDispatcher must be used as an async context manager"
+            )
+
+        assignments = plan.assignments
+        if not assignments:
+            raise ValueError("PipelinePlan.assignments must not be empty")
+
+        hidden_state: object = {"tokens": prompt_tokens}
+
+        for idx, assignment in enumerate(assignments):
+            is_last = idx == len(assignments) - 1
+
+            if is_last:
+                # Last worker streams tokens
+                async for token in self._stream_tokens(
+                    plan, assignment, hidden_state
+                ):
+                    yield token
+                return
+            else:
+                hidden_state = await self._forward_pass(
+                    plan, assignment, hidden_state
+                )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _forward_pass(
+        self,
+        plan: PipelinePlan,
+        assignment: ShardAssignment,
+        hidden_state: object,
+    ) -> object:
+        """POST hidden state to a worker; return the resulting hidden state.
+
+        Retries on peer workers from plan.peer_map on connection/timeout error.
+        """
+        candidates = [assignment.worker_id] + plan.peer_map.get(
+            assignment.worker_id, []
+        )
+
+        last_exc: Optional[Exception] = None
+        for worker_id in candidates:
+            url = self._worker_url(worker_id, FORWARD_PASS_PATH)
+            try:
+                payload = {
+                    "worker_id": worker_id,
+                    "layer_start": assignment.layer_range.start,
+                    "layer_end": assignment.layer_range.end,
+                    "hidden_state": hidden_state,
+                }
+                async with self._session.post(url, json=payload) as resp:
+                    resp.raise_for_status()
+                    result = await resp.json()
+                    logger.debug(
+                        "forward_pass: worker=%s layers=%r ok",
+                        worker_id,
+                        assignment.layer_range,
+                    )
+                    return result["hidden_state"]
+            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                logger.warning(
+                    "forward_pass: worker=%s failed (%s); trying next peer",
+                    worker_id,
+                    exc,
+                )
+                last_exc = exc
+
+        raise WorkerDropError(
+            f"Worker '{assignment.worker_id}' dropped mid-pass for layers "
+            f"{assignment.layer_range!r} and no failover peer succeeded. "
+            f"Last error: {last_exc}"
+        )
+
+    async def _stream_tokens(
+        self,
+        plan: PipelinePlan,
+        assignment: ShardAssignment,
+        hidden_state: object,
+    ) -> AsyncIterator[str]:
+        """POST to the last worker's /generate endpoint and stream tokens."""
+        candidates = [assignment.worker_id] + plan.peer_map.get(
+            assignment.worker_id, []
+        )
+
+        last_exc: Optional[Exception] = None
+        for worker_id in candidates:
+            url = self._worker_url(worker_id, TOKEN_STREAM_PATH)
+            try:
+                payload = {
+                    "worker_id": worker_id,
+                    "layer_start": assignment.layer_range.start,
+                    "layer_end": assignment.layer_range.end,
+                    "hidden_state": hidden_state,
+                }
+                async with self._session.post(url, json=payload) as resp:
+                    resp.raise_for_status()
+                    async for line in resp.content:
+                        token = line.decode().strip()
+                        if token:
+                            yield token
+                return
+            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                logger.warning(
+                    "stream_tokens: worker=%s failed (%s); trying next peer",
+                    worker_id,
+                    exc,
+                )
+                last_exc = exc
+
+        raise WorkerDropError(
+            f"Last worker '{assignment.worker_id}' dropped during token streaming "
+            f"and no failover peer succeeded. Last error: {last_exc}"
+        )
+
+    def _worker_url(self, worker_id: str, path: str) -> str:
+        base = self._worker_urls.get(worker_id)
+        if not base:
+            raise WorkerDropError(
+                f"No URL registered for worker '{worker_id}'"
+            )
+        return base.rstrip("/") + path

--- a/autobot-backend/services/npu_pipeline/test_dispatcher.py
+++ b/autobot-backend/services/npu_pipeline/test_dispatcher.py
@@ -1,0 +1,238 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for PipelineDispatcher."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Load the real modules from file, bypassing sys.modules stubs that the
+# root conftest installs for services.npu_pipeline.*.
+_PKG_DIR = Path(__file__).parent
+
+
+def _load_module(name: str, filename: str):
+    if name in sys.modules and hasattr(sys.modules[name], "__file__"):
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, str(_PKG_DIR / filename))
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "services.npu_pipeline"
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_shard_planner = _load_module("services.npu_pipeline.shard_planner", "shard_planner.py")
+_dispatcher_mod = _load_module("services.npu_pipeline.dispatcher", "dispatcher.py")
+
+LayerRange = _shard_planner.LayerRange
+ShardAssignment = _shard_planner.ShardAssignment
+PipelineDispatcher = _dispatcher_mod.PipelineDispatcher
+PipelinePlan = _dispatcher_mod.PipelinePlan
+WorkerDropError = _dispatcher_mod.WorkerDropError
+
+
+WORKER_URLS = {
+    "w0": "http://worker0:8080",
+    "w1": "http://worker1:8080",
+    "w2": "http://worker2:8080",
+}
+
+PROMPT_TOKENS = [1, 2, 3, 4]
+
+
+def _make_plan(*worker_ids: str, peer_map=None) -> PipelinePlan:
+    assignments = [
+        ShardAssignment(
+            worker_id=wid,
+            layer_range=LayerRange(i * 10, i * 10 + 9),
+        )
+        for i, wid in enumerate(worker_ids)
+    ]
+    return PipelinePlan(assignments=assignments, peer_map=peer_map or {})
+
+
+async def _collect(gen) -> List[str]:
+    return [t async for t in gen]
+
+
+# ---------------------------------------------------------------------------
+# Happy path: 3 workers, full pipeline
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_happy_path_three_workers():
+    plan = _make_plan("w0", "w1", "w2")
+
+    call_log: List[str] = []
+
+    async def mock_post(url, json=None):
+        resp = AsyncMock()
+        resp.raise_for_status = MagicMock()
+        if "/forward" in url:
+            call_log.append(f"forward:{url}")
+            resp.json = AsyncMock(return_value={"hidden_state": {"data": [0.1]}})
+            resp.__aenter__ = AsyncMock(return_value=resp)
+            resp.__aexit__ = AsyncMock(return_value=False)
+        else:  # /generate
+            call_log.append(f"generate:{url}")
+
+            async def _content():
+                for tok in [b"hello\n", b"world\n"]:
+                    yield tok
+
+            resp.content = _content()
+            resp.__aenter__ = AsyncMock(return_value=resp)
+            resp.__aexit__ = AsyncMock(return_value=False)
+        return resp
+
+    session_mock = MagicMock()
+    session_mock.post = mock_post
+    session_mock.close = AsyncMock()
+
+    async with PipelineDispatcher(WORKER_URLS) as d:
+        d._session = session_mock
+        tokens = await _collect(d.run_pipeline(plan, PROMPT_TOKENS))
+
+    assert tokens == ["hello", "world"]
+    assert sum(1 for c in call_log if c.startswith("forward")) == 2
+    assert sum(1 for c in call_log if c.startswith("generate")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Worker drop mid-pass: failover to peer
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_worker_drop_mid_pass_failover():
+    """w1 is last worker; it drops and peer w2 takes over its layer range."""
+    peer_map = {"w1": ["w2"]}
+    plan = _make_plan("w0", "w1", peer_map=peer_map)
+
+    call_counts: dict = {"w0_fwd": 0, "w1_gen": 0, "w2_gen": 0}
+
+    import aiohttp as _aiohttp
+
+    async def mock_post(url, json=None):
+        resp = AsyncMock()
+        resp.raise_for_status = MagicMock()
+
+        if "worker0" in url and "/forward" in url:
+            call_counts["w0_fwd"] += 1
+            resp.json = AsyncMock(return_value={"hidden_state": {"data": [0.5]}})
+            resp.__aenter__ = AsyncMock(return_value=resp)
+            resp.__aexit__ = AsyncMock(return_value=False)
+        elif "worker1" in url:
+            call_counts["w1_gen"] += 1
+            raise _aiohttp.ClientConnectionError("worker1 down")
+        elif "worker2" in url:
+            call_counts["w2_gen"] += 1
+
+            async def _content():
+                yield b"ok\n"
+
+            resp.content = _content()
+            resp.__aenter__ = AsyncMock(return_value=resp)
+            resp.__aexit__ = AsyncMock(return_value=False)
+        return resp
+
+    session_mock = MagicMock()
+    session_mock.post = mock_post
+    session_mock.close = AsyncMock()
+
+    async with PipelineDispatcher(WORKER_URLS) as d:
+        d._session = session_mock
+        tokens = await _collect(d.run_pipeline(plan, PROMPT_TOKENS))
+
+    assert tokens == ["ok"]
+    assert call_counts["w0_fwd"] == 1
+    assert call_counts["w1_gen"] == 1
+    assert call_counts["w2_gen"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Worker drop mid-pass: no peer → clear WorkerDropError
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_worker_drop_no_peer_raises():
+    """w0 drops in forward pass and has no peers — expect WorkerDropError."""
+    plan = _make_plan("w0", "w1")
+
+    import aiohttp as _aiohttp
+
+    async def mock_post(url, json=None):
+        raise _aiohttp.ClientConnectionError("worker0 down")
+
+    session_mock = MagicMock()
+    session_mock.post = mock_post
+    session_mock.close = AsyncMock()
+
+    with pytest.raises(WorkerDropError, match="w0"):
+        async with PipelineDispatcher(WORKER_URLS) as d:
+            d._session = session_mock
+            await _collect(d.run_pipeline(plan, PROMPT_TOKENS))
+
+
+# ---------------------------------------------------------------------------
+# Last worker produces tokens (single-worker plan)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_single_worker_produces_tokens():
+    """Single-worker plan: worker is both first and last, produces tokens."""
+    plan = _make_plan("w0")
+
+    async def mock_post(url, json=None):
+        assert "/generate" in url, f"Expected /generate, got {url}"
+        resp = AsyncMock()
+        resp.raise_for_status = MagicMock()
+
+        async def _content():
+            for tok in [b"a\n", b"b\n", b"c\n"]:
+                yield tok
+
+        resp.content = _content()
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        return resp
+
+    session_mock = MagicMock()
+    session_mock.post = mock_post
+    session_mock.close = AsyncMock()
+
+    async with PipelineDispatcher(WORKER_URLS) as d:
+        d._session = session_mock
+        tokens = await _collect(d.run_pipeline(plan, PROMPT_TOKENS))
+
+    assert tokens == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# Context manager teardown
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_context_manager_closes_session():
+    close_called = False
+
+    async def fake_close():
+        nonlocal close_called
+        close_called = True
+
+    with patch("aiohttp.ClientSession") as MockSession:
+        instance = MagicMock()
+        instance.close = AsyncMock(side_effect=fake_close)
+        MockSession.return_value = instance
+
+        async with PipelineDispatcher(WORKER_URLS):
+            pass
+
+    assert close_called


### PR DESCRIPTION
## Summary

- Implements `PipelineDispatcher` in `autobot-backend/services/npu_pipeline/dispatcher.py`
- Async context manager that opens/closes an `aiohttp.ClientSession` for pipeline lifecycle
- `run_pipeline(plan, prompt_tokens)` streams hidden state from worker N to N+1 via HTTP POST, then yields tokens from the last worker's `/generate` endpoint
- Worker-drop handling: retries on peer workers from `plan.peer_map`; raises `WorkerDropError` with a clear message when no failover succeeds
- 5 unit tests covering: happy path (3 workers), worker-drop failover, no-peer raises, single-worker produces tokens, context-manager teardown

## Test plan

- [ ] `test_happy_path_three_workers` — 3-worker pipeline, 2 forward passes + 1 token stream
- [ ] `test_worker_drop_mid_pass_failover` — last worker drops, peer w2 takes over
- [ ] `test_worker_drop_no_peer_raises` — worker drops with no peer → `WorkerDropError`
- [ ] `test_single_worker_produces_tokens` — single worker acts as both forwarder and generator
- [ ] `test_context_manager_closes_session` — verifies `aiohttp.ClientSession.close()` called on exit

**Note:** Tests in `services/npu_pipeline/` hit a pre-existing env issue where the `services` MagicMock stub causes `pytest_plugins` to be a MagicMock during test collection. The conftest patch in this PR (`pytest_plugins = []` on stubs) fixes collection; the remaining `__code__` error during setup is a separate pre-existing issue shared with `test_shard_planner.py` (MVA-1096) that requires a deeper conftest fix in a follow-up.

Depends on: issue-MVA-1096
Parent: MVA-1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)