### PR TITLE
feat(npu): pulse-probe correctness check (GH#6739)

### DIFF
--- a/autobot-backend/config/npu_pulse_canaries.yaml
+++ b/autobot-backend/config/npu_pulse_canaries.yaml
@@ -1,0 +1,70 @@
+# NPU Pulse-Probe Canary Configuration (GH#6739)
+#
+# Each model family defines a fixed canary prompt and the expected token
+# that must appear verbatim in the response.  A response is considered
+# valid only when:
+#   1. It arrives within pulse_timeout_seconds
+#   2. It is well-formed (parseable JSON / non-empty text)
+#   3. expected_token appears in the response text (case-sensitive)
+#
+# pulse_interval_seconds: base cadence per worker (jitter ±20 % applied)
+# pulse_timeout_seconds:  per-request deadline
+# degrade_after_failures: consecutive failures before DEGRADED state
+# unhealthy_after_failures: consecutive failures before OFFLINE/unhealthy state
+
+defaults:
+  pulse_interval_seconds: 300   # 5 minutes
+  pulse_timeout_seconds: 30
+  degrade_after_failures: 3
+  unhealthy_after_failures: 5
+  # p95 latency window — number of recent pulses to keep per worker
+  latency_window: 20
+  # p95 latency must stay within this multiplier of the pool median
+  latency_throttle_multiplier: 3.0
+
+model_families:
+  # Small/medium generative models (Gemma, Phi, Mistral, Llama ≤13 B)
+  gemma:
+    match_prefixes:
+      - "gemma-"
+    canary_prompt: "Reply with exactly: PULSE_OK"
+    expected_token: "PULSE_OK"
+
+  phi:
+    match_prefixes:
+      - "phi-"
+      - "phi3-"
+      - "phi4-"
+    canary_prompt: "Reply with exactly: PULSE_OK"
+    expected_token: "PULSE_OK"
+
+  mistral:
+    match_prefixes:
+      - "mistral-"
+      - "mixtral-"
+    canary_prompt: "Reply with exactly: PULSE_OK"
+    expected_token: "PULSE_OK"
+
+  llama:
+    match_prefixes:
+      - "llama-"
+      - "llama2-"
+      - "llama3-"
+      - "meta-llama"
+    canary_prompt: "Reply with exactly: PULSE_OK"
+    expected_token: "PULSE_OK"
+
+  # Embedding models — inference returns a vector, not text; probe via
+  # a single-token input and check that the response is a non-empty list.
+  nomic:
+    match_prefixes:
+      - "nomic-embed"
+    canary_prompt: "ok"
+    expected_token: "__embedding_vector__"   # sentinel: validate shape not text
+    probe_mode: "embedding"
+
+  # Fallback for any model not matched above
+  default:
+    match_prefixes: []
+    canary_prompt: "Reply with exactly: PULSE_OK"
+    expected_token: "PULSE_OK"

--- a/autobot-backend/models/npu_models.py
+++ b/autobot-backend/models/npu_models.py
@@ -29,6 +29,8 @@ class WorkerStatus(str, Enum):
     BUSY = "busy"
     ERROR = "error"
     UNKNOWN = "unknown"
+    # GH#6739: pulse-probe detected inference degradation; still gets traffic at lower priority
+    DEGRADED = "degraded"
 
 
 class LoadBalancingStrategy(str, Enum):

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -479,9 +479,7 @@ class NPUWorkerManager(AsyncInitializable):
                 },
             )
             if _PULSE_METRICS_AVAILABLE:
-                _pulse_failure_total.labels(
-                    worker_id=worker_id, model_id=model_id, failure_class=failure_class
-                ).inc()
+                _pulse_failure_total.labels(worker_id=worker_id, model_id=model_id, failure_class=failure_class).inc()
 
             consecutive = self._pulse_failure_counts.get(worker_id, 0) + 1
             self._pulse_failure_counts[worker_id] = consecutive
@@ -492,7 +490,9 @@ class NPUWorkerManager(AsyncInitializable):
                     status=WorkerStatus.OFFLINE,
                     error_message=f"Pulse-probe: {consecutive} consecutive failures (last: {failure_class})",
                 )
-                await self._store_and_emit_status(worker_id, new_status, status.status if status else WorkerStatus.UNKNOWN)
+                await self._store_and_emit_status(
+                    worker_id, new_status, status.status if status else WorkerStatus.UNKNOWN
+                )
                 logger.error(
                     "Pulse-probe: worker %s marked OFFLINE after %d consecutive failures",
                     worker_id,
@@ -504,7 +504,9 @@ class NPUWorkerManager(AsyncInitializable):
                     status=WorkerStatus.DEGRADED,
                     error_message=f"Pulse-probe: {consecutive} consecutive failures (last: {failure_class})",
                 )
-                await self._store_and_emit_status(worker_id, new_status, status.status if status else WorkerStatus.UNKNOWN)
+                await self._store_and_emit_status(
+                    worker_id, new_status, status.status if status else WorkerStatus.UNKNOWN
+                )
                 logger.warning(
                     "Pulse-probe: worker %s marked DEGRADED after %d consecutive failures",
                     worker_id,

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -9,9 +9,11 @@ Manages NPU worker registration, health monitoring, and state tracking.
 
 import asyncio
 import json
+import math
+import random
 import time
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import aiofiles
 import yaml
@@ -36,6 +38,33 @@ logger = get_logger(__name__)
 
 # Issue #380: Module-level frozenset for worker events that include full data
 _WORKER_FULL_DATA_EVENTS = frozenset({"worker.added", "worker.updated"})
+
+# GH#6739: Pulse-probe canary config path
+_PULSE_CANARIES_CONFIG = Path("config/npu_pulse_canaries.yaml")
+
+# GH#6739: Prometheus metrics (lazy-initialised to avoid import-time side-effects)
+try:
+    from prometheus_client import Counter, Histogram
+
+    _pulse_total = Counter(
+        "autobot_npu_pulse_total",
+        "Total NPU pulse-probe attempts",
+        ["worker_id", "model_id"],
+    )
+    _pulse_failure_total = Counter(
+        "autobot_npu_pulse_failure_total",
+        "Total NPU pulse-probe failures",
+        ["worker_id", "model_id", "failure_class"],
+    )
+    _pulse_latency = Histogram(
+        "autobot_npu_pulse_latency_seconds",
+        "NPU pulse-probe round-trip latency",
+        ["worker_id", "model_id"],
+        buckets=(0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0),
+    )
+    _PULSE_METRICS_AVAILABLE = True
+except Exception:
+    _PULSE_METRICS_AVAILABLE = False
 
 
 class NPUWorkerManager(AsyncInitializable):
@@ -75,6 +104,12 @@ class NPUWorkerManager(AsyncInitializable):
         # Issue #699: Track consecutive failures for exponential backoff
         self._worker_failure_counts: Dict[str, int] = {}
         self._worker_next_check: Dict[str, float] = {}
+
+        # GH#6739: Pulse-probe state
+        self._pulse_task: asyncio.Task | None = None
+        self._pulse_failure_counts: Dict[str, int] = {}
+        self._pulse_canaries: Dict[str, Any] = {}
+        self._pulse_defaults: Dict[str, Any] = {}
 
     async def _initialize_impl(self) -> bool:
         """Load worker configurations from YAML (deferred from __init__ to avoid blocking I/O)."""
@@ -162,7 +197,8 @@ class NPUWorkerManager(AsyncInitializable):
         self._running = True
         self._health_check_task = asyncio.create_task(self._health_check_loop())
         self._failover_monitor_task = asyncio.create_task(self.failover_monitor())
-        logger.info("Started NPU worker health monitoring and failover monitor")
+        self._pulse_task = asyncio.create_task(self._pulse_probe_loop())
+        logger.info("Started NPU worker health monitoring, failover monitor, and pulse-probe loop")
 
     async def stop_health_monitoring(self) -> None:
         """Stop background health monitoring and failover monitor tasks."""
@@ -181,6 +217,13 @@ class NPUWorkerManager(AsyncInitializable):
                 await self._failover_monitor_task
             except asyncio.CancelledError:
                 logger.debug("Failover monitor task cancelled")
+
+        if self._pulse_task:
+            self._pulse_task.cancel()
+            try:
+                await self._pulse_task
+            except asyncio.CancelledError:
+                logger.debug("Pulse-probe task cancelled")
 
         # Close all worker clients
         for client in self._worker_clients.values():
@@ -250,6 +293,288 @@ class NPUWorkerManager(AsyncInitializable):
             del self._worker_failure_counts[worker_id]
         if worker_id in self._worker_next_check:
             del self._worker_next_check[worker_id]
+
+    # ------------------------------------------------------------------ #
+    #  GH#6739 — Pulse-probe: correctness / inference-quality check       #
+    # ------------------------------------------------------------------ #
+
+    def _load_pulse_canaries(self) -> None:
+        """Load pulse canary config from YAML (called lazily on first probe)."""
+        try:
+            if not _PULSE_CANARIES_CONFIG.exists():
+                logger.warning("Pulse canary config not found: %s", _PULSE_CANARIES_CONFIG)
+                return
+            with open(_PULSE_CANARIES_CONFIG, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+            self._pulse_defaults = data.get("defaults", {})
+            self._pulse_canaries = data.get("model_families", {})
+            logger.debug("Loaded pulse canary config with %d model families", len(self._pulse_canaries))
+        except Exception as e:
+            logger.error("Failed to load pulse canary config: %s", e)
+
+    def _canary_for_model(self, model_id: str) -> Dict[str, Any]:
+        """Return the canary definition that matches model_id (longest prefix wins)."""
+        if not self._pulse_canaries:
+            self._load_pulse_canaries()
+        best: Dict[str, Any] = {}
+        best_len = -1
+        for _family, cfg in self._pulse_canaries.items():
+            for prefix in cfg.get("match_prefixes", []):
+                if model_id.startswith(prefix) and len(prefix) > best_len:
+                    best = cfg
+                    best_len = len(prefix)
+        if not best:
+            best = self._pulse_canaries.get("default", {})
+        return best
+
+    async def _store_pulse_latency(self, worker_id: str, model_id: str, latency_s: float) -> None:
+        """Append latest pulse latency to a Redis list for p95 tracking."""
+        if not self.redis_client:
+            return
+        window = int(self._pulse_defaults.get("latency_window", 20))
+        key = f"npu:worker:{worker_id}:pulse_latency:{model_id}"
+        try:
+            pipe = self.redis_client.pipeline()
+            pipe.rpush(key, latency_s)
+            pipe.ltrim(key, -window, -1)
+            pipe.expire(key, 86400)
+            await pipe.execute()
+        except Exception as e:
+            logger.debug("Failed to store pulse latency for %s: %s", worker_id, e)
+
+    async def _get_pulse_p95_latency(self, worker_id: str, model_id: str) -> Optional[float]:
+        """Return p95 latency (seconds) from the Redis window, or None if unavailable."""
+        if not self.redis_client:
+            return None
+        key = f"npu:worker:{worker_id}:pulse_latency:{model_id}"
+        try:
+            raw = await self.redis_client.lrange(key, 0, -1)
+            if not raw:
+                return None
+            samples = sorted(float(v) for v in raw)
+            idx = math.ceil(0.95 * len(samples)) - 1
+            return samples[max(idx, 0)]
+        except Exception:
+            return None
+
+    async def _get_pool_median_latency(self, model_id: str) -> Optional[float]:
+        """Return median p95 latency across all workers for throttle detection."""
+        p95s = []
+        for worker_id in list(self._workers):
+            v = await self._get_pulse_p95_latency(worker_id, model_id)
+            if v is not None:
+                p95s.append(v)
+        if not p95s:
+            return None
+        p95s.sort()
+        mid = len(p95s) // 2
+        return p95s[mid] if len(p95s) % 2 else (p95s[mid - 1] + p95s[mid]) / 2
+
+    async def _pulse_check_worker(self, worker_id: str) -> None:
+        """Send a canary inference request to verify worker correctness (GH#6739).
+
+        On failure increments pulse_failure counter; after K failures marks
+        worker DEGRADED; after M failures marks worker OFFLINE and lets the
+        existing exponential-backoff health-check path retry.
+        """
+        if not self._pulse_canaries:
+            self._load_pulse_canaries()
+
+        worker_config = self._workers.get(worker_id)
+        if not worker_config:
+            return
+
+        status = await self._get_worker_status(worker_id)
+        if status and status.status not in (WorkerStatus.ONLINE, WorkerStatus.DEGRADED):
+            return
+
+        # Pick a model to probe: prefer loaded_models from latest heartbeat, else skip
+        model_id = None
+        if status and hasattr(status, "error_message"):
+            pass  # no model list on NPUWorkerStatus — rely on client
+        # Use the client's available_models endpoint to pick one
+        client = self._worker_clients.get(worker_id)
+        if client is None:
+            client = NPUWorkerClient(worker_config.url)
+            self._worker_clients[worker_id] = client
+
+        degrade_k = int(self._pulse_defaults.get("degrade_after_failures", 3))
+        unhealthy_m = int(self._pulse_defaults.get("unhealthy_after_failures", 5))
+        pulse_timeout = float(self._pulse_defaults.get("pulse_timeout_seconds", 30))
+        throttle_mult = float(self._pulse_defaults.get("latency_throttle_multiplier", 3.0))
+
+        try:
+            models_data = await asyncio.wait_for(client.get_available_models(), timeout=10)
+            models_list = models_data.get("models", [])
+            if not models_list:
+                return  # nothing to probe
+            model_id = random.choice(models_list)
+        except Exception as e:
+            logger.debug("Pulse-probe: could not fetch models for worker %s: %s", worker_id, e)
+            return
+
+        canary = self._canary_for_model(model_id)
+        prompt = canary.get("canary_prompt", "Reply with exactly: PULSE_OK")
+        expected = canary.get("expected_token", "PULSE_OK")
+        probe_mode = canary.get("probe_mode", "inference")
+
+        if _PULSE_METRICS_AVAILABLE:
+            _pulse_total.labels(worker_id=worker_id, model_id=model_id).inc()
+
+        start = time.monotonic()
+        failure_class: Optional[str] = None
+
+        try:
+            if probe_mode == "embedding":
+                result = await asyncio.wait_for(
+                    client.offload_heavy_processing("embedding_batch", {"texts": [prompt]}),
+                    timeout=pulse_timeout,
+                )
+                embeddings = result.get("embeddings") or result.get("result", {}).get("embeddings")
+                if not embeddings or not isinstance(embeddings, list) or len(embeddings) == 0:
+                    failure_class = "malformed_response"
+            else:
+                result = await asyncio.wait_for(
+                    client.run_inference(model_id=model_id, input_text=prompt, max_tokens=16),
+                    timeout=pulse_timeout,
+                )
+                if result.get("error"):
+                    failure_class = "inference_error"
+                else:
+                    text = result.get("output") or result.get("text") or str(result)
+                    if expected not in text:
+                        failure_class = "canary_token_missing"
+        except asyncio.TimeoutError:
+            failure_class = "timeout"
+        except Exception as e:
+            logger.debug("Pulse-probe exception for worker %s model %s: %s", worker_id, model_id, e)
+            failure_class = "exception"
+
+        latency_s = time.monotonic() - start
+        await self._store_pulse_latency(worker_id, model_id, latency_s)
+
+        if _PULSE_METRICS_AVAILABLE:
+            _pulse_latency.labels(worker_id=worker_id, model_id=model_id).observe(latency_s)
+
+        # Throttling detection: p95 > multiplier * pool_median → treat as failure
+        if failure_class is None and latency_s < pulse_timeout:
+            p95 = await self._get_pulse_p95_latency(worker_id, model_id)
+            pool_med = await self._get_pool_median_latency(model_id)
+            if p95 is not None and pool_med is not None and pool_med > 0:
+                if p95 > throttle_mult * pool_med:
+                    failure_class = "throttling"
+
+        if failure_class:
+            logger.warning(
+                "Pulse-probe FAILED worker=%s model=%s latency=%.2fs class=%s",
+                worker_id,
+                model_id,
+                latency_s,
+                failure_class,
+                extra={
+                    "worker_id": worker_id,
+                    "model_id": model_id,
+                    "latency_s": latency_s,
+                    "failure_class": failure_class,
+                },
+            )
+            if _PULSE_METRICS_AVAILABLE:
+                _pulse_failure_total.labels(
+                    worker_id=worker_id, model_id=model_id, failure_class=failure_class
+                ).inc()
+
+            consecutive = self._pulse_failure_counts.get(worker_id, 0) + 1
+            self._pulse_failure_counts[worker_id] = consecutive
+
+            if consecutive >= unhealthy_m:
+                new_status = NPUWorkerStatus(
+                    id=worker_id,
+                    status=WorkerStatus.OFFLINE,
+                    error_message=f"Pulse-probe: {consecutive} consecutive failures (last: {failure_class})",
+                )
+                await self._store_and_emit_status(worker_id, new_status, status.status if status else WorkerStatus.UNKNOWN)
+                logger.error(
+                    "Pulse-probe: worker %s marked OFFLINE after %d consecutive failures",
+                    worker_id,
+                    consecutive,
+                )
+            elif consecutive >= degrade_k:
+                new_status = NPUWorkerStatus(
+                    id=worker_id,
+                    status=WorkerStatus.DEGRADED,
+                    error_message=f"Pulse-probe: {consecutive} consecutive failures (last: {failure_class})",
+                )
+                await self._store_and_emit_status(worker_id, new_status, status.status if status else WorkerStatus.UNKNOWN)
+                logger.warning(
+                    "Pulse-probe: worker %s marked DEGRADED after %d consecutive failures",
+                    worker_id,
+                    consecutive,
+                )
+        else:
+            if worker_id in self._pulse_failure_counts:
+                del self._pulse_failure_counts[worker_id]
+            # Recover DEGRADED → ONLINE on a clean pass
+            if status and status.status == WorkerStatus.DEGRADED:
+                new_status = NPUWorkerStatus(
+                    id=worker_id,
+                    status=WorkerStatus.ONLINE,
+                    error_message=None,
+                )
+                await self._store_and_emit_status(worker_id, new_status, WorkerStatus.DEGRADED)
+                logger.info("Pulse-probe: worker %s recovered (DEGRADED → ONLINE)", worker_id)
+            logger.debug(
+                "Pulse-probe OK worker=%s model=%s latency=%.2fs",
+                worker_id,
+                model_id,
+                latency_s,
+            )
+
+    async def _pulse_probe_loop(self) -> None:
+        """Background loop: probe each healthy worker at a jittered 5-minute cadence (GH#6739)."""
+        if not self._pulse_canaries:
+            self._load_pulse_canaries()
+        base_interval = float(self._pulse_defaults.get("pulse_interval_seconds", 300))
+        logger.info("NPU pulse-probe loop started (base interval %ds)", int(base_interval))
+
+        while self._running:
+            try:
+                for worker_id, cfg in list(self._workers.items()):
+                    if not cfg.enabled:
+                        continue
+                    try:
+                        await self._pulse_check_worker(worker_id)
+                    except Exception as e:
+                        logger.debug("Pulse-probe error for worker %s: %s", worker_id, e)
+
+                # Jitter: ±20 % of base_interval
+                jitter = base_interval * 0.2 * (random.random() * 2 - 1)
+                await asyncio.sleep(max(base_interval + jitter, 60))
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.debug("Pulse-probe loop error: %s", e)
+                await asyncio.sleep(TimingConstants.LONG_DELAY)
+
+    # ------------------------------------------------------------------ #
+    #  GH#6739 — Load-balancer: deprioritise DEGRADED workers             #
+    # ------------------------------------------------------------------ #
+
+    async def get_healthy_workers_sorted(self) -> List[NPUWorkerDetails]:
+        """Return workers sorted for task assignment: ONLINE first, then DEGRADED.
+
+        OFFLINE/ERROR/UNKNOWN workers are excluded.  Call sites in the task
+        dispatch path should prefer this method over list_workers() so that
+        degraded workers receive traffic only when no healthy alternative exists.
+        """
+        all_workers = await self.list_workers()
+        online = [w for w in all_workers if w.status.status == WorkerStatus.ONLINE and w.config.enabled]
+        degraded = [w for w in all_workers if w.status.status == WorkerStatus.DEGRADED and w.config.enabled]
+
+        def _by_priority(w: NPUWorkerDetails) -> tuple:
+            return (-w.config.priority, w.status.current_load)
+
+        return sorted(online, key=_by_priority) + sorted(degraded, key=_by_priority)
 
     async def _health_check_loop(self) -> None:
         """Background task that periodically checks worker health"""

--- a/autobot-backend/services/npu_worker_manager_pulse_test.py
+++ b/autobot-backend/services/npu_worker_manager_pulse_test.py
@@ -19,7 +19,6 @@ import pytest
 from models.npu_models import NPUWorkerConfig, NPUWorkerStatus, WorkerStatus
 from services.npu_worker_manager import NPUWorkerManager
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/npu_worker_manager_pulse_test.py
+++ b/autobot-backend/services/npu_worker_manager_pulse_test.py
@@ -1,0 +1,261 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for NPU pulse-probe correctness check (GH#6739).
+
+Covers:
+- Consecutive pulse failures → DEGRADED state
+- Continued failures → OFFLINE (unhealthy)
+- Recovery: clean pulse after DEGRADED → ONLINE
+"""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from models.npu_models import NPUWorkerConfig, NPUWorkerStatus, WorkerStatus
+from services.npu_worker_manager import NPUWorkerManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_worker_config(worker_id: str = "test-worker-1") -> NPUWorkerConfig:
+    return NPUWorkerConfig(
+        id=worker_id,
+        name="Test Worker",
+        url="http://127.0.0.1:8099",
+        enabled=True,
+        priority=5,
+    )
+
+
+def _make_manager(redis_client=None) -> NPUWorkerManager:
+    """Construct an NPUWorkerManager with __init__ bypassed for heavy I/O."""
+    mgr = NPUWorkerManager.__new__(NPUWorkerManager)
+    mgr._workers = {}
+    mgr._worker_clients = {}
+    mgr._health_check_task = None
+    mgr._failover_monitor_task = None
+    mgr._pulse_task = None
+    mgr._running = False
+    mgr._load_balancing_config = MagicMock()
+    mgr._load_balancing_config.health_check_interval = 30
+    mgr._load_balancing_config.timeout_seconds = 10
+    mgr._worker_failure_counts = {}
+    mgr._worker_next_check = {}
+    mgr._pulse_failure_counts = {}
+    mgr._pulse_canaries = {
+        "default": {
+            "match_prefixes": [],
+            "canary_prompt": "Reply with exactly: PULSE_OK",
+            "expected_token": "PULSE_OK",
+        }
+    }
+    mgr._pulse_defaults = {
+        "pulse_interval_seconds": 300,
+        "pulse_timeout_seconds": 30,
+        "degrade_after_failures": 3,
+        "unhealthy_after_failures": 5,
+        "latency_window": 20,
+        "latency_throttle_multiplier": 3.0,
+    }
+    mgr.redis_client = redis_client
+    mgr.config_file = Path("config/npu_workers.yaml")
+    return mgr
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mgr():
+    m = _make_manager()
+    cfg = _make_worker_config()
+    m._workers[cfg.id] = cfg
+    return m
+
+
+@pytest.fixture
+def online_status():
+    return NPUWorkerStatus(id="test-worker-1", status=WorkerStatus.ONLINE)
+
+
+@pytest.fixture
+def degraded_status():
+    return NPUWorkerStatus(
+        id="test-worker-1",
+        status=WorkerStatus.DEGRADED,
+        error_message="Pulse-probe: 3 consecutive failures (last: timeout)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pulse_failure_leads_to_degraded(mgr, online_status):
+    """K consecutive failures should mark the worker DEGRADED."""
+    worker_id = "test-worker-1"
+    degrade_k = int(mgr._pulse_defaults["degrade_after_failures"])
+
+    client_mock = AsyncMock()
+    client_mock.get_available_models = AsyncMock(return_value={"models": ["gemma-3-4b"]})
+    client_mock.run_inference = AsyncMock(return_value={"error": "model load failed"})
+    mgr._worker_clients[worker_id] = client_mock
+
+    stored_statuses = []
+
+    async def fake_get_status(wid):
+        if stored_statuses:
+            return stored_statuses[-1]
+        return online_status
+
+    async def fake_store_emit(wid, status, prev):
+        stored_statuses.append(status)
+
+    mgr._get_worker_status = fake_get_status
+    mgr._store_and_emit_status = fake_store_emit
+
+    # Accumulate degrade_k failures
+    for _ in range(degrade_k):
+        await mgr._pulse_check_worker(worker_id)
+
+    assert mgr._pulse_failure_counts[worker_id] == degrade_k
+    last = stored_statuses[-1]
+    assert last.status == WorkerStatus.DEGRADED
+
+
+@pytest.mark.asyncio
+async def test_pulse_failure_leads_to_unhealthy(mgr, online_status):
+    """M consecutive failures should mark the worker OFFLINE."""
+    worker_id = "test-worker-1"
+    unhealthy_m = int(mgr._pulse_defaults["unhealthy_after_failures"])
+
+    client_mock = AsyncMock()
+    client_mock.get_available_models = AsyncMock(return_value={"models": ["gemma-3-4b"]})
+    client_mock.run_inference = AsyncMock(return_value={"error": "inference failed"})
+    mgr._worker_clients[worker_id] = client_mock
+
+    stored_statuses = []
+
+    async def fake_get_status(wid):
+        if stored_statuses:
+            return stored_statuses[-1]
+        return online_status
+
+    async def fake_store_emit(wid, status, prev):
+        stored_statuses.append(status)
+
+    mgr._get_worker_status = fake_get_status
+    mgr._store_and_emit_status = fake_store_emit
+
+    for _ in range(unhealthy_m):
+        await mgr._pulse_check_worker(worker_id)
+
+    assert mgr._pulse_failure_counts[worker_id] == unhealthy_m
+    last = stored_statuses[-1]
+    assert last.status == WorkerStatus.OFFLINE
+
+
+@pytest.mark.asyncio
+async def test_pulse_recovery_from_degraded(mgr, degraded_status):
+    """A successful pulse after DEGRADED should restore the worker to ONLINE."""
+    worker_id = "test-worker-1"
+
+    client_mock = AsyncMock()
+    client_mock.get_available_models = AsyncMock(return_value={"models": ["gemma-3-4b"]})
+    client_mock.run_inference = AsyncMock(return_value={"output": "PULSE_OK"})
+    mgr._worker_clients[worker_id] = client_mock
+
+    # Seed pre-existing failure count at degrade threshold
+    mgr._pulse_failure_counts[worker_id] = int(mgr._pulse_defaults["degrade_after_failures"])
+
+    stored_statuses = []
+
+    async def fake_get_status(wid):
+        return degraded_status
+
+    async def fake_store_emit(wid, status, prev):
+        stored_statuses.append(status)
+
+    async def fake_store_latency(wid, mid, lat):
+        pass
+
+    async def fake_pool_median(mid):
+        return None
+
+    async def fake_p95(wid, mid):
+        return None
+
+    mgr._get_worker_status = fake_get_status
+    mgr._store_and_emit_status = fake_store_emit
+    mgr._store_pulse_latency = fake_store_latency
+    mgr._get_pool_median_latency = fake_pool_median
+    mgr._get_pulse_p95_latency = fake_p95
+
+    await mgr._pulse_check_worker(worker_id)
+
+    # Failure counter cleared
+    assert worker_id not in mgr._pulse_failure_counts
+    # Status restored to ONLINE
+    assert stored_statuses[-1].status == WorkerStatus.ONLINE
+
+
+@pytest.mark.asyncio
+async def test_pulse_skips_offline_worker(mgr):
+    """Workers that are already OFFLINE should not be probed."""
+    worker_id = "test-worker-1"
+    offline_status = NPUWorkerStatus(id=worker_id, status=WorkerStatus.OFFLINE)
+
+    client_mock = AsyncMock()
+    mgr._worker_clients[worker_id] = client_mock
+
+    async def fake_get_status(wid):
+        return offline_status
+
+    mgr._get_worker_status = fake_get_status
+
+    await mgr._pulse_check_worker(worker_id)
+
+    # No inference should be attempted
+    client_mock.run_inference.assert_not_called()
+    client_mock.get_available_models.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_healthy_workers_sorted_puts_degraded_last(mgr):
+    """get_healthy_workers_sorted should return ONLINE workers before DEGRADED."""
+    from models.npu_models import NPUWorkerDetails
+
+    worker_a = NPUWorkerDetails(
+        config=_make_worker_config("worker-a"),
+        status=NPUWorkerStatus(id="worker-a", status=WorkerStatus.ONLINE),
+    )
+    worker_b = NPUWorkerDetails(
+        config=_make_worker_config("worker-b"),
+        status=NPUWorkerStatus(id="worker-b", status=WorkerStatus.DEGRADED),
+    )
+    worker_c = NPUWorkerDetails(
+        config=_make_worker_config("worker-c"),
+        status=NPUWorkerStatus(id="worker-c", status=WorkerStatus.OFFLINE),
+    )
+
+    async def fake_list_workers():
+        return [worker_a, worker_b, worker_c]
+
+    mgr.list_workers = fake_list_workers
+
+    result = await mgr.get_healthy_workers_sorted()
+    assert len(result) == 2  # OFFLINE excluded
+    assert result[0].config.id == "worker-a"
+    assert result[1].config.id == "worker-b"


### PR DESCRIPTION
## Summary

Implements GH#6739 — heartbeat reachability alone does not verify workers are actually inferring correctly. This adds a periodic **pulse-probe** that sends a fixed canary prompt and validates the response.

- Add `WorkerStatus.DEGRADED` — worker still gets traffic but at lower priority than `ONLINE`
- New `_pulse_check_worker(worker_id)` sends a canary inference request to a randomly selected advertised model, validates token presence + response shape + p95 latency band
- `_pulse_probe_loop()` runs at a jittered 5-minute cadence per worker (separate from 30 s heartbeat to avoid worker spam)
- After 3 consecutive failures → `DEGRADED`; after 5 → `OFFLINE` (existing backoff path retries)
- Clean probe from `DEGRADED` → `ONLINE` recovery
- Per-worker p95 latency tracked in Redis; p95 > 3× pool median = `throttling` failure class
- Prometheus metrics: `autobot_npu_pulse_total`, `autobot_npu_pulse_failure_total`, `autobot_npu_pulse_latency_seconds`
- Structured logging on every pulse failure (`worker_id`, `model_id`, `latency`, `failure_class`)
- `config/npu_pulse_canaries.yaml` — canary prompt + expected token per model family
- `get_healthy_workers_sorted()` dispatch helper: ONLINE first, DEGRADED last, OFFLINE excluded

## Thinking Path

The existing heartbeat only checks TCP reachability, not inference correctness — a worker can respond 200 to `/health` while a model is silently producing garbage or timing out. The solution is a second, slower probe loop that actually runs a known-answer canary through the inference stack, tracked independently from the heartbeat. A graduated failure model (DEGRADED at 3 failures, OFFLINE at 5) avoids penalising workers on transient blips while still shedding traffic early when degradation is real. The p95 throttling check catches a different failure class — workers that answer but are systematically slow. Config-file-driven canaries (yaml, one entry per model family) keep the probing logic decoupled from model identifiers baked into code.

## What Changed

- `models/npu_models.py`: Added `WorkerStatus.DEGRADED = "degraded"` to the enum
- `services/npu_worker_manager.py`: Added ~330 lines — `_load_pulse_canaries()`, `_canary_for_model()`, `_store_pulse_latency()`, `_get_pulse_p95_latency()`, `_get_pool_median_latency()`, `_pulse_check_worker()`, `_pulse_probe_loop()`, `get_healthy_workers_sorted()`; wired `_pulse_task` into `start_health_monitoring` / `stop_health_monitoring`; Prometheus counters + histogram with graceful fallback
- `config/npu_pulse_canaries.yaml`: New file — canary prompts, expected tokens, probe defaults, and model family prefix matching
- `services/npu_worker_manager_pulse_test.py`: New file — 5 async unit tests covering failure→DEGRADED, failure→OFFLINE, recovery, skip-offline, and load-balancer ordering

## Verification

- 5 unit tests in `npu_worker_manager_pulse_test.py` exercise all state transitions and the dispatch helper
- `WorkerStatus.DEGRADED` serialises correctly as `"degraded"` string in the existing Redis status path (validated via model dump)
- Prometheus metric registration guarded by `try/except ImportError` — works with and without `prometheus_client` installed
- Black formatting applied to both modified files (code-quality CI)
- startup-import-smoke failures are pre-existing on Dev_new_gui base branch (tracked in PR #8646)

## Model Used

claude-sonnet-4-6

## Test plan

- [x] `services/npu_worker_manager_pulse_test.py` — 5 unit tests: failure→degraded, failure→unhealthy, recovery, skip-offline, load-balancer ordering
- [x] Confirm `WorkerStatus.DEGRADED` serialises correctly in existing Redis status paths
- [x] Confirm `_pulse_probe_loop` starts and stops with `start_health_monitoring` / `stop_health_monitoring`
- [x] Check Prometheus metric registration does not conflict if `prometheus_client` is unavailable (graceful fallback)

## Related

- Closes GH#6739
- Related GH#6738 (auto-profile) — recommend landing together so the recommended-models list is what gets pulse-probed
- Related GH#6636 (silent provider breakage) — pulse-probe is the worker-layer analog

🤖 Generated with [Claude Code](https://claude.com/claude-code)