### PR TITLE
feat(npu): pre-fill pair-confirm dialog with recommended_profile + capabilities_summary (GH#6738, MVA-1138)

### DIFF
--- a/autobot-frontend/src/components/admin/NpuWorkerPairConfirmDialog.stories.ts
+++ b/autobot-frontend/src/components/admin/NpuWorkerPairConfirmDialog.stories.ts
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { ref } from 'vue'
+import NpuWorkerPairConfirmDialog from './NpuWorkerPairConfirmDialog.vue'
+import type { NpuWorkerPairResult } from '@/composables/useNpuWorkers'
+
+const meta = {
+  title: 'Components/Admin/NpuWorkerPairConfirmDialog',
+  component: NpuWorkerPairConfirmDialog,
+} as Meta<typeof NpuWorkerPairConfirmDialog>
+
+export default meta
+// #7273: relaxed to StoryObj<any> for render-only stories
+type Story = StoryObj<any>
+
+const inferenceResult: NpuWorkerPairResult = {
+  success: true,
+  worker_id: 'npu-worker-rtx3060',
+  recommended_profile: 'inference',
+  recommended_models: [{ id: 'gemma-3-4b', reason: 'fits in 8GB VRAM' }],
+  vram_gb: 8.0,
+  compute_class: 'consumer-gpu',
+  capabilities_summary: 'CUDA, 1× RTX 3060 8 GB, 32 GB RAM',
+}
+
+const embeddingResult: NpuWorkerPairResult = {
+  success: true,
+  worker_id: 'npu-worker-cpu-only',
+  recommended_profile: 'embedding',
+  recommended_models: [],
+  vram_gb: 0,
+  compute_class: 'cpu-only',
+  capabilities_summary: 'No GPU detected, 32 GB RAM — embedding workloads only',
+}
+
+const noSuggestionResult: NpuWorkerPairResult = {
+  success: true,
+  worker_id: 'npu-worker-unknown',
+  recommended_profile: null,
+  recommended_models: null,
+  vram_gb: null,
+  compute_class: null,
+  capabilities_summary: null,
+}
+
+export const InferenceRecommended: Story = {
+  render: () => ({
+    components: { NpuWorkerPairConfirmDialog },
+    setup() {
+      const show = ref(true)
+      return { show, pairResult: inferenceResult }
+    },
+    template: `
+      <NpuWorkerPairConfirmDialog
+        v-model="show"
+        :pairResult="pairResult"
+        @confirm="(p) => console.log('confirmed', p)"
+        @cancel="console.log('cancelled')"
+      />
+    `,
+  }),
+}
+
+export const EmbeddingRecommended: Story = {
+  render: () => ({
+    components: { NpuWorkerPairConfirmDialog },
+    setup() {
+      const show = ref(true)
+      return { show, pairResult: embeddingResult }
+    },
+    template: `
+      <NpuWorkerPairConfirmDialog
+        v-model="show"
+        :pairResult="pairResult"
+        @confirm="(p) => console.log('confirmed', p)"
+        @cancel="console.log('cancelled')"
+      />
+    `,
+  }),
+}
+
+export const NoSuggestion: Story = {
+  render: () => ({
+    components: { NpuWorkerPairConfirmDialog },
+    setup() {
+      const show = ref(true)
+      return { show, pairResult: noSuggestionResult }
+    },
+    template: `
+      <NpuWorkerPairConfirmDialog
+        v-model="show"
+        :pairResult="pairResult"
+        @confirm="(p) => console.log('confirmed', p)"
+        @cancel="console.log('cancelled')"
+      />
+    `,
+  }),
+}

--- a/autobot-frontend/src/components/admin/NpuWorkerPairConfirmDialog.vue
+++ b/autobot-frontend/src/components/admin/NpuWorkerPairConfirmDialog.vue
@@ -1,0 +1,380 @@
+<template>
+  <Teleport to="body">
+    <Transition name="pair-confirm-fade">
+      <div
+        v-if="modelValue"
+        class="pair-confirm-overlay"
+        @click.self="cancel"
+        @keydown.esc="cancel"
+      >
+        <div
+          ref="dialogRef"
+          role="dialog"
+          aria-modal="true"
+          :aria-labelledby="titleId"
+          class="pair-confirm-dialog"
+          tabindex="-1"
+          @keydown="onFocusTrapKeydown"
+        >
+          <h3 :id="titleId" class="pair-confirm-title">Confirm NPU Worker Profile</h3>
+
+          <p class="pair-confirm-worker-id">
+            Worker <code>{{ pairResult.worker_id }}</code> paired successfully.
+          </p>
+
+          <div class="pair-confirm-profile-section">
+            <div class="pair-confirm-label-row">
+              <label :for="selectId" class="pair-confirm-label">Worker profile</label>
+              <div
+                v-if="pairResult.capabilities_summary"
+                class="pair-confirm-tooltip-wrap"
+              >
+                <button
+                  type="button"
+                  class="pair-confirm-why-btn"
+                  :aria-describedby="tooltipId"
+                  @mouseenter="tooltipVisible = true"
+                  @mouseleave="tooltipVisible = false"
+                  @focus="tooltipVisible = true"
+                  @blur="tooltipVisible = false"
+                >
+                  Why?
+                </button>
+                <div
+                  v-if="tooltipVisible"
+                  :id="tooltipId"
+                  role="tooltip"
+                  class="pair-confirm-tooltip"
+                >
+                  {{ pairResult.capabilities_summary }}
+                </div>
+              </div>
+            </div>
+
+            <select
+              :id="selectId"
+              v-model="selectedProfile"
+              class="pair-confirm-select"
+            >
+              <option
+                v-for="option in PROFILE_OPTIONS"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}
+                <template v-if="option.value === pairResult.recommended_profile"> (recommended)</template>
+              </option>
+            </select>
+
+            <p
+              v-if="isManualOverride"
+              class="pair-confirm-override-note"
+            >
+              Manual override — your choice will be saved.
+            </p>
+          </div>
+
+          <div class="pair-confirm-actions">
+            <button
+              ref="cancelRef"
+              type="button"
+              class="pair-confirm-btn pair-confirm-btn-cancel"
+              @click="cancel"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="pair-confirm-btn pair-confirm-btn-confirm"
+              @click="confirm"
+            >
+              Save profile
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, useId } from 'vue'
+import { useFocusTrap } from '@/composables/useFocusTrap'
+import type { NpuWorkerPairResult, NpuWorkerProfile } from '@/composables/useNpuWorkers'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROFILE_OPTIONS: Array<{ value: NpuWorkerProfile; label: string }> = [
+  { value: 'inference', label: 'Inference' },
+  { value: 'embedding', label: 'Embedding' },
+  { value: 'mixed', label: 'Mixed (inference + embedding)' },
+  { value: 'relay', label: 'Relay (CPU-only forwarding)' },
+]
+
+// ---------------------------------------------------------------------------
+// Props / Emits
+// ---------------------------------------------------------------------------
+
+const props = defineProps<{
+  modelValue: boolean
+  pairResult: NpuWorkerPairResult
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  confirm: [payload: { workerId: string; profile: NpuWorkerProfile }]
+  cancel: []
+}>()
+
+// ---------------------------------------------------------------------------
+// IDs
+// ---------------------------------------------------------------------------
+
+const _uid = useId()
+const titleId = `npu-pair-title-${_uid}`
+const selectId = `npu-pair-profile-${_uid}`
+const tooltipId = `npu-pair-tooltip-${_uid}`
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const dialogRef = ref<HTMLElement | null>(null)
+const cancelRef = ref<HTMLElement | null>(null)
+const tooltipVisible = ref(false)
+
+const selectedProfile = ref<NpuWorkerProfile>(
+  props.pairResult.recommended_profile ?? 'inference'
+)
+
+const isManualOverride = computed(
+  () =>
+    props.pairResult.recommended_profile !== null &&
+    selectedProfile.value !== props.pairResult.recommended_profile
+)
+
+// Focus cancel button when dialog opens; reset profile to recommendation
+watch(
+  () => props.modelValue,
+  (visible) => {
+    if (visible) {
+      selectedProfile.value = props.pairResult.recommended_profile ?? 'inference'
+      setTimeout(() => cancelRef.value?.focus(), 0)
+    }
+  }
+)
+
+// ---------------------------------------------------------------------------
+// Focus trap
+// ---------------------------------------------------------------------------
+
+const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+function confirm() {
+  emit('confirm', { workerId: props.pairResult.worker_id, profile: selectedProfile.value })
+  emit('update:modelValue', false)
+}
+
+function cancel() {
+  emit('cancel')
+  emit('update:modelValue', false)
+}
+</script>
+
+<style scoped>
+.pair-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-overlay-dark);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal);
+  padding: var(--spacing-4);
+}
+
+.pair-confirm-dialog {
+  background: var(--bg-primary);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-2xl);
+  padding: var(--spacing-6);
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.pair-confirm-dialog:focus {
+  outline: none;
+}
+
+.pair-confirm-title {
+  font-size: var(--text-xl);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.pair-confirm-worker-id {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.pair-confirm-worker-id code {
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  padding: 0 var(--spacing-1);
+  border-radius: var(--radius-sm);
+}
+
+/* Profile section */
+.pair-confirm-profile-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.pair-confirm-label-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.pair-confirm-label {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--text-primary);
+}
+
+/* Tooltip */
+.pair-confirm-tooltip-wrap {
+  position: relative;
+}
+
+.pair-confirm-why-btn {
+  background: none;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 1px var(--spacing-2);
+  line-height: 1.4;
+}
+
+.pair-confirm-why-btn:hover,
+.pair-confirm-why-btn:focus-visible {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+  outline: none;
+}
+
+.pair-confirm-tooltip {
+  position: absolute;
+  bottom: calc(100% + var(--spacing-2));
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-overlay-dark);
+  color: var(--text-inverse, #fff);
+  font-size: var(--text-xs);
+  padding: var(--spacing-2) var(--spacing-3);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+  max-width: 280px;
+  white-space: normal;
+  z-index: var(--z-tooltip, 9999);
+  pointer-events: none;
+}
+
+.pair-confirm-select {
+  padding: var(--spacing-2) var(--spacing-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-default);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  width: 100%;
+  cursor: pointer;
+}
+
+.pair-confirm-select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.pair-confirm-override-note {
+  font-size: var(--text-xs);
+  color: var(--color-warning, #f59e0b);
+  margin: 0;
+}
+
+/* Actions */
+.pair-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-3);
+}
+
+.pair-confirm-btn {
+  padding: var(--spacing-2) var(--spacing-4);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  border: none;
+  transition: background var(--duration-200) var(--ease-in-out);
+  min-height: 2.25rem;
+}
+
+.pair-confirm-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.pair-confirm-btn-cancel {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.pair-confirm-btn-cancel:hover {
+  background: var(--bg-tertiary);
+}
+
+.pair-confirm-btn-confirm {
+  background: var(--color-primary);
+  color: var(--text-inverse, #fff);
+}
+
+.pair-confirm-btn-confirm:hover {
+  opacity: 0.9;
+}
+
+/* Transitions */
+.pair-confirm-fade-enter-active,
+.pair-confirm-fade-leave-active {
+  transition: opacity var(--duration-200) var(--ease-in-out);
+}
+
+.pair-confirm-fade-enter-from,
+.pair-confirm-fade-leave-to {
+  opacity: 0;
+}
+
+.pair-confirm-fade-enter-active .pair-confirm-dialog,
+.pair-confirm-fade-leave-active .pair-confirm-dialog {
+  transition: transform var(--duration-200) var(--ease-in-out);
+}
+
+.pair-confirm-fade-enter-from .pair-confirm-dialog,
+.pair-confirm-fade-leave-to .pair-confirm-dialog {
+  transform: scale(0.95);
+}
+</style>

--- a/autobot-frontend/src/components/admin/__tests__/NpuWorkerPairConfirmDialog.spec.ts
+++ b/autobot-frontend/src/components/admin/__tests__/NpuWorkerPairConfirmDialog.spec.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { nextTick } from 'vue'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import NpuWorkerPairConfirmDialog from '../NpuWorkerPairConfirmDialog.vue'
+import type { NpuWorkerPairResult } from '@/composables/useNpuWorkers'
+
+const inferenceResult: NpuWorkerPairResult = {
+  success: true,
+  worker_id: 'npu-worker-rtx3060',
+  recommended_profile: 'inference',
+  recommended_models: [{ id: 'gemma-3-4b', reason: 'fits in 8GB VRAM' }],
+  vram_gb: 8.0,
+  compute_class: 'consumer-gpu',
+  capabilities_summary: 'CUDA, 1× RTX 3060 8 GB, 32 GB RAM',
+}
+
+const noSuggestionResult: NpuWorkerPairResult = {
+  success: true,
+  worker_id: 'npu-worker-unknown',
+  recommended_profile: null,
+  recommended_models: null,
+  vram_gb: null,
+  compute_class: null,
+  capabilities_summary: null,
+}
+
+// Teleport renders to document.body — query from there
+function q<T extends Element = Element>(sel: string): T | null {
+  return document.body.querySelector<T>(sel)
+}
+
+async function click(sel: string) {
+  const el = q<HTMLElement>(sel)
+  if (!el) throw new Error(`Element not found: ${sel}`)
+  el.click()
+  await nextTick()
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const wrappers: VueWrapper<any>[] = []
+
+function mountDialog(pairResult: NpuWorkerPairResult, modelValue = true) {
+  const w = mount(NpuWorkerPairConfirmDialog, {
+    props: { modelValue, pairResult },
+    attachTo: document.body,
+  })
+  wrappers.push(w)
+  return w
+}
+
+afterEach(() => {
+  wrappers.forEach((w) => w.unmount())
+  wrappers.length = 0
+})
+
+describe('NpuWorkerPairConfirmDialog', () => {
+  describe('profile selector pre-fill', () => {
+    it('pre-fills profile selector with recommended_profile', () => {
+      mountDialog(inferenceResult)
+      const select = q<HTMLSelectElement>('select')
+      expect(select?.value).toBe('inference')
+    })
+
+    it('defaults to inference when recommended_profile is null', () => {
+      mountDialog(noSuggestionResult)
+      const select = q<HTMLSelectElement>('select')
+      expect(select?.value).toBe('inference')
+    })
+
+    it('resets to recommended_profile when dialog reopens', async () => {
+      const wrapper = mountDialog(inferenceResult)
+      const select = q<HTMLSelectElement>('select')!
+
+      // Override to mixed via DOM + trigger Vue update
+      select.value = 'mixed'
+      select.dispatchEvent(new Event('change'))
+      await nextTick()
+      expect(select.value).toBe('mixed')
+
+      // Close and reopen
+      await wrapper.setProps({ modelValue: false })
+      await wrapper.setProps({ modelValue: true })
+
+      expect(q<HTMLSelectElement>('select')?.value).toBe('inference')
+    })
+  })
+
+  describe('capabilities_summary tooltip', () => {
+    it('shows Why? button when capabilities_summary is present', () => {
+      mountDialog(inferenceResult)
+      expect(q('.pair-confirm-why-btn')).toBeTruthy()
+    })
+
+    it('hides Why? button when capabilities_summary is null', () => {
+      mountDialog(noSuggestionResult)
+      expect(q('.pair-confirm-why-btn')).toBeNull()
+    })
+
+    it('shows tooltip on mouseenter', async () => {
+      mountDialog(inferenceResult)
+      const btn = q<HTMLElement>('.pair-confirm-why-btn')!
+      btn.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }))
+      await nextTick()
+      const tooltip = q('.pair-confirm-tooltip')
+      expect(tooltip).toBeTruthy()
+      expect(tooltip?.textContent).toContain('RTX 3060')
+    })
+
+    it('hides tooltip on mouseleave', async () => {
+      mountDialog(inferenceResult)
+      const btn = q<HTMLElement>('.pair-confirm-why-btn')!
+      btn.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }))
+      await nextTick()
+      btn.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }))
+      await nextTick()
+      expect(q('.pair-confirm-tooltip')).toBeNull()
+    })
+  })
+
+  describe('manual override', () => {
+    it('shows override note when profile changed from recommendation', async () => {
+      mountDialog(inferenceResult)
+      const select = q<HTMLSelectElement>('select')!
+      select.value = 'mixed'
+      select.dispatchEvent(new Event('change'))
+      await nextTick()
+      expect(q('.pair-confirm-override-note')).toBeTruthy()
+    })
+
+    it('hides override note when profile matches recommendation', async () => {
+      mountDialog(inferenceResult)
+      const select = q<HTMLSelectElement>('select')!
+      select.value = 'mixed'
+      select.dispatchEvent(new Event('change'))
+      await nextTick()
+      select.value = 'inference'
+      select.dispatchEvent(new Event('change'))
+      await nextTick()
+      expect(q('.pair-confirm-override-note')).toBeNull()
+    })
+
+    it('emits confirm with overridden profile', async () => {
+      const wrapper = mountDialog(inferenceResult)
+      const select = q<HTMLSelectElement>('select')!
+      select.value = 'embedding'
+      select.dispatchEvent(new Event('change'))
+      await nextTick()
+
+      await click('.pair-confirm-btn-confirm')
+
+      const events = wrapper.emitted('confirm')
+      expect(events).toHaveLength(1)
+      expect(events![0]).toEqual([{ workerId: 'npu-worker-rtx3060', profile: 'embedding' }])
+    })
+
+    it('emits confirm with recommended profile when no override', async () => {
+      const wrapper = mountDialog(inferenceResult)
+      await click('.pair-confirm-btn-confirm')
+
+      const events = wrapper.emitted('confirm')
+      expect(events).toHaveLength(1)
+      expect(events![0]).toEqual([{ workerId: 'npu-worker-rtx3060', profile: 'inference' }])
+    })
+  })
+
+  describe('cancel', () => {
+    it('emits cancel on cancel button click', async () => {
+      const wrapper = mountDialog(inferenceResult)
+      await click('.pair-confirm-btn-cancel')
+      expect(wrapper.emitted('cancel')).toHaveLength(1)
+    })
+
+    it('emits update:modelValue=false on cancel', async () => {
+      const wrapper = mountDialog(inferenceResult)
+      await click('.pair-confirm-btn-cancel')
+      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([false])
+    })
+  })
+
+  describe('visibility', () => {
+    it('renders dialog when modelValue is true', () => {
+      mountDialog(inferenceResult, true)
+      expect(q('.pair-confirm-dialog')).toBeTruthy()
+    })
+
+    it('hides dialog when modelValue is false', () => {
+      mountDialog(inferenceResult, false)
+      expect(q('.pair-confirm-dialog')).toBeNull()
+    })
+  })
+})

--- a/autobot-frontend/src/composables/useNpuWorkers.ts
+++ b/autobot-frontend/src/composables/useNpuWorkers.ts
@@ -1,0 +1,48 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+// GH#6738 / MVA-1138: NPU worker pair API + profile management
+
+import { useApiClient } from '@/plugins/api'
+import { getApiBase } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useNpuWorkers')
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type NpuWorkerProfile = 'inference' | 'embedding' | 'mixed' | 'relay'
+
+export interface NpuWorkerPairRequest {
+  url: string
+  name?: string
+  enabled?: boolean
+}
+
+export interface NpuWorkerPairResult {
+  success: boolean
+  worker_id: string
+  recommended_profile: NpuWorkerProfile | null
+  recommended_models: Array<{ id: string; reason: string }> | null
+  vram_gb: number | null
+  compute_class: string | null
+  capabilities_summary: string | null
+  error_message?: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Composable
+// ---------------------------------------------------------------------------
+
+export function useNpuWorkers() {
+  const api = useApiClient()
+
+  async function pairWorker(payload: NpuWorkerPairRequest): Promise<NpuWorkerPairResult> {
+    logger.info('Pairing NPU worker at', payload.url)
+    return api.post<NpuWorkerPairResult>(`${getApiBase()}/npu/workers/pair`, payload)
+  }
+
+  return { pairWorker }
+}


### PR DESCRIPTION
## Summary

- Adds `useNpuWorkers` composable with `pairWorker()` calling `POST /api/npu/workers/pair`
- Adds `NpuWorkerPairConfirmDialog.vue`: profile selector pre-filled from `recommended_profile`, "Why?" tooltip showing `capabilities_summary` on hover/focus, override note when operator picks a different profile, emits `{workerId, profile}` on confirm for callers to persist the choice
- Adds 3 Storybook stories (inference-recommended, embedding-recommended, no-suggestion)
- Adds 15 Vitest tests covering pre-fill reset, tooltip show/hide, manual override, cancel, visibility

## Acceptance criteria

- ✅ Profile selector pre-filled on pair-confirm open (`recommended_profile ?? 'inference'`, resets on each dialog open)
- ✅ Tooltip showing `capabilities_summary` visible on hover/focus of "Why?" button
- ✅ Manual override works and is saved (override note shown; `confirm` event carries the chosen profile so the caller persists it)

## Test plan

- [x] `npx vitest run src/components/admin/__tests__/NpuWorkerPairConfirmDialog.spec.ts` — 15/15 passing
- [x] `npx vue-tsc --noEmit -p tsconfig.app.json` — no new errors in modified files
- [ ] Reviewer: open Storybook → `Components/Admin/NpuWorkerPairConfirmDialog` → verify inference/embedding/no-suggestion stories render correctly

Depends on: `issue-MVA-1081` backend branch (recommendation fields in pair response).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)