### PR TITLE
feat(npu): auto-suggest profile from worker capabilities (GH#6738)

### DIFF
--- a/autobot-backend/config/npu_model_recommendations.yaml
+++ b/autobot-backend/config/npu_model_recommendations.yaml
@@ -1,0 +1,33 @@
+# SSOT: VRAM tier → recommended models for NPU worker auto-suggestion (GH#6738)
+# Tiers are evaluated in ascending order; all tiers with min_vram_gb <= available VRAM are eligible.
+tiers:
+  - min_vram_gb: 4
+    models:
+      - id: "gemma-3-1b"
+        reason: "fits in 4GB VRAM, lightweight inference"
+      - id: "phi-3-mini"
+        reason: "fits in 4GB VRAM, efficient small model"
+  - min_vram_gb: 8
+    models:
+      - id: "gemma-3-4b"
+        reason: "fits in 8GB VRAM, good quality/size tradeoff"
+      - id: "llama-3.2-3b"
+        reason: "fits in 8GB VRAM, fast generation"
+  - min_vram_gb: 12
+    models:
+      - id: "glm-4-9b"
+        reason: "fits in 12GB VRAM, strong reasoning"
+      - id: "qwen2.5-7b"
+        reason: "fits in 12GB VRAM, multilingual"
+  - min_vram_gb: 16
+    models:
+      - id: "gpt-oss-20b"
+        reason: "fits in 16GB VRAM, strong general capability"
+  - min_vram_gb: 24
+    models:
+      - id: "gemma-3-27b"
+        reason: "fits in 24GB VRAM, high quality output"
+  - min_vram_gb: 40
+    models:
+      - id: "qwen2.5-coder-32b"
+        reason: "fits in 40GB VRAM, expert coding ability"

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -214,6 +214,21 @@ for _npu_mod in [
 # so the npu_client / Redis chain it imports won't re-execute. (#MVA-1119)
 if "services" in sys.modules:
     sys.modules["services"].__path__ = [str(backend_root / "services")]  # type: ignore[attr-defined]
+# services.npu_profile_suggester (GH#6738) — pure-logic module with no heavy deps.
+# Load from the real file so test_npu_profile_suggester.py can import it directly
+# without being blocked by the services package stub above.
+if "services.npu_profile_suggester" not in sys.modules:
+    import importlib.util as _ilu_ps
+
+    _ps_spec = _ilu_ps.spec_from_file_location(
+        "services.npu_profile_suggester",
+        str(backend_root / "services" / "npu_profile_suggester.py"),
+    )
+    if _ps_spec and _ps_spec.loader:
+        _ps_mod = _ilu_ps.module_from_spec(_ps_spec)
+        _ps_mod.__package__ = "services"
+        sys.modules["services.npu_profile_suggester"] = _ps_mod
+        _ps_spec.loader.exec_module(_ps_mod)  # type: ignore[union-attr]
 # Provide the SUPPORTED_LANGUAGES symbol consumed by api.schemas_agent
 if not hasattr(sys.modules.get("services.personality_service", object()), "SUPPORTED_LANGUAGES"):
     sys.modules["services.personality_service"].SUPPORTED_LANGUAGES = {}  # type: ignore[attr-defined]

--- a/autobot-backend/models/npu_models.py
+++ b/autobot-backend/models/npu_models.py
@@ -9,7 +9,7 @@ Data validation models for NPU worker management and load balancing.
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -317,6 +317,27 @@ class WorkerTestResult(BaseModel):
     status_code: int | None = Field(default=None, description="HTTP status code")
     error_message: str | None = Field(default=None, description="Error message if test failed")
     health_data: Dict | None = Field(default=None, description="Health check response data")
+    # GH#6738: auto-suggestion fields (additive — no breaking change)
+    recommended_profile: str | None = Field(
+        default=None,
+        description="Suggested worker profile: inference | embedding | mixed | relay",
+    )
+    recommended_models: List[Dict[str, str]] | None = Field(
+        default=None,
+        description="Ordered list of models that fit the worker's VRAM",
+    )
+    vram_gb: float | None = Field(
+        default=None,
+        description="Largest single-GPU VRAM detected on the worker (GB)",
+    )
+    compute_class: str | None = Field(
+        default=None,
+        description="Hardware class: consumer-gpu | datacenter-gpu | apple-silicon | cpu-only",
+    )
+    capabilities_summary: str | None = Field(
+        default=None,
+        description="Human-readable summary of worker hardware for the UI tooltip",
+    )
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -331,6 +352,13 @@ class WorkerTestResult(BaseModel):
                     "models_loaded": 2,
                     "available_memory_gb": 8.5,
                 },
+                "recommended_profile": "inference",
+                "recommended_models": [
+                    {"id": "gemma-3-4b", "reason": "fits in 8GB VRAM, good quality/size tradeoff"}
+                ],
+                "vram_gb": 8.0,
+                "compute_class": "consumer-gpu",
+                "capabilities_summary": "CUDA, 1× RTX 3060 8GB, 32GB RAM",
             }
         }
     )

--- a/autobot-backend/services/npu_profile_suggester.py
+++ b/autobot-backend/services/npu_profile_suggester.py
@@ -1,0 +1,174 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Auto-suggest NPU worker profile and recommended models from worker capabilities.
+
+GH#6738: Reads hardware capabilities returned by the worker's /health endpoint
+and derives a recommended_profile, recommended_models, compute_class, and
+capabilities_summary so the pair-confirm dialog can pre-fill the profile selector.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import logging
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_RECOMMENDATIONS_YAML = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "config",
+    "npu_model_recommendations.yaml",
+)
+
+# Datacenter VRAM threshold (GB) — RTX A/H series start at ~16GB
+_DATACENTER_GPU_VRAM_THRESHOLD_GB = 16.0
+# "Strong CPU" threshold (logical cores) for mixed-mode decision
+_STRONG_CPU_CORE_THRESHOLD = 8
+# RAM threshold for embedding-only profile
+_EMBEDDING_RAM_THRESHOLD_GB = 16.0
+# Minimum GPU VRAM to qualify for inference profile
+_MIN_INFERENCE_VRAM_GB = 4.0
+
+
+@dataclass
+class ProfileSuggestion:
+    recommended_profile: str
+    recommended_models: List[Dict[str, str]]
+    vram_gb: float
+    compute_class: str
+    capabilities_summary: str
+
+
+def _load_tiers() -> List[Dict[str, Any]]:
+    try:
+        with open(_RECOMMENDATIONS_YAML, "r") as fh:
+            data = yaml.safe_load(fh)
+        tiers = data.get("tiers", [])
+        return sorted(tiers, key=lambda t: t["min_vram_gb"])
+    except Exception as exc:
+        logger.warning("Could not load npu_model_recommendations.yaml: %s", exc)
+        return []
+
+
+def _max_vram_gb(health_data: Dict[str, Any]) -> float:
+    """Return the largest single-GPU VRAM in GB reported by the worker."""
+    gpu = health_data.get("gpu", {})
+    cuda_devices = gpu.get("cuda_devices", [])
+    if not cuda_devices:
+        return 0.0
+    return max((d.get("memory_gb", 0.0) for d in cuda_devices), default=0.0)
+
+
+def _has_strong_cpu(health_data: Dict[str, Any]) -> bool:
+    cpu = health_data.get("cpu", {})
+    return (cpu.get("count") or 0) >= _STRONG_CPU_CORE_THRESHOLD
+
+
+def _has_openvino_or_onnx(health_data: Dict[str, Any]) -> bool:
+    return bool(health_data.get("openvino_available")) or bool(
+        health_data.get("onnxruntime_available")
+    )
+
+
+def _compute_class(health_data: Dict[str, Any], vram_gb: float) -> str:
+    arch = health_data.get("architecture", "")
+    if "arm" in arch.lower() and health_data.get("os") == "Darwin":
+        return "apple-silicon"
+    if vram_gb >= _DATACENTER_GPU_VRAM_THRESHOLD_GB:
+        return "datacenter-gpu"
+    if vram_gb > 0.0:
+        return "consumer-gpu"
+    return "cpu-only"
+
+
+def _recommend_models(vram_gb: float, tiers: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    """Return all models from all tiers whose min_vram_gb <= vram_gb."""
+    models: List[Dict[str, str]] = []
+    for tier in tiers:
+        if tier["min_vram_gb"] <= vram_gb:
+            for m in tier.get("models", []):
+                models.append({"id": m["id"], "reason": m["reason"]})
+    return models
+
+
+def _capabilities_summary(health_data: Dict[str, Any], vram_gb: float) -> str:
+    gpu = health_data.get("gpu", {})
+    cuda_available = gpu.get("cuda_available", False)
+    devices = gpu.get("cuda_devices", [])
+
+    parts: List[str] = []
+
+    # CUDA / GPU info
+    if cuda_available and devices:
+        device_str = ", ".join(
+            f"{d.get('name', 'GPU')} {d.get('memory_gb', 0):.0f}GB" for d in devices
+        )
+        parts.append(f"CUDA, {len(devices)}× {device_str}")
+    else:
+        parts.append("no GPU")
+
+    # OpenVINO
+    if health_data.get("openvino_available"):
+        ov_devices = health_data.get("openvino_devices", [])
+        parts.append(f"OpenVINO {', '.join(ov_devices) if ov_devices else 'yes'}")
+
+    # ONNX
+    if health_data.get("onnxruntime_available"):
+        providers = health_data.get("onnxruntime_providers", [])
+        parts.append(f"ONNX ({', '.join(providers[:2])})" if providers else "ONNX yes")
+
+    # RAM
+    ram = health_data.get("ram", {})
+    total_gb = ram.get("total_gb")
+    if total_gb:
+        parts.append(f"{total_gb:.0f}GB RAM")
+
+    return ", ".join(parts) if parts else "no capabilities detected"
+
+
+def suggest_profile(health_data: Dict[str, Any]) -> ProfileSuggestion:
+    """
+    Derive a ProfileSuggestion from worker health / capabilities data.
+
+    Decision table (GH#6738):
+    - GPU ≥ 12GB                        → inference (or mixed if also CPU-strong + ONNX/OV)
+    - GPU 4–8GB                         → inference (small models)
+    - GPU + ONNX/OpenVINO + strong CPU  → mixed
+    - No GPU, RAM ≥ 16GB               → embedding
+    - No GPU, RAM < 16GB               → relay
+    """
+    tiers = _load_tiers()
+    vram_gb = _max_vram_gb(health_data)
+    cls = _compute_class(health_data, vram_gb)
+    models = _recommend_models(vram_gb, tiers)
+    summary = _capabilities_summary(health_data, vram_gb)
+
+    has_gpu = vram_gb >= _MIN_INFERENCE_VRAM_GB
+    has_accel = _has_openvino_or_onnx(health_data)
+    strong_cpu = _has_strong_cpu(health_data)
+    ram_gb = (health_data.get("ram") or {}).get("total_gb", 0.0) or 0.0
+
+    if has_gpu and has_accel and strong_cpu:
+        profile = "mixed"
+    elif has_gpu:
+        profile = "inference"
+    elif ram_gb >= _EMBEDDING_RAM_THRESHOLD_GB:
+        profile = "embedding"
+    else:
+        profile = "relay"
+
+    return ProfileSuggestion(
+        recommended_profile=profile,
+        recommended_models=models,
+        vram_gb=vram_gb,
+        compute_class=cls,
+        capabilities_summary=summary,
+    )

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -916,6 +916,8 @@ class NPUWorkerManager(AsyncInitializable):
 
     async def test_worker_connection(self, worker_config: NPUWorkerConfig) -> WorkerTestResult:
         """Test connection to a worker"""
+        from services.npu_profile_suggester import suggest_profile  # GH#6738: lazy import
+
         client = NPUWorkerClient(worker_config.url)
 
         try:
@@ -930,12 +932,20 @@ class NPUWorkerManager(AsyncInitializable):
             end_time = now_utc()
             response_time_ms = (end_time - start_time).total_seconds() * 1000
 
+            # GH#6738: derive profile + model suggestions from capabilities in health_data
+            suggestion = suggest_profile(health_data)
+
             return WorkerTestResult(
                 worker_id=worker_config.id,
                 success=health_data.get("status") == "healthy",
                 response_time_ms=response_time_ms,
                 status_code=200,
                 health_data=health_data,
+                recommended_profile=suggestion.recommended_profile,
+                recommended_models=suggestion.recommended_models,
+                vram_gb=suggestion.vram_gb,
+                compute_class=suggestion.compute_class,
+                capabilities_summary=suggestion.capabilities_summary,
             )
 
         except asyncio.TimeoutError:

--- a/autobot-backend/tests/services/test_npu_profile_suggester.py
+++ b/autobot-backend/tests/services/test_npu_profile_suggester.py
@@ -1,0 +1,229 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Table-driven unit tests for npu_profile_suggester (GH#6738).
+
+Tests profile selection rules, model recommendation, compute class classification,
+and capabilities summary generation without any external dependencies.
+"""
+
+import pytest
+
+from services.npu_profile_suggester import (
+    ProfileSuggestion,
+    _capabilities_summary,
+    _compute_class,
+    _max_vram_gb,
+    _recommend_models,
+    suggest_profile,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _gpu_health(vram_gb: float, name: str = "RTX 3060") -> dict:
+    """Minimal health dict with a single CUDA device."""
+    return {
+        "gpu": {
+            "cuda_available": True,
+            "cuda_devices": [{"name": name, "memory_gb": vram_gb}],
+        },
+        "ram": {"total_gb": 32.0, "available_gb": 20.0},
+        "cpu": {"count": 16},
+    }
+
+
+def _cpu_health(ram_gb: float) -> dict:
+    """Minimal health dict with no GPU."""
+    return {
+        "gpu": {"cuda_available": False, "cuda_devices": []},
+        "ram": {"total_gb": ram_gb, "available_gb": ram_gb * 0.8},
+        "cpu": {"count": 8},
+    }
+
+
+# ---------------------------------------------------------------------------
+# _max_vram_gb
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "health,expected",
+    [
+        (_gpu_health(8.0), 8.0),
+        (_gpu_health(24.0), 24.0),
+        (_cpu_health(32.0), 0.0),
+        ({}, 0.0),
+        ({"gpu": {"cuda_devices": []}}, 0.0),
+        (
+            {
+                "gpu": {
+                    "cuda_devices": [
+                        {"memory_gb": 8.0},
+                        {"memory_gb": 16.0},
+                    ]
+                }
+            },
+            16.0,
+        ),
+    ],
+)
+def test_max_vram_gb(health, expected):
+    assert _max_vram_gb(health) == expected
+
+
+# ---------------------------------------------------------------------------
+# _compute_class
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "health,vram_gb,expected",
+    [
+        (_gpu_health(8.0), 8.0, "consumer-gpu"),
+        (_gpu_health(40.0, "A100"), 40.0, "datacenter-gpu"),
+        (_cpu_health(32.0), 0.0, "cpu-only"),
+        ({"architecture": "arm64", "os": "Darwin"}, 0.0, "apple-silicon"),
+    ],
+)
+def test_compute_class(health, vram_gb, expected):
+    assert _compute_class(health, vram_gb) == expected
+
+
+# ---------------------------------------------------------------------------
+# _recommend_models
+# ---------------------------------------------------------------------------
+
+_SAMPLE_TIERS = [
+    {"min_vram_gb": 4, "models": [{"id": "gemma-3-1b", "reason": "fits 4GB"}]},
+    {"min_vram_gb": 8, "models": [{"id": "gemma-3-4b", "reason": "fits 8GB"}]},
+    {"min_vram_gb": 12, "models": [{"id": "qwen2.5-7b", "reason": "fits 12GB"}]},
+]
+
+
+@pytest.mark.parametrize(
+    "vram_gb,expected_ids",
+    [
+        (0.0, []),
+        (4.0, ["gemma-3-1b"]),
+        (8.0, ["gemma-3-1b", "gemma-3-4b"]),
+        (12.0, ["gemma-3-1b", "gemma-3-4b", "qwen2.5-7b"]),
+        (100.0, ["gemma-3-1b", "gemma-3-4b", "qwen2.5-7b"]),
+    ],
+)
+def test_recommend_models(vram_gb, expected_ids):
+    models = _recommend_models(vram_gb, _SAMPLE_TIERS)
+    assert [m["id"] for m in models] == expected_ids
+
+
+# ---------------------------------------------------------------------------
+# suggest_profile — table-driven profile selection rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "health,expected_profile",
+    [
+        # GPU ≥ 12GB without ONNX/OpenVINO → inference
+        (_gpu_health(12.0), "inference"),
+        # GPU ≥ 12GB + OpenVINO + strong CPU → mixed
+        (
+            {
+                **_gpu_health(12.0),
+                "openvino_available": True,
+                "cpu": {"count": 16},
+            },
+            "mixed",
+        ),
+        # GPU 4–8GB without acceleration → inference
+        (_gpu_health(6.0), "inference"),
+        # GPU 4GB + ONNX + strong CPU → mixed
+        (
+            {
+                **_gpu_health(4.0),
+                "onnxruntime_available": True,
+                "cpu": {"count": 12},
+            },
+            "mixed",
+        ),
+        # No GPU, RAM ≥ 16GB → embedding
+        (_cpu_health(32.0), "embedding"),
+        (_cpu_health(16.0), "embedding"),
+        # No GPU, RAM < 16GB → relay
+        (_cpu_health(8.0), "relay"),
+        (_cpu_health(4.0), "relay"),
+        # GPU below 4GB threshold → treated as no-GPU (relay or embedding)
+        (
+            {
+                **_gpu_health(2.0),
+                "ram": {"total_gb": 8.0},
+                "cpu": {"count": 4},
+            },
+            "relay",
+        ),
+    ],
+)
+def test_suggest_profile_selection(health, expected_profile):
+    suggestion = suggest_profile(health)
+    assert suggestion.recommended_profile == expected_profile, (
+        f"Expected {expected_profile!r} but got {suggestion.recommended_profile!r} "
+        f"for health={health}"
+    )
+
+
+def test_suggest_profile_returns_models_for_gpu():
+    health = _gpu_health(8.0)
+    suggestion = suggest_profile(health)
+    assert isinstance(suggestion.recommended_models, list)
+    assert len(suggestion.recommended_models) > 0
+    assert "id" in suggestion.recommended_models[0]
+    assert "reason" in suggestion.recommended_models[0]
+
+
+def test_suggest_profile_no_models_for_cpu_only():
+    health = _cpu_health(32.0)
+    suggestion = suggest_profile(health)
+    # No VRAM → no model recommendations
+    assert suggestion.recommended_models == []
+    assert suggestion.vram_gb == 0.0
+
+
+def test_suggest_profile_compute_class_consumer():
+    suggestion = suggest_profile(_gpu_health(8.0))
+    assert suggestion.compute_class == "consumer-gpu"
+
+
+def test_suggest_profile_compute_class_datacenter():
+    suggestion = suggest_profile(_gpu_health(40.0, "A100"))
+    assert suggestion.compute_class == "datacenter-gpu"
+
+
+def test_suggest_profile_capabilities_summary_contains_gpu_name():
+    health = _gpu_health(8.0, "RTX 3060")
+    suggestion = suggest_profile(health)
+    assert "RTX 3060" in suggestion.capabilities_summary
+
+
+def test_suggest_profile_capabilities_summary_no_gpu():
+    health = _cpu_health(32.0)
+    suggestion = suggest_profile(health)
+    assert "no GPU" in suggestion.capabilities_summary
+
+
+def test_suggest_profile_empty_health():
+    """suggest_profile must not raise on empty/minimal health data."""
+    suggestion = suggest_profile({})
+    assert suggestion.recommended_profile in ("relay", "embedding", "inference", "mixed")
+
+
+def test_suggest_profile_openvino_in_summary():
+    health = {
+        **_gpu_health(8.0),
+        "openvino_available": True,
+        "openvino_devices": ["CPU", "GPU.0"],
+    }
+    suggestion = suggest_profile(health)
+    assert "OpenVINO" in suggestion.capabilities_summary


### PR DESCRIPTION
## Summary

- Adds `services/npu_profile_suggester.py` — pure-logic `suggest_profile(health_data)` that maps worker hardware to a recommended NPU profile and a ranked model list
- Extends `WorkerTestResult` with 5 additive Optional fields (`recommended_profile`, `recommended_models`, `vram_gb`, `compute_class`, `capabilities_summary`) — no breaking change
- Wires `suggest_profile` into `test_worker_connection` so the pair-confirm dialog can pre-fill profile + show a capabilities tooltip
- SSOT model tier table in `config/npu_model_recommendations.yaml` (VRAM → eligible models, 6 tiers from 4 GB to 40 GB)
- 32 unit tests, 32/32 passing (including conftest fix to load the pure-logic module)

## Profile selection rules

| Condition | Profile |
|---|---|
| GPU ≥ 4 GB + ONNX/OpenVINO + ≥ 8 CPU cores | `mixed` |
| GPU ≥ 4 GB | `inference` |
| No GPU, RAM ≥ 16 GB | `embedding` |
| No GPU, RAM < 16 GB | `relay` |

## Test plan

- [x] 32/32 unit tests pass: `python3 -m pytest autobot-backend/tests/services/test_npu_profile_suggester.py -v`
- [x] `conftest.py` updated so the pure-logic module is loadable in the stubbed test environment
- [x] No existing tests broken (conftest change is additive)
- [ ] Frontend pre-fill ([MVA-1138](/MVA/issues/MVA-1138) — delegated to SeniorFrontendDeveloper)

## Files changed

- `autobot-backend/config/npu_model_recommendations.yaml` — new SSOT
- `autobot-backend/services/npu_profile_suggester.py` — new pure-logic module
- `autobot-backend/models/npu_models.py` — additive fields on WorkerTestResult
- `autobot-backend/services/npu_worker_manager.py` — wire-in via lazy import
- `autobot-backend/tests/services/test_npu_profile_suggester.py` — 32 tests
- `autobot-backend/conftest.py` — load npu_profile_suggester from real file

Closes GH#6738

🤖 Generated with [Claude Code](https://claude.com/claude-code)