### PR TITLE
feat(chat): slash command presets backend API endpoints (GH#8595)

### DIFF
--- a/autobot-backend/api/chat_presets.py
+++ b/autobot-backend/api/chat_presets.py
@@ -1,0 +1,144 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Slash command presets API (GH#8595).
+
+GET    /api/chat/presets        -> SlashCommandPreset[]
+POST   /api/chat/presets        -> SlashCommandPreset
+PUT    /api/chat/presets/{id}   -> SlashCommandPreset
+DELETE /api/chat/presets/{id}   -> 204
+
+Storage: Redis hash `chat:presets:{user_id}` in the sessions database.
+Each field in the hash is a preset ID whose value is a JSON-encoded preset.
+
+Frontend contract: plain JSON, no envelope wrapper.
+"""
+
+import json
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
+
+from auth_middleware import get_current_user
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_async_redis_client
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["chat"])
+
+REDIS_DB = "sessions"
+
+
+def _hash_key(user_id: str) -> str:
+    return f"chat:presets:{user_id}"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class PresetCreate(BaseModel):
+    name: str
+    description: str
+    content: str
+
+
+class PresetUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    content: Optional[str] = None
+
+
+@router.get("/chat/presets")
+async def list_presets(
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Return all presets for the authenticated user."""
+    user_id = current_user.get("username", "")
+    redis = await get_async_redis_client(database=REDIS_DB)
+    raw = await redis.hgetall(_hash_key(user_id))
+    presets = []
+    for value in raw.values():
+        try:
+            presets.append(json.loads(value))
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Skipping corrupt preset entry for user %s", user_id)
+    presets.sort(key=lambda p: p.get("createdAt", ""))
+    return JSONResponse(content=presets)
+
+
+@router.post("/chat/presets", status_code=201)
+async def create_preset(
+    payload: PresetCreate,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Create a new preset for the authenticated user."""
+    user_id = current_user.get("username", "")
+    now = _now_iso()
+    preset = {
+        "id": str(uuid4()),
+        "name": payload.name,
+        "description": payload.description,
+        "content": payload.content,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+    redis = await get_async_redis_client(database=REDIS_DB)
+    await redis.hset(_hash_key(user_id), preset["id"], json.dumps(preset))
+    logger.info("Created preset %s for user %s", preset["id"], user_id)
+    return JSONResponse(content=preset, status_code=201)
+
+
+@router.put("/chat/presets/{preset_id}")
+async def update_preset(
+    preset_id: str,
+    payload: PresetUpdate,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Update an existing preset owned by the authenticated user."""
+    user_id = current_user.get("username", "")
+    redis = await get_async_redis_client(database=REDIS_DB)
+    raw = await redis.hget(_hash_key(user_id), preset_id)
+    if raw is None:
+        raise HTTPException(status_code=404, detail="Preset not found")
+    try:
+        preset = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        raise HTTPException(status_code=500, detail="Preset data corrupted")
+
+    if payload.name is not None:
+        preset["name"] = payload.name
+    if payload.description is not None:
+        preset["description"] = payload.description
+    if payload.content is not None:
+        preset["content"] = payload.content
+    preset["updatedAt"] = _now_iso()
+
+    await redis.hset(_hash_key(user_id), preset_id, json.dumps(preset))
+    logger.info("Updated preset %s for user %s", preset_id, user_id)
+    return JSONResponse(content=preset)
+
+
+@router.delete("/chat/presets/{preset_id}", status_code=204)
+async def delete_preset(
+    preset_id: str,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> Response:
+    """Delete a preset owned by the authenticated user."""
+    user_id = current_user.get("username", "")
+    redis = await get_async_redis_client(database=REDIS_DB)
+    deleted = await redis.hdel(_hash_key(user_id), preset_id)
+    if deleted == 0:
+        raise HTTPException(status_code=404, detail="Preset not found")
+    logger.info("Deleted preset %s for user %s", preset_id, user_id)
+    return Response(status_code=204)

--- a/autobot-backend/api/chat_presets.py
+++ b/autobot-backend/api/chat_presets.py
@@ -20,7 +20,7 @@ from datetime import datetime, timezone
 from typing import Optional
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel
 
@@ -57,12 +57,14 @@ class PresetUpdate(BaseModel):
 
 @router.get("/chat/presets")
 async def list_presets(
-    request: Request,
     current_user: dict = Depends(get_current_user),
 ) -> JSONResponse:
     """Return all presets for the authenticated user."""
     user_id = current_user.get("username", "")
     redis = await get_async_redis_client(database=REDIS_DB)
+    if redis is None:
+        logger.warning("chat_presets: Redis unavailable for user %s", user_id)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
     raw = await redis.hgetall(_hash_key(user_id))
     presets = []
     for value in raw.values():
@@ -77,7 +79,6 @@ async def list_presets(
 @router.post("/chat/presets", status_code=201)
 async def create_preset(
     payload: PresetCreate,
-    request: Request,
     current_user: dict = Depends(get_current_user),
 ) -> JSONResponse:
     """Create a new preset for the authenticated user."""
@@ -92,6 +93,9 @@ async def create_preset(
         "updatedAt": now,
     }
     redis = await get_async_redis_client(database=REDIS_DB)
+    if redis is None:
+        logger.warning("chat_presets: Redis unavailable for user %s", user_id)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
     await redis.hset(_hash_key(user_id), preset["id"], json.dumps(preset))
     logger.info("Created preset %s for user %s", preset["id"], user_id)
     return JSONResponse(content=preset, status_code=201)
@@ -101,12 +105,14 @@ async def create_preset(
 async def update_preset(
     preset_id: str,
     payload: PresetUpdate,
-    request: Request,
     current_user: dict = Depends(get_current_user),
 ) -> JSONResponse:
     """Update an existing preset owned by the authenticated user."""
     user_id = current_user.get("username", "")
     redis = await get_async_redis_client(database=REDIS_DB)
+    if redis is None:
+        logger.warning("chat_presets: Redis unavailable for user %s", user_id)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
     raw = await redis.hget(_hash_key(user_id), preset_id)
     if raw is None:
         raise HTTPException(status_code=404, detail="Preset not found")
@@ -131,12 +137,14 @@ async def update_preset(
 @router.delete("/chat/presets/{preset_id}", status_code=204)
 async def delete_preset(
     preset_id: str,
-    request: Request,
     current_user: dict = Depends(get_current_user),
 ) -> Response:
     """Delete a preset owned by the authenticated user."""
     user_id = current_user.get("username", "")
     redis = await get_async_redis_client(database=REDIS_DB)
+    if redis is None:
+        logger.warning("chat_presets: Redis unavailable for user %s", user_id)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
     deleted = await redis.hdel(_hash_key(user_id), preset_id)
     if deleted == 0:
         raise HTTPException(status_code=404, detail="Preset not found")

--- a/autobot-backend/api/chat_presets_test.py
+++ b/autobot-backend/api/chat_presets_test.py
@@ -1,0 +1,104 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for slash command presets API (GH#8595)."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.chat_presets import router
+
+USER = {"username": "testuser", "role": "user"}
+HASH_KEY = "chat:presets:testuser"
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+
+    async def _override_user():
+        return USER
+
+    from auth_middleware import get_current_user
+
+    app.dependency_overrides[get_current_user] = _override_user
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def mock_redis():
+    redis = AsyncMock()
+    with patch(
+        "api.chat_presets.get_async_redis_client", new_callable=AsyncMock, return_value=redis
+    ) as p:
+        p.return_value = redis
+        yield redis
+
+
+@pytest.fixture
+def client(mock_redis):
+    return TestClient(_make_app())
+
+
+class TestListPresets:
+    def test_empty(self, client, mock_redis):
+        mock_redis.hgetall.return_value = {}
+        resp = client.get("/chat/presets")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_returns_sorted_by_created_at(self, client, mock_redis):
+        p1 = {"id": "a", "name": "A", "description": "", "content": "x", "createdAt": "2025-01-01T00:00:00+00:00", "updatedAt": "2025-01-01T00:00:00+00:00"}
+        p2 = {"id": "b", "name": "B", "description": "", "content": "y", "createdAt": "2025-01-02T00:00:00+00:00", "updatedAt": "2025-01-02T00:00:00+00:00"}
+        mock_redis.hgetall.return_value = {"b": json.dumps(p2), "a": json.dumps(p1)}
+        resp = client.get("/chat/presets")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert [d["id"] for d in data] == ["a", "b"]
+
+
+class TestCreatePreset:
+    def test_creates_with_id(self, client, mock_redis):
+        mock_redis.hset.return_value = 1
+        resp = client.post("/chat/presets", json={"name": "greet", "description": "Greeting", "content": "Hello!"})
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "greet"
+        assert data["content"] == "Hello!"
+        assert "id" in data
+        assert "createdAt" in data
+        assert "updatedAt" in data
+        mock_redis.hset.assert_awaited_once()
+
+
+class TestUpdatePreset:
+    def test_updates_existing(self, client, mock_redis):
+        existing = {"id": "abc", "name": "old", "description": "d", "content": "c", "createdAt": "2025-01-01T00:00:00+00:00", "updatedAt": "2025-01-01T00:00:00+00:00"}
+        mock_redis.hget.return_value = json.dumps(existing)
+        mock_redis.hset.return_value = 0
+        resp = client.put("/chat/presets/abc", json={"name": "new"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "new"
+        assert data["content"] == "c"
+
+    def test_404_if_missing(self, client, mock_redis):
+        mock_redis.hget.return_value = None
+        resp = client.put("/chat/presets/missing", json={"name": "x"})
+        assert resp.status_code == 404
+
+
+class TestDeletePreset:
+    def test_deletes(self, client, mock_redis):
+        mock_redis.hdel.return_value = 1
+        resp = client.delete("/chat/presets/abc")
+        assert resp.status_code == 204
+
+    def test_404_if_missing(self, client, mock_redis):
+        mock_redis.hdel.return_value = 0
+        resp = client.delete("/chat/presets/missing")
+        assert resp.status_code == 404

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -23,6 +23,7 @@ from api.browser_mcp import router as browser_mcp_router
 from api.canvas import router as canvas_router  # MVA-359
 from api.chat import router as chat_router
 from api.chat_compare import router as chat_compare_router  # Issue #4414
+from api.chat_presets import router as chat_presets_router  # GH#8595
 from api.collaboration import router as collaboration_router
 from api.config_revisions import router as config_revisions_router  # #1404
 from api.data_storage import router as data_storage_router
@@ -102,6 +103,7 @@ def _get_system_routers() -> list:
         (service_messages_router, "", ["service-messages"], "service_messages"),
         (chat_router, "", ["chat"], "chat"),
         (chat_compare_router, "", ["chat", "compare"], "chat_compare"),  # Issue #4414
+        (chat_presets_router, "", ["chat"], "chat_presets"),  # GH#8595
         (collaboration_router, "", ["collaboration"], "collaboration"),
         (system_router, "/system", ["system"], "system"),
         (settings_router, "/settings", ["settings"], "settings"),


### PR DESCRIPTION
## Summary

- Add `GET/POST/PUT/DELETE /api/chat/presets` endpoints for user-scoped slash command presets
- Storage: Redis hash `chat:presets:{user_id}` in `sessions` database (matches spec from GH#8595)
- Returns plain JSON (no envelope) to match `useChatPresetsStore.ts` frontend contract
- Auth via `get_current_user` dependency; users see only their own presets
- 503 guard for Redis unavailability on all 4 handlers

## Files changed

- `autobot-backend/api/chat_presets.py` — new router (GH#8595)
- `autobot-backend/api/chat_presets_test.py` — 7 unit tests, all passing
- `autobot-backend/initialization/router_registry/core_routers.py` — register router

## Test plan

- [x] `pytest api/chat_presets_test.py` — 7/7 pass
- [ ] Manual: `GET /api/chat/presets` returns `[]` for new user
- [ ] Manual: `POST /api/chat/presets` creates preset, reflected in next `GET`
- [ ] Manual: `PUT /api/chat/presets/{id}` partial-updates the preset
- [ ] Manual: `DELETE /api/chat/presets/{id}` returns 204, preset absent on next `GET`
- [ ] Manual: crossing users — user A cannot see/edit user B's presets

Closes GH#8595. Unblocks MVA-1086 and MVA-1061 (frontend slash command presets UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)