### PR TITLE
feat(design-tokens): Phase 1 codemod — small→sm, medium→md, large→lg, danger→error

### DIFF
--- a/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
@@ -30,7 +30,7 @@
     <div v-if="activeTab === 'cost'" class="tab-content">
       <div class="metrics-grid">
         <!-- Total Cost Card -->
-        <BasePanel variant="bordered" size="small">
+        <BasePanel variant="bordered" size="sm">
           <template #header>
             <h4><Icon name="dollar-sign" /> {{ $t('analytics.advanced.totalCost30d') }}</h4>
           </template>
@@ -44,7 +44,7 @@
         </BasePanel>
 
         <!-- Daily Average Card -->
-        <BasePanel variant="bordered" size="small">
+        <BasePanel variant="bordered" size="sm">
           <template #header>
             <h4><Icon name="calendar" /> {{ $t('analytics.advanced.dailyAverage') }}</h4>
           </template>
@@ -54,7 +54,7 @@
         </BasePanel>
 
         <!-- Trend Card -->
-        <BasePanel variant="bordered" size="small">
+        <BasePanel variant="bordered" size="sm">
           <template #header>
             <h4><Icon name="arrow-trend-up" /> {{ $t('analytics.advanced.costTrend') }}</h4>
           </template>
@@ -97,7 +97,7 @@
     <div v-if="activeTab === 'agents'" class="tab-content">
       <div class="metrics-grid">
         <!-- Total Agents -->
-        <BasePanel variant="bordered" size="small">
+        <BasePanel variant="bordered" size="sm">
           <template #header>
             <h4><Icon name="users-cog" /> {{ $t('analytics.advanced.totalAgents') }}</h4>
           </template>
@@ -105,7 +105,7 @@
         </BasePanel>
 
         <!-- Total Tasks -->
-        <BasePanel variant="bordered" size="small">
+        <BasePanel variant="bordered" size="sm">
           <template #header>
             <h4><Icon name="tasks" /> {{ $t('analytics.advanced.totalTasks') }}</h4>
           </template>
@@ -115,7 +115,7 @@
         </BasePanel>
 
         <!-- Avg Success Rate -->
-        <BasePanel variant="bordered" size="small">
+        <BasePanel variant="bordered" size="sm">
           <template #header>
             <h4><Icon name="check-circle" /> {{ $t('analytics.advanced.avgSuccessRate') }}</h4>
           </template>
@@ -190,7 +190,7 @@
     <div v-if="activeTab === 'behavior'" class="tab-content">
       <div class="metrics-grid">
         <!-- Total Sessions -->
-        <BasePanel variant="bordered" size="small">
+        <BasePanel variant="bordered" size="sm">
           <template #header>
             <h4><Icon name="users" /> {{ $t('analytics.advanced.totalSessions') }}</h4>
           </template>
@@ -200,7 +200,7 @@
         </BasePanel>
 
         <!-- Page Views -->
-        <BasePanel variant="bordered" size="small">
+        <BasePanel variant="bordered" size="sm">
           <template #header>
             <h4><Icon name="eye" /> {{ $t('analytics.advanced.pageViews') }}</h4>
           </template>
@@ -210,7 +210,7 @@
         </BasePanel>
 
         <!-- Avg Session Duration -->
-        <BasePanel variant="bordered" size="small">
+        <BasePanel variant="bordered" size="sm">
           <template #header>
             <h4><Icon name="clock" /> {{ $t('analytics.advanced.avgSessionDuration') }}</h4>
           </template>
@@ -220,7 +220,7 @@
         </BasePanel>
 
         <!-- Pages Per Session -->
-        <BasePanel variant="bordered" size="small">
+        <BasePanel variant="bordered" size="sm">
           <template #header>
             <h4><Icon name="file-alt" /> {{ $t('analytics.advanced.pagesPerSession') }}</h4>
           </template>

--- a/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
@@ -2,7 +2,7 @@
   <!-- Enhanced Analytics Dashboard Cards -->
   <div class="enhanced-analytics-grid">
       <!-- System Overview -->
-      <BasePanel variant="dark" size="medium">
+      <BasePanel variant="dark" size="md">
         <template #header>
           <div class="card-header-content">
             <h3><Icon name="tachometer-alt" /> {{ $t('analytics.codebase.overview.title') }}</h3>
@@ -46,7 +46,7 @@
       </BasePanel>
 
       <!-- Communication Patterns -->
-      <BasePanel variant="dark" size="medium">
+      <BasePanel variant="dark" size="md">
         <template #header>
           <div class="card-header-content">
             <h3><Icon name="network-wired" /> {{ $t('analytics.codebase.communication.title') }}</h3>
@@ -81,7 +81,7 @@
       </BasePanel>
 
       <!-- Code Quality -->
-      <BasePanel variant="dark" size="medium">
+      <BasePanel variant="dark" size="md">
         <template #header>
           <div class="card-header-content">
             <h3><Icon name="code-branch" /> {{ $t('analytics.codebase.quality.title') }}</h3>
@@ -118,7 +118,7 @@
       </BasePanel>
 
       <!-- Performance Metrics -->
-      <BasePanel variant="dark" size="medium">
+      <BasePanel variant="dark" size="md">
         <template #header>
           <div class="card-header-content">
             <h3><Icon name="bolt" /> {{ $t('analytics.codebase.performance.title') }}</h3>

--- a/autobot-frontend/src/components/analytics/EnhancedAnalyticsGrid.vue
+++ b/autobot-frontend/src/components/analytics/EnhancedAnalyticsGrid.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="enhanced-analytics-grid">
     <!-- System Overview -->
-    <BasePanel variant="dark" size="medium">
+    <BasePanel variant="dark" size="md">
       <template #header>
         <div class="card-header-content">
           <h3><Icon name="tachometer-alt" /> {{ $t('analytics.grid.systemOverview') }}</h3>
@@ -43,7 +43,7 @@
     </BasePanel>
 
     <!-- Communication Patterns -->
-    <BasePanel variant="dark" size="medium">
+    <BasePanel variant="dark" size="md">
       <template #header>
         <div class="card-header-content">
           <h3><Icon name="network-wired" /> {{ $t('analytics.grid.communicationPatterns') }}</h3>
@@ -74,7 +74,7 @@
     </BasePanel>
 
     <!-- Code Quality -->
-    <BasePanel variant="dark" size="medium">
+    <BasePanel variant="dark" size="md">
       <template #header>
         <div class="card-header-content">
           <h3><Icon name="code-branch" /> {{ $t('analytics.grid.codeQuality') }}</h3>
@@ -111,7 +111,7 @@
     </BasePanel>
 
     <!-- Performance Metrics -->
-    <BasePanel variant="dark" size="medium">
+    <BasePanel variant="dark" size="md">
       <template #header>
         <div class="card-header-content">
           <h3><Icon name="bolt" /> {{ $t('analytics.grid.performanceMetrics') }}</h3>

--- a/autobot-frontend/src/components/analytics/panels/CodebaseChartsSection.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseChartsSection.vue
@@ -29,19 +29,19 @@
         </div>
       </h3>
       <div v-if="codebaseStats" class="stats-grid">
-        <BasePanel variant="elevated" size="small">
+        <BasePanel variant="elevated" size="sm">
           <div class="stat-value">{{ codebaseStats.total_files || 0 }}</div>
           <div class="stat-label">{{ $t('analytics.codebase.stats.totalFiles') }}</div>
         </BasePanel>
-        <BasePanel variant="elevated" size="small">
+        <BasePanel variant="elevated" size="sm">
           <div class="stat-value">{{ codebaseStats.total_lines || 0 }}</div>
           <div class="stat-label">{{ $t('analytics.codebase.stats.linesOfCode') }}</div>
         </BasePanel>
-        <BasePanel variant="elevated" size="small">
+        <BasePanel variant="elevated" size="sm">
           <div class="stat-value">{{ codebaseStats.total_functions || 0 }}</div>
           <div class="stat-label">{{ $t('analytics.codebase.stats.functions') }}</div>
         </BasePanel>
-        <BasePanel variant="elevated" size="small">
+        <BasePanel variant="elevated" size="sm">
           <div class="stat-value">{{ codebaseStats.total_classes || 0 }}</div>
           <div class="stat-label">{{ $t('analytics.codebase.stats.classes') }}</div>
         </BasePanel>

--- a/autobot-frontend/src/components/base/BaseBadge.stories.ts
+++ b/autobot-frontend/src/components/base/BaseBadge.stories.ts
@@ -7,7 +7,7 @@ const meta = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark'],
+      options: ['primary', 'secondary', 'success', 'error', 'warning', 'info', 'light', 'dark'],
       description: 'Badge color variant',
     },
     size: {
@@ -57,7 +57,7 @@ export const Success: Story = {
 
 export const Danger: Story = {
   args: {
-    variant: 'danger',
+    variant: 'error',
     label: 'Danger',
   },
 };
@@ -124,7 +124,7 @@ export const AllVariants: Story = {
         <BaseBadge variant="primary" label="Primary" />
         <BaseBadge variant="secondary" label="Secondary" />
         <BaseBadge variant="success" label="Success" />
-        <BaseBadge variant="danger" label="Danger" />
+        <BaseBadge variant="error" label="Danger" />
         <BaseBadge variant="warning" label="Warning" />
         <BaseBadge variant="info" label="Info" />
         <BaseBadge variant="light" label="Light" />

--- a/autobot-frontend/src/components/base/BaseButton.stories.ts
+++ b/autobot-frontend/src/components/base/BaseButton.stories.ts
@@ -7,7 +7,7 @@ const meta = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark', 'outline-solid', 'ghost', 'link'],
+      options: ['primary', 'secondary', 'success', 'error', 'warning', 'info', 'light', 'dark', 'outline-solid', 'ghost', 'link'],
       description: 'Button style variant',
     },
     size: {
@@ -70,7 +70,7 @@ export const Success: Story = {
 
 export const Danger: Story = {
   args: {
-    variant: 'danger',
+    variant: 'error',
     label: 'Danger Button',
   },
 };
@@ -160,7 +160,7 @@ export const AllVariants: Story = {
         <BaseButton variant="primary" label="Primary" />
         <BaseButton variant="secondary" label="Secondary" />
         <BaseButton variant="success" label="Success" />
-        <BaseButton variant="danger" label="Danger" />
+        <BaseButton variant="error" label="Danger" />
         <BaseButton variant="warning" label="Warning" />
         <BaseButton variant="info" label="Info" />
         <BaseButton variant="light" label="Light" />

--- a/autobot-frontend/src/components/base/BasePanel.vue
+++ b/autobot-frontend/src/components/base/BasePanel.vue
@@ -25,7 +25,7 @@ import { computed } from 'vue'
 interface Props {
   title?: string
   variant?: 'default' | 'bordered' | 'elevated' | 'flat' | 'dark'
-  size?: 'small' | 'medium' | 'large'
+  size?: 'sm' | 'md' | 'lg'
   loading?: boolean
   collapsible?: boolean
   collapsed?: boolean
@@ -35,7 +35,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   variant: 'default',
-  size: 'medium',
+  size: 'md',
   loading: false,
   collapsible: false,
   collapsed: false,
@@ -116,15 +116,15 @@ const toggleCollapse = () => {
   background-color: var(--bg-tertiary);
 }
 
-.panel-small {
+.panel-sm {
   font-size: var(--text-sm);
 }
 
-.panel-medium {
+.panel-md {
   font-size: var(--text-base);
 }
 
-.panel-large {
+.panel-lg {
   font-size: var(--text-lg);
 }
 

--- a/autobot-frontend/src/components/browser/BrowserSessionManager.vue
+++ b/autobot-frontend/src/components/browser/BrowserSessionManager.vue
@@ -102,7 +102,7 @@
             </div>
 
             <div class="flex items-center gap-2">
-              <StatusBadge :variant="getStatusVariant(session.status)" size="small">
+              <StatusBadge :variant="getStatusVariant(session.status)" size="sm">
                 {{ session.status.toUpperCase() }}
               </StatusBadge>
 
@@ -358,11 +358,11 @@ export default {
       }
     }
 
-    const getStatusVariant = (status: SessionStatus): 'success' | 'warning' | 'danger' | 'info' => {
+    const getStatusVariant = (status: SessionStatus): 'success' | 'warning' | 'error' | 'info' => {
       switch (status) {
         case 'active': return 'success'
         case 'idle': return 'warning'
-        case 'error': return 'danger'
+        case 'error': return 'error'
         default: return 'info'
       }
     }

--- a/autobot-frontend/src/components/chat/ApprovalRequestCard.vue
+++ b/autobot-frontend/src/components/chat/ApprovalRequestCard.vue
@@ -160,7 +160,7 @@
     <!-- Approval buttons -->
     <div class="approval-actions">
       <BaseButton
-        variant="danger"
+        variant="error"
         size="sm"
         @click="startDeny"
         :disabled="processing"

--- a/autobot-frontend/src/components/chat/ChatFilePanel.vue
+++ b/autobot-frontend/src/components/chat/ChatFilePanel.vue
@@ -186,7 +186,7 @@
             <StatusBadge
               v-if="file.file_type === 'generated'"
               variant="primary"
-              size="small"
+              size="sm"
               class="mt-1"
             >
               {{ $t('chat.filePanel.aiGenerated') }}

--- a/autobot-frontend/src/components/chat/ChatInput.vue
+++ b/autobot-frontend/src/components/chat/ChatInput.vue
@@ -22,7 +22,7 @@
         />
         <BaseButton
           v-if="upload.error"
-          variant="danger"
+          variant="error"
           size="xs"
           @click="retryUpload(upload.id)"
           class="retry-upload-btn"

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -406,7 +406,7 @@
                 <span>{{ $t('chat.approval.comment') }}</span>
               </BaseButton>
               <BaseButton
-                variant="danger"
+                variant="error"
                 size="sm"
                 @click="approveCommand((message.metadata as any).terminal_session_id as string, false, undefined, (message.metadata as any).command_id, { command: (message.metadata as any).command as string, risk_level: (message.metadata as any).risk_level as string })"
                 :disabled="processingApproval || showCommentInput"
@@ -478,7 +478,7 @@
   <BaseModal
     v-model="showEditModal"
     :title="$t('chat.messages.editMessage')"
-    size="medium"
+    size="md"
   >
     <textarea
       v-model="editingContent"

--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -174,7 +174,7 @@
             {{ $t('common.reset') }}
           </BaseButton>
           <BaseButton
-            variant="danger"
+            variant="error"
             size="xs"
             class="py-1.5 px-2"
             @click="deleteCurrentSession()"
@@ -199,7 +199,7 @@
         <!-- Selection Mode Actions -->
         <div v-else class="pt-2 border-t border-autobot-border shrink-0">
           <BaseButton
-            variant="danger"
+            variant="error"
             size="xs"
             class="w-full py-2"
             @click="deleteSelectedSessions()"
@@ -278,7 +278,7 @@
   <BaseModal
     v-model="showEditModal"
     :title="$t('chat.sidebar.editChatName')"
-    size="medium"
+    size="md"
   >
     <input
       v-model="editingName"

--- a/autobot-frontend/src/components/chat/DeleteConversationDialog.vue
+++ b/autobot-frontend/src/components/chat/DeleteConversationDialog.vue
@@ -2,7 +2,7 @@
   <BaseModal
     :model-value="visible"
     :title="$t('chat.deleteDialog.title')"
-    size="medium"
+    size="md"
     @update:model-value="$emit('update:visible', $event)"
     @close="handleCancel"
   >

--- a/autobot-frontend/src/components/chat/ShareConversationDialog.vue
+++ b/autobot-frontend/src/components/chat/ShareConversationDialog.vue
@@ -2,7 +2,7 @@
   <BaseModal
     :model-value="visible"
     :title="$t('chat.share.title')"
-    size="medium"
+    size="md"
     @update:model-value="$emit('update:visible', $event)"
     @close="handleCancel"
   >

--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -105,7 +105,7 @@
           ⌨️ {{ $t('desktop.interface.typeText') }}
         </TouchFriendlyButton>
         <TouchFriendlyButton
-          variant="danger"
+          variant="error"
           size="sm"
           @click="sendCtrlAltDel"
           :title="$t('desktop.interface.ctrlAltDel')"

--- a/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
+++ b/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
@@ -248,7 +248,7 @@
           <div class="mb-4">
             <div class="flex items-center justify-between mb-2">
               <h4 class="text-sm font-medium text-autobot-text-primary">{{ $t('desktop.popoutBrowser.browserSession') }}</h4>
-              <StatusBadge variant="success" size="small">{{ $t('desktop.popoutBrowser.connected') }}</StatusBadge>
+              <StatusBadge variant="success" size="sm">{{ $t('desktop.popoutBrowser.connected') }}</StatusBadge>
             </div>
             <div class="text-xs text-autobot-text-secondary">
               <div class="flex items-center gap-2">

--- a/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
+++ b/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
@@ -73,7 +73,7 @@
     <BaseModal
       v-model="showAddModal"
       :title="editingEndpoint ? $t('featureFlags.enforcement.editOverride') : $t('featureFlags.enforcement.addEndpointOverride')"
-      size="medium"
+      size="md"
     >
       <form @submit.prevent="saveOverride" class="override-form">
         <div class="form-group">
@@ -129,7 +129,7 @@
     <BaseModal
       v-model="showRemoveModal"
       :title="$t('featureFlags.enforcement.removeOverride')"
-      size="small"
+      size="sm"
     >
       <div class="remove-content">
         <div class="remove-icon">

--- a/autobot-frontend/src/components/knowledge/BulkActionsToolbar.vue
+++ b/autobot-frontend/src/components/knowledge/BulkActionsToolbar.vue
@@ -223,7 +223,7 @@ function handleClickOutside(event: MouseEvent): void {
 
         <!-- Delete Button -->
         <BaseButton
-          variant="danger"
+          variant="error"
           size="sm"
           @click="emit('delete')"
           class="action-btn danger"

--- a/autobot-frontend/src/components/knowledge/DeduplicationManager.vue
+++ b/autobot-frontend/src/components/knowledge/DeduplicationManager.vue
@@ -156,7 +156,7 @@
 
           <div class="action-buttons">
             <BaseButton
-              variant="danger"
+              variant="error"
               @click="cleanupOrphans"
               :disabled="cleaning"
               :loading="cleaning"

--- a/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.vue
+++ b/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.vue
@@ -19,7 +19,7 @@
         </BaseButton>
         <BaseButton
           v-if="failedJobs.length > 0"
-          variant="danger"
+          variant="error"
           size="sm"
           @click="clearAllFailed"
           :disabled="loading"

--- a/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
@@ -102,7 +102,7 @@
               <small class="action-meta">{{ $t('knowledge.advanced.clearAllMeta') }}</small>
             </div>
             <BaseButton
-              variant="danger"
+              variant="error"
               @click="clearAllKnowledge"
               :disabled="isClearing || isPopulating"
               :loading="isClearing"

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -89,7 +89,7 @@
     <BaseModal
       v-model="showCategoryDocuments"
       :title="`${formatCategoryName(selectedCategoryPath)} - Documents`"
-      size="large"
+      size="lg"
       @close="closeCategoryDocuments"
     >
       <div v-if="isLoadingCategoryDocs" class="loading-state">
@@ -129,7 +129,7 @@
     <BaseModal
       v-model="showDocumentModal"
       :title="currentDocument?.title || currentDocument?.filename || $t('knowledge.categories.documentDetails')"
-      size="large"
+      size="lg"
       @close="closeDocumentModal"
     >
       <div v-if="currentDocument">

--- a/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
@@ -292,7 +292,7 @@
     <BaseModal
       v-model="showDialog"
       :title="dialogMode === 'view' ? $t('knowledge.entries.viewEntry') : $t('knowledge.entries.editEntry')"
-      size="large"
+      size="lg"
       scrollable
     >
       <div v-if="currentEntry && dialogMode === 'view'" class="view-mode">

--- a/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
@@ -176,7 +176,7 @@
             {{ $t('knowledge.persistence.keepSelectedTemporarily') }}
           </BaseButton>
           <BaseButton
-            variant="danger"
+            variant="error"
             @click="applyBulkDecision('delete')"
             :disabled="!hasSelectedItems"
             class="bulk-button delete"

--- a/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
@@ -414,7 +414,7 @@ onBeforeUnmount(() => {
     <BaseModal
       v-model="showHistoryModal"
       :title="$t('knowledge.promptEditor.versionHistory')"
-      size="large"
+      size="lg"
       @close="showHistoryModal = false"
     >
       <div class="history-modal">

--- a/autobot-frontend/src/components/knowledge/KnowledgeStats.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeStats.vue
@@ -23,7 +23,7 @@
       </div>
 
       <div class="vector-overview-grid">
-        <BasePanel variant="elevated" size="medium">
+        <BasePanel variant="elevated" size="md">
           <div class="vector-stat-icon facts">
             <Icon name="lightbulb" />
           </div>
@@ -34,7 +34,7 @@
           </div>
         </BasePanel>
 
-        <BasePanel variant="elevated" size="medium" :class="{ 'needs-attention': needsVectorization }">
+        <BasePanel variant="elevated" size="md" :class="{ 'needs-attention': needsVectorization }">
           <div class="vector-stat-icon vectors">
             <Icon name="cubes" />
           </div>
@@ -48,7 +48,7 @@
           </div>
         </BasePanel>
 
-        <BasePanel variant="elevated" size="medium">
+        <BasePanel variant="elevated" size="md">
           <div class="vector-stat-icon database">
             <Icon name="database" />
           </div>
@@ -59,13 +59,13 @@
           </div>
         </BasePanel>
 
-        <BasePanel variant="elevated" size="medium">
+        <BasePanel variant="elevated" size="md">
           <div class="vector-stat-icon status">
             <Icon name="check-circle" />
           </div>
           <div class="vector-stat-content">
             <h4>{{ $t('knowledge.stats.status') }}</h4>
-            <StatusBadge :variant="getStatusVariant(vectorStats.status)" size="small" class="vector-stat-value">
+            <StatusBadge :variant="getStatusVariant(vectorStats.status)" size="sm" class="vector-stat-value">
               {{ vectorStats.status || 'unknown' }}
             </StatusBadge>
             <p class="vector-stat-label">{{ $t('knowledge.stats.rag') }}: {{ vectorStats.rag_available ? $t('knowledge.stats.available') : $t('knowledge.stats.unavailable') }}</p>
@@ -185,7 +185,7 @@
 
     <!-- Overview Cards -->
     <div class="stats-overview" role="region" :aria-label="$t('knowledge.stats.overviewAriaLabel')">
-      <BasePanel variant="elevated" size="small" role="article" aria-labelledby="facts-title">
+      <BasePanel variant="elevated" size="sm" role="article" aria-labelledby="facts-title">
         <div class="stat-icon facts" aria-hidden="true">
           <Icon name="lightbulb" />
         </div>
@@ -198,7 +198,7 @@
         </div>
       </BasePanel>
 
-      <BasePanel variant="elevated" size="small" role="article" aria-labelledby="documents-title">
+      <BasePanel variant="elevated" size="sm" role="article" aria-labelledby="documents-title">
         <div class="stat-icon documents" aria-hidden="true">
           <Icon name="file-alt" />
         </div>
@@ -213,7 +213,7 @@
         </div>
       </BasePanel>
 
-      <BasePanel variant="elevated" size="small" role="article" aria-labelledby="categories-title">
+      <BasePanel variant="elevated" size="sm" role="article" aria-labelledby="categories-title">
         <div class="stat-icon categories" aria-hidden="true">
           <Icon name="folder" />
         </div>
@@ -226,7 +226,7 @@
         </div>
       </BasePanel>
 
-      <BasePanel variant="elevated" size="small">
+      <BasePanel variant="elevated" size="sm">
         <div class="stat-icon tags">
           <Icon name="tags" />
         </div>
@@ -239,7 +239,7 @@
         </div>
       </BasePanel>
 
-      <BasePanel variant="elevated" size="small">
+      <BasePanel variant="elevated" size="sm">
         <div class="stat-icon storage">
           <Icon name="database" />
         </div>
@@ -256,7 +256,7 @@
     <!-- Charts Section -->
     <div class="charts-section">
       <!-- Documents by Category -->
-      <BasePanel variant="bordered" size="medium">
+      <BasePanel variant="bordered" size="md">
         <h4>{{ $t('knowledge.stats.docsByCategory') }}</h4>
         <div class="bar-chart">
           <div
@@ -280,7 +280,7 @@
       </BasePanel>
 
       <!-- Documents by Type -->
-      <BasePanel variant="bordered" size="medium">
+      <BasePanel variant="bordered" size="md">
         <h4>{{ $t('knowledge.stats.docsByType') }}</h4>
         <div class="pie-chart">
           <div class="type-stats">
@@ -296,7 +296,7 @@
     </div>
 
     <!-- Recent Activity -->
-    <BasePanel variant="bordered" size="medium">
+    <BasePanel variant="bordered" size="md">
       <h4>{{ $t('knowledge.stats.recentActivity') }}</h4>
       <div class="activity-timeline">
         <div v-for="activity in recentActivities" :key="activity.id" class="activity-item">
@@ -317,7 +317,7 @@
     </BasePanel>
 
     <!-- Tag Cloud -->
-    <BasePanel variant="bordered" size="medium">
+    <BasePanel variant="bordered" size="md">
       <h4>{{ $t('knowledge.stats.popularTags') }}</h4>
       <div class="tag-cloud" role="list" :aria-label="$t('knowledge.stats.popularTagsAriaLabel')">
         <span
@@ -338,7 +338,7 @@
     </BasePanel>
 
     <!-- System Knowledge Navigation Card (Issue #678: Consolidated ManPageManager to Manage → Advanced) -->
-    <BasePanel variant="bordered" size="medium" class="system-knowledge-nav">
+    <BasePanel variant="bordered" size="md" class="system-knowledge-nav">
       <div class="nav-card-content">
         <div class="nav-card-icon">
           <Icon name="terminal" />
@@ -727,10 +727,10 @@ const getActivityIcon = (type: string): string => {
 }
 
 // StatusBadge variant mapping function
-const getStatusVariant = (status: string): 'success' | 'danger' | 'secondary' => {
-  const variantMap: Record<string, 'success' | 'danger' | 'secondary'> = {
+const getStatusVariant = (status: string): 'success' | 'error' | 'secondary' => {
+  const variantMap: Record<string, 'success' | 'error' | 'secondary'> = {
     'online': 'success',
-    'offline': 'danger',
+    'offline': 'error',
     'unknown': 'secondary'
   }
   return variantMap[status] || 'secondary'

--- a/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
@@ -91,7 +91,7 @@
         {{ $t('knowledge.verification.approveSelected') }}
       </BaseButton>
       <BaseButton
-        variant="danger"
+        variant="error"
         size="sm"
         @click="bulkReject"
         :loading="bulkProcessing"
@@ -197,7 +197,7 @@
             {{ $t('knowledge.verification.approve') }}
           </BaseButton>
           <BaseButton
-            variant="danger"
+            variant="error"
             size="sm"
             @click="rejectSource(source.fact_id)"
             :loading="actionLoadingId === source.fact_id"

--- a/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue
+++ b/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue
@@ -17,7 +17,7 @@
 
     <!-- Status Cards -->
     <div class="status-cards">
-      <BasePanel variant="elevated" size="small">
+      <BasePanel variant="elevated" size="sm">
         <div class="status-card-content">
           <div class="status-icon">📚</div>
           <div class="status-content">
@@ -27,7 +27,7 @@
         </div>
       </BasePanel>
 
-      <BasePanel variant="elevated" size="small">
+      <BasePanel variant="elevated" size="sm">
         <div class="status-card-content">
           <div class="status-icon">🔍</div>
           <div class="status-content">
@@ -37,7 +37,7 @@
         </div>
       </BasePanel>
 
-      <BasePanel variant="elevated" size="small">
+      <BasePanel variant="elevated" size="sm">
         <div class="status-card-content">
           <div class="status-icon">⚙️</div>
           <div class="status-content">
@@ -47,7 +47,7 @@
         </div>
       </BasePanel>
 
-      <BasePanel variant="elevated" size="small">
+      <BasePanel variant="elevated" size="sm">
         <div class="status-card-content">
           <div class="status-icon">📄</div>
           <div class="status-content">
@@ -156,7 +156,7 @@
     </div>
 
     <!-- Info Section -->
-    <BasePanel variant="bordered" size="medium">
+    <BasePanel variant="bordered" size="md">
       <template #header>
         <h3>ℹ️ {{ $t('knowledge.systemKnowledge.aboutTitle') }}</h3>
       </template>

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
@@ -354,7 +354,7 @@ function closeModal() {
   <BaseModal
     :model-value="modelValue"
     :title="modalTitle"
-    size="medium"
+    size="md"
     @update:model-value="$emit('update:modelValue', $event)"
     @close="closeModal"
   >

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
@@ -268,7 +268,7 @@ onMounted(() => {
     <BaseModal
       v-model="showHistoryModal"
       :title="t('knowledge.connectors.syncHistoryTitle', { name: historyConnectorName })"
-      size="medium"
+      size="md"
     >
       <ConnectorHistoryPanel
         v-if="historyConnectorId"

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorStatusCard.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorStatusCard.vue
@@ -289,7 +289,7 @@ defineExpose({ resetSyncing })
       </template>
       <template v-else>
         <BaseButton
-          variant="danger"
+          variant="error"
           size="sm"
           @click="handleDelete"
         >

--- a/autobot-frontend/src/components/knowledge/modals/BulkEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/BulkEditModal.vue
@@ -232,7 +232,7 @@ watch(() => props.modelValue, (newValue) => {
   <BaseModal
     v-model="isOpen"
     :title="modalTitle"
-    size="medium"
+    size="md"
     @close="closeModal"
   >
     <div class="bulk-edit-content">

--- a/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
@@ -258,7 +258,7 @@ function selectIcon(icon: string): void {
   <BaseModal
     v-model="isOpen"
     :title="t('knowledge.modals.categoryEdit.editTitle', { name: categoryTitle })"
-    size="medium"
+    size="md"
     @close="closeModal"
   >
     <div class="category-edit-modal">
@@ -297,7 +297,7 @@ function selectIcon(icon: string): void {
             {{ $t('knowledge.modals.categoryEdit.cancel') }}
           </BaseButton>
           <BaseButton
-            variant="danger"
+            variant="error"
             @click="deleteCategory"
             :disabled="isLoading"
           >
@@ -396,7 +396,7 @@ function selectIcon(icon: string): void {
           <div class="left-actions">
             <BaseButton
               v-if="canDelete"
-              variant="danger"
+              variant="error"
               @click="confirmDelete"
               :disabled="isLoading"
             >

--- a/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
@@ -206,7 +206,7 @@ watch(() => props.modelValue, (isOpen) => {
   <BaseModal
     v-model="isOpen"
     :title="modalTitle"
-    size="small"
+    size="sm"
     @close="closeModal"
   >
     <div class="export-modal">

--- a/autobot-frontend/src/components/knowledge/stats/RecentActivityPanel.vue
+++ b/autobot-frontend/src/components/knowledge/stats/RecentActivityPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <BasePanel variant="bordered" size="medium">
+  <BasePanel variant="bordered" size="md">
     <h4>{{ $t('knowledge.stats.recentActivity.title') }}</h4>
     <div class="activity-timeline">
       <div v-for="activity in activities" :key="activity.id" class="activity-item">

--- a/autobot-frontend/src/components/knowledge/stats/StatsChartsSection.vue
+++ b/autobot-frontend/src/components/knowledge/stats/StatsChartsSection.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="charts-section">
     <!-- Documents by Category -->
-    <BasePanel variant="bordered" size="medium">
+    <BasePanel variant="bordered" size="md">
       <h4>{{ $t('knowledge.stats.charts.documentsByCategory') }}</h4>
       <div class="bar-chart">
         <div
@@ -25,7 +25,7 @@
     </BasePanel>
 
     <!-- Documents by Type -->
-    <BasePanel variant="bordered" size="medium">
+    <BasePanel variant="bordered" size="md">
       <h4>{{ $t('knowledge.stats.charts.documentsByType') }}</h4>
       <div class="pie-chart">
         <div class="type-stats">

--- a/autobot-frontend/src/components/knowledge/stats/StatsOverviewCards.vue
+++ b/autobot-frontend/src/components/knowledge/stats/StatsOverviewCards.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="stats-overview" role="region" :aria-label="$t('knowledge.stats.overview.ariaLabel')">
-    <BasePanel variant="elevated" size="small" role="article" aria-labelledby="facts-title">
+    <BasePanel variant="elevated" size="sm" role="article" aria-labelledby="facts-title">
       <div class="stat-icon facts" aria-hidden="true">
         <Icon name="lightbulb" />
       </div>
@@ -13,7 +13,7 @@
       </div>
     </BasePanel>
 
-    <BasePanel variant="elevated" size="small" role="article" aria-labelledby="documents-title">
+    <BasePanel variant="elevated" size="sm" role="article" aria-labelledby="documents-title">
       <div class="stat-icon documents" aria-hidden="true">
         <Icon name="file-alt" />
       </div>
@@ -28,7 +28,7 @@
       </div>
     </BasePanel>
 
-    <BasePanel variant="elevated" size="small" role="article" aria-labelledby="categories-title">
+    <BasePanel variant="elevated" size="sm" role="article" aria-labelledby="categories-title">
       <div class="stat-icon categories" aria-hidden="true">
         <Icon name="folder" />
       </div>
@@ -41,7 +41,7 @@
       </div>
     </BasePanel>
 
-    <BasePanel variant="elevated" size="small">
+    <BasePanel variant="elevated" size="sm">
       <div class="stat-icon tags">
         <Icon name="tags" />
       </div>
@@ -54,7 +54,7 @@
       </div>
     </BasePanel>
 
-    <BasePanel variant="elevated" size="small">
+    <BasePanel variant="elevated" size="sm">
       <div class="stat-icon storage">
         <Icon name="database" />
       </div>

--- a/autobot-frontend/src/components/knowledge/stats/TagCloudPanel.vue
+++ b/autobot-frontend/src/components/knowledge/stats/TagCloudPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <BasePanel variant="bordered" size="medium">
+  <BasePanel variant="bordered" size="md">
     <h4>{{ $t('knowledge.stats.tagCloud.title') }}</h4>
     <div class="tag-cloud" role="list" :aria-label="$t('knowledge.stats.tagCloud.ariaLabel')">
       <span

--- a/autobot-frontend/src/components/knowledge/stats/VectorStatsSection.vue
+++ b/autobot-frontend/src/components/knowledge/stats/VectorStatsSection.vue
@@ -12,7 +12,7 @@
     </div>
 
     <div class="vector-overview-grid">
-      <BasePanel variant="elevated" size="medium">
+      <BasePanel variant="elevated" size="md">
         <div class="vector-stat-icon facts">
           <Icon name="lightbulb" />
         </div>
@@ -23,7 +23,7 @@
         </div>
       </BasePanel>
 
-      <BasePanel variant="elevated" size="medium" :class="{ 'needs-attention': needsVectorization }">
+      <BasePanel variant="elevated" size="md" :class="{ 'needs-attention': needsVectorization }">
         <div class="vector-stat-icon vectors">
           <Icon name="cubes" />
         </div>
@@ -37,7 +37,7 @@
         </div>
       </BasePanel>
 
-      <BasePanel variant="elevated" size="medium">
+      <BasePanel variant="elevated" size="md">
         <div class="vector-stat-icon database">
           <Icon name="database" />
         </div>
@@ -48,13 +48,13 @@
         </div>
       </BasePanel>
 
-      <BasePanel variant="elevated" size="medium">
+      <BasePanel variant="elevated" size="md">
         <div class="vector-stat-icon status">
           <Icon name="check-circle" />
         </div>
         <div class="vector-stat-content">
           <h4>{{ $t('knowledge.stats.vector.status') }}</h4>
-          <StatusBadge :variant="getStatusVariant(stats.status)" size="small" class="vector-stat-value">
+          <StatusBadge :variant="getStatusVariant(stats.status)" size="sm" class="vector-stat-value">
             {{ stats.status || $t('knowledge.stats.vector.unknown') }}
           </StatusBadge>
           <p class="vector-stat-label">{{ $t('knowledge.stats.vector.rag') }}: {{ stats.rag_available ? $t('knowledge.stats.vector.available') : $t('knowledge.stats.vector.unavailable') }}</p>
@@ -237,10 +237,10 @@ const embeddingModelDisplay = computed(() => {
   return t('knowledge.stats.vector.notConfigured')
 })
 
-const getStatusVariant = (status: string): 'success' | 'danger' | 'secondary' => {
-  const variantMap: Record<string, 'success' | 'danger' | 'secondary'> = {
+const getStatusVariant = (status: string): 'success' | 'error' | 'secondary' => {
+  const variantMap: Record<string, 'success' | 'error' | 'secondary'> = {
     'online': 'success',
-    'offline': 'danger',
+    'offline': 'error',
     'unknown': 'secondary'
   }
   return variantMap[status] || 'secondary'

--- a/autobot-frontend/src/components/manpage/IntegrationStatusPanel.vue
+++ b/autobot-frontend/src/components/manpage/IntegrationStatusPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <BasePanel variant="bordered" size="medium">
+  <BasePanel variant="bordered" size="md">
     <template #header>
       <h3><Icon name="chart-bar" /> {{ $t('manpage.integrationStatus.title') }}</h3>
       <BaseButton

--- a/autobot-frontend/src/components/manpage/MachineProfilePanel.vue
+++ b/autobot-frontend/src/components/manpage/MachineProfilePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <BasePanel variant="bordered" size="medium">
+  <BasePanel variant="bordered" size="md">
     <template #header>
       <h3><Icon name="desktop" /> {{ $t('manpage.machineProfile.title') }}</h3>
       <BaseButton

--- a/autobot-frontend/src/components/manpage/ManPageManager.vue
+++ b/autobot-frontend/src/components/manpage/ManPageManager.vue
@@ -2,7 +2,7 @@
   <div class="man-page-manager">
 
     <!-- Machine Profile Section -->
-    <BasePanel variant="bordered" size="medium">
+    <BasePanel variant="bordered" size="md">
       <template #header>
         <h3><Icon name="desktop" /> {{ $t('manpage.manager.title') }}</h3>
         <BaseButton
@@ -59,7 +59,7 @@
     </BasePanel>
 
     <!-- Integration Status Section -->
-    <BasePanel variant="bordered" size="medium">
+    <BasePanel variant="bordered" size="md">
       <template #header>
         <h3><Icon name="chart-bar" /> {{ $t('manpage.manager.integrationStatus') }}</h3>
         <BaseButton
@@ -175,7 +175,7 @@
       </div>
 
       <!-- Real-time Progress Tracking -->
-      <BasePanel v-if="showProgressTracking" variant="bordered" size="medium">
+      <BasePanel v-if="showProgressTracking" variant="bordered" size="md">
         <template #header>
           <h3><Icon name="tasks" /> {{ $t('manpage.manager.progressTitle') }}</h3>
           <BaseButton
@@ -259,7 +259,7 @@
     </div>
 
     <!-- Search Section -->
-    <BasePanel v-if="showSearch" variant="bordered" size="medium">
+    <BasePanel v-if="showSearch" variant="bordered" size="md">
       <template #header>
         <h3><Icon name="search" /> {{ $t('manpage.manager.searchTitle') }}</h3>
       </template>

--- a/autobot-frontend/src/components/manpage/ManPageSearchPanel.vue
+++ b/autobot-frontend/src/components/manpage/ManPageSearchPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <BasePanel v-if="show" variant="bordered" size="medium">
+  <BasePanel v-if="show" variant="bordered" size="md">
     <template #header>
       <h3><Icon name="search" /> {{ $t('manpage.searchPanel.title') }}</h3>
     </template>

--- a/autobot-frontend/src/components/manpage/ProgressTrackingPanel.vue
+++ b/autobot-frontend/src/components/manpage/ProgressTrackingPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <BasePanel v-if="show" variant="bordered" size="medium">
+  <BasePanel v-if="show" variant="bordered" size="md">
     <template #header>
       <h3><Icon name="tasks" /> {{ $t('manpage.progressTracking.title') }}</h3>
       <BaseButton

--- a/autobot-frontend/src/components/operations/OperationDetail.vue
+++ b/autobot-frontend/src/components/operations/OperationDetail.vue
@@ -42,7 +42,7 @@
         :processed-items="operation.processed_items"
         :estimated-items="operation.estimated_items"
         :current-step="operation.current_step"
-        size="large"
+        size="lg"
       />
     </div>
 

--- a/autobot-frontend/src/components/operations/OperationProgress.stories.ts
+++ b/autobot-frontend/src/components/operations/OperationProgress.stories.ts
@@ -139,15 +139,15 @@ export const AllSizes: Story = {
       <div style="display:flex;flex-direction:column;gap:16px;padding:16px;max-width:400px">
         <div>
           <p style="margin:0 0 4px;font-size:12px;color:#6b7280">Small</p>
-          <OperationProgress :progress="60" status="running" size="small" :show-info="false" :show-step="false" />
+          <OperationProgress :progress="60" status="running" size="sm" :show-info="false" :show-step="false" />
         </div>
         <div>
           <p style="margin:0 0 4px;font-size:12px;color:#6b7280">Medium</p>
-          <OperationProgress :progress="60" status="running" size="medium" :show-info="true" :show-step="false" />
+          <OperationProgress :progress="60" status="running" size="md" :show-info="true" :show-step="false" />
         </div>
         <div>
           <p style="margin:0 0 4px;font-size:12px;color:#6b7280">Large</p>
-          <OperationProgress :progress="60" status="running" size="large" :show-info="true" current-step="Processing…" />
+          <OperationProgress :progress="60" status="running" size="lg" :show-info="true" current-step="Processing…" />
         </div>
       </div>
     `,

--- a/autobot-frontend/src/components/operations/OperationProgress.vue
+++ b/autobot-frontend/src/components/operations/OperationProgress.vue
@@ -44,7 +44,7 @@ interface Props {
   processedItems?: number
   estimatedItems?: number
   currentStep?: string
-  size?: 'small' | 'medium' | 'large'
+  size?: 'sm' | 'md' | 'lg'
   showInfo?: boolean
   showItems?: boolean
   showStep?: boolean
@@ -54,7 +54,7 @@ const props = withDefaults(defineProps<Props>(), {
   processedItems: 0,
   estimatedItems: 0,
   currentStep: '',
-  size: 'medium',
+  size: 'md',
   showInfo: true,
   showItems: true,
   showStep: true
@@ -99,15 +99,15 @@ const progressBarClasses = computed(() => {
   overflow: hidden;
 }
 
-.progress-small .progress-bar-container {
+.progress-sm .progress-bar-container {
   height: 4px;
 }
 
-.progress-medium .progress-bar-container {
+.progress-md .progress-bar-container {
   height: 8px;
 }
 
-.progress-large .progress-bar-container {
+.progress-lg .progress-bar-container {
   height: 12px;
 }
 

--- a/autobot-frontend/src/components/operations/OperationsList.vue
+++ b/autobot-frontend/src/components/operations/OperationsList.vue
@@ -73,7 +73,7 @@
                   :show-info="false"
                   :show-items="false"
                   :show-step="false"
-                  size="small"
+                  size="sm"
                 />
                 <span class="progress-text">{{ operation.progress }}%</span>
               </div>

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -273,7 +273,7 @@
       :modelValue="showCreateModal || showEditModal"
       @update:modelValue="val => !val && closeModals()"
       :title="modalTitle"
-      size="large"
+      size="lg"
       :closeOnOverlay="!saving"
     >
       <form @submit.prevent="saveSecret" class="credential-form">
@@ -652,7 +652,7 @@
     <BaseModal
       v-model="showViewModal"
       :title="viewingSecret?.name || $t('security.secretsManager.viewDetails')"
-      size="medium"
+      size="md"
     >
       <div class="view-credential">
         <div class="view-header">
@@ -730,7 +730,7 @@
     <BaseModal
       v-model="showTransferModal"
       :title="$t('security.secretsManager.transferTitle')"
-      size="small"
+      size="sm"
     >
       <div class="transfer-content">
         <div class="transfer-icon">
@@ -757,7 +757,7 @@
     <BaseModal
       v-model="showDeleteModal"
       :title="$t('security.secretsManager.deleteConfirmTitle')"
-      size="small"
+      size="sm"
     >
       <div class="delete-content">
         <div class="delete-icon">

--- a/autobot-frontend/src/components/services/RedisServiceControl.vue
+++ b/autobot-frontend/src/components/services/RedisServiceControl.vue
@@ -77,7 +77,7 @@
           </BaseButton>
 
           <BaseButton
-            variant="danger"
+            variant="error"
             @click="handleStopService"
             :disabled="serviceStatus.status !== 'running' || loading"
             class="flex items-center gap-2 px-4 py-2"
@@ -106,7 +106,7 @@
       <h4 class="text-md font-semibold text-autobot-text-primary mb-3">{{ $t('redis.healthStatus') }}</h4>
 
       <!-- Overall Health Indicator -->
-      <StatusBadge :variant="healthVariant" size="medium" class="font-semibold mb-4" data-testid="redis-service-health-badge">
+      <StatusBadge :variant="healthVariant" size="md" class="font-semibold mb-4" data-testid="redis-service-health-badge">
         {{ (healthStatus?.overall_status || 'unknown').toUpperCase() }}
       </StatusBadge>
 
@@ -121,7 +121,7 @@
         >
           <div class="flex items-center justify-between mb-2">
             <span class="text-sm font-medium text-autobot-text-secondary capitalize">{{ name }}</span>
-            <StatusBadge :variant="getHealthCheckVariant(check.status)" size="small" class="font-bold">
+            <StatusBadge :variant="getHealthCheckVariant(check.status)" size="sm" class="font-bold">
               {{ check.status }}
             </StatusBadge>
           </div>
@@ -191,7 +191,7 @@
     <BaseModal
       v-model="showConfirmDialog"
       :title="confirmDialog.title"
-      size="medium"
+      size="md"
       data-testid="redis-service-confirm-dialog"
     >
       <p class="text-sm text-autobot-text-secondary mb-4">{{ confirmDialog.message }}</p>
@@ -214,7 +214,7 @@
           {{ $t('common.cancel') }}
         </BaseButton>
         <BaseButton
-          :variant="confirmDialog.type === 'danger' ? 'danger' : 'primary'"
+          :variant="confirmDialog.type === 'error' ? 'error' : 'primary'"
           @click="confirmDialog.onConfirm"
           data-testid="redis-service-confirm-ok-btn"
         >
@@ -267,7 +267,7 @@ const statusVariant = computed(() => {
   const statusMap = {
     'running': 'success',
     'stopped': 'secondary',
-    'failed': 'danger'
+    'failed': 'error'
   }
   return statusMap[serviceStatus.value.status] || 'warning'
 })
@@ -277,7 +277,7 @@ const healthVariant = computed(() => {
   const healthMap = {
     'healthy': 'success',
     'degraded': 'warning',
-    'critical': 'danger'
+    'critical': 'error'
   }
   return healthMap[healthStatus.value?.overall_status] || 'secondary'
 })
@@ -287,7 +287,7 @@ const getHealthCheckVariant = (status) => {
   const variantMap = {
     'pass': 'success',
     'warning': 'warning',
-    'fail': 'danger'
+    'fail': 'error'
   }
   return variantMap[status] || 'secondary'
 }
@@ -341,7 +341,7 @@ const handleStopService = () => {
     title: t('redis.stopTitle'),
     message: t('redis.stopMsg'),
     warning: t('redis.stopWarning'),
-    type: 'danger',
+    type: 'error',
     onConfirm: async () => {
       showConfirmDialog.value = false
       try {

--- a/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
+++ b/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
@@ -3,7 +3,7 @@
     :modelValue="modelValue"
     @update:modelValue="$emit('update:modelValue', $event)"
     :title="t('settings.apiKeys.wizardTitle')"
-    size="large"
+    size="lg"
   >
     <!-- Step Indicators -->
     <div class="wizard-steps">

--- a/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
+++ b/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
@@ -183,7 +183,7 @@ function resetEdit(): void {
   <BaseModal
     v-model="isOpen"
     :title="t('terminal.window.workflowStepConfirmation')"
-    size="medium"
+    size="md"
     :close-on-overlay="false"
     @close="handleClose"
   >

--- a/autobot-frontend/src/components/terminal/TerminalModals.vue
+++ b/autobot-frontend/src/components/terminal/TerminalModals.vue
@@ -5,7 +5,7 @@
       :modelValue="showReconnectModal"
       @update:modelValue="val => !val && $emit('hide-reconnect-modal')"
       :title="$t('terminal.modals.connectionLost')"
-      size="small"
+      size="sm"
       :closeOnOverlay="!isReconnecting"
     >
       <p>{{ $t('terminal.modals.connectionLostMsg') }}</p>
@@ -45,7 +45,7 @@
       :modelValue="showCommandConfirmation"
       @update:modelValue="val => !val && cancelCommand()"
       :title="$t('terminal.modals.destructiveCommand')"
-      size="medium"
+      size="md"
       :closeOnOverlay="!isExecutingCommand"
       class="command-confirmation-modal"
     >
@@ -90,7 +90,7 @@
 
       <template #actions>
         <BaseButton
-          variant="danger"
+          variant="error"
           @click="handleExecuteCommand"
           :loading="isExecutingCommand"
         >
@@ -111,7 +111,7 @@
       :modelValue="showKillConfirmation"
       @update:modelValue="val => !val && cancelKill()"
       :title="$t('terminal.modals.emergencyKillTitle')"
-      size="medium"
+      size="md"
       :closeOnOverlay="!isKillingProcesses"
       class="emergency-kill-modal"
     >
@@ -140,7 +140,7 @@
 
       <template #actions>
         <BaseButton
-          variant="danger"
+          variant="error"
           @click="handleEmergencyKill"
           :loading="isKillingProcesses"
         >
@@ -161,7 +161,7 @@
       :modelValue="showLegacyModal"
       @update:modelValue="val => !val && handleTakeManualControl()"
       :title="$t('terminal.modals.workflowTitle')"
-      size="large"
+      size="lg"
       :closeOnOverlay="!isProcessingWorkflow"
       class="workflow-step-modal"
     >

--- a/autobot-frontend/src/components/ui/BaseModal.stories.ts
+++ b/autobot-frontend/src/components/ui/BaseModal.stories.ts
@@ -41,7 +41,7 @@ export const Default: Story = {
   render: () => ({
     components: { BaseModal },
     template: `
-      <BaseModal :model-value="true" title="Default Modal" size="medium">
+      <BaseModal :model-value="true" title="Default Modal" size="md">
         <p>This is the default modal body content. Replace with anything you need.</p>
       </BaseModal>
     `,
@@ -52,7 +52,7 @@ export const Small: Story = {
   render: () => ({
     components: { BaseModal },
     template: `
-      <BaseModal :model-value="true" title="Small Modal" size="small">
+      <BaseModal :model-value="true" title="Small Modal" size="sm">
         <p>Compact modal for confirmations and short messages.</p>
       </BaseModal>
     `,
@@ -63,7 +63,7 @@ export const Large: Story = {
   render: () => ({
     components: { BaseModal },
     template: `
-      <BaseModal :model-value="true" title="Large Modal" size="large">
+      <BaseModal :model-value="true" title="Large Modal" size="lg">
         <p>Wider modal (1200px) for forms or detailed content.</p>
       </BaseModal>
     `,
@@ -74,7 +74,7 @@ export const WithActions: Story = {
   render: () => ({
     components: { BaseModal },
     template: `
-      <BaseModal :model-value="true" title="Confirm Action" size="small">
+      <BaseModal :model-value="true" title="Confirm Action" size="sm">
         <p>Are you sure you want to proceed with this action?</p>
         <template #actions>
           <button class="px-4 py-2 bg-gray-200 rounded">Cancel</button>
@@ -108,7 +108,7 @@ export const LongContent: Story = {
   render: () => ({
     components: { BaseModal },
     template: `
-      <BaseModal :model-value="true" title="Scrollable Content" size="medium" :scrollable="true">
+      <BaseModal :model-value="true" title="Scrollable Content" size="md" :scrollable="true">
         <div>
           <p v-for="i in 20" :key="i" class="mb-3">
             Paragraph {{ i }}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/autobot-frontend/src/components/ui/BaseModal.vue
+++ b/autobot-frontend/src/components/ui/BaseModal.vue
@@ -79,7 +79,7 @@ import Icon from './Icon.vue'
  * <BaseModal
  *   v-model="showModal"
  *   title="Delete Item"
- *   size="small"
+ *   size="sm"
  *   @close="handleClose"
  * >
  *   <p>Are you sure you want to delete this item?</p>
@@ -96,8 +96,8 @@ interface Props {
   modelValue: boolean
   /** Modal title */
   title: string
-  /** Modal size: small (500px), medium (900px), large (1200px) */
-  size?: 'small' | 'medium' | 'large'
+  /** Modal size: sm (500px), md (900px), lg (1200px) */
+  size?: 'sm' | 'md' | 'lg'
   /** Show close button */
   showClose?: boolean
   /** Close on overlay click */
@@ -107,7 +107,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  size: 'medium',
+  size: 'md',
   showClose: true,
   closeOnOverlay: true,
   scrollable: true
@@ -140,12 +140,12 @@ const descriptionId = computed(() => `modal-desc-${_uid}`)
 
 const sizeClass = computed(() => {
   switch (props.size) {
-    case 'small':
-      return 'dialog-small'
-    case 'large':
-      return 'dialog-large'
+    case 'sm':
+      return 'dialog-sm'
+    case 'lg':
+      return 'dialog-lg'
     default:
-      return 'dialog-medium'
+      return 'dialog-md'
   }
 })
 
@@ -195,15 +195,15 @@ const onAfterEnter = () => focusFirst()
   contain: layout style;
 }
 
-.dialog-small {
+.dialog-sm {
   max-width: 500px;
 }
 
-.dialog-medium {
+.dialog-md {
   max-width: 900px;
 }
 
-.dialog-large {
+.dialog-lg {
   max-width: 1200px;
 }
 

--- a/autobot-frontend/src/components/ui/CommandPermissionDialog.vue
+++ b/autobot-frontend/src/components/ui/CommandPermissionDialog.vue
@@ -25,7 +25,7 @@
             </div>
             <div class="info-item" v-if="riskLevel">
               <span class="label">{{ t('ui.commandPermission.riskLevelLabel') }}:</span>
-              <StatusBadge :variant="getRiskVariant(riskLevel)" size="small">{{ riskLevel }}</StatusBadge>
+              <StatusBadge :variant="getRiskVariant(riskLevel)" size="sm">{{ riskLevel }}</StatusBadge>
             </div>
           </div>
         </div>
@@ -268,8 +268,8 @@ watch(() => props.show, (newValue) => {
   showDialog.value = newValue ?? false
 }, { immediate: true })
 
-const getRiskVariant = (riskLevel: string): 'success' | 'warning' | 'info' | 'primary' | 'secondary' | 'danger' | undefined => {
-  const variantMap: Record<string, 'success' | 'warning' | 'danger' | 'secondary'> = { LOW: 'success', MEDIUM: 'warning', HIGH: 'danger', CRITICAL: 'danger' }
+const getRiskVariant = (riskLevel: string): 'success' | 'warning' | 'info' | 'primary' | 'secondary' | 'error' | undefined => {
+  const variantMap: Record<string, 'success' | 'warning' | 'error' | 'secondary'> = { LOW: 'success', MEDIUM: 'warning', HIGH: 'error', CRITICAL: 'error' }
   return variantMap[riskLevel] ?? 'secondary'
 }
 </script>

--- a/autobot-frontend/src/components/ui/StatusBadge.stories.ts
+++ b/autobot-frontend/src/components/ui/StatusBadge.stories.ts
@@ -7,12 +7,12 @@ const meta = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['success', 'danger', 'warning', 'info', 'secondary', 'primary'],
+      options: ['success', 'error', 'warning', 'info', 'secondary', 'primary'],
       description: 'Color variant',
     },
     size: {
       control: 'select',
-      options: ['small', 'medium', 'large'],
+      options: ['sm', 'md', 'lg'],
       description: 'Badge size',
     },
     icon: {
@@ -37,7 +37,7 @@ export const Success: Story = {
 export const Danger: Story = {
   render: () => ({
     components: { StatusBadge },
-    template: '<StatusBadge variant="danger" icon="exclamation-circle">Failed</StatusBadge>',
+    template: '<StatusBadge variant="error" icon="exclamation-circle">Failed</StatusBadge>',
   }),
 };
 
@@ -72,14 +72,14 @@ export const Secondary: Story = {
 export const Small: Story = {
   render: () => ({
     components: { StatusBadge },
-    template: '<StatusBadge variant="success" size="small" icon="check-circle">OK</StatusBadge>',
+    template: '<StatusBadge variant="success" size="sm" icon="check-circle">OK</StatusBadge>',
   }),
 };
 
 export const Large: Story = {
   render: () => ({
     components: { StatusBadge },
-    template: '<StatusBadge variant="danger" size="large" icon="exclamation-circle">Critical</StatusBadge>',
+    template: '<StatusBadge variant="error" size="lg" icon="exclamation-circle">Critical</StatusBadge>',
   }),
 };
 
@@ -89,7 +89,7 @@ export const AllVariants: Story = {
     template: `
       <div class="flex flex-wrap gap-2">
         <StatusBadge variant="success" icon="check-circle">Success</StatusBadge>
-        <StatusBadge variant="danger" icon="exclamation-circle">Danger</StatusBadge>
+        <StatusBadge variant="error" icon="exclamation-circle">Danger</StatusBadge>
         <StatusBadge variant="warning" icon="exclamation-triangle">Warning</StatusBadge>
         <StatusBadge variant="info" icon="info-circle">Info</StatusBadge>
         <StatusBadge variant="primary">Primary</StatusBadge>
@@ -104,9 +104,9 @@ export const AllSizes: Story = {
     components: { StatusBadge },
     template: `
       <div class="flex items-center gap-2">
-        <StatusBadge variant="success" size="small" icon="check-circle">Small</StatusBadge>
-        <StatusBadge variant="success" size="medium" icon="check-circle">Medium</StatusBadge>
-        <StatusBadge variant="success" size="large" icon="check-circle">Large</StatusBadge>
+        <StatusBadge variant="success" size="sm" icon="check-circle">Small</StatusBadge>
+        <StatusBadge variant="success" size="md" icon="check-circle">Medium</StatusBadge>
+        <StatusBadge variant="success" size="lg" icon="check-circle">Large</StatusBadge>
       </div>
     `,
   }),

--- a/autobot-frontend/src/components/ui/StatusBadge.vue
+++ b/autobot-frontend/src/components/ui/StatusBadge.vue
@@ -19,23 +19,23 @@ import type { IconName } from '@/components/ui/Icon.vue'
  * Usage:
  * ```vue
  * <StatusBadge variant="success" icon="check-circle">Active</StatusBadge>
- * <StatusBadge variant="danger" size="large">Failed</StatusBadge>
+ * <StatusBadge variant="error" size="lg">Failed</StatusBadge>
  * <StatusBadge variant="warning">Pending</StatusBadge>
  * ```
  */
 
 interface Props {
-  /** Badge variant: success, danger, warning, info, secondary */
-  variant?: 'success' | 'danger' | 'warning' | 'info' | 'secondary' | 'primary'
-  /** Badge size: small, medium, large */
-  size?: 'small' | 'medium' | 'large'
+  /** Badge variant: success, error, warning, info, secondary */
+  variant?: 'success' | 'error' | 'warning' | 'info' | 'secondary' | 'primary'
+  /** Badge size: sm, md, lg */
+  size?: 'sm' | 'md' | 'lg'
   /** Optional icon name (IconName) */
   icon?: IconName
 }
 
 const props = withDefaults(defineProps<Props>(), {
   variant: 'secondary',
-  size: 'medium'
+  size: 'md'
 })
 
 const sizeClass = computed(() => `status-${props.size}`)
@@ -55,19 +55,19 @@ const sizeClass = computed(() => `status-${props.size}`)
 }
 
 /* Sizes */
-.status-small {
+.status-sm {
   padding: var(--spacing-0-5) var(--spacing-2);
   font-size: var(--text-xs);
   gap: var(--spacing-1);
 }
 
-.status-medium {
+.status-md {
   padding: var(--spacing-1) var(--spacing-3);
   font-size: var(--text-sm);
   gap: var(--spacing-1-5);
 }
 
-.status-large {
+.status-lg {
   padding: var(--spacing-1-5) var(--spacing-4);
   font-size: var(--text-base);
   gap: var(--spacing-2);
@@ -79,7 +79,7 @@ const sizeClass = computed(() => `status-${props.size}`)
   color: var(--color-success);
 }
 
-.status-danger {
+.status-error {
   background: var(--color-error-bg);
   color: var(--color-error);
 }

--- a/autobot-frontend/src/components/ui/TouchFriendlyButton.stories.ts
+++ b/autobot-frontend/src/components/ui/TouchFriendlyButton.stories.ts
@@ -7,7 +7,7 @@ const meta = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['primary', 'secondary', 'outline-solid', 'ghost', 'danger'],
+      options: ['primary', 'secondary', 'outline-solid', 'ghost', 'error'],
       description: 'Button style variant',
     },
     size: {
@@ -72,7 +72,7 @@ export const Ghost: Story = {
 export const Danger: Story = {
   render: () => ({
     components: { TouchFriendlyButton },
-    template: '<TouchFriendlyButton variant="danger">Delete</TouchFriendlyButton>',
+    template: '<TouchFriendlyButton variant="error">Delete</TouchFriendlyButton>',
   }),
 };
 
@@ -114,7 +114,7 @@ export const AllVariants: Story = {
         <TouchFriendlyButton variant="secondary">Secondary</TouchFriendlyButton>
         <TouchFriendlyButton variant="outline-solid">Outline</TouchFriendlyButton>
         <TouchFriendlyButton variant="ghost">Ghost</TouchFriendlyButton>
-        <TouchFriendlyButton variant="danger">Danger</TouchFriendlyButton>
+        <TouchFriendlyButton variant="error">Danger</TouchFriendlyButton>
       </div>
     `,
   }),

--- a/autobot-frontend/src/components/ui/TouchFriendlyButton.vue
+++ b/autobot-frontend/src/components/ui/TouchFriendlyButton.vue
@@ -30,7 +30,7 @@ import LoadingSpinner from './LoadingSpinner.vue'
 import type { ComponentSize } from '@/types/component-props'
 
 interface Props {
-  variant?: 'primary' | 'secondary' | 'outline-solid' | 'ghost' | 'danger'
+  variant?: 'primary' | 'secondary' | 'outline-solid' | 'ghost' | 'error'
   size?: ComponentSize
   loading?: boolean
   disabled?: boolean
@@ -240,18 +240,18 @@ const createRipple = (event: TouchEvent) => {
   @apply ring-autobot-border;
 }
 
-.button-danger {
+.button-error {
   @apply border border-transparent;
   background: var(--color-error);
   color: var(--text-inverse);
 }
 
-.button-danger:hover:not(.button-disabled):not(.button-loading) {
+.button-error:hover:not(.button-disabled):not(.button-loading) {
   background: var(--color-error);
   filter: brightness(0.9);
 }
 
-.button-danger:focus {
+.button-error:focus {
   @apply ring-red-500;
 }
 

--- a/autobot-frontend/src/types/component-props.ts
+++ b/autobot-frontend/src/types/component-props.ts
@@ -5,7 +5,7 @@ export type ButtonVariant =
   | 'primary'
   | 'secondary'
   | 'success'
-  | 'danger'
+  | 'error'
   | 'warning'
   | 'info'
   | 'light'

--- a/autobot-frontend/src/views/ComponentShowcaseView.vue
+++ b/autobot-frontend/src/views/ComponentShowcaseView.vue
@@ -15,7 +15,7 @@
             <BaseButton variant="primary">{{ $t('views.componentShowcase.primary') }}</BaseButton>
             <BaseButton variant="secondary">{{ $t('views.componentShowcase.secondary') }}</BaseButton>
             <BaseButton variant="success">{{ $t('views.componentShowcase.success') }}</BaseButton>
-            <BaseButton variant="danger">{{ $t('views.componentShowcase.danger') }}</BaseButton>
+            <BaseButton variant="error">{{ $t('views.componentShowcase.danger') }}</BaseButton>
             <BaseButton variant="warning">{{ $t('views.componentShowcase.warning') }}</BaseButton>
             <BaseButton variant="ghost">{{ $t('views.componentShowcase.ghost') }}</BaseButton>
             <BaseButton variant="link">{{ $t('views.componentShowcase.link') }}</BaseButton>

--- a/autobot-frontend/src/views/DocumentsView.vue
+++ b/autobot-frontend/src/views/DocumentsView.vue
@@ -121,7 +121,7 @@
             Cancel
           </BaseButton>
           <BaseButton
-            variant="danger"
+            variant="error"
             size="sm"
             :disabled="composable.isLoading.value"
             @click="executeDelete"


### PR DESCRIPTION
## Summary

Runs the Phase 1 design-token codemod across all Vue/TS/TSX files per [MVA-348](/MVA/issues/MVA-348).

**Replacements made:**
- `size="small"` → `size="sm"` (47 occurrences)
- `size="medium"` → `size="md"` (53 occurrences)
- `size="large"` → `size="lg"` (13 occurrences)
- `variant/color/type="danger"` → `...="error"` (29 occurrences)

**Also updated:**
- Component prop type unions (`StatusBadge`, `BaseModal`, `BasePanel`, `OperationProgress`, `TouchFriendlyButton`)
- CSS class names (`status-small/medium/large→sm/md/lg`, `button-danger→button-error`, etc.)
- `ButtonVariant` shared type: `danger→error`
- Runtime `variantMaps` in 5 components
- Storybook story controls

**Verification:**
- 64 files changed, 197 insertions, 197 deletions (pure rename — net zero)
- Zero new TypeScript errors (baseline 253, post-codemod 253)
- Rebased onto current Dev_new_gui

## Test plan
- [ ] Run `npm run type-check` — expect 0 new errors
- [ ] Spot-check mixed-usage files: `SecretsManager.vue`, `KnowledgeEntries.vue`, `ChatMessages.vue`, `AdvancedAnalytics.vue`
- [ ] Verify no `v-bind:size` dynamic bindings were missed (grep output in commit body)
- [ ] Confirm app builds without errors

Parent: [MVA-192](/MVA/issues/MVA-192) · Task: [MVA-348](/MVA/issues/MVA-348)

🤖 Generated with [Claude Code](https://claude.com/claude-code)