### PR TITLE
sec: bump langchain >=1.2.24 — fix PVE-2026-88512 SQL injection

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -53,7 +53,7 @@ llama-index-llms-ollama>=0.10.1,<1.0.0       # Ollama LLM integration
 llama-index-embeddings-ollama>=0.9.0,<1.0.0  # Ollama embeddings
 llama-index-vector-stores-chroma>=0.5.5,<1.0.0  # ChromaDB vector store
 # LangChain 1.x ecosystem — migrated from 0.3.x to fix SSRF CVE (#1572)
-langchain>=1.2.18,<2.0.0               # Issue #1572: Migrated to 1.x (was 0.3.x)
+langchain>=1.2.24,<2.0.0               # Issue #1572: Migrated to 1.x; GH#8675: floor bumped to 1.2.24 (PVE-2026-88512)
 langchain-core>=1.3.3,<2.0.0         # Issue #1572: SSRF CVE fix requires >=1.2.11
 langchain-community>=0.4.1,<0.5.0     # Issue #1572: Compatible with langchain 1.x
 langchain-ollama>=1.1.0,<2.0.0        # Issue #1572: ChatOllama for QA chain

--- a/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
+++ b/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
@@ -2,7 +2,7 @@
 # Includes LangChain, LlamaIndex and related packages with compatible versions
 
 # Core AI Frameworks
-langchain>=1.2.13,<2.0.0         # Issue #2808: upper bound unified with backend canonical
+langchain>=1.2.24,<2.0.0         # Issue #2808: upper bound unified; GH#8675: floor bumped to 1.2.24 (PVE-2026-88512)
 langchain-core>=1.2.22,<2.0.0   # Issue #2808: upper bound unified with backend canonical
 langchain-community>=0.4.1,<0.5.0  # Issue #2808: upper bound unified with backend canonical
 llama-index>=0.14.21,<0.15.0

--- a/requirements-ci/langchain.txt
+++ b/requirements-ci/langchain.txt
@@ -1,5 +1,5 @@
 # LangChain ecosystem — tightly coupled versions
-langchain==1.2.18                # Issue #2808: bumped to match canonical minimum (was 1.2.12)
+langchain==1.2.24                # GH#8675: bumped from 1.2.18 — PVE-2026-88512 SQL injection fix
 langchain-classic==1.0.7
 langchain-community==0.4.1
 langchain-core>=1.2.31,<2.0.0    # #7049: floor bumped from ==1.2.28 — langchain-text-splitters 1.1.2 requires >=1.2.31


### PR DESCRIPTION
## Summary

- Bumps `langchain` floor to `>=1.2.24` in all three requirements files to fix PVE-2026-88512 (SQL injection in @langchain/google-cloud, affected versions <1.2.24)
- `requirements-ci/langchain.txt`: pinned `==1.2.18` → `==1.2.24`
- `autobot-backend/requirements.txt`: floor `>=1.2.18` → `>=1.2.24`
- `autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt`: floor `>=1.2.13` → `>=1.2.24`

## Vulnerability

- **ID:** PVE-2026-88512
- **Type:** SQL injection in @langchain/google-cloud
- **Affected spec:** langchain <1.2.24
- **Source:** Safety scan on Dependency Security Scan CI check (GH#8675)

## Verification

- Dependency Security Scan CI will re-run and should pass after merge
- No API or behavioral changes — pure version floor bump

Closes GH#8675. Resolves MVA-1149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)