### PR TITLE
feature(llm): Anthropic-format passthrough endpoint /v1/messages (#6591)

### DIFF
--- a/autobot-backend/api/anthropic_compat.py
+++ b/autobot-backend/api/anthropic_compat.py
@@ -1,0 +1,359 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Anthropic-compatible API endpoint (#6591).
+
+Exposes:
+  POST /v1/messages  — accepts Anthropic Messages-format requests, delegates to
+                       ProviderRegistry, returns Anthropic-format responses
+
+Auth: Bearer token in Authorization header, validated via AutoBot's own JWT
+middleware or virtual sk-... API keys.  Same auth + rate limit middleware as
+openai_compat.py.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import time
+from typing import Any, AsyncIterator, Dict, List, Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel, Field
+
+from api.openai_compat import (
+    _AUTO_MODEL_NAMES,
+    _estimate_tokens,
+    _oai_limiter,
+    _remote_addr,
+    _resolve_auth,
+    _resolve_auto_model,
+)
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.logging_manager import get_logger
+from llm_shared import get_provider_registry
+from llm_shared.models import LLMRequest
+from services.llm_api_key_service import LLMApiKeyRecord, get_llm_api_key_service
+from services.llm_cost_tracker import get_cost_tracker
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["anthropic-compat"])
+
+# ---------------------------------------------------------------------------
+# Anthropic Messages API request/response schemas
+# ---------------------------------------------------------------------------
+
+
+class AnthropicContentBlock(BaseModel):
+    type: str = "text"
+    text: str = ""
+
+
+class AnthropicMessage(BaseModel):
+    role: str
+    # Anthropic supports both plain string and list-of-blocks for content
+    content: str | List[AnthropicContentBlock]
+
+
+class AnthropicRequest(BaseModel):
+    model: str = "autobot-default"
+    messages: List[AnthropicMessage]
+    system: Optional[str] = None
+    max_tokens: int = 1024
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    top_k: Optional[int] = None
+    stop_sequences: Optional[List[str]] = None
+    stream: bool = False
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class AnthropicUsage(BaseModel):
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+class AnthropicTextBlock(BaseModel):
+    type: str = "text"
+    text: str
+
+
+class AnthropicResponse(BaseModel):
+    id: str
+    type: str = "message"
+    role: str = "assistant"
+    content: List[AnthropicTextBlock]
+    model: str
+    stop_reason: str = "end_turn"
+    stop_sequence: Optional[str] = None
+    usage: AnthropicUsage
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_message_id() -> str:
+    return f"msg_{uuid4().hex[:24]}"
+
+
+def _extract_content_text(content: str | List[AnthropicContentBlock]) -> str:
+    """Flatten Anthropic content to plain text."""
+    if isinstance(content, str):
+        return content
+    return "".join(block.text for block in content if block.type == "text")
+
+
+def _map_finish_reason(finish_reason: str | None) -> str:
+    """Map provider finish_reason to Anthropic stop_reason vocabulary."""
+    if finish_reason in ("length", "max_tokens"):
+        return "max_tokens"
+    if finish_reason in ("tool_calls", "tool_use"):
+        return "tool_use"
+    return "end_turn"
+
+
+def _build_llm_request(body: AnthropicRequest, resolved_model: str | None = None) -> LLMRequest:
+    """Convert Anthropic Messages-format request to AutoBot LLMRequest."""
+    messages: List[Dict[str, str]] = []
+    if body.system:
+        messages.append({"role": "system", "content": body.system})
+    for m in body.messages:
+        messages.append({"role": m.role, "content": _extract_content_text(m.content)})
+    effective_model = resolved_model or (body.model if body.model != "autobot-default" else None)
+    return LLMRequest(
+        messages=messages,
+        model_name=effective_model,
+        temperature=body.temperature if body.temperature is not None else 0.7,
+        max_tokens=body.max_tokens,
+        top_p=body.top_p if body.top_p is not None else 1.0,
+        stop=body.stop_sequences,
+        stream=body.stream,
+    )
+
+
+async def _stream_generator_anthropic(
+    provider,
+    llm_request: LLMRequest,
+    message_id: str,
+    model_name: str,
+    *,
+    prompt_text: str = "",
+    api_key_record: LLMApiKeyRecord | None = None,
+) -> AsyncIterator[str]:
+    """Yield Anthropic SSE events for a streaming completion."""
+    completion_text_parts: List[str] = []
+    content_index = 0
+
+    def _sse(event_type: str, data: dict) -> str:
+        return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+
+    prompt_tokens = _estimate_tokens(prompt_text)
+
+    # message_start
+    yield _sse(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": message_id,
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": model_name,
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": prompt_tokens, "output_tokens": 0},
+            },
+        },
+    )
+
+    # content_block_start
+    yield _sse(
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": content_index,
+            "content_block": {"type": "text", "text": ""},
+        },
+    )
+
+    # ping — Anthropic sends these periodically; one is enough for clients
+    yield _sse("ping", {"type": "ping"})
+
+    async for text_chunk in provider.stream_completion(llm_request):
+        if not text_chunk:
+            continue
+        completion_text_parts.append(text_chunk)
+        yield _sse(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": content_index,
+                "delta": {"type": "text_delta", "text": text_chunk},
+            },
+        )
+
+    # content_block_stop
+    yield _sse("content_block_stop", {"type": "content_block_stop", "index": content_index})
+
+    completion_text = "".join(completion_text_parts)
+    completion_tokens = _estimate_tokens(completion_text)
+    tracker = get_cost_tracker()
+    cost_usd = tracker.calculate_cost(model_name, prompt_tokens, completion_tokens)
+
+    # message_delta — carries final stop_reason + output token count
+    yield _sse(
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": completion_tokens},
+        },
+    )
+
+    # message_stop
+    yield _sse("message_stop", {"type": "message_stop"})
+
+    # Record per-key spend and publish usage event after stream completes
+    if api_key_record is not None:
+        svc = get_llm_api_key_service()
+        await svc.record_spend(api_key_record, cost_usd)
+        await svc.publish_usage_event(api_key_record, model_name, prompt_tokens, completion_tokens, cost_usd)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post("/messages", response_model=None)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="messages",
+    error_code_prefix="ANTHROPIC_COMPAT",
+)
+async def messages(
+    body: AnthropicRequest,
+    request: Request,
+) -> Any:
+    """Anthropic-compatible messages endpoint (#6591).
+
+    Accepts Bearer token auth (platform JWT or virtual sk-... key), delegates
+    to ProviderRegistry, returns Anthropic Messages-format response.
+    Virtual keys enforce per-key monthly budget and model whitelist.
+    """
+    _user, api_key_record = await _resolve_auth(request)
+    await _oai_limiter.check_or_429(_remote_addr(request))
+
+    # Virtual key enforcement: model whitelist + budget
+    if api_key_record is not None:
+        from services.llm_api_key_service import LLMApiKeyService
+
+        if body.model not in _AUTO_MODEL_NAMES and body.model != "autobot-default":
+            if not LLMApiKeyService.model_allowed(api_key_record, body.model):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Model not permitted for this API key",
+                    headers={"x-llm-key-allowed-models": ",".join(api_key_record.allowed_models)},
+                )
+        allowed, _remaining = await get_llm_api_key_service().check_budget(api_key_record)
+        if not allowed:
+            raise HTTPException(
+                status_code=429,
+                detail="Monthly budget exhausted",
+                headers={"x-llm-budget-remaining": "0"},
+            )
+
+    # Resolve auto-* model aliases via tiered routing
+    if body.model in _AUTO_MODEL_NAMES:
+        messages_raw: List[Dict[str, str]] = []
+        if body.system:
+            messages_raw.append({"role": "system", "content": body.system})
+        messages_raw += [{"role": m.role, "content": _extract_content_text(m.content)} for m in body.messages]
+        resolved_model = await _resolve_auto_model(body.model, messages_raw)
+    elif body.model == "autobot-default":
+        resolved_model = None
+    else:
+        resolved_model = body.model
+
+    registry = get_provider_registry()
+    llm_request = _build_llm_request(body, resolved_model=resolved_model)
+
+    provider = await registry.get_provider_for_request(request=llm_request)
+    if provider is None:
+        raise HTTPException(status_code=503, detail="No LLM providers available")
+
+    if not inspect.isasyncgenfunction(provider.stream_completion):
+        raise ValueError(
+            f"Provider {provider.provider_name!r} stream_completion must be an async generator function"
+        )
+
+    message_id = _make_message_id()
+    if resolved_model is None:
+        resolved_model = provider.provider_name
+
+    if body.stream:
+        prompt_text = (body.system or "") + "\n" + "\n".join(
+            _extract_content_text(m.content) for m in body.messages
+        )
+        stream_headers: Dict[str, str] = {
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        }
+        if body.model in _AUTO_MODEL_NAMES:
+            stream_headers["x-llm-routed-from"] = body.model
+        return StreamingResponse(
+            _stream_generator_anthropic(
+                provider,
+                llm_request,
+                message_id,
+                resolved_model,
+                prompt_text=prompt_text,
+                api_key_record=api_key_record,
+            ),
+            media_type="text/event-stream",
+            headers=stream_headers,
+        )
+
+    # Non-streaming path
+    llm_response = await provider.chat_completion(llm_request)
+    if llm_response.error:
+        raise HTTPException(status_code=502, detail=llm_response.error)
+
+    tokens = llm_response.usage or {}
+    prompt_tokens = tokens.get("prompt_tokens", 0)
+    completion_tokens = tokens.get("completion_tokens", 0)
+
+    tracker = get_cost_tracker()
+    cost_usd = tracker.calculate_cost(resolved_model, prompt_tokens, completion_tokens)
+
+    response = AnthropicResponse(
+        id=message_id,
+        content=[AnthropicTextBlock(text=llm_response.content or "")],
+        model=resolved_model,
+        stop_reason=_map_finish_reason(llm_response.finish_reason),
+        usage=AnthropicUsage(input_tokens=prompt_tokens, output_tokens=completion_tokens),
+    )
+
+    headers: Dict[str, str] = {}
+    if cost_usd > 0:
+        headers["x-llm-cost"] = str(cost_usd)
+    if body.model in _AUTO_MODEL_NAMES:
+        headers["x-llm-routed-from"] = body.model
+
+    if api_key_record is not None:
+        svc = get_llm_api_key_service()
+        await svc.record_spend(api_key_record, cost_usd)
+        await svc.publish_usage_event(
+            api_key_record, resolved_model, prompt_tokens, completion_tokens, cost_usd
+        )
+
+    return JSONResponse(content=response.model_dump(exclude_none=True), headers=headers)

--- a/autobot-backend/api/anthropic_compat.py
+++ b/autobot-backend/api/anthropic_compat.py
@@ -291,18 +291,14 @@ async def messages(
         raise HTTPException(status_code=503, detail="No LLM providers available")
 
     if not inspect.isasyncgenfunction(provider.stream_completion):
-        raise ValueError(
-            f"Provider {provider.provider_name!r} stream_completion must be an async generator function"
-        )
+        raise ValueError(f"Provider {provider.provider_name!r} stream_completion must be an async generator function")
 
     message_id = _make_message_id()
     if resolved_model is None:
         resolved_model = provider.provider_name
 
     if body.stream:
-        prompt_text = (body.system or "") + "\n" + "\n".join(
-            _extract_content_text(m.content) for m in body.messages
-        )
+        prompt_text = (body.system or "") + "\n" + "\n".join(_extract_content_text(m.content) for m in body.messages)
         stream_headers: Dict[str, str] = {
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
@@ -352,8 +348,6 @@ async def messages(
     if api_key_record is not None:
         svc = get_llm_api_key_service()
         await svc.record_spend(api_key_record, cost_usd)
-        await svc.publish_usage_event(
-            api_key_record, resolved_model, prompt_tokens, completion_tokens, cost_usd
-        )
+        await svc.publish_usage_event(api_key_record, resolved_model, prompt_tokens, completion_tokens, cost_usd)
 
     return JSONResponse(content=response.model_dump(exclude_none=True), headers=headers)

--- a/autobot-backend/api/test_anthropic_compat.py
+++ b/autobot-backend/api/test_anthropic_compat.py
@@ -198,7 +198,7 @@ async def test_messages_streaming_returns_anthropic_sse_events():
     event_types = []
     for line in text.splitlines():
         if line.startswith("event: "):
-            event_types.append(line[len("event: "):].strip())
+            event_types.append(line[len("event: ") :].strip())
 
     # Required Anthropic SSE event order
     assert "message_start" in event_types
@@ -240,7 +240,7 @@ async def test_messages_streaming_data_lines_are_valid_json():
                 raw = await response.aread()
 
     text = raw.decode("utf-8")
-    data_lines = [line[len("data: "):].strip() for line in text.splitlines() if line.startswith("data: ")]
+    data_lines = [line[len("data: ") :].strip() for line in text.splitlines() if line.startswith("data: ")]
     assert len(data_lines) >= 1
     for raw_json in data_lines:
         parsed = json.loads(raw_json)
@@ -279,7 +279,7 @@ async def test_messages_streaming_content_delta_carries_text():
         if line.startswith("event: content_block_delta") and i + 1 < len(lines):
             data_line = lines[i + 1]
             if data_line.startswith("data: "):
-                data_payloads.append(json.loads(data_line[len("data: "):]))
+                data_payloads.append(json.loads(data_line[len("data: ") :]))
 
     assert len(data_payloads) >= 1, "Expected at least one content_block_delta"
     combined = "".join(p["delta"]["text"] for p in data_payloads)

--- a/autobot-backend/api/test_anthropic_compat.py
+++ b/autobot-backend/api/test_anthropic_compat.py
@@ -1,0 +1,348 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for Anthropic-compatible /v1/messages endpoint (#6591).
+
+Tests:
+  1. POST /v1/messages (non-streaming) returns Anthropic-shaped response
+  2. POST /v1/messages (streaming) returns correct Anthropic SSE event sequence
+  3. Round-trip: Anthropic request → provider → Anthropic response shape
+  4. stop_reason mapping from provider finish_reason
+  5. x-llm-cost header present on non-streaming response
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.anthropic_compat import router, _map_finish_reason
+from auth_middleware import get_current_user
+
+# ---------------------------------------------------------------------------
+# Minimal test app
+# ---------------------------------------------------------------------------
+
+app = FastAPI()
+app.include_router(router, prefix="/v1")
+# Bypass auth so tests never need real JWT tokens.
+app.dependency_overrides[get_current_user] = lambda: {"username": "test", "role": "user"}
+
+# ---------------------------------------------------------------------------
+# Shared mock helpers
+# ---------------------------------------------------------------------------
+
+_SYNTHETIC_USER = {"username": "test", "role": "user"}
+
+
+def _make_mock_registry(content: str = "Hello from AutoBot"):
+    """Return a mocked ProviderRegistry with one provider."""
+    from llm_shared.models import LLMResponse
+
+    mock_provider = MagicMock()
+    mock_provider.provider_name = "mock_provider"
+
+    llm_resp = LLMResponse(
+        content=content,
+        model="autobot-model-1",
+        provider="mock_provider",
+        finish_reason="stop",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
+    mock_provider.chat_completion = AsyncMock(return_value=llm_resp)
+
+    async def _fake_stream(request):
+        yield "Hello "
+        yield "from AutoBot"
+
+    mock_provider.stream_completion = _fake_stream
+
+    mock_registry = MagicMock()
+    mock_registry.get_provider_for_request = AsyncMock(return_value=mock_provider)
+    return mock_registry
+
+
+# ---------------------------------------------------------------------------
+# Tests: non-streaming
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_messages_non_streaming_returns_anthropic_shape():
+    """POST /v1/messages (non-streaming) must return Anthropic Messages response shape."""
+    mock_registry = _make_mock_registry("Hello from AutoBot")
+
+    with (
+        patch("api.anthropic_compat.get_provider_registry", return_value=mock_registry),
+        patch("api.anthropic_compat._resolve_auth", return_value=(_SYNTHETIC_USER, None)),
+        patch("api.anthropic_compat._oai_limiter") as mock_limiter,
+    ):
+        mock_limiter.check_or_429 = AsyncMock(return_value=None)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/v1/messages",
+                json={
+                    "model": "autobot-model-1",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "stream": False,
+                },
+            )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["type"] == "message"
+    assert data["role"] == "assistant"
+    assert data["id"].startswith("msg_")
+    assert isinstance(data["content"], list)
+    assert len(data["content"]) == 1
+    assert data["content"][0]["type"] == "text"
+    assert "Hello from AutoBot" in data["content"][0]["text"]
+    assert "usage" in data
+    assert "input_tokens" in data["usage"]
+    assert "output_tokens" in data["usage"]
+    assert data["stop_reason"] == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_messages_non_streaming_x_llm_cost_header():
+    """Non-streaming response must include x-llm-cost header when cost > 0."""
+    mock_registry = _make_mock_registry("Hello")
+
+    with (
+        patch("api.anthropic_compat.get_provider_registry", return_value=mock_registry),
+        patch("api.anthropic_compat._resolve_auth", return_value=(_SYNTHETIC_USER, None)),
+        patch("api.anthropic_compat._oai_limiter") as mock_limiter,
+        patch("api.anthropic_compat.get_cost_tracker") as mock_tracker,
+    ):
+        mock_limiter.check_or_429 = AsyncMock(return_value=None)
+        mock_tracker.return_value.calculate_cost.return_value = 0.00123
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/v1/messages",
+                json={
+                    "model": "autobot-model-1",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+
+    assert resp.status_code == 200
+    assert "x-llm-cost" in resp.headers
+    assert float(resp.headers["x-llm-cost"]) == pytest.approx(0.00123)
+
+
+@pytest.mark.asyncio
+async def test_messages_with_system_prompt():
+    """System field must be accepted and forwarded without error."""
+    mock_registry = _make_mock_registry("OK")
+
+    with (
+        patch("api.anthropic_compat.get_provider_registry", return_value=mock_registry),
+        patch("api.anthropic_compat._resolve_auth", return_value=(_SYNTHETIC_USER, None)),
+        patch("api.anthropic_compat._oai_limiter") as mock_limiter,
+    ):
+        mock_limiter.check_or_429 = AsyncMock(return_value=None)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/v1/messages",
+                json={
+                    "model": "autobot-model-1",
+                    "max_tokens": 50,
+                    "system": "You are a helpful assistant.",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+            )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["type"] == "message"
+
+
+# ---------------------------------------------------------------------------
+# Tests: streaming SSE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_messages_streaming_returns_anthropic_sse_events():
+    """POST /v1/messages (stream=true) must return correct Anthropic SSE event sequence."""
+    mock_registry = _make_mock_registry()
+
+    with (
+        patch("api.anthropic_compat.get_provider_registry", return_value=mock_registry),
+        patch("api.anthropic_compat._resolve_auth", return_value=(_SYNTHETIC_USER, None)),
+        patch("api.anthropic_compat._oai_limiter") as mock_limiter,
+    ):
+        mock_limiter.check_or_429 = AsyncMock(return_value=None)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            async with client.stream(
+                "POST",
+                "/v1/messages",
+                json={
+                    "model": "autobot-model-1",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "stream": True,
+                },
+            ) as response:
+                assert response.status_code == 200
+                raw = await response.aread()
+
+    text = raw.decode("utf-8")
+
+    # Parse event types from SSE
+    event_types = []
+    for line in text.splitlines():
+        if line.startswith("event: "):
+            event_types.append(line[len("event: "):].strip())
+
+    # Required Anthropic SSE event order
+    assert "message_start" in event_types
+    assert "content_block_start" in event_types
+    assert "ping" in event_types
+    assert "content_block_delta" in event_types
+    assert "content_block_stop" in event_types
+    assert "message_delta" in event_types
+    assert "message_stop" in event_types
+
+    # message_start must come first
+    assert event_types[0] == "message_start"
+    # message_stop must come last
+    assert event_types[-1] == "message_stop"
+
+
+@pytest.mark.asyncio
+async def test_messages_streaming_data_lines_are_valid_json():
+    """All data: lines in streaming response must be valid JSON dicts."""
+    mock_registry = _make_mock_registry()
+
+    with (
+        patch("api.anthropic_compat.get_provider_registry", return_value=mock_registry),
+        patch("api.anthropic_compat._resolve_auth", return_value=(_SYNTHETIC_USER, None)),
+        patch("api.anthropic_compat._oai_limiter") as mock_limiter,
+    ):
+        mock_limiter.check_or_429 = AsyncMock(return_value=None)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            async with client.stream(
+                "POST",
+                "/v1/messages",
+                json={
+                    "model": "autobot-model-1",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "stream": True,
+                },
+            ) as response:
+                raw = await response.aread()
+
+    text = raw.decode("utf-8")
+    data_lines = [line[len("data: "):].strip() for line in text.splitlines() if line.startswith("data: ")]
+    assert len(data_lines) >= 1
+    for raw_json in data_lines:
+        parsed = json.loads(raw_json)
+        assert "type" in parsed, f"Missing 'type' in: {parsed}"
+
+
+@pytest.mark.asyncio
+async def test_messages_streaming_content_delta_carries_text():
+    """content_block_delta events must carry the provider text chunks."""
+    mock_registry = _make_mock_registry()
+
+    with (
+        patch("api.anthropic_compat.get_provider_registry", return_value=mock_registry),
+        patch("api.anthropic_compat._resolve_auth", return_value=(_SYNTHETIC_USER, None)),
+        patch("api.anthropic_compat._oai_limiter") as mock_limiter,
+    ):
+        mock_limiter.check_or_429 = AsyncMock(return_value=None)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            async with client.stream(
+                "POST",
+                "/v1/messages",
+                json={
+                    "model": "autobot-model-1",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "stream": True,
+                },
+            ) as response:
+                raw = await response.aread()
+
+    text = raw.decode("utf-8")
+    # Collect all data payloads
+    data_payloads = []
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith("event: content_block_delta") and i + 1 < len(lines):
+            data_line = lines[i + 1]
+            if data_line.startswith("data: "):
+                data_payloads.append(json.loads(data_line[len("data: "):]))
+
+    assert len(data_payloads) >= 1, "Expected at least one content_block_delta"
+    combined = "".join(p["delta"]["text"] for p in data_payloads)
+    assert "Hello" in combined
+
+
+# ---------------------------------------------------------------------------
+# Tests: stop_reason mapping
+# ---------------------------------------------------------------------------
+
+
+def test_map_finish_reason_stop():
+    assert _map_finish_reason("stop") == "end_turn"
+    assert _map_finish_reason(None) == "end_turn"
+
+
+def test_map_finish_reason_length():
+    assert _map_finish_reason("length") == "max_tokens"
+    assert _map_finish_reason("max_tokens") == "max_tokens"
+
+
+def test_map_finish_reason_tool_use():
+    assert _map_finish_reason("tool_calls") == "tool_use"
+    assert _map_finish_reason("tool_use") == "tool_use"
+
+
+# ---------------------------------------------------------------------------
+# Tests: round-trip conversion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_trip_anthropic_request_openai_provider_anthropic_response():
+    """Round-trip: Anthropic-format request → provider → Anthropic-format response."""
+    mock_registry = _make_mock_registry("Round-trip success")
+
+    with (
+        patch("api.anthropic_compat.get_provider_registry", return_value=mock_registry),
+        patch("api.anthropic_compat._resolve_auth", return_value=(_SYNTHETIC_USER, None)),
+        patch("api.anthropic_compat._oai_limiter") as mock_limiter,
+    ):
+        mock_limiter.check_or_429 = AsyncMock(return_value=None)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/v1/messages",
+                json={
+                    "model": "autobot-model-1",
+                    "max_tokens": 256,
+                    "system": "Be concise.",
+                    "messages": [
+                        {"role": "user", "content": "What is 2+2?"},
+                        {"role": "assistant", "content": "4"},
+                        {"role": "user", "content": "And 3+3?"},
+                    ],
+                },
+            )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    # Must be valid Anthropic response shape
+    assert data["type"] == "message"
+    assert data["role"] == "assistant"
+    assert data["id"].startswith("msg_")
+    assert data["content"][0]["text"] == "Round-trip success"
+    assert data["stop_reason"] == "end_turn"
+    assert "usage" in data

--- a/autobot-backend/app_factory.py
+++ b/autobot-backend/app_factory.py
@@ -96,6 +96,16 @@ def _register_routers(app: FastAPI) -> None:
     except Exception as e:
         logger.warning("⚠️ Failed to register OpenAI-compat router: %s", e)
 
+    # Issue #6591: Anthropic-compatible /v1/messages endpoint so Anthropic-SDK
+    # consumers can point base_url at AutoBot without changing integration code.
+    try:
+        from api.anthropic_compat import router as anthropic_compat_router
+
+        app.include_router(anthropic_compat_router, prefix="/v1")
+        logger.info("✅ Registered Anthropic-compat router at /v1")
+    except Exception as e:
+        logger.warning("⚠️ Failed to register Anthropic-compat router: %s", e)
+
     logger.info("✅ API routes configured with optional AI Stack integration")
 
 


### PR DESCRIPTION
## Summary

Adds `POST /v1/messages` endpoint in Anthropic Messages API format, allowing Anthropic-SDK clients to point `base_url` at AutoBot without changing integration code.

Closes #6591

## Thinking Path

Reused the existing OpenAI-compat infrastructure (`_resolve_auth`, `_oai_limiter`, `_remote_addr`, `_resolve_auto_model`, `TieredModelRouter`) to minimise surface area. The Anthropic format differs in: (1) `messages[].content` can be a list of content blocks; (2) streaming uses named SSE event types (`message_start`, `content_block_delta`, etc.) rather than `data: [DONE]`; (3) stop_reason vocabulary maps stop→end_turn, length→max_tokens, tool_calls→tool_use. All three are handled explicitly.

## What Changed

- `autobot-backend/api/anthropic_compat.py` — new router at `/v1` prefix with `POST /messages`; Pydantic schemas for request/response; streaming generator producing correct Anthropic SSE event sequence; per-key budget and model-whitelist enforcement; `x-llm-cost` header
- `autobot-backend/api/test_anthropic_compat.py` — 10 unit tests: non-streaming shape, x-llm-cost header, system prompt forwarding, streaming event sequence/validity/content, stop_reason mapping (3 tests), round-trip conversion
- `autobot-backend/app_factory.py` — register `anthropic_compat_router` at `/v1` prefix inside feature-router try/except block

## Verification

- [x] 10 unit tests in `api/test_anthropic_compat.py` — all pass
- [x] Non-streaming response shape (type, role, content, stop_reason, usage)
- [x] Streaming event sequence and JSON validity
- [x] Round-trip: Anthropic request → provider → Anthropic response
- [x] `stop_reason` mapping (stop → end_turn, length → max_tokens, tool_calls → tool_use)
- [x] `x-llm-cost` header present and numeric
- [x] System prompt forwarded without error
- [x] Registered in `app_factory.py` under `/v1` prefix → endpoint at `POST /v1/messages`
- [x] Black formatting applied (`style: apply Black formatting` commit)

## Model Used

claude-sonnet-4-6

## Changelog fragment

- [ ] Added `changelog/unreleased/{issue}-{slug}.md` — or N/A (internal change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)