### PR TITLE
feat(design-tokens): add DEV prop validators for Size and Intent to base components (MVA-353)

### DIFF
--- a/autobot-frontend/src/components/base/BaseBadge.vue
+++ b/autobot-frontend/src/components/base/BaseBadge.vue
@@ -17,9 +17,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { BadgeVariant } from '@/types/component-props'
+import { createLogger } from '@/utils/debugUtils'
+
+const BADGE_SIZES = ['xs', 'sm', 'md', 'lg'] as const
+const BADGE_VARIANTS: BadgeVariant[] = ['default', 'primary', 'success', 'warning', 'error', 'info']
+
+const logger = createLogger('BaseBadge')
 
 interface Props {
   label?: string
@@ -60,6 +66,17 @@ const badgeClasses = computed(() => [
 const handleRemove = (event: MouseEvent) => {
   event.stopPropagation()
   emit('remove')
+}
+
+if (import.meta.env.DEV) {
+  watchEffect(() => {
+    if (props.size !== undefined && !(BADGE_SIZES as readonly string[]).includes(props.size)) {
+      logger.warn(`Invalid "size" prop: "${props.size}". Expected: ${BADGE_SIZES.join(' | ')}`)
+    }
+    if (props.variant !== undefined && !BADGE_VARIANTS.includes(props.variant)) {
+      logger.warn(`Invalid "variant" prop: "${props.variant}". Expected: ${BADGE_VARIANTS.join(' | ')}`)
+    }
+  })
 }
 </script>
 

--- a/autobot-frontend/src/components/base/BaseButton.vue
+++ b/autobot-frontend/src/components/base/BaseButton.vue
@@ -21,9 +21,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted, useSlots, Comment } from 'vue'
+import { computed, ref, onMounted, watchEffect, useSlots, Comment } from 'vue'
 import type { ButtonVariant, ComponentSize } from '@/types/component-props'
+import { size as SIZE_VALUES } from '@/design-tokens/tokens'
 import { createLogger } from '@/utils/debugUtils'
+
+const BUTTON_VARIANTS: ButtonVariant[] = [
+  'primary', 'secondary', 'success', 'error', 'warning', 'info',
+  'light', 'dark', 'outline-solid', 'ghost', 'link',
+]
 
 const logger = createLogger('BaseButton')
 
@@ -70,6 +76,15 @@ if (import.meta.env.DEV) {
         'Icon-only button rendered without ariaLabel prop. ' +
         'This is a WCAG 4.1.2 failure. Add :ariaLabel="$t(\'common.actionName\')" to the button.'
       )
+    }
+  })
+
+  watchEffect(() => {
+    if (props.size !== undefined && !(SIZE_VALUES as readonly string[]).includes(props.size)) {
+      logger.warn(`Invalid "size" prop: "${props.size}". Expected: ${SIZE_VALUES.join(' | ')}`)
+    }
+    if (props.variant !== undefined && !BUTTON_VARIANTS.includes(props.variant)) {
+      logger.warn(`Invalid "variant" prop: "${props.variant}". Expected: ${BUTTON_VARIANTS.join(' | ')}`)
     }
   })
 }

--- a/autobot-frontend/src/components/base/BaseCard.vue
+++ b/autobot-frontend/src/components/base/BaseCard.vue
@@ -26,7 +26,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watchEffect } from 'vue'
+import { createLogger } from '@/utils/debugUtils'
+
+const CARD_SIZES = ['sm', 'md', 'lg'] as const
+const CARD_VARIANTS = ['default', 'bordered', 'elevated', 'flat'] as const
+
+const logger = createLogger('BaseCard')
 
 interface Props {
   title?: string
@@ -66,6 +72,17 @@ const bodyClasses = computed(() => ({
 const footerClasses = computed(() => ({
   'footer-no-padding': props.noPadding
 }))
+
+if (import.meta.env.DEV) {
+  watchEffect(() => {
+    if (props.size !== undefined && !(CARD_SIZES as readonly string[]).includes(props.size)) {
+      logger.warn(`Invalid "size" prop: "${props.size}". Expected: ${CARD_SIZES.join(' | ')}`)
+    }
+    if (props.variant !== undefined && !(CARD_VARIANTS as readonly string[]).includes(props.variant)) {
+      logger.warn(`Invalid "variant" prop: "${props.variant}". Expected: ${CARD_VARIANTS.join(' | ')}`)
+    }
+  })
+}
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/components/base/BaseInput.vue
+++ b/autobot-frontend/src/components/base/BaseInput.vue
@@ -62,8 +62,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { createLogger } from '@/utils/debugUtils'
+
+const INPUT_SIZES = ['sm', 'md', 'lg'] as const
+const INPUT_TYPES = ['text', 'email', 'password', 'number', 'tel', 'url', 'search'] as const
+
+const logger = createLogger('BaseInput')
 
 interface Props {
   modelValue?: string | number
@@ -152,6 +158,17 @@ defineExpose({
   focus: () => inputRef.value?.focus(),
   blur: () => inputRef.value?.blur()
 })
+
+if (import.meta.env.DEV) {
+  watchEffect(() => {
+    if (props.size !== undefined && !(INPUT_SIZES as readonly string[]).includes(props.size)) {
+      logger.warn(`Invalid "size" prop: "${props.size}". Expected: ${INPUT_SIZES.join(' | ')}`)
+    }
+    if (props.type !== undefined && !(INPUT_TYPES as readonly string[]).includes(props.type)) {
+      logger.warn(`Invalid "type" prop: "${props.type}". Expected: ${INPUT_TYPES.join(' | ')}`)
+    }
+  })
+}
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/components/base/BasePanel.vue
+++ b/autobot-frontend/src/components/base/BasePanel.vue
@@ -20,7 +20,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watchEffect } from 'vue'
+import { createLogger } from '@/utils/debugUtils'
+
+const PANEL_SIZES = ['sm', 'md', 'lg'] as const
+const PANEL_VARIANTS = ['default', 'bordered', 'elevated', 'flat', 'dark'] as const
+
+const logger = createLogger('BasePanel')
 
 interface Props {
   title?: string
@@ -67,6 +73,17 @@ const toggleCollapse = () => {
   if (props.collapsible) {
     emit('toggle', !props.collapsed)
   }
+}
+
+if (import.meta.env.DEV) {
+  watchEffect(() => {
+    if (props.size !== undefined && !(PANEL_SIZES as readonly string[]).includes(props.size)) {
+      logger.warn(`Invalid "size" prop: "${props.size}". Expected: ${PANEL_SIZES.join(' | ')}`)
+    }
+    if (props.variant !== undefined && !(PANEL_VARIANTS as readonly string[]).includes(props.variant)) {
+      logger.warn(`Invalid "variant" prop: "${props.variant}". Expected: ${PANEL_VARIANTS.join(' | ')}`)
+    }
+  })
 }
 </script>
 

--- a/autobot-frontend/src/components/base/BaseTable.vue
+++ b/autobot-frontend/src/components/base/BaseTable.vue
@@ -133,9 +133,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, useSlots, watch } from 'vue'
+import { ref, computed, watchEffect, useSlots, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useBatchSelection } from '@/composables/useBatchSelection'
+import { createLogger } from '@/utils/debugUtils'
+
+const TABLE_SIZES = ['compact', 'comfortable', 'spacious'] as const
+const TABLE_VARIANTS = ['default', 'bordered', 'striped'] as const
+
+const logger = createLogger('BaseTable')
 
 interface TableColumn {
   key: string
@@ -243,6 +249,17 @@ const formatCellValue = (value: any, column: TableColumn) => {
     return column.formatter(value)
   }
   return value ?? '—'
+}
+
+if (import.meta.env.DEV) {
+  watchEffect(() => {
+    if (props.size !== undefined && !(TABLE_SIZES as readonly string[]).includes(props.size)) {
+      logger.warn(`Invalid "size" prop: "${props.size}". Expected: ${TABLE_SIZES.join(' | ')}`)
+    }
+    if (props.variant !== undefined && !(TABLE_VARIANTS as readonly string[]).includes(props.variant)) {
+      logger.warn(`Invalid "variant" prop: "${props.variant}". Expected: ${TABLE_VARIANTS.join(' | ')}`)
+    }
+  })
 }
 </script>
 

--- a/autobot-frontend/src/components/base/ErrorBanner.vue
+++ b/autobot-frontend/src/components/base/ErrorBanner.vue
@@ -26,9 +26,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, useSlots } from 'vue'
+import { computed, watchEffect, useSlots } from 'vue'
 import BaseButton from './BaseButton.vue'
 import Icon, { type IconName } from '@/components/ui/Icon.vue'
+import { createLogger } from '@/utils/debugUtils'
+
+const BANNER_VARIANTS = ['error', 'warning', 'info'] as const
+
+const logger = createLogger('ErrorBanner')
 
 interface Props {
   message?: string | null
@@ -61,6 +66,14 @@ const iconName = computed<IconName>(() => {
 
 const handleDismiss = () => {
   emit('dismiss')
+}
+
+if (import.meta.env.DEV) {
+  watchEffect(() => {
+    if (props.variant !== undefined && !(BANNER_VARIANTS as readonly string[]).includes(props.variant)) {
+      logger.warn(`Invalid "variant" prop: "${props.variant}". Expected: ${BANNER_VARIANTS.join(' | ')}`)
+    }
+  })
 }
 </script>
 

--- a/autobot-frontend/src/components/ui/BaseAlert.vue
+++ b/autobot-frontend/src/components/ui/BaseAlert.vue
@@ -37,8 +37,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { createLogger } from '@/utils/debugUtils'
+
+const ALERT_VARIANTS = ['success', 'info', 'warning', 'error', 'critical'] as const
+const ALERT_SIZES = ['default', 'compact'] as const
+
+const logger = createLogger('BaseAlert')
 import {
   CheckCircleIcon,
   InformationCircleIcon,
@@ -122,6 +128,17 @@ onMounted(() => {
     }, props.autoDismiss)
   }
 })
+
+if (import.meta.env.DEV) {
+  watchEffect(() => {
+    if (props.variant !== undefined && !(ALERT_VARIANTS as readonly string[]).includes(props.variant)) {
+      logger.warn(`Invalid "variant" prop: "${props.variant}". Expected: ${ALERT_VARIANTS.join(' | ')}`)
+    }
+    if (props.size !== undefined && !(ALERT_SIZES as readonly string[]).includes(props.size)) {
+      logger.warn(`Invalid "size" prop: "${props.size}". Expected: ${ALERT_SIZES.join(' | ')}`)
+    }
+  })
+}
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/components/ui/BaseAlert.vue
+++ b/autobot-frontend/src/components/ui/BaseAlert.vue
@@ -40,11 +40,6 @@
 import { ref, computed, onMounted, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
-
-const ALERT_VARIANTS = ['success', 'info', 'warning', 'error', 'critical'] as const
-const ALERT_SIZES = ['default', 'compact'] as const
-
-const logger = createLogger('BaseAlert')
 import {
   CheckCircleIcon,
   InformationCircleIcon,
@@ -52,6 +47,11 @@ import {
   XCircleIcon,
   XMarkIcon
 } from '@heroicons/vue/24/outline'
+
+const ALERT_VARIANTS = ['success', 'info', 'warning', 'error', 'critical'] as const
+const ALERT_SIZES = ['default', 'compact'] as const
+
+const logger = createLogger('BaseAlert')
 
 export interface BaseAlertProps {
   variant?: 'success' | 'info' | 'warning' | 'error' | 'critical'

--- a/autobot-frontend/src/components/ui/BaseModal.vue
+++ b/autobot-frontend/src/components/ui/BaseModal.vue
@@ -52,13 +52,18 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, useId, toRef } from 'vue'
+import { ref, computed, watchEffect, useId, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
 import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
+import { createLogger } from '@/utils/debugUtils'
 import Icon from './Icon.vue'
+
+const MODAL_SIZES = ['sm', 'md', 'lg'] as const
+
+const logger = createLogger('BaseModal')
 
 /**
  * Reusable Modal/Dialog Component
@@ -162,6 +167,14 @@ const handleOverlayClick = () => {
 
 // Focus, restore, and scroll-lock all driven by composables above.
 const onAfterEnter = () => focusFirst()
+
+if (import.meta.env.DEV) {
+  watchEffect(() => {
+    if (props.size !== undefined && !(MODAL_SIZES as readonly string[]).includes(props.size)) {
+      logger.warn(`Invalid "size" prop: "${props.size}". Expected: ${MODAL_SIZES.join(' | ')}`)
+    }
+  })
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary

- Added DEV-only `watchEffect` prop validators to all 9 base UI components that accept `size`, `variant`, `color`, or `type` props
- BaseButton's `size` validator imports the canonical `size` array from `src/design-tokens/tokens.ts`; all other components define a single local `const` array (no duplicated inline literals)
- Validators use `createLogger().warn()` consistent with the existing BaseButton a11y check pattern (no `console.*` calls)
- Zero new TypeScript errors introduced

## Components updated

| Component | Props validated |
|-----------|----------------|
| `BaseBadge` | `size`, `variant` |
| `BaseButton` | `size` (from `@/design-tokens/tokens`), `variant` |
| `BaseCard` | `size`, `variant` |
| `BaseInput` | `size`, `type` |
| `BasePanel` | `size`, `variant` |
| `BaseTable` | `size`, `variant` |
| `ErrorBanner` | `variant` |
| `BaseAlert` | `size`, `variant` |
| `BaseModal` | `size` |

## Test plan

- [ ] TypeScript: `npx vue-tsc --noEmit -p tsconfig.app.json` — no new errors in modified files
- [ ] Dev mode: run app and verify zero prop-validator warnings in console for valid prop values
- [ ] Pass an invalid size/variant prop in dev mode and confirm logger.warn fires with the expected message

Closes MVA-353

🤖 Generated with [Claude Code](https://claude.com/claude-code)