### PR TITLE
fix(deps): bump langchain 1.2.24→1.3.1 — version does not exist on PyPI

### DIFF
--- a/requirements-ci/langchain.txt
+++ b/requirements-ci/langchain.txt
@@ -1,5 +1,5 @@
 # LangChain ecosystem — tightly coupled versions
-langchain==1.2.24                # GH#8675: bumped from 1.2.18 — PVE-2026-88512 SQL injection fix
+langchain==1.3.1                 # GH#8675: bumped from 1.2.18 — PVE-2026-88512 SQL injection fix (1.2.24 does not exist on PyPI; 1.3.1 is lowest published version with fix)
 langchain-classic==1.0.7
 langchain-community==0.4.1
 langchain-core>=1.2.31,<2.0.0    # #7049: floor bumped from ==1.2.28 — langchain-text-splitters 1.1.2 requires >=1.2.31


### PR DESCRIPTION
## Summary

Closes MVA-1159

langchain==1.2.24 was pinned in MVA-1149 (PVE-2026-88512 SQL injection fix) but this version was never published to PyPI. Available versions jump 1.2.18 → 1.3.0 → 1.3.1. All backend CI was failing at dependency install.

## Thinking Path

1. MVA-1149 tried to pin to 1.2.24 for PVE-2026-88512 security fix
2. `pip index versions langchain` confirms 1.2.24 does not exist — series jumps 1.2.18 → 1.3.0
3. 1.3.1 is the lowest stable published version in the 1.3.x series that contains the security fix
4. Single-line change: `langchain==1.2.24` → `langchain==1.3.1` in requirements-ci/langchain.txt

## What Changed

- `requirements-ci/langchain.txt`: bumped `langchain==1.2.24` (non-existent) → `langchain==1.3.1` (lowest published stable with PVE-2026-88512 fix)
- Updated inline comment to document the corrected version reasoning

## Verification

- `pip index versions langchain` confirms 1.3.1 exists on PyPI (1.2.24 does not)
- `startup-import-smoke` CI check: ✅ PASS (was failing before this fix)
- `Dependency Security Scan`: ✅ PASS
- `SSOT Configuration Compliance`: ✅ PASS

## Model Used

claude-sonnet-4-6

## Test plan

- [x] startup-import-smoke passes (verified in CI)
- [ ] smoke-test in progress
- [ ] hardened-smoke-test in progress