### PR TITLE
fix(orchestration): prevent _enforce_limit from evicting active worktrees (MVA-1154)

### DIFF
--- a/autobot-backend/services/task_workspace.py
+++ b/autobot-backend/services/task_workspace.py
@@ -36,6 +36,7 @@ _REPO_ROOT = Path(
 )
 _WORKSPACE_BASE_NAME = ".task-workspaces"
 _META_FILENAME = ".workspace-meta.json"
+_ACTIVE_LOCK_FILENAME = ".active-lock"
 _MAX_WORKTREES_PER_AGENT = 5
 
 # task_id must be a safe identifier: UUID hex chars + hyphens, max 128 chars.
@@ -94,6 +95,7 @@ def allocate(
                 task_id,
                 workspace_dir,
             )
+            (workspace_dir / _ACTIVE_LOCK_FILENAME).touch()
             return WorkspaceInfo(
                 task_id=task_id,
                 agent_id=agent_id,
@@ -118,6 +120,7 @@ def allocate(
         "branch": branch,
     }
     (workspace_dir / _META_FILENAME).write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    (workspace_dir / _ACTIVE_LOCK_FILENAME).touch()
 
     logger.info(
         "Allocated new workspace for task=%s agent=%s at %s",
@@ -158,6 +161,9 @@ def release(
         return
 
     branch = f"task-{task_id}"
+    # Clear the active-lock before git removal so that if removal fails and
+    # keep_on_failure is True the directory can still be evicted later.
+    (workspace_dir / _ACTIVE_LOCK_FILENAME).unlink(missing_ok=True)
     try:
         subprocess.run(
             ["git", "worktree", "remove", "--force", str(workspace_dir)],
@@ -221,6 +227,10 @@ def cleanup_stale(
         if age_ts > cutoff:
             continue  # too young
 
+        if (entry / _ACTIVE_LOCK_FILENAME).exists():
+            logger.debug("Skipping locked workspace task=%s during stale cleanup", entry.name[len("task-"):])
+            continue
+
         task_id = entry.name[len("task-"):]
         try:
             release(task_id, root, keep_on_failure=True)
@@ -281,9 +291,15 @@ def _git_add_worktree(root: Path, workspace_dir: Path, branch: str) -> None:
 
 
 def _enforce_limit(agent_id: str, max_per_agent: int, root: Path) -> None:
-    """Evict oldest worktree(s) for agent_id if the per-agent limit would be exceeded."""
+    """Evict oldest worktree(s) for agent_id if the per-agent limit would be exceeded.
+
+    All worktrees count toward the limit, but only unlocked ones are eviction
+    candidates.  Worktrees with an active-lock file are in use by a running
+    subprocess and must never be evicted (GH#6471 follow-up: MVA-1154).
+    """
     workspace_base = root / _WORKSPACE_BASE_NAME
-    agent_slots: list[tuple[float, str]] = []
+    total_count = 0
+    eviction_candidates: list[tuple[float, str]] = []
 
     for entry in workspace_base.iterdir():
         if not entry.is_dir() or not entry.name.startswith("task-"):
@@ -296,18 +312,21 @@ def _enforce_limit(agent_id: str, max_per_agent: int, root: Path) -> None:
                 meta = json.load(fh)
             if meta.get("agent_id") != agent_id:
                 continue
+            total_count += 1
+            if (entry / _ACTIVE_LOCK_FILENAME).exists():
+                continue  # count but do not add to eviction candidates
             ts = datetime.fromisoformat(meta["created_at"]).timestamp()
             task_id = entry.name[len("task-"):]
-            agent_slots.append((ts, task_id))
+            eviction_candidates.append((ts, task_id))
         except (json.JSONDecodeError, KeyError, ValueError):
             pass
 
-    overage = len(agent_slots) - max_per_agent + 1
+    overage = total_count - max_per_agent + 1
     if overage <= 0:
         return
 
-    agent_slots.sort()  # oldest first
-    for _, oldest_task_id in agent_slots[:overage]:
+    eviction_candidates.sort()  # oldest first
+    for _, oldest_task_id in eviction_candidates[:overage]:
         logger.info(
             "Evicting oldest workspace task=%s for agent=%s (limit=%d)",
             oldest_task_id,

--- a/autobot-backend/tasks/test_task_workspace.py
+++ b/autobot-backend/tasks/test_task_workspace.py
@@ -35,6 +35,7 @@ def _load_tw():
 _tw = _load_tw()
 allocate = _tw.allocate
 release = _tw.release
+cleanup_stale = _tw.cleanup_stale
 
 
 @pytest.fixture()
@@ -171,3 +172,78 @@ class TestHeartbeatResume:
     ) -> None:
         with pytest.raises(ValueError, match="Invalid task_id"):
             release(bad_id, repo_root=git_repo)
+
+
+class TestActiveLock:
+    """active-lock file prevents eviction of running worktrees (MVA-1154)."""
+
+    def test_allocate_writes_lock_file(self, git_repo: Path) -> None:
+        task_id = "eeeeeee0-0000-0000-0000-000000000001"
+        ws = allocate(task_id, "agent-lock", repo_root=git_repo)
+        assert (Path(ws.worktree_path) / ".active-lock").exists()
+
+    def test_resume_refreshes_lock_file(self, git_repo: Path) -> None:
+        task_id = "eeeeeee0-0000-0000-0000-000000000002"
+        ws = allocate(task_id, "agent-lock", repo_root=git_repo)
+        lock_file = Path(ws.worktree_path) / ".active-lock"
+        lock_file.unlink()
+        assert not lock_file.exists()
+        allocate(task_id, "agent-lock", repo_root=git_repo)
+        assert lock_file.exists()
+
+    def test_release_removes_entire_workspace(self, git_repo: Path) -> None:
+        task_id = "eeeeeee0-0000-0000-0000-000000000003"
+        ws = allocate(task_id, "agent-lock", repo_root=git_repo)
+        assert (Path(ws.worktree_path) / ".active-lock").exists()
+        release(task_id, repo_root=git_repo)
+        assert not Path(ws.worktree_path).exists()
+
+    def test_enforce_limit_skips_locked_evicts_unlocked(self, git_repo: Path) -> None:
+        old_task = "eeeeeee0-0000-0000-0000-000000000010"
+        active_task = "eeeeeee0-0000-0000-0000-000000000011"
+        new_task = "eeeeeee0-0000-0000-0000-000000000012"
+
+        ws_old = allocate(old_task, "agent-evict", repo_root=git_repo, max_per_agent=2)
+        ws_active = allocate(active_task, "agent-evict", repo_root=git_repo, max_per_agent=2)
+
+        # Simulate ws_old's subprocess finishing without calling release()
+        (Path(ws_old.worktree_path) / ".active-lock").unlink()
+
+        # Third allocation must evict the unlocked ws_old, not the locked ws_active
+        allocate(new_task, "agent-evict", repo_root=git_repo, max_per_agent=2)
+
+        assert not Path(ws_old.worktree_path).exists(), "unlocked worktree must be evicted"
+        assert Path(ws_active.worktree_path).exists(), "locked active worktree must be preserved"
+
+    def test_enforce_limit_preserves_all_locked_worktrees(self, git_repo: Path) -> None:
+        task_a = "eeeeeee0-0000-0000-0000-000000000020"
+        task_b = "eeeeeee0-0000-0000-0000-000000000021"
+        task_c = "eeeeeee0-0000-0000-0000-000000000022"
+
+        ws_a = allocate(task_a, "agent-noevict", repo_root=git_repo, max_per_agent=2)
+        ws_b = allocate(task_b, "agent-noevict", repo_root=git_repo, max_per_agent=2)
+        # Both locked; _enforce_limit finds no eviction candidates — all survive
+        ws_c = allocate(task_c, "agent-noevict", repo_root=git_repo, max_per_agent=2)
+
+        assert Path(ws_a.worktree_path).exists(), "locked worktree A must not be evicted"
+        assert Path(ws_b.worktree_path).exists(), "locked worktree B must not be evicted"
+        assert Path(ws_c.worktree_path).exists(), "new worktree C must exist"
+
+    def test_cleanup_stale_skips_locked_worktree(self, git_repo: Path) -> None:
+        import json as _json
+
+        task_id = "eeeeeee0-0000-0000-0000-000000000030"
+        ws = allocate(task_id, "agent-stale", repo_root=git_repo)
+        workspace_dir = Path(ws.worktree_path)
+
+        # Backdate metadata so the worktree looks ancient
+        meta_file = workspace_dir / ".workspace-meta.json"
+        meta = _json.loads(meta_file.read_text())
+        meta["created_at"] = "2000-01-01T00:00:00+00:00"
+        meta_file.write_text(_json.dumps(meta))
+
+        # Lock is still present — stale cleanup must skip this worktree
+        cleaned = cleanup_stale(max_age_days=0, repo_root=git_repo)
+
+        assert task_id not in cleaned
+        assert workspace_dir.exists()


### PR DESCRIPTION
## Summary

`_enforce_limit` was selecting the oldest worktree by metadata timestamp and calling `release()` without checking if a subprocess was actively using that worktree. Concurrent or ad-hoc heartbeat wakeups could trigger eviction while a subprocess was mid-execution.

## Changes

- Added `_ACTIVE_LOCK_FILENAME = ".active-lock"` constant
- `allocate()` touches `.active-lock` on both new-allocation and resume paths — lock is present for the entire duration an agent uses the worktree
- `release()` removes the lock **before** `git worktree remove` so that a `keep_on_failure=True` failed-removal still leaves the directory evictable
- `_enforce_limit()` counts all worktrees toward the per-agent limit, but only adds **unlocked** worktrees to the eviction candidate list — active worktrees are never evicted
- `cleanup_stale()` skips directories with an active-lock file

## Tests

6 new tests in `TestActiveLock`:
- lock written on allocate
- lock refreshed on resume
- lock cleared on release (entire workspace removed)
- eviction skips locked / evicts oldest unlocked
- all-locked scenario — limit exceeded gracefully, no eviction
- stale cleanup skips locked worktrees

22/22 tests pass.

## Related

Parent: GH#6471 (MVA-1078)
Closes MVA-1154

## Test plan

- [x] 22 unit tests pass
- [x] Lock file present in workspace after allocate
- [x] Lock file absent after release
- [x] Concurrent allocations evict only unlocked worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)