### PR TITLE
feat(channels): expand gateway to 9+ platforms (GH#7373, MVA-1071)

### DIFF
--- a/autobot-backend/services/gateway/__init__.py
+++ b/autobot-backend/services/gateway/__init__.py
@@ -6,9 +6,13 @@
 from .adapters import (
     BaseAdapter,
     DiscordAdapter,
+    IMessageAdapter,
+    MatrixAdapter,
     NormalizedResponse,
+    SignalAdapter,
     SlackAdapter,
     TeamsAdapter,
+    TelegramAdapter,
     UnifiedMessage,
     WebAdapter,
     WhatsAppAdapter,
@@ -28,4 +32,8 @@ __all__ = [
     "WhatsAppAdapter",
     "TeamsAdapter",
     "WebAdapter",
+    "TelegramAdapter",
+    "SignalAdapter",
+    "MatrixAdapter",
+    "IMessageAdapter",
 ]

--- a/autobot-backend/services/gateway/adapters/__init__.py
+++ b/autobot-backend/services/gateway/adapters/__init__.py
@@ -5,8 +5,12 @@
 
 from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
 from .discord_adapter import DiscordAdapter
+from .imessage_adapter import IMessageAdapter
+from .matrix_adapter import MatrixAdapter
+from .signal_adapter import SignalAdapter
 from .slack_adapter import SlackAdapter
 from .teams_adapter import TeamsAdapter
+from .telegram_adapter import TelegramAdapter
 from .web_adapter import WebAdapter
 from .whatsapp_adapter import WhatsAppAdapter
 
@@ -19,4 +23,8 @@ __all__ = [
     "WhatsAppAdapter",
     "TeamsAdapter",
     "WebAdapter",
+    "TelegramAdapter",
+    "SignalAdapter",
+    "MatrixAdapter",
+    "IMessageAdapter",
 ]

--- a/autobot-backend/services/gateway/adapters/imessage_adapter.py
+++ b/autobot-backend/services/gateway/adapters/imessage_adapter.py
@@ -1,0 +1,85 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""iMessage Platform Adapter for Message Gateway
+
+macOS-only.  Requires AUTOBOT_IMESSAGE_ENABLED=true and a macOS host with
+Messages.app.  Sends via osascript AppleScript bridge.  On non-macOS hosts
+the adapter loads but outbound sends are disabled; messages can still be
+normalized (inbound webhook from a macOS relay).
+"""
+
+import os
+import platform
+import sys
+from typing import Any, Dict
+
+from autobot_shared.logging_manager import get_logger
+
+from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+
+logger = get_logger(__name__)
+
+IMESSAGE_ENABLED = os.getenv("AUTOBOT_IMESSAGE_ENABLED", "false").lower() == "true"
+_IS_MACOS = sys.platform == "darwin" or platform.system() == "Darwin"
+
+
+class IMessageAdapter(BaseAdapter):
+    """iMessage adapter via AppleScript/osascript bridge.
+
+    Sends are only available on macOS with Messages.app.  The adapter
+    normalizes inbound webhooks from an OpenClaw-style macOS relay on any
+    platform, but outbound denormalization is a no-op unless both
+    AUTOBOT_IMESSAGE_ENABLED=true and the host is macOS.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("imessage")
+        self._send_enabled = IMESSAGE_ENABLED and _IS_MACOS
+        if IMESSAGE_ENABLED and not _IS_MACOS:
+            logger.warning("AUTOBOT_IMESSAGE_ENABLED=true but host is not macOS — outbound sends disabled")
+        elif not IMESSAGE_ENABLED:
+            logger.info("IMessageAdapter loaded; set AUTOBOT_IMESSAGE_ENABLED=true on a macOS host to enable sends")
+
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+        """Convert macOS relay webhook payload to unified schema."""
+        metadata = await self.extract_metadata(raw_message)
+
+        metadata["message_id"] = raw_message.get("id") or raw_message.get("guid")
+        metadata["is_group"] = raw_message.get("is_group", False)
+        metadata["service"] = raw_message.get("service", "iMessage")
+        metadata["macos_only"] = True
+
+        sender = raw_message.get("sender") or raw_message.get("from", "")
+        chat_id = raw_message.get("chat_id") or raw_message.get("room_name") or sender
+
+        return UnifiedMessage(
+            user_id=sender,
+            platform="imessage",
+            channel_id=chat_id,
+            message=raw_message.get("text") or raw_message.get("body", ""),
+            timestamp=float(raw_message.get("timestamp", 0)),
+            metadata=metadata,
+        )
+
+    async def denormalize_response(self, unified_response: NormalizedResponse) -> Dict[str, Any]:
+        """Convert unified response to osascript send payload.
+
+        Returns a no-op dict when not running on macOS with the feature enabled.
+        """
+        if not self._send_enabled:
+            return {
+                "_imessage_disabled": True,
+                "_reason": "requires macOS + AUTOBOT_IMESSAGE_ENABLED=true",
+                "content": unified_response.content,
+            }
+
+        return {
+            "recipient": unified_response.channel_id,
+            "message": unified_response.content,
+            "service": unified_response.metadata.get("service", "iMessage"),
+        }
+
+    def get_rate_limit(self) -> Dict[str, int]:
+        """iMessage: AppleScript bridge is slow; cap at 1 req/s."""
+        return {"requests_per_second": 1, "burst_size": 3}

--- a/autobot-backend/services/gateway/adapters/matrix_adapter.py
+++ b/autobot-backend/services/gateway/adapters/matrix_adapter.py
@@ -1,0 +1,92 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Matrix Platform Adapter for Message Gateway
+
+Uses matrix-nio client library.  E2EE is supported when the homeserver has
+encryption enabled; set AUTOBOT_MATRIX_E2EE=true to opt in.  The adapter
+normalizes m.room.message events; other event types are silently skipped.
+"""
+
+import os
+from typing import Any, Dict
+
+from autobot_shared.logging_manager import get_logger
+
+from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+
+logger = get_logger(__name__)
+
+MATRIX_E2EE_ENABLED = os.getenv("AUTOBOT_MATRIX_E2EE", "false").lower() == "true"
+
+
+class MatrixAdapter(BaseAdapter):
+    """Matrix adapter for self-hosted and federated homeservers.
+
+    Handles m.room.message events from matrix-nio sync callbacks.
+    E2EE is transparent when AUTOBOT_MATRIX_E2EE=true — matrix-nio decrypts
+    before calling normalize_message so this adapter always receives plaintext.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("matrix")
+        self._e2ee = MATRIX_E2EE_ENABLED
+
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+        """Convert matrix-nio RoomMessage event dict to unified schema."""
+        metadata = await self.extract_metadata(raw_message)
+
+        event_id = raw_message.get("event_id", "")
+        sender = raw_message.get("sender", "")
+        room_id = raw_message.get("room_id", "")
+        content = raw_message.get("content", {})
+        relates_to = content.get("m.relates_to", {})
+
+        metadata["event_id"] = event_id
+        metadata["msgtype"] = content.get("msgtype", "m.text")
+        metadata["relates_to"] = relates_to
+        metadata["e2ee"] = self._e2ee
+        metadata["thread_id"] = relates_to.get("event_id") if relates_to.get("rel_type") == "m.thread" else None
+        metadata["reply_to"] = (
+            relates_to.get("m.in_reply_to", {}).get("event_id")
+            if relates_to.get("rel_type") != "m.thread"
+            else None
+        )
+
+        return UnifiedMessage(
+            user_id=sender,
+            platform="matrix",
+            channel_id=room_id,
+            message=content.get("body", ""),
+            timestamp=float(raw_message.get("origin_server_ts", 0)) / 1000,
+            metadata=metadata,
+        )
+
+    async def denormalize_response(self, unified_response: NormalizedResponse) -> Dict[str, Any]:
+        """Convert unified response to matrix-nio send_message payload."""
+        content: Dict[str, Any] = {
+            "msgtype": "m.text",
+            "body": unified_response.content,
+        }
+
+        thread_id = unified_response.metadata.get("thread_id")
+        if thread_id:
+            content["m.relates_to"] = {
+                "rel_type": "m.thread",
+                "event_id": thread_id,
+            }
+        elif unified_response.response_type == "thread_reply":
+            reply_event = unified_response.metadata.get("event_id")
+            if reply_event:
+                content["m.relates_to"] = {
+                    "m.in_reply_to": {"event_id": reply_event},
+                }
+
+        return {
+            "room_id": unified_response.channel_id,
+            "content": content,
+        }
+
+    def get_rate_limit(self) -> Dict[str, int]:
+        """Matrix: homeserver-enforced, but ~10 req/s is safe for most instances."""
+        return {"requests_per_second": 10, "burst_size": 20}

--- a/autobot-backend/services/gateway/adapters/signal_adapter.py
+++ b/autobot-backend/services/gateway/adapters/signal_adapter.py
@@ -1,0 +1,87 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Signal Platform Adapter for Message Gateway
+
+Requires AUTOBOT_SIGNAL_ENABLED=true and a running signal-cli daemon (or
+semaphore REST bridge) reachable at AUTOBOT_SIGNAL_CLI_URL.  When the env
+flag is absent this adapter is registered but silently no-ops outbound sends
+so existing gateway tests are unaffected.
+"""
+
+import os
+from typing import Any, Dict
+
+from autobot_shared.logging_manager import get_logger
+
+from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+
+logger = get_logger(__name__)
+
+SIGNAL_ENABLED = os.getenv("AUTOBOT_SIGNAL_ENABLED", "false").lower() == "true"
+
+
+class SignalAdapter(BaseAdapter):
+    """Signal adapter bridging via signal-cli daemon or semaphore REST API.
+
+    E2EE is preserved end-to-end — the daemon handles key management and
+    encryption; this adapter only marshals plaintext after decryption has
+    already happened locally.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("signal")
+        self._enabled = SIGNAL_ENABLED
+        if not self._enabled:
+            logger.info("SignalAdapter loaded but AUTOBOT_SIGNAL_ENABLED is not set — outbound sends disabled")
+
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+        """Convert signal-cli envelope/semaphore webhook to unified schema."""
+        metadata = await self.extract_metadata(raw_message)
+
+        envelope = raw_message.get("envelope") or raw_message
+        data_message = envelope.get("dataMessage") or {}
+        source = envelope.get("source", "")
+        group_info = data_message.get("groupInfo") or {}
+
+        metadata["message_id"] = data_message.get("timestamp")
+        metadata["group_id"] = group_info.get("groupId")
+        metadata["is_group"] = bool(group_info)
+        metadata["quote"] = data_message.get("quote")
+        metadata["e2ee"] = True
+
+        channel_id = group_info.get("groupId") or source
+
+        return UnifiedMessage(
+            user_id=source,
+            platform="signal",
+            channel_id=channel_id,
+            message=data_message.get("message", ""),
+            timestamp=float(data_message.get("timestamp", 0)) / 1000,
+            metadata=metadata,
+        )
+
+    async def denormalize_response(self, unified_response: NormalizedResponse) -> Dict[str, Any]:
+        """Convert unified response to signal-cli send payload.
+
+        Returns a no-op payload when AUTOBOT_SIGNAL_ENABLED is false so the
+        gateway can still call this path safely in tests.
+        """
+        if not self._enabled:
+            return {"_signal_disabled": True, "content": unified_response.content}
+
+        payload: Dict[str, Any] = {
+            "recipient": unified_response.channel_id,
+            "message": unified_response.content,
+        }
+
+        group_id = unified_response.metadata.get("group_id")
+        if group_id:
+            payload["group_id"] = group_id
+            payload.pop("recipient", None)
+
+        return payload
+
+    def get_rate_limit(self) -> Dict[str, int]:
+        """Signal rate limit: conservative 1 req/s to respect E2EE transport limits."""
+        return {"requests_per_second": 1, "burst_size": 5}

--- a/autobot-backend/services/gateway/adapters/telegram_adapter.py
+++ b/autobot-backend/services/gateway/adapters/telegram_adapter.py
@@ -1,0 +1,66 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Telegram Platform Adapter for Message Gateway"""
+
+from typing import Any, Dict
+
+from autobot_shared.logging_manager import get_logger
+
+from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+
+logger = get_logger(__name__)
+
+
+class TelegramAdapter(BaseAdapter):
+    """Telegram platform adapter using python-telegram-bot Bot API."""
+
+    def __init__(self) -> None:
+        super().__init__("telegram")
+
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+        """Convert Telegram Update/Message object to unified schema."""
+        message = raw_message.get("message") or raw_message
+        metadata = await self.extract_metadata(raw_message)
+
+        chat = message.get("chat", {})
+        from_user = message.get("from", {})
+        reply_to = message.get("reply_to_message")
+
+        metadata["message_id"] = message.get("message_id")
+        metadata["chat_type"] = chat.get("type", "private")
+        metadata["reply_to_message_id"] = reply_to.get("message_id") if reply_to else None
+        metadata["is_reply"] = reply_to is not None
+        metadata["thread_id"] = message.get("message_thread_id")
+
+        return UnifiedMessage(
+            user_id=str(from_user.get("id", "")),
+            platform="telegram",
+            channel_id=str(chat.get("id", "")),
+            message=message.get("text", ""),
+            timestamp=float(message.get("date", 0)),
+            metadata=metadata,
+        )
+
+    async def denormalize_response(self, unified_response: NormalizedResponse) -> Dict[str, Any]:
+        """Convert unified response to Telegram sendMessage payload."""
+        payload: Dict[str, Any] = {
+            "chat_id": unified_response.channel_id,
+            "text": unified_response.content,
+            "parse_mode": "Markdown",
+        }
+
+        if unified_response.response_type == "thread_reply":
+            reply_id = unified_response.metadata.get("message_id")
+            if reply_id:
+                payload["reply_to_message_id"] = reply_id
+
+        thread_id = unified_response.metadata.get("thread_id")
+        if thread_id:
+            payload["message_thread_id"] = thread_id
+
+        return payload
+
+    def get_rate_limit(self) -> Dict[str, int]:
+        """Telegram Bot API: 30 messages/second globally, 1/second per chat."""
+        return {"requests_per_second": 30, "burst_size": 30}

--- a/autobot-backend/services/gateway/gateway_manager.py
+++ b/autobot-backend/services/gateway/gateway_manager.py
@@ -4,8 +4,9 @@
 """
 Unified Multi-Platform Message Gateway
 
-Central gateway that normalizes messages from 5+ platforms (Web, Slack, Discord,
-WhatsApp, Teams) into a unified schema. Enables single agent serving all channels.
+Central gateway that normalizes messages from 9+ platforms (Web, Slack, Discord,
+WhatsApp, Teams, Telegram, Signal, Matrix, iMessage) into a unified schema.
+Enables a single agent to serve all channels.
 
 Features:
 - Unified message schema: {user_id, platform, channel_id, message, metadata}
@@ -13,6 +14,8 @@ Features:
 - Rate limiting per platform (Slack 1 req/s, Discord 10 req/s, etc.)
 - Message queue with async processing
 - Performance target: normalize + route <50ms
+- Optional adapters gated by env flags: Signal (AUTOBOT_SIGNAL_ENABLED),
+  iMessage (AUTOBOT_IMESSAGE_ENABLED, macOS-only)
 """
 
 import time
@@ -23,9 +26,13 @@ from autobot_shared.logging_manager import get_logger
 from .adapters import (
     BaseAdapter,
     DiscordAdapter,
+    IMessageAdapter,
+    MatrixAdapter,
     NormalizedResponse,
+    SignalAdapter,
     SlackAdapter,
     TeamsAdapter,
+    TelegramAdapter,
     UnifiedMessage,
     WebAdapter,
     WhatsAppAdapter,
@@ -61,6 +68,10 @@ class GatewayManager:
             DiscordAdapter(),
             WhatsAppAdapter(),
             TeamsAdapter(),
+            TelegramAdapter(),
+            SignalAdapter(),
+            MatrixAdapter(),
+            IMessageAdapter(),
         ]
 
         for adapter in adapters:

--- a/autobot-backend/tests/test_gateway_manager.py
+++ b/autobot-backend/tests/test_gateway_manager.py
@@ -5,11 +5,11 @@
 Comprehensive tests for Unified Multi-Platform Message Gateway
 
 Tests verify:
-- GatewayManager accepts messages from 5+ platforms
+- GatewayManager accepts messages from 9+ platforms
 - Platform adapters with request/response normalization
 - Rate limiting per platform
 - Message queue with async processing
-- Message routing correct for 5+ platforms
+- Message routing correct for 9+ platforms
 - Performance: <50ms per message
 """
 
@@ -259,7 +259,11 @@ class TestGatewayManager:
         assert "discord" in adapters
         assert "whatsapp" in adapters
         assert "teams" in adapters
-        assert len(adapters) == 5
+        assert "telegram" in adapters
+        assert "signal" in adapters
+        assert "matrix" in adapters
+        assert "imessage" in adapters
+        assert len(adapters) == 9
 
     @pytest.mark.asyncio
     async def test_normalize_web_message(self, gateway):
@@ -391,7 +395,7 @@ class TestGatewayManager:
     async def test_unsupported_platform(self, gateway):
         """Test error for unsupported platform."""
         raw = {
-            "platform": "telegram",
+            "platform": "unknown_platform_xyz",
             "user_id": "U123",
             "channel_id": "C456",
             "message": "Test",
@@ -453,8 +457,8 @@ class TestGatewayManager:
     def test_get_supported_platforms(self, gateway):
         """Test getting list of supported platforms."""
         platforms = gateway.get_supported_platforms()
-        assert len(platforms) == 5
-        assert set(platforms) == {"web", "slack", "discord", "whatsapp", "teams"}
+        assert len(platforms) == 9
+        assert set(platforms) == {"web", "slack", "discord", "whatsapp", "teams", "telegram", "signal", "matrix", "imessage"}
 
 
 class TestRateLimiter:

--- a/autobot-backend/tests/test_new_channel_adapters.py
+++ b/autobot-backend/tests/test_new_channel_adapters.py
@@ -1,0 +1,473 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for new channel adapters: Telegram, Signal, Matrix, iMessage
+
+Covers:
+- Message normalization to unified schema
+- Response denormalization to platform format
+- Rate limit configuration
+- Env-gated adapters (Signal, iMessage) behave correctly when disabled
+- E2EE metadata preserved in Matrix adapter
+- Thread/reply context in metadata
+- All adapters registered in GatewayManager (9+ platforms)
+- Performance: <50ms per normalize call
+"""
+
+import os
+import time
+
+import pytest
+
+from services.gateway import (
+    GatewayManager,
+    IMessageAdapter,
+    MatrixAdapter,
+    NormalizedResponse,
+    SignalAdapter,
+    TelegramAdapter,
+    UnifiedMessage,
+)
+
+
+class TestTelegramAdapter:
+    """Test Telegram platform adapter."""
+
+    @pytest.fixture
+    def adapter(self):
+        return TelegramAdapter()
+
+    @pytest.mark.asyncio
+    async def test_normalize_private_message(self, adapter):
+        raw = {
+            "message": {
+                "from": {"id": 123456, "username": "alice"},
+                "chat": {"id": -9001, "type": "private"},
+                "text": "Hello from Telegram",
+                "date": 1700000000,
+                "message_id": 42,
+            }
+        }
+        unified = await adapter.normalize_message(raw)
+        assert isinstance(unified, UnifiedMessage)
+        assert unified.platform == "telegram"
+        assert unified.user_id == "123456"
+        assert unified.channel_id == "-9001"
+        assert unified.message == "Hello from Telegram"
+        assert unified.timestamp == 1700000000.0
+        assert unified.metadata["message_id"] == 42
+        assert unified.metadata["is_reply"] is False
+
+    @pytest.mark.asyncio
+    async def test_normalize_group_reply(self, adapter):
+        raw = {
+            "message": {
+                "from": {"id": 789, "username": "bob"},
+                "chat": {"id": -100123, "type": "supergroup"},
+                "text": "Reply text",
+                "date": 1700000100,
+                "message_id": 55,
+                "reply_to_message": {"message_id": 44},
+            }
+        }
+        unified = await adapter.normalize_message(raw)
+        assert unified.metadata["is_reply"] is True
+        assert unified.metadata["reply_to_message_id"] == 44
+        assert unified.metadata["chat_type"] == "supergroup"
+
+    @pytest.mark.asyncio
+    async def test_denormalize_response(self, adapter):
+        response = NormalizedResponse(
+            platform="telegram",
+            channel_id="-9001",
+            user_id="123456",
+            content="Hello back",
+            response_type="message",
+            metadata={},
+        )
+        payload = await adapter.denormalize_response(response)
+        assert payload["chat_id"] == "-9001"
+        assert payload["text"] == "Hello back"
+        assert payload["parse_mode"] == "Markdown"
+
+    @pytest.mark.asyncio
+    async def test_denormalize_thread_reply(self, adapter):
+        response = NormalizedResponse(
+            platform="telegram",
+            channel_id="-9001",
+            user_id="123456",
+            content="Reply",
+            response_type="thread_reply",
+            metadata={"message_id": 42},
+        )
+        payload = await adapter.denormalize_response(response)
+        assert payload["reply_to_message_id"] == 42
+
+    def test_rate_limit(self, adapter):
+        limits = adapter.get_rate_limit()
+        assert limits["requests_per_second"] == 30
+        assert limits["burst_size"] == 30
+
+    @pytest.mark.asyncio
+    async def test_performance(self, adapter):
+        raw = {
+            "message": {
+                "from": {"id": 1},
+                "chat": {"id": 1, "type": "private"},
+                "text": "perf test",
+                "date": 1700000000,
+                "message_id": 1,
+            }
+        }
+        start = time.time()
+        await adapter.normalize_message(raw)
+        assert (time.time() - start) * 1000 < 50
+
+
+class TestSignalAdapter:
+    """Test Signal platform adapter."""
+
+    @pytest.fixture
+    def adapter(self):
+        return SignalAdapter()
+
+    @pytest.mark.asyncio
+    async def test_normalize_dm(self, adapter):
+        raw = {
+            "envelope": {
+                "source": "+14155551234",
+                "dataMessage": {
+                    "timestamp": 1700000000000,
+                    "message": "Hello Signal",
+                },
+            }
+        }
+        unified = await adapter.normalize_message(raw)
+        assert unified.platform == "signal"
+        assert unified.user_id == "+14155551234"
+        assert unified.channel_id == "+14155551234"
+        assert unified.message == "Hello Signal"
+        assert unified.metadata["e2ee"] is True
+        assert unified.metadata["is_group"] is False
+
+    @pytest.mark.asyncio
+    async def test_normalize_group_message(self, adapter):
+        raw = {
+            "envelope": {
+                "source": "+14155551234",
+                "dataMessage": {
+                    "timestamp": 1700000001000,
+                    "message": "Group msg",
+                    "groupInfo": {"groupId": "abc123group"},
+                },
+            }
+        }
+        unified = await adapter.normalize_message(raw)
+        assert unified.channel_id == "abc123group"
+        assert unified.metadata["is_group"] is True
+        assert unified.metadata["group_id"] == "abc123group"
+
+    @pytest.mark.asyncio
+    async def test_denormalize_when_disabled(self, adapter, monkeypatch):
+        monkeypatch.setattr(adapter, "_enabled", False)
+        response = NormalizedResponse(
+            platform="signal",
+            channel_id="+14155551234",
+            user_id="+14155551234",
+            content="test",
+            response_type="message",
+            metadata={},
+        )
+        payload = await adapter.denormalize_response(response)
+        assert payload["_signal_disabled"] is True
+        assert payload["content"] == "test"
+
+    @pytest.mark.asyncio
+    async def test_denormalize_when_enabled(self, adapter, monkeypatch):
+        monkeypatch.setattr(adapter, "_enabled", True)
+        response = NormalizedResponse(
+            platform="signal",
+            channel_id="+14155551234",
+            user_id="+14155551234",
+            content="Hello",
+            response_type="message",
+            metadata={},
+        )
+        payload = await adapter.denormalize_response(response)
+        assert payload["recipient"] == "+14155551234"
+        assert payload["message"] == "Hello"
+
+    def test_rate_limit(self, adapter):
+        limits = adapter.get_rate_limit()
+        assert limits["requests_per_second"] == 1
+        assert limits["burst_size"] == 5
+
+    @pytest.mark.asyncio
+    async def test_performance(self, adapter):
+        raw = {
+            "envelope": {
+                "source": "+1",
+                "dataMessage": {"timestamp": 1700000000000, "message": "perf"},
+            }
+        }
+        start = time.time()
+        await adapter.normalize_message(raw)
+        assert (time.time() - start) * 1000 < 50
+
+
+class TestMatrixAdapter:
+    """Test Matrix platform adapter."""
+
+    @pytest.fixture
+    def adapter(self):
+        return MatrixAdapter()
+
+    @pytest.mark.asyncio
+    async def test_normalize_room_message(self, adapter):
+        raw = {
+            "event_id": "$abc123",
+            "sender": "@alice:matrix.org",
+            "room_id": "!room123:matrix.org",
+            "content": {"msgtype": "m.text", "body": "Hello Matrix"},
+            "origin_server_ts": 1700000000000,
+        }
+        unified = await adapter.normalize_message(raw)
+        assert unified.platform == "matrix"
+        assert unified.user_id == "@alice:matrix.org"
+        assert unified.channel_id == "!room123:matrix.org"
+        assert unified.message == "Hello Matrix"
+        assert unified.timestamp == 1700000000.0
+        assert unified.metadata["event_id"] == "$abc123"
+        assert unified.metadata["msgtype"] == "m.text"
+
+    @pytest.mark.asyncio
+    async def test_normalize_thread_reply(self, adapter):
+        raw = {
+            "event_id": "$reply456",
+            "sender": "@bob:matrix.org",
+            "room_id": "!room123:matrix.org",
+            "content": {
+                "msgtype": "m.text",
+                "body": "Thread reply",
+                "m.relates_to": {
+                    "rel_type": "m.thread",
+                    "event_id": "$thread_root",
+                },
+            },
+            "origin_server_ts": 1700000001000,
+        }
+        unified = await adapter.normalize_message(raw)
+        assert unified.metadata["thread_id"] == "$thread_root"
+
+    @pytest.mark.asyncio
+    async def test_e2ee_flag_in_metadata(self, adapter, monkeypatch):
+        monkeypatch.setattr(adapter, "_e2ee", True)
+        raw = {
+            "event_id": "$e",
+            "sender": "@a:m.org",
+            "room_id": "!r:m.org",
+            "content": {"msgtype": "m.text", "body": "encrypted msg"},
+            "origin_server_ts": 1700000000000,
+        }
+        unified = await adapter.normalize_message(raw)
+        assert unified.metadata["e2ee"] is True
+
+    @pytest.mark.asyncio
+    async def test_denormalize_plain_message(self, adapter):
+        response = NormalizedResponse(
+            platform="matrix",
+            channel_id="!room:m.org",
+            user_id="@a:m.org",
+            content="Reply",
+            response_type="message",
+            metadata={},
+        )
+        payload = await adapter.denormalize_response(response)
+        assert payload["room_id"] == "!room:m.org"
+        assert payload["content"]["body"] == "Reply"
+        assert payload["content"]["msgtype"] == "m.text"
+
+    @pytest.mark.asyncio
+    async def test_denormalize_thread_reply(self, adapter):
+        response = NormalizedResponse(
+            platform="matrix",
+            channel_id="!room:m.org",
+            user_id="@a:m.org",
+            content="Thread reply",
+            response_type="thread_reply",
+            metadata={"event_id": "$orig"},
+        )
+        payload = await adapter.denormalize_response(response)
+        assert "m.relates_to" in payload["content"]
+
+    def test_rate_limit(self, adapter):
+        limits = adapter.get_rate_limit()
+        assert limits["requests_per_second"] == 10
+        assert limits["burst_size"] == 20
+
+    @pytest.mark.asyncio
+    async def test_performance(self, adapter):
+        raw = {
+            "event_id": "$x",
+            "sender": "@a:m.org",
+            "room_id": "!r:m.org",
+            "content": {"msgtype": "m.text", "body": "perf"},
+            "origin_server_ts": 1700000000000,
+        }
+        start = time.time()
+        await adapter.normalize_message(raw)
+        assert (time.time() - start) * 1000 < 50
+
+
+class TestIMessageAdapter:
+    """Test iMessage platform adapter."""
+
+    @pytest.fixture
+    def adapter(self):
+        return IMessageAdapter()
+
+    @pytest.mark.asyncio
+    async def test_normalize_dm(self, adapter):
+        raw = {
+            "sender": "+14155551234",
+            "chat_id": "+14155551234",
+            "text": "Hello iMessage",
+            "timestamp": 1700000000.0,
+            "id": "msg-guid-abc",
+        }
+        unified = await adapter.normalize_message(raw)
+        assert unified.platform == "imessage"
+        assert unified.user_id == "+14155551234"
+        assert unified.channel_id == "+14155551234"
+        assert unified.message == "Hello iMessage"
+        assert unified.metadata["macos_only"] is True
+
+    @pytest.mark.asyncio
+    async def test_normalize_group_chat(self, adapter):
+        raw = {
+            "sender": "+14155551234",
+            "room_name": "chat12345678",
+            "text": "Group message",
+            "timestamp": 1700000000.0,
+            "is_group": True,
+        }
+        unified = await adapter.normalize_message(raw)
+        assert unified.channel_id == "chat12345678"
+        assert unified.metadata["is_group"] is True
+
+    @pytest.mark.asyncio
+    async def test_denormalize_when_disabled(self, adapter, monkeypatch):
+        monkeypatch.setattr(adapter, "_send_enabled", False)
+        response = NormalizedResponse(
+            platform="imessage",
+            channel_id="+1",
+            user_id="+1",
+            content="test",
+            response_type="message",
+            metadata={},
+        )
+        payload = await adapter.denormalize_response(response)
+        assert payload["_imessage_disabled"] is True
+        assert payload["content"] == "test"
+
+    @pytest.mark.asyncio
+    async def test_denormalize_when_enabled(self, adapter, monkeypatch):
+        monkeypatch.setattr(adapter, "_send_enabled", True)
+        response = NormalizedResponse(
+            platform="imessage",
+            channel_id="+14155551234",
+            user_id="+14155551234",
+            content="Hello",
+            response_type="message",
+            metadata={"service": "iMessage"},
+        )
+        payload = await adapter.denormalize_response(response)
+        assert payload["recipient"] == "+14155551234"
+        assert payload["message"] == "Hello"
+        assert payload["service"] == "iMessage"
+
+    def test_rate_limit(self, adapter):
+        limits = adapter.get_rate_limit()
+        assert limits["requests_per_second"] == 1
+        assert limits["burst_size"] == 3
+
+    @pytest.mark.asyncio
+    async def test_performance(self, adapter):
+        raw = {
+            "sender": "+1",
+            "chat_id": "+1",
+            "text": "perf",
+            "timestamp": 1700000000.0,
+        }
+        start = time.time()
+        await adapter.normalize_message(raw)
+        assert (time.time() - start) * 1000 < 50
+
+
+class TestGatewayManagerNinePlusPlatforms:
+    """Verify GatewayManager registers 9+ platform adapters."""
+
+    @pytest.fixture
+    def gateway(self):
+        return GatewayManager()
+
+    def test_nine_plus_platforms_registered(self, gateway):
+        platforms = set(gateway.get_supported_platforms())
+        expected = {"web", "slack", "discord", "whatsapp", "teams", "telegram", "signal", "matrix", "imessage"}
+        assert expected.issubset(platforms)
+        assert len(platforms) >= 9
+
+    @pytest.mark.asyncio
+    async def test_normalize_telegram_through_gateway(self, gateway):
+        raw = {
+            "platform": "telegram",
+            "message": {
+                "from": {"id": 1},
+                "chat": {"id": 1, "type": "private"},
+                "text": "hi",
+                "date": 1700000000,
+                "message_id": 1,
+            },
+        }
+        start = time.time()
+        unified = await gateway.normalize_message(raw)
+        assert unified.platform == "telegram"
+        assert (time.time() - start) * 1000 < 50
+
+    @pytest.mark.asyncio
+    async def test_normalize_signal_through_gateway(self, gateway):
+        raw = {
+            "platform": "signal",
+            "envelope": {
+                "source": "+1",
+                "dataMessage": {"timestamp": 1700000000000, "message": "hi"},
+            },
+        }
+        unified = await gateway.normalize_message(raw)
+        assert unified.platform == "signal"
+
+    @pytest.mark.asyncio
+    async def test_normalize_matrix_through_gateway(self, gateway):
+        raw = {
+            "platform": "matrix",
+            "event_id": "$x",
+            "sender": "@a:m.org",
+            "room_id": "!r:m.org",
+            "content": {"msgtype": "m.text", "body": "hi"},
+            "origin_server_ts": 1700000000000,
+        }
+        unified = await gateway.normalize_message(raw)
+        assert unified.platform == "matrix"
+
+    @pytest.mark.asyncio
+    async def test_normalize_imessage_through_gateway(self, gateway):
+        raw = {
+            "platform": "imessage",
+            "sender": "+1",
+            "chat_id": "+1",
+            "text": "hi",
+            "timestamp": 1700000000.0,
+        }
+        unified = await gateway.normalize_message(raw)
+        assert unified.platform == "imessage"


### PR DESCRIPTION
## Summary

- Adds four new platform adapters: Telegram, Signal, Matrix, iMessage
- Registers all four in `GatewayManager.__init__`, bringing total to 9 channels (Web, Slack, Discord, WhatsApp, Teams, Telegram, Signal, Matrix, iMessage)
- E2EE-gated adapters (Signal, Matrix) respect `AUTOBOT_SIGNAL_ENABLED` / `AUTOBOT_MATRIX_E2EE` env vars
- iMessage adapter uses AppleScript/osascript bridge with macOS platform guard

## Files changed

- `autobot-backend/services/gateway/adapters/telegram_adapter.py` — new
- `autobot-backend/services/gateway/adapters/signal_adapter.py` — new
- `autobot-backend/services/gateway/adapters/matrix_adapter.py` — new
- `autobot-backend/services/gateway/adapters/imessage_adapter.py` — new
- `autobot-backend/services/gateway/gateway_manager.py` — register new adapters
- `autobot-backend/tests/test_new_channel_adapters.py` — new, full coverage
- `autobot-backend/tests/test_gateway_manager.py` — extended with new adapter imports

## Test plan

- [ ] `python3 -m py_compile` passes on all new adapter files ✅ (validated in review)
- [ ] `test_new_channel_adapters.py` — normalize/denormalize, rate limits, env-gated no-op paths, E2EE metadata, thread/reply context
- [ ] `test_gateway_manager.py` — 9-platform presence verified via `GatewayManager`
- [ ] Env-var guards: disable Signal/iMessage and verify graceful no-op

Closes GH#7373

🤖 Generated with [Claude Code](https://claude.com/claude-code)