### PR TITLE
fix(coordination): add None guard to all 6 SharedRuntimeBag Redis methods (MVA-1158 CR must-fix)

### DIFF
--- a/autobot_shared/coordination/shared_runtime_bag.py
+++ b/autobot_shared/coordination/shared_runtime_bag.py
@@ -111,6 +111,8 @@ class SharedRuntimeBag(Generic[T]):
     async def get(self, key: str) -> T | None:
         """Return the value stored under *key*, or None if absent / expired."""
         redis = await get_async_redis_client(database="main")
+        if redis is None:
+            raise RuntimeError(f"SharedRuntimeBag: Redis client unavailable (namespace='{self._namespace}')")
         raw = await redis.get(_value_key(self._namespace, key))
         if raw is None:
             return None
@@ -124,6 +126,8 @@ class SharedRuntimeBag(Generic[T]):
     ) -> None:
         """Persist *value* under *key* with an optional TTL (defaults to namespace TTL)."""
         redis = await get_async_redis_client(database="main")
+        if redis is None:
+            raise RuntimeError(f"SharedRuntimeBag: Redis client unavailable (namespace='{self._namespace}')")
         encoded = self._encode(value)
         ttl = ttl_s if ttl_s is not None else self._default_ttl_s
         await redis.set(_value_key(self._namespace, key), encoded, ex=ttl)
@@ -147,6 +151,8 @@ class SharedRuntimeBag(Generic[T]):
             RuntimeError: if all CAS retries are exhausted.
         """
         redis = await get_async_redis_client(database="main")
+        if redis is None:
+            raise RuntimeError(f"SharedRuntimeBag: Redis client unavailable (namespace='{self._namespace}')")
         rkey = _value_key(self._namespace, key)
         ttl = ttl_s if ttl_s is not None else self._default_ttl_s
 
@@ -190,6 +196,8 @@ class SharedRuntimeBag(Generic[T]):
     async def delete(self, key: str) -> None:
         """Remove *key* from the bag and publish a delete change event."""
         redis = await get_async_redis_client(database="main")
+        if redis is None:
+            raise RuntimeError(f"SharedRuntimeBag: Redis client unavailable (namespace='{self._namespace}')")
         await redis.delete(_value_key(self._namespace, key))
         await self._publish(redis, key, "delete", None)
 
@@ -199,6 +207,8 @@ class SharedRuntimeBag(Generic[T]):
         The returned keys are the bare key names (namespace prefix is stripped).
         """
         redis = await get_async_redis_client(database="main")
+        if redis is None:
+            raise RuntimeError(f"SharedRuntimeBag: Redis client unavailable (namespace='{self._namespace}')")
         prefix = f"runtime_bag:{self._namespace}:"
         full_pattern = f"{prefix}{pattern}"
         raw_keys = await redis.keys(full_pattern)
@@ -217,6 +227,8 @@ class SharedRuntimeBag(Generic[T]):
                     handle_update(event.key, event.value)
         """
         redis = await get_async_redis_client(database="main")
+        if redis is None:
+            raise RuntimeError(f"SharedRuntimeBag: Redis client unavailable (namespace='{self._namespace}')")
         channel = _changes_channel(self._namespace)
         pubsub = redis.pubsub()
         await pubsub.subscribe(channel)


### PR DESCRIPTION
## Summary

Adds `None` guard to all 6 `SharedRuntimeBag` methods that call `get_async_redis_client()`, raising `RuntimeError` when Redis is unavailable. This addresses the code review must-fix raised in MVA-1158 ([MVA-1158](/MVA/issues/MVA-1158)).

## Changes

- All 6 `SharedRuntimeBag` Redis methods now guard against `None` client and raise `RuntimeError` with a clear message when Redis is unavailable
- Prevents silent failures / `AttributeError` when Redis is not initialized

## Test plan

- [ ] Verify `RuntimeError` is raised with a meaningful message when Redis client is `None`
- [ ] Confirm existing Redis-dependent paths continue working normally
- [ ] No regressions on existing tests

Related: [MVA-1165](/MVA/issues/MVA-1165) | Commit: `6d5e69877`

🤖 Generated with [Claude Code](https://claude.com/claude-code)