### PR TITLE
fix(voice-rbac): fix VoiceBundleInfo stories — share state via provide/inject (MVA-1162)

### DIFF
--- a/autobot-frontend/src/composables/useVoiceBundle.ts
+++ b/autobot-frontend/src/composables/useVoiceBundle.ts
@@ -10,6 +10,7 @@
  */
 
 import { ref } from 'vue'
+import type { InjectionKey, Ref } from 'vue'
 import { getBackendUrl } from '@/config/ssot-config'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
@@ -35,6 +36,15 @@ export interface UserBundleAssignment {
   user_id: string
   bundle_name: VoiceBundleName | null
 }
+
+export interface VoiceBundleInjectedState {
+  bundleInfo: Ref<UserBundleInfo | null>
+  loading: Ref<boolean>
+  error: Ref<string | null>
+}
+
+export const VOICE_BUNDLE_STATE_KEY: InjectionKey<VoiceBundleInjectedState> =
+  Symbol('VoiceBundleInfo.state')
 
 export function useVoiceBundle() {
   const bundleInfo = ref<UserBundleInfo | null>(null)

--- a/autobot-frontend/src/views/voice/VoiceBundleInfo.stories.ts
+++ b/autobot-frontend/src/views/voice/VoiceBundleInfo.stories.ts
@@ -4,12 +4,21 @@
  * Author: mrveiss
  *
  * VoiceBundleInfo.stories.ts — Storybook stories for VoiceBundleInfo (GH#7422).
+ *
+ * State is injected via VOICE_BUNDLE_STATE_KEY so each story's decorator provides
+ * its own reactive refs, shared with the component instance.  This avoids the
+ * broken pattern of calling useVoiceBundle() in story setup() — that creates
+ * separate ref instances that the component never reads (MVA-1162).
  */
 
-import type { Meta } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 import VoiceBundleInfo from './VoiceBundleInfo.vue'
-import { useVoiceBundle } from '@/composables/useVoiceBundle'
-import { ref } from 'vue'
+import { VOICE_BUNDLE_STATE_KEY } from '@/composables/useVoiceBundle'
+import type { UserBundleInfo, VoiceBundleInjectedState } from '@/composables/useVoiceBundle'
+import { ref, provide } from 'vue'
+
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>
 
 const meta: Meta = {
   title: 'Views/Voice/VoiceBundleInfo',
@@ -18,98 +27,71 @@ const meta: Meta = {
 
 export default meta
 
-export const AdminOverride = {
-  render: () => ({
-    components: { VoiceBundleInfo },
-    setup() {
-      const { bundleInfo, loading, error } = useVoiceBundle()
-      bundleInfo.value = {
-        bundle_name: 'voice_admin',
-        tool_count: 28,
-        resolution: 'user_override',
-      }
-      loading.value = false
-      error.value = null
-      return {}
-    },
-    template: `<div style="padding:24px;max-width:320px;"><VoiceBundleInfo /></div>`,
-  }),
+function withState(state: {
+  bundleInfo: UserBundleInfo | null
+  loading: boolean
+  error: string | null
+}): Story['decorators'] {
+  return [
+    () => ({
+      setup() {
+        const injected: VoiceBundleInjectedState = {
+          bundleInfo: ref(state.bundleInfo),
+          loading: ref(state.loading),
+          error: ref(state.error),
+        }
+        provide(VOICE_BUNDLE_STATE_KEY, injected)
+        return {}
+      },
+      template: '<story />',
+    }),
+  ]
 }
 
-export const RoleDefault = {
-  render: () => ({
-    components: { VoiceBundleInfo },
-    setup() {
-      const { bundleInfo, loading, error } = useVoiceBundle()
-      bundleInfo.value = {
-        bundle_name: 'voice_extended',
-        tool_count: 19,
-        resolution: 'role_default',
-      }
-      loading.value = false
-      error.value = null
-      return {}
-    },
-    template: `<div style="padding:24px;max-width:320px;"><VoiceBundleInfo /></div>`,
+const wrapper = `<div style="padding:24px;max-width:320px;"><VoiceBundleInfo /></div>`
+
+export const AdminOverride: Story = {
+  decorators: withState({
+    bundleInfo: { bundle_name: 'voice_admin', tool_count: 28, resolution: 'user_override' },
+    loading: false,
+    error: null,
   }),
+  render: () => ({ components: { VoiceBundleInfo }, template: wrapper }),
 }
 
-export const SystemDefault = {
-  render: () => ({
-    components: { VoiceBundleInfo },
-    setup() {
-      const { bundleInfo, loading, error } = useVoiceBundle()
-      bundleInfo.value = {
-        bundle_name: 'voice_safe',
-        tool_count: 12,
-        resolution: 'global_env',
-      }
-      loading.value = false
-      error.value = null
-      return {}
-    },
-    template: `<div style="padding:24px;max-width:320px;"><VoiceBundleInfo /></div>`,
+export const RoleDefault: Story = {
+  decorators: withState({
+    bundleInfo: { bundle_name: 'voice_extended', tool_count: 19, resolution: 'role_default' },
+    loading: false,
+    error: null,
   }),
+  render: () => ({ components: { VoiceBundleInfo }, template: wrapper }),
 }
 
-export const Loading = {
-  render: () => ({
-    components: { VoiceBundleInfo },
-    setup() {
-      const { bundleInfo, loading, error } = useVoiceBundle()
-      bundleInfo.value = null
-      loading.value = true
-      error.value = null
-      return {}
-    },
-    template: `<div style="padding:24px;max-width:320px;"><VoiceBundleInfo /></div>`,
+export const SystemDefault: Story = {
+  decorators: withState({
+    bundleInfo: { bundle_name: 'voice_safe', tool_count: 12, resolution: 'global_env' },
+    loading: false,
+    error: null,
   }),
+  render: () => ({ components: { VoiceBundleInfo }, template: wrapper }),
 }
 
-export const ErrorState = {
-  render: () => ({
-    components: { VoiceBundleInfo },
-    setup() {
-      const { bundleInfo, loading, error } = useVoiceBundle()
-      bundleInfo.value = null
-      loading.value = false
-      error.value = 'Unable to load voice bundle'
-      return {}
-    },
-    template: `<div style="padding:24px;max-width:320px;"><VoiceBundleInfo /></div>`,
-  }),
+export const Loading: Story = {
+  decorators: withState({ bundleInfo: null, loading: true, error: null }),
+  render: () => ({ components: { VoiceBundleInfo }, template: wrapper }),
 }
 
-export const NoBundleAssigned = {
-  render: () => ({
-    components: { VoiceBundleInfo },
-    setup() {
-      const { bundleInfo, loading, error } = useVoiceBundle()
-      bundleInfo.value = null
-      loading.value = false
-      error.value = null
-      return {}
-    },
-    template: `<div style="padding:24px;max-width:320px;"><VoiceBundleInfo /></div>`,
+export const ErrorState: Story = {
+  decorators: withState({
+    bundleInfo: null,
+    loading: false,
+    error: 'Unable to load voice bundle',
   }),
+  render: () => ({ components: { VoiceBundleInfo }, template: wrapper }),
+}
+
+export const NoBundleAssigned: Story = {
+  decorators: withState({ bundleInfo: null, loading: false, error: null }),
+  render: () => ({ components: { VoiceBundleInfo }, template: wrapper }),
 }

--- a/autobot-frontend/src/views/voice/VoiceBundleInfo.vue
+++ b/autobot-frontend/src/views/voice/VoiceBundleInfo.vue
@@ -39,9 +39,14 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { inject, onMounted } from 'vue'
 import Icon from '@/components/ui/Icon.vue'
-import { useVoiceBundle, VOICE_BUNDLE_LABELS } from '@/composables/useVoiceBundle'
+import {
+  useVoiceBundle,
+  VOICE_BUNDLE_LABELS,
+  VOICE_BUNDLE_STATE_KEY,
+} from '@/composables/useVoiceBundle'
+import type { VoiceBundleInjectedState } from '@/composables/useVoiceBundle'
 
 const RESOLUTION_LABELS = {
   user_override: 'Admin override',
@@ -49,9 +54,15 @@ const RESOLUTION_LABELS = {
   global_env: 'System default',
 } as const
 
-const { bundleInfo, loading, error, fetchMyBundle } = useVoiceBundle()
+const injected = inject<VoiceBundleInjectedState | null>(VOICE_BUNDLE_STATE_KEY, null)
+const composable = injected === null ? useVoiceBundle() : null
+const bundleInfo = injected?.bundleInfo ?? composable!.bundleInfo
+const loading = injected?.loading ?? composable!.loading
+const error = injected?.error ?? composable!.error
 
-onMounted(fetchMyBundle)
+onMounted(() => {
+  if (composable) composable.fetchMyBundle()
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary

- **Bug**: `VoiceBundleInfo.stories.ts` called `useVoiceBundle()` in each story `setup()` and mutated `bundleInfo.value` etc., but those are separate ref instances from the component's own `useVoiceBundle()` call. Story mutations never reached the component; all stories rendered in the empty/loading state regardless of setup.
- **Fix**: Export `VoiceBundleInjectedState` interface and `VOICE_BUNDLE_STATE_KEY` (an `InjectionKey`) from `useVoiceBundle.ts`. `VoiceBundleInfo.vue` now injects provided state when a parent provides it, and only falls back to `useVoiceBundle()` + `fetchMyBundle()` when no injection is active. Stories use a `withState()` decorator factory that calls Vue's `provide()` with fresh reactive refs matching each story's desired state.

**Files changed:**
- `autobot-frontend/src/composables/useVoiceBundle.ts` — added `VoiceBundleInjectedState` + `VOICE_BUNDLE_STATE_KEY`
- `autobot-frontend/src/views/voice/VoiceBundleInfo.vue` — use inject-with-fallback + guard `onMounted`
- `autobot-frontend/src/views/voice/VoiceBundleInfo.stories.ts` — rewrite using `withState()` decorator factory

## Test plan

- [ ] `npm run type-check` passes (no new errors in modified files — verified)
- [ ] Open Storybook and verify each story renders correct state: Admin Override, Role Default, System Default show bundle content; Loading shows spinner; Error shows error message; No Bundle Assigned shows empty state
- [ ] Confirm component still auto-fetches in normal (non-Storybook) rendering by navigating to the voice bundle panel

Fixes MVA-1162 / raised from PR review of GH#7422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)