### PR TITLE
feat(voice): MCP tools as Realtime function tools (GH#7343)

### DIFF
--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -13,8 +13,9 @@ import os
 import tempfile
 from typing import Any, Dict, List
 
-from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
+from fastapi import APIRouter, Body, Depends, File, Form, Request, UploadFile
 from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
 
 from api.schemas_agent import VoiceCreateResponse
 from api.schemas_code import (
@@ -23,15 +24,81 @@ from api.schemas_code import (
     VoiceSpeakResponse,
     VoiceTranscribeResponse,
 )
-from auth_middleware import check_admin_permission
+from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from services.realtime_mcp_bridge import get_realtime_bridge
 from services.tts_client import get_tts_client
 
 router = APIRouter(
     dependencies=[Depends(check_admin_permission)],
 )
 logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Realtime MCP tool endpoints (Issue #7343)
+# ---------------------------------------------------------------------------
+
+
+class _RealtimeToolCallRequest(BaseModel):
+    name: str
+    arguments: Dict[str, Any] = {}
+
+
+@router.get("/realtime/tools")
+async def voice_realtime_list_tools(
+    current_user: dict = Depends(get_current_user),
+):
+    """Return MCP tools as OpenAI Realtime function-tool schemas.
+
+    The frontend calls this before ``session.update`` to populate the tools
+    array for the Realtime session. Tools are filtered by voice bundle and
+    the caller's RBAC role.
+    """
+    is_admin = current_user.get("role") == "admin"
+    bridge = await get_realtime_bridge(is_admin=is_admin)
+    tools = await bridge.list_realtime_tools()
+    return {
+        "tools": [
+            {
+                "type": t.type,
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.parameters,
+            }
+            for t in tools
+        ]
+    }
+
+
+@router.post("/realtime/tools/call")
+async def voice_realtime_call_tool(
+    body: _RealtimeToolCallRequest,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+):
+    """Invoke an MCP tool by name and return the result envelope.
+
+    Accepts ``{name, arguments}`` and proxies the call through MCPClient.
+    Errors surface as ``{is_error: true, content: "<message>"}`` so the
+    Realtime model can self-correct verbally without the session crashing.
+    """
+    is_admin = current_user.get("role") == "admin"
+    user_id = current_user.get("id") or current_user.get("sub")
+    session_id = request.headers.get("X-Session-Id")
+
+    bridge = await get_realtime_bridge(is_admin=is_admin)
+    # Ensure the routing registry is populated before calling
+    await bridge.list_realtime_tools()
+
+    result = await bridge.call_tool(
+        body.name,
+        body.arguments,
+        user_id=user_id,
+        session_id=session_id,
+    )
+    return {"is_error": result.is_error, "content": result.content}
 
 
 @router.post("/listen", response_model=VoiceListenResponse)

--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -33,6 +33,8 @@ from services.tts_client import get_tts_client
 router = APIRouter(
     dependencies=[Depends(check_admin_permission)],
 )
+# Separate router for Realtime MCP endpoints — authenticated users (not admin-only)
+realtime_router = APIRouter()
 logger = get_logger(__name__)
 
 
@@ -46,7 +48,12 @@ class _RealtimeToolCallRequest(BaseModel):
     arguments: Dict[str, Any] = {}
 
 
-@router.get("/realtime/tools")
+@realtime_router.get("/realtime/tools")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="voice_realtime_list_tools",
+    error_code_prefix="VOICE",
+)
 async def voice_realtime_list_tools(
     current_user: dict = Depends(get_current_user),
 ):
@@ -72,7 +79,12 @@ async def voice_realtime_list_tools(
     }
 
 
-@router.post("/realtime/tools/call")
+@realtime_router.post("/realtime/tools/call")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="voice_realtime_call_tool",
+    error_code_prefix="VOICE",
+)
 async def voice_realtime_call_tool(
     body: _RealtimeToolCallRequest,
     request: Request,
@@ -84,13 +96,18 @@ async def voice_realtime_call_tool(
     Errors surface as ``{is_error: true, content: "<message>"}`` so the
     Realtime model can self-correct verbally without the session crashing.
     """
+    from fastapi import HTTPException
+
     is_admin = current_user.get("role") == "admin"
-    user_id = current_user.get("id") or current_user.get("sub")
+    _id = current_user.get("id")
+    user_id = _id if _id is not None else current_user.get("sub")
     session_id = request.headers.get("X-Session-Id")
 
     bridge = await get_realtime_bridge(is_admin=is_admin)
-    # Ensure the routing registry is populated before calling
-    await bridge.list_realtime_tools()
+    allowed_tools = await bridge.list_realtime_tools()
+    allowed_names = {t.name for t in allowed_tools}
+    if body.name not in allowed_names:
+        raise HTTPException(status_code=403, detail="Tool not permitted in active voice bundle")
 
     result = await bridge.call_tool(
         body.name,

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -82,6 +82,7 @@ from api.user_management.router import router as user_management_router  # Issue
 from api.vnc_manager import router as vnc_router
 from api.vnc_mcp import router as vnc_mcp_router
 from api.vnc_proxy import router as vnc_proxy_router
+from api.voice import realtime_router as voice_realtime_router
 from api.voice import router as voice_router
 from api.voice_stream import router as voice_stream_router
 from api.wake_word import router as wake_word_router
@@ -305,6 +306,7 @@ def _get_service_routers() -> list:
         (models_router, "/models", ["models"], "models"),
         (adapters_router, "/adapters", ["adapters"], "adapters"),
         (redis_router, "/redis", ["redis"], "redis"),
+        (voice_realtime_router, "/voice", ["voice"], "voice_realtime"),
         (voice_router, "/voice", ["voice"], "voice"),
         (voice_stream_router, "/voice", ["voice", "websocket"], "voice_stream"),
         (wake_word_router, "/wake_word", ["wake_word", "voice"], "wake_word"),

--- a/autobot-backend/services/realtime_mcp_bridge.py
+++ b/autobot-backend/services/realtime_mcp_bridge.py
@@ -472,7 +472,7 @@ class RealtimeMCPBridge:
                         parts.append(item["text"])
                     else:
                         parts.append(str(item))
-                return "\n".join(parts) if parts else str(raw)
+                return "\n".join(parts) if parts else ""
         import json  # noqa: PLC0415
 
         try:

--- a/autobot-backend/services/realtime_mcp_bridge.py
+++ b/autobot-backend/services/realtime_mcp_bridge.py
@@ -7,27 +7,60 @@ Realtime MCP Bridge — surfaces MCP tools as OpenAI Realtime function tools.
 Issue #7343 (full bridge), #7344 (voice bundle filtering).
 
 This module provides:
-- list_realtime_tools(): returns Realtime-shaped schemas filtered by the active
-  voice bundle and the caller's RBAC role.
-- call_tool(): routes tool calls back through MCPClient (stub — wired in #7343).
+- list_realtime_tools(): discovers all MCP tools via MCPClient, translates each
+  tool's inputSchema into an OpenAI Realtime function-tool entry, and applies
+  voice bundle + RBAC filtering before returning to the frontend.
+- call_tool(): routes incoming Realtime tool calls back through MCPClient and
+  returns a RealtimeToolResult with is_error semantics so the model can
+  self-correct verbally on failure.
 
-Bundle filtering (#7344) happens BEFORE schemas are returned to the frontend so
-the model never sees tools it isn't allowed to call in its voice context.
+Multi-server support: when MCP_SERVER_URIS is configured (comma-separated),
+each server gets a stable server_id (slugified from the URI). Tool names are
+prefixed as "{server_id}__{name}" when two or more servers expose a tool with
+the same name, ensuring deterministic collision resolution. Single-server
+deployments retain bare names for backwards compatibility.
+
+Audit log entries are written for every tools/call via the existing audit
+pipeline (correlate on operation "voice.realtime.tool_call").
 """
 
+from __future__ import annotations
+
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
-from api.redis_mcp.rbac import filter_tools_for_bundle
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
 
 logger = get_logger(__name__)
 
 
+def _get_mcp_client_class():
+    """Lazy import MCPClient to avoid pulling in the skills package init at module load."""
+    from skills.sync.mcp_client import MCPClient  # noqa: PLC0415
+    return MCPClient
+
+
+def _get_filter_tools_for_bundle():
+    """Lazy import to avoid circular import at module init time."""
+    from api.redis_mcp.rbac import filter_tools_for_bundle  # noqa: PLC0415
+    return filter_tools_for_bundle
+
+
+async def _audit_log(*args, **kwargs):
+    """Lazy-import audit_log to avoid pulling in Redis at module init time."""
+    from services.audit_logger import audit_log  # noqa: PLC0415
+    return await audit_log(*args, **kwargs)
+
+# ---------------------------------------------------------------------------
+# Realtime schema types
+# ---------------------------------------------------------------------------
+
+
 @dataclass
 class RealtimeTool:
-    """OpenAI Realtime function-tool schema."""
+    """OpenAI Realtime function-tool schema entry."""
 
     name: str
     description: str
@@ -43,27 +76,177 @@ class RealtimeToolResult:
     is_error: bool = False
 
 
+# ---------------------------------------------------------------------------
+# Internal routing registry entry
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _ToolEntry:
+    """Maps a public (possibly-prefixed) Realtime name back to its origin."""
+
+    server_id: str
+    server_uri: str | None  # None → in-process _TOOLS dict
+    original_name: str
+
+
+# ---------------------------------------------------------------------------
+# Schema translation helpers
+# ---------------------------------------------------------------------------
+
+_REALTIME_FALLBACK_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": True,
+}
+
+
+def _translate_property(prop: Any) -> dict[str, Any]:
+    """Recursively convert an MCPPropertyDefinition (or raw dict) to a plain JSON-Schema dict."""
+    if prop is None:
+        return {}
+    if isinstance(prop, dict):
+        raw = prop
+    else:
+        # Pydantic model — dump to dict
+        raw = prop.model_dump(exclude_none=True)
+
+    out: dict[str, Any] = {}
+
+    if "type" in raw:
+        out["type"] = raw["type"]
+
+    if "description" in raw and raw["description"]:
+        out["description"] = raw["description"]
+
+    if "default" in raw and raw["default"] is not None:
+        out["default"] = raw["default"]
+
+    if "enum" in raw and raw["enum"]:
+        out["enum"] = raw["enum"]
+
+    # Recursive: array items
+    if "items" in raw and raw["items"] is not None:
+        out["items"] = _translate_property(raw["items"])
+
+    # Recursive: object properties
+    if "properties" in raw and raw["properties"]:
+        out["properties"] = {k: _translate_property(v) for k, v in raw["properties"].items()}
+
+    if "required" in raw and raw["required"]:
+        out["required"] = raw["required"]
+
+    # additionalProperties — preserve explicit false/true
+    if "additionalProperties" in raw:
+        out["additionalProperties"] = raw["additionalProperties"]
+
+    return out
+
+
+def _translate_input_schema(input_schema: Any) -> dict[str, Any]:
+    """Convert MCPInputSchema (or raw dict) to an OpenAI Realtime parameters object.
+
+    Falls back to {type:object, additionalProperties:true} when the schema is
+    absent or unparseable so the Realtime model can still attempt the call.
+    """
+    if input_schema is None:
+        return dict(_REALTIME_FALLBACK_SCHEMA)
+
+    if isinstance(input_schema, dict):
+        raw = input_schema
+    else:
+        try:
+            raw = input_schema.model_dump(exclude_none=True)
+        except Exception:
+            return dict(_REALTIME_FALLBACK_SCHEMA)
+
+    if not raw:
+        return dict(_REALTIME_FALLBACK_SCHEMA)
+
+    out: dict[str, Any] = {"type": raw.get("type", "object")}
+
+    props_raw = raw.get("properties") or {}
+    if props_raw:
+        out["properties"] = {k: _translate_property(v) for k, v in props_raw.items()}
+
+    required = raw.get("required") or []
+    if required:
+        out["required"] = required
+
+    # additionalProperties defaults to False (stricter validation in Realtime)
+    out["additionalProperties"] = raw.get("additionalProperties", False)
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Server-ID helpers
+# ---------------------------------------------------------------------------
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _server_id_from_uri(uri: str) -> str:
+    """Return a stable, lowercase slug for *uri* suitable as a name prefix."""
+    # Strip scheme
+    slug = re.sub(r"^[a-z]+://", "", uri.lower())
+    # Strip path components beyond the host:port
+    slug = slug.split("/")[0]
+    return _SLUG_RE.sub("_", slug).strip("_") or "mcp"
+
+
+# ---------------------------------------------------------------------------
+# Main bridge
+# ---------------------------------------------------------------------------
+
+
 class RealtimeMCPBridge:
     """Bridge between AutoBot MCP tools and OpenAI Realtime function-tool format.
 
-    Bundle filtering is applied in list_realtime_tools() so the model only
-    sees the tools permitted by the active voice context.
+    Discovery flow:
+      1. Enumerate configured MCP server URIs from ``mcp_server_uris`` config.
+      2. For each server, open an MCPClient connection and call discover_tools().
+      3. Unreachable servers are logged and skipped (best-effort).
+      4. When no external servers are configured, fall back to the in-process
+         ``mcp.autobot_server._TOOLS`` dict (zero-dependency baseline).
+      5. Name collisions across servers are resolved by prefixing with server_id.
+      6. Voice bundle + RBAC filtering is applied before returning.
 
-    Full MCP transport wiring is deferred to #7343.
+    Routing:
+      call_tool() looks up the routing registry built during _discover_tools() to
+      find which server owns the tool and opens a fresh MCPClient for the call.
     """
 
-    def __init__(self, is_admin: bool = False) -> None:
+    def __init__(
+        self,
+        is_admin: bool = False,
+        server_uris: list[str] | None = None,
+    ) -> None:
         self._is_admin = is_admin
-        self._bundle = config.voice_toolset_bundle
-        self._disabled = [t.strip() for t in config.voice_disabled_tools.split(",") if t.strip()]
+        self._bundle = getattr(config, "voice_toolset_bundle", "voice_safe")
+        disabled_raw = getattr(config, "voice_disabled_tools", "")
+        self._disabled = [t.strip() for t in disabled_raw.split(",") if t.strip()]
+
+        # Routing registry populated during _discover_tools()
+        self._registry: dict[str, _ToolEntry] = {}
+
+        # Server URIs — prefer explicit arg, then config, then empty (in-process)
+        if server_uris is not None:
+            self._server_uris = server_uris
+        else:
+            raw = getattr(config, "mcp_server_uris", "") or ""
+            self._server_uris = [u.strip() for u in raw.split(",") if u.strip()]
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
 
     async def list_realtime_tools(self) -> list[RealtimeTool]:
         """Return Realtime-shaped tool schemas filtered by the active bundle.
 
-        Applies voice bundle + RBAC filtering before returning. The frontend
-        uses this list to populate session.update tools.
+        The frontend uses this list to populate the ``session.update`` tools
+        array before opening a Realtime session.
         """
         all_tools = await self._discover_tools()
+        filter_tools_for_bundle = _get_filter_tools_for_bundle()
         allowed_names = filter_tools_for_bundle(
             [t.name for t in all_tools],
             bundle=self._bundle,
@@ -73,45 +256,239 @@ class RealtimeMCPBridge:
         allowed_set = set(allowed_names)
         filtered = [t for t in all_tools if t.name in allowed_set]
         logger.info(
-            "realtime_mcp_bridge bundle=%s is_admin=%s tools=%d",
+            "realtime_mcp_bridge list bundle=%s is_admin=%s discovered=%d filtered=%d",
             self._bundle,
             self._is_admin,
+            len(all_tools),
             len(filtered),
         )
         return filtered
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> RealtimeToolResult:
-        """Route a Realtime tool call back through MCPClient.
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        *,
+        user_id: str | None = None,
+        session_id: str | None = None,
+    ) -> RealtimeToolResult:
+        """Route a Realtime tool call through MCPClient and return the result.
 
-        Full transport wiring deferred to #7343.
+        Errors from the transport surface as ``is_error=True`` with the
+        original message in ``content`` so the model can self-correct verbally.
+        An audit log entry is written for every invocation.
         """
-        # Stub: full wiring in #7343
-        logger.warning("realtime_mcp_bridge.call_tool not yet wired: tool=%s", name)
-        return RealtimeToolResult(
-            content=f"Tool '{name}' transport not yet wired (#7343)",
-            is_error=True,
-        )
+        entry = self._registry.get(name)
+
+        audit_details: dict[str, Any] = {
+            "tool": name,
+            "has_entry": entry is not None,
+            "server_id": entry.server_id if entry else None,
+        }
+
+        if entry is None:
+            logger.warning("realtime_mcp_bridge.call_tool unknown tool=%s", name)
+            await _audit_log(
+                "voice.realtime.tool_call",
+                result="failed",
+                user_id=user_id,
+                session_id=session_id,
+                resource=name,
+                details={**audit_details, "error": "unknown_tool"},
+            )
+            return RealtimeToolResult(
+                content=f"Unknown tool '{name}'. No MCP server registered this tool.",
+                is_error=True,
+            )
+
+        try:
+            raw_result = await self._call_via_transport(entry, arguments)
+            content = self._format_result(raw_result)
+            await _audit_log(
+                "voice.realtime.tool_call",
+                result="success",
+                user_id=user_id,
+                session_id=session_id,
+                resource=name,
+                details=audit_details,
+            )
+            return RealtimeToolResult(content=content, is_error=False)
+
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "realtime_mcp_bridge.call_tool error tool=%s (%s): %s",
+                name, type(exc).__name__, exc,
+            )
+            await _audit_log(
+                "voice.realtime.tool_call",
+                result="error",
+                user_id=user_id,
+                session_id=session_id,
+                resource=name,
+                details={**audit_details, "error": str(exc)},
+            )
+            return RealtimeToolResult(content=str(exc), is_error=True)
+
+    # ------------------------------------------------------------------
+    # Discovery internals
+    # ------------------------------------------------------------------
 
     async def _discover_tools(self) -> list[RealtimeTool]:
-        """Enumerate available MCP tools.
+        """Enumerate MCP tools from all configured servers and build the routing registry.
 
-        Stub: full discovery via MCPClient deferred to #7343.
-        Returns the AutoBot MCP server tool list as a baseline.
+        When no external server URIs are configured, falls back to in-process
+        _TOOLS dict from mcp.autobot_server.
         """
-        from mcp.autobot_server import _TOOLS
+        self._registry = {}
 
-        result = []
-        for name, meta in _TOOLS.items():
-            result.append(
-                RealtimeTool(
-                    name=name,
-                    description=meta.get("description", ""),
-                    parameters=meta.get("inputSchema", {}),
+        if not self._server_uris:
+            return self._discover_inprocess()
+
+        # Multi-server: collect per-server tool lists
+        server_tool_lists: list[tuple[str, str, list[Any]]] = []
+        for uri in self._server_uris:
+            sid = _server_id_from_uri(uri)
+            try:
+                MCPClient = _get_mcp_client_class()
+                async with MCPClient(uri) as client:
+                    tools = await client.discover_tools()
+                server_tool_lists.append((sid, uri, tools))
+                logger.info(
+                    "realtime_mcp_bridge discovered server=%s tools=%d", sid, len(tools)
                 )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "realtime_mcp_bridge skipping unreachable server %s: %s", uri, exc
+                )
+
+        return self._build_registry(server_tool_lists)
+
+    def _discover_inprocess(self) -> list[RealtimeTool]:
+        """Discover tools from the in-process AutoBot MCP server dict (zero-dependency baseline)."""
+        from mcp.autobot_server import _TOOLS  # noqa: PLC0415
+
+        result: list[RealtimeTool] = []
+        for name, meta in _TOOLS.items():
+            rt = RealtimeTool(
+                name=name,
+                description=meta.get("description", ""),
+                parameters=_translate_input_schema(meta.get("inputSchema")),
             )
+            result.append(rt)
+            self._registry[name] = _ToolEntry(
+                server_id="autobot",
+                server_uri=None,
+                original_name=name,
+            )
+        logger.info("realtime_mcp_bridge in-process tools=%d", len(result))
         return result
 
+    def _build_registry(
+        self, server_tool_lists: list[tuple[str, str, list[Any]]]
+    ) -> list[RealtimeTool]:
+        """Resolve name collisions and build the routing registry.
 
-async def get_realtime_bridge(is_admin: bool = False) -> RealtimeMCPBridge:
+        A tool name that appears on exactly one server keeps its bare name.
+        A tool name that appears on two or more servers is prefixed as
+        "{server_id}__{original_name}" on every server to ensure determinism.
+        """
+        # Count how many servers expose each original tool name
+        name_count: dict[str, int] = {}
+        for _sid, _uri, tools in server_tool_lists:
+            for tool in tools:
+                name_count[tool.name] = name_count.get(tool.name, 0) + 1
+
+        result: list[RealtimeTool] = []
+        for sid, uri, tools in server_tool_lists:
+            for tool in tools:
+                original_name = tool.name
+                if name_count[original_name] > 1:
+                    public_name = f"{sid}__{original_name}"
+                else:
+                    public_name = original_name
+
+                rt = RealtimeTool(
+                    name=public_name,
+                    description=tool.description,
+                    parameters=_translate_input_schema(
+                        getattr(tool, "input_schema", None)
+                    ),
+                )
+                result.append(rt)
+                self._registry[public_name] = _ToolEntry(
+                    server_id=sid,
+                    server_uri=uri,
+                    original_name=original_name,
+                )
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Transport routing
+    # ------------------------------------------------------------------
+
+    async def _call_via_transport(
+        self, entry: _ToolEntry, arguments: dict[str, Any]
+    ) -> Any:
+        """Invoke the tool via MCPClient transport or in-process handler."""
+        if entry.server_uri is None:
+            return await self._call_inprocess(entry.original_name, arguments)
+
+        MCPClient = _get_mcp_client_class()
+        async with MCPClient(entry.server_uri) as client:
+            return await client.call_tool(entry.original_name, arguments)
+
+    @staticmethod
+    async def _call_inprocess(name: str, arguments: dict[str, Any]) -> Any:
+        """Call a tool via the in-process AutoBotMCPServer handler."""
+        from mcp.autobot_server import AutoBotMCPServer  # noqa: PLC0415
+
+        server = AutoBotMCPServer()
+        if hasattr(server, "handle_tool_call"):
+            return await server.handle_tool_call(name, arguments)
+
+        # Fallback: direct dispatch via _TOOLS handler map
+        from mcp.autobot_server import _TOOLS  # noqa: PLC0415
+
+        if name not in _TOOLS:
+            raise RuntimeError(f"Tool not found: {name}")
+        handler = _TOOLS[name].get("handler")
+        if handler is None:
+            raise RuntimeError(f"Tool '{name}' has no handler")
+        return await handler(arguments)
+
+    @staticmethod
+    def _format_result(raw: Any) -> str:
+        """Serialise a raw MCP result to the string content for Realtime."""
+        if raw is None:
+            return ""
+        if isinstance(raw, str):
+            return raw
+        if isinstance(raw, dict):
+            if "content" in raw:
+                parts = []
+                for item in raw.get("content", []):
+                    if isinstance(item, dict) and "text" in item:
+                        parts.append(item["text"])
+                    else:
+                        parts.append(str(item))
+                return "\n".join(parts) if parts else str(raw)
+        import json  # noqa: PLC0415
+
+        try:
+            return json.dumps(raw)
+        except (TypeError, ValueError):
+            return str(raw)
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+async def get_realtime_bridge(
+    is_admin: bool = False,
+    server_uris: list[str] | None = None,
+) -> RealtimeMCPBridge:
     """Return a configured RealtimeMCPBridge for the current session."""
-    return RealtimeMCPBridge(is_admin=is_admin)
+    return RealtimeMCPBridge(is_admin=is_admin, server_uris=server_uris)

--- a/autobot-backend/services/realtime_mcp_bridge_test.py
+++ b/autobot-backend/services/realtime_mcp_bridge_test.py
@@ -1,0 +1,458 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Pytest suite for RealtimeMCPBridge (Issue #7343).
+
+Covers:
+ 1. Schema translation (object/array/primitive/missing-schema)
+ 2. Name-collision resolution across servers
+ 3. Successful tool call routing
+ 4. Tool call error (MCPError) surfaced as is_error=True
+ 5. Transport-down (connection failure) handled gracefully
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.realtime_mcp_bridge import (
+    RealtimeMCPBridge,
+    RealtimeToolResult,
+    _server_id_from_uri,
+    _translate_input_schema,
+    _translate_property,
+)
+from type_defs.mcp import MCPInputSchema, MCPPropertyDefinition, MCPToolDefinition
+
+
+class MCPError(Exception):
+    """Minimal MCPError stand-in for tests (avoids importing skills package)."""
+
+    def __init__(self, code: int = -1, message: str = "error", data=None):
+        super().__init__(f"MCP error {code}: {message}")
+        self.code = code
+        self.data = data
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tool(name: str, description: str = "A tool", schema: dict | None = None) -> MCPToolDefinition:
+    """Build a minimal MCPToolDefinition for tests."""
+    if schema is None:
+        schema = {
+            "type": "object",
+            "properties": {"q": {"type": "string", "description": "query"}},
+            "required": ["q"],
+        }
+    raw = {"name": name, "description": description, "inputSchema": schema}
+    return MCPToolDefinition.model_validate(raw)
+
+
+def _make_bridge(server_uris: list[str] | None = None, is_admin: bool = False) -> RealtimeMCPBridge:
+    """Return a bridge with optional server URIs and mocked bundle filtering."""
+    bridge = RealtimeMCPBridge(is_admin=is_admin, server_uris=server_uris or [])
+    return bridge
+
+
+# ---------------------------------------------------------------------------
+# 1. Schema translation
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateProperty:
+    """Unit tests for _translate_property."""
+
+    def test_primitive_string(self):
+        result = _translate_property({"type": "string", "description": "A string"})
+        assert result == {"type": "string", "description": "A string"}
+
+    def test_primitive_integer(self):
+        result = _translate_property({"type": "integer", "default": 10})
+        assert result["type"] == "integer"
+        assert result["default"] == 10
+
+    def test_enum(self):
+        result = _translate_property({"type": "string", "enum": ["a", "b"]})
+        assert result["enum"] == ["a", "b"]
+
+    def test_array_with_items(self):
+        prop = {"type": "array", "items": {"type": "string"}}
+        result = _translate_property(prop)
+        assert result["type"] == "array"
+        assert result["items"] == {"type": "string"}
+
+    def test_nested_object(self):
+        prop = {
+            "type": "object",
+            "properties": {
+                "inner": {"type": "integer", "description": "inner field"}
+            },
+            "required": ["inner"],
+        }
+        result = _translate_property(prop)
+        assert result["type"] == "object"
+        assert "inner" in result["properties"]
+        assert result["required"] == ["inner"]
+
+    def test_none_returns_empty(self):
+        assert _translate_property(None) == {}
+
+    def test_pydantic_model(self):
+        prop = MCPPropertyDefinition(type="boolean", description="flag")
+        result = _translate_property(prop)
+        assert result["type"] == "boolean"
+        assert result["description"] == "flag"
+
+
+class TestTranslateInputSchema:
+    """Unit tests for _translate_input_schema."""
+
+    def test_none_returns_fallback(self):
+        result = _translate_input_schema(None)
+        assert result["type"] == "object"
+        assert result["additionalProperties"] is True
+
+    def test_empty_dict_returns_fallback(self):
+        result = _translate_input_schema({})
+        assert result["type"] == "object"
+        assert result["additionalProperties"] is True
+
+    def test_basic_object_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+            "additionalProperties": False,
+        }
+        result = _translate_input_schema(schema)
+        assert result["type"] == "object"
+        assert "name" in result["properties"]
+        assert result["required"] == ["name"]
+        assert result["additionalProperties"] is False
+
+    def test_additionalproperties_defaults_false(self):
+        schema = {
+            "type": "object",
+            "properties": {"x": {"type": "integer"}},
+        }
+        result = _translate_input_schema(schema)
+        assert result["additionalProperties"] is False
+
+    def test_missing_schema_on_tool_falls_back(self):
+        """A tool with no inputSchema gets the fallback parameters dict."""
+        tool_raw = {
+            "name": "no_schema_tool",
+            "description": "no schema",
+            "inputSchema": {},
+        }
+        tool = MCPToolDefinition.model_validate(tool_raw)
+        result = _translate_input_schema(tool.input_schema)
+        # MCPInputSchema with empty properties → default schema with type=object
+        assert result["type"] == "object"
+
+    def test_pydantic_mcp_input_schema(self):
+        schema = MCPInputSchema(
+            properties={"path": MCPPropertyDefinition(type="string", description="file path")},
+            required=["path"],
+        )
+        result = _translate_input_schema(schema)
+        assert result["type"] == "object"
+        assert "path" in result["properties"]
+        assert result["required"] == ["path"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Server-ID helper
+# ---------------------------------------------------------------------------
+
+
+class TestServerIdFromUri:
+    def test_http_uri(self):
+        assert _server_id_from_uri("http://localhost:8200") == "localhost_8200"
+
+    def test_sse_uri(self):
+        assert _server_id_from_uri("sse://mcp.example.com/events") == "mcp_example_com"
+
+    def test_stdio_uri(self):
+        sid = _server_id_from_uri("stdio://npx -y server")
+        assert sid.startswith("npx")
+
+    def test_empty_fallback(self):
+        assert _server_id_from_uri("://") == "mcp"
+
+
+# ---------------------------------------------------------------------------
+# 3. Name-collision resolution
+# ---------------------------------------------------------------------------
+
+
+class TestNameCollisionResolution:
+    """Verify that tools with the same name across servers get prefixed."""
+
+    @pytest.mark.asyncio
+    async def test_no_collision_keeps_bare_name(self):
+        """Single server: tool keeps its original name."""
+        tool = _make_tool("search")
+        bridge = _make_bridge(server_uris=["http://server-a:8200"])
+
+        mock_client = AsyncMock()
+        mock_client.discover_tools = AsyncMock(return_value=[tool])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("services.realtime_mcp_bridge.MCPClient", return_value=mock_client):
+            with patch(
+                "services.realtime_mcp_bridge.filter_tools_for_bundle",
+                side_effect=lambda tools, **_: tools,
+            ):
+                result = await bridge.list_realtime_tools()
+
+        names = [t.name for t in result]
+        assert "search" in names
+        assert all("__" not in n for n in names)
+
+    @pytest.mark.asyncio
+    async def test_collision_prefixes_both(self):
+        """Two servers with the same tool name → both get prefixed."""
+        tool_a = _make_tool("search")
+        tool_b = _make_tool("search")
+
+        uris = ["http://server-a:8200", "http://server-b:8200"]
+        bridge = _make_bridge(server_uris=uris)
+
+        # server-a client
+        client_a = AsyncMock()
+        client_a.discover_tools = AsyncMock(return_value=[tool_a])
+        client_a.__aenter__ = AsyncMock(return_value=client_a)
+        client_a.__aexit__ = AsyncMock(return_value=False)
+
+        # server-b client
+        client_b = AsyncMock()
+        client_b.discover_tools = AsyncMock(return_value=[tool_b])
+        client_b.__aenter__ = AsyncMock(return_value=client_b)
+        client_b.__aexit__ = AsyncMock(return_value=False)
+
+        call_count = [0]
+
+        def _client_factory(uri, **_kwargs):
+            call_count[0] += 1
+            return client_a if "server-a" in uri else client_b
+
+        with patch("services.realtime_mcp_bridge.MCPClient", side_effect=_client_factory):
+            with patch(
+                "services.realtime_mcp_bridge.filter_tools_for_bundle",
+                side_effect=lambda tools, **_: tools,
+            ):
+                result = await bridge.list_realtime_tools()
+
+        names = {t.name for t in result}
+        assert len(result) == 2
+        assert all("__search" in n for n in names)
+
+    @pytest.mark.asyncio
+    async def test_unique_tool_not_prefixed_when_collision_elsewhere(self):
+        """Unique tool on one server is not prefixed even if another tool has a collision."""
+        tool_shared_a = _make_tool("shared")
+        tool_shared_b = _make_tool("shared")
+        tool_unique = _make_tool("unique_only_on_a")
+
+        uris = ["http://server-a:8200", "http://server-b:8200"]
+        bridge = _make_bridge(server_uris=uris)
+
+        client_a = AsyncMock()
+        client_a.discover_tools = AsyncMock(return_value=[tool_shared_a, tool_unique])
+        client_a.__aenter__ = AsyncMock(return_value=client_a)
+        client_a.__aexit__ = AsyncMock(return_value=False)
+
+        client_b = AsyncMock()
+        client_b.discover_tools = AsyncMock(return_value=[tool_shared_b])
+        client_b.__aenter__ = AsyncMock(return_value=client_b)
+        client_b.__aexit__ = AsyncMock(return_value=False)
+
+        def _client_factory(uri, **_kwargs):
+            return client_a if "server-a" in uri else client_b
+
+        with patch("services.realtime_mcp_bridge.MCPClient", side_effect=_client_factory):
+            with patch(
+                "services.realtime_mcp_bridge.filter_tools_for_bundle",
+                side_effect=lambda tools, **_: tools,
+            ):
+                result = await bridge.list_realtime_tools()
+
+        names = {t.name for t in result}
+        assert "unique_only_on_a" in names
+        assert any("shared" in n and "__" in n for n in names)
+
+
+# ---------------------------------------------------------------------------
+# 4. Successful tool call
+# ---------------------------------------------------------------------------
+
+
+class TestCallToolSuccess:
+    @pytest.mark.asyncio
+    async def test_call_external_server_success(self):
+        """call_tool routes through MCPClient and returns content."""
+        bridge = _make_bridge(server_uris=["http://srv:8200"])
+
+        # Pre-populate registry
+        from services.realtime_mcp_bridge import _ToolEntry
+        bridge._registry = {
+            "search": _ToolEntry(server_id="srv_8200", server_uri="http://srv:8200", original_name="search")
+        }
+
+        mock_client = AsyncMock()
+        mock_client.call_tool = AsyncMock(return_value={"content": [{"text": "hello result"}]})
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("services.realtime_mcp_bridge.MCPClient", return_value=mock_client):
+            with patch("services.realtime_mcp_bridge._audit_log", new_callable=AsyncMock):
+                result = await bridge.call_tool("search", {"q": "test"})
+
+        assert result.is_error is False
+        assert "hello result" in result.content
+
+    @pytest.mark.asyncio
+    async def test_call_inprocess_fallback(self):
+        """call_tool with server_uri=None routes in-process."""
+        bridge = _make_bridge()
+
+        from services.realtime_mcp_bridge import _ToolEntry
+        bridge._registry = {
+            "kb.search": _ToolEntry(server_id="autobot", server_uri=None, original_name="kb.search")
+        }
+
+        with patch(
+            "services.realtime_mcp_bridge.RealtimeMCPBridge._call_inprocess",
+            new=AsyncMock(return_value="inprocess result"),
+        ):
+            with patch("services.realtime_mcp_bridge._audit_log", new_callable=AsyncMock):
+                result = await bridge.call_tool("kb.search", {"query": "test"})
+
+        assert result.is_error is False
+        assert "inprocess result" in result.content
+
+
+# ---------------------------------------------------------------------------
+# 5. Tool call error
+# ---------------------------------------------------------------------------
+
+
+class TestCallToolError:
+    @pytest.mark.asyncio
+    async def test_mcp_error_surfaces_as_is_error(self):
+        """MCPError from the server returns is_error=True with the message."""
+        bridge = _make_bridge(server_uris=["http://srv:8200"])
+
+        from services.realtime_mcp_bridge import _ToolEntry
+        bridge._registry = {
+            "broken": _ToolEntry(server_id="srv_8200", server_uri="http://srv:8200", original_name="broken")
+        }
+
+        mock_client = AsyncMock()
+        mock_client.call_tool = AsyncMock(
+            side_effect=MCPError(code=-32000, message="backend exploded")
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("services.realtime_mcp_bridge.MCPClient", return_value=mock_client):
+            with patch("services.realtime_mcp_bridge._audit_log", new_callable=AsyncMock):
+                result = await bridge.call_tool("broken", {})
+
+        assert result.is_error is True
+        assert "backend exploded" in result.content
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_is_error(self):
+        """Calling a tool not in the registry returns is_error=True."""
+        bridge = _make_bridge()
+
+        with patch("services.realtime_mcp_bridge.audit_log", new_callable=AsyncMock):
+            result = await bridge.call_tool("nonexistent", {})
+
+        assert result.is_error is True
+        assert "nonexistent" in result.content
+
+
+# ---------------------------------------------------------------------------
+# 6. Transport down
+# ---------------------------------------------------------------------------
+
+
+class TestTransportDown:
+    @pytest.mark.asyncio
+    async def test_unreachable_server_skipped_gracefully(self):
+        """If a server is down, its tools are omitted and other servers proceed."""
+        tool_b = _make_tool("tool_on_b")
+
+        uris = ["http://dead:9999", "http://alive:8200"]
+        bridge = _make_bridge(server_uris=uris)
+
+        dead_client = AsyncMock()
+        dead_client.__aenter__ = AsyncMock(side_effect=ConnectionRefusedError("no connection"))
+        dead_client.__aexit__ = AsyncMock(return_value=False)
+
+        alive_client = AsyncMock()
+        alive_client.discover_tools = AsyncMock(return_value=[tool_b])
+        alive_client.__aenter__ = AsyncMock(return_value=alive_client)
+        alive_client.__aexit__ = AsyncMock(return_value=False)
+
+        def _client_factory(uri, **_kwargs):
+            return dead_client if "dead" in uri else alive_client
+
+        with patch("services.realtime_mcp_bridge.MCPClient", side_effect=_client_factory):
+            with patch(
+                "services.realtime_mcp_bridge.filter_tools_for_bundle",
+                side_effect=lambda tools, **_: tools,
+            ):
+                result = await bridge.list_realtime_tools()
+
+        names = [t.name for t in result]
+        assert "tool_on_b" in names
+
+    @pytest.mark.asyncio
+    async def test_all_servers_down_returns_empty(self):
+        """If all servers are unreachable, list_realtime_tools returns empty list."""
+        uris = ["http://dead-a:9999", "http://dead-b:9999"]
+        bridge = _make_bridge(server_uris=uris)
+
+        dead_client = AsyncMock()
+        dead_client.__aenter__ = AsyncMock(side_effect=ConnectionRefusedError("no connection"))
+        dead_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("services.realtime_mcp_bridge.MCPClient", return_value=dead_client):
+            with patch(
+                "services.realtime_mcp_bridge.filter_tools_for_bundle",
+                side_effect=lambda tools, **_: tools,
+            ):
+                result = await bridge.list_realtime_tools()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_transport_exception_on_call_returns_is_error(self):
+        """If MCPClient.call_tool raises a generic exception, is_error=True is returned."""
+        bridge = _make_bridge(server_uris=["http://srv:8200"])
+
+        from services.realtime_mcp_bridge import _ToolEntry
+        bridge._registry = {
+            "flaky": _ToolEntry(server_id="srv_8200", server_uri="http://srv:8200", original_name="flaky")
+        }
+
+        mock_client = AsyncMock()
+        mock_client.call_tool = AsyncMock(side_effect=OSError("socket closed"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("services.realtime_mcp_bridge.MCPClient", return_value=mock_client):
+            with patch("services.realtime_mcp_bridge._audit_log", new_callable=AsyncMock):
+                result = await bridge.call_tool("flaky", {})
+
+        assert result.is_error is True
+        assert "socket closed" in result.content

--- a/autobot-backend/services/realtime_mcp_bridge_test.py
+++ b/autobot-backend/services/realtime_mcp_bridge_test.py
@@ -204,10 +204,10 @@ class TestNameCollisionResolution:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.realtime_mcp_bridge.MCPClient", return_value=mock_client):
+        with patch("services.realtime_mcp_bridge._get_mcp_client_class", return_value=lambda uri: mock_client):
             with patch(
-                "services.realtime_mcp_bridge.filter_tools_for_bundle",
-                side_effect=lambda tools, **_: tools,
+                "services.realtime_mcp_bridge._get_filter_tools_for_bundle",
+                return_value=lambda tools, **_: tools,
             ):
                 result = await bridge.list_realtime_tools()
 
@@ -242,10 +242,10 @@ class TestNameCollisionResolution:
             call_count[0] += 1
             return client_a if "server-a" in uri else client_b
 
-        with patch("services.realtime_mcp_bridge.MCPClient", side_effect=_client_factory):
+        with patch("services.realtime_mcp_bridge._get_mcp_client_class", return_value=_client_factory):
             with patch(
-                "services.realtime_mcp_bridge.filter_tools_for_bundle",
-                side_effect=lambda tools, **_: tools,
+                "services.realtime_mcp_bridge._get_filter_tools_for_bundle",
+                return_value=lambda tools, **_: tools,
             ):
                 result = await bridge.list_realtime_tools()
 
@@ -276,10 +276,10 @@ class TestNameCollisionResolution:
         def _client_factory(uri, **_kwargs):
             return client_a if "server-a" in uri else client_b
 
-        with patch("services.realtime_mcp_bridge.MCPClient", side_effect=_client_factory):
+        with patch("services.realtime_mcp_bridge._get_mcp_client_class", return_value=_client_factory):
             with patch(
-                "services.realtime_mcp_bridge.filter_tools_for_bundle",
-                side_effect=lambda tools, **_: tools,
+                "services.realtime_mcp_bridge._get_filter_tools_for_bundle",
+                return_value=lambda tools, **_: tools,
             ):
                 result = await bridge.list_realtime_tools()
 
@@ -310,7 +310,7 @@ class TestCallToolSuccess:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.realtime_mcp_bridge.MCPClient", return_value=mock_client):
+        with patch("services.realtime_mcp_bridge._get_mcp_client_class", return_value=lambda uri: mock_client):
             with patch("services.realtime_mcp_bridge._audit_log", new_callable=AsyncMock):
                 result = await bridge.call_tool("search", {"q": "test"})
 
@@ -361,7 +361,7 @@ class TestCallToolError:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.realtime_mcp_bridge.MCPClient", return_value=mock_client):
+        with patch("services.realtime_mcp_bridge._get_mcp_client_class", return_value=lambda uri: mock_client):
             with patch("services.realtime_mcp_bridge._audit_log", new_callable=AsyncMock):
                 result = await bridge.call_tool("broken", {})
 
@@ -373,7 +373,7 @@ class TestCallToolError:
         """Calling a tool not in the registry returns is_error=True."""
         bridge = _make_bridge()
 
-        with patch("services.realtime_mcp_bridge.audit_log", new_callable=AsyncMock):
+        with patch("services.realtime_mcp_bridge._audit_log", new_callable=AsyncMock):
             result = await bridge.call_tool("nonexistent", {})
 
         assert result.is_error is True
@@ -406,10 +406,10 @@ class TestTransportDown:
         def _client_factory(uri, **_kwargs):
             return dead_client if "dead" in uri else alive_client
 
-        with patch("services.realtime_mcp_bridge.MCPClient", side_effect=_client_factory):
+        with patch("services.realtime_mcp_bridge._get_mcp_client_class", return_value=_client_factory):
             with patch(
-                "services.realtime_mcp_bridge.filter_tools_for_bundle",
-                side_effect=lambda tools, **_: tools,
+                "services.realtime_mcp_bridge._get_filter_tools_for_bundle",
+                return_value=lambda tools, **_: tools,
             ):
                 result = await bridge.list_realtime_tools()
 
@@ -426,10 +426,10 @@ class TestTransportDown:
         dead_client.__aenter__ = AsyncMock(side_effect=ConnectionRefusedError("no connection"))
         dead_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.realtime_mcp_bridge.MCPClient", return_value=dead_client):
+        with patch("services.realtime_mcp_bridge._get_mcp_client_class", return_value=lambda uri: dead_client):
             with patch(
-                "services.realtime_mcp_bridge.filter_tools_for_bundle",
-                side_effect=lambda tools, **_: tools,
+                "services.realtime_mcp_bridge._get_filter_tools_for_bundle",
+                return_value=lambda tools, **_: tools,
             ):
                 result = await bridge.list_realtime_tools()
 
@@ -450,7 +450,7 @@ class TestTransportDown:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("services.realtime_mcp_bridge.MCPClient", return_value=mock_client):
+        with patch("services.realtime_mcp_bridge._get_mcp_client_class", return_value=lambda uri: mock_client):
             with patch("services.realtime_mcp_bridge._audit_log", new_callable=AsyncMock):
                 result = await bridge.call_tool("flaky", {})
 


### PR DESCRIPTION
## Summary

- Adds `RealtimeMCPBridge` in `services/realtime_mcp_bridge.py` — discovers MCP tools from configured servers via `MCPClient`, translates `inputSchema` → Realtime function-tool parameters, applies voice bundle + RBAC filtering
- Adds `GET /api/voice/realtime/tools` and `POST /api/voice/realtime/tools/call` endpoints on a separate `realtime_router` (no blanket admin guard) so non-admin users can list and invoke their permitted tools
- Enforces bundle RBAC in the call endpoint: verifies tool name is in the allowed set before dispatching; raises HTTP 403 if not permitted
- Multi-server name collision resolution: prefixes `{server_id}__{name}` when 2+ servers expose the same tool name
- Full test suite in `services/realtime_mcp_bridge_test.py`

## Code review fixes (blocking items from review comment `2c9a3b09`)

1. **Router guard** — moved Realtime endpoints to `realtime_router` (no `check_admin_permission`); registered in `core_routers.py`
2. **RBAC bypass** — added explicit allowed-set check in `voice_realtime_call_tool` before `bridge.call_tool()`
3. **Broken test patches** — replaced all `patch("...MCPClient")` / `patch("...filter_tools_for_bundle")` with `patch("..._get_mcp_client_class")` / `patch("..._get_filter_tools_for_bundle")`
4. **Wrong mock name** — fixed `audit_log` → `_audit_log` in `test_unknown_tool_returns_is_error`
5. **`_format_result` empty content** — returns `""` instead of Python dict repr
6. **`user_id` falsy-zero guard** — uses `is not None` check
7. **Missing `@with_error_handling`** — added to both realtime endpoints

## Test plan

- [ ] `pytest autobot-backend/services/realtime_mcp_bridge_test.py` — all tests pass without live Redis or MCP servers
- [ ] `GET /api/voice/realtime/tools` — returns tool list for authenticated non-admin user
- [ ] `POST /api/voice/realtime/tools/call` with a permitted tool — proxies and returns result
- [ ] `POST /api/voice/realtime/tools/call` with a forbidden tool — returns HTTP 403
- [ ] Admin user sees full tool set; non-admin sees bundle-filtered subset

🤖 Generated with [Claude Code](https://claude.com/claude-code)