### PR TITLE
fix(design-tokens): BaseBadge BADGE_VARIANTS as const + merge dual watchEffect in BaseButton (MVA-1161)

### DIFF
--- a/autobot-frontend/src/components/base/BaseBadge.vue
+++ b/autobot-frontend/src/components/base/BaseBadge.vue
@@ -23,7 +23,7 @@ import type { BadgeVariant } from '@/types/component-props'
 import { createLogger } from '@/utils/debugUtils'
 
 const BADGE_SIZES = ['xs', 'sm', 'md', 'lg'] as const
-const BADGE_VARIANTS: BadgeVariant[] = ['default', 'primary', 'success', 'warning', 'error', 'info']
+const BADGE_VARIANTS = ['default', 'primary', 'success', 'warning', 'error', 'info'] as const
 
 const logger = createLogger('BaseBadge')
 
@@ -73,7 +73,7 @@ if (import.meta.env.DEV) {
     if (props.size !== undefined && !(BADGE_SIZES as readonly string[]).includes(props.size)) {
       logger.warn(`Invalid "size" prop: "${props.size}". Expected: ${BADGE_SIZES.join(' | ')}`)
     }
-    if (props.variant !== undefined && !BADGE_VARIANTS.includes(props.variant)) {
+    if (props.variant !== undefined && !(BADGE_VARIANTS as readonly string[]).includes(props.variant)) {
       logger.warn(`Invalid "variant" prop: "${props.variant}". Expected: ${BADGE_VARIANTS.join(' | ')}`)
     }
   })

--- a/autobot-frontend/src/components/base/BaseButton.vue
+++ b/autobot-frontend/src/components/base/BaseButton.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted, watchEffect, useSlots, Comment } from 'vue'
+import { computed, ref, watchEffect, useSlots, Comment } from 'vue'
 import type { ButtonVariant, ComponentSize } from '@/types/component-props'
 import { size as SIZE_VALUES } from '@/design-tokens/tokens'
 import { createLogger } from '@/utils/debugUtils'
@@ -67,7 +67,7 @@ const props = withDefaults(defineProps<Props>(), {
 const slots = useSlots()
 
 if (import.meta.env.DEV) {
-  onMounted(() => {
+  watchEffect(() => {
     const hasVisibleText = !!props.label || !!slots.default?.()?.some(
       (vnode: any) => vnode.type !== Comment && vnode.children
     )
@@ -77,9 +77,6 @@ if (import.meta.env.DEV) {
         'This is a WCAG 4.1.2 failure. Add :ariaLabel="$t(\'common.actionName\')" to the button.'
       )
     }
-  })
-
-  watchEffect(() => {
     if (props.size !== undefined && !(SIZE_VALUES as readonly string[]).includes(props.size)) {
       logger.warn(`Invalid "size" prop: "${props.size}". Expected: ${SIZE_VALUES.join(' | ')}`)
     }


### PR DESCRIPTION
## Summary

- `BaseBadge.vue`: `BADGE_VARIANTS` lacked `as const`, inconsistent with the other 8 components in MVA-353. Changed to `as const` and updated the `includes()` guard to cast `(BADGE_VARIANTS as readonly string[])`, matching the existing `BADGE_SIZES` pattern.
- `BaseButton.vue`: had two separate DEV-only blocks — an `onMounted` for a11y checks and a `watchEffect` for size/variant validation. Merged into a single `watchEffect` to reduce watcher overhead in development. Removed now-unused `onMounted` import.

Both changes are DEV-only; no production impact.

## Acceptance Criteria

- ✅ `BADGE_VARIANTS` in `BaseBadge.vue` uses `as const`
- ✅ `BaseButton.vue` merges a11y and prop-validator `watchEffect` blocks into one

## Test plan

- [ ] Storybook: `BaseBadge` renders correctly for all variants
- [ ] Storybook: `BaseButton` renders correctly and DEV console shows no spurious warnings on valid props
- [ ] `npm run type-check` passes (no new TS errors)

Closes MVA-1161