### PR TITLE
feat(design-tokens): Phase 4 ESLint rule — block deprecated size/color tokens in Vue templates (MVA-356)

### DIFF
--- a/autobot-frontend/eslint-tests/README.md
+++ b/autobot-frontend/eslint-tests/README.md
@@ -13,6 +13,8 @@ Expected output:
 
 * `no-hardcoded-vm-ip-deny.test.ts` — **6 errors** (one per `// EXPECT-ERROR` line)
 * `no-hardcoded-vm-ip-allow.test.ts` — **0 errors**
+* `no-deprecated-design-tokens-deny.test.vue` — **8 errors** (one per `<!-- EXPECT-ERROR -->` line)
+* `no-deprecated-design-tokens-allow.test.vue` — **0 errors**
 
 ## When to add fixtures here
 
@@ -24,3 +26,4 @@ When introducing a new custom ESLint rule, add a deny + allow fixture pair so fu
 ## Issue references
 
 * `no-restricted-syntax`: hardcoded VM-IP rule — `#6784`
+* `vue/no-restricted-static-attribute` + `vue/no-restricted-syntax`: deprecated design tokens — MVA-192

--- a/autobot-frontend/eslint-tests/no-deprecated-design-tokens-allow.test.vue
+++ b/autobot-frontend/eslint-tests/no-deprecated-design-tokens-allow.test.vue
@@ -1,0 +1,47 @@
+<!--
+  AutoBot - AI-Powered Automation Platform
+  Copyright (c) 2025 mrveiss
+  Author: mrveiss
+
+  ESLint test fixture for the MVA-192 deprecated design-token rules.
+  Every usage below MUST NOT trigger a rule violation.
+
+  To verify locally:
+    cd autobot-frontend
+    npx eslint --no-ignore eslint-tests/no-deprecated-design-tokens-allow.test.vue
+    # Expected: 0 errors
+-->
+
+<!-- eslint-disable vue/no-undef-components -->
+<template>
+  <!-- Canonical size tokens — all OK -->
+  <BaseButton size="sm" />
+  <BaseButton size="md" />
+  <BaseButton size="lg" />
+  <BaseButton size="xs" />
+  <BaseButton size="xl" />
+
+  <!-- Canonical intent/variant tokens — all OK -->
+  <BaseButton variant="error" />
+  <BaseButton variant="warning" />
+  <BaseButton variant="success" />
+  <BaseButton variant="info" />
+
+  <!-- Bound canonical tokens — OK -->
+  <BaseButton :size="'sm'" />
+  <BaseButton :size="'md'" />
+  <BaseButton :variant="'error'" />
+
+  <!-- Dynamic prop from variable — rule can't know the value, so not flagged -->
+  <BaseButton :size="sizeVar" />
+  <BaseButton :variant="computedVariant" />
+
+  <!-- The word "small" in non-prop contexts (interpolation, JS, class) is OK -->
+  <span>{{ 'small text here' }}</span>
+  <div class="small-header">content</div>
+</template>
+
+<script setup lang="ts">
+const sizeVar = 'sm'
+const computedVariant = 'error'
+</script>

--- a/autobot-frontend/eslint-tests/no-deprecated-design-tokens-deny.test.vue
+++ b/autobot-frontend/eslint-tests/no-deprecated-design-tokens-deny.test.vue
@@ -1,0 +1,44 @@
+<!--
+  AutoBot - AI-Powered Automation Platform
+  Copyright (c) 2025 mrveiss
+  Author: mrveiss
+
+  ESLint test fixture for the MVA-192 deprecated design-token rules:
+    vue/no-restricted-static-attribute — catches size="small|medium|large" and variant="danger"
+    vue/no-restricted-syntax            — catches :size="'small'|..." bound string literals
+
+  Every attr tagged // EXPECT-ERROR SHOULD trigger the rule when scanned directly.
+  This file is excluded from the production lint step (see eslint.config.ts ignore list).
+
+  To verify locally:
+    cd autobot-frontend
+    npx eslint --no-ignore eslint-tests/no-deprecated-design-tokens-deny.test.vue
+    # Expected: 8 errors (one per // EXPECT-ERROR line)
+-->
+
+<!-- eslint-disable vue/no-undef-components -->
+<template>
+  <!-- EXPECT-ERROR: static size="small" -->
+  <BaseButton size="small" />
+
+  <!-- EXPECT-ERROR: static size="medium" -->
+  <BaseButton size="medium" />
+
+  <!-- EXPECT-ERROR: static size="large" -->
+  <BaseButton size="large" />
+
+  <!-- EXPECT-ERROR: static variant="danger" -->
+  <BaseButton variant="danger" />
+
+  <!-- EXPECT-ERROR: bound :size="'small'" (string literal in expression) -->
+  <BaseButton :size="'small'" />
+
+  <!-- EXPECT-ERROR: bound :size="'medium'" -->
+  <BaseButton :size="'medium'" />
+
+  <!-- EXPECT-ERROR: bound :size="'large'" -->
+  <BaseButton :size="'large'" />
+
+  <!-- EXPECT-ERROR: bound :variant="'danger'" -->
+  <BaseButton :variant="'danger'" />
+</template>

--- a/autobot-frontend/eslint.config.ts
+++ b/autobot-frontend/eslint.config.ts
@@ -99,6 +99,37 @@ export default defineConfigWithVueTs(
       // Issue #7085: forbid console.* in production code — use createLogger from @/utils/debugUtils instead.
       // eslint-disable-next-line suppression of this rule is also blocked by reportUnusedDisableDirectives.
       'no-console': 'error',
+      // MVA-192 design-token spec — Phase 4: block re-introduction of deprecated size/color tokens.
+      // Use canonical tokens instead: size → sm|md|lg, danger → error.
+      // See src/design-tokens/tokens.ts for the full token registry.
+      'vue/no-restricted-static-attribute': [
+        'error',
+        { key: 'size', value: 'small',  message: "Deprecated size token 'small' — use 'sm' (MVA-192)." },
+        { key: 'size', value: 'medium', message: "Deprecated size token 'medium' — use 'md' (MVA-192)." },
+        { key: 'size', value: 'large',  message: "Deprecated size token 'large' — use 'lg' (MVA-192)." },
+        { key: 'variant', value: 'danger', message: "Deprecated color token 'danger' — use 'error' (MVA-192)." },
+      ],
+      // Catches the same deprecated values passed as bound string literals, e.g. :size="'small'".
+      // Scoped to VExpressionContainer inside VAttribute (template attribute expressions only).
+      'vue/no-restricted-syntax': [
+        'error',
+        {
+          selector: "VAttribute[directive=true] > VExpressionContainer > Literal[value='small']",
+          message: "Deprecated size token 'small' — use 'sm' (MVA-192).",
+        },
+        {
+          selector: "VAttribute[directive=true] > VExpressionContainer > Literal[value='medium']",
+          message: "Deprecated size token 'medium' — use 'md' (MVA-192).",
+        },
+        {
+          selector: "VAttribute[directive=true] > VExpressionContainer > Literal[value='large']",
+          message: "Deprecated size token 'large' — use 'lg' (MVA-192).",
+        },
+        {
+          selector: "VAttribute[directive=true] > VExpressionContainer > Literal[value='danger']",
+          message: "Deprecated color token 'danger' — use 'error' (MVA-192).",
+        },
+      ],
     },
   },
   {

--- a/autobot-frontend/src/components/chat/PresetManagementModal.vue
+++ b/autobot-frontend/src/components/chat/PresetManagementModal.vue
@@ -6,7 +6,7 @@
   <BaseModal
     :model-value="modelValue"
     :title="$t('chat.presets.modalTitle')"
-    size="medium"
+    size="md"
     :scrollable="true"
     @update:model-value="emit('update:modelValue', $event)"
     @close="emit('close')"
@@ -114,7 +114,7 @@
             <Icon name="edit" />
           </BaseButton>
           <BaseButton
-            variant="danger"
+            variant="error"
             size="xs"
             :aria-label="$t('chat.presets.deleteAriaLabel', { name: preset.name })"
             :disabled="isSaving || deletingId === preset.id"
@@ -143,7 +143,7 @@
             {{ $t('chat.presets.cancel') }}
           </BaseButton>
           <BaseButton
-            variant="danger"
+            variant="error"
             size="sm"
             :loading="deletingId === deleteConfirm.id"
             @click="executeDelete(deleteConfirm.id)"


### PR DESCRIPTION
## Summary

- Add `vue/no-restricted-static-attribute` to fail on `size="small|medium|large"` and `variant="danger"` as static Vue template attributes
- Add `vue/no-restricted-syntax` to catch the same deprecated tokens as bound string literals (`:size="'small'"`)
- Fix 3 missed codemod violations in `PresetManagementModal.vue` (`size="medium"→md`, `variant="danger"→error` ×2)
- Add `eslint-tests/` fixture pair: deny (8 errors) + allow (0 errors) for manual rule verification

**Parent spec:** MVA-192 — design system canonical size + semantic color tokens
**Phase 1 codemod prerequisite:** MVA-348 (merged #8680)

## What the rule catches

Static deprecated token — blocked:
`<BaseButton size="small" />` / `<BaseButton variant="danger" />`

Bound string literal — blocked:
`<BaseButton :size="'medium'" />`

Canonical tokens — OK:
`<BaseButton size="sm" />` / `<BaseButton variant="error" />` / `<BaseButton :size="sizeVar" />`

## Verification

Zero violations on `src/` after fix (no `vue/no-restricted-*` hits).
Deny fixture: 8 errors correct. Allow fixture: 0 errors correct.

## Test plan

- [ ] `npx eslint --no-ignore eslint-tests/no-deprecated-design-tokens-deny.test.vue` → 8 errors
- [ ] `npx eslint --no-ignore eslint-tests/no-deprecated-design-tokens-allow.test.vue` → 0 errors
- [ ] `npx eslint src/ --ext .vue` → no `vue/no-restricted-*` violations
- [ ] Manually introduce `size="small"` in any `.vue` file and confirm `npx eslint` catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)