### PR TITLE
feat(voice): cost + duration telemetry for Realtime WebRTC (GH#7421)

### DIFF
--- a/autobot-backend/api/realtime_session.py
+++ b/autobot-backend/api/realtime_session.py
@@ -3,6 +3,7 @@
 # Author: mrveiss
 """
 Backend SDP proxy for OpenAI Realtime WebRTC (GH#7342).
+Cost + duration telemetry wired in (GH#7421).
 
 Accepts a WebRTC SDP offer from the browser, forwards it as multipart to
 OpenAI's Realtime API with the OPENAI_API_KEY injected server-side, and
@@ -12,10 +13,13 @@ returns the SDP answer.  The key never reaches the browser.
 from __future__ import annotations
 
 import os
+import uuid
+from typing import Any
 
 import aiohttp
 from fastapi import APIRouter, Form, HTTPException
 from fastapi.responses import Response
+from pydantic import BaseModel, Field
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import get_config
@@ -25,6 +29,42 @@ router = APIRouter()
 
 _OPENAI_REALTIME_URL = "https://api.openai.com/v1/realtime/sessions"
 _OPENAI_BETA_HEADER = "realtime=v1"
+
+
+# ── Telemetry endpoint models (Issue #7421) ───────────────────────────────────
+
+class SessionEndRequest(BaseModel):
+    reason: str = "normal"
+
+
+class ResponseDoneRequest(BaseModel):
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_input_tokens: int = 0
+    audio_in_s: float = 0.0
+    audio_out_s: float = 0.0
+
+
+class ToolCallRequest(BaseModel):
+    call_id: str
+    name: str
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+class SessionSummary(BaseModel):
+    session_id: str
+    user_id: str | None
+    model: str
+    started_at: str
+    ended_at: str | None
+    duration_s: float
+    audio_in_s: float
+    audio_out_s: float
+    input_tokens: int
+    output_tokens: int
+    tool_calls: int
+    estimated_cost_usd: float
+    disconnect_reason: str
 
 
 def _get_api_key() -> str:
@@ -40,7 +80,7 @@ def _get_model() -> str:
 
 
 @router.post("/session")
-async def create_realtime_session(
+async def create_realtime_session(  # noqa: PLR0912
     sdp: str = Form(..., media_type="text/plain"),
     session: str = Form(..., media_type="application/json"),
 ) -> Response:
@@ -54,6 +94,9 @@ async def create_realtime_session(
     Returns the SDP answer from OpenAI with Content-Type: application/sdp.
     Maps upstream 401 → 502 and 5xx → 502; missing key → 503.
     """
+    # Issue #7421: generate a session_id for telemetry tracking
+    session_id = str(uuid.uuid4())
+
     api_key = _get_api_key()
     if not api_key:
         logger.error("OPENAI_API_KEY not configured — cannot proxy SDP offer")
@@ -107,7 +150,21 @@ async def create_realtime_session(
                         detail={"success": False, "message": f"Unexpected upstream status: {upstream.status}"},
                     )
 
-                return Response(content=body, media_type="application/sdp")
+                # Issue #7421: start telemetry for this session
+                try:
+                    from services.voice_realtime_telemetry import get_voice_realtime_telemetry
+                    await get_voice_realtime_telemetry().session_start(
+                        session_id=session_id, model=_get_model()
+                    )
+                except Exception as exc:  # telemetry must never break the session
+                    logger.warning("voice_realtime telemetry start failed: %s", exc)
+
+                # Return SDP answer with session_id header so frontend can close telemetry
+                return Response(
+                    content=body,
+                    media_type="application/sdp",
+                    headers={"X-Realtime-Session-Id": session_id},
+                )
 
     except HTTPException:
         raise
@@ -123,3 +180,73 @@ async def create_realtime_session(
             status_code=500,
             detail={"success": False, "message": "Internal error in voice service"},
         )
+
+
+# ── Telemetry endpoints (Issue #7421) ─────────────────────────────────────────
+
+@router.post("/session/{session_id}/end")
+async def end_realtime_session(session_id: str, body: SessionEndRequest) -> dict:
+    """Finalise telemetry for a Realtime session."""
+    from services.voice_realtime_telemetry import DisconnectReason, get_voice_realtime_telemetry
+    try:
+        reason = DisconnectReason(body.reason)
+    except ValueError:
+        reason = DisconnectReason.NORMAL
+    await get_voice_realtime_telemetry().session_end(session_id=session_id, reason=reason)
+    return {"status": "ok", "session_id": session_id}
+
+
+@router.post("/session/{session_id}/response_done")
+async def ingest_response_done(session_id: str, body: ResponseDoneRequest) -> dict:
+    """Ingest a response.done payload and enforce soft-caps."""
+    from services.voice_realtime_telemetry import CapBreachError, get_voice_realtime_telemetry
+    telemetry = get_voice_realtime_telemetry()
+    await telemetry.record_response_done(
+        session_id=session_id,
+        input_tokens=body.input_tokens,
+        output_tokens=body.output_tokens,
+        cached_input_tokens=body.cached_input_tokens,
+        audio_in_s=body.audio_in_s,
+        audio_out_s=body.audio_out_s,
+    )
+    try:
+        await telemetry.check_caps(session_id)
+    except CapBreachError as exc:
+        await telemetry.session_end(session_id=session_id, reason=exc.reason)
+        return {"status": "cap_breach", "reason": exc.reason.value, "message": str(exc)}
+    return {"status": "ok"}
+
+
+@router.post("/tools/call")
+async def call_realtime_tool(body: ToolCallRequest) -> dict:
+    """Route a Realtime tool call through the MCP bridge (#7343 stub)."""
+    from services.realtime_mcp_bridge import get_realtime_bridge
+    bridge = await get_realtime_bridge()
+    result = await bridge.call_tool(name=body.name, arguments=body.arguments)
+    return {"call_id": body.call_id, "content": result.content, "is_error": result.is_error}
+
+
+@router.get("/sessions", response_model=list[SessionSummary])
+async def list_realtime_sessions(user_id: str | None = None, limit: int = 20) -> list[SessionSummary]:
+    """Return recent Realtime sessions for the UsageView (#7421)."""
+    from services.voice_realtime_telemetry import get_voice_realtime_telemetry
+    telemetry = get_voice_realtime_telemetry()
+    records = await telemetry.list_recent_sessions(user_id=user_id, limit=limit)
+    return [
+        SessionSummary(
+            session_id=r.session_id,
+            user_id=r.user_id,
+            model=r.model,
+            started_at=r.started_at,
+            ended_at=r.ended_at,
+            duration_s=r.duration_s,
+            audio_in_s=r.audio_in_s,
+            audio_out_s=r.audio_out_s,
+            input_tokens=r.input_tokens,
+            output_tokens=r.output_tokens,
+            tool_calls=r.tool_calls,
+            estimated_cost_usd=r.estimated_cost_usd,
+            disconnect_reason=r.disconnect_reason,
+        )
+        for r in records
+    ]

--- a/autobot-backend/api/realtime_session.py
+++ b/autobot-backend/api/realtime_session.py
@@ -49,6 +49,7 @@ class ToolCallRequest(BaseModel):
     call_id: str
     name: str
     arguments: dict[str, Any] = Field(default_factory=dict)
+    session_id: str | None = None
 
 
 class SessionSummary(BaseModel):
@@ -222,7 +223,7 @@ async def call_realtime_tool(body: ToolCallRequest) -> dict:
     """Route a Realtime tool call through the MCP bridge (#7343 stub)."""
     from services.realtime_mcp_bridge import get_realtime_bridge
     bridge = await get_realtime_bridge()
-    result = await bridge.call_tool(name=body.name, arguments=body.arguments)
+    result = await bridge.call_tool(name=body.name, arguments=body.arguments, session_id=body.session_id)
     return {"call_id": body.call_id, "content": result.content, "is_error": result.is_error}
 
 

--- a/autobot-backend/services/realtime_mcp_bridge.py
+++ b/autobot-backend/services/realtime_mcp_bridge.py
@@ -80,17 +80,48 @@ class RealtimeMCPBridge:
         )
         return filtered
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> RealtimeToolResult:
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        session_id: str | None = None,
+    ) -> RealtimeToolResult:
         """Route a Realtime tool call back through MCPClient.
 
+        Emits per-tool Prometheus metrics (Issue #7421).
         Full transport wiring deferred to #7343.
         """
+        import time
+
+        start = time.monotonic()
         # Stub: full wiring in #7343
         logger.warning("realtime_mcp_bridge.call_tool not yet wired: tool=%s", name)
-        return RealtimeToolResult(
+        result = RealtimeToolResult(
             content=f"Tool '{name}' transport not yet wired (#7343)",
             is_error=True,
         )
+        latency_s = time.monotonic() - start
+
+        # Issue #7421: emit per-tool metrics
+        try:
+            from autobot_shared.monitoring.prometheus_metrics import PrometheusMetricsManager
+            m = PrometheusMetricsManager()
+            outcome = "error" if result.is_error else "success"
+            m._voice_realtime.tool_calls_total.labels(tool=name, outcome=outcome).inc()
+            m._voice_realtime.tool_call_duration.labels(tool=name).observe(latency_s)
+
+            if session_id:
+                from services.voice_realtime_telemetry import get_voice_realtime_telemetry
+                await get_voice_realtime_telemetry().record_tool_call(
+                    session_id=session_id,
+                    tool=name,
+                    latency_s=latency_s,
+                    outcome=outcome,
+                )
+        except Exception as exc:  # metrics must never break the tool call path
+            logger.debug("voice_realtime metrics emit failed: %s", exc)
+
+        return result
 
     async def _discover_tools(self) -> list[RealtimeTool]:
         """Enumerate available MCP tools.

--- a/autobot-backend/services/realtime_mcp_bridge.py
+++ b/autobot-backend/services/realtime_mcp_bridge.py
@@ -102,15 +102,10 @@ class RealtimeMCPBridge:
         )
         latency_s = time.monotonic() - start
 
-        # Issue #7421: emit per-tool metrics
-        try:
-            from autobot_shared.monitoring.prometheus_metrics import PrometheusMetricsManager
-            m = PrometheusMetricsManager()
-            outcome = "error" if result.is_error else "success"
-            m._voice_realtime.tool_calls_total.labels(tool=name, outcome=outcome).inc()
-            m._voice_realtime.tool_call_duration.labels(tool=name).observe(latency_s)
-
-            if session_id:
+        # Issue #7421: emit per-tool metrics; record_tool_call handles Prometheus + Redis
+        outcome = "error" if result.is_error else "success"
+        if session_id:
+            try:
                 from services.voice_realtime_telemetry import get_voice_realtime_telemetry
                 await get_voice_realtime_telemetry().record_tool_call(
                     session_id=session_id,
@@ -118,8 +113,8 @@ class RealtimeMCPBridge:
                     latency_s=latency_s,
                     outcome=outcome,
                 )
-        except Exception as exc:  # metrics must never break the tool call path
-            logger.debug("voice_realtime metrics emit failed: %s", exc)
+            except Exception as exc:  # metrics must never break the tool call path
+                logger.debug("voice_realtime metrics emit failed: %s", exc)
 
         return result
 

--- a/autobot-backend/services/voice_realtime_telemetry.py
+++ b/autobot-backend/services/voice_realtime_telemetry.py
@@ -1,0 +1,382 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Voice Realtime Telemetry Service
+
+Per-session cost + duration accounting for OpenAI Realtime WebRTC sessions.
+
+Issue #7421 — Implements:
+- Session lifecycle tracking (start/end/duration)
+- Audio seconds accounting (input + output)
+- Token counts from response.done events
+- Tool-call count + per-tool latency
+- Cost estimation (per-second audio + per-token)
+- Soft-cap enforcement with auto-disconnect signal
+- Prometheus metrics via VoiceRealtimeMetricsRecorder
+- Redis persistence (analytics database)
+"""
+
+import json
+import time
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import Any
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
+from autobot_shared.ssot_config import config
+from autobot_shared.time_utils import now_utc
+
+logger = get_logger(__name__)
+
+# ── Realtime audio pricing (USD per second, gpt-4o-realtime-preview) ────────
+# Source: OpenAI pricing page – audio input $0.10/min, output $0.20/min
+# Update alongside PRICING_VERSION in llm_cost_tracker.py when prices change.
+_AUDIO_COST_PER_SEC: dict[str, float] = {
+    "input": 0.10 / 60,   # ~$0.001667/s
+    "output": 0.20 / 60,  # ~$0.003333/s
+}
+
+# Token pricing for gpt-4o-realtime-preview (USD per 1M tokens)
+_TOKEN_COST_PER_1M: dict[str, float] = {
+    "input": 5.00,
+    "output": 20.00,
+    "cached_input": 2.50,
+}
+
+# Redis key prefix + TTL
+_KEY_PREFIX = "voice_realtime_session"
+_SESSION_TTL = 90 * 24 * 3600  # 90 days
+
+
+class DisconnectReason(str, Enum):
+    NORMAL = "normal"
+    DURATION_CAP = "duration_cap"
+    COST_CAP = "cost_cap"
+    ERROR = "error"
+
+
+@dataclass
+class RealtimeSessionRecord:
+    """Persisted record for a single Realtime WebRTC session."""
+
+    session_id: str
+    user_id: str | None
+    model: str
+    started_at: str
+    ended_at: str | None = None
+    duration_s: float = 0.0
+    audio_in_s: float = 0.0
+    audio_out_s: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_input_tokens: int = 0
+    tool_calls: int = 0
+    estimated_cost_usd: float = 0.0
+    disconnect_reason: str = DisconnectReason.NORMAL
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "RealtimeSessionRecord":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+class CapBreachError(Exception):
+    """Raised when a soft-cap is exceeded; callers should close the session."""
+
+    def __init__(self, reason: DisconnectReason, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+class VoiceRealtimeTelemetry(AsyncRedisClientMixin):
+    """Tracks cost + duration telemetry for Realtime WebRTC sessions.
+
+    Typical lifecycle
+    -----------------
+    telemetry = VoiceRealtimeTelemetry()
+    await telemetry.session_start(session_id, user_id, model)
+    # ... session events ...
+    await telemetry.record_response_done(session_id, input_tokens=..., output_tokens=...)
+    await telemetry.record_tool_call(session_id, tool="search", latency_s=0.3)
+    await telemetry.check_caps(session_id)   # raises CapBreachError if over limit
+    await telemetry.session_end(session_id)
+
+    Raises CapBreachError from check_caps(); the caller should close the WebRTC
+    connection and surface the reason to the user.
+    """
+
+    _redis_database = "analytics"
+
+    def __init__(self) -> None:
+        self._model = config.misc.voice_realtime_model
+        self._max_seconds = config.misc.voice_realtime_max_seconds
+        self._max_cost_usd = config.misc.voice_realtime_max_cost_usd
+
+        # Lazy import to avoid circular dependency with prometheus_metrics module
+        from autobot_shared.monitoring.prometheus_metrics import PrometheusMetricsManager
+        self._prom = PrometheusMetricsManager()
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    async def session_start(
+        self,
+        session_id: str,
+        user_id: str | None = None,
+        model: str | None = None,
+    ) -> RealtimeSessionRecord:
+        """Create and persist an in-progress session record."""
+        model = model or self._model
+        record = RealtimeSessionRecord(
+            session_id=session_id,
+            user_id=user_id,
+            model=model,
+            started_at=now_utc().isoformat(),
+        )
+        await self._save_record(record)
+
+        self._prom._voice_realtime.sessions_total.labels(model=model).inc()
+        self._prom._voice_realtime.sessions_active.labels(model=model).inc()
+        logger.info("voice_realtime session_start session_id=%s model=%s", session_id, model)
+        return record
+
+    async def session_end(
+        self,
+        session_id: str,
+        reason: DisconnectReason = DisconnectReason.NORMAL,
+    ) -> RealtimeSessionRecord | None:
+        """Finalise the session record and flush Prometheus counters."""
+        record = await self._load_record(session_id)
+        if record is None:
+            logger.warning("voice_realtime session_end: unknown session_id=%s", session_id)
+            return None
+
+        end_time = now_utc()
+        started = _parse_iso(record.started_at)
+        duration_s = max(0.0, (end_time - started).total_seconds())
+
+        record.ended_at = end_time.isoformat()
+        record.duration_s = duration_s
+        record.disconnect_reason = reason.value if isinstance(reason, DisconnectReason) else reason
+
+        # Accumulate audio cost if not already computed incrementally
+        record.estimated_cost_usd = _estimate_cost(record)
+
+        await self._save_record(record)
+
+        m = self._prom._voice_realtime
+        m.sessions_active.labels(model=record.model).dec()
+        m.session_seconds_total.labels(model=record.model).inc(duration_s)
+        m.session_duration.labels(
+            model=record.model, disconnect_reason=record.disconnect_reason
+        ).observe(duration_s)
+        m.estimated_cost_usd.labels(model=record.model).inc(record.estimated_cost_usd)
+
+        if reason in (DisconnectReason.DURATION_CAP, DisconnectReason.COST_CAP):
+            m.cap_breaches_total.labels(reason=reason.value).inc()
+
+        logger.info(
+            "voice_realtime session_end session_id=%s duration_s=%.1f cost_usd=%.4f reason=%s",
+            session_id, duration_s, record.estimated_cost_usd, reason.value,
+        )
+        return record
+
+    async def record_audio(
+        self,
+        session_id: str,
+        direction: str,
+        seconds: float,
+    ) -> None:
+        """Accumulate audio seconds (direction: 'input' | 'output')."""
+        record = await self._load_record(session_id)
+        if record is None:
+            return
+
+        if direction == "input":
+            record.audio_in_s += seconds
+        else:
+            record.audio_out_s += seconds
+
+        await self._save_record(record)
+        self._prom._voice_realtime.audio_seconds_total.labels(direction=direction).inc(seconds)
+
+    async def record_response_done(
+        self,
+        session_id: str,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cached_input_tokens: int = 0,
+        audio_in_s: float = 0.0,
+        audio_out_s: float = 0.0,
+    ) -> None:
+        """Handle a response.done event — update token counts and audio."""
+        record = await self._load_record(session_id)
+        if record is None:
+            return
+
+        record.input_tokens += input_tokens
+        record.output_tokens += output_tokens
+        record.cached_input_tokens += cached_input_tokens
+        record.audio_in_s += audio_in_s
+        record.audio_out_s += audio_out_s
+
+        await self._save_record(record)
+
+        m = self._prom._voice_realtime
+        if input_tokens:
+            m.tokens_total.labels(type="input").inc(input_tokens)
+        if output_tokens:
+            m.tokens_total.labels(type="output").inc(output_tokens)
+        if cached_input_tokens:
+            m.tokens_total.labels(type="cached_input").inc(cached_input_tokens)
+        if audio_in_s:
+            m.audio_seconds_total.labels(direction="input").inc(audio_in_s)
+        if audio_out_s:
+            m.audio_seconds_total.labels(direction="output").inc(audio_out_s)
+
+    async def record_tool_call(
+        self,
+        session_id: str,
+        tool: str,
+        latency_s: float = 0.0,
+        outcome: str = "success",
+    ) -> None:
+        """Record a single tool-call event."""
+        record = await self._load_record(session_id)
+        if record is not None:
+            record.tool_calls += 1
+            await self._save_record(record)
+
+        m = self._prom._voice_realtime
+        m.tool_calls_total.labels(tool=tool, outcome=outcome).inc()
+        if latency_s > 0:
+            m.tool_call_duration.labels(tool=tool).observe(latency_s)
+
+    async def check_caps(self, session_id: str) -> None:
+        """Check soft-caps and raise CapBreachError if exceeded.
+
+        Callers (e.g. the SDP proxy or heartbeat task) should catch
+        CapBreachError, close the WebRTC session, and surface the reason
+        to the user.
+        """
+        record = await self._load_record(session_id)
+        if record is None:
+            return
+
+        elapsed = _elapsed_seconds(record)
+
+        if elapsed >= self._max_seconds:
+            msg = f"session ended: {self._max_seconds // 60} minute limit reached"
+            raise CapBreachError(DisconnectReason.DURATION_CAP, msg)
+
+        cost = _estimate_cost(record)
+        if cost >= self._max_cost_usd:
+            msg = f"session ended: ${self._max_cost_usd:.2f} cost limit reached"
+            raise CapBreachError(DisconnectReason.COST_CAP, msg)
+
+    async def get_session(self, session_id: str) -> RealtimeSessionRecord | None:
+        """Return the current (or completed) record for a session."""
+        return await self._load_record(session_id)
+
+    async def list_recent_sessions(
+        self,
+        user_id: str | None = None,
+        limit: int = 20,
+    ) -> list[RealtimeSessionRecord]:
+        """Return recent session records, optionally filtered by user."""
+        redis = await self._get_redis()
+        if redis is None:
+            return []
+
+        pattern = f"{_KEY_PREFIX}:*"
+        keys = []
+        async for key in redis.scan_iter(match=pattern, count=100):
+            keys.append(key)
+            if len(keys) >= limit * 5:  # fetch extra for filtering
+                break
+
+        records = []
+        for key in keys:
+            raw = await redis.get(key)
+            if raw is None:
+                continue
+            try:
+                data = json.loads(raw)
+                rec = RealtimeSessionRecord.from_dict(data)
+                if user_id is not None and rec.user_id != user_id:
+                    continue
+                records.append(rec)
+            except Exception:
+                logger.debug("voice_realtime: failed to parse record key=%s", key)
+
+        records.sort(key=lambda r: r.started_at, reverse=True)
+        return records[:limit]
+
+    # ── Private helpers ───────────────────────────────────────────────────────
+
+    async def _save_record(self, record: RealtimeSessionRecord) -> None:
+        redis = await self._get_redis()
+        if redis is None:
+            return
+        key = f"{_KEY_PREFIX}:{record.session_id}"
+        await redis.set(key, json.dumps(record.to_dict()), ex=_SESSION_TTL)
+
+    async def _load_record(self, session_id: str) -> RealtimeSessionRecord | None:
+        redis = await self._get_redis()
+        if redis is None:
+            return None
+        key = f"{_KEY_PREFIX}:{session_id}"
+        raw = await redis.get(key)
+        if raw is None:
+            return None
+        try:
+            return RealtimeSessionRecord.from_dict(json.loads(raw))
+        except Exception as exc:
+            logger.warning("voice_realtime: failed to parse record session_id=%s: %s", session_id, exc)
+            return None
+
+
+# ── Module-level helpers ──────────────────────────────────────────────────────
+
+def _estimate_cost(record: RealtimeSessionRecord) -> float:
+    """Compute estimated USD cost from the session record."""
+    audio_cost = (
+        record.audio_in_s * _AUDIO_COST_PER_SEC["input"]
+        + record.audio_out_s * _AUDIO_COST_PER_SEC["output"]
+    )
+    token_cost = (
+        record.input_tokens * _TOKEN_COST_PER_1M["input"] / 1_000_000
+        + record.output_tokens * _TOKEN_COST_PER_1M["output"] / 1_000_000
+        + record.cached_input_tokens * _TOKEN_COST_PER_1M["cached_input"] / 1_000_000
+    )
+    return audio_cost + token_cost
+
+
+def _elapsed_seconds(record: RealtimeSessionRecord) -> float:
+    if record.ended_at:
+        return record.duration_s
+    started = _parse_iso(record.started_at)
+    return max(0.0, (now_utc() - started).total_seconds())
+
+
+def _parse_iso(iso_str: str):
+    from datetime import datetime, timezone
+    dt = datetime.fromisoformat(iso_str)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+_telemetry_singleton: VoiceRealtimeTelemetry | None = None
+
+
+def get_voice_realtime_telemetry() -> VoiceRealtimeTelemetry:
+    """Return the module-level singleton (lazy init)."""
+    global _telemetry_singleton
+    if _telemetry_singleton is None:
+        _telemetry_singleton = VoiceRealtimeTelemetry()
+    return _telemetry_singleton

--- a/autobot-backend/services/voice_realtime_telemetry.py
+++ b/autobot-backend/services/voice_realtime_telemetry.py
@@ -25,6 +25,7 @@ from typing import Any
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_mixin import AsyncRedisClientMixin
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config
 from autobot_shared.time_utils import now_utc
 
@@ -371,12 +372,4 @@ def _parse_iso(iso_str: str):
     return dt
 
 
-_telemetry_singleton: VoiceRealtimeTelemetry | None = None
-
-
-def get_voice_realtime_telemetry() -> VoiceRealtimeTelemetry:
-    """Return the module-level singleton (lazy init)."""
-    global _telemetry_singleton
-    if _telemetry_singleton is None:
-        _telemetry_singleton = VoiceRealtimeTelemetry()
-    return _telemetry_singleton
+get_voice_realtime_telemetry = lazy_singleton(VoiceRealtimeTelemetry)

--- a/autobot-backend/tests/test_voice_realtime_telemetry.py
+++ b/autobot-backend/tests/test_voice_realtime_telemetry.py
@@ -1,0 +1,333 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Pytest suite for VoiceRealtimeTelemetry.
+
+Issue #7421 — covers:
+- Metric counter increments on session start/end
+- Cost calculation (audio + token rates)
+- Cap-breach disconnect path (duration and cost)
+- Redis persistence shape (keys and field presence)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_record(**kwargs):
+    """Return a RealtimeSessionRecord with sensible defaults."""
+    from services.voice_realtime_telemetry import RealtimeSessionRecord
+
+    defaults: dict[str, Any] = {
+        "session_id": "test-session-1",
+        "user_id": "user-42",
+        "model": "gpt-realtime-2",
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "ended_at": None,
+        "duration_s": 0.0,
+        "audio_in_s": 0.0,
+        "audio_out_s": 0.0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cached_input_tokens": 0,
+        "tool_calls": 0,
+        "estimated_cost_usd": 0.0,
+        "disconnect_reason": "normal",
+        "metadata": {},
+    }
+    defaults.update(kwargs)
+    return RealtimeSessionRecord(**defaults)
+
+
+def _fake_prom():
+    """Return a MagicMock that mimics PrometheusMetricsManager._voice_realtime."""
+    m = MagicMock()
+    # All label calls return mock objects with .inc() / .observe()
+    for attr in (
+        "sessions_total",
+        "sessions_active",
+        "session_seconds_total",
+        "session_duration",
+        "audio_seconds_total",
+        "tokens_total",
+        "tool_calls_total",
+        "tool_call_duration",
+        "estimated_cost_usd",
+        "cap_breaches_total",
+    ):
+        child = MagicMock()
+        child.labels.return_value = child
+        setattr(m, attr, child)
+    return m
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestCostCalculation:
+    """Unit tests for _estimate_cost — pure function, no I/O."""
+
+    def test_audio_only_cost(self):
+        from services.voice_realtime_telemetry import _estimate_cost, _AUDIO_COST_PER_SEC
+
+        rec = _make_record(audio_in_s=60.0, audio_out_s=30.0)
+        expected = 60.0 * _AUDIO_COST_PER_SEC["input"] + 30.0 * _AUDIO_COST_PER_SEC["output"]
+        assert abs(_estimate_cost(rec) - expected) < 1e-9
+
+    def test_token_only_cost(self):
+        from services.voice_realtime_telemetry import _estimate_cost, _TOKEN_COST_PER_1M
+
+        rec = _make_record(input_tokens=1_000_000, output_tokens=500_000, cached_input_tokens=200_000)
+        expected = (
+            1_000_000 * _TOKEN_COST_PER_1M["input"] / 1_000_000
+            + 500_000 * _TOKEN_COST_PER_1M["output"] / 1_000_000
+            + 200_000 * _TOKEN_COST_PER_1M["cached_input"] / 1_000_000
+        )
+        assert abs(_estimate_cost(rec) - expected) < 1e-9
+
+    def test_combined_cost(self):
+        from services.voice_realtime_telemetry import _estimate_cost
+
+        rec = _make_record(
+            audio_in_s=10.0,
+            audio_out_s=20.0,
+            input_tokens=100,
+            output_tokens=200,
+        )
+        cost = _estimate_cost(rec)
+        assert cost > 0.0
+
+    def test_zero_cost_for_empty_record(self):
+        from services.voice_realtime_telemetry import _estimate_cost
+
+        rec = _make_record()
+        assert _estimate_cost(rec) == 0.0
+
+
+class TestRedisShape:
+    """Verify persistence key format and round-trip serialisation."""
+
+    @pytest.mark.asyncio
+    async def test_save_and_load_round_trip(self):
+        from services.voice_realtime_telemetry import VoiceRealtimeTelemetry
+
+        stored: dict[str, str] = {}
+
+        async def fake_set(key, value, ex=None):
+            stored[key] = value
+
+        async def fake_get(key):
+            return stored.get(key)
+
+        fake_redis = AsyncMock()
+        fake_redis.set = fake_set
+        fake_redis.get = fake_get
+
+        telemetry = VoiceRealtimeTelemetry.__new__(VoiceRealtimeTelemetry)
+        telemetry._redis = fake_redis
+        telemetry._model = "gpt-realtime-2"
+        telemetry._max_seconds = 1800
+        telemetry._max_cost_usd = 5.0
+        telemetry._prom = MagicMock()
+        telemetry._prom._voice_realtime = _fake_prom()
+
+        rec = _make_record(session_id="abc-123", user_id="u1")
+        await telemetry._save_record(rec)
+
+        assert "voice_realtime_session:abc-123" in stored
+        loaded = await telemetry._load_record("abc-123")
+        assert loaded is not None
+        assert loaded.session_id == "abc-123"
+        assert loaded.user_id == "u1"
+
+    @pytest.mark.asyncio
+    async def test_load_returns_none_for_missing_key(self):
+        from services.voice_realtime_telemetry import VoiceRealtimeTelemetry
+
+        fake_redis = AsyncMock()
+        fake_redis.get = AsyncMock(return_value=None)
+
+        telemetry = VoiceRealtimeTelemetry.__new__(VoiceRealtimeTelemetry)
+        telemetry._redis = fake_redis
+        telemetry._prom = MagicMock()
+
+        result = await telemetry._load_record("nonexistent")
+        assert result is None
+
+
+class TestMetricIncrements:
+    """Verify Prometheus metric increments on session lifecycle calls."""
+
+    def _make_telemetry(self, fake_redis, prom_mock):
+        from services.voice_realtime_telemetry import VoiceRealtimeTelemetry
+
+        t = VoiceRealtimeTelemetry.__new__(VoiceRealtimeTelemetry)
+        t._redis = fake_redis
+        t._model = "gpt-realtime-2"
+        t._max_seconds = 1800
+        t._max_cost_usd = 5.0
+        t._prom = prom_mock
+        return t
+
+    @pytest.mark.asyncio
+    async def test_session_start_increments_counter(self):
+        stored: dict[str, str] = {}
+        fake_redis = AsyncMock()
+        fake_redis.set = AsyncMock(side_effect=lambda k, v, ex=None: stored.update({k: v}))
+        fake_redis.get = AsyncMock(side_effect=lambda k: stored.get(k))
+
+        prom = MagicMock()
+        vr = _fake_prom()
+        prom._voice_realtime = vr
+
+        t = self._make_telemetry(fake_redis, prom)
+        await t.session_start("s1", user_id="u1")
+
+        vr.sessions_total.labels.assert_called_once_with(model="gpt-realtime-2")
+        vr.sessions_total.inc.assert_called_once()
+        vr.sessions_active.labels.assert_called_once_with(model="gpt-realtime-2")
+        vr.sessions_active.inc.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_session_end_emits_duration_counter(self):
+        from services.voice_realtime_telemetry import DisconnectReason
+
+        record = _make_record(
+            session_id="s2",
+            started_at=(datetime.now(timezone.utc) - timedelta(seconds=90)).isoformat(),
+        )
+        stored = {"voice_realtime_session:s2": json.dumps(record.to_dict())}
+
+        fake_redis = AsyncMock()
+        fake_redis.set = AsyncMock(side_effect=lambda k, v, ex=None: stored.update({k: v}))
+        fake_redis.get = AsyncMock(side_effect=lambda k: stored.get(k))
+
+        prom = MagicMock()
+        vr = _fake_prom()
+        prom._voice_realtime = vr
+
+        t = self._make_telemetry(fake_redis, prom)
+        result = await t.session_end("s2", reason=DisconnectReason.NORMAL)
+
+        assert result is not None
+        assert result.duration_s >= 90.0
+        vr.session_seconds_total.labels.assert_called()
+        vr.session_seconds_total.inc.assert_called()
+        vr.session_duration.labels.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_response_done_increments_tokens(self):
+        record = _make_record(session_id="s3")
+        stored = {"voice_realtime_session:s3": json.dumps(record.to_dict())}
+
+        fake_redis = AsyncMock()
+        fake_redis.set = AsyncMock(side_effect=lambda k, v, ex=None: stored.update({k: v}))
+        fake_redis.get = AsyncMock(side_effect=lambda k: stored.get(k))
+
+        prom = MagicMock()
+        vr = _fake_prom()
+        prom._voice_realtime = vr
+
+        t = self._make_telemetry(fake_redis, prom)
+        await t.record_response_done("s3", input_tokens=500, output_tokens=250)
+
+        vr.tokens_total.labels.assert_any_call(type="input")
+        vr.tokens_total.inc.assert_any_call(500)
+
+        loaded = await t._load_record("s3")
+        assert loaded.input_tokens == 500
+        assert loaded.output_tokens == 250
+
+    @pytest.mark.asyncio
+    async def test_tool_call_increments_counter(self):
+        record = _make_record(session_id="s4")
+        stored = {"voice_realtime_session:s4": json.dumps(record.to_dict())}
+
+        fake_redis = AsyncMock()
+        fake_redis.set = AsyncMock(side_effect=lambda k, v, ex=None: stored.update({k: v}))
+        fake_redis.get = AsyncMock(side_effect=lambda k: stored.get(k))
+
+        prom = MagicMock()
+        vr = _fake_prom()
+        prom._voice_realtime = vr
+
+        t = self._make_telemetry(fake_redis, prom)
+        await t.record_tool_call("s4", tool="search", latency_s=0.3, outcome="success")
+
+        # tool_calls_total incremented in record_tool_call
+        vr.tool_calls_total.labels.assert_called_with(tool="search", outcome="success")
+
+
+class TestCapBreachDisconnect:
+    """Verify CapBreachError is raised on threshold breach."""
+
+    def _make_telemetry_with_record(self, record, max_seconds=1800, max_cost=5.0):
+        from services.voice_realtime_telemetry import VoiceRealtimeTelemetry
+
+        stored = {f"voice_realtime_session:{record.session_id}": json.dumps(record.to_dict())}
+        fake_redis = AsyncMock()
+        fake_redis.get = AsyncMock(side_effect=lambda k: stored.get(k))
+
+        t = VoiceRealtimeTelemetry.__new__(VoiceRealtimeTelemetry)
+        t._redis = fake_redis
+        t._model = "gpt-realtime-2"
+        t._max_seconds = max_seconds
+        t._max_cost_usd = max_cost
+        t._prom = MagicMock()
+        return t
+
+    @pytest.mark.asyncio
+    async def test_duration_cap_raises(self):
+        from services.voice_realtime_telemetry import CapBreachError, DisconnectReason
+
+        record = _make_record(
+            session_id="cap1",
+            started_at=(datetime.now(timezone.utc) - timedelta(seconds=1810)).isoformat(),
+        )
+        t = self._make_telemetry_with_record(record, max_seconds=1800)
+
+        with pytest.raises(CapBreachError) as exc_info:
+            await t.check_caps("cap1")
+
+        assert exc_info.value.reason == DisconnectReason.DURATION_CAP
+        assert "minute limit" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_cost_cap_raises(self):
+        from services.voice_realtime_telemetry import CapBreachError, DisconnectReason
+
+        record = _make_record(
+            session_id="cap2",
+            # 90 min of output audio at $0.004/s ≈ $21.6 — well over $5 cap
+            audio_out_s=5400.0,
+        )
+        t = self._make_telemetry_with_record(record, max_cost=5.0)
+
+        with pytest.raises(CapBreachError) as exc_info:
+            await t.check_caps("cap2")
+
+        assert exc_info.value.reason == DisconnectReason.COST_CAP
+        assert "cost limit" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_no_breach_within_limits(self):
+        from services.voice_realtime_telemetry import CapBreachError
+
+        record = _make_record(
+            session_id="cap3",
+            started_at=(datetime.now(timezone.utc) - timedelta(seconds=60)).isoformat(),
+            audio_out_s=10.0,
+        )
+        t = self._make_telemetry_with_record(record, max_seconds=1800, max_cost=5.0)
+
+        # Should not raise
+        await t.check_caps("cap3")

--- a/autobot-frontend/src/composables/useRealtimeVoice.ts
+++ b/autobot-frontend/src/composables/useRealtimeVoice.ts
@@ -39,18 +39,33 @@ interface OaiToolCall {
 
 const connectionState = ref<RealtimeConnectionState>('disconnected')
 const errorMessage = ref('')
+// Issue #7421: surface disconnect reason from cap-breach events
+const disconnectReason = ref<string | null>(null)
 
 let _peerConnection: RTCPeerConnection | null = null
 let _dataChannel: RTCDataChannel | null = null
 let _localStream: MediaStream | null = null
+// Issue #7421: session_id from backend header — used to finalise telemetry on disconnect
+let _sessionId: string | null = null
 // In-flight tool calls keyed by call_id — aborted on disconnect
 const _pendingToolCalls = new Map<string, AbortController>()
 
 // ─── Helpers ─────────────────────────────────────────────
 
-function _cleanup(): void {
+function _cleanup(reason = 'normal'): void {
   _pendingToolCalls.forEach((ctrl) => ctrl.abort())
   _pendingToolCalls.clear()
+
+  // Issue #7421: notify backend to finalise telemetry
+  if (_sessionId) {
+    const sid = _sessionId
+    _sessionId = null
+    void fetchWithAuth(`${getApiBase()}/voice/realtime/session/${sid}/end`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason }),
+    }).catch((e) => logger.debug('telemetry end call failed:', e))
+  }
 
   if (_dataChannel) {
     _dataChannel.close()
@@ -183,6 +198,34 @@ function _handleDataChannelMessage(raw: string): void {
       })
       break
     }
+    // Issue #7421: forward response.done usage to backend telemetry
+    case 'response.done': {
+      if (_sessionId) {
+        const usage = (event as { response?: { usage?: Record<string, number> } }).response?.usage
+        if (usage) {
+          void fetchWithAuth(`${getApiBase()}/voice/realtime/session/${_sessionId}/response_done`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              input_tokens: usage.input_tokens ?? 0,
+              output_tokens: usage.output_tokens ?? 0,
+              cached_input_tokens: usage.input_token_details?.cached_tokens ?? 0,
+            }),
+          }).then(async (res) => {
+            if (res.ok) {
+              const data = await res.json() as { status?: string; reason?: string; message?: string }
+              if (data.status === 'cap_breach') {
+                // Backend has ended the session — surface reason to user
+                disconnectReason.value = data.message ?? 'Session limit reached'
+                _cleanup(data.reason ?? 'cap_breach')
+                connectionState.value = 'disconnected'
+              }
+            }
+          }).catch((e) => logger.debug('response_done telemetry failed:', e))
+        }
+      }
+      break
+    }
     case 'error':
       logger.error('oai-events error:', event)
       errorMessage.value = String((event as { message?: string }).message ?? 'Realtime error')
@@ -260,12 +303,15 @@ export function useRealtimeVoice() {
         throw new Error(`SDP proxy returned ${sessionRes.status}`)
       }
 
+      // Issue #7421: capture session_id for telemetry
+      _sessionId = sessionRes.headers.get('X-Realtime-Session-Id')
+
       const sessionData = await sessionRes.json() as { sdp: string }
       await _peerConnection.setRemoteDescription(
         new RTCSessionDescription({ type: 'answer', sdp: sessionData.sdp }),
       )
 
-      logger.debug('WebRTC Realtime connection established')
+      logger.debug('WebRTC Realtime connection established session_id=%s', _sessionId)
     } catch (e) {
       const err = e instanceof Error ? e : new Error(String(e))
       logger.error('Realtime connect failed:', err)
@@ -275,16 +321,18 @@ export function useRealtimeVoice() {
     }
   }
 
-  function disconnect(): void {
-    _cleanup()
+  function disconnect(reason = 'normal'): void {
+    _cleanup(reason)
     connectionState.value = 'disconnected'
     errorMessage.value = ''
-    logger.debug('Realtime voice disconnected')
+    logger.debug('Realtime voice disconnected reason=%s', reason)
   }
 
   return {
     connectionState,
     errorMessage,
+    // Issue #7421: expose disconnect reason (cap breach message) to UI
+    disconnectReason,
     connect,
     disconnect,
   }

--- a/autobot-frontend/src/views/UsageView.vue
+++ b/autobot-frontend/src/views/UsageView.vue
@@ -41,6 +41,13 @@
         My Usage
       </button>
       <button
+        class="tab-btn"
+        :class="{ active: activeTab === 'realtime' }"
+        @click="activeTab = 'realtime'; loadRealtimeSessions()"
+      >
+        Realtime Sessions
+      </button>
+      <button
         v-if="isAdmin"
         class="tab-btn"
         :class="{ active: activeTab === 'admin' }"
@@ -108,6 +115,69 @@
         </div>
       </template>
       <div v-else class="empty-row">No personal usage data available.</div>
+    </template>
+
+    <!-- Realtime Sessions Tab (Issue #7421) -->
+    <template v-if="activeTab === 'realtime'">
+      <div v-if="realtimeLoading" class="loading-row">
+        <Icon name="sync-alt" :spin="true" /> Loading Realtime sessions...
+      </div>
+      <template v-else>
+        <div class="summary-grid">
+          <div class="stat-card">
+            <div class="stat-label">Sessions</div>
+            <div class="stat-value">{{ realtimeSessions.length }}</div>
+            <div class="stat-sub">Last {{ limit }} loaded</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-label">Total Duration</div>
+            <div class="stat-value">{{ fmtSeconds(realtimeTotalDuration) }}</div>
+            <div class="stat-sub">Audio in + out</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-label">Estimated Cost</div>
+            <div class="stat-value">${{ realtimeTotalCost.toFixed(4) }}</div>
+            <div class="stat-sub">Audio + token charges</div>
+          </div>
+        </div>
+
+        <div class="table-section">
+          <h3 class="section-title">Realtime Sessions</h3>
+          <table v-if="realtimeSessions.length" class="usage-table">
+            <thead>
+              <tr>
+                <th>Started</th>
+                <th>Model</th>
+                <th>Duration</th>
+                <th>Audio In</th>
+                <th>Audio Out</th>
+                <th>Tokens In</th>
+                <th>Tokens Out</th>
+                <th>Tool Calls</th>
+                <th>Cost (USD)</th>
+                <th>Ended</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="s in realtimeSessions" :key="s.session_id">
+                <td>{{ fmtDate(s.started_at) }}</td>
+                <td>{{ s.model }}</td>
+                <td>{{ fmtSeconds(s.duration_s) }}</td>
+                <td>{{ fmtSeconds(s.audio_in_s) }}</td>
+                <td>{{ fmtSeconds(s.audio_out_s) }}</td>
+                <td>{{ s.input_tokens.toLocaleString() }}</td>
+                <td>{{ s.output_tokens.toLocaleString() }}</td>
+                <td>{{ s.tool_calls }}</td>
+                <td>${{ s.estimated_cost_usd.toFixed(4) }}</td>
+                <td :class="{ 'text-warning': s.disconnect_reason !== 'normal' }">
+                  {{ s.disconnect_reason }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <div v-else class="empty-row">No Realtime session history found.</div>
+        </div>
+      </template>
     </template>
 
     <!-- Admin Tab -->
@@ -216,7 +286,24 @@ interface RecentRequest {
   cost_usd?: number
 }
 
-const activeTab = ref<'personal' | 'admin'>('personal')
+// Issue #7421: Realtime session record type (mirrors SessionSummary on backend)
+interface RealtimeSession {
+  session_id: string
+  user_id: string | null
+  model: string
+  started_at: string
+  ended_at: string | null
+  duration_s: number
+  audio_in_s: number
+  audio_out_s: number
+  input_tokens: number
+  output_tokens: number
+  tool_calls: number
+  estimated_cost_usd: number
+  disconnect_reason: string
+}
+
+const activeTab = ref<'personal' | 'admin' | 'realtime'>('personal')
 const days = ref(30)
 const loading = ref(false)
 const csvLoading = ref(false)
@@ -225,6 +312,13 @@ const summary = ref<UsageSummary | null>(null)
 const users = ref<UserUsage[]>([])
 const personal = ref<PersonalUsage | null>(null)
 const personalRecent = computed<RecentRequest[]>(() => personal.value?.recent_requests ?? [])
+
+// Issue #7421: Realtime sessions state
+const realtimeSessions = ref<RealtimeSession[]>([])
+const realtimeLoading = ref(false)
+const limit = 20
+const realtimeTotalDuration = computed(() => realtimeSessions.value.reduce((s, r) => s + r.duration_s, 0))
+const realtimeTotalCost = computed(() => realtimeSessions.value.reduce((s, r) => s + r.estimated_cost_usd, 0))
 
 async function load() {
   loading.value = true
@@ -267,6 +361,31 @@ async function downloadCsv() {
   } finally {
     csvLoading.value = false
   }
+}
+
+// Issue #7421: load recent Realtime sessions
+async function loadRealtimeSessions() {
+  realtimeLoading.value = true
+  try {
+    const res = await fetchWithAuth(`${getApiBase()}/voice/realtime/sessions?limit=${limit}`)
+    if (!res.ok) throw new Error(`${res.status}`)
+    realtimeSessions.value = (await res.json()) as RealtimeSession[]
+  } catch (e) {
+    logger.error('Failed to load Realtime sessions:', e)
+  } finally {
+    realtimeLoading.value = false
+  }
+}
+
+function fmtSeconds(s: number): string {
+  if (s < 60) return `${s.toFixed(0)}s`
+  const m = Math.floor(s / 60)
+  const sec = Math.round(s % 60)
+  return `${m}m ${sec}s`
+}
+
+function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleString()
 }
 
 onMounted(load)
@@ -455,5 +574,10 @@ onMounted(load)
   text-align: center;
   color: var(--text-secondary);
   font-size: var(--text-sm);
+}
+
+.text-warning {
+  color: var(--color-warning, #f59e0b);
+  font-weight: var(--font-medium);
 }
 </style>

--- a/autobot_shared/monitoring/metrics/__init__.py
+++ b/autobot_shared/monitoring/metrics/__init__.py
@@ -10,6 +10,7 @@ Extended with PerformanceMetricsRecorder as part of Issue #469.
 Extended with KnowledgeBase, LLMProvider, WebSocket, Redis recorders (Issue #470).
 Extended with FrontendMetricsRecorder for RUM metrics (Issue #476).
 Extended with MCPWorkerMetricsRecorder for worker restart budget tracking (Issue #4109).
+Extended with VoiceRealtimeMetricsRecorder for Realtime WebRTC session metrics (Issue #7421).
 
 Package Structure:
 - base.py: Base recorder class with shared functionality
@@ -52,6 +53,7 @@ from .redis import RedisMetricsRecorder
 from .service_health import ServiceHealthMetricsRecorder
 from .system import SystemMetricsRecorder
 from .task import TaskMetricsRecorder
+from .voice_realtime import VoiceRealtimeMetricsRecorder
 from .websocket import WebSocketMetricsRecorder
 from .workflow import WorkflowMetricsRecorder
 
@@ -77,4 +79,6 @@ __all__ = [
     "InferenceProfilerMetricsRecorder",
     # Issue #4109: MCP worker metrics
     "MCPWorkerMetricsRecorder",
+    # Issue #7421: Voice Realtime WebRTC session metrics
+    "VoiceRealtimeMetricsRecorder",
 ]

--- a/autobot_shared/monitoring/metrics/voice_realtime.py
+++ b/autobot_shared/monitoring/metrics/voice_realtime.py
@@ -1,0 +1,95 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Voice Realtime WebRTC metrics recorder.
+
+Prometheus metrics for OpenAI Realtime API sessions.
+Issue #7421 — cost + duration telemetry for Realtime WebRTC.
+"""
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from .base import BaseMetricsRecorder
+
+
+class VoiceRealtimeMetricsRecorder(BaseMetricsRecorder):
+    """Recorder for OpenAI Realtime WebRTC session metrics."""
+
+    def _init_metrics(self) -> None:
+        self._init_session_metrics()
+        self._init_audio_metrics()
+        self._init_token_metrics()
+        self._init_tool_metrics()
+        self._init_cost_metrics()
+
+    def _init_session_metrics(self) -> None:
+        self.sessions_total = Counter(
+            "autobot_voice_realtime_sessions_total",
+            "Total Realtime WebRTC sessions started",
+            ["model"],
+            registry=self.registry,
+        )
+        self.session_seconds_total = Counter(
+            "autobot_voice_realtime_session_seconds_total",
+            "Cumulative Realtime session wall-clock duration in seconds",
+            ["model"],
+            registry=self.registry,
+        )
+        self.sessions_active = Gauge(
+            "autobot_voice_realtime_sessions_active",
+            "Currently active Realtime WebRTC sessions",
+            ["model"],
+            registry=self.registry,
+        )
+        self.session_duration = Histogram(
+            "autobot_voice_realtime_session_duration_seconds",
+            "Per-session duration in seconds",
+            ["model", "disconnect_reason"],
+            buckets=[10, 30, 60, 300, 600, 1800, 3600],
+            registry=self.registry,
+        )
+
+    def _init_audio_metrics(self) -> None:
+        self.audio_seconds_total = Counter(
+            "autobot_voice_realtime_audio_seconds_total",
+            "Cumulative audio seconds streamed",
+            ["direction"],  # input | output
+            registry=self.registry,
+        )
+
+    def _init_token_metrics(self) -> None:
+        self.tokens_total = Counter(
+            "autobot_voice_realtime_tokens_total",
+            "Cumulative Realtime API tokens consumed",
+            ["type"],  # input | output | cached_input
+            registry=self.registry,
+        )
+
+    def _init_tool_metrics(self) -> None:
+        self.tool_calls_total = Counter(
+            "autobot_voice_realtime_tool_calls_total",
+            "Total tool calls made during Realtime sessions",
+            ["tool", "outcome"],  # outcome: success | error
+            registry=self.registry,
+        )
+        self.tool_call_duration = Histogram(
+            "autobot_voice_realtime_tool_call_duration_seconds",
+            "Realtime tool call round-trip latency",
+            ["tool"],
+            buckets=[0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+            registry=self.registry,
+        )
+
+    def _init_cost_metrics(self) -> None:
+        self.estimated_cost_usd = Counter(
+            "autobot_voice_realtime_estimated_cost_usd_total",
+            "Cumulative estimated USD cost for Realtime sessions",
+            ["model"],
+            registry=self.registry,
+        )
+        self.cap_breaches_total = Counter(
+            "autobot_voice_realtime_cap_breaches_total",
+            "Total sessions auto-disconnected due to cap breach",
+            ["reason"],  # duration | cost
+            registry=self.registry,
+        )

--- a/autobot_shared/monitoring/prometheus_metrics.py
+++ b/autobot_shared/monitoring/prometheus_metrics.py
@@ -30,6 +30,7 @@ from prometheus_client import (
 # Issue #476: Added FrontendMetricsRecorder for RUM metrics
 # Issue #4109: Added MCPWorkerMetricsRecorder for worker restart monitoring
 # Phase 4 (#7590): Added ChatMetricsRecorder for SSOT observability
+# Issue #7421: Added VoiceRealtimeMetricsRecorder for Realtime WebRTC session metrics
 from .metrics import (
     ChatMetricsRecorder,
     ClaudeAPIMetricsRecorder,
@@ -44,6 +45,7 @@ from .metrics import (
     ServiceHealthMetricsRecorder,
     SystemMetricsRecorder,
     TaskMetricsRecorder,
+    VoiceRealtimeMetricsRecorder,
     WebSocketMetricsRecorder,
     WorkflowMetricsRecorder,
 )
@@ -81,6 +83,7 @@ class PrometheusMetricsManager:
     - RedisMetricsRecorder: Redis operation metrics (Issue #470)
     - FrontendMetricsRecorder: Frontend RUM metrics (Issue #476)
     - MCPWorkerMetricsRecorder: MCP worker restart budget metrics (Issue #4109)
+    - VoiceRealtimeMetricsRecorder: Realtime WebRTC session metrics (Issue #7421)
     """
 
     def __init__(self, registry: CollectorRegistry | None = None) -> None:
@@ -117,6 +120,8 @@ class PrometheusMetricsManager:
         self._mcp_worker = MCPWorkerMetricsRecorder(self.registry)
         # Phase 4 (#7590): Initialize chat SSOT observability recorder
         self._chat = ChatMetricsRecorder(self.registry)
+        # Issue #7421: Initialize Voice Realtime WebRTC metrics recorder
+        self._voice_realtime = VoiceRealtimeMetricsRecorder(self.registry)
 
     # =========================================================================
     # Core Infrastructure Metrics Initialization

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1243,6 +1243,16 @@ class MiscConfig(BaseSettings):
     voice_toolset_bundle: str = Field(default="voice_safe", alias="AUTOBOT_VOICE_TOOLSETS")
     voice_disabled_tools: str = Field(default="", alias="AUTOBOT_VOICE_DISABLED_TOOLS")
     voice_realtime_model: str = Field(default="gpt-realtime-2", alias="AUTOBOT_VOICE_REALTIME_MODEL")
+    voice_realtime_max_seconds: int = Field(
+        default=1800,
+        alias="AUTOBOT_VOICE_REALTIME_MAX_SECONDS",
+        description="Soft-cap: auto-disconnect Realtime sessions exceeding this wall-clock seconds. Default 30 min.",
+    )
+    voice_realtime_max_cost_usd: float = Field(
+        default=5.0,
+        alias="AUTOBOT_VOICE_REALTIME_MAX_COST_USD",
+        description="Soft-cap: auto-disconnect Realtime sessions exceeding this estimated USD cost. Default $5.00.",
+    )
     memory_log_threshold_mb: int = Field(default=0, alias="AUTOBOT_MEMORY_LOG_THRESHOLD_MB")
     memory_pool_size: int = Field(default=0, alias="AUTOBOT_MEMORY_POOL_SIZE")
     memory_threshold_mb: int = Field(default=0, alias="AUTOBOT_MEMORY_THRESHOLD_MB")


### PR DESCRIPTION
## Summary

- **New** `autobot-backend/services/voice_realtime_telemetry.py` (~200 LOC): per-session Redis records (90-day TTL), audio seconds + token accounting, cost estimation (gpt-4o-realtime-preview rates), soft-cap enforcement with `CapBreachError`
- **New** `autobot_shared/monitoring/metrics/voice_realtime.py`: `VoiceRealtimeMetricsRecorder` with all 5 required Prometheus metrics (`session_seconds_total`, `audio_seconds_total`, `tokens_total`, `tool_calls_total`, `estimated_cost_usd_total`)
- **Extended** `realtime_session.py` (GH#7342): telemetry start wired to SDP exchange, `X-Realtime-Session-Id` response header, new endpoints `/session/{id}/end`, `/session/{id}/response_done`, GET `/sessions`
- **Extended** `realtime_mcp_bridge.py` (GH#7343): per-tool metrics emitted in `call_tool()` via `record_tool_call()`
- **Extended** `useRealtimeVoice.ts` (GH#7345): session_id captured from response header, `response.done` forwarded to backend, `disconnectReason` ref exposed for cap-breach UI
- **Extended** `UsageView.vue`: Realtime Sessions tab with summary cards (count, total duration, total cost) + per-session table
- **Config** `ssot_config.py`: `AUTOBOT_VOICE_REALTIME_MAX_SECONDS=1800`, `AUTOBOT_VOICE_REALTIME_MAX_COST_USD=5.0`

## Test plan

- [x] 13 pytest tests pass: metric increments, cost calculation, cap-breach disconnect (duration + cost), Redis round-trip shape
- [ ] Integration: `POST /voice/realtime/session` returns `X-Realtime-Session-Id` header
- [ ] Integration: `POST /voice/realtime/session/{id}/response_done` returns `cap_breach` status when over limit
- [ ] Frontend: Realtime Sessions tab loads in UsageView without errors (empty state shows "No Realtime session history found")
- [ ] Prometheus: `GET /metrics` contains `autobot_voice_realtime_*` families after a session

## Code review fixes applied (MVA-1168)

- Removed double-counting in `realtime_mcp_bridge.call_tool()` — metrics now delegated entirely to `record_tool_call()`
- Replaced raw module singleton with `lazy_singleton(VoiceRealtimeTelemetry)` from `singleton_factory`
- Added `session_id` field to `ToolCallRequest` and forwarded to `bridge.call_tool()` for per-session tool accounting

🤖 Generated with [Claude Code](https://claude.com/claude-code)