### PR TITLE
chore(ci): fix pre-existing Black formatting violations in Dev_new_gui (9+ files)

### DIFF
--- a/autobot-backend/api/realtime_session.py
+++ b/autobot-backend/api/realtime_session.py
@@ -33,6 +33,7 @@ _OPENAI_BETA_HEADER = "realtime=v1"
 
 # ── Telemetry endpoint models (Issue #7421) ───────────────────────────────────
 
+
 class SessionEndRequest(BaseModel):
     reason: str = "normal"
 
@@ -154,9 +155,8 @@ async def create_realtime_session(  # noqa: PLR0912
                 # Issue #7421: start telemetry for this session
                 try:
                     from services.voice_realtime_telemetry import get_voice_realtime_telemetry
-                    await get_voice_realtime_telemetry().session_start(
-                        session_id=session_id, model=_get_model()
-                    )
+
+                    await get_voice_realtime_telemetry().session_start(session_id=session_id, model=_get_model())
                 except Exception as exc:  # telemetry must never break the session
                     logger.warning("voice_realtime telemetry start failed: %s", exc)
 
@@ -185,10 +185,12 @@ async def create_realtime_session(  # noqa: PLR0912
 
 # ── Telemetry endpoints (Issue #7421) ─────────────────────────────────────────
 
+
 @router.post("/session/{session_id}/end")
 async def end_realtime_session(session_id: str, body: SessionEndRequest) -> dict:
     """Finalise telemetry for a Realtime session."""
     from services.voice_realtime_telemetry import DisconnectReason, get_voice_realtime_telemetry
+
     try:
         reason = DisconnectReason(body.reason)
     except ValueError:
@@ -201,6 +203,7 @@ async def end_realtime_session(session_id: str, body: SessionEndRequest) -> dict
 async def ingest_response_done(session_id: str, body: ResponseDoneRequest) -> dict:
     """Ingest a response.done payload and enforce soft-caps."""
     from services.voice_realtime_telemetry import CapBreachError, get_voice_realtime_telemetry
+
     telemetry = get_voice_realtime_telemetry()
     await telemetry.record_response_done(
         session_id=session_id,
@@ -222,6 +225,7 @@ async def ingest_response_done(session_id: str, body: ResponseDoneRequest) -> di
 async def call_realtime_tool(body: ToolCallRequest) -> dict:
     """Route a Realtime tool call through the MCP bridge (#7343 stub)."""
     from services.realtime_mcp_bridge import get_realtime_bridge
+
     bridge = await get_realtime_bridge()
     result = await bridge.call_tool(name=body.name, arguments=body.arguments, session_id=body.session_id)
     return {"call_id": body.call_id, "content": result.content, "is_error": result.is_error}
@@ -231,6 +235,7 @@ async def call_realtime_tool(body: ToolCallRequest) -> dict:
 async def list_realtime_sessions(user_id: str | None = None, limit: int = 20) -> list[SessionSummary]:
     """Return recent Realtime sessions for the UsageView (#7421)."""
     from services.voice_realtime_telemetry import get_voice_realtime_telemetry
+
     telemetry = get_voice_realtime_telemetry()
     records = await telemetry.list_recent_sessions(user_id=user_id, limit=limit)
     return [

--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -145,7 +145,6 @@ celery_app.autodiscover_tasks(["tasks", "workers"])
 # workers register it. autodiscover_tasks only scans the listed packages.
 import services.pricing_refresh  # noqa: F401
 
-
 # =========================================================================
 # Issue #4455: Periodic knowledge-base cleanup schedule
 # =========================================================================

--- a/autobot-backend/llc/services/handoff.py
+++ b/autobot-backend/llc/services/handoff.py
@@ -198,6 +198,7 @@ class HandoffService(LLCServiceBase):
         # Release per-task workspace on handoff approval (MVA-1152)
         try:
             from services.task_workspace import release_for_task
+
             await release_for_task(work_item_id, session)
         except Exception:
             logger.warning("workspace release skipped for task=%s", work_item_id, exc_info=True)

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -682,6 +682,7 @@ class WorkItemService(LLCServiceBase):
         if new_status in {WorkItemStatus.DONE, WorkItemStatus.CANCELLED}:
             try:
                 from services.task_workspace import release_for_task
+
                 await release_for_task(work_item_id, session)
             except Exception:
                 logger.warning(
@@ -770,6 +771,7 @@ class WorkItemService(LLCServiceBase):
         # Release per-task workspace (MVA-1152)
         try:
             from services.task_workspace import release_for_task
+
             await release_for_task(work_item_id, session)
         except Exception:
             logger.warning("workspace release skipped for task=%s", work_item_id, exc_info=True)

--- a/autobot-backend/services/gateway/adapters/matrix_adapter.py
+++ b/autobot-backend/services/gateway/adapters/matrix_adapter.py
@@ -48,9 +48,7 @@ class MatrixAdapter(BaseAdapter):
         metadata["e2ee"] = self._e2ee
         metadata["thread_id"] = relates_to.get("event_id") if relates_to.get("rel_type") == "m.thread" else None
         metadata["reply_to"] = (
-            relates_to.get("m.in_reply_to", {}).get("event_id")
-            if relates_to.get("rel_type") != "m.thread"
-            else None
+            relates_to.get("m.in_reply_to", {}).get("event_id") if relates_to.get("rel_type") != "m.thread" else None
         )
 
         return UnifiedMessage(

--- a/autobot-backend/services/pricing_refresh.py
+++ b/autobot-backend/services/pricing_refresh.py
@@ -31,10 +31,12 @@ logger = get_logger(__name__)
 
 DRIFT_THRESHOLD_PERCENT: float = 10.0
 
+
 # All active pricing sources; add new providers here.
 def _build_sources():
     from llm_shared.pricing.anthropic_source import AnthropicPricingSource
     from llm_shared.pricing.openai_source import OpenAIPricingSource
+
     return [AnthropicPricingSource(), OpenAIPricingSource()]
 
 

--- a/autobot-backend/services/pricing_refresh_test.py
+++ b/autobot-backend/services/pricing_refresh_test.py
@@ -13,7 +13,6 @@ import pytest
 
 from llm_shared.pricing.sources import ModelPricing
 
-
 # ---------------------------------------------------------------------------
 # ModelPricing round-trip
 # ---------------------------------------------------------------------------
@@ -212,8 +211,18 @@ async def test_cost_tracker_uses_redis_pricing_when_available():
             nonlocal cost
             # intercept at the record-creation step
             record = await tracker._build_and_persist_record(
-                "anthropic", "claude-opus-4-0", 1_000_000, 1_000_000,
-                None, None, None, None, None, True, None, None,
+                "anthropic",
+                "claude-opus-4-0",
+                1_000_000,
+                1_000_000,
+                None,
+                None,
+                None,
+                None,
+                None,
+                True,
+                None,
+                None,
             )
             cost = record.cost_usd
             return True

--- a/autobot-backend/services/realtime_mcp_bridge.py
+++ b/autobot-backend/services/realtime_mcp_bridge.py
@@ -39,19 +39,23 @@ logger = get_logger(__name__)
 def _get_mcp_client_class():
     """Lazy import MCPClient to avoid pulling in the skills package init at module load."""
     from skills.sync.mcp_client import MCPClient  # noqa: PLC0415
+
     return MCPClient
 
 
 def _get_filter_tools_for_bundle():
     """Lazy import to avoid circular import at module init time."""
     from api.redis_mcp.rbac import filter_tools_for_bundle  # noqa: PLC0415
+
     return filter_tools_for_bundle
 
 
 async def _audit_log(*args, **kwargs):
     """Lazy-import audit_log to avoid pulling in Redis at module init time."""
     from services.audit_logger import audit_log  # noqa: PLC0415
+
     return await audit_log(*args, **kwargs)
+
 
 # ---------------------------------------------------------------------------
 # Realtime schema types
@@ -79,6 +83,7 @@ class RealtimeToolResult:
 # ---------------------------------------------------------------------------
 # Internal routing registry entry
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class _ToolEntry:
@@ -321,8 +326,12 @@ class RealtimeMCPBridge:
             if session_id:
                 try:
                     from services.voice_realtime_telemetry import get_voice_realtime_telemetry
+
                     await get_voice_realtime_telemetry().record_tool_call(
-                        session_id=session_id, tool=name, latency_s=latency_s, outcome="success",
+                        session_id=session_id,
+                        tool=name,
+                        latency_s=latency_s,
+                        outcome="success",
                     )
                 except Exception as _te:
                     logger.debug("voice_realtime telemetry emit failed: %s", _te)
@@ -332,7 +341,9 @@ class RealtimeMCPBridge:
             latency_s = time.monotonic() - start
             logger.warning(
                 "realtime_mcp_bridge.call_tool error tool=%s (%s): %s",
-                name, type(exc).__name__, exc,
+                name,
+                type(exc).__name__,
+                exc,
             )
             await _audit_log(
                 "voice.realtime.tool_call",
@@ -345,8 +356,12 @@ class RealtimeMCPBridge:
             if session_id:
                 try:
                     from services.voice_realtime_telemetry import get_voice_realtime_telemetry
+
                     await get_voice_realtime_telemetry().record_tool_call(
-                        session_id=session_id, tool=name, latency_s=latency_s, outcome="error",
+                        session_id=session_id,
+                        tool=name,
+                        latency_s=latency_s,
+                        outcome="error",
                     )
                 except Exception as _te:
                     logger.debug("voice_realtime telemetry emit failed: %s", _te)
@@ -376,13 +391,9 @@ class RealtimeMCPBridge:
                 async with MCPClient(uri) as client:
                     tools = await client.discover_tools()
                 server_tool_lists.append((sid, uri, tools))
-                logger.info(
-                    "realtime_mcp_bridge discovered server=%s tools=%d", sid, len(tools)
-                )
+                logger.info("realtime_mcp_bridge discovered server=%s tools=%d", sid, len(tools))
             except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "realtime_mcp_bridge skipping unreachable server %s: %s", uri, exc
-                )
+                logger.warning("realtime_mcp_bridge skipping unreachable server %s: %s", uri, exc)
 
         return self._build_registry(server_tool_lists)
 
@@ -406,9 +417,7 @@ class RealtimeMCPBridge:
         logger.info("realtime_mcp_bridge in-process tools=%d", len(result))
         return result
 
-    def _build_registry(
-        self, server_tool_lists: list[tuple[str, str, list[Any]]]
-    ) -> list[RealtimeTool]:
+    def _build_registry(self, server_tool_lists: list[tuple[str, str, list[Any]]]) -> list[RealtimeTool]:
         """Resolve name collisions and build the routing registry.
 
         A tool name that appears on exactly one server keeps its bare name.
@@ -433,9 +442,7 @@ class RealtimeMCPBridge:
                 rt = RealtimeTool(
                     name=public_name,
                     description=tool.description,
-                    parameters=_translate_input_schema(
-                        getattr(tool, "input_schema", None)
-                    ),
+                    parameters=_translate_input_schema(getattr(tool, "input_schema", None)),
                 )
                 result.append(rt)
                 self._registry[public_name] = _ToolEntry(
@@ -450,9 +457,7 @@ class RealtimeMCPBridge:
     # Transport routing
     # ------------------------------------------------------------------
 
-    async def _call_via_transport(
-        self, entry: _ToolEntry, arguments: dict[str, Any]
-    ) -> Any:
+    async def _call_via_transport(self, entry: _ToolEntry, arguments: dict[str, Any]) -> Any:
         """Invoke the tool via MCPClient transport or in-process handler."""
         if entry.server_uri is None:
             return await self._call_inprocess(entry.original_name, arguments)

--- a/autobot-backend/services/realtime_mcp_bridge_test.py
+++ b/autobot-backend/services/realtime_mcp_bridge_test.py
@@ -40,6 +40,7 @@ class MCPError(Exception):
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_tool(name: str, description: str = "A tool", schema: dict | None = None) -> MCPToolDefinition:
     """Build a minimal MCPToolDefinition for tests."""
     if schema is None:
@@ -88,9 +89,7 @@ class TestTranslateProperty:
     def test_nested_object(self):
         prop = {
             "type": "object",
-            "properties": {
-                "inner": {"type": "integer", "description": "inner field"}
-            },
+            "properties": {"inner": {"type": "integer", "description": "inner field"}},
             "required": ["inner"],
         }
         result = _translate_property(prop)
@@ -301,6 +300,7 @@ class TestCallToolSuccess:
 
         # Pre-populate registry
         from services.realtime_mcp_bridge import _ToolEntry
+
         bridge._registry = {
             "search": _ToolEntry(server_id="srv_8200", server_uri="http://srv:8200", original_name="search")
         }
@@ -323,9 +323,8 @@ class TestCallToolSuccess:
         bridge = _make_bridge()
 
         from services.realtime_mcp_bridge import _ToolEntry
-        bridge._registry = {
-            "kb.search": _ToolEntry(server_id="autobot", server_uri=None, original_name="kb.search")
-        }
+
+        bridge._registry = {"kb.search": _ToolEntry(server_id="autobot", server_uri=None, original_name="kb.search")}
 
         with patch(
             "services.realtime_mcp_bridge.RealtimeMCPBridge._call_inprocess",
@@ -350,14 +349,13 @@ class TestCallToolError:
         bridge = _make_bridge(server_uris=["http://srv:8200"])
 
         from services.realtime_mcp_bridge import _ToolEntry
+
         bridge._registry = {
             "broken": _ToolEntry(server_id="srv_8200", server_uri="http://srv:8200", original_name="broken")
         }
 
         mock_client = AsyncMock()
-        mock_client.call_tool = AsyncMock(
-            side_effect=MCPError(code=-32000, message="backend exploded")
-        )
+        mock_client.call_tool = AsyncMock(side_effect=MCPError(code=-32000, message="backend exploded"))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
@@ -441,6 +439,7 @@ class TestTransportDown:
         bridge = _make_bridge(server_uris=["http://srv:8200"])
 
         from services.realtime_mcp_bridge import _ToolEntry
+
         bridge._registry = {
             "flaky": _ToolEntry(server_id="srv_8200", server_uri="http://srv:8200", original_name="flaky")
         }

--- a/autobot-backend/services/task_workspace.py
+++ b/autobot-backend/services/task_workspace.py
@@ -262,11 +262,7 @@ async def release_for_task(
         from sqlalchemy import select  # local import — avoids heavy dep at module load
         from models.heartbeat import AgentRuntimeState
 
-        result = await session.execute(
-            select(AgentRuntimeState).where(
-                AgentRuntimeState.current_task_id == task_id
-            )
-        )
+        result = await session.execute(select(AgentRuntimeState).where(AgentRuntimeState.current_task_id == task_id))
         state = result.scalar_one_or_none()
         if state is None or state.workspace_dir is None:
             return

--- a/autobot-backend/services/voice_realtime_telemetry.py
+++ b/autobot-backend/services/voice_realtime_telemetry.py
@@ -35,7 +35,7 @@ logger = get_logger(__name__)
 # Source: OpenAI pricing page – audio input $0.10/min, output $0.20/min
 # Update alongside PRICING_VERSION in llm_cost_tracker.py when prices change.
 _AUDIO_COST_PER_SEC: dict[str, float] = {
-    "input": 0.10 / 60,   # ~$0.001667/s
+    "input": 0.10 / 60,  # ~$0.001667/s
     "output": 0.20 / 60,  # ~$0.003333/s
 }
 
@@ -120,6 +120,7 @@ class VoiceRealtimeTelemetry(AsyncRedisClientMixin):
 
         # Lazy import to avoid circular dependency with prometheus_metrics module
         from autobot_shared.monitoring.prometheus_metrics import PrometheusMetricsManager
+
         self._prom = PrometheusMetricsManager()
 
     # ── Public API ────────────────────────────────────────────────────────────
@@ -172,9 +173,7 @@ class VoiceRealtimeTelemetry(AsyncRedisClientMixin):
         m = self._prom._voice_realtime
         m.sessions_active.labels(model=record.model).dec()
         m.session_seconds_total.labels(model=record.model).inc(duration_s)
-        m.session_duration.labels(
-            model=record.model, disconnect_reason=record.disconnect_reason
-        ).observe(duration_s)
+        m.session_duration.labels(model=record.model, disconnect_reason=record.disconnect_reason).observe(duration_s)
         m.estimated_cost_usd.labels(model=record.model).inc(record.estimated_cost_usd)
 
         if reason in (DisconnectReason.DURATION_CAP, DisconnectReason.COST_CAP):
@@ -182,7 +181,10 @@ class VoiceRealtimeTelemetry(AsyncRedisClientMixin):
 
         logger.info(
             "voice_realtime session_end session_id=%s duration_s=%.1f cost_usd=%.4f reason=%s",
-            session_id, duration_s, record.estimated_cost_usd, reason.value,
+            session_id,
+            duration_s,
+            record.estimated_cost_usd,
+            reason.value,
         )
         return record
 
@@ -343,12 +345,10 @@ class VoiceRealtimeTelemetry(AsyncRedisClientMixin):
 
 # ── Module-level helpers ──────────────────────────────────────────────────────
 
+
 def _estimate_cost(record: RealtimeSessionRecord) -> float:
     """Compute estimated USD cost from the session record."""
-    audio_cost = (
-        record.audio_in_s * _AUDIO_COST_PER_SEC["input"]
-        + record.audio_out_s * _AUDIO_COST_PER_SEC["output"]
-    )
+    audio_cost = record.audio_in_s * _AUDIO_COST_PER_SEC["input"] + record.audio_out_s * _AUDIO_COST_PER_SEC["output"]
     token_cost = (
         record.input_tokens * _TOKEN_COST_PER_1M["input"] / 1_000_000
         + record.output_tokens * _TOKEN_COST_PER_1M["output"] / 1_000_000
@@ -366,6 +366,7 @@ def _elapsed_seconds(record: RealtimeSessionRecord) -> float:
 
 def _parse_iso(iso_str: str):
     from datetime import datetime, timezone
+
     dt = datetime.fromisoformat(iso_str)
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)

--- a/autobot-backend/tests/test_gateway_manager.py
+++ b/autobot-backend/tests/test_gateway_manager.py
@@ -458,7 +458,17 @@ class TestGatewayManager:
         """Test getting list of supported platforms."""
         platforms = gateway.get_supported_platforms()
         assert len(platforms) == 9
-        assert set(platforms) == {"web", "slack", "discord", "whatsapp", "teams", "telegram", "signal", "matrix", "imessage"}
+        assert set(platforms) == {
+            "web",
+            "slack",
+            "discord",
+            "whatsapp",
+            "teams",
+            "telegram",
+            "signal",
+            "matrix",
+            "imessage",
+        }
 
 
 class TestRateLimiter:


### PR DESCRIPTION
## Summary

Fixes pre-existing Black formatting violations that have been failing `code-quality` CI on all PRs targeting `Dev_new_gui`. These files were introduced by earlier merges without being formatted.

**Files fixed (12 total):**
- `autobot-backend/api/realtime_session.py`
- `autobot-backend/api/enterprise_features.py`
- `autobot-backend/services/gateway/adapters/matrix_adapter.py`
- `autobot-backend/services/pricing_refresh.py`
- `autobot-backend/services/pricing_refresh_test.py`
- `autobot-backend/services/task_workspace.py`
- `autobot-backend/services/voice_realtime_telemetry.py`
- `autobot-backend/services/realtime_mcp_bridge.py`
- `autobot-backend/services/realtime_mcp_bridge_test.py`
- `autobot-backend/celery_app.py`
- `autobot-backend/llc/services/handoff.py`
- `autobot-backend/llc/services/work_item_service.py`

## Thinking Path

The `code-quality` CI job runs `black --check` on all Python files. Multiple recent merges introduced unformatted files to `Dev_new_gui`, causing ALL PR branches to fail `code-quality` even when their own code is clean. This PR fixes the base branch so downstream PRs get a clean slate after rebasing.

## What Changed

Ran `python3 -m black --line-length=120 autobot-backend/ autobot-slm-backend/ autobot_shared/` on `Dev_new_gui`. No logic changes — formatting only.

## Verification

- `python3 -m black --check --line-length=120 autobot-backend/ autobot-slm-backend/ autobot_shared/` — 0 files would reformat
- No functional code changes

## Model Used

claude-sonnet-4-6

## Test plan

- [ ] `code-quality` CI passes on this PR
- [ ] Other open PRs (`code-quality` fix) after rebasing onto merged commit

Closes MVA-1173