### PR TITLE
fix(security): require admin for task workspace endpoint (GH#8686)

### DIFF
--- a/autobot-backend/api/entity_extraction.py
+++ b/autobot-backend/api/entity_extraction.py
@@ -25,7 +25,6 @@ Endpoints:
 
 from typing import List
 
-from autobot_shared.logging_manager import get_logger
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
@@ -40,6 +39,7 @@ from api.schemas_knowledge import (
 )
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import utc_timestamp
 from utils.request_utils import generate_request_id
 

--- a/autobot-backend/api/pricing_health.py
+++ b/autobot-backend/api/pricing_health.py
@@ -21,8 +21,9 @@ _MAX_STALE_SECONDS = 26 * 60 * 60  # 26 h — 24 h refresh cadence + 2 h grace
 @register_health_probe(KnownProbes.PRICING)
 async def _pricing_health_probe(request: Request | None) -> ComponentHealth:
     try:
-        from llm_shared.pricing.redis_store import PricingRedisStore
         from datetime import datetime, timezone
+
+        from llm_shared.pricing.redis_store import PricingRedisStore
 
         store = PricingRedisStore()
         status = await store.get_refresh_status()

--- a/autobot-backend/api/realtime_session.py
+++ b/autobot-backend/api/realtime_session.py
@@ -33,6 +33,7 @@ _OPENAI_BETA_HEADER = "realtime=v1"
 
 # ── Telemetry endpoint models (Issue #7421) ───────────────────────────────────
 
+
 class SessionEndRequest(BaseModel):
     reason: str = "normal"
 
@@ -154,9 +155,8 @@ async def create_realtime_session(  # noqa: PLR0912
                 # Issue #7421: start telemetry for this session
                 try:
                     from services.voice_realtime_telemetry import get_voice_realtime_telemetry
-                    await get_voice_realtime_telemetry().session_start(
-                        session_id=session_id, model=_get_model()
-                    )
+
+                    await get_voice_realtime_telemetry().session_start(session_id=session_id, model=_get_model())
                 except Exception as exc:  # telemetry must never break the session
                     logger.warning("voice_realtime telemetry start failed: %s", exc)
 
@@ -185,10 +185,12 @@ async def create_realtime_session(  # noqa: PLR0912
 
 # ── Telemetry endpoints (Issue #7421) ─────────────────────────────────────────
 
+
 @router.post("/session/{session_id}/end")
 async def end_realtime_session(session_id: str, body: SessionEndRequest) -> dict:
     """Finalise telemetry for a Realtime session."""
     from services.voice_realtime_telemetry import DisconnectReason, get_voice_realtime_telemetry
+
     try:
         reason = DisconnectReason(body.reason)
     except ValueError:
@@ -201,6 +203,7 @@ async def end_realtime_session(session_id: str, body: SessionEndRequest) -> dict
 async def ingest_response_done(session_id: str, body: ResponseDoneRequest) -> dict:
     """Ingest a response.done payload and enforce soft-caps."""
     from services.voice_realtime_telemetry import CapBreachError, get_voice_realtime_telemetry
+
     telemetry = get_voice_realtime_telemetry()
     await telemetry.record_response_done(
         session_id=session_id,
@@ -222,6 +225,7 @@ async def ingest_response_done(session_id: str, body: ResponseDoneRequest) -> di
 async def call_realtime_tool(body: ToolCallRequest) -> dict:
     """Route a Realtime tool call through the MCP bridge (#7343 stub)."""
     from services.realtime_mcp_bridge import get_realtime_bridge
+
     bridge = await get_realtime_bridge()
     result = await bridge.call_tool(name=body.name, arguments=body.arguments, session_id=body.session_id)
     return {"call_id": body.call_id, "content": result.content, "is_error": result.is_error}
@@ -231,6 +235,7 @@ async def call_realtime_tool(body: ToolCallRequest) -> dict:
 async def list_realtime_sessions(user_id: str | None = None, limit: int = 20) -> list[SessionSummary]:
     """Return recent Realtime sessions for the UsageView (#7421)."""
     from services.voice_realtime_telemetry import get_voice_realtime_telemetry
+
     telemetry = get_voice_realtime_telemetry()
     records = await telemetry.list_recent_sessions(user_id=user_id, limit=limit)
     return [

--- a/autobot-backend/api/task_workspace.py
+++ b/autobot-backend/api/task_workspace.py
@@ -16,7 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.user_management.dependencies import get_db_session
-from auth_middleware import get_current_user
+from auth_middleware import check_admin_permission
 from autobot_shared.logging_manager import get_logger
 from models.heartbeat import AgentRuntimeState
 from services.task_workspace import _SAFE_TASK_ID_RE
@@ -44,13 +44,13 @@ class TaskWorkspaceResponse(BaseModel):
 async def get_task_workspace(
     task_id: str,
     session: AsyncSession = Depends(get_db_session),
-    _user: dict = Depends(get_current_user),
+    _admin: bool = Depends(check_admin_permission),
 ) -> TaskWorkspaceResponse:
     """
     Return the git worktree workspace directory, branch, and preview URL
     for the agent currently running the given task (GH#6471).
 
-    Requires authentication.  Returns 404 when no agent has an active workspace
+    Requires admin role.  Returns 404 when no agent has an active workspace
     for this task.
     """
     if not _SAFE_TASK_ID_RE.match(task_id):

--- a/autobot-backend/api/test_anthropic_compat.py
+++ b/autobot-backend/api/test_anthropic_compat.py
@@ -19,7 +19,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from api.anthropic_compat import router, _map_finish_reason
+from api.anthropic_compat import _map_finish_reason, router
 from auth_middleware import get_current_user
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -145,7 +145,6 @@ celery_app.autodiscover_tasks(["tasks", "workers"])
 # workers register it. autodiscover_tasks only scans the listed packages.
 import services.pricing_refresh  # noqa: F401
 
-
 # =========================================================================
 # Issue #4455: Periodic knowledge-base cleanup schedule
 # =========================================================================

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -9,10 +9,11 @@ basic AutoBot functionality. These routers should always be available
 and are imported at module level to fail fast if missing.
 """
 
+import api.pricing_health  # noqa: F401 — registers KnownProbes.PRICING probe (GH#6480)
+
 # Core router imports - these are required for basic functionality
 from api.adapters import router as adapters_router  # Issue #1403
 from api.admin_event_logs import router as admin_event_logs_router  # Issue #4461
-import api.pricing_health  # noqa: F401 — registers KnownProbes.PRICING probe (GH#6480)
 from api.admin_pricing import router as admin_pricing_router  # GH#6480
 from api.admin_schedulers import router as admin_schedulers_router  # GH#6594
 from api.agent import router as agent_router

--- a/autobot-backend/llc/services/__init__.py
+++ b/autobot-backend/llc/services/__init__.py
@@ -6,10 +6,10 @@ receive a typed ``activity_log`` reference at construction time.
 """
 
 from .activity_log import LLCActivityLogService
+from .agent_budget_tracker import AgentBudgetState, AgentBudgetTracker
 from .approval import ApprovalService
 from .base import LLCServiceBase
 from .board import BoardService
-from .agent_budget_tracker import AgentBudgetState, AgentBudgetTracker
 from .budget import BudgetService
 from .ceo_chat import CeoChatService
 from .goal import GoalService

--- a/autobot-backend/llc/services/handoff.py
+++ b/autobot-backend/llc/services/handoff.py
@@ -198,6 +198,7 @@ class HandoffService(LLCServiceBase):
         # Release per-task workspace on handoff approval (MVA-1152)
         try:
             from services.task_workspace import release_for_task
+
             await release_for_task(work_item_id, session)
         except Exception:
             logger.warning("workspace release skipped for task=%s", work_item_id, exc_info=True)

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -682,6 +682,7 @@ class WorkItemService(LLCServiceBase):
         if new_status in {WorkItemStatus.DONE, WorkItemStatus.CANCELLED}:
             try:
                 from services.task_workspace import release_for_task
+
                 await release_for_task(work_item_id, session)
             except Exception:
                 logger.warning(
@@ -770,6 +771,7 @@ class WorkItemService(LLCServiceBase):
         # Release per-task workspace (MVA-1152)
         try:
             from services.task_workspace import release_for_task
+
             await release_for_task(work_item_id, session)
         except Exception:
             logger.warning("workspace release skipped for task=%s", work_item_id, exc_info=True)

--- a/autobot-backend/llm_shared/pricing/__init__.py
+++ b/autobot-backend/llm_shared/pricing/__init__.py
@@ -3,7 +3,7 @@
 # Author: mrveiss
 """LLM pricing sub-package: abstract sources, Redis store, and refresh logic (GH#6480)."""
 
-from llm_shared.pricing.sources import ModelPricing, PricingSource
 from llm_shared.pricing.redis_store import PricingRedisStore
+from llm_shared.pricing.sources import ModelPricing, PricingSource
 
 __all__ = ["ModelPricing", "PricingSource", "PricingRedisStore"]

--- a/autobot-backend/llm_shared/pricing/anthropic_source.py
+++ b/autobot-backend/llm_shared/pricing/anthropic_source.py
@@ -12,7 +12,6 @@ the hardcoded fallback.
 from __future__ import annotations
 
 from autobot_shared.logging_manager import get_logger
-
 from llm_shared.pricing.sources import ModelPricing, PricingSource
 
 logger = get_logger(__name__)

--- a/autobot-backend/llm_shared/pricing/openai_source.py
+++ b/autobot-backend/llm_shared/pricing/openai_source.py
@@ -11,7 +11,6 @@ accept a future live-fetch implementation without changes to callers.
 from __future__ import annotations
 
 from autobot_shared.logging_manager import get_logger
-
 from llm_shared.pricing.sources import ModelPricing, PricingSource
 
 logger = get_logger(__name__)

--- a/autobot-backend/llm_shared/pricing/redis_store.py
+++ b/autobot-backend/llm_shared/pricing/redis_store.py
@@ -15,7 +15,6 @@ from datetime import datetime, timezone
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
-
 from llm_shared.pricing.sources import ModelPricing
 
 logger = get_logger(__name__)

--- a/autobot-backend/llm_shared/providers/ollama_test.py
+++ b/autobot-backend/llm_shared/providers/ollama_test.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-
 from llm_shared.models import LLMRequest, LLMSettings, ToolCall, ToolDefinition
 from llm_shared.providers.ollama import OllamaProvider, _model_supports_tools
 

--- a/autobot-backend/services/gateway/adapters/matrix_adapter.py
+++ b/autobot-backend/services/gateway/adapters/matrix_adapter.py
@@ -48,9 +48,7 @@ class MatrixAdapter(BaseAdapter):
         metadata["e2ee"] = self._e2ee
         metadata["thread_id"] = relates_to.get("event_id") if relates_to.get("rel_type") == "m.thread" else None
         metadata["reply_to"] = (
-            relates_to.get("m.in_reply_to", {}).get("event_id")
-            if relates_to.get("rel_type") != "m.thread"
-            else None
+            relates_to.get("m.in_reply_to", {}).get("event_id") if relates_to.get("rel_type") != "m.thread" else None
         )
 
         return UnifiedMessage(

--- a/autobot-backend/services/heartbeat_scheduler.py
+++ b/autobot-backend/services/heartbeat_scheduler.py
@@ -32,9 +32,9 @@ from models.heartbeat import (
     HeartbeatRunStatus,
     WakeupTrigger,
 )
+from services import task_workspace
 from services.run_jwt import get_run_jwt_scopes, mint_run_jwt, revoke_run_jwt_async
 from services.task_claim import renew_claim
-from services import task_workspace
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/services/npu_pipeline/invalidation.py
+++ b/autobot-backend/services/npu_pipeline/invalidation.py
@@ -22,8 +22,7 @@ from typing import Any, Dict
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 from events.bus import get_event_bus
-
-from services.npu_pipeline.plan_cache import RedisShardPlanCache, _KEY_PREFIX
+from services.npu_pipeline.plan_cache import _KEY_PREFIX, RedisShardPlanCache
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/services/npu_pipeline/pipeline_dispatcher.py
+++ b/autobot-backend/services/npu_pipeline/pipeline_dispatcher.py
@@ -11,12 +11,11 @@ cross-host, and falls back to single-worker mode when workers drop mid-run.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, AsyncIterator, Dict, List, Optional
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/services/npu_pipeline/plan_cache.py
+++ b/autobot-backend/services/npu_pipeline/plan_cache.py
@@ -16,7 +16,6 @@ from typing import List, Optional
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
-
 from services.npu_pipeline.shard_planner import LayerRange, ShardAssignment
 
 logger = get_logger(__name__)

--- a/autobot-backend/services/npu_pipeline/test_shard_planner.py
+++ b/autobot-backend/services/npu_pipeline/test_shard_planner.py
@@ -4,7 +4,6 @@
 """Unit tests for shard_planner (MVA-1096)."""
 
 import pytest
-
 from shard_planner import (
     InsufficientPoolError,
     LayerRange,

--- a/autobot-backend/services/npu_profile_suggester.py
+++ b/autobot-backend/services/npu_profile_suggester.py
@@ -11,11 +11,10 @@ capabilities_summary so the pair-confirm dialog can pre-fill the profile selecto
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
 from typing import Any, Dict, List
-
-import logging
 
 import yaml
 

--- a/autobot-backend/services/pricing_refresh.py
+++ b/autobot-backend/services/pricing_refresh.py
@@ -31,10 +31,12 @@ logger = get_logger(__name__)
 
 DRIFT_THRESHOLD_PERCENT: float = 10.0
 
+
 # All active pricing sources; add new providers here.
 def _build_sources():
     from llm_shared.pricing.anthropic_source import AnthropicPricingSource
     from llm_shared.pricing.openai_source import OpenAIPricingSource
+
     return [AnthropicPricingSource(), OpenAIPricingSource()]
 
 

--- a/autobot-backend/services/pricing_refresh_test.py
+++ b/autobot-backend/services/pricing_refresh_test.py
@@ -13,7 +13,6 @@ import pytest
 
 from llm_shared.pricing.sources import ModelPricing
 
-
 # ---------------------------------------------------------------------------
 # ModelPricing round-trip
 # ---------------------------------------------------------------------------
@@ -212,8 +211,18 @@ async def test_cost_tracker_uses_redis_pricing_when_available():
             nonlocal cost
             # intercept at the record-creation step
             record = await tracker._build_and_persist_record(
-                "anthropic", "claude-opus-4-0", 1_000_000, 1_000_000,
-                None, None, None, None, None, True, None, None,
+                "anthropic",
+                "claude-opus-4-0",
+                1_000_000,
+                1_000_000,
+                None,
+                None,
+                None,
+                None,
+                None,
+                True,
+                None,
+                None,
             )
             cost = record.cost_usd
             return True

--- a/autobot-backend/services/realtime_mcp_bridge.py
+++ b/autobot-backend/services/realtime_mcp_bridge.py
@@ -39,19 +39,23 @@ logger = get_logger(__name__)
 def _get_mcp_client_class():
     """Lazy import MCPClient to avoid pulling in the skills package init at module load."""
     from skills.sync.mcp_client import MCPClient  # noqa: PLC0415
+
     return MCPClient
 
 
 def _get_filter_tools_for_bundle():
     """Lazy import to avoid circular import at module init time."""
     from api.redis_mcp.rbac import filter_tools_for_bundle  # noqa: PLC0415
+
     return filter_tools_for_bundle
 
 
 async def _audit_log(*args, **kwargs):
     """Lazy-import audit_log to avoid pulling in Redis at module init time."""
     from services.audit_logger import audit_log  # noqa: PLC0415
+
     return await audit_log(*args, **kwargs)
+
 
 # ---------------------------------------------------------------------------
 # Realtime schema types
@@ -79,6 +83,7 @@ class RealtimeToolResult:
 # ---------------------------------------------------------------------------
 # Internal routing registry entry
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class _ToolEntry:
@@ -321,8 +326,12 @@ class RealtimeMCPBridge:
             if session_id:
                 try:
                     from services.voice_realtime_telemetry import get_voice_realtime_telemetry
+
                     await get_voice_realtime_telemetry().record_tool_call(
-                        session_id=session_id, tool=name, latency_s=latency_s, outcome="success",
+                        session_id=session_id,
+                        tool=name,
+                        latency_s=latency_s,
+                        outcome="success",
                     )
                 except Exception as _te:
                     logger.debug("voice_realtime telemetry emit failed: %s", _te)
@@ -332,7 +341,9 @@ class RealtimeMCPBridge:
             latency_s = time.monotonic() - start
             logger.warning(
                 "realtime_mcp_bridge.call_tool error tool=%s (%s): %s",
-                name, type(exc).__name__, exc,
+                name,
+                type(exc).__name__,
+                exc,
             )
             await _audit_log(
                 "voice.realtime.tool_call",
@@ -345,8 +356,12 @@ class RealtimeMCPBridge:
             if session_id:
                 try:
                     from services.voice_realtime_telemetry import get_voice_realtime_telemetry
+
                     await get_voice_realtime_telemetry().record_tool_call(
-                        session_id=session_id, tool=name, latency_s=latency_s, outcome="error",
+                        session_id=session_id,
+                        tool=name,
+                        latency_s=latency_s,
+                        outcome="error",
                     )
                 except Exception as _te:
                     logger.debug("voice_realtime telemetry emit failed: %s", _te)
@@ -376,13 +391,9 @@ class RealtimeMCPBridge:
                 async with MCPClient(uri) as client:
                     tools = await client.discover_tools()
                 server_tool_lists.append((sid, uri, tools))
-                logger.info(
-                    "realtime_mcp_bridge discovered server=%s tools=%d", sid, len(tools)
-                )
+                logger.info("realtime_mcp_bridge discovered server=%s tools=%d", sid, len(tools))
             except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "realtime_mcp_bridge skipping unreachable server %s: %s", uri, exc
-                )
+                logger.warning("realtime_mcp_bridge skipping unreachable server %s: %s", uri, exc)
 
         return self._build_registry(server_tool_lists)
 
@@ -406,9 +417,7 @@ class RealtimeMCPBridge:
         logger.info("realtime_mcp_bridge in-process tools=%d", len(result))
         return result
 
-    def _build_registry(
-        self, server_tool_lists: list[tuple[str, str, list[Any]]]
-    ) -> list[RealtimeTool]:
+    def _build_registry(self, server_tool_lists: list[tuple[str, str, list[Any]]]) -> list[RealtimeTool]:
         """Resolve name collisions and build the routing registry.
 
         A tool name that appears on exactly one server keeps its bare name.
@@ -433,9 +442,7 @@ class RealtimeMCPBridge:
                 rt = RealtimeTool(
                     name=public_name,
                     description=tool.description,
-                    parameters=_translate_input_schema(
-                        getattr(tool, "input_schema", None)
-                    ),
+                    parameters=_translate_input_schema(getattr(tool, "input_schema", None)),
                 )
                 result.append(rt)
                 self._registry[public_name] = _ToolEntry(
@@ -450,9 +457,7 @@ class RealtimeMCPBridge:
     # Transport routing
     # ------------------------------------------------------------------
 
-    async def _call_via_transport(
-        self, entry: _ToolEntry, arguments: dict[str, Any]
-    ) -> Any:
+    async def _call_via_transport(self, entry: _ToolEntry, arguments: dict[str, Any]) -> Any:
         """Invoke the tool via MCPClient transport or in-process handler."""
         if entry.server_uri is None:
             return await self._call_inprocess(entry.original_name, arguments)

--- a/autobot-backend/services/realtime_mcp_bridge_test.py
+++ b/autobot-backend/services/realtime_mcp_bridge_test.py
@@ -40,6 +40,7 @@ class MCPError(Exception):
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_tool(name: str, description: str = "A tool", schema: dict | None = None) -> MCPToolDefinition:
     """Build a minimal MCPToolDefinition for tests."""
     if schema is None:
@@ -88,9 +89,7 @@ class TestTranslateProperty:
     def test_nested_object(self):
         prop = {
             "type": "object",
-            "properties": {
-                "inner": {"type": "integer", "description": "inner field"}
-            },
+            "properties": {"inner": {"type": "integer", "description": "inner field"}},
             "required": ["inner"],
         }
         result = _translate_property(prop)
@@ -301,6 +300,7 @@ class TestCallToolSuccess:
 
         # Pre-populate registry
         from services.realtime_mcp_bridge import _ToolEntry
+
         bridge._registry = {
             "search": _ToolEntry(server_id="srv_8200", server_uri="http://srv:8200", original_name="search")
         }
@@ -323,9 +323,8 @@ class TestCallToolSuccess:
         bridge = _make_bridge()
 
         from services.realtime_mcp_bridge import _ToolEntry
-        bridge._registry = {
-            "kb.search": _ToolEntry(server_id="autobot", server_uri=None, original_name="kb.search")
-        }
+
+        bridge._registry = {"kb.search": _ToolEntry(server_id="autobot", server_uri=None, original_name="kb.search")}
 
         with patch(
             "services.realtime_mcp_bridge.RealtimeMCPBridge._call_inprocess",
@@ -350,14 +349,13 @@ class TestCallToolError:
         bridge = _make_bridge(server_uris=["http://srv:8200"])
 
         from services.realtime_mcp_bridge import _ToolEntry
+
         bridge._registry = {
             "broken": _ToolEntry(server_id="srv_8200", server_uri="http://srv:8200", original_name="broken")
         }
 
         mock_client = AsyncMock()
-        mock_client.call_tool = AsyncMock(
-            side_effect=MCPError(code=-32000, message="backend exploded")
-        )
+        mock_client.call_tool = AsyncMock(side_effect=MCPError(code=-32000, message="backend exploded"))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
@@ -441,6 +439,7 @@ class TestTransportDown:
         bridge = _make_bridge(server_uris=["http://srv:8200"])
 
         from services.realtime_mcp_bridge import _ToolEntry
+
         bridge._registry = {
             "flaky": _ToolEntry(server_id="srv_8200", server_uri="http://srv:8200", original_name="flaky")
         }

--- a/autobot-backend/services/task_workspace.py
+++ b/autobot-backend/services/task_workspace.py
@@ -262,11 +262,7 @@ async def release_for_task(
         from sqlalchemy import select  # local import — avoids heavy dep at module load
         from models.heartbeat import AgentRuntimeState
 
-        result = await session.execute(
-            select(AgentRuntimeState).where(
-                AgentRuntimeState.current_task_id == task_id
-            )
-        )
+        result = await session.execute(select(AgentRuntimeState).where(AgentRuntimeState.current_task_id == task_id))
         state = result.scalar_one_or_none()
         if state is None or state.workspace_dir is None:
             return

--- a/autobot-backend/services/task_workspace.py
+++ b/autobot-backend/services/task_workspace.py
@@ -260,6 +260,7 @@ async def release_for_task(
     """
     try:
         from sqlalchemy import select  # local import — avoids heavy dep at module load
+
         from models.heartbeat import AgentRuntimeState
 
         result = await session.execute(select(AgentRuntimeState).where(AgentRuntimeState.current_task_id == task_id))

--- a/autobot-backend/services/voice_realtime_telemetry.py
+++ b/autobot-backend/services/voice_realtime_telemetry.py
@@ -19,7 +19,7 @@ Issue #7421 — Implements:
 
 import json
 import time
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any
 

--- a/autobot-backend/services/voice_realtime_telemetry.py
+++ b/autobot-backend/services/voice_realtime_telemetry.py
@@ -35,7 +35,7 @@ logger = get_logger(__name__)
 # Source: OpenAI pricing page – audio input $0.10/min, output $0.20/min
 # Update alongside PRICING_VERSION in llm_cost_tracker.py when prices change.
 _AUDIO_COST_PER_SEC: dict[str, float] = {
-    "input": 0.10 / 60,   # ~$0.001667/s
+    "input": 0.10 / 60,  # ~$0.001667/s
     "output": 0.20 / 60,  # ~$0.003333/s
 }
 
@@ -120,6 +120,7 @@ class VoiceRealtimeTelemetry(AsyncRedisClientMixin):
 
         # Lazy import to avoid circular dependency with prometheus_metrics module
         from autobot_shared.monitoring.prometheus_metrics import PrometheusMetricsManager
+
         self._prom = PrometheusMetricsManager()
 
     # ── Public API ────────────────────────────────────────────────────────────
@@ -172,9 +173,7 @@ class VoiceRealtimeTelemetry(AsyncRedisClientMixin):
         m = self._prom._voice_realtime
         m.sessions_active.labels(model=record.model).dec()
         m.session_seconds_total.labels(model=record.model).inc(duration_s)
-        m.session_duration.labels(
-            model=record.model, disconnect_reason=record.disconnect_reason
-        ).observe(duration_s)
+        m.session_duration.labels(model=record.model, disconnect_reason=record.disconnect_reason).observe(duration_s)
         m.estimated_cost_usd.labels(model=record.model).inc(record.estimated_cost_usd)
 
         if reason in (DisconnectReason.DURATION_CAP, DisconnectReason.COST_CAP):
@@ -182,7 +181,10 @@ class VoiceRealtimeTelemetry(AsyncRedisClientMixin):
 
         logger.info(
             "voice_realtime session_end session_id=%s duration_s=%.1f cost_usd=%.4f reason=%s",
-            session_id, duration_s, record.estimated_cost_usd, reason.value,
+            session_id,
+            duration_s,
+            record.estimated_cost_usd,
+            reason.value,
         )
         return record
 
@@ -343,12 +345,10 @@ class VoiceRealtimeTelemetry(AsyncRedisClientMixin):
 
 # ── Module-level helpers ──────────────────────────────────────────────────────
 
+
 def _estimate_cost(record: RealtimeSessionRecord) -> float:
     """Compute estimated USD cost from the session record."""
-    audio_cost = (
-        record.audio_in_s * _AUDIO_COST_PER_SEC["input"]
-        + record.audio_out_s * _AUDIO_COST_PER_SEC["output"]
-    )
+    audio_cost = record.audio_in_s * _AUDIO_COST_PER_SEC["input"] + record.audio_out_s * _AUDIO_COST_PER_SEC["output"]
     token_cost = (
         record.input_tokens * _TOKEN_COST_PER_1M["input"] / 1_000_000
         + record.output_tokens * _TOKEN_COST_PER_1M["output"] / 1_000_000
@@ -366,6 +366,7 @@ def _elapsed_seconds(record: RealtimeSessionRecord) -> float:
 
 def _parse_iso(iso_str: str):
     from datetime import datetime, timezone
+
     dt = datetime.fromisoformat(iso_str)
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)

--- a/autobot-backend/tests/test_gateway_manager.py
+++ b/autobot-backend/tests/test_gateway_manager.py
@@ -458,7 +458,17 @@ class TestGatewayManager:
         """Test getting list of supported platforms."""
         platforms = gateway.get_supported_platforms()
         assert len(platforms) == 9
-        assert set(platforms) == {"web", "slack", "discord", "whatsapp", "teams", "telegram", "signal", "matrix", "imessage"}
+        assert set(platforms) == {
+            "web",
+            "slack",
+            "discord",
+            "whatsapp",
+            "teams",
+            "telegram",
+            "signal",
+            "matrix",
+            "imessage",
+        }
 
 
 class TestRateLimiter:

--- a/autobot-backend/tests/test_voice_realtime_telemetry.py
+++ b/autobot-backend/tests/test_voice_realtime_telemetry.py
@@ -77,14 +77,14 @@ class TestCostCalculation:
     """Unit tests for _estimate_cost — pure function, no I/O."""
 
     def test_audio_only_cost(self):
-        from services.voice_realtime_telemetry import _estimate_cost, _AUDIO_COST_PER_SEC
+        from services.voice_realtime_telemetry import _AUDIO_COST_PER_SEC, _estimate_cost
 
         rec = _make_record(audio_in_s=60.0, audio_out_s=30.0)
         expected = 60.0 * _AUDIO_COST_PER_SEC["input"] + 30.0 * _AUDIO_COST_PER_SEC["output"]
         assert abs(_estimate_cost(rec) - expected) < 1e-9
 
     def test_token_only_cost(self):
-        from services.voice_realtime_telemetry import _estimate_cost, _TOKEN_COST_PER_1M
+        from services.voice_realtime_telemetry import _TOKEN_COST_PER_1M, _estimate_cost
 
         rec = _make_record(input_tokens=1_000_000, output_tokens=500_000, cached_input_tokens=200_000)
         expected = (


### PR DESCRIPTION
## Summary

Fixes IDOR vulnerability in `GET /api/tasks/{task_id}/workspace`: any authenticated user could read another user's agent workspace filesystem path by knowing a valid `task_id`.

- Replace `get_current_user` with `check_admin_permission` in `task_workspace.py`
- Non-admin authenticated users now receive 403 Forbidden
- One-line import swap, zero schema changes

**Root cause:** `AgentRuntimeState` has no `user_id` field, making per-user ownership checks impossible without a schema migration. Workspace paths are system infrastructure data (sensitive filesystem paths), placing them in the same sensitivity tier as VNC manager and Prometheus MCP endpoints — both admin-only.

## Test plan

- [ ] `GET /api/tasks/{task_id}/workspace` with non-admin token → 403 Forbidden
- [ ] `GET /api/tasks/{task_id}/workspace` with unauthenticated request → 401
- [ ] `GET /api/tasks/{task_id}/workspace` with admin token → 200 (workspace data)
- [ ] Invalid `task_id` format still returns 422

Fixes GH#8686

🤖 Generated with [Claude Code](https://claude.com/claude-code)