### PR TITLE
fix(db): resolve duplicate Alembic revision ID 20260525_043 (MVA-1185)

### DIFF
--- a/autobot-backend/migrations/versions/20260525_043b_agent_runtime_state_budget_pause.py
+++ b/autobot-backend/migrations/versions/20260525_043b_agent_runtime_state_budget_pause.py
@@ -1,7 +1,10 @@
 """Add budget pause fields to agent_runtime_state (GH#6470).
 
-Revision ID: 20260525_043
-Revises: 20260525_042
+Renamed from 20260525_043 → 20260525_043b to resolve duplicate revision ID
+conflict with 20260525_043_llc_membershiprole_add_lead.py.
+
+Revision ID: 20260525_043b
+Revises: 20260525_043
 """
 
 from typing import Sequence, Union
@@ -9,8 +12,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "20260525_043"
-down_revision: Union[str, None] = "20260525_042"
+revision: str = "20260525_043b"
+down_revision: Union[str, None] = "20260525_043"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/autobot-backend/migrations/versions/20260526_044_agent_runtime_state_workspace.py
+++ b/autobot-backend/migrations/versions/20260526_044_agent_runtime_state_workspace.py
@@ -1,7 +1,7 @@
 """Add workspace fields to agent_runtime_state (GH#6471).
 
 Revision ID: 20260526_044
-Revises: 20260525_043
+Revises: 20260525_043b
 """
 
 from typing import Sequence, Union
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260526_044"
-down_revision: Union[str, None] = "20260525_043"
+down_revision: Union[str, None] = "20260525_043b"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary

- Rename `20260525_043_agent_runtime_state_budget_pause.py` → `20260525_043b_agent_runtime_state_budget_pause.py` and set its `revision = "20260525_043b"`, `down_revision = "20260525_043"`
- Update `20260526_044_agent_runtime_state_workspace.py` to `down_revision = "20260525_043b"`
- Removes the duplicate `revision = "20260525_043"` that would cause `alembic upgrade head` to fail with an ambiguous-parent error

**Clean linear chain after this PR:**
```
… → 20260525_042
    → 20260525_043  (llc_membershiprole_add_lead — unchanged)
    → 20260525_043b (agent_runtime_state_budget_pause — renamed)
    → 20260526_044  (agent_runtime_state_workspace — down_revision updated)
```

**Unblocks:** PR #8724 (MVA-1077) which references `20260525_043b` and cannot merge while the base branch has the ambiguous ID.

## Thinking Path

Two migrations share `revision = "20260525_043"`: the original `llc_membershiprole_add_lead` and the newly added `agent_runtime_state_budget_pause`. Alembic treats revision IDs as unique keys; duplicate IDs create an ambiguous DAG that breaks `alembic upgrade head`. The fix is to rename the newer migration to `20260525_043b` and update its `down_revision` to chain correctly off `20260525_043`, then update the next migration (`20260526_044`) to point to `20260525_043b` so the linear chain is preserved.

## What Changed

- `autobot-backend/migrations/versions/20260525_043_agent_runtime_state_budget_pause.py` → renamed to `20260525_043b_agent_runtime_state_budget_pause.py`
- `revision` field in that file changed from `"20260525_043"` to `"20260525_043b"`
- `down_revision` in `20260526_044_agent_runtime_state_workspace.py` updated from `"20260525_043"` to `"20260525_043b"`

## Verification

- `alembic history` on the updated branch shows a single linear chain with no branch ambiguity at `20260525_043`
- `alembic check` reports no errors
- No other migration file references the old budget_pause revision ID
- PR #8724 (MVA-1077) can now be rebased cleanly onto this base

## Model Used

claude-sonnet-4-6

## Test plan

- [ ] `alembic history` on Dev_new_gui after merge shows a single linear chain with no branch ambiguity at `20260525_043`
- [ ] `alembic check` reports no errors
- [ ] No other migration file references the old `20260525_043` ID for `budget_pause`

🤖 Generated with [Claude Code](https://claude.com/claude-code)