### PR TITLE
fix(llc): narrow FileNotFoundError catch in workspace retry (MVA-1192)

### DIFF
--- a/autobot-backend/llc/adapters/claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/claude_code_adapter.py
@@ -131,17 +131,18 @@ class ClaudeCodeAdapter:
                     env=env,
                     cwd=workspace_dir or None,
                 )
-            except FileNotFoundError:
-                if not workspace_dir:
+            except FileNotFoundError as e:
+                if workspace_dir and e.filename and os.path.abspath(str(e.filename)) == os.path.abspath(workspace_dir):
+                    logger.warning(
+                        "ClaudeCodeAdapter: workspace_dir %r missing, retrying without cwd",
+                        workspace_dir,
+                    )
+                    context.pop("workspace_dir", None)
+                    env.pop("AUTOBOT_WORKSPACE_DIR", None)
+                    env["LLC_INVOKE_CONTEXT"] = json.dumps(context, default=str)
+                    workspace_dir = None
+                else:
                     raise
-                logger.warning(
-                    "ClaudeCodeAdapter: workspace_dir %r missing, retrying without cwd",
-                    workspace_dir,
-                )
-                context.pop("workspace_dir", None)
-                env.pop("AUTOBOT_WORKSPACE_DIR", None)
-                env["LLC_INVOKE_CONTEXT"] = json.dumps(context, default=str)
-                workspace_dir = None
                 proc = await asyncio.create_subprocess_exec(
                     *cmd,
                     stdout=out_fh,


### PR DESCRIPTION
Fixes P1 CR finding from PR #8722: narrow the FileNotFoundError guard in \`claude_code_adapter.py\` to only mutate context when the missing file is the workspace directory itself, not an unrelated binary (e.g., missing claude CLI).

## Problem

The original broad \`except FileNotFoundError\` catch incorrectly mutated \`LLC_INVOKE_CONTEXT\` (popping \`workspace_dir\`, stripping \`AUTOBOT_WORKSPACE_DIR\`) even when the error was caused by a missing executable unrelated to the workspace. This caused a silent workspace leak when the LLC binary was absent.

## Fix

Added a targeted check: only strip workspace context when \`e.filename\` resolves to the workspace directory itself. Otherwise, re-raise the exception to let the caller handle it correctly.

Closes MVA-1192.

## Thinking Path

The original broad \`except FileNotFoundError\` catch was intended to handle the case where the workspace directory no longer exists (e.g., cleaned up between retry attempts). However, \`FileNotFoundError\` is also raised when the \`claude\` binary itself is not found on \`PATH\`, which is an entirely different failure mode. By checking \`e.filename\` against the workspace path, we can distinguish the two cases: only clear workspace context for workspace-not-found errors and re-raise for all other \`FileNotFoundError\` variants (e.g., missing binary).

## What Changed

- \`autobot-backend/llc/adapters/claude_code_adapter.py\`: Added \`os.path.abspath\` comparison of \`e.filename\` to \`workspace_dir\` inside the \`except FileNotFoundError\` handler. When the filename matches the workspace dir, proceed with existing context-stripping logic. When it does not match (or \`e.filename\` is None/unset), re-raise the exception unchanged.

## Verification

CodeReviewer confirmed via runtime analysis that:
- \`e.filename\` is set to the \`cwd\` path when the workspace directory is missing
- \`e.filename\` is set to the binary path when the binary is missing
- The comparison correctly distinguishes both cases

No regression in the existing retry path — workspace-not-found still clears context; binary-not-found now correctly propagates the exception.

## Model Used

claude-sonnet-4-6