### PR TITLE
fix(ci): suppress pre-existing bandit B310 in cli/doctor.py (MVA-1208)

### DIFF
--- a/autobot-backend/cli/doctor.py
+++ b/autobot-backend/cli/doctor.py
@@ -145,7 +145,7 @@ def check_npu_worker_registry() -> CheckResult:
         npu_host = os.environ.get("NPU_WORKER_HOST", "localhost")
         npu_port = os.environ.get("NPU_WORKER_PORT", "8080")  # ssot-config-exempt: diagnostic CLI, NPU_* namespace
         url = f"http://{npu_host}:{npu_port}/health"
-        with urllib.request.urlopen(url, timeout=2) as resp:
+        with urllib.request.urlopen(url, timeout=2) as resp:  # nosec B310
             if resp.status == 200:
                 return CheckResult(
                     name="NPU worker registry",


### PR DESCRIPTION
## Summary

- Adds `# nosec B310` to `autobot-backend/cli/doctor.py:148` where `urllib.request.urlopen()` is called with a safely-constructed `http://` URL
- The URL is built from an internal host/port, making B310 a false positive; suppression is the correct fix per bandit convention
- Eliminates the `--admin` bypass debt on PRs #8747 and #8739 caused by this pre-existing violation blocking `code-quality` CI

## Thinking Path

Bandit B310 fires on any `urllib.request.urlopen()` call as a blanket audit warning. The suppression is justified here because:
1. The URL scheme is unconditionally `http://` — it is a string literal prefix, not derived from user input or an environment variable.
2. The host and port come from `NPU_WORKER_HOST` / `NPU_WORKER_PORT` env vars, but those only control the target address within the already-safe `http://` scheme.
3. No `file://`, `ftp://`, or custom scheme injection is possible from the construction `f"http://{npu_host}:{npu_port}/health"`.
4. The call site is inside the diagnostic CLI (`doctor.py`), not a user-facing web handler — attack surface is internal tooling only.

`# nosec B310` is the standard bandit inline suppression for exactly this pattern and is preferable to widening the bandit exclude list, restructuring the code, or continuing to use `--admin` CI bypasses.

## What Changed

- **`autobot-backend/cli/doctor.py:148`** — added `# nosec B310` as a trailing inline comment on the `urllib.request.urlopen()` call. No logic change; one character added to a comment.

## Verification

Verified locally:
```
bandit autobot-backend/cli/doctor.py
```
Output: no issues reported for line 148 after suppression. The rest of the file is clean. Existing unit tests for `check_npu_worker_registry` are unaffected (suppression comments are invisible to the interpreter).

## Model Used

claude-sonnet-4-6

## Test plan

- [ ] `bandit -r autobot-backend/cli/doctor.py` passes with no B310 errors on this file
- [ ] Code-quality CI runs green without `--admin` bypass
- [ ] Existing NPU health-check logic is unchanged (only comment added)

Closes #8762

🤖 Generated with [Claude Code](https://claude.com/claude-code)