### PR TITLE
fix(startup): break circular import in retry_mechanism (MVA-1209)

### DIFF
--- a/autobot-backend/retry_mechanism.py
+++ b/autobot-backend/retry_mechanism.py
@@ -16,13 +16,14 @@ from enum import Enum
 from functools import wraps
 from typing import Any, Callable, Dict
 
+import logging  # stdlib: avoids circular import — retry_mechanism is on the config-manager init path (GH#7765 pattern)
+
 from autobot_shared.async_compat import run_or_schedule
-from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 from constants.threshold_constants import RetryConfig as ThresholdRetryConfig
 from constants.threshold_constants import TimingConstants
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class RetryStrategy(Enum):


### PR DESCRIPTION
## Root Cause

On a fresh install, the backend (uvicorn workers) and Celery both failed to start due to a circular import:

```
retry_mechanism → logging_manager.get_logger
  → config._get_config_manager
    → config.manager.AsyncOperationsMixin
      → config.async_ops
        → retry_mechanism  ← CIRCULAR (partially initialised)
```

`retry_mechanism.py` called `get_logger(__name__)` at module level. This triggered the full config-manager initialisation chain, which itself imported `retry_mechanism` via `config/async_ops.py`, returning a partially initialised module and raising `ImportError: cannot import name 'RetryConfig'`.

This caused uvicorn workers to crash immediately on spawn (leaving the master process alive with 0 workers and nothing listening on port 8001), and Celery to fail the same way.

## Fix

Replace `from autobot_shared.logging_manager import get_logger` with stdlib `import logging` and use `logging.getLogger(__name__)`. This is the established pattern already used in `config/async_ops.py` (GH#7765 pattern — see the comment on line 17 of that file).

## Verification

```
# Exact Celery import chain that was failing — now passes:
from autobot_shared.redis_management.types import DATABASE_MAPPING
# SUCCESS: DATABASE_MAPPING imported

# Direct retry_mechanism import — now passes:
from retry_mechanism import RetryConfig
# SUCCESS: RetryConfig imported
```

## Deploy

After merge to Dev_new_gui, re-run the Ansible playbook to pick up the fix:

```bash
cd /opt/autobot/code_source/autobot-slm-backend/ansible
ansible-playbook -i inventory/localhost.yml playbooks/deploy-slm-manager.yml --skip-tags seed,provision
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)