### PR TITLE
fix(ci): suppress pre-existing mypy type errors in autobot_shared/ (MVA-1214)

### DIFF
--- a/autobot-backend/retry_mechanism.py
+++ b/autobot-backend/retry_mechanism.py
@@ -8,6 +8,7 @@ Handles transient failures in network requests, database operations, and externa
 """
 
 import asyncio
+import logging  # stdlib: avoids circular import — retry_mechanism is on the config-manager init path (GH#7765 pattern)
 import random
 import threading
 import time
@@ -15,8 +16,6 @@ from dataclasses import dataclass
 from enum import Enum
 from functools import wraps
 from typing import Any, Callable, Dict
-
-import logging  # stdlib: avoids circular import — retry_mechanism is on the config-manager init path (GH#7765 pattern)
 
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.singleton_factory import lazy_singleton

--- a/autobot_shared/coordination/shared_runtime_bag.py
+++ b/autobot_shared/coordination/shared_runtime_bag.py
@@ -260,7 +260,7 @@ class SharedRuntimeBag(Generic[T]):
                     )
         finally:
             await pubsub.unsubscribe(channel)
-            await pubsub.aclose()
+            await pubsub.aclose()  # type: ignore[attr-defined]  # GH#7105
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/autobot_shared/http_client.py
+++ b/autobot_shared/http_client.py
@@ -44,7 +44,7 @@ class HTTPClientManager:
         if not hasattr(self, "_initialized"):
             self._initialized = True
             self._session = None
-            self._connector = None
+            self._connector: TCPConnector | None = None
             self._closed = False
             self._request_count = 0
             self._error_count = 0
@@ -55,7 +55,7 @@ class HTTPClientManager:
             self._pool_max = 200  # Maximum pool size
             self._current_pool_size = 100  # Start at default
             self._pool_adjustment_interval = TimingConstants.STANDARD_TIMEOUT  # Adjust every 60s
-            self._last_adjustment_time = 0
+            self._last_adjustment_time: float = 0.0
             self._active_requests = 0  # Track concurrent requests
             self._pending_pool_recreation = False  # Issue #352: Track deferred recreation
 

--- a/autobot_shared/plugin_sdk/unified_registry.py
+++ b/autobot_shared/plugin_sdk/unified_registry.py
@@ -22,13 +22,14 @@ class UnifiedRegistry:
 
     _instance: "UnifiedRegistry" | None = None
     _lock: threading.Lock = threading.Lock()
+    _manifests: dict[str, ManifestContract]
 
     def __new__(cls) -> "UnifiedRegistry":
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
                     instance = super().__new__(cls)
-                    instance._manifests: dict[str, ManifestContract] = {}
+                    instance._manifests = {}
                     cls._instance = instance
         return cls._instance
 

--- a/autobot_shared/redis_management/connection_manager.py
+++ b/autobot_shared/redis_management/connection_manager.py
@@ -733,7 +733,7 @@ class RedisConnectionManager:
                 socket_connect_timeout=self._pool_config.socket_connect_timeout,
                 retry_on_timeout=self._pool_config.retry_on_timeout,
                 max_retries=self._pool_config.max_retries,
-                health_check_interval=self._pool_config.health_check_interval,
+                health_check_interval=int(self._pool_config.health_check_interval),
             )
 
         return await self._create_async_pool_with_retry(database_name, config)
@@ -1152,9 +1152,9 @@ class RedisConnectionManager:
             except Exception as e:
                 logger.warning("Error closing async pool: %s", e)
 
-        for pool in self._sync_pools.values():
+        for sync_pool in self._sync_pools.values():
             try:
-                pool.disconnect()
+                sync_pool.disconnect()
             except Exception as e:
                 logger.warning("Error closing sync pool: %s", e)
 

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1338,7 +1338,7 @@ class MiscConfig(BaseSettings):
     display: str = Field(default="", alias="DISPLAY")
     display_height: str = Field(default="", alias="DISPLAY_HEIGHT")
     display_width: str = Field(default="", alias="DISPLAY_WIDTH")
-    encryption_key: str = Field(default="", alias="ENCRYPTION_KEY")
+    encryption_key: str = Field(default="", alias="ENCRYPTION_KEY")  # type: ignore[no-redef]  # GH#7105
     file_cache_ttl_seconds: int = Field(default=0, alias="FILE_CACHE_TTL_SECONDS")
     gateway_enable_sandbox: str = Field(default="", alias="GATEWAY_ENABLE_SANDBOX")
     gateway_heartbeat_interval: str = Field(default="", alias="GATEWAY_HEARTBEAT_INTERVAL")
@@ -1376,7 +1376,7 @@ class MiscConfig(BaseSettings):
     nous_api_key: str = Field(default="", alias="NOUS_API_KEY")
     nous_default_model: str = Field(default="", alias="NOUS_DEFAULT_MODEL")
     ollama_host: str = Field(default="", alias="OLLAMA_HOST")
-    ollama_url: str = Field(default="", alias="OLLAMA_URL")
+    ollama_url: str = Field(default="", alias="OLLAMA_URL")  # type: ignore[no-redef]  # GH#7105
     openai_api_base_url: str = Field(default="", alias="OPENAI_API_BASE_URL")
     openrouter_api_base_url: str = Field(default="", alias="OPENROUTER_API_BASE_URL")
     openrouter_api_key: str = Field(default="", alias="OPENROUTER_API_KEY")


### PR DESCRIPTION
## Thinking Path

CI `code-quality` job was failing on the `Type-check autobot_shared (required)` step with 15 pre-existing mypy errors across 5 files. These errors existed on `Dev_new_gui` before any in-flight PR touched them; they became visible when PR #8764 (MVA-1208) pushed past the bandit step and reached mypy.

Approach: fix each error with the minimal correct change — proper type annotations where the fix is unambiguous, and `# type: ignore[code]  # GH#7105` inline suppression only where fixing requires touching business logic (duplicate pydantic field aliases, missing redis-py stub method).

isort failure in `autobot-backend/retry_mechanism.py` was pre-existing on `Dev_new_gui` (introduced by c831fb13a / MVA-1209); fixed here so CI passes on this branch.

## What Changed

- `autobot_shared/plugin_sdk/unified_registry.py`: Added class-level `_manifests: dict[str, ManifestContract]` annotation; removed inline type annotation from `__new__` assignment — fixes `[misc]` + 7x `[attr-defined]`
- `autobot_shared/http_client.py`: Typed `_connector` as `TCPConnector | None`; changed `_last_adjustment_time` initializer to `float = 0.0` — fixes 2x `[assignment]`
- `autobot_shared/ssot_config.py`: Added `# type: ignore[no-redef]  # GH#7105` on duplicate `encryption_key` / `ollama_url` field defs — fixes 2x `[no-redef]`
- `autobot_shared/redis_management/connection_manager.py`: Cast `health_check_interval` to `int()`; renamed sync-pool loop variable to `sync_pool` — fixes `[arg-type]` + `[assignment]` + `[unused-coroutine]`
- `autobot_shared/coordination/shared_runtime_bag.py`: Added `# type: ignore[attr-defined]  # GH#7105` on `pubsub.aclose()` — fixes `[attr-defined]`
- `autobot-backend/retry_mechanism.py`: Fixed isort order (pre-existing on `Dev_new_gui` from c831fb13a / MVA-1209)

## Verification

```bash
python3 -m mypy autobot_shared/plugin_sdk/unified_registry.py autobot_shared/http_client.py \
  autobot_shared/ssot_config.py autobot_shared/redis_management/connection_manager.py \
  autobot_shared/coordination/shared_runtime_bag.py --ignore-missing-imports
# Result: Success: no issues found in 5 source files

python3 -m isort --check-only --settings-path=. --line-length=120 autobot-backend/ autobot-slm-backend/ autobot_shared/
# Result: no output (clean)
```

## Risks

- `ssot_config.py` `no-redef` suppressions: runtime uses last definition (non-`AUTOBOT_`-prefixed aliases win). This was true before this PR; suppression silences the mypy warning only.
- `shared_runtime_bag.py`: `pubsub.aclose()` exists at runtime but is absent from redis-py stubs; suppression is safe.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Closes #MVA-1214

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A — type annotation fixes only)
- [x] Documentation updated if behavior changed — N/A
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff