### PR TITLE
fix(storybook): fix 3 pre-existing syntax/import errors blocking Storybook build (MVA-1223)

### DIFF
--- a/autobot-frontend/src/components/browser/BrowserSessionManager.stories.ts
+++ b/autobot-frontend/src/components/browser/BrowserSessionManager.stories.ts
@@ -4,7 +4,8 @@
 
 import type { Meta, StoryObj } from '@storybook/vue3';
 import BrowserSessionManager from './BrowserSessionManager.vue';
-import { config } from '@/config/ssot-config';
+import { getConfig } from '@/config/ssot-config';
+const config = getConfig();
 
 const meta = {
   title: 'Components/Browser/BrowserSessionManager',

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -159,7 +159,6 @@
       @updated="handleCategoryUpdated"
       @deleted="handleCategoryDeleted"
     />
-    </div>
 
   </div>
 </template>

--- a/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
@@ -401,9 +401,8 @@ onBeforeUnmount(() => {
                 v-for="variable in detectedVariables"
                 :key="variable"
                 class="variable-tag"
-              >
-                {{ '{{' + variable + '}}' }}
-              </span>
+                v-text="`{{${variable}}}`"
+              />
             </div>
           </div>
         </template>

--- a/autobot-frontend/src/components/terminal/HostSelector.stories.ts
+++ b/autobot-frontend/src/components/terminal/HostSelector.stories.ts
@@ -1,7 +1,8 @@
 import type { Meta } from '@storybook/vue3';
 import type { StoryObj } from '@storybook/vue3';
 import HostSelector from './HostSelector.vue';
-import { config } from '@/config/ssot-config';
+import { getConfig } from '@/config/ssot-config';
+const config = getConfig();
 
 const sampleHosts = [
   { id: 'main', name: 'Main Server', ip: config.vm.main, description: 'Primary AutoBot backend server' },


### PR DESCRIPTION
## Thinking Path

Three pre-existing errors in `Dev_new_gui` were masked by the TypeScript ERESOLVE that blocked npm install. Once MVA-1222 (typescript ~5.9.0 downgrade) resolved the ERESOLVE, Storybook could attempt to build and exposed these errors one by one.

**Fix 1 — `KnowledgePromptEditor.vue`:** `{{ '{{' + variable + '}}' }}` — the `}}` inside the string literal is mis-parsed as the Vue template interpolation close token. Fixed with `v-text` + JS template literal.

**Fix 2 — `KnowledgeCategories.vue`:** Spurious `</div>` at line 162 (after `CategoryEditModal` self-close) had no matching open tag, causing `RolldownError: Invalid end tag`. Removed the orphaned tag.

**Fix 3 — `BrowserSessionManager.stories.ts` + `HostSelector.stories.ts`:** `import { config } from '@/config/ssot-config'` — `ssot-config.ts` exports `getConfig()` not a named `config` constant. Changed to `import { getConfig }` + `const config = getConfig()`.

## What Changed

- `autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue`: replaced template interpolation with `v-text` binding
- `autobot-frontend/src/components/knowledge/KnowledgeCategories.vue`: removed spurious `</div>`
- `autobot-frontend/src/components/browser/BrowserSessionManager.stories.ts`: fixed `config` import
- `autobot-frontend/src/components/terminal/HostSelector.stories.ts`: fixed `config` import

## Verification

- Storybook build reaches completion without parser errors
- `KnowledgePromptEditor.vue` still renders `{{variableName}}` placeholder tags correctly via `v-text`
- All 3 pre-existing errors resolved; no new errors introduced

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)