### PR TITLE
fix(layers): replace .lower() on bool TIERED_CONTEXT_ENABLED with bool()

### DIFF
--- a/autobot-backend/chat_history/layers.py
+++ b/autobot-backend/chat_history/layers.py
@@ -42,7 +42,7 @@ logger = get_logger(__name__)
 # Feature flag
 # ---------------------------------------------------------------------------
 
-TIERED_CONTEXT_ENABLED: bool = _ssot_config.tiered_context_enabled.lower() == "true"
+TIERED_CONTEXT_ENABLED: bool = bool(_ssot_config.tiered_context_enabled)
 
 # ---------------------------------------------------------------------------
 # Retrieval-trigger keywords for L3


### PR DESCRIPTION
## Thinking Path

`ssot_config.tiered_context_enabled` is a Pydantic `bool` field. The code in `layers.py` called `.lower()` on it expecting a string — this raised `AttributeError` at import time and crashed pytest collection for any module importing `chat_history.layers`. The fix is to cast through `bool()` instead of `.lower() == "true"`.

## What Changed

- `autobot-backend/chat_history/layers.py`: replaced `_ssot_config.tiered_context_enabled.lower() == "true"` with `bool(_ssot_config.tiered_context_enabled)`

## Verification

- `pytest autobot-backend/chat_history/layers_test.py` — collection succeeds, all tests pass
- `pytest autobot-backend/tests/test_goal_ancestry_layer.py` — collection no longer crashes

## Model Used

claude-sonnet-4-6

---

## Summary

- `ssot_config.tiered_context_enabled` is a Pydantic `bool` field; calling `.lower()` on it raised `AttributeError` at import time
- This crashed pytest collection for any module importing `chat_history.layers`, blocking all Layer4GoalAncestry tests
- Fix: replace `_ssot_config.tiered_context_enabled.lower() == "true"` with `bool(_ssot_config.tiered_context_enabled)`

Fixes GH#8744 / MVA-1250.

## Test plan

- [ ] `pytest autobot-backend/chat_history/layers_test.py` — collection no longer crashes, all existing tests pass
- [ ] `pytest autobot-backend/tests/test_goal_ancestry_layer.py` — collection succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)