### PR TITLE
fix(tests): replace sys.modules guard with unconditional attr patch in test_goal_ancestry_layer (MVA-1251, #8745)

### DIFF
--- a/autobot-backend/tests/test_goal_ancestry_layer.py
+++ b/autobot-backend/tests/test_goal_ancestry_layer.py
@@ -33,12 +33,12 @@ def _load_layers_module():
     # Provide a minimal stub for autobot_shared.ssot_config / config so that
     # ``TIERED_CONTEXT_ENABLED = config.tiered_context_enabled.lower() == "true"``
     # resolves to False at import time.
-    if "autobot_shared.ssot_config" not in sys.modules:
-        cfg_mock = MagicMock()
-        cfg_mock.tiered_context_enabled = "false"
-        cfg_stub = types.ModuleType("autobot_shared.ssot_config")
-        cfg_stub.config = cfg_mock  # type: ignore[attr-defined]
-        sys.modules["autobot_shared.ssot_config"] = cfg_stub
+    # conftest.py imports `from autobot_shared.ssot_config import config` before
+    # test collection, so sys.modules["autobot_shared.ssot_config"] is already
+    # populated with the real module — the if-not-in guard would never fire.
+    # Unconditionally patch the attribute on whatever config object is present.
+    import autobot_shared.ssot_config as _ssot_cfg_mod
+    _ssot_cfg_mod.config.tiered_context_enabled = "false"  # type: ignore[attr-defined]
 
     spec = importlib.util.spec_from_file_location("chat_history.layers", layers_path)
     module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]


### PR DESCRIPTION
## Thinking Path

`conftest.py:20` runs `from autobot_shared.ssot_config import config` before any test is collected, pre-populating `sys.modules["autobot_shared.ssot_config"]` with the real module. The `if "autobot_shared.ssot_config" not in sys.modules:` guard in `_load_layers_module()` therefore always short-circuits — the stub is never injected. Additionally the real `config.tiered_context_enabled` is a `bool`, so `layers.py`'s `.lower()` call crashes collection. The fix is to remove the dead guard and patch the attribute directly on the already-imported module.

## What Changed

- `autobot-backend/tests/test_goal_ancestry_layer.py`: removed the dead `if-not-in` guard and its mock-module construction; replaced with a direct unconditional `autobot_shared.ssot_config.config.tiered_context_enabled = "false"` patch

## Verification

```
python3 -m pytest tests/test_goal_ancestry_layer.py -v
# 11 passed in 0.61s
```

## Model Used

claude-sonnet-4-6

---

## Summary

- `conftest.py:20` runs `from autobot_shared.ssot_config import config` before any test is collected, populating `sys.modules["autobot_shared.ssot_config"]` with the real module
- The `if "autobot_shared.ssot_config" not in sys.modules:` guard in `_load_layers_module()` therefore always short-circuits — the stub is never injected
- The real `config.tiered_context_enabled` is a `bool`, so `layers.py`'s `.lower()` call crashes test collection

Closes GH#8745

🤖 Generated with [Claude Code](https://claude.com/claude-code)