### PR TITLE
fix(a2a): persist trust audit DB to data dir instead of /tmp (GH#8742)

### DIFF
--- a/autobot-backend/a2a/trust_score.py
+++ b/autobot-backend/a2a/trust_score.py
@@ -200,6 +200,7 @@ class TrustRecord:
 
 _KEY_TRUST = "a2a:trust:{}"
 
+
 def _default_trust_audit_db() -> Path:
     env_override = os.environ.get("AUTOBOT_TRUST_AUDIT_DB")
     if env_override:

--- a/autobot-backend/a2a/trust_score.py
+++ b/autobot-backend/a2a/trust_score.py
@@ -52,6 +52,7 @@ from pathlib import Path
 from typing import Dict, Optional, Set
 
 from autobot_shared.logging_manager import get_logger
+from utils.paths_manager import PathsManager
 
 logger = get_logger(__name__)
 
@@ -199,7 +200,14 @@ class TrustRecord:
 
 _KEY_TRUST = "a2a:trust:{}"
 
-_SQLITE_DB_DEFAULT = Path(os.environ.get("AUTOBOT_TRUST_AUDIT_DB", "/tmp/a2a_trust_audit.db"))
+def _default_trust_audit_db() -> Path:
+    env_override = os.environ.get("AUTOBOT_TRUST_AUDIT_DB")
+    if env_override:
+        return Path(env_override)
+    return PathsManager.get_data_path("a2a_trust_audit.db")
+
+
+_SQLITE_DB_DEFAULT = _default_trust_audit_db()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Changes default SQLite path for A2A trust audit from `/tmp/a2a_trust_audit.db` (lost on reboot) to `PathsManager.get_data_path("a2a_trust_audit.db")` (persistent data directory)
- `AUTOBOT_TRUST_AUDIT_DB` env var override still takes full precedence
- No schema changes; existing behaviour unchanged when env var is set

## Thinking Path

The bug: `_SQLITE_DB_DEFAULT` was computed at module import time using a hardcoded `/tmp/` fallback. On reboot, `/tmp` is cleared, wiping all audit history. The fix wraps the path resolution in `_default_trust_audit_db()` which delegates to `PathsManager.get_data_path()` — the same pattern every other persistent data file in AutoBot uses.

## What Changed

- `autobot-backend/a2a/trust_score.py`: import `PathsManager`; replace inline `Path(os.environ.get(..., "/tmp/..."))` with a `_default_trust_audit_db()` helper that prefers the env var and falls back to the persistent data directory.

## Verification

- All 40 existing `trust_score_test.py` tests pass — tests already pass an explicit `sqlite_path` so no test changes needed.

## Model Used

claude-sonnet-4-6

Closes GH#8742

🤖 Generated with [Claude Code](https://claude.com/claude-code)