### PR TITLE
fix(accessibility): add role=listbox and arrow key nav to onboarding preset cards (GH#8752)

### DIFF
--- a/autobot-frontend/src/views/OnboardingWizard.vue
+++ b/autobot-frontend/src/views/OnboardingWizard.vue
@@ -93,6 +93,14 @@ const canGoNext = computed(() => {
   return false
 })
 
+function navigatePreset(currentIndex: number, direction: number) {
+  const next = currentIndex + direction
+  if (next < 0 || next >= presets.value.length) return
+  selectedPreset.value = presets.value[next].name
+  const cards = document.querySelectorAll<HTMLElement>('[role="listbox"] [role="option"]')
+  cards[next]?.focus()
+}
+
 const tierBadgeClass = (tier: string) => {
   switch (tier) {
     case 'powerful': return 'badge-tier-powerful'
@@ -303,17 +311,24 @@ onMounted(async () => {
             Choose a starter configuration that best matches your primary use-case.
             You can adjust everything later in Settings.
           </p>
-          <div class="presets-grid">
+          <div
+            class="presets-grid"
+            role="listbox"
+            aria-label="Choose a starter preset"
+            aria-required="true"
+          >
             <div
-              v-for="preset in presets"
+              v-for="(preset, index) in presets"
               :key="preset.name"
               :class="['preset-card', { selected: selectedPreset === preset.name }]"
               @click="selectedPreset = preset.name"
               :aria-selected="selectedPreset === preset.name"
               role="option"
-              tabindex="0"
+              :tabindex="selectedPreset === preset.name || (!selectedPreset && index === 0) ? 0 : -1"
               @keydown.enter="selectedPreset = preset.name"
               @keydown.space.prevent="selectedPreset = preset.name"
+              @keydown.up.prevent="navigatePreset(index, -1)"
+              @keydown.down.prevent="navigatePreset(index, 1)"
             >
               <div class="preset-card-header">
                 <span class="preset-title">{{ preset.title }}</span>


### PR DESCRIPTION
## Thinking Path

Per ARIA spec, `role="option"` elements must be owned by a `role="listbox"` element. Without the parent listbox, screen readers cannot announce the preset cards as selectable options and `aria-selected` has no semantic meaning. The fix is to add `role="listbox"` to the `.presets-grid` container. Arrow key navigation is missing from the current implementation (only Enter/Space handled) — the ARIA listbox pattern requires roving tabindex with Up/Down arrow support to be fully keyboard accessible.

## What Changed

- `autobot-frontend/src/views/OnboardingWizard.vue`: Added `role="listbox"`, `aria-label="Choose a starter preset"`, `aria-required="true"` to `.presets-grid` container
- Added roving `tabindex` pattern: selected/first card gets `tabindex="0"`, all others `tabindex="-1"`
- Added `navigatePreset()` function for Up/Down arrow key navigation with automatic focus management
- Changed `v-for` to expose `index` for arrow key navigation

## Verification

- `.presets-grid` now has `role="listbox"` so screen readers announce the container correctly
- Each `role="option"` child is semantically valid under its listbox parent — `aria-selected` is now meaningful
- Up/Down arrow keys move focus and selection between preset cards
- Enter/Space still select cards as before
- Only one card in tab order at a time (roving tabindex)

## Model Used

claude-sonnet-4-6

---

## Summary

Fixes the broken ARIA listbox pattern on the onboarding preset picker. Preset cards used `role="option"` but the parent container had no `role="listbox"`, making screen readers unable to announce them as selectable options.

Closes #8752

## Changes

- Added `role="listbox"`, `aria-label`, `aria-required` to `.presets-grid`
- Roving tabindex for keyboard focus management
- Up/Down arrow key navigation between cards

## Test plan

- [ ] Open onboarding wizard step 2
- [ ] Verify screen reader announces the container as a listbox
- [ ] Verify Up/Down arrow keys navigate between preset cards
- [ ] Verify Enter/Space still select cards

## Changelog fragment

- [ ] Added `changelog/unreleased/{issue}-{slug}.md` — or N/A (internal change)