### PR TITLE
fix(llc/kb): write kb_summary sentinel for small sprints (<=10 docs) (GH#8657)

### DIFF
--- a/autobot-backend/llc/kb/sprint_summarizer.py
+++ b/autobot-backend/llc/kb/sprint_summarizer.py
@@ -100,6 +100,7 @@ class SprintKbSummarizer:
             logger.info("Sprint %s KB collection is empty; nothing to merge", sprint_id)
         elif doc_count <= _SUMMARIZE_THRESHOLD:
             await self._direct_merge(docs, project_collection, sprint_id, project_id)
+            summary_text = f"[direct-merged: {doc_count} docs]"
         else:
             summary_text = await self._llm_summarize_and_index(
                 docs, project_collection, sprint_id, project_id, sprint=sprint

--- a/autobot-backend/llc/tests/test_sprint_summarizer.py
+++ b/autobot-backend/llc/tests/test_sprint_summarizer.py
@@ -99,7 +99,29 @@ async def test_small_collection_direct_merge(summarizer, km_mock):
 
     dm.assert_called_once()
     lsi.assert_not_called()
-    assert result is None  # direct merge returns None
+    assert result == f"[direct-merged: {_SUMMARIZE_THRESHOLD} docs]"
+
+
+@pytest.mark.asyncio
+async def test_small_collection_writes_kb_summary(summarizer, km_mock):
+    """Bug fix: small sprints (<=10 docs) must write kb_summary on the sprint row."""
+    sprint_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    docs = _make_docs(5)
+    sprint_mock = MagicMock()
+    session_mock = MagicMock()
+    session_mock.flush = AsyncMock()
+
+    with (
+        patch.object(summarizer, "_load_sprint_context", new=AsyncMock(return_value=(sprint_mock, project_id))),
+        patch.object(summarizer, "_fetch_documents", new=AsyncMock(return_value=docs)),
+        patch.object(summarizer, "_direct_merge", new=AsyncMock()),
+    ):
+        result = await summarizer.summarize_and_merge(sprint_id, session=session_mock)
+
+    assert result == "[direct-merged: 5 docs]"
+    assert sprint_mock.kb_summary == "[direct-merged: 5 docs]"
+    session_mock.flush.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path

`_direct_merge` returns `None` (void). After calling it for the ≤10-docs path, `summary_text` remains `None`, so the guard `if summary_text and session is not None and sprint is not None` at line 110 never fires and `sprint.kb_summary` is never written. `GET /sprints/{id}/summary` always returns `{'kb_summary': null}` for the common small-sprint case.

## What Changed

- `sprint_summarizer.py`: after `_direct_merge`, assign `summary_text = f"[direct-merged: {doc_count} docs]"` so the guard fires and persists `kb_summary` on the sprint row.
- `test_sprint_summarizer.py`:
  - Updated `test_small_collection_direct_merge` — assertion changed from `result is None` to `result == "[direct-merged: N docs]"` (matches fixed behavior).
  - Added `test_small_collection_writes_kb_summary` — verifies `sprint.kb_summary` is set and `session.flush()` is called when sprint and session are both non-None.

## Verification

All 11 tests pass:
```
autobot-backend/llc/tests/test_sprint_summarizer.py  11 passed in 1.51s
```

## Model Used

claude-sonnet-4-6

Closes GH#8657
Relates to MVA-1253