### PR TITLE
security(a2a): default-deny callers without X-A2A-Agent-Id header (GH#8743)

### DIFF
--- a/autobot-backend/api/a2a.py
+++ b/autobot-backend/api/a2a.py
@@ -208,17 +208,23 @@ async def submit_task(
     caller_id = extract_caller_id(x_a2a_agent_id, jwt_sub, addr)
     trace_id = new_trace_id()
 
-    # Issue #7358: gate task submission by behavioural trust level.
-    # Peers that have not yet earned LIMITED trust (≥ 0.30 score) are
-    # restricted to discovery endpoints only.
-    if x_a2a_agent_id:
-        try:
-            get_trust_manager().require_capability(x_a2a_agent_id, Capability.SUBMIT_TASKS)
-        except TrustAccessDenied as exc:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Peer trust level insufficient for task submission: {exc.level.value}",
-            ) from exc
+    # Issue #7358 + GH#8743: gate task submission by behavioural trust level.
+    # X-A2A-Agent-Id is required — callers without it are anonymous and
+    # cannot earn/have a trust record, so they are default-denied (no implicit
+    # trust for unauthenticated callers).  Identified peers must hold at least
+    # LIMITED trust (score > 0.30) to submit tasks.
+    if not x_a2a_agent_id:
+        raise HTTPException(
+            status_code=401,
+            detail="X-A2A-Agent-Id header is required for task submission",
+        )
+    try:
+        get_trust_manager().require_capability(x_a2a_agent_id, Capability.SUBMIT_TASKS)
+    except TrustAccessDenied as exc:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Peer trust level insufficient for task submission: {exc.level.value}",
+        ) from exc
 
     manager = get_task_manager()
     task = manager.create_task(

--- a/autobot-backend/tests/security/test_a2a_trust_gate.py
+++ b/autobot-backend/tests/security/test_a2a_trust_gate.py
@@ -1,0 +1,120 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Regression tests for GH#8743 / MVA-1249.
+
+Before the fix in api/a2a.py, callers that omitted X-A2A-Agent-Id bypassed
+all capability checks entirely.  The fix adds a mandatory header check:
+missing header → 401 Unauthorized before any trust evaluation fires.
+
+Import note: a2a.task_manager creates a TaskManager singleton at module
+level (Redis-backed).  We pre-stub it in sys.modules before any import of
+the a2a package to prevent socket connections during test collection.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pre-stub a2a.task_manager so the a2a package can be imported without
+# triggering the module-level TaskManager() Redis initialisation.
+# ---------------------------------------------------------------------------
+
+if "a2a.task_manager" not in sys.modules:
+    _tm_stub = types.ModuleType("a2a.task_manager")
+    _tm_stub.__path__ = []  # type: ignore[attr-defined]
+    _tm_stub.TaskManager = MagicMock  # type: ignore[attr-defined]
+    _tm_stub.get_task_manager = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
+    _tm_stub.__getattr__ = lambda attr: MagicMock()  # type: ignore[attr-defined]
+    sys.modules["a2a.task_manager"] = _tm_stub
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrustCapabilityGateMissingHeader:
+    """GH#8743 regression: missing X-A2A-Agent-Id must be default-denied."""
+
+    @pytest.mark.asyncio
+    async def test_missing_agent_id_returns_401(self):
+        """No X-A2A-Agent-Id header → 401 before any trust check runs."""
+        from unittest.mock import AsyncMock, patch
+
+        from fastapi import HTTPException
+
+        from api.a2a import submit_task
+        from api.schemas_agent import TaskSendRequest
+
+        body = TaskSendRequest(message="do something", context=None)
+        request = MagicMock()
+        request.headers = {}
+        request.client = MagicMock()
+        request.client.host = "10.0.0.1"
+        background_tasks = MagicMock()
+
+        with patch("api.a2a._a2a_limiter") as mock_limiter, patch(
+            "api.a2a.get_trust_manager"
+        ) as mock_trust:
+            mock_limiter.check_or_429 = AsyncMock()
+            with pytest.raises(HTTPException) as exc_info:
+                await submit_task(
+                    body=body,
+                    background_tasks=background_tasks,
+                    request=request,
+                    x_a2a_agent_id=None,
+                    authorization=None,
+                )
+
+        assert exc_info.value.status_code == 401
+        assert "X-A2A-Agent-Id" in exc_info.value.detail
+        # Trust manager must never be consulted for anonymous callers.
+        mock_trust.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_untrusted_peer_returns_403(self):
+        """An identified but UNTRUSTED peer must be denied with 403."""
+        from unittest.mock import AsyncMock, patch
+
+        from fastapi import HTTPException
+
+        from a2a.trust_score import Capability, TrustAccessDenied, TrustLevel
+        from api.a2a import submit_task
+        from api.schemas_agent import TaskSendRequest
+
+        body = TaskSendRequest(message="do something", context=None)
+        request = MagicMock()
+        request.headers = {}
+        request.client = MagicMock()
+        request.client.host = "10.0.0.2"
+        background_tasks = MagicMock()
+
+        mock_mgr = MagicMock()
+        mock_mgr.require_capability.side_effect = TrustAccessDenied(
+            "untrusted-peer", Capability.SUBMIT_TASKS, TrustLevel.UNTRUSTED
+        )
+
+        with patch("api.a2a._a2a_limiter") as mock_limiter, patch(
+            "api.a2a.get_trust_manager", return_value=mock_mgr
+        ):
+            mock_limiter.check_or_429 = AsyncMock()
+            with pytest.raises(HTTPException) as exc_info:
+                await submit_task(
+                    body=body,
+                    background_tasks=background_tasks,
+                    request=request,
+                    x_a2a_agent_id="untrusted-peer",
+                    authorization=None,
+                )
+
+        assert exc_info.value.status_code == 403
+        mock_mgr.require_capability.assert_called_once_with(
+            "untrusted-peer", Capability.SUBMIT_TASKS
+        )


### PR DESCRIPTION
## Summary

Fixes trust capability gate bypass (GH#8743 / MVA-1249).

**Root cause:** The original guard `if x_a2a_agent_id:` placed the `require_capability()` call inside a conditional, meaning callers that omitted the `X-A2A-Agent-Id` header bypassed all capability checks and could submit tasks anonymously.

**Fix:** Inverted the guard to `if not x_a2a_agent_id: raise HTTPException(401)`. Anonymous callers are default-denied before any trust evaluation. Identified peers proceed to the trust check unconditionally.

**Changes:**
- `autobot-backend/api/a2a.py:216` — inverted guard + promoted `require_capability()` call outside the conditional
- `autobot-backend/tests/security/test_a2a_trust_gate.py` — two regression tests:
  - `test_missing_agent_id_returns_401`: verifies 401 + trust manager never called for anonymous callers
  - `test_untrusted_peer_returns_403`: verifies existing UNTRUSTED-peer 403 path is preserved

## Security analysis

| Caller type | Before fix | After fix |
|---|---|---|
| No header (anonymous) | ✅ Bypassed all checks, task submitted | ✅ 401 Unauthorized |
| Identified, UNTRUSTED | ✅ 403 Forbidden | ✅ 403 Forbidden (unchanged) |
| Identified, LIMITED+ | ✅ Allowed | ✅ Allowed (unchanged) |

No other endpoints in `a2a.py` use `x_a2a_agent_id` in a trust gate — the fix is scoped to `submit_task`.

## Test plan

- [x] `test_missing_agent_id_returns_401` — passes
- [x] `test_untrusted_peer_returns_403` — passes
- [x] No Redis connections required during test collection (pre-stub pattern)
- [x] Pre-existing `a2a/a2a_security_test.py` collection failure is unrelated (missing `AutoBotConfig.get_redis_config` method, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)