### PR TITLE
ux(nav): consolidate navigation to ≤7 items — Miller's Law fix (GH#8748)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -94,19 +94,84 @@
 
           <!-- Right side - Status and controls -->
           <div class="flex items-center gap-4">
-            <!-- User Profile Button -->
-            <button
-              v-if="userStore.isAuthenticated"
-              @click="showProfileModal = true"
-              class="hidden sm:flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium text-autobot-text-primary hover:bg-autobot-bg-tertiary transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-autobot-primary"
-              :title="$t('nav.profileSettings')"
-              :aria-label="$t('nav.profileSettings')"
-            >
-              <div class="w-6 h-6 rounded-full bg-autobot-primary flex items-center justify-center text-white text-xs font-bold shrink-0">
-                {{ displayUsername?.charAt(0)?.toUpperCase() || 'U' }}
-              </div>
-              <span class="max-w-[120px] truncate">{{ displayUsername || $t('nav.profile') }}</span>
-            </button>
+            <!-- User Profile Dropdown (GH#8748: surfaces settings/admin items moved from primary nav) -->
+            <div v-if="userStore.isAuthenticated" class="relative hidden sm:block" ref="profileDropdownRef">
+              <button
+                @click="showProfileDropdown = !showProfileDropdown"
+                class="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium text-autobot-text-primary hover:bg-autobot-bg-tertiary transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-autobot-primary"
+                :title="$t('nav.profileSettings')"
+                :aria-label="$t('nav.profileSettings')"
+                :aria-expanded="showProfileDropdown"
+                aria-haspopup="menu"
+              >
+                <div class="w-6 h-6 rounded-full bg-autobot-primary flex items-center justify-center text-white text-xs font-bold shrink-0">
+                  {{ displayUsername?.charAt(0)?.toUpperCase() || 'U' }}
+                </div>
+                <span class="max-w-[120px] truncate">{{ displayUsername || $t('nav.profile') }}</span>
+                <svg class="w-3 h-3" :class="showProfileDropdown ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8l5 5 5-5" />
+                </svg>
+              </button>
+
+              <Teleport to="body">
+                <div
+                  v-if="showProfileDropdown"
+                  ref="profileDropdownMenuRef"
+                  :style="profileDropdownStyle"
+                  class="fixed z-50 bg-autobot-bg-secondary border border-autobot-border rounded-md shadow-lg py-1 min-w-48"
+                  role="menu"
+                >
+                  <!-- Open full profile modal -->
+                  <button
+                    role="menuitem"
+                    class="flex items-center gap-2 w-full text-start px-3 py-2 text-sm transition-colors duration-150 hover:bg-autobot-bg-tertiary text-autobot-text-primary"
+                    @click="showProfileModal = true; showProfileDropdown = false"
+                  >
+                    <div class="w-4 h-4 rounded-full bg-autobot-primary flex items-center justify-center text-white text-[10px] font-bold shrink-0">
+                      {{ displayUsername?.charAt(0)?.toUpperCase() || 'U' }}
+                    </div>
+                    <span>{{ $t('nav.profileSettings') }}</span>
+                  </button>
+
+                  <hr class="my-1 border-autobot-border" />
+
+                  <!-- Settings & Tools section -->
+                  <p class="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-autobot-text-secondary">{{ $t('nav.settingsAndTools') }}</p>
+                  <router-link
+                    v-for="item in profileMenuItems"
+                    :key="item.to"
+                    :to="item.to"
+                    role="menuitem"
+                    class="flex items-center gap-2 px-3 py-2 text-sm transition-colors duration-150 hover:bg-autobot-bg-tertiary text-autobot-text-primary"
+                    @click="showProfileDropdown = false"
+                  >
+                    <svg class="w-4 h-4 shrink-0" :fill="item.iconStroke ? 'none' : 'currentColor'" :stroke="item.iconStroke ? 'currentColor' : undefined" viewBox="0 0 20 20" aria-hidden="true">
+                      <path :d="item.icon" :fill-rule="item.iconRule" :clip-rule="item.iconRule" :stroke-linecap="item.iconStroke ? 'round' : undefined" :stroke-linejoin="item.iconStroke ? 'round' : undefined" :stroke-width="item.iconStroke ? '2' : undefined" />
+                    </svg>
+                    <span>{{ $t(item.labelKey) }}</span>
+                  </router-link>
+
+                  <!-- Admin section (admin-only) -->
+                  <template v-if="userStore.isAdmin">
+                    <hr class="my-1 border-autobot-border" />
+                    <p class="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-autobot-text-secondary">{{ $t('nav.adminPanel') }}</p>
+                    <router-link
+                      v-for="item in adminMenuItems"
+                      :key="item.to"
+                      :to="item.to"
+                      role="menuitem"
+                      class="flex items-center gap-2 px-3 py-2 text-sm transition-colors duration-150 hover:bg-autobot-bg-tertiary text-autobot-text-primary"
+                      @click="showProfileDropdown = false"
+                    >
+                      <svg class="w-4 h-4 shrink-0" :fill="item.iconStroke ? 'none' : 'currentColor'" :stroke="item.iconStroke ? 'currentColor' : undefined" viewBox="0 0 20 20" aria-hidden="true">
+                        <path :d="item.icon" :fill-rule="item.iconRule" :clip-rule="item.iconRule" :stroke-linecap="item.iconStroke ? 'round' : undefined" :stroke-linejoin="item.iconStroke ? 'round' : undefined" :stroke-width="item.iconStroke ? '2' : undefined" />
+                      </svg>
+                      <span>{{ $t(item.labelKey) }}</span>
+                    </router-link>
+                  </template>
+                </div>
+              </Teleport>
+            </div>
 
             <!-- Dark Mode Toggle -->
             <DarkModeToggle />
@@ -195,6 +260,50 @@
 
                         <!-- Language Switcher -->
             <LanguageSwitcher :mobile="true" />
+
+            <!-- GH#8748: Settings & Tools (moved from primary nav) -->
+            <div class="border-t border-autobot-border pt-2 mt-1">
+              <p class="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-autobot-text-secondary">{{ $t('nav.settingsAndTools') }}</p>
+              <router-link
+                v-for="item in profileMenuItems"
+                :key="item.to"
+                :to="item.to"
+                @click="closeMobileNav"
+                :class="{
+                  'bg-autobot-primary text-white': $route.path.startsWith(item.to),
+                  'text-autobot-text-primary hover:bg-autobot-bg-tertiary': !$route.path.startsWith(item.to)
+                }"
+                class="flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200"
+              >
+                <svg class="w-4 h-4 shrink-0" :fill="item.iconStroke ? 'none' : 'currentColor'" :stroke="item.iconStroke ? 'currentColor' : undefined" viewBox="0 0 20 20" aria-hidden="true">
+                  <path :d="item.icon" :fill-rule="item.iconRule" :clip-rule="item.iconRule" :stroke-linecap="item.iconStroke ? 'round' : undefined" :stroke-linejoin="item.iconStroke ? 'round' : undefined" :stroke-width="item.iconStroke ? '2' : undefined" />
+                </svg>
+                <span>{{ $t(item.labelKey) }}</span>
+              </router-link>
+            </div>
+
+            <!-- GH#8748: Admin tools (moved from primary nav, admin-only) -->
+            <template v-if="userStore.isAdmin">
+              <div class="border-t border-autobot-border pt-2 mt-1">
+                <p class="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-autobot-text-secondary">{{ $t('nav.adminPanel') }}</p>
+                <router-link
+                  v-for="item in adminMenuItems"
+                  :key="item.to"
+                  :to="item.to"
+                  @click="closeMobileNav"
+                  :class="{
+                    'bg-autobot-primary text-white': $route.path.startsWith(item.to),
+                    'text-autobot-text-primary hover:bg-autobot-bg-tertiary': !$route.path.startsWith(item.to)
+                  }"
+                  class="flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200"
+                >
+                  <svg class="w-4 h-4 shrink-0" :fill="item.iconStroke ? 'none' : 'currentColor'" :stroke="item.iconStroke ? 'currentColor' : undefined" viewBox="0 0 20 20" aria-hidden="true">
+                    <path :d="item.icon" :fill-rule="item.iconRule" :clip-rule="item.iconRule" :stroke-linecap="item.iconStroke ? 'round' : undefined" :stroke-linejoin="item.iconStroke ? 'round' : undefined" :stroke-width="item.iconStroke ? '2' : undefined" />
+                  </svg>
+                  <span>{{ $t(item.labelKey) }}</span>
+                </router-link>
+              </div>
+            </template>
 
             <!-- Profile Settings (Issue #950) -->
             <button
@@ -413,7 +522,7 @@
 </template>
 
 <script lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted, defineAsyncComponent } from 'vue';
+import { ref, computed, watch, nextTick, onMounted, onUnmounted, defineAsyncComponent } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { useAppStore } from '@/stores/useAppStore'
@@ -431,7 +540,7 @@ import { initializeNotificationBridge } from '@/utils/notificationBridge';
 import { smartMonitoringController, getAdaptiveInterval } from '@/config/OptimizedPerformance.js';
 import { clearAllSystemNotifications, resetHealthMonitor } from '@/utils/ClearNotifications.js';
 import { getSLMAdminUrl } from '@/config/ssot-config';
-import { navItems } from '@/config/navItems';
+import { navItems, profileMenuItems, adminMenuItems } from '@/config/navItems';
 import SystemStatusNotification from '@/components/ui/SystemStatusNotification.vue';
 import CaptchaNotification from '@/components/research/CaptchaNotification.vue';
 import ToastContainer from '@/components/ui/ToastContainer.vue';
@@ -535,6 +644,46 @@ export default {
     // Reactive data (non-status related)
     const showMobileNav = ref(false);
     const showProfileModal = ref(false);
+
+    // GH#8748: profile dropdown (settings/admin items moved from primary nav)
+    const showProfileDropdown = ref(false);
+    const profileDropdownRef = ref<HTMLElement | null>(null);
+    const profileDropdownMenuRef = ref<HTMLElement | null>(null);
+    const profileDropdownStyle = ref<Record<string, string>>({});
+
+    function positionProfileDropdown() {
+      if (!profileDropdownRef.value) return;
+      const rect = profileDropdownRef.value.getBoundingClientRect();
+      const menuWidth = profileDropdownMenuRef.value?.getBoundingClientRect().width || 192;
+      const spaceRight = window.innerWidth - rect.left;
+      const left = spaceRight < menuWidth ? rect.right - menuWidth : rect.left;
+      profileDropdownStyle.value = {
+        top: `${rect.bottom + 4}px`,
+        left: `${Math.max(0, left)}px`,
+      };
+    }
+
+    function onProfileDropdownClickOutside(event: MouseEvent) {
+      const target = event.target as Node;
+      if (
+        !profileDropdownRef.value?.contains(target) &&
+        !profileDropdownMenuRef.value?.contains(target)
+      ) {
+        showProfileDropdown.value = false;
+      }
+    }
+
+    watch(showProfileDropdown, async (open) => {
+      if (open) {
+        positionProfileDropdown();
+        await nextTick();
+        positionProfileDropdown();
+        document.addEventListener('click', onProfileDropdownClickOutside, true);
+      } else {
+        document.removeEventListener('click', onProfileDropdownClickOutside, true);
+      }
+    });
+
     let notificationCleanup: number | null = null;
 
     // Computed properties
@@ -833,6 +982,10 @@ export default {
       // Reactive data
       showMobileNav,
       showProfileModal,
+      showProfileDropdown,
+      profileDropdownRef,
+      profileDropdownMenuRef,
+      profileDropdownStyle,
 
       // System status (from composable)
       showSystemStatus,
@@ -846,6 +999,8 @@ export default {
       showAuthChrome,
       hideFooter,
       navItems,
+      profileMenuItems,
+      adminMenuItems,
       slmAdminUrl,
       displayUsername,
 

--- a/autobot-frontend/src/components/layout/NavOverflowMenu.vue
+++ b/autobot-frontend/src/components/layout/NavOverflowMenu.vue
@@ -14,6 +14,11 @@
       @keydown.escape="close(true)"
     >
       <span>{{ $t('nav.more') }}</span>
+      <!-- GH#8748: count badge — Information Scent for hidden items -->
+      <span
+        class="ml-0.5 min-w-[18px] h-[18px] px-1 rounded-full bg-autobot-primary text-white text-[10px] font-bold leading-[18px] text-center"
+        aria-hidden="true"
+      >{{ items.length }}</span>
       <svg
         class="w-3 h-3 transition-transform duration-150"
         :class="open ? 'rotate-180' : ''"

--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -6,7 +6,12 @@
  *
  * Extracted from App.vue (#6499) so it can be unit-tested for coverage
  * against the router. Every top-level `requiresAuth: true` route in
- * `router/index.ts` MUST appear here unless it is in the test allowlist.
+ * `router/index.ts` MUST appear here unless it carries `hideInNav: true`
+ * on its route meta or is in the test allowlist.
+ *
+ * GH#8748: consolidated from 17+ items to ≤7 primary items (Miller's Law).
+ * Secondary items moved to profileMenuItems / adminMenuItems and surfaced
+ * from the profile dropdown rather than the primary nav rail.
  *
  * @see src/__tests__/nav-items-coverage.test.ts
  */
@@ -24,45 +29,44 @@ export interface NavItem {
   adminOnly?: boolean;
 }
 
+// ─── Primary nav (≤7 items for non-admin users at 1440 px) ───────────────────
 // Data-driven navigation items: single source of truth for desktop + mobile nav
 export const navItems: NavItem[] = [
   { to: '/home', labelKey: 'nav.home', icon: 'M10.707 2.293a1 1 0 00-1.414 0l-7 7v11a1 1 0 001 1h2a1 1 0 001-1v-5a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 001 1h2a1 1 0 001-1v-7l7-7a1 1 0 000-1.414z', iconRule: 'evenodd' },
   { to: '/chat', labelKey: 'nav.chat', icon: 'M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z', iconRule: 'evenodd' },
-  // MVA-360: Live Canvas (behind VITE_FEATURE_CANVAS flag)
-  { to: '/canvas', labelKey: 'nav.canvas', icon: 'M3 3h7v7H3V3zm0 11h7v7H3v-7zm11-11h7v7h-7V3zm0 11h7v7h-7v-7z', iconStroke: true },
   { to: '/knowledge', labelKey: 'nav.knowledge', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' },
   { to: '/automation', labelKey: 'nav.automation', icon: 'M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z', iconRule: 'evenodd' },
   { to: '/analytics', labelKey: 'nav.analytics', iconPaths: ['M2 10a8 8 0 018-8v8h8a8 8 0 11-16 0z', 'M12 2.252A8.014 8.014 0 0117.748 8H12V2.252z'] },
-  // Issue #4703 / #6634: single Agents nav entry — Activity and Heartbeat
-  // are reached as tabs inside the AgentsLayout shell, not as separate
-  // sidebar items.
+  // Issue #4703 / #6634: single Agents nav entry — Activity and Heartbeat are reached as tabs
   { to: '/agents/registry', labelKey: 'nav.agentRegistry', icon: 'M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2V9M9 21H5a2 2 0 01-2-2V9m0 0h18', iconStroke: true },
-  // Issue #929: Plugin Manager — marketplace integrated within /plugins
+  // GH#8748: LLC views consolidated to one "Company OS" entry (was 5 separate items)
+  { to: '/llc/dashboard', labelKey: 'nav.companyOs', icon: 'M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4', iconStroke: true },
+];
+
+// ─── Profile/settings menu items (GH#8748) ───────────────────────────────────
+// Shown in the profile dropdown — not in the primary nav rail.
+// Routes must carry hideInNav: true in router/index.ts.
+export const profileMenuItems: NavItem[] = [
+  // MVA-360: Live Canvas
+  { to: '/canvas', labelKey: 'nav.canvas', icon: 'M3 3h7v7H3V3zm0 11h7v7H3v-7zm11-11h7v7h-7V3zm0 11h7v7h-7v-7z', iconStroke: true },
+  // Issue #929: Plugin Manager
   { to: '/plugins', labelKey: 'nav.plugins', icon: 'M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z', iconStroke: true },
   { to: '/secrets', labelKey: 'nav.secrets', icon: 'M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z', iconRule: 'evenodd' },
-  // Issue #4270: Operations moved under /analytics/operations tab
-  // Code Intelligence removed from main nav — merged into /analytics/codebase
-  // Desktop nav removed — noVNC lives in the Chat tab. /desktop redirects to /chat.
-  // Issue #902: Dev Tools moved into /analytics/dev-tools tab
-  // Issue #4492: Custom Dashboard renamed to /home (removed separate nav entry)
   { to: '/preferences', labelKey: 'nav.preferences', icon: 'M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z', iconRule: 'evenodd' },
-  // Issue #8247: LLC group — Company OS views
-  { to: '/llc/dashboard', labelKey: 'nav.llcDashboard', icon: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6', iconStroke: true },
-  { to: '/llc/org-chart', labelKey: 'nav.llcOrgChart', icon: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z', iconStroke: true },
-  { to: '/llc/goals', labelKey: 'nav.llcGoals', icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z', iconStroke: true },
-  { to: '/llc/companies', labelKey: 'nav.llcCompanies', icon: 'M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4', iconStroke: true },
-  // About moved to footer link
-  // Issue #4465: Usage moved under /analytics/usage tab
-  // Issue #1440: AutoResearch experiment dashboard (admin-only)
-  { to: '/experiments', labelKey: 'nav.experiments', adminOnly: true, icon: 'M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z' },
-  // Issue #6590: Virtual LLM API keys admin view (admin-only)
-  { to: '/admin/llm-keys', labelKey: 'nav.llmApiKeys', adminOnly: true, icon: 'M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z', iconRule: 'evenodd' },
-  // Issue #7773: Sandbox file inspector (admin-only)
-  { to: '/admin/sandbox', labelKey: 'nav.adminSandbox', adminOnly: true, icon: 'M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z', iconStroke: true },
-  // Issue #7513: Host inventory management (admin-only)
-  { to: '/admin/hosts', labelKey: 'nav.adminHosts', adminOnly: true, icon: 'M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01', iconStroke: true },
-  // GH#6470: Budget policy management (admin-only)
-  { to: '/admin/budget-policies', labelKey: 'nav.budgetPolicies', adminOnly: true, icon: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z', iconStroke: true },
-  // GH#8250: LLC Company Portability — export + import
-  { to: '/llc/portability', labelKey: 'nav.llcPortability', icon: 'M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12', iconStroke: true },
+];
+
+// ─── Admin-only menu items (GH#8748) ─────────────────────────────────────────
+// Shown in an "Admin" section of the profile dropdown — not in the primary nav.
+// Routes must carry hideInNav: true in router/index.ts.
+export const adminMenuItems: NavItem[] = [
+  // Issue #1440: AutoResearch experiment dashboard
+  { to: '/experiments', labelKey: 'nav.experiments', icon: 'M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z' },
+  // Issue #6590: Virtual LLM API keys admin view
+  { to: '/admin/llm-keys', labelKey: 'nav.llmApiKeys', icon: 'M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z', iconRule: 'evenodd' },
+  // Issue #7773: Sandbox file inspector
+  { to: '/admin/sandbox', labelKey: 'nav.adminSandbox', icon: 'M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z', iconStroke: true },
+  // Issue #7513: Host inventory management
+  { to: '/admin/hosts', labelKey: 'nav.adminHosts', icon: 'M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01', iconStroke: true },
+  // GH#6470: Budget policy management
+  { to: '/admin/budget-policies', labelKey: 'nav.budgetPolicies', icon: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z', iconStroke: true },
 ];

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7312,7 +7312,15 @@
     "moreItems": "More navigation items",
     "adminHosts": "Host Inventory",
     "adminSandbox": "Sandbox",
-    "budgetPolicies": "Budget Policies"
+    "budgetPolicies": "Budget Policies",
+    "companyOs": "Company OS",
+    "llcDashboard": "Dashboard",
+    "llcOrgChart": "Org Chart",
+    "llcGoals": "Goals",
+    "llcCompanies": "Companies",
+    "llcPortability": "Portability",
+    "settingsAndTools": "Settings & Tools",
+    "adminPanel": "Admin Panel"
   },
   "reasoningTrace": {
     "title": "Reasoning trace",

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -554,7 +554,8 @@ export const routes: RouteRecordRaw[] = [
       title: 'Preferences',
       icon: 'fas fa-sliders-h',
       description: 'Customize your AutoBot experience',
-      requiresAuth: true
+      requiresAuth: true,
+      hideInNav: true,
     }
   },
   // Issue #4492: Home serves custom dashboard — renamed from /custom-dashboard
@@ -692,6 +693,7 @@ export const routes: RouteRecordRaw[] = [
     meta: {
       title: 'Canvas',
       requiresAuth: true,
+      hideInNav: true,
     },
   },
   // Issue #3201: AutoResearch Experiment Dashboard
@@ -704,6 +706,7 @@ export const routes: RouteRecordRaw[] = [
       icon: 'BeakerIcon',
       description: 'AutoResearch experiment dashboard',
       requiresAuth: true,
+      hideInNav: true,
     },
   },
   // Issue #6590: Virtual LLM API Keys admin view
@@ -716,6 +719,7 @@ export const routes: RouteRecordRaw[] = [
       description: 'Manage virtual LLM API keys with per-key budgets',
       requiresAuth: true,
       admin: true,
+      hideInNav: true,
     },
   },
   // Issue #1801: Admin User Management
@@ -741,6 +745,7 @@ export const routes: RouteRecordRaw[] = [
       description: 'Browse code-execution sandbox files',
       requiresAuth: true,
       admin: true,
+      hideInNav: true,
     },
   },
   // Issue #7513: Host inventory admin view
@@ -753,6 +758,7 @@ export const routes: RouteRecordRaw[] = [
       description: 'Manage multi-host role deployment',
       requiresAuth: true,
       admin: true,
+      hideInNav: true,
     },
   },
   // GH#6470: Budget policy management (admin-only)
@@ -765,6 +771,7 @@ export const routes: RouteRecordRaw[] = [
       description: 'Manage agent spend thresholds and auto-pause rules',
       requiresAuth: true,
       admin: true,
+      hideInNav: true,
     },
   },
   // /desktop removed from nav — noVNC is accessible via the Chat tab's noVNC tab.
@@ -851,7 +858,8 @@ export const routes: RouteRecordRaw[] = [
       title: 'Plugin Manager',
       icon: 'fas fa-puzzle-piece',
       description: 'Browse, install, and manage AutoBot plugins',
-      requiresAuth: true
+      requiresAuth: true,
+      hideInNav: true,
     },
     children: [
       // Issue #1803: Marketplace as sub-route of plugins
@@ -877,7 +885,7 @@ export const routes: RouteRecordRaw[] = [
     path: '/llc/portability',
     name: 'llc-portability',
     component: () => import('@/views/llc/CompanyPortabilityView.vue'),
-    meta: { title: 'Company Portability', requiresAuth: true },
+    meta: { title: 'Company Portability', requiresAuth: true, hideInNav: true },
   },
   // Issue #729: Secrets stays in autobot-vue - user functionality for chat/agent credentials
   {
@@ -888,7 +896,8 @@ export const routes: RouteRecordRaw[] = [
       title: 'Secrets Manager',
       icon: 'fas fa-key',
       description: 'Manage API keys and secrets for chat and agent access',
-      requiresAuth: true
+      requiresAuth: true,
+      hideInNav: true,
     },
     children: [
       {
@@ -913,19 +922,19 @@ export const routes: RouteRecordRaw[] = [
     path: '/llc/org-chart',
     name: 'llc-org-chart',
     component: () => import('@/views/llc/OrgChart.vue'),
-    meta: { title: 'Org Chart', requiresAuth: true, llcScope: true },
+    meta: { title: 'Org Chart', requiresAuth: true, llcScope: true, hideInNav: true },
   },
   {
     path: '/llc/goals',
     name: 'llc-goals',
     component: () => import('@/views/llc/GoalTree.vue'),
-    meta: { title: 'Goal Tree', requiresAuth: true, llcScope: true },
+    meta: { title: 'Goal Tree', requiresAuth: true, llcScope: true, hideInNav: true },
   },
   {
     path: '/llc/companies',
     name: 'llc-companies',
     component: () => import('@/views/llc/SubCompanyTree.vue'),
-    meta: { title: 'Company Hierarchy', requiresAuth: true, llcScope: true },
+    meta: { title: 'Company Hierarchy', requiresAuth: true, llcScope: true, hideInNav: true },
   },
   // Issue #4465: Usage moved under /analytics/usage
   { path: '/usage', redirect: '/analytics/usage' },


### PR DESCRIPTION
## Summary

Fixes #8748 — top-level navigation violated Miller's Law with 17+ items.

- **7 primary nav items** for non-admin users at 1440px: Home · Chat · Knowledge · Automation · Analytics · Agents · Company OS (was 15+)
- **5 LLC views consolidated** to one "Company OS" entry at `/llc/dashboard`; sub-views (Org Chart, Goals, Companies, Portability) remain routable via direct URL
- **Settings & Tools moved to profile dropdown**: Canvas, Plugins, Secrets, Preferences
- **Admin items moved to profile dropdown admin section**: Experiments, LLM Keys, Sandbox, Hosts, Budget Policies (admin-only, only visible to isAdmin users)
- **Overflow menu count badge**: `More (N)` button now shows how many items are hidden (Information Scent fix)
- **Mobile nav**: Settings & Tools and Admin sections added as labelled groups after primary nav items
- **No route removals**: all 13 relocated routes keep `requiresAuth: true` and gain `hideInNav: true` so the nav coverage test continues to pass without growing the allowlist

## Acceptance Criteria

- [x] Non-admin users see ≤7 primary nav items at 1440px viewport
- [x] Admin-specific routes accessible from profile/admin menu, not primary nav
- [x] LLC section consolidated to one nav entry
- [x] Overflow menu shows item count badge when items are hidden
- [x] Existing URLs remain functional (no redirects needed — routes unchanged)

## Test plan

- [ ] Verify 7 primary nav items visible for non-admin at wide viewport
- [ ] Open profile dropdown → confirm Canvas, Plugins, Secrets, Preferences listed under "Settings & Tools"
- [ ] Log in as admin → confirm Experiments, LLM Keys, Sandbox, Hosts, Budget Policies in "Admin Panel" section
- [ ] Navigate to `/llc/org-chart` directly — should still load
- [ ] Resize viewport narrow → overflow "More (N)" badge shows correct count
- [ ] Mobile nav → confirm Settings & Tools and Admin Panel sections present

🤖 Generated with [Claude Code](https://claude.com/claude-code)