### PR TITLE
fix(knowledge): add mobile sidebar collapse toggle with drawer overlay (GH#8749)

### DIFF
--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -2423,7 +2423,9 @@
       "analytics": "Analytics",
       "statistics": "Statistics",
       "webResearch": "Web Research",
-      "webResearchAriaLabel": "4-tab web research panel"
+      "webResearchAriaLabel": "4-tab web research panel",
+      "openSidebar": "Open navigation menu",
+      "closeSidebar": "Close navigation menu"
     },
     "backup": {
       "title": "Backup & Restore",

--- a/autobot-frontend/src/views/KnowledgeView.vue
+++ b/autobot-frontend/src/views/KnowledgeView.vue
@@ -1,7 +1,18 @@
 <template>
   <div class="knowledge-view">
+    <!-- Mobile overlay backdrop -->
+    <div
+      v-if="showMobileSidebar"
+      class="mobile-overlay"
+      aria-hidden="true"
+      @click="showMobileSidebar = false"
+    />
+
     <!-- Sidebar Navigation - Issue #901: Technical Precision Design -->
-    <aside class="knowledge-sidebar">
+    <aside
+      class="knowledge-sidebar"
+      :class="{ 'mobile-open': showMobileSidebar }"
+    >
       <div class="sidebar-header">
         <h3>
           <svg class="header-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -9,10 +20,23 @@
           </svg>
           {{ $t('knowledge.views.title') }}
         </h3>
+        <button
+          class="mobile-toggle"
+          :aria-label="showMobileSidebar ? $t('knowledge.views.closeSidebar') : $t('knowledge.views.openSidebar')"
+          :aria-expanded="showMobileSidebar"
+          @click="toggleMobileSidebar"
+        >
+          <svg v-if="showMobileSidebar" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+          <svg v-else fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
       </div>
 
       <!-- Category Navigation -->
-      <nav class="category-nav" :aria-label="$t('knowledge.views.navAriaLabel')">
+      <nav class="category-nav" :aria-label="$t('knowledge.views.navAriaLabel')" @click="onNavClick">
         <div class="category-divider">
           <span>{{ $t('knowledge.views.browse') }}</span>
         </div>
@@ -193,8 +217,31 @@
 </template>
 
 <script setup lang="ts">
-// View-level component for knowledge base layout
-// Issue #901: Technical Precision sidebar design with electric blue accents
+import { ref, onMounted } from 'vue'
+
+const STORAGE_KEY = 'knowledge-sidebar-mobile-open'
+
+const showMobileSidebar = ref(false)
+
+onMounted(() => {
+  const saved = localStorage.getItem(STORAGE_KEY)
+  showMobileSidebar.value = saved === 'true'
+})
+
+function toggleMobileSidebar() {
+  showMobileSidebar.value = !showMobileSidebar.value
+  localStorage.setItem(STORAGE_KEY, String(showMobileSidebar.value))
+}
+
+function onNavClick(e: Event) {
+  if (window.innerWidth <= 768 && showMobileSidebar.value) {
+    const target = e.target as HTMLElement
+    if (target.closest('a')) {
+      showMobileSidebar.value = false
+      localStorage.setItem(STORAGE_KEY, 'false')
+    }
+  }
+}
 </script>
 
 <style scoped>
@@ -323,20 +370,102 @@
 }
 
 /* ============================================
+ * MOBILE TOGGLE BUTTON (hidden on desktop)
+ * ============================================ */
+
+.mobile-toggle {
+  display: none;
+}
+
+/* ============================================
+ * MOBILE OVERLAY
+ * ============================================ */
+
+.mobile-overlay {
+  display: none;
+}
+
+/* ============================================
  * RESPONSIVE - Mobile
  * ============================================ */
 
 @media (max-width: 768px) {
   .knowledge-view {
     flex-direction: column;
+    position: relative;
   }
 
+  /* Collapsed header strip — no 50vh content, just the header bar */
   .knowledge-sidebar {
     width: 100%;
     min-width: 100%;
-    max-height: 50vh;
+    max-height: none;
+    height: auto;
     border-right: none;
     border-bottom: 1px solid var(--border-default);
+    overflow: hidden;
+    position: relative;
+    z-index: 200;
+  }
+
+  /* Hide nav in collapsed state */
+  .knowledge-sidebar:not(.mobile-open) .category-nav {
+    display: none;
+  }
+
+  /* Expanded drawer — overlays content, full-height */
+  .knowledge-sidebar.mobile-open {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 80vw;
+    max-width: 320px;
+    height: 100dvh;
+    z-index: 300;
+    border-right: 1px solid var(--border-default);
+    border-bottom: none;
+    overflow-y: auto;
+  }
+
+  /* Overlay backdrop */
+  .mobile-overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 299;
+  }
+
+  /* Toggle button visible on mobile */
+  .mobile-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    background: transparent;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md, 6px);
+    color: var(--text-secondary);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background var(--duration-150) var(--ease-in-out);
+  }
+
+  .mobile-toggle:hover {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+  }
+
+  .mobile-toggle svg {
+    width: 18px;
+    height: 18px;
+  }
+
+  .sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
   }
 
   .sidebar-header h3 {


### PR DESCRIPTION
## Summary

- Removes the cramped `max-height: 50vh` strip that locked 11 nav items into a fixed half-screen band on mobile (≤768px)
- Collapsed state: only the sidebar header bar is visible, with a hamburger toggle button on the right
- Expanded state: sidebar slides in as a full-height drawer (`80vw`, max 320px) overlaying the content area, with a dark backdrop that closes it on tap
- Toggle state persisted to `localStorage` (`knowledge-sidebar-mobile-open`) so it survives page reloads
- Nav-item clicks auto-close the drawer
- `openSidebar` / `closeSidebar` i18n keys added to `en.json` for the toggle button aria-labels

## Test plan

- [ ] On a ≤768px viewport: sidebar header visible, nav hidden — hamburger button present
- [ ] Tap hamburger → drawer slides in, all 11 items reachable without scrolling
- [ ] Tap overlay / tap X → drawer closes, content fills full height
- [ ] Reload page → collapsed/expanded state restored from localStorage
- [ ] On desktop (>768px): toggle button hidden, sidebar renders as before

Closes #8749

🤖 Generated with [Claude Code](https://claude.com/claude-code)