### PR TITLE
fix(task-workspace): preserve workspace_dir on transient allocation failure (GH#8687)

### DIFF
--- a/autobot-backend/services/heartbeat_scheduler.py
+++ b/autobot-backend/services/heartbeat_scheduler.py
@@ -257,13 +257,16 @@ class HeartbeatScheduler:
                     workspace_dir = ws_info.worktree_path
                     state.workspace_dir = workspace_dir
                 except Exception as exc:
-                    # Clear stale workspace_dir so the adapter does not run
-                    # in a deleted or invalid worktree (GH#6471 review finding).
-                    state.workspace_dir = None
+                    # Do not overwrite a valid prior workspace path on transient
+                    # allocation failures (GH#8687).  Leave state.workspace_dir
+                    # unchanged so the adapter can still use the last known good
+                    # path.  Only a successful allocation updates the path above.
                     logger.warning(
-                        "Workspace allocation failed for task=%s agent=%s: %s",
+                        "Workspace allocation failed for task=%s agent=%s"
+                        " (preserving existing workspace_dir=%r): %s",
                         state.current_task_id,
                         agent_id,
+                        state.workspace_dir,
                         exc,
                     )
 


### PR DESCRIPTION
## Summary

Fixes GH#8687. In `heartbeat_scheduler.py` `_start_run()`, when workspace allocation raises an exception, the handler previously set `state.workspace_dir = None` unconditionally and committed — overwriting any valid workspace path from a prior successful run.

**Root cause:** The `state.workspace_dir = None` line assumed every allocation failure meant the on-disk workspace was gone, but a transient error (lock contention, network hiccup during `git worktree add`) can fail while the prior workspace is still valid and intact.

**Fix:** Remove the unconditional `state.workspace_dir = None`. The path is only updated on a *successful* allocation (`state.workspace_dir = workspace_dir` in the `try` block). On failure, we log a warning including the preserved path and leave `state.workspace_dir` unchanged.

The original GH#6471 guard still holds for the success path — a new allocation always overwrites the stored path with the freshly allocated worktree.

## Files Changed

- `autobot-backend/services/heartbeat_scheduler.py`: removed `state.workspace_dir = None` from the exception handler; improved warning log to show the preserved path.

## Test plan

- [ ] Simulate a transient `git worktree add` failure; verify `state.workspace_dir` retains its prior value after the heartbeat tick.
- [ ] Normal allocation success: verify `state.workspace_dir` is updated to the new worktree path.
- [ ] First-run with no prior workspace and allocation failure: `state.workspace_dir` stays `None` (unchanged from its initial value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)