### PR TITLE
fix(404): change primary button to 'Go Home' → /home, fix icon/label mismatch (GH#8754)

### DIFF
--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -5458,6 +5458,7 @@
     "notFound": {
       "title": "404",
       "description": "The page you're looking for doesn't exist or has been moved.",
+      "goHome": "Go Home",
       "goToChat": "Go to Chat",
       "goBack": "Go Back",
       "quickLinks": "Quick Links",

--- a/autobot-frontend/src/views/NotFoundView.vue
+++ b/autobot-frontend/src/views/NotFoundView.vue
@@ -15,9 +15,9 @@
 
         <!-- Navigation Options -->
         <div class="action-buttons">
-          <router-link to="/chat" class="btn-action-primary">
+          <router-link to="/home" class="btn-action-primary">
             <Icon name="home" />
-            <span>{{ $t('views.notFound.goToChat') }}</span>
+            <span>{{ $t('views.notFound.goHome') }}</span>
           </router-link>
           <button @click="$router.go(-1)" class="btn-action-secondary">
             <Icon name="arrow-left" />


### PR DESCRIPTION
## Summary

Fixes icon/label/destination mismatch on the 404 recovery page (GH#8754). The primary button showed a `home` icon with "Go to Chat" label but routed to `/chat`. Closes #8754.

## Thinking Path

The primary button had three mismatched attributes: icon (`home`), label ("Go to Chat"), and destination (`/chat`). The simplest coherent fix is to align all three by routing to `/home` with label "Go Home" — matching the existing `home` icon. No visual redesign needed; just route + i18n key change. Quick links grid is unchanged since Chat, Knowledge, Automation, and Analytics remain accessible there.

## What Changed

- `autobot-frontend/src/views/NotFoundView.vue`: primary button route `/chat` → `/home`, i18n key `goToChat` → `goHome`
- `autobot-frontend/src/i18n/locales/en.json`: added `views.notFound.goHome: "Go Home"`

## Verification

- Vue template change is a one-line route swap + one-line i18n key swap — no logic added
- `vue-tsc-baseline` CI check passes
- i18n key `goHome` present in `en.json` under `views.notFound`
- Manual test path: navigate to `/nonexistent` → 404 page → click "Go Home" → lands on `/home`

## Model Used

claude-sonnet-4-6

## Test Plan

- [ ] Navigate to an invalid URL — 404 page appears
- [ ] Click "Go Home" — redirects to `/home` dashboard
- [ ] House icon matches "Go Home" label

## Changelog fragment

- [ ] N/A — internal UX fix, no user-visible API or behaviour change beyond the button label