### PR TITLE
fix(coordination/hook): fix duplicate endswith — exempt test_*.py (GH#8706)

### DIFF
--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-module-singletons
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-module-singletons
@@ -95,7 +95,7 @@ def _is_test_file(path: str) -> bool:
     return (
         "/tests/" in p
         or p.endswith("_test.py")
-        or p.endswith("_test.py")
+        or p.split("/")[-1].startswith("test_")
         or "/test_" in p
         or "conftest" in p
     )


### PR DESCRIPTION
## Summary

- Fixes duplicate `p.endswith("_test.py")` check in `_is_test_file()` in `pre-commit-no-module-singletons`
- The second line was intended to exempt `test_*.py` files but was a copy-paste error; replaced with `p.split("/")[-1].startswith("test_")` to correctly exempt `test_*.py`-named files
- Closes GH#8706

## What Changed

`autobot-infrastructure/shared/scripts/hooks/pre-commit-no-module-singletons`:
- Line 98: `p.endswith("_test.py")` → `p.split("/")[-1].startswith("test_")`

## Verification

- Files like `test_foo.py` now pass through `_is_test_file()` and are correctly identified as test files (exempted from the check)
- Files like `foo_test.py` still matched by line 97 — unchanged
- `/tests/` dirs, `conftest`, `/test_` path segments still covered by other conditions

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)