### PR TITLE
feat(llc): wire GoalService.get_goal_ancestry_for_work_item() into production paths (GH#8746)

### DIFF
--- a/autobot-backend/chat_history/layers.py
+++ b/autobot-backend/chat_history/layers.py
@@ -236,7 +236,7 @@ class Layer4GoalAncestry:
 
     Loaded when ``goal_ancestry`` is present in the build context — a list of
     dicts with at minimum ``title`` and ``level`` keys (mirrors LLCGoal fields).
-    Callers are responsible for fetching the chain via GoalService.get_ancestors().
+    Callers are responsible for fetching the chain via GoalService.get_goal_ancestry_for_work_item().
     """
 
     async def should_load(self, goal_ancestry: list | None) -> bool:

--- a/autobot-backend/llc/kb/context_builder.py
+++ b/autobot-backend/llc/kb/context_builder.py
@@ -192,10 +192,7 @@ class HeartbeatContextBuilder:
         # Build goal ancestry
         goal_ancestry = []
         if work_item.goal_id:
-            goal = await self.goal_service.get(session, work_item.goal_id)
-            if goal:
-                ancestors = await self.goal_service.get_ancestors(session, work_item.goal_id)
-                goal_ancestry = [{"id": str(g.id), "title": g.title, "level": g.level} for g in ancestors + [goal]]
+            goal_ancestry = await self.goal_service.get_goal_ancestry_for_work_item(session, work_item.goal_id)
 
         return {
             "work_item_id": str(work_item_id),

--- a/autobot-backend/llc/tests/test_heartbeat_context.py
+++ b/autobot-backend/llc/tests/test_heartbeat_context.py
@@ -122,8 +122,7 @@ def builder() -> HeartbeatContextBuilder:
         metadata={"total_results": 1},
     )
     goal_svc = AsyncMock()
-    goal_svc.get.return_value = None
-    goal_svc.get_ancestors.return_value = []
+    goal_svc.get_goal_ancestry_for_work_item.return_value = []
 
     work_svc = AsyncMock()
     work_svc.get.return_value = _make_work_item(company_id="co1", project_id=None)
@@ -203,12 +202,10 @@ async def test_build_fat_with_goal_ancestry(builder: HeartbeatContextBuilder) ->
     goal_id = uuid.uuid4()
     wi = _make_work_item(company_id="co1", goal_id=goal_id)
     builder.work_item_service.get.return_value = wi
-
-    parent_goal = _make_goal(title="Top Level", level=0)
-    child_goal = _make_goal(title="Project Goal", level=1)
-    child_goal.id = goal_id
-    builder.goal_service.get.return_value = child_goal
-    builder.goal_service.get_ancestors.return_value = [parent_goal]
+    builder.goal_service.get_goal_ancestry_for_work_item.return_value = [
+        {"id": str(uuid.uuid4()), "title": "Top Level", "level": 0, "status": "active"},
+        {"id": str(goal_id), "title": "Project Goal", "level": 1, "status": "active"},
+    ]
 
     session = AsyncMock()
     result = await builder.build(
@@ -218,6 +215,7 @@ async def test_build_fat_with_goal_ancestry(builder: HeartbeatContextBuilder) ->
         context_mode="fat",
     )
 
+    builder.goal_service.get_goal_ancestry_for_work_item.assert_called_once_with(session, goal_id)
     assert len(result["goal_ancestry"]) == 2
     assert result["goal_ancestry"][0]["title"] == "Top Level"
     assert result["goal_ancestry"][1]["title"] == "Project Goal"


### PR DESCRIPTION
## Summary

- Replaces the inline `get_ancestors()` + manual dict construction in `HeartbeatContextBuilder._build_fat()` with a call to the dedicated `GoalService.get_goal_ancestry_for_work_item()` method (GH#6469)
- The dedicated method already returns the correct `[{id, title, level, status}]` dict list, eliminating duplicated traversal logic
- Updates `Layer4GoalAncestry` docstring to reference the correct method
- Updates `test_heartbeat_context.py` to mock `get_goal_ancestry_for_work_item` directly and adds a call-site assertion

## Test plan

- [x] All 10 `test_heartbeat_context.py` tests pass (including `test_build_fat_with_goal_ancestry`)
- [x] All 22 `test_goals.py` tests pass (covering `get_goal_ancestry_for_work_item` itself)
- [x] No regressions — only the manual inline pattern was replaced with the purpose-built method

Closes #8746

🤖 Generated with [Claude Code](https://claude.com/claude-code)