### PR TITLE
ux(nav): add /documents to main nav — AI Documents discoverability (GH#8757)

### DIFF
--- a/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
+++ b/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
@@ -43,7 +43,6 @@ const INTENTIONALLY_HIDDEN: Record<string, string> = {
   '/agents': 'Parent shell — redirects to /agents/registry; nav uses the deep-link entry (#6634)',
   '/agents/activity': 'Reached as a tab inside /agents shell (#6634); standalone URL kept for bookmarks',
   '/agents/heartbeat': 'Reached as a tab inside /agents shell (#6634); standalone URL kept for bookmarks',
-  '/documents': 'Opened from chat output ("Save as document"), not main nav',
   '/admin/users': 'Admin-only — surfaced via separate admin entrypoint',
   '/slm/tools/novnc': 'Accessed via Chat tab\'s noVNC sub-tab (#6414/#6415); standalone URL kept for bookmarks',
 }

--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -34,6 +34,8 @@ export interface NavItem {
 export const navItems: NavItem[] = [
   { to: '/home', labelKey: 'nav.home', icon: 'M10.707 2.293a1 1 0 00-1.414 0l-7 7v11a1 1 0 001 1h2a1 1 0 001-1v-5a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 001 1h2a1 1 0 001-1v-7l7-7a1 1 0 000-1.414z', iconRule: 'evenodd' },
   { to: '/chat', labelKey: 'nav.chat', icon: 'M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z', iconRule: 'evenodd' },
+  // GH#8757: AI Documents — saved chat outputs, now reachable from main nav
+  { to: '/documents', labelKey: 'nav.documents', icon: 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z', iconStroke: true },
   { to: '/knowledge', labelKey: 'nav.knowledge', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' },
   { to: '/automation', labelKey: 'nav.automation', icon: 'M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z', iconRule: 'evenodd' },
   { to: '/analytics', labelKey: 'nav.analytics', iconPaths: ['M2 10a8 8 0 018-8v8h8a8 8 0 11-16 0z', 'M12 2.252A8.014 8.014 0 0117.748 8H12V2.252z'] },

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7323,7 +7323,8 @@
     "llcCompanies": "Companies",
     "llcPortability": "Portability",
     "settingsAndTools": "Settings & Tools",
-    "adminPanel": "Admin Panel"
+    "adminPanel": "Admin Panel",
+    "documents": "AI Documents"
   },
   "reasoningTrace": {
     "title": "Reasoning trace",


### PR DESCRIPTION
## Summary
- Added `/documents` route to `navItems.ts` with a document-text stroke icon positioned after `/chat`
- Added `nav.documents` → `"AI Documents"` i18n key to `en.json`
- Removed `/documents` from `INTENTIONALLY_HIDDEN` in the nav coverage test (now has a real entry)

## Test Plan
- [x] `nav-items-coverage.test.ts` passes: every top-level `requiresAuth` route has a nav entry or is allowlisted
- [x] No new TypeScript errors introduced
- [x] Icon style consistent with other stroke-style nav icons (canvas, knowledge)

## Related Issues
Closes #8757