### PR TITLE
fix(rbac): guard openBundleModal against stale in-flight bundle fetch (GH#8705)

### DIFF
--- a/autobot-frontend/src/views/AdminUsersView.vue
+++ b/autobot-frontend/src/views/AdminUsersView.vue
@@ -190,13 +190,13 @@
     </div>
 
     <!-- Assign Voice Bundle Modal -->
-    <div v-if="bundleTarget" class="modal-overlay" @click.self="bundleTarget = null">
+    <div v-if="bundleTarget" class="modal-overlay" @click.self="closeBundleModal">
       <div class="modal modal-sm">
         <div class="modal-header">
           <h3>Assign Voice Bundle</h3>
           <button
             class="btn-close"
-            @click="bundleTarget = null"
+            @click="closeBundleModal"
             :aria-label="$t('common.close')"
             type="button"
           ><Icon name="times" /></button>
@@ -217,14 +217,14 @@
           <div v-if="bundleError" class="error-inline">{{ bundleError }}</div>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn-action-secondary" @click="bundleTarget = null">Cancel</button>
+          <button type="button" class="btn-action-secondary" @click="closeBundleModal">Cancel</button>
           <button
             type="button"
             class="btn-action-primary"
-            :disabled="bundleSaving"
+            :disabled="bundleSaving || bundleModalLoading"
             @click="doAssignBundle"
           >
-            <Icon v-if="bundleSaving" name="sync-alt" :spin="true" />
+            <Icon v-if="bundleSaving || bundleModalLoading" name="sync-alt" :spin="true" />
             Save
           </button>
         </div>
@@ -302,6 +302,9 @@ const { saving: bundleSaving, saveError: bundleError, assignBundle, getUserBundl
 const userBundles = ref<Record<string, VoiceBundleName | null | undefined>>({})
 const bundleTarget = ref<UserRecord | null>(null)
 const newBundleName = ref<VoiceBundleName | null>(null)
+// Stale-result guard: tracks which user's bundle fetch was initiated for the open modal
+const bundleModalUserId = ref<string | null>(null)
+const bundleModalLoading = ref(false)
 
 const totalPages = computed(() => Math.ceil(total.value / pageSize))
 
@@ -353,7 +356,39 @@ function loadUserBundles(userList: UserRecord[]): void {
 
 function openBundleModal(user: UserRecord): void {
   bundleTarget.value = user
-  newBundleName.value = (userBundles.value[user.id] as VoiceBundleName | null) ?? null
+  bundleModalUserId.value = user.id
+  const cached = userBundles.value[user.id]
+  if (cached !== undefined) {
+    newBundleName.value = cached
+    return
+  }
+  // loadUserBundles fetch for this user is still in flight — fetch it directly now
+  // so the modal shows the real current value rather than null.
+  // The bundleModalUserId guard discards the result if the modal is closed or
+  // switched to a different user before this resolves.
+  newBundleName.value = null
+  bundleModalLoading.value = true
+  getUserBundle(user.id)
+    .then(assignment => {
+      if (bundleModalUserId.value !== user.id) return
+      const bundleName = assignment?.bundle_name ?? null
+      userBundles.value[user.id] = bundleName
+      newBundleName.value = bundleName
+    })
+    .catch(() => {
+      if (bundleModalUserId.value !== user.id) return
+      userBundles.value[user.id] = null
+      newBundleName.value = null
+    })
+    .finally(() => {
+      if (bundleModalUserId.value === user.id) bundleModalLoading.value = false
+    })
+}
+
+function closeBundleModal(): void {
+  bundleModalUserId.value = null
+  bundleModalLoading.value = false
+  bundleTarget.value = null
 }
 
 async function doAssignBundle(): Promise<void> {
@@ -362,7 +397,7 @@ async function doAssignBundle(): Promise<void> {
   const ok = await assignBundle(userId, newBundleName.value)
   if (ok) {
     userBundles.value[userId] = newBundleName.value
-    bundleTarget.value = null
+    closeBundleModal()
   }
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `openBundleModal` read `userBundles[user.id]` synchronously. If `loadUserBundles` hadn't finished yet, `userBundles[user.id]` was `undefined`, falling back to `null`. Saving immediately without selecting anything would silently remove the user's existing bundle assignment.
- **Fix**: when `userBundles[user.id]` is absent on modal open, fire a targeted `getUserBundle` fetch. A `bundleModalUserId` ref guards stale results — if the modal is closed or switched to another user before the response arrives, the result is discarded.
- **Save disabled** (with spinner) while `bundleModalLoading` is true, preventing blind saves with unresolved state.
- **`closeBundleModal()`** centralises all three close paths (overlay click, × button, Cancel) so the guard ref is always cleared.

## Thinking Path

Race condition in `openBundleModal`: bundle data loaded async, but modal read it synchronously → stale undefined fell through to null → silent bundle removal on save. Fix: load on demand with a guard ref to discard stale responses.

## What Changed

- `autobot-frontend/src/views/AdminUsersView.vue` — added `bundleModalUserId`/`bundleModalLoading` refs, rewrote `openBundleModal`, added `closeBundleModal`, updated template

## Verification

- Open voice-bundle modal immediately after page load (before bundle fetch completes) — modal shows spinner, Save disabled, then resolves to correct current value
- Open modal for user A, then immediately close and open for user B before A's fetch returns — stale A result does NOT overwrite B's selection
- Normal flow (modal opened after bundles cached): initialises instantly from cache, no loading state
- Save with changed selection — still works correctly
- Cancel / overlay click / × button all close cleanly with no lingering `bundleModalLoading`

## Model Used

claude-sonnet-4-6

Fixes GH#8705, MVA-1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)