### PR TITLE
fix(a2a): replace bare module-level guard in get_trust_manager() with lazy_singleton()

### DIFF
--- a/autobot-backend/a2a/trust_score.py
+++ b/autobot-backend/a2a/trust_score.py
@@ -52,6 +52,7 @@ from pathlib import Path
 from typing import Dict, Optional, Set
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from utils.paths_manager import PathsManager
 
 logger = get_logger(__name__)
@@ -452,11 +453,4 @@ class TrustScoreManager:
 # Module-level singleton
 # ---------------------------------------------------------------------------
 
-_manager: Optional[TrustScoreManager] = None
-
-
-def get_trust_manager() -> TrustScoreManager:
-    global _manager
-    if _manager is None:
-        _manager = TrustScoreManager()
-    return _manager
+get_trust_manager = lazy_singleton(TrustScoreManager)


### PR DESCRIPTION
## Summary

- Replaces the bare `_manager: Optional[TrustScoreManager] = None` guard pattern in `trust_score.py` with the project-standard `lazy_singleton(TrustScoreManager)` from `autobot_shared.singleton_factory`
- Adds the `lazy_singleton` import alongside existing `autobot_shared` imports
- Removes 8 lines (guard variable + function body) and replaces with 1 line

## Thinking Path

The GitHub discovery issue (#8741) flagged that `get_trust_manager()` diverged from the `lazy_singleton` pattern standardised in #5622/#5626. The fix is mechanical: import `lazy_singleton` from `autobot_shared.singleton_factory` and replace the guard+function with a single assignment. Callers are unaffected — `get_trust_manager()` remains callable as before.

## What Changed

- `autobot-backend/a2a/trust_score.py`: added `lazy_singleton` import; replaced 8-line bare guard function with `get_trust_manager = lazy_singleton(TrustScoreManager)`

## Verification

- Verified callers in docstring (lines 37-39) still work — `get_trust_manager()` call signature is preserved
- Pattern matches existing usages in `llm_shared/cache.py`, `routers/code_completion.py`, etc.

## Model Used

claude-sonnet-4-6

Closes GH#8741
Relates to MVA-1270

🤖 Generated with [Claude Code](https://claude.com/claude-code)