### PR TITLE
fix(coordination): move WatchError import to top of shared_runtime_bag.py

### DIFF
--- a/autobot_shared/coordination/shared_runtime_bag.py
+++ b/autobot_shared/coordination/shared_runtime_bag.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from typing import Any, Generic, TypeVar
 
 from pydantic import TypeAdapter
+from redis.exceptions import WatchError
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
@@ -173,10 +174,6 @@ class SharedRuntimeBag(Generic[T]):
                     await self._publish(redis, key, "set", updated)
                     return updated
                 except Exception as exc:
-                    # WatchError is raised by aioredis on concurrent modification.
-                    # Re-raise anything that is not a WatchError on the last attempt.
-                    from redis.exceptions import WatchError
-
                     if not isinstance(exc, WatchError):
                         raise
                     if attempt == retries:


### PR DESCRIPTION
## Summary

- Moves `from redis.exceptions import WatchError` from inside the `except` block of the CAS retry loop to module-level imports in `autobot_shared/coordination/shared_runtime_bag.py`
- Removes stale inline comment from inside the `except` block (now unnecessary at call site)
- The import was previously re-evaluated on every CAS failure; it is now evaluated once at module load

## Thinking Path

`WatchError` was imported inside the `except` block — an unusual pattern that causes `sys.modules` lookups on every CAS failure. Moving it to module level follows Python convention and eliminates the per-failure lookup overhead. The inline comment that explained the import was only relevant at the import site, so it was removed along with the deferred import.

## What Changed

- `autobot_shared/coordination/shared_runtime_bag.py` — moved `from redis.exceptions import WatchError` to module-level imports; removed now-redundant inline comment from the `except` block

## Verification

- Existing `SharedRuntimeBag` tests cover the CAS retry logic end-to-end — no behaviour change, so passing tests confirm the `WatchError` catch still fires correctly
- Import location does not affect `isinstance(exc, WatchError)` — the class identity is the same

## Model Used

claude-sonnet-4-6

Fixes GH#8707
Paperclip: MVA-1261

🤖 Generated with [Claude Code](https://claude.com/claude-code)