### PR TITLE
ux(chat): group voice header buttons with divider — fix Gestalt proximity (GH#8755)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -56,24 +56,29 @@
         >
           <!-- File Panel Toggle Button (injected into header) -->
           <template #actions>
-            <!-- Voice Output Toggle (#928) -->
-            <button
-              @click="toggleVoiceOutput"
-              class="header-btn"
-              :class="{ 'bg-electric-100 text-electric-600': voiceOutputEnabled }"
-              :title="voiceOutputEnabled ? $t('chat.interface.voiceOutputOn') : $t('chat.interface.voiceOutputOff')"
-            >
-              <Icon :name="isSpeaking || voiceOutputEnabled ? 'volume-up' : 'volume-mute'" :class="isSpeaking ? 'animate-pulse' : ''" />
-            </button>
-            <!-- Voice Conversation (#1029) -->
-            <button
-              @click="openVoiceConversation"
-              class="header-btn"
-              :class="{ 'bg-electric-100 text-electric-600': showVoiceOverlay || showVoicePanel }"
-              :title="$t('chat.interface.voiceChat')"
-            >
-              <Icon name="headset" />
-            </button>
+            <!-- Voice controls group (GH#8755): proximity grouping for audio actions -->
+            <div role="group" aria-label="Voice controls" class="header-btn-group">
+              <!-- Voice Output Toggle (#928) -->
+              <button
+                @click="toggleVoiceOutput"
+                class="header-btn"
+                :class="{ 'bg-electric-100 text-electric-600': voiceOutputEnabled }"
+                :title="voiceOutputEnabled ? $t('chat.interface.voiceOutputOn') : $t('chat.interface.voiceOutputOff')"
+              >
+                <Icon :name="isSpeaking || voiceOutputEnabled ? 'volume-up' : 'volume-mute'" :class="isSpeaking ? 'animate-pulse' : ''" />
+              </button>
+              <!-- Voice Conversation (#1029) -->
+              <button
+                @click="openVoiceConversation"
+                class="header-btn"
+                :class="{ 'bg-electric-100 text-electric-600': showVoiceOverlay || showVoicePanel }"
+                :title="$t('chat.interface.voiceChat')"
+              >
+                <Icon name="headset" />
+              </button>
+            </div>
+            <!-- Divider between voice group and utility actions -->
+            <div class="header-btn-divider" aria-hidden="true"></div>
             <button
               v-if="store.currentSessionId"
               @click="toggleFilePanel"
@@ -1261,6 +1266,19 @@ function _extractCompleteSentences(text: string): string[] {
 /* Header button styling for file panel toggle */
 .header-btn {
   @apply w-8 h-8 flex items-center justify-center rounded-md transition-colors text-autobot-text-secondary hover:bg-autobot-bg-tertiary;
+}
+
+/* GH#8755: voice action group — subtle pill wraps related audio controls */
+.header-btn-group {
+  @apply flex items-center gap-0.5 rounded-md px-0.5;
+  background: var(--bg-tertiary);
+}
+
+/* GH#8755: vertical divider between voice group and utility buttons */
+.header-btn-divider {
+  @apply self-stretch my-1 mx-1;
+  width: 1px;
+  background: var(--border-light);
 }
 
 /* Agent-loop tool approval dialog (#4952) */


### PR DESCRIPTION
## Summary

- Wraps Voice Output + Voice Conversation in `<div role="group" aria-label="Voice controls" class="header-btn-group">` — subtle pill background so the two audio controls read as a single unit
- Adds `<div class="header-btn-divider" aria-hidden="true">` — 1 px vertical line — between the voice group and utility buttons (File Panel, Multi-model Compare)
- No new TypeScript errors (pre-existing errors in unrelated `src/views/llc/` and `src/views/voice/` files unchanged)

## Thinking Path

Two adjacent audio controls (volume, headset) lacked visual grouping — Gestalt proximity principle requires related controls to share a container so users perceive them as a unit. Wrapping in `role=group` + `aria-label` satisfies WCAG 1.3.1 (info and relationships). A subtle pill background provides the visual affordance. A 1 px divider separates voice controls from unrelated utility buttons (File Panel, Multi-model Compare).

## What Changed

- `autobot-frontend/src/components/chat/ChatInterface.vue` — wrapped Voice Output + Voice Conversation in `.header-btn-group` div with `role=group` and `aria-label="Voice controls"`; added `.header-btn-divider` between voice group and utility buttons; added CSS for `.header-btn-group` and `.header-btn-divider`

## Verification

- Open Chat view — Voice Output and Voice Conversation buttons appear inside a faint pill, visually distinct from File Panel and Columns buttons
- Confirm 1 px divider is visible between the pill and utility buttons
- Hover each button — active highlight (`bg-electric-100 text-electric-600`) still renders correctly inside the group
- Toggle Voice Output and Voice Conversation — active states render inside group as expected
- No console errors on mount

## Model Used

claude-sonnet-4-6

Closes #8755

🤖 Generated with [Claude Code](https://claude.com/claude-code)