### PR TITLE
fix(coordination): remove spurious type-ignore on AgentBudgetTracker.subscribe_changes (GH#8708)

### DIFF
--- a/autobot-backend/llc/services/agent_budget_tracker.py
+++ b/autobot-backend/llc/services/agent_budget_tracker.py
@@ -25,11 +25,12 @@ Read path:
 from __future__ import annotations
 
 import logging
+from collections.abc import AsyncIterator
 from decimal import Decimal
 
 from pydantic import BaseModel
 
-from autobot_shared.coordination.shared_runtime_bag import SharedRuntimeBag
+from autobot_shared.coordination.shared_runtime_bag import ChangeEvent, SharedRuntimeBag
 
 logger = logging.getLogger(__name__)
 
@@ -125,7 +126,7 @@ class AgentBudgetTracker:
                 agent_id,
             )
 
-    async def subscribe_changes(self):  # type: ignore[override]
+    async def subscribe_changes(self) -> AsyncIterator[ChangeEvent]:
         """Yield AgentBudgetState change events for all agents.
 
         Useful for the BudgetWatchdog to react to cross-worker budget updates


### PR DESCRIPTION
## Thinking Path

`AgentBudgetTracker` does not subclass any class — it composes a `SharedRuntimeBag` instance via `self._bag`. The `# type: ignore[override]` on `subscribe_changes` was therefore meaningless (there is nothing to override), and mypy would flag it as an unused ignore under `--warn-unused-ignores`. The fix is to remove it and add the correct return type annotation so the method's signature is explicit and type-safe.

## What Changed

- `autobot-backend/llc/services/agent_budget_tracker.py`
  - Removed `# type: ignore[override]` from `subscribe_changes` (class has no superclass with that method)
  - Added `-> AsyncIterator[ChangeEvent]` return type annotation
  - Imported `AsyncIterator` from `collections.abc`
  - Imported `ChangeEvent` from `autobot_shared.coordination.shared_runtime_bag`

## Verification

- Diff is a 3-line additive change (two new imports + return type) and a 1-line removal of the spurious ignore
- No logic changes — `subscribe_changes` body is identical
- Type annotation matches the `SharedRuntimeBag.subscribe_changes` signature (`-> AsyncIterator[ChangeEvent]`)

## Model Used

claude-sonnet-4-6

---
Closes GH#8708