### PR TITLE
fix(a2a): use logging.getLogger instead of get_logger in trust_score.py (GH#8741)

### DIFF
--- a/autobot-backend/a2a/trust_score.py
+++ b/autobot-backend/a2a/trust_score.py
@@ -43,6 +43,7 @@ Usage
 """
 
 import json
+import logging
 import os
 import sqlite3
 import time
@@ -51,11 +52,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, Optional, Set
 
-from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 from utils.paths_manager import PathsManager
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Trust levels


### PR DESCRIPTION
## Summary

- Replace `from autobot_shared.logging_manager import get_logger` + `logger = get_logger(__name__)` with Python's standard `import logging` + `logger = logging.getLogger(__name__)` in `autobot-backend/a2a/trust_score.py`
- Consistent with the pattern in `pii_pipeline.py` in the same package (GH#7358 standard)
- Removes unnecessary dependency on `autobot_shared.logging_manager` in this file

## Thinking Path

`trust_score.py` used the custom `get_logger` wrapper while adjacent files in the same package use stdlib `logging.getLogger`. Custom wrapper is unnecessary here — removing it reduces the import surface and aligns with the project standard established in GH#7358.

## What Changed

- `autobot-backend/a2a/trust_score.py` — replaced `from autobot_shared.logging_manager import get_logger` + `logger = get_logger(__name__)` with `import logging` + `logger = logging.getLogger(__name__)`

## Verification

- No `autobot_shared.logging_manager` import remaining in `trust_score.py`
- `logger` still resolves correctly via standard Python logging hierarchy
- Existing A2A trust scoring tests pass unmodified

## Model Used

claude-sonnet-4-6

Closes #8741

🤖 Generated with [Claude Code](https://claude.com/claude-code)