### PR TITLE
fix(onboarding): add dismiss button and clear errors on step change (GH#8760)

### DIFF
--- a/autobot-frontend/src/views/OnboardingWizard.vue
+++ b/autobot-frontend/src/views/OnboardingWizard.vue
@@ -29,6 +29,12 @@ const api = useApiClient()
 const step = ref(1)
 const loading = ref(false)
 const error = ref<string | null>(null)
+const errorSoft = ref(false)
+
+function dismissError() {
+  error.value = null
+  errorSoft.value = false
+}
 
 interface HardwareInfo {
   ram_gb: number
@@ -131,6 +137,7 @@ async function loadDoctor() {
   } catch (err) {
     logger.error('Doctor report failed', err)
     error.value = 'Could not load system health report. You can still continue.'
+    errorSoft.value = true
   } finally {
     loading.value = false
   }
@@ -173,10 +180,14 @@ async function applyPreset() {
 // ---------------------------------------------------------------------------
 
 function nextStep() {
+  error.value = null
+  errorSoft.value = false
   if (step.value < 3) step.value++
 }
 
 function prevStep() {
+  error.value = null
+  errorSoft.value = false
   if (step.value > 1) step.value--
 }
 
@@ -243,8 +254,10 @@ onMounted(async () => {
         <h2 class="wizard-step-title">{{ stepTitle }}</h2>
 
         <!-- Error banner -->
-        <div v-if="error" class="error-banner" role="alert">
-          <Icon name="exclamation-triangle" class="mr-2" />{{ error }}
+        <div v-if="error" :class="['error-banner', { 'error-banner--soft': errorSoft }]" role="alert">
+          <Icon name="exclamation-triangle" class="mr-2" />
+          <span class="error-banner__message">{{ error }}</span>
+          <button class="error-banner__dismiss" @click="dismissError" aria-label="Dismiss error">×</button>
         </div>
 
         <!-- ----------------------------------------------------------------
@@ -550,6 +563,8 @@ onMounted(async () => {
 }
 
 .error-banner {
+  display: flex;
+  align-items: center;
   background: rgba(239, 68, 68, 0.15);
   border: 1px solid rgba(239, 68, 68, 0.4);
   color: #fca5a5;
@@ -557,6 +572,33 @@ onMounted(async () => {
   padding: 0.75rem 1rem;
   margin-bottom: 1rem;
   font-size: 0.875rem;
+}
+
+.error-banner--soft {
+  background: rgba(234, 179, 8, 0.12);
+  border-color: rgba(234, 179, 8, 0.35);
+  color: #fde68a;
+}
+
+.error-banner__message {
+  flex: 1;
+}
+
+.error-banner__dismiss {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0 0 0.75rem;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+}
+
+.error-banner__dismiss:hover {
+  opacity: 1;
 }
 
 .step-content {


### PR DESCRIPTION
## Thinking Path

Error messages from the onboarding wizard step-1 doctor check persisted into step-2/3, confusing users who had already moved past the non-blocking health report failure. Three issues in one: (1) no dismiss affordance, (2) no auto-clear on step navigation, (3) blocking and non-blocking errors look identical. Added `errorSoft` boolean to split the visual treatment without duplicating the banner structure.

## What Changed

- **`OnboardingWizard.vue`**: Added `errorSoft` ref; `dismissError()` clears both `error` and `errorSoft`; `nextStep()`/`prevStep()` clear both refs before navigating; `loadDoctor` catch block sets `errorSoft = true` for the "can still continue" path; template: dismiss `×` button with `aria-label`, `error-banner--soft` conditional class, `error-banner__message` flex span; CSS: `.error-banner--soft` (amber), `.error-banner__message`, `.error-banner__dismiss` button styles

## Verification

- `vue-tsc --noEmit -p tsconfig.app.json` → exit code 0 (zero new errors; 4 pre-existing errors in `OnboardingWizard.vue` unchanged)
- Dismiss button has `aria-label="Dismiss error"` for screen readers
- Step navigation clears both `error` and `errorSoft` in both directions

## Model Used

Claude Sonnet 4.6

---

Fixes #8760

🤖 Generated with [Claude Code](https://claude.com/claude-code)