### PR TITLE
fix(install): clean stale git lock files before checkout (MVA-1293)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -471,6 +471,17 @@ code_deployment() {
 
     if [[ -d "${CODE_SOURCE}/.git" ]]; then
         info "Updating existing repository..."
+
+        # Remove stale git lock files left by prior crashed processes (exit 128 guard)
+        local _lock _lf
+        for _lock in index config HEAD; do
+            _lf="${CODE_SOURCE}/.git/${_lock}.lock"
+            if [[ -f "${_lf}" ]]; then
+                warn "Removing stale git lock: ${_lf}"
+                rm -f "${_lf}"
+            fi
+        done
+
         run_ok "Fetching latest code" \
             sudo -u autobot git -C "${CODE_SOURCE}" fetch origin
         run_ok "Checking out ${GIT_BRANCH}" \


### PR DESCRIPTION
## Summary

- Root cause: stale `/opt/autobot/code_source/.git/index.lock` (0-byte file left by prior crashed git process) caused `git checkout Dev_new_gui` to exit 128 during reinstall
- Fix: `code_deployment()` now iterates `index.lock`, `config.lock`, and `HEAD.lock` before any git operation, removes each if found, and logs a warning
- Immediate remediation was manual `rm` of the lock; this commit makes future reinstalls self-healing

## Test plan

- [ ] Fresh `./install.sh --reinstall` with no lock files present — no change in behavior
- [ ] `./install.sh --reinstall` with a planted `index.lock` — warning logged, lock removed, checkout succeeds
- [ ] Lock files absent after successful run — no false-positive removals

Fixes MVA-1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)