### PR TITLE
fix(nav): guard Canvas profile menu item behind VITE_FEATURE_CANVAS flag (GH#8758)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -141,7 +141,7 @@
                   <!-- Settings & Tools section -->
                   <p class="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-autobot-text-secondary">{{ $t('nav.settingsAndTools') }}</p>
                   <router-link
-                    v-for="item in profileMenuItems"
+                    v-for="item in filteredProfileMenuItems"
                     :key="item.to"
                     :to="item.to"
                     role="menuitem"
@@ -271,7 +271,7 @@
             <div class="border-t border-autobot-border pt-2 mt-1">
               <p class="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-autobot-text-secondary">{{ $t('nav.settingsAndTools') }}</p>
               <router-link
-                v-for="item in profileMenuItems"
+                v-for="item in filteredProfileMenuItems"
                 :key="item.to"
                 :to="item.to"
                 @click="closeMobileNav"
@@ -546,7 +546,7 @@ import { initializeNotificationBridge } from '@/utils/notificationBridge';
 import { smartMonitoringController, getAdaptiveInterval } from '@/config/OptimizedPerformance.js';
 import { clearAllSystemNotifications, resetHealthMonitor } from '@/utils/ClearNotifications.js';
 import { getSLMAdminUrl } from '@/config/ssot-config';
-import { navItems, profileMenuItems, adminMenuItems } from '@/config/navItems';
+import { navItems, profileMenuItems, adminMenuItems, filterByFeatureFlag } from '@/config/navItems';
 import SystemStatusNotification from '@/components/ui/SystemStatusNotification.vue';
 import CaptchaNotification from '@/components/research/CaptchaNotification.vue';
 import ToastContainer from '@/components/ui/ToastContainer.vue';
@@ -964,6 +964,10 @@ export default {
       navItems.filter(item => !item.adminOnly || userStore.isAdmin)
     )
 
+    const filteredProfileMenuItems = computed(() =>
+      filterByFeatureFlag(profileMenuItems)
+    )
+
     const { visibleCount } = useNavOverflow(
       navContainerRef,
       computed(() => filteredNavItems.value.length)
@@ -1006,6 +1010,7 @@ export default {
       hideFooter,
       navItems,
       profileMenuItems,
+      filteredProfileMenuItems,
       adminMenuItems,
       slmAdminUrl,
       displayUsername,

--- a/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
+++ b/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
@@ -26,7 +26,7 @@
 import { describe, it, expect } from 'vitest'
 import type { RouteRecordRaw } from 'vue-router'
 import { routes } from '@/router'
-import { navItems } from '@/config/navItems'
+import { navItems, profileMenuItems, filterByFeatureFlag } from '@/config/navItems'
 
 /**
  * Routes that are intentionally NOT in main nav.
@@ -108,6 +108,21 @@ describe('navItems coverage (#6499)', () => {
     const stale = Object.keys(INTENTIONALLY_HIDDEN).filter((p) => !topLevelPaths.has(p))
 
     expect(stale).toEqual([])
+  })
+
+  it('canvas is hidden in profileMenuItems when VITE_FEATURE_CANVAS is unset', () => {
+    const result = filterByFeatureFlag(profileMenuItems, {})
+    expect(result.map((i) => i.to)).not.toContain('/canvas')
+  })
+
+  it('canvas is visible in profileMenuItems when VITE_FEATURE_CANVAS=true', () => {
+    const result = filterByFeatureFlag(profileMenuItems, { VITE_FEATURE_CANVAS: 'true' })
+    expect(result.map((i) => i.to)).toContain('/canvas')
+  })
+
+  it('canvas profileMenuItem has featureFlag set to "canvas"', () => {
+    const canvasItem = profileMenuItems.find((i) => i.to === '/canvas')
+    expect(canvasItem?.featureFlag).toBe('canvas')
   })
 
   it('allowlist size and route counts (regression sentinel)', () => {

--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -27,6 +27,21 @@ export interface NavItem {
   iconRule?: SvgFillRule;
   iconStroke?: boolean;
   adminOnly?: boolean;
+  /** VITE_FEATURE_<featureFlag.toUpperCase()> must equal 'true' to show this item. */
+  featureFlag?: string;
+}
+
+/**
+ * Returns items whose featureFlag (if any) is enabled in the given env object.
+ * Pass `import.meta.env` in production; pass a plain object in tests.
+ */
+export function filterByFeatureFlag(
+  items: NavItem[],
+  env: Record<string, string | boolean | undefined> = import.meta.env,
+): NavItem[] {
+  return items.filter(
+    (item) => !item.featureFlag || env[`VITE_FEATURE_${item.featureFlag.toUpperCase()}`] === 'true',
+  );
 }
 
 // ─── Primary nav (≤7 items for non-admin users at 1440 px) ───────────────────
@@ -49,8 +64,8 @@ export const navItems: NavItem[] = [
 // Shown in the profile dropdown — not in the primary nav rail.
 // Routes must carry hideInNav: true in router/index.ts.
 export const profileMenuItems: NavItem[] = [
-  // MVA-360: Live Canvas
-  { to: '/canvas', labelKey: 'nav.canvas', icon: 'M3 3h7v7H3V3zm0 11h7v7H3v-7zm11-11h7v7h-7V3zm0 11h7v7h-7v-7z', iconStroke: true },
+  // MVA-360: Live Canvas — gated by VITE_FEATURE_CANVAS (GH#8758)
+  { to: '/canvas', labelKey: 'nav.canvas', icon: 'M3 3h7v7H3V3zm0 11h7v7H3v-7zm11-11h7v7h-7V3zm0 11h7v7h-7v-7z', iconStroke: true, featureFlag: 'canvas' },
   // Issue #929: Plugin Manager
   { to: '/plugins', labelKey: 'nav.plugins', icon: 'M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z', iconStroke: true },
   { to: '/secrets', labelKey: 'nav.secrets', icon: 'M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z', iconRule: 'evenodd' },


### PR DESCRIPTION
## Thinking Path

After the GH#8748 navItems consolidation, Canvas moved from the primary nav to `profileMenuItems` — but remained unconditionally visible there, still ignoring `VITE_FEATURE_CANVAS`. The right fix is a small, reusable `filterByFeatureFlag()` utility on `NavItem`, rather than ad-hoc spread conditionals. This lets any future feature-flagged nav item use the same pattern. Canvas gets `featureFlag: 'canvas'`; App.vue swaps `profileMenuItems` for `filteredProfileMenuItems` in both desktop and mobile renderers.

## What Changed

- `autobot-frontend/src/config/navItems.ts`: added `featureFlag?: string` to `NavItem` interface; added exported `filterByFeatureFlag(items, env)` utility; Canvas `profileMenuItems` entry now carries `featureFlag: 'canvas'`
- `autobot-frontend/src/App.vue`: imports `filterByFeatureFlag`; adds `filteredProfileMenuItems` computed; both desktop and mobile profile-menu `v-for` use it
- `autobot-frontend/src/__tests__/nav-items-coverage.test.ts`: 3 new tests covering canvas hidden/visible by flag and `featureFlag` field presence

Fixes #8758

## Verification

- When `VITE_FEATURE_CANVAS` is unset/false: Canvas absent from profile dropdown (both desktop and mobile)
- When `VITE_FEATURE_CANVAS=true`: Canvas appears in profile dropdown
- Other profile menu items unaffected
- Tests pass: `filterByFeatureFlag` test suite

## Model Used

claude-sonnet-4-6