### PR TITLE
fix(tests): use allRoutePaths() in nav-items-coverage for child routes (GH#8818)

### DIFF
--- a/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
+++ b/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
@@ -44,7 +44,7 @@ const INTENTIONALLY_HIDDEN: Record<string, string> = {
   '/agents/activity': 'Reached as a tab inside /agents shell (#6634); standalone URL kept for bookmarks',
   '/agents/heartbeat': 'Reached as a tab inside /agents shell (#6634); standalone URL kept for bookmarks',
   '/admin/users': 'Admin-only — surfaced via separate admin entrypoint',
-  '/slm/tools/novnc': 'Accessed via Chat tab\'s noVNC sub-tab (#6414/#6415); standalone URL kept for bookmarks',
+  '/slm/tools/novnc': "Accessed via Chat tab's noVNC sub-tab (#6414/#6415); standalone URL kept for bookmarks",
 }
 
 /** True if route is hidden from nav by an explicit meta flag. */
@@ -68,6 +68,28 @@ function isRedirectOrCatchAll(route: RouteRecordRaw): boolean {
 /** Collect top-level routes (children are sub-routes, not main nav targets). */
 function topLevelRoutes(): RouteRecordRaw[] {
   return routes.filter((r) => !isRedirectOrCatchAll(r))
+}
+
+/** Collect all absolute route paths recursively (including children). */
+function allRoutePaths(
+  routeList: RouteRecordRaw[] = routes,
+  parentPath = '',
+): Set<string> {
+  const paths = new Set<string>()
+  for (const route of routeList) {
+    if (typeof route.path !== 'string') continue
+    const fullPath = route.path.startsWith('/')
+      ? route.path
+      : (parentPath ? `${parentPath}/${route.path}` : `/${route.path}`).replace(/\/+/g, '/')
+    if (!route.path.includes(':') && !route.path.includes('*') && route.redirect === undefined) {
+      paths.add(fullPath)
+    }
+    const children = (route as RouteRecordRaw & { children?: RouteRecordRaw[] }).children
+    if (children) {
+      for (const p of allRoutePaths(children, fullPath)) paths.add(p)
+    }
+  }
+  return paths
 }
 
 describe('navItems coverage (#6499)', () => {
@@ -96,16 +118,16 @@ describe('navItems coverage (#6499)', () => {
     expect(missing).toEqual([])
   })
 
-  it('every navItems entry corresponds to a real top-level route', () => {
-    const topLevelPaths = new Set(topLevelRoutes().map((r) => r.path))
-    const orphans = navItems.filter((n) => !topLevelPaths.has(n.to)).map((n) => n.to)
+  it('every navItems entry corresponds to a real route', () => {
+    const allPaths = allRoutePaths()
+    const orphans = navItems.filter((n) => !allPaths.has(n.to)).map((n) => n.to)
 
     expect(orphans).toEqual([])
   })
 
-  it('every allowlisted path corresponds to a real top-level route', () => {
-    const topLevelPaths = new Set(topLevelRoutes().map((r) => r.path))
-    const stale = Object.keys(INTENTIONALLY_HIDDEN).filter((p) => !topLevelPaths.has(p))
+  it('every allowlisted path corresponds to a real route', () => {
+    const allPaths = allRoutePaths()
+    const stale = Object.keys(INTENTIONALLY_HIDDEN).filter((p) => !allPaths.has(p))
 
     expect(stale).toEqual([])
   })


### PR DESCRIPTION
## Thinking Path

After GH#8748 consolidated navItems, `/agents/registry` is now a deep-link nav entry pointing to a *child* route of `/agents`. INTENTIONALLY_HIDDEN also contains `/agents/activity` and `/agents/heartbeat` which are children of `/agents`. The existing tests 2 and 3 used `topLevelPaths` (top-level route paths only), so these child paths were not found, causing spurious failures.

## What Changed

- **Added `allRoutePaths()`**: Recursively collects all route paths including children with full absolute paths (e.g. `/agents` + child `registry` → `/agents/registry`). Skips dynamic params, catch-alls, and redirects — same filters as `isRedirectOrCatchAll`.
- **Updated test 2** ("every navItems entry corresponds to a real route"): now uses `allRoutePaths()` instead of `topLevelPaths`.
- **Updated test 3** ("every allowlisted path corresponds to a real route"): same fix.
- **Minor**: changed the single-quoted string with escaped apostrophe to a double-quoted string (no behaviour change).

## Verification

All 7 tests pass locally:
```
✓ every top-level requiresAuth route has a navItems entry or is allowlisted
✓ every navItems entry corresponds to a real route
✓ every allowlisted path corresponds to a real route
✓ canvas is hidden in profileMenuItems when VITE_FEATURE_CANVAS is unset
✓ canvas is visible in profileMenuItems when VITE_FEATURE_CANVAS=true
✓ canvas profileMenuItem has featureFlag set to "canvas"
✓ allowlist size and route counts (regression sentinel)
Tests  7 passed (7)
```

## Model Used

claude-sonnet-4-6