### PR TITLE
chore(nav): remove dead adminOnly filter in App.vue (GH#8811)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -219,7 +219,6 @@
           <div class="px-4 py-3 space-y-2">
             <template v-for="item in navItems" :key="item.to">
             <router-link
-              v-if="!item.adminOnly || userStore.isAdmin"
               :to="item.to"
               @click="closeMobileNav"
               :class="{
@@ -960,9 +959,7 @@ export default {
     // Nav overflow: ref for container, filtered/visible/overflow computed slices
     const navContainerRef = ref<HTMLElement | null>(null)
 
-    const filteredNavItems = computed(() =>
-      navItems.filter(item => !item.adminOnly || userStore.isAdmin)
-    )
+    const filteredNavItems = computed(() => navItems)
 
     const filteredProfileMenuItems = computed(() =>
       filterByFeatureFlag(profileMenuItems)

--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -26,7 +26,6 @@ export interface NavItem {
   iconPaths?: string[];
   iconRule?: SvgFillRule;
   iconStroke?: boolean;
-  adminOnly?: boolean;
   /** VITE_FEATURE_<featureFlag.toUpperCase()> must equal 'true' to show this item. */
   featureFlag?: string;
 }

--- a/autobot-frontend/src/types/router.d.ts
+++ b/autobot-frontend/src/types/router.d.ts
@@ -63,10 +63,6 @@ declare module 'vue-router' {
      */
     minRole?: 'admin' | 'user' | 'readonly' | 'guest'
 
-    /**
-     * Whether this route is admin-only (shorthand for minRole: 'admin')
-     */
-    adminOnly?: boolean
   }
 }
 


### PR DESCRIPTION
## Thinking Path

GH#8748 moved all adminOnly nav items into adminMenuItems. No navItem has adminOnly:true set, making both filter occurrences dead code.

## What Changed

- **App.vue ~222**: Removed dead v-if from mobile nav router-link
- **App.vue ~964**: Simplified filteredNavItems computed to return navItems directly
- **navItems.ts**: Removed adminOnly?: boolean from NavItem interface
- **router.d.ts**: Removed adminOnly?: boolean from route meta augmentation

## Verification

grep for adminOnly: in src/ returns 0 results. nav-items-coverage tests unaffected.

## Model Used

claude-sonnet-4-6