### PR TITLE
fix(frontend): merge duplicate Icon imports into single statements (GH#8601)

### DIFF
--- a/autobot-frontend/src/components/ui/StatusBadge.vue
+++ b/autobot-frontend/src/components/ui/StatusBadge.vue
@@ -7,8 +7,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import Icon from '@/components/ui/Icon.vue'
-import type { IconName } from '@/components/ui/Icon.vue'
+import Icon, { type IconName } from '@/components/ui/Icon.vue'
 
 /**
  * Reusable Status Badge Component

--- a/autobot-frontend/src/views/BusinessIntelligenceView.vue
+++ b/autobot-frontend/src/views/BusinessIntelligenceView.vue
@@ -312,12 +312,11 @@
 
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { IconName } from '@/components/ui/Icon.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import AdvancedAnalytics from '@/components/analytics/AdvancedAnalytics.vue'
 import AgentCostPanel from '@/components/analytics/AgentCostPanel.vue'
-import Icon from '@/components/ui/Icon.vue'
+import Icon, { type IconName } from '@/components/ui/Icon.vue'
 import api from '@/services/api'
 import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'

--- a/autobot-frontend/src/views/CustomDashboard.vue
+++ b/autobot-frontend/src/views/CustomDashboard.vue
@@ -263,8 +263,7 @@ import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 import { usePollingJob } from '@/composables/usePollingJob'
 import { useToast } from '@/composables/useToast'
-import type { IconName } from '@/components/ui/Icon.vue'
-import Icon from '@/components/ui/Icon.vue'
+import Icon, { type IconName } from '@/components/ui/Icon.vue'
 
 // Import visualization components
 import ResourceHeatmap from '@/components/visualizations/ResourceHeatmap.vue'

--- a/autobot-frontend/src/views/WorkflowBuilderView.vue
+++ b/autobot-frontend/src/views/WorkflowBuilderView.vue
@@ -659,8 +659,7 @@ import {
 import type { WorkflowTemplateSummary } from '@/types/workflowTemplates';
 import { useWorkflowTemplates } from '@/composables/useWorkflowTemplates';
 import LoadingSpinner from '@/components/ui/LoadingSpinner.vue';
-import Icon from '@/components/ui/Icon.vue';
-import type { IconName } from '@/components/ui/Icon.vue';
+import Icon, { type IconName } from '@/components/ui/Icon.vue';
 import WorkflowCanvas from '@/components/workflow/WorkflowCanvas.vue';
 import WorkflowTemplateGallery from '@/components/workflow/WorkflowTemplateGallery.vue';
 import WorkflowRunner from '@/components/workflow/WorkflowRunner.vue';


### PR DESCRIPTION
## Summary

- Merges split `import Icon` + `import type { IconName }` from same `Icon.vue` path into a single combined import in 4 files
- Eliminates `no-duplicate-imports` lint errors that were blocking the Vite build
- Pattern: `import Icon, { type IconName } from '@/components/ui/Icon.vue'`

## Files changed

- `src/components/ui/StatusBadge.vue`
- `src/views/BusinessIntelligenceView.vue`
- `src/views/CustomDashboard.vue`
- `src/views/WorkflowBuilderView.vue`

## Test plan

- [x] Zero duplicate Icon imports remain (verified with Python script)
- [x] No new `any` introduced
- [x] Canonical import discipline maintained (`@/` alias)
- [ ] `npm run type-check` — confirm passes in CI

Closes #8601

🤖 Generated with [Claude Code](https://claude.com/claude-code)