### PR TITLE
fix(ansible): replace ansible_user_id with lookup('env','USER') — resolves remote_user race (MVA-1314)

### DIFF
--- a/autobot-slm-backend/ansible/inventory/localhost.yml
+++ b/autobot-slm-backend/ansible/inventory/localhost.yml
@@ -7,7 +7,7 @@ all:
   hosts:
     localhost:
       ansible_connection: local
-      ansible_user: "{{ ansible_user_id }}"
+      ansible_user: "{{ lookup('env', 'USER') }}"
       ansible_become: true
       ansible_become_method: sudo
 

--- a/autobot-slm-backend/ansible/playbooks/pre-flight-code-sync.yml
+++ b/autobot-slm-backend/ansible/playbooks/pre-flight-code-sync.yml
@@ -54,8 +54,8 @@
       ansible.builtin.file:
         path: "{{ git_repo_root }}"
         state: directory
-        owner: "{{ ansible_user_id | default('autobot') }}"
-        group: "{{ ansible_user_id | default('autobot') }}"
+        owner: "{{ lookup('env', 'USER') | default('autobot') }}"
+        group: "{{ lookup('env', 'USER') | default('autobot') }}"
         recurse: true
       become: true
       failed_when: false

--- a/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
@@ -66,8 +66,8 @@
       ansible.builtin.file:
         path: "{{ git_repo_root }}"
         state: directory
-        owner: "{{ ansible_user_id | default('autobot') }}"
-        group: "{{ ansible_user_id | default('autobot') }}"
+        owner: "{{ lookup('env', 'USER') | default('autobot') }}"
+        group: "{{ lookup('env', 'USER') | default('autobot') }}"
         recurse: true
       become: true
       failed_when: false


### PR DESCRIPTION
## Summary

- **Root cause**: `ansible_user: "{{ ansible_user_id }}"` in `inventory/localhost.yml` — `ansible_user_id` is a gathered fact but `ansible_user` (= `remote_user`) is a connection parameter resolved *before* `gather_facts` runs, causing `fatal: 'ansible_user_id' is undefined` at every `localhost` connection attempt
- **Fix**: Replace all three `ansible_user_id` references with `lookup('env', 'USER')`, which is a Jinja2 lookup plugin available at connection time with no facts dependency
- **Scope**: `inventory/localhost.yml` (connection var, root cause), `pre-flight-code-sync.yml` (ownership task under `gather_facts: false`), `provision-fleet-roles.yml` (Play 0 ownership task)

## Files changed

| File | Change |
|------|--------|
| `ansible/inventory/localhost.yml` | `ansible_user: "{{ ansible_user_id }}"` → `"{{ lookup('env', 'USER') }}"` |
| `ansible/playbooks/pre-flight-code-sync.yml` | `owner/group: ansible_user_id\|default('autobot')` → `lookup('env','USER')\|default('autobot')` |
| `ansible/playbooks/provision-fleet-roles.yml` | same ownership fix in Play 0 pre-flight block |

## Test plan

- [ ] `ansible-inventory -i inventory/localhost.yml --list` parses without undefined-variable errors
- [ ] Re-run `ansible-playbook -i inventory/localhost.yml playbooks/deploy-slm-manager.yml --skip-tags seed,provision` — Play 0 pre-flight task completes instead of failing at `[PRE-FLIGHT] Verify code_source exists`
- [ ] Full install via `install.sh` completes past Ansible pre-flight step

Fixes install run `install-20260527-145958`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)