### PR TITLE
sec(scanning): exclude vendored JS bundles from secret scanning (MVA-1306)

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,8 @@
+paths-ignore:
+  # Vendored third-party JavaScript bundles may contain class/variable names
+  # that match secret-scanning patterns (e.g., s.<24chars> for Vault tokens).
+  # These are not real secrets.
+  - "frontend/js/**"
+  - "autobot-frontend/js/**"
+  - "**/node_modules/**"
+  - "**/*.min.js"


### PR DESCRIPTION
## Summary

- **Root cause**: GitHub secret-scanning alert #1 was a confirmed false positive. The string `s.DebertaV2PreTrainedModel` in the (since-removed) vendored `frontend/js/transformers@3.0.2.js` matched the HashiCorp Vault service-token regex `s.[A-Za-z0-9]{24}` because `DebertaV2PreTrainedModel` is exactly 24 alphanumeric characters — it is a HuggingFace Transformers model class name, not a Vault token.
- **Immediate action**: Alert #1 resolved as `false_positive` on GitHub (2026-05-27).
- **Prevention**: Added `.github/secret_scanning.yml` to exclude `frontend/js/**`, `autobot-frontend/js/**`, `**/node_modules/**`, and `**/*.min.js` from future secret-scanning runs, preventing similar vendor-bundle false positives.

## Verification

- No real HashiCorp Vault tokens exist in this repository or its history.
- The file `frontend/js/transformers@3.0.2.js` was removed from the codebase in commit `b925cfc7` — only old git history retains it.
- Alert #1 is now in `resolved/false_positive` state on GitHub.

## Test plan

- [ ] Confirm GitHub shows secret-scanning alert #1 as resolved
- [ ] Confirm no new false-positive alerts triggered for vendor JS files after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)