### PR TITLE
feat(execution): pre-warmed Docker container pool for fast sandbox cold start (GH#4452)

### DIFF
--- a/autobot-backend/services/execution/container_pool.py
+++ b/autobot-backend/services/execution/container_pool.py
@@ -1,0 +1,271 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Pre-warmed Docker Container Pool (GH#4452)
+
+Reduces sandbox cold-start latency by maintaining a pool of already-running
+containers. Callers acquire a warm container, execute via docker exec, then
+release it. Released containers are destroyed and replaced asynchronously so
+the pool stays at the target size.
+"""
+
+import asyncio
+from typing import Any, Dict
+
+from autobot_shared.logging_manager import get_logger
+
+try:
+    import docker
+    from docker.errors import DockerException
+except ImportError:
+    docker = None
+    DockerException = Exception
+
+logger = get_logger(__name__)
+
+_DEFAULT_POOL_SIZE = 2
+_ACQUIRE_TIMEOUT = 5.0  # seconds before falling back to cold start
+
+
+class WarmContainerPool:
+    """Pool of pre-started Docker containers for near-zero cold-start execution.
+
+    Each container runs ``sleep infinity`` until a caller acquires it and
+    uses ``container.exec_run()`` to execute code. After use the container is
+    destroyed and a replacement is created asynchronously, keeping the pool at
+    *pool_size* ready containers.
+    """
+
+    def __init__(
+        self,
+        docker_client: "docker.DockerClient",
+        image: str,
+        pool_size: int = _DEFAULT_POOL_SIZE,
+        container_kwargs: Dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Args:
+            docker_client: Connected Docker client.
+            image: Image to pre-start (e.g. ``"python:3.10-slim"``).
+            pool_size: Number of warm containers to maintain.
+            container_kwargs: Extra kwargs forwarded to ``containers.run()``.
+        """
+        self._client = docker_client
+        self._image = image
+        self._pool_size = pool_size
+        self._container_kwargs: Dict[str, Any] = container_kwargs or {}
+        self._pool: asyncio.Queue = asyncio.Queue()
+        self._running = False
+        self._replenish_lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Warm the pool by pre-creating *pool_size* containers.
+
+        Failures are logged but do not prevent partial warm-up; any remaining
+        slots will be filled on demand.
+        """
+        self._running = True
+        results = await asyncio.gather(
+            *[self._create_warm_container() for _ in range(self._pool_size)],
+            return_exceptions=True,
+        )
+        for result in results:
+            if isinstance(result, Exception):
+                logger.warning("Failed to pre-warm container for %s: %s", self._image, result)
+            elif result is not None:
+                await self._pool.put(result)
+
+        logger.info(
+            "Container pool started for %s: %d/%d warm",
+            self._image,
+            self._pool.qsize(),
+            self._pool_size,
+        )
+
+    async def stop(self) -> None:
+        """Drain and destroy all containers in the pool."""
+        self._running = False
+        while not self._pool.empty():
+            try:
+                container = self._pool.get_nowait()
+                await asyncio.to_thread(container.remove, force=True)
+            except Exception as exc:
+                logger.warning("Error destroying pool container: %s", exc)
+        logger.info("Container pool stopped for %s", self._image)
+
+    # ------------------------------------------------------------------
+    # Acquire / release
+    # ------------------------------------------------------------------
+
+    async def acquire(self) -> "docker.models.containers.Container":
+        """Return a warm container from the pool.
+
+        If the pool is empty (all containers acquired concurrently), falls
+        back to an on-demand cold start. In either case the pool is
+        replenished in the background.
+
+        Returns:
+            A running Docker container ready for ``exec_run()``.
+        """
+        try:
+            container = await asyncio.wait_for(
+                self._try_get_from_pool(),
+                timeout=_ACQUIRE_TIMEOUT,
+            )
+            logger.debug("Acquired warm container %s from pool", container.short_id)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Container pool empty for %s — falling back to cold start",
+                self._image,
+            )
+            container = await self._create_warm_container()
+            if container is None:
+                raise RuntimeError(f"Failed to create container for image {self._image}")
+
+        # Refill in the background without blocking the caller
+        asyncio.create_task(self._replenish())
+        return container
+
+    async def release(self, container: "docker.models.containers.Container") -> None:
+        """Destroy a used container.
+
+        Containers are not reused between executions — each request gets a
+        fresh environment. The pool is replenished by ``_replenish()``,
+        which ``acquire()`` schedules automatically.
+
+        Args:
+            container: Container returned by :meth:`acquire`.
+        """
+        try:
+            await asyncio.to_thread(container.remove, force=True)
+            logger.debug("Released and removed container %s", container.short_id)
+        except Exception as exc:
+            logger.warning("Failed to remove used container: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Stats
+    # ------------------------------------------------------------------
+
+    @property
+    def available(self) -> int:
+        """Number of warm containers currently in the pool."""
+        return self._pool.qsize()
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Return pool statistics for monitoring."""
+        return {
+            "image": self._image,
+            "pool_size": self._pool_size,
+            "available": self.available,
+            "running": self._running,
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _try_get_from_pool(self) -> "docker.models.containers.Container":
+        """Blocking coroutine that waits for a container from the queue."""
+        return await self._pool.get()
+
+    async def _create_warm_container(self) -> "docker.models.containers.Container | None":
+        """Start a new idle container and return it.
+
+        The container runs ``sleep infinity`` so it stays alive until
+        explicitly removed.
+
+        Returns:
+            Running container, or ``None`` on failure.
+        """
+        try:
+            container = await asyncio.to_thread(
+                self._client.containers.run,
+                self._image,
+                ["sleep", "infinity"],
+                detach=True,
+                remove=False,
+                **self._container_kwargs,
+            )
+            logger.debug("Created warm container %s for %s", container.short_id, self._image)
+            return container
+        except Exception as exc:
+            logger.error("Failed to create warm container for %s: %s", self._image, exc)
+            return None
+
+    async def _replenish(self) -> None:
+        """Add one container to the pool if it is below target size.
+
+        Protected by a lock to prevent concurrent over-creation.
+        """
+        if not self._running:
+            return
+
+        async with self._replenish_lock:
+            if self._pool.qsize() < self._pool_size:
+                container = await self._create_warm_container()
+                if container and self._running:
+                    await self._pool.put(container)
+                    logger.debug(
+                        "Replenished pool for %s: %d/%d",
+                        self._image,
+                        self._pool.qsize(),
+                        self._pool_size,
+                    )
+
+
+class ContainerPoolRegistry:
+    """Manages one WarmContainerPool per Docker image.
+
+    A single registry can serve multiple images (e.g. python, node, bash)
+    without callers needing to know which pool to use.
+    """
+
+    def __init__(
+        self,
+        docker_client: "docker.DockerClient",
+        pool_size: int = _DEFAULT_POOL_SIZE,
+        default_container_kwargs: Dict[str, Any] | None = None,
+    ) -> None:
+        self._client = docker_client
+        self._pool_size = pool_size
+        self._default_kwargs = default_container_kwargs or {}
+        self._pools: Dict[str, WarmContainerPool] = {}
+        self._started = False
+
+    async def start(self, images: list[str]) -> None:
+        """Start pools for all given images concurrently.
+
+        Args:
+            images: Docker image names to pre-warm.
+        """
+        for image in images:
+            pool = WarmContainerPool(
+                docker_client=self._client,
+                image=image,
+                pool_size=self._pool_size,
+                container_kwargs=self._default_kwargs.copy(),
+            )
+            self._pools[image] = pool
+
+        await asyncio.gather(*[p.start() for p in self._pools.values()])
+        self._started = True
+        logger.info("ContainerPoolRegistry started for images: %s", images)
+
+    async def stop(self) -> None:
+        """Stop all pools and destroy their containers."""
+        await asyncio.gather(*[p.stop() for p in self._pools.values()])
+        self._pools.clear()
+        self._started = False
+
+    def get_pool(self, image: str) -> WarmContainerPool | None:
+        """Return the pool for *image*, or ``None`` if not registered."""
+        return self._pools.get(image)
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Return stats for all pools."""
+        return {image: pool.get_stats() for image, pool in self._pools.items()}

--- a/autobot-backend/services/execution/docker_backend.py
+++ b/autobot-backend/services/execution/docker_backend.py
@@ -6,9 +6,15 @@ Docker Execution Backend (Issue #4343)
 
 Executes tasks in isolated Docker containers with resource limits.
 Provides CPU, memory, and timeout constraints.
+
+GH#4452: Optional pre-warmed container pool for near-zero cold-start latency.
+Enable it by passing ``use_pool=True`` (and optionally ``pool_size``) to the
+constructor. The pool runs ``sleep infinity`` containers per image and uses
+``exec_run`` instead of ``containers.run`` so callers skip image-layer spin-up.
 """
 
-from typing import Dict, Tuple
+import asyncio
+from typing import Any, Dict, Tuple
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
@@ -27,18 +33,34 @@ from services.execution.base_backend import (
     ExecutionStatus,
     ExecutionTask,
 )
+from services.execution.container_pool import ContainerPoolRegistry
 
 logger = get_logger(__name__)
 
+_DEFAULT_POOL_SIZE = 2
+
 
 class DockerBackend(ExecutionBackend):
-    """Execute tasks in Docker containers (Issue #4343)."""
+    """Execute tasks in Docker containers (Issue #4343).
 
-    def __init__(self, docker_host: str | None = None) -> None:
+    When *use_pool* is ``True`` a :class:`ContainerPoolRegistry` keeps
+    pre-started containers warm per image (GH#4452).  Each acquired container
+    receives commands via ``exec_run``; after execution the container is
+    destroyed and the pool is refilled asynchronously.
+    """
+
+    def __init__(
+        self,
+        docker_host: str | None = None,
+        use_pool: bool = False,
+        pool_size: int = _DEFAULT_POOL_SIZE,
+    ) -> None:
         """Initialize Docker backend.
 
         Args:
             docker_host: Docker daemon URL (default: unix socket)
+            use_pool: Enable pre-warmed container pool (GH#4452).
+            pool_size: Number of warm containers to maintain per image.
 
         Raises:
             RuntimeError: If Docker is not available or not configured
@@ -57,8 +79,47 @@ class DockerBackend(ExecutionBackend):
         self._container_map: Dict[str, str] = {}  # task_id -> container_id
         self._default_image = "python:3.10-slim"
 
+        # Pre-warmed pool (GH#4452)
+        self._use_pool = use_pool
+        self._pool_size = pool_size
+        self._pool_registry: ContainerPoolRegistry | None = None
+        if use_pool:
+            self._pool_registry = ContainerPoolRegistry(
+                docker_client=self.client,
+                pool_size=pool_size,
+            )
+
+    # ------------------------------------------------------------------
+    # Pool lifecycle helpers
+    # ------------------------------------------------------------------
+
+    async def warm_pool(self, images: list[str] | None = None) -> None:
+        """Pre-warm the container pool for the given images.
+
+        Args:
+            images: Docker images to pre-warm. Defaults to all supported images.
+        """
+        if self._pool_registry is None:
+            return
+        if images is None:
+            images = list(self._get_image_map().values())
+        await self._pool_registry.start(images)
+
+    def get_pool_stats(self) -> Dict[str, Any]:
+        """Return pool statistics for monitoring."""
+        if self._pool_registry is None:
+            return {}
+        return self._pool_registry.get_stats()
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
     async def execute(self, task: ExecutionTask) -> ExecutionResult:
         """Execute task in Docker container.
+
+        Uses a warm container from the pool when *use_pool* is ``True``
+        (GH#4452); otherwise falls back to the original cold-start path.
 
         Args:
             task: ExecutionTask with code and parameters
@@ -72,6 +133,86 @@ class DockerBackend(ExecutionBackend):
         if not await self.is_healthy():
             raise RuntimeError("Docker backend is not healthy")
 
+        image = self._get_image_for_language(task.language)
+
+        if self._use_pool and self._pool_registry is not None:
+            pool = self._pool_registry.get_pool(image)
+            if pool is not None:
+                return await self._execute_pooled(task, image, pool)
+
+        return await self._execute_cold(task, image)
+
+    async def _execute_pooled(self, task: ExecutionTask, image: str, pool: Any) -> ExecutionResult:
+        """Execute *task* using a pre-warmed container from *pool* (GH#4452).
+
+        Acquires a warm container, runs the command with ``exec_run`` inside
+        it, then releases (destroys) the container so the pool can refill.
+
+        Args:
+            task: ExecutionTask with code and parameters.
+            image: Docker image name (used for logging).
+            pool: WarmContainerPool to acquire from.
+
+        Returns:
+            ExecutionResult with captured output.
+        """
+        result = ExecutionResult(
+            task_id=task.task_id,
+            status=ExecutionStatus.PENDING,
+            backend_type=self.backend_type.value,
+        )
+
+        container = None
+        try:
+            result.started_at = now_utc()
+            result.status = ExecutionStatus.RUNNING
+
+            container = await pool.acquire()
+            self._container_map[task.task_id] = container.id
+
+            cmd = self._prepare_command(task)
+            env = {k: str(v) for k, v in (task.env_vars or {}).items()}
+
+            exec_result = await asyncio.to_thread(
+                container.exec_run,
+                cmd,
+                environment=env,
+                demux=False,
+            )
+
+            output = (exec_result.output or b"").decode("utf-8", errors="replace")
+            result.stdout = output
+            result.stderr = ""
+            result.return_code = exec_result.exit_code if exec_result.exit_code is not None else -1
+            result.status = ExecutionStatus.SUCCESS if result.return_code == 0 else ExecutionStatus.FAILED
+
+        except Exception as exc:
+            logger.exception("Pooled execution error for task %s: %s", task.task_id, exc)
+            result.status = ExecutionStatus.FAILED
+            result.stderr = str(exc)
+            result.return_code = -1
+
+        finally:
+            if container is not None:
+                self._container_map.pop(task.task_id, None)
+                await pool.release(container)
+
+            result.completed_at = now_utc()
+            if result.started_at:
+                result.execution_time_ms = (result.completed_at - result.started_at).total_seconds() * 1000
+
+        return result
+
+    async def _execute_cold(self, task: ExecutionTask, image: str) -> ExecutionResult:
+        """Original cold-start execution path: create a new container per task.
+
+        Args:
+            task: ExecutionTask with code and parameters.
+            image: Docker image to use.
+
+        Returns:
+            ExecutionResult with captured output.
+        """
         result = ExecutionResult(
             task_id=task.task_id,
             status=ExecutionStatus.PENDING,
@@ -84,11 +225,8 @@ class DockerBackend(ExecutionBackend):
             result.started_at = now_utc()
             result.status = ExecutionStatus.RUNNING
 
-            # Prepare image and command
-            image = self._get_image_for_language(task.language)
             cmd = self._prepare_command(task)
 
-            # Create container with resource limits
             try:
                 container = self.client.containers.run(
                     image,
@@ -104,53 +242,52 @@ class DockerBackend(ExecutionBackend):
 
                 self._container_map[task.task_id] = container.id
 
-                # Wait for container with timeout
                 try:
                     exit_code = container.wait(timeout=task.timeout_seconds)
                     result.return_code = exit_code["StatusCode"]
 
                 except Exception as timeout_error:
-                    logger.warning(f"Container {container.id} timed out: {timeout_error}")
+                    logger.warning("Container %s timed out: %s", container.id, timeout_error)
                     container.kill()
                     result.status = ExecutionStatus.TIMEOUT
-                    result.stderr = f"Container execution exceeded timeout of " f"{task.timeout_seconds}s"
+                    result.stderr = f"Container execution exceeded timeout of {task.timeout_seconds}s"
                     result.return_code = -1
                     return result
 
-                # Capture output
                 try:
                     logs = container.logs(stdout=True, stderr=True)
                     output = logs.decode(encoding="utf-8", errors="replace")
-                    # Simple heuristic: if container has stderr, assume it's there
                     result.stdout = output
                     result.stderr = ""
                 except Exception as e:
-                    logger.warning(f"Failed to capture container logs: {e}")
+                    logger.warning("Failed to capture container logs: %s", e)
                     result.stderr = f"Failed to capture logs: {str(e)}"
 
-                # Determine status
                 result.status = ExecutionStatus.SUCCESS if result.return_code == 0 else ExecutionStatus.FAILED
 
             except Exception as e:
                 result.status = ExecutionStatus.FAILED
                 result.stderr = f"Container execution failed: {str(e)}"
                 result.return_code = -1
-                logger.exception(f"Error executing task {task.task_id}: {e}")
+                logger.exception("Error executing task %s: %s", task.task_id, e)
 
         finally:
-            # Clean up container
             if container:
                 try:
                     container.remove(force=True)
                     self._container_map.pop(task.task_id, None)
                 except Exception as e:
-                    logger.warning(f"Error removing container {container.id}: {e}")
+                    logger.warning("Error removing container %s: %s", container.id, e)
 
             result.completed_at = now_utc()
             if result.started_at:
                 result.execution_time_ms = (result.completed_at - result.started_at).total_seconds() * 1000
 
         return result
+
+    # ------------------------------------------------------------------
+    # Health / cleanup
+    # ------------------------------------------------------------------
 
     async def health_check(self) -> bool:
         """Check if Docker daemon is accessible.
@@ -162,11 +299,11 @@ class DockerBackend(ExecutionBackend):
             self.client.ping()
             return True
         except Exception as e:
-            logger.warning(f"Docker health check failed: {e}")
+            logger.warning("Docker health check failed: %s", e)
             return False
 
     async def cleanup(self) -> None:
-        """Clean up active containers."""
+        """Clean up active containers and stop the pool if running."""
         for task_id, container_id in list(self._container_map.items()):
             try:
                 container = self.client.containers.get(container_id)
@@ -174,7 +311,10 @@ class DockerBackend(ExecutionBackend):
                     container.kill()
                 container.remove(force=True)
             except Exception as e:
-                logger.warning(f"Error cleaning up container {container_id}: {e}")
+                logger.warning("Error cleaning up container %s: %s", container_id, e)
+
+        if self._pool_registry is not None:
+            await self._pool_registry.stop()
 
     async def verify_task_compatibility(self, task: ExecutionTask) -> Tuple[bool, str]:
         """Verify task can run in Docker.
@@ -192,15 +332,26 @@ class DockerBackend(ExecutionBackend):
                 f"Language '{task.language}' not supported in Docker. " f"Supported: {', '.join(supported_languages)}",
             )
 
-        # Check if image is available
         try:
             image = self._get_image_for_language(task.language)
             self.client.images.get(image)
         except Exception:
-            # Image not available locally, but can be pulled
             pass
 
         return True, ""
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_image_map(self) -> Dict[str, str]:
+        """Return the language-to-image mapping."""
+        return {
+            "python": "python:3.10-slim",
+            "javascript": "node:18-slim",
+            "bash": "bash:5.1",
+            "shell": "bash:5.1",
+        }
 
     def _get_image_for_language(self, language: str) -> str:
         """Get Docker image for language.
@@ -211,14 +362,7 @@ class DockerBackend(ExecutionBackend):
         Returns:
             Docker image name
         """
-        language = language.lower()
-        images = {
-            "python": "python:3.10-slim",
-            "javascript": "node:18-slim",
-            "bash": "bash:5.1",
-            "shell": "bash:5.1",
-        }
-        return images.get(language, self._default_image)
+        return self._get_image_map().get(language.lower(), self._default_image)
 
     def _prepare_command(self, task: ExecutionTask) -> list:
         """Prepare command for container execution.
@@ -227,7 +371,7 @@ class DockerBackend(ExecutionBackend):
             task: ExecutionTask with code
 
         Returns:
-            Command list for container.run()
+            Command list for container.run() or exec_run()
         """
         language = task.language.lower()
 

--- a/autobot-backend/tests/test_container_pool.py
+++ b/autobot-backend/tests/test_container_pool.py
@@ -1,0 +1,333 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for WarmContainerPool and ContainerPoolRegistry (GH#4452)
+
+Validates pool start/stop, acquire/release, cold-start fallback, replenishment,
+and DockerBackend integration with pool enabled.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.execution.container_pool import (
+    ContainerPoolRegistry,
+    WarmContainerPool,
+)
+from services.execution.base_backend import (
+    BackendType,
+    ExecutionStatus,
+    ExecutionTask,
+)
+
+
+def _make_container(short_id: str = "abc123") -> MagicMock:
+    """Build a minimal mock Docker container."""
+    c = MagicMock()
+    c.short_id = short_id
+    c.id = short_id * 2
+    c.remove = MagicMock()
+    return c
+
+
+def _make_docker_client(*container_ids: str) -> MagicMock:
+    """Build a mock Docker client that returns containers for run() calls."""
+    client = MagicMock()
+    containers = [_make_container(cid) for cid in container_ids] if container_ids else [_make_container()]
+    client.containers.run.side_effect = list(containers)
+    return client
+
+
+@pytest.mark.asyncio
+class TestWarmContainerPool:
+    """Unit tests for WarmContainerPool."""
+
+    async def test_start_fills_pool(self):
+        """start() should place pool_size containers into the queue."""
+        containers = [_make_container(f"c{i}") for i in range(2)]
+        client = MagicMock()
+        client.containers.run.side_effect = list(containers)
+
+        pool = WarmContainerPool(docker_client=client, image="python:3.10-slim", pool_size=2)
+        await pool.start()
+
+        assert pool.available == 2
+        assert client.containers.run.call_count == 2
+
+    async def test_start_partial_failure(self):
+        """start() tolerates individual container creation failures."""
+        good = _make_container("good")
+        client = MagicMock()
+        client.containers.run.side_effect = [Exception("daemon error"), good]
+
+        pool = WarmContainerPool(docker_client=client, image="python:3.10-slim", pool_size=2)
+        await pool.start()
+
+        # One succeeded despite one failure
+        assert pool.available == 1
+
+    async def test_acquire_returns_warm_container(self):
+        """acquire() dequeues a warm container without calling containers.run again."""
+        container = _make_container("warm1")
+        client = MagicMock()
+        client.containers.run.return_value = container
+
+        pool = WarmContainerPool(docker_client=client, image="python:3.10-slim", pool_size=1)
+        await pool.start()
+
+        # Reset call count after start
+        client.containers.run.reset_mock()
+
+        acquired = await pool.acquire()
+        assert acquired is container
+        # Pool was pre-filled; acquire should not create a new one synchronously
+        # (replenish runs as a background task)
+        assert client.containers.run.call_count == 0
+
+    async def test_acquire_cold_start_when_pool_empty(self):
+        """acquire() falls back to a fresh container when the pool is empty."""
+        fresh = _make_container("fresh")
+        client = MagicMock()
+        # start() gets nothing (size 0), then fallback creates one
+        client.containers.run.side_effect = [fresh]
+
+        pool = WarmContainerPool(docker_client=client, image="python:3.10-slim", pool_size=0)
+        await pool.start()  # pool_size=0, nothing pre-created
+
+        # Provide a container for the cold-start path
+        client.containers.run.reset_mock()
+        client.containers.run.return_value = fresh
+
+        # Patch the timeout so the queue wait immediately times out
+        with patch("services.execution.container_pool._ACQUIRE_TIMEOUT", 0.01):
+            acquired = await pool.acquire()
+
+        assert acquired is fresh
+
+    async def test_release_removes_container(self):
+        """release() calls remove(force=True) on the container."""
+        container = _make_container("used")
+        client = MagicMock()
+        client.containers.run.return_value = container
+
+        pool = WarmContainerPool(docker_client=client, image="python:3.10-slim", pool_size=1)
+        await pool.start()
+        acquired = await pool.acquire()
+        await pool.release(acquired)
+
+        container.remove.assert_called_once_with(force=True)
+
+    async def test_release_tolerates_remove_error(self):
+        """release() does not raise if remove() fails."""
+        container = _make_container("bad")
+        container.remove.side_effect = Exception("already gone")
+
+        client = MagicMock()
+        client.containers.run.return_value = container
+
+        pool = WarmContainerPool(docker_client=client, image="python:3.10-slim", pool_size=1)
+        await pool.start()
+        acquired = await pool.acquire()
+
+        # Should not raise
+        await pool.release(acquired)
+
+    async def test_stop_destroys_all_containers(self):
+        """stop() removes every container remaining in the pool."""
+        containers = [_make_container(f"s{i}") for i in range(3)]
+        client = MagicMock()
+        client.containers.run.side_effect = list(containers)
+
+        pool = WarmContainerPool(docker_client=client, image="python:3.10-slim", pool_size=3)
+        await pool.start()
+        await pool.stop()
+
+        for c in containers:
+            c.remove.assert_called_with(force=True)
+        assert pool.available == 0
+
+    async def test_get_stats(self):
+        """get_stats() returns expected keys."""
+        client = MagicMock()
+        client.containers.run.return_value = _make_container()
+
+        pool = WarmContainerPool(docker_client=client, image="my-image", pool_size=1)
+        await pool.start()
+
+        stats = pool.get_stats()
+        assert stats["image"] == "my-image"
+        assert stats["pool_size"] == 1
+        assert "available" in stats
+        assert stats["running"] is True
+
+    async def test_replenish_adds_container(self):
+        """_replenish() adds a container to a depleted pool."""
+        c1 = _make_container("c1")
+        c2 = _make_container("c2")
+        client = MagicMock()
+        client.containers.run.side_effect = [c1, c2]
+
+        pool = WarmContainerPool(docker_client=client, image="python:3.10-slim", pool_size=1)
+        await pool.start()
+
+        assert pool.available == 1
+        await pool.acquire()  # drains pool, triggers background replenish
+        # Give the background task a chance to run
+        await asyncio.sleep(0.05)
+        assert pool.available == 1  # replenished
+
+    async def test_replenish_noop_when_pool_full(self):
+        """_replenish() does not over-create when pool is already full."""
+        c1 = _make_container("c1")
+        client = MagicMock()
+        client.containers.run.return_value = c1
+
+        pool = WarmContainerPool(docker_client=client, image="python:3.10-slim", pool_size=1)
+        await pool.start()
+
+        pre = client.containers.run.call_count
+        await pool._replenish()
+        # Pool was already at capacity — no new container needed
+        assert client.containers.run.call_count == pre
+
+
+@pytest.mark.asyncio
+class TestContainerPoolRegistry:
+    """Unit tests for ContainerPoolRegistry."""
+
+    async def test_start_creates_pools_for_each_image(self):
+        """start() initialises one pool per image."""
+        client = MagicMock()
+        client.containers.run.return_value = _make_container()
+
+        registry = ContainerPoolRegistry(docker_client=client, pool_size=1)
+        await registry.start(["img-a", "img-b"])
+
+        assert registry.get_pool("img-a") is not None
+        assert registry.get_pool("img-b") is not None
+        assert registry.get_pool("img-c") is None
+
+    async def test_stop_clears_pools(self):
+        """stop() calls stop() on every pool and removes them from the registry."""
+        client = MagicMock()
+        client.containers.run.return_value = _make_container()
+
+        registry = ContainerPoolRegistry(docker_client=client, pool_size=1)
+        await registry.start(["my-img"])
+        await registry.stop()
+
+        assert registry.get_pool("my-img") is None
+
+    async def test_get_stats_returns_all_images(self):
+        """get_stats() includes every registered image."""
+        client = MagicMock()
+        client.containers.run.return_value = _make_container()
+
+        registry = ContainerPoolRegistry(docker_client=client, pool_size=1)
+        await registry.start(["img-x", "img-y"])
+
+        stats = registry.get_stats()
+        assert "img-x" in stats
+        assert "img-y" in stats
+
+
+@pytest.mark.asyncio
+class TestDockerBackendWithPool:
+    """Integration tests for DockerBackend with use_pool=True (GH#4452)."""
+
+    @pytest.fixture
+    def mock_docker(self):
+        with patch("services.execution.docker_backend.docker") as m:
+            client = MagicMock()
+            m.from_env.return_value = client
+            client.ping.return_value = None
+            yield client
+
+    async def test_pooled_execute_calls_exec_run(self, mock_docker):
+        """When pool is warmed, execute uses exec_run instead of containers.run."""
+        from services.execution.docker_backend import DockerBackend
+
+        warm_container = _make_container("warm")
+        exec_result = MagicMock()
+        exec_result.exit_code = 0
+        exec_result.output = b"hello pooled"
+        warm_container.exec_run.return_value = exec_result
+
+        # containers.run only called for pool warm-up
+        mock_docker.containers.run.return_value = warm_container
+
+        backend = DockerBackend(use_pool=True, pool_size=1)
+        await backend.warm_pool(["python:3.10-slim"])
+
+        task = ExecutionTask(
+            task_id="pool-1",
+            code="print('hello pooled')",
+            language="python",
+            timeout_seconds=10,
+        )
+
+        result = await backend.execute(task)
+
+        assert result.status == ExecutionStatus.SUCCESS
+        assert "hello pooled" in result.stdout
+        # exec_run was used, not a fresh containers.run for the task itself
+        warm_container.exec_run.assert_called_once()
+
+    async def test_pooled_execute_falls_back_when_pool_not_warmed(self, mock_docker):
+        """When the pool has no containers for the image, cold-start runs."""
+        from services.execution.docker_backend import DockerBackend
+
+        cold_container = _make_container("cold")
+        cold_container.wait.return_value = {"StatusCode": 0}
+        cold_container.logs.return_value = b"cold output"
+        mock_docker.containers.run.return_value = cold_container
+
+        # Pool is enabled but we never call warm_pool — so no pool for "python:3.10-slim"
+        backend = DockerBackend(use_pool=True, pool_size=1)
+        # Do NOT call warm_pool → pool_registry has no pool for the image
+
+        task = ExecutionTask(
+            task_id="cold-1",
+            code="print('cold')",
+            language="python",
+            timeout_seconds=10,
+        )
+
+        result = await backend.execute(task)
+
+        # Should still succeed via cold-start path
+        assert result.status == ExecutionStatus.SUCCESS
+
+    async def test_cleanup_stops_pool(self, mock_docker):
+        """cleanup() stops the pool registry."""
+        from services.execution.docker_backend import DockerBackend
+
+        mock_docker.containers.run.return_value = _make_container()
+
+        backend = DockerBackend(use_pool=True, pool_size=1)
+        await backend.warm_pool(["python:3.10-slim"])
+
+        # Should not raise
+        await backend.cleanup()
+
+    async def test_get_pool_stats_empty_without_pool(self, mock_docker):
+        """get_pool_stats() returns {} when use_pool=False."""
+        from services.execution.docker_backend import DockerBackend
+
+        backend = DockerBackend(use_pool=False)
+        assert backend.get_pool_stats() == {}
+
+    async def test_get_pool_stats_populated_with_pool(self, mock_docker):
+        """get_pool_stats() returns image keys when pool is warmed."""
+        from services.execution.docker_backend import DockerBackend
+
+        mock_docker.containers.run.return_value = _make_container()
+
+        backend = DockerBackend(use_pool=True, pool_size=1)
+        await backend.warm_pool(["python:3.10-slim"])
+
+        stats = backend.get_pool_stats()
+        assert "python:3.10-slim" in stats


### PR DESCRIPTION
## Summary

- Adds `WarmContainerPool`: keeps N pre-started containers per Docker image running `sleep infinity`; task commands are dispatched via `exec_run` instead of spinning up a new container each time — eliminating image-layer cold-start latency.
- Adds `ContainerPoolRegistry`: manages one pool per image, starts/stops them concurrently.
- Extends `DockerBackend` with opt-in `use_pool=True` / `pool_size` args, `warm_pool()`, and `get_pool_stats()`.
- Pool refills asynchronously after each acquire; falls back to cold-start if the pool is empty.

## Test plan

- [x] 18 new unit tests in `tests/test_container_pool.py` — all pass
- [x] 35 existing `tests/test_execution_backends.py` tests still pass (0 regressions)
- [ ] Manual integration test: instantiate `DockerBackend(use_pool=True)`, call `warm_pool()`, execute a Python task, verify `exec_run` is used and output is correct

Closes GH#4452

🤖 Generated with [Claude Code](https://claude.com/claude-code)