### PR TITLE
feat(heartbeat): add AgentStatus badge and Pause/Resume controls to HeartbeatPanel (GH#8732)

### DIFF
--- a/autobot-frontend/src/components/agents/HeartbeatPanel.stories.ts
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.stories.ts
@@ -55,3 +55,36 @@ export const NarrowColumn: Story = {
     `,
   }),
 };
+
+/**
+ * Visual preview of all four AgentStatus badge variants (GH#8732 / GH#6476 AC-8).
+ * These badges appear in the Configuration card once data is loaded.
+ * active → green, disabled → gray, paused → orange (with pause details), terminated → red.
+ */
+export const StatusBadgeVariants: Story = {
+  render: () => ({
+    template: `
+      <div style="background: #0f172a; padding: 1.5rem; font-family: sans-serif; display: flex; flex-direction: column; gap: 1.5rem;">
+        <div style="color: #94a3b8; font-size: 0.8rem; margin-bottom: 0.5rem;">AgentStatus badge variants (GH#6476 AC-8)</div>
+        <div style="display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center;">
+          <span style="background: rgba(16,185,129,0.2); color: #34d399; border-radius: 4px; font-size: 0.72rem; font-weight: 600; padding: 0.1rem 0.45rem; text-transform: uppercase;">active</span>
+          <span style="background: rgba(100,116,139,0.2); color: #94a3b8; border-radius: 4px; font-size: 0.72rem; font-weight: 600; padding: 0.1rem 0.45rem; text-transform: uppercase;">disabled</span>
+          <span style="background: rgba(249,115,22,0.2); color: #fb923c; border-radius: 4px; font-size: 0.72rem; font-weight: 600; padding: 0.1rem 0.45rem; text-transform: uppercase;">paused</span>
+          <span style="background: rgba(239,68,68,0.2); color: #f87171; border-radius: 4px; font-size: 0.72rem; font-weight: 600; padding: 0.1rem 0.45rem; text-transform: uppercase;">terminated</span>
+        </div>
+        <div style="background: #1e293b; border: 1px solid #334155; border-radius: 8px; padding: 1rem;">
+          <div style="font-weight: 600; color: #e2e8f0; margin-bottom: 0.75rem;">Paused state — shows pause details</div>
+          <div style="display: flex; flex-direction: column; gap: 0.4rem; font-size: 0.8rem;">
+            <div style="display: flex; gap: 0.75rem;"><span style="width: 130px; color: #94a3b8;">Status</span><span style="background: rgba(249,115,22,0.2); color: #fb923c; border-radius: 4px; font-size: 0.72rem; font-weight: 600; padding: 0.1rem 0.45rem; text-transform: uppercase;">paused</span></div>
+            <div style="display: flex; gap: 0.75rem;"><span style="width: 130px; color: #94a3b8;">Paused By</span><span style="font-family: monospace; color: #e2e8f0;">system:budget</span></div>
+            <div style="display: flex; gap: 0.75rem;"><span style="width: 130px; color: #94a3b8;">Paused At</span><span style="color: #e2e8f0;">5/26/2026, 3:42:00 PM</span></div>
+            <div style="display: flex; gap: 0.75rem;"><span style="width: 130px; color: #94a3b8;">Reason</span><span style="color: #e2e8f0;">Budget threshold exceeded (80%)</span></div>
+          </div>
+          <div style="border-top: 1px solid #334155; margin-top: 0.75rem; padding-top: 0.75rem; display: flex; gap: 0.5rem;">
+            <button style="background: rgba(16,185,129,0.2); border: 1px solid rgba(16,185,129,0.5); border-radius: 4px; color: #34d399; font-size: 0.8rem; padding: 0.3rem 0.6rem; cursor: pointer;">Resume</button>
+          </div>
+        </div>
+      </div>
+    `,
+  }),
+};

--- a/autobot-frontend/src/components/agents/HeartbeatPanel.vue
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.vue
@@ -22,11 +22,25 @@
         <div class="card-title">Configuration</div>
         <div class="config-grid">
           <div class="config-row">
-            <span class="label">Enabled</span>
-            <span :class="['badge', config.heartbeat_enabled ? 'badge-green' : 'badge-gray']">
-              {{ config.heartbeat_enabled ? 'Active' : 'Disabled' }}
+            <span class="label">Status</span>
+            <span :class="['badge', agentStatusClass(config.status)]">
+              {{ config.status }}
             </span>
           </div>
+          <template v-if="config.status === 'paused'">
+            <div class="config-row">
+              <span class="label">Paused By</span>
+              <span class="value mono">{{ config.paused_by || '—' }}</span>
+            </div>
+            <div class="config-row">
+              <span class="label">Paused At</span>
+              <span class="value">{{ formatTime(config.paused_at) }}</span>
+            </div>
+            <div class="config-row">
+              <span class="label">Reason</span>
+              <span class="value">{{ config.paused_reason || '—' }}</span>
+            </div>
+          </template>
           <div class="config-row">
             <span class="label">Interval</span>
             <span class="value">{{ config.heartbeat_interval_seconds }}s</span>
@@ -45,8 +59,15 @@
           </div>
         </div>
         <div class="config-actions">
-          <label class="toggle-label">
-            <input v-model="editEnabled" type="checkbox" />
+          <label
+            class="toggle-label"
+            :title="config.status === 'paused' ? 'Use Resume to re-enable a paused agent' : config.status === 'terminated' ? 'Terminated agents cannot be re-enabled' : ''"
+          >
+            <input
+              v-model="editEnabled"
+              type="checkbox"
+              :disabled="config.status === 'paused' || config.status === 'terminated'"
+            />
             Enable heartbeat
           </label>
           <div class="interval-input">
@@ -62,6 +83,22 @@
           </button>
           <button class="btn-trigger" :disabled="triggering" @click="triggerManual">
             {{ triggering ? 'Triggering…' : 'Run Now' }}
+          </button>
+          <button
+            v-if="config.status === 'active'"
+            class="btn-pause"
+            :disabled="pausing"
+            @click="pauseAgent"
+          >
+            {{ pausing ? 'Pausing…' : 'Pause' }}
+          </button>
+          <button
+            v-if="config.status === 'paused'"
+            class="btn-resume"
+            :disabled="resuming"
+            @click="resumeAgent"
+          >
+            {{ resuming ? 'Resuming…' : 'Resume' }}
           </button>
         </div>
       </div>
@@ -165,6 +202,10 @@ const { subscribe, unsubscribe } = useEventBus()
 interface HeartbeatConfig {
   agent_id: string
   heartbeat_enabled: boolean
+  status: string
+  paused_reason: string | null
+  paused_at: string | null
+  paused_by: string | null
   heartbeat_interval_seconds: number
   max_run_duration_seconds: number
   current_task_id: string | null
@@ -216,6 +257,8 @@ const loading = ref(false)
 const saving = ref(false)
 const triggering = ref(false)
 const queueing = ref(false)
+const pausing = ref(false)
+const resuming = ref(false)
 const error = ref<string | null>(null)
 const config = ref<HeartbeatConfig | null>(null)
 const runs = ref<HeartbeatRun[]>([])
@@ -362,6 +405,47 @@ async function queueWakeup(): Promise<void> {
   } finally {
     queueing.value = false
   }
+}
+
+async function pauseAgent(): Promise<void> {
+  if (!agentId.value) return
+  pausing.value = true
+  error.value = null
+  try {
+    const updated = await apiFetch(`/${agentId.value}/pause`, {
+      method: 'POST',
+      body: JSON.stringify({ reason: 'Manual pause from UI', paused_by: 'user' }),
+    })
+    config.value = updated as HeartbeatConfig
+  } catch (err) {
+    error.value = String(err)
+  } finally {
+    pausing.value = false
+  }
+}
+
+async function resumeAgent(): Promise<void> {
+  if (!agentId.value) return
+  resuming.value = true
+  error.value = null
+  try {
+    const updated = await apiFetch(`/${agentId.value}/resume`, { method: 'POST' })
+    config.value = updated as HeartbeatConfig
+  } catch (err) {
+    error.value = String(err)
+  } finally {
+    resuming.value = false
+  }
+}
+
+function agentStatusClass(status: string): string {
+  const map: Record<string, string> = {
+    active: 'badge-green',
+    disabled: 'badge-gray',
+    paused: 'badge-orange',
+    terminated: 'badge-red',
+  }
+  return map[status] ?? 'badge-gray'
 }
 
 function toggleEvents(runId: string): void {
@@ -602,6 +686,22 @@ button:not(:disabled):hover {
 .btn-queue {
   background: var(--color-info);
   border-color: var(--color-info);
+}
+.btn-pause {
+  background: rgba(249, 115, 22, 0.25);
+  border-color: rgba(249, 115, 22, 0.6);
+  color: #fb923c;
+}
+.btn-pause:not(:disabled):hover {
+  background: rgba(249, 115, 22, 0.4);
+}
+.btn-resume {
+  background: rgba(16, 185, 129, 0.2);
+  border-color: rgba(16, 185, 129, 0.5);
+  color: #34d399;
+}
+.btn-resume:not(:disabled):hover {
+  background: rgba(16, 185, 129, 0.35);
 }
 .btn-sm {
   font-size: var(--text-xs);

--- a/autobot-frontend/src/components/agents/HeartbeatPanel.vue
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.vue
@@ -286,7 +286,7 @@ function _onLiveEvent(event: LiveEvent): void {
   }
 }
 
-watch(agentId, (newId: string, oldId: string) => {
+watch(agentId, (newId: string, oldId: string | undefined) => {
   if (oldId) {
     const oldChannel = `heartbeat:${oldId}`
     if (_liveUnsub) {


### PR DESCRIPTION
## Summary

- Extended `HeartbeatConfig` interface with `status`, `paused_reason`, `paused_at`, `paused_by` from `HeartbeatConfigResponse`
- Replaced binary "Enabled/Disabled" badge with 4-state `AgentStatus` badge: `active` (green) / `disabled` (gray) / `paused` (orange) / `terminated` (red)
- When `status === 'paused'`, shows inline details: Paused By, Paused At, Reason
- Added **Pause** button (visible when `active`) → `POST /{id}/pause`
- Added **Resume** button (visible when `paused`) → `POST /{id}/resume`
- Disabled `heartbeat_enabled` toggle for paused/terminated agents
- Fixed pre-existing TS2769 type error: `oldId: string | undefined` in watch callback
- Added `StatusBadgeVariants` Storybook story showing all 4 badge states

## Acceptance Criterion

Implements GH#6476 AC-8: agent panel badge for `AgentStatus`.

## Test plan

- [ ] All 4 badge states render correctly (active/disabled/paused/terminated)
- [ ] Pause button calls `POST /{id}/pause` and badge transitions to orange
- [ ] Resume button calls `POST /{id}/resume` and badge transitions to green
- [ ] Paused state shows Paused By / Paused At / Reason details inline
- [ ] Toggle disabled when status is paused or terminated
- [ ] `npm run type-check` passes — TS2769 fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)