### PR TITLE
sec(backend): block SSRF in ExternalSkillImporter.import_git_repo (MVA-1307)

### DIFF
--- a/autobot-backend/skills/external_importer.py
+++ b/autobot-backend/skills/external_importer.py
@@ -95,8 +95,7 @@ def _validate_git_ref(ref: str) -> None:
     """Reject ref strings that look like flag injection or path traversal."""
     if not ref or ref.startswith("-") or ".." in ref or not _GIT_REF_RE.match(ref):
         raise RuntimeError(
-            f"Invalid git ref {ref!r}: refs must match [A-Za-z0-9._/-]+ "
-            "and cannot start with '-' or contain '..'"
+            f"Invalid git ref {ref!r}: refs must match [A-Za-z0-9._/-]+ " "and cannot start with '-' or contain '..'"
         )
 
 

--- a/autobot-backend/skills/external_importer.py
+++ b/autobot-backend/skills/external_importer.py
@@ -11,8 +11,10 @@ automatically promoted to BUILTIN or TRUSTED.
 
 import asyncio
 import os
+import re
 import uuid
 from typing import Any
+from urllib.parse import urlparse
 
 import aiohttp
 
@@ -25,6 +27,77 @@ logger = get_logger(__name__)
 _SKILL_CACHE_DIR = "/var/lib/autobot/skill_cache"
 _GIT_TIMEOUT = 120
 _SOURCE_META_KEY = "external_import"
+
+# Allowlist of git URL schemes.  file://, http://, git:// and any other scheme
+# are rejected outright to prevent SSRF via the git binary.
+_ALLOWED_GIT_SCHEMES = frozenset({"https", "ssh", "git+ssh"})
+
+# Valid git ref characters — rejects flag-injection strings like --upload-pack=x
+# and path-traversal sequences.
+_GIT_REF_RE = re.compile(r"^[A-Za-z0-9._/\-]+$")
+
+
+def _parse_git_remote(url: str) -> tuple[str, str]:
+    """Return (scheme, host) for a git remote URL.
+
+    Supports https://, ssh://, git+ssh://, and SCP-style git@host:path remotes.
+    Raises ValueError for disallowed or unrecognisable formats.
+    """
+    if "://" not in url:
+        # SCP-style: [user@]host:path  — treated as SSH
+        host_part = url.split(":", 1)[0]
+        host = host_part.split("@", 1)[-1]
+        if not host:
+            raise ValueError(f"Cannot parse host from SCP-style git URL: {url!r}")
+        return "ssh", host
+
+    parsed = urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in _ALLOWED_GIT_SCHEMES:
+        raise ValueError(
+            f"Disallowed git URL scheme {scheme!r} in {url!r}: "
+            f"only https and ssh are permitted (got scheme from allowlist {_ALLOWED_GIT_SCHEMES})"
+        )
+    host = parsed.hostname or ""
+    if not host:
+        raise ValueError(f"Git URL has no hostname: {url!r}")
+    return scheme, host
+
+
+async def _validate_git_url(url: str) -> None:
+    """SSRF guard for git remote URLs.
+
+    Rejects file://, http://, git://, and any private/internal host.
+    For https:// delegates to is_public_url_async; for ssh/git+ssh resolves
+    the host via resolve_safe_ip_async to block private RFC-range IPs.
+
+    Raises RuntimeError with a descriptive message on any rejection.
+    """
+    from autobot_shared.url_safety import is_public_url_async, resolve_safe_ip_async
+
+    try:
+        scheme, host = _parse_git_remote(url)
+    except ValueError as exc:
+        raise RuntimeError(f"Git URL rejected: {exc}") from exc
+
+    if scheme == "https":
+        if not await is_public_url_async(url):
+            raise RuntimeError(f"Git HTTPS URL blocked by SSRF guard: {url}")
+    else:
+        # SSH variants: validate the resolved IP is publicly routable.
+        try:
+            await resolve_safe_ip_async(host)
+        except ValueError as exc:
+            raise RuntimeError(f"Git SSH URL blocked by SSRF guard ({host}): {exc}") from exc
+
+
+def _validate_git_ref(ref: str) -> None:
+    """Reject ref strings that look like flag injection or path traversal."""
+    if not ref or ref.startswith("-") or ".." in ref or not _GIT_REF_RE.match(ref):
+        raise RuntimeError(
+            f"Invalid git ref {ref!r}: refs must match [A-Za-z0-9._/-]+ "
+            "and cannot start with '-' or contain '..'"
+        )
 
 
 def _ensure_cache_dir() -> str:
@@ -143,8 +216,12 @@ class ExternalSkillImporter:
             List of SANDBOXED SkillPackage instances (not yet DB-committed).
 
         Raises:
-            RuntimeError: If git is not available or cloning fails.
+            RuntimeError: If git is not available, the URL is blocked by the
+                SSRF guard, or cloning fails.
         """
+        await _validate_git_url(url)
+        _validate_git_ref(ref)
+
         if not await _git_available():
             raise RuntimeError("git binary not found on PATH -- cannot import git repo")
 

--- a/autobot-backend/skills/external_importer_test.py
+++ b/autobot-backend/skills/external_importer_test.py
@@ -7,7 +7,6 @@ import pytest
 
 from skills.external_importer import _parse_git_remote, _validate_git_ref, _validate_git_url
 
-
 # ---------------------------------------------------------------------------
 # _parse_git_remote — pure URL parsing, no network
 # ---------------------------------------------------------------------------

--- a/autobot-backend/skills/external_importer_test.py
+++ b/autobot-backend/skills/external_importer_test.py
@@ -1,0 +1,137 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for SSRF guards in ExternalSkillImporter (MVA-1307)."""
+
+import pytest
+
+from skills.external_importer import _parse_git_remote, _validate_git_ref, _validate_git_url
+
+
+# ---------------------------------------------------------------------------
+# _parse_git_remote — pure URL parsing, no network
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://github.com/user/repo", ("https", "github.com")),
+        ("ssh://github.com/user/repo", ("ssh", "github.com")),
+        ("git+ssh://github.com/user/repo", ("git+ssh", "github.com")),
+        ("git@github.com:user/repo.git", ("ssh", "github.com")),
+        ("user@bitbucket.org:team/repo.git", ("ssh", "bitbucket.org")),
+    ],
+)
+def test_parse_git_remote_allowed(url, expected):
+    assert _parse_git_remote(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "file://localhost/etc/shadow",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.1/internal",
+        "git://github.com/user/repo",
+    ],
+)
+def test_parse_git_remote_blocked_scheme(url):
+    with pytest.raises(ValueError, match="Disallowed git URL scheme"):
+        _parse_git_remote(url)
+
+
+# ---------------------------------------------------------------------------
+# _validate_git_ref — pure validation, no network
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ref", ["main", "v1.2.3", "feature/my-branch", "abc123def", "release-2026"])
+def test_validate_git_ref_allowed(ref):
+    _validate_git_ref(ref)  # must not raise
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "--upload-pack=evil",
+        "-v",
+        "",
+        "../../../etc/passwd",
+        "ref\x00null",
+        "ref with spaces",
+    ],
+)
+def test_validate_git_ref_blocked(ref):
+    with pytest.raises(RuntimeError, match="Invalid git ref"):
+        _validate_git_ref(ref)
+
+
+# ---------------------------------------------------------------------------
+# _validate_git_url — async, mocked network
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_validate_git_url_https_public(monkeypatch):
+    """Public HTTPS git URLs must pass the SSRF guard."""
+    import autobot_shared.url_safety as _us
+
+    monkeypatch.setattr(_us, "is_public_url", lambda url: True)
+    # No exception expected
+    await _validate_git_url("https://github.com/user/repo")
+
+
+@pytest.mark.anyio
+async def test_validate_git_url_https_private_blocked(monkeypatch):
+    """HTTPS URLs resolving to private IPs must be blocked."""
+    import autobot_shared.url_safety as _us
+
+    monkeypatch.setattr(_us, "is_public_url", lambda url: False)
+    with pytest.raises(RuntimeError, match="SSRF guard"):
+        await _validate_git_url("https://internal.corp/secret/repo")
+
+
+@pytest.mark.anyio
+async def test_validate_git_url_file_blocked():
+    """file:// git URLs must always be blocked (scheme allowlist)."""
+    with pytest.raises(RuntimeError, match="Git URL rejected"):
+        await _validate_git_url("file:///etc/passwd")
+
+
+@pytest.mark.anyio
+async def test_validate_git_url_http_blocked():
+    """Plain http:// git URLs must always be blocked (scheme allowlist)."""
+    with pytest.raises(RuntimeError, match="Git URL rejected"):
+        await _validate_git_url("http://169.254.169.254/latest/meta-data/")
+
+
+@pytest.mark.anyio
+async def test_validate_git_url_ssh_private_blocked(monkeypatch):
+    """SSH URLs resolving to private/internal IPs must be blocked."""
+    import autobot_shared.url_safety as _us
+
+    async def _bad_resolve(host, *, timeout=2.0):
+        raise ValueError(f"Host '{host}' resolves to a non-public address: 10.0.0.1")
+
+    monkeypatch.setattr(_us, "resolve_safe_ip_async", _bad_resolve)
+    with pytest.raises(RuntimeError, match="SSRF guard"):
+        await _validate_git_url("git@internal-host.corp:repo.git")
+
+
+@pytest.mark.anyio
+async def test_validate_git_url_scp_public(monkeypatch):
+    """SCP-style git@host:path URLs for public hosts must pass."""
+    import autobot_shared.url_safety as _us
+
+    async def _good_resolve(host, *, timeout=2.0):
+        return "140.82.121.4"
+
+    monkeypatch.setattr(_us, "resolve_safe_ip_async", _good_resolve)
+    await _validate_git_url("git@github.com:user/repo.git")  # must not raise


### PR DESCRIPTION
## Summary

- Blocks SSRF vulnerability in `ExternalSkillImporter.import_git_repo`
- Validates and sanitizes git URLs before shell execution
- Prevents attacker-controlled URLs from reaching internal network endpoints

## Security Impact

Fixes SSRF vector that allowed external skill import URLs to reach internal services.

## Test plan

- [ ] Malicious internal URLs are rejected with clear error
- [ ] Legitimate external git URLs continue to work
- [ ] Unit tests for URL validation logic pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)