### PR TITLE
fix(infra): add autobot-chromadb.service to deploy pipeline, fix port 8000→8100 (MVA-1294)

### DIFF
--- a/autobot-infrastructure/autobot-database/manifest.yml
+++ b/autobot-infrastructure/autobot-database/manifest.yml
@@ -1,5 +1,5 @@
 role: autobot-database
-description: "Redis Stack + PostgreSQL — session storage, caching, vector search, and relational data"
+description: "Redis Stack + PostgreSQL + ChromaDB — session storage, caching, vector search, and relational data"
 version: "1.0.0"
 target_node: database
 
@@ -26,6 +26,11 @@ services:
     system_service: postgresql
     start_order: 2
     user: postgres
+  - name: autobot-chromadb
+    type: systemd
+    unit_file: autobot-chromadb.service
+    start_order: 3
+    user: autobot
 
 ports:
   - port: 6379
@@ -43,6 +48,11 @@ ports:
     public: false
     loopback_only: true
     description: "PostgreSQL (user management DB for autobot-backend)"
+  - port: 8100
+    protocol: http
+    public: false
+    loopback_only: false
+    description: "ChromaDB HTTP API (vector store for embeddings)"
 
 health:
   endpoint: "http://localhost:6379"
@@ -78,4 +88,5 @@ notes: |
   Redis Stack binds :6379 (all interfaces — fleet-wide access).
   Redis databases: main (0), knowledge (1), prompts (2), analytics (3).
   PostgreSQL on localhost:5432 — user management DB for autobot-backend.
+  ChromaDB on :8100 — vector store for embeddings, accessed by autobot-backend and autobot-ai-stack.
   system_updates policy = manual: database nodes require planned maintenance window.

--- a/autobot-infrastructure/autobot-database/templates/autobot-chromadb.service
+++ b/autobot-infrastructure/autobot-database/templates/autobot-chromadb.service
@@ -29,7 +29,7 @@ EnvironmentFile=-/opt/autobot/autobot-db-stack/.env
 # Start ChromaDB server
 ExecStart=/opt/autobot/autobot-db-stack/chromadb/venv/bin/chroma run \
     --host 0.0.0.0 \
-    --port 8000 \
+    --port 8100 \
     --path /opt/autobot/autobot-db-stack/chromadb/data
 
 # Restart policy

--- a/autobot-infrastructure/autobot-database/templates/db-start.sh
+++ b/autobot-infrastructure/autobot-database/templates/db-start.sh
@@ -61,8 +61,8 @@ else
 fi
 
 # ChromaDB
-echo -n "  ChromaDB (8000): "
-if curl -s "http://127.0.0.1:8000/api/v1/heartbeat" 2>/dev/null | grep -q "nanosecond"; then
+echo -n "  ChromaDB (8100): "
+if curl -s "http://127.0.0.1:8100/api/v1/heartbeat" 2>/dev/null | grep -q "nanosecond"; then
     echo "OK"
 else
     echo "FAILED"

--- a/autobot-infrastructure/autobot-database/templates/db-status.sh
+++ b/autobot-infrastructure/autobot-database/templates/db-status.sh
@@ -35,10 +35,10 @@ fi
 echo ""
 
 # ChromaDB status
-echo "ChromaDB (8000):"
+echo "ChromaDB (8100):"
 if systemctl is-active --quiet autobot-chromadb 2>/dev/null; then
     echo "  Service: RUNNING"
-    if curl -s "http://127.0.0.1:8000/api/v1/heartbeat" 2>/dev/null | grep -q "nanosecond"; then
+    if curl -s "http://127.0.0.1:8100/api/v1/heartbeat" 2>/dev/null | grep -q "nanosecond"; then
         echo "  Health: HEALTHY"
     else
         echo "  Health: NOT RESPONDING"

--- a/autobot-infrastructure/shared/scripts/install-bare-metal.sh
+++ b/autobot-infrastructure/shared/scripts/install-bare-metal.sh
@@ -333,6 +333,69 @@ install_slm() {
     setup_venv "slm" "${code_dir}/autobot-slm-backend/requirements.txt"
 }
 
+install_chromadb() {
+    if [[ "$SKIP_CHROMADB" == true ]]; then
+        log_info "Skipping ChromaDB installation (--skip-chromadb)"
+        return
+    fi
+
+    log_step "Installing ChromaDB (port ${CHROMADB_PORT})"
+
+    local chromadb_dir="${INSTALL_DIR}/chromadb"
+    local venv_dir="${chromadb_dir}/venv"
+    local data_dir="${chromadb_dir}/data"
+
+    # Directories
+    mkdir -p "${chromadb_dir}" "${data_dir}"
+    chown -R "${AUTOBOT_USER}:${AUTOBOT_GROUP}" "${chromadb_dir}"
+
+    # Virtual environment + package
+    sudo -u "${AUTOBOT_USER}" "${PYTHON_BIN}" -m venv "${venv_dir}" --clear
+    sudo -u "${AUTOBOT_USER}" "${venv_dir}/bin/pip" install --upgrade pip -q
+    sudo -u "${AUTOBOT_USER}" "${venv_dir}/bin/pip" install "chromadb>=0.5" -q
+    log_info "ChromaDB installed: $(${venv_dir}/bin/chroma --version 2>/dev/null || echo 'unknown')"
+
+    # Systemd unit
+    cat > /etc/systemd/system/autobot-chromadb.service <<EOF
+[Unit]
+Description=AutoBot ChromaDB - Vector Database
+Documentation=https://github.com/mrveiss/AutoBot-AI
+After=network.target
+
+[Service]
+Type=simple
+User=${AUTOBOT_USER}
+Group=${AUTOBOT_GROUP}
+WorkingDirectory=${chromadb_dir}
+Environment="PYTHONUNBUFFERED=1"
+Environment="ANONYMIZED_TELEMETRY=FALSE"
+EnvironmentFile=-${INSTALL_DIR}/.env
+ExecStart=${venv_dir}/bin/chroma run \\
+    --host 127.0.0.1 \\
+    --port ${CHROMADB_PORT} \\
+    --path ${data_dir}
+Restart=on-failure
+RestartSec=10
+TimeoutStartSec=30
+TimeoutStopSec=30
+MemoryMax=4G
+PrivateTmp=true
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=${data_dir}
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=autobot-chromadb
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    systemctl daemon-reload
+    systemctl enable autobot-chromadb
+    log_info "Created and enabled systemd service: autobot-chromadb (port ${CHROMADB_PORT})"
+}
+
 # =============================================================================
 # Frontend Build
 # =============================================================================
@@ -599,6 +662,9 @@ tune_resources() {
 start_services() {
     log_step "Starting AutoBot services"
 
+    if [[ "$SKIP_CHROMADB" == false ]]; then
+        systemctl start autobot-chromadb
+    fi
     systemctl start autobot-backend
     systemctl start autobot-slm
 
@@ -607,7 +673,11 @@ start_services() {
 
     # Verify
     local all_ok=true
-    for service in autobot-backend autobot-slm; do
+    local services_to_check=(autobot-backend autobot-slm)
+    if [[ "$SKIP_CHROMADB" == false ]]; then
+        services_to_check=(autobot-chromadb "${services_to_check[@]}")
+    fi
+    for service in "${services_to_check[@]}"; do
         if systemctl is-active --quiet "${service}"; then
             log_info "${service}: running"
         else
@@ -663,6 +733,16 @@ verify_installation() {
         ((errors++)) || true
     fi
 
+    # Check ChromaDB
+    if [[ "$SKIP_CHROMADB" == false ]]; then
+        if curl -sf "http://127.0.0.1:${CHROMADB_PORT}/api/v1/heartbeat" >/dev/null 2>&1; then
+            log_info "ChromaDB: OK"
+        else
+            log_warn "ChromaDB: not responding (may still be starting)"
+            ((errors++)) || true
+        fi
+    fi
+
     # Check Ollama
     if [[ "$INSTALL_OLLAMA" == true ]]; then
         if curl -sf "http://127.0.0.1:${OLLAMA_PORT}/api/tags" >/dev/null 2>&1; then
@@ -691,6 +771,9 @@ print_summary() {
     echo "    SLM:       http://127.0.0.1:${SLM_PORT}"
     echo "    Frontend:  http://127.0.0.1 (via nginx)"
     echo "    Redis:     127.0.0.1:${REDIS_PORT}"
+    if [[ "$SKIP_CHROMADB" == false ]]; then
+        echo "    ChromaDB:  http://127.0.0.1:${CHROMADB_PORT}"
+    fi
     if [[ "$INSTALL_OLLAMA" == true ]]; then
         echo "    Ollama:    http://127.0.0.1:${OLLAMA_PORT}"
     fi
@@ -736,6 +819,7 @@ main() {
     checkout_code
     install_backend
     install_slm
+    install_chromadb
     build_frontend
     generate_env
     configure_nginx


### PR DESCRIPTION
## Summary

Fixes GH#8786 / [MVA-1294](/MVA/issues/MVA-1294) — `autobot-chromadb.service` was never installed by the deploy pipeline and used the wrong port.

- **Port mismatch fixed**: `autobot-chromadb.service` ExecStart changed from `--port 8000` to `--port 8100` (canonical `CHROMADB_PORT` from install script)
- **Health-check scripts fixed**: `db-start.sh` and `db-status.sh` updated to probe port 8100
- **Manifest updated**: `autobot-database/manifest.yml` now declares `autobot-chromadb` as a service and exposes port 8100
- **install-bare-metal.sh**: Added `install_chromadb()` function — creates venv, installs `chromadb>=0.5`, writes the systemd unit to `/etc/systemd/system/`, enables it; wired into `main()`, `start_services()`, `verify_installation()`, and `print_summary()`; honours `--skip-chromadb` flag

## Test plan

- [ ] Run `install-bare-metal.sh` on a fresh VM and verify `systemctl is-active autobot-chromadb` → `active`
- [ ] Verify `curl http://127.0.0.1:8100/api/v1/heartbeat` returns `{"nanosecond heartbeat":…}`
- [ ] Run `db-start.sh` and confirm ChromaDB health check shows `OK` instead of `FAILED`
- [ ] Run `db-status.sh` and confirm `ChromaDB (8100): Service: RUNNING / Health: HEALTHY`
- [ ] Run with `--skip-chromadb` and confirm service is not created

🤖 Generated with [Claude Code](https://claude.com/claude-code)