### PR TITLE
fix(deps): correct langchain floor to >=1.3.0 in backend and AI-stack requirements (MVA-1330)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -53,7 +53,7 @@ llama-index-llms-ollama>=0.10.1,<1.0.0       # Ollama LLM integration
 llama-index-embeddings-ollama>=0.9.0,<1.0.0  # Ollama embeddings
 llama-index-vector-stores-chroma>=0.5.5,<1.0.0  # ChromaDB vector store
 # LangChain 1.x ecosystem — migrated from 0.3.x to fix SSRF CVE (#1572)
-langchain>=1.2.24,<2.0.0               # Issue #1572: Migrated to 1.x; GH#8675: floor bumped to 1.2.24 (PVE-2026-88512)
+langchain>=1.3.0,<2.0.0                # Issue #1572: Migrated to 1.x; MVA-1330: floor corrected to 1.3.0 — 1.2.24 does not exist on PyPI; PVE-2026-88512 SQL injection fix
 langchain-core>=1.3.3,<2.0.0         # Issue #1572: SSRF CVE fix requires >=1.2.11
 langchain-community>=0.4.1,<0.5.0     # Issue #1572: Compatible with langchain 1.x
 langchain-ollama>=1.1.0,<2.0.0        # Issue #1572: ChatOllama for QA chain

--- a/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
+++ b/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
@@ -2,7 +2,7 @@
 # Includes LangChain, LlamaIndex and related packages with compatible versions
 
 # Core AI Frameworks
-langchain>=1.2.24,<2.0.0         # Issue #2808: upper bound unified; GH#8675: floor bumped to 1.2.24 (PVE-2026-88512)
+langchain>=1.3.0,<2.0.0          # Issue #2808: upper bound unified; MVA-1330: floor corrected to 1.3.0 — 1.2.24 does not exist on PyPI; PVE-2026-88512 SQL injection fix
 langchain-core>=1.2.22,<2.0.0   # Issue #2808: upper bound unified with backend canonical
 langchain-community>=0.4.1,<0.5.0  # Issue #2808: upper bound unified with backend canonical
 llama-index>=0.14.21,<0.15.0


### PR DESCRIPTION
## Summary

- Corrects langchain version floor from `>=1.2.24` (non-existent on PyPI) to `>=1.3.0` in two requirements files
- `langchain 1.2.24` was specified as a security floor for PVE-2026-88512 (SQL injection) but that version was never published — the 1.2.x series ended at 1.2.18; 1.3.0 is the next published version
- `>=1.2.24` worked at runtime (pip resolved to 1.3.0+) but is misleading and fragile on constrained/offline package indexes

## Files Changed

- `autobot-backend/requirements.txt` — floor bumped to `>=1.3.0`
- `autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt` — floor bumped to `>=1.3.0`
- `requirements-ci/langchain.txt` was already correctly pinned to `==1.3.1` by MVA-1159 (no change needed)

## Security Impact

Closes the PVE-2026-88512 SQL injection vector with a correct, unambiguous version constraint.

## Test plan

- [x] `pip install -r autobot-backend/requirements.txt --dry-run` resolves to langchain >=1.3.0
- [x] `pip install -r autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt --dry-run` resolves correctly
- [ ] CI smoke-test passes with corrected constraint

Closes MVA-1330

🤖 Generated with [Claude Code](https://claude.com/claude-code)