### PR TITLE
style(backend): Black-format 5 pre-existing unformatted files — unblock code-quality CI

### DIFF
--- a/autobot-backend/api/heartbeat.py
+++ b/autobot-backend/api/heartbeat.py
@@ -292,9 +292,7 @@ async def pause_agent(
     return _state_to_response(state)
 
 
-async def _request_skill_approval_for_resume(
-    agent_id: str, paused_by: str, requested_by: str
-) -> str:
+async def _request_skill_approval_for_resume(agent_id: str, paused_by: str, requested_by: str) -> str:
     """Queue a SkillApproval for a non-admin resume of a system-paused agent (GH#8734).
 
     Delegates to GovernanceEngine so the request appears in the SLM Approvals
@@ -346,9 +344,7 @@ async def resume_agent(
     # _user is always a Dict with keys "role" (str) and "username" (str).
     paused_by = state.paused_by or ""
     if paused_by.startswith("system:"):
-        username = (
-            _user.get("username", "") if isinstance(_user, dict) else getattr(_user, "username", "")
-        )
+        username = _user.get("username", "") if isinstance(_user, dict) else getattr(_user, "username", "")
         user_role = _user.get("role", "") if isinstance(_user, dict) else getattr(_user, "role", "")
         if user_role != "admin":
             approval_id = await _request_skill_approval_for_resume(agent_id, paused_by, username)
@@ -357,9 +353,7 @@ async def resume_agent(
                 content={
                     "approval_id": approval_id,
                     "status": "pending",
-                    "message": (
-                        f"Agent was paused by {paused_by}; resume request queued for admin approval"
-                    ),
+                    "message": (f"Agent was paused by {paused_by}; resume request queued for admin approval"),
                 },
             )
     state.status = AgentStatus.ACTIVE.value

--- a/autobot-backend/tests/integration/test_paused_agent_wakeup_drain.py
+++ b/autobot-backend/tests/integration/test_paused_agent_wakeup_drain.py
@@ -29,7 +29,6 @@ import sqlalchemy.dialects.postgresql as pg
 from sqlalchemy import JSON, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-
 # ---------------------------------------------------------------------------
 # Stub helpers (mirrors test_agent_status.py / test_heartbeat_coalescing.py)
 # ---------------------------------------------------------------------------
@@ -80,9 +79,7 @@ def _load_models_and_scheduler():
     original_jsonb = pg.JSONB
 
     with patch.object(pg, "JSONB", JSON):
-        hb_spec = importlib.util.spec_from_file_location(
-            "models.heartbeat", backend_root / "models" / "heartbeat.py"
-        )
+        hb_spec = importlib.util.spec_from_file_location("models.heartbeat", backend_root / "models" / "heartbeat.py")
         assert hb_spec and hb_spec.loader
         hb_mod = importlib.util.module_from_spec(hb_spec)
         models_pkg = types.ModuleType("models")
@@ -170,9 +167,7 @@ async def _seed_active_agent(factory: async_sessionmaker, agent_id: str) -> Agen
         return state
 
 
-async def _seed_wakeup_requests(
-    factory: async_sessionmaker, agent_id: str, state_id: uuid.UUID, count: int
-) -> None:
+async def _seed_wakeup_requests(factory: async_sessionmaker, agent_id: str, state_id: uuid.UUID, count: int) -> None:
     async with factory() as session:
         for i in range(count):
             req = AgentWakeupRequest(

--- a/autobot-backend/tests/security/test_a2a_trust_gate.py
+++ b/autobot-backend/tests/security/test_a2a_trust_gate.py
@@ -60,9 +60,7 @@ class TestTrustCapabilityGateMissingHeader:
         request.client.host = "10.0.0.1"
         background_tasks = MagicMock()
 
-        with patch("api.a2a._a2a_limiter") as mock_limiter, patch(
-            "api.a2a.get_trust_manager"
-        ) as mock_trust:
+        with patch("api.a2a._a2a_limiter") as mock_limiter, patch("api.a2a.get_trust_manager") as mock_trust:
             mock_limiter.check_or_429 = AsyncMock()
             with pytest.raises(HTTPException) as exc_info:
                 await submit_task(
@@ -101,9 +99,7 @@ class TestTrustCapabilityGateMissingHeader:
             "untrusted-peer", Capability.SUBMIT_TASKS, TrustLevel.UNTRUSTED
         )
 
-        with patch("api.a2a._a2a_limiter") as mock_limiter, patch(
-            "api.a2a.get_trust_manager", return_value=mock_mgr
-        ):
+        with patch("api.a2a._a2a_limiter") as mock_limiter, patch("api.a2a.get_trust_manager", return_value=mock_mgr):
             mock_limiter.check_or_429 = AsyncMock()
             with pytest.raises(HTTPException) as exc_info:
                 await submit_task(
@@ -115,6 +111,4 @@ class TestTrustCapabilityGateMissingHeader:
                 )
 
         assert exc_info.value.status_code == 403
-        mock_mgr.require_capability.assert_called_once_with(
-            "untrusted-peer", Capability.SUBMIT_TASKS
-        )
+        mock_mgr.require_capability.assert_called_once_with("untrusted-peer", Capability.SUBMIT_TASKS)

--- a/autobot-backend/tests/test_goal_ancestry_layer.py
+++ b/autobot-backend/tests/test_goal_ancestry_layer.py
@@ -38,6 +38,7 @@ def _load_layers_module():
     # populated with the real module — the if-not-in guard would never fire.
     # Unconditionally patch the attribute on whatever config object is present.
     import autobot_shared.ssot_config as _ssot_cfg_mod
+
     _ssot_cfg_mod.config.tiered_context_enabled = "false"  # type: ignore[attr-defined]
 
     spec = importlib.util.spec_from_file_location("chat_history.layers", layers_path)

--- a/autobot-backend/tests/unit/api/test_heartbeat_resume_approval.py
+++ b/autobot-backend/tests/unit/api/test_heartbeat_resume_approval.py
@@ -181,10 +181,7 @@ class TestResumeApprovalBranching:
     def test_admin_role_bypasses_approval(self):
         """Admin users are identified by role=='admin' and bypass the 202 path."""
         admin_user = {"role": "admin", "username": "superadmin"}
-        user_role = (
-            admin_user.get("role", "") if isinstance(admin_user, dict)
-            else getattr(admin_user, "role", "")
-        )
+        user_role = admin_user.get("role", "") if isinstance(admin_user, dict) else getattr(admin_user, "role", "")
         assert user_role == "admin"
 
     def test_non_admin_role_enters_approval(self):
@@ -195,14 +192,12 @@ class TestResumeApprovalBranching:
             {"role": "", "username": "carol"},
             {"username": "dave"},  # no 'role' key
         ):
-            user_role = (
-                user.get("role", "") if isinstance(user, dict)
-                else getattr(user, "role", "")
-            )
+            user_role = user.get("role", "") if isinstance(user, dict) else getattr(user, "role", "")
             assert user_role != "admin", f"{user} should enter the approval gate"
 
     def test_getattr_fallback_for_non_dict_user(self):
         """_user can also be an object with a .role attribute."""
+
         class _User:
             role = "user"
             username = "eve"


### PR DESCRIPTION
## Summary

- Black (line-length=120) was failing on `Dev_new_gui` itself due to 5 pre-existing unformatted files, blocking `code-quality` CI for **all** open PRs (#8829, #8830, #8831)
- Reformatted 5 files with `python3.12 -m black --line-length=120`: no logic changes, formatting only
- Discovered while landing the SSRF fix for MVA-1307 (PR #8826)

Files reformatted:
- `autobot-backend/api/heartbeat.py`
- `autobot-backend/tests/integration/test_paused_agent_wakeup_drain.py`
- `autobot-backend/tests/security/test_a2a_trust_gate.py`
- `autobot-backend/tests/test_goal_ancestry_layer.py`
- `autobot-backend/tests/unit/api/test_heartbeat_resume_approval.py`

## Test plan
- [ ] `code-quality` CI check passes on this PR
- [ ] No changes to test assertions or logic — diff is whitespace/formatting only

🤖 Generated with [Claude Code](https://claude.ai/claude-code)