### PR TITLE
fix(llc/kb): archive ChromaDB sprint collection only after confirmed write (GH#8653)

### DIFF
--- a/autobot-backend/llc/kb/sprint_summarizer.py
+++ b/autobot-backend/llc/kb/sprint_summarizer.py
@@ -107,8 +107,14 @@ class SprintKbSummarizer:
                 summary_text = await self._llm_summarize_and_index(
                     docs, project_collection, sprint_id, project_id, sprint=sprint
                 )
-        finally:
-            await self._km.archive_collection(KbCollectionManager.SPRINT_PREFIX, sprint_id)
+        except Exception:
+            logger.error(
+                "Write to project KB failed for sprint %s — archive skipped to prevent data loss",
+                sprint_id,
+            )
+            raise
+
+        await self._km.archive_collection(KbCollectionManager.SPRINT_PREFIX, sprint_id)
 
         if summary_text and session is not None and sprint is not None:
             sprint.kb_summary = summary_text  # type: ignore[attr-defined]

--- a/autobot-backend/llc/tests/test_sprint_summarizer.py
+++ b/autobot-backend/llc/tests/test_sprint_summarizer.py
@@ -279,8 +279,8 @@ async def test_llm_exception_falls_back_to_direct_merge(summarizer, km_mock):
 
 
 @pytest.mark.asyncio
-async def test_archive_called_even_if_llm_raises(summarizer, km_mock):
-    """GH#8656: archive_collection must be called even when LLM summarization raises."""
+async def test_archive_skipped_if_write_raises(summarizer, km_mock):
+    """GH#8653: archive must NOT be called when the write to project KB fails."""
     sprint_id = uuid.uuid4()
     project_id = uuid.uuid4()
     docs = _make_docs(_SUMMARIZE_THRESHOLD + 1)
@@ -297,7 +297,29 @@ async def test_archive_called_even_if_llm_raises(summarizer, km_mock):
         with pytest.raises(RuntimeError, match="unexpected"):
             await summarizer.summarize_and_merge(sprint_id, session=MagicMock())
 
-    km_mock.archive_collection.assert_called_once_with(KbCollectionManager.SPRINT_PREFIX, sprint_id)
+    km_mock.archive_collection.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_archive_skipped_if_direct_merge_raises(summarizer, km_mock):
+    """GH#8653: archive must NOT be called when direct-merge write to project KB fails."""
+    sprint_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    docs = _make_docs(_SUMMARIZE_THRESHOLD)  # <= threshold → takes direct-merge path
+
+    with (
+        patch.object(summarizer, "_load_sprint_context", new=AsyncMock(return_value=(None, project_id))),
+        patch.object(summarizer, "_fetch_documents", new=AsyncMock(return_value=docs)),
+        patch.object(
+            summarizer,
+            "_direct_merge",
+            new=AsyncMock(side_effect=RuntimeError("chroma write failed")),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="chroma write failed"):
+            await summarizer.summarize_and_merge(sprint_id, session=MagicMock())
+
+    km_mock.archive_collection.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path
The `SprintKbSummarizer.summarize_and_merge` method used a `try/finally` pattern where `archive_collection` always ran — even when the write to the project KB failed. This is a data-loss hazard: if `_direct_merge` or `_llm_summarize_and_index` raised an exception, the sprint collection was archived (and later deleted by `archive_collection`) before any documents reached the project KB. The sprint's data would be permanently lost with no recovery path.

The fix is minimal and surgical: replace the `finally` block with a `try/except` that re-raises on failure, and move `archive_collection` to the success path below the try-block. This guarantees that if the write fails, the sprint collection is left intact for manual intervention or retry.

Alternatives considered:
- "Verify then archive" (read back from dst collection) — too expensive and doesn't cover partial writes
- Saga/two-phase approach — over-engineered for this code path

## What Changed
- `autobot-backend/llc/kb/sprint_summarizer.py` — `summarize_and_merge`: replaced `finally: archive_collection()` with a `try/except` that logs and re-raises on write failure, then calls `archive_collection()` only on the success path
- `autobot-backend/llc/tests/test_sprint_summarizer.py`:
  - Renamed `test_archive_called_even_if_llm_raises` → `test_archive_skipped_if_write_raises`; assertion changed from `assert_called_once_with` to `assert_not_called()` (the old assertion was testing the buggy behavior)
  - Added `test_archive_skipped_if_direct_merge_raises` to cover the small-collection (≤10 docs) write-failure path

## Verification
```bash
# From repo root or the worktree:
python3 -m pytest autobot-backend/llc/tests/test_sprint_summarizer.py -v
# Expected: 15 passed, 0 failed
```

## Risks
- If a write fails and the collection is left unarchived, operators must manually archive/clean the sprint collection after fixing the underlying issue. This is the correct safer default — better to have a live collection to recover from than a silently-lost archive.
- No behaviour change on the success path (archive still runs after every successful write).

## Model Used
Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link
Closes #8653

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (2 tests updated/added)
- [x] Documentation updated if behavior changed
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff