### PR TITLE
fix(rbac): replace userId guard with Symbol token in openBundleModal (GH#8705, MVA-1337)

### DIFF
--- a/autobot-frontend/src/views/AdminUsersView.vue
+++ b/autobot-frontend/src/views/AdminUsersView.vue
@@ -207,7 +207,7 @@
           </p>
           <div class="form-group">
             <label>Voice Bundle</label>
-            <select v-model="newBundleName" class="form-input">
+            <select v-model="newBundleName" class="form-input" :disabled="bundleModalLoading">
               <option :value="null">— Use role default —</option>
               <option v-for="name in VOICE_BUNDLE_NAMES" :key="name" :value="name">
                 {{ VOICE_BUNDLE_LABELS[name] }}
@@ -302,8 +302,11 @@ const { saving: bundleSaving, saveError: bundleError, assignBundle, getUserBundl
 const userBundles = ref<Record<string, VoiceBundleName | null | undefined>>({})
 const bundleTarget = ref<UserRecord | null>(null)
 const newBundleName = ref<VoiceBundleName | null>(null)
-// Stale-result guard: tracks which user's bundle fetch was initiated for the open modal
-const bundleModalUserId = ref<string | null>(null)
+// Stale-result guard: unique symbol per openBundleModal call — survives same-user reopen.
+// A string userId guard fails when the modal is closed and reopened for the same user:
+// both opens share the same id, so the stale first fetch passes the guard and overwrites
+// newBundleName with its result (coercing null to string or vice versa).
+const bundleModalFetchToken = ref<symbol | null>(null)
 const bundleModalLoading = ref(false)
 
 const totalPages = computed(() => Math.ceil(total.value / pageSize))
@@ -356,37 +359,40 @@ function loadUserBundles(userList: UserRecord[]): void {
 
 function openBundleModal(user: UserRecord): void {
   bundleTarget.value = user
-  bundleModalUserId.value = user.id
   const cached = userBundles.value[user.id]
   if (cached !== undefined) {
     newBundleName.value = cached
+    bundleModalFetchToken.value = null
     return
   }
-  // loadUserBundles fetch for this user is still in flight — fetch it directly now
-  // so the modal shows the real current value rather than null.
-  // The bundleModalUserId guard discards the result if the modal is closed or
-  // switched to a different user before this resolves.
+  // Cache miss: loadUserBundles fetch is still in flight. Issue a targeted fetch so
+  // the modal shows the real current value rather than defaulting to null.
+  // Use a Symbol token (not user.id) as the stale-result guard: a string id fails
+  // when the modal is closed and reopened for the same user — both calls share the
+  // same id so the first fetch's result passes the guard and overwrites newBundleName.
   newBundleName.value = null
   bundleModalLoading.value = true
+  const token = Symbol()
+  bundleModalFetchToken.value = token
   getUserBundle(user.id)
     .then(assignment => {
-      if (bundleModalUserId.value !== user.id) return
+      if (bundleModalFetchToken.value !== token) return
       const bundleName = assignment?.bundle_name ?? null
       userBundles.value[user.id] = bundleName
       newBundleName.value = bundleName
     })
     .catch(() => {
-      if (bundleModalUserId.value !== user.id) return
+      if (bundleModalFetchToken.value !== token) return
       userBundles.value[user.id] = null
       newBundleName.value = null
     })
     .finally(() => {
-      if (bundleModalUserId.value === user.id) bundleModalLoading.value = false
+      if (bundleModalFetchToken.value === token) bundleModalLoading.value = false
     })
 }
 
 function closeBundleModal(): void {
-  bundleModalUserId.value = null
+  bundleModalFetchToken.value = null
   bundleModalLoading.value = false
   bundleTarget.value = null
 }


### PR DESCRIPTION
## Summary

- Replaces the `bundleModalUserId` string guard in `openBundleModal` with a per-invocation `Symbol` token
- Adds `:disabled="bundleModalLoading"` to the bundle `<select>` to block user input during the initial fetch

## Thinking Path

The prior `bundleModalUserId` guard failed when the admin closed and reopened the modal for the **same user**: both calls wrote the same string id, so the stale first fetch's guard passed and overwrote `newBundleName` with its fetched result — coercing `null` to a string bundle name (or vice versa). A `Symbol()` is unique per call, so reopening the modal always invalidates the previous in-flight fetch regardless of which user is targeted. The second change addresses the symmetric race: the select had no `:disabled` binding while `bundleModalLoading` was `true`, so a user who changed the select before the fetch resolved would have their selection silently overwritten when the fetch completed.

## What Changed

- `autobot-frontend/src/views/AdminUsersView.vue`
  - Replaced `bundleModalUserId ref<string | null>` with `bundleModalFetchToken ref<symbol | null>`
  - `openBundleModal`: creates a fresh `Symbol()` each call, stored in `bundleModalFetchToken`; fetch callbacks compare their closed-over token and discard stale results
  - `closeBundleModal`: nulls out `bundleModalFetchToken` to invalidate any pending fetch
  - `<select>`: added `:disabled="bundleModalLoading"` to prevent interaction during initial fetch

## Verification

- `oxlint`: 0 warnings, 0 errors on `AdminUsersView.vue`
- `vue-tsc --noEmit`: no new errors introduced in `AdminUsersView.vue`
- Remaining CI failures (`smoke-test`, `hardened-smoke-test`, `visual regression`) are pre-existing infrastructure failures present on `Dev_new_gui` base, unrelated to this change

## Model Used

claude-sonnet-4-6 (Paperclip SeniorFrontendDeveloper agent, MVA-1337)

## Test plan

- [ ] Open bundle modal while `loadUserBundles` fetch is still in flight — modal shows correct bundle after fetch resolves
- [ ] Close and immediately reopen modal for the **same** user before first fetch returns — stale fetch result must not overwrite the second open's state
- [ ] Bundle select is disabled (unclickable) while the loading spinner is shown
- [ ] Normal assign-bundle flow (select → Save) still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)