### PR TITLE
fix(ansible): deploy ChromaDB via redis role for fleet database nodes (MVA-1319 / GH#8786)

### DIFF
--- a/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
@@ -54,3 +54,8 @@ slm_admin_url: "https://{{ slm_host | default('127.0.0.1') }}"
 # Health check (retry-based polling instead of fixed timeout)
 redis_health_check_retries: 60       # Max attempts (60 × 5s = 300s)
 redis_health_check_delay: 5          # Seconds between retries
+
+# ChromaDB (vector database, co-located with Redis on database nodes — MVA-1319)
+chromadb_port: 8100
+chromadb_install_dir: /opt/autobot/autobot-db-stack/chromadb
+chromadb_data_dir: /opt/autobot/autobot-db-stack/chromadb/data

--- a/autobot-slm-backend/ansible/roles/redis/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/handlers/main.yml
@@ -27,3 +27,9 @@
     name: redis_exporter
     state: restarted
   become: true
+
+- name: restart chromadb
+  ansible.builtin.systemd:
+    name: autobot-chromadb
+    state: restarted
+  become: true

--- a/autobot-slm-backend/ansible/roles/redis/tasks/chromadb.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/chromadb.yml
@@ -1,0 +1,82 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# ChromaDB tasks for the database role (MVA-1319 / GH#8786)
+# Deploys ChromaDB vector store alongside Redis Stack on database nodes.
+---
+
+- name: "ChromaDB | Create install and data directories"
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0755"
+    owner: "{{ redis_owner }}"
+    group: "{{ redis_group }}"
+  loop:
+    - "{{ chromadb_install_dir }}"
+    - "{{ chromadb_data_dir }}"
+  become: true
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Create Python venv"
+  ansible.builtin.command:
+    cmd: "python3.12 -m venv {{ chromadb_install_dir }}/venv --clear"
+    creates: "{{ chromadb_install_dir }}/venv/bin/python"
+  become: true
+  become_user: "{{ redis_owner }}"
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Upgrade pip in venv"
+  ansible.builtin.pip:
+    name: pip
+    state: latest
+    virtualenv: "{{ chromadb_install_dir }}/venv"
+  become: true
+  become_user: "{{ redis_owner }}"
+  environment:
+    HOME: "{{ chromadb_install_dir }}"
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Install chromadb package"
+  ansible.builtin.pip:
+    name: "chromadb>=0.5"
+    state: present
+    virtualenv: "{{ chromadb_install_dir }}/venv"
+    extra_args: "--timeout 300"
+  become: true
+  become_user: "{{ redis_owner }}"
+  environment:
+    HOME: "{{ chromadb_install_dir }}"
+  timeout: 600
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Fix venv ownership"
+  ansible.builtin.file:
+    path: "{{ chromadb_install_dir }}/venv"
+    state: directory
+    owner: "{{ redis_owner }}"
+    group: "{{ redis_group }}"
+    recurse: true
+  become: true
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Deploy systemd service unit"
+  ansible.builtin.template:
+    src: autobot-chromadb.service.j2
+    dest: /etc/systemd/system/autobot-chromadb.service
+    mode: "0644"
+  become: true
+  notify:
+    - reload systemd
+    - restart chromadb
+  tags: ['redis', 'chromadb']
+
+- name: "ChromaDB | Enable and start service"
+  ansible.builtin.systemd:
+    name: autobot-chromadb
+    state: started
+    enabled: true
+    daemon_reload: true
+  become: true
+  tags: ['redis', 'chromadb']

--- a/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
@@ -274,6 +274,11 @@
   ansible.builtin.import_tasks: redis_exporter.yml
   tags: ['redis', 'redis_exporter']
 
+# ChromaDB vector database — co-located on database nodes (MVA-1319 / GH#8786)
+- name: "Redis | Deploy ChromaDB vector database"
+  ansible.builtin.import_tasks: chromadb.yml
+  tags: ['redis', 'chromadb']
+
 - name: "Redis | Display configuration summary"
   debug:
     msg:

--- a/autobot-slm-backend/ansible/roles/redis/templates/autobot-chromadb.service.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/autobot-chromadb.service.j2
@@ -14,6 +14,7 @@ WorkingDirectory={{ chromadb_install_dir }}
 
 Environment="PYTHONUNBUFFERED=1"
 Environment="ANONYMIZED_TELEMETRY=FALSE"
+Environment="PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python"
 EnvironmentFile=-/opt/autobot/autobot-db-stack/.env
 
 ExecStart={{ chromadb_install_dir }}/venv/bin/chroma run \

--- a/autobot-slm-backend/ansible/roles/redis/templates/autobot-chromadb.service.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/autobot-chromadb.service.j2
@@ -1,0 +1,40 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+[Unit]
+Description=AutoBot ChromaDB - Vector Database
+Documentation=https://github.com/mrveiss/AutoBot-AI
+After=network.target
+
+[Service]
+Type=simple
+User={{ redis_owner }}
+Group={{ redis_group }}
+WorkingDirectory={{ chromadb_install_dir }}
+
+Environment="PYTHONUNBUFFERED=1"
+Environment="ANONYMIZED_TELEMETRY=FALSE"
+EnvironmentFile=-/opt/autobot/autobot-db-stack/.env
+
+ExecStart={{ chromadb_install_dir }}/venv/bin/chroma run \
+    --host 0.0.0.0 \
+    --port {{ chromadb_port }} \
+    --path {{ chromadb_data_dir }}
+
+Restart=on-failure
+RestartSec=10
+TimeoutStartSec=30
+TimeoutStopSec=30
+MemoryMax=4G
+
+PrivateTmp=true
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths={{ chromadb_data_dir }}
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=autobot-chromadb
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- `autobot-chromadb.service` was absent from fleet database nodes because the Ansible `redis` role (used by `provision-fleet-roles.yml` Phase 3 for DB-role nodes) had no ChromaDB tasks — only the `ai-stack` role deployed it, and that role doesn't run on database-only nodes.
- This was **not an intentional removal** — a deployment path gap.
- Adds 5 files to the `redis` role: `tasks/chromadb.yml`, `templates/autobot-chromadb.service.j2`, updates to `defaults/main.yml`, `handlers/main.yml`, and `tasks/main.yml`.
- Code review fix applied: added `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` to the service template (matches the `ai-stack` role counterpart — prevents protobuf C++/Python implementation mismatch on startup).

## Files changed

| File | Change |
|------|--------|
| `roles/redis/tasks/chromadb.yml` | New — creates venv, installs `chromadb>=0.5`, deploys service, enables it |
| `roles/redis/templates/autobot-chromadb.service.j2` | New — Jinja2 service template (port 8100, hardened unit) |
| `roles/redis/defaults/main.yml` | Added `chromadb_port`, `chromadb_install_dir`, `chromadb_data_dir` |
| `roles/redis/handlers/main.yml` | Added `restart chromadb` handler |
| `roles/redis/tasks/main.yml` | Wired in `import_tasks: chromadb.yml` |

## Test plan

- [ ] Run `provision-fleet-roles.yml --tags chromadb` against a test database node
- [ ] Verify `systemctl status autobot-chromadb` shows active on port 8100
- [ ] Verify RAG/knowledge queries succeed after deployment

Closes GH#8786

🤖 Generated with [Claude Code](https://claude.com/claude-code)