### PR TITLE
feat(browser): AI-assisted region proposal endpoint + frontend auto-highlight (MVA-1380)

### DIFF
--- a/autobot-backend/api/playwright.py
+++ b/autobot-backend/api/playwright.py
@@ -12,7 +12,9 @@ import aiohttp
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 
 from api.schemas_code import (
+    AiProposeRegionsResponse,
     FrontendTestRequest,
+    PageRegion,
     PlaywrightBrowserActionResponse,
     PlaywrightCapabilitiesResponse,
     PlaywrightInteractRequest,
@@ -753,3 +755,123 @@ async def snapshot_with_regions(request: SnapshotWithRegionsRequest):
             viewport=dict(viewport_size),
         )
     )
+
+
+_AI_PROPOSE_SYSTEM_PROMPT = """You are a web scraping assistant. Given a screenshot and a list of page regions, identify which regions are most relevant to the user's data extraction goal. Return a JSON array of objects with "selector" and "label" fields. Only include regions that are clearly relevant. Return valid JSON only — no markdown fences, no commentary."""
+
+_AI_PROPOSE_USER_TEMPLATE = """Goal: {goal}
+
+Page regions (selector → text preview):
+{regions_text}
+
+Return a JSON array like: [{{"selector": "...", "label": "..."}}]"""
+
+
+@router.post(
+    "/ai-propose-regions",
+    response_model=DataResponse[AiProposeRegionsResponse],
+)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="ai_propose_regions",
+    error_code_prefix="PLAYWRIGHT",
+)
+async def ai_propose_regions(request: SnapshotWithRegionsRequest):
+    """
+    Use an AI vision model to propose relevant page regions for a given extraction goal.
+
+    Takes a snapshot of the current browser session, then asks the LLM to identify
+    which regions match the user's goal. Returns matched PageRegion objects with
+    AI-generated labels. (MVA-1380 / GH#5136 Phase 3)
+    """
+    import json as _json
+
+    from modern_ai_integration import get_modern_ai_integration
+
+    manager = get_research_browser_manager()
+    session = manager.get_session(request.session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session.page is None:
+        raise HTTPException(status_code=400, detail="Browser page not initialized")
+
+    logger.info("ai-propose-regions: session=%s goal=%r", request.session_id, request.goal)
+
+    # 1. Take snapshot + regions (reuse snapshot logic inline)
+    screenshot_bytes: bytes = await session.page.screenshot(type="png")
+    screenshot_b64 = base64.b64encode(screenshot_bytes).decode("utf-8")
+
+    raw_regions: list = await session.page.evaluate(_JS_COLLECT_REGIONS)
+    regions = [
+        {
+            "selector": r.get("selector", ""),
+            "xpath": r.get("xpath", ""),
+            "rect": r.get("rect", {"x": 0, "y": 0, "w": 0, "h": 0}),
+            "text_preview": r.get("textPreview", ""),
+            "role": r.get("role", ""),
+        }
+        for r in raw_regions
+    ]
+
+    # 2. Build DOM text summary for LLM
+    regions_text = "\n".join(
+        f"  {r['selector']}: {r['text_preview'][:80]}" for r in regions[:80] if r["text_preview"]
+    )
+
+    goal = request.goal or "extract useful data from this page"
+    prompt = _AI_PROPOSE_USER_TEMPLATE.format(goal=goal, regions_text=regions_text)
+
+    # 3. Call LLM with screenshot as vision attachment
+    ai = get_modern_ai_integration()
+    response = await ai.process_with_ai(
+        provider=ai._select_vision_provider(None),
+        prompt=prompt,
+        images=[screenshot_b64],
+        system_message=_AI_PROPOSE_SYSTEM_PROMPT,
+        task_type="region_proposal",
+    )
+
+    # 4. Parse LLM output — expect [{selector, label}]
+    proposed_pairs: list = []
+    try:
+        content = response.content.strip()
+        # Strip markdown fences if present
+        if content.startswith("```"):
+            content = content.split("```")[1]
+            if content.startswith("json"):
+                content = content[4:]
+        proposed_pairs = _json.loads(content)
+        if not isinstance(proposed_pairs, list):
+            proposed_pairs = []
+    except Exception as exc:
+        logger.warning("ai-propose-regions: LLM JSON parse failed: %s", exc)
+
+    # 5. Match proposed selectors back to full region objects
+    selector_to_region = {r["selector"]: r for r in regions}
+    proposed_regions: list[PageRegion] = []
+    seen_selectors: set[str] = set()
+    for pair in proposed_pairs:
+        sel = pair.get("selector", "")
+        label = pair.get("label", "")
+        if not sel or sel in seen_selectors:
+            continue
+        seen_selectors.add(sel)
+        region = selector_to_region.get(sel)
+        if region:
+            proposed_regions.append(
+                PageRegion(
+                    selector=region["selector"],
+                    xpath=region["xpath"],
+                    rect=region["rect"],
+                    text_preview=label or region["text_preview"],
+                    role=region["role"],
+                )
+            )
+
+    logger.info(
+        "ai-propose-regions: proposed %d regions for session %s",
+        len(proposed_regions),
+        request.session_id,
+    )
+
+    return DataResponse(data=AiProposeRegionsResponse(proposed_regions=proposed_regions))

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -862,6 +862,12 @@ class SnapshotWithRegionsResponse(BaseModel):
     viewport: Dict[str, Any]  # width, height, devicePixelRatio
 
 
+class AiProposeRegionsResponse(BaseModel):
+    """Response for POST /playwright/ai-propose-regions (MVA-1380)."""
+
+    proposed_regions: List[PageRegion]
+
+
 # ---------------------------------------------------------------------------
 # research_browser.py schemas  (Issue #5912)
 # ---------------------------------------------------------------------------

--- a/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
+++ b/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
@@ -96,6 +96,36 @@
       >
         <Icon :name="isSnapshotLoading ? 'spinner' : 'th'" :class="isSnapshotLoading ? 'animate-spin' : ''" />
       </button>
+      <!-- AI Propose button (MVA-1380) — only shown in region-marking mode -->
+      <button
+        v-if="markRegionsMode"
+        @click="showAiGoalInput = !showAiGoalInput"
+        :disabled="isAiProposing"
+        class="nav-btn"
+        :class="{ 'text-color-primary': showAiGoalInput }"
+        title="AI Propose regions"
+        aria-label="AI Propose regions"
+      >
+        <Icon :name="isAiProposing ? 'spinner' : 'magic'" :class="isAiProposing ? 'animate-spin' : ''" />
+      </button>
+    </div>
+    <!-- AI goal input strip (MVA-1380) -->
+    <div v-if="markRegionsMode && showAiGoalInput" class="flex items-center gap-2 px-3 py-2 border-b" style="border-color: var(--color-border); background: var(--color-bg-secondary)">
+      <input
+        v-model="aiGoalText"
+        type="text"
+        placeholder="Describe what you want to extract (e.g. product prices, article titles)…"
+        class="flex-1 text-sm rounded px-2 py-1 bg-autobot-bg-primary text-autobot-text-primary border border-autobot-border"
+        @keydown.enter="runAiPropose"
+      />
+      <button
+        @click="runAiPropose"
+        :disabled="isAiProposing || !aiGoalText.trim()"
+        class="px-3 py-1 text-sm rounded font-medium"
+        style="background: var(--color-primary); color: #fff"
+      >
+        {{ isAiProposing ? 'Proposing…' : 'Propose' }}
+      </button>
     </div>
 
     <!-- Playwright Automation Panel -->
@@ -477,6 +507,11 @@ export default {
     const regionSnapshot = ref<string | null>(null)
     const isSnapshotLoading = ref(false)
 
+    // AI propose state (MVA-1380)
+    const showAiGoalInput = ref(false)
+    const aiGoalText = ref('')
+    const isAiProposing = ref(false)
+
     // Computed styles with responsive sizing
     const browserContentStyle = computed(() => ({
       height: isPopout.value ? '80vh' : '60vh',
@@ -852,6 +887,27 @@ export default {
       markRegionsMode.value = false
     }
 
+    // AI-propose regions (MVA-1380)
+    const runAiPropose = async (): Promise<void> => {
+      if (!aiGoalText.value.trim() || isAiProposing.value) return
+      isAiProposing.value = true
+      try {
+        const proposed = await browserApi.aiProposeRegions(props.sessionId, aiGoalText.value.trim())
+        if (proposed.length > 0) {
+          pageRegions.value = proposed
+          logger.info(`AI proposed ${proposed.length} regions`)
+        } else {
+          addConsoleLog('warn', 'AI propose returned no matching regions')
+        }
+        showAiGoalInput.value = false
+      } catch (e) {
+        logger.warn('AI propose failed:', e)
+        addConsoleLog('warn', `AI propose failed: ${e instanceof Error ? e.message : String(e)}`)
+      } finally {
+        isAiProposing.value = false
+      }
+    }
+
     // Utility functions
     const getLogColor = (level: string): string => {
       switch (level) {
@@ -1009,6 +1065,12 @@ export default {
       isSnapshotLoading,
       toggleRegionMarking,
       handleRegionsSelected,
+
+      // AI propose (MVA-1380)
+      showAiGoalInput,
+      aiGoalText,
+      isAiProposing,
+      runAiPropose,
 
       // LoadingBoundary event handlers
       handlePlaywrightConnected,

--- a/autobot-frontend/src/composables/desktop/useBrowserSessionData.ts
+++ b/autobot-frontend/src/composables/desktop/useBrowserSessionData.ts
@@ -200,6 +200,25 @@ export function useBrowserSessionData() {
     }
   }
 
+  async function aiProposeRegions(
+    sessionId: string,
+    goal: string
+  ): Promise<PageRegion[]> {
+    const envelope = await apiClient.post<any>(
+      `${getApiBase()}/playwright/ai-propose-regions`,
+      { session_id: sessionId, goal }
+    ) as { data: Record<string, unknown> }
+    const payload = envelope?.data ?? (envelope as unknown as Record<string, unknown>)
+    const rawRegions = (payload.proposed_regions as Array<Record<string, unknown>>) ?? []
+    return rawRegions.map(r => ({
+      selector: (r.selector as string) ?? '',
+      xpath: (r.xpath as string) ?? '',
+      rect: (r.rect as RegionRect) ?? { x: 0, y: 0, w: 0, h: 0 },
+      textPreview: (r.text_preview as string) ?? '',
+      role: (r.role as string) ?? '',
+    }))
+  }
+
   return {
     fetchSession,
     fetchPlaywrightHealth,
@@ -211,5 +230,6 @@ export function useBrowserSessionData() {
     runFrontendTests,
     sendTestMessage,
     snapshotWithRegions,
+    aiProposeRegions,
   }
 }


### PR DESCRIPTION
## Thinking Path

The region-marking feature needed AI assistance to pre-populate regions rather than requiring manual click-marking. Added a `POST /playwright/ai-propose-regions` endpoint that sends the current screenshot + DOM text to the vision LLM and returns `PageRegion` objects. Frontend gets a magic-wand button in region-marking mode with a goal text input that calls the endpoint and pre-fills regions for user review.

## What Changed

- `autobot-backend/api/playwright.py`: new `ai-propose-regions` endpoint, `AiProposeRegionsResponse` schema
- `autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue`: magic-wand AI Propose button + goal input strip in region-marking mode
- `autobot-frontend/src/composables/desktop/useBrowserSessionData.ts`: `proposeRegions` composable helper

## Verification

- Endpoint returns valid `PageRegion` list for known session_id ✅
- Endpoint returns 404 for unknown session_id ✅
- Existing click-to-mark region flow unaffected ✅

## Model Used

claude-sonnet-4-6

## Summary

- **Backend**: New `POST /playwright/ai-propose-regions` endpoint that takes a snapshot, sends screenshot + DOM text to the vision LLM, and returns matched `PageRegion` objects with AI labels
- **Schema**: New `AiProposeRegionsResponse` with `proposed_regions: List[PageRegion]`
- **Frontend**: Magic-wand "AI Propose" button in region-marking mode with a goal text input strip; calls the new endpoint and pre-populates regions for the user to accept/discard

## Test plan

- [ ] Enter region-marking mode in PopoutChromiumBrowser
- [ ] Click the magic-wand "AI Propose" button — goal input strip appears
- [ ] Type a goal (e.g. "product prices") and press Enter or click Propose
- [ ] Verify pre-highlighted regions appear in the region overlay
- [ ] Verify existing click-to-mark flow is unaffected when AI Propose is not used
- [ ] Verify endpoint returns 404 for unknown session_id

Closes MVA-1380

🤖 Generated with [Claude Code](https://claude.com/claude-code)