### PR TITLE
fix(ci): remove unused imports to resolve autoflake CI violations (MVA-1333)

### DIFF
--- a/autobot-backend/tests/test_container_pool.py
+++ b/autobot-backend/tests/test_container_pool.py
@@ -9,7 +9,7 @@ and DockerBackend integration with pool enabled.
 """
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -18,7 +18,6 @@ from services.execution.container_pool import (
     WarmContainerPool,
 )
 from services.execution.base_backend import (
-    BackendType,
     ExecutionStatus,
     ExecutionTask,
 )

--- a/autobot-backend/tests/test_goal_ancestry_layer.py
+++ b/autobot-backend/tests/test_goal_ancestry_layer.py
@@ -10,7 +10,7 @@ import importlib.util
 import sys
 import types
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 


### PR DESCRIPTION
## Summary

- Removes 3 unused imports across 2 test files that were causing the CI autoflake job to fail
- `test_container_pool.py`: removes `AsyncMock` (from mock imports) and `BackendType` (from base_backend)
- `test_goal_ancestry_layer.py`: removes `MagicMock`

## Verification

```
python3 -m autoflake --check --recursive \
  --remove-all-unused-imports --remove-unused-variables \
  --expand-star-imports --ignore-init-module-imports \
  autobot-backend/ autobot-slm-backend/ autobot_shared/
```
Returns exit code 0 with no violations detected.

## Thinking Path

Ran autoflake in check mode, found 2 files with unused imports, applied in-place fixes, verified clean pass.

## What Changed

- `autobot-backend/tests/test_container_pool.py`: removed `AsyncMock`, `BackendType`
- `autobot-backend/tests/test_goal_ancestry_layer.py`: removed `MagicMock`

## Model Used

claude-sonnet-4-6

Closes MVA-1333