### PR TITLE
chore(ci): fix pre-existing flake8 violations blocking code-quality CI (MVA-1334)

### DIFF
--- a/autobot-backend/ai_hardware_accelerator.py
+++ b/autobot-backend/ai_hardware_accelerator.py
@@ -606,13 +606,11 @@ class AIHardwareAccelerator:
         self.clip_processor = CLIPProcessor.from_pretrained(
             "openai/clip-vit-base-patch32", resume_download=True
         )  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
-        self.clip_model = CLIPModel.from_pretrained(  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+        self.clip_model = CLIPModel.from_pretrained(  # nosec B615
             "openai/clip-vit-base-patch32",
             torch_dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),
             resume_download=True,
-        ).to(
-            device
-        )
+        ).to(device)
         self.clip_model.eval()
 
     def _initialize_wav2vec_model(self, device: Any) -> None:
@@ -626,13 +624,11 @@ class AIHardwareAccelerator:
         self.wav2vec_processor = Wav2Vec2Processor.from_pretrained(
             "facebook/wav2vec2-base-960h", resume_download=True
         )  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
-        self.wav2vec_model = Wav2Vec2Model.from_pretrained(  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+        self.wav2vec_model = Wav2Vec2Model.from_pretrained(  # nosec B615
             "facebook/wav2vec2-base-960h",
             torch_dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),
             resume_download=True,
-        ).to(
-            device
-        )
+        ).to(device)
         self.wav2vec_model.eval()
 
     def _initialize_projection_matrices(self, device: Any) -> None:

--- a/autobot-backend/api/playwright.py
+++ b/autobot-backend/api/playwright.py
@@ -770,7 +770,13 @@ async def snapshot_with_regions(request: SnapshotWithRegionsRequest):
     )
 
 
-_AI_PROPOSE_SYSTEM_PROMPT = """You are a web scraping assistant. Given a screenshot and a list of page regions, identify which regions are most relevant to the user's data extraction goal. Return a JSON array of objects with "selector" and "label" fields. Only include regions that are clearly relevant. Return valid JSON only — no markdown fences, no commentary."""
+_AI_PROPOSE_SYSTEM_PROMPT = (
+    "You are a web scraping assistant. Given a screenshot and a list of page regions,"
+    " identify which regions are most relevant to the user's data extraction goal."
+    ' Return a JSON array of objects with "selector" and "label" fields.'
+    " Only include regions that are clearly relevant."
+    " Return valid JSON only — no markdown fences, no commentary."
+)
 
 _AI_PROPOSE_USER_TEMPLATE = """Goal: {goal}
 
@@ -827,9 +833,7 @@ async def ai_propose_regions(request: SnapshotWithRegionsRequest):
     ]
 
     # 2. Build DOM text summary for LLM
-    regions_text = "\n".join(
-        f"  {r['selector']}: {r['text_preview'][:80]}" for r in regions[:80] if r["text_preview"]
-    )
+    regions_text = "\n".join(f"  {r['selector']}: {r['text_preview'][:80]}" for r in regions[:80] if r["text_preview"])
 
     goal = request.goal or "extract useful data from this page"
     prompt = _AI_PROPOSE_USER_TEMPLATE.format(goal=goal, regions_text=regions_text)

--- a/autobot-backend/multimodal_processor/processors/vision.py
+++ b/autobot-backend/multimodal_processor/processors/vision.py
@@ -107,14 +107,14 @@ class VisionProcessor(BaseModalProcessor):
             ).to(  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
                 self.device
             )
-            self.clip_processor = CLIPProcessor.from_pretrained(  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+            self.clip_processor = CLIPProcessor.from_pretrained(  # nosec B615
                 "openai/clip-vit-base-patch32", use_fast=True, resume_download=True
             )
 
             # Load BLIP-2 model for image captioning and VQA
             # Using smaller model for memory efficiency
             self.logger.info("Loading BLIP-2 model...")
-            self.blip_processor = Blip2Processor.from_pretrained(  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+            self.blip_processor = Blip2Processor.from_pretrained(  # nosec B615
                 "Salesforce/blip2-opt-2.7b", use_fast=True, resume_download=True
             )
 
@@ -127,20 +127,18 @@ class VisionProcessor(BaseModalProcessor):
 
             # Load BLIP-2 model with device_map only if accelerate is available
             if accelerate_available and torch.cuda.is_available():
-                self.blip_model = Blip2ForConditionalGeneration.from_pretrained(  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+                self.blip_model = Blip2ForConditionalGeneration.from_pretrained(  # nosec B615
                     "Salesforce/blip2-opt-2.7b",
                     torch_dtype=torch.float16,
                     device_map="auto",
                     resume_download=True,
                 )
             else:
-                self.blip_model = Blip2ForConditionalGeneration.from_pretrained(  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+                self.blip_model = Blip2ForConditionalGeneration.from_pretrained(  # nosec B615
                     "Salesforce/blip2-opt-2.7b",
                     torch_dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),
                     resume_download=True,
-                ).to(
-                    self.device
-                )
+                ).to(self.device)
 
             # Set models to evaluation mode
             self.clip_model.eval()

--- a/autobot-backend/multimodal_processor/processors/voice.py
+++ b/autobot-backend/multimodal_processor/processors/voice.py
@@ -100,26 +100,22 @@ class VoiceProcessor(BaseModalProcessor):
             self.whisper_processor = WhisperProcessor.from_pretrained(
                 "openai/whisper-base", resume_download=True
             )  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
-            self.whisper_model = WhisperForConditionalGeneration.from_pretrained(  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+            self.whisper_model = WhisperForConditionalGeneration.from_pretrained(  # nosec B615
                 "openai/whisper-base",
                 torch_dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),
                 resume_download=True,
-            ).to(
-                self.device
-            )
+            ).to(self.device)
 
             # Load Wav2Vec2 model for audio embeddings and feature extraction
             self.logger.info("Loading Wav2Vec2 model...")
-            self.wav2vec_processor = Wav2Vec2Processor.from_pretrained(  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+            self.wav2vec_processor = Wav2Vec2Processor.from_pretrained(  # nosec B615
                 "facebook/wav2vec2-base-960h", use_fast=True, resume_download=True
             )
-            self.wav2vec_model = Wav2Vec2ForCTC.from_pretrained(  # nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally
+            self.wav2vec_model = Wav2Vec2ForCTC.from_pretrained(  # nosec B615
                 "facebook/wav2vec2-base-960h",
                 torch_dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),
                 resume_download=True,
-            ).to(
-                self.device
-            )
+            ).to(self.device)
 
             # Set models to evaluation mode
             self.whisper_model.eval()


### PR DESCRIPTION
## Thinking Path

The code-quality CI job runs `flake8 --config=.flake8 autobot-backend/ autobot-slm-backend/ autobot_shared/`. Running that locally revealed 10 E501 violations (all nosec prose comments) and confirmed no F401 violations existed on the base branch.

## What Changed

- **`autobot-backend/ai_hardware_accelerator.py`** — shortened `# nosec B615 - HuggingFace model loaded by name; revision pinning managed operationally` to `# nosec B615` on two `from_pretrained()` calls that exceeded the 120-char limit; bandit only needs the marker, not the prose.
- **`autobot-backend/api/playwright.py`** — rewrapped a 366-char one-liner AI system prompt string into an implicit string concatenation (no logic change).
- **`autobot-backend/multimodal_processor/processors/vision.py`** — same nosec comment shortening on four `from_pretrained()` calls.
- **`autobot-backend/multimodal_processor/processors/voice.py`** — same nosec comment shortening on three `from_pretrained()` calls.

## Verification

```
$ flake8 --config=.flake8 autobot-backend/ autobot-slm-backend/ autobot_shared/
$ echo $?
0
```

Zero violations — matches the CI command exactly.

## Model Used

claude-sonnet-4-6