### PR TITLE
fix(agent-loop): _should_continue() respects per-severity error budget (GH#8649)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -167,6 +167,10 @@ class AgentLoop:
         # GH#6628: set when a CRITICAL error causes an immediate halt
         self._fatal_error: Exception | None = None
         self._fatal_reason: str | None = None
+        # GH#8649: set when per-severity retry budget is exhausted in
+        # _handle_iteration_error(); checked by _should_continue() so the guard
+        # uses the correct severity-aware limit rather than max_consecutive_errors.
+        self._error_budget_exhausted: bool = False
         # Issue #6627: semantic stagnation halt state
         self._halted_on_stagnation: bool = False
         self._halt_outcome: "LoopOutcome | None" = None
@@ -232,6 +236,7 @@ class AgentLoop:
         self._halted_on_stagnation = False
         self._halt_outcome = None
         self._halt_reason = ""
+        self._error_budget_exhausted = False
 
     async def _execute_main_loop(self) -> list[IterationResult]:
         """Execute the main iteration loop.
@@ -498,6 +503,7 @@ class AgentLoop:
 
         result.phase_completed = LoopPhase.ITERATE
         self._consecutive_errors = 0
+        self._error_budget_exhausted = False
         return result
 
     def _log_iteration_completion(self, start_time: float, result: IterationResult) -> None:
@@ -1067,7 +1073,7 @@ Duration: {self._current_context.get_duration_ms():.0f}ms
             return False
         if self._iteration_count >= self.config.max_iterations:
             return False
-        if self._consecutive_errors >= self.config.max_consecutive_errors:
+        if self._error_budget_exhausted:
             return False
         if self.config.abstain_on_low_confidence and self._current_context is not None:
             window = self.config.confidence_window
@@ -1146,6 +1152,7 @@ Duration: {self._current_context.get_duration_ms():.0f}ms
                 self._consecutive_errors,
                 max_for_severity,
             )
+            self._error_budget_exhausted = True
             return False
 
         # Think about error recovery

--- a/autobot-backend/tests/agent_loop/test_error_severity.py
+++ b/autobot-backend/tests/agent_loop/test_error_severity.py
@@ -155,6 +155,34 @@ class TestRetryClassBudget:
         built = loop._build_result([])
         assert "fatal_reason" not in built
 
+    @pytest.mark.asyncio
+    async def test_should_continue_respects_low_budget_not_max_consecutive_errors(self):
+        """GH#8649: _should_continue() must not use max_consecutive_errors=3 as a hard
+        cap when LOW-severity errors have a larger per-severity budget (max_retries_low=5).
+
+        Before the fix, _should_continue() would return False after 3 errors regardless
+        of severity, preventing retries 4 and 5 from ever running.
+        RuntimeError is LOW severity (falls through to the default path in classify_error).
+        """
+        loop = _make_loop(max_retries_low=5, max_consecutive_errors=3)
+        for _ in range(3):
+            result = await loop._handle_iteration_error(RuntimeError("transient"))
+            # _handle_iteration_error should still say "retry" (budget=5 not yet hit)
+            assert result is True
+        # The loop guard must also say "continue" — not stop at max_consecutive_errors
+        assert loop._should_continue() is True, (
+            "_should_continue() stopped at max_consecutive_errors=3 instead of "
+            "honoring max_retries_low=5 (GH#8649)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_should_continue_false_after_low_budget_exhausted(self):
+        """After the LOW budget (5) is fully exhausted, _should_continue() returns False."""
+        loop = _make_loop(max_retries_low=5, max_consecutive_errors=3)
+        for _ in range(5):
+            await loop._handle_iteration_error(RuntimeError("transient"))
+        assert loop._should_continue() is False
+
 
 # ---------------------------------------------------------------------------
 # Integration: backward compat — MEDIUM uses legacy default (3)


### PR DESCRIPTION
## Thinking Path

GH#8649: `_should_continue()` used a single `max_consecutive_errors` cap (3) but per-severity budgets differ (LOW=5, HIGH=1). The loop exited at 3 for LOW errors, silently discarding retries 4–5. Fix: added `_error_budget_exhausted` flag set by `_handle_iteration_error` when the per-severity budget is depleted, and let `_should_continue()` check that flag instead of the raw count.

## What Changed

- `autobot-backend/agent_loop.py`: added `_error_budget_exhausted: bool` flag; updated `_handle_iteration_error` to set it and `_should_continue()` to check it

## Verification

- LOW-severity errors now allow up to 5 retries before stopping ✅
- HIGH-severity errors still stop at 1 consecutive error ✅
- Existing agent-loop tests pass ✅

## Model Used

claude-sonnet-4-6

## Summary

- `_should_continue()` was checking `_consecutive_errors >= max_consecutive_errors` (3) as a hard cap, but per-severity budgets can differ (`max_retries_low=5`, `max_retries_high=1`).
- For LOW-severity errors, the loop exited at 3 consecutive errors instead of the configured 5, silently discarding retries 4 and 5.
- Fix: add `_error_budget_exhausted: bool` flag set by `_handle_iteration_error()` when the per-severity budget is exhausted; `_should_continue()` checks that flag instead.

## Test plan

- [x] New tests in `TestRetryClassBudget`: `test_should_continue_respects_low_budget_not_max_consecutive_errors` and `test_should_continue_false_after_low_budget_exhausted`
- [x] All 16 existing+new `test_error_severity.py` tests pass
- [x] MEDIUM/CRITICAL behavior unchanged (backward compat preserved)

Fixes: MVA-1347 / GH#8649

🤖 Generated with [Claude Code](https://claude.com/claude-code)