### PR TITLE
feat(npu): cross-host pipeline parallelism for 70B+ model sharding (GH#6737)

### DIFF
--- a/autobot-npu-worker/tests/test_pipeline_parallel.py
+++ b/autobot-npu-worker/tests/test_pipeline_parallel.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from typing import Any, Dict
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -32,7 +32,6 @@ from pipeline_parallel import (  # noqa: E402
     discover_workers,
     run_pipeline,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/autobot-npu-worker/tests/test_pipeline_parallel.py
+++ b/autobot-npu-worker/tests/test_pipeline_parallel.py
@@ -1,0 +1,275 @@
+"""
+Tests for cross-host pipeline parallelism (GH#6737 / MVA-1400).
+
+Covers:
+  - build_shard_plan: correct layer allocation across workers
+  - build_shard_plan: error on insufficient capacity
+  - ShardPlan.validate: gap / overlap / under-coverage detection
+  - run_pipeline: hidden state flows through workers in order
+  - run_pipeline: token_ids returned from last worker
+  - discover_workers: failed hosts are excluded, not fatal
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_npu_root = Path(__file__).parent.parent
+for _p in (_npu_root, _npu_root / "workers"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from pipeline_parallel import (  # noqa: E402
+    LayerShard,
+    ShardPlan,
+    WorkerInfo,
+    build_shard_plan,
+    discover_workers,
+    run_pipeline,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_worker(host: str, max_layers: int = 40) -> WorkerInfo:
+    return WorkerInfo(host=host, max_layers=max_layers, vram_bytes_per_layer=256 * 1024 * 1024, device="NPU")
+
+
+# ---------------------------------------------------------------------------
+# build_shard_plan
+# ---------------------------------------------------------------------------
+
+
+class TestBuildShardPlan:
+    def test_single_worker_covers_all_layers(self):
+        workers = [make_worker("http://w1", max_layers=80)]
+        plan = build_shard_plan(workers, total_layers=80)
+        assert len(plan.shards) == 1
+        shard = plan.shards[0]
+        assert shard.layer_start == 0
+        assert shard.layer_end == 79
+        assert shard.is_last is True
+
+    def test_two_workers_split_evenly(self):
+        workers = [make_worker("http://w1", 40), make_worker("http://w2", 40)]
+        plan = build_shard_plan(workers, total_layers=80)
+        assert len(plan.shards) == 2
+        assert plan.shards[0].layer_start == 0
+        assert plan.shards[0].layer_end == 39
+        assert plan.shards[0].is_last is False
+        assert plan.shards[1].layer_start == 40
+        assert plan.shards[1].layer_end == 79
+        assert plan.shards[1].is_last is True
+
+    def test_uneven_split_uses_full_first_worker(self):
+        # w1 can hold 32, w2 holds remainder (48)
+        workers = [make_worker("http://w1", 32), make_worker("http://w2", 80)]
+        plan = build_shard_plan(workers, total_layers=80)
+        assert plan.shards[0].layer_end == 31
+        assert plan.shards[1].layer_start == 32
+        assert plan.shards[1].layer_end == 79
+
+    def test_extra_capacity_leaves_some_workers_idle(self):
+        # 3 workers, only 2 needed
+        workers = [make_worker("http://w1", 40), make_worker("http://w2", 40), make_worker("http://w3", 40)]
+        plan = build_shard_plan(workers, total_layers=60)
+        assert len(plan.shards) == 2  # w3 not assigned
+        assert plan.shards[-1].is_last is True
+
+    def test_raises_on_insufficient_capacity(self):
+        workers = [make_worker("http://w1", 10)]
+        with pytest.raises(ValueError, match="Workers can hold"):
+            build_shard_plan(workers, total_layers=80)
+
+    def test_raises_on_empty_worker_list(self):
+        with pytest.raises(ValueError, match="No workers"):
+            build_shard_plan([], total_layers=80)
+
+    def test_raises_on_zero_layers(self):
+        with pytest.raises(ValueError, match="total_layers must be positive"):
+            build_shard_plan([make_worker("http://w1")], total_layers=0)
+
+
+# ---------------------------------------------------------------------------
+# ShardPlan.validate
+# ---------------------------------------------------------------------------
+
+
+class TestShardPlanValidate:
+    def _make_plan(self, shards, total_layers):
+        plan = ShardPlan(shards=shards, total_layers=total_layers)
+        return plan
+
+    def test_valid_plan_passes(self):
+        w = make_worker("http://w1")
+        plan = self._make_plan(
+            [LayerShard(w, 0, 39, is_last=False), LayerShard(w, 40, 79, is_last=True)],
+            total_layers=80,
+        )
+        plan.validate()  # no exception
+
+    def test_gap_detected(self):
+        w = make_worker("http://w1")
+        plan = self._make_plan(
+            [LayerShard(w, 0, 39, is_last=False), LayerShard(w, 41, 79, is_last=True)],
+            total_layers=80,
+        )
+        with pytest.raises(ValueError, match="Gap or overlap"):
+            plan.validate()
+
+    def test_under_coverage_detected(self):
+        w = make_worker("http://w1")
+        plan = self._make_plan(
+            [LayerShard(w, 0, 39, is_last=True)],
+            total_layers=80,
+        )
+        with pytest.raises(ValueError, match="cover 40 layers"):
+            plan.validate()
+
+    def test_empty_plan_fails(self):
+        plan = ShardPlan(shards=[], total_layers=80)
+        with pytest.raises(ValueError, match="empty"):
+            plan.validate()
+
+
+# ---------------------------------------------------------------------------
+# run_pipeline
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_response(data: Dict[str, Any], status: int = 200):
+    """Return an async context-manager mock that yields a response-like object."""
+    resp = AsyncMock()
+    resp.status = status
+    resp.json = AsyncMock(return_value=data)
+    resp.text = AsyncMock(return_value=str(data))
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=resp)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+class TestRunPipeline:
+    def _make_session(self, responses):
+        """responses: list of dicts in shard order."""
+        session = MagicMock()
+        cms = [_make_mock_response(r) for r in responses]
+        session.post = MagicMock(side_effect=cms)
+        return session
+
+    @pytest.mark.asyncio
+    async def test_hidden_state_threaded_through_workers(self):
+        w1 = make_worker("http://w1", 40)
+        w2 = make_worker("http://w2", 40)
+        plan = build_shard_plan([w1, w2], total_layers=80)
+
+        responses = [
+            {"hidden_state_out": [0.5] * 512},
+            {"token_ids": [42]},
+        ]
+        session = self._make_session(responses)
+
+        result = await run_pipeline(plan, "llama-70b", [1.0] * 512, session)
+        assert result == [42]
+
+        # Second call should have received the first worker's hidden_state_out
+        second_call_kwargs = session.post.call_args_list[1]
+        payload = second_call_kwargs[1]["json"]
+        assert payload["hidden_state"] == [0.5] * 512
+        assert payload["layer_start"] == 40
+        assert payload["is_last_worker"] is True
+
+    @pytest.mark.asyncio
+    async def test_single_worker_returns_token_ids(self):
+        w1 = make_worker("http://w1", 80)
+        plan = build_shard_plan([w1], total_layers=80)
+        session = self._make_session([{"token_ids": [7, 8, 9]}])
+
+        result = await run_pipeline(plan, "model", [0.1] * 256, session)
+        assert result == [7, 8, 9]
+
+    @pytest.mark.asyncio
+    async def test_http_error_raises_runtime_error(self):
+        w1 = make_worker("http://w1", 80)
+        plan = build_shard_plan([w1], total_layers=80)
+
+        bad_resp = AsyncMock()
+        bad_resp.status = 500
+        bad_resp.text = AsyncMock(return_value="internal error")
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=bad_resp)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.post = MagicMock(return_value=cm)
+
+        with pytest.raises(RuntimeError, match="returned 500"):
+            await run_pipeline(plan, "model", [], session)
+
+
+# ---------------------------------------------------------------------------
+# discover_workers
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverWorkers:
+    @pytest.mark.asyncio
+    async def test_reachable_workers_returned(self):
+        cap = {"max_layers": 40, "vram_bytes_per_layer": 268435456, "device": "NPU"}
+
+        resp = AsyncMock()
+        resp.status = 200
+        resp.json = AsyncMock(return_value=cap)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=resp)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        session = MagicMock()
+        session.get = MagicMock(return_value=cm)
+
+        workers = await discover_workers(["http://w1"], session)
+        assert len(workers) == 1
+        assert workers[0].max_layers == 40
+        assert workers[0].device == "NPU"
+
+    @pytest.mark.asyncio
+    async def test_failed_host_excluded_not_fatal(self):
+        cap = {"max_layers": 40, "vram_bytes_per_layer": 268435456, "device": "NPU"}
+
+        good_resp = AsyncMock()
+        good_resp.status = 200
+        good_resp.json = AsyncMock(return_value=cap)
+        good_cm = MagicMock()
+        good_cm.__aenter__ = AsyncMock(return_value=good_resp)
+        good_cm.__aexit__ = AsyncMock(return_value=False)
+
+        bad_cm = MagicMock()
+        bad_cm.__aenter__ = AsyncMock(side_effect=RuntimeError("connection refused"))
+        bad_cm.__aexit__ = AsyncMock(return_value=False)
+
+        session = MagicMock()
+        session.get = MagicMock(side_effect=[bad_cm, good_cm])
+
+        workers = await discover_workers(["http://dead", "http://w2"], session)
+        assert len(workers) == 1
+        assert workers[0].host == "http://w2"
+
+    @pytest.mark.asyncio
+    async def test_all_hosts_failed_raises(self):
+        bad_cm = MagicMock()
+        bad_cm.__aenter__ = AsyncMock(side_effect=RuntimeError("refused"))
+        bad_cm.__aexit__ = AsyncMock(return_value=False)
+
+        session = MagicMock()
+        session.get = MagicMock(return_value=bad_cm)
+
+        with pytest.raises(RuntimeError, match="No NPU workers responded"):
+            await discover_workers(["http://dead"], session)

--- a/autobot-npu-worker/workers/pipeline_parallel.py
+++ b/autobot-npu-worker/workers/pipeline_parallel.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Cross-host pipeline parallelism for sharding 70B+ models (GH#6737).
+
+Orchestrates a multi-worker forward pass by:
+  1. Discovering worker capabilities via GET /capabilities on each host.
+  2. Allocating contiguous layer shards greedily by worker capacity.
+  3. Chaining the forward pass: each worker receives the previous worker's
+     hidden_state_out and returns its own hidden_state_out (or token_ids
+     on the final worker).
+
+Usage::
+
+    plan = build_shard_plan(workers, total_layers)
+    result = await run_pipeline(plan, model_id, input_hidden_state, session)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WorkerInfo:
+    """Capabilities reported by a single remote NPU worker."""
+
+    host: str  # e.g. "http://npu-worker-2:8080"
+    max_layers: int
+    vram_bytes_per_layer: int
+    device: str = "CPU"
+
+
+@dataclass
+class LayerShard:
+    """Assignment of a contiguous layer range to one worker."""
+
+    worker: WorkerInfo
+    layer_start: int
+    layer_end: int  # inclusive
+    is_last: bool = False
+
+
+@dataclass
+class ShardPlan:
+    """Ordered list of shards that together cover all model layers."""
+
+    shards: List[LayerShard] = field(default_factory=list)
+    total_layers: int = 0
+
+    def validate(self) -> None:
+        """Raise ValueError if the plan does not cover every layer exactly once."""
+        if not self.shards:
+            raise ValueError("ShardPlan is empty.")
+        expected = 0
+        for shard in self.shards:
+            if shard.layer_start != expected:
+                raise ValueError(
+                    f"Gap or overlap at layer {expected}: "
+                    f"shard starts at {shard.layer_start}."
+                )
+            expected = shard.layer_end + 1
+        if expected != self.total_layers:
+            raise ValueError(
+                f"Shards cover {expected} layers but model has {self.total_layers}."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Capability discovery
+# ---------------------------------------------------------------------------
+
+
+async def fetch_worker_capabilities(
+    host: str,
+    session: Any,
+    timeout: float = 10.0,
+) -> WorkerInfo:
+    """Query GET /capabilities on a remote worker and return WorkerInfo.
+
+    Args:
+        host: Base URL of the worker, e.g. ``http://npu-3:8080``.
+        session: An aiohttp ClientSession (or compatible) for HTTP requests.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        WorkerInfo populated from the worker's response.
+
+    Raises:
+        RuntimeError: When the capabilities endpoint returns an error.
+    """
+    url = f"{host.rstrip('/')}/capabilities"
+    try:
+        async with session.get(url, timeout=timeout) as resp:
+            if resp.status != 200:
+                text = await resp.text()
+                raise RuntimeError(
+                    f"Worker {host} /capabilities returned {resp.status}: {text}"
+                )
+            data: Dict[str, Any] = await resp.json()
+    except asyncio.TimeoutError:
+        raise RuntimeError(f"Worker {host} /capabilities timed out after {timeout}s.")
+
+    return WorkerInfo(
+        host=host,
+        max_layers=int(data["max_layers"]),
+        vram_bytes_per_layer=int(data["vram_bytes_per_layer"]),
+        device=str(data.get("device", "CPU")),
+    )
+
+
+async def discover_workers(
+    hosts: Sequence[str],
+    session: Any,
+    timeout: float = 10.0,
+) -> List[WorkerInfo]:
+    """Fetch capabilities from all hosts concurrently.
+
+    Hosts that fail to respond are logged and excluded from the result.
+
+    Args:
+        hosts: Sequence of worker base URLs.
+        session: aiohttp ClientSession.
+        timeout: Per-request timeout.
+
+    Returns:
+        List of WorkerInfo for reachable workers, in the same order as *hosts*.
+    """
+    tasks = [fetch_worker_capabilities(h, session, timeout) for h in hosts]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    workers: List[WorkerInfo] = []
+    for host, result in zip(hosts, results):
+        if isinstance(result, Exception):
+            logger.warning("pipeline_parallel: skipping %s — %s", host, result)
+        else:
+            workers.append(result)
+
+    if not workers:
+        raise RuntimeError("No NPU workers responded to capability queries.")
+
+    return workers
+
+
+# ---------------------------------------------------------------------------
+# Shard planning
+# ---------------------------------------------------------------------------
+
+
+def build_shard_plan(
+    workers: Sequence[WorkerInfo],
+    total_layers: int,
+) -> ShardPlan:
+    """Greedily assign contiguous layer shards to workers by their capacity.
+
+    Each worker receives at most ``worker.max_layers`` consecutive layers.
+    Assignment proceeds left-to-right through the model; if workers cannot
+    collectively cover all layers a ValueError is raised.
+
+    Args:
+        workers: Ordered list of available workers.
+        total_layers: Total number of transformer layers in the model.
+
+    Returns:
+        A validated ShardPlan.
+
+    Raises:
+        ValueError: If total worker capacity is less than total_layers.
+    """
+    if not workers:
+        raise ValueError("No workers provided for shard planning.")
+    if total_layers <= 0:
+        raise ValueError(f"total_layers must be positive, got {total_layers}.")
+
+    total_capacity = sum(w.max_layers for w in workers)
+    if total_capacity < total_layers:
+        raise ValueError(
+            f"Workers can hold {total_capacity} layers in total but model has "
+            f"{total_layers}. Add more NPU workers or reduce model size."
+        )
+
+    plan = ShardPlan(total_layers=total_layers)
+    remaining = total_layers
+    layer_cursor = 0
+
+    for worker in workers:
+        if remaining == 0:
+            break
+        assigned = min(worker.max_layers, remaining)
+        plan.shards.append(
+            LayerShard(
+                worker=worker,
+                layer_start=layer_cursor,
+                layer_end=layer_cursor + assigned - 1,
+                is_last=False,
+            )
+        )
+        layer_cursor += assigned
+        remaining -= assigned
+
+    if remaining > 0:
+        raise ValueError(
+            f"Could not assign {remaining} remaining layers; "
+            "worker list exhausted."
+        )
+
+    if plan.shards:
+        plan.shards[-1].is_last = True
+
+    plan.validate()
+    logger.info(
+        "pipeline_parallel: plan covers %d layers across %d workers",
+        total_layers,
+        len(plan.shards),
+    )
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# Pipeline execution
+# ---------------------------------------------------------------------------
+
+
+async def _forward_one_shard(
+    shard: LayerShard,
+    model_id: str,
+    hidden_state: Any,
+    session: Any,
+    timeout: float = 120.0,
+) -> Any:
+    """POST /partial_forward to one worker and return the output.
+
+    Args:
+        shard: The layer shard to execute on its assigned worker.
+        model_id: Model identifier forwarded to the worker.
+        hidden_state: Input activations for this shard.
+        session: aiohttp ClientSession.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        hidden_state_out (activations) or token_ids (list of ints) for the
+        last shard.
+
+    Raises:
+        RuntimeError: On HTTP error or unexpected response shape.
+    """
+    url = f"{shard.worker.host.rstrip('/')}/partial_forward"
+    payload = {
+        "model_id": model_id,
+        "layer_start": shard.layer_start,
+        "layer_end": shard.layer_end,
+        "is_last_worker": shard.is_last,
+        "hidden_state": hidden_state,
+    }
+
+    try:
+        async with session.post(url, json=payload, timeout=timeout) as resp:
+            if resp.status != 200:
+                text = await resp.text()
+                raise RuntimeError(
+                    f"Worker {shard.worker.host} /partial_forward "
+                    f"layers {shard.layer_start}–{shard.layer_end} "
+                    f"returned {resp.status}: {text}"
+                )
+            data: Dict[str, Any] = await resp.json()
+    except asyncio.TimeoutError:
+        raise RuntimeError(
+            f"Worker {shard.worker.host} /partial_forward timed out after {timeout}s "
+            f"(layers {shard.layer_start}–{shard.layer_end})."
+        )
+
+    if shard.is_last:
+        if "token_ids" not in data:
+            raise RuntimeError(
+                f"Last worker {shard.worker.host} did not return 'token_ids'. "
+                f"Got keys: {list(data.keys())}"
+            )
+        return data["token_ids"]
+
+    if "hidden_state_out" not in data:
+        raise RuntimeError(
+            f"Worker {shard.worker.host} did not return 'hidden_state_out'. "
+            f"Got keys: {list(data.keys())}"
+        )
+    return data["hidden_state_out"]
+
+
+async def run_pipeline(
+    plan: ShardPlan,
+    model_id: str,
+    input_hidden_state: Any,
+    session: Any,
+    *,
+    shard_timeout: float = 120.0,
+) -> Any:
+    """Execute a full cross-host pipeline forward pass.
+
+    Iterates through the shard plan sequentially, forwarding each worker's
+    output as the next worker's input.
+
+    Args:
+        plan: Validated ShardPlan from build_shard_plan.
+        model_id: Model identifier.
+        input_hidden_state: Token embeddings / initial activations for the
+            first layer of the model.
+        session: aiohttp ClientSession shared across all shard requests.
+        shard_timeout: Per-shard HTTP timeout in seconds.
+
+    Returns:
+        List of token IDs from the final worker.
+    """
+    plan.validate()
+    hidden = input_hidden_state
+
+    for shard in plan.shards:
+        logger.debug(
+            "pipeline_parallel: forwarding layers %d–%d to %s",
+            shard.layer_start,
+            shard.layer_end,
+            shard.worker.host,
+        )
+        hidden = await _forward_one_shard(shard, model_id, hidden, session, shard_timeout)
+
+    return hidden

--- a/autobot-npu-worker/workers/pipeline_parallel.py
+++ b/autobot-npu-worker/workers/pipeline_parallel.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -66,15 +66,10 @@ class ShardPlan:
         expected = 0
         for shard in self.shards:
             if shard.layer_start != expected:
-                raise ValueError(
-                    f"Gap or overlap at layer {expected}: "
-                    f"shard starts at {shard.layer_start}."
-                )
+                raise ValueError(f"Gap or overlap at layer {expected}: " f"shard starts at {shard.layer_start}.")
             expected = shard.layer_end + 1
         if expected != self.total_layers:
-            raise ValueError(
-                f"Shards cover {expected} layers but model has {self.total_layers}."
-            )
+            raise ValueError(f"Shards cover {expected} layers but model has {self.total_layers}.")
 
 
 # ---------------------------------------------------------------------------
@@ -105,9 +100,7 @@ async def fetch_worker_capabilities(
         async with session.get(url, timeout=timeout) as resp:
             if resp.status != 200:
                 text = await resp.text()
-                raise RuntimeError(
-                    f"Worker {host} /capabilities returned {resp.status}: {text}"
-                )
+                raise RuntimeError(f"Worker {host} /capabilities returned {resp.status}: {text}")
             data: Dict[str, Any] = await resp.json()
     except asyncio.TimeoutError:
         raise RuntimeError(f"Worker {host} /capabilities timed out after {timeout}s.")
@@ -210,10 +203,7 @@ def build_shard_plan(
         remaining -= assigned
 
     if remaining > 0:
-        raise ValueError(
-            f"Could not assign {remaining} remaining layers; "
-            "worker list exhausted."
-        )
+        raise ValueError(f"Could not assign {remaining} remaining layers; " "worker list exhausted.")
 
     if plan.shards:
         plan.shards[-1].is_last = True
@@ -283,15 +273,13 @@ async def _forward_one_shard(
     if shard.is_last:
         if "token_ids" not in data:
             raise RuntimeError(
-                f"Last worker {shard.worker.host} did not return 'token_ids'. "
-                f"Got keys: {list(data.keys())}"
+                f"Last worker {shard.worker.host} did not return 'token_ids'. " f"Got keys: {list(data.keys())}"
             )
         return data["token_ids"]
 
     if "hidden_state_out" not in data:
         raise RuntimeError(
-            f"Worker {shard.worker.host} did not return 'hidden_state_out'. "
-            f"Got keys: {list(data.keys())}"
+            f"Worker {shard.worker.host} did not return 'hidden_state_out'. " f"Got keys: {list(data.keys())}"
         )
     return data["hidden_state_out"]
 


### PR DESCRIPTION
## Thinking Path

GH#6737: Cross-host pipeline parallelism for 70B+ model sharding. NPU workers have bounded `max_layers` capacity; a single host cannot hold a full 70B+ model. The solution is a pipeline parallel scheme where layers are sharded across multiple NPU worker hosts and executed sequentially, threading the hidden state output from each shard as input to the next.

Key design decisions:
- `discover_workers`: async concurrent `/capabilities` polling — unreachable hosts excluded gracefully so a single failed worker doesn't block the pipeline.
- `build_shard_plan`: greedy left-to-right layer allocation respecting per-worker `max_layers`; raises `ValueError` with diagnostic message when aggregate capacity is insufficient.
- `run_pipeline`: sequential hidden-state threading — each worker's `hidden_state_out` is passed as the next worker's input; final worker returns `token_ids`.

## What Changed

- `autobot-npu-worker/workers/pipeline_parallel.py`: new module — `discover_workers`, `build_shard_plan`, `run_pipeline` implementing cross-host pipeline parallelism for 70B+ transformer model sharding.
- `autobot-npu-worker/tests/test_pipeline_parallel.py`: 17 unit tests covering shard planning, plan validation, pipeline execution, and worker discovery edge cases.

## Verification

- 17 unit tests pass: `python3 -m pytest autobot-npu-worker/tests/test_pipeline_parallel.py -v` ✅
- Shard planning: single worker, two-worker even split, uneven split, excess capacity, insufficient capacity ✅
- Plan validation: gap detection, under-coverage, empty plan ✅
- Pipeline execution: hidden state threaded correctly, final worker returns token_ids, HTTP error raised ✅
- Worker discovery: failed hosts excluded, all-failed raises ✅

## Model Used

claude-sonnet-4-6