### PR TITLE
feat(llm/tiered-routing): add long_context tier (MVA-1372)

### DIFF
--- a/autobot-backend/tests/llm_interface_pkg/tier_routing_test.py
+++ b/autobot-backend/tests/llm_interface_pkg/tier_routing_test.py
@@ -1,0 +1,124 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for long_context tier routing (MVA-1372).
+
+Covers all four routing cases mandated by the acceptance criteria:
+  - short input, low complexity  → simple
+  - short input, high complexity → complex
+  - long input, low complexity   → long_context
+  - long input, high complexity  → long_context
+"""
+
+from llm_shared.tiered_routing.complexity_router import ComplexityRouter
+from llm_shared.tiered_routing.tier_config import TierConfig, TierModels
+
+# ─── Message fixtures ─────────────────────────────────────────────────────────
+
+# Short, low-complexity: ~1 token, no technical indicators
+_SHORT_SIMPLE = [{"role": "user", "content": "hi"}]
+
+# Short, high-complexity: technical multi-step content, well under 16k tokens
+_SHORT_COMPLEX = [
+    {
+        "role": "user",
+        "content": (
+            "Write a multi-step algorithm in Python that implements "
+            "a distributed consensus protocol with fault tolerance, "
+            "including detailed code comments and error handling. " + "x" * 2000
+        ),
+    }
+]
+
+# Long content: 70_000 chars → ~17_500 tokens (char/4 estimate), safely above 16_000 threshold
+_LONG_CONTENT = "x" * 70_000
+
+# Long, low-complexity: large input but no complexity indicators
+_LONG_SIMPLE = [{"role": "user", "content": _LONG_CONTENT}]
+
+# Long, high-complexity: large input AND high-complexity indicators
+_LONG_COMPLEX = [
+    {
+        "role": "user",
+        "content": (
+            "Write a multi-step algorithm in Python that implements "
+            "a distributed consensus protocol with fault tolerance, "
+            "including detailed code comments and error handling. " + _LONG_CONTENT
+        ),
+    }
+]
+
+
+def _make_router(long_context_threshold: int = 16_000) -> ComplexityRouter:
+    cfg = TierConfig(
+        enabled=True,
+        complexity_threshold=3.0,
+        long_context_threshold=long_context_threshold,
+        models=TierModels(
+            simple="cheap-model",
+            complex="capable-model",
+            long_context="long-model",
+        ),
+    )
+    return ComplexityRouter(cfg)
+
+
+# ─── Four required routing cases ──────────────────────────────────────────────
+
+
+def test_short_low_routes_to_simple():
+    """Short input + low complexity score → simple tier."""
+    router = _make_router()
+    model, result = router.route(_SHORT_SIMPLE)
+    assert result.tier == "simple", f"expected simple, got {result.tier}"
+    assert model == "cheap-model"
+
+
+def test_short_high_routes_to_complex():
+    """Short input + high complexity score → complex tier."""
+    router = _make_router()
+    model, result = router.route(_SHORT_COMPLEX)
+    assert result.tier == "complex", f"expected complex, got {result.tier}"
+    assert model == "capable-model"
+
+
+def test_long_low_routes_to_long_context():
+    """Long input + low complexity → long_context tier overrides complexity score."""
+    router = _make_router()
+    model, result = router.route(_LONG_SIMPLE)
+    assert result.tier == "long_context", f"expected long_context, got {result.tier}"
+    assert model == "long-model"
+
+
+def test_long_high_routes_to_long_context():
+    """Long input + high complexity → long_context tier still overrides."""
+    router = _make_router()
+    model, result = router.route(_LONG_COMPLEX)
+    assert result.tier == "long_context", f"expected long_context, got {result.tier}"
+    assert model == "long-model"
+
+
+# ─── Supporting checks ────────────────────────────────────────────────────────
+
+
+def test_long_context_threshold_is_configurable():
+    """An extremely high threshold means long content still routes by complexity."""
+    router = _make_router(long_context_threshold=999_999)
+    _, result = router.route(_LONG_SIMPLE)
+    assert result.tier != "long_context"
+
+
+def test_input_tokens_exposed_on_result():
+    """ComplexityResult.input_tokens must be populated for long_context detection."""
+    router = _make_router()
+    _, result = router.route(_LONG_SIMPLE)
+    assert result.input_tokens > 16_000
+
+
+def test_tier_models_has_long_context_field():
+    """TierModels carries long_context str with a sensible default."""
+    models = TierModels()
+    assert hasattr(models, "long_context")
+    assert isinstance(models.long_context, str)
+    assert models.long_context  # non-empty default


### PR DESCRIPTION
## Summary

- `TierModels` already carries `long_context: str` field (defaulting to `DEFAULT_LLM_MODEL`) — verified present in `tier_config.py`
- `TierConfig` already exposes `long_context_threshold: int = 16_000` as a config knob
- `TaskComplexityScorer.estimate_input_tokens()` already exposes the input token count, stored in `ComplexityResult.input_tokens`
- `ComplexityRouter.route()` already checks `result.input_tokens > long_context_threshold` before the simple/complex branch, routing to `long_context` tier when exceeded
- **This PR adds the missing test coverage** (`tier_routing_test.py`) with all four mandated cases:
  - short-low → `simple`
  - short-high → `complex`
  - long-low → `long_context`
  - long-high → `long_context`

## Test plan

- [ ] `pytest autobot-backend/tests/llm_interface_pkg/tier_routing_test.py` — all 7 tests pass
- [ ] Existing `test_routing_strategies.py` tests continue to pass unchanged
- [ ] `long_context_threshold` knob verified: setting to `999_999` reverts long inputs to complexity-based routing

## Related

Part of GH#7349 (parent GH#7346). Sequencing note: the token-based length scoring fix (sibling under GH#7346) was checked — the `estimate_input_tokens` implementation already uses the tokenizer if provided, falling back to `char/4` estimate.

Paperclip issue: MVA-1372

🤖 Generated with [Claude Code](https://claude.com/claude-code)