### PR TITLE
feat(registry): add architecture_family field to model metadata (GH#7347)

### DIFF
--- a/autobot-backend/config/llm_models.yaml
+++ b/autobot-backend/config/llm_models.yaml
@@ -2,10 +2,13 @@
 # Models are auto-discovered from Ollama; this file provides overrides.
 #
 # Schema:
-#   display_name   — canonical identifier used internally
-#   api_name       — provider-specific identifiers (provider: api_model_id)
-#   aliases        — alternative names resolved to this entry
-#   prompt_prefix  — optional string prepended to the first user turn (#3263)
+#   display_name        — canonical identifier used internally
+#   api_name            — provider-specific identifiers (provider: api_model_id)
+#   aliases             — alternative names resolved to this entry
+#   prompt_prefix       — optional string prepended to the first user turn (#3263)
+#   architecture_family — model architecture: transformer | ssm | linear_attention | hybrid | moe
+#                         (GH#7347) used by NPU dispatch and routing. Falls back to pattern-match
+#                         on model_id when absent; new models should set this explicitly.
 #   api_kwargs:
 #     default      — applied to every provider unless overridden
 #     <provider>   — merged on top of default for that provider only
@@ -43,6 +46,7 @@ anthropic_default_thinking_budget: 16000
 # =============================================================================
 models:
   - display_name: claude-sonnet-4-6
+    architecture_family: transformer
     api_name:
       anthropic: claude-sonnet-4-6
     aliases:
@@ -53,6 +57,7 @@ models:
         max_tokens: 8192
 
   - display_name: claude-opus-4-6
+    architecture_family: transformer
     api_name:
       anthropic: claude-opus-4-6
     aliases:
@@ -63,6 +68,7 @@ models:
         max_tokens: 4096
 
   - display_name: claude-sonnet-4-20250514
+    architecture_family: transformer
     api_name:
       anthropic: claude-sonnet-4-20250514
     aliases:
@@ -73,6 +79,7 @@ models:
         max_tokens: 8192
 
   - display_name: claude-opus-4-20250514
+    architecture_family: transformer
     api_name:
       anthropic: claude-opus-4-20250514
     aliases:
@@ -83,6 +90,7 @@ models:
         max_tokens: 4096
 
   - display_name: claude-3-5-sonnet-20241022
+    architecture_family: transformer
     api_name:
       anthropic: claude-3-5-sonnet-20241022
     aliases:
@@ -94,6 +102,7 @@ models:
         max_tokens: 8192
 
   - display_name: claude-3-5-haiku-20241022
+    architecture_family: transformer
     api_name:
       anthropic: claude-3-5-haiku-20241022
     aliases:
@@ -105,6 +114,7 @@ models:
         max_tokens: 4096
 
   - display_name: claude-haiku-4-5-20251001
+    architecture_family: transformer
     api_name:
       anthropic: claude-haiku-4-5-20251001
     aliases:
@@ -115,6 +125,7 @@ models:
         max_tokens: 4096
 
   - display_name: claude-3-opus-20240229
+    architecture_family: transformer
     api_name:
       anthropic: claude-3-opus-20240229
     aliases:
@@ -125,6 +136,7 @@ models:
         max_tokens: 4096
 
   - display_name: gpt-4o
+    architecture_family: transformer
     api_name:
       openai: gpt-4o
     aliases:
@@ -135,6 +147,7 @@ models:
         max_tokens: 4096
 
   - display_name: gpt-4o-mini
+    architecture_family: transformer
     api_name:
       openai: gpt-4o-mini
     aliases:
@@ -145,6 +158,7 @@ models:
         max_tokens: 4096
 
   - display_name: gpt-4.1
+    architecture_family: transformer
     api_name:
       openai: gpt-4.1
     aliases: []
@@ -154,6 +168,7 @@ models:
         max_tokens: 8192
 
   - display_name: gpt-4.1-mini
+    architecture_family: transformer
     api_name:
       openai: gpt-4.1-mini
     aliases: []
@@ -163,6 +178,7 @@ models:
         max_tokens: 4096
 
   - display_name: gpt-4.1-nano
+    architecture_family: transformer
     api_name:
       openai: gpt-4.1-nano
     aliases: []
@@ -172,6 +188,7 @@ models:
         max_tokens: 2048
 
   - display_name: gpt-4-turbo
+    architecture_family: transformer
     api_name:
       openai: gpt-4-turbo
     aliases: []
@@ -181,6 +198,7 @@ models:
         max_tokens: 4096
 
   - display_name: gpt-4
+    architecture_family: transformer
     api_name:
       openai: gpt-4
     aliases: []
@@ -190,6 +208,7 @@ models:
         max_tokens: 4096
 
   - display_name: gpt-3.5-turbo
+    architecture_family: transformer
     api_name:
       openai: gpt-3.5-turbo
     aliases:
@@ -200,6 +219,7 @@ models:
         max_tokens: 4096
 
   - display_name: o1
+    architecture_family: transformer
     api_name:
       openai: o1
     aliases: []
@@ -208,6 +228,7 @@ models:
         max_tokens: 32768
 
   - display_name: o1-mini
+    architecture_family: transformer
     api_name:
       openai: o1-mini
     aliases: []
@@ -216,6 +237,7 @@ models:
         max_tokens: 16384
 
   - display_name: o3
+    architecture_family: transformer
     api_name:
       openai: o3
     aliases: []
@@ -224,6 +246,7 @@ models:
         max_tokens: 32768
 
   - display_name: o3-mini
+    architecture_family: transformer
     api_name:
       openai: o3-mini
     aliases: []
@@ -232,6 +255,7 @@ models:
         max_tokens: 16384
 
   - display_name: o4-mini
+    architecture_family: transformer
     api_name:
       openai: o4-mini
     aliases: []
@@ -240,6 +264,7 @@ models:
         max_tokens: 16384
 
   - display_name: gemini-2.5-pro
+    architecture_family: transformer
     api_name:
       google: gemini-2.5-pro
     aliases: []
@@ -249,6 +274,7 @@ models:
         max_tokens: 8192
 
   - display_name: gemini-2.5-flash
+    architecture_family: transformer
     api_name:
       google: gemini-2.5-flash
     aliases: []
@@ -258,6 +284,7 @@ models:
         max_tokens: 8192
 
   - display_name: gemini-2.0-flash
+    architecture_family: transformer
     api_name:
       google: gemini-2.0-flash
     aliases: []
@@ -267,6 +294,7 @@ models:
         max_tokens: 8192
 
   - display_name: gemini-1.5-pro
+    architecture_family: transformer
     api_name:
       google: gemini-1.5-pro
     aliases: []
@@ -276,6 +304,7 @@ models:
         max_tokens: 8192
 
   - display_name: gemini-1.5-flash
+    architecture_family: transformer
     api_name:
       google: gemini-1.5-flash
     aliases: []
@@ -285,6 +314,7 @@ models:
         max_tokens: 8192
 
   - display_name: deepseek-v3
+    architecture_family: transformer
     api_name:
       openai: deepseek-v3
     aliases: []
@@ -294,6 +324,7 @@ models:
         max_tokens: 4096
 
   - display_name: deepseek-r1-api
+    architecture_family: transformer
     api_name:
       openai: deepseek-r1-api
     aliases: []
@@ -303,6 +334,7 @@ models:
         max_tokens: 8192
 
   - display_name: llama3.3
+    architecture_family: transformer
     api_name:
       ollama: llama3.3
     aliases:
@@ -313,6 +345,7 @@ models:
         max_tokens: 4096
 
   - display_name: llama3.2
+    architecture_family: transformer
     api_name:
       ollama: llama3.2
     aliases:
@@ -323,6 +356,7 @@ models:
         max_tokens: 4096
 
   - display_name: llama3.1
+    architecture_family: transformer
     api_name:
       ollama: llama3.1
     aliases:
@@ -333,6 +367,7 @@ models:
         max_tokens: 4096
 
   - display_name: llama3
+    architecture_family: transformer
     api_name:
       ollama: llama3
     aliases:
@@ -343,6 +378,7 @@ models:
         max_tokens: 4096
 
   - display_name: mistral
+    architecture_family: transformer
     api_name:
       ollama: mistral
     aliases:
@@ -353,6 +389,7 @@ models:
         max_tokens: 4096
 
   - display_name: mixtral
+    architecture_family: transformer
     api_name:
       ollama: mixtral
     aliases:
@@ -363,6 +400,7 @@ models:
         max_tokens: 4096
 
   - display_name: codellama
+    architecture_family: transformer
     api_name:
       ollama: codellama
     aliases:
@@ -373,6 +411,7 @@ models:
         max_tokens: 4096
 
   - display_name: qwen2.5
+    architecture_family: transformer
     api_name:
       ollama: qwen2.5
     aliases:
@@ -383,6 +422,7 @@ models:
         max_tokens: 4096
 
   - display_name: qwen3
+    architecture_family: transformer
     api_name:
       ollama: qwen3
     aliases:
@@ -393,6 +433,7 @@ models:
         max_tokens: 4096
 
   - display_name: deepseek-coder
+    architecture_family: transformer
     api_name:
       ollama: deepseek-coder
     aliases:
@@ -403,6 +444,7 @@ models:
         max_tokens: 4096
 
   - display_name: deepseek-r1
+    architecture_family: transformer
     api_name:
       ollama: deepseek-r1
     aliases:
@@ -414,6 +456,7 @@ models:
         max_tokens: 8192
 
   - display_name: phi3
+    architecture_family: transformer
     api_name:
       ollama: phi3
     aliases:
@@ -424,6 +467,7 @@ models:
         max_tokens: 2048
 
   - display_name: phi4
+    architecture_family: transformer
     api_name:
       ollama: phi4
     aliases:
@@ -434,6 +478,7 @@ models:
         max_tokens: 4096
 
   - display_name: gemma2
+    architecture_family: transformer
     api_name:
       ollama: gemma2
     aliases:
@@ -444,6 +489,7 @@ models:
         max_tokens: 4096
 
   - display_name: gemma3
+    architecture_family: transformer
     api_name:
       ollama: gemma3
     aliases:

--- a/autobot-backend/llm_shared/__init__.py
+++ b/autobot-backend/llm_shared/__init__.py
@@ -47,8 +47,10 @@ from .hardware import TORCH_AVAILABLE, HardwareDetector
 # Mock providers
 from .mock_providers import LocalLLM, MockPalm, local_llm, palm
 from .model_param_registry import (
+    ArchitectureFamily,
     apply_model_defaults,
     apply_prompt_prefix,
+    get_architecture_family,
     get_model_kwargs,
     get_prompt_prefix,
     get_provider_model_id,

--- a/autobot-backend/llm_shared/model_param_registry.py
+++ b/autobot-backend/llm_shared/model_param_registry.py
@@ -26,9 +26,10 @@ Moved from llm_providers/ as part of Phase 2 consolidation (MVA-178 / GH#7637).
 
 from __future__ import annotations
 
+from enum import Enum
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
@@ -51,6 +52,67 @@ _FALLBACK_KWARGS: Dict[str, Any] = {
     "temperature": 0.7,
     "max_tokens": 2048,
 }
+
+# ---------------------------------------------------------------------------
+# Architecture family
+# ---------------------------------------------------------------------------
+
+
+class ArchitectureFamily(str, Enum):
+    """Model architecture families (GH#7347).
+
+    Used by NPU dispatch and tiered routing to select the correct inference
+    backend.  New families can be added here without any code change — just
+    add the value to the YAML entry for the model.
+    """
+
+    TRANSFORMER = "transformer"
+    SSM = "ssm"
+    LINEAR_ATTENTION = "linear_attention"
+    HYBRID = "hybrid"
+    MOE = "moe"
+
+
+# model_type strings found in HuggingFace config.json → ArchitectureFamily
+_MODEL_TYPE_MAP: Dict[str, str] = {
+    # Transformer variants
+    "llama": ArchitectureFamily.TRANSFORMER,
+    "mistral": ArchitectureFamily.TRANSFORMER,
+    "mixtral": ArchitectureFamily.MOE,
+    "falcon": ArchitectureFamily.TRANSFORMER,
+    "gpt2": ArchitectureFamily.TRANSFORMER,
+    "gpt_neo": ArchitectureFamily.TRANSFORMER,
+    "gpt_neox": ArchitectureFamily.TRANSFORMER,
+    "bloom": ArchitectureFamily.TRANSFORMER,
+    "opt": ArchitectureFamily.TRANSFORMER,
+    "t5": ArchitectureFamily.TRANSFORMER,
+    "bert": ArchitectureFamily.TRANSFORMER,
+    "roberta": ArchitectureFamily.TRANSFORMER,
+    "phi": ArchitectureFamily.TRANSFORMER,
+    "gemma": ArchitectureFamily.TRANSFORMER,
+    "qwen2": ArchitectureFamily.TRANSFORMER,
+    "deepseek": ArchitectureFamily.TRANSFORMER,
+    # SSM / state-space variants
+    "mamba": ArchitectureFamily.SSM,
+    "mamba2": ArchitectureFamily.SSM,
+    "jamba": ArchitectureFamily.HYBRID,
+    "rwkv": ArchitectureFamily.SSM,
+    # Linear attention
+    "retnet": ArchitectureFamily.LINEAR_ATTENTION,
+    "gla": ArchitectureFamily.LINEAR_ATTENTION,
+    "hgrn": ArchitectureFamily.LINEAR_ATTENTION,
+}
+
+# Pattern-match heuristics keyed on substrings of the model_id.
+# Used as last resort when neither YAML nor config.json provides the family.
+_PATTERN_MAP: list[tuple[str, str]] = [
+    ("mamba", ArchitectureFamily.SSM),
+    ("rwkv", ArchitectureFamily.SSM),
+    ("jamba", ArchitectureFamily.HYBRID),
+    ("retnet", ArchitectureFamily.LINEAR_ATTENTION),
+    ("mixtral", ArchitectureFamily.MOE),
+    ("moe", ArchitectureFamily.MOE),
+]
 
 # OpenAI reasoning models reject the ``temperature`` parameter with HTTP 400.
 # These canonical display_names must never receive the temperature fallback.
@@ -257,11 +319,78 @@ def apply_prompt_prefix(
     return messages
 
 
+def get_architecture_family(
+    model: str,
+    model_card_config: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Return the ``architecture_family`` for *model*.
+
+    Resolution order (first match wins):
+
+    1. ``architecture_family`` field in ``llm_models.yaml`` for the model.
+    2. ``model_type`` key in *model_card_config* (HuggingFace ``config.json``),
+       mapped through ``_MODEL_TYPE_MAP``.
+    3. Pattern-match on the canonical model name via ``_PATTERN_MAP``.
+       A ``WARNING`` is emitted so operators know to add an explicit entry.
+    4. Default: ``"transformer"``.
+
+    Args:
+        model:             Model name or alias.
+        model_card_config: Optional parsed ``config.json`` dict from the model
+                           card (e.g. fetched from HuggingFace Hub or a local
+                           Ollama model directory).
+
+    Returns:
+        One of the ``ArchitectureFamily`` string values.
+    """
+    canonical = resolve_model_name(model)
+    reg = _load_registry()
+    entry = reg.get(canonical)
+
+    # 1. Explicit YAML field
+    if entry is not None:
+        family = entry.get("architecture_family")
+        if family:
+            return str(family)
+
+    # 2. model_type from HuggingFace config.json
+    if model_card_config:
+        model_type = str(model_card_config.get("model_type", "")).lower()
+        if model_type:
+            mapped = _MODEL_TYPE_MAP.get(model_type)
+            if mapped:
+                return mapped
+            logger.warning(
+                "Unknown model_type %r for model %r — falling back to pattern match. "
+                "Add an entry to _MODEL_TYPE_MAP or set architecture_family in llm_models.yaml.",
+                model_type,
+                model,
+            )
+
+    # 3. Pattern-match fallback
+    name_lower = canonical.lower()
+    for pattern, family in _PATTERN_MAP:
+        if pattern in name_lower:
+            logger.warning(
+                "architecture_family for model %r inferred from pattern %r → %r. "
+                "Set architecture_family explicitly in llm_models.yaml to suppress this warning.",
+                model,
+                pattern,
+                family,
+            )
+            return family
+
+    # 4. Default
+    return ArchitectureFamily.TRANSFORMER
+
+
 __all__ = [
+    "ArchitectureFamily",
     "resolve_model_name",
     "get_model_kwargs",
     "get_provider_model_id",
     "apply_model_defaults",
     "get_prompt_prefix",
     "apply_prompt_prefix",
+    "get_architecture_family",
 ]

--- a/autobot-backend/services/model_manager_service.py
+++ b/autobot-backend/services/model_manager_service.py
@@ -68,6 +68,8 @@ def _build_model_entry(
     name: str, provider: str, available: bool, extra: Dict[str, Any] | None = None
 ) -> Dict[str, Any]:
     """Return a standardised model metadata dict."""
+    from llm_shared.model_param_registry import get_architecture_family
+
     hints = _hints_for_model(name)
     entry: Dict[str, Any] = {
         "name": name,
@@ -75,6 +77,7 @@ def _build_model_entry(
         "available": available,
         "context_window": hints["context_window"],
         "capabilities": hints["capabilities"],
+        "architecture_family": get_architecture_family(name),
     }
     if extra:
         entry.update(extra)

--- a/autobot-backend/tests/llm_interface_pkg/test_model_param_registry.py
+++ b/autobot-backend/tests/llm_interface_pkg/test_model_param_registry.py
@@ -49,10 +49,12 @@ from llm_shared.model_param_registry import (  # noqa: E402
     _load_registry,
     apply_model_defaults,
     apply_prompt_prefix,
+    get_architecture_family,
     get_model_kwargs,
     get_prompt_prefix,
     get_provider_model_id,
     resolve_model_name,
+    ArchitectureFamily,
 )
 
 # ---------------------------------------------------------------------------
@@ -438,3 +440,77 @@ class TestApplyPromptPrefix:
             _clear_cache()
             result = apply_prompt_prefix("system-only-model", messages)
         assert result[0]["content"] == "Only a system message"
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_architecture_family (GH#7347)
+# ---------------------------------------------------------------------------
+
+
+class TestGetArchitectureFamily:
+    def test_known_yaml_model_returns_transformer(self):
+        assert get_architecture_family("claude-sonnet-4-6") == ArchitectureFamily.TRANSFORMER
+
+    def test_gpt4o_returns_transformer(self):
+        assert get_architecture_family("gpt-4o") == ArchitectureFamily.TRANSFORMER
+
+    def test_ollama_model_returns_transformer(self):
+        assert get_architecture_family("llama3.3") == ArchitectureFamily.TRANSFORMER
+
+    def test_model_card_mamba_returns_ssm(self):
+        fam = get_architecture_family("unknown-local", model_card_config={"model_type": "mamba"})
+        assert fam == ArchitectureFamily.SSM
+
+    def test_model_card_mamba2_returns_ssm(self):
+        fam = get_architecture_family("some-model", model_card_config={"model_type": "mamba2"})
+        assert fam == ArchitectureFamily.SSM
+
+    def test_model_card_mixtral_returns_moe(self):
+        fam = get_architecture_family("some-model", model_card_config={"model_type": "mixtral"})
+        assert fam == ArchitectureFamily.MOE
+
+    def test_pattern_match_mamba_name_returns_ssm(self):
+        fam = get_architecture_family("mamba-3b-local")
+        assert fam == ArchitectureFamily.SSM
+
+    def test_pattern_match_emits_warning(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING):
+            get_architecture_family("mamba-unknown-7b")
+        assert "architecture_family" in caplog.text
+        assert "pattern" in caplog.text
+
+    def test_unknown_model_no_config_defaults_transformer(self):
+        fam = get_architecture_family("totally-unknown-xyz-model")
+        assert fam == ArchitectureFamily.TRANSFORMER
+
+    def test_alias_resolved_before_lookup(self):
+        fam = get_architecture_family("gpt4o")
+        assert fam == ArchitectureFamily.TRANSFORMER
+
+    def test_explicit_yaml_field_wins_over_config(self, tmp_path):
+        import textwrap
+        from unittest.mock import patch
+
+        yaml_content = textwrap.dedent("""\
+            models:
+              - display_name: my-ssm-model
+                architecture_family: ssm
+                api_name:
+                  ollama: my-ssm-model
+                aliases: []
+                api_kwargs:
+                  default:
+                    temperature: 0.7
+                    max_tokens: 2048
+        """)
+        yaml_file = tmp_path / "llm_models.yaml"
+        yaml_file.write_text(yaml_content, encoding="utf-8")
+        with patch.dict("os.environ", {"AUTOBOT_LLM_MODELS_YAML": str(yaml_file)}):
+            _clear_cache()
+            # config.json says transformer but YAML says ssm — YAML wins
+            fam = get_architecture_family(
+                "my-ssm-model",
+                model_card_config={"model_type": "llama"},
+            )
+        assert fam == ArchitectureFamily.SSM


### PR DESCRIPTION
## Summary

- Add `ArchitectureFamily` enum (`transformer | ssm | linear_attention | hybrid | moe`) to `model_param_registry.py`
- Implement `get_architecture_family()` with 4-level resolution: explicit YAML field → `model_type` from HuggingFace `config.json` → pattern-match on model_id (with WARNING log) → default `transformer`
- Backfill `architecture_family: transformer` for all 43 existing models in `llm_models.yaml`
- Expose field via `GET /api/models/available` (model_manager_service) and `llm_shared` package exports

## Acceptance Criteria Verification

- ✅ All 43 registry models have `architecture_family: transformer` populated
- ✅ A model with `model_type: "mamba"` in config.json registers as `architecture_family: ssm` automatically (via `_MODEL_TYPE_MAP`)
- ✅ No code change required for a new model — set `architecture_family` in YAML config only

## Test plan

- [ ] 11 new unit tests added to `test_model_param_registry.py::TestGetArchitectureFamily`
- [ ] Covers: YAML lookup, config.json mapping (mamba→ssm, mixtral→moe), pattern fallback, warning log, alias resolution, YAML-over-config priority
- [ ] `GET /api/models/available` returns `architecture_family` in each model entry

Closes GH#7347 · Paperclip issue [MVA-1379](/MVA/issues/MVA-1379)

🤖 Generated with [Claude Code](https://claude.com/claude-code)