### PR TITLE
feat(backend): bypass 4K/8K context cap for non-transformer models (GH#7351)

### DIFF
--- a/autobot-backend/context_window_manager.py
+++ b/autobot-backend/context_window_manager.py
@@ -22,9 +22,10 @@ from constants.model_constants import ModelConfig, ModelConstants
 logger = get_logger(__name__)
 
 # Architecture families whose cost curve does not require transformer caps.
-# Matches the string values of llm_shared.types.ArchitectureFamily; kept as a
-# frozenset of strings here to avoid a circular import with llm_shared.
-_NON_TRANSFORMER_FAMILIES: frozenset[str] = frozenset({"state_space", "linear_attention", "hybrid"})
+# "ssm" matches llm_shared.ArchitectureFamily.SSM; "state_space" is kept for
+# backward-compatible YAML entries written before MVA-1379 standardised the
+# enum.  Both string values bypass the 4K/8K compression trigger.
+_NON_TRANSFORMER_FAMILIES: frozenset[str] = frozenset({"ssm", "state_space", "linear_attention", "hybrid"})
 
 # Lazy singleton — imported on first call to avoid circular imports.
 _compression_service = None
@@ -208,27 +209,42 @@ class ContextWindowManager:
         max_tokens = self.get_max_history_tokens(model_name)
         return estimated_tokens > max_tokens
 
+    @staticmethod
+    def _registry_family(model: str) -> str:
+        """Look up architecture_family from llm_shared registry (lazy import)."""
+        try:
+            from llm_shared.model_param_registry import (
+                get_architecture_family as _get,
+            )
+
+            return _get(model)
+        except Exception:
+            return "transformer"
+
     def get_architecture_family(self, model_name: str | None = None) -> str:
         """Return the architecture_family for a model (defaults to 'transformer').
 
-        Issue #7351: reads the ``architecture_family`` key from the YAML config
-        entry for the model.  When absent or unknown the safe default is
-        ``'transformer'``, preserving existing compression behaviour.
+        Issue #7351: resolution order:
+        1. ``architecture_family`` key from ``context_windows.yaml`` (normalized).
+        2. ``llm_shared.get_architecture_family()`` — reads ``llm_models.yaml``
+           and, optionally, HuggingFace ``config.json`` (MVA-1379).
+        3. ``'transformer'`` safe default.
 
         Args:
             model_name: Optional model name, uses current if not specified.
 
         Returns:
-            Architecture family string (e.g. ``'transformer'``, ``'state_space'``).
+            Architecture family string (e.g. ``'transformer'``, ``'ssm'``).
         """
         model = model_name or self.current_model
-        # Issue #8360: unknown models fall through to default, inheriting its
-        # architecture_family.  Return the safe default directly instead.
+        # Issue #8360: unknown models must not inherit default model's family.
         if model not in self.config["models"]:
-            return "transformer"
-        # Issue #8361: normalize whitespace and case before returning so callers
-        # don't see e.g. "State_Space" fail the frozenset membership check.
-        raw = self.config["models"][model].get("architecture_family", "transformer")
+            return self._registry_family(model)
+        raw = self.config["models"][model].get("architecture_family")
+        if raw is None:
+            # Entry exists but omits architecture_family — delegate to registry.
+            return self._registry_family(model)
+        # Issue #8361: normalize whitespace and case before frozenset check.
         return raw.strip().lower()
 
     def get_compression_threshold(self, model_name: str | None = None) -> int:
@@ -254,8 +270,8 @@ class ContextWindowManager:
             model = self.config["models"]["default"]["name"]
 
         entry = self.config["models"][model]
-        # Issue #8361: normalize before frozenset check.
-        family = entry.get("architecture_family", "transformer").strip().lower()
+        # Use the method so the llm_shared registry fallback is applied.
+        family = self.get_architecture_family(model_name)
 
         # Issue #8359: explicit compression_threshold always wins, regardless of
         # architecture family.  Only fall back to family-specific defaults when

--- a/autobot-backend/context_window_manager.py
+++ b/autobot-backend/context_window_manager.py
@@ -213,9 +213,7 @@ class ContextWindowManager:
     def _registry_family(model: str) -> str:
         """Look up architecture_family from llm_shared registry (lazy import)."""
         try:
-            from llm_shared.model_param_registry import (
-                get_architecture_family as _get,
-            )
+            from llm_shared.model_param_registry import get_architecture_family as _get
 
             return _get(model)
         except Exception:

--- a/autobot-backend/context_window_manager_test.py
+++ b/autobot-backend/context_window_manager_test.py
@@ -7,6 +7,8 @@ Unit tests for context_window_manager — architecture-family-aware cap bypass.
 Issue #7351: non-transformer models must not be compressed at the 4K/8K cap.
 """
 
+from unittest.mock import patch
+
 import pytest
 
 from context_window_manager import _NON_TRANSFORMER_FAMILIES, ContextWindowManager
@@ -38,6 +40,16 @@ _TRANSFORMER_CONFIG = {
         },
         "mamba-3b": {
             "architecture_family": "state_space",
+            "context_window_tokens": 131072,
+            "max_output_tokens": 4096,
+            "message_budget": {
+                "system_prompt": 500,
+                "recent_messages": 50,
+                "max_history_tokens": 100000,
+            },
+        },
+        "mamba2-7b": {
+            "architecture_family": "ssm",
             "context_window_tokens": 131072,
             "max_output_tokens": 4096,
             "message_budget": {
@@ -366,3 +378,154 @@ class TestArchitectureFamilyNormalization:
         mgr = _manager_with_config(config)
         # Should use context_window_tokens (100000), not the transformer 8192 cap.
         assert mgr.get_compression_threshold("ssm") == 100000
+
+
+# ---------------------------------------------------------------------------
+# New in MVA-1387: "ssm" family value from llm_shared.ArchitectureFamily.SSM
+# ---------------------------------------------------------------------------
+
+
+class TestSsmFamilyValue:
+    def test_ssm_in_non_transformer_families(self):
+        assert "ssm" in _NON_TRANSFORMER_FAMILIES
+
+    def test_ssm_family_returns_ssm(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        assert mgr.get_architecture_family("mamba2-7b") == "ssm"
+
+    def test_ssm_compression_threshold_uses_context_window(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        assert mgr.get_compression_threshold("mamba2-7b") == 131072
+
+    def test_ssm_not_capped_at_8192(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        assert mgr.get_compression_threshold("mamba2-7b") > 8192
+
+    @pytest.mark.asyncio
+    async def test_ssm_async_compress_returns_false(self):
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        result = await mgr.async_should_compress(50000, "mamba2-7b")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# New in MVA-1387: registry fallback via llm_shared.get_architecture_family
+# ---------------------------------------------------------------------------
+
+_TRANSFORMER_ONLY_CONFIG = {
+    "models": {
+        "default": {
+            "name": "llama3",
+            "context_window_tokens": 4096,
+            "max_output_tokens": 2048,
+            "message_budget": {"system_prompt": 500, "recent_messages": 20, "max_history_tokens": 3000},
+        },
+        "llama3": {
+            "context_window_tokens": 4096,
+            "max_output_tokens": 2048,
+            "message_budget": {"system_prompt": 500, "recent_messages": 20, "max_history_tokens": 3000},
+        },
+    },
+    "token_estimation": {"chars_per_token": 4, "safety_margin": 0.9},
+}
+
+
+class TestRegistryFallback:
+    """get_architecture_family delegates to llm_shared when model absent from YAML."""
+
+    def test_model_not_in_config_calls_registry(self):
+        mgr = _manager_with_config(_TRANSFORMER_ONLY_CONFIG)
+        with patch(
+            "context_window_manager.ContextWindowManager._registry_family",
+            return_value="ssm",
+        ) as mock_reg:
+            result = mgr.get_architecture_family("mamba-unknown")
+        mock_reg.assert_called_once_with("mamba-unknown")
+        assert result == "ssm"
+
+    def test_model_in_config_without_family_calls_registry(self):
+        """Entry exists but has no architecture_family key → delegate to registry."""
+        config = {
+            "models": {
+                "default": {
+                    "name": "no-family-model",
+                    "message_budget": {"system_prompt": 0, "recent_messages": 10, "max_history_tokens": 1000},
+                },
+                "no-family-model": {
+                    "context_window_tokens": 131072,
+                    "message_budget": {"system_prompt": 0, "recent_messages": 10, "max_history_tokens": 1000},
+                    # no architecture_family key
+                },
+            },
+            "token_estimation": {"chars_per_token": 4, "safety_margin": 0.9},
+        }
+        mgr = _manager_with_config(config)
+        with patch(
+            "context_window_manager.ContextWindowManager._registry_family",
+            return_value="hybrid",
+        ) as mock_reg:
+            result = mgr.get_architecture_family("no-family-model")
+        mock_reg.assert_called_once_with("no-family-model")
+        assert result == "hybrid"
+
+    def test_model_in_config_with_family_does_not_call_registry(self):
+        """Explicit family in YAML must skip the registry lookup."""
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        with patch(
+            "context_window_manager.ContextWindowManager._registry_family",
+        ) as mock_reg:
+            result = mgr.get_architecture_family("mamba-3b")
+        mock_reg.assert_not_called()
+        assert result == "state_space"
+
+    def test_registry_exception_falls_back_to_transformer(self):
+        """If llm_shared import fails, must not raise — return 'transformer'."""
+        mgr = _manager_with_config(_TRANSFORMER_ONLY_CONFIG)
+        with patch(
+            "context_window_manager.ContextWindowManager._registry_family",
+            side_effect=RuntimeError("import error"),
+        ):
+            # get_architecture_family delegates to _registry_family which raises;
+            # we verify the integration handles ImportError at the _registry_family
+            # boundary (the static method catches exceptions internally).
+            pass
+        # Test _registry_family's own exception guard directly.
+        with patch(
+            "llm_shared.model_param_registry.get_architecture_family",
+            side_effect=ImportError("llm_shared unavailable"),
+        ):
+            result = ContextWindowManager._registry_family("any-model")
+        assert result == "transformer"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion (MVA-1387): SSM 128K model accepts 50K prompt
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptanceCriteria:
+    @pytest.mark.asyncio
+    async def test_ssm_128k_accepts_50k_prompt_without_compression(self):
+        """AC: SSM/hybrid model with 128K native context must not compress 50K tokens."""
+        config = {
+            "models": {
+                "default": {
+                    "name": "mamba-128k",
+                    "message_budget": {"system_prompt": 0, "recent_messages": 10, "max_history_tokens": 1000},
+                },
+                "mamba-128k": {
+                    "architecture_family": "ssm",
+                    "context_window_tokens": 131072,
+                    "message_budget": {"system_prompt": 0, "recent_messages": 50, "max_history_tokens": 100000},
+                },
+            },
+            "token_estimation": {"chars_per_token": 4, "safety_margin": 0.9},
+        }
+        mgr = _manager_with_config(config)
+        result = await mgr.async_should_compress(50000, "mamba-128k")
+        assert result is False, "SSM 128K model must not compress a 50K-token prompt"
+
+    def test_transformer_continues_to_cap(self):
+        """AC: transformer models must still return the 8192 threshold."""
+        mgr = _manager_with_config(_TRANSFORMER_CONFIG)
+        assert mgr.get_compression_threshold("llama3") == 8192


### PR DESCRIPTION
## Summary

- Add `"ssm"` to `_NON_TRANSFORMER_FAMILIES` so the `llm_shared.ArchitectureFamily.SSM` value (from MVA-1379) is recognized alongside the legacy `"state_space"` string
- `get_architecture_family()` now falls back to `llm_shared.get_architecture_family()` (MVA-1379) when the model is absent from `context_windows.yaml` or its entry has no `architecture_family` key — enabling the 4-level registry resolution chain (YAML → HuggingFace config.json → pattern-match → default)
- `get_compression_threshold()` now calls the method instead of reading from the entry dict directly, so the registry fallback is applied consistently

## Thinking Path

The existing stub already had the bypass logic wired in `async_should_compress()` and `get_compression_threshold()`, but used `"state_space"` instead of `"ssm"` (the canonical value from `ArchitectureFamily.SSM`) and did not fall back to the `llm_shared` registry for models not in `context_windows.yaml`. MVA-1379 merged before this issue and provides the 4-level family resolution.

## What Changed

- `autobot-backend/context_window_manager.py`: `_NON_TRANSFORMER_FAMILIES` gains `"ssm"`; `_registry_family()` static helper added; `get_architecture_family()` delegates to registry on miss or absent key; `get_compression_threshold()` uses the method not the raw entry
- `autobot-backend/context_window_manager_test.py`: +11 tests for `ssm` family value, registry fallback via `unittest.mock.patch`, and both MVA-1387 acceptance criteria

## Verification

```
35 passed in 0.38s
```

All 35 tests pass including:
- SSM/hybrid model with 128K native context accepts a 50K-token prompt without compression
- Transformer models continue to cap at 8192
- Registry fallback invoked correctly when model absent from YAML or entry has no family key
- Import exception in registry falls back to transformer safely

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)