### PR TITLE
feat(npu): architecture-aware SSM kernel path with NPU_SSM_ENABLED flag (MVA-1383)

### DIFF
--- a/autobot-npu-worker/tests/integration/test_ssm_npu_loading.py
+++ b/autobot-npu-worker/tests/integration/test_ssm_npu_loading.py
@@ -35,7 +35,6 @@ from workers.openvino_dispatch import (  # noqa: E402
 )
 from workers.worker_node import handle_partial_forward  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/autobot-npu-worker/tests/integration/test_ssm_npu_loading.py
+++ b/autobot-npu-worker/tests/integration/test_ssm_npu_loading.py
@@ -1,0 +1,204 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Integration test: SSM model loading on NPU worker with OpenVINO SSM kernel (MVA-1383).
+
+Verifies:
+- NPUWorkerClient.load_model sends architecture_family=ssm for Mamba checkpoints
+- get_inference_engine selects openvino_ssm backend when NPU_SSM_ENABLED=true
+- handle_partial_forward invokes the SSM engine for a Mamba model layer range
+- SSM kernel path is NOT activated when NPU_SSM_ENABLED is unset (default off)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_npu_root = Path(__file__).parent.parent.parent
+_core_path = _npu_root / "core"
+_workers_path = _npu_root / "workers"
+for _p in (_npu_root, _core_path, _workers_path):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from workers.openvino_dispatch import (  # noqa: E402
+    InferenceEngine,
+    UnsupportedArchitectureError,
+    get_inference_engine,
+)
+from workers.worker_node import handle_partial_forward  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MambaLayer:
+    """Minimal SSM-like layer: accumulates a running state vector."""
+
+    def __init__(self, idx: int) -> None:
+        self._idx = idx
+
+    def __call__(self, hidden: Dict[str, Any]) -> Dict[str, Any]:
+        result = dict(hidden)
+        result.setdefault("ssm_layers_run", []).append(self._idx)
+        result["state"] = result.get("state", 0) + self._idx
+        return result
+
+
+class _MambaModelLoader:
+    def __init__(self, num_layers: int = 4) -> None:
+        self._layers = [_MambaLayer(i) for i in range(num_layers)]
+
+    def get_layers(self, model_id: str) -> List[_MambaLayer]:
+        return self._layers
+
+
+# ---------------------------------------------------------------------------
+# Integration: handle_partial_forward with SSM model
+# ---------------------------------------------------------------------------
+
+
+class TestSSMPartialForward:
+    """Verify handle_partial_forward routes Mamba layers through the SSM engine."""
+
+    def test_ssm_kernel_invoked_when_flag_enabled(self):
+        """SSM engine must be selected and all layers run for architecture_family=ssm."""
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "true"}):
+            loader = _MambaModelLoader(num_layers=4)
+            result = handle_partial_forward(
+                model_id="mamba-370m",
+                layer_range=(0, 3),
+                hidden_state_in={"state": 0},
+                model_loader=loader,
+                architecture_family="ssm",
+                device="CPU",
+            )
+
+        assert "hidden_state_out" in result
+        out = result["hidden_state_out"]
+        assert out["ssm_layers_run"] == [0, 1, 2, 3]
+        assert out["state"] == 0 + 1 + 2 + 3  # 6
+
+    def test_ssm_kernel_gated_when_flag_disabled(self):
+        """handle_partial_forward must raise for ssm when flag is off."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NPU_SSM_ENABLED", None)
+            loader = _MambaModelLoader(num_layers=4)
+            with pytest.raises(UnsupportedArchitectureError) as exc_info:
+                handle_partial_forward(
+                    model_id="mamba-370m",
+                    layer_range=(0, 3),
+                    hidden_state_in={"state": 0},
+                    model_loader=loader,
+                    architecture_family="ssm",
+                    device="CPU",
+                )
+            assert exc_info.value.family == "ssm"
+
+    def test_ssm_last_worker_produces_token_ids(self):
+        """When is_last_worker=True, the SSM path must still run argmax for token IDs."""
+        import numpy as np
+
+        class _LogitLayer:
+            def __call__(self, hidden: Any) -> Any:
+                return np.array([0.1, 0.9, 0.2, 0.05])
+
+        class _LogitLoader:
+            def get_layers(self, model_id: str):
+                return [_LogitLayer()]
+
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "true"}):
+            result = handle_partial_forward(
+                model_id="mamba-130m",
+                layer_range=(0, 0),
+                hidden_state_in=None,
+                model_loader=_LogitLoader(),
+                is_last_worker=True,
+                architecture_family="ssm",
+                device="CPU",
+            )
+
+        assert "token_ids" in result
+        assert result["token_ids"] == [1]  # argmax of [0.1, 0.9, 0.2, 0.05]
+
+    def test_transformer_unaffected_when_ssm_flag_on(self):
+        """Enabling NPU_SSM_ENABLED must not change transformer model dispatch."""
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "true"}):
+            loader = _MambaModelLoader(num_layers=4)
+            result = handle_partial_forward(
+                model_id="llama-7b",
+                layer_range=(0, 2),
+                hidden_state_in={"state": 0},
+                model_loader=loader,
+                architecture_family="transformer",
+                device="CPU",
+            )
+        assert "hidden_state_out" in result
+
+
+# ---------------------------------------------------------------------------
+# Integration: NPUWorkerClient load_model for Mamba checkpoint
+# ---------------------------------------------------------------------------
+
+
+class TestMambaCheckpointLoading:
+    """Verify the client sends the correct payload when loading a Mamba checkpoint."""
+
+    def _make_client(self):
+        from npu_integration import NPUWorkerClient
+
+        return NPUWorkerClient(npu_endpoint="http://npu-worker:8001", use_auth=False)
+
+    def _mock_response(self, data: Dict[str, Any]) -> MagicMock:
+        response = AsyncMock()
+        response.__aenter__ = AsyncMock(return_value=response)
+        response.__aexit__ = AsyncMock(return_value=None)
+        response.json = AsyncMock(return_value=data)
+        return response
+
+    @pytest.mark.asyncio
+    async def test_mamba_checkpoint_load_sends_ssm_family(self):
+        """Loading a Mamba model must send architecture_family=ssm in the HTTP payload."""
+        client = self._make_client()
+        captured: List[Dict[str, Any]] = []
+
+        async def fake_post(url, json=None, **kwargs):
+            captured.append({"url": url, "json": json})
+            return self._mock_response({"success": True, "model_id": "mamba-370m"})
+
+        mock_http = MagicMock()
+        mock_http.post = fake_post
+        client._http_client = mock_http
+
+        result = await client.load_model(
+            model_id="mamba-370m",
+            device="NPU",
+            architecture_family="ssm",
+        )
+
+        assert result["success"] is True
+        payload = captured[0]["json"]
+        assert payload["architecture_family"] == "ssm"
+        assert payload["model_id"] == "mamba-370m"
+        assert payload["device"] == "NPU"
+
+    @pytest.mark.asyncio
+    async def test_ssm_engine_selected_for_mamba_model(self):
+        """get_inference_engine must return openvino_ssm for a Mamba model with flag on."""
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "true"}):
+            engine = get_inference_engine("mamba-370m", "ssm", device="NPU")
+
+        assert isinstance(engine, InferenceEngine)
+        assert engine.inference_backend == "openvino_ssm"
+        assert engine.architecture_family == "ssm"
+        assert engine.device == "NPU"
+        assert engine.model_id == "mamba-370m"

--- a/autobot-npu-worker/tests/test_architecture_aware_loading.py
+++ b/autobot-npu-worker/tests/test_architecture_aware_loading.py
@@ -1,19 +1,22 @@
 """
-End-to-end tests for architecture-aware model loading (GH#7352).
+End-to-end tests for architecture-aware model loading (GH#7352, MVA-1383).
 
 Covers:
 - load_model forwards architecture_family in the HTTP payload
 - load_model omits architecture_family when not provided (backward compat)
 - Worker dispatch: transformer family uses openvino_transformer backend
-- Worker dispatch: unsupported family raises UnsupportedArchitectureError
+- Worker dispatch: ssm family uses openvino_ssm backend (NPU_SSM_ENABLED=true)
+- Worker dispatch: ssm family raises UnsupportedArchitectureError when flag off
+- Worker dispatch: unsupported families always raise UnsupportedArchitectureError
 """
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -31,6 +34,7 @@ from openvino_dispatch import (  # noqa: E402
     UnsupportedArchitectureError,
     get_inference_config,
     get_inference_engine,
+    is_npu_ssm_enabled,
 )
 
 # ---------------------------------------------------------------------------
@@ -79,6 +83,77 @@ class TestGetInferenceConfig:
     def test_device_is_forwarded(self):
         cfg = get_inference_config("my-model", "transformer", device="NPU")
         assert cfg["device"] == "NPU"
+
+    # -------------------------------------------------------------------
+    # SSM family — feature flag gating (MVA-1383)
+    # -------------------------------------------------------------------
+
+    def test_ssm_family_raises_when_flag_disabled(self):
+        """ssm must raise UnsupportedArchitectureError when NPU_SSM_ENABLED is off."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NPU_SSM_ENABLED", None)
+            with pytest.raises(UnsupportedArchitectureError) as exc_info:
+                get_inference_config("mamba-370m", "ssm")
+            assert exc_info.value.family == "ssm"
+
+    def test_ssm_family_accepted_when_flag_enabled(self):
+        """ssm must resolve to openvino_ssm backend when NPU_SSM_ENABLED=true."""
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "true"}):
+            cfg = get_inference_config("mamba-370m", "ssm", device="NPU")
+        assert cfg["architecture_family"] == "ssm"
+        assert cfg["inference_backend"] == "openvino_ssm"
+        assert cfg["model_id"] == "mamba-370m"
+        assert cfg["device"] == "NPU"
+
+    def test_ssm_flag_accepts_numeric_one(self):
+        """NPU_SSM_ENABLED=1 must also enable the SSM path."""
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "1"}):
+            cfg = get_inference_config("mamba-130m", "ssm")
+        assert cfg["inference_backend"] == "openvino_ssm"
+
+    def test_ssm_flag_rejects_false_string(self):
+        """NPU_SSM_ENABLED=false must keep the SSM path disabled."""
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "false"}):
+            with pytest.raises(UnsupportedArchitectureError):
+                get_inference_config("mamba-130m", "ssm")
+
+    def test_transformer_unaffected_by_ssm_flag(self):
+        """Enabling NPU_SSM_ENABLED must not change transformer dispatch."""
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "true"}):
+            cfg = get_inference_config("llama-7b", "transformer")
+        assert cfg["inference_backend"] == "openvino_transformer"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: is_npu_ssm_enabled helper
+# ---------------------------------------------------------------------------
+
+
+class TestIsNpuSsmEnabled:
+    def test_disabled_by_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NPU_SSM_ENABLED", None)
+            assert is_npu_ssm_enabled() is False
+
+    def test_enabled_by_true(self):
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "true"}):
+            assert is_npu_ssm_enabled() is True
+
+    def test_enabled_by_1(self):
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "1"}):
+            assert is_npu_ssm_enabled() is True
+
+    def test_enabled_by_yes(self):
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "yes"}):
+            assert is_npu_ssm_enabled() is True
+
+    def test_disabled_by_false(self):
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "false"}):
+            assert is_npu_ssm_enabled() is False
+
+    def test_disabled_by_0(self):
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "0"}):
+            assert is_npu_ssm_enabled() is False
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +229,33 @@ class TestNPUWorkerClientLoadModel:
         assert "architecture_family" not in payload
 
     @pytest.mark.asyncio
+    async def test_load_model_ssm_family_forwards_field(self):
+        """architecture_family=ssm must be forwarded in the POST payload (MVA-1383)."""
+        client = self._make_client()
+        expected_response = {"success": True, "model_id": "mamba-370m"}
+        captured_calls = []
+
+        async def fake_post(url, json=None, **kwargs):
+            captured_calls.append({"url": url, "json": json})
+            return self._mock_response(expected_response)
+
+        mock_http = MagicMock()
+        mock_http.post = fake_post
+        client._http_client = mock_http
+
+        result = await client.load_model(
+            model_id="mamba-370m",
+            device="NPU",
+            architecture_family="ssm",
+        )
+
+        assert result == expected_response
+        payload = captured_calls[0]["json"]
+        assert payload["architecture_family"] == "ssm"
+        assert payload["model_id"] == "mamba-370m"
+        assert payload["device"] == "NPU"
+
+    @pytest.mark.asyncio
     async def test_load_model_unsupported_family_returns_clean_error(self):
         """
         Worker-side: when the HTTP response signals an unsupported architecture,
@@ -166,7 +268,7 @@ class TestNPUWorkerClientLoadModel:
         client = self._make_client()
         worker_error_response = {
             "success": False,
-            "error": "architecture_family 'state_space' is not supported on this OpenVINO worker.",
+            "error": "architecture_family 'ssm' is not supported on this OpenVINO worker.",
             "error_code": "unsupported_architecture",
         }
 
@@ -179,12 +281,12 @@ class TestNPUWorkerClientLoadModel:
 
         result = await client.load_model(
             model_id="mamba-370m",
-            device="CPU",
-            architecture_family="state_space",
+            device="NPU",
+            architecture_family="ssm",
         )
 
         assert result["success"] is False
-        assert "state_space" in result["error"]
+        assert "ssm" in result["error"]
         assert result.get("error_code") == "unsupported_architecture"
 
 
@@ -216,6 +318,39 @@ class TestGetInferenceEngine:
     def test_unsupported_family_raises(self):
         with pytest.raises(UnsupportedArchitectureError):
             get_inference_engine("m", "state_space")
+
+    def test_ssm_raises_when_flag_disabled(self):
+        """SSM path must be gated by NPU_SSM_ENABLED (MVA-1383)."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NPU_SSM_ENABLED", None)
+            with pytest.raises(UnsupportedArchitectureError) as exc_info:
+                get_inference_engine("mamba-370m", "ssm")
+            assert exc_info.value.family == "ssm"
+
+    def test_ssm_engine_accepted_when_flag_enabled(self):
+        """ssm must yield openvino_ssm backend when NPU_SSM_ENABLED=true (MVA-1383)."""
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "true"}):
+            engine = get_inference_engine("mamba-370m", "ssm", device="NPU")
+        assert isinstance(engine, InferenceEngine)
+        assert engine.architecture_family == "ssm"
+        assert engine.inference_backend == "openvino_ssm"
+        assert engine.device == "NPU"
+
+    def test_ssm_engine_invokes_run_layer(self):
+        """SSM engine must invoke run_layer for each layer when forward() called."""
+        invoked_layers = []
+
+        def spy_run_layer(layer, hidden):
+            invoked_layers.append(layer)
+            return layer(hidden)
+
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "true"}):
+            engine = get_inference_engine("mamba-370m", "ssm", run_layer=spy_run_layer)
+
+        layers = [lambda x: x + 1, lambda x: x * 2]  # noqa: E731
+        result = engine.forward(layers, 0)
+        assert result == 2  # (0 + 1) * 2
+        assert len(invoked_layers) == 2
 
     def test_custom_run_layer_is_used(self):
         calls = []

--- a/autobot-npu-worker/workers/openvino_dispatch.py
+++ b/autobot-npu-worker/workers/openvino_dispatch.py
@@ -6,18 +6,22 @@
 Architecture-aware OpenVINO inference dispatcher.
 
 Dispatches model-load and inference requests to the correct OpenVINO code path
-based on the model's architecture_family field (GH#7352).
+based on the model's architecture_family field (GH#7352, MVA-1383).
 
 Supported families track the enum defined in llm_interface_pkg/types.py
-(GH#7347): transformer, state_space, linear_attention, hybrid.
+(GH#7347): transformer, ssm, linear_attention, hybrid.
+
+SSM path (Mamba/S4 models) is gated behind the NPU_SSM_ENABLED env-var
+feature flag (default off until validated in staging).
 """
 
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, FrozenSet, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +31,7 @@ __all__ = [
     "UnsupportedArchitectureError",
     "get_inference_config",
     "get_inference_engine",
+    "is_npu_ssm_enabled",
     "SUPPORTED_FAMILIES",
 ]
 
@@ -35,15 +40,35 @@ class ArchitectureFamily(str, Enum):
     """Architecture families understood by the NPU worker."""
 
     TRANSFORMER = "transformer"
-    STATE_SPACE = "state_space"
+    SSM = "ssm"
     LINEAR_ATTENTION = "linear_attention"
     HYBRID = "hybrid"
 
 
-# Families for which an OpenVINO inference path exists on this worker.
-# state_space / linear_attention / hybrid paths are placeholders until the
-# corresponding OpenVINO SSM kernel work lands (out of scope for GH#7352).
-SUPPORTED_FAMILIES: frozenset[str] = frozenset({ArchitectureFamily.TRANSFORMER})
+def is_npu_ssm_enabled() -> bool:
+    """Return True when the NPU_SSM_ENABLED feature flag is set.
+
+    Reads the NPU_SSM_ENABLED env var at call time so tests can patch it
+    without re-importing the module.  Default is off (False).
+    """
+    return os.environ.get("NPU_SSM_ENABLED", "").lower() in ("1", "true", "yes")
+
+
+def _get_supported_families() -> FrozenSet[str]:
+    """Return the set of currently supported architecture families.
+
+    Computed at call time so the SSM feature flag is respected without a
+    module reload.
+    """
+    families = {ArchitectureFamily.TRANSFORMER}
+    if is_npu_ssm_enabled():
+        families.add(ArchitectureFamily.SSM)
+    return frozenset(families)
+
+
+# Module-level constant exposed for introspection; callers that need runtime
+# accuracy should use _get_supported_families() instead.
+SUPPORTED_FAMILIES: FrozenSet[str] = frozenset({ArchitectureFamily.TRANSFORMER})
 
 
 class UnsupportedArchitectureError(ValueError):
@@ -53,9 +78,9 @@ class UnsupportedArchitectureError(ValueError):
         self.family = family
         super().__init__(
             f"architecture_family '{family}' is not supported on this OpenVINO worker. "
-            f"Supported families: {sorted(SUPPORTED_FAMILIES)}. "
-            "Support for state_space / linear_attention / hybrid requires an OpenVINO "
-            "SSM kernel upgrade — see GH#7352 for the planned follow-up."
+            f"Supported families: {sorted(_get_supported_families())}. "
+            "SSM path requires NPU_SSM_ENABLED=true and validated OpenVINO SSM kernels "
+            "— see GH#7352 / MVA-1383 for details."
         )
 
 
@@ -71,7 +96,7 @@ class InferenceEngine:
         device: Target OpenVINO device (e.g. "CPU", "NPU", "GPU").
         architecture_family: Resolved family string (always lowercase).
         inference_backend: Backend identifier selected by the dispatcher
-            (e.g. "openvino_transformer").
+            (e.g. "openvino_transformer", "openvino_ssm").
         run_layer: Callable that executes one model layer.  Injected at
             construction time; defaults to a direct call so the engine is
             usable without OpenVINO installed (tests, CPU-only workers).
@@ -124,7 +149,7 @@ def get_inference_engine(
 
     Raises:
         UnsupportedArchitectureError: When no inference path exists for the
-            requested family.
+            requested family (including ssm when NPU_SSM_ENABLED is not set).
     """
     cfg = get_inference_config(model_id, architecture_family, device)
     engine = InferenceEngine(
@@ -153,6 +178,7 @@ def get_inference_config(
     Return the OpenVINO inference configuration for a given model and family.
 
     Raises UnsupportedArchitectureError for families without an inference path.
+    The SSM path (family="ssm") is only available when NPU_SSM_ENABLED=true.
 
     Args:
         model_id: Opaque model identifier forwarded to OpenVINO.
@@ -165,12 +191,9 @@ def get_inference_config(
     """
     resolved_family = (architecture_family or ArchitectureFamily.TRANSFORMER).lower()
 
-    if resolved_family not in SUPPORTED_FAMILIES:
+    if resolved_family not in _get_supported_families():
         raise UnsupportedArchitectureError(resolved_family)
 
-    # Currently only the transformer path exists; this branch is where
-    # state_space / linear_attention / hybrid paths will be added when
-    # OpenVINO SSM kernel support lands.
     inference_backend = _select_backend(resolved_family)
 
     logger.debug(
@@ -193,5 +216,8 @@ def _select_backend(family: str) -> str:
     """Map a validated architecture family to an OpenVINO backend identifier."""
     if family == ArchitectureFamily.TRANSFORMER:
         return "openvino_transformer"
-    # Unreachable until SUPPORTED_FAMILIES is expanded, but explicit for clarity.
+    if family == ArchitectureFamily.SSM:
+        return "openvino_ssm"
+    # linear_attention and hybrid are not yet supported; this is unreachable
+    # until SUPPORTED_FAMILIES is expanded for those families.
     raise UnsupportedArchitectureError(family)


### PR DESCRIPTION
## Thinking Path

MVA-1379 added `architecture_family` to model metadata using values `transformer | ssm | linear_attention | hybrid | moe`. This PR activates the OpenVINO SSM kernel path in the NPU worker when `architecture_family == ssm`, gated behind `NPU_SSM_ENABLED` env var (default off).

The existing `ArchitectureFamily.STATE_SPACE = "state_space"` did not match the registry enum; renamed to `SSM = "ssm"` to align with the canonical discriminator defined in MVA-1379/ADR.

## What Changed

- `autobot-npu-worker/workers/openvino_dispatch.py`
  - `ArchitectureFamily.STATE_SPACE` → `ArchitectureFamily.SSM = "ssm"` to match registry enum
  - Added `is_npu_ssm_enabled()` — reads `NPU_SSM_ENABLED` env var at call time (testable, default off)
  - Added `_get_supported_families()` — returns runtime-accurate family set including `ssm` when flag is on
  - `_select_backend("ssm")` → `"openvino_ssm"` kernel path
  - `get_inference_config()` now uses `_get_supported_families()` instead of module-level constant
  - `UnsupportedArchitectureError` message updated with flag name and issue reference
  - Exported `is_npu_ssm_enabled` in `__all__`

- `autobot-npu-worker/tests/test_architecture_aware_loading.py`
  - Added `TestIsNpuSsmEnabled` — 6 cases for env var variants (true/1/yes/false/0/unset)
  - Added 5 SSM flag-aware cases in `TestGetInferenceConfig`
  - Added 3 SSM-specific cases in `TestGetInferenceEngine` including layer invocation check
  - Added `test_load_model_ssm_family_forwards_field` to client payload tests

- `autobot-npu-worker/tests/integration/test_ssm_npu_loading.py` (new)
  - `TestSSMPartialForward`: Mamba layer routing via `handle_partial_forward`, flag-gating, last-worker token_ids
  - `TestMambaCheckpointLoading`: client HTTP payload carries `architecture_family=ssm`, engine selection

## Verification

- 32/32 unit tests pass: `pytest autobot-npu-worker/tests/test_architecture_aware_loading.py`
- Integration assertions verified directly (pytest collection hangs on project-wide `testpaths` — pre-existing limitation)
- All 4 integration scenarios confirmed: flag on/off × SSM/transformer routing

## Model Used

claude-sonnet-4-6

Closes MVA-1383
GH#7352