### PR TITLE
fix(belief-state): truncate ReadFileExtractor hash to 8 chars (MVA-1432)

### DIFF
--- a/autobot-backend/agent_loop/extractors/read_file.py
+++ b/autobot-backend/agent_loop/extractors/read_file.py
@@ -5,7 +5,7 @@ Extractor for read_file tool output (MVA-1407).
 
 Keys produced:
   read_file:{path}:exists   → bool, confidence 1.0
-  read_file:{path}:hash     → str (sha256 hex), confidence 1.0
+  read_file:{path}:hash     → str (sha256 first 8 hex chars), confidence 1.0
 """
 
 from __future__ import annotations
@@ -47,7 +47,7 @@ class ReadFileExtractor:
         else:
             content_bytes = str(content).encode("utf-8")
 
-        content_hash = hashlib.sha256(content_bytes).hexdigest()
+        content_hash = hashlib.sha256(content_bytes).hexdigest()[:8]
         results.append((f"read_file:{path}:hash", content_hash, 1.0))
 
         return results

--- a/autobot-backend/tests/agent_loop/test_belief_state.py
+++ b/autobot-backend/tests/agent_loop/test_belief_state.py
@@ -202,10 +202,11 @@ def test_read_file_extractor_exists_and_hash():
     keys = {k for k, _, _ in items}
     assert "read_file:/tmp/foo.txt:exists" in keys
     assert "read_file:/tmp/foo.txt:hash" in keys
-    expected_hash = hashlib.sha256(content.encode()).hexdigest()
+    expected_hash = hashlib.sha256(content.encode()).hexdigest()[:8]
     for k, v, _ in items:
         if k.endswith(":hash"):
             assert v == expected_hash
+            assert len(v) == 8
 
 
 def test_read_file_extractor_missing():


### PR DESCRIPTION
## Thinking Path

Token regression benchmarked in [MVA-1408](/MVA/issues/MVA-1408) Task 2 showed 17.3% extra tokens caused by 64-char SHA256 digests stored per file read. Truncating to 8 chars (still collision-safe for dedup within a session) eliminates the verbosity at no functional cost.

## What Changed

- `autobot-backend/agent_loop/extractors/read_file.py`: `hexdigest()` → `hexdigest()[:8]`; docstring updated to reflect 8-char value
- `autobot-backend/tests/agent_loop/test_belief_state.py`: `test_read_file_extractor_exists_and_hash` updated to assert `hexdigest()[:8]` and `len(v) == 8`

## Verification

- 22/22 belief-state tests pass locally
- Dedup confirmed: same content → same 8-char prefix → same assertion key → `reconfirm`, not new assertion
- Hash length: 8 chars (≤8 chars AC satisfied)

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)