### PR TITLE
feat(belief-state): add ConfigFileExtractor for YAML/TOML/JSON config key-value extraction

### DIFF
--- a/autobot-backend/agent_loop/extractors/__init__.py
+++ b/autobot-backend/agent_loop/extractors/__init__.py
@@ -9,18 +9,36 @@ The EXTRACTOR_REGISTRY maps tool names to extractor instances.
 
 from __future__ import annotations
 
+from typing import Any
+
+from agent_loop.extractors.config_file import ConfigFileExtractor
 from agent_loop.extractors.read_file import ReadFileExtractor
 from agent_loop.extractors.run_command import RunCommandExtractor
 from agent_loop.extractors.web_search import WebSearchExtractor
 
+
+class _ChainedExtractor:
+    """Run multiple extractors in sequence and merge their results."""
+
+    def __init__(self, *extractors: object) -> None:
+        self._extractors = extractors
+
+    def extract(self, tool_output: Any) -> list[tuple[str, Any, float]]:
+        results: list[tuple[str, Any, float]] = []
+        for extractor in self._extractors:
+            results.extend(extractor.extract(tool_output))  # type: ignore[attr-defined]
+        return results
+
+
 EXTRACTOR_REGISTRY: dict[str, object] = {
-    "read_file": ReadFileExtractor(),
+    "read_file": _ChainedExtractor(ReadFileExtractor(), ConfigFileExtractor()),
     "run_command": RunCommandExtractor(),
     "web_search": WebSearchExtractor(),
 }
 
 __all__ = [
     "EXTRACTOR_REGISTRY",
+    "ConfigFileExtractor",
     "ReadFileExtractor",
     "RunCommandExtractor",
     "WebSearchExtractor",

--- a/autobot-backend/agent_loop/extractors/config_file.py
+++ b/autobot-backend/agent_loop/extractors/config_file.py
@@ -11,7 +11,6 @@ Parses top-level scalar key-value pairs and produces:
 from __future__ import annotations
 
 import json
-import re
 from typing import Any
 
 _CONFIG_EXTENSIONS = {".yml", ".yaml", ".toml", ".json"}
@@ -25,6 +24,7 @@ def _is_config_path(path: str) -> bool:
 def _parse_yaml(content: str) -> dict:
     try:
         import yaml  # type: ignore[import-untyped]
+
         result = yaml.safe_load(content)
         return result if isinstance(result, dict) else {}
     except Exception:

--- a/autobot-backend/agent_loop/extractors/config_file.py
+++ b/autobot-backend/agent_loop/extractors/config_file.py
@@ -1,0 +1,102 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+"""
+Extractor for config file content from read_file tool output (MVA-1433).
+
+Triggered when the file path ends in .yml/.yaml/.toml/.json.
+Parses top-level scalar key-value pairs and produces:
+  config:{path}/{key}  →  value @ confidence 0.9
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+_CONFIG_EXTENSIONS = {".yml", ".yaml", ".toml", ".json"}
+
+
+def _is_config_path(path: str) -> bool:
+    lower = path.lower()
+    return any(lower.endswith(ext) for ext in _CONFIG_EXTENSIONS)
+
+
+def _parse_yaml(content: str) -> dict:
+    try:
+        import yaml  # type: ignore[import-untyped]
+        result = yaml.safe_load(content)
+        return result if isinstance(result, dict) else {}
+    except Exception:
+        return {}
+
+
+def _parse_toml(content: str) -> dict:
+    try:
+        import tomllib  # Python 3.11+
+    except ImportError:
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except ImportError:
+            return {}
+    try:
+        result = tomllib.loads(content)
+        return result if isinstance(result, dict) else {}
+    except Exception:
+        return {}
+
+
+def _parse_json(content: str) -> dict:
+    try:
+        result = json.loads(content)
+        return result if isinstance(result, dict) else {}
+    except Exception:
+        return {}
+
+
+def _parse_config(path: str, content: str) -> dict:
+    lower = path.lower()
+    if lower.endswith(".toml"):
+        return _parse_toml(content)
+    if lower.endswith(".json"):
+        return _parse_json(content)
+    # .yml / .yaml
+    return _parse_yaml(content)
+
+
+class ConfigFileExtractor:
+    """Extract top-level scalar key-value assertions from config file content."""
+
+    CONFIDENCE = 0.9
+
+    def extract(self, tool_output: Any) -> list[tuple[str, Any, float]]:
+        """Return (key, value, confidence) triples for top-level scalars.
+
+        Only fires when the file path ends in a recognised config extension.
+        Malformed or empty files silently return [].
+        """
+        if not isinstance(tool_output, dict):
+            return []
+
+        path = tool_output.get("path") or tool_output.get("file_path") or tool_output.get("filename")
+        if not path or not _is_config_path(str(path)):
+            return []
+
+        if tool_output.get("error"):
+            return []
+
+        content = tool_output.get("content") or tool_output.get("text") or tool_output.get("data")
+        if not isinstance(content, str) or not content.strip():
+            return []
+
+        parsed = _parse_config(str(path), content)
+        if not parsed:
+            return []
+
+        results: list[tuple[str, Any, float]] = []
+        for key, value in parsed.items():
+            if isinstance(value, (str, int, float, bool)):
+                assertion_key = f"config:{path}/{key}"
+                results.append((assertion_key, value, self.CONFIDENCE))
+
+        return results

--- a/autobot-backend/agent_loop/extractors/tests/test_config_file_extractor.py
+++ b/autobot-backend/agent_loop/extractors/tests/test_config_file_extractor.py
@@ -1,0 +1,256 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+"""
+Unit tests for ConfigFileExtractor (MVA-1433).
+
+Covers:
+  - YAML top-level scalar extraction
+  - TOML top-level scalar extraction
+  - JSON top-level scalar extraction
+  - Non-config path → no output
+  - Malformed content → empty list (no exception)
+  - Error field set → empty list
+  - Nested values are skipped (only top-level scalars)
+  - Integration: config contradiction detectable vs run_command port
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_loop.extractors.config_file import ConfigFileExtractor
+
+
+@pytest.fixture
+def extractor() -> ConfigFileExtractor:
+    return ConfigFileExtractor()
+
+
+# ---------------------------------------------------------------------------
+# YAML
+# ---------------------------------------------------------------------------
+
+
+def test_yaml_extracts_top_level_scalars(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/app/config.yaml",
+        "content": "port: 8080\nhost: localhost\ndebug: true\n",
+    }
+    results = extractor.extract(output)
+    keys = {k for k, _, _ in results}
+    assert "config:/app/config.yaml/port" in keys
+    assert "config:/app/config.yaml/host" in keys
+    assert "config:/app/config.yaml/debug" in keys
+
+
+def test_yaml_values_and_confidence(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/app/config.yml",
+        "content": "port: 3000\n",
+    }
+    results = extractor.extract(output)
+    assert len(results) == 1
+    key, value, confidence = results[0]
+    assert key == "config:/app/config.yml/port"
+    assert value == 3000
+    assert confidence == pytest.approx(0.9)
+
+
+def test_yaml_skips_nested_values(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/srv/app.yaml",
+        "content": "port: 8080\ndatabase:\n  host: db\n  port: 5432\n",
+    }
+    results = extractor.extract(output)
+    keys = {k for k, _, _ in results}
+    assert "config:/srv/app.yaml/port" in keys
+    # nested keys must not be extracted
+    assert not any("database" in k for k in keys)
+
+
+def test_yaml_malformed_returns_empty(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/app/config.yaml",
+        "content": "port: [unclosed",
+    }
+    results = extractor.extract(output)
+    assert results == []
+
+
+def test_yaml_non_dict_root_returns_empty(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/app/config.yaml",
+        "content": "- item1\n- item2\n",
+    }
+    results = extractor.extract(output)
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# TOML
+# ---------------------------------------------------------------------------
+
+
+def test_toml_extracts_top_level_scalars(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/app/config.toml",
+        "content": 'port = 9000\nhost = "0.0.0.0"\nenabled = true\n',
+    }
+    results = extractor.extract(output)
+    keys = {k for k, _, _ in results}
+    assert "config:/app/config.toml/port" in keys
+    assert "config:/app/config.toml/host" in keys
+    assert "config:/app/config.toml/enabled" in keys
+
+
+def test_toml_skips_table_sections(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/app/settings.toml",
+        "content": 'port = 8080\n\n[database]\nhost = "db"\n',
+    }
+    results = extractor.extract(output)
+    keys = {k for k, _, _ in results}
+    assert "config:/app/settings.toml/port" in keys
+    assert not any("database" in k for k in keys)
+
+
+def test_toml_malformed_returns_empty(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/app/bad.toml",
+        "content": "port = [[[",
+    }
+    results = extractor.extract(output)
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# JSON
+# ---------------------------------------------------------------------------
+
+
+def test_json_extracts_top_level_scalars(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/etc/app/config.json",
+        "content": '{"port": 8080, "host": "localhost", "debug": false}',
+    }
+    results = extractor.extract(output)
+    keys = {k for k, _, _ in results}
+    assert "config:/etc/app/config.json/port" in keys
+    assert "config:/etc/app/config.json/host" in keys
+    assert "config:/etc/app/config.json/debug" in keys
+
+
+def test_json_skips_nested_objects(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/etc/config.json",
+        "content": '{"port": 8080, "db": {"host": "localhost"}}',
+    }
+    results = extractor.extract(output)
+    keys = {k for k, _, _ in results}
+    assert "config:/etc/config.json/port" in keys
+    assert not any("db" in k for k in keys)
+
+
+def test_json_array_root_returns_empty(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/etc/config.json",
+        "content": '[{"port": 8080}]',
+    }
+    results = extractor.extract(output)
+    assert results == []
+
+
+def test_json_malformed_returns_empty(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/etc/config.json",
+        "content": '{"port": 8080',
+    }
+    results = extractor.extract(output)
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Guard conditions
+# ---------------------------------------------------------------------------
+
+
+def test_non_config_extension_returns_empty(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/app/server.py",
+        "content": "port = 8080\n",
+    }
+    results = extractor.extract(output)
+    assert results == []
+
+
+def test_non_dict_tool_output_returns_empty(extractor: ConfigFileExtractor) -> None:
+    assert extractor.extract("not a dict") == []
+    assert extractor.extract(None) == []
+    assert extractor.extract(42) == []
+
+
+def test_missing_path_returns_empty(extractor: ConfigFileExtractor) -> None:
+    output = {"content": "port: 8080\n"}
+    results = extractor.extract(output)
+    assert results == []
+
+
+def test_error_field_set_returns_empty(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/app/config.yaml",
+        "error": "file not found",
+        "content": "port: 8080\n",
+    }
+    results = extractor.extract(output)
+    assert results == []
+
+
+def test_empty_content_returns_empty(extractor: ConfigFileExtractor) -> None:
+    output = {
+        "path": "/app/config.yaml",
+        "content": "   ",
+    }
+    results = extractor.extract(output)
+    assert results == []
+
+
+def test_alternative_path_fields(extractor: ConfigFileExtractor) -> None:
+    """file_path and filename fields should also trigger extraction."""
+    output_file_path = {
+        "file_path": "/tmp/settings.yaml",
+        "content": "timeout: 30\n",
+    }
+    results = extractor.extract(output_file_path)
+    assert any(k == "config:/tmp/settings.yaml/timeout" for k, _, _ in results)
+
+    output_filename = {
+        "filename": "/tmp/settings.json",
+        "content": '{"timeout": 30}',
+    }
+    results = extractor.extract(output_filename)
+    assert any(k == "config:/tmp/settings.json/timeout" for k, _, _ in results)
+
+
+# ---------------------------------------------------------------------------
+# Contradiction scenario (Task 5 benchmark)
+# ---------------------------------------------------------------------------
+
+
+def test_config_port_contradicts_process_port() -> None:
+    """Config file port 8080 vs run_command port 3000 → values differ.
+
+    This test verifies the raw key produced by ConfigFileExtractor so that
+    BeliefStateUpdater can detect the contradiction when run_command reports
+    a different port via the run_command:port/* key family.
+    """
+    extractor = ConfigFileExtractor()
+    output = {
+        "path": "/app/config.yaml",
+        "content": "port: 8080\n",
+    }
+    results = extractor.extract(output)
+    assert len(results) == 1
+    key, value, confidence = results[0]
+    assert key == "config:/app/config.yaml/port"
+    assert value == 8080
+    assert confidence == pytest.approx(0.9)


### PR DESCRIPTION
## Summary

- Adds `ConfigFileExtractor` that fires when `read_file` output path ends in `.yml`/`.yaml`/`.toml`/`.json`
- Extracts top-level scalar key-value pairs as `config:{path}/{key}` assertions at confidence 0.9
- Integrates via `_ChainedExtractor` on the `read_file` registry entry — `ReadFileExtractor` (exists/hash) and `ConfigFileExtractor` (kv pairs) both run on every `read_file` call
- Enables config contradiction detection (e.g. `port: 8080` in config vs `port: 3000` from process list) as required for Task 5 benchmark [MVA-1408](https://github.com/mrveiss/AutoBot-AI/issues/MVA-1408)

## Thinking Path

`BeliefStateUpdater` looks up one extractor per `tool_name`. Since `read_file` already had a registry entry I introduced `_ChainedExtractor` to fan out to both extractors without changing `BeliefStateUpdater` or coupling the two extractors to each other. `ConfigFileExtractor` is self-contained and only activates on config-extension paths — non-config `read_file` calls add zero overhead.

TOML parsing uses `tomllib` (stdlib in Python 3.11+) with a `tomli` fallback for 3.10.

## What Changed

- `autobot-backend/agent_loop/extractors/config_file.py` — new extractor
- `autobot-backend/agent_loop/extractors/__init__.py` — `_ChainedExtractor`, register `ConfigFileExtractor`
- `autobot-backend/agent_loop/extractors/tests/test_config_file_extractor.py` — 19 unit tests
- `autobot-backend/agent_loop/extractors/tests/__init__.py` — package marker

## Verification

```
pytest autobot-backend/agent_loop/extractors/tests/test_config_file_extractor.py -v
# 19 passed in 1.22s
```

Covers: YAML/TOML/JSON extraction, nested-value skip, malformed content, error guard, missing path, alternative field names, and contradiction scenario.

## Model Used

claude-sonnet-4-6

---

Closes MVA-1433

🤖 Generated with [Claude Code](https://claude.com/claude-code)