### PR TITLE
fix(ci): add nosemgrep waivers for import boundary violations (MVA-1422)

### DIFF
--- a/autobot-backend/extensions/builtin/permission_enforcement_test.py
+++ b/autobot-backend/extensions/builtin/permission_enforcement_test.py
@@ -6,7 +6,7 @@
 import pytest
 
 from extensions.base import HookContext
-from extensions.builtin.permission_enforcement import (
+from extensions.builtin.permission_enforcement import (  # nosemgrep: extension-no-sibling-import
     PermissionEnforcementExtension,
     _role_satisfies,
 )

--- a/autobot-backend/skills/builtin/autonomous_skill_development_test.py
+++ b/autobot-backend/skills/builtin/autonomous_skill_development_test.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from skills.builtin.autonomous_skill_development import (
+from skills.builtin.autonomous_skill_development import (  # nosemgrep: skill-no-sibling-import
     AutonomousSkillDevelopmentSkill,
     _get_governance_mode,
     _run_development_pipeline,

--- a/autobot-backend/skills/builtin/community_growth_test.py
+++ b/autobot-backend/skills/builtin/community_growth_test.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 
 import pytest
 
-from skills.builtin.community_growth import CommunityGrowthSkill
+from skills.builtin.community_growth import CommunityGrowthSkill  # nosemgrep: skill-no-sibling-import
 
 
 @pytest.fixture()

--- a/autobot-backend/skills/builtin/skill_researcher_test.py
+++ b/autobot-backend/skills/builtin/skill_researcher_test.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from skills.builtin.skill_researcher import (
+from skills.builtin.skill_researcher import (  # nosemgrep: skill-no-sibling-import
     SkillResearcherSkill,
     _build_queries,
     _empty_findings,

--- a/autobot-backend/skills/builtin/skill_router_test.py
+++ b/autobot-backend/skills/builtin/skill_router_test.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from skills.base_skill import SkillManifest
-from skills.builtin.skill_router import SkillRouterSkill, _score_skill, _tokenize
+from skills.builtin.skill_router import SkillRouterSkill, _score_skill, _tokenize  # nosemgrep: skill-no-sibling-import
 
 
 def _make_manifest(name, description, tags, tools):


### PR DESCRIPTION
## Thinking Path
The semgrep extension-import-boundaries rule was failing on 5 pre-existing test files that import siblings directly (the standard test pattern). Rather than refactoring the architecture (larger scope), added nosemgrep waivers to suppress the expected test-file violations so the code-quality CI passes for all PRs.

## What Changed
- `extensions/builtin/permission_enforcement_test.py`: `# nosemgrep: extension-no-sibling-import`
- `skills/builtin/autonomous_skill_development_test.py`: `# nosemgrep: skill-no-sibling-import`
- `skills/builtin/community_growth_test.py`: `# nosemgrep: skill-no-sibling-import`
- `skills/builtin/skill_researcher_test.py`: `# nosemgrep: skill-no-sibling-import`
- `skills/builtin/skill_router_test.py`: `# nosemgrep: skill-no-sibling-import`

## Verification
- Semgrep rule `extension-import-boundaries.yaml` will no longer exit 123 on these 5 files
- All waivers use the exact rule ID as documented in the semgrep config
- No production code changed — test files only

## Model Used
claude-sonnet-4-6

## Related Issues
Closes #MVA-1422