### PR TITLE
fix(agent-loop): classify RETRY-class errors as LOW before HIGH check (GH#8649)

### DIFF
--- a/autobot-backend/tests/agent_loop/test_error_severity.py
+++ b/autobot-backend/tests/agent_loop/test_error_severity.py
@@ -36,8 +36,10 @@ def _make_loop(**config_kwargs) -> AgentLoop:
     event_stream.publish = AsyncMock()
     think_tool = MagicMock()
     think_tool.think = AsyncMock(return_value=MagicMock())
+    # Pop before passing so callers can override without a duplicate-keyword error.
+    mandatory_think = config_kwargs.pop("mandatory_think_enabled", False)
     config = AgentLoopConfig(
-        mandatory_think_enabled=False,  # disabled by default; override per-test
+        mandatory_think_enabled=mandatory_think,
         **config_kwargs,
     )
     loop = AgentLoop(event_stream=event_stream, think_tool=think_tool, config=config)

--- a/autobot-backend/utils/error_boundaries/types.py
+++ b/autobot-backend/utils/error_boundaries/types.py
@@ -34,16 +34,19 @@ class ErrorSeverity(Enum):
 def classify_error(error: Exception) -> ErrorSeverity:
     """Return the ErrorSeverity for an exception (GH#6628).
 
-    Precedence: CRITICAL → HIGH → RETRY (LOW) → MEDIUM → else LOW.
+    Precedence: CRITICAL → RETRY (LOW) → HIGH → MEDIUM → else LOW.
     CRITICAL is checked first as a defensive invariant so a future exception that
     subclasses both a RETRY type and a CRITICAL type is never silently downgraded.
+    RETRY must precede HIGH because ConnectionError and TimeoutError are subclasses
+    of OSError (which is in HIGH_SEVERITY_ERROR_TYPES); checking HIGH first would
+    prematurely cap transient network errors at the 1-retry HIGH budget (GH#8649).
     """
     if isinstance(error, CRITICAL_ERROR_TYPES):
         return ErrorSeverity.CRITICAL
-    if isinstance(error, HIGH_SEVERITY_ERROR_TYPES):
-        return ErrorSeverity.HIGH
     if isinstance(error, RETRY_ERROR_TYPES):
         return ErrorSeverity.LOW
+    if isinstance(error, HIGH_SEVERITY_ERROR_TYPES):
+        return ErrorSeverity.HIGH
     if isinstance(error, MEDIUM_SEVERITY_ERROR_TYPES):
         return ErrorSeverity.MEDIUM
     return ErrorSeverity.LOW


### PR DESCRIPTION
## Thinking Path
`classify_error()` had CRITICAL → HIGH → RETRY(LOW) → MEDIUM → LOW precedence. However,
`ConnectionError` and `TimeoutError` are Python subclasses of `OSError`, which is listed
in `HIGH_SEVERITY_ERROR_TYPES`. The HIGH check therefore always matched before the RETRY
check, giving transient network errors the 1-retry HIGH budget instead of the 5-retry LOW
budget — prematurely halting discovery agents on recoverable failures.

The minimal correct fix is to check RETRY_ERROR_TYPES before HIGH_SEVERITY_ERROR_TYPES.
This leaves all other severity mappings unchanged and preserves the CRITICAL-first invariant.

A second bug in the test helper `_make_loop()` caused a duplicate-keyword error when callers
passed `mandatory_think_enabled` via `**config_kwargs`: fixed by popping the key first.

## What Changed
- `autobot-backend/utils/error_boundaries/types.py`: swapped RETRY check before HIGH in
  `classify_error()` so `ConnectionError`/`TimeoutError` → LOW, OSError (non-retry) → HIGH.
  Updated docstring to document the corrected precedence and the reasoning (GH#8649).
- `autobot-backend/tests/agent_loop/test_error_severity.py`: fixed `_make_loop()` helper to
  pop `mandatory_think_enabled` from `config_kwargs` before constructing `AgentLoopConfig`,
  preventing a `TypeError: multiple values for keyword argument` when overriding that flag.

## Verification
```bash
cd autobot-backend
python3 -m pytest tests/agent_loop/test_error_severity.py -v
# Expected: 19 passed, 0 failed
```

All three previously failing tests now pass:
- `TestClassifyError::test_retry_type_is_low` — ConnectionError/TimeoutError → LOW
- `TestCriticalErrorHalts::test_critical_does_not_call_think_tool` — no more duplicate kwarg
- `TestRetryClassBudget::test_network_error_retries_up_to_low_budget` — 5 retries, not 1

## Risks
None identified. The change only reorders two `isinstance` checks within a single function;
no new branches are introduced. CRITICAL still takes precedence over everything, and the
fallthrough `return ErrorSeverity.LOW` is unchanged.

## Model Used
Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link
Closes #MVA-1298

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason)
- [x] Documentation updated if behavior changed
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff