### PR TITLE
fix(coordination): remove spurious type-ignore on AgentBudget (GH#8708, MVA-1351)

### DIFF
--- a/autobot-backend/llc/scheduler/budget_watchdog.py
+++ b/autobot-backend/llc/scheduler/budget_watchdog.py
@@ -42,7 +42,7 @@ class BudgetWatchdog:
     def __init__(self, poll_interval: int = _POLL_INTERVAL_SECONDS) -> None:
         self._poll_interval = poll_interval
         self._running = False
-        self._task: Optional[asyncio.Task] = None  # type: ignore[type-arg]
+        self._task: Optional[asyncio.Task[None]] = None
         self._budget_svc = BudgetService()
 
     def start(self) -> None:


### PR DESCRIPTION
## Thinking Path

`BudgetWatchdog._task` was typed as `Optional[asyncio.Task]` — missing the required type argument — so a `# type: ignore[type-arg]` suppressor was used. The correct type argument is `None` (matching `_loop`'s return annotation), so `asyncio.Task[None]` resolves the error cleanly.

## What Changed

- `autobot-backend/llc/scheduler/budget_watchdog.py`: `Optional[asyncio.Task]  # type: ignore[type-arg]` → `Optional[asyncio.Task[None]]`

## Verification

- `ast.parse` confirms syntax is valid
- No remaining `type: ignore` comments in the file
- One-line diff — no logic change

## Related Issues

Closes #MVA-1351

## Model Used

claude-sonnet-4-6