### PR TITLE
fix(coordination): move WatchError import to module top-level (GH#8707)

### DIFF
--- a/autobot-backend/tests/coordination/test_shared_runtime_bag.py
+++ b/autobot-backend/tests/coordination/test_shared_runtime_bag.py
@@ -16,6 +16,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from redis.exceptions import WatchError
 
 from autobot_shared.coordination.shared_runtime_bag import (
     SharedRuntimeBag,
@@ -59,8 +60,6 @@ class _FakePipeline:
         self._commands.append(("set", key, value, ex))
 
     async def execute(self) -> list[Any]:
-        from redis.exceptions import WatchError
-
         if self._fail_once and not self._failed:
             self._failed = True
             raise WatchError()
@@ -338,8 +337,6 @@ async def test_update_retries_on_watch_error(fake_redis: _FakeRedis) -> None:
 
 @pytest.mark.asyncio
 async def test_update_raises_after_max_retries(fake_redis: _FakeRedis) -> None:
-    from redis.exceptions import WatchError
-
     bag: SharedRuntimeBag[int] = SharedRuntimeBag("ns", int)
     fake_redis._store[_value_key("ns", "counter")] = "5"
 


### PR DESCRIPTION
## Summary

- Moves `from redis.exceptions import WatchError` out of two function bodies (`_FakePipeline.execute` and `test_update_raises_after_max_retries`) and into the module top-level imports in `autobot-backend/tests/coordination/test_shared_runtime_bag.py`
- Follows Python convention — imports belong at module top-level, not deferred inside functions unless lazy-loading is explicitly needed

## Thinking Path

The issue description (GH#8707) identified `WatchError` being imported inside a function body in the test file for `shared_runtime_bag`. There were two separate inline imports; both are eliminated by a single top-level import.

## What Changed

- `autobot-backend/tests/coordination/test_shared_runtime_bag.py`: added `from redis.exceptions import WatchError` at module level; removed two inline `from redis.exceptions import WatchError` statements inside function bodies

## Verification

- Grep confirms only one `WatchError` import remains, at line 19 (module top-level)
- `git diff --stat`: 1 file, 1 insertion, 4 deletions — exactly expected

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)