### PR TITLE
test(a2a): regression test for get_trust_manager() lazy_singleton (MVA-1359)

### DIFF
--- a/autobot-backend/tests/security/test_trust_score_singleton.py
+++ b/autobot-backend/tests/security/test_trust_score_singleton.py
@@ -1,0 +1,32 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Regression tests for get_trust_manager() lazy_singleton pattern (MVA-1359 / GH#8741).
+
+Verifies that get_trust_manager() returns a TrustScoreManager instance (not a
+callable) and that repeated calls return the same object.
+"""
+
+import inspect
+from unittest.mock import patch
+
+from a2a.trust_score import TrustScoreManager, get_trust_manager
+
+
+def test_get_trust_manager_returns_instance_not_callable():
+    """get_trust_manager() must return a TrustScoreManager, not a function."""
+    with patch.object(TrustScoreManager, "__init__", return_value=None):
+        result = get_trust_manager()
+    assert not inspect.isfunction(result), (
+        f"get_trust_manager() returned {type(result).__name__!r}; "
+        "expected TrustScoreManager instance — bare module-level global regression"
+    )
+    assert isinstance(result, TrustScoreManager)
+
+
+def test_get_trust_manager_is_singleton():
+    """Two calls to get_trust_manager() must return the same object."""
+    with patch.object(TrustScoreManager, "__init__", return_value=None):
+        a = get_trust_manager()
+        b = get_trust_manager()
+    assert a is b, "get_trust_manager() must return the same singleton instance on every call"


### PR DESCRIPTION
## Summary

- Verifies `get_trust_manager()` returns a `TrustScoreManager` instance, not a callable — guarding against re-introduction of the bare module-level global
- Verifies repeated calls return the same singleton object
- Follows the established pattern from `tests/memory/test_compat_singletons.py`

## Thinking Path

The `lazy_singleton` fix was already applied in commit `8cf6901e8` (MVA-1270). This PR adds the missing regression test so the CI catches any reversion.

## What Changed

- **New:** `autobot-backend/tests/security/test_trust_score_singleton.py` — two tests: instance type check + singleton identity check

## Verification

- `a2a/trust_score.py:504` confirms `get_trust_manager = lazy_singleton(TrustScoreManager)` is in place
- Test file follows `test_compat_singletons.py` pattern already used for memory managers

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)