### PR TITLE
fix(a2a): migrate trust_score.py from logging.getLogger to get_logger (MVA-1360)

### DIFF
--- a/autobot-backend/a2a/trust_score.py
+++ b/autobot-backend/a2a/trust_score.py
@@ -43,7 +43,6 @@ Usage
 """
 
 import json
-import logging
 import os
 import sqlite3
 import time
@@ -52,10 +51,11 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, Optional, Set
 
+from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 from utils.paths_manager import PathsManager
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Trust levels


### PR DESCRIPTION
## Thinking Path
All other a2a modules (`agent_card.py`, `capability_verifier.py`, `security.py`, `task_executor.py`, `task_manager.py`, `tracing.py`, `self_evaluator.py`) use `from autobot_shared.logging_manager import get_logger` and `logger = get_logger(__name__)`. `trust_score.py` was inconsistently using the stdlib `logging.getLogger(__name__)`. The fix is a straightforward swap to the project-standard `get_logger` — no logic change, just import alignment.

## What Changed
- `autobot-backend/a2a/trust_score.py`: removed `import logging`, added `from autobot_shared.logging_manager import get_logger`, changed `logger = logging.getLogger(__name__)` → `logger = get_logger(__name__)`

## Verification
```bash
# Confirm no stdlib logging.getLogger usage remains in trust_score.py
grep -n "logging.getLogger" autobot-backend/a2a/trust_score.py  # should return nothing

# Confirm get_logger is now used
grep -n "get_logger" autobot-backend/a2a/trust_score.py  # should show import + assignment

# Confirm syntax is valid
python3 -m py_compile autobot-backend/a2a/trust_score.py && echo OK
```

## Risks
None identified. Purely a logger initialisation change; `get_logger(__name__)` returns a standard-compatible logger object and all call sites (`logger.info`, `logger.warning`) remain unchanged.

## Model Used
Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link
Closes #8740

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason) — N/A: logger swap has no observable behaviour change; existing unit tests cover the class
- [x] Documentation updated if behavior changed — N/A
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff