### PR TITLE
feat(npu): add heartbeat reachability check to pulse-probe (MVA-1399)

### DIFF
--- a/autobot-backend/config/npu_pulse_canaries.yaml
+++ b/autobot-backend/config/npu_pulse_canaries.yaml
@@ -21,6 +21,9 @@ defaults:
   latency_window: 20
   # p95 latency must stay within this multiplier of the pool median
   latency_throttle_multiplier: 3.0
+  # MVA-1399: heartbeat reachability — max seconds since last_heartbeat before
+  # treating the worker as unreachable.  0 disables the check entirely.
+  heartbeat_max_silence_seconds: 600  # 2× pulse_interval_seconds
 
 model_families:
   # Small/medium generative models (Gemma, Phi, Mistral, Llama ≤13 B)

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -370,6 +370,47 @@ class NPUWorkerManager(AsyncInitializable):
         mid = len(p95s) // 2
         return p95s[mid] if len(p95s) % 2 else (p95s[mid - 1] + p95s[mid]) / 2
 
+    def _check_heartbeat_reachability(
+        self, worker_id: str, status: NPUWorkerStatus | None
+    ) -> Optional[str]:
+        """Return 'heartbeat_stale' if last_heartbeat exceeds the silence threshold.
+
+        MVA-1399: The pulse-probe correctness check now includes heartbeat
+        reachability — a worker whose last_heartbeat has gone silent beyond
+        heartbeat_max_silence_seconds is classified as unreachable regardless
+        of whether its inference endpoint still responds.
+
+        Returns None when the worker is reachable (or when the check is
+        disabled / no baseline has been established yet).
+        """
+        max_silence = float(self._pulse_defaults.get("heartbeat_max_silence_seconds", 600))
+        if max_silence <= 0:
+            return None
+
+        if status is None or status.last_heartbeat is None:
+            # No heartbeat baseline yet — skip; cannot distinguish a fresh
+            # worker from a silent one until at least one heartbeat arrives.
+            return None
+
+        last_hb = status.last_heartbeat
+        now = now_utc()
+        # Normalise to tz-aware for safe subtraction (last_heartbeat is
+        # written by now_utc() so it should always be tz-aware; guard anyway).
+        if last_hb.tzinfo is None:
+            from datetime import timezone as _tz
+            last_hb = last_hb.replace(tzinfo=_tz.utc)
+
+        silence_s = (now - last_hb).total_seconds()
+        if silence_s > max_silence:
+            logger.warning(
+                "Pulse-probe: heartbeat silent for %.1fs (threshold %.0fs) on worker %s",
+                silence_s,
+                max_silence,
+                worker_id,
+            )
+            return "heartbeat_stale"
+        return None
+
     async def _pulse_check_worker(self, worker_id: str) -> None:
         """Send a canary inference request to verify worker correctness (GH#6739).
 
@@ -388,6 +429,51 @@ class NPUWorkerManager(AsyncInitializable):
         if status and status.status not in (WorkerStatus.ONLINE, WorkerStatus.DEGRADED):
             return
 
+        degrade_k = int(self._pulse_defaults.get("degrade_after_failures", 3))
+        unhealthy_m = int(self._pulse_defaults.get("unhealthy_after_failures", 5))
+        pulse_timeout = float(self._pulse_defaults.get("pulse_timeout_seconds", 30))
+        throttle_mult = float(self._pulse_defaults.get("latency_throttle_multiplier", 3.0))
+
+        # MVA-1399: heartbeat reachability check — runs before the inference
+        # probe so a silent worker fails fast without consuming model resources.
+        heartbeat_failure = self._check_heartbeat_reachability(worker_id, status)
+        if heartbeat_failure:
+            if _PULSE_METRICS_AVAILABLE:
+                _pulse_failure_total.labels(
+                    worker_id=worker_id, model_id="__heartbeat__", failure_class=heartbeat_failure
+                ).inc()
+            consecutive = self._pulse_failure_counts.get(worker_id, 0) + 1
+            self._pulse_failure_counts[worker_id] = consecutive
+            if consecutive >= unhealthy_m:
+                new_status = NPUWorkerStatus(
+                    id=worker_id,
+                    status=WorkerStatus.OFFLINE,
+                    error_message=f"Pulse-probe: heartbeat silent for {consecutive} consecutive checks",
+                )
+                await self._store_and_emit_status(
+                    worker_id, new_status, status.status if status else WorkerStatus.UNKNOWN
+                )
+                logger.error(
+                    "Pulse-probe: worker %s marked OFFLINE — heartbeat silent for %d checks",
+                    worker_id,
+                    consecutive,
+                )
+            elif consecutive >= degrade_k:
+                new_status = NPUWorkerStatus(
+                    id=worker_id,
+                    status=WorkerStatus.DEGRADED,
+                    error_message=f"Pulse-probe: heartbeat silent for {consecutive} consecutive checks",
+                )
+                await self._store_and_emit_status(
+                    worker_id, new_status, status.status if status else WorkerStatus.UNKNOWN
+                )
+                logger.warning(
+                    "Pulse-probe: worker %s marked DEGRADED — heartbeat silent for %d checks",
+                    worker_id,
+                    consecutive,
+                )
+            return
+
         # Pick a model to probe: prefer loaded_models from latest heartbeat, else skip
         model_id = None
         if status and hasattr(status, "error_message"):
@@ -397,11 +483,6 @@ class NPUWorkerManager(AsyncInitializable):
         if client is None:
             client = NPUWorkerClient(worker_config.url)
             self._worker_clients[worker_id] = client
-
-        degrade_k = int(self._pulse_defaults.get("degrade_after_failures", 3))
-        unhealthy_m = int(self._pulse_defaults.get("unhealthy_after_failures", 5))
-        pulse_timeout = float(self._pulse_defaults.get("pulse_timeout_seconds", 30))
-        throttle_mult = float(self._pulse_defaults.get("latency_throttle_multiplier", 3.0))
 
         try:
             models_data = await asyncio.wait_for(client.get_available_models(), timeout=10)

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -370,9 +370,7 @@ class NPUWorkerManager(AsyncInitializable):
         mid = len(p95s) // 2
         return p95s[mid] if len(p95s) % 2 else (p95s[mid - 1] + p95s[mid]) / 2
 
-    def _check_heartbeat_reachability(
-        self, worker_id: str, status: NPUWorkerStatus | None
-    ) -> Optional[str]:
+    def _check_heartbeat_reachability(self, worker_id: str, status: NPUWorkerStatus | None) -> Optional[str]:
         """Return 'heartbeat_stale' if last_heartbeat exceeds the silence threshold.
 
         MVA-1399: The pulse-probe correctness check now includes heartbeat
@@ -398,6 +396,7 @@ class NPUWorkerManager(AsyncInitializable):
         # written by now_utc() so it should always be tz-aware; guard anyway).
         if last_hb.tzinfo is None:
             from datetime import timezone as _tz
+
             last_hb = last_hb.replace(tzinfo=_tz.utc)
 
         silence_s = (now - last_hb).total_seconds()

--- a/autobot-backend/services/npu_worker_manager_pulse_test.py
+++ b/autobot-backend/services/npu_worker_manager_pulse_test.py
@@ -8,8 +8,10 @@ Covers:
 - Consecutive pulse failures → DEGRADED state
 - Continued failures → OFFLINE (unhealthy)
 - Recovery: clean pulse after DEGRADED → ONLINE
+- MVA-1399: Heartbeat reachability — stale last_heartbeat → failure class
 """
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -257,3 +259,141 @@ async def test_get_healthy_workers_sorted_puts_degraded_last(mgr):
     assert len(result) == 2  # OFFLINE excluded
     assert result[0].config.id == "worker-a"
     assert result[1].config.id == "worker-b"
+
+
+# ---------------------------------------------------------------------------
+# MVA-1399: Heartbeat reachability tests
+# ---------------------------------------------------------------------------
+
+
+def _status_with_heartbeat(age_seconds: float, worker_id: str = "test-worker-1") -> NPUWorkerStatus:
+    """Build an ONLINE NPUWorkerStatus whose last_heartbeat is age_seconds old."""
+    last_hb = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+    return NPUWorkerStatus(id=worker_id, status=WorkerStatus.ONLINE, last_heartbeat=last_hb)
+
+
+def test_check_heartbeat_reachability_fresh(mgr):
+    """A heartbeat within the silence window should return None (reachable)."""
+    status = _status_with_heartbeat(age_seconds=60)  # 60 s old, threshold 600 s
+    result = mgr._check_heartbeat_reachability("test-worker-1", status)
+    assert result is None
+
+
+def test_check_heartbeat_reachability_stale(mgr):
+    """A heartbeat older than the threshold should return 'heartbeat_stale'."""
+    status = _status_with_heartbeat(age_seconds=700)  # 700 s > 600 s threshold
+    result = mgr._check_heartbeat_reachability("test-worker-1", status)
+    assert result == "heartbeat_stale"
+
+
+def test_check_heartbeat_reachability_no_baseline(mgr):
+    """A worker with last_heartbeat=None has no baseline — check is skipped."""
+    status = NPUWorkerStatus(id="test-worker-1", status=WorkerStatus.ONLINE, last_heartbeat=None)
+    result = mgr._check_heartbeat_reachability("test-worker-1", status)
+    assert result is None
+
+
+def test_check_heartbeat_reachability_disabled(mgr):
+    """Setting heartbeat_max_silence_seconds to 0 disables the check."""
+    mgr._pulse_defaults["heartbeat_max_silence_seconds"] = 0
+    status = _status_with_heartbeat(age_seconds=9999)
+    result = mgr._check_heartbeat_reachability("test-worker-1", status)
+    assert result is None
+
+
+def test_check_heartbeat_reachability_naive_datetime(mgr):
+    """A tz-naive last_heartbeat is normalised safely; stale naive dt → stale."""
+    naive_old = datetime.utcnow() - timedelta(seconds=700)
+    status = NPUWorkerStatus(id="test-worker-1", status=WorkerStatus.ONLINE, last_heartbeat=naive_old)
+    result = mgr._check_heartbeat_reachability("test-worker-1", status)
+    assert result == "heartbeat_stale"
+
+
+@pytest.mark.asyncio
+async def test_stale_heartbeat_accumulates_failures_toward_degraded(mgr, online_status):
+    """K consecutive stale-heartbeat checks should mark the worker DEGRADED."""
+    worker_id = "test-worker-1"
+    degrade_k = int(mgr._pulse_defaults["degrade_after_failures"])
+    mgr._pulse_defaults["heartbeat_max_silence_seconds"] = 600
+
+    stale_status = _status_with_heartbeat(age_seconds=700)
+    stored_statuses = []
+
+    async def fake_get_status(wid):
+        return stale_status
+
+    async def fake_store_emit(wid, status, prev):
+        stored_statuses.append(status)
+
+    mgr._get_worker_status = fake_get_status
+    mgr._store_and_emit_status = fake_store_emit
+
+    for _ in range(degrade_k):
+        await mgr._pulse_check_worker(worker_id)
+
+    assert mgr._pulse_failure_counts[worker_id] == degrade_k
+    assert stored_statuses[-1].status == WorkerStatus.DEGRADED
+
+
+@pytest.mark.asyncio
+async def test_stale_heartbeat_does_not_invoke_inference(mgr):
+    """A stale-heartbeat short-circuit must not call get_available_models or run_inference."""
+    worker_id = "test-worker-1"
+    mgr._pulse_defaults["heartbeat_max_silence_seconds"] = 600
+
+    stale_status = _status_with_heartbeat(age_seconds=700)
+    client_mock = AsyncMock()
+    mgr._worker_clients[worker_id] = client_mock
+
+    async def fake_get_status(wid):
+        return stale_status
+
+    async def fake_store_emit(wid, status, prev):
+        pass
+
+    mgr._get_worker_status = fake_get_status
+    mgr._store_and_emit_status = fake_store_emit
+
+    await mgr._pulse_check_worker(worker_id)
+
+    client_mock.get_available_models.assert_not_called()
+    client_mock.run_inference.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fresh_heartbeat_proceeds_to_inference(mgr, online_status):
+    """A fresh heartbeat should not short-circuit; inference must be attempted."""
+    worker_id = "test-worker-1"
+    mgr._pulse_defaults["heartbeat_max_silence_seconds"] = 600
+
+    fresh_status = _status_with_heartbeat(age_seconds=60)
+    client_mock = AsyncMock()
+    client_mock.get_available_models = AsyncMock(return_value={"models": ["gemma-3-4b"]})
+    client_mock.run_inference = AsyncMock(return_value={"output": "PULSE_OK"})
+    mgr._worker_clients[worker_id] = client_mock
+
+    async def fake_get_status(wid):
+        return fresh_status
+
+    async def fake_store_emit(wid, status, prev):
+        pass
+
+    async def fake_store_latency(wid, mid, lat):
+        pass
+
+    async def fake_pool_median(mid):
+        return None
+
+    async def fake_p95(wid, mid):
+        return None
+
+    mgr._get_worker_status = fake_get_status
+    mgr._store_and_emit_status = fake_store_emit
+    mgr._store_pulse_latency = fake_store_latency
+    mgr._get_pool_median_latency = fake_pool_median
+    mgr._get_pulse_p95_latency = fake_p95
+
+    await mgr._pulse_check_worker(worker_id)
+
+    client_mock.get_available_models.assert_called_once()
+    client_mock.run_inference.assert_called_once()


### PR DESCRIPTION
## Summary

- Adds `_check_heartbeat_reachability()` to `NPUWorkerManager` that inspects `last_heartbeat` staleness before attempting canary inference
- Stale heartbeat (`heartbeat_stale` failure class) feeds the same K→DEGRADED / M→OFFLINE escalation path as inference failures, short-circuiting the inference call
- New config key `heartbeat_max_silence_seconds` (default 600 s, set to 0 to disable) added to `npu_pulse_canaries.yaml`
- 8 new tests added to `npu_worker_manager_pulse_test.py`; all 13 tests pass

## Thinking Path

NPU workers send periodic heartbeats that update `last_heartbeat` on `NPUWorkerStatus`. The existing pulse-probe checked inference correctness (canary token, latency) but had no awareness of whether the worker was still phoning home. A worker whose inference endpoint is up but whose heartbeat stopped (e.g., a stuck background thread or a partial network partition) was invisible to the probe. This PR adds the guard as an early-exit check so: (a) the diagnosis is fast — no model resources consumed, (b) the existing state-machine semantics are reused without a new code path.

## What Changed

| File | Change |
|---|---|
| `autobot-backend/config/npu_pulse_canaries.yaml` | Add `heartbeat_max_silence_seconds: 600` to defaults |
| `autobot-backend/services/npu_worker_manager.py` | `_check_heartbeat_reachability()` helper; early-exit branch in `_pulse_check_worker` |
| `autobot-backend/services/npu_worker_manager_pulse_test.py` | 8 new tests; `datetime`/`timedelta`/`timezone` imports added |

## Verification

```
pytest autobot-backend/services/npu_worker_manager_pulse_test.py -v
# 13 passed in 0.94 s
```

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)