### PR TITLE
ops(chromadb): standalone service — wire backend dependency and fix health check endpoints (MVA-1445)

### DIFF
--- a/autobot-infrastructure/autobot-backend/templates/autobot-user-backend.service
+++ b/autobot-infrastructure/autobot-backend/templates/autobot-user-backend.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=AutoBot User Backend API
 Documentation=https://github.com/mrveiss/AutoBot-AI
-After=network.target redis.service
-Wants=redis.service
+After=network.target redis.service autobot-chromadb.service
+Wants=redis.service autobot-chromadb.service
 
 [Service]
 Type=simple

--- a/autobot-infrastructure/autobot-database/manifest.yml
+++ b/autobot-infrastructure/autobot-database/manifest.yml
@@ -55,7 +55,7 @@ ports:
     description: "ChromaDB HTTP API (vector store for embeddings)"
 
 health:
-  endpoint: "http://localhost:6379"
+  endpoint: "http://localhost:8100/api/v2/heartbeat"
   interval: "30s"
   timeout: "5s"
   retries: 3

--- a/autobot-infrastructure/autobot-database/templates/db-status.sh
+++ b/autobot-infrastructure/autobot-database/templates/db-status.sh
@@ -38,7 +38,7 @@ echo ""
 echo "ChromaDB (8100):"
 if systemctl is-active --quiet autobot-chromadb 2>/dev/null; then
     echo "  Service: RUNNING"
-    if curl -s "http://127.0.0.1:8100/api/v1/heartbeat" 2>/dev/null | grep -q "nanosecond"; then
+    if curl -s "http://127.0.0.1:8100/api/v2/heartbeat" 2>/dev/null | grep -q "nanosecond"; then
         echo "  Health: HEALTHY"
     else
         echo "  Health: NOT RESPONDING"


### PR DESCRIPTION
## Thinking Path
MVA-1445 decided on standalone ChromaDB service over embedded. The `autobot-chromadb.service` template already existed in the `autobot-database` role — the gaps were: (1) backend had no systemd dependency on ChromaDB so outages were masked, (2) the health check URL used the deprecated v1 API path that returns 404 in chromadb>=1.5.9, (3) the manifest health endpoint pointed at Redis TCP rather than ChromaDB HTTP.

## What Changed
- `autobot-user-backend.service`: Added `autobot-chromadb.service` to `After=` and `Wants=` so systemd starts ChromaDB before the backend
- `db-status.sh`: Fixed ChromaDB heartbeat URL from `/api/v1/heartbeat` → `/api/v2/heartbeat`
- `manifest.yml`: Fixed `health.endpoint` from `http://localhost:6379` (Redis TCP) to `http://localhost:8100/api/v2/heartbeat`

## Verification
- `systemctl status autobot-chromadb` reports `active (running)`
- `curl -s http://127.0.0.1:8100/api/v2/heartbeat` returns `{"nanosecond heartbeat": ...}`
- `./db-status.sh` shows `ChromaDB (8100): Health: HEALTHY`
- Stopping `autobot-chromadb` and restarting backend causes backend to wait/delay instead of starting blind

## Risks
Ansible-only change — no application code touched. Rollback: revert the three file changes. systemd `Wants=` (not `Requires=`) means backend still starts if ChromaDB is unavailable, just with a delay.

## Model Used
Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link
Closes MVA-1445

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (N/A — Ansible/systemd config only)
- [x] Documentation updated if behavior changed (N/A)
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff