### PR TITLE
fix(browser): add AiProposeRegionsResponse to schemas_code.py (MVA-1458)

### DIFF
--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -863,6 +863,12 @@ class SnapshotWithRegionsResponse(BaseModel):
     accessibility_text: str = ""  # ARIA tree rendered as indented text (#5136 Phase 1)
 
 
+class AiProposeRegionsResponse(BaseModel):
+    """Response for POST /playwright/ai-propose-regions."""
+
+    proposed_regions: List[PageRegion]
+
+
 # ---------------------------------------------------------------------------
 # research_browser.py schemas  (Issue #5912)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path
MVA-1380 (PR #8840) added `AiProposeRegionsResponse` usage in `playwright.py` but omitted the class definition from `schemas_code.py`, causing an ImportError at startup and breaking `startup-import-smoke` CI on all open PRs.

## What Changed
- `autobot-backend/api/schemas_code.py`: Added `AiProposeRegionsResponse(BaseModel)` class after `SnapshotWithRegionsResponse`

## Verification
`startup-import-smoke` CI passes after merge. Local check: `python -c 'from api.schemas_code import AiProposeRegionsResponse'`

## Risks
None identified — additive only, no existing code paths changed.

## Model Used
Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link
Closes #MVA-1458

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (N/A — schema addition only)
- [x] Documentation updated if behavior changed (N/A)
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff