### PR TITLE
fix(frontend): reduce vue-tsc errors from 239 back to baseline 188 (MVA-1451)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -236,7 +236,7 @@
                 :stroke-dasharray="segment.dashArray"
                 :stroke-dashoffset="segment.offset"
                 class="segment"
-                :style="{ animationDelay: `${index * 100}ms` }"
+                :style="{ animationDelay: `${(index as number) * 100}ms` }"
               />
               <!-- Center text -->
               <text x="100" y="95" text-anchor="middle" class="center-value">

--- a/autobot-frontend/src/components/artifact-cells/ChartCell.vue
+++ b/autobot-frontend/src/components/artifact-cells/ChartCell.vue
@@ -178,8 +178,8 @@ const renderChart = async () => {
     if (prefersReducedMotion.value) {
       spec.config = {
         ...(spec.config as Record<string, unknown>),
-        mark: { ...(spec.config as Record<string, unknown>)?.mark, animationDuration: 0 },
-        axis: { ...(spec.config as Record<string, unknown>)?.axis, minExtent: 30 }
+        mark: { ...((spec.config as Record<string, unknown>)?.mark as Record<string, unknown>), animationDuration: 0 },
+        axis: { ...((spec.config as Record<string, unknown>)?.axis as Record<string, unknown>), minExtent: 30 }
       }
     }
 

--- a/autobot-frontend/src/components/canvas/ChartCell.vue
+++ b/autobot-frontend/src/components/canvas/ChartCell.vue
@@ -129,6 +129,7 @@ async function renderChart() {
 
   try {
     const embed = await loadVegaEmbed()
+    if (!embed) return
 
     // Apply prefers-reduced-motion: disable animations
     const spec = { ...chartSpec.value } as any

--- a/autobot-frontend/src/components/chat/ChatInput.vue
+++ b/autobot-frontend/src/components/chat/ChatInput.vue
@@ -360,6 +360,8 @@ const submitOverseerQuery = inject<(query: string) => Promise<boolean>>('submitO
 const store = useChatStore()
 const controller = useChatController()
 
+const messageText = ref('')
+
 // GH#4449: Slash command preset autocomplete
 const {
   suggestions: slashSuggestions,
@@ -390,7 +392,6 @@ const fileInput = ref<HTMLInputElement>()
 const emojiPicker = ref<HTMLElement>()
 
 // State
-const messageText = ref('')
 const attachedFiles = ref<File[]>([])
 const isInputFocused = ref(false)
 const isVoiceRecording = ref(false)

--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -409,7 +409,7 @@ const handleDesktopError = (err: Error | unknown) => {
   logger.error('Desktop connection error:', err)
   loading.value = false
   connectionStatus.value = 'Error'
-  error.value = t('desktop.interface.errorVncConnection', { error: error.value.message || error })
+  error.value = t('desktop.interface.errorVncConnection', { error: error.value?.message || error })
 }
 
 const handleDesktopTimeout = () => {

--- a/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
@@ -1,6 +1,6 @@
 <template>
-  <div v-if="visible" class="dialog-overlay" @click="closeDialog" tabindex="0" @keyup.enter="$event.target.click()" @keyup.space="$event.target.click()">
-    <div class="knowledge-dialog" @click.stop tabindex="0" @keyup.enter="$event.target.click()" @keyup.space="$event.target.click()">
+  <div v-if="visible" class="dialog-overlay" @click="closeDialog" tabindex="0" @keyup.enter="$event.target?.click()" @keyup.space="$event.target?.click()">
+    <div class="knowledge-dialog" @click.stop tabindex="0" @keyup.enter="$event.target?.click()" @keyup.space="$event.target?.click()">
       <!-- Header -->
       <div class="dialog-header">
         <h3 class="dialog-title">{{ $t('knowledge.persistence.title') }}</h3>

--- a/autobot-frontend/src/components/profile/ProfileModal.stories.ts
+++ b/autobot-frontend/src/components/profile/ProfileModal.stories.ts
@@ -20,7 +20,7 @@ export const Default: Story = {
   args: {
     isOpen: true
   },
-  render: (args) => ({
+  render: (args: any) => ({
     components: { ProfileModal },
     setup() {
       return { args };
@@ -41,7 +41,7 @@ export const Closed: Story = {
   args: {
     isOpen: false
   },
-  render: (args) => ({
+  render: (args: any) => ({
     components: { ProfileModal },
     setup() {
       return { args };
@@ -62,7 +62,7 @@ export const WithBackdrop: Story = {
   args: {
     isOpen: true
   },
-  render: (args) => ({
+  render: (args: any) => ({
     components: { ProfileModal },
     setup() {
       return { args };

--- a/autobot-frontend/src/components/workflow/PhaseProgressionIndicator.vue
+++ b/autobot-frontend/src/components/workflow/PhaseProgressionIndicator.vue
@@ -199,7 +199,8 @@ async function loadValidationData(): Promise<void> {
       const overview = data.report.system_overview
       systemMaturity.value = overview?.overall_maturity ?? 0
 
-      phases.value = (data.report.phase_details ?? []).map((p) => ({
+      type PhaseDetail = NonNullable<NonNullable<typeof data.report>['phase_details']>[number]
+      phases.value = (data.report.phase_details ?? []).map((p: PhaseDetail) => ({
         name: p.display_name ?? p.name ?? t('workflow.phaseProgression.unknownPhase'),
         completion_percentage: p.completion_percentage ?? 0,
         status:

--- a/autobot-frontend/src/composables/useKnowledgeVectorization.ts
+++ b/autobot-frontend/src/composables/useKnowledgeVectorization.ts
@@ -27,6 +27,7 @@ interface VectorizationStatusResponse {
 interface VectorizationJobResponse {
   job_id?: string
   status?: string
+  results?: Array<{ id: string; status: string; error?: string }>
   [key: string]: unknown
 }
 

--- a/autobot-frontend/src/types/workflowTemplates.ts
+++ b/autobot-frontend/src/types/workflowTemplates.ts
@@ -30,7 +30,7 @@ import type {
   WorkflowStepStatus,
   RiskLevel,
 } from './_generated/workflow'
-export type { PromptSpec, WorkflowTask, WorkflowPlan, WorkflowStepStatus, RiskLevel }
+export type { PromptSpec, WorkflowTask, WorkflowPlan, RiskLevel }
 
 /**
  * Static template step — matches backend `_template_step_dict()` from

--- a/autobot-frontend/src/views/llc/KanbanBoardView.vue
+++ b/autobot-frontend/src/views/llc/KanbanBoardView.vue
@@ -140,6 +140,7 @@ interface WorkItem {
   story_points: number | null
   assignee_name: string | null
   assignee_type: 'human' | 'agent' | null
+  sprint_id: string | null
   column_id: string
   status: string
   labels: string[]

--- a/autobot-frontend/src/views/llc/SprintBoardView.vue
+++ b/autobot-frontend/src/views/llc/SprintBoardView.vue
@@ -136,6 +136,7 @@ interface WorkItem {
   assignee_name: string | null
   column_id: string
   status: string
+  sprint_id: string | null
   labels: string[]
   acceptance_criteria: string[]
   description: string

--- a/autobot-frontend/tsconfig.app.json
+++ b/autobot-frontend/tsconfig.app.json
@@ -6,7 +6,12 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "skipLibCheck": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "vue": ["./node_modules/vue"],
+      "pinia": ["./node_modules/pinia"],
+      "@xterm/xterm": ["./node_modules/@xterm/xterm"],
+      "@xterm/addon-fit": ["./node_modules/@xterm/addon-fit"],
+      "@xterm/addon-web-links": ["./node_modules/@xterm/addon-web-links"]
     }
   }
 }


### PR DESCRIPTION
## Thinking Path

CI's \`check-ts-delta.sh\` script was failing on all PRs (including Dependabot #8882) because local \`vue-tsc --noEmit -p tsconfig.app.json\` reported **239 errors** against the **188 baseline** in \`docs/developer/audits/typescript-baseline.md\`. Detected during MVA-1449 CI health check (2026-05-28). The regressions were introduced incrementally: missing \`tsconfig.app.json\` path mappings causing module resolution failures, plus TypeScript null-safety gaps across 12 files.

The fix is two-pronged: (1) add explicit path mappings for `vue`, `pinia`, and `@xterm/*` packages so tsc resolves them correctly; (2) fix the null-safety regressions identified by the resulting clean error output.

## What Changed

- `autobot-frontend/tsconfig.app.json` — add path mappings for `vue`, `pinia`, `@xterm/xterm`, `@xterm/addon-fit`, `@xterm/addon-web-links`
- `CodeReviewDashboard.vue` — explicit `(index as number)` cast in `animationDelay` style binding
- `ChartCell.vue` (artifact-cells) — double-cast `spec.config` spread to `Record<string, unknown>` for mark/axis properties
- `ChartCell.vue` (canvas) — add `if (!embed) return` null guard after `loadVegaEmbed()`
- `ChatInput.vue` — hoist `messageText = ref('')` declaration before first reference
- `DesktopInterface.vue` — optional chain `error.value?.message` (was bare `.message` on potentially null ref)
- `KnowledgePersistenceDialog.vue` — optional chain `$event.target?.click()` in keyup handlers
- `ProfileModal.stories.ts` — type `render` callback argument as `args: any` (StoryObj pattern)
- `PhaseProgressionIndicator.vue` — annotate map callback parameter with `PhaseDetail` type alias
- `useKnowledgeVectorization.ts` — add `results` field to `VectorizationJobResponse` interface
- `workflowTemplates.ts` — remove stale `WorkflowStepStatus` re-export (already exported from generated type file directly)
- `KanbanBoardView.vue` + `SprintBoardView.vue` — add `sprint_id: string | null` to `WorkItem` interface

## Verification

```bash
cd autobot-frontend
npx vue-tsc --noEmit -p tsconfig.app.json 2>&1 | tail -3
# Expected: Found 188 errors.
```

Verified locally: exactly 188 errors — matches baseline in `docs/developer/audits/typescript-baseline.md`.

## Risks

- `WorkflowStepStatus` re-export removal: the type is still exported directly from `types/_generated/workflow`. Any import `from 'types/workflowTemplates'` would need to switch to the generated file, but grep shows no such callers.
- All other changes are additive (new fields, null guards, type casts) — no functional behaviour change.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Closes #MVA-1451

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (N/A — pure type-check fixes, no runtime logic changed)
- [x] Documentation updated if behavior changed (N/A)
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff