### PR TITLE
fix(a2a): trust audit SQLite defaults to persistent AUTOBOT_BASE_DIR path (GH#8742)

### DIFF
--- a/autobot-backend/a2a/trust_score.py
+++ b/autobot-backend/a2a/trust_score.py
@@ -53,7 +53,7 @@ from typing import Dict, Optional, Set
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
-from utils.paths_manager import PathsManager
+from autobot_shared.ssot_config import config
 
 logger = get_logger(__name__)
 
@@ -206,7 +206,7 @@ def _default_trust_audit_db() -> Path:
     env_override = os.environ.get("AUTOBOT_TRUST_AUDIT_DB")
     if env_override:
         return Path(env_override)
-    return PathsManager.get_data_path("a2a_trust_audit.db")
+    return config.data_path / "a2a_trust_audit.db"
 
 
 _SQLITE_DB_DEFAULT = _default_trust_audit_db()


### PR DESCRIPTION
## Thinking Path

`PathsManager.get_data_path` falls back to `PROJECT_ROOT / "data"` — a path relative to the codebase install location. In containerised or systemd deployments where the app directory is ephemeral, this silently loses audit records on restart. The fix replaces it with `config.data_path` from `autobot_shared.ssot_config`, which resolves `AUTOBOT_BASE_DIR/data/` (default `/opt/autobot/data/`), the same mechanism used by `skills/db.py`.

## What Changed

- `autobot-backend/a2a/trust_score.py`
  - Import: `from utils.paths_manager import PathsManager` → `from autobot_shared.ssot_config import config`
  - `_default_trust_audit_db()`: `PathsManager.get_data_path("a2a_trust_audit.db")` → `config.data_path / "a2a_trust_audit.db"`
  - `AUTOBOT_TRUST_AUDIT_DB` env override preserved unchanged

## Verification

- Tests in `trust_score_test.py` already pass an explicit `sqlite_path=tmp_path / "audit.db"` fixture — no changes needed and they continue to pass.
- `config.data_path` is `@property` resolving `AUTOBOT_BASE_DIR/data` (`/opt/autobot/data` by default); verified against `ssot_config.py:1104`.
- Matches `skills/db.py` pattern exactly (`base = config.base_dir; db_path = os.path.join(base, "data", ...)`).

## Model Used

claude-sonnet-4-6

Fixes GH#8742