### PR TITLE
fix(backend): restore correct audit_middleware import — unblocks smoke-test CI (MVA-1466)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1745,7 +1745,7 @@ def create_lifespan_manager():
         logger.info("🧵 Bounded thread pool configured (max %d workers)", MAX_WORKER_THREADS)
 
         # Register the running event loop for sync-endpoint audit scheduling (#1568)
-        from autobot_backend.audit_middleware import set_main_event_loop
+        from middleware.audit_middleware import set_main_event_loop
 
         set_main_event_loop(asyncio.get_running_loop())
 


### PR DESCRIPTION
## Thinking Path
Smoke-test CI was failing across all PRs with `ModuleNotFoundError: No module named 'autobot_backend'` in `initialization/lifespan.py:1748`. Investigation via failure-log artifact (run 26572931286) traced the import to `from autobot_backend.audit_middleware import set_main_event_loop`. All other audit_middleware callsites use the correct relative path `from middleware.audit_middleware import ...`. `git pickaxe` identified PR #7426 (2026-05-16) as the commit that introduced the wrong import. One-line revert fixes the startup crash.

## What Changed
- `autobot-backend/initialization/lifespan.py:1748`: Changed import from `autobot_backend.audit_middleware` (nonexistent under PYTHONPATH) to `middleware.audit_middleware` (correct path)

## Verification
- `smoke-test` CI passes on this PR
- `hardened-smoke-test` CI passes on this PR
- Backend container reaches healthy state (no `ModuleNotFoundError` at startup)

## Risks
None — single-line import correction, reverts a regression. All other audit_middleware callsites already use the correct path.

## Model Used
Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link
Closes MVA-1466

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (N/A — import fix only)
- [x] Documentation updated if behavior changed (N/A)
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff