### PR TITLE
fix(frontend): extend ESLint no-console override to all service workers and scripts (GH#8896)

### DIFF
--- a/autobot-frontend/eslint.config.ts
+++ b/autobot-frontend/eslint.config.ts
@@ -146,7 +146,15 @@ export default defineConfigWithVueTs(
   {
     // Service workers run in a separate runtime context with no access to createLogger.
     name: 'app/console-allowed-in-service-worker',
-    files: ['public/service-worker.ts'],
+    files: ['public/service-worker.ts', 'public/service-worker.js', 'public/sw-cache-bust.js'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
+  {
+    // Build/check scripts and test fixtures run in Node.js, not the app bundle.
+    name: 'app/console-allowed-in-scripts',
+    files: ['scripts/**/*.{ts,js,mjs,mts}', 'scripts/**/__tests__/**'],
     rules: {
       'no-console': 'off',
     },


### PR DESCRIPTION
## Summary

- The previous fix (bc0f2e1f, #8899) only exempted `public/service-worker.ts` from the `no-console` rule
- This extends the override to the remaining files still failing CI:
  - `public/service-worker.js` (line 317)
  - `public/sw-cache-bust.js` (lines 29, 39, 52, 80, 118, 137, 157, 176, 186, 199, 203, 206)
  - `scripts/**/*.{ts,js,mjs}` (covers `check-i18n-keys.mjs` lines 144-146 and test fixtures)

Service workers have no access to the app's `createLogger` utility; scripts/build tools run outside the app bundle. `console.*` is appropriate in both contexts.

## Test plan

- [ ] `npm run lint` passes in `autobot-frontend/`
- [ ] CI `frontend-tests` check passes on `Dev_new_gui`
- [ ] Unblocks dependabot PR #8882 from merging

Closes the remaining gap from GH#8896.