### PR TITLE
chore(deps): bump tmp 0.2.5→0.2.7 in autobot-frontend

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -13537,9 +13537,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- Bumps `tmp` from 0.2.5 to 0.2.7 in `autobot-frontend`
- Clean cherry-pick from dependabot PR #8882 onto Dev_new_gui

## Why not PR #8882?

PR #8882 had 1769 changed files due to branch divergence from an old `main` base. This clean PR contains only the actual package change (1 file, 3 lines).

The `qs` bumps from #8882 were already present in Dev_new_gui.

Closes #8882

## Thinking Path

Dependabot opened #8882 to bump `tmp` 0.2.5→0.2.7. The PR had 1769 changed files because it was based on an old `main` branch rather than `Dev_new_gui`. Rather than fixing the branch divergence, I cherry-picked only the actual `tmp` version change into a clean PR targeting `Dev_new_gui`. The `qs` bumps from #8882 were already present in `Dev_new_gui`, so only the `tmp` bump was missing. This approach gives CI a minimal, reviewable diff.

## What Changed

- `autobot-frontend/package-lock.json`: bumped `tmp` from 0.2.5 to 0.2.7 (1 file, 3 lines changed)

## Verification

- CI workflows on `Dev_new_gui` already use Node.js 22 (no ESM/CJS extension issues)
- Package lock diff confirmed to contain only `tmp` version change
- PR #8882 (original dependabot PR) closed in favour of this clean PR

## Model Used

claude-sonnet-4-6