### PR TITLE
fix(ansible): remove dead backend symlink task (#8905)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -305,15 +305,6 @@
   changed_when: false
   tags: ['backend', 'deploy']
 
-- name: Create backend symlink for imports
-  ansible.builtin.file:
-    src: "{{ backend_code_dir }}"
-    dest: "{{ backend_install_dir }}/backend"
-    state: link
-    force: true
-    owner: "{{ backend_user }}"
-    group: "{{ backend_group }}"
-
 # Issue #912: Deploy error catalog so it is always available on the VM.
 # path_constants.py resolves PROJECT_ROOT as 3 levels up from constants/,
 # putting CONFIG_DIR at /opt/autobot/infrastructure/shared/config/ which is


### PR DESCRIPTION
## Thinking Path

The `Create backend symlink for imports` Ansible task in `autobot-slm-backend/ansible/roles/backend/tasks/main.yml` created a self-referential symlink: `{{ backend_install_dir }}/backend → {{ backend_code_dir }}` (i.e., pointing a subdirectory back to the parent install directory). This was added historically to support `from autobot_backend.X import ...` style imports, but PR #8901 already corrected the one remaining caller to `from middleware.audit_middleware import ...`.

Two additional signals confirm the task is dead:
1. No Python file imports through this path — grepping the codebase finds zero `from autobot_backend.` or `import autobot_backend.` references in the backend source.
2. `update-all-nodes.yml` already contains a `Remove legacy backend symlink` task, meaning the symlink was known to be legacy — yet `main.yml` kept re-creating it on every deploy. Removing the creation task ends that contradiction.

The fix is a pure deletion: no new logic, no replacement needed.

## What Changed

- `autobot-slm-backend/ansible/roles/backend/tasks/main.yml`: removed the 9-line `Create backend symlink for imports` task (lines 308–316 pre-change) that ran `ansible.builtin.file` to create a symlink at `{{ backend_install_dir }}/backend` pointing to `{{ backend_code_dir }}`

## Verification

1. Run the backend Ansible role against a staging node: all tasks should complete green with no errors on the symlink task (it no longer exists).
2. After deploy, confirm no `ModuleNotFoundError: No module named 'autobot_backend'` in `/var/log/autobot/backend-error.log`.
3. `curl http://127.0.0.1:8001/api/health` returns 200 — the backend is still importable without the symlink.
4. Grep confirms zero callers: `grep -r "from autobot_backend\." autobot-slm-backend/ --include="*.py"` returns empty.

## Risks

None identified. The symlink was never imported by Python code, its removal counterpart already exists in `update-all-nodes.yml`, and PR #8901 fixed the last real import path.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Closes #8905

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason) — N/A: Ansible task removal, no unit test surface
- [x] Documentation updated if behavior changed — N/A
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff