### PR TITLE
fix(visual): increase Storybook regression timeout for 1154 stories (MVA-1467)

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -64,7 +64,7 @@ jobs:
   visual-regression:
     name: Storybook visual regression
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 180
 
     steps:
       - name: Checkout code

--- a/autobot-frontend/playwright.visual.config.ts
+++ b/autobot-frontend/playwright.visual.config.ts
@@ -29,9 +29,9 @@ export default defineConfig({
   reporter: process.env.CI ? 'github' : [['html', { open: 'never' }]],
 
   // The single test in storybook-stories.spec.ts loops through every
-  // discovered story (one iframe load + screenshot per story). With 226 stories
-  // at ~3-5s each = ~680-1130s, we budget 30 minutes per project for headroom.
-  timeout: 1_800_000,
+  // discovered story (one iframe load + screenshot per story). With 1154 stories
+  // at ~3-5s each = ~3462-5770s, we budget 150 minutes per project for headroom.
+  timeout: 9_000_000,
 
   // Snapshot baselines live next to the tests, organized per project (light/dark)
   // and OS to avoid cross-platform rendering noise and theme conflicts.


### PR DESCRIPTION
## Thinking Path
The Storybook visual regression CI job was failing after 62 minutes because the Playwright per-test timeout was sized for 226 stories (the original count), but we now have 1154 story exports. At ~5s per story snapshot, each project (chromium-light + chromium-dark) needs ~96 minutes — well past the old 30-min per-test timeout and 70-min job limit.

## What Changed
- `playwright.visual.config.ts`: Increased timeout from 1,800,000ms (30 min) to 9,000,000ms (150 min)
- `.github/workflows/visual-regression.yml`: Increased job `timeout-minutes` from 70 to 180 (3h)

## Verification
Storybook visual regression CI passes on this PR without timing out.

## Risks
Longer CI job window (up to 3h instead of 70 min). Acceptable trade-off given the 5x growth in story count. If stories grow further, a separate sharding strategy should be considered.

## Model Used
Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link
Closes MVA-1467

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (N/A — timeout config only)
- [x] Documentation updated if behavior changed (N/A)
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff