### PR TITLE
fix(ansible): add slm_node_id to localhost.yml single-host inventory (#8909)

### DIFF
--- a/autobot-slm-backend/ansible/inventory/localhost.yml
+++ b/autobot-slm-backend/ansible/inventory/localhost.yml
@@ -10,6 +10,7 @@ all:
       ansible_user: "{{ lookup('env', 'USER') }}"
       ansible_become: true
       ansible_become_method: sudo
+      slm_node_id: "00-SLM-Manager"
 
   children:
     # Single-host: all groups map to localhost


### PR DESCRIPTION
## Thinking Path

The \`slm_agent\` role asserts \`slm_node_id\` is defined on every host it runs against. \`provision-fleet-roles.yml\` uses \`hosts: all\`, which includes \`localhost\` in single-host deployments. Multi-host inventory (\`slm-nodes.yml\`) already defines \`slm_node_id\` per node, but the single-host equivalent (\`inventory/localhost.yml\`) was missing it — causing the assertion task to fail on fresh single-host installs.

## What Changed

- \`inventory/localhost.yml\`: added \`slm_node_id: "00-SLM-Manager"\` to the \`localhost\` host vars, matching the convention already used in \`slm-nodes.yml\`

## Verification

- \`./install.sh --reinstall\` passes the \`slm_agent | Validate required variables\` task without error
- Full install completes with all tasks green
- Multi-host deployments are unaffected (their per-node \`slm_node_id\` values remain in \`slm-nodes.yml\`)

## Model Used

claude-sonnet-4-6

Closes #8909

🤖 Generated with Claude Code