### PR TITLE
fix(ci): fix Docker smoke-test disk-full and hardened chromadb failures (MVA-1470)

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -47,28 +47,30 @@ jobs:
         run: |
           docker buildx build \
             --cache-from type=local,src=/tmp/.buildx-cache \
-            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=min \
             --file docker/backend/Dockerfile \
             --tag autobot/backend:latest \
             --load \
             .
           docker buildx build \
             --cache-from type=local,src=/tmp/.buildx-cache \
-            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=min \
             --file docker/slm/Dockerfile \
             --tag autobot/slm:latest \
             --load \
             .
           docker buildx build \
             --cache-from type=local,src=/tmp/.buildx-cache \
-            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=min \
             --file docker/frontend/Dockerfile \
             --tag autobot/frontend:latest \
             --load \
             .
-          # Rotate cache so next run gets the freshest layers
+          # Rotate cache so next run gets the freshest layers (mode=min keeps only
+          # final exported layers; mode=max kept all intermediate layers and exhausted disk)
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          df -h
 
       - name: Start services with Docker Compose
         run: docker compose --env-file docker/.env.docker up -d

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6.0.2
 
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
 

--- a/.github/workflows/hardened-smoke-test.yml
+++ b/.github/workflows/hardened-smoke-test.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6.0.2
 
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
 

--- a/.github/workflows/hardened-smoke-test.yml
+++ b/.github/workflows/hardened-smoke-test.yml
@@ -59,27 +59,28 @@ jobs:
         run: |
           docker buildx build \
             --cache-from type=local,src=/tmp/.buildx-cache \
-            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=min \
             --file docker/backend/Dockerfile \
             --tag autobot/backend:latest \
             --load \
             .
           docker buildx build \
             --cache-from type=local,src=/tmp/.buildx-cache \
-            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=min \
             --file docker/slm/Dockerfile \
             --tag autobot/slm:latest \
             --load \
             .
           docker buildx build \
             --cache-from type=local,src=/tmp/.buildx-cache \
-            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=min \
             --file docker/frontend/Dockerfile \
             --tag autobot/frontend:latest \
             --load \
             .
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          df -h
 
       - name: Start services with hardened overlay
         run: |

--- a/docker-compose.hardened.yml
+++ b/docker-compose.hardened.yml
@@ -75,7 +75,10 @@ services:
     tmpfs:
       - /tmp
       - /var/run
-      - /chroma
+    # NOTE: /chroma intentionally omitted — mounting it as tmpfs shadows
+    # chromadb/log_config.yml that the image bundles at /chroma/chromadb/.
+    # The chroma_data named volume (base compose) already provides write
+    # access to /chroma/chroma where persistent data is stored.
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary

- Reclaims ~14 GB on GitHub-hosted runners before Docker builds by removing dotnet, android, ghc, and CodeQL tool-cache (fixes disk-full failures)
- Removes `/chroma` from tmpfs in `docker-compose.hardened.yml` — the tmpfs was shadowing the bundled `chromadb/log_config.yml`, causing uvicorn to exit immediately; the `chroma_data` named volume already covers the writes needed

## Test plan

- [ ] `smoke-test` job passes without disk-full error on next PR targeting `Dev_new_gui`
- [ ] `hardened-smoke-test` job shows `autobot-chromadb` healthy
- [ ] No regression to base compose (only hardened file changed for chromadb fix)

Closes #8909 (follow-up from [MVA-1475](/MVA/issues/MVA-1475))

## Thinking Path

`smoke-test` and `hardened-smoke-test` jobs were failing with two independent root causes:

1. **Disk-full on GitHub-hosted runners** — `df -h` before Docker builds showed <2 GB free after the runner image pre-installs dotnet, android, ghc, and CodeQL caches. Docker layer writes exhaust the remaining space. Solution: add a `Free disk space` step to both CI jobs that removes these unused caches (~14 GB recovered) before any Docker operation.

2. **ChromaDB container unhealthy in hardened compose** — `docker-compose.hardened.yml` mounted `/chroma` as a tmpfs volume. This shadowed the `/chroma` directory inside the container where `chromadb/log_config.yml` lives. On startup, ChromaDB's uvicorn process couldn't find its logging config and exited immediately. The `chroma_data` named volume already handles the data path; removing the tmpfs entry restores the bundled config visibility.

## What Changed

- `.github/workflows/smoke-test.yml`: added `Free disk space` step (removes dotnet, android, ghc, CodeQL tool-cache) before Docker Buildx setup in both `smoke-test` and `hardened-smoke-test` jobs
- `docker-compose.hardened.yml`: removed the `/chroma` tmpfs volume entry from the `chromadb` service

## Verification

- CI logs confirmed `No space left on device` errors in Docker layer writes before this fix
- ChromaDB healthcheck failure traced to missing `log_config.yml` — confirmed by container exit code and uvicorn startup traceback
- The `chroma_data` named volume in the base compose covers all data writes; removing tmpfs does not lose data persistence

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)