### PR TITLE
improvement(ci): add disk-space threshold guard and composite action for smoke-test cleanup (GH#8914)

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,53 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Composite action: Free disk space + threshold guard (GH#8914)
+#
+# Removes large pre-installed toolchains that are unused by AutoBot CI, then
+# asserts that at least MIN_FREE_GB of disk space is available. Fails fast
+# before Docker builds begin, producing a clear error rather than an opaque
+# "no space left on device" inside buildx logs.
+#
+# Usage:
+#   - uses: ./.github/actions/free-disk-space
+#     with:
+#       min-free-gb: '10'   # optional, default 10
+
+name: Free Disk Space
+description: >
+  Remove unused pre-installed toolchains and assert a minimum free-disk
+  threshold so Docker builds fail fast with a clear message rather than
+  opaque buildx "no space left on device" errors.
+
+inputs:
+  min-free-gb:
+    description: 'Minimum free disk space in GB required after cleanup. Fails the step if not met.'
+    required: false
+    default: '10'
+
+runs:
+  using: composite
+  steps:
+    - name: Remove unused toolchains
+      shell: bash
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        df -h
+
+    - name: Assert minimum free disk space
+      shell: bash
+      env:
+        MIN_FREE_GB: ${{ inputs.min-free-gb }}
+      run: |
+        # Available KB on the root filesystem
+        avail_kb=$(df --output=avail / | tail -1)
+        avail_gb=$(( avail_kb / 1024 / 1024 ))
+        echo "Available disk space: ${avail_gb} GB (minimum required: ${MIN_FREE_GB} GB)"
+        if [ "${avail_gb}" -lt "${MIN_FREE_GB}" ]; then
+          echo "ERROR: Insufficient disk space: ${avail_gb} GB available, ${MIN_FREE_GB} GB required."
+          echo "       Docker builds would fail mid-run with 'no space left on device'."
+          df -h
+          exit 1
+        fi
+        echo "OK: ${avail_gb} GB >= ${MIN_FREE_GB} GB — disk space check passed."

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -25,9 +25,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          df -h
+        uses: ./.github/actions/free-disk-space
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4

--- a/.github/workflows/hardened-smoke-test.yml
+++ b/.github/workflows/hardened-smoke-test.yml
@@ -28,9 +28,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          df -h
+        uses: ./.github/actions/free-disk-space
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -150,8 +150,8 @@ jobs:
           echo "Phase validation passed: ${MATURITY}% >= ${THRESHOLD}%"
         else
           echo "::error::Phase validation below threshold: ${MATURITY}% < ${THRESHOLD}%"
-          echo "## Phase Validation Below Threshold" >> $GITHUB_STEP_SUMMARY
-          echo "Current maturity (${MATURITY}%) is below threshold (${THRESHOLD}%)" >> $GITHUB_STEP_SUMMARY
+          echo "## Phase Validation Below Threshold" >> "$GITHUB_STEP_SUMMARY"
+          echo "Current maturity (${MATURITY}%) is below threshold (${THRESHOLD}%)" >> "$GITHUB_STEP_SUMMARY"
           exit 1
         fi
 
@@ -245,12 +245,12 @@ jobs:
 
         if (( $(echo "$MATURITY >= 70" | bc -l) )); then
           echo "System ready for integration (${MATURITY}%)"
-          echo "## Integration Ready" >> $GITHUB_STEP_SUMMARY
-          echo "System maturity: ${MATURITY}% - Ready for integration testing" >> $GITHUB_STEP_SUMMARY
+          echo "## Integration Ready" >> "$GITHUB_STEP_SUMMARY"
+          echo "System maturity: ${MATURITY}% - Ready for integration testing" >> "$GITHUB_STEP_SUMMARY"
         else
           echo "::error::System not ready for integration (${MATURITY}%)"
-          echo "## Integration Not Ready" >> $GITHUB_STEP_SUMMARY
-          echo "System maturity: ${MATURITY}% - Additional development required" >> $GITHUB_STEP_SUMMARY
+          echo "## Integration Not Ready" >> "$GITHUB_STEP_SUMMARY"
+          echo "System maturity: ${MATURITY}% - Additional development required" >> "$GITHUB_STEP_SUMMARY"
           exit 1
         fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,11 @@ jobs:
           NEXT_VERSION="${{ steps.version.outputs.version }}"
           if [ -z "$NEXT_VERSION" ]; then
             echo "No version bump needed (no conventional commits since last tag)"
-            echo "release_needed=false" >> $GITHUB_OUTPUT
+            echo "release_needed=false" >> "$GITHUB_OUTPUT"
           else
             echo "Next version: $NEXT_VERSION"
-            echo "release_needed=true" >> $GITHUB_OUTPUT
-            echo "version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+            echo "release_needed=true" >> "$GITHUB_OUTPUT"
+            echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Generate release notes (git-cliff)
@@ -98,8 +98,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md "changelog/${VERSION}.md" changelog/
-          git diff --staged --quiet && echo "No changelog changes" || \
+          if git diff --staged --quiet; then
+            echo "No changelog changes"
+          else
             git commit -m "chore(release): changelog and fragments for ${VERSION}"
+          fi
           git tag -a "${VERSION}" -m "Release ${VERSION}"
           git push origin main --follow-tags
 


### PR DESCRIPTION
## Summary

- Extracts the duplicated "Free disk space" inline step from `docker-smoke-test.yml` and `hardened-smoke-test.yml` into a new reusable composite action at `.github/actions/free-disk-space/`.
- The composite action runs in two sub-steps: (1) removes unused pre-installed toolchains (`/usr/share/dotnet`, `/usr/local/lib/android`, `/opt/ghc`, `/opt/hostedtoolcache/CodeQL`) and prints `df -h`; (2) asserts that ≥ 10 GB of free space is available on `/` and fails with a clear human-readable error if not. This prevents opaque `no space left on device` failures buried inside buildx logs.
- The threshold input (`min-free-gb`, default `10`) is passed to the shell via an `env:` block, not via direct `${{ inputs.* }}` interpolation in `run:`, to avoid shell injection.
- Also fixes pre-existing SC2086/SC2015 shellcheck violations in `phase_validation.yml` and `release.yml` surfaced by actionlint.

## Thinking Path

1. Identified duplicated free-disk-space steps in both smoke-test workflows.
2. Extracted into a composite action with a configurable threshold input passed via `env:` (not inline expression) to prevent shell injection.
3. Added a threshold guard step that asserts ≥ min-free-gb before builds start, with a clear error message.
4. On CI run, actionlint surfaced pre-existing SC2086 (unquoted `$GITHUB_STEP_SUMMARY`/`$GITHUB_OUTPUT` redirects) and SC2015 (`A && B || C` pattern) in unrelated workflow files — fixed those in the same PR since they block the lint gate.

## What Changed

- `.github/actions/free-disk-space/action.yml` — new composite action with `remove-toolchains` and `assert-threshold` steps
- `.github/workflows/docker-smoke-test.yml` — replaced inline free-disk-space step with `uses: ./.github/actions/free-disk-space`
- `.github/workflows/hardened-smoke-test.yml` — same replacement
- `.github/workflows/phase_validation.yml` — quote `$GITHUB_STEP_SUMMARY` in 4 redirect targets (SC2086)
- `.github/workflows/release.yml` — quote `$GITHUB_OUTPUT` in 3 redirect targets (SC2086); rewrite `A && B || C` as `if/else` (SC2015)
- `autobot-slm-backend/ansible/inventory/localhost.yml` — (rebased from Dev_new_gui, no additional changes)

## Verification

- CI `Validate PR template sections`: passes on latest run
- `SSOT Configuration Compliance`: pass
- `Security Compliance Check`: pass
- `smoke-test` and `hardened-smoke-test`: in progress (composite action exercised directly)
- `lint` (actionlint): expected to pass after SC2086/SC2015 fixes
- All fixes are mechanical quoting changes with no logic impact

## Model Used

claude-sonnet-4-6 (SeniorCodeArchitect / Paperclip MVA-1486 CodeReviewer heartbeat)

## Test plan

- [x] CI runs `docker-smoke-test.yml` and `hardened-smoke-test.yml` on this PR — both should pass with the new composite action step visible in the logs
- [ ] Confirm "Remove unused toolchains" and "Assert minimum free disk space" appear as distinct sub-steps in the Actions run
- [ ] Verify the threshold check prints `OK: N GB >= 10 GB — disk space check passed.`

## References

- Closes [MVA-1485](/MVA/issues/MVA-1485)
- GH#8914 (tracking issue)
- PR #8912 (introduced the original free-disk-space step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)