### PR TITLE
fix(backend): resolve startup crash from AutoBotConfig.get() AttributeError (MVA-1489)

### DIFF
--- a/autobot-backend/onboarding/doctor.py
+++ b/autobot-backend/onboarding/doctor.py
@@ -98,8 +98,8 @@ async def run_doctor() -> dict[str, Any]:
 
     # Build service probe targets from env / defaults (no hardcoded IPs)
     ollama_base = config.ollama_url
-    chromadb_host = config.chromadb_host
-    chromadb_port = int(config.chromadb_port)
+    chromadb_host = config.vm.chromadb
+    chromadb_port = config.port.chromadb
 
     ollama_reachable, ollama_detail = await _probe_http(f"{ollama_base}/api/tags")
     chromadb_reachable, chromadb_detail = await _probe_http(f"http://{chromadb_host}:{chromadb_port}/api/v1/heartbeat")

--- a/autobot-backend/security_layer.py
+++ b/autobot-backend/security_layer.py
@@ -18,7 +18,7 @@ import yaml
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
-from config import config as global_config_manager
+from config import get_config_manager
 from constants.network_constants import NetworkConstants
 
 logger = get_logger(__name__)
@@ -34,7 +34,7 @@ class SecurityLayer:
     def __init__(self):
         """Initialize security layer with config, role permissions, and audit logging."""
         # Use centralized config manager instead of direct file loading
-        self.security_config = global_config_manager.get("security_config", {})
+        self.security_config = get_config_manager().get("security_config", {})
 
         # Check for single-user mode (development/personal use)
         self.single_user_mode = config.single_user_mode.lower() in BOOLEAN_TRUE_VALUES

--- a/autobot-backend/utils/async_chromadb_client.py
+++ b/autobot-backend/utils/async_chromadb_client.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 
 # Issue #3094: Use SSOT config port so the default (8100) matches Ansible deployment.
 # Host remains os.getenv-based: empty string = use local PersistentClient (dev mode).
-_CHROMADB_HOST = _ssot_config.chromadb_host
+_CHROMADB_HOST = _ssot_config.vm.chromadb
 _CHROMADB_PORT = _ssot_config.port.chromadb
 
 logger = get_logger(__name__)


### PR DESCRIPTION
## Thinking Path

`security_layer.py` does `from config import config as global_config_manager`. The `config/__init__.py` explicitly re-exports `config` from `autobot_shared.ssot_config` at module level (line 37), so this resolves to `AutoBotConfig` — not `ConfigManager`. The `__getattr__` backward-compat alias on the module is shadowed by this explicit import.

`AutoBotConfig` has no `.get()` method; its custom `__getattr__` (ssot_config.py:1894) delegates to sub-configs, but none of them expose `.get()`, so it raises `AttributeError: AutoBotConfig object has no attribute 'get'` and aborts startup.

For the secondary issue: `chromadb_host` doesn't exist as a flat attribute on `AutoBotConfig`. The correct path is `config.vm.chromadb` (`VMConfig.chromadb` field aliased to `AUTOBOT_CHROMADB_HOST`).

## What Changed

- **`autobot-backend/security_layer.py`**: Replaced `from config import config as global_config_manager` with `from config import get_config_manager`. Changed `global_config_manager.get("security_config", {})` to `get_config_manager().get("security_config", {})`.
- **`autobot-backend/onboarding/doctor.py`**: Changed `config.chromadb_host` → `config.vm.chromadb` and `config.chromadb_port` → `config.port.chromadb`.
- **`autobot-backend/utils/async_chromadb_client.py`**: Changed `_ssot_config.chromadb_host` → `_ssot_config.vm.chromadb`.

## Verification

- Confirmed `config/__init__.py` line 37 explicitly imports `config` from `autobot_shared.ssot_config`, shadowing the `__getattr__` backward-compat alias that would return `ConfigManager`.
- Confirmed `AutoBotConfig.__getattr__` raises `AttributeError` for unknown attrs not found in sub-configs (including `.get()`).
- Confirmed `VMConfig` has `chromadb: str` at line 109 (alias `AUTOBOT_CHROMADB_HOST`) and `PortConfig` has `chromadb: int` at line 132 (alias `AUTOBOT_CHROMADB_PORT`).

## Test Plan

- [ ] Backend starts without `AttributeError: AutoBotConfig object has no attribute 'get'` in `security_layer.py`
- [ ] `smoke-test` and `hardened-smoke-test` CI runs pass
- [ ] ChromaDB health checks in `doctor.py` correctly probe `config.vm.chromadb:config.port.chromadb`
- [ ] `async_chromadb_client.py` module loads without `AttributeError` on import

## Model Used

claude-sonnet-4-6

## Related Issues

Closes #MVA-1489