### PR TITLE
fix(backend): security_layer.py:40 — bool.lower() crash on single_user_mode

### DIFF
--- a/autobot-backend/security_layer.py
+++ b/autobot-backend/security_layer.py
@@ -37,7 +37,7 @@ class SecurityLayer:
         self.security_config = get_config_manager().get("security_config", {})
 
         # Check for single-user mode (development/personal use)
-        self.single_user_mode = config.single_user_mode.lower() in BOOLEAN_TRUE_VALUES
+        self.single_user_mode = str(config.single_user_mode).lower() in BOOLEAN_TRUE_VALUES
 
         # If single-user mode is enabled, disable all authentication
         # Issue #745: Added security warning for production awareness


### PR DESCRIPTION
## Summary

- Fixes `AttributeError: 'bool' object has no attribute 'lower'` at `security_layer.py:40`
- `config.single_user_mode` is typed `bool` (Pydantic converts the env var); calling `.lower()` on it crashes
- Replaces `.lower() in BOOLEAN_TRUE_VALUES` with `str(...).lower() in BOOLEAN_TRUE_VALUES` — handles both `bool` and `str` inputs, preventing a potential auth-bypass if Pydantic coercion is bypassed (`bool("false")` is `True` in Python)

## What Changed

- `autobot-backend/security_layer.py:40`: `config.single_user_mode.lower()` → `str(config.single_user_mode).lower()`

## Thinking Path

The original crash was that Pydantic already converts `AUTOBOT_SINGLE_USER_MODE` env var to a Python `bool`, so `.lower()` was called on a `bool`. Simple `bool(config.single_user_mode)` would work for the happy path but could silently enable single-user mode (disabling auth) if someone passed a non-empty falsy string and Pydantic coercion was bypassed. `str(...).lower() in BOOLEAN_TRUE_VALUES` is the safe approach: correctly handles `True`→`"true"`, `False`→`"false"`, and any string representation.

## Verification

- `str(True).lower() in {"true","1","yes"}` → `True` ✓
- `str(False).lower() in {"true","1","yes"}` → `False` ✓
- No `.lower()` called on a bare `bool` ✓
- Follows up on [MVA-1489](/MVA/issues/MVA-1489) / PR #8918 (partial fix that missed line 40)

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)