### PR TITLE
fix(backend): replace AutoBotConfig.get() with get_config_manager() in chat_history/base.py (GH#8929)

### DIFF
--- a/autobot-backend/chat_history/base.py
+++ b/autobot-backend/chat_history/base.py
@@ -18,7 +18,7 @@ from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.ssot_config import config as _ssot_config
-from config import config as global_config_manager
+from config import get_config_manager
 from context_window_manager import ContextWindowManager
 from encryption_service import get_encryption_service, is_encryption_enabled
 
@@ -56,7 +56,7 @@ class ChatHistoryBase:
             redis_host: Optional override for Redis host
             redis_port: Optional override for Redis port
         """
-        data_config = global_config_manager.get("data", {})
+        data_config = get_config_manager().get("data", {})
 
         self.history_file = history_file or data_config.get(
             "chat_history_file",
@@ -199,7 +199,7 @@ class ChatHistoryBase:
 
     def _get_chats_directory(self) -> str:
         """Get the chats directory path from configuration."""
-        data_config = global_config_manager.get("data", {})
+        data_config = get_config_manager().get("data", {})
         return data_config.get(
             "chats_directory",
             _ssot_config.misc.chats_directory or "data/chats",


### PR DESCRIPTION
## Summary

- **Critical production fix** — autobot-backend workers crash-looping; port 8001 never binds
- `chat_history/base.py` called `global_config_manager.get("data", {})` where `global_config_manager` resolves to `AutoBotConfig` (via `ssot_config._ConfigProxy`), which has no `.get()` method
- `AttributeError: 'AutoBotConfig' object has no attribute 'get'` raised in lifespan startup, killing all 4 uvicorn workers before they bind
- Fix: use `get_config_manager().get(...)` — same pattern as MVA-1489 (`security_layer.py`, commit `a1912d698`)

## Root Cause

```
File "chat_history/base.py", line 59, in _load_config_values
    data_config = global_config_manager.get("data", {})
AttributeError: 'AutoBotConfig' object has no attribute 'get'
```

`from config import config` re-exports `AutoBotConfig` proxy, not `ConfigManager`. `ConfigManager` is the class with `.get()`.

## Test plan

- [ ] `systemctl restart autobot-backend` succeeds and port 8001 binds
- [ ] `curl http://localhost:8001/api/health` returns 200
- [ ] No `AutoBotConfig.get()` `AttributeError` in `/var/log/autobot/backend-error.log`

Fixes GH#8929 (blocks MVA-1544)

🤖 Generated with [Claude Code](https://claude.com/claude-code)