### PR TITLE
fix(security): replace hardcoded audit log fallback with env-var resolver (MVA-1558 / GH#8929)

### DIFF
--- a/autobot-backend/enhanced_security_layer.py
+++ b/autobot-backend/enhanced_security_layer.py
@@ -24,6 +24,25 @@ from secure_command_executor import CommandRisk, SecureCommandExecutor, Security
 
 logger = get_logger(__name__)
 
+# Audit log file path resolved from AUTOBOT_AUDIT_LOG_FILE env var at import time.
+# Set AUTOBOT_AUDIT_LOG_FILE to override the default path.
+_AUDIT_LOG_FILE_DEFAULT = "/opt/autobot/logs/audit.log"
+
+
+def _resolve_audit_log_file() -> str:
+    """Return audit log file path from AUTOBOT_AUDIT_LOG_FILE env var with logged fallback."""
+    value = config.audit_log_file
+    if not value:
+        logger.warning(
+            "AUTOBOT_AUDIT_LOG_FILE is not set or empty; falling back to %s",
+            _AUDIT_LOG_FILE_DEFAULT,
+        )
+        return _AUDIT_LOG_FILE_DEFAULT
+    return value
+
+
+_AUDIT_LOG_FILE = _resolve_audit_log_file()
+
 # Performance optimization: O(1) lookup for security checks (Issue #326)
 DEPRECATED_PRIVILEGED_ROLES = {"god", "superuser", "root"}
 HIGH_RISK_COMMAND_RISKS = {CommandRisk.HIGH, CommandRisk.MODERATE}
@@ -67,11 +86,7 @@ class EnhancedSecurityLayer:
         self.security_config = global_config_manager.get("security_config", {})
         self.enable_auth = self.security_config.get("enable_auth", False)
         self.enable_command_security = self.security_config.get("enable_command_security", True)
-        self.audit_log_file = (
-            self.security_config.get("audit_log_file")
-            or config.audit_log_file
-            or "/opt/autobot/logs/audit.log"
-        )
+        self.audit_log_file = self.security_config.get("audit_log_file") or _AUDIT_LOG_FILE
         self.roles = self.security_config.get("roles", {})
         self.allowed_users = self.security_config.get("allowed_users", {})
 

--- a/autobot-backend/security_layer.py
+++ b/autobot-backend/security_layer.py
@@ -23,6 +23,25 @@ from constants.network_constants import NetworkConstants
 
 logger = get_logger(__name__)
 
+# Audit log file path resolved from AUTOBOT_AUDIT_LOG_FILE env var at import time.
+# Set AUTOBOT_AUDIT_LOG_FILE to override the default path.
+_AUDIT_LOG_FILE_DEFAULT = "/opt/autobot/logs/audit.log"
+
+
+def _resolve_audit_log_file() -> str:
+    """Return audit log file path from AUTOBOT_AUDIT_LOG_FILE env var with logged fallback."""
+    value = config.audit_log_file
+    if not value:
+        logger.warning(
+            "AUTOBOT_AUDIT_LOG_FILE is not set or empty; falling back to %s",
+            _AUDIT_LOG_FILE_DEFAULT,
+        )
+        return _AUDIT_LOG_FILE_DEFAULT
+    return value
+
+
+_AUDIT_LOG_FILE = _resolve_audit_log_file()
+
 # Performance optimization: O(1) lookup for boolean string values (Issue #326)
 BOOLEAN_TRUE_VALUES = {"true", "1", "yes"}
 
@@ -53,11 +72,7 @@ class SecurityLayer:
             self.enable_auth = self.security_config.get("enable_auth", True)
             logger.info("Multi-user mode - authentication enabled by default")
 
-        self.audit_log_file = (
-            self.security_config.get("audit_log_file")
-            or config.audit_log_file
-            or "/opt/autobot/logs/audit.log"
-        )
+        self.audit_log_file = self.security_config.get("audit_log_file") or _AUDIT_LOG_FILE
         self.roles = self.security_config.get("roles", {})
         self.allowed_users = self.security_config.get("allowed_users", {})  # For simple demo auth
 


### PR DESCRIPTION
## Thinking Path

GH#8923 / MVA-1503 guarded against empty `audit_log_file` at runtime but left the hardcoded fallback string in place. The canonical fix (issue #6743) is a module-level constant resolved from an env var with a logged WARNING fallback — the same pattern used in `chat_history/cache.py`. Both `SecurityLayer` and `EnhancedSecurityLayer` had identical hardcoded paths, so both are fixed together.

## What Changed

- `autobot-backend/security_layer.py`: added `_AUDIT_LOG_FILE_DEFAULT`, `_resolve_audit_log_file()` resolver, `_AUDIT_LOG_FILE` module-level constant; replaced inline hardcoded fallback
- `autobot-backend/enhanced_security_layer.py`: identical change for `EnhancedSecurityLayer.__init__`

## Summary

Replaces hardcoded `/opt/autobot/logs/audit.log` fallback path in `SecurityLayer` and `EnhancedSecurityLayer.__init__` with a module-level constant resolved from `AUTOBOT_AUDIT_LOG_FILE` env var (via `config.audit_log_file`) with a logged fallback, following the pattern established in `chat_history/cache.py` (issue #6743).

Closes #8929

## Verification

- [x] `python3 -m py_compile autobot-backend/security_layer.py` → OK
- [x] `python3 -m py_compile autobot-backend/enhanced_security_layer.py` → OK
- [x] SSOT Configuration Compliance check: SUCCESS
- [x] Security Compliance Check: SUCCESS
- [x] startup-import-smoke: SUCCESS

## Model Used

claude-sonnet-4-6