### PR TITLE
fix(npu-worker): wire get_inference_config into load_model for early architecture validation (GH#8690)

### DIFF
--- a/autobot-npu-worker/core/npu_integration.py
+++ b/autobot-npu-worker/core/npu_integration.py
@@ -32,6 +32,16 @@ _backend_path = _project_root / "autobot-backend"
 if str(_backend_path) not in sys.path:
     sys.path.insert(0, str(_backend_path))
 
+# Workers path for openvino_dispatch (GH#8690)
+_workers_path = Path(__file__).parent.parent / "workers"
+if str(_workers_path) not in sys.path:
+    sys.path.insert(0, str(_workers_path))
+
+try:
+    from workers.openvino_dispatch import UnsupportedArchitectureError, get_inference_config
+except ImportError:
+    from openvino_dispatch import UnsupportedArchitectureError, get_inference_config  # type: ignore[no-redef]
+
 try:
     from autobot_shared.http_client import HTTPClientManager, get_http_client
     from constants.threshold_constants import LLMDefaults, TimingConstants
@@ -286,6 +296,21 @@ class NPUWorkerClient:
                 One of "transformer", "state_space", "linear_attention", "hybrid".
                 Defaults to "transformer" on the worker side when omitted.
         """
+        if architecture_family is not None:
+            try:
+                get_inference_config(model_id, architecture_family, device)
+            except UnsupportedArchitectureError as exc:
+                logger.warning(
+                    "load_model rejected unsupported architecture_family=%s for model=%s: %s",
+                    architecture_family,
+                    model_id,
+                    exc,
+                )
+                return {
+                    "success": False,
+                    "error": str(exc),
+                    "error_code": "unsupported_architecture",
+                }
         try:
             http_client = await self._get_http_client()
             payload: Dict[str, Any] = {"model_id": model_id, "device": device}

--- a/autobot-npu-worker/tests/test_architecture_aware_loading.py
+++ b/autobot-npu-worker/tests/test_architecture_aware_loading.py
@@ -230,7 +230,7 @@ class TestNPUWorkerClientLoadModel:
 
     @pytest.mark.asyncio
     async def test_load_model_ssm_family_forwards_field(self):
-        """architecture_family=ssm must be forwarded in the POST payload (MVA-1383)."""
+        """architecture_family=ssm must be forwarded in the POST payload when NPU_SSM_ENABLED=true (MVA-1383)."""
         client = self._make_client()
         expected_response = {"success": True, "model_id": "mamba-370m"}
         captured_calls = []
@@ -243,11 +243,12 @@ class TestNPUWorkerClientLoadModel:
         mock_http.post = fake_post
         client._http_client = mock_http
 
-        result = await client.load_model(
-            model_id="mamba-370m",
-            device="NPU",
-            architecture_family="ssm",
-        )
+        with patch.dict(os.environ, {"NPU_SSM_ENABLED": "true"}):
+            result = await client.load_model(
+                model_id="mamba-370m",
+                device="NPU",
+                architecture_family="ssm",
+            )
 
         assert result == expected_response
         payload = captured_calls[0]["json"]
@@ -288,6 +289,52 @@ class TestNPUWorkerClientLoadModel:
         assert result["success"] is False
         assert "ssm" in result["error"]
         assert result.get("error_code") == "unsupported_architecture"
+
+    @pytest.mark.asyncio
+    async def test_load_model_ssm_without_flag_rejected_before_http(self):
+        """load_model must reject ssm family locally when NPU_SSM_ENABLED is off — no HTTP call (GH#8690)."""
+        client = self._make_client()
+        http_calls = []
+
+        async def fake_post(url, json=None, **kwargs):
+            http_calls.append(url)
+            return self._mock_response({"success": True})
+
+        mock_http = MagicMock()
+        mock_http.post = fake_post
+        client._http_client = mock_http
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NPU_SSM_ENABLED", None)
+            result = await client.load_model(
+                model_id="mamba-370m",
+                device="NPU",
+                architecture_family="ssm",
+            )
+
+        assert result["success"] is False
+        assert result.get("error_code") == "unsupported_architecture"
+        assert len(http_calls) == 0, "no HTTP request should be made for unsupported family"
+
+    @pytest.mark.asyncio
+    async def test_load_model_none_family_skips_validation(self):
+        """Omitting architecture_family must skip get_inference_config and forward to worker (GH#8690)."""
+        client = self._make_client()
+        captured_calls = []
+
+        async def fake_post(url, json=None, **kwargs):
+            captured_calls.append({"url": url, "json": json})
+            return self._mock_response({"success": True})
+
+        mock_http = MagicMock()
+        mock_http.post = fake_post
+        client._http_client = mock_http
+
+        result = await client.load_model(model_id="bert-base", device="CPU")
+
+        assert result == {"success": True}
+        assert len(captured_calls) == 1
+        assert "architecture_family" not in captured_calls[0]["json"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path

GH#8690 required early architecture family validation in `NPUWorkerClient.load_model` before any HTTP call. The fix wires `openvino_dispatch.get_inference_config` at the client layer so unsupported families are rejected immediately without hitting the NPU worker endpoint. The import uses a try/fallback pattern because the dispatch module lives in the workers path rather than the standard package hierarchy.

## What Changed

**`autobot-npu-worker/core/npu_integration.py`**
- Added `_workers_path` to `sys.path` and try/fallback import of `get_inference_config` + `UnsupportedArchitectureError` from `workers.openvino_dispatch`
- `NPUWorkerClient.load_model` now calls `get_inference_config(model_id, architecture_family, device)` when `architecture_family` is provided
- Returns `{"success": False, "error_code": "unsupported_architecture"}` immediately for unsupported families — no HTTP request made

**`autobot-npu-worker/tests/test_architecture_aware_loading.py`**
- Updated existing test to set `NPU_SSM_ENABLED=true` (required now that client-side validation is live)
- Added two new tests: SSM rejected locally when flag off (zero HTTP calls), `None` family bypasses validation

## Summary

Wires `openvino_dispatch.get_inference_config` into `NPUWorkerClient.load_model` in `autobot-npu-worker/core/npu_integration.py` to provide early architecture family validation before any HTTP call is made.

## Verification

- [x] 34/34 tests pass in `test_architecture_aware_loading.py`
- [x] Early rejection verified: unsupported family returns error without HTTP call
- [x] `None` family forwards unchanged to NPU worker endpoint
- [x] Supported families (with env gate) pass validation and reach HTTP

## Model Used

claude-sonnet-4-6

Fixes [GH#8690](https://github.com/mrveiss/AutoBot-AI/issues/8690).

🤖 Generated with [Claude Code](https://claude.com/claude-code)