### PR TITLE
fix(voice): migrate _SESSION_TTL to ssot_config canonical pattern (GH#8718)

### DIFF
--- a/autobot-backend/services/voice_realtime_telemetry.py
+++ b/autobot-backend/services/voice_realtime_telemetry.py
@@ -18,7 +18,6 @@ Issue #7421 — Implements:
 """
 
 import json
-import os
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any
@@ -48,7 +47,7 @@ _TOKEN_COST_PER_1M: dict[str, float] = {
 
 # Redis key prefix + TTL
 _KEY_PREFIX = "voice_realtime_session"
-_SESSION_TTL = int(os.getenv("AUTOBOT_VOICE_REALTIME_SESSION_TTL", str(90 * 24 * 3600)))  # default 90 days
+_SESSION_TTL = config.misc.voice_realtime_session_ttl_days * 86400
 
 
 class DisconnectReason(str, Enum):

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1253,6 +1253,11 @@ class MiscConfig(BaseSettings):
         alias="AUTOBOT_VOICE_REALTIME_MAX_COST_USD",
         description="Soft-cap: auto-disconnect Realtime sessions exceeding this estimated USD cost. Default $5.00.",
     )
+    voice_realtime_session_ttl_days: int = Field(
+        default=90,
+        alias="AUTOBOT_VOICE_REALTIME_SESSION_TTL_DAYS",
+        description="Redis TTL (days) for voice_realtime_session:* keys. Default 90 days.",
+    )
     memory_log_threshold_mb: int = Field(default=0, alias="AUTOBOT_MEMORY_LOG_THRESHOLD_MB")
     memory_pool_size: int = Field(default=0, alias="AUTOBOT_MEMORY_POOL_SIZE")
     memory_threshold_mb: int = Field(default=0, alias="AUTOBOT_MEMORY_THRESHOLD_MB")


### PR DESCRIPTION
## Thinking Path

`_SESSION_TTL` was using a raw `os.getenv("AUTOBOT_VOICE_REALTIME_SESSION_TTL", ...)` call — the old pattern that issue #6743 identified as a bug. The canonical fix is to add the field to `MiscConfig` in `ssot_config.py` alongside the other `voice_realtime_*` tuning fields, then resolve via `config.misc.voice_realtime_session_ttl_days * 86400`. The `import os` that was only used for this call is also removed.

## What Changed

- `autobot_shared/ssot_config.py`: added `voice_realtime_session_ttl_days: int` field (default 90, alias `AUTOBOT_VOICE_REALTIME_SESSION_TTL_DAYS`) to `MiscConfig`
- `voice_realtime_telemetry.py`: replaced raw `os.getenv` with `config.misc.voice_realtime_session_ttl_days * 86400`; removed now-unused `import os`

## Summary

- Adds `voice_realtime_session_ttl_days: int` (default 90, alias `AUTOBOT_VOICE_REALTIME_SESSION_TTL_DAYS`) to `MiscConfig` in `autobot_shared/ssot_config.py` alongside the other `voice_realtime_*` tuning fields
- Replaces `int(os.getenv("AUTOBOT_VOICE_REALTIME_SESSION_TTL", ...))` in `voice_realtime_telemetry.py:51` with `config.misc.voice_realtime_session_ttl_days * 86400` — the canonical ssot_config pattern per CLAUDE.md / GH#6743
- Removes the now-unused `import os` from the same file

## Verification

- ✅ `AUTOBOT_VOICE_REALTIME_SESSION_TTL_DAYS` field added to `MiscConfig` with default 90
- ✅ `_SESSION_TTL` resolved via `config.misc.voice_realtime_session_ttl_days * 86400` — no raw `os.getenv`
- ✅ `import os` removed (was only used for the replaced line)
- ✅ Both files pass `py_compile`

## Model Used

claude-sonnet-4-6

Closes #8718

🤖 Generated with [Claude Code](https://claude.com/claude-code)