### PR TITLE
feat(chat): add SlashCommandDropdown story and managePresets i18n key (GH#4449-2)

### DIFF
--- a/autobot-frontend/src/components/chat/SlashCommandDropdown.stories.ts
+++ b/autobot-frontend/src/components/chat/SlashCommandDropdown.stories.ts
@@ -1,0 +1,63 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import type { Meta } from '@storybook/vue3'
+import type { StoryObj } from '@storybook/vue3'
+import SlashCommandDropdown from './SlashCommandDropdown.vue'
+
+const meta = {
+  title: 'Components/Chat/SlashCommandDropdown',
+  component: SlashCommandDropdown,
+  tags: ['autodocs'],
+  argTypes: {
+    show: { control: 'boolean' },
+    selectedIndex: { control: 'number' },
+  },
+} as Meta<typeof SlashCommandDropdown>
+
+export default meta
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+type Story = StoryObj<any>
+
+const samplePresets = [
+  { id: '1', name: 'standup', description: 'Daily standup summary', content: 'Give me a standup summary...', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+  { id: '2', name: 'summarize', description: 'Summarize the conversation', content: 'Please summarize our conversation so far.', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+  { id: '3', name: 'explain', description: 'Explain a concept in detail', content: 'Please explain the following concept in detail:', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+]
+
+export const Default: Story = {
+  args: {
+    show: true,
+    suggestions: samplePresets,
+    selectedIndex: 0,
+    anchorEl: null,
+  },
+}
+
+export const SecondItemSelected: Story = {
+  args: {
+    show: true,
+    suggestions: samplePresets,
+    selectedIndex: 1,
+    anchorEl: null,
+  },
+}
+
+export const SingleSuggestion: Story = {
+  args: {
+    show: true,
+    suggestions: [samplePresets[0]],
+    selectedIndex: 0,
+    anchorEl: null,
+  },
+}
+
+export const Hidden: Story = {
+  args: {
+    show: false,
+    suggestions: samplePresets,
+    selectedIndex: 0,
+    anchorEl: null,
+  },
+}

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -266,6 +266,7 @@
       "explain": "Explain",
       "attachFile": "Attach file",
       "analyzeImage": "Analyze image",
+      "managePresets": "Manage slash command presets",
       "voiceInput": "Voice input",
       "addEmoji": "Add emoji",
       "sending": "Sending...",


### PR DESCRIPTION
## Summary

- Adds Storybook story for `SlashCommandDropdown` component (Default, SecondItemSelected, SingleSuggestion, Hidden states) — required by frontend done criteria
- Adds missing `chat.input.managePresets` i18n key used as aria-label on the preset management button in ChatInput

## Context

Most of the slash command preset feature was already implemented and committed in earlier runs:

- `useChatPresetsStore` with full CRUD + tests (22 passing)
- `useSlashCommands` composable with slash detection/autocomplete + tests
- `SlashCommandDropdown.vue` — keyboard-navigable autocomplete component
- `PresetManagementModal.vue` — create/edit/delete preset modal
- `ChatInput.vue` — wired with preset button, dropdown, and modal
- Backend API at `/api/chat/presets` (already in Dev_new_gui via GH#8595)

This PR adds the two remaining gaps: the missing Storybook story (done criteria) and the missing i18n key (causing an empty aria-label string at runtime).

## Test Plan

- [x] `npm run type-check` — passes (exit code 0)
- [x] `npm run test src/stores/__tests__/useChatPresetsStore.test.ts src/composables/__tests__/useSlashCommands.test.ts` — 22/22 tests pass
- [x] `SlashCommandDropdown.stories.ts` added with 4 story variants
- [x] `managePresets` i18n key present and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)