### PR TITLE
fix(ansible): add AUTOBOT_AUDIT_LOG_FILE to backend.env.j2 template (#8936)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -91,3 +91,6 @@ service_auth_rate_limit_max_failures: 10
 backend_health_check_port: 8001
 backend_health_check_retries: 120      # Max retry attempts (120 × 5s = 600s total)
 backend_health_check_delay: 5          # Seconds between retries
+
+# Audit log file path (#8936: ensures AUTOBOT_AUDIT_LOG_FILE is always set in prod)
+backend_audit_log_file: /opt/autobot/logs/audit.log

--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -26,6 +26,8 @@ AUTOBOT_JWT_SECRET={{ backend_jwt_secret | default(backend_secret_key) }}
 CORS_ORIGINS={{ backend_cors_origins }}
 # Internal API key for SLM→backend proxy authentication (#1779)
 AUTOBOT_INTERNAL_API_KEY={{ autobot_internal_api_key }}
+# Audit log file path (#8936: ensure var is always set explicitly in prod)
+AUTOBOT_AUDIT_LOG_FILE={{ backend_audit_log_file | default('/opt/autobot/logs/audit.log') }}
 
 # Service Authentication
 SERVICE_ID={{ service_auth_service_id | default('main-backend') }}


### PR DESCRIPTION
## Summary

- Add `AUTOBOT_AUDIT_LOG_FILE` to the **Security** section of `backend.env.j2`, templated as `{{ backend_audit_log_file | default('/opt/autobot/logs/audit.log') }}`
- Add `backend_audit_log_file: /opt/autobot/logs/audit.log` default to `roles/backend/defaults/main.yml`

## Context

The env var was unset in production, contributing to the 2026-05-29 incident (GH#8926 / MVA-1544). A code-level guard was added in GH#8923; this PR ensures the Ansible template also sets the var explicitly so all production deploys get a sane default.

## Test plan

- [ ] Verify `ansible-lint` passes on the role
- [ ] Confirm `backend.env.j2` renders correctly with and without `backend_audit_log_file` override in inventory
- [ ] Confirm Ansible deploy produces `/opt/autobot/logs/audit.log` as `AUTOBOT_AUDIT_LOG_FILE` in `/opt/autobot/autobot-backend/.env`

Closes GH#8936

🤖 Generated with [Claude Code](https://claude.com/claude-code)