### PR TITLE
feat(core): idempotent Paperclip API wrappers in autobot_shared (GH#8944)

### DIFF
--- a/autobot_shared/paperclip_client.py
+++ b/autobot_shared/paperclip_client.py
@@ -49,10 +49,11 @@ import logging
 import os
 import re
 from typing import Any
+from urllib.parse import quote as _url_quote
 
 import aiohttp
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +64,7 @@ logger = logging.getLogger(__name__)
 _COMMENT_DEDUP_TTL_SECONDS = int(
     os.environ.get("AUTOBOT_PAPERCLIP_COMMENT_DEDUP_TTL", 3600)
 )
-_ISSUE_SEARCH_LIMIT = 20  # max results to scan when checking for duplicates
+_ISSUE_SEARCH_LIMIT = 50  # max results to scan when checking for duplicates
 _REDIS_KEY_PREFIX = "paperclip:idem:"
 
 
@@ -88,15 +89,6 @@ def _comment_dedup_key(issue_id: str, fingerprint: str) -> str:
 
 def _issue_search_key(company_id: str, title_fingerprint: str) -> str:
     return f"{_REDIS_KEY_PREFIX}issue:{company_id}:{title_fingerprint}"
-
-
-def _get_sync_redis():
-    """Return a synchronous Redis client, or None when unavailable."""
-    try:
-        return get_redis_client(async_client=False, database="main")
-    except Exception as exc:
-        logger.warning("paperclip_client: Redis unavailable (%s) — failing open", exc)
-        return None
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +124,7 @@ class PaperclipClient:
         self._run_id = run_id or os.environ.get("PAPERCLIP_RUN_ID", "")
         self._comment_dedup_ttl = comment_dedup_ttl
         self._session: aiohttp.ClientSession | None = None
+        self._redis: Any | None = None  # async Redis client; None when unavailable
 
     # ------------------------------------------------------------------
     # Context manager / lifecycle
@@ -150,11 +143,18 @@ class PaperclipClient:
                 headers=self._base_headers(),
                 timeout=aiohttp.ClientTimeout(total=30, connect=5),
             )
+        if self._redis is None:
+            try:
+                self._redis = await get_async_redis_client(database="main")
+            except Exception as exc:
+                logger.warning("paperclip_client: Redis unavailable (%s) — failing open", exc)
+                self._redis = None
 
     async def close(self) -> None:
         if self._session and not self._session.closed:
             await self._session.close()
         self._session = None
+        self._redis = None
 
     # ------------------------------------------------------------------
     # Idempotent public API
@@ -193,7 +193,7 @@ class PaperclipClient:
         cache_key = _issue_search_key(company_id, fp)
 
         # Fast path: Redis has the issue ID from a previous call.
-        cached_id = self._redis_get(cache_key)
+        cached_id = await self._redis_get(cache_key)
         if cached_id:
             existing = await self._get_issue(session, cached_id)
             if existing:
@@ -204,7 +204,7 @@ class PaperclipClient:
                 )
                 return existing
             # Cached ID no longer resolves — fall through to search.
-            self._redis_delete(cache_key)
+            await self._redis_delete(cache_key)
 
         # Slow path: search the API for an existing issue.
         existing = await self._search_issue_by_title(session, company_id, title)
@@ -214,7 +214,7 @@ class PaperclipClient:
                 title,
                 existing.get("id"),
             )
-            self._redis_set(cache_key, existing["id"], ttl=86400)
+            await self._redis_set(cache_key, existing["id"], ttl=86400)
             return existing
 
         # Not found — create it.
@@ -234,7 +234,7 @@ class PaperclipClient:
             title,
         )
         if created.get("id"):
-            self._redis_set(cache_key, created["id"], ttl=86400)
+            await self._redis_set(cache_key, created["id"], ttl=86400)
         return created
 
     async def post_comment_idempotent(
@@ -260,11 +260,11 @@ class PaperclipClient:
             The created comment dict, or ``None`` when the post was suppressed.
         """
         ttl = self._comment_dedup_ttl if dedup_ttl is None else dedup_ttl
+        fp = _content_fingerprint(body)
 
         if ttl > 0:
-            fp = _content_fingerprint(body)
             dedup_key = _comment_dedup_key(issue_id, fp)
-            if self._redis_exists(dedup_key):
+            if await self._redis_exists(dedup_key):
                 logger.debug(
                     "paperclip_client.post_comment_idempotent: suppressed duplicate "
                     "issue_id=%s fingerprint=%s",
@@ -279,8 +279,7 @@ class PaperclipClient:
         )
 
         if ttl > 0 and comment.get("id"):
-            fp = _content_fingerprint(body)
-            self._redis_set(_comment_dedup_key(issue_id, fp), "1", ttl=ttl)
+            await self._redis_set(_comment_dedup_key(issue_id, fp), "1", ttl=ttl)
 
         logger.debug(
             "paperclip_client.post_comment_idempotent: posted id=%s issue=%s",
@@ -370,17 +369,25 @@ class PaperclipClient:
         self, session: aiohttp.ClientSession, path: str, payload: dict
     ) -> dict:
         url = f"{self._api_url}{path}"
-        async with session.post(url, json=payload) as resp:
-            resp.raise_for_status()
-            return await resp.json()
+        try:
+            async with session.post(url, json=payload) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+        except aiohttp.ClientError as exc:
+            logger.error("paperclip_client POST %s failed: %s", path, exc)
+            raise
 
     async def _patch_json(
         self, session: aiohttp.ClientSession, path: str, payload: dict
     ) -> dict:
         url = f"{self._api_url}{path}"
-        async with session.patch(url, json=payload) as resp:
-            resp.raise_for_status()
-            return await resp.json()
+        try:
+            async with session.patch(url, json=payload) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+        except aiohttp.ClientError as exc:
+            logger.error("paperclip_client PATCH %s failed: %s", path, exc)
+            raise
 
     async def _get_issue(
         self, session: aiohttp.ClientSession, issue_id: str
@@ -391,56 +398,59 @@ class PaperclipClient:
         self, session: aiohttp.ClientSession, company_id: str, title: str
     ) -> dict | None:
         """Return the first open issue whose title exactly matches *title*."""
-        encoded = aiohttp.helpers.quote(title, safe="")
+        encoded = _url_quote(title, safe="")
         path = f"/api/companies/{company_id}/issues?q={encoded}&limit={_ISSUE_SEARCH_LIMIT}"
         result = await self._get_json(session, path)
         if not result:
             return None
         items: list[dict] = result if isinstance(result, list) else result.get("items", [])
+        if len(items) >= _ISSUE_SEARCH_LIMIT:
+            logger.warning(
+                "paperclip_client._search_issue_by_title: hit scan limit (%d) for title=%r"
+                " — exact match may have been missed",
+                _ISSUE_SEARCH_LIMIT,
+                title,
+            )
         for item in items:
             if item.get("title") == title and item.get("status") not in ("done", "cancelled"):
                 return item
         return None
 
     # ------------------------------------------------------------------
-    # Redis helpers — synchronous, fail-open
+    # Redis helpers — async, fail-open
     # ------------------------------------------------------------------
 
-    def _redis_get(self, key: str) -> str | None:
-        redis = _get_sync_redis()
-        if redis is None:
+    async def _redis_get(self, key: str) -> str | None:
+        if self._redis is None:
             return None
         try:
-            value = redis.get(key)
+            value = await self._redis.get(key)
             return value.decode() if isinstance(value, bytes) else value
         except Exception as exc:
             logger.warning("paperclip_client: Redis GET %s failed: %s", key, exc)
             return None
 
-    def _redis_set(self, key: str, value: str, *, ttl: int) -> None:
-        redis = _get_sync_redis()
-        if redis is None:
+    async def _redis_set(self, key: str, value: str, *, ttl: int) -> None:
+        if self._redis is None:
             return
         try:
-            redis.set(key, value, ex=ttl)
+            await self._redis.set(key, value, ex=ttl)
         except Exception as exc:
             logger.warning("paperclip_client: Redis SET %s failed: %s", key, exc)
 
-    def _redis_exists(self, key: str) -> bool:
-        redis = _get_sync_redis()
-        if redis is None:
+    async def _redis_exists(self, key: str) -> bool:
+        if self._redis is None:
             return False
         try:
-            return bool(redis.exists(key))
+            return bool(await self._redis.exists(key))
         except Exception as exc:
             logger.warning("paperclip_client: Redis EXISTS %s failed: %s", key, exc)
             return False
 
-    def _redis_delete(self, key: str) -> None:
-        redis = _get_sync_redis()
-        if redis is None:
+    async def _redis_delete(self, key: str) -> None:
+        if self._redis is None:
             return
         try:
-            redis.delete(key)
+            await self._redis.delete(key)
         except Exception as exc:
             logger.warning("paperclip_client: Redis DELETE %s failed: %s", key, exc)

--- a/autobot_shared/paperclip_client.py
+++ b/autobot_shared/paperclip_client.py
@@ -1,0 +1,446 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Idempotent Paperclip API client for autobot_shared (GH#8944).
+
+Prevents three routine-agent failure modes:
+  1. Duplicate task creation — creates only when no matching issue exists.
+  2. Comment flooding     — skips posts whose fingerprint was sent recently.
+  3. Status churn         — no-ops when the issue already has the target status.
+
+All idempotency state is backed by Redis so the guard holds across multiple
+processes and restarts.  Every method fails open: if Redis is unavailable the
+underlying API call proceeds normally rather than silently dropping data.
+
+Configuration
+-------------
+Environment variables (same ones injected by the Paperclip harness):
+
+  PAPERCLIP_API_URL   Base URL of the Paperclip server (required).
+  PAPERCLIP_API_KEY   Bearer token for all requests (required).
+  PAPERCLIP_RUN_ID    Injected run-ID forwarded in X-Paperclip-Run-Id header
+                      (optional; omit for calls outside a harness run).
+
+Redis database
+--------------
+All keys use the ``"main"`` logical database and live under the namespace
+``paperclip:idem:``.  TTLs default to the values below but callers may
+override them per-call.
+
+Usage
+-----
+    from autobot_shared.paperclip_client import PaperclipClient
+
+    async with PaperclipClient() as client:
+        issue = await client.create_issue_idempotent(
+            company_id="...",
+            title="[GH#1234] Fix the thing",
+            description="...",
+        )
+        await client.post_comment_idempotent(issue["id"], "Work complete.")
+        await client.update_status_idempotent(issue["id"], "done")
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+from typing import Any
+
+import aiohttp
+
+from autobot_shared.redis_client import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+_COMMENT_DEDUP_TTL_SECONDS = int(
+    os.environ.get("AUTOBOT_PAPERCLIP_COMMENT_DEDUP_TTL", 3600)
+)
+_ISSUE_SEARCH_LIMIT = 20  # max results to scan when checking for duplicates
+_REDIS_KEY_PREFIX = "paperclip:idem:"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _content_fingerprint(text: str) -> str:
+    """SHA-256 hex digest of normalised text.
+
+    Strips leading/trailing whitespace and collapses internal runs of
+    whitespace so that two messages differing only in spacing compare equal.
+    """
+    normalised = re.sub(r"\s+", " ", text.strip())
+    return hashlib.sha256(normalised.encode("utf-8")).hexdigest()
+
+
+def _comment_dedup_key(issue_id: str, fingerprint: str) -> str:
+    return f"{_REDIS_KEY_PREFIX}comment:{issue_id}:{fingerprint}"
+
+
+def _issue_search_key(company_id: str, title_fingerprint: str) -> str:
+    return f"{_REDIS_KEY_PREFIX}issue:{company_id}:{title_fingerprint}"
+
+
+def _get_sync_redis():
+    """Return a synchronous Redis client, or None when unavailable."""
+    try:
+        return get_redis_client(async_client=False, database="main")
+    except Exception as exc:
+        logger.warning("paperclip_client: Redis unavailable (%s) — failing open", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# PaperclipClient
+# ---------------------------------------------------------------------------
+
+
+class PaperclipClient:
+    """Async Paperclip HTTP client with idempotency guards.
+
+    Can be used as an async context manager (preferred) or with explicit
+    ``open()`` / ``close()`` calls.
+
+    Args:
+        api_url:  Base URL; defaults to ``PAPERCLIP_API_URL`` env var.
+        api_key:  Bearer token; defaults to ``PAPERCLIP_API_KEY`` env var.
+        run_id:   Heartbeat run ID forwarded as ``X-Paperclip-Run-Id``;
+                  defaults to ``PAPERCLIP_RUN_ID`` env var.
+        comment_dedup_ttl: Seconds a comment fingerprint is suppressed after
+                  the first successful post.  0 disables dedup.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_url: str | None = None,
+        api_key: str | None = None,
+        run_id: str | None = None,
+        comment_dedup_ttl: int = _COMMENT_DEDUP_TTL_SECONDS,
+    ) -> None:
+        self._api_url = (api_url or os.environ.get("PAPERCLIP_API_URL", "")).rstrip("/")
+        self._api_key = api_key or os.environ.get("PAPERCLIP_API_KEY", "")
+        self._run_id = run_id or os.environ.get("PAPERCLIP_RUN_ID", "")
+        self._comment_dedup_ttl = comment_dedup_ttl
+        self._session: aiohttp.ClientSession | None = None
+
+    # ------------------------------------------------------------------
+    # Context manager / lifecycle
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> "PaperclipClient":
+        await self.open()
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        await self.close()
+
+    async def open(self) -> None:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                headers=self._base_headers(),
+                timeout=aiohttp.ClientTimeout(total=30, connect=5),
+            )
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
+    # ------------------------------------------------------------------
+    # Idempotent public API
+    # ------------------------------------------------------------------
+
+    async def create_issue_idempotent(
+        self,
+        company_id: str,
+        title: str,
+        *,
+        description: str = "",
+        status: str = "todo",
+        priority: str = "medium",
+        **extra_fields: Any,
+    ) -> dict:
+        """Create an issue unless one with the same title already exists.
+
+        Searches for an open issue whose title exactly matches *title*. If a
+        match is found, returns that issue rather than creating a duplicate.
+        On a cache-miss it creates the issue and caches the new ID in Redis
+        so subsequent calls within the dedup window are instant.
+
+        Args:
+            company_id:    Paperclip company UUID.
+            title:         Issue title (used as the idempotency key).
+            description:   Issue body markdown.
+            status:        Initial status for newly created issues.
+            priority:      Issue priority.
+            **extra_fields: Any additional fields forwarded to the create API.
+
+        Returns:
+            The existing or newly created issue object (dict).
+        """
+        session = await self._ensure_session()
+        fp = _content_fingerprint(title)
+        cache_key = _issue_search_key(company_id, fp)
+
+        # Fast path: Redis has the issue ID from a previous call.
+        cached_id = self._redis_get(cache_key)
+        if cached_id:
+            existing = await self._get_issue(session, cached_id)
+            if existing:
+                logger.debug(
+                    "paperclip_client.create_issue_idempotent: cache hit title=%r id=%s",
+                    title,
+                    cached_id,
+                )
+                return existing
+            # Cached ID no longer resolves — fall through to search.
+            self._redis_delete(cache_key)
+
+        # Slow path: search the API for an existing issue.
+        existing = await self._search_issue_by_title(session, company_id, title)
+        if existing:
+            logger.info(
+                "paperclip_client.create_issue_idempotent: duplicate suppressed title=%r id=%s",
+                title,
+                existing.get("id"),
+            )
+            self._redis_set(cache_key, existing["id"], ttl=86400)
+            return existing
+
+        # Not found — create it.
+        payload: dict[str, Any] = {
+            "title": title,
+            "description": description,
+            "status": status,
+            "priority": priority,
+            **extra_fields,
+        }
+        created = await self._post_json(
+            session, f"/api/companies/{company_id}/issues", payload
+        )
+        logger.info(
+            "paperclip_client.create_issue_idempotent: created id=%s title=%r",
+            created.get("id"),
+            title,
+        )
+        if created.get("id"):
+            self._redis_set(cache_key, created["id"], ttl=86400)
+        return created
+
+    async def post_comment_idempotent(
+        self,
+        issue_id: str,
+        body: str,
+        *,
+        dedup_ttl: int | None = None,
+    ) -> dict | None:
+        """Post a comment only if the same content wasn't posted recently.
+
+        A SHA-256 fingerprint of the normalised *body* is stored in Redis
+        with a TTL.  Duplicate calls within the TTL window are silently
+        dropped (returns ``None``).
+
+        Args:
+            issue_id:  Paperclip issue UUID.
+            body:      Markdown comment body.
+            dedup_ttl: Override the instance-level comment dedup TTL (seconds).
+                       Pass 0 to disable dedup for this call.
+
+        Returns:
+            The created comment dict, or ``None`` when the post was suppressed.
+        """
+        ttl = self._comment_dedup_ttl if dedup_ttl is None else dedup_ttl
+
+        if ttl > 0:
+            fp = _content_fingerprint(body)
+            dedup_key = _comment_dedup_key(issue_id, fp)
+            if self._redis_exists(dedup_key):
+                logger.debug(
+                    "paperclip_client.post_comment_idempotent: suppressed duplicate "
+                    "issue_id=%s fingerprint=%s",
+                    issue_id,
+                    fp,
+                )
+                return None
+
+        session = await self._ensure_session()
+        comment = await self._post_json(
+            session, f"/api/issues/{issue_id}/comments", {"body": body}
+        )
+
+        if ttl > 0 and comment.get("id"):
+            fp = _content_fingerprint(body)
+            self._redis_set(_comment_dedup_key(issue_id, fp), "1", ttl=ttl)
+
+        logger.debug(
+            "paperclip_client.post_comment_idempotent: posted id=%s issue=%s",
+            comment.get("id"),
+            issue_id,
+        )
+        return comment
+
+    async def update_status_idempotent(
+        self,
+        issue_id: str,
+        status: str,
+        *,
+        comment: str | None = None,
+        extra_fields: dict[str, Any] | None = None,
+    ) -> dict | None:
+        """Update issue status only when it differs from the current value.
+
+        Fetches the current issue state first. If the issue is already in
+        *status*, the update is skipped and ``None`` is returned.
+
+        Args:
+            issue_id:     Paperclip issue UUID.
+            status:       Target status string (e.g. ``"done"``, ``"blocked"``).
+            comment:      Optional comment to include in the PATCH body.
+            extra_fields: Additional fields to include in the PATCH body.
+
+        Returns:
+            The updated issue dict, or ``None`` when the update was skipped.
+        """
+        session = await self._ensure_session()
+        current = await self._get_issue(session, issue_id)
+        if current and current.get("status") == status:
+            logger.debug(
+                "paperclip_client.update_status_idempotent: no-op issue=%s status=%s",
+                issue_id,
+                status,
+            )
+            return None
+
+        payload: dict[str, Any] = {"status": status}
+        if comment:
+            payload["comment"] = comment
+        if extra_fields:
+            payload.update(extra_fields)
+
+        updated = await self._patch_json(session, f"/api/issues/{issue_id}", payload)
+        logger.info(
+            "paperclip_client.update_status_idempotent: updated issue=%s %s→%s",
+            issue_id,
+            current.get("status") if current else "?",
+            status,
+        )
+        return updated
+
+    # ------------------------------------------------------------------
+    # Low-level HTTP helpers
+    # ------------------------------------------------------------------
+
+    def _base_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        if self._run_id:
+            headers["X-Paperclip-Run-Id"] = self._run_id
+        return headers
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            await self.open()
+        assert self._session is not None
+        return self._session
+
+    async def _get_json(self, session: aiohttp.ClientSession, path: str) -> dict | None:
+        url = f"{self._api_url}{path}"
+        try:
+            async with session.get(url) as resp:
+                if resp.status == 404:
+                    return None
+                resp.raise_for_status()
+                return await resp.json()
+        except aiohttp.ClientError as exc:
+            logger.error("paperclip_client GET %s failed: %s", path, exc)
+            raise
+
+    async def _post_json(
+        self, session: aiohttp.ClientSession, path: str, payload: dict
+    ) -> dict:
+        url = f"{self._api_url}{path}"
+        async with session.post(url, json=payload) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+    async def _patch_json(
+        self, session: aiohttp.ClientSession, path: str, payload: dict
+    ) -> dict:
+        url = f"{self._api_url}{path}"
+        async with session.patch(url, json=payload) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+    async def _get_issue(
+        self, session: aiohttp.ClientSession, issue_id: str
+    ) -> dict | None:
+        return await self._get_json(session, f"/api/issues/{issue_id}")
+
+    async def _search_issue_by_title(
+        self, session: aiohttp.ClientSession, company_id: str, title: str
+    ) -> dict | None:
+        """Return the first open issue whose title exactly matches *title*."""
+        encoded = aiohttp.helpers.quote(title, safe="")
+        path = f"/api/companies/{company_id}/issues?q={encoded}&limit={_ISSUE_SEARCH_LIMIT}"
+        result = await self._get_json(session, path)
+        if not result:
+            return None
+        items: list[dict] = result if isinstance(result, list) else result.get("items", [])
+        for item in items:
+            if item.get("title") == title and item.get("status") not in ("done", "cancelled"):
+                return item
+        return None
+
+    # ------------------------------------------------------------------
+    # Redis helpers — synchronous, fail-open
+    # ------------------------------------------------------------------
+
+    def _redis_get(self, key: str) -> str | None:
+        redis = _get_sync_redis()
+        if redis is None:
+            return None
+        try:
+            value = redis.get(key)
+            return value.decode() if isinstance(value, bytes) else value
+        except Exception as exc:
+            logger.warning("paperclip_client: Redis GET %s failed: %s", key, exc)
+            return None
+
+    def _redis_set(self, key: str, value: str, *, ttl: int) -> None:
+        redis = _get_sync_redis()
+        if redis is None:
+            return
+        try:
+            redis.set(key, value, ex=ttl)
+        except Exception as exc:
+            logger.warning("paperclip_client: Redis SET %s failed: %s", key, exc)
+
+    def _redis_exists(self, key: str) -> bool:
+        redis = _get_sync_redis()
+        if redis is None:
+            return False
+        try:
+            return bool(redis.exists(key))
+        except Exception as exc:
+            logger.warning("paperclip_client: Redis EXISTS %s failed: %s", key, exc)
+            return False
+
+    def _redis_delete(self, key: str) -> None:
+        redis = _get_sync_redis()
+        if redis is None:
+            return
+        try:
+            redis.delete(key)
+        except Exception as exc:
+            logger.warning("paperclip_client: Redis DELETE %s failed: %s", key, exc)

--- a/autobot_shared/paperclip_client_test.py
+++ b/autobot_shared/paperclip_client_test.py
@@ -26,6 +26,24 @@ def _make_client(**kwargs) -> PaperclipClient:
 
 
 # ---------------------------------------------------------------------------
+# Base headers — X-Paperclip-Run-Id contract
+# ---------------------------------------------------------------------------
+
+
+def test_base_headers_includes_run_id():
+    client = _make_client()
+    headers = client._base_headers()
+    assert headers.get("X-Paperclip-Run-Id") == "run-123"
+
+
+def test_base_headers_omits_run_id_when_explicitly_cleared():
+    client = PaperclipClient(api_url="http://x.test", run_id="placeholder")
+    client._run_id = ""  # clear after construction to bypass env fallback
+    headers = client._base_headers()
+    assert "X-Paperclip-Run-Id" not in headers
+
+
+# ---------------------------------------------------------------------------
 # _content_fingerprint
 # ---------------------------------------------------------------------------
 
@@ -56,8 +74,8 @@ async def test_create_issue_returns_existing_when_found():
         patch.object(client, "_get_issue", new_callable=AsyncMock, return_value=None),
         patch.object(client, "_search_issue_by_title", new_callable=AsyncMock, return_value=existing),
         patch.object(client, "_post_json", new_callable=AsyncMock) as mock_post,
-        patch.object(client, "_redis_get", return_value=None),
-        patch.object(client, "_redis_set"),
+        patch.object(client, "_redis_get", new_callable=AsyncMock, return_value=None),
+        patch.object(client, "_redis_set", new_callable=AsyncMock),
         patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
     ):
         result = await client.create_issue_idempotent("co-1", "Fix 99")
@@ -72,8 +90,8 @@ async def test_create_issue_creates_when_not_found():
 
     client = _make_client()
     with (
-        patch.object(client, "_redis_get", return_value=None),
-        patch.object(client, "_redis_set"),
+        patch.object(client, "_redis_get", new_callable=AsyncMock, return_value=None),
+        patch.object(client, "_redis_set", new_callable=AsyncMock),
         patch.object(client, "_search_issue_by_title", new_callable=AsyncMock, return_value=None),
         patch.object(client, "_post_json", new_callable=AsyncMock, return_value=new_issue),
         patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
@@ -89,7 +107,7 @@ async def test_create_issue_uses_redis_cache_hit():
 
     client = _make_client()
     with (
-        patch.object(client, "_redis_get", return_value="issue-cached"),
+        patch.object(client, "_redis_get", new_callable=AsyncMock, return_value="issue-cached"),
         patch.object(client, "_get_issue", new_callable=AsyncMock, return_value=existing),
         patch.object(client, "_search_issue_by_title", new_callable=AsyncMock) as mock_search,
         patch.object(client, "_post_json", new_callable=AsyncMock) as mock_post,
@@ -108,9 +126,9 @@ async def test_create_issue_falls_through_on_stale_cache():
 
     client = _make_client()
     with (
-        patch.object(client, "_redis_get", return_value="issue-stale"),
-        patch.object(client, "_redis_delete"),
-        patch.object(client, "_redis_set"),
+        patch.object(client, "_redis_get", new_callable=AsyncMock, return_value="issue-stale"),
+        patch.object(client, "_redis_delete", new_callable=AsyncMock),
+        patch.object(client, "_redis_set", new_callable=AsyncMock),
         patch.object(client, "_get_issue", new_callable=AsyncMock, return_value=None),
         patch.object(client, "_search_issue_by_title", new_callable=AsyncMock, return_value=None),
         patch.object(client, "_post_json", new_callable=AsyncMock, return_value=new_issue),
@@ -130,7 +148,7 @@ async def test_create_issue_falls_through_on_stale_cache():
 async def test_post_comment_suppressed_when_redis_hit():
     client = _make_client()
     with (
-        patch.object(client, "_redis_exists", return_value=True),
+        patch.object(client, "_redis_exists", new_callable=AsyncMock, return_value=True),
         patch.object(client, "_post_json", new_callable=AsyncMock) as mock_post,
     ):
         result = await client.post_comment_idempotent("issue-1", "All good.")
@@ -144,8 +162,8 @@ async def test_post_comment_proceeds_and_sets_dedup_key():
     comment = {"id": "c-1", "body": "All good."}
     client = _make_client()
     with (
-        patch.object(client, "_redis_exists", return_value=False),
-        patch.object(client, "_redis_set") as mock_set,
+        patch.object(client, "_redis_exists", new_callable=AsyncMock, return_value=False),
+        patch.object(client, "_redis_set", new_callable=AsyncMock) as mock_set,
         patch.object(client, "_post_json", new_callable=AsyncMock, return_value=comment),
         patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
     ):
@@ -160,8 +178,8 @@ async def test_post_comment_dedup_disabled_via_ttl_zero():
     comment = {"id": "c-2", "body": "Always post."}
     client = _make_client()
     with (
-        patch.object(client, "_redis_exists") as mock_exists,
-        patch.object(client, "_redis_set") as mock_set,
+        patch.object(client, "_redis_exists", new_callable=AsyncMock) as mock_exists,
+        patch.object(client, "_redis_set", new_callable=AsyncMock) as mock_set,
         patch.object(client, "_post_json", new_callable=AsyncMock, return_value=comment),
         patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
     ):
@@ -228,8 +246,8 @@ async def test_update_status_applies_when_issue_not_found():
 async def test_create_issue_continues_when_redis_unavailable():
     new_issue = {"id": "issue-new", "title": "Fix 99", "status": "todo"}
     client = _make_client()
+    client._redis = None  # simulate Redis unavailable
     with (
-        patch("autobot_shared.paperclip_client._get_sync_redis", return_value=None),
         patch.object(client, "_search_issue_by_title", new_callable=AsyncMock, return_value=None),
         patch.object(client, "_post_json", new_callable=AsyncMock, return_value=new_issue),
         patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
@@ -243,8 +261,8 @@ async def test_create_issue_continues_when_redis_unavailable():
 async def test_post_comment_continues_when_redis_unavailable():
     comment = {"id": "c-3", "body": "ok"}
     client = _make_client()
+    client._redis = None  # simulate Redis unavailable
     with (
-        patch("autobot_shared.paperclip_client._get_sync_redis", return_value=None),
         patch.object(client, "_post_json", new_callable=AsyncMock, return_value=comment),
         patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
     ):

--- a/autobot_shared/paperclip_client_test.py
+++ b/autobot_shared/paperclip_client_test.py
@@ -1,0 +1,253 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for autobot_shared.paperclip_client (GH#8944)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from autobot_shared.paperclip_client import (
+    PaperclipClient,
+    _content_fingerprint,
+)
+
+
+def _make_client(**kwargs) -> PaperclipClient:
+    return PaperclipClient(
+        api_url="http://paperclip.test",
+        api_key="test-key",
+        run_id="run-123",
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _content_fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_stable():
+    assert _content_fingerprint("hello world") == _content_fingerprint("hello world")
+
+
+def test_fingerprint_normalises_whitespace():
+    assert _content_fingerprint("  hello   world  ") == _content_fingerprint("hello world")
+
+
+def test_fingerprint_different_texts():
+    assert _content_fingerprint("foo") != _content_fingerprint("bar")
+
+
+# ---------------------------------------------------------------------------
+# create_issue_idempotent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_issue_returns_existing_when_found():
+    existing = {"id": "issue-abc", "title": "Fix 99", "status": "in_progress"}
+
+    client = _make_client()
+    with (
+        patch.object(client, "_get_issue", new_callable=AsyncMock, return_value=None),
+        patch.object(client, "_search_issue_by_title", new_callable=AsyncMock, return_value=existing),
+        patch.object(client, "_post_json", new_callable=AsyncMock) as mock_post,
+        patch.object(client, "_redis_get", return_value=None),
+        patch.object(client, "_redis_set"),
+        patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
+    ):
+        result = await client.create_issue_idempotent("co-1", "Fix 99")
+
+    assert result == existing
+    mock_post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_issue_creates_when_not_found():
+    new_issue = {"id": "issue-new", "title": "Fix 99", "status": "todo"}
+
+    client = _make_client()
+    with (
+        patch.object(client, "_redis_get", return_value=None),
+        patch.object(client, "_redis_set"),
+        patch.object(client, "_search_issue_by_title", new_callable=AsyncMock, return_value=None),
+        patch.object(client, "_post_json", new_callable=AsyncMock, return_value=new_issue),
+        patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
+    ):
+        result = await client.create_issue_idempotent("co-1", "Fix 99")
+
+    assert result == new_issue
+
+
+@pytest.mark.asyncio
+async def test_create_issue_uses_redis_cache_hit():
+    existing = {"id": "issue-cached", "title": "Fix 99", "status": "in_progress"}
+
+    client = _make_client()
+    with (
+        patch.object(client, "_redis_get", return_value="issue-cached"),
+        patch.object(client, "_get_issue", new_callable=AsyncMock, return_value=existing),
+        patch.object(client, "_search_issue_by_title", new_callable=AsyncMock) as mock_search,
+        patch.object(client, "_post_json", new_callable=AsyncMock) as mock_post,
+        patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
+    ):
+        result = await client.create_issue_idempotent("co-1", "Fix 99")
+
+    assert result == existing
+    mock_search.assert_not_called()
+    mock_post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_issue_falls_through_on_stale_cache():
+    new_issue = {"id": "issue-new", "title": "Fix 99", "status": "todo"}
+
+    client = _make_client()
+    with (
+        patch.object(client, "_redis_get", return_value="issue-stale"),
+        patch.object(client, "_redis_delete"),
+        patch.object(client, "_redis_set"),
+        patch.object(client, "_get_issue", new_callable=AsyncMock, return_value=None),
+        patch.object(client, "_search_issue_by_title", new_callable=AsyncMock, return_value=None),
+        patch.object(client, "_post_json", new_callable=AsyncMock, return_value=new_issue),
+        patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
+    ):
+        result = await client.create_issue_idempotent("co-1", "Fix 99")
+
+    assert result == new_issue
+
+
+# ---------------------------------------------------------------------------
+# post_comment_idempotent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_comment_suppressed_when_redis_hit():
+    client = _make_client()
+    with (
+        patch.object(client, "_redis_exists", return_value=True),
+        patch.object(client, "_post_json", new_callable=AsyncMock) as mock_post,
+    ):
+        result = await client.post_comment_idempotent("issue-1", "All good.")
+
+    assert result is None
+    mock_post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_comment_proceeds_and_sets_dedup_key():
+    comment = {"id": "c-1", "body": "All good."}
+    client = _make_client()
+    with (
+        patch.object(client, "_redis_exists", return_value=False),
+        patch.object(client, "_redis_set") as mock_set,
+        patch.object(client, "_post_json", new_callable=AsyncMock, return_value=comment),
+        patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
+    ):
+        result = await client.post_comment_idempotent("issue-1", "All good.")
+
+    assert result == comment
+    mock_set.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_post_comment_dedup_disabled_via_ttl_zero():
+    comment = {"id": "c-2", "body": "Always post."}
+    client = _make_client()
+    with (
+        patch.object(client, "_redis_exists") as mock_exists,
+        patch.object(client, "_redis_set") as mock_set,
+        patch.object(client, "_post_json", new_callable=AsyncMock, return_value=comment),
+        patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
+    ):
+        result = await client.post_comment_idempotent("issue-1", "Always post.", dedup_ttl=0)
+
+    assert result == comment
+    mock_exists.assert_not_called()
+    mock_set.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# update_status_idempotent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_status_no_op_when_already_same():
+    client = _make_client()
+    with (
+        patch.object(client, "_get_issue", new_callable=AsyncMock, return_value={"id": "i-1", "status": "done"}),
+        patch.object(client, "_patch_json", new_callable=AsyncMock) as mock_patch,
+        patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
+    ):
+        result = await client.update_status_idempotent("i-1", "done")
+
+    assert result is None
+    mock_patch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_status_applies_when_different():
+    updated = {"id": "i-1", "status": "done"}
+    client = _make_client()
+    with (
+        patch.object(client, "_get_issue", new_callable=AsyncMock, return_value={"id": "i-1", "status": "in_progress"}),
+        patch.object(client, "_patch_json", new_callable=AsyncMock, return_value=updated),
+        patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
+    ):
+        result = await client.update_status_idempotent("i-1", "done", comment="Done!")
+
+    assert result == updated
+
+
+@pytest.mark.asyncio
+async def test_update_status_applies_when_issue_not_found():
+    updated = {"id": "i-1", "status": "done"}
+    client = _make_client()
+    with (
+        patch.object(client, "_get_issue", new_callable=AsyncMock, return_value=None),
+        patch.object(client, "_patch_json", new_callable=AsyncMock, return_value=updated),
+        patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
+    ):
+        result = await client.update_status_idempotent("i-1", "done")
+
+    assert result == updated
+
+
+# ---------------------------------------------------------------------------
+# Redis fail-open
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_issue_continues_when_redis_unavailable():
+    new_issue = {"id": "issue-new", "title": "Fix 99", "status": "todo"}
+    client = _make_client()
+    with (
+        patch("autobot_shared.paperclip_client._get_sync_redis", return_value=None),
+        patch.object(client, "_search_issue_by_title", new_callable=AsyncMock, return_value=None),
+        patch.object(client, "_post_json", new_callable=AsyncMock, return_value=new_issue),
+        patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
+    ):
+        result = await client.create_issue_idempotent("co-1", "Fix 99")
+
+    assert result == new_issue
+
+
+@pytest.mark.asyncio
+async def test_post_comment_continues_when_redis_unavailable():
+    comment = {"id": "c-3", "body": "ok"}
+    client = _make_client()
+    with (
+        patch("autobot_shared.paperclip_client._get_sync_redis", return_value=None),
+        patch.object(client, "_post_json", new_callable=AsyncMock, return_value=comment),
+        patch.object(client, "_ensure_session", new_callable=AsyncMock, return_value=MagicMock()),
+    ):
+        result = await client.post_comment_idempotent("issue-1", "ok")
+
+    assert result == comment


### PR DESCRIPTION
## Summary

- Adds `autobot_shared/paperclip_client.py` with `PaperclipClient` async context manager
- Implements three idempotency guards: `create_issue_idempotent`, `post_comment_idempotent`, `update_status_idempotent`
- All guards fail open when Redis is unavailable — cache outage never silently drops Paperclip operations
- 17 unit tests covering cache-hit, stale-cache fallthrough, Redis-unavailable, and dedup-disabled paths

Closes #8944

## Thinking Path

Routine agents are stateless so each heartbeat independently creates tasks and posts comments with no memory of prior actions. The fix is lightweight idempotency at the call site: fingerprint each operation and skip if already performed within a configurable TTL window. Redis is used as the shared store so it works across workers. Fail-open design ensures Redis outage never blocks Paperclip operations.

## What Changed

- `autobot_shared/paperclip_client.py` (new): `PaperclipClient` with `create_issue_idempotent`, `post_comment_idempotent`, `update_status_idempotent`
- `autobot_shared/paperclip_client_test.py` (new): 17 unit tests
- Private `_redis_*` helpers converted to `async def`; `get_async_redis_client()` stored at instance level
- `urllib.parse.quote` replaces removed `aiohttp.helpers.quote` private API

## Verification

```
pytest autobot_shared/paperclip_client_test.py -v
# 17 passed
```

- Verified `create_issue_idempotent` skips creation when title already exists in open issues
- Verified `post_comment_idempotent` deduplicates via SHA-256 fingerprint in Redis
- Verified `update_status_idempotent` skips PATCH when already in target state
- Verified Redis-unavailable path fails open (no exception propagated)

## Model Used

claude-sonnet-4-6

## Test plan
- [x] `pytest autobot_shared/paperclip_client_test.py` — all 17 tests pass
- [x] Verify `create_issue_idempotent` skips creation when title already exists in open issues
- [x] Verify `post_comment_idempotent` deduplicates via SHA-256 fingerprint in Redis
- [x] Verify `update_status_idempotent` skips PATCH when already in target state
- [x] Verify Redis-unavailable path fails open (no exception propagated)

Paperclip issue: MVA-1604

🤖 Generated with Claude Code