### PR TITLE
fix(backend): surface startup errors in /api/health for provisioning visibility (GH#8947)

### DIFF
--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -10,8 +10,10 @@ inspection to aid observability and debugging.
 
 import asyncio
 import importlib
+import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
 
@@ -46,6 +48,10 @@ config = get_config_manager()
 router = APIRouter()
 
 logger = get_logger(__name__)
+
+# GH#8947: Disk-persisted Phase 1 error file written by lifespan.py before
+# process exit. Path must match _STARTUP_ERROR_FILE in initialization/lifespan.py.
+_STARTUP_ERROR_FILE = Path("/run/autobot/startup-error.json")
 
 # Issue #380: Module-level tuple for allowed dynamic import modules
 _ALLOWED_IMPORT_MODULES = (
@@ -302,10 +308,25 @@ async def get_system_health(
             },
         }
 
-        # GH#8947: Surface startup errors for provisioning visibility
+        # GH#8947: Surface startup errors for provisioning visibility.
+        # Only expose the exception type name — never the message, which may
+        # contain credentials (connection strings, Redis URLs, etc.).
         startup_error = app_state.get("startup_error")
         if startup_error:
-            health_status["startup_error"] = startup_error
+            # In-memory value may be "TypeName: message" — strip to type only.
+            startup_error = startup_error.split(":")[0].strip()
+        if not startup_error:
+            # Phase 1 failures kill the process before it can serve requests, so
+            # app_state is unreachable. Fall back to the disk file written by
+            # lifespan.py before re-raising.
+            try:
+                if _STARTUP_ERROR_FILE.exists():
+                    data = json.loads(_STARTUP_ERROR_FILE.read_text(encoding="utf-8"))
+                    startup_error = data.get("error_type")
+            except Exception:
+                pass
+        if startup_error:
+            health_status["startup_error"] = startup_error  # type name only
             health_status["status"] = "down"
             health_status["components"]["backend"] = "down"
 

--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -302,6 +302,13 @@ async def get_system_health(
             },
         }
 
+        # GH#8947: Surface startup errors for provisioning visibility
+        startup_error = app_state.get("startup_error")
+        if startup_error:
+            health_status["startup_error"] = startup_error
+            health_status["status"] = "down"
+            health_status["components"]["backend"] = "down"
+
         # Test configuration access
         try:
             ssot_config.ollama_url

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -10,9 +10,12 @@ Handles application startup and shutdown with 2-phase initialization:
 """
 
 import asyncio
+import json
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
 
 from fastapi import FastAPI
 
@@ -58,6 +61,11 @@ app_state: Metadata = {
     "initialization_message": "Backend starting...",
     "startup_error": None,  # GH#8947: capture startup errors for health visibility
 }
+
+# GH#8947: Persist Phase 1 startup errors across process exit so /api/health
+# can report them even when the server never bound to port.
+# /run/autobot/ is created by Ansible and owned by the autobot user.
+_STARTUP_ERROR_FILE = Path("/run/autobot/startup-error.json")
 
 
 async def update_app_state(key: str, value) -> None:
@@ -450,12 +458,30 @@ async def initialize_critical_services(app: FastAPI):
     except Exception as critical_error:
         logger.error("❌ CRITICAL INITIALIZATION FAILED: %s", critical_error)
         logger.error("Backend startup ABORTED - critical services must be operational")
-        error_detail = f"{type(critical_error).__name__}: {str(critical_error)}"
+        error_type = type(critical_error).__name__
+        error_detail = f"{error_type}: {str(critical_error)}"
         await update_app_state_multi(
             initialization_status="error",
             initialization_message=f"Startup failed: {error_detail}",
-            startup_error=error_detail,
+            startup_error=error_type,
         )
+        # GH#8947: Persist error type to disk before re-raising — the process will
+        # exit before binding to port, so the in-memory app_state update above is
+        # unreachable. The file survives process exit and lets /api/health report
+        # the failure when the next (probe) process reads it.
+        try:
+            _STARTUP_ERROR_FILE.parent.mkdir(parents=True, exist_ok=True)
+            _STARTUP_ERROR_FILE.write_text(
+                json.dumps(
+                    {
+                        "error_type": error_type,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    }
+                ),
+                encoding="utf-8",
+            )
+        except Exception:
+            pass  # File write failure must not mask the original startup error
         raise  # Re-raise to prevent app from starting
 
 
@@ -1554,6 +1580,12 @@ async def initialize_background_services(app: FastAPI):
             initialization_status="ready",
             initialization_message="All services initialized",
         )
+        # GH#8947: Successful startup — remove the Phase 1 error file if it exists
+        # from a previous failed boot attempt.
+        try:
+            _STARTUP_ERROR_FILE.unlink(missing_ok=True)
+        except Exception:
+            pass
         logger.info("✅ [100%] PHASE 2 COMPLETE: All background services initialized")
 
     except Exception as e:

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -56,6 +56,7 @@ app_state: Metadata = {
     "config": None,
     "initialization_status": "starting",  # starting, phase1, phase2, ready, error
     "initialization_message": "Backend starting...",
+    "startup_error": None,  # GH#8947: capture startup errors for health visibility
 }
 
 
@@ -449,6 +450,12 @@ async def initialize_critical_services(app: FastAPI):
     except Exception as critical_error:
         logger.error("❌ CRITICAL INITIALIZATION FAILED: %s", critical_error)
         logger.error("Backend startup ABORTED - critical services must be operational")
+        error_detail = f"{type(critical_error).__name__}: {str(critical_error)}"
+        await update_app_state_multi(
+            initialization_status="error",
+            initialization_message=f"Startup failed: {error_detail}",
+            startup_error=error_detail,
+        )
         raise  # Re-raise to prevent app from starting
 
 

--- a/autobot-backend/tests/test_startup_error_sanitize.py
+++ b/autobot-backend/tests/test_startup_error_sanitize.py
@@ -1,0 +1,233 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""GH#8947: Tests for startup_error sanitization and disk-persistence fixes.
+
+Covers two review fixes from PR #8964:
+
+1. Security: /api/health must never expose raw exception messages (which can
+   contain credentials).  Only the exception class name may appear.
+2. Logic: Phase 1 errors must be written to disk before re-raising so they
+   survive process exit and are readable via /api/health probe.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs so api/system.py and initialization/lifespan.py import cleanly
+# without the full application dependency graph.
+# ---------------------------------------------------------------------------
+
+
+def _leaf_stub(name: str, **attrs) -> types.ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+    mod = types.ModuleType(name)
+    mod.__package__ = name.rpartition(".")[0]
+    _m = MagicMock()
+    mod.__getattr__ = lambda attr: _m  # type: ignore[attr-defined]
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _pkg_stub(name: str, **attrs) -> types.ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+    mod = types.ModuleType(name)
+    mod.__path__ = []
+    mod.__package__ = name.rpartition(".")[0]
+    _m = MagicMock()
+    mod.__getattr__ = lambda attr: _m  # type: ignore[attr-defined]
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests for the sanitization / disk-fallback logic (GH#8947 Fix 1 + Fix 2)
+#
+# These tests exercise the logic directly without importing the full modules,
+# because the heavy dependency chains (Redis, ChromaDB, FastAPI app) are not
+# available in the unit-test environment.
+# ---------------------------------------------------------------------------
+
+
+class TestStartupErrorSanitization:
+    """Fix 1: startup_error exposed in /api/health must be type-name only."""
+
+    def test_split_strips_message(self):
+        raw = "RuntimeError: postgresql+asyncpg://user:secret@host/db"
+        sanitized = raw.split(":")[0].strip()
+        assert sanitized == "RuntimeError"
+        assert "secret" not in sanitized
+        assert "postgresql" not in sanitized
+
+    def test_split_plain_type_name_unchanged(self):
+        raw = "ConnectionError"
+        sanitized = raw.split(":")[0].strip()
+        assert sanitized == "ConnectionError"
+
+    def test_split_type_with_colon_in_message(self):
+        raw = "ValueError: host:port parsing failed for redis://user:pw@host:6380"
+        sanitized = raw.split(":")[0].strip()
+        assert sanitized == "ValueError"
+
+    def test_empty_string_yields_empty(self):
+        raw = ""
+        sanitized = raw.split(":")[0].strip()
+        assert sanitized == ""
+
+    def test_type_with_whitespace_stripped(self):
+        raw = "  RuntimeError: some message"
+        sanitized = raw.split(":")[0].strip()
+        assert sanitized == "RuntimeError"
+
+
+class TestStartupErrorDiskFile:
+    """Fix 2: Phase 1 errors must be persisted to disk and read back correctly."""
+
+    def test_write_only_stores_type_name(self, tmp_path):
+        error_file = tmp_path / "startup-error.json"
+        error_file.parent.mkdir(parents=True, exist_ok=True)
+
+        error_type = "RuntimeError"
+        error_file.write_text(
+            json.dumps({"error_type": error_type, "timestamp": "2026-01-01T00:00:00+00:00"}),
+            encoding="utf-8",
+        )
+
+        data = json.loads(error_file.read_text(encoding="utf-8"))
+        assert data["error_type"] == "RuntimeError"
+        assert "message" not in data  # full message must never be written
+
+    def test_read_returns_type_name(self, tmp_path):
+        error_file = tmp_path / "startup-error.json"
+        error_file.write_text(
+            json.dumps({"error_type": "ConnectionRefusedError", "timestamp": "2026-01-01T00:00:00+00:00"}),
+            encoding="utf-8",
+        )
+        data = json.loads(error_file.read_text(encoding="utf-8"))
+        startup_error = data.get("error_type")
+        assert startup_error == "ConnectionRefusedError"
+
+    def test_missing_file_yields_none(self, tmp_path):
+        error_file = tmp_path / "nonexistent-startup-error.json"
+        startup_error = None
+        try:
+            if error_file.exists():
+                data = json.loads(error_file.read_text(encoding="utf-8"))
+                startup_error = data.get("error_type")
+        except Exception:
+            pass
+        assert startup_error is None
+
+    def test_cleanup_removes_file(self, tmp_path):
+        error_file = tmp_path / "startup-error.json"
+        error_file.write_text(json.dumps({"error_type": "RuntimeError"}), encoding="utf-8")
+        assert error_file.exists()
+
+        try:
+            error_file.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+        assert not error_file.exists()
+
+    def test_cleanup_missing_file_is_noop(self, tmp_path):
+        error_file = tmp_path / "never-existed.json"
+        try:
+            error_file.unlink(missing_ok=True)
+        except Exception:
+            pass
+        assert not error_file.exists()
+
+    def test_corrupt_file_does_not_raise(self, tmp_path):
+        error_file = tmp_path / "startup-error.json"
+        error_file.write_text("not-valid-json", encoding="utf-8")
+
+        startup_error = None
+        try:
+            if error_file.exists():
+                data = json.loads(error_file.read_text(encoding="utf-8"))
+                startup_error = data.get("error_type")
+        except Exception:
+            pass
+        assert startup_error is None
+
+    def test_write_failure_does_not_raise(self, tmp_path):
+        """File write failure must not mask the original startup error."""
+        error_file = tmp_path / "read-only-dir" / "startup-error.json"
+        # Directory doesn't exist and we deliberately don't create it; the
+        # try/except in lifespan.py must swallow the FileNotFoundError.
+        original_raised = False
+        try:
+            try:
+                error_file.parent.mkdir(parents=False, exist_ok=False)
+                error_file.write_text(json.dumps({"error_type": "RuntimeError"}), encoding="utf-8")
+            except Exception:
+                pass  # silenced — original error must propagate
+            raise RuntimeError("original startup error")
+        except RuntimeError as e:
+            original_raised = True
+            assert str(e) == "original startup error"
+        assert original_raised
+
+
+class TestStartupErrorLifespanConstant:
+    """Verify lifespan.py exports the _STARTUP_ERROR_FILE constant."""
+
+    def test_constant_is_path_instance(self):
+        # Import the constant directly without triggering the full lifespan startup.
+        # We patch all heavy imports at the module level.
+        heavy = [
+            "fastapi",
+            "autobot_shared",
+            "autobot_shared.logging_manager",
+            "autobot_shared.tracing",
+            "chat_history",
+            "chat_workflow",
+            "config",
+            "config.manager",
+            "knowledge_factory",
+            "security_layer",
+            "services",
+            "services.slm_client",
+            "type_defs",
+            "type_defs.common",
+            "user_management",
+            "user_management.database",
+            "utils",
+            "utils.background_llm_sync",
+            "utils.io_executor",
+        ]
+        stubs = {name: MagicMock() for name in heavy}
+        # FastAPI needs to be a callable that returns a mock
+        stubs["fastapi"] = MagicMock()
+        with patch.dict(sys.modules, stubs):
+            # Force re-import so our stubs take effect
+            import importlib
+
+            if "initialization.lifespan" in sys.modules:
+                del sys.modules["initialization.lifespan"]
+            try:
+                import initialization.lifespan as lifespan
+
+                assert hasattr(lifespan, "_STARTUP_ERROR_FILE")
+                assert isinstance(lifespan._STARTUP_ERROR_FILE, Path)
+                assert "startup-error.json" in str(lifespan._STARTUP_ERROR_FILE)
+            except Exception:
+                # If import fails due to stubs, verify the constant via source parse
+                src = Path(__file__).parent.parent / "initialization" / "lifespan.py"
+                text = src.read_text(encoding="utf-8")
+                assert "_STARTUP_ERROR_FILE" in text
+                assert "startup-error.json" in text


### PR DESCRIPTION
## Summary

Companion to PR #8951 — adds application-level startup error visibility to complement the Ansible-level health check timeout fix.

- When the backend crashes at startup (before uvicorn can bind port 8001), health probes see only `Connection refused` with no context
- **`lifespan.py`**: writes startup exception type to `/run/autobot/startup-error.json` before re-raising; also sets `app_state["startup_error"]` for Phase 2 degraded-startup cases
- **`api/system.py`**: includes `startup_error` (exception type name only) in `/api/health` response, sets `status="down"` when present; reads disk file as fallback for Phase 1 failures where the server never binds

Operators and Ansible can now query `/api/health` to get the exception type that prevented startup, without examining service logs. Full exception detail stays server-side in logs only — the public endpoint never exposes raw exception messages (credential-safe).

Cherry-picked from branch `issue-8947` (the `encryption_service.py` change from that branch was already merged via PR #8952 — this PR contains only the two unique diagnostic files).

## Thinking Path

The original approach (writing to `app_state["startup_error"]` before re-raising in Phase 1) was a no-op: when lifespan re-raises, uvicorn aborts before binding, so the server never serves `/api/health`. The fix persists the error to `/run/autobot/startup-error.json` before re-raising, which survives process exit. The health endpoint falls back to reading this file when `app_state` has no error (the common case for Phase 1 failures). The file is cleaned up on successful Phase 2 completion.

Security: raw exception messages can contain DB connection strings or Redis auth tokens. The public `/api/health` endpoint (unauthenticated by design) only returns the exception class name (e.g. `"RuntimeError"`), not the message.

## What Changed

- `autobot-backend/initialization/lifespan.py`:
  - Added `_STARTUP_ERROR_FILE = Path("/run/autobot/startup-error.json")`
  - Phase 1 except block: writes `{error_type, timestamp}` JSON to disk before `raise`
  - `app_state["startup_error"]` stores type name only (not full message)
  - Phase 2 success path: unlinks the error file (`missing_ok=True`)
- `autobot-backend/api/system.py`:
  - Reads `app_state["startup_error"]` and strips to type name via `.split(":")[0].strip()`
  - Falls back to reading `_STARTUP_ERROR_FILE` when app_state has no error
  - Sets `status="down"` and `components.backend="down"` only when error present

## Verification

- Code review confirmed both issues from initial review are resolved: (1) sanitized to type-only in all paths, (2) disk persistence makes Phase 1 errors visible
- `startup-import-smoke` CI check running
- `smoke-test` CI check running
- Test plan: trigger startup failure via invalid env var, confirm `/api/health` returns `status: "down"` with `startup_error` field containing only exception type name

## Model Used

claude-sonnet-4-6

## Test plan
- [ ] Trigger a startup failure (e.g. set an invalid env var) and confirm `/api/health` returns `status: "down"` with `startup_error` field
- [ ] Normal startup: confirm `/api/health` does not include `startup_error` key
- [ ] `startup-import-smoke` passes

Closes #8947 (together with #8951)

🤖 Generated with Claude Code