### PR TITLE
feat(rbac): per-user voice bundle assignment endpoints (GH#8605)

### DIFF
--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -1,0 +1,262 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""User endpoints for per-user voice bundle assignment (GH#8605).
+
+Endpoints:
+    GET  /api/voice/bundles              — list available bundles
+    GET  /api/voice/users/{userId}/bundle  — get user's bundle assignment
+    PUT  /api/voice/users/{userId}/bundle  — assign bundle to user
+"""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from auth_middleware import get_auth_middleware, get_current_user
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.logging_manager import get_logger
+from utils.catalog_http_exceptions import raise_auth_error
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["voice", "rbac"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class BundleInfo(BaseModel):
+    name: str
+    label: str
+    tool_count: int
+
+
+class UserBundleResponse(BaseModel):
+    user_id: str
+    bundle_name: Optional[str]
+
+
+class BundleAssignRequest(BaseModel):
+    bundle_name: Optional[str] = None  # None = clear override
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VALID_BUNDLES = {"voice_safe", "voice_extended", "voice_admin"}
+ADMIN_ONLY_BUNDLES = {"voice_admin"}  # Non-admins may not self-assign these
+
+BUNDLE_LABELS = {
+    "voice_safe": "Voice Safe",
+    "voice_extended": "Voice Extended",
+    "voice_admin": "Voice Admin",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _count_tools_for_bundle(bundle: str, is_admin: bool) -> int:
+    """Return the number of tools available in this bundle."""
+    from api.redis_mcp.rbac import TOOL_ACCESS_MATRIX, filter_tools_for_bundle  # noqa: PLC0415
+
+    all_tools = list(TOOL_ACCESS_MATRIX.keys())
+    return len(filter_tools_for_bundle(all_tools, bundle=bundle, is_admin=is_admin))
+
+
+def _get_user_id(user: dict) -> str:
+    """Extract user_id from auth payload."""
+    return user.get("user_id") or user.get("sub") or user.get("username") or "unknown"
+
+
+def _check_self_or_admin(request: Request, current_user: dict, target_user_id: str) -> bool:
+    """Verify user can access target_user_id (self or admin)."""
+    current_user_id = _get_user_id(current_user)
+    is_admin = current_user.get("role") == "admin"
+    return current_user_id == target_user_id or is_admin
+
+
+# ---------------------------------------------------------------------------
+# GET /voice/bundles — list available bundles
+# ---------------------------------------------------------------------------
+
+
+@router.get("/bundles", response_model=List[BundleInfo])
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="voice_list_bundles",
+    error_code_prefix="VOICE",
+)
+async def list_voice_bundles(
+    current_user: dict = Depends(get_current_user),
+) -> List[BundleInfo]:
+    """Return list of available voice bundles.
+
+    Filters bundles based on user role (admins see all, users see allowed).
+    """
+    role = current_user.get("role", "user")
+    is_admin = role == "admin"
+
+    result = []
+    for bundle_name in VALID_BUNDLES:
+        try:
+            tool_count = await _count_tools_for_bundle(bundle_name, is_admin=is_admin)
+            label = BUNDLE_LABELS.get(bundle_name, bundle_name)
+            result.append(
+                BundleInfo(
+                    name=bundle_name,
+                    label=label,
+                    tool_count=tool_count,
+                )
+            )
+        except Exception as exc:
+            logger.warning("Failed to count tools for bundle %s: %s", bundle_name, exc)
+            # Include bundle even if tool count fails
+            label = BUNDLE_LABELS.get(bundle_name, bundle_name)
+            result.append(
+                BundleInfo(
+                    name=bundle_name,
+                    label=label,
+                    tool_count=0,
+                )
+            )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# GET /voice/users/{userId}/bundle — get user's bundle assignment
+# ---------------------------------------------------------------------------
+
+
+@router.get("/users/{user_id}/bundle", response_model=UserBundleResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="voice_get_user_bundle",
+    error_code_prefix="VOICE",
+)
+async def get_user_bundle(
+    user_id: str,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> UserBundleResponse:
+    """Return the explicit bundle assignment for a user.
+
+    Users can only view their own assignment (or admins can view any user).
+    """
+    if not _check_self_or_admin(request, current_user, user_id):
+        raise_auth_error("AUTH_0003", "Cannot access other user's bundle assignment")
+
+    try:
+        from database.session import get_async_session  # noqa: PLC0415
+        from sqlalchemy import text  # noqa: PLC0415
+
+        async with get_async_session() as session:
+            row = await session.execute(
+                text("SELECT bundle_name FROM user_voice_bundle WHERE user_id = :uid"),
+                {"uid": user_id},
+            )
+            result = row.fetchone()
+            bundle_name = result[0] if result else None
+    except Exception as exc:
+        logger.error("get_user_bundle: DB error: %s", exc)
+        raise HTTPException(status_code=500, detail="Database error") from exc
+
+    return UserBundleResponse(user_id=user_id, bundle_name=bundle_name)
+
+
+# ---------------------------------------------------------------------------
+# PUT /voice/users/{userId}/bundle — assign bundle to user
+# ---------------------------------------------------------------------------
+
+
+@router.put("/users/{user_id}/bundle", response_model=UserBundleResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="voice_set_user_bundle",
+    error_code_prefix="VOICE",
+)
+async def set_user_bundle(
+    user_id: str,
+    body: BundleAssignRequest,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> UserBundleResponse:
+    """Assign or clear a voice bundle override for a user.
+
+    Users can only manage their own assignment (admins can manage any user).
+    """
+    if not _check_self_or_admin(request, current_user, user_id):
+        raise_auth_error("AUTH_0003", "Cannot assign bundles to other users")
+
+    if body.bundle_name is not None and body.bundle_name not in VALID_BUNDLES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid bundle_name '{body.bundle_name}'. Valid: {sorted(VALID_BUNDLES)}",
+        )
+
+    is_admin = current_user.get("role") == "admin"
+    if body.bundle_name in ADMIN_ONLY_BUNDLES and not is_admin:
+        raise_auth_error("AUTH_0003", "Only admins may assign the voice_admin bundle")
+
+    current_user_id = _get_user_id(current_user)
+
+    try:
+        from database.session import get_async_session  # noqa: PLC0415
+        from sqlalchemy import text  # noqa: PLC0415
+
+        async with get_async_session() as session:
+            if body.bundle_name is None:
+                # Clear override
+                await session.execute(
+                    text("DELETE FROM user_voice_bundle WHERE user_id = :uid"),
+                    {"uid": user_id},
+                )
+            else:
+                # Upsert
+                await session.execute(
+                    text("""
+                        INSERT INTO user_voice_bundle (user_id, bundle_name, assigned_by, assigned_at)
+                        VALUES (:uid, :bundle, :by, NOW())
+                        ON CONFLICT (user_id) DO UPDATE
+                          SET bundle_name = EXCLUDED.bundle_name,
+                              assigned_by = EXCLUDED.assigned_by,
+                              assigned_at = EXCLUDED.assigned_at
+                        """),
+                    {"uid": user_id, "bundle": body.bundle_name, "by": str(current_user_id)},
+                )
+            await session.commit()
+    except Exception as exc:
+        logger.error("set_user_bundle: DB error: %s", exc)
+        raise HTTPException(status_code=500, detail="Database error") from exc
+
+    # Audit log
+    from services.event_log import EventType, emit  # noqa: PLC0415
+
+    emit(
+        EventType.CONFIG_CHANGED,
+        user_id=str(current_user_id),
+        resource_type="user_voice_bundle",
+        resource_id=user_id,
+        metadata={
+            "target_user_id": user_id,
+            "bundle_name": body.bundle_name,
+            "action": "clear" if body.bundle_name is None else "assign",
+        },
+    )
+
+    logger.info(
+        "voice_bundle user_id=%s target=%s bundle=%s",
+        current_user_id,
+        user_id,
+        body.bundle_name,
+    )
+
+    return UserBundleResponse(user_id=user_id, bundle_name=body.bundle_name)

--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -155,7 +155,7 @@ async def get_user_bundle(
         raise_auth_error("AUTH_0003", "Cannot access other user's bundle assignment")
 
     try:
-        from database.session import get_async_session  # noqa: PLC0415
+        from user_management.database import get_async_session  # noqa: PLC0415
         from sqlalchemy import text  # noqa: PLC0415
 
         async with get_async_session() as session:
@@ -209,7 +209,7 @@ async def set_user_bundle(
     current_user_id = _get_user_id(current_user)
 
     try:
-        from database.session import get_async_session  # noqa: PLC0415
+        from user_management.database import get_async_session  # noqa: PLC0415
         from sqlalchemy import text  # noqa: PLC0415
 
         async with get_async_session() as session:
@@ -238,18 +238,21 @@ async def set_user_bundle(
         raise HTTPException(status_code=500, detail="Database error") from exc
 
     # Audit log
-    from services.event_log import EventType, emit  # noqa: PLC0415
+    from services.audit.unified_audit import AuditCategory, AuditEvent, emit  # noqa: PLC0415
 
     emit(
-        EventType.CONFIG_CHANGED,
-        user_id=str(current_user_id),
-        resource_type="user_voice_bundle",
-        resource_id=user_id,
-        metadata={
-            "target_user_id": user_id,
-            "bundle_name": body.bundle_name,
-            "action": "clear" if body.bundle_name is None else "assign",
-        },
+        AuditEvent(
+            category=AuditCategory.SECURITY,
+            action="voice_bundle_assignment_changed",
+            actor_id=str(current_user_id),
+            resource_type="user_voice_bundle",
+            resource_id=user_id,
+            metadata={
+                "target_user_id": user_id,
+                "bundle_name": body.bundle_name,
+                "assignment_action": "clear" if body.bundle_name is None else "assign",
+            },
+        )
     )
 
     logger.info(

--- a/autobot-backend/api/voice_bundle_user_test.py
+++ b/autobot-backend/api/voice_bundle_user_test.py
@@ -1,0 +1,262 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for user voice bundle endpoints (GH#8605)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# GET /voice/bundles — list available bundles
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_bundles_user_role():
+    """User can list bundles filtered for their role."""
+    from api.voice_bundle_user import list_voice_bundles
+
+    mock_tools_safe = ["tool1", "tool2"]
+    mock_tools_extended = ["tool1", "tool2", "tool3", "tool4"]
+
+    async def mock_count(bundle: str, is_admin: bool) -> int:
+        if bundle == "voice_safe":
+            return len(mock_tools_safe)
+        elif bundle == "voice_extended":
+            return len(mock_tools_extended)
+        elif bundle == "voice_admin":
+            return 0 if not is_admin else 10
+        return 0
+
+    current_user = {"user_id": "user-123", "role": "user"}
+
+    with patch("api.voice_bundle_user._count_tools_for_bundle", side_effect=mock_count):
+        bundles = await list_voice_bundles(current_user)
+
+    assert len(bundles) == 3
+    assert any(b.name == "voice_safe" for b in bundles)
+    assert any(b.name == "voice_extended" for b in bundles)
+    assert any(b.name == "voice_admin" for b in bundles)
+
+
+@pytest.mark.asyncio
+async def test_list_bundles_admin_role():
+    """Admin can list all bundles."""
+    from api.voice_bundle_user import list_voice_bundles
+
+    async def mock_count(bundle: str, is_admin: bool) -> int:
+        return {"voice_safe": 2, "voice_extended": 4, "voice_admin": 10}.get(bundle, 0)
+
+    current_user = {"user_id": "admin-1", "role": "admin"}
+
+    with patch("api.voice_bundle_user._count_tools_for_bundle", side_effect=mock_count):
+        bundles = await list_voice_bundles(current_user)
+
+    assert len(bundles) == 3
+    admin_bundle = next(b for b in bundles if b.name == "voice_admin")
+    assert admin_bundle.tool_count == 10
+
+
+# ---------------------------------------------------------------------------
+# GET /voice/users/{userId}/bundle — get user's bundle assignment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_own_bundle():
+    """User can view their own bundle assignment."""
+    from api.voice_bundle_user import get_user_bundle
+
+    user_id = "user-123"
+    current_user = {"user_id": user_id, "role": "user"}
+    mock_request = MagicMock()
+
+    mock_row = MagicMock()
+    mock_row.fetchone.return_value = ("voice_extended",)
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session.execute = AsyncMock(return_value=mock_row)
+
+    with patch("database.session.get_async_session", return_value=mock_session):
+        result = await get_user_bundle(user_id, mock_request, current_user)
+
+    assert result.user_id == user_id
+    assert result.bundle_name == "voice_extended"
+
+
+@pytest.mark.asyncio
+async def test_admin_can_view_other_user_bundle():
+    """Admin can view any user's bundle assignment."""
+    from api.voice_bundle_user import get_user_bundle
+
+    target_user_id = "other-user"
+    current_user = {"user_id": "admin-1", "role": "admin"}
+    mock_request = MagicMock()
+
+    mock_row = MagicMock()
+    mock_row.fetchone.return_value = ("voice_safe",)
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session.execute = AsyncMock(return_value=mock_row)
+
+    with patch("database.session.get_async_session", return_value=mock_session):
+        result = await get_user_bundle(target_user_id, mock_request, current_user)
+
+    assert result.user_id == target_user_id
+    assert result.bundle_name == "voice_safe"
+
+
+@pytest.mark.asyncio
+async def test_user_cannot_view_other_user_bundle():
+    """User cannot view other user's bundle assignment."""
+    from api.voice_bundle_user import get_user_bundle
+    from utils.catalog_http_exceptions import CatalogHTTPException
+
+    target_user_id = "other-user"
+    current_user = {"user_id": "user-123", "role": "user"}
+    mock_request = MagicMock()
+
+    with pytest.raises(CatalogHTTPException):
+        await get_user_bundle(target_user_id, mock_request, current_user)
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_no_assignment():
+    """Return None when user has no explicit assignment."""
+    from api.voice_bundle_user import get_user_bundle
+
+    user_id = "user-123"
+    current_user = {"user_id": user_id, "role": "user"}
+    mock_request = MagicMock()
+
+    mock_row = MagicMock()
+    mock_row.fetchone.return_value = None
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session.execute = AsyncMock(return_value=mock_row)
+
+    with patch("database.session.get_async_session", return_value=mock_session):
+        result = await get_user_bundle(user_id, mock_request, current_user)
+
+    assert result.user_id == user_id
+    assert result.bundle_name is None
+
+
+# ---------------------------------------------------------------------------
+# PUT /voice/users/{userId}/bundle — assign bundle to user
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_can_assign_own_bundle():
+    """User can assign bundle to themselves."""
+    from api.voice_bundle_user import set_user_bundle, BundleAssignRequest
+
+    user_id = "user-123"
+    current_user = {"user_id": user_id, "role": "user"}
+    mock_request = MagicMock()
+    body = BundleAssignRequest(bundle_name="voice_extended")
+
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session.execute = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    with patch("database.session.get_async_session", return_value=mock_session):
+        with patch("services.event_log.emit"):
+            result = await set_user_bundle(user_id, body, mock_request, current_user)
+
+    assert result.user_id == user_id
+    assert result.bundle_name == "voice_extended"
+    mock_session.execute.assert_called_once()
+    mock_session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_admin_can_assign_bundle_to_other_user():
+    """Admin can assign bundle to any user."""
+    from api.voice_bundle_user import set_user_bundle, BundleAssignRequest
+
+    target_user_id = "other-user"
+    current_user = {"user_id": "admin-1", "role": "admin"}
+    mock_request = MagicMock()
+    body = BundleAssignRequest(bundle_name="voice_safe")
+
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session.execute = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    with patch("database.session.get_async_session", return_value=mock_session):
+        with patch("services.event_log.emit"):
+            result = await set_user_bundle(target_user_id, body, mock_request, current_user)
+
+    assert result.user_id == target_user_id
+    assert result.bundle_name == "voice_safe"
+
+
+@pytest.mark.asyncio
+async def test_user_cannot_assign_bundle_to_other_user():
+    """User cannot assign bundle to other users."""
+    from api.voice_bundle_user import set_user_bundle, BundleAssignRequest
+    from utils.catalog_http_exceptions import CatalogHTTPException
+
+    target_user_id = "other-user"
+    current_user = {"user_id": "user-123", "role": "user"}
+    mock_request = MagicMock()
+    body = BundleAssignRequest(bundle_name="voice_extended")
+
+    with pytest.raises(CatalogHTTPException):
+        await set_user_bundle(target_user_id, body, mock_request, current_user)
+
+
+@pytest.mark.asyncio
+async def test_set_bundle_invalid_name():
+    """Reject invalid bundle names."""
+    from api.voice_bundle_user import set_user_bundle, BundleAssignRequest
+    from fastapi import HTTPException
+
+    user_id = "user-123"
+    current_user = {"user_id": user_id, "role": "user"}
+    mock_request = MagicMock()
+    body = BundleAssignRequest(bundle_name="invalid_bundle")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await set_user_bundle(user_id, body, mock_request, current_user)
+
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_clear_bundle_assignment():
+    """User can clear their bundle assignment (set to None)."""
+    from api.voice_bundle_user import set_user_bundle, BundleAssignRequest
+
+    user_id = "user-123"
+    current_user = {"user_id": user_id, "role": "user"}
+    mock_request = MagicMock()
+    body = BundleAssignRequest(bundle_name=None)
+
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session.execute = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    with patch("database.session.get_async_session", return_value=mock_session):
+        with patch("services.event_log.emit"):
+            result = await set_user_bundle(user_id, body, mock_request, current_user)
+
+    assert result.user_id == user_id
+    assert result.bundle_name is None
+    # Verify DELETE was called
+    mock_session.execute.assert_called_once()
+    call_args = mock_session.execute.call_args[0]
+    assert "DELETE" in str(call_args[0])

--- a/autobot-backend/api/voice_bundle_user_test.py
+++ b/autobot-backend/api/voice_bundle_user_test.py
@@ -80,7 +80,7 @@ async def test_get_own_bundle():
     mock_session.__aexit__ = AsyncMock(return_value=False)
     mock_session.execute = AsyncMock(return_value=mock_row)
 
-    with patch("database.session.get_async_session", return_value=mock_session):
+    with patch("user_management.database.get_async_session", return_value=mock_session):
         result = await get_user_bundle(user_id, mock_request, current_user)
 
     assert result.user_id == user_id
@@ -103,7 +103,7 @@ async def test_admin_can_view_other_user_bundle():
     mock_session.__aexit__ = AsyncMock(return_value=False)
     mock_session.execute = AsyncMock(return_value=mock_row)
 
-    with patch("database.session.get_async_session", return_value=mock_session):
+    with patch("user_management.database.get_async_session", return_value=mock_session):
         result = await get_user_bundle(target_user_id, mock_request, current_user)
 
     assert result.user_id == target_user_id
@@ -113,14 +113,15 @@ async def test_admin_can_view_other_user_bundle():
 @pytest.mark.asyncio
 async def test_user_cannot_view_other_user_bundle():
     """User cannot view other user's bundle assignment."""
+    from fastapi import HTTPException
+
     from api.voice_bundle_user import get_user_bundle
-    from utils.catalog_http_exceptions import CatalogHTTPException
 
     target_user_id = "other-user"
     current_user = {"user_id": "user-123", "role": "user"}
     mock_request = MagicMock()
 
-    with pytest.raises(CatalogHTTPException):
+    with pytest.raises(HTTPException):
         await get_user_bundle(target_user_id, mock_request, current_user)
 
 
@@ -140,7 +141,7 @@ async def test_get_bundle_no_assignment():
     mock_session.__aexit__ = AsyncMock(return_value=False)
     mock_session.execute = AsyncMock(return_value=mock_row)
 
-    with patch("database.session.get_async_session", return_value=mock_session):
+    with patch("user_management.database.get_async_session", return_value=mock_session):
         result = await get_user_bundle(user_id, mock_request, current_user)
 
     assert result.user_id == user_id
@@ -168,7 +169,7 @@ async def test_user_can_assign_own_bundle():
     mock_session.execute = AsyncMock()
     mock_session.commit = AsyncMock()
 
-    with patch("database.session.get_async_session", return_value=mock_session):
+    with patch("user_management.database.get_async_session", return_value=mock_session):
         with patch("services.event_log.emit"):
             result = await set_user_bundle(user_id, body, mock_request, current_user)
 
@@ -194,7 +195,7 @@ async def test_admin_can_assign_bundle_to_other_user():
     mock_session.execute = AsyncMock()
     mock_session.commit = AsyncMock()
 
-    with patch("database.session.get_async_session", return_value=mock_session):
+    with patch("user_management.database.get_async_session", return_value=mock_session):
         with patch("services.event_log.emit"):
             result = await set_user_bundle(target_user_id, body, mock_request, current_user)
 
@@ -205,15 +206,16 @@ async def test_admin_can_assign_bundle_to_other_user():
 @pytest.mark.asyncio
 async def test_user_cannot_assign_bundle_to_other_user():
     """User cannot assign bundle to other users."""
-    from api.voice_bundle_user import set_user_bundle, BundleAssignRequest
-    from utils.catalog_http_exceptions import CatalogHTTPException
+    from fastapi import HTTPException
+
+    from api.voice_bundle_user import BundleAssignRequest, set_user_bundle
 
     target_user_id = "other-user"
     current_user = {"user_id": "user-123", "role": "user"}
     mock_request = MagicMock()
     body = BundleAssignRequest(bundle_name="voice_extended")
 
-    with pytest.raises(CatalogHTTPException):
+    with pytest.raises(HTTPException):
         await set_user_bundle(target_user_id, body, mock_request, current_user)
 
 
@@ -250,7 +252,7 @@ async def test_clear_bundle_assignment():
     mock_session.execute = AsyncMock()
     mock_session.commit = AsyncMock()
 
-    with patch("database.session.get_async_session", return_value=mock_session):
+    with patch("user_management.database.get_async_session", return_value=mock_session):
         with patch("services.event_log.emit"):
             result = await set_user_bundle(user_id, body, mock_request, current_user)
 

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -89,6 +89,7 @@ from api.vnc_proxy import router as vnc_proxy_router
 from api.voice import realtime_router as voice_realtime_router
 from api.voice import router as voice_router
 from api.voice_bundle_admin import bundle_admin_router, bundle_me_router
+from api.voice_bundle_user import router as voice_bundle_user_router
 from api.voice_stream import router as voice_stream_router
 from api.wake_word import router as wake_word_router
 from api.websockets import router as websockets_router  # Issue #6229
@@ -316,6 +317,7 @@ def _get_service_routers() -> list:
         (voice_realtime_router, "/voice", ["voice"], "voice_realtime"),
         (voice_router, "/voice", ["voice"], "voice"),
         (bundle_me_router, "/voice", ["voice", "rbac"], "voice_bundle_me"),
+        (voice_bundle_user_router, "/voice", ["voice", "rbac"], "voice_bundle_user"),
         (bundle_admin_router, "", ["admin", "voice", "rbac"], "voice_bundle_admin"),
         (voice_stream_router, "/voice", ["voice", "websocket"], "voice_stream"),
         (wake_word_router, "/wake_word", ["wake_word", "voice"], "wake_word"),


### PR DESCRIPTION
## Summary

Implements GH#8605 — per-user voice bundle assignment backend. Users can view and self-assign voice bundles; admins can assign to any user.

Closes #8605

## Thinking Path

Work was found orphaned on wrong branch (issue-MVA-1644). Rescued, applied privilege escalation security fix (voice_admin self-assignment by non-admins), then committed to correct branch.

## What Changed

- `autobot-backend/api/voice_bundle_user.py` — 3 FastAPI endpoints: list bundles, get user assignment, assign/clear override. UPSERT via SQLAlchemy. Audit event emitted on every change.
- `autobot-backend/api/voice_bundle_user_test.py` — test suite
- `autobot-backend/initialization/router_registry/core_routers.py` — wire-in: `voice_bundle_user_router` registered under `/voice` with `["voice", "rbac"]` tags

## Verification

- `python3 -m py_compile voice_bundle_user.py` ✅
- Security fix applied: `ADMIN_ONLY_BUNDLES = {"voice_admin"}` guard blocks non-admins from self-escalating to voice_admin bundle
- Wire-in confirmed in core_routers.py

## Security

**Privilege escalation patched before first commit:** original code allowed any authenticated user to self-assign `voice_admin` bundle via PUT. Fix adds `ADMIN_ONLY_BUNDLES` check — non-admins who request a bundle in that set receive AUTH_0003.

## Model Used

claude-sonnet-4-6

## Changes

- `voice_bundle_user.py`: 3 endpoints + ADMIN_ONLY_BUNDLES security guard
- `voice_bundle_user_test.py`: tests
- `core_routers.py`: router wire-in

## Test plan

- [ ] `py_compile` passes ✅
- [ ] Non-admin cannot self-assign `voice_admin` → AUTH_0003
- [ ] Admin can assign `voice_admin` to any user
- [ ] Regular user can assign `voice_safe` / `voice_extended` to self
- [ ] PUT with `bundle_name: null` clears assignment

## Changelog fragment

- [ ] N/A — new RBAC endpoint, internal feature