### PR TITLE
fix(rbac): enforce admin-only authorization on PUT /voice/users/{user_id}/bundle (GH#8969)

### DIFF
--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -1,0 +1,262 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""User endpoints for per-user voice bundle assignment (GH#8605).
+
+Endpoints:
+    GET  /api/voice/bundles              — list available bundles
+    GET  /api/voice/users/{userId}/bundle  — get user's bundle assignment (self or admin)
+    PUT  /api/voice/users/{userId}/bundle  — assign bundle to user (admin only, GH#8969)
+"""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from auth_middleware import get_auth_middleware, get_current_user
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.logging_manager import get_logger
+from utils.catalog_http_exceptions import raise_auth_error
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["voice", "rbac"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class BundleInfo(BaseModel):
+    name: str
+    label: str
+    tool_count: int
+
+
+class UserBundleResponse(BaseModel):
+    user_id: str
+    bundle_name: Optional[str]
+
+
+class BundleAssignRequest(BaseModel):
+    bundle_name: Optional[str] = None  # None = clear override
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VALID_BUNDLES = {"voice_safe", "voice_extended", "voice_admin"}
+
+BUNDLE_LABELS = {
+    "voice_safe": "Voice Safe",
+    "voice_extended": "Voice Extended",
+    "voice_admin": "Voice Admin",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _count_tools_for_bundle(bundle: str, is_admin: bool) -> int:
+    """Return the number of tools available in this bundle."""
+    from api.redis_mcp.rbac import TOOL_ACCESS_MATRIX, filter_tools_for_bundle  # noqa: PLC0415
+
+    all_tools = list(TOOL_ACCESS_MATRIX.keys())
+    return len(filter_tools_for_bundle(all_tools, bundle=bundle, is_admin=is_admin))
+
+
+def _get_user_id(user: dict) -> str:
+    """Extract user_id from auth payload."""
+    return user.get("user_id") or user.get("sub") or user.get("username") or "unknown"
+
+
+def _check_self_or_admin(request: Request, current_user: dict, target_user_id: str) -> bool:
+    """Verify user can access target_user_id (self or admin)."""
+    current_user_id = _get_user_id(current_user)
+    is_admin = current_user.get("role") == "admin"
+    return current_user_id == target_user_id or is_admin
+
+
+# ---------------------------------------------------------------------------
+# GET /voice/bundles — list available bundles
+# ---------------------------------------------------------------------------
+
+
+@router.get("/bundles", response_model=List[BundleInfo])
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="voice_list_bundles",
+    error_code_prefix="VOICE",
+)
+async def list_voice_bundles(
+    current_user: dict = Depends(get_current_user),
+) -> List[BundleInfo]:
+    """Return list of available voice bundles.
+
+    Filters bundles based on user role (admins see all, users see allowed).
+    """
+    role = current_user.get("role", "user")
+    is_admin = role == "admin"
+
+    result = []
+    for bundle_name in VALID_BUNDLES:
+        try:
+            tool_count = await _count_tools_for_bundle(bundle_name, is_admin=is_admin)
+            label = BUNDLE_LABELS.get(bundle_name, bundle_name)
+            result.append(
+                BundleInfo(
+                    name=bundle_name,
+                    label=label,
+                    tool_count=tool_count,
+                )
+            )
+        except Exception as exc:
+            logger.warning("Failed to count tools for bundle %s: %s", bundle_name, exc)
+            label = BUNDLE_LABELS.get(bundle_name, bundle_name)
+            result.append(
+                BundleInfo(
+                    name=bundle_name,
+                    label=label,
+                    tool_count=0,
+                )
+            )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# GET /voice/users/{userId}/bundle — get user's bundle assignment
+# ---------------------------------------------------------------------------
+
+
+@router.get("/users/{user_id}/bundle", response_model=UserBundleResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="voice_get_user_bundle",
+    error_code_prefix="VOICE",
+)
+async def get_user_bundle(
+    user_id: str,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> UserBundleResponse:
+    """Return the explicit bundle assignment for a user.
+
+    Users can only view their own assignment (or admins can view any user).
+    """
+    if not _check_self_or_admin(request, current_user, user_id):
+        raise_auth_error("AUTH_0003", "Cannot access other user's bundle assignment")
+
+    try:
+        from user_management.database import get_async_session  # noqa: PLC0415
+        from sqlalchemy import text  # noqa: PLC0415
+
+        async with get_async_session() as session:
+            row = await session.execute(
+                text("SELECT bundle_name FROM user_voice_bundle WHERE user_id = :uid"),
+                {"uid": user_id},
+            )
+            result = row.fetchone()
+            bundle_name = result[0] if result else None
+    except Exception as exc:
+        logger.error("get_user_bundle: DB error: %s", exc)
+        raise HTTPException(status_code=500, detail="Database error") from exc
+
+    return UserBundleResponse(user_id=user_id, bundle_name=bundle_name)
+
+
+# ---------------------------------------------------------------------------
+# PUT /voice/users/{userId}/bundle — assign bundle to user (admin only)
+# ---------------------------------------------------------------------------
+
+
+@router.put("/users/{user_id}/bundle", response_model=UserBundleResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="voice_set_user_bundle",
+    error_code_prefix="VOICE",
+)
+async def set_user_bundle(
+    user_id: str,
+    body: BundleAssignRequest,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> UserBundleResponse:
+    """Assign or clear a voice bundle override for a user.
+
+    Admin-only. Bundle assignment changes a user's privilege level, so
+    self-service is explicitly prohibited to prevent privilege escalation
+    (GH#8969).
+    """
+    is_admin = current_user.get("role") == "admin"
+    if not is_admin:
+        raise_auth_error("AUTH_0003", "Only admins may assign voice bundles")
+
+    if body.bundle_name is not None and body.bundle_name not in VALID_BUNDLES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid bundle_name '{body.bundle_name}'. Valid: {sorted(VALID_BUNDLES)}",
+        )
+
+    current_user_id = _get_user_id(current_user)
+
+    try:
+        from user_management.database import get_async_session  # noqa: PLC0415
+        from sqlalchemy import text  # noqa: PLC0415
+
+        async with get_async_session() as session:
+            if body.bundle_name is None:
+                # Clear override
+                await session.execute(
+                    text("DELETE FROM user_voice_bundle WHERE user_id = :uid"),
+                    {"uid": user_id},
+                )
+            else:
+                # Upsert
+                await session.execute(
+                    text("""
+                        INSERT INTO user_voice_bundle (user_id, bundle_name, assigned_by, assigned_at)
+                        VALUES (:uid, :bundle, :by, NOW())
+                        ON CONFLICT (user_id) DO UPDATE
+                          SET bundle_name = EXCLUDED.bundle_name,
+                              assigned_by = EXCLUDED.assigned_by,
+                              assigned_at = EXCLUDED.assigned_at
+                        """),
+                    {"uid": user_id, "bundle": body.bundle_name, "by": str(current_user_id)},
+                )
+            await session.commit()
+    except Exception as exc:
+        logger.error("set_user_bundle: DB error: %s", exc)
+        raise HTTPException(status_code=500, detail="Database error") from exc
+
+    # Audit log
+    from services.audit.unified_audit import AuditCategory, AuditEvent, emit  # noqa: PLC0415
+
+    emit(
+        AuditEvent(
+            category=AuditCategory.SECURITY,
+            action="voice_bundle_assignment_changed",
+            actor_id=str(current_user_id),
+            resource_type="user_voice_bundle",
+            resource_id=user_id,
+            metadata={
+                "target_user_id": user_id,
+                "bundle_name": body.bundle_name,
+                "assignment_action": "clear" if body.bundle_name is None else "assign",
+            },
+        )
+    )
+
+    logger.info(
+        "voice_bundle user_id=%s target=%s bundle=%s",
+        current_user_id,
+        user_id,
+        body.bundle_name,
+    )
+
+    return UserBundleResponse(user_id=user_id, bundle_name=body.bundle_name)

--- a/autobot-backend/tests/api/test_voice_bundle_user.py
+++ b/autobot-backend/tests/api/test_voice_bundle_user.py
@@ -1,12 +1,12 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Tests for per-user voice bundle assignment endpoints (GH#8605).
+"""Tests for per-user voice bundle assignment endpoints (GH#8605, GH#8969).
 
 Covers:
 - GET /api/voice/bundles: list available bundles with tool counts
 - GET /api/voice/users/{userId}/bundle: get user's bundle assignment (self/admin only)
-- PUT /api/voice/users/{userId}/bundle: assign/clear bundle (self/admin only)
+- PUT /api/voice/users/{userId}/bundle: assign/clear bundle (admin only — GH#8969)
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,6 +22,7 @@ from api.voice_bundle_user import (
     UserBundleResponse,
     router,
 )
+from auth_middleware import get_current_user
 
 
 # Test users
@@ -30,57 +31,41 @@ _USER_BOB = {"user_id": "bob", "username": "bob", "role": "user"}
 _ADMIN = {"user_id": "admin-user", "username": "admin", "role": "admin"}
 
 
-@pytest.fixture()
-def app():
-    """Create FastAPI app with voice_bundle_user router and mocked dependencies."""
+def _make_client(user: dict) -> TestClient:
+    """Create a TestClient with dependency_overrides for get_current_user."""
     app = FastAPI()
     app.include_router(router, prefix="/api/voice")
-    return app
 
-
-@pytest.fixture()
-def client(app):
-    """Create TestClient for the app."""
-    return TestClient(app)
-
-
-def _mock_get_current_user(user: dict):
-    """Create a mock for get_current_user dependency."""
-    async def _current_user():
+    async def _override():
         return user
-    return _current_user
+
+    app.dependency_overrides[get_current_user] = _override
+    return TestClient(app)
 
 
 class TestListVoiceBundles:
     """Tests for GET /api/voice/bundles."""
 
-    def test_list_bundles_user(self, client):
+    def test_list_bundles_user(self):
         """User can list available bundles."""
-        with patch(
-            "api.voice_bundle_user.get_current_user",
-            _mock_get_current_user(_USER_ALICE),
-        ):
-            response = client.get("/api/voice/bundles")
+        client = _make_client(_USER_ALICE)
+        response = client.get("/api/voice/bundles")
 
         assert response.status_code == 200
         bundles = response.json()
         assert isinstance(bundles, list)
         assert len(bundles) > 0
 
-        # Verify structure of each bundle
         for bundle in bundles:
             assert "name" in bundle
             assert "label" in bundle
             assert "tool_count" in bundle
             assert isinstance(bundle["tool_count"], int)
 
-    def test_list_bundles_admin(self, client):
+    def test_list_bundles_admin(self):
         """Admin can list bundles (should see all)."""
-        with patch(
-            "api.voice_bundle_user.get_current_user",
-            _mock_get_current_user(_ADMIN),
-        ):
-            response = client.get("/api/voice/bundles")
+        client = _make_client(_ADMIN)
+        response = client.get("/api/voice/bundles")
 
         assert response.status_code == 200
         bundles = response.json()
@@ -90,15 +75,11 @@ class TestListVoiceBundles:
 class TestGetUserBundle:
     """Tests for GET /api/voice/users/{userId}/bundle."""
 
-    def test_get_own_bundle(self, client):
+    def test_get_own_bundle(self):
         """User can get their own bundle assignment."""
-        with patch(
-            "api.voice_bundle_user.get_current_user",
-            _mock_get_current_user(_USER_ALICE),
-        ), patch(
-            "api.voice_bundle_user.get_async_session"
-        ) as mock_session_ctx:
-            # Mock database response
+        client = _make_client(_USER_ALICE)
+
+        with patch("user_management.database.get_async_session") as mock_session_ctx:
             mock_session = AsyncMock(spec=AsyncSession)
             mock_result = MagicMock()
             mock_result.fetchone.return_value = ("voice_extended",)
@@ -112,14 +93,11 @@ class TestGetUserBundle:
         assert data["user_id"] == "alice"
         assert data["bundle_name"] == "voice_extended"
 
-    def test_admin_can_get_other_bundle(self, client):
+    def test_admin_can_get_other_bundle(self):
         """Admin can get any user's bundle assignment."""
-        with patch(
-            "api.voice_bundle_user.get_current_user",
-            _mock_get_current_user(_ADMIN),
-        ), patch(
-            "api.voice_bundle_user.get_async_session"
-        ) as mock_session_ctx:
+        client = _make_client(_ADMIN)
+
+        with patch("user_management.database.get_async_session") as mock_session_ctx:
             mock_session = AsyncMock(spec=AsyncSession)
             mock_result = MagicMock()
             mock_result.fetchone.return_value = ("voice_admin",)
@@ -133,27 +111,21 @@ class TestGetUserBundle:
         assert data["user_id"] == "bob"
         assert data["bundle_name"] == "voice_admin"
 
-    def test_user_cannot_access_other_bundle(self, client):
+    def test_user_cannot_access_other_bundle(self):
         """Non-admin user cannot access another user's bundle."""
-        with patch(
-            "api.voice_bundle_user.get_current_user",
-            _mock_get_current_user(_USER_ALICE),
-        ):
-            response = client.get("/api/voice/users/bob/bundle")
+        client = _make_client(_USER_ALICE)
+        response = client.get("/api/voice/users/bob/bundle")
 
         assert response.status_code == 403
 
-    def test_get_bundle_not_assigned(self, client):
+    def test_get_bundle_not_assigned(self):
         """Getting bundle when none assigned returns null."""
-        with patch(
-            "api.voice_bundle_user.get_current_user",
-            _mock_get_current_user(_USER_ALICE),
-        ), patch(
-            "api.voice_bundle_user.get_async_session"
-        ) as mock_session_ctx:
+        client = _make_client(_USER_ALICE)
+
+        with patch("user_management.database.get_async_session") as mock_session_ctx:
             mock_session = AsyncMock(spec=AsyncSession)
             mock_result = MagicMock()
-            mock_result.fetchone.return_value = None  # No assignment
+            mock_result.fetchone.return_value = None
             mock_session.execute.return_value = mock_result
             mock_session_ctx.return_value.__aenter__.return_value = mock_session
 
@@ -165,42 +137,47 @@ class TestGetUserBundle:
 
 
 class TestSetUserBundle:
-    """Tests for PUT /api/voice/users/{userId}/bundle."""
+    """Tests for PUT /api/voice/users/{userId}/bundle.
 
-    def test_assign_bundle_to_self(self, client):
-        """User can assign a bundle to themselves."""
-        with patch(
-            "api.voice_bundle_user.get_current_user",
-            _mock_get_current_user(_USER_ALICE),
-        ), patch(
-            "api.voice_bundle_user.get_async_session"
-        ) as mock_session_ctx, patch(
-            "api.voice_bundle_user.emit"
-        ) as mock_emit:
-            mock_session = AsyncMock(spec=AsyncSession)
-            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+    PUT is admin-only (GH#8969 — privilege escalation fix).
+    """
 
-            response = client.put(
-                "/api/voice/users/alice/bundle",
-                json={"bundle_name": "voice_extended"},
-            )
+    def test_non_admin_cannot_self_assign_bundle(self):
+        """Non-admin user cannot assign a bundle to themselves (GH#8969)."""
+        client = _make_client(_USER_ALICE)
+        response = client.put(
+            "/api/voice/users/alice/bundle",
+            json={"bundle_name": "voice_extended"},
+        )
 
-        assert response.status_code == 200
-        data = response.json()
-        assert data["user_id"] == "alice"
-        assert data["bundle_name"] == "voice_extended"
-        mock_session.commit.assert_called_once()
-        mock_emit.assert_called_once()
+        assert response.status_code == 403
 
-    def test_admin_assigns_bundle_to_other_user(self, client):
+    def test_non_admin_cannot_self_clear_bundle(self):
+        """Non-admin user cannot clear their own bundle assignment (admin-only operation)."""
+        client = _make_client(_USER_ALICE)
+        response = client.put(
+            "/api/voice/users/alice/bundle",
+            json={"bundle_name": None},
+        )
+
+        assert response.status_code == 403
+
+    def test_user_cannot_assign_to_other_user(self):
+        """Non-admin user cannot assign bundle to another user."""
+        client = _make_client(_USER_ALICE)
+        response = client.put(
+            "/api/voice/users/bob/bundle",
+            json={"bundle_name": "voice_extended"},
+        )
+
+        assert response.status_code == 403
+
+    def test_admin_assigns_bundle_to_user(self):
         """Admin can assign a bundle to any user."""
-        with patch(
-            "api.voice_bundle_user.get_current_user",
-            _mock_get_current_user(_ADMIN),
-        ), patch(
-            "api.voice_bundle_user.get_async_session"
-        ) as mock_session_ctx, patch(
-            "api.voice_bundle_user.emit"
+        client = _make_client(_ADMIN)
+
+        with patch("user_management.database.get_async_session") as mock_session_ctx, patch(
+            "services.audit.unified_audit.emit"
         ) as mock_emit:
             mock_session = AsyncMock(spec=AsyncSession)
             mock_session_ctx.return_value.__aenter__.return_value = mock_session
@@ -214,29 +191,14 @@ class TestSetUserBundle:
         data = response.json()
         assert data["user_id"] == "bob"
         assert data["bundle_name"] == "voice_safe"
+        mock_session.commit.assert_called_once()
 
-    def test_user_cannot_assign_to_other_user(self, client):
-        """Non-admin user cannot assign bundle to another user."""
-        with patch(
-            "api.voice_bundle_user.get_current_user",
-            _mock_get_current_user(_USER_ALICE),
-        ):
-            response = client.put(
-                "/api/voice/users/bob/bundle",
-                json={"bundle_name": "voice_extended"},
-            )
+    def test_admin_clears_bundle_for_user(self):
+        """Admin can clear a user's bundle assignment."""
+        client = _make_client(_ADMIN)
 
-        assert response.status_code == 403
-
-    def test_clear_bundle_assignment(self, client):
-        """User can clear their bundle assignment (set to None)."""
-        with patch(
-            "api.voice_bundle_user.get_current_user",
-            _mock_get_current_user(_USER_ALICE),
-        ), patch(
-            "api.voice_bundle_user.get_async_session"
-        ) as mock_session_ctx, patch(
-            "api.voice_bundle_user.emit"
+        with patch("user_management.database.get_async_session") as mock_session_ctx, patch(
+            "services.audit.unified_audit.emit"
         ) as mock_emit:
             mock_session = AsyncMock(spec=AsyncSession)
             mock_session_ctx.return_value.__aenter__.return_value = mock_session
@@ -251,43 +213,33 @@ class TestSetUserBundle:
         assert data["user_id"] == "alice"
         assert data["bundle_name"] is None
         mock_session.execute.assert_called_once()
-        mock_emit.assert_called_once()
 
-    def test_invalid_bundle_name(self, client):
-        """Assigning invalid bundle name fails."""
-        with patch(
-            "api.voice_bundle_user.get_current_user",
-            _mock_get_current_user(_USER_ALICE),
-        ):
-            response = client.put(
-                "/api/voice/users/alice/bundle",
-                json={"bundle_name": "invalid_bundle"},
-            )
+    def test_invalid_bundle_name(self):
+        """Admin assigning invalid bundle name fails with 422."""
+        client = _make_client(_ADMIN)
+        response = client.put(
+            "/api/voice/users/alice/bundle",
+            json={"bundle_name": "invalid_bundle"},
+        )
 
         assert response.status_code == 422
 
-    def test_user_cannot_assign_admin_bundle(self, client):
+    def test_user_cannot_assign_admin_bundle(self):
         """Non-admin user cannot assign voice_admin bundle."""
-        with patch(
-            "api.voice_bundle_user.get_current_user",
-            _mock_get_current_user(_USER_ALICE),
-        ):
-            response = client.put(
-                "/api/voice/users/alice/bundle",
-                json={"bundle_name": "voice_admin"},
-            )
+        client = _make_client(_USER_ALICE)
+        response = client.put(
+            "/api/voice/users/alice/bundle",
+            json={"bundle_name": "voice_admin"},
+        )
 
         assert response.status_code == 403
 
-    def test_admin_can_assign_admin_bundle(self, client):
+    def test_admin_can_assign_admin_bundle(self):
         """Admin can assign voice_admin bundle."""
-        with patch(
-            "api.voice_bundle_user.get_current_user",
-            _mock_get_current_user(_ADMIN),
-        ), patch(
-            "api.voice_bundle_user.get_async_session"
-        ) as mock_session_ctx, patch(
-            "api.voice_bundle_user.emit"
+        client = _make_client(_ADMIN)
+
+        with patch("user_management.database.get_async_session") as mock_session_ctx, patch(
+            "services.audit.unified_audit.emit"
         ) as mock_emit:
             mock_session = AsyncMock(spec=AsyncSession)
             mock_session_ctx.return_value.__aenter__.return_value = mock_session


### PR DESCRIPTION
## Summary

- Fixes privilege escalation: `PUT /voice/users/{user_id}/bundle` now enforces admin-only authorization
- Removes `_check_self_or_admin()` from PUT endpoint (self-service bundle assignment was allowing `voice_extended` upgrade without admin approval)
- GET endpoint retains self-or-admin access (read-only, no escalation risk)
- Adds missing `voice_bundle_user.py` implementation (file was absent from `origin/Dev_new_gui` — router registration had landed without the module)
- Fixes broken test dependency-override pattern (`app.dependency_overrides` instead of `patch(module.attr)`)

## Thinking Path

Any authenticated user could call `PUT /voice/users/{user_id}/bundle` with their own `user_id`. The endpoint used `_check_self_or_admin()` which passes when `current_user_id == target_user_id`, allowing self-upgrade from `voice_safe` to `voice_extended` without admin approval. The fix is a strict `is_admin` gate at function entry — `GET` stays self-or-admin because reading your own record carries no privilege risk.

## What Changed

- `autobot-backend/api/voice_bundle_user.py` (new): `set_user_bundle()` checks `is_admin` at entry; returns 403 for non-admins before any DB access. Removed now-redundant `ADMIN_ONLY_BUNDLES` secondary check.
- `autobot-backend/tests/api/test_voice_bundle_user.py`: Rewrote `TestSetUserBundle` tests — self-assign tests now expect 403; added `test_admin_clears_bundle_for_user`; fixed `app.dependency_overrides` pattern; fixed mock targets (`user_management.database.get_async_session`).

## Verification

- 14/14 tests pass: `python3 -m pytest autobot-backend/tests/api/test_voice_bundle_user.py` (exit 0)
- Security scenarios explicitly covered: `test_non_admin_cannot_self_assign_bundle`, `test_non_admin_cannot_self_clear_bundle`, `test_user_cannot_assign_to_other_user` all assert 403
- CodeQL scan: pass; SAST: pass; Semgrep: pass; startup-import-smoke: pass

## Model Used

claude-sonnet-4-6