### PR TITLE
fix(backend): P1 hotfix — use getattr fallback for storage_dir (#8978)

### DIFF
--- a/autobot-backend/conversation_file_manager.py
+++ b/autobot-backend/conversation_file_manager.py
@@ -123,7 +123,7 @@ class ConversationFileManager:
     @staticmethod
     def _get_default_paths() -> tuple:
         """Get default storage directory and database path from environment or defaults."""
-        storage = Path(config.storage_dir or str(_PROJECT_ROOT / "data" / "conversation_files"))
+        storage = Path(getattr(config, "storage_dir", None) or str(_PROJECT_ROOT / "data" / "conversation_files"))
         db = Path(config.data_db or str(_PROJECT_ROOT / "data" / "conversation_files.db"))
         return storage, db
 


### PR DESCRIPTION
## P1 Production Hotfix

**autobot-backend is DOWN** — all 4 uvicorn workers crash on startup since 2026-05-30 ~11:00 EEST.

Fixes: #8978

## Root Cause

`AutoBotConfig` object has no `storage_dir` attribute. Direct attribute access (`config.storage_dir`) raises `AttributeError: 'AutoBotConfig' object has no attribute 'storage_dir'`, crashing every worker during `ConversationFileManager._get_default_paths()` initialization.

## Change

`autobot-backend/conversation_file_manager.py:126`

```python
# Before (crashes on startup):
storage = Path(config.storage_dir or str(_PROJECT_ROOT / "data" / "conversation_files"))

# After (safe fallback):
storage = Path(getattr(config, "storage_dir", None) or str(_PROJECT_ROOT / "data" / "conversation_files"))
```

## Verification

- `py_compile` passes ✅
- Diff is exactly 1 line, surgical change ✅
- Matches the orphaned hotfix commit `1b28047249e7e5dfec7281da3d5d04677b19faab` that was previously applied to disk only ✅

## Gate Override

PR queue has 8 open PRs (exceeds 3-PR gate). **P1 severity authorizes bypass** per MVA-1695 issue description.

## Notes

- Do NOT merge PR #8951 (branch `mva-1627`) alongside this — it is conflicting
- Secondary error (`No module named 'backend'` in `tool_handler.py:841`) is a separate non-P1 issue and will be filed separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)