### PR TITLE
feat(execution): sandbox state snapshot and restore for resumable agent sessions (GH#4458)

### DIFF
--- a/autobot-backend/services/execution/docker_backend.py
+++ b/autobot-backend/services/execution/docker_backend.py
@@ -106,9 +106,7 @@ class DockerBackend(ExecutionBackend):
             try:
                 pool_size = int(os.getenv("AUTOBOT_DOCKER_POOL_SIZE", str(_DEFAULT_POOL_SIZE)))
             except ValueError:
-                logger.warning(
-                    "Invalid AUTOBOT_DOCKER_POOL_SIZE env var, using default %d", _DEFAULT_POOL_SIZE
-                )
+                logger.warning("Invalid AUTOBOT_DOCKER_POOL_SIZE env var, using default %d", _DEFAULT_POOL_SIZE)
                 pool_size = _DEFAULT_POOL_SIZE
 
         self._use_pool = use_pool

--- a/autobot-backend/services/execution/docker_backend.py
+++ b/autobot-backend/services/execution/docker_backend.py
@@ -16,7 +16,7 @@ GH#4458: Snapshot/restore for resumable agent sessions.
 ``snapshot(container_id, session_id)`` commits a container to a named image and
 records metadata in a file-based index (``SnapshotIndex``).
 ``restore(snapshot_id)`` starts a new detached container from the saved image.
-Storage path is controlled by AUTOBOT_SNAPSHOT_STORAGE_PATH (default /tmp/autobot_snapshots).
+Storage path is controlled by AUTOBOT_SNAPSHOT_STORAGE_PATH (default /opt/autobot/snapshots).
 """
 
 import asyncio
@@ -96,6 +96,7 @@ class DockerBackend(ExecutionBackend):
             raise RuntimeError(f"Failed to connect to Docker daemon: {e}")
 
         self._container_map: Dict[str, str] = {}  # task_id -> container_id
+        self._restored_containers: Dict[str, str] = {}  # snapshot_id -> container_id
         self._default_image = "python:3.10-slim"
 
         # Pre-warmed pool (GH#4452)
@@ -337,14 +338,17 @@ class DockerBackend(ExecutionBackend):
 
     async def cleanup(self) -> None:
         """Clean up active containers and stop the pool if running."""
-        for task_id, container_id in list(self._container_map.items()):
+        all_containers = list(self._container_map.items()) + [
+            (f"restored:{k}", v) for k, v in self._restored_containers.items()
+        ]
+        for key, container_id in all_containers:
             try:
                 container = self.client.containers.get(container_id)
                 if container.status == "running":
                     container.kill()
                 container.remove(force=True)
             except Exception as e:
-                logger.warning("Error cleaning up container %s: %s", container_id, e)
+                logger.warning("Error cleaning up container %s (key=%s): %s", container_id, key, e)
 
         if self._pool_registry is not None:
             await self._pool_registry.stop()
@@ -470,8 +474,10 @@ class DockerBackend(ExecutionBackend):
                 f"Failed to restore snapshot {snapshot_id} from image {record.image_name}: {exc}"
             ) from exc
 
-        # Track restored container so cleanup() can stop it at session end.
-        self._container_map[snapshot_id] = container.id
+        # Track restored container in a dedicated map so cleanup() can stop it.
+        # Using _container_map (keyed by task_id) would cause cleanup to skip these
+        # containers because snapshot_id is not a task_id.
+        self._restored_containers[snapshot_id] = container.id
 
         logger.info(
             "Restored snapshot %s → container %s (session=%s)",

--- a/autobot-backend/services/execution/docker_backend.py
+++ b/autobot-backend/services/execution/docker_backend.py
@@ -11,11 +11,17 @@ GH#4452: Optional pre-warmed container pool for near-zero cold-start latency.
 Enable it by passing ``use_pool=True`` (and optionally ``pool_size``) to the
 constructor. The pool runs ``sleep infinity`` containers per image and uses
 ``exec_run`` instead of ``containers.run`` so callers skip image-layer spin-up.
+
+GH#4458: Snapshot/restore for resumable agent sessions.
+``snapshot(container_id, session_id)`` commits a container to a named image and
+records metadata in a file-based index (``SnapshotIndex``).
+``restore(snapshot_id)`` starts a new detached container from the saved image.
+Storage path is controlled by AUTOBOT_SNAPSHOT_STORAGE_PATH (default /tmp/autobot_snapshots).
 """
 
 import asyncio
 import os
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
@@ -35,6 +41,12 @@ from services.execution.base_backend import (
     ExecutionTask,
 )
 from services.execution.container_pool import ContainerPoolRegistry
+from services.execution.snapshot_index import (
+    SnapshotIndex,
+    SnapshotRecord,
+    _image_name_for_snapshot,
+    make_snapshot_id,
+)
 
 logger = get_logger(__name__)
 
@@ -55,6 +67,7 @@ class DockerBackend(ExecutionBackend):
         docker_host: str | None = None,
         use_pool: bool | None = None,
         pool_size: int | None = None,
+        snapshot_index: Optional[SnapshotIndex] = None,
     ) -> None:
         """Initialize Docker backend.
 
@@ -64,6 +77,9 @@ class DockerBackend(ExecutionBackend):
                 Overrides AUTOBOT_DOCKER_USE_POOL env var if provided.
             pool_size: Number of warm containers to maintain per image.
                 Overrides AUTOBOT_DOCKER_POOL_SIZE env var if provided.
+            snapshot_index: SnapshotIndex instance for GH#4458 snapshot/restore.
+                Defaults to a new SnapshotIndex resolved from
+                AUTOBOT_SNAPSHOT_STORAGE_PATH env var.
 
         Raises:
             RuntimeError: If Docker is not available or not configured
@@ -104,6 +120,9 @@ class DockerBackend(ExecutionBackend):
                 pool_size=pool_size,
             )
             logger.info("Docker pool enabled with size %d (GH#4452)", pool_size)
+
+        # Snapshot/restore index (GH#4458)
+        self._snapshot_index: SnapshotIndex = snapshot_index or SnapshotIndex()
 
     # ------------------------------------------------------------------
     # Pool lifecycle helpers
@@ -355,6 +374,125 @@ class DockerBackend(ExecutionBackend):
             pass
 
         return True, ""
+
+    # ------------------------------------------------------------------
+    # Snapshot / restore (GH#4458)
+    # ------------------------------------------------------------------
+
+    async def snapshot(self, container_id: str, session_id: str = "") -> SnapshotRecord:
+        """Commit a running container's filesystem to a named image and record metadata.
+
+        Args:
+            container_id: ID or name of the Docker container to snapshot.
+            session_id: Caller-supplied identifier for the agent session.
+
+        Returns:
+            SnapshotRecord with snapshot_id, image_name, size_bytes, and timestamps.
+
+        Raises:
+            RuntimeError: If the container cannot be found or committed.
+        """
+        snapshot_id = make_snapshot_id()
+        image_name = _image_name_for_snapshot(snapshot_id)
+        created_at = now_utc().isoformat()
+
+        try:
+            container = await asyncio.to_thread(self.client.containers.get, container_id)
+            image = await asyncio.to_thread(
+                container.commit,
+                repository=f"autobot-snapshot-{snapshot_id}",
+                tag="latest",
+            )
+        except Exception as exc:
+            raise RuntimeError(f"Failed to snapshot container {container_id}: {exc}") from exc
+
+        size_bytes = 0
+        try:
+            size_bytes = image.attrs.get("Size", 0)
+        except Exception:
+            pass
+
+        record = SnapshotRecord(
+            snapshot_id=snapshot_id,
+            session_id=session_id,
+            container_id=container_id,
+            image_name=image_name,
+            created_at=created_at,
+            size_bytes=size_bytes,
+        )
+        await asyncio.to_thread(self._snapshot_index.add, record)
+        logger.info(
+            "Snapshot %s created for container %s (session=%s, size=%d bytes)",
+            snapshot_id,
+            container_id,
+            session_id,
+            size_bytes,
+        )
+        return record
+
+    async def restore(self, snapshot_id: str) -> str:
+        """Start a new detached container from a previously saved snapshot.
+
+        Args:
+            snapshot_id: ID returned by a prior ``snapshot()`` call.
+
+        Returns:
+            The new container ID.
+
+        Raises:
+            KeyError: If snapshot_id is not found in the index.
+            RuntimeError: If container creation from the snapshot image fails.
+        """
+        record = await asyncio.to_thread(self._snapshot_index.get, snapshot_id)
+        if record is None:
+            raise KeyError(f"Snapshot '{snapshot_id}' not found")
+
+        try:
+            container = await asyncio.to_thread(
+                self.client.containers.run,
+                record.image_name,
+                "sleep infinity",
+                detach=True,
+                remove=False,
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to restore snapshot {snapshot_id} from image {record.image_name}: {exc}"
+            ) from exc
+
+        logger.info(
+            "Restored snapshot %s → container %s (session=%s)",
+            snapshot_id,
+            container.id,
+            record.session_id,
+        )
+        return container.id
+
+    async def delete_snapshot(self, snapshot_id: str) -> bool:
+        """Remove the snapshot image and its index entry.
+
+        Args:
+            snapshot_id: ID returned by a prior ``snapshot()`` call.
+
+        Returns:
+            True if the snapshot was found and removed; False if not found.
+        """
+        record = await asyncio.to_thread(self._snapshot_index.get, snapshot_id)
+        if record is None:
+            return False
+
+        try:
+            await asyncio.to_thread(self.client.images.remove, record.image_name, force=True)
+        except Exception as exc:
+            logger.warning("Could not remove snapshot image %s: %s", record.image_name, exc)
+
+        removed = await asyncio.to_thread(self._snapshot_index.remove, snapshot_id)
+        logger.info("Snapshot %s deleted", snapshot_id)
+        return removed
+
+    def get_snapshots_for_session(self, session_id: str) -> list:
+        """Return all SnapshotRecords for the given session_id (synchronous helper)."""
+        return self._snapshot_index.list_by_session(session_id)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/autobot-backend/services/execution/docker_backend.py
+++ b/autobot-backend/services/execution/docker_backend.py
@@ -420,7 +420,19 @@ class DockerBackend(ExecutionBackend):
             created_at=created_at,
             size_bytes=size_bytes,
         )
-        await asyncio.to_thread(self._snapshot_index.add, record)
+        try:
+            await asyncio.to_thread(self._snapshot_index.add, record)
+        except Exception as exc:
+            # Roll back the committed image — without an index entry it would be an orphan.
+            try:
+                await asyncio.to_thread(self.client.images.remove, image_name, force=True)
+            except Exception as cleanup_exc:
+                logger.warning(
+                    "Failed to clean up orphaned snapshot image %s after index failure: %s",
+                    image_name,
+                    cleanup_exc,
+                )
+            raise RuntimeError(f"Failed to record snapshot {snapshot_id} in index: {exc}") from exc
         logger.info(
             "Snapshot %s created for container %s (session=%s, size=%d bytes)",
             snapshot_id,
@@ -460,6 +472,9 @@ class DockerBackend(ExecutionBackend):
                 f"Failed to restore snapshot {snapshot_id} from image {record.image_name}: {exc}"
             ) from exc
 
+        # Track restored container so cleanup() can stop it at session end.
+        self._container_map[snapshot_id] = container.id
+
         logger.info(
             "Restored snapshot %s → container %s (session=%s)",
             snapshot_id,
@@ -484,15 +499,20 @@ class DockerBackend(ExecutionBackend):
         try:
             await asyncio.to_thread(self.client.images.remove, record.image_name, force=True)
         except Exception as exc:
-            logger.warning("Could not remove snapshot image %s: %s", record.image_name, exc)
+            logger.warning(
+                "Could not remove snapshot image %s, index entry preserved for retry: %s",
+                record.image_name,
+                exc,
+            )
+            return False
 
         removed = await asyncio.to_thread(self._snapshot_index.remove, snapshot_id)
         logger.info("Snapshot %s deleted", snapshot_id)
         return removed
 
-    def get_snapshots_for_session(self, session_id: str) -> list:
-        """Return all SnapshotRecords for the given session_id (synchronous helper)."""
-        return self._snapshot_index.list_by_session(session_id)
+    async def get_snapshots_for_session(self, session_id: str) -> list:
+        """Return all SnapshotRecords for the given session_id."""
+        return await asyncio.to_thread(self._snapshot_index.list_by_session, session_id)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/autobot-backend/services/execution/snapshot_index.py
+++ b/autobot-backend/services/execution/snapshot_index.py
@@ -23,7 +23,7 @@ from autobot_shared.time_utils import now_utc
 
 logger = get_logger(__name__)
 
-_DEFAULT_SNAPSHOT_PATH = "/tmp/autobot_snapshots"
+_DEFAULT_SNAPSHOT_PATH = "/opt/autobot/snapshots"
 _INDEX_FILENAME = "snapshot_index.json"
 
 _SNAPSHOT_STORAGE_PATH: str = os.getenv("AUTOBOT_SNAPSHOT_STORAGE_PATH", _DEFAULT_SNAPSHOT_PATH)
@@ -37,7 +37,14 @@ def _resolve_storage_path() -> Path:
             _DEFAULT_SNAPSHOT_PATH,
         )
         raw = _DEFAULT_SNAPSHOT_PATH
-    return Path(raw)
+    path = Path(raw)
+    if str(path).startswith("/tmp"):
+        logger.warning(
+            "Snapshot storage path %s is under /tmp — snapshots will not survive a host restart. "
+            "Set AUTOBOT_SNAPSHOT_STORAGE_PATH to a persistent directory (e.g. /opt/autobot/snapshots).",
+            path,
+        )
+    return path
 
 
 @dataclass

--- a/autobot-backend/services/execution/snapshot_index.py
+++ b/autobot-backend/services/execution/snapshot_index.py
@@ -10,8 +10,10 @@ Snapshots are Docker images created via ``docker commit``.
 
 import json
 import os
+import threading
 import uuid
 from dataclasses import asdict, dataclass
+from dataclasses import fields as dataclass_fields
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -59,7 +61,9 @@ class SnapshotRecord:
 
     @classmethod
     def from_dict(cls, data: Dict) -> "SnapshotRecord":
-        return cls(**data)
+        # Filter to known fields so future schema additions don't crash older code.
+        known = {f.name for f in dataclass_fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
 
 
 class SnapshotIndex:
@@ -72,6 +76,7 @@ class SnapshotIndex:
     def __init__(self, storage_path: Optional[Path] = None) -> None:
         self._storage_path = storage_path or _resolve_storage_path()
         self._index_path = self._storage_path / _INDEX_FILENAME
+        self._lock = threading.Lock()
 
     def _ensure_storage(self) -> None:
         self._storage_path.mkdir(parents=True, exist_ok=True)
@@ -94,38 +99,54 @@ class SnapshotIndex:
         tmp.replace(self._index_path)
 
     def add(self, record: SnapshotRecord) -> None:
-        records = self._load()
-        records[record.snapshot_id] = record.to_dict()
-        self._save(records)
-        logger.debug("Snapshot %s added to index", record.snapshot_id)
+        with self._lock:
+            records = self._load()
+            records[record.snapshot_id] = record.to_dict()
+            self._save(records)
+            logger.debug("Snapshot %s added to index", record.snapshot_id)
 
     def get(self, snapshot_id: str) -> Optional[SnapshotRecord]:
         records = self._load()
         data = records.get(snapshot_id)
         if data is None:
             return None
-        return SnapshotRecord.from_dict(data)
+        try:
+            return SnapshotRecord.from_dict(data)
+        except (TypeError, KeyError) as exc:
+            logger.warning("Malformed snapshot record for %s: %s", snapshot_id, exc)
+            return None
 
     def list_by_session(self, session_id: str) -> List[SnapshotRecord]:
         records = self._load()
-        return [
-            SnapshotRecord.from_dict(v)
-            for v in records.values()
-            if v.get("session_id") == session_id
-        ]
+        result = []
+        for v in records.values():
+            if v.get("session_id") != session_id:
+                continue
+            try:
+                result.append(SnapshotRecord.from_dict(v))
+            except (TypeError, KeyError) as exc:
+                logger.warning("Skipping malformed snapshot record: %s", exc)
+        return result
 
     def list_all(self) -> List[SnapshotRecord]:
         records = self._load()
-        return [SnapshotRecord.from_dict(v) for v in records.values()]
+        result = []
+        for v in records.values():
+            try:
+                result.append(SnapshotRecord.from_dict(v))
+            except (TypeError, KeyError) as exc:
+                logger.warning("Skipping malformed snapshot record: %s", exc)
+        return result
 
     def remove(self, snapshot_id: str) -> bool:
-        records = self._load()
-        if snapshot_id not in records:
-            return False
-        del records[snapshot_id]
-        self._save(records)
-        logger.debug("Snapshot %s removed from index", snapshot_id)
-        return True
+        with self._lock:
+            records = self._load()
+            if snapshot_id not in records:
+                return False
+            del records[snapshot_id]
+            self._save(records)
+            logger.debug("Snapshot %s removed from index", snapshot_id)
+            return True
 
 
 def make_snapshot_id() -> str:

--- a/autobot-backend/services/execution/snapshot_index.py
+++ b/autobot-backend/services/execution/snapshot_index.py
@@ -1,0 +1,136 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Snapshot index for resumable agent sessions (GH#4458).
+
+Maintains a JSON file-based index of container snapshot metadata.
+Snapshots are Docker images created via ``docker commit``.
+"""
+
+import json
+import os
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import now_utc
+
+logger = get_logger(__name__)
+
+_DEFAULT_SNAPSHOT_PATH = "/tmp/autobot_snapshots"
+_INDEX_FILENAME = "snapshot_index.json"
+
+_SNAPSHOT_STORAGE_PATH: str = os.getenv("AUTOBOT_SNAPSHOT_STORAGE_PATH", _DEFAULT_SNAPSHOT_PATH)
+
+
+def _resolve_storage_path() -> Path:
+    raw = os.getenv("AUTOBOT_SNAPSHOT_STORAGE_PATH", _DEFAULT_SNAPSHOT_PATH)
+    if not raw:
+        logger.warning(
+            "AUTOBOT_SNAPSHOT_STORAGE_PATH is empty, using default %s",
+            _DEFAULT_SNAPSHOT_PATH,
+        )
+        raw = _DEFAULT_SNAPSHOT_PATH
+    return Path(raw)
+
+
+@dataclass
+class SnapshotRecord:
+    """Metadata for one container snapshot."""
+
+    snapshot_id: str
+    session_id: str
+    container_id: str
+    image_name: str
+    created_at: str
+    size_bytes: int = 0
+    labels: Dict[str, str] = None
+
+    def __post_init__(self) -> None:
+        if self.labels is None:
+            self.labels = {}
+
+    def to_dict(self) -> Dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "SnapshotRecord":
+        return cls(**data)
+
+
+class SnapshotIndex:
+    """File-backed index of container snapshot records (GH#4458).
+
+    Thread-safety: each operation re-reads and re-writes the index file.
+    This is safe for the expected low-frequency snapshot operations.
+    """
+
+    def __init__(self, storage_path: Optional[Path] = None) -> None:
+        self._storage_path = storage_path or _resolve_storage_path()
+        self._index_path = self._storage_path / _INDEX_FILENAME
+
+    def _ensure_storage(self) -> None:
+        self._storage_path.mkdir(parents=True, exist_ok=True)
+
+    def _load(self) -> Dict[str, dict]:
+        if not self._index_path.exists():
+            return {}
+        try:
+            with open(self._index_path, encoding="utf-8") as fh:
+                return json.load(fh)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to load snapshot index, starting fresh: %s", exc)
+            return {}
+
+    def _save(self, records: Dict[str, dict]) -> None:
+        self._ensure_storage()
+        tmp = self._index_path.with_suffix(".tmp")
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(records, fh, indent=2)
+        tmp.replace(self._index_path)
+
+    def add(self, record: SnapshotRecord) -> None:
+        records = self._load()
+        records[record.snapshot_id] = record.to_dict()
+        self._save(records)
+        logger.debug("Snapshot %s added to index", record.snapshot_id)
+
+    def get(self, snapshot_id: str) -> Optional[SnapshotRecord]:
+        records = self._load()
+        data = records.get(snapshot_id)
+        if data is None:
+            return None
+        return SnapshotRecord.from_dict(data)
+
+    def list_by_session(self, session_id: str) -> List[SnapshotRecord]:
+        records = self._load()
+        return [
+            SnapshotRecord.from_dict(v)
+            for v in records.values()
+            if v.get("session_id") == session_id
+        ]
+
+    def list_all(self) -> List[SnapshotRecord]:
+        records = self._load()
+        return [SnapshotRecord.from_dict(v) for v in records.values()]
+
+    def remove(self, snapshot_id: str) -> bool:
+        records = self._load()
+        if snapshot_id not in records:
+            return False
+        del records[snapshot_id]
+        self._save(records)
+        logger.debug("Snapshot %s removed from index", snapshot_id)
+        return True
+
+
+def make_snapshot_id() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+def _image_name_for_snapshot(snapshot_id: str) -> str:
+    return f"autobot-snapshot-{snapshot_id}:latest"

--- a/autobot-backend/tests/test_execution_backends.py
+++ b/autobot-backend/tests/test_execution_backends.py
@@ -700,7 +700,8 @@ class TestDockerBackendSnapshot:
         result = await backend.delete_snapshot("ghost-snap")
         assert result is False
 
-    def test_get_snapshots_for_session(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_get_snapshots_for_session(self, tmp_path):
         from services.execution.snapshot_index import SnapshotIndex, SnapshotRecord
 
         idx = SnapshotIndex(storage_path=tmp_path)
@@ -723,7 +724,7 @@ class TestDockerBackendSnapshot:
             backend = DockerBackend(snapshot_index=idx)
             backend.client = mock_client
 
-        records = backend.get_snapshots_for_session("sess-Q")
+        records = await backend.get_snapshots_for_session("sess-Q")
         assert len(records) == 2
 
     @pytest.mark.asyncio

--- a/autobot-backend/tests/test_execution_backends.py
+++ b/autobot-backend/tests/test_execution_backends.py
@@ -500,3 +500,266 @@ class TestExecutionResult:
 
         assert result.metadata["run_id"] == "abc123"
         assert result.metadata["cost"] == 0.01
+
+
+# ---------------------------------------------------------------------------
+# Snapshot / restore tests (GH#4458)
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotIndex:
+    """Unit tests for SnapshotIndex file-based storage."""
+
+    def test_add_and_get(self, tmp_path):
+        from pathlib import Path
+
+        from services.execution.snapshot_index import SnapshotIndex, SnapshotRecord
+
+        idx = SnapshotIndex(storage_path=tmp_path)
+        rec = SnapshotRecord(
+            snapshot_id="abc123",
+            session_id="sess-1",
+            container_id="cont-xyz",
+            image_name="autobot-snapshot-abc123:latest",
+            created_at="2025-01-01T00:00:00",
+            size_bytes=1024,
+        )
+        idx.add(rec)
+        fetched = idx.get("abc123")
+        assert fetched is not None
+        assert fetched.snapshot_id == "abc123"
+        assert fetched.session_id == "sess-1"
+        assert fetched.size_bytes == 1024
+
+    def test_get_missing_returns_none(self, tmp_path):
+        from services.execution.snapshot_index import SnapshotIndex
+
+        idx = SnapshotIndex(storage_path=tmp_path)
+        assert idx.get("does-not-exist") is None
+
+    def test_list_by_session(self, tmp_path):
+        from services.execution.snapshot_index import SnapshotIndex, SnapshotRecord
+
+        idx = SnapshotIndex(storage_path=tmp_path)
+        for i in range(3):
+            idx.add(
+                SnapshotRecord(
+                    snapshot_id=f"snap{i}",
+                    session_id="sess-A" if i < 2 else "sess-B",
+                    container_id=f"c{i}",
+                    image_name=f"autobot-snapshot-snap{i}:latest",
+                    created_at="2025-01-01T00:00:00",
+                )
+            )
+        sess_a = idx.list_by_session("sess-A")
+        assert len(sess_a) == 2
+        assert all(r.session_id == "sess-A" for r in sess_a)
+
+    def test_remove(self, tmp_path):
+        from services.execution.snapshot_index import SnapshotIndex, SnapshotRecord
+
+        idx = SnapshotIndex(storage_path=tmp_path)
+        rec = SnapshotRecord(
+            snapshot_id="del-me",
+            session_id="s",
+            container_id="c",
+            image_name="autobot-snapshot-del-me:latest",
+            created_at="2025-01-01T00:00:00",
+        )
+        idx.add(rec)
+        assert idx.remove("del-me") is True
+        assert idx.get("del-me") is None
+        assert idx.remove("del-me") is False  # idempotent
+
+    def test_index_survives_empty_file(self, tmp_path):
+        from services.execution.snapshot_index import SnapshotIndex
+
+        idx_file = tmp_path / "snapshot_index.json"
+        idx_file.write_text("", encoding="utf-8")
+        idx = SnapshotIndex(storage_path=tmp_path)
+        assert idx.list_all() == []
+
+
+class TestDockerBackendSnapshot:
+    """Tests for DockerBackend snapshot/restore (GH#4458)."""
+
+    def _make_backend(self, tmp_path):
+        from services.execution.snapshot_index import SnapshotIndex
+
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+        with patch("services.execution.docker_backend.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.DockerException = Exception
+            idx = SnapshotIndex(storage_path=tmp_path)
+            backend = DockerBackend(snapshot_index=idx)
+            backend.client = mock_client
+            return backend, mock_client, idx
+
+    @pytest.mark.asyncio
+    async def test_snapshot_creates_record(self, tmp_path):
+        backend, mock_client, idx = self._make_backend(tmp_path)
+
+        mock_container = MagicMock()
+        mock_image = MagicMock()
+        mock_image.attrs = {"Size": 4096}
+        mock_container.commit.return_value = mock_image
+        mock_client.containers.get.return_value = mock_container
+
+        record = await backend.snapshot("cont-abc", session_id="sess-xyz")
+
+        assert record.session_id == "sess-xyz"
+        assert record.container_id == "cont-abc"
+        assert record.size_bytes == 4096
+        assert record.image_name.startswith("autobot-snapshot-")
+        stored = idx.get(record.snapshot_id)
+        assert stored is not None
+        assert stored.snapshot_id == record.snapshot_id
+
+    @pytest.mark.asyncio
+    async def test_snapshot_raises_on_missing_container(self, tmp_path):
+        backend, mock_client, _ = self._make_backend(tmp_path)
+        mock_client.containers.get.side_effect = Exception("Not found")
+
+        with pytest.raises(RuntimeError, match="Failed to snapshot"):
+            await backend.snapshot("no-such-container")
+
+    @pytest.mark.asyncio
+    async def test_restore_starts_container(self, tmp_path):
+        from services.execution.snapshot_index import SnapshotIndex, SnapshotRecord
+
+        idx = SnapshotIndex(storage_path=tmp_path)
+        idx.add(
+            SnapshotRecord(
+                snapshot_id="snap-001",
+                session_id="sess-1",
+                container_id="orig-cont",
+                image_name="autobot-snapshot-snap-001:latest",
+                created_at="2025-01-01T00:00:00",
+            )
+        )
+
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+        with patch("services.execution.docker_backend.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.DockerException = Exception
+            backend = DockerBackend(snapshot_index=idx)
+            backend.client = mock_client
+
+        mock_new_container = MagicMock()
+        mock_new_container.id = "new-cont-id-123"
+        mock_client.containers.run.return_value = mock_new_container
+
+        new_id = await backend.restore("snap-001")
+
+        assert new_id == "new-cont-id-123"
+        mock_client.containers.run.assert_called_once_with(
+            "autobot-snapshot-snap-001:latest",
+            "sleep infinity",
+            detach=True,
+            remove=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_restore_raises_for_unknown_snapshot(self, tmp_path):
+        from services.execution.snapshot_index import SnapshotIndex
+
+        idx = SnapshotIndex(storage_path=tmp_path)
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+        with patch("services.execution.docker_backend.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.DockerException = Exception
+            backend = DockerBackend(snapshot_index=idx)
+            backend.client = mock_client
+
+        with pytest.raises(KeyError, match="not found"):
+            await backend.restore("nonexistent-snap")
+
+    @pytest.mark.asyncio
+    async def test_delete_snapshot_removes_record(self, tmp_path):
+        backend, mock_client, idx = self._make_backend(tmp_path)
+
+        mock_container = MagicMock()
+        mock_image = MagicMock()
+        mock_image.attrs = {"Size": 512}
+        mock_container.commit.return_value = mock_image
+        mock_client.containers.get.return_value = mock_container
+
+        record = await backend.snapshot("cont-del", session_id="s")
+        assert idx.get(record.snapshot_id) is not None
+
+        deleted = await backend.delete_snapshot(record.snapshot_id)
+        assert deleted is True
+        assert idx.get(record.snapshot_id) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_snapshot_returns_false(self, tmp_path):
+        backend, _, _ = self._make_backend(tmp_path)
+        result = await backend.delete_snapshot("ghost-snap")
+        assert result is False
+
+    def test_get_snapshots_for_session(self, tmp_path):
+        from services.execution.snapshot_index import SnapshotIndex, SnapshotRecord
+
+        idx = SnapshotIndex(storage_path=tmp_path)
+        for i in range(2):
+            idx.add(
+                SnapshotRecord(
+                    snapshot_id=f"s{i}",
+                    session_id="sess-Q",
+                    container_id=f"c{i}",
+                    image_name=f"autobot-snapshot-s{i}:latest",
+                    created_at="2025-01-01T00:00:00",
+                )
+            )
+
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+        with patch("services.execution.docker_backend.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.DockerException = Exception
+            backend = DockerBackend(snapshot_index=idx)
+            backend.client = mock_client
+
+        records = backend.get_snapshots_for_session("sess-Q")
+        assert len(records) == 2
+
+    @pytest.mark.asyncio
+    async def test_snapshot_env_var_storage_path(self, tmp_path, monkeypatch):
+        """AUTOBOT_SNAPSHOT_STORAGE_PATH controls where the index is stored."""
+        monkeypatch.setenv("AUTOBOT_SNAPSHOT_STORAGE_PATH", str(tmp_path))
+
+        from services.execution.snapshot_index import SnapshotIndex
+
+        idx = SnapshotIndex()
+        assert idx._storage_path == tmp_path
+
+    @pytest.mark.asyncio
+    async def test_existing_ephemeral_execution_unchanged(self, tmp_path):
+        """Snapshot feature must not affect normal cold-start execution."""
+        from services.execution.snapshot_index import SnapshotIndex
+
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+
+        mock_container = MagicMock()
+        mock_container.id = "ephemeral-id"
+        mock_container.wait.return_value = {"StatusCode": 0}
+        mock_container.logs.return_value = b"hello"
+        mock_client.containers.run.return_value = mock_container
+
+        snapshot_idx = SnapshotIndex(storage_path=tmp_path)
+        with patch("services.execution.docker_backend.docker") as mock_docker:
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.DockerException = Exception
+            backend = DockerBackend(snapshot_index=snapshot_idx)
+            backend.client = mock_client
+
+        task = ExecutionTask(task_id="t1", code="print('hi')", language="python")
+        result = await backend._execute_cold(task, "python:3.10-slim")
+
+        assert result.status == ExecutionStatus.SUCCESS
+        assert result.stdout == "hello"
+        assert snapshot_idx.list_all() == []  # no snapshots created by normal execution


### PR DESCRIPTION
Supersedes #8942 (closed — rebased onto latest Dev_new_gui). Closes GH#4458.

## What Changed

- `autobot-backend/services/execution/snapshot_index.py` (new) — SnapshotIndex with atomic tmp-file swap, threading.Lock on writes, defensive from_dict, configurable via AUTOBOT_SNAPSHOT_STORAGE_PATH
- `autobot-backend/services/execution/docker_backend.py` — snapshot/restore/delete_snapshot/get_snapshots_for_session; all Docker calls asyncio.to_thread-wrapped; snapshot rollback on index failure
- `autobot-backend/tests/test_execution_backends.py` — 14 new tests (CRUD, round-trip, error paths, env-var config, regression)

## Verification

```
pytest autobot-backend/tests/test_execution_backends.py -k Snapshot -v
14 passed, 37 deselected in 1.95s
```

Acceptance criteria:
- ✅ DockerBackend.snapshot(container_id) → saves container state via docker commit
- ✅ DockerBackend.restore(snapshot_id) → creates new container from snapshot
- ✅ File-based index with session_id, created_at, size_bytes
- ✅ Configurable storage path via AUTOBOT_SNAPSHOT_STORAGE_PATH
- ✅ Existing ephemeral behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>