### PR TITLE
fix(voice-rbac): re-read DB after commit in set_user_bundle (#8981)

### DIFF
--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -230,6 +230,13 @@ async def set_user_bundle(
                     {"uid": user_id, "bundle": body.bundle_name, "by": str(current_user_id)},
                 )
             await session.commit()
+            # Re-read after commit so response reflects actual stored value, not request input.
+            row = await session.execute(
+                text("SELECT bundle_name FROM user_voice_bundle WHERE user_id = :uid"),
+                {"uid": user_id},
+            )
+            result = row.fetchone()
+            stored_bundle_name: Optional[str] = result[0] if result else None
     except Exception as exc:
         logger.error("set_user_bundle: DB error: %s", exc)
         raise HTTPException(status_code=500, detail="Database error") from exc
@@ -246,8 +253,8 @@ async def set_user_bundle(
             resource_id=user_id,
             metadata={
                 "target_user_id": user_id,
-                "bundle_name": body.bundle_name,
-                "assignment_action": "clear" if body.bundle_name is None else "assign",
+                "bundle_name": stored_bundle_name,
+                "assignment_action": "clear" if stored_bundle_name is None else "assign",
             },
         )
     )
@@ -256,7 +263,7 @@ async def set_user_bundle(
         "voice_bundle user_id=%s target=%s bundle=%s",
         current_user_id,
         user_id,
-        body.bundle_name,
+        stored_bundle_name,
     )
 
-    return UserBundleResponse(user_id=user_id, bundle_name=body.bundle_name)
+    return UserBundleResponse(user_id=user_id, bundle_name=stored_bundle_name)


### PR DESCRIPTION
## Thinking Path

`set_user_bundle` returned `UserBundleResponse(user_id=user_id, bundle_name=body.bundle_name)` — the value from the request body, not the database. If a DB trigger or concurrent write changed the stored value during the transaction, the caller receives a misleading success confirmation. The fix is a post-commit SELECT to fetch the actual stored value, which is the same pattern already used in `get_user_bundle`. No alternative considered — the issue explicitly calls out re-reading from DB as the correct approach.

## What Changed

- `autobot-backend/api/voice_bundle_user.py` — `set_user_bundle`: added `SELECT bundle_name FROM user_voice_bundle WHERE user_id = :uid` after `session.commit()` within the same session; result stored as `stored_bundle_name`
- Response, audit event metadata, and log line all changed from `body.bundle_name` → `stored_bundle_name`

## Verification

```bash
# Assign a bundle and confirm response reflects DB value
curl -X PUT http://localhost:8001/api/voice/users/{userId}/bundle \
  -H "Authorization: Bearer $TOKEN" \
  -d '{"bundle_name": "voice_extended"}'
# Response bundle_name should equal what is stored in user_voice_bundle table

# Clear and confirm null is returned
curl -X PUT http://localhost:8001/api/voice/users/{userId}/bundle \
  -H "Authorization: Bearer $TOKEN" \
  -d '{}'
```

## Risks

None identified. The added SELECT runs in the same DB session after commit, so no extra round-trip overhead beyond what the fix requires. The clear (DELETE) path correctly returns `null` since no row remains.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Closes #8981

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason) — N/A: no existing test suite for this endpoint; fix mirrors existing `get_user_bundle` pattern
- [x] Documentation updated if behavior changed — N/A: API contract unchanged
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff