### PR TITLE
fix(voice-rbac): security audit findings — audit emit, VALID_BUNDLES drift, missing test assertions (#8977)

### DIFF
--- a/autobot-backend/api/redis_mcp/rbac.py
+++ b/autobot-backend/api/redis_mcp/rbac.py
@@ -178,6 +178,7 @@ _ROLE_DEFAULT_BUNDLE: dict[str, str] = {
 }
 
 _VALID_BUNDLES = frozenset(_BUNDLE_TAG_MAP.keys())
+VALID_BUNDLES: frozenset = _VALID_BUNDLES
 
 
 async def resolve_bundle_for_user(user_id: str, role: str = "user") -> tuple[str, str]:

--- a/autobot-backend/api/voice_bundle_admin.py
+++ b/autobot-backend/api/voice_bundle_admin.py
@@ -14,6 +14,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
+from api.redis_mcp.rbac import VALID_BUNDLES
 from auth_middleware import get_auth_middleware, get_current_user
 from autobot_shared.logging_manager import get_logger
 from services.event_log import EventType, emit
@@ -65,8 +66,6 @@ class BundleAssignRequest(BaseModel):
 # ---------------------------------------------------------------------------
 # GET /voice/realtime/bundle/me
 # ---------------------------------------------------------------------------
-
-VALID_BUNDLES = {"voice_safe", "voice_extended", "voice_admin"}
 
 _BUNDLE_TOOL_COUNTS: dict[str, int] = {
     "voice_safe": 0,  # computed lazily below

--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -14,6 +14,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
+from api.redis_mcp.rbac import VALID_BUNDLES
 from auth_middleware import get_auth_middleware, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -54,8 +55,6 @@ class BundleAssignRequest(BaseModel):
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-VALID_BUNDLES = {"voice_safe", "voice_extended", "voice_admin"}
 
 BUNDLE_DEFINITIONS: dict[str, dict[str, str]] = {
     "voice_safe": {
@@ -222,6 +221,14 @@ async def set_user_bundle(
 
     current_user_id = _get_user_id(current_user)
 
+    from services.audit.unified_audit import AuditCategory, AuditEvent, emit  # noqa: PLC0415
+
+    _audit_meta = {
+        "target_user_id": user_id,
+        "bundle_name": body.bundle_name,
+        "assignment_action": "clear" if body.bundle_name is None else "assign",
+    }
+
     try:
         from user_management.database import get_async_session  # noqa: PLC0415
         from sqlalchemy import text  # noqa: PLC0415
@@ -252,26 +259,31 @@ async def set_user_bundle(
             )
             result = row.fetchone()
             stored_bundle_name: Optional[str] = result[0] if result else None
+        emit(
+            AuditEvent(
+                category=AuditCategory.SECURITY,
+                action="voice_bundle_assignment_changed",
+                actor_id=str(current_user_id),
+                resource_type="user_voice_bundle",
+                resource_id=user_id,
+                outcome="success",
+                metadata=_audit_meta,
+            )
+        )
     except Exception as exc:
+        emit(
+            AuditEvent(
+                category=AuditCategory.SECURITY,
+                action="voice_bundle_assignment_changed",
+                actor_id=str(current_user_id),
+                resource_type="user_voice_bundle",
+                resource_id=user_id,
+                outcome="failure",
+                metadata={**_audit_meta, "error": str(exc)},
+            )
+        )
         logger.error("set_user_bundle: DB error: %s", exc)
         raise HTTPException(status_code=500, detail="Database error") from exc
-
-    from services.audit.unified_audit import AuditCategory, AuditEvent, emit  # noqa: PLC0415
-
-    emit(
-        AuditEvent(
-            category=AuditCategory.SECURITY,
-            action="voice_bundle_assignment_changed",
-            actor_id=str(current_user_id),
-            resource_type="user_voice_bundle",
-            resource_id=user_id,
-            metadata={
-                "target_user_id": user_id,
-                "bundle_name": stored_bundle_name,
-                "assignment_action": "clear" if stored_bundle_name is None else "assign",
-            },
-        )
-    )
 
     logger.info(
         "voice_bundle user_id=%s target=%s bundle=%s",

--- a/autobot-backend/services/audit/unified_audit.py
+++ b/autobot-backend/services/audit/unified_audit.py
@@ -114,6 +114,12 @@ def emit(event: AuditEvent) -> None:
     run_redis_write(record(event), label="unified_audit")
 
 
+# Capture the real emit before the Phase-2 bridge shadows the name below.
+# emit_compliance / emit_security must call _emit_real to avoid a recursion
+# cycle: bridge-emit → emit_compliance → emit → bridge-emit → ...
+_emit_real = emit
+
+
 # ---------------------------------------------------------------------------
 # Read path
 # ---------------------------------------------------------------------------
@@ -168,7 +174,7 @@ def emit_compliance(
     ip_address: str | None = None,
 ) -> None:
     """Drop-in shim for services/event_log.emit()."""
-    emit(
+    _emit_real(
         AuditEvent(
             category=AuditCategory.COMPLIANCE,
             action=action,
@@ -193,7 +199,7 @@ def emit_security(
     outcome: str = "success",
 ) -> None:
     """Drop-in shim for services/audit/audit_log.audit_record()."""
-    emit(
+    _emit_real(
         AuditEvent(
             category=AuditCategory.SECURITY,
             action=action,

--- a/autobot-backend/tests/api/test_voice_bundle_user.py
+++ b/autobot-backend/tests/api/test_voice_bundle_user.py
@@ -192,6 +192,7 @@ class TestSetUserBundle:
         assert data["user_id"] == "bob"
         assert data["bundle_name"] == "voice_safe"
         mock_session.commit.assert_called_once()
+        mock_emit.assert_called_once()
 
     def test_admin_clears_bundle_for_user(self):
         """Admin can clear a user's bundle assignment."""
@@ -213,6 +214,7 @@ class TestSetUserBundle:
         assert data["user_id"] == "alice"
         assert data["bundle_name"] is None
         mock_session.execute.assert_called_once()
+        mock_emit.assert_called_once()
 
     def test_invalid_bundle_name(self):
         """Admin assigning invalid bundle name fails with 422."""
@@ -252,3 +254,4 @@ class TestSetUserBundle:
         assert response.status_code == 200
         data = response.json()
         assert data["bundle_name"] == "voice_admin"
+        mock_emit.assert_called_once()


### PR DESCRIPTION
## Thinking Path

Three findings from the security audit of PR #8974. The audit emit was placed after the try/except block, meaning any DB exception silently dropped the SECURITY event. VALID_BUNDLES was duplicated between voice_bundle_user.py and rbac.py and could drift. Test assertions for mock_emit were missing from three test cases, creating a silent regression path.

## What Changed

- `autobot-backend/api/redis_mcp/rbac.py`: Added `VALID_BUNDLES: frozenset = _VALID_BUNDLES` public export so downstream modules have a single canonical source.
- `autobot-backend/api/voice_bundle_user.py`: Imported `VALID_BUNDLES` from rbac; moved success audit emit inside try block after commit+re-read; added failure-path emit with `outcome="failure"` and error detail; fixed recursion in `unified_audit.py` by capturing `_emit_real` before bridge shadowing.
- `autobot-backend/api/voice_bundle_admin.py`: Imports `VALID_BUNDLES` from rbac; removes hardcoded local copy.
- `autobot-backend/services/audit/unified_audit.py`: Added `_emit_real` alias to avoid recursion cycle where bridge-emit → emit_compliance → emit → bridge-emit.
- `autobot-backend/tests/api/test_voice_bundle_user.py`: Added `mock_emit.assert_called_once()` to three test cases that were missing it.

## Verification

- `python3 -m py_compile` passes on all changed files
- `VALID_BUNDLES` has single source of truth in `rbac.py`
- Success emit has `outcome="success"` inside try; failure emit has `outcome="failure"` with error detail in except
- Recursion in `unified_audit.emit_compliance`/`emit_security` broken by `_emit_real` alias
- Three previously-uncovered test cases now assert `mock_emit.assert_called_once()`

## Model Used

claude-sonnet-4-6

---

Fixes https://github.com/mrveiss/AutoBot-AI/issues/8977