### PR TITLE
fix(backend): correct import path in tool_handler.py (#8986)

### DIFF
--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -838,7 +838,7 @@ class ToolHandlerMixin:
     def _init_terminal_tool(self):
         """Initialize terminal tool for command execution."""
         try:
-            import backend.api.agent_terminal as agent_terminal_api
+            import api.agent_terminal as agent_terminal_api
 
             from tools.terminal_tool import TerminalTool
 


### PR DESCRIPTION
## Summary

- Fixes wrong import path at `autobot-backend/chat_workflow/tool_handler.py:841`
- `import backend.api.agent_terminal` → `import api.agent_terminal`
- Module `backend` does not exist at the import root; this caused the terminal tool to silently fail with `No module named 'backend'` on every load

## Test plan
- [ ] Python syntax verified (`ast.parse` passes)
- [ ] Terminal tool initializes without "No module named 'backend'" error
- [ ] Ref: https://github.com/mrveiss/AutoBot-AI/issues/8986

🤖 Generated with [Claude Code](https://claude.com/claude-code)