### PR TITLE
perf+refactor(voice-rbac): cache tool counts + _is_admin helper (#8979 #8980)

### DIFF
--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -77,13 +77,22 @@ BUNDLE_DEFINITIONS: dict[str, dict[str, str]] = {
 # Helpers
 # ---------------------------------------------------------------------------
 
+_tool_count_cache: dict[tuple[str, bool], int] = {}
+
 
 async def _count_tools_for_bundle(bundle: str, is_admin: bool) -> int:
-    """Return the number of tools available in this bundle."""
-    from api.redis_mcp.rbac import TOOL_ACCESS_MATRIX, filter_tools_for_bundle  # noqa: PLC0415
+    """Return the number of tools available in this bundle (cached per bundle+role)."""
+    key = (bundle, is_admin)
+    if key not in _tool_count_cache:
+        from api.redis_mcp.rbac import TOOL_ACCESS_MATRIX, filter_tools_for_bundle  # noqa: PLC0415
 
-    all_tools = list(TOOL_ACCESS_MATRIX.keys())
-    return len(filter_tools_for_bundle(all_tools, bundle=bundle, is_admin=is_admin))
+        all_tools = list(TOOL_ACCESS_MATRIX.keys())
+        _tool_count_cache[key] = len(filter_tools_for_bundle(all_tools, bundle=bundle, is_admin=is_admin))
+    return _tool_count_cache[key]
+
+
+def _is_admin(user: dict) -> bool:
+    return user.get("role") == "admin"
 
 
 def _get_user_id(user: dict) -> str:
@@ -94,8 +103,7 @@ def _get_user_id(user: dict) -> str:
 def _check_self_or_admin(request: Request, current_user: dict, target_user_id: str) -> bool:
     """Verify user can access target_user_id (self or admin)."""
     current_user_id = _get_user_id(current_user)
-    is_admin = current_user.get("role") == "admin"
-    return current_user_id == target_user_id or is_admin
+    return current_user_id == target_user_id or _is_admin(current_user)
 
 
 # ---------------------------------------------------------------------------
@@ -117,7 +125,7 @@ async def list_voice_bundles(
     Filters bundles based on user role (admins see all, users see allowed).
     Results are sorted by bundle name for deterministic ordering.
     """
-    is_admin = current_user.get("role", "user") == "admin"
+    is_admin = _is_admin(current_user)
 
     result = []
     for bundle_name in sorted(VALID_BUNDLES):
@@ -203,8 +211,7 @@ async def set_user_bundle(
     self-service is explicitly prohibited to prevent privilege escalation
     (GH#8969).
     """
-    is_admin = current_user.get("role") == "admin"
-    if not is_admin:
+    if not _is_admin(current_user):
         raise_auth_error("AUTH_0003", "Only admins may assign voice bundles")
 
     if body.bundle_name is not None and body.bundle_name not in VALID_BUNDLES:


### PR DESCRIPTION
## Summary

- **GH#8979 (perf):** Added module-level `_tool_count_cache: dict[tuple[str, bool], int]` in `voice_bundle_user.py`. `_count_tools_for_bundle()` now returns cached counts on subsequent calls per `(bundle, is_admin)` pair — the `TOOL_ACCESS_MATRIX` import and `filter_tools_for_bundle` filter only run on first miss. Eliminates 3 redundant compute + import cycles per `GET /voice/bundles` request.
- **GH#8980 (refactor):** Extracted `_is_admin(user: dict) -> bool` helper and replaced all 3 inline `current_user.get("role") == "admin"` expressions in `_check_self_or_admin`, `list_voice_bundles`, and `set_user_bundle`.

## Scope

Single file changed: `autobot-backend/api/voice_bundle_user.py` (+16 / -10 lines)

## Thinking Path

GH#8979: `_count_tools_for_bundle()` is called once per bundle per `GET /voice/bundles` request (3 bundles × 1 call = 3 calls). Each call re-imports `TOOL_ACCESS_MATRIX` and re-filters the full tool list. Since the result depends only on `(bundle, is_admin)` and neither changes at runtime, a module-level dict keyed by that tuple is the minimal correct cache. No invalidation needed — bundles and the access matrix are static config.

GH#8980: Three copies of `current_user.get("role") == "admin"` in the same file is a maintenance hazard — a future role name change (e.g. "superadmin") would need 3 edits. Extracting `_is_admin(user)` eliminates the duplication. `voice_bundle_admin.py`'s `_require_admin()` is a Depends gate (raises HTTP 403) not a predicate, so it can't replace the boolean checks here — a local helper is the right choice.

## What Changed

- `autobot-backend/api/voice_bundle_user.py`:
  - Added `_tool_count_cache: dict[tuple[str, bool], int] = {}` at module level
  - `_count_tools_for_bundle()` checks cache before importing/filtering; populates on miss
  - Added `_is_admin(user: dict) -> bool` helper
  - Replaced 3 inline `current_user.get("role") == "admin"` expressions with `_is_admin(current_user)`

## Verification

- `python3 -m py_compile autobot-backend/api/voice_bundle_user.py` → clean (no syntax errors)
- `smoke-test` CI check → pass
- Code reviewed by CodeReviewer agent: cache key correctness, helper correctness, no behavior change verified

## Model Used

claude-sonnet-4-6

## Test plan

- [x] `python3 -m py_compile autobot-backend/api/voice_bundle_user.py` ✅ (verified before push)
- [ ] `GET /voice/bundles` returns same bundle list for both admin and regular user roles
- [ ] Cache is populated on first call; subsequent calls skip import path (no functional change, only timing)
- [ ] `set_user_bundle` still rejects non-admin callers with AUTH_0003

Closes #8979
Closes #8980

🤖 Generated with [Claude Code](https://claude.com/claude-code)