### PR TITLE
feat(chat): conversation folders and collections (#8987)

### DIFF
--- a/autobot-backend/api/chat_folders.py
+++ b/autobot-backend/api/chat_folders.py
@@ -1,0 +1,278 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+
+"""
+CRUD endpoints for chat conversation folders (GH#8987).
+
+Folders are stored per-user in Redis as a JSON array under the key
+``chat:folders:{username}``.  Each folder carries its own ``session_ids``
+list so a single read gives the full folder tree without a secondary lookup.
+
+Response shape: plain JSONResponse (matches chat_presets.py pattern).
+"""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse, Response
+
+from api.schemas_chat import FolderCreate, FolderUpdate, SessionFolderAssign
+from auth_middleware import get_current_user
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.logging_manager import get_logger
+from constants.redis_constants import REDIS_KEY
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+_MAX_NESTING = 3
+
+
+def _folder_redis_key(username: str) -> str:
+    return REDIS_KEY.CHAT_FOLDERS.format(username=username)
+
+
+async def _load_folders(redis: Any, username: str) -> List[Dict]:
+    raw = await redis.get(_folder_redis_key(username))
+    if not raw:
+        return []
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+
+async def _save_folders(redis: Any, username: str, folders: List[Dict]) -> None:
+    await redis.set(_folder_redis_key(username), json.dumps(folders))
+
+
+def _folder_depth(folders: List[Dict], folder_id: str, seen: set | None = None) -> int:
+    """Return 1-based depth of folder_id in the tree."""
+    if seen is None:
+        seen = set()
+    if folder_id in seen:
+        return 0
+    seen.add(folder_id)
+    folder = next((f for f in folders if f["id"] == folder_id), None)
+    if not folder or folder.get("parent_id") is None:
+        return 1
+    return 1 + _folder_depth(folders, folder["parent_id"], seen)
+
+
+def _serialize_folder(f: Dict) -> Dict:
+    session_ids = f.get("session_ids", [])
+    return {
+        "id": f["id"],
+        "name": f["name"],
+        "parent_id": f.get("parent_id"),
+        "owner": f.get("owner", ""),
+        "pinned": f.get("pinned", False),
+        "created_at": f.get("created_at", ""),
+        "session_ids": session_ids,
+        "session_count": len(session_ids),
+    }
+
+
+@router.get("/chat/folders")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_chat_folders",
+    error_code_prefix="CHAT_FOLDERS",
+)
+async def list_folders(
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Return all folders for the authenticated user."""
+    from autobot_shared.redis_client import get_redis_client as get_redis_mgr
+
+    username = current_user.get("username", "")
+    redis = await get_redis_mgr(async_client=True, database="main")
+    if redis is None:
+        return JSONResponse(status_code=503, content={"error": "Redis unavailable"})
+
+    folders = await _load_folders(redis, username)
+    sorted_folders = sorted(folders, key=lambda f: (not f.get("pinned", False), f.get("name", "")))
+    result = [_serialize_folder(f) for f in sorted_folders]
+    return JSONResponse(content={"folders": result, "count": len(result)})
+
+
+@router.post("/chat/folders", status_code=201)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="create_chat_folder",
+    error_code_prefix="CHAT_FOLDERS",
+)
+async def create_folder(
+    request: Request,
+    body: FolderCreate,
+    current_user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Create a new folder. Enforces max 3-level nesting."""
+    from autobot_shared.redis_client import get_redis_client as get_redis_mgr
+    from exceptions import get_exceptions_lazy
+
+    _, _, _, ValidationError, _ = get_exceptions_lazy()
+
+    username = current_user.get("username", "")
+    redis = await get_redis_mgr(async_client=True, database="main")
+    if redis is None:
+        return JSONResponse(status_code=503, content={"error": "Redis unavailable"})
+
+    folders = await _load_folders(redis, username)
+
+    if body.parent_id:
+        parent = next((f for f in folders if f["id"] == body.parent_id), None)
+        if not parent:
+            raise ValidationError("Parent folder not found")
+        depth = _folder_depth(folders, body.parent_id)
+        if depth >= _MAX_NESTING:
+            raise ValidationError(f"Maximum folder nesting depth ({_MAX_NESTING}) reached")
+
+    folder: Dict = {
+        "id": str(uuid.uuid4()),
+        "name": body.name,
+        "parent_id": body.parent_id,
+        "owner": username,
+        "pinned": False,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "session_ids": [],
+    }
+    folders.append(folder)
+    await _save_folders(redis, username, folders)
+    logger.info("Created folder %s for user %s", folder["id"], username)
+    return JSONResponse(content=_serialize_folder(folder), status_code=201)
+
+
+@router.put("/chat/folders/{folder_id}")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="update_chat_folder",
+    error_code_prefix="CHAT_FOLDERS",
+)
+async def update_folder(
+    folder_id: str,
+    request: Request,
+    body: FolderUpdate,
+    current_user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Rename, pin, or re-parent a folder."""
+    from autobot_shared.redis_client import get_redis_client as get_redis_mgr
+    from exceptions import get_exceptions_lazy
+
+    _, _, ResourceNotFoundError, ValidationError, _ = get_exceptions_lazy()
+
+    username = current_user.get("username", "")
+    redis = await get_redis_mgr(async_client=True, database="main")
+    if redis is None:
+        return JSONResponse(status_code=503, content={"error": "Redis unavailable"})
+
+    folders = await _load_folders(redis, username)
+    folder = next((f for f in folders if f["id"] == folder_id), None)
+    if not folder:
+        raise ResourceNotFoundError(f"Folder {folder_id} not found")
+
+    if body.name is not None:
+        folder["name"] = body.name
+    if body.pinned is not None:
+        folder["pinned"] = body.pinned
+    if body.parent_id is not None:
+        if body.parent_id == folder_id:
+            raise ValidationError("A folder cannot be its own parent")
+        parent = next((f for f in folders if f["id"] == body.parent_id), None)
+        if not parent:
+            raise ValidationError("Parent folder not found")
+        depth = _folder_depth(folders, body.parent_id)
+        if depth >= _MAX_NESTING:
+            raise ValidationError(f"Maximum folder nesting depth ({_MAX_NESTING}) reached")
+        folder["parent_id"] = body.parent_id
+
+    await _save_folders(redis, username, folders)
+    return JSONResponse(content=_serialize_folder(folder))
+
+
+@router.delete("/chat/folders/{folder_id}", status_code=204)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="delete_chat_folder",
+    error_code_prefix="CHAT_FOLDERS",
+)
+async def delete_folder(
+    folder_id: str,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> Response:
+    """Delete a folder. Child folders are re-parented to root; sessions stay unfoldered."""
+    from autobot_shared.redis_client import get_redis_client as get_redis_mgr
+    from exceptions import get_exceptions_lazy
+
+    _, _, ResourceNotFoundError, _, _ = get_exceptions_lazy()
+
+    username = current_user.get("username", "")
+    redis = await get_redis_mgr(async_client=True, database="main")
+    if redis is None:
+        return Response(status_code=503)
+
+    folders = await _load_folders(redis, username)
+    folder = next((f for f in folders if f["id"] == folder_id), None)
+    if not folder:
+        raise ResourceNotFoundError(f"Folder {folder_id} not found")
+
+    # Re-parent direct children to deleted folder's parent
+    for f in folders:
+        if f.get("parent_id") == folder_id:
+            f["parent_id"] = folder.get("parent_id")
+
+    folders = [f for f in folders if f["id"] != folder_id]
+    await _save_folders(redis, username, folders)
+    logger.info("Deleted folder %s for user %s", folder_id, username)
+    return Response(status_code=204)
+
+
+@router.put("/chat/sessions/{session_id}/folder")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="assign_session_folder",
+    error_code_prefix="CHAT_FOLDERS",
+)
+async def assign_session_to_folder(
+    session_id: str,
+    request: Request,
+    body: SessionFolderAssign,
+    current_user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Assign a chat session to a folder (or remove it when folder_id is None)."""
+    from autobot_shared.redis_client import get_redis_client as get_redis_mgr
+    from exceptions import get_exceptions_lazy
+
+    _, _, ResourceNotFoundError, _, _ = get_exceptions_lazy()
+
+    username = current_user.get("username", "")
+    redis = await get_redis_mgr(async_client=True, database="main")
+    if redis is None:
+        return JSONResponse(status_code=503, content={"error": "Redis unavailable"})
+
+    folders = await _load_folders(redis, username)
+
+    # Remove session from all folders first
+    for f in folders:
+        f.setdefault("session_ids", [])
+        if session_id in f["session_ids"]:
+            f["session_ids"].remove(session_id)
+
+    # Add to target folder
+    if body.folder_id:
+        target = next((f for f in folders if f["id"] == body.folder_id), None)
+        if not target:
+            raise ResourceNotFoundError(f"Folder {body.folder_id} not found")
+        if session_id not in target["session_ids"]:
+            target["session_ids"].append(session_id)
+
+    await _save_folders(redis, username, folders)
+    logger.info("Assigned session %s to folder %s for user %s", session_id, body.folder_id, username)
+    return JSONResponse(content={"session_id": session_id, "folder_id": body.folder_id})

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -536,3 +536,47 @@ class SessionMcpCallData(BaseModel):
     model_config = {"extra": "allow"}
 
     success: bool
+
+
+# ── Chat Folder schemas (GH#8987) ────────────────────────────────────────────
+
+
+class FolderCreate(BaseModel):
+    """Request body for POST /chat/folders."""
+
+    name: str = Field(..., min_length=1, max_length=100, description="Folder display name")
+    parent_id: str | None = Field(None, description="Parent folder ID for nesting (max 3 levels)")
+
+
+class FolderUpdate(BaseModel):
+    """Request body for PUT /chat/folders/{folder_id}."""
+
+    name: str | None = Field(None, min_length=1, max_length=100, description="New folder name")
+    parent_id: str | None = Field(None, description="New parent folder ID (None = root)")
+    pinned: bool | None = Field(None, description="Pin folder to top of list")
+
+
+class FolderData(BaseModel):
+    """Single folder object returned by the API."""
+
+    id: str
+    name: str
+    parent_id: str | None = None
+    owner: str
+    pinned: bool = False
+    created_at: str
+    session_ids: List[str] = Field(default_factory=list)
+    session_count: int = 0
+
+
+class FolderListData(BaseModel):
+    """data payload for GET /chat/folders."""
+
+    folders: List[FolderData]
+    count: int
+
+
+class SessionFolderAssign(BaseModel):
+    """Request body for PUT /chat/sessions/{session_id}/folder."""
+
+    folder_id: str | None = Field(None, description="Folder ID to assign; None removes from folder")

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -614,6 +614,8 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
     ("api.agent_diary", "/agent-diary", ["agents"], "agent_diary"),
     # Partially wired or legacy feature routers
     ("api.chat_sessions", "", ["chat-sessions"], "chat_sessions"),
+    # GH#8987: conversation folders and collections
+    ("api.chat_folders", "", ["chat-folders"], "chat_folders"),
     # Issue #5061: First-run onboarding presets + doctor
     ("api.onboarding", "/onboarding", ["onboarding"], "onboarding"),
     # NOTE (#4203): api.diagnostics removed — already registered in monitoring_routers.py

--- a/autobot-frontend/src/components/chat/ChatFolderNode.vue
+++ b/autobot-frontend/src/components/chat/ChatFolderNode.vue
@@ -1,0 +1,228 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025 mrveiss -->
+<!-- Author: mrveiss -->
+
+<!-- GH#8987: Single folder node in the tree. Recursive for up to 3 levels. -->
+<template>
+  <div class="folder-node" :style="{ paddingLeft: `${depth * 12}px` }">
+    <!-- Folder row -->
+    <div
+      class="flex items-center gap-1 px-1 py-1 rounded cursor-pointer hover:bg-autobot-bg-secondary group relative text-sm"
+      :class="{ 'bg-autobot-bg-secondary': isExpanded }"
+      @click="isExpanded = !isExpanded"
+    >
+      <!-- Expand chevron -->
+      <Icon
+        :name="isExpanded ? 'chevron-down' : 'chevron-right'"
+        class="text-xs text-autobot-text-muted shrink-0 w-3"
+      />
+
+      <!-- Folder icon -->
+      <Icon
+        :name="isExpanded ? 'folder-open' : 'folder'"
+        class="text-xs shrink-0"
+        :class="folder.pinned ? 'text-electric-500' : 'text-autobot-text-muted'"
+      />
+
+      <!-- Folder name or inline edit -->
+      <span v-if="!editing" class="flex-1 truncate text-autobot-text-primary text-xs leading-tight">
+        {{ folder.name }}
+      </span>
+      <input
+        v-else
+        ref="editInput"
+        v-model="editName"
+        type="text"
+        class="flex-1 text-xs px-1 border border-electric-500 rounded bg-autobot-bg-card focus:outline-none"
+        @keyup.enter="saveRename"
+        @keyup.escape="cancelRename"
+        @blur="cancelRename"
+        @click.stop
+      />
+
+      <!-- Session count badge -->
+      <span
+        v-if="!editing && totalSessionCount > 0"
+        class="text-xs text-autobot-text-muted shrink-0"
+      >
+        {{ totalSessionCount }}
+      </span>
+
+      <!-- Folder actions (on hover) -->
+      <div
+        v-if="!editing"
+        class="opacity-0 group-hover:opacity-100 flex items-center gap-0.5 shrink-0 transition-opacity"
+        @click.stop
+      >
+        <!-- Pin -->
+        <button
+          class="p-0.5 rounded hover:bg-autobot-bg-card"
+          :class="folder.pinned ? 'text-electric-500' : 'text-autobot-text-muted'"
+          :title="folder.pinned ? $t('chat.folders.unpin') : $t('chat.folders.pin')"
+          @click="folderStore.togglePin(folder.id)"
+        >
+          <Icon name="thumbtack" class="text-xs" />
+        </button>
+
+        <!-- Add sub-folder (only if depth < 2, i.e. max depth 3) -->
+        <button
+          v-if="depth < 2"
+          class="p-0.5 rounded hover:bg-autobot-bg-card text-autobot-text-muted hover:text-autobot-text-secondary"
+          :title="$t('chat.folders.addSubfolder')"
+          @click="startChildCreate"
+        >
+          <Icon name="folder-plus" class="text-xs" />
+        </button>
+
+        <!-- Rename -->
+        <button
+          class="p-0.5 rounded hover:bg-autobot-bg-card text-autobot-text-muted hover:text-autobot-text-secondary"
+          :title="$t('chat.folders.rename')"
+          @click="startRename"
+        >
+          <Icon name="edit" class="text-xs" />
+        </button>
+
+        <!-- Delete -->
+        <button
+          class="p-0.5 rounded hover:bg-autobot-bg-card text-red-400 hover:text-red-500"
+          :title="$t('common.delete')"
+          @click="deleteThisFolder"
+        >
+          <Icon name="trash" class="text-xs" />
+        </button>
+      </div>
+    </div>
+
+    <!-- Expanded content -->
+    <div v-if="isExpanded" class="ms-1">
+      <!-- Child folder creation input -->
+      <div v-if="creatingChild" class="flex items-center gap-1 ps-4 py-0.5">
+        <input
+          ref="childInput"
+          v-model="childFolderName"
+          type="text"
+          class="flex-1 text-xs px-2 py-0.5 border border-autobot-border rounded bg-autobot-bg-card focus:outline-none focus:ring-1 focus:ring-electric-500"
+          :placeholder="$t('chat.folders.folderName')"
+          @keyup.enter="createChildFolder"
+          @keyup.escape="cancelChildCreate"
+          @blur="cancelChildCreate"
+        />
+      </div>
+
+      <!-- Child folders (recursive) -->
+      <FolderNode
+        v-for="child in childFolders"
+        :key="child.id"
+        :folder="child"
+        :depth="depth + 1"
+        :sessions="sessions"
+        :current-session-id="currentSessionId"
+        @session-click="$emit('session-click', $event)"
+        @folder-created="$emit('folder-created')"
+      />
+
+      <!-- Sessions inside this folder -->
+      <div
+        v-for="session in folderSessions"
+        :key="session.id"
+        class="flex items-center gap-1 ps-5 py-1 rounded cursor-pointer hover:bg-autobot-bg-secondary text-xs"
+        :class="session.id === currentSessionId ? 'bg-electric-100 text-electric-800' : 'text-autobot-text-secondary'"
+        @click="$emit('session-click', session.id)"
+      >
+        <Icon name="comment-dots" class="text-xs shrink-0 opacity-60" />
+        <span class="truncate flex-1">{{ session.title }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, nextTick } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Icon from '@/components/ui/Icon.vue'
+import { useFolderStore, type ChatFolder } from '@/stores/useFolderStore'
+import type { ChatSession } from '@/stores/useChatStore'
+
+const { t } = useI18n()
+
+const props = defineProps<{
+  folder: ChatFolder
+  depth: number
+  sessions: ChatSession[]
+  currentSessionId: string | null
+}>()
+
+defineEmits<{
+  'session-click': [sessionId: string]
+  'folder-created': []
+}>()
+
+const folderStore = useFolderStore()
+
+const isExpanded = ref(props.folder.pinned)
+const editing = ref(false)
+const editName = ref('')
+const editInput = ref<HTMLInputElement>()
+const creatingChild = ref(false)
+const childFolderName = ref('')
+const childInput = ref<HTMLInputElement>()
+
+const childFolders = computed(() => folderStore.childrenOf(props.folder.id))
+
+const folderSessions = computed(() =>
+  props.sessions.filter((s) => props.folder.session_ids.includes(s.id))
+)
+
+const totalSessionCount = computed(
+  () => props.folder.session_ids.length + childFolders.value.reduce((acc, c) => acc + c.session_ids.length, 0)
+)
+
+function startRename() {
+  editName.value = props.folder.name
+  editing.value = true
+  nextTick(() => editInput.value?.focus())
+}
+
+async function saveRename() {
+  const name = editName.value.trim()
+  if (name && name !== props.folder.name) {
+    await folderStore.updateFolder(props.folder.id, { name })
+  }
+  editing.value = false
+}
+
+function cancelRename() {
+  editing.value = false
+}
+
+async function deleteThisFolder() {
+  if (!confirm(t('chat.folders.confirmDelete', { name: props.folder.name }))) return
+  await folderStore.deleteFolder(props.folder.id)
+}
+
+function startChildCreate() {
+  isExpanded.value = true
+  creatingChild.value = true
+  nextTick(() => childInput.value?.focus())
+}
+
+async function createChildFolder() {
+  const name = childFolderName.value.trim()
+  if (name) {
+    await folderStore.createFolder({ name, parent_id: props.folder.id })
+  }
+  childFolderName.value = ''
+  creatingChild.value = false
+}
+
+function cancelChildCreate() {
+  childFolderName.value = ''
+  creatingChild.value = false
+}
+</script>
+
+<!-- Recursive self-reference: using defineComponent name for recursion -->
+<script lang="ts">
+export default { name: 'FolderNode' }
+</script>

--- a/autobot-frontend/src/components/chat/ChatFolderTree.vue
+++ b/autobot-frontend/src/components/chat/ChatFolderTree.vue
@@ -1,0 +1,98 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025 mrveiss -->
+<!-- Author: mrveiss -->
+
+<!-- GH#8987: Recursive folder tree shown in ChatSidebar.
+     Supports create / rename / delete / pin / nest (max 3 levels).
+     Sessions are displayed under their folder; drag-assign via session context menu. -->
+<template>
+  <div class="folder-tree">
+    <!-- Root-level folders -->
+    <FolderNode
+      v-for="folder in folderStore.rootFolders"
+      :key="folder.id"
+      :folder="folder"
+      :depth="0"
+      :sessions="sessions"
+      :current-session-id="currentSessionId"
+      @session-click="$emit('session-click', $event)"
+      @folder-created="onFolderCreated"
+    />
+
+    <!-- Create root folder button -->
+    <button
+      v-if="!creatingRoot"
+      class="mt-1 flex items-center gap-1 w-full text-xs text-autobot-text-muted hover:text-autobot-text-secondary px-1 py-1 rounded transition-colors"
+      @click="creatingRoot = true"
+    >
+      <Icon name="folder-plus" class="text-xs" />
+      {{ $t('chat.folders.newFolder') }}
+    </button>
+    <div v-else class="mt-1 flex items-center gap-1">
+      <input
+        ref="rootInput"
+        v-model="rootFolderName"
+        type="text"
+        class="flex-1 text-xs px-2 py-1 border border-autobot-border rounded bg-autobot-bg-card focus:outline-none focus:ring-1 focus:ring-electric-500"
+        :placeholder="$t('chat.folders.folderName')"
+        @keyup.enter="createRootFolder"
+        @keyup.escape="cancelRootCreate"
+        @blur="cancelRootCreate"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, nextTick, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Icon from '@/components/ui/Icon.vue'
+import FolderNode from './ChatFolderNode.vue'
+import { useFolderStore } from '@/stores/useFolderStore'
+import type { ChatSession } from '@/stores/useChatStore'
+
+const { t } = useI18n()
+
+defineProps<{
+  sessions: ChatSession[]
+  currentSessionId: string | null
+}>()
+
+defineEmits<{
+  'session-click': [sessionId: string]
+}>()
+
+const folderStore = useFolderStore()
+
+const creatingRoot = ref(false)
+const rootFolderName = ref('')
+const rootInput = ref<HTMLInputElement>()
+
+function onFolderCreated() {
+  // nothing needed — store updates reactively
+}
+
+async function createRootFolder() {
+  const name = rootFolderName.value.trim()
+  if (!name) {
+    creatingRoot.value = false
+    return
+  }
+  await folderStore.createFolder({ name, parent_id: null })
+  rootFolderName.value = ''
+  creatingRoot.value = false
+}
+
+function cancelRootCreate() {
+  rootFolderName.value = ''
+  creatingRoot.value = false
+}
+
+watch(creatingRoot, async (v) => {
+  if (v) {
+    await nextTick()
+    rootInput.value?.focus()
+  }
+})
+</script>
+

--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -38,6 +38,26 @@
     <!-- Sidebar Content - FIXED: Better scroll behavior -->
     <div v-if="!store.sidebarCollapsed" class="flex-1 flex flex-col min-h-0 overflow-hidden">
 
+      <!-- Folders Section (GH#8987) -->
+      <section v-if="folderStore.folders.length > 0 || true" class="border-b border-autobot-border p-3 pb-2 shrink-0 max-h-56 overflow-y-auto" style="scrollbar-width: thin;">
+        <div class="flex items-center justify-between mb-1">
+          <button
+            class="flex items-center gap-1 text-xs font-semibold text-autobot-text-secondary hover:text-autobot-text-primary transition-colors"
+            @click="showFolders = !showFolders"
+          >
+            <Icon :name="showFolders ? 'chevron-down' : 'chevron-right'" class="text-xs" />
+            {{ $t('chat.folders.folders') }}
+            <span v-if="folderStore.folders.length" class="text-autobot-text-muted font-normal">({{ folderStore.folders.length }})</span>
+          </button>
+        </div>
+        <ChatFolderTree
+          v-if="showFolders"
+          :sessions="store.sessions"
+          :current-session-id="store.currentSessionId"
+          @session-click="(id) => controller.switchToSession(id)"
+        />
+      </section>
+
       <!-- Chat History Section - FIXED: Scrollable area with multi-select -->
       <section class="flex-1 flex flex-col min-h-0 overflow-hidden p-4 pb-0">
         <div class="flex items-center justify-between mb-3 shrink-0">
@@ -102,6 +122,39 @@
                 {{ session.title || getSessionPreview(session) }}
               </span>
               <div v-if="!selectionMode" class="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+                <!-- GH#8987: Assign to folder -->
+                <div class="relative" @click.stop>
+                  <BaseButton
+                    variant="ghost"
+                    size="xs"
+                    class="text-autobot-text-muted p-1"
+                    :title="$t('chat.folders.assignToFolder')"
+                    tabindex="-1"
+                    @click.stop="folderAssignTarget = folderAssignTarget === session.id ? null : session.id"
+                  >
+                    <Icon name="folder" class="text-xs" />
+                  </BaseButton>
+                  <div
+                    v-if="folderAssignTarget === session.id"
+                    class="absolute end-0 top-6 z-50 min-w-36 bg-autobot-bg-card border border-autobot-border rounded shadow-lg p-1 text-xs"
+                  >
+                    <button
+                      class="w-full text-start px-2 py-1 rounded hover:bg-autobot-bg-secondary text-autobot-text-muted"
+                      @click="folderStore.assignSessionToFolder(session.id, null); folderAssignTarget = null"
+                    >
+                      {{ $t('chat.folders.removeFromFolder') }}
+                    </button>
+                    <hr class="border-autobot-border my-0.5" />
+                    <button
+                      v-for="f in folderStore.folders"
+                      :key="f.id"
+                      class="w-full text-start px-2 py-1 rounded hover:bg-autobot-bg-secondary text-autobot-text-primary"
+                      @click="folderStore.assignSessionToFolder(session.id, f.id); folderAssignTarget = null"
+                    >
+                      <Icon name="folder" class="text-xs me-1" />{{ f.name }}
+                    </button>
+                  </div>
+                </div>
                 <BaseButton
                   variant="ghost"
                   size="xs"
@@ -309,7 +362,7 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
-import { ref, computed, nextTick } from 'vue'
+import { ref, computed, nextTick, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 // #1804: emit close-mobile so ChatInterface can close the mobile overlay
@@ -317,6 +370,8 @@ const emit = defineEmits<{ 'close-mobile': [] }>()
 import { useChatStore } from '@/stores/useChatStore'
 import { useChatController } from '@/models/controllers'
 import { useDisplaySettings, type DisplaySettings } from '@/composables/useDisplaySettings'
+import ChatFolderTree from './ChatFolderTree.vue'
+import { useFolderStore } from '@/stores/useFolderStore'
 import { useBatchSelection } from '@/composables/useBatchSelection'
 import type { ChatSession } from '@/stores/useChatStore'
 import DeleteConversationDialog from './DeleteConversationDialog.vue'
@@ -338,6 +393,15 @@ const { t } = useI18n()
 const store = useChatStore()
 const controller = useChatController()
 const { getSetting, setSetting } = useDisplaySettings()
+const folderStore = useFolderStore()
+
+// GH#8987: state for folder section
+const showFolders = ref(true)
+const folderAssignTarget = ref<string | null>(null)
+
+onMounted(() => {
+  folderStore.fetchFolders()
+})
 
 // Local state
 const showEditModal = ref(false)

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -205,6 +205,18 @@
       "deleteFailed": "Failed to delete some chats",
       "sharedSuccess": "Chat shared successfully"
     },
+    "folders": {
+      "folders": "Folders",
+      "newFolder": "New folder",
+      "folderName": "Folder name",
+      "rename": "Rename folder",
+      "addSubfolder": "Add subfolder",
+      "pin": "Pin folder",
+      "unpin": "Unpin folder",
+      "assignToFolder": "Move to folder",
+      "removeFromFolder": "Remove from folder",
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+    },
     "interface": {
       "loadFailed": "Failed to load chat interface",
       "voiceOutputOn": "Voice output on",

--- a/autobot-frontend/src/stores/useChatStore.ts
+++ b/autobot-frontend/src/stores/useChatStore.ts
@@ -55,6 +55,8 @@ export interface ChatSession {
   activities?: SessionActivity[]
   // Issue #608: Session-scoped secrets
   sessionSecrets?: SessionSecret[]
+  // GH#8987: folder assignment (folder_id from useFolderStore)
+  folderId?: string | null
   // Desktop automation context
   // DORMANT: vncUrl preserved for future VNC re-integration (#1130 → #5136)
   desktopSession?: {

--- a/autobot-frontend/src/stores/useFolderStore.ts
+++ b/autobot-frontend/src/stores/useFolderStore.ts
@@ -1,0 +1,169 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+// GH#8987: Pinia store for conversation folder management.
+
+import { ref, computed } from 'vue'
+import { defineStore } from 'pinia'
+import { useApiClient } from '@/plugins/api'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useFolderStore')
+
+const FOLDERS_ENDPOINT = '/api/chat/folders'
+
+export interface ChatFolder {
+  id: string
+  name: string
+  parent_id: string | null
+  owner: string
+  pinned: boolean
+  created_at: string
+  session_ids: string[]
+  session_count: number
+}
+
+export interface FolderCreate {
+  name: string
+  parent_id?: string | null
+}
+
+export interface FolderUpdate {
+  name?: string
+  parent_id?: string | null
+  pinned?: boolean
+}
+
+export const useFolderStore = defineStore('chatFolders', () => {
+  const folders = ref<ChatFolder[]>([])
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  // Folders that have no parent (root level)
+  const rootFolders = computed(() =>
+    folders.value.filter((f) => !f.parent_id).sort((a, b) => {
+      if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+  )
+
+  function childrenOf(parentId: string): ChatFolder[] {
+    return folders.value
+      .filter((f) => f.parent_id === parentId)
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  function folderForSession(sessionId: string): ChatFolder | undefined {
+    return folders.value.find((f) => f.session_ids.includes(sessionId))
+  }
+
+  async function fetchFolders(): Promise<void> {
+    const api = useApiClient()
+    isLoading.value = true
+    error.value = null
+    try {
+      // Backend returns plain JSON: { folders: ChatFolder[], count: number }
+      const resp = await api.get<{ folders: ChatFolder[]; count: number }>(FOLDERS_ENDPOINT)
+      folders.value = resp?.folders ?? []
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to load folders'
+      logger.error('[useFolderStore] fetchFolders failed:', err)
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function createFolder(payload: FolderCreate): Promise<ChatFolder | null> {
+    const api = useApiClient()
+    try {
+      const created = await api.post<ChatFolder>(FOLDERS_ENDPOINT, payload)
+      folders.value.push(created)
+      return created
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to create folder'
+      logger.error('[useFolderStore] createFolder failed:', err)
+      return null
+    }
+  }
+
+  async function updateFolder(id: string, payload: FolderUpdate): Promise<ChatFolder | null> {
+    const api = useApiClient()
+    try {
+      const updated = await api.put<ChatFolder>(`${FOLDERS_ENDPOINT}/${id}`, payload)
+      const idx = folders.value.findIndex((f) => f.id === id)
+      if (idx !== -1) folders.value[idx] = updated
+      return updated
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to update folder'
+      logger.error('[useFolderStore] updateFolder failed:', err)
+      return null
+    }
+  }
+
+  async function deleteFolder(id: string): Promise<boolean> {
+    const api = useApiClient()
+    try {
+      await api.delete(`${FOLDERS_ENDPOINT}/${id}`)
+      // Re-parent children locally to mirror server behaviour
+      const toDelete = folders.value.find((f) => f.id === id)
+      folders.value.forEach((f) => {
+        if (f.parent_id === id) f.parent_id = toDelete?.parent_id ?? null
+      })
+      folders.value = folders.value.filter((f) => f.id !== id)
+      return true
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to delete folder'
+      logger.error('[useFolderStore] deleteFolder failed:', err)
+      return false
+    }
+  }
+
+  async function assignSessionToFolder(sessionId: string, folderId: string | null): Promise<boolean> {
+    const api = useApiClient()
+    try {
+      await api.put(`/api/chat/sessions/${sessionId}/folder`, { folder_id: folderId })
+      // Update local state
+      folders.value.forEach((f) => {
+        const idx = f.session_ids.indexOf(sessionId)
+        if (idx !== -1) {
+          f.session_ids.splice(idx, 1)
+          f.session_count = f.session_ids.length
+        }
+      })
+      if (folderId) {
+        const target = folders.value.find((f) => f.id === folderId)
+        if (target && !target.session_ids.includes(sessionId)) {
+          target.session_ids.push(sessionId)
+          target.session_count = target.session_ids.length
+        }
+      }
+      return true
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to assign session to folder'
+      logger.error('[useFolderStore] assignSessionToFolder failed:', err)
+      return false
+    }
+  }
+
+  async function togglePin(id: string): Promise<void> {
+    const folder = folders.value.find((f) => f.id === id)
+    if (!folder) return
+    await updateFolder(id, { pinned: !folder.pinned })
+  }
+
+  return {
+    folders,
+    rootFolders,
+    isLoading,
+    error,
+    childrenOf,
+    folderForSession,
+    fetchFolders,
+    createFolder,
+    updateFolder,
+    deleteFolder,
+    assignSessionToFolder,
+    togglePin,
+  }
+})

--- a/autobot_shared/ssot_constants.py
+++ b/autobot_shared/ssot_constants.py
@@ -400,6 +400,7 @@ class RedisKeyConstants:
     SYSTEM_KNOWLEDGE_FILE_STATES: str = f"{NAMESPACE}:system_knowledge:file_states"
     WORKFLOW_CLASSIFICATION_RULES: str = f"{NAMESPACE}:workflow:classification:rules"
     CHAT_RECENT: str = "chat:recent"
+    CHAT_FOLDERS: str = "chat:folders:{username}"
     LLM_MODELS_CACHE: str = "llm_models"
 
 


### PR DESCRIPTION
## Summary

Implements the #1 most-requested feature: conversation folders in the chat sidebar (145👍).

- **Backend**: `ChatFolder` CRUD API (list/create/update/delete + assign-session) — stored per-user in Redis, max 3-level nesting, pin support
- **Frontend**: recursive folder tree in sidebar, create/rename/delete/pin/add-subfolder per node, per-session folder-assign dropdown
- **Integration**: folder panel injected above chat history in `ChatSidebar.vue`, `useFolderStore` Pinia store, full i18n

## Files changed

| File | Change |
|------|--------|
| `autobot-backend/api/chat_folders.py` | NEW — 5 REST endpoints |
| `autobot-backend/api/schemas_chat.py` | FolderCreate/FolderUpdate/SessionFolderAssign schemas |
| `autobot_shared/ssot_constants.py` | CHAT_FOLDERS Redis key |
| `initialization/router_registry/feature_routers.py` | register chat_folders router |
| `autobot-frontend/src/stores/useFolderStore.ts` | NEW — Pinia store |
| `autobot-frontend/src/components/chat/ChatFolderTree.vue` | NEW — tree root component |
| `autobot-frontend/src/components/chat/ChatFolderNode.vue` | NEW — recursive node |
| `autobot-frontend/src/components/chat/ChatSidebar.vue` | integrate folder tree + assign dropdown |
| `autobot-frontend/src/i18n/locales/en.json` | chat.folders.* keys |
| `autobot-frontend/src/stores/useChatStore.ts` | folderId field on ChatSession |

## Test plan

- [ ] Create folder → appears in sidebar tree
- [ ] Rename / pin folder → persists after page reload
- [ ] Add subfolder (up to 3 levels) → 4th level rejected with error
- [ ] Delete folder → child folders re-parent to root
- [ ] Assign chat to folder via session row → chat appears under folder
- [ ] Remove chat from folder → returns to unfoldered list
- [ ] Collapse/expand folder → sessions show/hide
- [ ] Folder count badge updates when sessions are added/removed

## Out of scope (per issue)

- Folder sharing (separate issue)
- Folder-level permissions
- Drag-and-drop (filed as follow-up — complex without a dnd library)

🤖 Generated with [Claude Code](https://claude.com/claude-code)