### PR TITLE
fix(ci): group consecutive GITHUB_STEP_SUMMARY redirects (SC2129) (#8917)

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -232,11 +232,13 @@ jobs:
           fi
 
           if [ -d "test-artifacts" ]; then
-            echo "## Available Artifacts:" >> "$GITHUB_STEP_SUMMARY"
-            find test-artifacts -type d -name "*results*" | while read -r dir; do
-              echo "- $(basename "$dir")" >> "$GITHUB_STEP_SUMMARY"
-            done
-            echo "" >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "## Available Artifacts:"
+              find test-artifacts -type d -name "*results*" | while read -r dir; do
+                echo "- $(basename "$dir")"
+              done
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
           {


### PR DESCRIPTION
## Summary

- Fixes SC2129 in `frontend-test.yml` lines 232–240: groups 5 consecutive `echo "..." >> "$GITHUB_STEP_SUMMARY"` redirects inside a `find` loop into a single `{ ... } >> "$GITHUB_STEP_SUMMARY"` block
- Completes #8917 — this is the last remaining violation (SC2162 + SC2086 already landed in Dev_new_gui via `12f8ca533`)

## Violations fixed

| Violation | File | Fix |
|-----------|------|-----|
| SC2129 (consecutive `>>` redirects) | `.github/workflows/frontend-test.yml:232–240` | Group into `{ ... } >> "$GITHUB_STEP_SUMMARY"` |

SC2162 and SC2086 fixes are already in `Dev_new_gui` (commit `12f8ca533`).

## Test plan
- [ ] CI-only change — no runtime logic affected
- [ ] actionlint passes on modified workflow
- [ ] No shellcheck warnings in the patched block

Closes #8917

🤖 Generated with [Claude Code](https://claude.com/claude-code)