### PR TITLE
fix(sso): replace in-memory OAuth state dict with Redis-backed storage (MVA-1733)

### DIFF
--- a/autobot-slm-backend/tests/services/test_sso_service.py
+++ b/autobot-slm-backend/tests/services/test_sso_service.py
@@ -1,0 +1,179 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for Redis-backed OAuth2 state in SSOService (MVA-1733)."""
+
+import importlib.util
+import sys
+import types
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ── Load sso_service.py directly, bypassing conftest stubs ───────────────────
+# autobot-slm-backend/conftest.py pre-stubs all user_management.* modules as
+# MagicMocks to prevent the api/__init__.py import chain (Issue #3499).
+# Because user_management.services is a MagicMock (not a real package), the
+# standard `from user_management.services.sso_service import ...` path always
+# fails with "not a package".  The fix: load the real .py file directly via
+# spec_from_file_location, mirroring the pattern in drift_checker_test.py.
+#
+# Before exec'ing the module we pre-populate sys.modules for every import that
+# sso_service.py contains so that its top-level imports resolve without hitting
+# the real SQLAlchemy/DB stack:
+#   - user_management.models.sso   (not in conftest list — add it)
+#   - user_management.services.base_service  (replace MagicMock with real cls)
+#   - autobot_shared.redis_client  (real module, available via pythonpath)
+
+_MODELS_SSO = "user_management.models.sso"
+if _MODELS_SSO not in sys.modules:
+    sys.modules[_MODELS_SSO] = MagicMock()
+
+# Provide a minimal real BaseService so `class SSOService(BaseService)` compiles
+# and SSOService(session=...) is constructable.
+_base_mod = types.ModuleType("user_management.services.base_service")
+
+
+class _BaseService:
+    def __init__(self, session):
+        self.session = session
+
+
+_base_mod.BaseService = _BaseService  # type: ignore[attr-defined]
+sys.modules["user_management.services.base_service"] = _base_mod
+
+_SSO_PY = (
+    Path(__file__).parent.parent.parent
+    / "user_management"
+    / "services"
+    / "sso_service.py"
+)
+_spec = importlib.util.spec_from_file_location("_sso_service_under_test", _SSO_PY)
+_sso_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_sso_mod)  # type: ignore[union-attr]
+
+SSOService = _sso_mod.SSOService
+SSOAuthenticationError = _sso_mod.SSOAuthenticationError
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PROVIDER_ID = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+
+def _make_service() -> SSOService:  # type: ignore[valid-type]
+    """Return an SSOService with a mock DB session (state tests need no real DB)."""
+    return SSOService(session=MagicMock())
+
+
+def _mock_redis(stored: dict | None = None) -> tuple[MagicMock, dict]:
+    """Return a (redis_mock, store) tuple backed by an optional in-memory dict."""
+    store: dict = stored if stored is not None else {}
+
+    async def _set(key, value, ex=None):
+        store[key] = value
+
+    async def _getdel(key):
+        return store.pop(key, None)
+
+    redis = MagicMock()
+    redis.set = AsyncMock(side_effect=_set)
+    redis.getdel = AsyncMock(side_effect=_getdel)
+    return redis, store
+
+
+# ---------------------------------------------------------------------------
+# _generate_oauth_state
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateOauthState:
+    @pytest.mark.asyncio
+    async def test_stores_provider_id_in_redis(self):
+        redis, store = _mock_redis()
+        service = _make_service()
+        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+            state = await service._generate_oauth_state(_PROVIDER_ID)
+
+        assert state
+        assert len(store) == 1
+        key = f"sso:state:{state}"
+        assert key in store
+        assert store[key] == str(_PROVIDER_ID)
+
+    @pytest.mark.asyncio
+    async def test_set_called_with_correct_ttl(self):
+        redis, _ = _mock_redis()
+        service = _make_service()
+        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+            state = await service._generate_oauth_state(_PROVIDER_ID)
+
+        redis.set.assert_awaited_once_with(
+            f"sso:state:{state}", str(_PROVIDER_ID), ex=600
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_token_even_when_redis_unavailable(self):
+        service = _make_service()
+        with patch.object(_sso_mod, "get_redis_client", return_value=None):
+            state = await service._generate_oauth_state(_PROVIDER_ID)
+        assert state  # token still generated; Redis write silently skipped
+
+
+# ---------------------------------------------------------------------------
+# _validate_oauth_state
+# ---------------------------------------------------------------------------
+
+
+class TestValidateOauthState:
+    @pytest.mark.asyncio
+    async def test_round_trip_returns_provider_id(self):
+        redis, store = _mock_redis()
+        service = _make_service()
+        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+            state = await service._generate_oauth_state(_PROVIDER_ID)
+            recovered = await service._validate_oauth_state(state)
+
+        assert recovered == _PROVIDER_ID
+
+    @pytest.mark.asyncio
+    async def test_second_use_raises(self):
+        """GETDEL must make state single-use to prevent replay attacks."""
+        redis, store = _mock_redis()
+        service = _make_service()
+        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+            state = await service._generate_oauth_state(_PROVIDER_ID)
+            await service._validate_oauth_state(state)  # first use succeeds
+            with pytest.raises(SSOAuthenticationError, match="Invalid or expired"):
+                await service._validate_oauth_state(state)  # second use raises
+
+    @pytest.mark.asyncio
+    async def test_invalid_state_raises(self):
+        redis, _ = _mock_redis()
+        service = _make_service()
+        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+            with pytest.raises(SSOAuthenticationError, match="Invalid or expired"):
+                await service._validate_oauth_state("nonexistent-state-token")
+
+    @pytest.mark.asyncio
+    async def test_redis_unavailable_raises(self):
+        service = _make_service()
+        with patch.object(_sso_mod, "get_redis_client", return_value=None):
+            with pytest.raises(SSOAuthenticationError, match="Redis unavailable"):
+                await service._validate_oauth_state("any-state")
+
+    @pytest.mark.asyncio
+    async def test_state_removed_after_validation(self):
+        """Key must be consumed — no residual entry in Redis after successful validation."""
+        redis, store = _mock_redis()
+        service = _make_service()
+        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+            state = await service._generate_oauth_state(_PROVIDER_ID)
+            await service._validate_oauth_state(state)
+
+        assert f"sso:state:{state}" not in store

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from sqlalchemy import select
 
+from autobot_shared.redis_client import get_redis_client
 from user_management.models.sso import SSOProvider, SSOProviderType, UserSSOLink
 from user_management.models.user import User
 from user_management.schemas.sso import SSOProviderCreate, SSOProviderUpdate
@@ -38,9 +39,6 @@ except ImportError:
     Saml2Client = Saml2Config = None  # type: ignore
 
 logger = logging.getLogger(__name__)
-
-# Module-level OAuth2 state storage
-_oauth_states: dict[str, uuid.UUID] = {}
 
 
 class SSOServiceError(Exception):
@@ -143,18 +141,23 @@ class SSOService(BaseService):
             logger.error("LDAP connection test failed: %s", e)
             return {"success": False, "message": "LDAP connection test failed"}
 
-    def _generate_oauth_state(self, provider_id: uuid.UUID) -> str:
-        """Generate OAuth2 state token and store provider mapping."""
+    async def _generate_oauth_state(self, provider_id: uuid.UUID) -> str:
+        """Generate OAuth2 state token and store provider mapping in Redis with 10-min TTL."""
         state = secrets.token_urlsafe(32)
-        _oauth_states[state] = provider_id
+        redis = get_redis_client()
+        if redis:
+            await redis.set(f"sso:state:{state}", str(provider_id), ex=600)
         return state
 
-    def _validate_oauth_state(self, state: str) -> uuid.UUID:
-        """Validate OAuth2 state token and return provider ID."""
-        provider_id = _oauth_states.pop(state, None)
-        if not provider_id:
-            raise SSOAuthenticationError("Invalid or expired OAuth state")
-        return provider_id
+    async def _validate_oauth_state(self, state: str) -> uuid.UUID:
+        """Validate OAuth2 state token via atomic GETDEL (single-use, replay-safe)."""
+        redis = get_redis_client()
+        if redis:
+            provider_id_str = await redis.getdel(f"sso:state:{state}")
+            if not provider_id_str:
+                raise SSOAuthenticationError("Invalid or expired OAuth state")
+            return uuid.UUID(provider_id_str)
+        raise SSOAuthenticationError("Redis unavailable for state validation")
 
     def _build_oauth_client(self, provider: SSOProvider) -> Any:
         """Build OAuth2 client from provider config."""
@@ -170,7 +173,7 @@ class SSOService(BaseService):
     async def _get_oauth_authorize_url(self, provider: SSOProvider, callback_url: str) -> tuple[str, str]:
         """Generate OAuth2 authorization URL."""
         client = self._build_oauth_client(provider)
-        state = self._generate_oauth_state(provider.id)
+        state = await self._generate_oauth_state(provider.id)
         authorize_url = provider.config.get("authorize_url")
         scope = provider.config.get("scope", "openid email profile")
         url, _ = await client.create_authorization_url(
@@ -210,7 +213,7 @@ class SSOService(BaseService):
 
     async def complete_oauth_login(self, provider_id: uuid.UUID, code: str, state: str, callback_url: str) -> User:
         """Complete OAuth2 login flow and return authenticated user."""
-        validated_provider_id = self._validate_oauth_state(state)
+        validated_provider_id = await self._validate_oauth_state(state)
         if validated_provider_id != provider_id:
             raise SSOAuthenticationError("OAuth state mismatch")
         provider = await self.get_provider(provider_id)
@@ -314,11 +317,13 @@ class SSOService(BaseService):
         saml_config.load(config_dict)
         return Saml2Client(config=saml_config)
 
-    def _generate_saml_authn_request(self, provider: SSOProvider) -> tuple[str, str]:
-        """Generate SAML AuthnRequest."""
+    async def _generate_saml_authn_request(self, provider: SSOProvider) -> tuple[str, str]:
+        """Generate SAML AuthnRequest; relay state stored in Redis with 10-min TTL."""
         client = self._build_saml_client(provider)
         relay_state = secrets.token_urlsafe(32)
-        _oauth_states[relay_state] = provider.id
+        redis = get_redis_client()
+        if redis:
+            await redis.set(f"sso:state:{relay_state}", str(provider.id), ex=600)
         request_id, info = client.prepare_for_authenticate()
         redirect_url = dict(info["headers"])["Location"]
         return redirect_url, relay_state


### PR DESCRIPTION
## Summary

Fixes a P0 production bug where all SSO logins silently fail in multi-worker deployments.

- **Root cause**: `_oauth_states: dict[str, uuid.UUID] = {}` at module scope — state written in worker A is invisible to worker B that receives the IdP callback
- **Fix**: Replace the in-memory dict with Redis-backed storage using `get_redis_client()` from `autobot_shared.redis_client`
- **SAML relay state** receives the same treatment in `_generate_saml_authn_request`
- **Atomicity**: `GETDEL` (Redis ≥ 6.2) makes each state token single-use, preventing replay attacks
- **Graceful degradation**: `_generate_oauth_state` still returns a token if Redis is unavailable (silent skip); `_validate_oauth_state` raises `SSOAuthenticationError("Redis unavailable…")` rather than silently accepting invalid state

## Changed files

- `autobot-slm-backend/user_management/services/sso_service.py` — remove dict, add Redis calls
- `autobot-slm-backend/tests/services/test_sso_service.py` — 8 new unit tests (all passing)

## Test results

```
8 passed in 0.55s
```

Covers: round-trip, single-use enforcement, TTL assertion, invalid-state rejection, Redis-unavailable paths, key consumption.

## Acceptance criteria

- ✅ `_oauth_states` dict removed from module scope
- ✅ State stored in Redis with key `sso:state:{token}`, TTL 600s
- ✅ State consumed atomically via `GETDEL` (prevents replay)
- ✅ Both `initiate_oauth_login` and `complete_oauth_login` are async throughout
- ✅ Unit test: mock Redis; state round-trip works; expired/invalid state raises `SSOAuthenticationError`
- ✅ Unit test: second use of same state raises `SSOAuthenticationError`

Closes MVA-1733 | Parent: MVA-1730