### PR TITLE
feat(llc/adapters): add CopilotLocalAdapter for gh copilot CLI sessions (#9008)

### DIFF
--- a/autobot-backend/llc/adapters/__init__.py
+++ b/autobot-backend/llc/adapters/__init__.py
@@ -1,7 +1,7 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""LLC adapters package (GH#8226 / GH#8227 / GH#8228 / GH#8258).
+"""LLC adapters package (GH#8226 / GH#8227 / GH#8228 / GH#8258 / GH#9008).
 
 Public surface:
 - ``LLCAdapter``            — structural Protocol every adapter satisfies
@@ -10,6 +10,7 @@ Public surface:
 - ``register_adapter``      — registry mutator
 - ``AutoBotAgentAdapter``   — wraps any AutoBot agent for LLC dispatch
 - ``ClaudeCodeAdapter``     — runs Claude Code CLI sessions (GH#8258)
+- ``CopilotLocalAdapter``   — wraps local ``gh copilot`` CLI sessions (GH#9008)
 - ``get_adapter_for_agent`` — stub; concrete registry wired in GH#8225
 """
 
@@ -18,19 +19,22 @@ from typing import Optional
 from .autobot_agent_adapter import AutoBotAgentAdapter
 from .base import AdapterRunStatus, LLCAdapter, get_adapter, register_adapter
 from .claude_code_adapter import ClaudeCodeAdapter
+from .copilot_local_adapter import CopilotLocalAdapter
 
 __all__ = [
     "AdapterRunStatus",
     "AutoBotAgentAdapter",
     "ClaudeCodeAdapter",
+    "CopilotLocalAdapter",
     "LLCAdapter",
     "get_adapter",
     "get_adapter_for_agent",
     "register_adapter",
 ]
 
-# Register claude_code adapter under its canonical type key.
+# Register adapters under their canonical type keys.
 register_adapter("claude_code", ClaudeCodeAdapter())
+register_adapter("copilot_local", CopilotLocalAdapter())
 
 
 async def get_adapter_for_agent(agent_id: str) -> Optional[LLCAdapter]:

--- a/autobot-backend/llc/adapters/copilot_local_adapter.py
+++ b/autobot-backend/llc/adapters/copilot_local_adapter.py
@@ -1,0 +1,268 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""CopilotLocalAdapter — wraps a local ``gh copilot`` CLI session as an LLC heartbeat (GH#9008).
+
+adapter_config schema::
+
+    {
+        "gh_token": "ghp_...",          # optional; falls back to ambient GH_TOKEN/GITHUB_TOKEN
+        "copilot_model": "copilot-4o",  # default; exposed as GH_COPILOT_MODEL env var
+        "workspace_dir": "/path/to",    # subprocess cwd; cleared on missing-dir retry
+        "output_dir": "/tmp",           # where .jsonl output and state files land
+        "timeout_seconds": 3600         # wall-clock limit per invocation
+    }
+
+``run_id`` is ``"<pid>/<session_id>"`` where ``session_id`` is a UUID assigned at
+invoke time and used to locate the state file on disk (mirrors ClaudeCodeAdapter).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import pathlib
+import shutil
+import signal
+import time
+import uuid
+from typing import Optional
+
+from autobot_shared.logging_manager import get_logger
+
+from ..models.enums import LLCRunStatus
+from .base import AdapterRunStatus
+
+logger = get_logger(__name__)
+
+_SIGTERM_GRACE_SECONDS = 5
+_DEFAULT_TIMEOUT_SECONDS = 3600
+_DEFAULT_OUTPUT_DIR = "/tmp"  # nosec B108 - test/controlled code uses tmpdir intentionally
+_DEFAULT_COPILOT_MODEL = "copilot-4o"
+
+
+def _resolve_gh_cli() -> str:
+    path = shutil.which("gh")
+    if path is None:
+        raise RuntimeError(
+            "gh CLI not found on PATH. "
+            "Install the GitHub CLI and ensure 'gh' is on PATH."
+        )
+    return path
+
+
+def _output_path(output_dir: str, agent_id: str, run_id: str) -> str:
+    safe_run = run_id.replace("/", "_")
+    return os.path.join(output_dir, f"llc_copilot_{agent_id}_{safe_run}.jsonl")
+
+
+def _state_path(output_dir: str, run_id: str) -> str:
+    safe_run = run_id.replace("/", "_")
+    return os.path.join(output_dir, f"llc_copilot_state_{safe_run}.json")
+
+
+class CopilotLocalAdapter:
+    """Adapter that manages agent runs as local ``gh copilot`` CLI subprocess sessions."""
+
+    async def invoke(self, agent_config: dict, context: dict) -> str:
+        try:
+            return await self._invoke(agent_config, context)
+        except Exception as exc:
+            logger.exception("CopilotLocalAdapter.invoke failed: %s", exc)
+            raise
+
+    async def _invoke(self, agent_config: dict, context: dict) -> str:
+        gh_cli = _resolve_gh_cli()
+        agent_id: str = agent_config.get("agent_id", "unknown")
+        cfg = agent_config.get("adapter_config", {})
+
+        output_dir: str = cfg.get("output_dir", _DEFAULT_OUTPUT_DIR)
+        timeout_sec: int = int(cfg.get("timeout_seconds", _DEFAULT_TIMEOUT_SECONDS))
+        gh_token: Optional[str] = cfg.get("gh_token")
+        copilot_model: str = cfg.get("copilot_model", _DEFAULT_COPILOT_MODEL)
+
+        session_id = str(uuid.uuid4())
+        run_id_placeholder = f"0/{session_id}"
+        output_file = _output_path(output_dir, agent_id, run_id_placeholder)
+        os.makedirs(output_dir, exist_ok=True)
+
+        prompt = self._build_prompt(context)
+        workspace_dir: str | None = cfg.get("workspace_dir") or context.get("workspace_dir")
+
+        cmd: list[str] = [gh_cli, "copilot", "suggest", "--target", "bash", prompt]
+
+        env = {**os.environ, "LLC_INVOKE_CONTEXT": json.dumps(context, default=str)}
+        if gh_token:
+            env["GITHUB_TOKEN"] = gh_token
+            env["GH_TOKEN"] = gh_token
+        env["GH_COPILOT_MODEL"] = copilot_model
+        if workspace_dir:
+            env["AUTOBOT_WORKSPACE_DIR"] = workspace_dir
+
+        out_fh = open(output_file, "w", encoding="utf-8")
+        try:
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdout=out_fh,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=env,
+                    cwd=workspace_dir or None,
+                )
+            except FileNotFoundError as e:
+                if (
+                    workspace_dir
+                    and e.filename
+                    and os.path.abspath(str(e.filename)) == os.path.abspath(workspace_dir)
+                ):
+                    logger.warning(
+                        "CopilotLocalAdapter: workspace_dir %r missing, retrying without cwd",
+                        workspace_dir,
+                    )
+                    env.pop("AUTOBOT_WORKSPACE_DIR", None)
+                    workspace_dir = None
+                    env["LLC_INVOKE_CONTEXT"] = json.dumps(
+                        {k: v for k, v in context.items() if k != "workspace_dir"},
+                        default=str,
+                    )
+                else:
+                    raise
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdout=out_fh,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=env,
+                )
+        finally:
+            out_fh.close()
+
+        run_id = f"{proc.pid}/{session_id}"
+        logger.info(
+            "CopilotLocalAdapter: spawned PID %d session %s agent %s output=%s",
+            proc.pid,
+            session_id,
+            agent_id,
+            output_file,
+        )
+
+        state = {
+            "pid": proc.pid,
+            "session_id": session_id,
+            "agent_id": agent_id,
+            "output_file": output_file,
+            "started_at": time.time(),
+            "timeout_seconds": timeout_sec,
+        }
+        with open(_state_path(output_dir, run_id), "w", encoding="utf-8") as fh:
+            json.dump(state, fh)
+
+        return run_id
+
+    async def status(self, agent_config: dict, run_id: str) -> AdapterRunStatus:
+        try:
+            return await self._status(agent_config, run_id)
+        except Exception as exc:
+            logger.exception("CopilotLocalAdapter.status failed: %s", exc)
+            return AdapterRunStatus(status=LLCRunStatus.FAILED, error=str(exc))
+
+    async def _status(self, agent_config: dict, run_id: str) -> AdapterRunStatus:
+        cfg = agent_config.get("adapter_config", {})
+        output_dir: str = cfg.get("output_dir", _DEFAULT_OUTPUT_DIR)
+        state = self._load_state(_state_path(output_dir, run_id), output_dir)
+
+        if state is None:
+            try:
+                pid = int(run_id.split("/")[0])
+            except (ValueError, IndexError):
+                return AdapterRunStatus(
+                    status=LLCRunStatus.FAILED,
+                    error=f"Unparseable run_id: {run_id!r}",
+                )
+            return self._probe_pid(pid)
+
+        pid: int = state["pid"]
+        timeout_sec: float = state.get("timeout_seconds", _DEFAULT_TIMEOUT_SECONDS)
+        started_at: float = state.get("started_at", 0.0)
+
+        if time.time() - started_at > timeout_sec:
+            logger.warning("CopilotLocalAdapter: run_id %s timed out (%ss)", run_id, timeout_sec)
+            await self.cancel(agent_config, run_id)
+            return AdapterRunStatus(status=LLCRunStatus.TIMEOUT)
+
+        return self._probe_pid(pid)
+
+    def _probe_pid(self, pid: int) -> AdapterRunStatus:
+        try:
+            os.kill(pid, 0)
+            return AdapterRunStatus(status=LLCRunStatus.RUNNING)
+        except ProcessLookupError:
+            return AdapterRunStatus(status=LLCRunStatus.COMPLETED)
+        except PermissionError:
+            return AdapterRunStatus(status=LLCRunStatus.RUNNING)
+        except OSError as exc:
+            return AdapterRunStatus(status=LLCRunStatus.FAILED, error=str(exc))
+
+    async def cancel(self, agent_config: dict, run_id: str) -> None:
+        try:
+            await self._cancel(agent_config, run_id)
+        except Exception as exc:
+            logger.exception("CopilotLocalAdapter.cancel failed: %s", exc)
+
+    async def _cancel(self, agent_config: dict, run_id: str) -> None:
+        cfg = agent_config.get("adapter_config", {})
+        output_dir: str = cfg.get("output_dir", _DEFAULT_OUTPUT_DIR)
+
+        try:
+            pid = int(run_id.split("/")[0])
+        except (ValueError, IndexError):
+            logger.error("CopilotLocalAdapter.cancel: unparseable run_id %r", run_id)
+            return
+
+        try:
+            os.kill(pid, signal.SIGTERM)
+            logger.info("CopilotLocalAdapter: SIGTERM -> PID %d", pid)
+        except ProcessLookupError:
+            pass
+        else:
+            for _ in range(_SIGTERM_GRACE_SECONDS * 10):
+                await asyncio.sleep(0.1)
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    break
+            else:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                    logger.warning("CopilotLocalAdapter: SIGKILL -> PID %d", pid)
+                except ProcessLookupError:
+                    pass
+
+        try:
+            os.unlink(_state_path(output_dir, run_id))
+        except FileNotFoundError:
+            pass
+
+    def _build_prompt(self, context: dict) -> str:
+        parts: list[str] = []
+        if rag_brief := context.get("rag_brief"):
+            parts.append(rag_brief)
+        if task_id := context.get("task_id", ""):
+            parts.append(f"Task ID: {task_id}")
+        if api_base := context.get("api_base_url", ""):
+            parts.append(f"API base URL: {api_base}")
+        if not parts:
+            parts.append(json.dumps(context, default=str))
+        return "\n\n".join(parts)
+
+    @staticmethod
+    def _load_state(state_file: str, safe_dir: str = _DEFAULT_OUTPUT_DIR) -> Optional[dict]:
+        try:
+            resolved = pathlib.Path(state_file).resolve()
+            base = pathlib.Path(safe_dir).resolve()
+            if not resolved.is_relative_to(base):
+                return None
+            with open(resolved, encoding="utf-8") as fh:
+                return json.load(fh)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None

--- a/autobot-backend/llc/adapters/tests/test_copilot_local_adapter.py
+++ b/autobot-backend/llc/adapters/tests/test_copilot_local_adapter.py
@@ -1,0 +1,404 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for CopilotLocalAdapter (GH#9008)."""
+
+import json
+import os
+import tempfile
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.adapters.base import LLCAdapter
+from llc.adapters.copilot_local_adapter import (
+    CopilotLocalAdapter,
+    _state_path,
+)
+from llc.models.enums import LLCRunStatus
+
+# A dummy auth value that won't match secret-scanner patterns.
+_AUTH_STUB = "dummy-auth-fixture-xyz"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _agent_cfg(agent_id: str = "agent-1", output_dir: str | None = None, **kwargs) -> dict:
+    cfg: dict = {"agent_id": agent_id, "adapter_config": {**kwargs}}
+    if output_dir:
+        cfg["adapter_config"]["output_dir"] = output_dir
+    return cfg
+
+
+def _make_fake_proc(pid: int = 12345) -> MagicMock:
+    proc = MagicMock()
+    proc.pid = pid
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_satisfies_llc_adapter_protocol(self) -> None:
+        assert isinstance(CopilotLocalAdapter(), LLCAdapter)
+
+
+# ---------------------------------------------------------------------------
+# _build_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPrompt:
+    def _prompt(self, context: dict) -> str:
+        return CopilotLocalAdapter()._build_prompt(context)
+
+    def test_includes_rag_brief_and_task_id(self) -> None:
+        p = self._prompt({"rag_brief": "# Policy\nDo X.", "task_id": "t1"})
+        assert "# Policy" in p
+        assert "Task ID: t1" in p
+
+    def test_task_and_api_base(self) -> None:
+        p = self._prompt({"task_id": "t2", "api_base_url": "http://api"})
+        assert "Task ID: t2" in p
+        assert "API base URL: http://api" in p
+
+    def test_empty_context_falls_back_to_json(self) -> None:
+        p = self._prompt({})
+        assert p
+
+    def test_unknown_keys_serialised_as_json(self) -> None:
+        p = self._prompt({"foo": "bar"})
+        assert "bar" in p
+
+
+# ---------------------------------------------------------------------------
+# invoke
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestInvoke:
+    async def test_invoke_returns_pid_slash_session(self) -> None:
+        adapter = CopilotLocalAdapter()
+        fake_proc = _make_fake_proc(99)
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = _agent_cfg(output_dir=td)
+            with (
+                patch("llc.adapters.copilot_local_adapter.shutil.which", return_value="/usr/bin/gh"),
+                patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
+                patch("builtins.open", MagicMock(return_value=MagicMock())),
+            ):
+                run_id = await adapter.invoke(cfg, {"task_id": "t1"})
+
+        parts = run_id.split("/")
+        assert parts[0] == "99"
+        assert len(parts[1]) == 36  # UUID
+
+    async def test_invoke_raises_when_gh_missing(self) -> None:
+        adapter = CopilotLocalAdapter()
+        with patch("llc.adapters.copilot_local_adapter.shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match="gh CLI not found"):
+                await adapter.invoke(_agent_cfg(), {})
+
+    async def test_invoke_writes_state_file(self) -> None:
+        adapter = CopilotLocalAdapter()
+        fake_proc = _make_fake_proc(77)
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = _agent_cfg(output_dir=td)
+            with (
+                patch("llc.adapters.copilot_local_adapter.shutil.which", return_value="/usr/bin/gh"),
+                patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
+            ):
+                run_id = await adapter.invoke(cfg, {"task_id": "t99"})
+
+            state_file = _state_path(td, run_id)
+            assert os.path.exists(state_file)
+            with open(state_file) as fh:
+                state = json.load(fh)
+            assert state["pid"] == 77
+            assert "session_id" in state
+
+    async def test_invoke_sets_github_auth_env_vars(self) -> None:
+        adapter = CopilotLocalAdapter()
+        fake_proc = _make_fake_proc(44)
+        captured_envs: list[dict] = []
+
+        async def fake_exec(*args, **kwargs):
+            captured_envs.append(dict(kwargs.get("env", {})))
+            return fake_proc
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = _agent_cfg(output_dir=td, gh_token=_AUTH_STUB)
+            with (
+                patch("llc.adapters.copilot_local_adapter.shutil.which", return_value="/usr/bin/gh"),
+                patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+                patch("builtins.open", MagicMock(return_value=MagicMock())),
+            ):
+                await adapter.invoke(cfg, {})
+
+        assert captured_envs[0].get("GITHUB_TOKEN") == _AUTH_STUB
+        assert captured_envs[0].get("GH_TOKEN") == _AUTH_STUB
+
+    async def test_invoke_sets_copilot_model_env_var(self) -> None:
+        adapter = CopilotLocalAdapter()
+        fake_proc = _make_fake_proc(55)
+        captured_envs: list[dict] = []
+
+        async def fake_exec(*args, **kwargs):
+            captured_envs.append(dict(kwargs.get("env", {})))
+            return fake_proc
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = _agent_cfg(output_dir=td, copilot_model="copilot-4o")
+            with (
+                patch("llc.adapters.copilot_local_adapter.shutil.which", return_value="/usr/bin/gh"),
+                patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+                patch("builtins.open", MagicMock(return_value=MagicMock())),
+            ):
+                await adapter.invoke(cfg, {})
+
+        assert captured_envs[0].get("GH_COPILOT_MODEL") == "copilot-4o"
+
+    async def test_invoke_default_model_is_copilot_4o(self) -> None:
+        adapter = CopilotLocalAdapter()
+        fake_proc = _make_fake_proc(56)
+        captured_envs: list[dict] = []
+
+        async def fake_exec(*args, **kwargs):
+            captured_envs.append(dict(kwargs.get("env", {})))
+            return fake_proc
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = _agent_cfg(output_dir=td)
+            with (
+                patch("llc.adapters.copilot_local_adapter.shutil.which", return_value="/usr/bin/gh"),
+                patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+                patch("builtins.open", MagicMock(return_value=MagicMock())),
+            ):
+                await adapter.invoke(cfg, {})
+
+        assert captured_envs[0].get("GH_COPILOT_MODEL") == "copilot-4o"
+
+    async def test_invoke_passes_workspace_dir_as_cwd(self) -> None:
+        adapter = CopilotLocalAdapter()
+        fake_proc = _make_fake_proc(66)
+        captured_kwargs: list[dict] = []
+
+        async def fake_exec(*args, **kwargs):
+            captured_kwargs.append(kwargs)
+            return fake_proc
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = _agent_cfg(output_dir=td, workspace_dir="/workspace/dir")
+            with (
+                patch("llc.adapters.copilot_local_adapter.shutil.which", return_value="/usr/bin/gh"),
+                patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+                patch("builtins.open", MagicMock(return_value=MagicMock())),
+            ):
+                await adapter.invoke(cfg, {})
+
+        assert captured_kwargs[0].get("cwd") == "/workspace/dir"
+
+    async def test_fd_closed_when_exec_raises(self) -> None:
+        adapter = CopilotLocalAdapter()
+        fake_fh = MagicMock()
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = _agent_cfg(output_dir=td)
+            with (
+                patch("llc.adapters.copilot_local_adapter.shutil.which", return_value="/usr/bin/gh"),
+                patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, side_effect=OSError("boom")),
+                patch("builtins.open", MagicMock(return_value=fake_fh)),
+            ):
+                with pytest.raises(OSError):
+                    await adapter.invoke(cfg, {})
+
+        fake_fh.close.assert_called_once()
+
+    async def test_fd_closed_on_success(self) -> None:
+        adapter = CopilotLocalAdapter()
+        fake_proc = _make_fake_proc(88)
+        fake_fh = MagicMock()
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = _agent_cfg(output_dir=td)
+            with (
+                patch("llc.adapters.copilot_local_adapter.shutil.which", return_value="/usr/bin/gh"),
+                patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
+                patch("builtins.open", MagicMock(return_value=fake_fh)),
+            ):
+                await adapter.invoke(cfg, {})
+
+        fake_fh.close.assert_called_once()
+
+    async def test_workspace_dir_missing_retries_without_cwd(self) -> None:
+        adapter = CopilotLocalAdapter()
+        fake_proc = _make_fake_proc(77)
+        call_count = 0
+        fake_fh = MagicMock()
+        captured_kwargs: list[dict] = []
+
+        async def exec_raising_first(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            captured_kwargs.append(dict(kwargs))
+            if call_count == 1:
+                import errno as _errno
+                raise FileNotFoundError(_errno.ENOENT, "No such file or directory", "/deleted/worktree")
+            return fake_proc
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = _agent_cfg(output_dir=td, workspace_dir="/deleted/worktree")
+            with (
+                patch("llc.adapters.copilot_local_adapter.shutil.which", return_value="/usr/bin/gh"),
+                patch("asyncio.create_subprocess_exec", side_effect=exec_raising_first),
+                patch("builtins.open", MagicMock(return_value=fake_fh)),
+            ):
+                run_id = await adapter.invoke(cfg, {"task_id": "t1"})
+
+        assert call_count == 2
+        assert run_id.startswith("77/")
+        assert captured_kwargs[0].get("cwd") == "/deleted/worktree"
+        assert captured_kwargs[1].get("cwd") is None
+        fake_fh.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestStatus:
+    async def test_running_pid_returns_running(self) -> None:
+        adapter = CopilotLocalAdapter()
+        with patch("os.kill", return_value=None):
+            result = await adapter.status(_agent_cfg(), "1234/session-abc")
+        assert result.status == LLCRunStatus.RUNNING
+
+    async def test_dead_pid_returns_completed(self) -> None:
+        adapter = CopilotLocalAdapter()
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        with patch("os.kill", side_effect=fake_kill):
+            result = await adapter.status(_agent_cfg(), "9999/session-abc")
+        assert result.status == LLCRunStatus.COMPLETED
+
+    async def test_timeout_triggers_cancel_and_returns_timeout(self) -> None:
+        adapter = CopilotLocalAdapter()
+
+        with tempfile.TemporaryDirectory() as td:
+            run_id = "1111/session-xyz"
+            state_file = _state_path(td, run_id)
+            state = {
+                "pid": 1111,
+                "session_id": "session-xyz",
+                "agent_id": "a1",
+                "started_at": time.time() - 9999,
+                "timeout_seconds": 10,
+            }
+            with open(state_file, "w") as fh:
+                json.dump(state, fh)
+
+            cancel_called = []
+
+            async def fake_cancel(agent_config, run_id):
+                cancel_called.append(run_id)
+
+            adapter.cancel = fake_cancel  # type: ignore[assignment]
+            result = await adapter.status(_agent_cfg(output_dir=td), run_id)
+
+        assert result.status == LLCRunStatus.TIMEOUT
+        assert run_id in cancel_called
+
+    async def test_unparseable_run_id_returns_failed(self) -> None:
+        adapter = CopilotLocalAdapter()
+        result = await adapter.status(_agent_cfg(), "not-a-valid-run-id")
+        assert result.status == LLCRunStatus.FAILED
+
+    async def test_exception_in_probe_returns_failed(self) -> None:
+        adapter = CopilotLocalAdapter()
+
+        def bad_kill(pid, sig):
+            raise OSError("unexpected")
+
+        with patch("os.kill", side_effect=bad_kill):
+            result = await adapter.status(_agent_cfg(), "1234/session-abc")
+        assert result.status == LLCRunStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestCancel:
+    async def test_cancel_sends_sigterm(self) -> None:
+        adapter = CopilotLocalAdapter()
+        import signal as sig_mod
+
+        killed: list = []
+
+        def smart_kill(pid, s):
+            killed.append((pid, s))
+            if s == sig_mod.SIGTERM:
+                return
+            if s == 0 and any(s2 == sig_mod.SIGTERM for _, s2 in killed):
+                raise ProcessLookupError
+
+        with (
+            patch("os.kill", side_effect=smart_kill),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with tempfile.TemporaryDirectory() as td:
+                await adapter.cancel(_agent_cfg(agent_id="a1", output_dir=td), "5678/session-q")
+
+        assert any(s == sig_mod.SIGTERM for _, s in killed)
+
+    async def test_cancel_already_dead_does_not_raise(self) -> None:
+        adapter = CopilotLocalAdapter()
+        with tempfile.TemporaryDirectory() as td:
+            with patch("os.kill", side_effect=ProcessLookupError()):
+                await adapter.cancel(_agent_cfg(agent_id="a2", output_dir=td), "9999/session-r")
+
+    async def test_cancel_unparseable_run_id_is_noop(self) -> None:
+        adapter = CopilotLocalAdapter()
+        await adapter.cancel(_agent_cfg(), "bad-run-id")
+
+    async def test_cancel_removes_state_file(self) -> None:
+        adapter = CopilotLocalAdapter()
+
+        with tempfile.TemporaryDirectory() as td:
+            run_id = "4321/session-del"
+            state_file = _state_path(td, run_id)
+            with open(state_file, "w") as fh:
+                json.dump({"pid": 4321}, fh)
+
+            with patch("os.kill", side_effect=ProcessLookupError()):
+                await adapter.cancel(_agent_cfg(output_dir=td), run_id)
+
+            assert not os.path.exists(state_file)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_copilot_local_registered(self) -> None:
+        from llc.adapters import get_adapter
+
+        adapter = get_adapter("copilot_local")
+        assert isinstance(adapter, CopilotLocalAdapter)


### PR DESCRIPTION
## Summary

Implements a `CopilotLocalAdapter` that wraps local `gh copilot` CLI sessions as LLC heartbeat agents, mirroring the pattern established by `ClaudeCodeAdapter`.

- **`copilot_local_adapter.py`** — subprocess wrapper around `gh copilot suggest --target bash`, with SSRF-safe state file path validation, graceful SIGTERM→SIGKILL cancel, and timeout handling
- **`adapters/__init__.py`** — registers `copilot_local` in the LLC adapter registry
- **`tests/test_copilot_local_adapter.py`** — protocol conformance, invoke/status/cancel unit tests with mocked subprocess

Closes GH#9008

## Thinking Path

Followed the exact pattern of `claude_code_adapter.py`: spawn CLI subprocess, capture output to a `.jsonl` file, return `pid/session_id` as the run_id, probe liveness via `os.kill(pid, 0)`. Used `gh copilot suggest --target bash <prompt>` to send the LLC heartbeat context as a CLI argument. SSRF protection via `pathlib.Path.resolve().is_relative_to()` guard on the state file load. Graceful shutdown via SIGTERM with 5s grace period before SIGKILL.

## What Changed

- `autobot-backend/llc/adapters/copilot_local_adapter.py` — new adapter wrapping `gh copilot suggest`; manages subprocess lifecycle, state files, timeout, and cancel
- `autobot-backend/llc/adapters/__init__.py` — exports `CopilotLocalAdapter`, registers `copilot_local` type
- `autobot-backend/llc/adapters/tests/test_copilot_local_adapter.py` — unit tests: protocol conformance, invoke returns `pid/session`, status probes PID, cancel sends SIGTERM/SIGKILL

## Verification

- Follows `ClaudeCodeAdapter` pattern exactly (same invoke/status/cancel contract)
- SSRF guard on state file path prevents directory traversal
- Tests pass with mocked subprocess (`asyncio.create_subprocess_exec` patched)

## Test plan

- [ ] `CopilotLocalAdapter` satisfies `LLCAdapter` protocol
- [ ] `invoke()` returns `"{pid}/{session_id}"` run_id
- [ ] `status()` returns RUNNING for live PID, COMPLETED for dead PID
- [ ] `cancel()` sends SIGTERM then SIGKILL after grace period
- [ ] `register_adapter("copilot_local", ...)` in `__init__.py` makes it selectable

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)