### PR TITLE
fix(slm-agent): reduce memory footprint and add systemd memory limits (#9086)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
@@ -57,6 +57,13 @@ WatchdogSec={{ slm_agent_watchdog_sec }}
 LimitNOFILE=65536
 LimitNPROC=4096
 
+# Memory limits — agent is lightweight; hard cap prevents OOM cascade (#9086)
+MemoryMax=256M
+MemoryHigh=200M
+
+# OOM priority — kernel kills agent before critical services like Paperclip (#9086)
+OOMScoreAdjust=500
+
 # Security hardening
 NoNewPrivileges=true
 PrivateTmp=true

--- a/autobot-slm-backend/slm/agent/agent.py
+++ b/autobot-slm-backend/slm/agent/agent.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import logging
 import os
+import platform
 import signal
 import socket
 import sqlite3
@@ -130,6 +131,10 @@ class SLMAgent:
         self.role_detector = RoleDetector()
         self._role_definitions_loaded = False
 
+        # Single session reused across all requests — avoids per-request
+        # connection pool + SSL context allocation (#9086)
+        self._session: aiohttp.ClientSession | None = None
+
     def _init_buffer_db(self):
         """Initialize SQLite buffer database."""
         Path(self.buffer_db).parent.mkdir(parents=True, exist_ok=True)
@@ -179,20 +184,20 @@ class SLMAgent:
 
     async def _fetch_role_definitions(self) -> bool:
         """Fetch role definitions from SLM server (Issue #779)."""
+        assert self._session is not None
         try:
-            async with aiohttp.ClientSession() as session:
-                url = f"{self.admin_url}/api/roles/definitions"
-                async with session.get(
-                    url,
-                    timeout=aiohttp.ClientTimeout(total=10),
-                    ssl=False,
-                ) as response:
-                    if response.status == 200:
-                        definitions = await response.json()
-                        self.role_detector.load_definitions(definitions)
-                        self._role_definitions_loaded = True
-                        logger.info("Loaded %d role definitions", len(definitions))
-                        return True
+            url = f"{self.admin_url}/api/roles/definitions"
+            async with self._session.get(
+                url,
+                timeout=aiohttp.ClientTimeout(total=10),
+                ssl=False,
+            ) as response:
+                if response.status == 200:
+                    definitions = await response.json()
+                    self.role_detector.load_definitions(definitions)
+                    self._role_definitions_loaded = True
+                    logger.info("Loaded %d role definitions", len(definitions))
+                    return True
         except Exception as e:
             logger.debug("Failed to fetch role definitions: %s", e)
         return False
@@ -230,7 +235,9 @@ class SLMAgent:
         """
         return [{"port": p.port, "process": p.process, "pid": p.pid} for p in get_listening_ports()]
 
-    def _build_heartbeat_payload(self, health: dict, os_info: str, code_version: str | None) -> dict:
+    def _build_heartbeat_payload(
+        self, health: dict, os_info: str, code_version: str | None
+    ) -> dict:
         """
         Build the complete heartbeat payload.
 
@@ -272,28 +279,28 @@ class SLMAgent:
             True if heartbeat was accepted, False otherwise.
         Issue #620.
         """
+        assert self._session is not None
         try:
-            async with aiohttp.ClientSession() as session:
-                url = f"{self.admin_url}/api/nodes/{self.node_id}/heartbeat"
-                async with session.post(
-                    url,
-                    json=payload,
-                    timeout=aiohttp.ClientTimeout(total=10),
-                    ssl=False,  # mTLS pending PKI setup (Issue #725)
-                ) as response:
-                    if response.status == 200:
-                        # Issue #741: Process heartbeat response
-                        response_data = await response.json()
-                        self._process_heartbeat_response(response_data)
-                        logger.debug("Heartbeat sent successfully")
-                        return True
-                    else:
-                        logger.warning(
-                            "Heartbeat rejected: %s %s",
-                            response.status,
-                            await response.text(),
-                        )
-                        return False
+            url = f"{self.admin_url}/api/nodes/{self.node_id}/heartbeat"
+            async with self._session.post(
+                url,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=10),
+                ssl=False,  # mTLS pending PKI setup (Issue #725)
+            ) as response:
+                if response.status == 200:
+                    # Issue #741: Process heartbeat response
+                    response_data = await response.json()
+                    self._process_heartbeat_response(response_data)
+                    logger.debug("Heartbeat sent successfully")
+                    return True
+                else:
+                    logger.warning(
+                        "Heartbeat rejected: %s %s",
+                        response.status,
+                        await response.text(),
+                    )
+                    return False
         except aiohttp.ClientError as e:
             logger.warning("Failed to send heartbeat: %s", e)
             self.buffer_event("heartbeat", payload)
@@ -301,8 +308,6 @@ class SLMAgent:
 
     async def send_heartbeat(self) -> bool:
         """Send heartbeat with health data to admin."""
-        import platform
-
         # Fetch role definitions if not loaded (Issue #779)
         if not self._role_definitions_loaded:
             await self._fetch_role_definitions()
@@ -316,11 +321,13 @@ class SLMAgent:
 
     async def sync_buffered_events(self):
         """Sync buffered events to admin (#1106)."""
+        assert self._session is not None
         self._prune_old_events()
         conn = sqlite3.connect(self.buffer_db)
         try:
             cursor = conn.execute(
-                "SELECT id, event_type, data FROM event_buffer " "WHERE synced = 0 ORDER BY id LIMIT 100"
+                "SELECT id, event_type, data FROM event_buffer"
+                " WHERE synced = 0 ORDER BY id LIMIT 100"
             )
             events = cursor.fetchall()
 
@@ -329,37 +336,36 @@ class SLMAgent:
 
             logger.info("Syncing %d buffered events", len(events))
 
-            async with aiohttp.ClientSession() as session:
-                url = f"{self.admin_url}/api/events/sync"
-                payload = [
-                    {
-                        "id": e[0],
-                        "type": e[1],
-                        "data": json.loads(e[2]),
-                        "node_id": self.node_id,
-                    }
-                    for e in events
-                ]
-                async with session.post(
-                    url,
-                    json=payload,
-                    timeout=aiohttp.ClientTimeout(total=30),
-                    ssl=False,
-                ) as response:
-                    if response.status == 200:
-                        ids = [e[0] for e in events]
-                        placeholders = ",".join("?" * len(ids))
-                        query = "UPDATE event_buffer SET synced = 1 " f"WHERE id IN ({placeholders})"
-                        conn.execute(query, ids)
-                        conn.commit()
-                        logger.info("Synced %d events", len(events))
-                    else:
-                        body = await response.text()
-                        logger.warning(
-                            "Event sync rejected: %s %s",
-                            response.status,
-                            body[:200],
-                        )
+            url = f"{self.admin_url}/api/events/sync"
+            payload = [
+                {
+                    "id": e[0],
+                    "type": e[1],
+                    "data": json.loads(e[2]),
+                    "node_id": self.node_id,
+                }
+                for e in events
+            ]
+            async with self._session.post(
+                url,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=30),
+                ssl=False,
+            ) as response:
+                if response.status == 200:
+                    ids = [e[0] for e in events]
+                    placeholders = ",".join("?" * len(ids))
+                    query = "UPDATE event_buffer SET synced = 1 " f"WHERE id IN ({placeholders})"
+                    conn.execute(query, ids)
+                    conn.commit()
+                    logger.info("Synced %d events", len(events))
+                else:
+                    body = await response.text()
+                    logger.warning(
+                        "Event sync rejected: %s %s",
+                        response.status,
+                        body[:200],
+                    )
         except aiohttp.ClientError as e:
             logger.warning("Failed to sync events: %s", e)
         finally:
@@ -399,23 +405,29 @@ class SLMAgent:
         # Notify systemd that we're ready
         sd_notify("READY=1")
 
-        # Issue #741: Start notification server if enabled (code-source nodes)
-        if enable_notify_server:
-            await self.start_notify_server(notify_port)
+        # Single session for the lifetime of the agent (#9086)
+        async with aiohttp.ClientSession() as session:
+            self._session = session
 
-        while self.running:
-            # Send systemd watchdog notification (prevents timeout restart)
-            sd_notify("WATCHDOG=1")
+            # Issue #741: Start notification server if enabled (code-source nodes)
+            if enable_notify_server:
+                await self.start_notify_server(notify_port)
 
-            # Send heartbeat
-            success = await self.send_heartbeat()
+            while self.running:
+                # Send systemd watchdog notification (prevents timeout restart)
+                sd_notify("WATCHDOG=1")
 
-            # If connected, try to sync buffered events
-            if success:
-                await self.sync_buffered_events()
+                # Send heartbeat
+                success = await self.send_heartbeat()
 
-            # Wait for next heartbeat
-            await asyncio.sleep(self.heartbeat_interval)
+                # If connected, try to sync buffered events
+                if success:
+                    await self.sync_buffered_events()
+
+                # Wait for next heartbeat
+                await asyncio.sleep(self.heartbeat_interval)
+
+            self._session = None
 
         # Notify systemd we're stopping
         sd_notify("STOPPING=1")
@@ -498,31 +510,31 @@ class SLMAgent:
 
     async def _notify_code_change(self, commit: str) -> None:
         """Send immediate notification to SLM server about code change."""
+        assert self._session is not None
         try:
-            async with aiohttp.ClientSession() as session:
-                url = f"{self.admin_url}/api/code-sync/notify"
-                payload = {
-                    "node_id": self.node_id,
-                    "commit": commit,
-                    "is_code_source": True,
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
-                }
-                async with session.post(
-                    url,
-                    json=payload,
-                    timeout=aiohttp.ClientTimeout(total=10),
-                    ssl=False,
-                ) as response:
-                    if response.status == 200:
-                        logger.info(
-                            "SLM server notified of new code version: %s",
-                            commit[:12],
-                        )
-                    else:
-                        logger.warning(
-                            "Failed to notify SLM server: %s",
-                            response.status,
-                        )
+            url = f"{self.admin_url}/api/code-sync/notify"
+            payload = {
+                "node_id": self.node_id,
+                "commit": commit,
+                "is_code_source": True,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+            async with self._session.post(
+                url,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=10),
+                ssl=False,
+            ) as response:
+                if response.status == 200:
+                    logger.info(
+                        "SLM server notified of new code version: %s",
+                        commit[:12],
+                    )
+                else:
+                    logger.warning(
+                        "Failed to notify SLM server: %s",
+                        response.status,
+                    )
         except Exception as e:
             logger.warning("Failed to notify SLM server: %s", e)
             # Event is already buffered, will sync on next heartbeat

--- a/autobot-slm-backend/slm/agent/health_collector.py
+++ b/autobot-slm-backend/slm/agent/health_collector.py
@@ -14,6 +14,7 @@ import os
 import platform
 import socket
 import subprocess  # nosec B404 - required for systemctl interaction
+import time
 from datetime import datetime, timezone
 from typing import Dict, List
 
@@ -24,6 +25,9 @@ from autobot_shared.redis_client import get_redis_client
 logger = logging.getLogger(__name__)
 
 _STATE_CHANGE_CHANNEL_TEMPLATE = "autobot:services:{service}:state_change"
+
+# Subprocess-heavy service sweep is cached this long to reduce system load (#9086)
+_SERVICE_DISCOVERY_TTL = 300  # seconds
 
 
 class HealthCollector:
@@ -58,6 +62,10 @@ class HealthCollector:
         # Tracks the last known status per service name for state-change detection.
         # Populated on first collect(); events are only published on transitions.
         self._last_known_status: Dict[str, str] = {}
+        # Cache for discover_all_services() — avoids spawning 100+ subprocesses
+        # every heartbeat (#9086)
+        self._service_cache: List[Dict] = []
+        self._service_cache_ts: float = 0.0
 
     def collect(self) -> Dict:
         """Collect all health metrics."""
@@ -86,11 +94,21 @@ class HealthCollector:
                 key = f"{host}:{port}"
                 health["ports"][key] = self.check_port(host, port)
 
-        # Discover all systemd services (for Issue #728)
+        # Discover all systemd services (for Issue #728).
+        # Result is cached for _SERVICE_DISCOVERY_TTL seconds — the sweep
+        # spawns 100+ subprocesses and must not run every heartbeat (#9086).
         if self.discover_services:
-            health["discovered_services"] = self.discover_all_services()
+            health["discovered_services"] = self._get_discovered_services()
 
         return health
+
+    def _get_discovered_services(self) -> List[Dict]:
+        """Return cached service list, refreshing when TTL has expired."""
+        now = time.monotonic()
+        if now - self._service_cache_ts >= _SERVICE_DISCOVERY_TTL:
+            self._service_cache = self.discover_all_services()
+            self._service_cache_ts = now
+        return self._service_cache
 
     def check_service(self, service_name: str) -> Dict:
         """Check systemd service status."""


### PR DESCRIPTION
## Summary

- **Ansible template**: add \`MemoryMax=256M\`, \`MemoryHigh=200M\`, \`OOMScoreAdjust=500\` to \`slm-agent.service\` — hard memory cap + kernel prefers killing agent over Paperclip/journald under OOM pressure
- **\`agent.py\`**: create one \`aiohttp.ClientSession\` for the agent lifetime (in \`run()\`) instead of a new session per heartbeat/sync/notify — was leaking connection pools during crash loops
- **\`health_collector.py\`**: cache \`discover_all_services()\` for 300 s — was spawning 100+ subprocesses every 30 s heartbeat

## Thinking Path

Root cause analysis from boot -1 journal: slm-agent crash-looped with watchdog kills starting 20:19. Each restart spun up a new Python process that (a) allocated a fresh aiohttp session per HTTP call and (b) ran a full systemctl list-units + per-service systemctl show sweep every 30 s. Under memory pressure these leaked. By 20:39 swap was exhausted (~28 GB anon), systemd-journald itself was killed, WSL became unresponsive. Fix targets three independent causes: no memory ceiling, per-request session alloc, and unbounded subprocess rate.

## What Changed

- \`ansible/roles/slm_agent/templates/slm-agent.service.j2\`: added MemoryMax=256M, MemoryHigh=200M, OOMScoreAdjust=500
- \`slm/agent/agent.py\`: single aiohttp.ClientSession created at run() entry, shared across all HTTP methods; moved platform import to top-level
- \`slm/agent/health_collector.py\`: added 300s TTL cache for discover_all_services() via new _get_discovered_services() method; collect() uses cache

## Verification

- flake8 --max-line-length=100 clean on changed files
- 16/16 tests pass (slm/agent_test.py + health_collector_state_change_test.py); 2 pre-existing TestServiceFailedEvent failures unrelated to this change

## Model Used

claude-sonnet-4-6

Closes #9086