### PR TITLE
fix(connectors): replace deprecated asyncio.get_event_loop() with get_running_loop() (#9092)

### DIFF
--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -60,7 +60,7 @@ class ConnectorCredentialStore:
         name = f"connector:{connector_id}:auth"
         secret_type = _AUTH_TYPE_TO_SECRET_TYPE.get(auth_cls.__name__, "connector_api_key")
 
-        result = await asyncio.get_event_loop().run_in_executor(
+        result = await asyncio.get_running_loop().run_in_executor(
             None,
             lambda: self._svc.create_secret(
                 name=name,
@@ -84,7 +84,7 @@ class ConnectorCredentialStore:
         Raises PermissionError when owner_id does not match the stored secret.
         Raises LookupError when secret_id is not found or has expired.
         """
-        secret = await asyncio.get_event_loop().run_in_executor(
+        secret = await asyncio.get_running_loop().run_in_executor(
             None,
             lambda: self._svc.get_secret(
                 secret_id=secret_id,
@@ -109,7 +109,7 @@ class ConnectorCredentialStore:
         owner_id: str,
     ) -> None:
         """Replace the stored secret value with new_credentials in-place."""
-        existing = await asyncio.get_event_loop().run_in_executor(
+        existing = await asyncio.get_running_loop().run_in_executor(
             None,
             lambda: self._svc.get_secret(secret_id=secret_id, include_value=True),
         )
@@ -123,7 +123,7 @@ class ConnectorCredentialStore:
         current_creds.update(new_credentials)
         new_value = json.dumps(current_creds, ensure_ascii=False)
 
-        await asyncio.get_event_loop().run_in_executor(
+        await asyncio.get_running_loop().run_in_executor(
             None,
             lambda: self._svc.update_secret(
                 secret_id=secret_id,
@@ -134,7 +134,7 @@ class ConnectorCredentialStore:
 
     async def revoke(self, secret_id: str, owner_id: str) -> None:
         """Delete the secret. Called on connector delete."""
-        await asyncio.get_event_loop().run_in_executor(
+        await asyncio.get_running_loop().run_in_executor(
             None,
             lambda: self._svc.delete_secret(
                 secret_id=secret_id,


### PR DESCRIPTION
## Thinking Path

`asyncio.get_event_loop()` is deprecated in Python 3.12 (raises `DeprecationWarning`, slated to error in a future release). All 5 call sites in `credential_store.py` are inside `async def` methods that are already running under an event loop, so `asyncio.get_running_loop()` is the correct and canonical replacement — it returns the running loop or raises `RuntimeError` if there is none (which would already be a bug in the calling context).

## What Changed

- `autobot-backend/knowledge/connectors/credential_store.py`: replaced 5 instances of `asyncio.get_event_loop().run_in_executor(...)` with `asyncio.get_running_loop().run_in_executor(...)` in methods `store`, `load`, `rotate` (×2), and `revoke`

## Verification

```bash
python3 -m py_compile autobot-backend/knowledge/connectors/credential_store.py && echo OK
grep -n "get_event_loop\|get_running_loop" autobot-backend/knowledge/connectors/credential_store.py
```

Expected: `OK` and 5 lines showing `get_running_loop`, zero showing `get_event_loop`.

## Risks

None identified — `get_running_loop()` is semantically identical to `get_event_loop()` when called from within an async context (which all 5 sites are).

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Closes #9092

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason)
- [x] Documentation updated if behavior changed
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff