### PR TITLE
fix(backend): async/sync violations in startup + push (#9071 #9091 #9093)

### DIFF
--- a/autobot-backend/api/push.py
+++ b/autobot-backend/api/push.py
@@ -10,6 +10,7 @@ Endpoints:
   GET    /api/push/vapid-public-key — return the VAPID public key for the SW
 """
 
+import asyncio
 import ipaddress
 import socket
 import uuid
@@ -44,10 +45,11 @@ class SubscribeRequest(BaseModel):
     @field_validator("endpoint")
     @classmethod
     def validate_endpoint_https(cls, v: str) -> str:
-        """Reject non-HTTPS endpoints and SSRF targets.
+        """Reject non-HTTPS endpoints; verify hostname is present.
 
-        Validates scheme, resolves hostname, and rejects private/loopback/
-        link-local IPs to prevent SSRF via arbitrary push endpoint registration.
+        GH#9093: DNS resolution (SSRF check) has been moved to the async
+        subscribe() handler so it doesn't block the event loop from inside a
+        synchronous Pydantic validator.
         """
         try:
             parsed = urlparse(v)
@@ -55,22 +57,8 @@ class SubscribeRequest(BaseModel):
             raise ValueError(f"Invalid endpoint URL: {exc}") from exc
         if parsed.scheme != "https":
             raise ValueError("Push endpoint must use https:// scheme")
-        hostname = parsed.hostname
-        if not hostname:
+        if not parsed.hostname:
             raise ValueError("Push endpoint must include a valid host")
-        # DNS resolution check: reject if any resolved IP is internal.
-        try:
-            addr_infos = socket.getaddrinfo(hostname, None)
-        except socket.gaierror as exc:
-            raise ValueError(f"Push endpoint hostname could not be resolved: {exc}") from exc
-        for addr_info in addr_infos:
-            ip_str = addr_info[4][0]
-            try:
-                ip = ipaddress.ip_address(ip_str)
-            except ValueError:
-                continue
-            if ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_reserved:
-                raise ValueError("Push endpoint resolves to a private/internal address — SSRF rejected")
         return v
 
 
@@ -79,6 +67,32 @@ class UnsubscribeRequest(BaseModel):
     # GH#8967: user_id MUST NOT be accepted from request body.
     # Unsubscribe targets ONLY the authenticated user's subscription.
     user_id: str | None = None
+
+
+async def _check_endpoint_not_ssrf(hostname: str) -> None:
+    """Resolve hostname and reject private/loopback/link-local IPs (SSRF guard).
+
+    GH#9093: runs DNS resolution in a thread pool via asyncio.to_thread so it
+    doesn't stall the uvicorn event loop.  Raises HTTPException(422) on failure.
+    """
+    try:
+        addr_infos = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
+    except socket.gaierror as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Push endpoint hostname could not be resolved: {exc}",
+        ) from exc
+    for addr_info in addr_infos:
+        ip_str = addr_info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_reserved:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Push endpoint resolves to a private/internal address — SSRF rejected",
+            )
 
 
 @router.get("/vapid-public-key", response_model=Dict[str, str])
@@ -117,6 +131,10 @@ async def subscribe(
     user_id = current_user.get("user_id") or current_user.get("username", "")
     if not user_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Cannot identify user")
+
+    # GH#9093: async SSRF guard — DNS check moved here from the Pydantic validator.
+    hostname = urlparse(body.endpoint).hostname
+    await _check_endpoint_not_ssrf(hostname)
 
     # GH#8967: Reject IDOR attempts by logging and ignoring any user_id in request body.
     if body.user_id and body.user_id != user_id:

--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -319,9 +319,15 @@ async def get_system_health(
             # Phase 1 failures kill the process before it can serve requests, so
             # app_state is unreachable. Fall back to the disk file written by
             # lifespan.py before re-raising.
+            # GH#9071: offload pathlib I/O to a thread so we don't block the event loop.
             try:
-                if _STARTUP_ERROR_FILE.exists():
-                    data = json.loads(_STARTUP_ERROR_FILE.read_text(encoding="utf-8"))
+                def _read_startup_error_file():
+                    if not _STARTUP_ERROR_FILE.exists():
+                        return None
+                    return json.loads(_STARTUP_ERROR_FILE.read_text(encoding="utf-8"))
+
+                data = await asyncio.to_thread(_read_startup_error_file)
+                if data:
                     startup_error = data.get("error_type")
             except Exception:
                 pass

--- a/autobot-backend/services/push_notification_service.py
+++ b/autobot-backend/services/push_notification_service.py
@@ -173,14 +173,21 @@ def register_celery_task_success_hook() -> None:
             return
 
         task_name = getattr(sender, "name", str(sender))
+        # GH#9091: asyncio.run() raises RuntimeError when the Celery worker already
+        # has a running event loop (gevent/eventlet mode).  Create a fresh loop
+        # instead so we're never subject to the "already running" constraint.
         try:
-            asyncio.run(
-                send_push_notification(
-                    user_id=str(user_id),
-                    title="Task complete",
-                    body=f"{task_name} finished successfully.",
-                    url="/",
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(
+                    send_push_notification(
+                        user_id=str(user_id),
+                        title="Task complete",
+                        body=f"{task_name} finished successfully.",
+                        url="/",
+                    )
                 )
-            )
+            finally:
+                loop.close()
         except Exception:
             logger.debug("Push notification dispatch failed after task %s", task_name, exc_info=True)


### PR DESCRIPTION
## Summary

Three async/sync violations that stall or crash the uvicorn event loop:

- **GH#9071** `get_system_health()` (`api/system.py`): `_STARTUP_ERROR_FILE.exists()` + `.read_text()` are synchronous pathlib calls inside an async handler. Wrapped in `asyncio.to_thread()` via a nested helper so I/O is offloaded to the thread pool.

- **GH#9091** Celery `task_success` signal handler (`services/push_notification_service.py`): `asyncio.run()` raises `RuntimeError: This event loop is already running` in gevent/eventlet Celery workers that have a running loop. Replaced with explicit `asyncio.new_event_loop()` + `run_until_complete()` + `loop.close()`.

- **GH#9093** `SubscribeRequest.validate_endpoint_https` Pydantic validator (`api/push.py`): `socket.getaddrinfo()` is a blocking DNS call inside a synchronous validator that runs during async request deserialization. DNS check extracted to `_check_endpoint_not_ssrf()` and awaited in the `subscribe()` endpoint via `asyncio.to_thread()`. Format-only checks (scheme, hostname presence) remain in the validator.

## Test plan

- [ ] `python3 -m py_compile` passes on all three changed files (verified in worktree)
- [ ] `/api/system/health` responds under load without blocking other concurrent requests
- [ ] Celery worker fires `task_success` hook without `RuntimeError: This event loop is already running`
- [ ] `POST /api/push/subscribe` with a private-IP endpoint returns 422 (SSRF rejected); valid public endpoint stores subscription

Refs: GH#9071 GH#9091 GH#9093

🤖 Generated with [Claude Code](https://claude.com/claude-code)