### PR TITLE
fix(voice-rbac): emit() exception swallowing + stale audit name (GH#9096, GH#9098)

### DIFF
--- a/autobot-backend/api/voice_bundle_admin_test.py
+++ b/autobot-backend/api/voice_bundle_admin_test.py
@@ -176,101 +176,67 @@ async def test_list_realtime_tools_uses_user_bundle():
 
 @pytest.mark.asyncio
 async def test_set_user_bundle_emit_raises_in_except_still_raises_http_exception():
-    """If the failure-path emit raises, the original HTTPException is still raised (GH#9096)."""
-    from fastapi import FastAPI
-    from fastapi.testclient import TestClient
+    """Failure-path emit that raises must not swallow the original HTTPException (GH#9096)."""
+    from fastapi import HTTPException
 
-    from api.voice_bundle_user import router
-
-    app = FastAPI()
-    app.include_router(router)
-
-    with TestClient(app, raise_server_exceptions=False) as client:
-        with (
-            patch(
-                "api.voice_bundle_user.get_current_user",
-                return_value={"user_id": "admin-1", "role": "admin"},
-            ),
-            patch(
-                "api.voice_bundle_user.get_auth_middleware",
-                return_value=MagicMock(),
-            ),
-            patch(
-                "user_management.database.get_async_session",
-                side_effect=RuntimeError("db gone"),
-            ),
-            patch(
-                "api.voice_bundle_user.emit",
-                side_effect=RuntimeError("audit bus down"),
-            ),
-        ):
-            resp = client.put(
-                "/users/user-42/bundle",
-                json={"bundle_name": "voice_safe"},
-                headers={"Authorization": "Bearer fake"},
-            )
-
-    assert resp.status_code == 500
-    assert resp.json()["detail"] == "Database error"
-
-
-@pytest.mark.asyncio
-async def test_set_user_bundle_success_audit_uses_stored_bundle_name():
-    """Success audit metadata must include stored_bundle_name, not body.bundle_name (GH#9098)."""
-    from fastapi import FastAPI
-    from fastapi.testclient import TestClient
-
-    from api.voice_bundle_user import router
-
-    mock_row_write = MagicMock()
-    mock_row_write.fetchone.return_value = None
-
-    mock_row_read = MagicMock()
-    mock_row_read.fetchone.return_value = ("voice_extended",)
-
-    execute_calls = []
-
-    async def fake_execute(query, params=None):
-        execute_calls.append(params)
-        if params and "uid" in params and len(execute_calls) >= 3:
-            return mock_row_read
-        return mock_row_write
+    from api.voice_bundle_user import BundleAssignRequest, set_user_bundle
 
     mock_session = AsyncMock()
     mock_session.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session.__aexit__ = AsyncMock(return_value=False)
-    mock_session.execute = fake_execute
+    mock_session.execute = AsyncMock(side_effect=RuntimeError("db gone"))
     mock_session.commit = AsyncMock()
 
-    emitted_events = []
-
-    def fake_emit(event):
-        emitted_events.append(event)
-
-    app = FastAPI()
-    app.include_router(router)
-
-    with TestClient(app) as client:
-        with (
-            patch(
-                "api.voice_bundle_user.get_current_user",
-                return_value={"user_id": "admin-1", "role": "admin"},
-            ),
-            patch(
-                "user_management.database.get_async_session",
-                return_value=mock_session,
-            ),
-            patch("api.voice_bundle_user.emit", side_effect=fake_emit),
-        ):
-            resp = client.put(
-                "/users/user-77/bundle",
-                json={"bundle_name": "voice_extended"},
-                headers={"Authorization": "Bearer fake"},
+    with (
+        patch("user_management.database.get_async_session", return_value=mock_session),
+        patch("api.voice_bundle_user.emit", side_effect=RuntimeError("audit bus down")),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await set_user_bundle(
+                "user-42",
+                BundleAssignRequest(bundle_name="voice_safe"),
+                MagicMock(),
+                {"user_id": "admin-1", "role": "admin"},
             )
 
-    assert resp.status_code == 200
-    assert len(emitted_events) == 1
-    event = emitted_events[0]
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Database error"
+
+
+@pytest.mark.asyncio
+async def test_set_user_bundle_success_audit_uses_stored_bundle_name():
+    """Success audit must use DB-stored value for bundle_name, not body.bundle_name (GH#9098).
+
+    The requested value goes into requested_bundle_name; the actual stored
+    value (returned by the re-read after commit) goes into bundle_name.
+    """
+    from api.voice_bundle_user import BundleAssignRequest, set_user_bundle
+
+    mock_row = MagicMock()
+    mock_row.fetchone.return_value = ("voice_extended",)
+
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session.execute = AsyncMock(return_value=mock_row)
+    mock_session.commit = AsyncMock()
+
+    emitted: list = []
+
+    with (
+        patch("user_management.database.get_async_session", return_value=mock_session),
+        patch("api.voice_bundle_user.emit", side_effect=emitted.append),
+    ):
+        resp = await set_user_bundle(
+            "user-77",
+            BundleAssignRequest(bundle_name="voice_safe"),
+            MagicMock(),
+            {"user_id": "admin-1", "role": "admin"},
+        )
+
+    assert resp.bundle_name == "voice_extended"
+    assert len(emitted) == 1
+    event = emitted[0]
     assert event.outcome == "success"
     assert event.metadata.get("bundle_name") == "voice_extended"
-    assert "requested_bundle_name" in event.metadata
+    assert event.metadata.get("requested_bundle_name") == "voice_safe"

--- a/autobot-backend/api/voice_bundle_admin_test.py
+++ b/autobot-backend/api/voice_bundle_admin_test.py
@@ -167,3 +167,110 @@ async def test_list_realtime_tools_uses_user_bundle():
 
     assert len(result) == 1
     assert result[0].name == "redis_get"
+
+
+# ---------------------------------------------------------------------------
+# set_user_bundle — GH#9096 / GH#9098
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_user_bundle_emit_raises_in_except_still_raises_http_exception():
+    """If the failure-path emit raises, the original HTTPException is still raised (GH#9096)."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.voice_bundle_user import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        with (
+            patch(
+                "api.voice_bundle_user.get_current_user",
+                return_value={"user_id": "admin-1", "role": "admin"},
+            ),
+            patch(
+                "api.voice_bundle_user.get_auth_middleware",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "user_management.database.get_async_session",
+                side_effect=RuntimeError("db gone"),
+            ),
+            patch(
+                "api.voice_bundle_user.emit",
+                side_effect=RuntimeError("audit bus down"),
+            ),
+        ):
+            resp = client.put(
+                "/users/user-42/bundle",
+                json={"bundle_name": "voice_safe"},
+                headers={"Authorization": "Bearer fake"},
+            )
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Database error"
+
+
+@pytest.mark.asyncio
+async def test_set_user_bundle_success_audit_uses_stored_bundle_name():
+    """Success audit metadata must include stored_bundle_name, not body.bundle_name (GH#9098)."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.voice_bundle_user import router
+
+    mock_row_write = MagicMock()
+    mock_row_write.fetchone.return_value = None
+
+    mock_row_read = MagicMock()
+    mock_row_read.fetchone.return_value = ("voice_extended",)
+
+    execute_calls = []
+
+    async def fake_execute(query, params=None):
+        execute_calls.append(params)
+        if params and "uid" in params and len(execute_calls) >= 3:
+            return mock_row_read
+        return mock_row_write
+
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session.execute = fake_execute
+    mock_session.commit = AsyncMock()
+
+    emitted_events = []
+
+    def fake_emit(event):
+        emitted_events.append(event)
+
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        with (
+            patch(
+                "api.voice_bundle_user.get_current_user",
+                return_value={"user_id": "admin-1", "role": "admin"},
+            ),
+            patch(
+                "user_management.database.get_async_session",
+                return_value=mock_session,
+            ),
+            patch("api.voice_bundle_user.emit", side_effect=fake_emit),
+        ):
+            resp = client.put(
+                "/users/user-77/bundle",
+                json={"bundle_name": "voice_extended"},
+                headers={"Authorization": "Bearer fake"},
+            )
+
+    assert resp.status_code == 200
+    assert len(emitted_events) == 1
+    event = emitted_events[0]
+    assert event.outcome == "success"
+    assert event.metadata.get("bundle_name") == "voice_extended"
+    assert "requested_bundle_name" in event.metadata

--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -224,9 +224,11 @@ async def set_user_bundle(
 
     _audit_meta = {
         "target_user_id": user_id,
-        "bundle_name": body.bundle_name,
+        "requested_bundle_name": body.bundle_name,
         "assignment_action": "clear" if body.bundle_name is None else "assign",
     }
+
+    stored_bundle_name: Optional[str] = None
 
     try:
         from user_management.database import get_async_session  # noqa: PLC0415
@@ -257,32 +259,36 @@ async def set_user_bundle(
                 {"uid": user_id},
             )
             result = row.fetchone()
-            stored_bundle_name: Optional[str] = result[0] if result else None
-        emit(
-            AuditEvent(
-                category=AuditCategory.SECURITY,
-                action="voice_bundle_assignment_changed",
-                actor_id=str(current_user_id),
-                resource_type="user_voice_bundle",
-                resource_id=user_id,
-                outcome="success",
-                metadata={**_audit_meta, "stored_bundle_name": stored_bundle_name},
-            )
-        )
+            stored_bundle_name = result[0] if result else None
     except Exception as exc:
-        emit(
-            AuditEvent(
-                category=AuditCategory.SECURITY,
-                action="voice_bundle_assignment_changed",
-                actor_id=str(current_user_id),
-                resource_type="user_voice_bundle",
-                resource_id=user_id,
-                outcome="failure",
-                metadata={**_audit_meta, "error": str(exc)},
+        try:
+            emit(
+                AuditEvent(
+                    category=AuditCategory.SECURITY,
+                    action="voice_bundle_assignment_changed",
+                    actor_id=str(current_user_id),
+                    resource_type="user_voice_bundle",
+                    resource_id=user_id,
+                    outcome="failure",
+                    metadata={**_audit_meta, "error": str(exc)},
+                )
             )
-        )
+        except Exception:
+            logger.warning("set_user_bundle: failed to emit failure audit", exc_info=True)
         logger.error("set_user_bundle: DB error: %s", exc)
         raise HTTPException(status_code=500, detail="Database error") from exc
+
+    emit(
+        AuditEvent(
+            category=AuditCategory.SECURITY,
+            action="voice_bundle_assignment_changed",
+            actor_id=str(current_user_id),
+            resource_type="user_voice_bundle",
+            resource_id=user_id,
+            outcome="success",
+            metadata={**_audit_meta, "bundle_name": stored_bundle_name},
+        )
+    )
 
     logger.info(
         "voice_bundle user_id=%s target=%s bundle=%s",


### PR DESCRIPTION
## Thinking Path

`set_user_bundle` in `voice_bundle_user.py` had two correlated bugs (GH#9096, GH#9098):

1. **GH#9096** — The failure-path `emit()` call (for audit logging) was placed outside its own try/except. If the audit bus (Redis) was down when a DB error occurred, the `emit()` raise would shadow the original `HTTPException`, causing callers to receive a generic 500 with no `"Database error"` detail. Root fix: wrap failure-path emit in its own `try/except` and log the audit failure as a warning, never letting it suppress the DB exception.

2. **GH#9098** — `_audit_meta` was pre-built from `body.bundle_name` before the DB commit. In a concurrent-write race or silent re-routing, the success audit event recorded the *requested* value rather than the *actual stored* value. Root fix: declare `stored_bundle_name` before the try block, populate it from the post-commit re-read, rename the original key to `requested_bundle_name`, and move the success emit to after the try/except so it only fires when the DB operation succeeds.

## What Changed

- `autobot-backend/api/voice_bundle_user.py` — semantic fix to `set_user_bundle`: failure-path emit wrapped in try/except; success emit moved after try/except using DB-verified `stored_bundle_name`; metadata key renamed from `bundle_name` to `requested_bundle_name` pre-commit, with `bundle_name` now reflecting the stored value.
- `autobot-backend/api/voice_bundle_admin_test.py` — two regression tests covering both bugs: emit-raises-in-except (GH#9096) and success-audit-uses-stored-value (GH#9098).

## Verification

```bash
python3 -m py_compile autobot-backend/api/voice_bundle_user.py autobot-backend/api/voice_bundle_admin_test.py
# Both files compile without errors

# Test coverage:
# test_set_user_bundle_emit_raises_in_except_still_raises_http_exception:
#   DB raises + emit raises → caller still gets HTTP 500 "Database error"
# test_set_user_bundle_success_audit_uses_stored_bundle_name:
#   success path emits one event with bundle_name == stored DB value
#   and requested_bundle_name present in metadata
```

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Closes #9096
Closes #9098

## Checklist

- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff