### PR TITLE
fix(voice-rbac+embed): dedup tool count + add embed message endpoint

### DIFF
--- a/autobot-backend/api/chat_embed.py
+++ b/autobot-backend/api/chat_embed.py
@@ -46,9 +46,7 @@ async def _stream_embed(llm_service: Any, message: str):
                 data = json.dumps({"content": chunk.get("content", "")})
                 yield f"data: {data}\n\n"
         else:
-            response = await llm_service.chat(
-                messages=[{"role": "user", "content": message}]
-            )
+            response = await llm_service.chat(messages=[{"role": "user", "content": message}])
             content = response.content if not response.error else "Sorry, something went wrong."
             data = json.dumps({"content": content})
             yield f"data: {data}\n\n"
@@ -94,9 +92,7 @@ async def embed_message(
         )
 
     try:
-        response = await llm_service.chat(
-            messages=[{"role": "user", "content": message}]
-        )
+        response = await llm_service.chat(messages=[{"role": "user", "content": message}])
         content = response.content if not response.error else "Sorry, something went wrong. Please try again."
     except Exception as exc:
         logger.error("embed message error: %s", exc)

--- a/autobot-backend/api/chat_embed.py
+++ b/autobot-backend/api/chat_embed.py
@@ -1,0 +1,121 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Embed widget chat endpoint (GH#9047).
+
+Provides an unauthenticated POST endpoint consumed by the AutobotWidget
+custom element.  The embed widget runs on third-party pages and cannot
+hold session cookies or Bearer tokens, so this endpoint accepts an
+optional X-Org-Id header for future multi-tenant scoping but requires
+no auth.
+
+Endpoints:
+    POST /api/chats/embed/message  — send a message, receive JSON reply
+"""
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["chat", "embed"])
+
+
+class EmbedMessageRequest(BaseModel):
+    message: str
+
+
+async def _get_llm_service(request: Request) -> Any:
+    from services.llm_service import LLMService
+    from utils.lazy_singleton import lazy_init_singleton
+
+    return lazy_init_singleton(request.app.state, "llm_service", LLMService)
+
+
+async def _stream_embed(llm_service: Any, message: str):
+    """Yield SSE chunks compatible with the AutobotWidget SSE reader."""
+    try:
+        if hasattr(llm_service, "stream_response"):
+            async for chunk in llm_service.stream_response(message, session_id=None):
+                data = json.dumps({"content": chunk.get("content", "")})
+                yield f"data: {data}\n\n"
+        else:
+            response = await llm_service.chat(
+                messages=[{"role": "user", "content": message}]
+            )
+            content = response.content if not response.error else "Sorry, something went wrong."
+            data = json.dumps({"content": content})
+            yield f"data: {data}\n\n"
+        yield "data: [DONE]\n\n"
+    except Exception as exc:
+        logger.error("embed stream error: %s", exc)
+        yield f"data: {json.dumps({'content': 'Sorry, something went wrong.'})}\n\n"
+        yield "data: [DONE]\n\n"
+
+
+@router.post("/chats/embed/message")
+async def embed_message(
+    body: EmbedMessageRequest,
+    request: Request,
+) -> JSONResponse:
+    """Accept a chat message from the embed widget and return an AI reply.
+
+    Supports both plain JSON and SSE streaming.  The response format is
+    selected by the ``Accept`` header:
+    - ``text/event-stream`` → SSE stream
+    - anything else (default) → JSON ``{"content": "..."}``
+
+    No authentication required — the endpoint is designed for unauthenticated
+    embed contexts.  Rate-limiting is delegated to the upstream reverse proxy.
+    """
+    accept = request.headers.get("accept", "")
+    message = body.message.strip()
+    if not message:
+        return JSONResponse({"content": ""}, status_code=200)
+
+    llm_service = await _get_llm_service(request)
+
+    if "text/event-stream" in accept:
+        return StreamingResponse(
+            _stream_embed(llm_service, message),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Headers": "Content-Type, X-Org-Id",
+            },
+        )
+
+    try:
+        response = await llm_service.chat(
+            messages=[{"role": "user", "content": message}]
+        )
+        content = response.content if not response.error else "Sorry, something went wrong. Please try again."
+    except Exception as exc:
+        logger.error("embed message error: %s", exc)
+        content = "Sorry, something went wrong. Please try again."
+
+    return JSONResponse(
+        {"content": content},
+        headers={"Access-Control-Allow-Origin": "*"},
+    )
+
+
+@router.options("/chats/embed/message")
+async def embed_message_preflight() -> JSONResponse:
+    """CORS preflight for embed widget cross-origin requests."""
+    return JSONResponse(
+        {},
+        headers={
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type, X-Org-Id",
+        },
+    )

--- a/autobot-backend/api/voice_bundle_admin.py
+++ b/autobot-backend/api/voice_bundle_admin.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from api.redis_mcp.rbac import VALID_BUNDLES
+from api.voice_bundle_user import _count_tools_for_bundle
 from auth_middleware import get_auth_middleware, get_current_user
 from autobot_shared.logging_manager import get_logger
 from services.event_log import EventType, emit
@@ -66,20 +67,6 @@ class BundleAssignRequest(BaseModel):
 # ---------------------------------------------------------------------------
 # GET /voice/realtime/bundle/me
 # ---------------------------------------------------------------------------
-
-_BUNDLE_TOOL_COUNTS: dict[str, int] = {
-    "voice_safe": 0,  # computed lazily below
-    "voice_extended": 0,
-    "voice_admin": 0,
-}
-
-
-async def _count_tools_for_bundle(bundle: str, is_admin: bool) -> int:
-    """Return the number of tools available in this bundle."""
-    from api.redis_mcp.rbac import TOOL_ACCESS_MATRIX, filter_tools_for_bundle  # noqa: PLC0415
-
-    all_tools = list(TOOL_ACCESS_MATRIX.keys())
-    return len(filter_tools_for_bundle(all_tools, bundle=bundle, is_admin=is_admin))
 
 
 @bundle_me_router.get("/realtime/bundle/me", response_model=BundleMeResponse)

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -26,6 +26,7 @@ from api.browser_mcp import router as browser_mcp_router
 from api.canvas import router as canvas_router  # MVA-359
 from api.chat import router as chat_router
 from api.chat_compare import router as chat_compare_router  # Issue #4414
+from api.chat_embed import router as chat_embed_router  # GH#9047
 from api.chat_presets import router as chat_presets_router  # GH#8595
 from api.collaboration import router as collaboration_router
 from api.config_revisions import router as config_revisions_router  # #1404
@@ -110,6 +111,7 @@ def _get_system_routers() -> list:
         (service_messages_router, "", ["service-messages"], "service_messages"),
         (chat_router, "", ["chat"], "chat"),
         (chat_compare_router, "", ["chat", "compare"], "chat_compare"),  # Issue #4414
+        (chat_embed_router, "", ["chat", "embed"], "chat_embed"),  # GH#9047
         (chat_presets_router, "", ["chat"], "chat_presets"),  # GH#8595
         (collaboration_router, "", ["collaboration"], "collaboration"),
         (system_router, "/system", ["system"], "system"),


### PR DESCRIPTION
## Thinking Path

GH#9045: `_count_tools_for_bundle` existed in both `voice_bundle_admin.py` (uncached) and `voice_bundle_user.py` (cached with `_tool_count_cache`). The admin file's version did extra work on every call with no caching. Consolidate by importing the cached version from `voice_bundle_user`. The dead `_BUNDLE_TOOL_COUNTS` dict (all-zero initialisation, never updated) is also removed.

GH#9047: `AutobotWidget` (`src/embed/AutobotWidget.ts`) POSTs to `/api/chats/embed/message` but no backend route existed. The widget handles both SSE streaming and plain JSON. The new endpoint: (a) requires no auth, (b) returns plain JSON by default, (c) streams SSE when `Accept: text/event-stream`, (d) handles CORS via an OPTIONS preflight route.

## What Changed

- `autobot-backend/api/voice_bundle_admin.py` — removed local `_count_tools_for_bundle` + dead `_BUNDLE_TOOL_COUNTS` dict; added `from api.voice_bundle_user import _count_tools_for_bundle`
- `autobot-backend/api/chat_embed.py` — new file: `POST /api/chats/embed/message` (unauthenticated), `OPTIONS` preflight, SSE streaming path
- `autobot-backend/initialization/router_registry/core_routers.py` — import and register `chat_embed_router`

## Verification

```bash
python3 -m py_compile autobot-backend/api/voice_bundle_admin.py   # OK
python3 -m py_compile autobot-backend/api/chat_embed.py            # OK

curl -X POST http://localhost:8001/api/chats/embed/message \
  -H "Content-Type: application/json" \
  -d '{"message":"hello"}' | jq .
```

## Risks

`chat_embed.py` is unauthenticated; rate-limiting must be enforced at the reverse proxy. No secrets or user data are accessible through this endpoint.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Closes #9045
Closes #9047

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason) — N/A: thin endpoint wiring
- [x] Documentation updated if behavior changed — N/A
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff