### PR TITLE
fix(voice-rbac): guard emit in except + use stored_bundle_name in audit

### DIFF
--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -224,9 +224,10 @@ async def set_user_bundle(
 
     _audit_meta = {
         "target_user_id": user_id,
-        "bundle_name": body.bundle_name,
+        "requested_bundle_name": body.bundle_name,
         "assignment_action": "clear" if body.bundle_name is None else "assign",
     }
+    stored_bundle_name: Optional[str] = None
 
     try:
         from user_management.database import get_async_session  # noqa: PLC0415
@@ -257,32 +258,36 @@ async def set_user_bundle(
                 {"uid": user_id},
             )
             result = row.fetchone()
-            stored_bundle_name: Optional[str] = result[0] if result else None
-        emit(
-            AuditEvent(
-                category=AuditCategory.SECURITY,
-                action="voice_bundle_assignment_changed",
-                actor_id=str(current_user_id),
-                resource_type="user_voice_bundle",
-                resource_id=user_id,
-                outcome="success",
-                metadata={**_audit_meta, "stored_bundle_name": stored_bundle_name},
-            )
-        )
+            stored_bundle_name = result[0] if result else None
     except Exception as exc:
-        emit(
-            AuditEvent(
-                category=AuditCategory.SECURITY,
-                action="voice_bundle_assignment_changed",
-                actor_id=str(current_user_id),
-                resource_type="user_voice_bundle",
-                resource_id=user_id,
-                outcome="failure",
-                metadata={**_audit_meta, "error": str(exc)},
+        try:
+            emit(
+                AuditEvent(
+                    category=AuditCategory.SECURITY,
+                    action="voice_bundle_assignment_changed",
+                    actor_id=str(current_user_id),
+                    resource_type="user_voice_bundle",
+                    resource_id=user_id,
+                    outcome="failure",
+                    metadata={**_audit_meta, "error": str(exc)},
+                )
             )
-        )
+        except Exception:
+            logger.warning("set_user_bundle: failed to emit failure audit", exc_info=True)
         logger.error("set_user_bundle: DB error: %s", exc)
         raise HTTPException(status_code=500, detail="Database error") from exc
+
+    emit(
+        AuditEvent(
+            category=AuditCategory.SECURITY,
+            action="voice_bundle_assignment_changed",
+            actor_id=str(current_user_id),
+            resource_type="user_voice_bundle",
+            resource_id=user_id,
+            outcome="success",
+            metadata={**_audit_meta, "bundle_name": stored_bundle_name},
+        )
+    )
 
     logger.info(
         "voice_bundle user_id=%s target=%s bundle=%s",


### PR DESCRIPTION
## Thinking Path

GH#9096: `set_user_bundle()` had its failure-path `emit()` call inside the outer `try` block. If `emit()` raised, the exception would propagate and shadow the original DB exception. Also, the success `emit()` was inside the try block, so an emit error after a successful DB write would be incorrectly classified as a DB failure. Fix: wrap the failure-path emit in its own `try/except` so DB errors always surface correctly, and move the success emit outside the outer try block.

GH#9098: The success audit was recording the bundle name from the request body under the key `bundle_name`. Fix: rename to `requested_bundle_name` and add `bundle_name` from `stored_bundle_name` (post-commit DB value).

## What Changed

- `autobot-backend/api/voice_bundle_user.py` — `set_user_bundle()` only:
  - Failure-path `emit()` wrapped in isolated `try/except` so DB exceptions propagate cleanly
  - Success `emit()` moved outside the outer `try` block
  - Audit key renamed: `bundle_name` → `requested_bundle_name`; `bundle_name` now from post-commit `stored_bundle_name`

## Verification

```bash
python3 -m py_compile autobot-backend/api/voice_bundle_user.py  # OK
# Unit: emit raises in failure path → HTTPException propagates with original exc as __cause__
# Unit: success audit metadata["bundle_name"] == stored_bundle_name (post-commit)
```

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

Fixes GH#9096, GH#9098

🤖 Generated with [Claude Code](https://claude.com/claude-code)
