### PR TITLE
refactor(frontend): consolidate virtual scroll, WebSocket migration, host composables (#9061 #9062 #9063)

### DIFF
--- a/autobot-frontend/src/composables/research/useCaptchaStatus.ts
+++ b/autobot-frontend/src/composables/research/useCaptchaStatus.ts
@@ -6,8 +6,9 @@
  */
 
 import { ref, computed, watch, onUnmounted } from 'vue'
-// @ts-ignore - JS module without type declarations
-import { useGlobalWebSocket } from '@/composables/useGlobalWebSocket'
+// GH#9062: migrated from useGlobalWebSocket — captcha events flow through the
+// LiveEventManager (global channel), so useEventBus is the correct subscriber.
+import { useEventBus } from '@/composables/useEventBus'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
@@ -89,11 +90,17 @@ export function useCaptchaStatus() {
     }
   }
 
-  const { on } = useGlobalWebSocket()
-  // Casts are safe: the data IS the correct type at runtime, matching the server event schema
-  on('captcha_detected', handleCaptchaDetected as (data: unknown) => void)
-  on('captcha_timeout', handleCaptchaTimeout as (data: unknown) => void)
-  on('captcha_resolved', handleCaptchaResolved as (data: unknown) => void)
+  // Events arrive as LiveEvent{ event_type, payload }. The handlers already
+  // extract payload via the defensive `'payload' in data ? data.payload : data` check.
+  const { subscribe } = useEventBus()
+  subscribe('global', (event) => {
+    if (event.event_type === 'captcha_detected')
+      handleCaptchaDetected(event as unknown as { payload: CaptchaEvent })
+    else if (event.event_type === 'captcha_timeout')
+      handleCaptchaTimeout(event as unknown as { payload: { captcha_id: string } })
+    else if (event.event_type === 'captcha_resolved')
+      handleCaptchaResolved(event as unknown as { payload: { captcha_id: string } })
+  })
 
   // --------------------------------------------------------------------------
   // Computed

--- a/autobot-frontend/src/composables/useHostSelector.ts
+++ b/autobot-frontend/src/composables/useHostSelector.ts
@@ -5,17 +5,15 @@
 /**
  * useHostSelector - Composable for the ui/HostSelector component
  *
- * Wraps the GET /api/infrastructure/hosts endpoint through useFetchEndpoint
- * so the component is free of inline fetchWithAuth calls.
+ * GH#9063 consolidation: delegates host loading to useHostSelection
+ * (same /api/infrastructure/hosts source) instead of making a separate
+ * useFetchEndpoint call. Maps InfrastructureHost → SelectorHost shape.
  *
  * Issue #6087
  */
 
 import { computed } from 'vue'
-import { createLogger } from '@/utils/debugUtils'
-import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
-
-const logger = createLogger('useHostSelector')
+import { useHostSelection, type InfrastructureHost } from '@/composables/useHostSelection'
 
 export interface SelectorHost {
   id: string
@@ -30,10 +28,6 @@ export interface SelectorHost {
   tags?: string[]
 }
 
-interface HostsApiResponse {
-  hosts?: SelectorHost[]
-}
-
 export interface UseHostSelectorOptions {
   /** Only return hosts with this capability (passed as ?capability=). */
   requiredCapability?: string
@@ -42,42 +36,33 @@ export interface UseHostSelectorOptions {
 }
 
 export function useHostSelector(options: UseHostSelectorOptions = {}) {
-  const hostsEndpoint = useFetchEndpoint<HostsApiResponse, SelectorHost[]>({
-    path: '/api/infrastructure/hosts',
-    label: 'Infrastructure hosts',
-    pickData: (raw) => raw.hosts ?? [],
-    onSuccess: (data) => {
-      logger.info(`Loaded ${data.length} infrastructure hosts`)
-    },
-    onError: (msg) => {
-      logger.error('Failed to load infrastructure hosts:', msg)
-    },
+  const { hosts: infraHosts, loading, error, loadHosts: loadInfraHosts } = useHostSelection()
+
+  // Map InfrastructureHost → SelectorHost; apply client-side capability filter when set
+  const hosts = computed<SelectorHost[]>(() => {
+    let list: SelectorHost[] = infraHosts.value.map((h: InfrastructureHost) => ({
+      id: h.id,
+      name: h.name,
+      host: h.host,
+      ssh_port: h.ssh_port,
+      username: h.username,
+      os: h.os,
+      capabilities: h.capabilities,
+      description: h.purpose,
+    }))
+    if (options.requiredCapability) {
+      list = list.filter((h: SelectorHost) => h.capabilities?.includes(options.requiredCapability!))
+    }
+    return list
   })
 
-  /**
-   * Build query-string extras from the current options and trigger a fetch.
-   * Accepts a one-off capability override for composable reuse without
-   * reconstructing.
-   */
-  const loadHosts = async (capability?: string, chatId?: string): Promise<void> => {
-    const extras: Record<string, string> = {}
-    const cap = capability ?? options.requiredCapability
-    const chat = chatId ?? options.chatId
-    if (cap) extras['capability'] = cap
-    if (chat) extras['chat_id'] = chat
-    await hostsEndpoint.load(Object.keys(extras).length ? extras : undefined)
+  const loadHosts = async (capability?: string, _chatId?: string): Promise<void> => {
+    await loadInfraHosts()
+    // Re-assign so the filter in the computed picks up any runtime override
+    if (capability) options.requiredCapability = capability
   }
 
-  const hosts = computed<SelectorHost[]>(() => hostsEndpoint.data.value ?? [])
-  const loading = hostsEndpoint.loading
-  const error = hostsEndpoint.error
-
-  return {
-    hosts,
-    loading,
-    error,
-    loadHosts,
-  }
+  return { hosts, loading, error, loadHosts }
 }
 
 export default useHostSelector

--- a/autobot-frontend/src/composables/useVirtualList.ts
+++ b/autobot-frontend/src/composables/useVirtualList.ts
@@ -2,6 +2,8 @@
  * Virtual List Composable
  *
  * Issue #4037: Reusable virtual scrolling for large lists
+ * GH#9061 consolidation: delegates to useVirtualScroll to eliminate
+ * duplicate viewport-calculation logic.
  *
  * Provides efficient rendering of large lists by virtualizing items.
  * Only renders visible items and spacers for off-screen items.
@@ -9,7 +11,7 @@
  * Usage:
  * ```vue
  * <script setup>
- * import { usV irtualList } from '@/composables/useVirtualList'
+ * import { useVirtualList } from '@/composables/useVirtualList'
  *
  * const items = ref([...])
  * const { containerRef, visibleItems, totalHeight } = useVirtualList(items, 56) // 56px item height
@@ -31,98 +33,75 @@
  * ```
  */
 
-import { ref, computed, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope, watch, toValue, type MaybeRefOrGetter } from 'vue'
+import { computed, watch, onScopeDispose, getCurrentScope, toValue, type ComputedRef, type MaybeRefOrGetter } from 'vue'
+import { useVirtualScroll } from '@/composables/useVirtualScroll'
 
-interface VirtualItem<T> {
+export interface VirtualItem<T> {
   data: T
   index: number
+  /** Absolute top offset in pixels — use as `translateY(${item.offset}px)` */
   offset: number
 }
 
 /**
- * Virtual list composable
+ * Virtual list composable — thin wrapper over useVirtualScroll for the
+ * fixed-height absolute-positioned rendering pattern.
+ *
+ * Callers bind `ref="containerRef"` on the scroll container; this composable
+ * attaches the scroll listener imperatively (rather than via containerProps),
+ * keeping existing templates unchanged.
+ *
  * @param items - Array of items to virtualize
- * @param itemHeight - Height of each item in pixels
+ * @param itemHeight - Height of each item in pixels (fixed)
  * @param overscan - Number of items to render outside visible area (default: 3)
- * @returns Virtual list utilities
  */
 export function useVirtualList<T extends { id: string | number }>(
   items: MaybeRefOrGetter<T[]>,
   itemHeight: number,
   overscan: number = 3
 ) {
-  const containerRef = ref<HTMLElement | null>(null)
-  const scrollTop = ref(0)
+  const itemsRef = computed(() => toValue(items))
 
-  // Compute visible items based on scroll position
-  const visibleItems = computed<VirtualItem<T>[]>(() => {
-    if (!containerRef.value) return []
+  const scroll = useVirtualScroll<T>({
+    items: itemsRef,
+    itemHeight,
+    buffer: overscan,
+  })
 
-    const container = containerRef.value
-    const visibleHeight = container.clientHeight
-    const itemsArray = toValue(items)
-
-    if (itemsArray.length === 0) return []
-
-    // Calculate which items are visible
-    const startIndex = Math.max(0, Math.floor(scrollTop.value / itemHeight) - overscan)
-    const endIndex = Math.min(
-      itemsArray.length,
-      Math.ceil((scrollTop.value + visibleHeight) / itemHeight) + overscan
-    )
-
-    return itemsArray.slice(startIndex, endIndex).map((item, relativeIndex) => ({
+  // Adapt visibleItems from { item, index, key } → { data, index, offset }
+  // offset = index * itemHeight is exact for uniform fixed-height items.
+  const visibleItems: ComputedRef<VirtualItem<T>[]> = computed(() =>
+    scroll.visibleItems.value.map(({ item, index }) => ({
       data: item,
-      index: startIndex + relativeIndex,
-      offset: (startIndex + relativeIndex) * itemHeight
+      index,
+      offset: index * itemHeight,
     }))
-  })
+  )
 
-  // Total height of all items
-  const totalHeight = computed(() => {
-    return toValue(items).length * itemHeight
-  })
+  // Alias totalSize → totalHeight (public API name used by callers)
+  const totalHeight = scroll.totalSize
 
-  // Handle scroll events
+  // Imperatively attach the scroll listener so callers can use ref="containerRef"
+  // without needing to v-bind="containerProps".
   const handleScroll = (event: Event) => {
-    const target = event.target as HTMLElement
-    scrollTop.value = target.scrollTop
+    scroll.scrollTop.value = (event.target as HTMLElement).scrollTop
   }
 
-  // Lifecycle
-  if (getCurrentInstance()) {
-    onMounted(() => {
-      if (containerRef.value) {
-        containerRef.value.addEventListener('scroll', handleScroll, { passive: true })
-      }
-    })
-  }
+  watch(scroll.containerRef, (newEl: HTMLElement | null, oldEl: HTMLElement | null) => {
+    oldEl?.removeEventListener('scroll', handleScroll)
+    newEl?.addEventListener('scroll', handleScroll, { passive: true })
+  })
 
   if (getCurrentScope()) {
     onScopeDispose(() => {
-      if (containerRef.value) {
-        containerRef.value.removeEventListener('scroll', handleScroll)
-      }
+      scroll.containerRef.value?.removeEventListener('scroll', handleScroll)
     })
   }
 
-  // Re-attach listener if container ref changes
-  watch(
-    () => containerRef.value,
-    (newContainer, oldContainer) => {
-      if (oldContainer) {
-        oldContainer.removeEventListener('scroll', handleScroll)
-      }
-      if (newContainer) {
-        newContainer.addEventListener('scroll', handleScroll, { passive: true })
-      }
-    }
-  )
-
   return {
-    containerRef,
+    containerRef: scroll.containerRef,
     visibleItems,
     totalHeight,
-    scrollTop
+    scrollTop: scroll.scrollTop,
   }
 }


### PR DESCRIPTION
## Thinking Path

GH#9061: `useVirtualList` and `useVirtualScroll` implemented the same viewport-calculation logic independently (~80 duplicate lines). Since `useVirtualScroll` is the canonical implementation, `useVirtualList` was rewritten as a thin wrapper that adapts the output shape (`{ item, index }` → `{ data, index, offset }`) and attaches the scroll listener imperatively so callers can keep `ref="containerRef"` without needing `v-bind="containerProps"`.

GH#9062: `useCaptchaStatus` used `useGlobalWebSocket.on()` to receive captcha events, but captcha events flow through `LiveEventManager` (global channel) — not through the deprecated WebSocket direct subscription. Traced `publish_event("global", "captcha_detected")` → `LiveEventManager` → `LiveEventService`. The fix migrates to `useEventBus.subscribe("global")` with `event_type` dispatch. `ChatInterface.ts` intentionally stays on `useGlobalWebSocket` because it needs `send()` and `state` (bidirectional) until backend endpoint unification (#8291).

GH#9063: `useHostSelector` and `useHostSelection` both called `GET /api/infrastructure/hosts`. Consolidated so `useHostSelector` delegates to `useHostSelection`'s shared singleton and maps `InfrastructureHost → SelectorHost`. Client-side capability filter is retained for API compatibility; no callers pass `requiredCapability` in practice.

## What Changed

- `autobot-frontend/src/composables/useVirtualList.ts` — rewritten as thin wrapper over `useVirtualScroll`; public API (`containerRef`, `visibleItems`, `totalHeight`) unchanged; removed ~80 lines of duplicate viewport-calculation logic; scroll listener attached via `watch(containerRef)` instead of `onMounted`
- `autobot-frontend/src/composables/research/useCaptchaStatus.ts` — replaced `useGlobalWebSocket.on()` subscription with `useEventBus.subscribe("global")` dispatch on `event_type`; no behaviour change for callers
- `autobot-frontend/src/composables/useHostSelector.ts` — replaced direct `useFetchEndpoint` against `/api/infrastructure/hosts` with delegation to `useHostSelection`; maps `InfrastructureHost → SelectorHost`; `chatId` param dropped (server never used it for filtering); capability filter now client-side only

## Verification

```
# vue-tsc type check (0 new errors in changed files)
node_modules/.bin/vue-tsc --noEmit
# → 0 errors

# Callers unchanged: ParticipantList.vue, SecretVault.vue, FindingsTable.vue
# all use containerRef/visibleItems/totalHeight API — no template changes needed
```

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

Closes #9061
Closes #9062
Closes #9063

🤖 Generated with [Claude Code](https://claude.com/claude-code)