### PR TITLE
fix(sso+connectors+tests): SAML coverage + singleton + voice-rbac tests + agent-loop tests (#9075 #9099 #9113 #9114)

### DIFF
--- a/autobot-backend/agent_loop/belief_state.py
+++ b/autobot-backend/agent_loop/belief_state.py
@@ -177,6 +177,22 @@ class BeliefState:
 class BeliefStateUpdater:
     """Update TaskContext.assertions from raw tool output."""
 
+    CONTRADICTION_SURFACE_THRESHOLD = _CONTRADICTION_SURFACE_THRESHOLD
+
+    def _resolve_contradiction_surface(self, prior_confidence: float, new_confidence: float) -> str:
+        """Determine contradiction resolution strategy based on confidence delta.
+
+        Returns one of "surfaced_to_think", "updated", or "suppressed".
+        A large delta (>= threshold) surfaces the contradiction for agent review;
+        otherwise the higher-confidence value wins or the new value is suppressed.
+        """
+        delta = abs(new_confidence - prior_confidence)
+        if delta >= self.CONTRADICTION_SURFACE_THRESHOLD:
+            return "surfaced_to_think"
+        if new_confidence >= prior_confidence:
+            return "updated"
+        return "suppressed"
+
     def update(
         self,
         ctx: "TaskContext",
@@ -227,12 +243,7 @@ class BeliefStateUpdater:
             else:
                 # Contradiction
                 confidence_delta = abs(confidence - existing.confidence)
-                if confidence_delta >= _CONTRADICTION_SURFACE_THRESHOLD:
-                    resolution = "surfaced_to_think"
-                elif confidence >= existing.confidence:
-                    resolution = "updated"
-                else:
-                    resolution = "suppressed"
+                resolution = self._resolve_contradiction_surface(existing.confidence, confidence)
 
                 _log = logger.warning if resolution == "surfaced_to_think" else logger.debug
                 _log(

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -10,10 +10,10 @@ Bridges ConnectorConfig ↔ SecretsService so that sensitive auth fields
 
 import asyncio
 import json
-import threading
 from typing import Optional
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 
 logger = get_logger(__name__)
 
@@ -155,27 +155,24 @@ class ConnectorCredentialStore:
 
 
 # ---------------------------------------------------------------------------
-# Module-level singleton factory
+# Module-level singleton factory (ADR-007, GH#9099)
 # ---------------------------------------------------------------------------
 
-_store: Optional["ConnectorCredentialStore"] = None
-_store_lock = threading.Lock()
+
+def _build_credential_store() -> "ConnectorCredentialStore":
+    from services.secrets_service import get_secrets_service
+
+    return ConnectorCredentialStore(get_secrets_service())
 
 
-def get_credential_store() -> ConnectorCredentialStore:
-    """Return the module-level ConnectorCredentialStore singleton."""
-    global _store
-    if _store is None:
-        with _store_lock:
-            if _store is None:
-                from services.secrets_service import get_secrets_service
-
-                _store = ConnectorCredentialStore(get_secrets_service())
-    return _store
+get_credential_store = lazy_singleton(_build_credential_store)
 
 
 def reset_credential_store() -> None:
-    """Reset the singleton (test isolation / key rotation)."""
-    global _store
-    with _store_lock:
-        _store = None
+    """Reset the singleton (test isolation / key rotation).
+
+    Creates a fresh lazy_singleton closure so the next get_credential_store()
+    call rebuilds with the current SecretsService instance.
+    """
+    global get_credential_store
+    get_credential_store = lazy_singleton(_build_credential_store)

--- a/autobot-backend/tests/agent_loop/test_belief_state.py
+++ b/autobot-backend/tests/agent_loop/test_belief_state.py
@@ -120,6 +120,62 @@ def _registry(mapping: dict):
             ext_mod.EXTRACTOR_REGISTRY = original
 
 
+# ---------------------------------------------------------------------------
+# BeliefStateUpdater._resolve_contradiction_surface (GH#9114)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_contradiction_surface_surfaced_positive_delta():
+    updater = BeliefStateUpdater()
+    # |0.9 - 0.5| = 0.4 >= 0.3 → surfaced_to_think
+    assert updater._resolve_contradiction_surface(0.5, 0.9) == "surfaced_to_think"
+
+
+def test_resolve_contradiction_surface_surfaced_negative_delta():
+    updater = BeliefStateUpdater()
+    # |0.5 - 0.9| = 0.4 >= 0.3 → surfaced_to_think regardless of direction
+    assert updater._resolve_contradiction_surface(0.9, 0.5) == "surfaced_to_think"
+
+
+def test_resolve_contradiction_surface_surfaced_at_threshold():
+    updater = BeliefStateUpdater()
+    # |0.6 - 0.3| = 0.3 exactly at threshold → surfaced_to_think
+    assert updater._resolve_contradiction_surface(0.3, 0.6) == "surfaced_to_think"
+
+
+def test_resolve_contradiction_surface_updated_new_higher():
+    updater = BeliefStateUpdater()
+    # delta = |0.7 - 0.6| = 0.1 < 0.3, new 0.7 >= prior 0.6 → updated
+    assert updater._resolve_contradiction_surface(0.6, 0.7) == "updated"
+
+
+def test_resolve_contradiction_surface_updated_equal_confidence():
+    updater = BeliefStateUpdater()
+    # delta = 0, new == prior → updated (ties go to new value)
+    assert updater._resolve_contradiction_surface(0.8, 0.8) == "updated"
+
+
+def test_resolve_contradiction_surface_suppressed_new_lower():
+    updater = BeliefStateUpdater()
+    # delta = |0.6 - 0.7| = 0.1 < 0.3, new 0.6 < prior 0.7 → suppressed
+    assert updater._resolve_contradiction_surface(0.7, 0.6) == "suppressed"
+
+
+def test_resolve_contradiction_surface_just_below_threshold_suppressed():
+    updater = BeliefStateUpdater()
+    # delta = |0.5 - 0.8| = 0.3 → exactly threshold is surfaced, so 0.29 is below
+    assert updater._resolve_contradiction_surface(0.8, 0.51) == "suppressed"
+
+
+def test_resolve_contradiction_surface_custom_threshold():
+    updater = BeliefStateUpdater()
+    updater.CONTRADICTION_SURFACE_THRESHOLD = 0.5
+    # With threshold 0.5: delta=0.4 < 0.5 → updated (not surfaced)
+    assert updater._resolve_contradiction_surface(0.5, 0.9) == "updated"
+    # delta=0.6 >= 0.5 → surfaced_to_think
+    assert updater._resolve_contradiction_surface(0.1, 0.7) == "surfaced_to_think"
+
+
 def test_belief_updater_insert():
     ctx = make_ctx()
     updater = BeliefStateUpdater()

--- a/autobot-backend/tests/api/test_voice_bundle_user.py
+++ b/autobot-backend/tests/api/test_voice_bundle_user.py
@@ -1,9 +1,10 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Tests for per-user voice bundle assignment endpoints (GH#8605, GH#8969).
+"""Tests for per-user voice bundle assignment endpoints (GH#8605, GH#8969, GH#9113).
 
 Covers:
+- Helper functions: _is_admin, _get_user_id, _check_self_or_admin, _count_tools_for_bundle
 - GET /api/voice/bundles: list available bundles with tool counts
 - GET /api/voice/users/{userId}/bundle: get user's bundle assignment (self/admin only)
 - PUT /api/voice/users/{userId}/bundle: assign/clear bundle (admin only — GH#8969)
@@ -20,6 +21,9 @@ from api.voice_bundle_user import (
     BundleAssignRequest,
     BundleInfo,
     UserBundleResponse,
+    _check_self_or_admin,
+    _get_user_id,
+    _is_admin,
     router,
 )
 from auth_middleware import get_current_user
@@ -40,6 +44,113 @@ def _make_client(user: dict) -> TestClient:
 
     app.dependency_overrides[get_current_user] = _override
     return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helper function unit tests (GH#9113)
+# ---------------------------------------------------------------------------
+
+
+class TestIsAdmin:
+    def test_admin_role_returns_true(self):
+        assert _is_admin({"role": "admin"}) is True
+
+    def test_user_role_returns_false(self):
+        assert _is_admin({"role": "user"}) is False
+
+    def test_missing_role_returns_false(self):
+        assert _is_admin({}) is False
+
+    def test_other_role_returns_false(self):
+        assert _is_admin({"role": "moderator"}) is False
+
+
+class TestGetUserId:
+    def test_user_id_field(self):
+        assert _get_user_id({"user_id": "alice"}) == "alice"
+
+    def test_sub_field_fallback(self):
+        assert _get_user_id({"sub": "bob"}) == "bob"
+
+    def test_username_field_fallback(self):
+        assert _get_user_id({"username": "carol"}) == "carol"
+
+    def test_user_id_takes_precedence_over_sub(self):
+        assert _get_user_id({"user_id": "alice", "sub": "alice-sub"}) == "alice"
+
+    def test_empty_dict_returns_unknown(self):
+        assert _get_user_id({}) == "unknown"
+
+
+class TestCheckSelfOrAdmin:
+    """_check_self_or_admin is a security gate — must be tested thoroughly."""
+
+    def _make_request(self):
+        return MagicMock()
+
+    def test_user_accessing_own_id_allowed(self):
+        user = {"user_id": "alice", "role": "user"}
+        assert _check_self_or_admin(self._make_request(), user, "alice") is True
+
+    def test_user_accessing_other_id_denied(self):
+        user = {"user_id": "alice", "role": "user"}
+        assert _check_self_or_admin(self._make_request(), user, "bob") is False
+
+    def test_admin_accessing_own_id_allowed(self):
+        user = {"user_id": "admin-user", "role": "admin"}
+        assert _check_self_or_admin(self._make_request(), user, "admin-user") is True
+
+    def test_admin_accessing_other_id_allowed(self):
+        user = {"user_id": "admin-user", "role": "admin"}
+        assert _check_self_or_admin(self._make_request(), user, "alice") is True
+
+    def test_sub_field_used_when_no_user_id(self):
+        user = {"sub": "alice", "role": "user"}
+        assert _check_self_or_admin(self._make_request(), user, "alice") is True
+        assert _check_self_or_admin(self._make_request(), user, "bob") is False
+
+
+class TestCountToolsForBundle:
+    @pytest.mark.asyncio
+    async def test_count_tools_returns_integer(self):
+        from api.voice_bundle_user import _count_tools_for_bundle, _tool_count_cache
+
+        _tool_count_cache.clear()
+
+        mock_matrix = {"tool_a": {}, "tool_b": {}, "tool_c": {}}
+
+        def mock_filter(tools, bundle, is_admin):
+            return tools[:2]
+
+        with (
+            patch("api.redis_mcp.rbac.TOOL_ACCESS_MATRIX", mock_matrix),
+            patch("api.redis_mcp.rbac.filter_tools_for_bundle", mock_filter),
+        ):
+            count = await _count_tools_for_bundle("voice_safe", is_admin=False)
+
+        assert count == 2
+
+    @pytest.mark.asyncio
+    async def test_count_tools_result_cached(self):
+        from api.voice_bundle_user import _count_tools_for_bundle, _tool_count_cache
+
+        _tool_count_cache.clear()
+        call_count = 0
+        mock_matrix = {"tool_x": {}}
+
+        def counting_filter(tools, bundle, is_admin):
+            nonlocal call_count
+            call_count += 1
+            return tools
+
+        with (
+            patch("api.redis_mcp.rbac.TOOL_ACCESS_MATRIX", mock_matrix),
+            patch("api.redis_mcp.rbac.filter_tools_for_bundle", counting_filter),
+        ):
+            await _count_tools_for_bundle("voice_extended", is_admin=True)
+            await _count_tools_for_bundle("voice_extended", is_admin=True)
+
+        assert call_count == 1  # second call used cache
 
 
 class TestListVoiceBundles:

--- a/autobot-slm-backend/tests/services/test_sso_service.py
+++ b/autobot-slm-backend/tests/services/test_sso_service.py
@@ -170,3 +170,148 @@ class TestValidateOauthState:
             await service._validate_oauth_state(state)
 
         assert f"sso:state:{state}" not in store
+
+
+# ---------------------------------------------------------------------------
+# SAML relay state Redis round-trip (GH#9075)
+# ---------------------------------------------------------------------------
+
+
+def _make_saml_provider() -> MagicMock:
+    """Return a minimal SSOProvider mock for SAML tests."""
+    provider = MagicMock()
+    provider.id = _PROVIDER_ID
+    provider.config = {
+        "entity_id": "https://sp.example.com",
+        "idp_metadata_url": "https://idp.example.com/metadata",
+    }
+    return provider
+
+
+class TestSamlRelayStateRedisRoundTrip:
+    """SAML relay state uses the same Redis key-space as OAuth state.
+
+    _generate_saml_authn_request stores relay_state → provider.id in Redis
+    under sso:state:{relay_state} with a 10-minute TTL.  _validate_oauth_state
+    consumes it atomically via GETDEL (single-use, replay-safe).
+    """
+
+    @pytest.mark.asyncio
+    async def test_saml_relay_state_stored_in_redis(self):
+        redis, store = _mock_redis()
+        service = _make_service()
+        provider = _make_saml_provider()
+
+        mock_client = MagicMock()
+        mock_client.prepare_for_authenticate.return_value = (
+            "req-id",
+            {"headers": [("Location", "https://idp.example.com/sso")]},
+        )
+        with (
+            patch.object(_sso_mod, "get_redis_client", return_value=redis),
+            patch.object(service, "_build_saml_client", return_value=mock_client),
+        ):
+            redirect_url, relay_state = await service._generate_saml_authn_request(provider)
+
+        assert relay_state
+        assert f"sso:state:{relay_state}" in store
+        assert store[f"sso:state:{relay_state}"] == str(_PROVIDER_ID)
+
+    @pytest.mark.asyncio
+    async def test_saml_relay_state_stored_with_600s_ttl(self):
+        redis, _ = _mock_redis()
+        service = _make_service()
+        provider = _make_saml_provider()
+
+        mock_client = MagicMock()
+        mock_client.prepare_for_authenticate.return_value = (
+            "req-id",
+            {"headers": [("Location", "https://idp.example.com/sso")]},
+        )
+        with (
+            patch.object(_sso_mod, "get_redis_client", return_value=redis),
+            patch.object(service, "_build_saml_client", return_value=mock_client),
+        ):
+            _, relay_state = await service._generate_saml_authn_request(provider)
+
+        redis.set.assert_awaited_once_with(f"sso:state:{relay_state}", str(_PROVIDER_ID), ex=600)
+
+    @pytest.mark.asyncio
+    async def test_saml_relay_state_round_trip_via_validate(self):
+        """Relay state stored by initiation is consumable by _validate_oauth_state."""
+        redis, store = _mock_redis()
+        service = _make_service()
+        provider = _make_saml_provider()
+
+        mock_client = MagicMock()
+        mock_client.prepare_for_authenticate.return_value = (
+            "req-id",
+            {"headers": [("Location", "https://idp.example.com/sso")]},
+        )
+        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+            with patch.object(service, "_build_saml_client", return_value=mock_client):
+                _, relay_state = await service._generate_saml_authn_request(provider)
+            recovered_id = await service._validate_oauth_state(relay_state)
+
+        assert recovered_id == _PROVIDER_ID
+        assert f"sso:state:{relay_state}" not in store
+
+    @pytest.mark.asyncio
+    async def test_saml_relay_state_single_use(self):
+        """Relay state is single-use — second validation attempt must raise."""
+        redis, _ = _mock_redis()
+        service = _make_service()
+        provider = _make_saml_provider()
+
+        mock_client = MagicMock()
+        mock_client.prepare_for_authenticate.return_value = (
+            "req-id",
+            {"headers": [("Location", "https://idp.example.com/sso")]},
+        )
+        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+            with patch.object(service, "_build_saml_client", return_value=mock_client):
+                _, relay_state = await service._generate_saml_authn_request(provider)
+            await service._validate_oauth_state(relay_state)
+            with pytest.raises(SSOAuthenticationError, match="Invalid or expired"):
+                await service._validate_oauth_state(relay_state)
+
+    @pytest.mark.asyncio
+    async def test_saml_relay_state_redis_unavailable_silently_skips_store(self):
+        """If Redis is down, initiation still returns a relay_state token."""
+        service = _make_service()
+        provider = _make_saml_provider()
+
+        mock_client = MagicMock()
+        mock_client.prepare_for_authenticate.return_value = (
+            "req-id",
+            {"headers": [("Location", "https://idp.example.com/sso")]},
+        )
+        with (
+            patch.object(_sso_mod, "get_redis_client", return_value=None),
+            patch.object(service, "_build_saml_client", return_value=mock_client),
+        ):
+            redirect_url, relay_state = await service._generate_saml_authn_request(provider)
+
+        assert relay_state
+        assert redirect_url == "https://idp.example.com/sso"
+
+    @pytest.mark.asyncio
+    async def test_saml_returns_idp_redirect_url(self):
+        """_generate_saml_authn_request must return the IdP Location URL."""
+        redis, _ = _mock_redis()
+        service = _make_service()
+        provider = _make_saml_provider()
+
+        expected_url = "https://idp.example.com/sso?SAMLRequest=abc123"
+        mock_client = MagicMock()
+        mock_client.prepare_for_authenticate.return_value = (
+            "req-id",
+            {"headers": [("Location", expected_url)]},
+        )
+        with (
+            patch.object(_sso_mod, "get_redis_client", return_value=redis),
+            patch.object(service, "_build_saml_client", return_value=mock_client),
+        ):
+            redirect_url, _ = await service._generate_saml_authn_request(provider)
+
+        assert redirect_url == expected_url


### PR DESCRIPTION
## Summary

- **GH#9075** — Add `TestSamlRelayStateRedisRoundTrip` to `autobot-slm-backend/tests/services/test_sso_service.py` (6 tests): store→retrieve round-trip, 600 s TTL assertion, single-use GETDEL, Redis-down graceful skip, IdP redirect URL.
- **GH#9099** — Replace hand-rolled double-checked locking in `autobot-backend/knowledge/connectors/credential_store.py` with `lazy_singleton()` from `autobot_shared.singleton_factory`. `reset_credential_store()` now reassigns module-level closure. `threading` import removed.
- **GH#9113** — Add 4 test classes to `autobot-backend/tests/api/test_voice_bundle_user.py`: `TestIsAdmin`, `TestGetUserId`, `TestCheckSelfOrAdmin`, `TestCountToolsForBundle` — security-gate helpers previously had zero direct coverage.
- **GH#9114** — Extract `_resolve_contradiction_surface()` in `autobot-backend/agent_loop/belief_state.py` and add 8 unit tests covering all 3 resolution paths (surfaced_to_think, updated, suppressed), boundary values, and custom threshold.

## Thinking Path

1. GH#9075: SAML relay-state tests were missing — added 6 unit tests covering Redis round-trip, TTL, single-use GETDEL, Redis-down graceful skip, and IdP redirect.
2. GH#9099: credential_store singleton used hand-rolled double-checked locking with threading.Lock. The codebase has lazy_singleton() helper for this pattern — replaced to standardize.
3. GH#9113: Voice bundle RBAC helper functions (_is_admin, _get_user_id, _check_self_or_admin) had no direct unit test coverage despite being security-critical gate — added TestCheckSelfOrAdmin with 5 cases covering self/admin/other access patterns.
4. GH#9114: Contradiction resolution logic was inline 7-line if/elif/else inside update() — extracted to _resolve_contradiction_surface() for testability. Added 8 unit tests covering all paths including custom threshold override.

## What Changed

- `autobot-slm-backend/tests/services/test_sso_service.py`: 6 SAML relay-state round-trip tests added
- `autobot-backend/knowledge/connectors/credential_store.py`: replaced threading.Lock double-checked locking with lazy_singleton(); reset_credential_store() reassigns closure
- `autobot-backend/tests/api/test_voice_bundle_user.py`: 4 test classes for RBAC helper functions with 12 test cases
- `autobot-backend/agent_loop/belief_state.py`: extracted _resolve_contradiction_surface() method with CONTRADICTION_SURFACE_THRESHOLD class attr defaulting from module-level env-configurable constant
- `autobot-backend/tests/agent_loop/test_belief_state.py`: 8 unit tests for the extracted method

## Verification

- All 5 files pass `python3 -m py_compile` (verified in worktree)
- Rebase onto current Dev_new_gui completed cleanly (conflict in belief_state.py resolved: class attr defaults from env-configurable module constant, method uses self.CONTRADICTION_SURFACE_THRESHOLD for test overridability)
- No callers of reset_credential_store() use the old threading interface
- _resolve_contradiction_surface() behavior preserved: same 3 paths, same threshold logic

## Test plan

- [ ] All 5 modified files pass `python3 -m py_compile` (verified in worktree)
- [ ] `test_sso_service.py` — 6 new SAML relay-state tests with mock Redis
- [ ] `test_voice_bundle_user.py` — 4 new test classes covering RBAC helper functions
- [ ] `test_belief_state.py` — 8 new unit tests for `_resolve_contradiction_surface()`
- [ ] `credential_store.py` — `lazy_singleton()` refactor; existing callers unchanged

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)