### PR TITLE
feat(chat): context window usage indicator (#8990)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatHeader.vue
+++ b/autobot-frontend/src/components/chat/ChatHeader.vue
@@ -28,6 +28,13 @@
 
       <!-- Right: Actions + connection status -->
       <div class="flex items-center gap-1 sm:gap-2 shrink-0">
+        <!-- GH#8990: context window usage indicator (hidden on mobile to save space) -->
+        <ContextWindowIndicator
+          v-if="contextWindowProps?.hasData"
+          class="hidden sm:flex"
+          v-bind="contextWindowProps"
+        />
+
         <!-- Custom Actions Slot -->
         <slot name="actions"></slot>
 
@@ -62,7 +69,17 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
+import ContextWindowIndicator from './ContextWindowIndicator.vue'
 import { computed } from 'vue'
+
+interface ContextWindowProps {
+  tokensUsed: number
+  contextWindow: number
+  usagePercent: number
+  isWarning: boolean
+  isCritical: boolean
+  hasData: boolean
+}
 
 interface Props {
   currentSessionId: string | null
@@ -70,6 +87,7 @@ interface Props {
   sessionInfo: string
   connectionStatus: string
   isConnected: boolean
+  contextWindowProps?: ContextWindowProps
 }
 
 interface Emits {
@@ -81,7 +99,6 @@ interface Emits {
 const props = defineProps<Props>()
 defineEmits<Emits>()
 
-// Computed properties for connection status
 const connectionStatusClass = computed(() => ({
   'text-green-600': props.isConnected,
   'text-red-600': !props.isConnected,

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -49,6 +49,7 @@
           :session-info="sessionInfo"
           :connection-status="connectionStatus"
           :is-connected="isConnected"
+          :context-window-props="contextWindowProps"
           @export-session="exportSession"
           @clear-session="clearSession"
           @toggle-mobile-sidebar="showMobileSidebar = !showMobileSidebar"
@@ -308,6 +309,8 @@ import { useReasoningTrace } from '@/composables/useReasoningTrace'
 import { useToolApproval, type PendingToolApproval } from '@/composables/useToolApproval'
 // Issue #4414: multi-model comparison
 import MultiModelChat from './MultiModelChat.vue'
+// GH#8990: context window usage indicator
+import { useContextWindow } from '@/composables/chat/useContextWindow'
 
 // i18n
 const { t } = useI18n()
@@ -327,6 +330,20 @@ const {
   isActive: cotIsActive,
   clear: cotClear,
 } = useReasoningTrace(store.currentSessionId)
+
+// GH#8990: context window usage indicator
+const _ctxWindow = useContextWindow(
+  computed(() => store.currentSession?.messages ?? []),
+  computed(() => store.settings.model),
+)
+const contextWindowProps = computed(() => ({
+  tokensUsed: _ctxWindow.tokensUsed.value,
+  contextWindow: _ctxWindow.contextWindow.value,
+  usagePercent: _ctxWindow.usagePercent.value,
+  isWarning: _ctxWindow.isWarning.value,
+  isCritical: _ctxWindow.isCritical.value,
+  hasData: _ctxWindow.hasData.value,
+}))
 
 // Issue #4952: agent-loop tool approval via POST /api/agent-terminal/tools/approve/{id}
 const {

--- a/autobot-frontend/src/components/chat/ContextWindowIndicator.vue
+++ b/autobot-frontend/src/components/chat/ContextWindowIndicator.vue
@@ -1,0 +1,105 @@
+<template>
+  <div
+    v-if="hasData"
+    class="ctx-indicator"
+    :class="{
+      'ctx-indicator--warning': isWarning && !isCritical,
+      'ctx-indicator--critical': isCritical,
+    }"
+    :title="tooltip"
+    role="meter"
+    :aria-valuenow="usagePercent"
+    :aria-valuemin="0"
+    :aria-valuemax="100"
+    :aria-label="$t('chat.contextWindow.ariaLabel', { used: formattedUsed, max: formattedMax })"
+  >
+    <!-- Token count text -->
+    <span class="ctx-indicator__text">
+      {{ formattedUsed }} / {{ formattedMax }}
+    </span>
+    <!-- Progress bar -->
+    <div class="ctx-indicator__bar-track" aria-hidden="true">
+      <div
+        class="ctx-indicator__bar-fill"
+        :style="{ width: `${usagePercent}%` }"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+interface Props {
+  tokensUsed: number
+  contextWindow: number
+  usagePercent: number
+  isWarning: boolean
+  isCritical: boolean
+  hasData: boolean
+}
+
+const props = defineProps<Props>()
+const { t } = useI18n()
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
+const formattedUsed = computed(() => formatTokens(props.tokensUsed))
+const formattedMax = computed(() => formatTokens(props.contextWindow))
+
+const tooltip = computed(() =>
+  t('chat.contextWindow.tooltip', {
+    used: props.tokensUsed.toLocaleString(),
+    max: props.contextWindow.toLocaleString(),
+    percent: props.usagePercent.toFixed(1),
+  }),
+)
+</script>
+
+<style scoped>
+@reference "../../assets/tailwind.css";
+
+.ctx-indicator {
+  @apply flex items-center gap-1.5 px-2 py-1 rounded-md text-xs select-none;
+  color: var(--text-tertiary);
+  background: var(--bg-tertiary);
+  min-width: 0;
+}
+
+.ctx-indicator__text {
+  @apply font-mono whitespace-nowrap shrink-0;
+}
+
+.ctx-indicator__bar-track {
+  @apply rounded-full overflow-hidden shrink-0;
+  width: 48px;
+  height: 4px;
+  background: var(--border-light);
+}
+
+.ctx-indicator__bar-fill {
+  height: 4px;
+  border-radius: 9999px;
+  background: var(--color-success);
+  transition: width 0.4s ease, background 0.3s ease;
+}
+
+.ctx-indicator--warning .ctx-indicator__text {
+  color: var(--color-warning);
+}
+.ctx-indicator--warning .ctx-indicator__bar-fill {
+  background: var(--color-warning);
+}
+
+.ctx-indicator--critical .ctx-indicator__text {
+  color: var(--color-error);
+}
+.ctx-indicator--critical .ctx-indicator__bar-fill {
+  background: var(--color-error);
+}
+</style>

--- a/autobot-frontend/src/components/chat/MultiModelChat.vue
+++ b/autobot-frontend/src/components/chat/MultiModelChat.vue
@@ -18,6 +18,11 @@
             :aria-label="model"
           />
           <span class="multi-model-chat__model-name">{{ model }}</span>
+          <span
+            v-if="contextWindowLabel[model]"
+            class="multi-model-chat__model-ctx"
+            :title="`Context window: ${contextWindowLabel[model]} tokens`"
+          >{{ contextWindowLabel[model] }}</span>
         </label>
       </div>
     </div>
@@ -92,8 +97,10 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { useMultiModelCompare } from '@/composables/useMultiModelCompare'
+// GH#8990: show per-model context window in picker
+import { useAvailableModels } from '@/composables/useAvailableModels'
 
 // ---------------------------------------------------------------------------
 // Defaults — user can change via the picker
@@ -105,8 +112,25 @@ const DEFAULT_MODELS = [
 ]
 
 const { responses, selectedModels, isComparing, compare, reset } = useMultiModelCompare()
+const { models: llmModels, fetchModels } = useAvailableModels()
+fetchModels().catch(() => {})
 
 const promptText = ref('')
+
+// Map model name → formatted context window label (GH#8990)
+const contextWindowLabel = computed(() => {
+  const map: Record<string, string> = {}
+  for (const m of llmModels.value) {
+    if (!m.context_window) continue
+    const cw = m.context_window
+    map[m.name] = cw >= 1_000_000
+      ? `${(cw / 1_000_000).toFixed(1)}M`
+      : cw >= 1_000
+      ? `${Math.round(cw / 1_000)}k`
+      : String(cw)
+  }
+  return map
+})
 
 // Populate defaults on first mount if localStorage is empty
 if (selectedModels.value.length === 0) {
@@ -181,6 +205,16 @@ defineExpose({ reset })
 .multi-model-chat__model-name {
   font-family: ui-monospace, monospace;
   font-size: 0.75rem;
+}
+
+.multi-model-chat__model-ctx {
+  font-size: 0.6875rem;
+  font-family: ui-monospace, monospace;
+  color: var(--color-text-muted, #9ca3af);
+  background: var(--color-bg-tertiary, #1a1a2e);
+  border-radius: 0.25rem;
+  padding: 0 0.25rem;
+  cursor: default;
 }
 
 /* ---- Input row ---- */

--- a/autobot-frontend/src/composables/chat/useContextWindow.ts
+++ b/autobot-frontend/src/composables/chat/useContextWindow.ts
@@ -1,0 +1,91 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import { computed } from 'vue'
+import type { ComputedRef, Ref } from 'vue'
+import type { ChatMessage } from '@/types/api'
+import { useAvailableModels } from '@/composables/useAvailableModels'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useContextWindow')
+
+export interface ContextWindowState {
+  tokensUsed: ComputedRef<number>
+  contextWindow: ComputedRef<number>
+  usagePercent: ComputedRef<number>
+  isWarning: ComputedRef<boolean>
+  isCritical: ComputedRef<boolean>
+  hasData: ComputedRef<boolean>
+}
+
+// Known context windows for common models when live data is unavailable
+const FALLBACK_CONTEXT_WINDOWS: Record<string, number> = {
+  'claude-3-opus': 200_000,
+  'claude-3-sonnet': 200_000,
+  'claude-3-haiku': 200_000,
+  'claude-3-5-sonnet': 200_000,
+  'claude-sonnet': 200_000,
+  'claude-opus': 200_000,
+  'gpt-4o': 128_000,
+  'gpt-4': 128_000,
+  'gpt-4-turbo': 128_000,
+  'gpt-3.5-turbo': 16_385,
+  'gpt-3.5': 16_385,
+  'llama3': 8_192,
+  'llama3.1': 131_072,
+  'llama3.2': 131_072,
+  'mistral': 32_768,
+  'mixtral': 32_768,
+  'gemma': 8_192,
+  'gemma2': 8_192,
+  'qwen': 32_768,
+  'deepseek': 32_768,
+  'phi3': 4_096,
+}
+
+function lookupFallback(modelName: string): number {
+  const lower = modelName.toLowerCase()
+  for (const [key, value] of Object.entries(FALLBACK_CONTEXT_WINDOWS)) {
+    if (lower.startsWith(key) || lower.includes(key)) return value
+  }
+  return 0
+}
+
+export function useContextWindow(
+  messages: Ref<ChatMessage[]> | ComputedRef<ChatMessage[]>,
+  modelName: Ref<string> | ComputedRef<string>,
+): ContextWindowState {
+  const { models, fetchModels } = useAvailableModels()
+
+  // Fetch model list once if empty
+  fetchModels().catch((err) => logger.warn('Failed to fetch models for context window:', err))
+
+  const tokensUsed = computed<number>(() => {
+    return messages.value.reduce((sum, msg) => {
+      return sum + (msg.metadata?.tokens ?? 0)
+    }, 0)
+  })
+
+  const contextWindow = computed<number>(() => {
+    const name = modelName.value
+    if (!name) return 0
+    const found = models.value.find(
+      (m) => m.name === name || m.name.toLowerCase() === name.toLowerCase(),
+    )
+    if (found?.context_window) return found.context_window
+    return lookupFallback(name)
+  })
+
+  const usagePercent = computed<number>(() => {
+    if (!contextWindow.value || !tokensUsed.value) return 0
+    return Math.min(100, (tokensUsed.value / contextWindow.value) * 100)
+  })
+
+  const isWarning = computed<boolean>(() => usagePercent.value >= 80)
+  const isCritical = computed<boolean>(() => usagePercent.value >= 95)
+
+  const hasData = computed<boolean>(() => tokensUsed.value > 0 && contextWindow.value > 0)
+
+  return { tokensUsed, contextWindow, usagePercent, isWarning, isCritical, hasData }
+}

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -104,6 +104,10 @@
     "filterByCategory": "Filter by category"
   },
   "chat": {
+    "contextWindow": {
+      "ariaLabel": "{used} of {max} tokens used",
+      "tooltip": "{used} / {max} tokens used ({percent}% of context window)"
+    },
     "sendMessage": "Send a message...",
     "newChat": "New Chat",
     "clearChat": "Clear chat",


### PR DESCRIPTION
## Summary

Implements GH#8990 — context window usage indicator for the chat interface.

- **`useContextWindow` composable** (`src/composables/chat/useContextWindow.ts`): accumulates token counts from `message.metadata.tokens`, resolves context window size from `useAvailableModels` (with hard-coded fallbacks for Anthropic/OpenAI/Ollama models)
- **`ContextWindowIndicator.vue`** (`src/components/chat/`): displays `used / max` token counts, a progress bar, warning state at ≥80%, critical state at ≥95%. Hidden when no token data exists.
- **`ChatHeader.vue`**: accepts optional `contextWindowProps` and renders the indicator (hidden on mobile via `hidden sm:flex`)
- **`ChatInterface.vue`**: uses the composable, creates a flat `contextWindowProps` computed object (avoids ComputedRef-in-object reactive pitfall), passes to `ChatHeader`
- **`MultiModelChat.vue`**: shows per-model context window size (e.g. `128k`) next to each model label in the comparison picker, sourced from `useAvailableModels`
- **i18n** (`en.json`): `chat.contextWindow.ariaLabel` + `chat.contextWindow.tooltip` keys

## Thinking Path

1. Token accumulation: messages carry metadata.tokens; composable sums across all messages. Reactive computed chain ensures real-time updates on stream completion.
2. Context window size resolution: useAvailableModels has per-model info; fallback table covers common Anthropic/OpenAI/Ollama models for when model isn't in the registry.
3. Flat contextWindowProps computed (not ComputedRef-in-object): avoids the common Vue 3 reactive pitfall where nested ComputedRefs don't unwrap properly in template bindings.
4. Accessibility: role='meter', aria-valuenow/min/max, aria-label for screen readers.
5. Mobile: hidden on mobile (hidden sm:flex) to save header space.

## What Changed

- `src/composables/chat/useContextWindow.ts`: new composable for token accumulation and context window resolution
- `src/components/chat/ContextWindowIndicator.vue`: new indicator component with progress bar, warning/critical states
- `src/components/chat/ChatHeader.vue`: optional contextWindowProps prop, renders ContextWindowIndicator
- `src/components/chat/ChatInterface.vue`: uses composable, creates contextWindowProps computed, passes to ChatHeader
- `src/components/chat/MultiModelChat.vue`: per-model context size label in comparison picker
- `src/i18n/locales/en.json`: two new i18n keys for accessibility

## Verification

- smoke-test: PASS
- vue-tsc-baseline: PASS
- hardened-smoke-test: FAIL (pre-existing project-wide, non-blocking)

## Test plan

- [ ] Start a conversation, send several messages — indicator appears in chat header showing `X.Xk / 128k` with bar
- [ ] Bar turns amber at >80%, red at >95%
- [ ] Open multi-model compare panel — each model checkbox shows context size label (e.g. `128k`)
- [ ] Model with no token metadata (e.g. empty session) — indicator is hidden

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)