### PR TITLE
fix(embed): clear shadow DOM on re-mount and surface errorMsg (GH#9046 GH#9067)

### DIFF
--- a/autobot-frontend/src/embed/AutobotWidget.ts
+++ b/autobot-frontend/src/embed/AutobotWidget.ts
@@ -94,6 +94,9 @@ export class AutobotWidget extends HTMLElement {
   }
 
   private _mount(): void {
+    // Clear any existing nodes to prevent accumulation on re-mount (GH#9046)
+    while (this._shadow.firstChild) this._shadow.removeChild(this._shadow.firstChild)
+
     // Inject styles into shadow root
     const style = document.createElement('style')
     style.textContent = WIDGET_STYLES
@@ -262,7 +265,7 @@ const EmbedChatApp = defineComponent({
     }
   },
   render() {
-    const { config, open, input, messages, loading, cssVars, toggleOpen, sendMessage, onKeydown } = this
+    const { config, open, input, messages, loading, errorMsg, cssVars, toggleOpen, sendMessage, onKeydown } = this
 
     const posClass = config.position === 'bottom-left' ? 'ab-pos-left' : 'ab-pos-right'
 
@@ -321,6 +324,11 @@ const EmbedChatApp = defineComponent({
                     ])
                   )
             ),
+
+            // Error banner — only rendered when errorMsg is non-empty (GH#9067)
+            errorMsg
+              ? h('p', { class: 'ab-error', role: 'alert' }, errorMsg)
+              : null,
 
             // Input row
             h('div', { class: 'ab-input-row' }, [

--- a/autobot-frontend/src/embed/embed-styles.ts
+++ b/autobot-frontend/src/embed/embed-styles.ts
@@ -165,6 +165,16 @@ export const WIDGET_STYLES = `
   40%           { transform: scale(1);   opacity: 1; }
 }
 
+/* ── Error banner ───────────────────────────────────────────────────────── */
+.ab-error {
+  flex-shrink: 0;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: #b91c1c;
+  background: #fef2f2;
+  border-top: 1px solid #fecaca;
+}
+
 /* ── Input row ──────────────────────────────────────────────────────────── */
 .ab-input-row {
   display: flex;


### PR DESCRIPTION
## Summary

- **GH#9046 — Shadow DOM accumulation:** `_mount()` now drains all shadow root children with `while (firstChild) removeChild(…)` before appending `<style>` and `#autobot-root`. Previously each `attributeChangedCallback` re-mount appended duplicate nodes without clearing first.
- **GH#9067 — `errorMsg` ref never rendered:** Added `errorMsg` to the `render()` destructuring and inserted `h('p', { class: 'ab-error', role: 'alert' }, errorMsg)` between the messages list and input row (only rendered when non-empty). Added `.ab-error` CSS class to `embed-styles.ts`.

## Thinking Path

1. GH#9046: Each re-mount via attributeChangedCallback was appending new style/root nodes without clearing existing ones. The fix is to drain the shadow root before mounting — standard DOM cleanup pattern.
2. GH#9067: errorMsg was computed but never included in render() destructuring, so error messages were silently swallowed. Adding it with a conditional h('p') element with role='alert' follows the existing render pattern.

## What Changed

- `autobot-frontend/src/embed/AutobotWidget.ts`: added shadow DOM drain loop in `_mount()`, added `errorMsg` to render destructuring, added error banner `h('p', { class: 'ab-error', role: 'alert' }, errorMsg)`
- `autobot-frontend/src/embed/embed-styles.ts`: added `.ab-error` CSS class (red text, light red background, border-top)

## Verification

- Both files are focused TypeScript/style changes — no business logic changes
- Shadow DOM drain loop is a standard pattern for custom elements
- Error banner is conditionally rendered only when errorMsg is non-empty (no visual impact on clean state)

## Test plan

- [ ] Trigger multiple attribute changes on a mounted `<autobot-widget>` — shadow root should contain exactly one `<style>` and one `#autobot-root` after any number of re-mounts
- [ ] Simulate a failed fetch (bad `data-api-url`) — error message should appear in the panel above the input row
- [ ] TypeScript: no new errors in embed files (`vue-tsc --noEmit -p tsconfig.app.json`)

Closes https://github.com/mrveiss/AutoBot-AI/issues/9046
Closes https://github.com/mrveiss/AutoBot-AI/issues/9067

## Model Used

claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)