### PR TITLE
fix(auth): remove duplicate indexes in chat_shared_links migration 049 (#9129)

### DIFF
--- a/autobot-backend/migrations/versions/20260531_049_chat_shared_links.py
+++ b/autobot-backend/migrations/versions/20260531_049_chat_shared_links.py
@@ -19,8 +19,8 @@ def upgrade() -> None:
     op.create_table(
         "chat_shared_links",
         sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True),
-        sa.Column("session_id", sa.String(128), nullable=False, index=True),
-        sa.Column("token", sa.String(64), nullable=False, unique=True),
+        sa.Column("session_id", sa.String(128), nullable=False),
+        sa.Column("token", sa.String(64), nullable=False),
         sa.Column("password_hash", sa.Text, nullable=True),
         sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("created_by", sa.String(128), nullable=False),


### PR DESCRIPTION
## Summary

- Removes redundant `index=True` from `session_id` and `unique=True` from `token` in `op.create_table` call
- Both columns already had explicit named `op.create_index` calls below them — the column-level flags created duplicate indexes
- Downgrade path already drops the named indexes correctly; no downgrade changes needed

## Thinking Path

Migration `20260531_049_chat_shared_links.py` declares two columns with inline uniqueness hints (`index=True`, `unique=True`) and then immediately follows with explicit `op.create_index` / `UniqueConstraint` calls for the same columns. SQLAlchemy/Alembic would create each index twice — once from the column flag and once from the explicit call. The fix is to remove the redundant column-level flags, leaving only the explicit named constraints.

## What Changed

- `autobot-backend/migrations/versions/20260531_049_chat_shared_links.py`: removed `index=True` from `session_id` column and `unique=True` from `token` column in `op.create_table` — 2-line change

## Verification

- Both indexes still exist via the explicit `op.create_index` calls already present below
- Downgrade path drops named indexes — no change required
- `startup-import-smoke: SUCCESS`, `submit-pypi: SUCCESS`, `Security Compliance Check: SUCCESS`

## Model Used

claude-sonnet-4-6

Fixes [MVA-1831](/MVA/issues/MVA-1831) · Ref GH#9129

🤖 Code review body update by SeniorCodeArchitect