### PR TITLE
fix(auth): reject shared link ops when Redis owner unknown — IDOR cold-cache bypass (#9128)

### DIFF
--- a/autobot-backend/api/chat_shared_links.py
+++ b/autobot-backend/api/chat_shared_links.py
@@ -95,7 +95,7 @@ async def create_shared_link(
     user_id = current_user.get("user_id") or current_user.get("username", "")
 
     owner = await validator.get_session_owner(session_id)
-    if owner is not None and owner != user_id:
+    if owner is None or owner != user_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not the session owner")
 
     password_hash: str | None = None
@@ -201,7 +201,7 @@ async def list_shared_links(
     user_id = current_user.get("user_id") or current_user.get("username", "")
 
     owner = await validator.get_session_owner(session_id)
-    if owner is not None and owner != user_id:
+    if owner is None or owner != user_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not the session owner")
 
     result = await db.execute(


### PR DESCRIPTION
## Summary

T0 security regression introduced in #9122 (shipped today). Fixes IDOR vulnerability in `chat_shared_links` where any authenticated user could create/enumerate shared links for sessions they don't own.

**Root cause:** `get_session_owner()` returns `None` on Redis cold-cache miss. The old ownership check `if owner is not None and owner != user_id` treated `None` as "no owner → allow". Unknown ownership must be denied.

**Fix:** Two-line change in `autobot-backend/api/chat_shared_links.py`:
- `create_shared_link()` line 98: `if owner is not None and owner != user_id` → `if owner is None or owner != user_id`
- `list_shared_links()` line 204: same pattern, same fix

**Scope:** Minimal — 2 lines changed, no schema/model impact, no migration needed.

## Impact

Without this fix: any authenticated user can call `POST /chat/sessions/{any_session_id}/share` or `GET /chat/sessions/{any_session_id}/shared-links` while Redis is cold (e.g. after restart, cache eviction) and succeed with HTTP 200.

With this fix: unknown session ownership (Redis miss) returns 403 immediately, consistent with the fail-closed security principle.

## Test plan

- [ ] Confirmed fix is correct: `None is None or None != user_id` → True → 403 raised ✅
- [ ] Confirmed non-regression: when `owner == user_id` → `owner is None` is False, `owner != user_id` is False → False → operation proceeds ✅
- [ ] Smoke test against API endpoint after Redis flush

Fixes #9128 (GH security regression from #9122)

🤖 Generated with [Claude Code](https://claude.com/claude-code)