### PR TITLE
feat(integrations): frontend for web push notifications — service worker + permission UI (GH#4459)

### DIFF
--- a/autobot-frontend/public/service-worker.js
+++ b/autobot-frontend/public/service-worker.js
@@ -313,5 +313,62 @@ self.addEventListener('message', (event) => {
   }
 })
 
+// ==================================================================================
+// Web Push Notifications (GH#4459)
+// ==================================================================================
+
+/**
+ * Push event handler — shows a browser notification when the backend delivers
+ * a Web Push message.  Expected payload shape:
+ *   { title: string, body: string, url?: string, icon?: string }
+ */
+self.addEventListener('push', (event) => {
+  if (!event.data) return
+
+  let payload = { title: 'AutoBot', body: 'You have a new notification.', url: '/', icon: '/favicon.ico' }
+  try {
+    Object.assign(payload, event.data.json())
+  } catch {
+    payload.body = event.data.text() || payload.body
+  }
+
+  event.waitUntil(
+    self.registration.showNotification(payload.title, {
+      body: payload.body,
+      icon: payload.icon || '/favicon.ico',
+      badge: '/favicon.ico',
+      data: { url: payload.url || '/' },
+    })
+  )
+})
+
+/**
+ * Notification click handler — focuses the AutoBot tab (or opens a new one)
+ * and navigates to the URL embedded in the notification data.
+ */
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/'
+
+  event.waitUntil(
+    clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((windowClients) => {
+        // Re-use an existing AutoBot tab if one is open
+        for (const client of windowClients) {
+          if (new URL(client.url).origin === self.location.origin && 'focus' in client) {
+            client.navigate(targetUrl)
+            return client.focus()
+          }
+        }
+        // Otherwise open a new tab
+        if (clients.openWindow) {
+          return clients.openWindow(targetUrl)
+        }
+      })
+  )
+})
+
 // Log service worker activation
 console.log('[AutoBot SW] Service Worker loaded with stale-while-revalidate strategy')

--- a/autobot-frontend/src/components/settings/PushNotificationSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/settings/PushNotificationSettingsPanel.stories.ts
@@ -1,0 +1,45 @@
+import type { Meta } from '@storybook/vue3'
+// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+import type { StoryObj } from '@storybook/vue3'
+import PushNotificationSettingsPanel from './PushNotificationSettingsPanel.vue'
+
+type Story = StoryObj<any>
+
+const meta = {
+  title: 'Components/Settings/PushNotificationSettingsPanel',
+  component: PushNotificationSettingsPanel,
+  tags: ['autodocs'],
+  argTypes: {},
+} as Meta<typeof PushNotificationSettingsPanel>
+
+export default meta
+
+export const Default: Story = {
+  name: 'Default (browser-supported)',
+  render: () => ({
+    components: { PushNotificationSettingsPanel },
+    template: `
+      <div style="max-width:640px;padding:24px">
+        <PushNotificationSettingsPanel />
+      </div>
+    `,
+  }),
+}
+
+export const InSettingsContainer: Story = {
+  name: 'Inside Settings Container',
+  render: () => ({
+    components: { PushNotificationSettingsPanel },
+    template: `
+      <div style="max-width:800px;background:var(--bg-secondary);border-radius:12px;border:1px solid var(--border-default);overflow:hidden">
+        <div style="padding:24px 28px;border-bottom:1px solid var(--border-default)">
+          <h2 style="margin:0;font-size:1.1rem;font-weight:600">Notifications</h2>
+          <p style="margin:4px 0 0;font-size:0.875rem;color:var(--text-secondary)">Manage browser push notifications for this device.</p>
+        </div>
+        <div style="padding:24px 28px">
+          <PushNotificationSettingsPanel />
+        </div>
+      </div>
+    `,
+  }),
+}

--- a/autobot-frontend/src/components/settings/PushNotificationSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/PushNotificationSettingsPanel.vue
@@ -1,0 +1,300 @@
+<!--
+AutoBot - AI-Powered Automation Platform
+Copyright (c) 2025 mrveiss
+Author: mrveiss
+
+PushNotificationSettingsPanel.vue — per-device web push notification toggle
+Issue GH#4459: Web push notifications for async task completion
+-->
+
+<template>
+  <div class="push-notification-settings-panel">
+    <!-- Browser not supported -->
+    <div v-if="!isSupported" class="unsupported-state">
+      <Icon name="bell-slash" />
+      <p>Push notifications are not supported in this browser.</p>
+      <p class="hint">Try Chrome, Edge, or Firefox on desktop.</p>
+    </div>
+
+    <!-- Supported -->
+    <template v-else>
+      <!-- Error banner -->
+      <div v-if="error" class="error-banner" role="alert">
+        <Icon name="exclamation-triangle" />
+        <span>{{ error }}</span>
+        <button class="dismiss-btn" @click="clearError" aria-label="Dismiss error">
+          <Icon name="times" />
+        </button>
+      </div>
+
+      <!-- Permission denied warning -->
+      <div v-if="permissionState === 'denied'" class="permission-denied-banner">
+        <Icon name="ban" />
+        <span>
+          Notifications are blocked. Enable them in your browser's site settings, then reload this
+          page.
+        </span>
+      </div>
+
+      <!-- Main toggle row -->
+      <div class="toggle-row">
+        <div class="toggle-info">
+          <span class="toggle-label">Browser push notifications</span>
+          <span class="toggle-description">
+            Receive notifications when background tasks complete — even when AutoBot is not the
+            active tab.
+          </span>
+        </div>
+
+        <button
+          :class="['toggle-btn', { active: subscribed, loading: loading }]"
+          :disabled="loading || permissionState === 'denied'"
+          :aria-pressed="subscribed"
+          :aria-label="subscribed ? 'Disable push notifications' : 'Enable push notifications'"
+          @click="handleToggle"
+        >
+          <span class="toggle-track">
+            <span class="toggle-thumb" />
+          </span>
+          <span class="toggle-text">
+            <template v-if="loading">
+              <Icon name="spinner" class="spin" />
+              {{ subscribed ? 'Disabling…' : 'Enabling…' }}
+            </template>
+            <template v-else>
+              {{ subscribed ? 'On' : 'Off' }}
+            </template>
+          </span>
+        </button>
+      </div>
+
+      <!-- Status line -->
+      <p class="status-line">
+        <template v-if="subscribed">
+          <Icon name="check-circle" class="status-icon ok" />
+          Notifications are active on this device.
+        </template>
+        <template v-else-if="permissionState === 'granted'">
+          <Icon name="info-circle" class="status-icon info" />
+          Permission granted — toggle on to receive notifications.
+        </template>
+        <template v-else-if="permissionState === 'default'">
+          <Icon name="info-circle" class="status-icon info" />
+          Toggle on to be asked for notification permission.
+        </template>
+      </p>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Icon from '@/components/ui/Icon.vue'
+import { usePushNotifications } from '@/composables/usePushNotifications'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('PushNotificationSettingsPanel')
+
+const { subscribed, permissionState, loading, error: pushError, isSupported, subscribe, unsubscribe } =
+  usePushNotifications()
+
+// Re-expose error as writable ref for dismiss button
+import { ref, watch } from 'vue'
+const error = ref<string | null>(null)
+watch(pushError, (v: string | null) => (error.value = v))
+
+function clearError() {
+  error.value = null
+}
+
+async function handleToggle() {
+  logger.info('Push toggle clicked, subscribed=', subscribed.value)
+  if (subscribed.value) {
+    await unsubscribe()
+  } else {
+    await subscribe()
+  }
+}
+</script>
+
+<style scoped>
+.push-notification-settings-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.unsupported-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-10);
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.unsupported-state .hint {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+}
+
+.error-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3) var(--spacing-4);
+  background: var(--color-error-bg);
+  color: var(--color-error);
+  border: 1px solid var(--color-error);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+}
+
+.error-banner .dismiss-btn {
+  margin-left: auto;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  padding: 0;
+  line-height: 1;
+}
+
+.permission-denied-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3) var(--spacing-4);
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+  border: 1px solid var(--color-warning);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+}
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+}
+
+.toggle-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.toggle-label {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.toggle-description {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  max-width: 420px;
+  line-height: 1.5;
+}
+
+/* Toggle button */
+.toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-1-5) var(--spacing-3);
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  transition: all var(--duration-200);
+  white-space: nowrap;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.toggle-btn.active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--text-on-primary, #fff);
+}
+
+.toggle-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.toggle-btn.loading {
+  opacity: 0.7;
+}
+
+.toggle-track {
+  display: inline-flex;
+  width: 32px;
+  height: 18px;
+  background: var(--border-color);
+  border-radius: var(--radius-full);
+  padding: 2px;
+  transition: background var(--duration-200);
+}
+
+.toggle-btn.active .toggle-track {
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.toggle-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--text-secondary);
+  transition: transform var(--duration-200), background var(--duration-200);
+}
+
+.toggle-btn.active .toggle-thumb {
+  transform: translateX(14px);
+  background: #fff;
+}
+
+.toggle-text {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  min-width: 56px;
+}
+
+.spin {
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.status-line {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1-5);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  padding: 0 var(--spacing-1);
+}
+
+.status-icon {
+  flex-shrink: 0;
+}
+
+.status-icon.ok {
+  color: var(--color-success);
+}
+
+.status-icon.info {
+  color: var(--color-info, var(--color-primary));
+}
+</style>

--- a/autobot-frontend/src/composables/__tests__/usePushNotifications.test.ts
+++ b/autobot-frontend/src/composables/__tests__/usePushNotifications.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for usePushNotifications composable (GH#4459)
+ *
+ * Coverage:
+ * - Unsupported browser detection
+ * - subscribe() → requestPermission → VAPID key fetch → pushManager.subscribe → POST backend
+ * - subscribe() when permission is 'denied'
+ * - unsubscribe() → DELETE backend → pushManager.unsubscribe
+ * - Error propagation into error ref
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockPost = vi.fn()
+const mockGet = vi.fn()
+vi.mock('@/utils/ApiClient', () => ({
+  default: { get: mockGet, post: mockPost },
+}))
+
+const mockFetchWithAuth = vi.fn()
+vi.mock('@/utils/fetchWithAuth', () => ({ fetchWithAuth: mockFetchWithAuth }))
+
+vi.mock('@/config/ssot-config', () => ({ getApiBase: () => '/api' }))
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const makePushSubscription = (endpoint = 'https://push.example.com/sub') => ({
+  endpoint,
+  toJSON: () => ({
+    endpoint,
+    keys: { p256dh: 'cHVibGljS2V5', auth: 'YXV0aEtleQ==' },
+  }),
+  unsubscribe: vi.fn().mockResolvedValue(true),
+})
+
+function mockPushSupported(
+  permissionState: NotificationPermission = 'default',
+  existingSub: ReturnType<typeof makePushSubscription> | null = null,
+  requestPermissionResult: NotificationPermission = 'granted',
+) {
+  const sub = existingSub
+
+  const pushManager = {
+    getSubscription: vi.fn().mockResolvedValue(sub),
+    subscribe: vi.fn().mockResolvedValue(makePushSubscription()),
+  }
+
+  Object.defineProperty(window, 'Notification', {
+    value: {
+      permission: permissionState,
+      requestPermission: vi.fn().mockResolvedValue(requestPermissionResult),
+    },
+    writable: true,
+    configurable: true,
+  })
+
+  Object.defineProperty(navigator, 'serviceWorker', {
+    value: {
+      ready: Promise.resolve({ pushManager }),
+    },
+    writable: true,
+    configurable: true,
+  })
+
+  Object.defineProperty(window, 'PushManager', {
+    value: class {},
+    writable: true,
+    configurable: true,
+  })
+
+  return { pushManager }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('usePushNotifications', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockPost.mockReset()
+    mockGet.mockReset()
+    mockFetchWithAuth.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('isSupported', () => {
+    it('returns false when Notification API is absent', async () => {
+      Object.defineProperty(window, 'Notification', { value: undefined, writable: true, configurable: true })
+      Object.defineProperty(window, 'PushManager', { value: undefined, writable: true, configurable: true })
+
+      const { usePushNotifications } = await import('../usePushNotifications')
+      const { isSupported } = usePushNotifications()
+      expect(isSupported).toBe(false)
+    })
+
+    it('returns true when all APIs are present', async () => {
+      mockPushSupported()
+      const { usePushNotifications } = await import('../usePushNotifications')
+      const { isSupported } = usePushNotifications()
+      expect(isSupported).toBe(true)
+    })
+  })
+
+  describe('subscribe()', () => {
+    it('fetches VAPID key, subscribes via PushManager, and POSTs to backend', async () => {
+      const { pushManager } = mockPushSupported('default', null, 'granted')
+      mockGet.mockResolvedValue({ vapidPublicKey: 'dGVzdEtleQ==' }) // base64 "testKey"
+      mockPost.mockResolvedValue({ status: 'subscribed' })
+
+      const { usePushNotifications } = await import('../usePushNotifications')
+      const { subscribe, subscribed, error } = usePushNotifications()
+
+      await subscribe()
+
+      expect(mockGet).toHaveBeenCalledWith('/api/push/vapid-public-key')
+      expect(pushManager.subscribe).toHaveBeenCalledWith(
+        expect.objectContaining({ userVisibleOnly: true }),
+      )
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/push/subscribe',
+        expect.objectContaining({ endpoint: expect.any(String) }),
+      )
+      expect(subscribed.value).toBe(true)
+      expect(error.value).toBeNull()
+    })
+
+    it('sets error when permission is denied', async () => {
+      mockPushSupported('denied', null, 'denied')
+
+      const { usePushNotifications } = await import('../usePushNotifications')
+      const { subscribe, subscribed, error } = usePushNotifications()
+
+      await subscribe()
+
+      expect(subscribed.value).toBe(false)
+      expect(error.value).toContain('denied')
+      expect(mockPost).not.toHaveBeenCalled()
+    })
+
+    it('sets error when backend POST fails', async () => {
+      mockPushSupported('granted', null, 'granted')
+      mockGet.mockResolvedValue({ vapidPublicKey: 'dGVzdEtleQ==' })
+      mockPost.mockRejectedValue(new Error('HTTP 500: Internal Server Error'))
+
+      const { usePushNotifications } = await import('../usePushNotifications')
+      const { subscribe, subscribed, error } = usePushNotifications()
+
+      await subscribe()
+
+      expect(subscribed.value).toBe(false)
+      expect(error.value).toContain('HTTP 500')
+    })
+  })
+
+  describe('unsubscribe()', () => {
+    it('calls DELETE endpoint and unsubscribes via PushManager', async () => {
+      const existingSub = makePushSubscription()
+      // Start with existing subscription so getSubscription returns it
+      mockPushSupported('granted', existingSub, 'granted')
+      mockGet.mockResolvedValue({ vapidPublicKey: 'dGVzdEtleQ==' })
+      mockPost.mockResolvedValue({ status: 'subscribed' })
+      mockFetchWithAuth.mockResolvedValue({ ok: true, status: 200 })
+
+      const { usePushNotifications } = await import('../usePushNotifications')
+      const push = usePushNotifications()
+      // Subscribe first so _subscribed is true
+      await push.subscribe()
+
+      // Reset mocks for the actual unsubscribe call
+      mockFetchWithAuth.mockResolvedValue({ ok: true, status: 200 })
+
+      await push.unsubscribe()
+
+      expect(mockFetchWithAuth).toHaveBeenCalledWith(
+        expect.stringContaining('/api/push/unsubscribe'),
+        expect.objectContaining({ method: 'DELETE' }),
+      )
+      expect(existingSub.unsubscribe).toHaveBeenCalled()
+      expect(push.subscribed.value).toBe(false)
+    })
+
+    it('sets error when DELETE fails with non-404 status', async () => {
+      const existingSub = makePushSubscription()
+      mockPushSupported('granted', existingSub, 'granted')
+      mockFetchWithAuth.mockResolvedValue({ ok: false, status: 500 })
+
+      const { usePushNotifications } = await import('../usePushNotifications')
+      const push = usePushNotifications()
+
+      await push.unsubscribe()
+
+      expect(push.error.value).toContain('HTTP 500')
+    })
+
+    it('tolerates 404 from backend (subscription already gone)', async () => {
+      const existingSub = makePushSubscription()
+      mockPushSupported('granted', existingSub, 'granted')
+      mockFetchWithAuth.mockResolvedValue({ ok: false, status: 404 })
+
+      const { usePushNotifications } = await import('../usePushNotifications')
+      const push = usePushNotifications()
+
+      await push.unsubscribe()
+
+      expect(push.error.value).toBeNull()
+      expect(push.subscribed.value).toBe(false)
+    })
+  })
+})

--- a/autobot-frontend/src/composables/usePushNotifications.ts
+++ b/autobot-frontend/src/composables/usePushNotifications.ts
@@ -1,0 +1,177 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+import { ref, readonly } from 'vue'
+import apiClient from '@/utils/ApiClient'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { getApiBase } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('usePushNotifications')
+
+export type PushPermissionState = 'default' | 'granted' | 'denied' | 'unsupported'
+
+// Module-level singleton — subscription state survives navigation
+const _subscribed = ref(false)
+const _permissionState = ref<PushPermissionState>('default')
+const _loading = ref(false)
+const _error = ref<string | null>(null)
+
+function _getPushSupported(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    'Notification' in window &&
+    'serviceWorker' in navigator &&
+    'PushManager' in window
+  )
+}
+
+function _urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const rawData = atob(base64)
+  return Uint8Array.from(Array.from(rawData).map((c) => c.charCodeAt(0)))
+}
+
+async function _getVapidPublicKey(): Promise<string> {
+  const data = await apiClient.get<{ vapidPublicKey: string }>(
+    `${getApiBase()}/push/vapid-public-key`,
+  )
+  return data.vapidPublicKey
+}
+
+// Sync subscription state once the SW is ready (fire-and-forget, best-effort)
+if (_getPushSupported()) {
+  _permissionState.value = Notification.permission as PushPermissionState
+  navigator.serviceWorker.ready
+    .then((reg) => reg.pushManager.getSubscription())
+    .then((sub) => {
+      _subscribed.value = sub !== null
+    })
+    .catch(() => {})
+}
+
+/**
+ * Composable for Web Push Notification lifecycle (GH#4459).
+ *
+ * - requestPermission() asks the user for Notification permission.
+ * - subscribe() fetches VAPID key, creates PushSubscription, POSTs to backend.
+ * - unsubscribe() removes subscription locally and DELETEs from backend.
+ * - State is module-level so it survives navigation without re-requesting.
+ */
+export function usePushNotifications() {
+  const isSupported = _getPushSupported()
+
+  if (!isSupported) {
+    _permissionState.value = 'unsupported'
+  }
+
+  async function requestPermission(): Promise<PushPermissionState> {
+    if (!isSupported) {
+      _permissionState.value = 'unsupported'
+      return 'unsupported'
+    }
+    const result = await Notification.requestPermission()
+    _permissionState.value = result as PushPermissionState
+    return result as PushPermissionState
+  }
+
+  async function subscribe(): Promise<void> {
+    if (!isSupported) {
+      _error.value = 'Push notifications are not supported in this browser.'
+      return
+    }
+    if (_loading.value) return
+
+    _loading.value = true
+    _error.value = null
+
+    try {
+      let permission: PushPermissionState = Notification.permission as PushPermissionState
+      if (permission === 'default') {
+        permission = await requestPermission()
+      }
+      if (permission !== 'granted') {
+        _error.value =
+          permission === 'denied'
+            ? 'Notification permission denied. Enable it in your browser settings.'
+            : 'Notification permission was not granted.'
+        return
+      }
+
+      const reg = await navigator.serviceWorker.ready
+      const [vapidPublicKey] = await Promise.all([_getVapidPublicKey()])
+      const applicationServerKey = _urlBase64ToUint8Array(vapidPublicKey)
+
+      const subscription = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: applicationServerKey as BufferSource,
+      })
+
+      const json = subscription.toJSON()
+      const keys = json.keys as { p256dh?: string; auth?: string } | undefined
+
+      await apiClient.post(`${getApiBase()}/push/subscribe`, {
+        endpoint: json.endpoint,
+        p256dh: keys?.p256dh ?? '',
+        auth: keys?.auth ?? '',
+      })
+
+      _subscribed.value = true
+      logger.info('Push subscription created')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      logger.error('Push subscribe failed:', msg)
+      _error.value = `Could not enable push notifications: ${msg}`
+    } finally {
+      _loading.value = false
+    }
+  }
+
+  async function unsubscribe(): Promise<void> {
+    if (!isSupported || _loading.value) return
+
+    _loading.value = true
+    _error.value = null
+
+    try {
+      const reg = await navigator.serviceWorker.ready
+      const subscription = await reg.pushManager.getSubscription()
+
+      if (subscription) {
+        // DELETE with body — use fetchWithAuth since ApiClient.delete has no body support
+        const base = getApiBase()
+        const response = await fetchWithAuth(`${location.origin}${base}/push/unsubscribe`, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ endpoint: subscription.endpoint }),
+        })
+        if (!response.ok && response.status !== 404) {
+          throw new Error(`HTTP ${response.status}`)
+        }
+        await subscription.unsubscribe()
+      }
+
+      _subscribed.value = false
+      logger.info('Push subscription removed')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      logger.error('Push unsubscribe failed:', msg)
+      _error.value = `Could not disable push notifications: ${msg}`
+    } finally {
+      _loading.value = false
+    }
+  }
+
+  return {
+    subscribed: readonly(_subscribed),
+    permissionState: readonly(_permissionState),
+    loading: readonly(_loading),
+    error: readonly(_error),
+    isSupported,
+    requestPermission,
+    subscribe,
+    unsubscribe,
+  }
+}

--- a/autobot-frontend/src/views/SettingsView.vue
+++ b/autobot-frontend/src/views/SettingsView.vue
@@ -81,6 +81,13 @@ Issue #753: User preference management interface
           <Icon name="bookmark" />
           {{ $t('settings.presets.title') }}
         </button>
+        <button
+          @click="activeTab = 'notifications'"
+          :class="['settings-tab', { active: activeTab === 'notifications' }]"
+        >
+          <Icon name="bell" />
+          Notifications
+        </button>
       </div>
 
       <!-- Tab Content -->
@@ -242,6 +249,20 @@ Issue #753: User preference management interface
             <PresetsSettingsPanel />
           </div>
         </section>
+
+        <!-- GH#4459: Web push notification toggle -->
+        <section v-if="activeTab === 'notifications'" class="settings-section">
+          <div class="section-header">
+            <h2 class="section-title">
+              <Icon name="bell" />
+              Notifications
+            </h2>
+            <p class="section-description">Manage browser push notifications for this device.</p>
+          </div>
+          <div class="section-content">
+            <PushNotificationSettingsPanel />
+          </div>
+        </section>
       </div>
 
     <ApiKeySetupWizard v-model="showApiKeyWizard" @saved="onApiKeysSaved" />
@@ -258,6 +279,7 @@ import ApiKeySetupWizard from '@/components/settings/ApiKeySetupWizard.vue'
 import ConnectionSettingsPanel from '@/components/desktop/ConnectionSettingsPanel.vue'
 import FeatureFlagsSettingsPanel from '@/components/settings/FeatureFlagsSettingsPanel.vue'
 import PresetsSettingsPanel from '@/components/settings/PresetsSettingsPanel.vue'
+import PushNotificationSettingsPanel from '@/components/settings/PushNotificationSettingsPanel.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -271,7 +293,7 @@ const { showToast } = useNotificationBus()
 
 logger.debug('Settings view initialized')
 
-type PreferenceTab = 'appearance' | 'language' | 'voice' | 'webresearch' | 'apikeys' | 'connection' | 'featureflags' | 'presets'
+type PreferenceTab = 'appearance' | 'language' | 'voice' | 'webresearch' | 'apikeys' | 'connection' | 'featureflags' | 'presets' | 'notifications'
 const activeTab = ref<PreferenceTab>('appearance')
 const showApiKeyWizard = ref(false)
 


### PR DESCRIPTION
## Thinking Path

Web push notifications require a service worker push event handler, a VAPID key exchange with the backend, and a user-facing toggle in Settings. The frontend must work when the tab is not focused, so push handling lives in the existing service worker rather than Vue app logic. Module-level singleton state (`usePushNotifications`) avoids re-requesting permission on navigation. `fetchWithAuth` is used for the DELETE endpoint because `ApiClient.delete` does not support a request body.

## What Changed

- `public/service-worker.js` — added `push` and `notificationclick` event handlers; push shows a browser notification, click focuses/opens the AutoBot tab with the embedded URL
- `src/composables/usePushNotifications.ts` — new composable: VAPID subscribe/unsubscribe, permission flow, module-level singleton reactive state, error propagation
- `src/components/settings/PushNotificationSettingsPanel.vue` — new component: per-device toggle, permission-denied banner, unsupported browser guard, loading/error state
- `src/components/settings/PushNotificationSettingsPanel.stories.ts` — two Storybook stories for the new panel
- `src/composables/__tests__/usePushNotifications.test.ts` — 8 Vitest tests covering isSupported, subscribe (VAPID flow, permission denied, backend error), unsubscribe (success, 404 tolerated, 500 error)
- `src/views/SettingsView.vue` — added "Notifications" tab wired to `PushNotificationSettingsPanel`; extended `PreferenceTab` type

## Verification

```bash
# Run unit tests
cd autobot-frontend && npx vitest run src/composables/__tests__/usePushNotifications.test.ts

# Manual QA
# 1. Open Settings → Notifications tab
# 2. Toggle push on → browser permission prompt appears
# 3. Accept → subscribed state shown, backend POST /api/push/subscribe called
# 4. Toggle off → DELETE /api/push/unsubscribe called
# 5. Test push in background tab — notification appears; click opens AutoBot tab
```

## Risks

- Storybook visual regression CI failure is expected for net-new stories (new baseline required). Not a code defect.
- Push permission state is device-scoped; no cross-device sync (by design for this MVP).
- `navigator.serviceWorker.ready` blocks if SW registration fails — guarded by `isSupported` check.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Closes #4459
Resolves [MVA-1593](/MVA/issues/MVA-1593)

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (8 Vitest tests passing)
- [x] Documentation updated if behavior changed
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff