### PR TITLE
fix(agent-loop): add refutation_source to Assertion.to_dict() (#9069)

### DIFF
--- a/autobot-backend/agent_loop/types.py
+++ b/autobot-backend/agent_loop/types.py
@@ -311,6 +311,9 @@ class ToolExecutionRef:
     iteration: int
     call_hash: str
 
+    def to_dict(self) -> dict:
+        return {"tool_name": self.tool_name, "iteration": self.iteration, "call_hash": self.call_hash}
+
 
 @dataclass
 class Assertion:
@@ -334,11 +337,10 @@ class Assertion:
             "key": self.key,
             "value": self.value,
             "confidence": self.confidence,
-            "sources": [
-                {"tool_name": s.tool_name, "iteration": s.iteration, "call_hash": s.call_hash} for s in self.sources
-            ],
+            "sources": [s.to_dict() for s in self.sources],
             "confirmed_at": self.confirmed_at.isoformat(),
             "refuted_at": self.refuted_at.isoformat() if self.refuted_at else None,
+            "refutation_source": self.refutation_source.to_dict() if self.refutation_source else None,
             "is_active": self.is_active,
         }
 


### PR DESCRIPTION
## Thinking Path

`Assertion.to_dict()` serialized `sources` as inline dicts but had no mechanism to serialize `refutation_source` — a field added when contradiction tracking was introduced. Adding `ToolExecutionRef.to_dict()` both fixes the omission (via `refutation_source.to_dict() if self.refutation_source else None`) and DRYs up the sources list serialization.

## What Changed

- `autobot-backend/agent_loop/types.py`: added `ToolExecutionRef.to_dict()` helper; updated `Assertion.to_dict()` to use `s.to_dict()` for sources and include `refutation_source` field

## Verification

```bash
# Import smoke test
python -c 'from agent_loop.types import Assertion, ToolExecutionRef; print("OK")'

# Verify refutation_source included in serialization
python -c "
from agent_loop.types import Assertion, ToolExecutionRef
from datetime import datetime, timezone
ref = ToolExecutionRef('tool', 1, 'hash')
a = Assertion('k', 'v', 1.0, [ref], datetime.now(timezone.utc))
d = a.to_dict()
assert 'refutation_source' in d
assert d['refutation_source'] is None
print('OK:', d.keys())
"
```

## Risks

None — pure additive change. No existing callers are broken.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Fixes https://github.com/mrveiss/AutoBot-AI/issues/9069

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (N/A — pure additive serialization fix, covered by import smoke test)
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff