### PR TITLE
fix(llm-routing): call public chat_completion() instead of private _chat_completion_impl() (#8960)

### DIFF
--- a/autobot-backend/llm_shared/tiered_routing/complexity_router.py
+++ b/autobot-backend/llm_shared/tiered_routing/complexity_router.py
@@ -164,7 +164,7 @@ class ComplexityRouter:
             if claude is None:
                 logger.warning("ComplexityRouter: Anthropic provider not available; falling through")
                 return None
-            response = await claude._chat_completion_impl(escalation_request)
+            response = await claude.chat_completion(escalation_request)
             if response.error:
                 logger.warning(
                     "ComplexityRouter: Claude escalation returned error=%s; falling through",


### PR DESCRIPTION
## Thinking Path

`route_with_escalation()` in `complexity_router.py` was calling `claude._chat_completion_impl()` directly, bypassing the public `chat_completion()` wrapper defined in `BaseProvider`. The wrapper adds cross-worker Redis rate limiting (Issue #8170), exponential backoff/auto-resume on provider rate-limit (GH#8502), and observer fan-out (GH#6593). Calling the private method skips all three, making escalation paths second-class citizens.

Fix: call `claude.chat_completion()` — the existing public API — which internally calls `_chat_completion_impl` with the wrappers applied.

GH#8959 (singleton) and GH#8961 (provider registry) were already fixed in earlier commits on Dev_new_gui.

## What Changed

- `autobot-backend/llm_shared/tiered_routing/complexity_router.py` line 167: `claude._chat_completion_impl(escalation_request)` → `claude.chat_completion(escalation_request)` (1-line fix)

## Verification

- `python3 -m py_compile autobot-backend/llm_shared/tiered_routing/complexity_router.py` passes
- CI smoke-test running (startup-import-smoke, smoke-test)
- `AnthropicProvider` inherits `chat_completion` from `BaseProvider` which wraps `_chat_completion_impl` with rate limiting, retry, and telemetry

## Model Used

claude-sonnet-4-6

Refs: GH#8960 GH#8959 GH#8961