### PR TITLE
security(auth+embed): rate-limit shared link access + embed origin allowlist (#9127 #9117)

### DIFF
--- a/autobot-backend/api/chat_embed.py
+++ b/autobot-backend/api/chat_embed.py
@@ -25,7 +25,7 @@ import json
 import os
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
@@ -70,7 +70,7 @@ def _check_embed_origin(request: Request) -> str | None:
     origin = request.headers.get("origin", "")
     if not origin or origin not in _EMBED_ALLOWED_ORIGINS:
         logger.warning("embed: blocked request from disallowed origin %r", origin or "(none)")
-        raise _origin_forbidden()
+        raise HTTPException(status_code=403, detail="Origin not allowed")
     return origin
 
 

--- a/autobot-backend/api/chat_embed.py
+++ b/autobot-backend/api/chat_embed.py
@@ -11,9 +11,18 @@ no auth.
 
 Endpoints:
     POST /api/chats/embed/message  — send a message, receive JSON reply
+
+Config:
+    AUTOBOT_EMBED_ALLOWED_ORIGINS — comma-separated list of allowed request
+        origins, e.g. "https://example.com,https://app.acme.io".
+        When set to "*" (the default) all origins are permitted (backward
+        compatible open mode).  When any specific origins are listed only
+        those origins may call the embed endpoint; requests from other
+        origins receive 403 (GH#9117).
 """
 
 import json
+import os
 from typing import Any
 
 from fastapi import APIRouter, Request
@@ -25,6 +34,53 @@ from autobot_shared.logging_manager import get_logger
 logger = get_logger(__name__)
 
 router = APIRouter(tags=["chat", "embed"])
+
+# ---------------------------------------------------------------------------
+# Origin allowlist (GH#9117)
+# ---------------------------------------------------------------------------
+_EMBED_ALLOWED_ORIGINS_ENV = "AUTOBOT_EMBED_ALLOWED_ORIGINS"
+_EMBED_ALLOWED_ORIGINS_RAW: str = os.environ.get(_EMBED_ALLOWED_ORIGINS_ENV, "*").strip()
+
+# When the env var is "*" (default) enforcement is disabled for backward compat.
+_EMBED_ORIGIN_ENFORCEMENT_ENABLED: bool = _EMBED_ALLOWED_ORIGINS_RAW != "*"
+_EMBED_ALLOWED_ORIGINS: frozenset[str] = (
+    frozenset(o.strip() for o in _EMBED_ALLOWED_ORIGINS_RAW.split(",") if o.strip())
+    if _EMBED_ORIGIN_ENFORCEMENT_ENABLED
+    else frozenset()
+)
+
+if _EMBED_ORIGIN_ENFORCEMENT_ENABLED:
+    logger.info(
+        "Embed origin allowlist active (%d entries): %s",
+        len(_EMBED_ALLOWED_ORIGINS),
+        ", ".join(sorted(_EMBED_ALLOWED_ORIGINS)),
+    )
+else:
+    logger.info("Embed origin allowlist: open (*) — set %s to restrict", _EMBED_ALLOWED_ORIGINS_ENV)
+
+
+def _check_embed_origin(request: Request) -> str | None:
+    """Return the validated origin string, or None when enforcement is off.
+
+    Raises JSONResponse (403) when enforcement is active and the request
+    origin is not in the allowlist.
+    """
+    if not _EMBED_ORIGIN_ENFORCEMENT_ENABLED:
+        return None
+    origin = request.headers.get("origin", "")
+    if not origin or origin not in _EMBED_ALLOWED_ORIGINS:
+        logger.warning("embed: blocked request from disallowed origin %r", origin or "(none)")
+        raise _origin_forbidden()
+    return origin
+
+
+def _origin_forbidden() -> JSONResponse:
+    return JSONResponse({"detail": "Origin not allowed"}, status_code=403)
+
+
+def _acao_header(origin: str | None) -> str:
+    """Return the Access-Control-Allow-Origin header value for a response."""
+    return origin if origin else "*"
 
 
 class EmbedMessageRequest(BaseModel):
@@ -70,8 +126,12 @@ async def embed_message(
     - anything else (default) → JSON ``{"content": "..."}``
 
     No authentication required — the endpoint is designed for unauthenticated
-    embed contexts.  Rate-limiting is delegated to the upstream reverse proxy.
+    embed contexts.  Origin enforcement via AUTOBOT_EMBED_ALLOWED_ORIGINS
+    (GH#9117).
     """
+    origin = _check_embed_origin(request)
+    acao = _acao_header(origin)
+
     accept = request.headers.get("accept", "")
     message = body.message.strip()
     if not message:
@@ -86,7 +146,7 @@ async def embed_message(
             headers={
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",
-                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Origin": acao,
                 "Access-Control-Allow-Headers": "Content-Type, X-Org-Id",
             },
         )
@@ -100,17 +160,25 @@ async def embed_message(
 
     return JSONResponse(
         {"content": content},
-        headers={"Access-Control-Allow-Origin": "*"},
+        headers={"Access-Control-Allow-Origin": acao},
     )
 
 
 @router.options("/chats/embed/message")
-async def embed_message_preflight() -> JSONResponse:
-    """CORS preflight for embed widget cross-origin requests."""
+async def embed_message_preflight(request: Request) -> JSONResponse:
+    """CORS preflight for embed widget cross-origin requests (GH#9117)."""
+    if _EMBED_ORIGIN_ENFORCEMENT_ENABLED:
+        origin = request.headers.get("origin", "")
+        if not origin or origin not in _EMBED_ALLOWED_ORIGINS:
+            return _origin_forbidden()
+        acao = origin
+    else:
+        acao = "*"
+
     return JSONResponse(
         {},
         headers={
-            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Origin": acao,
             "Access-Control-Allow-Methods": "POST, OPTIONS",
             "Access-Control-Allow-Headers": "Content-Type, X-Org-Id",
         },

--- a/autobot-backend/api/chat_shared_links.py
+++ b/autobot-backend/api/chat_shared_links.py
@@ -14,7 +14,9 @@ Authenticated (owner-only) routes:
   GET    /chat/sessions/{session_id}/share-links          — list active links for a session
 
 Config:
-  AUTOBOT_SHARED_LINK_DEFAULT_TTL — default TTL in seconds (0 = no expiry, default: 0)
+  AUTOBOT_SHARED_LINK_DEFAULT_TTL    — default TTL in seconds (0 = no expiry, default: 0)
+  AUTOBOT_SHARED_LINK_ACCESS_RPM     — max password attempts per minute per IP (default: 10)
+  AUTOBOT_SHARED_LINK_ACCESS_RPH     — max password attempts per hour per IP (default: 100)
 """
 
 import os
@@ -38,6 +40,8 @@ from api.user_management.dependencies import get_db_session
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.proxy_utils import get_client_ip
+from autobot_shared.rate_limiter import RateLimiter
 from autobot_shared.time_utils import now_utc
 from models.chat_shared_link import ChatSharedLink
 from security.session_ownership import SessionOwnershipValidator
@@ -55,6 +59,22 @@ if _DEFAULT_TTL_SECONDS > 0:
     logger.info("Shared link default TTL: %ds (from %s)", _DEFAULT_TTL_SECONDS, _DEFAULT_TTL_ENV)
 else:
     logger.info("Shared link default TTL: none (links never expire unless requested)")
+
+# Rate limiter for the unauthenticated /access endpoint — brute-force guard (GH#9127).
+# Keyed per client IP, sliding-window via Redis.
+_ACCESS_RPM: int = int(os.environ.get("AUTOBOT_SHARED_LINK_ACCESS_RPM", "10"))
+_ACCESS_RPH: int = int(os.environ.get("AUTOBOT_SHARED_LINK_ACCESS_RPH", "100"))
+_access_limiter = RateLimiter(
+    scope_prefix="shared_link_access",
+    default_tier="anonymous",
+    requests_per_minute=_ACCESS_RPM,
+    requests_per_hour=_ACCESS_RPH,
+)
+logger.info(
+    "Shared link access rate limit: %d/min %d/hr per IP (AUTOBOT_SHARED_LINK_ACCESS_RPM/RPH)",
+    _ACCESS_RPM,
+    _ACCESS_RPH,
+)
 
 _TOKEN_BYTES = 24  # 32-char URL-safe base64 token
 
@@ -299,7 +319,17 @@ async def access_shared_session(
     request: Request,
     db: AsyncSession = Depends(get_db_session),
 ) -> Dict[str, Any]:
-    """Verify password and return conversation content (GH#8996)."""
+    """Verify password and return conversation content (GH#8996, rate-limited GH#9127)."""
+    client_ip = get_client_ip(request) or "unknown"
+    allowed = await _access_limiter.acquire(client_ip)
+    if not allowed:
+        retry_after = await _access_limiter.get_retry_after_seconds(client_ip)
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many access attempts. Please try again later.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
     link = await _resolve_link(token, db)
 
     if link.has_password:


### PR DESCRIPTION
## Thinking Path

The shared-link `/access` endpoint was unauthenticated and lacked rate limiting — an attacker could brute-force shared link passwords without any throttling (Issue #9127). Separately, the embed widget used `Access-Control-Allow-Origin: *` with no origin gating, allowing any third-party site to embed the AutoBot chat widget and potentially scrape responses (Issue #9117). Both are hardened in this PR using existing infrastructure: `autobot_shared.rate_limiter.RateLimiter` (Redis-backed sliding window, already used for API endpoints) for rate limiting, and a new `AUTOBOT_EMBED_ALLOWED_ORIGINS` env var for origin enforcement. Default behaviour is backward-compatible in both cases.

## What Changed

- `autobot-backend/api/chat_shared_links.py`: Added `RateLimiter` on `POST /chat/shared/{token}/access` — 10 req/min / 100 req/hr per client IP (configurable via `AUTOBOT_SHARED_LINK_ACCESS_RPM` / `AUTOBOT_SHARED_LINK_ACCESS_RPH`), returns 429 with `Retry-After` header, falls back to allow-all when Redis is unavailable
- `autobot-backend/api/chat_embed.py`: Added `AUTOBOT_EMBED_ALLOWED_ORIGINS` env var (comma-separated allowed origins). Default `*` = allow all (backward compatible). When origins are set: `Origin` header checked on POST and OPTIONS; non-listed origins return 403. ACAO response header reflects the actual allowed origin.

## Verification

- startup-import-smoke CI: ✅ PASS
- SSOT Configuration Compliance: ✅ PASS
- Security Compliance Check: ✅ PASS
- SAST / CodeQL: pending CI
- Manual test plan below

## Model Used

claude-sonnet-4-6

---

## Summary

Implements two security hardening items from [MVA-1861](/MVA/issues/MVA-1861):

- **GH#9127** — Rate-limit `POST /chat/shared/{token}/access` (brute-force protection)
- **GH#9117** — Embed widget origin allowlist (CORS enforcement)

## Changes

### `api/chat_shared_links.py` (GH#9127)

- Adds `RateLimiter` scoped to `"shared_link_access"` (anonymous tier) using the existing `autobot_shared.rate_limiter.RateLimiter` (sliding-window, Redis-backed, cross-worker)
- Rate key is the client IP extracted via `autobot_shared.proxy_utils.get_client_ip` (honours trusted-proxy `X-Forwarded-For`)
- Default: **10 req/min, 100 req/hr** — configurable via `AUTOBOT_SHARED_LINK_ACCESS_RPM` / `AUTOBOT_SHARED_LINK_ACCESS_RPH`
- Exceeded limit → 429 with `Retry-After` header
- Falls back to allow-all when Redis is unavailable (no hard block)

### `api/chat_embed.py` (GH#9117)

- Adds `AUTOBOT_EMBED_ALLOWED_ORIGINS` env var (comma-separated). Default `*` = allow all (backward compatible)
- When origins are set: `Origin` header checked on `POST` and `OPTIONS`; non-listed origins → 403
- `Access-Control-Allow-Origin` response header reflects the actual allowed origin (not `*`) when enforcement is active

## Test plan

- [ ] `AUTOBOT_SHARED_LINK_ACCESS_RPM=2` → 11th `/access` attempt within a minute returns 429 with `Retry-After`
- [ ] Without env var → default 10/min behaviour, Redis-backed
- [ ] `AUTOBOT_EMBED_ALLOWED_ORIGINS=*` (default) → any `Origin` accepted (no regression)
- [ ] `AUTOBOT_EMBED_ALLOWED_ORIGINS=https://allowed.example.com` → `https://allowed.example.com` accepted, others 403
- [ ] Preflight OPTIONS with disallowed origin → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)