### PR TITLE
fix(ci): resolve Black formatting and oxlint errors on Dev_new_gui

### DIFF
--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -110,7 +110,11 @@ jobs:
         # file/directory presence is what we can measure pre-deploy.
         python3 autobot-infrastructure/shared/scripts/phase_validation_system.py \
           --ci-mode --output-format json \
-          > phase_validation_results.json \
+          > phase_validation_results.json || true
+        # Only apply zero-maturity fallback when the script produced no valid JSON
+        # (e.g. import error). A non-zero exit due to Redis unavailability still
+        # writes valid JSON — overwriting it with 0 was the cause of false failures.
+        python3 -c 'import json; json.load(open("phase_validation_results.json"))' 2>/dev/null \
           || echo '{"overall_maturity": 0, "phases": []}' > phase_validation_results.json
 
         # Display results summary

--- a/autobot-backend/cli/agent_wiki.py
+++ b/autobot-backend/cli/agent_wiki.py
@@ -30,9 +30,9 @@ def _get_company_id(args: argparse.Namespace) -> uuid.UUID:
 
 
 async def _list(args: argparse.Namespace) -> None:
-    from user_management.database import get_async_session_factory
-
     from autobot_backend.llc.services.agent_wiki_service import AgentWikiService
+
+    from user_management.database import get_async_session_factory
 
     company_id = _get_company_id(args)
     factory = get_async_session_factory()
@@ -49,9 +49,9 @@ async def _list(args: argparse.Namespace) -> None:
 
 
 async def _create(args: argparse.Namespace) -> None:
-    from user_management.database import get_async_session_factory
-
     from autobot_backend.llc.services.agent_wiki_service import AgentWikiService
+
+    from user_management.database import get_async_session_factory
 
     company_id = _get_company_id(args)
     factory = get_async_session_factory()
@@ -71,9 +71,9 @@ async def _create(args: argparse.Namespace) -> None:
 
 
 async def _delete(args: argparse.Namespace) -> None:
-    from user_management.database import get_async_session_factory
-
     from autobot_backend.llc.services.agent_wiki_service import AgentWikiService
+
+    from user_management.database import get_async_session_factory
 
     company_id = _get_company_id(args)
     factory = get_async_session_factory()
@@ -89,9 +89,9 @@ async def _delete(args: argparse.Namespace) -> None:
 
 
 async def _context(args: argparse.Namespace) -> None:
-    from user_management.database import get_async_session_factory
-
     from autobot_backend.llc.services.agent_wiki_service import AgentWikiService
+
+    from user_management.database import get_async_session_factory
 
     company_id = _get_company_id(args)
     factory = get_async_session_factory()

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -10,6 +10,7 @@ Bridges ConnectorConfig ↔ SecretsService so that sensitive auth fields
 
 import asyncio
 import json
+
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -10,8 +10,6 @@ Bridges ConnectorConfig ↔ SecretsService so that sensitive auth fields
 
 import asyncio
 import json
-from typing import Optional
-
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 

--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -4,8 +4,8 @@ from fastapi import APIRouter
 
 from .activity import router as activity_router
 from .agent_api import router as agent_router
-from .agent_wiki import router as agent_wiki_router
 from .agent_hires import router as agent_hires_router
+from .agent_wiki import router as agent_wiki_router
 from .agents import router as agents_router
 from .api_keys import router as api_keys_router
 from .approvals import router as approvals_router

--- a/autobot-backend/llc/api/agent_api.py
+++ b/autobot-backend/llc/api/agent_api.py
@@ -293,12 +293,12 @@ class AgentWikiEntryOut(BaseModel):
 async def agent_list_wiki(namespace: Optional[str] = None, request: Request = None) -> Dict[str, Any]:
     """List this agent's own wiki entries."""
     agent_id, company_id = _agent_context(request)
+    import uuid as _uuid
+
     from autobot_shared.singleton_factory import lazy_singleton
     from user_management.database import get_async_session_factory
 
     from ..services.agent_wiki_service import AgentWikiService
-
-    import uuid as _uuid
 
     factory = get_async_session_factory()
     async with factory() as session:
@@ -316,12 +316,12 @@ async def agent_list_wiki(namespace: Optional[str] = None, request: Request = No
 async def agent_create_wiki_entry(body: AgentWikiEntryIn, request: Request = None) -> Dict[str, Any]:
     """Create a wiki entry scoped to this agent."""
     agent_id, company_id = _agent_context(request)
+    import uuid as _uuid
+
     from autobot_shared.singleton_factory import lazy_singleton
     from user_management.database import get_async_session_factory
 
     from ..services.agent_wiki_service import AgentWikiService
-
-    import uuid as _uuid
 
     factory = get_async_session_factory()
     async with factory() as session:

--- a/autobot-backend/llm_shared/providers/vertexai.py
+++ b/autobot-backend/llm_shared/providers/vertexai.py
@@ -434,7 +434,7 @@ class VertexAIProvider(BaseProvider):
     async def is_available(self) -> bool:
         """Return True when the vertexai SDK can be imported and a project is configured."""
         try:
-            import vertexai  # type: ignore[import] noqa: F401
+            import vertexai  # type: ignore[import]  # noqa: F401
         except ImportError:
             return False
         project = self._resolve_project()

--- a/autobot-backend/llm_shared/providers/vertexai.py
+++ b/autobot-backend/llm_shared/providers/vertexai.py
@@ -166,9 +166,7 @@ class VertexAIProvider(BaseProvider):
         try:
             from anthropic import AsyncAnthropicVertex  # type: ignore[import]
         except ImportError as exc:
-            raise ImportError(
-                "anthropic[vertex] not installed. Run: pip install 'anthropic[vertex]'"
-            ) from exc
+            raise ImportError("anthropic[vertex] not installed. Run: pip install 'anthropic[vertex]'") from exc
 
         project = self._resolve_project()
         location = self._resolve_location()

--- a/autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py
@@ -17,8 +17,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from knowledge.connectors.gitlab import (
-    GitLabConnector,
     GiteaConnector,
+    GitLabConnector,
     _is_text_file,
     _issue_to_text,
 )

--- a/autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py
@@ -24,7 +24,6 @@ from knowledge.connectors.gitlab import (
 )
 from knowledge.connectors.models import ConnectorConfig
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -130,8 +129,14 @@ def test_issue_to_text_basic():
 
 
 def test_issue_to_text_pr_flag():
-    issue = {"iid": 5, "title": "Add feature", "state": "merged",
-             "author": {"username": "bob"}, "created_at": "", "updated_at": ""}
+    issue = {
+        "iid": 5,
+        "title": "Add feature",
+        "state": "merged",
+        "author": {"username": "bob"},
+        "created_at": "",
+        "updated_at": "",
+    }
     text = _issue_to_text(issue, is_pr=True)
     assert "Merge Request" in text
 
@@ -171,14 +176,26 @@ async def test_gitlab_discover_sources_issues_and_mrs():
     connector = GitLabConnector(_gl_config())
 
     issues_page = [
-        {"iid": 1, "title": "Bug", "state": "opened",
-         "author": {"username": "u"}, "created_at": "2026-01-01T00:00:00Z",
-         "updated_at": "2026-01-02T00:00:00Z", "web_url": "https://gl/p/1"},
+        {
+            "iid": 1,
+            "title": "Bug",
+            "state": "opened",
+            "author": {"username": "u"},
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-02T00:00:00Z",
+            "web_url": "https://gl/p/1",
+        },
     ]
     mrs_page = [
-        {"iid": 2, "title": "Feature", "state": "merged",
-         "author": {"username": "v"}, "created_at": "2026-01-01T00:00:00Z",
-         "updated_at": "2026-01-03T00:00:00Z", "web_url": "https://gl/p/2"},
+        {
+            "iid": 2,
+            "title": "Feature",
+            "state": "merged",
+            "author": {"username": "v"},
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-03T00:00:00Z",
+            "web_url": "https://gl/p/2",
+        },
     ]
 
     async def fake_gl_get(path: str) -> Dict[str, Any]:
@@ -200,12 +217,18 @@ async def test_gitlab_detect_changes_full_sync():
 
     async def fake_gl_get(path: str) -> Dict[str, Any]:
         if "merge_requests" in path:
-            return {"status_code": 200, "body": [
-                {"iid": 10, "title": "MR", "updated_at": "2026-02-01T00:00:00Z"},
-            ]}
-        return {"status_code": 200, "body": [
-            {"iid": 5, "title": "Issue", "updated_at": "2026-01-15T00:00:00Z"},
-        ]}
+            return {
+                "status_code": 200,
+                "body": [
+                    {"iid": 10, "title": "MR", "updated_at": "2026-02-01T00:00:00Z"},
+                ],
+            }
+        return {
+            "status_code": 200,
+            "body": [
+                {"iid": 5, "title": "Issue", "updated_at": "2026-01-15T00:00:00Z"},
+            ],
+        }
 
     with (
         patch.object(connector, "_gl_get", side_effect=fake_gl_get),
@@ -347,14 +370,26 @@ async def test_gitea_discover_sources():
     connector = GiteaConnector(_gitea_config())
 
     issues = [
-        {"number": 1, "title": "Bug", "state": "open",
-         "updated_at": "2026-01-01T00:00:00Z", "html_url": "https://gitea/alice/my-repo/issues/1",
-         "user": {"login": "alice"}, "created_at": "2026-01-01T00:00:00Z"},
+        {
+            "number": 1,
+            "title": "Bug",
+            "state": "open",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "html_url": "https://gitea/alice/my-repo/issues/1",
+            "user": {"login": "alice"},
+            "created_at": "2026-01-01T00:00:00Z",
+        },
     ]
     prs = [
-        {"number": 2, "title": "PR title", "state": "open",
-         "updated_at": "2026-01-01T00:00:00Z", "html_url": "https://gitea/alice/my-repo/pulls/2",
-         "user": {"login": "alice"}, "created_at": "2026-01-01T00:00:00Z"},
+        {
+            "number": 2,
+            "title": "PR title",
+            "state": "open",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "html_url": "https://gitea/alice/my-repo/pulls/2",
+            "user": {"login": "alice"},
+            "created_at": "2026-01-01T00:00:00Z",
+        },
     ]
 
     async def fake_gitea_get(path: str) -> Dict[str, Any]:

--- a/autobot-frontend/src/composables/usePushNotifications.ts
+++ b/autobot-frontend/src/composables/usePushNotifications.ts
@@ -101,7 +101,7 @@ export function usePushNotifications() {
       }
 
       const reg = await navigator.serviceWorker.ready
-      const [vapidPublicKey] = await Promise.all([_getVapidPublicKey()])
+      const vapidPublicKey = await _getVapidPublicKey()
       const applicationServerKey = _urlBase64ToUint8Array(vapidPublicKey)
 
       const subscription = await reg.pushManager.subscribe({

--- a/autobot-frontend/src/embed/AutobotWidget.ts
+++ b/autobot-frontend/src/embed/AutobotWidget.ts
@@ -69,7 +69,7 @@ export class AutobotWidget extends HTMLElement {
     this._app = null
   }
 
-  attributeChangedCallback(name: string, _old: string | null, next: string | null): void {
+  attributeChangedCallback(_name: string, _old: string | null, _next: string | null): void {
     this._readAttributes()
     // If already mounted, re-mount with updated config
     if (this._app) {

--- a/autobot-frontend/src/embed/__tests__/AutobotWidget.test.ts
+++ b/autobot-frontend/src/embed/__tests__/AutobotWidget.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { AutobotWidget } from '../AutobotWidget'
 
 // Register custom element once per test suite


### PR DESCRIPTION
## Thinking Path

Three CI jobs failing on Dev_new_gui as of 2026-05-31:

1. **Black formatting**: 2 newly-added files (`vertexai.py`, `test_gitlab_connector.py`) were not run through `black --line-length=120` before merge. Fixed by running black on them.

2. **oxlint**: 4 lint errors introduced by recent frontend changes — an unused import, an unnecessary single-element `Promise.all()`, and two unnamed unused parameters. Fixed inline.

3. **Phase Validation false failure (root cause)**: `phase_validation_system.py` exits non-zero in CI (Redis unavailable). The `|| echo '...'` fallback was overwriting the valid 96.49% JSON it had already written to `phase_validation_results.json` with `{"overall_maturity": 0}`, causing the 60% gate to always fail. Fixed by separating exit-code handling from output validity.

## What Changed

- `autobot-backend/llm_shared/providers/vertexai.py` — Black reformat
- `autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py` — Black reformat
- `autobot-frontend/src/embed/__tests__/AutobotWidget.test.ts` — remove unused `beforeEach` import
- `autobot-frontend/src/composables/usePushNotifications.ts` — unwrap unnecessary `Promise.all()`
- `autobot-frontend/src/embed/AutobotWidget.ts` — rename unused params to `_name`/`_next`
- `.github/workflows/phase_validation.yml` — run script with `|| true`; only apply zero-maturity fallback when JSON output is invalid/empty

## Verification

- `python3 -m black --check --line-length=120 autobot-backend/ autobot-slm-backend/ autobot_shared/` → `3021 files would be left unchanged` ✅
- `npx oxlint . -D correctness --ignore-path .gitignore` (in autobot-frontend) → exit 0 ✅
- Phase Validation script locally outputs `"overall_maturity": 96.49` — workflow now preserves that value

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6) via Paperclip DevOpsEngineer agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)