### PR TITLE
bug(llc): skip LivenessMonitor DB checks in single_user mode (#9089)

### DIFF
--- a/autobot-backend/llc/scheduler/liveness_monitor.py
+++ b/autobot-backend/llc/scheduler/liveness_monitor.py
@@ -23,6 +23,7 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.redis_client import get_async_redis_client
+from user_management.config import DeploymentMode, get_deployment_config
 from user_management.database import get_async_session_factory
 
 from ..models.enums import ActivityEventType, WorkItemStatus, WorkItemType
@@ -80,6 +81,12 @@ class LivenessMonitor:
 
     async def _check_once(self) -> None:
         """Single scan — find stuck runs and trigger recovery for each."""
+        # Skip DB checks in single_user mode where PostgreSQL is not configured (#9089)
+        deployment_config = get_deployment_config()
+        if deployment_config.mode == DeploymentMode.SINGLE_USER:
+            logger.debug("LivenessMonitor: skipping check in single_user mode (no PostgreSQL)")
+            return
+
         factory = get_async_session_factory()
         async with factory() as session:
             stuck = await self._find_stuck_runs(session)

--- a/autobot-backend/llc/tests/test_liveness_monitor_single_user.py
+++ b/autobot-backend/llc/tests/test_liveness_monitor_single_user.py
@@ -1,0 +1,66 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Test LivenessMonitor single_user mode behavior (GH#9089)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.scheduler.liveness_monitor import LivenessMonitor
+from user_management.config import DeploymentConfig, DeploymentMode, FeatureFlags
+
+
+@pytest.mark.asyncio
+async def test_single_user_mode_skips_db_checks() -> None:
+    """In single_user mode, _check_once() returns early without DB access."""
+    monitor = LivenessMonitor(poll_interval=9999)
+
+    single_user_config = DeploymentConfig(
+        mode=DeploymentMode.SINGLE_USER,
+        features=FeatureFlags(),
+        postgres_enabled=False,
+    )
+
+    with (
+        patch("llc.scheduler.liveness_monitor.get_deployment_config", return_value=single_user_config),
+        patch("llc.scheduler.liveness_monitor.get_async_session_factory") as mock_factory,
+    ):
+        await monitor._check_once()
+
+        # get_async_session_factory should never be called in single_user mode
+        mock_factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multi_user_mode_proceeds_normally() -> None:
+    """In multi-user modes, _check_once() proceeds with DB checks."""
+    monitor = LivenessMonitor(poll_interval=9999)
+
+    multi_user_config = DeploymentConfig(
+        mode=DeploymentMode.SINGLE_COMPANY,
+        features=FeatureFlags(user_management=True),
+        postgres_enabled=True,
+    )
+
+    # Create session mock matching the pattern in test_liveness_monitor.py
+    session = AsyncMock()
+    # Simplest test: just verify the factory is called and no exceptions are raised
+    # We don't need to mock the full query chain for this test
+    session.execute = AsyncMock()
+    execute_result = MagicMock()
+    execute_result.scalars.return_value.all.return_value = []
+    session.execute.return_value = execute_result
+
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("llc.scheduler.liveness_monitor.get_deployment_config", return_value=multi_user_config),
+        patch("llc.scheduler.liveness_monitor.get_async_session_factory", return_value=factory) as mock_factory,
+    ):
+        await monitor._check_once()
+
+        # In multi-user mode, the factory should be called
+        mock_factory.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes LivenessMonitor crash in single_user mode when PostgreSQL is not configured.

## Thinking Path

LivenessMonitor crashes in single_user mode when PostgreSQL is not configured. The `_check_once()` method attempts DB operations via `get_async_engine()`, which raises `RuntimeError` when `postgres_enabled` is False. Added deployment mode check to skip DB operations in `SINGLE_USER` mode, as liveness monitoring is only relevant in multi-user deployments.

## What Changed

- Added deployment mode check in `_check_once()` to detect `SINGLE_USER` mode
- Returns early with debug log message when PostgreSQL is not enabled
- Added unit tests for both `single_user` and `multi-user` deployment modes
- Prevents `RuntimeError` from `get_async_engine()` when `postgres_enabled` is False

## Changes

- Added deployment mode check in `_check_once()` to skip DB operations in `SINGLE_USER` mode
- Returns early with a debug log message when PostgreSQL is not enabled
- Prevents `RuntimeError` from `get_async_engine()` when `postgres_enabled` is False

## Verification

- ✅ pytest tests pass (both single_user and multi_user mode tests)
- ✅ Syntax check: `python3 -m py_compile` passed
- ✅ Import verification: Module compiles without errors
- ✅ Function signature unchanged: no call-site impact

## Testing

- Syntax check: ✅ `python3 -m py_compile` passed
- Import verification: ✅ Module compiles without errors

## Model Used

claude-sonnet-4.5

## Resolves

- MVA-1926
- GH#9089

🤖 Generated with Paperclip
