### PR TITLE
fix(sso): remove provider_id from OAuth callback (#MVA-1734)

### DIFF
--- a/autobot-slm-backend/api/sso_auth.py
+++ b/autobot-slm-backend/api/sso_auth.py
@@ -83,7 +83,9 @@ async def initiate_sso_login(
                 detail="LDAP login requires POST to /auth/sso/ldap/login",
             )
 
-        redirect_url, state = await sso_service.initiate_oauth_login(provider_id, callback_url)
+        redirect_url, state = await sso_service.initiate_oauth_login(
+            provider_id, callback_url
+        )
 
         return SSOLoginInitResponse(
             provider_id=provider.id,
@@ -110,17 +112,16 @@ async def oauth_callback(
     request: Request,
     code: str = Query(...),
     state: str = Query(...),
-    provider_id: uuid.UUID = Query(...),
     db: AsyncSession = Depends(get_slm_db),
 ) -> RedirectResponse:
     """Handle OAuth2 callback."""
-    logger.info("Processing OAuth2 callback for provider: %s", provider_id)
+    logger.info("Processing OAuth2 callback")
     context = TenantContext(is_platform_admin=False)
     sso_service = SSOService(db, context)
 
     try:
         callback_url = _build_callback_url(request)
-        user = await sso_service.complete_oauth_login(provider_id, code, state, callback_url)
+        user = await sso_service.complete_oauth_login(code, state, callback_url)
 
         # Convert User ORM object to dict-like structure for auth_service
         user_dict = type(
@@ -128,7 +129,11 @@ async def oauth_callback(
             (),
             {
                 "username": user.username,
-                "is_admin": (user.is_platform_admin if hasattr(user, "is_platform_admin") else False),
+                "is_admin": (
+                    user.is_platform_admin
+                    if hasattr(user, "is_platform_admin")
+                    else False
+                ),
             },
         )()
 
@@ -168,7 +173,11 @@ async def ldap_login(
             (),
             {
                 "username": user.username,
-                "is_admin": (user.is_platform_admin if hasattr(user, "is_platform_admin") else False),
+                "is_admin": (
+                    user.is_platform_admin
+                    if hasattr(user, "is_platform_admin")
+                    else False
+                ),
             },
         )()
 
@@ -218,7 +227,11 @@ async def saml_callback(
             (),
             {
                 "username": user.username,
-                "is_admin": (user.is_platform_admin if hasattr(user, "is_platform_admin") else False),
+                "is_admin": (
+                    user.is_platform_admin
+                    if hasattr(user, "is_platform_admin")
+                    else False
+                ),
             },
         )()
 

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -71,7 +71,9 @@ class SSOService(BaseService):
         )
         self.session.add(provider)
         await self.session.flush()
-        logger.info("Created SSO provider: %s (%s)", provider.name, provider.provider_type)
+        logger.info(
+            "Created SSO provider: %s (%s)", provider.name, provider.provider_type
+        )
         return provider
 
     async def list_providers(
@@ -80,7 +82,9 @@ class SSOService(BaseService):
         """List SSO providers with optional filtering."""
         query = select(SSOProvider)
         if org_id is not None:
-            query = query.where((SSOProvider.org_id == org_id) | (SSOProvider.org_id.is_(None)))
+            query = query.where(
+                (SSOProvider.org_id == org_id) | (SSOProvider.org_id.is_(None))
+            )
         if active_only:
             query = query.where(SSOProvider.is_active.is_(True))
         result = await self.session.execute(query)
@@ -89,13 +93,17 @@ class SSOService(BaseService):
 
     async def get_provider(self, provider_id: uuid.UUID) -> SSOProvider:
         """Get SSO provider by ID."""
-        result = await self.session.execute(select(SSOProvider).where(SSOProvider.id == provider_id))
+        result = await self.session.execute(
+            select(SSOProvider).where(SSOProvider.id == provider_id)
+        )
         provider = result.scalar_one_or_none()
         if not provider:
             raise SSOProviderNotFoundError(f"SSO provider {provider_id} not found")
         return provider
 
-    async def update_provider(self, provider_id: uuid.UUID, data: SSOProviderUpdate) -> SSOProvider:
+    async def update_provider(
+        self, provider_id: uuid.UUID, data: SSOProviderUpdate
+    ) -> SSOProvider:
         """Update an existing SSO provider."""
         provider = await self.get_provider(provider_id)
         update_data = data.model_dump(exclude_unset=True)
@@ -170,7 +178,9 @@ class SSOService(BaseService):
             client_secret=client_secret,
         )
 
-    async def _get_oauth_authorize_url(self, provider: SSOProvider, callback_url: str) -> tuple[str, str]:
+    async def _get_oauth_authorize_url(
+        self, provider: SSOProvider, callback_url: str
+    ) -> tuple[str, str]:
         """Generate OAuth2 authorization URL."""
         client = self._build_oauth_client(provider)
         state = await self._generate_oauth_state(provider.id)
@@ -184,7 +194,9 @@ class SSOService(BaseService):
         )
         return url, state
 
-    async def _exchange_oauth_code(self, provider: SSOProvider, code: str, callback_url: str) -> dict[str, Any]:
+    async def _exchange_oauth_code(
+        self, provider: SSOProvider, code: str, callback_url: str
+    ) -> dict[str, Any]:
         """Exchange OAuth2 authorization code for access token."""
         client = self._build_oauth_client(provider)
         token_url = provider.config.get("token_url")
@@ -195,7 +207,9 @@ class SSOService(BaseService):
         )
         return token
 
-    async def _get_oauth_userinfo(self, provider: SSOProvider, token: dict[str, Any]) -> dict[str, Any]:
+    async def _get_oauth_userinfo(
+        self, provider: SSOProvider, token: dict[str, Any]
+    ) -> dict[str, Any]:
         """Fetch user info from OAuth2 provider."""
         client = self._build_oauth_client(provider)
         userinfo_url = provider.config.get("userinfo_url")
@@ -204,18 +218,20 @@ class SSOService(BaseService):
         response.raise_for_status()
         return response.json()
 
-    async def initiate_oauth_login(self, provider_id: uuid.UUID, callback_url: str) -> tuple[str, str]:
+    async def initiate_oauth_login(
+        self, provider_id: uuid.UUID, callback_url: str
+    ) -> tuple[str, str]:
         """Initiate OAuth2 login flow."""
         provider = await self.get_provider(provider_id)
         if not provider.is_active:
             raise SSOAuthenticationError(f"SSO provider {provider.name} is disabled")
         return await self._get_oauth_authorize_url(provider, callback_url)
 
-    async def complete_oauth_login(self, provider_id: uuid.UUID, code: str, state: str, callback_url: str) -> User:
+    async def complete_oauth_login(
+        self, code: str, state: str, callback_url: str
+    ) -> User:
         """Complete OAuth2 login flow and return authenticated user."""
-        validated_provider_id = await self._validate_oauth_state(state)
-        if validated_provider_id != provider_id:
-            raise SSOAuthenticationError("OAuth state mismatch")
+        provider_id = await self._validate_oauth_state(state)
         provider = await self.get_provider(provider_id)
         token = await self._exchange_oauth_code(provider, code, callback_url)
         userinfo = await self._get_oauth_userinfo(provider, token)
@@ -223,11 +239,15 @@ class SSOService(BaseService):
         user_data = self._extract_oauth_user_data(userinfo, provider)
         return await self._find_or_provision_user(provider, external_id, user_data)
 
-    def _extract_oauth_user_data(self, userinfo: dict[str, Any], provider: SSOProvider) -> dict[str, Any]:
+    def _extract_oauth_user_data(
+        self, userinfo: dict[str, Any], provider: SSOProvider
+    ) -> dict[str, Any]:
         """Extract user data from OAuth2 userinfo."""
         email = userinfo.get("email")
         name = userinfo.get("name") or userinfo.get("display_name")
-        username = userinfo.get("preferred_username") or email.split("@")[0] if email else None
+        username = (
+            userinfo.get("preferred_username") or email.split("@")[0] if email else None
+        )
         return {
             "email": email,
             "display_name": name,
@@ -235,7 +255,9 @@ class SSOService(BaseService):
             "avatar_url": userinfo.get("picture"),
         }
 
-    def _build_ldap_connection(self, provider: SSOProvider, username: str, password: str) -> Any:
+    def _build_ldap_connection(
+        self, provider: SSOProvider, username: str, password: str
+    ) -> Any:
         """Create LDAP connection."""
         from autobot_shared.security.input_sanitizer import sanitize_ldap_dn
 
@@ -244,18 +266,24 @@ class SSOService(BaseService):
         server_uri = provider.config.get("server_uri")
         use_ssl = provider.config.get("use_ssl", True)
         server = Server(server_uri, use_ssl=use_ssl, get_info=ALL)
-        user_dn_template = provider.config.get("user_dn_template", "uid={},ou=users,dc=example,dc=com")
+        user_dn_template = provider.config.get(
+            "user_dn_template", "uid={},ou=users,dc=example,dc=com"
+        )
         safe_username = sanitize_ldap_dn(username)
         user_dn = user_dn_template.format(safe_username)
         return Connection(server, user_dn, password)
 
-    def _search_ldap_user(self, conn: Any, provider: SSOProvider, username: str) -> dict[str, Any] | None:
+    def _search_ldap_user(
+        self, conn: Any, provider: SSOProvider, username: str
+    ) -> dict[str, Any] | None:
         """Search for user in LDAP directory."""
         from autobot_shared.security.input_sanitizer import sanitize_ldap_filter
 
         base_dn = provider.config.get("base_dn", "dc=example,dc=com")
         safe_username = sanitize_ldap_filter(username)
-        search_filter = provider.config.get("search_filter", "(uid={})").format(safe_username)
+        search_filter = provider.config.get("search_filter", "(uid={})").format(
+            safe_username
+        )
         conn.search(  # codeql[py/ldap-injection] safe_username is RFC-4515-escaped by sanitize_ldap_filter above
             base_dn, search_filter, search_scope=SUBTREE
         )
@@ -263,7 +291,9 @@ class SSOService(BaseService):
             return conn.entries[0].entry_attributes_as_dict
         return None
 
-    def _extract_ldap_user_data(self, entry: dict[str, Any], provider: SSOProvider) -> dict[str, Any]:
+    def _extract_ldap_user_data(
+        self, entry: dict[str, Any], provider: SSOProvider
+    ) -> dict[str, Any]:
         """Extract user data from LDAP entry."""
         attr_map = provider.config.get("attribute_mapping", {})
         email = entry.get(attr_map.get("email", "mail"), [None])[0]
@@ -274,7 +304,9 @@ class SSOService(BaseService):
             "username": entry.get(attr_map.get("username", "uid"), [None])[0],
         }
 
-    async def authenticate_ldap(self, provider_id: uuid.UUID, username: str, password: str) -> User:
+    async def authenticate_ldap(
+        self, provider_id: uuid.UUID, username: str, password: str
+    ) -> User:
         """Authenticate user via LDAP."""
         provider = await self.get_provider(provider_id)
         if not provider.is_active:
@@ -317,7 +349,9 @@ class SSOService(BaseService):
         saml_config.load(config_dict)
         return Saml2Client(config=saml_config)
 
-    async def _generate_saml_authn_request(self, provider: SSOProvider) -> tuple[str, str]:
+    async def _generate_saml_authn_request(
+        self, provider: SSOProvider
+    ) -> tuple[str, str]:
         """Generate SAML AuthnRequest; relay state stored in Redis with 10-min TTL."""
         client = self._build_saml_client(provider)
         relay_state = secrets.token_urlsafe(32)
@@ -328,7 +362,9 @@ class SSOService(BaseService):
         redirect_url = dict(info["headers"])["Location"]
         return redirect_url, relay_state
 
-    def _extract_saml_user_data(self, authn_response: Any, provider: SSOProvider) -> dict[str, Any]:
+    def _extract_saml_user_data(
+        self, authn_response: Any, provider: SSOProvider
+    ) -> dict[str, Any]:
         """Extract user data from SAML assertion."""
         attrs = authn_response.ava
         attr_map = provider.config.get("attribute_mapping", {})
@@ -337,7 +373,9 @@ class SSOService(BaseService):
         username = attrs.get(attr_map.get("username", "uid"), [None])[0]
         return {"email": email, "display_name": display_name, "username": username}
 
-    async def complete_saml_login(self, provider_id: uuid.UUID, saml_response: str) -> User:
+    async def complete_saml_login(
+        self, provider_id: uuid.UUID, saml_response: str
+    ) -> User:
         """Complete SAML login flow."""
         provider = await self.get_provider(provider_id)
         if not provider.is_active:
@@ -348,7 +386,9 @@ class SSOService(BaseService):
         user_data = self._extract_saml_user_data(authn_response, provider)
         return await self._find_or_provision_user(provider, external_id, user_data)
 
-    async def _find_existing_sso_link(self, provider_id: uuid.UUID, external_id: str) -> UserSSOLink | None:
+    async def _find_existing_sso_link(
+        self, provider_id: uuid.UUID, external_id: str
+    ) -> UserSSOLink | None:
         """Find existing SSO link."""
         result = await self.session.execute(
             select(UserSSOLink).where(
@@ -363,7 +403,9 @@ class SSOService(BaseService):
         result = await self.session.execute(select(User).where(User.email == email))
         return result.scalar_one_or_none()
 
-    async def _create_sso_user(self, provider: SSOProvider, user_data: dict[str, Any]) -> User:
+    async def _create_sso_user(
+        self, provider: SSOProvider, user_data: dict[str, Any]
+    ) -> User:
         """Create new user from SSO authentication."""
         user = User(
             email=user_data["email"],
@@ -397,19 +439,27 @@ class SSOService(BaseService):
         )
         self.session.add(link)
         await self.session.flush()
-        logger.info("Created SSO link for user %s with provider %s", user.id, provider.id)
+        logger.info(
+            "Created SSO link for user %s with provider %s", user.id, provider.id
+        )
         return link
 
-    async def _find_or_provision_user(self, provider: SSOProvider, external_id: str, user_data: dict[str, Any]) -> User:
+    async def _find_or_provision_user(
+        self, provider: SSOProvider, external_id: str, user_data: dict[str, Any]
+    ) -> User:
         """Find existing user or provision new one via JIT."""
         link = await self._find_existing_sso_link(provider.id, external_id)
         if link:
             link.record_login()
             await self.session.flush()
-            result = await self.session.execute(select(User).where(User.id == link.user_id))
+            result = await self.session.execute(
+                select(User).where(User.id == link.user_id)
+            )
             return result.scalar_one()
         if not provider.allow_user_creation:
-            raise SSOAuthenticationError("User not found and auto-provisioning is disabled")
+            raise SSOAuthenticationError(
+                "User not found and auto-provisioning is disabled"
+            )
         email = user_data.get("email")
         if not email:
             raise SSOAuthenticationError("Email not provided by SSO provider")


### PR DESCRIPTION
## Thinking Path
External OAuth2 IdPs (Okta, Azure AD, Google) only pass `code` and `state` on callback per OAuth2 spec. The callback endpoint required a third param `provider_id` that IdPs would never send, breaking all SSO logins. MVA-1733 added Redis-backed state storage; this fix uses it to derive `provider_id` from state alone.

## What Changed
- `autobot-slm-backend/api/sso_auth.py:113` — removed `provider_id: uuid.UUID = Query(...)` from callback signature
- `autobot-slm-backend/user_management/services/sso_service.py:214` — `complete_oauth_login` now derives `provider_id` from state via Redis, removed redundant cross-check

## Verification
- Python syntax check passed
- Callback signature now matches OAuth2 spec (only `code` + `state`)
- `provider_id` resolution via Redis state lookup (MVA-1733 dependency satisfied)

## Model Used
Claude Sonnet 4.5

## Related Issues
Depends on: #9074 (MVA-1733 — Redis-backed OAuth state)
Parent: MVA-1730 (OIDC/SSO federation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)