### PR TITLE
fix(ci): remove unused imports blocking code-quality check

### DIFF
--- a/autobot-backend/knowledge/connectors/tests/test_credential_store.py
+++ b/autobot-backend/knowledge/connectors/tests/test_credential_store.py
@@ -4,7 +4,7 @@
 """Unit and integration tests for ConnectorCredentialStore (ADR-007 / GH#9019)."""
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -14,7 +14,7 @@ from autobot_shared.auth.connector_auth import (
     BearerAuth,
     OAuthRefreshAuth,
 )
-from knowledge.connectors.credential_store import ConnectorCredentialStore, reset_credential_store
+from knowledge.connectors.credential_store import ConnectorCredentialStore
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/autobot-backend/llc/tests/test_diary_writer.py
+++ b/autobot-backend/llc/tests/test_diary_writer.py
@@ -403,7 +403,7 @@ async def test_on_run_complete_swallows_writer_exception() -> None:
 @pytest.mark.asyncio
 async def test_write_from_run_enforces_write_guard_on_ancestor_work_item() -> None:
     """Verify write_from_run() raises HTTPException(403) if requester writes to ancestor's work item."""
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from unittest.mock import AsyncMock, patch
 
     from fastapi import HTTPException
 

--- a/autobot-backend/llc/tests/test_session_checkpointer.py
+++ b/autobot-backend/llc/tests/test_session_checkpointer.py
@@ -4,9 +4,7 @@
 """Unit tests for SessionCheckpointer (GH#9026)."""
 
 import json
-import time
 import uuid
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/autobot-backend/tests/api/test_push_idor.py
+++ b/autobot-backend/tests/api/test_push_idor.py
@@ -3,7 +3,6 @@
 # Author: mrveiss
 """Tests for push subscription IDOR vulnerability fix (GH#8967)."""
 
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -87,7 +86,7 @@ async def test_unsubscribe_ignores_user_id_in_request_body():
     session.execute.return_value = mock_query
 
     with patch("api.push.logger") as mock_logger:
-        result = await unsubscribe(body, current_user, session)
+        await unsubscribe(body, current_user, session)
 
         # Verify IDOR attempt was logged
         mock_logger.warning.assert_called_once()

--- a/autobot-backend/tests/api/test_voice_bundle_user.py
+++ b/autobot-backend/tests/api/test_voice_bundle_user.py
@@ -18,9 +18,6 @@ from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.voice_bundle_user import (
-    BundleAssignRequest,
-    BundleInfo,
-    UserBundleResponse,
     _check_self_or_admin,
     _get_user_id,
     _is_admin,

--- a/autobot-backend/tests/test_execution_backends.py
+++ b/autobot-backend/tests/test_execution_backends.py
@@ -511,7 +511,7 @@ class TestSnapshotIndex:
     """Unit tests for SnapshotIndex file-based storage."""
 
     def test_add_and_get(self, tmp_path):
-        from pathlib import Path
+        pass
 
         from services.execution.snapshot_index import SnapshotIndex, SnapshotRecord
 

--- a/autobot-backend/tests/test_startup_error_sanitize.py
+++ b/autobot-backend/tests/test_startup_error_sanitize.py
@@ -214,7 +214,7 @@ class TestStartupErrorLifespanConstant:
         stubs["fastapi"] = MagicMock()
         with patch.dict(sys.modules, stubs):
             # Force re-import so our stubs take effect
-            import importlib
+            pass
 
             if "initialization.lifespan" in sys.modules:
                 del sys.modules["initialization.lifespan"]


### PR DESCRIPTION
## Thinking Path

Three separate pre-existing CI failures were blocking every PR:

1. **Unused imports** — 7 test files had stale imports flagged by `autoflake`, failing the `code-quality` gate globally.
2. **Ansible slm_agent drift** — `autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/` had diverged from the canonical `autobot-slm-backend/slm/agent/`. The drift check (issue #1629) was failing every code-quality run.
3. **Hardened smoke-test chromadb crash** — ChromaDB 0.5.23's `log_config.yml` defines a `RotatingFileHandler` writing to `/chroma/chroma.log`. Under `read_only: true` that path is not writable and not covered by any tmpfs, so uvicorn crashes before healthcheck. Fix: override the container command to drop `--log-config`, falling back to stdout-only logging.

## What Changed

- `autobot-backend/knowledge/connectors/tests/test_credential_store.py` — removed unused imports
- `autobot-backend/tests/test_startup_error_sanitize.py` — removed unused imports
- `autobot-backend/tests/api/test_voice_bundle_user.py` — removed unused imports
- `autobot-backend/tests/test_execution_backends.py` — removed unused imports
- `autobot-backend/tests/api/test_push_idor.py` — removed unused imports
- `autobot-backend/llc/tests/test_session_checkpointer.py` — removed unused imports
- `autobot-backend/llc/tests/test_diary_writer.py` — removed unused imports
- `autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py` — synced from canonical source
- `autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py` — synced from canonical source
- `docker-compose.hardened.yml` — override chromadb command to drop `--log-config`, fix read-only filesystem crash

## Verification

```bash
# 1. Unused imports clean
python3 -m autoflake --check --recursive --remove-all-unused-imports --remove-unused-variables autobot-backend/
# 2. Ansible drift gone
diff -rq autobot-slm-backend/slm/agent/ autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/ | grep -v __pycache__ | grep -v _test.py
# 3. Hardened smoke — chromadb starts successfully
docker compose -f docker-compose.yml -f docker-compose.hardened.yml --env-file docker/.env.docker up autobot-chromadb
```

## Risks

- Chromadb command override: uvicorn stdout logging is slightly less verbose than file logging. Logs are still visible via `docker logs`. No data loss risk.
- Ansible sync: test files intentionally excluded from Ansible role (they run in CI, not on nodes).

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Fixes #1629 (Ansible drift), closes ongoing CI failures on code-quality and hardened-smoke-test.

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason)
- [x] Documentation updated if behavior changed
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff