### PR TITLE
fix(ci): sync Ansible slm_agent role + fix chromadb hardened-smoke crash

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import logging
 import os
+import platform
 import signal
 import socket
 import sqlite3
@@ -130,6 +131,10 @@ class SLMAgent:
         self.role_detector = RoleDetector()
         self._role_definitions_loaded = False
 
+        # Single session reused across all requests — avoids per-request
+        # connection pool + SSL context allocation (#9086)
+        self._session: aiohttp.ClientSession | None = None
+
     def _init_buffer_db(self):
         """Initialize SQLite buffer database."""
         Path(self.buffer_db).parent.mkdir(parents=True, exist_ok=True)
@@ -179,20 +184,20 @@ class SLMAgent:
 
     async def _fetch_role_definitions(self) -> bool:
         """Fetch role definitions from SLM server (Issue #779)."""
+        assert self._session is not None
         try:
-            async with aiohttp.ClientSession() as session:
-                url = f"{self.admin_url}/api/roles/definitions"
-                async with session.get(
-                    url,
-                    timeout=aiohttp.ClientTimeout(total=10),
-                    ssl=False,
-                ) as response:
-                    if response.status == 200:
-                        definitions = await response.json()
-                        self.role_detector.load_definitions(definitions)
-                        self._role_definitions_loaded = True
-                        logger.info("Loaded %d role definitions", len(definitions))
-                        return True
+            url = f"{self.admin_url}/api/roles/definitions"
+            async with self._session.get(
+                url,
+                timeout=aiohttp.ClientTimeout(total=10),
+                ssl=False,
+            ) as response:
+                if response.status == 200:
+                    definitions = await response.json()
+                    self.role_detector.load_definitions(definitions)
+                    self._role_definitions_loaded = True
+                    logger.info("Loaded %d role definitions", len(definitions))
+                    return True
         except Exception as e:
             logger.debug("Failed to fetch role definitions: %s", e)
         return False
@@ -272,28 +277,28 @@ class SLMAgent:
             True if heartbeat was accepted, False otherwise.
         Issue #620.
         """
+        assert self._session is not None
         try:
-            async with aiohttp.ClientSession() as session:
-                url = f"{self.admin_url}/api/nodes/{self.node_id}/heartbeat"
-                async with session.post(
-                    url,
-                    json=payload,
-                    timeout=aiohttp.ClientTimeout(total=10),
-                    ssl=False,  # mTLS pending PKI setup (Issue #725)
-                ) as response:
-                    if response.status == 200:
-                        # Issue #741: Process heartbeat response
-                        response_data = await response.json()
-                        self._process_heartbeat_response(response_data)
-                        logger.debug("Heartbeat sent successfully")
-                        return True
-                    else:
-                        logger.warning(
-                            "Heartbeat rejected: %s %s",
-                            response.status,
-                            await response.text(),
-                        )
-                        return False
+            url = f"{self.admin_url}/api/nodes/{self.node_id}/heartbeat"
+            async with self._session.post(
+                url,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=10),
+                ssl=False,  # mTLS pending PKI setup (Issue #725)
+            ) as response:
+                if response.status == 200:
+                    # Issue #741: Process heartbeat response
+                    response_data = await response.json()
+                    self._process_heartbeat_response(response_data)
+                    logger.debug("Heartbeat sent successfully")
+                    return True
+                else:
+                    logger.warning(
+                        "Heartbeat rejected: %s %s",
+                        response.status,
+                        await response.text(),
+                    )
+                    return False
         except aiohttp.ClientError as e:
             logger.warning("Failed to send heartbeat: %s", e)
             self.buffer_event("heartbeat", payload)
@@ -301,8 +306,6 @@ class SLMAgent:
 
     async def send_heartbeat(self) -> bool:
         """Send heartbeat with health data to admin."""
-        import platform
-
         # Fetch role definitions if not loaded (Issue #779)
         if not self._role_definitions_loaded:
             await self._fetch_role_definitions()
@@ -316,11 +319,12 @@ class SLMAgent:
 
     async def sync_buffered_events(self):
         """Sync buffered events to admin (#1106)."""
+        assert self._session is not None
         self._prune_old_events()
         conn = sqlite3.connect(self.buffer_db)
         try:
             cursor = conn.execute(
-                "SELECT id, event_type, data FROM event_buffer " "WHERE synced = 0 ORDER BY id LIMIT 100"
+                "SELECT id, event_type, data FROM event_buffer" " WHERE synced = 0 ORDER BY id LIMIT 100"
             )
             events = cursor.fetchall()
 
@@ -329,37 +333,36 @@ class SLMAgent:
 
             logger.info("Syncing %d buffered events", len(events))
 
-            async with aiohttp.ClientSession() as session:
-                url = f"{self.admin_url}/api/events/sync"
-                payload = [
-                    {
-                        "id": e[0],
-                        "type": e[1],
-                        "data": json.loads(e[2]),
-                        "node_id": self.node_id,
-                    }
-                    for e in events
-                ]
-                async with session.post(
-                    url,
-                    json=payload,
-                    timeout=aiohttp.ClientTimeout(total=30),
-                    ssl=False,
-                ) as response:
-                    if response.status == 200:
-                        ids = [e[0] for e in events]
-                        placeholders = ",".join("?" * len(ids))
-                        query = "UPDATE event_buffer SET synced = 1 " f"WHERE id IN ({placeholders})"
-                        conn.execute(query, ids)
-                        conn.commit()
-                        logger.info("Synced %d events", len(events))
-                    else:
-                        body = await response.text()
-                        logger.warning(
-                            "Event sync rejected: %s %s",
-                            response.status,
-                            body[:200],
-                        )
+            url = f"{self.admin_url}/api/events/sync"
+            payload = [
+                {
+                    "id": e[0],
+                    "type": e[1],
+                    "data": json.loads(e[2]),
+                    "node_id": self.node_id,
+                }
+                for e in events
+            ]
+            async with self._session.post(
+                url,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=30),
+                ssl=False,
+            ) as response:
+                if response.status == 200:
+                    ids = [e[0] for e in events]
+                    placeholders = ",".join("?" * len(ids))
+                    query = "UPDATE event_buffer SET synced = 1 " f"WHERE id IN ({placeholders})"
+                    conn.execute(query, ids)
+                    conn.commit()
+                    logger.info("Synced %d events", len(events))
+                else:
+                    body = await response.text()
+                    logger.warning(
+                        "Event sync rejected: %s %s",
+                        response.status,
+                        body[:200],
+                    )
         except aiohttp.ClientError as e:
             logger.warning("Failed to sync events: %s", e)
         finally:
@@ -399,23 +402,29 @@ class SLMAgent:
         # Notify systemd that we're ready
         sd_notify("READY=1")
 
-        # Issue #741: Start notification server if enabled (code-source nodes)
-        if enable_notify_server:
-            await self.start_notify_server(notify_port)
+        # Single session for the lifetime of the agent (#9086)
+        async with aiohttp.ClientSession() as session:
+            self._session = session
 
-        while self.running:
-            # Send systemd watchdog notification (prevents timeout restart)
-            sd_notify("WATCHDOG=1")
+            # Issue #741: Start notification server if enabled (code-source nodes)
+            if enable_notify_server:
+                await self.start_notify_server(notify_port)
 
-            # Send heartbeat
-            success = await self.send_heartbeat()
+            while self.running:
+                # Send systemd watchdog notification (prevents timeout restart)
+                sd_notify("WATCHDOG=1")
 
-            # If connected, try to sync buffered events
-            if success:
-                await self.sync_buffered_events()
+                # Send heartbeat
+                success = await self.send_heartbeat()
 
-            # Wait for next heartbeat
-            await asyncio.sleep(self.heartbeat_interval)
+                # If connected, try to sync buffered events
+                if success:
+                    await self.sync_buffered_events()
+
+                # Wait for next heartbeat
+                await asyncio.sleep(self.heartbeat_interval)
+
+            self._session = None
 
         # Notify systemd we're stopping
         sd_notify("STOPPING=1")
@@ -498,31 +507,31 @@ class SLMAgent:
 
     async def _notify_code_change(self, commit: str) -> None:
         """Send immediate notification to SLM server about code change."""
+        assert self._session is not None
         try:
-            async with aiohttp.ClientSession() as session:
-                url = f"{self.admin_url}/api/code-sync/notify"
-                payload = {
-                    "node_id": self.node_id,
-                    "commit": commit,
-                    "is_code_source": True,
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
-                }
-                async with session.post(
-                    url,
-                    json=payload,
-                    timeout=aiohttp.ClientTimeout(total=10),
-                    ssl=False,
-                ) as response:
-                    if response.status == 200:
-                        logger.info(
-                            "SLM server notified of new code version: %s",
-                            commit[:12],
-                        )
-                    else:
-                        logger.warning(
-                            "Failed to notify SLM server: %s",
-                            response.status,
-                        )
+            url = f"{self.admin_url}/api/code-sync/notify"
+            payload = {
+                "node_id": self.node_id,
+                "commit": commit,
+                "is_code_source": True,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+            async with self._session.post(
+                url,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=10),
+                ssl=False,
+            ) as response:
+                if response.status == 200:
+                    logger.info(
+                        "SLM server notified of new code version: %s",
+                        commit[:12],
+                    )
+                else:
+                    logger.warning(
+                        "Failed to notify SLM server: %s",
+                        response.status,
+                    )
         except Exception as e:
             logger.warning("Failed to notify SLM server: %s", e)
             # Event is already buffered, will sync on next heartbeat

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py
@@ -14,6 +14,7 @@ import os
 import platform
 import socket
 import subprocess  # nosec B404 - required for systemctl interaction
+import time
 from datetime import datetime, timezone
 from typing import Dict, List
 
@@ -24,6 +25,9 @@ from autobot_shared.redis_client import get_redis_client
 logger = logging.getLogger(__name__)
 
 _STATE_CHANGE_CHANNEL_TEMPLATE = "autobot:services:{service}:state_change"
+
+# Subprocess-heavy service sweep is cached this long to reduce system load (#9086)
+_SERVICE_DISCOVERY_TTL = 300  # seconds
 
 
 class HealthCollector:
@@ -58,6 +62,10 @@ class HealthCollector:
         # Tracks the last known status per service name for state-change detection.
         # Populated on first collect(); events are only published on transitions.
         self._last_known_status: Dict[str, str] = {}
+        # Cache for discover_all_services() — avoids spawning 100+ subprocesses
+        # every heartbeat (#9086)
+        self._service_cache: List[Dict] = []
+        self._service_cache_ts: float = 0.0
 
     def collect(self) -> Dict:
         """Collect all health metrics."""
@@ -86,11 +94,21 @@ class HealthCollector:
                 key = f"{host}:{port}"
                 health["ports"][key] = self.check_port(host, port)
 
-        # Discover all systemd services (for Issue #728)
+        # Discover all systemd services (for Issue #728).
+        # Result is cached for _SERVICE_DISCOVERY_TTL seconds — the sweep
+        # spawns 100+ subprocesses and must not run every heartbeat (#9086).
         if self.discover_services:
-            health["discovered_services"] = self.discover_all_services()
+            health["discovered_services"] = self._get_discovered_services()
 
         return health
+
+    def _get_discovered_services(self) -> List[Dict]:
+        """Return cached service list, refreshing when TTL has expired."""
+        now = time.monotonic()
+        if now - self._service_cache_ts >= _SERVICE_DISCOVERY_TTL:
+            self._service_cache = self.discover_all_services()
+            self._service_cache_ts = now
+        return self._service_cache
 
     def check_service(self, service_name: str) -> Dict:
         """Check systemd service status."""

--- a/docker-compose.hardened.yml
+++ b/docker-compose.hardened.yml
@@ -86,6 +86,20 @@ services:
     # tmpfs the process hits EROFS on first write under read_only: true.
     # Mounting /chroma as tmpfs would shadow /chroma/chromadb/log_config.yml
     # (the regression introduced by PR #8912 that caused GH#8913).
+    #
+    # ChromaDB 0.5.23 log_config.yml defines a RotatingFileHandler writing to
+    # /chroma/chroma.log.  Under read_only: true that path is not writable and
+    # not covered by any volume or tmpfs above, so uvicorn crashes before the
+    # health-check endpoint comes up.  Override the command to drop the
+    # --log-config flag; uvicorn then falls back to stdout-only logging.
+    command: >
+      uvicorn chromadb.app:app
+      --workers 1
+      --host 0.0.0.0
+      --port 8000
+      --proxy-headers
+      --log-level warning
+      --timeout-keep-alive 30
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Thinking Path

Two pre-existing CI failures were squash-dropped when PR #9147 was merged:

1. **Ansible slm_agent drift** — `autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/` had diverged from the canonical `autobot-slm-backend/slm/agent/`. The drift check (issue #1629) fails the `code-quality` gate on every PR that touches slm_agent files.

2. **ChromaDB hardened-smoke-test crash** — ChromaDB 0.5.23's `log_config.yml` defines a `RotatingFileHandler` writing to `/chroma/chroma.log`. Under `read_only: true` in `docker-compose.hardened.yml`, that path is not writable and not covered by any tmpfs, so uvicorn crashes before the healthcheck endpoint comes up. Fix: override the container `command` to drop `--log-config`; uvicorn falls back to stdout-only logging.

## What Changed

- `autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py` — synced from canonical source
- `autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py` — synced from canonical source
- `docker-compose.hardened.yml` — override chromadb `command` to drop `--log-config chromadb/log_config.yml`

## Verification

```bash
# Ansible drift
diff -rq autobot-slm-backend/slm/agent/ autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/ | grep -v __pycache__ | grep -v _test.py
# Should produce no output

# Hardened smoke — chromadb starts
docker compose -f docker-compose.yml -f docker-compose.hardened.yml --env-file docker/.env.docker up autobot-chromadb
# Should reach healthy state
```

## Risks

Chromadb logs to stdout only in hardened mode — still visible via `docker logs`, no data loss.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Issue Link

Fixes #1629 (Ansible drift). Restores hardened-smoke-test CI.

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason)
- [x] Documentation updated if behavior changed
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff