### PR TITLE
feat(plugins): capability approval dialog and audit log UI (MVA-1989)

### DIFF
--- a/autobot-frontend/src/components/plugins/CapabilityApprovalDialog.vue
+++ b/autobot-frontend/src/components/plugins/CapabilityApprovalDialog.vue
@@ -1,0 +1,473 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025 mrveiss -->
+<!-- Author: mrveiss -->
+<!-- Issue #9049 - Plugin capability approval dialog -->
+
+<template>
+  <div
+    v-if="open"
+    class="capability-approval-overlay"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="capability-dialog-title"
+    @click.self="handleCancel"
+  >
+    <div class="capability-approval-dialog">
+      <div class="dialog-header">
+        <h2 id="capability-dialog-title">{{ $t('plugins.capabilities.approvalTitle') }}</h2>
+        <button
+          class="close-btn"
+          @click="handleCancel"
+          :aria-label="$t('common.close')"
+        >
+          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <div v-if="loading" class="dialog-loading">
+        <svg class="spinner" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+          <path
+            class="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+          />
+        </svg>
+        <span>{{ $t('plugins.capabilities.loading') }}</span>
+      </div>
+
+      <div v-else-if="error" class="dialog-error">
+        <svg fill="currentColor" viewBox="0 0 20 20">
+          <path
+            fill-rule="evenodd"
+            d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+            clip-rule="evenodd"
+          />
+        </svg>
+        <span>{{ error }}</span>
+      </div>
+
+      <div v-else class="dialog-body">
+        <div class="plugin-info">
+          <h3>{{ pluginName }}</h3>
+          <span v-if="capabilityInfo" :class="['trust-tier-badge', `tier-${capabilityInfo.trust_tier}`]">
+            {{ capabilityInfo.trust_tier }}
+          </span>
+        </div>
+
+        <p class="approval-description">{{ $t('plugins.capabilities.approvalDescription') }}</p>
+
+        <div v-if="capabilityInfo && capabilityInfo.pending_approval.length > 0" class="capabilities-list">
+          <div
+            v-for="capability in capabilityInfo.pending_approval"
+            :key="capability"
+            class="capability-item"
+          >
+            <label class="capability-label">
+              <input
+                type="checkbox"
+                :value="capability"
+                v-model="selectedCapabilities"
+                class="capability-checkbox"
+              />
+              <span class="capability-name">{{ capability }}</span>
+            </label>
+            <span class="capability-description">{{ getCapabilityDescription(capability) }}</span>
+          </div>
+        </div>
+        <div v-else class="no-pending">
+          {{ $t('plugins.capabilities.noPending') }}
+        </div>
+      </div>
+
+      <div class="dialog-actions">
+        <button
+          class="btn btn-secondary"
+          @click="handleCancel"
+        >
+          {{ $t('common.cancel') }}
+        </button>
+        <button
+          v-if="capabilityInfo && capabilityInfo.pending_approval.length > 0"
+          class="btn btn-primary"
+          @click="handleApproveSelected"
+          :disabled="selectedCapabilities.length === 0 || approving"
+        >
+          {{ approving ? $t('plugins.capabilities.approving') : $t('plugins.capabilities.approveSelected') }}
+        </button>
+        <button
+          v-if="capabilityInfo && capabilityInfo.pending_approval.length > 0"
+          class="btn btn-primary"
+          @click="handleApproveAll"
+          :disabled="approving"
+        >
+          {{ approving ? $t('plugins.capabilities.approving') : $t('plugins.capabilities.approveAll') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { usePlugins, type CapabilityInfo } from '@/composables/usePlugins'
+
+const { t } = useI18n()
+
+const props = defineProps<{
+  pluginName: string
+  open: boolean
+}>()
+
+const emit = defineEmits<{
+  approved: []
+  close: []
+}>()
+
+const { getCapabilities, approveCapabilities } = usePlugins()
+
+const loading = ref(false)
+const error = ref<string | null>(null)
+const capabilityInfo = ref<CapabilityInfo | null>(null)
+const selectedCapabilities = ref<string[]>([])
+const approving = ref(false)
+
+// Capability descriptions map
+const capabilityDescriptions: Record<string, string> = {
+  'kb:read': 'Read from Knowledge Base',
+  'kb:write': 'Write to Knowledge Base',
+  'kb:admin': 'Admin operations on KB',
+  'llm:call': 'Call LLM providers',
+  'llm:embedding': 'Generate embeddings',
+  'llm:fine_tune': 'Fine-tune models',
+  'filesystem:read': 'Read files from disk',
+  'filesystem:write': 'Write files to disk',
+  'filesystem:delete': 'Delete files from disk',
+  'network:outbound': 'Make outbound HTTP requests',
+  'network:inbound': 'Accept inbound HTTP requests',
+  'database:read': 'Read from AutoBot database',
+  'database:write': 'Write to AutoBot database',
+  'database:admin': 'Database admin operations',
+  'agent:read': 'Read agent metadata',
+  'agent:execute': 'Execute agent tasks',
+  'agent:admin': 'Create/delete agents',
+  'system:env': 'Access environment variables',
+  'system:process': 'Spawn processes',
+  'system:admin': 'System-level admin operations',
+  'redis:read': 'Read from Redis',
+  'redis:write': 'Write to Redis',
+  'workflow:read': 'Read workflow definitions',
+  'workflow:execute': 'Execute workflows',
+}
+
+function getCapabilityDescription(capability: string): string {
+  return capabilityDescriptions[capability] || 'Unknown capability'
+}
+
+async function fetchCapabilities() {
+  loading.value = true
+  error.value = null
+  try {
+    const data = await getCapabilities(props.pluginName)
+    if (data) {
+      capabilityInfo.value = data
+      selectedCapabilities.value = []
+    } else {
+      error.value = 'Failed to fetch capabilities'
+    }
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to fetch capabilities'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleApproveSelected() {
+  if (selectedCapabilities.value.length === 0) return
+
+  approving.value = true
+  try {
+    const success = await approveCapabilities(props.pluginName, selectedCapabilities.value)
+    if (success) {
+      emit('approved')
+      emit('close')
+    } else {
+      error.value = 'Failed to approve capabilities'
+    }
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to approve capabilities'
+  } finally {
+    approving.value = false
+  }
+}
+
+async function handleApproveAll() {
+  if (!capabilityInfo.value) return
+
+  approving.value = true
+  try {
+    const success = await approveCapabilities(
+      props.pluginName,
+      capabilityInfo.value.pending_approval
+    )
+    if (success) {
+      emit('approved')
+      emit('close')
+    } else {
+      error.value = 'Failed to approve capabilities'
+    }
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to approve capabilities'
+  } finally {
+    approving.value = false
+  }
+}
+
+function handleCancel() {
+  emit('close')
+}
+
+watch(() => props.open, (isOpen) => {
+  if (isOpen) {
+    fetchCapabilities()
+  }
+})
+</script>
+
+<style scoped>
+.capability-approval-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.capability-approval-dialog {
+  background: var(--color-background);
+  border-radius: 8px;
+  max-width: 600px;
+  width: 90%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}
+
+.dialog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.dialog-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  padding: 0.5rem;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.close-btn:hover {
+  background-color: var(--color-background-hover);
+}
+
+.close-btn svg {
+  width: 20px;
+  height: 20px;
+}
+
+.dialog-loading,
+.dialog-error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 2rem;
+  color: var(--color-text-secondary);
+}
+
+.dialog-error {
+  color: var(--color-error);
+}
+
+.spinner {
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.dialog-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+}
+
+.plugin-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.plugin-info h3 {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.trust-tier-badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.tier-official {
+  background-color: #10b981;
+  color: white;
+}
+
+.tier-verified {
+  background-color: #3b82f6;
+  color: white;
+}
+
+.tier-community {
+  background-color: #f59e0b;
+  color: white;
+}
+
+.tier-unverified {
+  background-color: #ef4444;
+  color: white;
+}
+
+.approval-description {
+  margin-bottom: 1.5rem;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+}
+
+.capabilities-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.capability-item {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 0.75rem;
+  transition: background-color 0.2s;
+}
+
+.capability-item:hover {
+  background-color: var(--color-background-hover);
+}
+
+.capability-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  margin-bottom: 0.25rem;
+}
+
+.capability-checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.capability-name {
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-family: monospace;
+}
+
+.capability-description {
+  display: block;
+  margin-left: 1.65rem;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+}
+
+.no-pending {
+  text-align: center;
+  padding: 2rem;
+  color: var(--color-text-secondary);
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: none;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background-color: var(--color-background-secondary);
+  color: var(--color-text-primary);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background-color: var(--color-background-hover);
+}
+
+.btn-primary {
+  background-color: var(--color-primary);
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  opacity: 0.9;
+}
+</style>

--- a/autobot-frontend/src/components/plugins/CapabilityAuditLog.vue
+++ b/autobot-frontend/src/components/plugins/CapabilityAuditLog.vue
@@ -1,0 +1,368 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025 mrveiss -->
+<!-- Author: mrveiss -->
+<!-- Issue #9049 - Plugin capability audit log -->
+
+<template>
+  <div class="capability-audit-log">
+    <div class="audit-header">
+      <h2>{{ $t('plugins.capabilities.auditLogTitle') }}</h2>
+      <div class="audit-controls">
+        <input
+          v-model="filterPluginName"
+          type="text"
+          class="filter-input"
+          :placeholder="$t('plugins.capabilities.filterByPlugin')"
+        />
+        <button class="btn-refresh" @click="fetchAuditLog" :disabled="loading">
+          <svg
+            class="refresh-icon"
+            :class="{ spinning: loading }"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <div v-if="loading && entries.length === 0" class="loading-state">
+      <svg class="spinner" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+        <path
+          class="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+        />
+      </svg>
+      <span>{{ $t('plugins.capabilities.loadingAudit') }}</span>
+    </div>
+
+    <div v-else-if="error" class="error-banner">
+      <svg fill="currentColor" viewBox="0 0 20 20">
+        <path
+          fill-rule="evenodd"
+          d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+          clip-rule="evenodd"
+        />
+      </svg>
+      <span>{{ error }}</span>
+    </div>
+
+    <div v-else-if="filteredEntries.length === 0" class="empty-state">
+      <svg class="empty-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.5"
+          d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+        />
+      </svg>
+      <p>{{ $t('plugins.capabilities.noAuditEntries') }}</p>
+    </div>
+
+    <div v-else class="audit-table-container">
+      <table class="audit-table">
+        <thead>
+          <tr>
+            <th>{{ $t('plugins.capabilities.timestamp') }}</th>
+            <th>{{ $t('plugins.capabilities.plugin') }}</th>
+            <th>{{ $t('plugins.capabilities.capability') }}</th>
+            <th>{{ $t('plugins.capabilities.operation') }}</th>
+            <th>{{ $t('plugins.capabilities.status') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="(entry, index) in filteredEntries"
+            :key="index"
+            :class="{ denied: !entry.granted }"
+          >
+            <td class="timestamp">{{ formatTimestamp(entry.timestamp) }}</td>
+            <td class="plugin-name">{{ entry.plugin_name }}</td>
+            <td class="capability">
+              <code>{{ entry.capability }}</code>
+            </td>
+            <td class="operation">{{ entry.operation }}</td>
+            <td class="status">
+              <span :class="['status-badge', entry.granted ? 'granted' : 'denied']">
+                {{ entry.granted ? $t('plugins.capabilities.granted') : $t('plugins.capabilities.denied') }}
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { usePlugins, type AuditLogEntry } from '@/composables/usePlugins'
+
+const { t } = useI18n()
+const { getAuditLog } = usePlugins()
+
+const loading = ref(false)
+const error = ref<string | null>(null)
+const entries = ref<AuditLogEntry[]>([])
+const filterPluginName = ref('')
+
+const filteredEntries = computed(() => {
+  if (!filterPluginName.value) {
+    return entries.value
+  }
+  const filter = filterPluginName.value.toLowerCase()
+  return entries.value.filter(entry =>
+    entry.plugin_name.toLowerCase().includes(filter)
+  )
+})
+
+async function fetchAuditLog() {
+  loading.value = true
+  error.value = null
+  try {
+    const data = await getAuditLog(100)
+    entries.value = data
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to fetch audit log'
+  } finally {
+    loading.value = false
+  }
+}
+
+function formatTimestamp(timestamp: string): string {
+  try {
+    const date = new Date(timestamp)
+    return date.toLocaleString()
+  } catch {
+    return timestamp
+  }
+}
+
+onMounted(() => {
+  fetchAuditLog()
+})
+</script>
+
+<style scoped>
+.capability-audit-log {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.audit-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.audit-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.audit-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.filter-input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background-color: var(--color-background);
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+  min-width: 200px;
+}
+
+.filter-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.btn-refresh {
+  padding: 0.5rem;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  transition: all 0.2s;
+}
+
+.btn-refresh:hover:not(:disabled) {
+  background-color: var(--color-background-hover);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.btn-refresh:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.refresh-icon {
+  width: 20px;
+  height: 20px;
+}
+
+.refresh-icon.spinning {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 3rem;
+  color: var(--color-text-secondary);
+}
+
+.spinner {
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+}
+
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  background-color: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 6px;
+  color: #ef4444;
+}
+
+.error-banner svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem;
+  color: var(--color-text-secondary);
+}
+
+.empty-icon {
+  width: 48px;
+  height: 48px;
+  margin-bottom: 1rem;
+  opacity: 0.5;
+}
+
+.audit-table-container {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+}
+
+.audit-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.audit-table th {
+  background-color: var(--color-background-secondary);
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.audit-table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+}
+
+.audit-table tr:last-child td {
+  border-bottom: none;
+}
+
+.audit-table tr:hover {
+  background-color: var(--color-background-hover);
+}
+
+.audit-table tr.denied {
+  background-color: rgba(239, 68, 68, 0.05);
+}
+
+.audit-table tr.denied:hover {
+  background-color: rgba(239, 68, 68, 0.1);
+}
+
+.timestamp {
+  font-family: monospace;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.plugin-name {
+  font-weight: 500;
+}
+
+.capability code {
+  background-color: var(--color-background-secondary);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8125rem;
+  font-family: monospace;
+}
+
+.operation {
+  color: var(--color-text-secondary);
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.status-badge.granted {
+  background-color: rgba(16, 185, 129, 0.1);
+  color: #10b981;
+}
+
+.status-badge.denied {
+  background-color: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+}
+</style>

--- a/autobot-frontend/src/composables/usePlugins.ts
+++ b/autobot-frontend/src/composables/usePlugins.ts
@@ -45,6 +45,23 @@ export interface DiscoveredPlugin {
   manifest: PluginManifest
 }
 
+export interface CapabilityInfo {
+  plugin_name: string
+  trust_tier: 'official' | 'verified' | 'community' | 'unverified'
+  required_capabilities: string[]
+  granted_capabilities: string[]
+  pending_approval: string[]
+}
+
+export interface AuditLogEntry {
+  timestamp: string
+  plugin_name: string
+  capability: string
+  granted: boolean
+  operation: string
+  metadata?: string
+}
+
 // ===== Composable =====
 
 export function usePlugins() {
@@ -223,6 +240,54 @@ export function usePlugins() {
     }
   }
 
+  async function getCapabilities(pluginName: string): Promise<CapabilityInfo | null> {
+    error.value = null
+    try {
+      const data = await wrap(() =>
+        ApiClient.get<CapabilityInfo>(`${getApiBase()}/plugins/${pluginName}/capabilities`),
+      )
+      return data
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : `Failed to get capabilities for ${pluginName}`
+      error.value = msg
+      logger.error('getCapabilities error: %s', msg)
+      return null
+    }
+  }
+
+  async function approveCapabilities(
+    pluginName: string,
+    capabilities: string[],
+  ): Promise<boolean> {
+    error.value = null
+    try {
+      await ApiClient.post(`${getApiBase()}/plugins/${pluginName}/approve-capabilities`, {
+        capabilities,
+      })
+      return true
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : `Failed to approve capabilities for ${pluginName}`
+      error.value = msg
+      logger.error('approveCapabilities error: %s', msg)
+      return false
+    }
+  }
+
+  async function getAuditLog(limit = 50): Promise<AuditLogEntry[]> {
+    error.value = null
+    try {
+      const data = await wrap(() =>
+        ApiClient.get<{ entries: AuditLogEntry[] }>(`${getApiBase()}/plugins/audit?limit=${limit}`),
+      )
+      return data.entries ?? []
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to fetch audit log'
+      error.value = msg
+      logger.error('getAuditLog error: %s', msg)
+      return []
+    }
+  }
+
   return {
     plugins,
     discovered,
@@ -240,5 +305,8 @@ export function usePlugins() {
     updatePluginConfig,
     installFromZip,
     installFromGit,
+    getCapabilities,
+    approveCapabilities,
+    getAuditLog,
   }
 }

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -109,6 +109,23 @@
           </svg>
           {{ $t('views.plugins.marketplace') }}
         </router-link>
+        <!-- Issue #9049: Capability audit log tab -->
+        <button
+          v-if="!isMarketplaceActive"
+          class="tab-btn"
+          :class="{ active: activeTab === 'audit' }"
+          @click="activeTab = 'audit'"
+        >
+          <svg class="tab-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+            />
+          </svg>
+          {{ $t('views.plugins.auditLog') }}
+        </button>
       </div>
 
       <!-- Installed Tab -->
@@ -389,7 +406,21 @@
           </div>
         </div>
       </div>
+
+      <!-- Audit Log Tab -->
+      <div v-if="!isMarketplaceActive && activeTab === 'audit'">
+        <CapabilityAuditLog />
+      </div>
     </div>
+
+    <!-- Capability Approval Dialog — Issue #9049 -->
+    <CapabilityApprovalDialog
+      v-if="pendingPluginName"
+      :plugin-name="pendingPluginName"
+      :open="approvalDialogOpen"
+      @approved="handleApprovalComplete"
+      @close="handleApprovalClose"
+    />
 
     <!-- Install plugin modal — Issue #6464 -->
     <PluginInstallModal
@@ -412,6 +443,8 @@ import { useInitialFocus } from '@/composables/useInitialFocus'
 import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 import { usePlugins, type PluginInfo, type PluginManifest } from '@/composables/usePlugins'
 import PluginInstallModal from '@/components/plugins/PluginInstallModal.vue'
+import CapabilityApprovalDialog from '@/components/plugins/CapabilityApprovalDialog.vue'
+import CapabilityAuditLog from '@/components/plugins/CapabilityAuditLog.vue'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -431,10 +464,13 @@ const {
   disablePlugin,
   getPluginConfig,
   updatePluginConfig,
+  getCapabilities,
 } = usePlugins()
 
-const activeTab = ref<'installed' | 'discover'>('installed')
+const activeTab = ref<'installed' | 'discover' | 'audit'>('installed')
 const installModalOpen = ref(false)
+const approvalDialogOpen = ref(false)
+const pendingPluginName = ref<string | null>(null)
 
 async function onPluginInstalled(): Promise<void> {
   await listPlugins()
@@ -479,12 +515,47 @@ async function switchToDiscover() {
 async function handleLoad(name: string) {
   actionLoading.value[name] = true
   try {
+    // Check if plugin has pending capability approvals
+    const capabilityInfo = await getCapabilities(name)
+
+    if (capabilityInfo && capabilityInfo.pending_approval.length > 0 && capabilityInfo.trust_tier !== 'official') {
+      // Non-official plugin with pending approvals - show approval dialog
+      pendingPluginName.value = name
+      approvalDialogOpen.value = true
+      actionLoading.value[name] = false
+      return
+    }
+
+    // Official plugin or no pending approvals - proceed with load
     await loadPlugin(name)
     await discoverPlugins()
     activeTab.value = 'installed'
   } finally {
     actionLoading.value[name] = false
   }
+}
+
+async function handleApprovalComplete() {
+  if (!pendingPluginName.value) return
+
+  const name = pendingPluginName.value
+  actionLoading.value[name] = true
+  try {
+    await loadPlugin(name)
+    await discoverPlugins()
+    activeTab.value = 'installed'
+  } finally {
+    actionLoading.value[name] = false
+    pendingPluginName.value = null
+  }
+}
+
+function handleApprovalClose() {
+  if (pendingPluginName.value) {
+    actionLoading.value[pendingPluginName.value] = false
+  }
+  approvalDialogOpen.value = false
+  pendingPluginName.value = null
 }
 
 async function handleUnload(name: string) {


### PR DESCRIPTION
## Thinking Path

Second phase of plugin capability approval UI. Added the approval dialog and audit log components to allow operators to review and approve plugin capabilities before loading non-official plugins.

## What Changed

- Added `getCapabilities`, `approveCapabilities`, `getAuditLog` to `usePlugins` composable
- Created `CapabilityApprovalDialog.vue` — displays pending capabilities with checkbox selection, trust tier badge, approve-all / approve-selected actions
- Created `CapabilityAuditLog.vue` — filterable table of audit entries with denied rows highlighted in red
- Integrated approval flow into `PluginsView`: non-official plugins with pending approvals show dialog before load proceeds
- Added "Audit Log" tab to plugin management interface

## Verification

Frontend type-check passed. Manual testing required:
- Install a non-official plugin; verify approval dialog appears on load
- Approve selected capabilities; verify plugin loads after approval
- Approve all capabilities; verify `approveCapabilities` API called correctly
- Cancel approval dialog; verify plugin load is aborted
- Switch to Audit Log tab; verify table renders correctly
- Filter audit log by plugin name; verify entries filter correctly
- Verify denied entries are highlighted in red
- Official plugin loads without showing dialog

## Model Used

Claude Sonnet 4.5

## Related

Closes #9049 (GH issue). Second phase of plugin capability approval UI, parent: MVA-1974. Depends on capability manifest from MVA-1955 / PR #9151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)